### PR TITLE
docs(agents): name the component node `BaseSchema` in AGENTS.md section 4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ You don't just build components — you build a **Renderer** that interprets JSO
 Every node in the UI tree follows this shape (`@object-ui/types`):
 
 ```ts
-interface UIComponent {
+interface BaseSchema {
   type: string;                         // registry key: 'input', 'grid', 'card'
   id?: string;                          // DOM accessibility / event targeting
   props?: Record<string, any>;          // visual props (mapped to Shadcn props)
@@ -79,7 +79,7 @@ interface UIComponent {
   hidden?: string;                      // expression: "${data.role != 'admin'}"
   disabled?: string;                    // expression
   events?: Record<string, ActionDef[]>; // onClick -> [Action1, Action2]
-  children?: UIComponent[];             // layout slots
+  children?: BaseSchema[];              // layout slots
 }
 ```
 
@@ -121,7 +121,7 @@ export function resolveComponent(type: string) { return registry.get(type) || Fa
 **Renderer loop (recursion):**
 ```tsx
 // packages/react/src/SchemaRenderer.tsx
-export const SchemaRenderer = ({ schema }: { schema: UIComponent }) => {
+export const SchemaRenderer = ({ schema }: { schema: BaseSchema }) => {
   const Component = resolveComponent(schema.type);
   const { isHidden } = useExpression(schema.hidden);
   if (isHidden) return null;


### PR DESCRIPTION
Fixes #7434

PR B of triage prescription 5556499148 — the `domain:skills` half. PR A (the `domain:devx` half, PR #8064) landed 2026-09-06T14:22Z. Under maintainer ruling 5556352576 (option 1), the documented name for "a component node" — the object half a renderer receives — is `BaseSchema`.

Root `AGENTS.md` section 4 was the last authored surface still teaching `UIComponent`. Three in-place renames, **line-neutral**: 558 lines before, 558 after; no new lines, no new section, no other file.

## 改前 → 改后

| line | 改前 | 改后 |
|---:|:--|:--|
| 73 | `interface UIComponent {` | `interface BaseSchema {` |
| 82 | `children?: UIComponent[];` | `children?: BaseSchema[];` |
| 124 | `({ schema }: { schema: UIComponent })` | `({ schema }: { schema: BaseSchema })` |

Line 82's trailing comment column is preserved: the `//` starts at column 41 on every row of that fence, before and after (measured, not eyeballed).

## Why `BaseSchema` and not the other two

- `UIComponent` is **not exported** by `@object-ui/types`. Measured on this branch: 0 files under `packages/types/src` name it, against **101** for `BaseSchema` — a live control, so that zero is a real zero and not a dead grep. A reader following this file reached for an identifier they could not import or type-check. Ruling option 2 (minting the export) was declined: a public-surface widening for a word.
- `SchemaNode` is **not written anywhere in this diff**, deliberately. It is `BaseSchema` widened with `string | number | boolean | null | undefined`, and a node-slot position does not admit those — renderers narrow with a `typeof` object guard before reading keys and drop the primitives on the floor. Flattening that distinction is the regression the card, both triage comments and the ruling each warn against; this is the fourth restatement.
- The topology table at line 51 already said `BaseSchema`. Section 4 now agrees with it.

## Verification

Every exit code captured by redirecting first, then reading `$?` — never through a pipe.

| gate | exit | verdict line |
|:--|--:|:--|
| `node scripts/check-governed-queue-guard.mjs --test AGENTS.md` | **3** | `⛔ GOVERNED — 1 of 1 path(s) are on a governed surface: AGENTS.md x1 — the repo-root agent instruction file`. This is the expected answer, and it is why this PR is a draft. |
| `pnpm check:doc-fences` | 0 | `every TypeScript block in 227 document(s) is fenced ts/tsx/typescript…` |
| `pnpm check:control-bytes` | 0 | `OK (scanned 6473 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-changeset-presence.mjs` | 0 | `1 file(s) changed, 0 of them published source… no changeset is owed` |
| `node scripts/check-doc-links.mjs` | 0 | `Links are valid across 17 scan roots` (`AGENTS.md` is in its list under the `disk` rule) |
| `pnpm lint` (whole repo) | 0 | `Tasks: 47 successful, 47 total`; 0 errors, warnings all pre-existing and none in this diff |
| `pnpm lint:root` | 0 | `32 problems (0 errors, 32 warnings)` — pre-existing |
| `pnpm exec vitest run scripts/__tests__` | 0 | `Test Files 112 passed (112) · Tests 3341 passed (3341)` |

The vocabulary pin PR A added was confirmed collected **by name**, not inferred from a green total: `scripts/__tests__/component-node-vocabulary-7434.test.ts`, all four assertions green under `--reporter=verbose`, alongside `check-governed-queue-guard.test.ts` (19 tests over the two files). Manual control-byte scan of `AGENTS.md`: 0 hits, with a positive control that fires.

**No ablation was run, and the reason is itself the finding below**: no gate reads `AGENTS.md`'s vocabulary today, so there is no nail to turn red. `check-doc-fence-languages.mjs` sets `ROOT_PAGES = ['README.md']`, and `check-doc-snippet-types.mjs`'s own coverage ledger lists the root pages that are not `README.md` — `AGENTS.md` among them — as read by no doc gate at all. Reporting that plainly beats staging a green ablation that measured nothing.

## Measured: could PR A's pin cover this file?

Ruling item 4 asked. Answer: **yes, and cheaply** — but only after this PR merges. Probe run on both revisions of the file:

| revision | banned `UIComponent` | banned `ComponentSchema` | live control `BaseSchema` |
|:--|--:|--:|--:|
| `origin/main` (pre-edit) | **3** (lines 73, 82, 124) | 0 | 1 |
| this branch (post-edit) | **0** | 0 | 4 |

The pin's regexes catch all three residue sites unmodified, and its live-control requirement — a must-hit word firing on the surface — is already satisfied on this file in **both** revisions, so the control is not vacuous. Extending the corpus is one line in `scanSurface()` plus one control assertion. The ordering is load-bearing and is why this PR does not do it: PR A's pin excludes `AGENTS.md` with the reason written into the file — adding it before this governed, human-merged PR lands would red the pin on `main`. That follow-up is filed rather than ridden here.

## 维护者速读(草稿)

**这次改的是什么。** 仓库根 `AGENTS.md` 第 4 节「The JSON Protocol」把「一个组件节点」这个概念叫作 `UIComponent`,而代码里根本没有这个导出。三处改名之后,这份指令文件用的词和 `@object-ui/types` 真正导出的名字一致了。业务上的意义只有一句:这是每个 agent 和每个新人写第一行 schema 之前会读的那份文件,它教的名字必须是能 import、能被类型检查的那个。

**为什么值得单独走一趟。** 这个词汇缺口已经复发过两次(#7082 更正九行、PR #7432 顺手修八处),而且代价不是「文档不好看」:其中一次把 `check-doc-snippet-types` 门禁自己的正对照打掉了,那一轮门禁以「HARNESS CONTROL FAILED」退出,对任何文档都没给出结论。一个没有约定的名字,能让一道质量门整轮失效 —— 这是把它当缺陷而不是当洁癖来处理的理由。

**为什么是 `BaseSchema`。** 三个候选里,只有它已经是真实导出(实测 101 个文件在用),而且是前两次独立修复各自落到的那个名字。选它零代码、零新公共面、不动发版。另一个候选 `UIComponent` 要先新增一个公共导出才配被写进文档 —— 为一个词加宽公共表面,踩人工底线,维护者已裁决不走。第三个候选 `SchemaNode` 是错的:它比节点槽位宽,会把原始值放进只接受对象的位置。

**风险面。** 改动是三行原地替换,行数不变(558 → 558),不含代码、不含发版、不欠 changeset(门禁自己判定「no changeset is owed」)。整仓 lint 与 `scripts/__tests__` 全套均绿。唯一的行为性影响是文档语义:今后照这份文件抄的人拿到一个真实存在的类型名。

**合并方式。** `AGENTS.md` 在受管面册上(守卫以 exit 3 明确判定),所以这个 PR 停在 **draft**,等人类合并 —— 席位不翻 ready、不入队、不挂 auto-merge、不 approve。这是本卡最后一个未完成的半边,合并后 #7434 可以关闭。

**席位意见:**

## Out of scope — reported, not repaired

1. **The fenced interface in section 4 does not match the real `BaseSchema`, and ruling item 3 asked for the measurement.** The fence is illustrative prose, so it was **not** expanded — only the name changed. Measured against `packages/types/src/base.ts` on this branch:
   - **Absent from the real interface:** `props` and `events`. The fence's `events` value type also names `ActionDef`, which `@object-ui/types` does not export either (`ActionSchema` is the exported one).
   - **Present but declared differently:** `hidden` and `disabled` are expression-or-boolean wire types on the real interface, not plain strings; `children` is the wider `SchemaNode` shape there, not an array of the object half.
   - **On the real interface but absent from the fence:** `name`, `label`, `description`, `placeholder`, `style`, `data`, `body`, `visible`, `visibleWhen`, `visibleOn`, `hiddenOn`, `disabledOn`, `testId`, `ariaLabel`.

   Whether an illustrative fence in an instruction file should track the real interface is a judgment call for the maintainer, not a mechanical repair, which is why it is here and not in the diff.

2. **The published `skills/objectui` tree teaches the same unexported name in five places**, already filed by PR A's dev as objectui#8065 (`finding`, unassigned). It is a third governed surface that neither PR A nor this PR covers. Noted here only so this PR is not read as having emptied the class.

3. **Extending PR A's pin to `AGENTS.md`** — measured above, one line plus a control, and it must land after this PR merges. Filed as a follow-up rather than ridden here.

---

Session: `session_019RfFHiRCSs3JXLK4cwcfox` (written as prose so it survives a body edit).

_Generated by [Claude Code](https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox)_


---
_Generated by [Claude Code](https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox)_