### PR TITLE
test(plugin-detail): derive the docs activity-map transcription from the map

### DIFF
--- a/.changeset/7876-activity-map-docs-transcription-pin.md
+++ b/.changeset/7876-activity-map-docs-transcription-pin.md
@@ -1,0 +1,7 @@
+---
+---
+
+Pin the `sys_activity` mapping paragraph on `content/docs/plugins/plugin-detail.mdx`
+against `ACTIVITY_TYPE_TO_FEED_TYPE`, derived from the map in both directions
+(objectui#7876, ruling A). Test only; no package is released by this change, and the
+published behaviour of `@object-ui/plugin-detail` is unchanged.

--- a/packages/plugin-detail/src/renderers/__tests__/docsActivityMapTranscription-7876.test.ts
+++ b/packages/plugin-detail/src/renderers/__tests__/docsActivityMapTranscription-7876.test.ts
@@ -1,0 +1,233 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The docs transcription pin for `ACTIVITY_TYPE_TO_FEED_TYPE` (objectui#7876).
+ *
+ * `content/docs/plugins/plugin-detail.mdx` restates the map in prose so readers
+ * can see the mapping without opening the source. Nothing read that sentence:
+ * `check:doc-types` reads documented component type literals, `check:doc-snippets`
+ * reads fenced code blocks, and `check:doc-fences` / `docs:check-links` /
+ * `check:docs-route-closure` read fence languages, links and routes. None of them
+ * reads a sentence, which is how objectui#6932 (PR objectui#7871) found two
+ * `record:activity` statements on this page that were true when written and false
+ * on `main`. This pin closes the mechanically checkable half: the transcription is
+ * DERIVED from the map here, never hand-copied, so moving a type in the map
+ * without moving it on the page turns this red.
+ *
+ * ## ⚠️ The bound, stated rather than sold past
+ *
+ * This covers the MAP TRANSCRIPTION and nothing else. It does NOT cover the free
+ * prose around it — sentences like "a row whose type is in neither list is not
+ * dropped", which is the class objectui#6932 actually corrected. Those statements
+ * remain ungated, and objectui#7876 says so in its own words: option A "is worth
+ * doing because the map is mechanically checkable; it should not be sold as
+ * closing the whole gap." ⛔ Do not read a green run here as "the page agrees with
+ * the code"; read it as "the page's mapping paragraph agrees with the map".
+ *
+ * ## ⛔ Not the pin `recordActivityFeed.test.ts` forbids — a different object
+ *
+ * That file's `PLATFORM_BUILTIN_ACTIVITY_TYPES` docblock says: "Do not derive this
+ * list from `ACTIVITY_TYPE_TO_FEED_TYPE`. A pin that reads its expectation out of
+ * the thing it is pinning cannot fail." That ban is about the PLATFORM-DECLARED
+ * vocabulary, which lives upstream (`@objectstack/plugin-audit`) and is transcribed
+ * by hand into that file — deriving it from the map would compare the map with
+ * itself. The object here is a DIFFERENT one: prose on a `.mdx` page, authored
+ * independently of the map, which is exactly what a derived expectation is for.
+ * Deriving from the map is what objectui#7876's ruling A asks for.
+ *
+ * Its neighbour `feedTypeProducerCensus-5877.test.ts` names this same `.mdx` in
+ * order to declare it OUT of the producer census ("a documentation example
+ * produces nothing at runtime"). This is the pin that does read it; the two do not
+ * overlap. The `repoRoot` resolution below is that file's, reused rather than
+ * re-invented.
+ *
+ * ⛔ The map is read from `../recordActivityFeed`, never from app-shell's
+ * `activityItemType.ts` — that is a second, separate mapping for the
+ * `ActivityItem` surface, and the census test excludes it for the same reason.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ACTIVITY_TYPE_TO_FEED_TYPE } from '../recordActivityFeed';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+// packages/plugin-detail/src/renderers/__tests__ -> repository root
+const repoRoot = path.resolve(here, '../../../../..');
+const PAGE = path.join(repoRoot, 'content', 'docs', 'plugins', 'plugin-detail.mdx');
+
+/**
+ * The paragraph is located by its OPENING SENTENCE, never by line number.
+ *
+ * A line number goes stale silently the first time anything above it moves, and a
+ * stale slice reads whatever prose now sits there — a pin that passes vacuously.
+ * An anchor that stops matching is a page restructure, and this file fails loudly
+ * saying so instead of quietly checking nothing.
+ */
+const ANCHOR = '`sys_activity` rows map to feed items like this:';
+
+/** `sys_*` in backticks is an ObjectStack OBJECT name, not an activity type. */
+const OBJECT_NAME = /^sys_/;
+
+/** One `` `a` / `b` → `feed_type` `` clause of the transcription. */
+const ARROW_CLAUSE = /((?:`[a-z_]+`(?:\s*\/\s*)?)+)\s*→\s*`([a-z_]+)`/g;
+
+const BACKTICKED = /`([a-z_]+)`/g;
+
+interface Transcription {
+  /** The paragraph's lines, as found on the page. */
+  lines: string[];
+  /** activity type -> the feed type the PROSE gives it. */
+  pairs: Map<string, string>;
+  /** Activity types the prose names WITHOUT putting them under a feed type. */
+  namedWithoutFeedType: Set<string>;
+  /** How many lines carried the anchor (must be exactly 1). */
+  anchorHits: number;
+}
+
+function readTranscription(): Transcription {
+  if (!existsSync(PAGE)) {
+    throw new Error(
+      `objectui#7876: the documented page is gone from disk: ${PAGE}. ` +
+        `If the page moved, move this pin's path with it; do not delete the pin.`,
+    );
+  }
+  const fileLines = readFileSync(PAGE, 'utf8').split('\n');
+  const anchorAt = fileLines.flatMap((line, i) => (line.includes(ANCHOR) ? [i] : []));
+  if (anchorAt.length !== 1) {
+    throw new Error(
+      `objectui#7876: expected exactly ONE line on ${path.relative(repoRoot, PAGE)} carrying the ` +
+        `transcription anchor ${JSON.stringify(ANCHOR)}, found ${anchorAt.length}. ` +
+        `The mapping paragraph was restructured or renamed: re-anchor this pin on its new ` +
+        `opening sentence. Failing here is deliberate — a missing anchor must never be read ` +
+        `as "the transcription is fine".`,
+    );
+  }
+
+  // The paragraph is the contiguous block from the anchor to the next blank line.
+  // Stopping there is what keeps LATER prose out: `:239` names
+  // `ACTIVITY_TYPE_TO_FEED_TYPE` and a paragraph further down re-lists the four
+  // non-activity types, and neither of those is the transcription.
+  const lines: string[] = [];
+  for (let i = anchorAt[0]; i < fileLines.length && fileLines[i].trim() !== ''; i += 1) {
+    lines.push(fileLines[i]);
+  }
+
+  const pairs = new Map<string, string>();
+  const remainder = lines
+    .join(' ')
+    .replace(ARROW_CLAUSE, (_match, lhs: string, feedType: string) => {
+      for (const [, activityType] of lhs.matchAll(BACKTICKED)) pairs.set(activityType, feedType);
+      return ' ';
+    });
+
+  const namedWithoutFeedType = new Set<string>();
+  for (const [, identifier] of remainder.matchAll(BACKTICKED)) {
+    if (!OBJECT_NAME.test(identifier)) namedWithoutFeedType.add(identifier);
+  }
+
+  return { lines, pairs, namedWithoutFeedType, anchorHits: anchorAt.length };
+}
+
+const mappedKeys = Object.keys(ACTIVITY_TYPE_TO_FEED_TYPE).filter(
+  (key) => ACTIVITY_TYPE_TO_FEED_TYPE[key] !== undefined,
+);
+const skippedKeys = Object.keys(ACTIVITY_TYPE_TO_FEED_TYPE).filter(
+  (key) => ACTIVITY_TYPE_TO_FEED_TYPE[key] === undefined,
+);
+
+describe('docs transcription of ACTIVITY_TYPE_TO_FEED_TYPE (objectui#7876)', () => {
+  /**
+   * NON-VACUITY, the source side. Both halves of the assertion below need a
+   * subject: if the map ever had no mapped keys, or no `undefined` keys, the two
+   * direction tests would pass over empty sets and prove nothing.
+   */
+  it('has something to check on both sides of the map', () => {
+    expect({ mapped: mappedKeys.length > 0, skipped: skippedKeys.length > 0 }).toEqual({
+      mapped: true,
+      skipped: true,
+    });
+  });
+
+  /**
+   * NON-VACUITY, the page side, plus the anchor's own liveness: the paragraph was
+   * found exactly once and it actually names types in both shapes.
+   */
+  it('finds the mapping paragraph and reads types out of it', () => {
+    const { lines, pairs, namedWithoutFeedType, anchorHits } = readTranscription();
+    expect({
+      anchorHits,
+      paragraphLines: lines.length > 1,
+      typesUnderAFeedType: pairs.size > 0,
+      typesNamedWithoutOne: namedWithoutFeedType.size > 0,
+    }).toEqual({
+      anchorHits: 1,
+      paragraphLines: true,
+      typesUnderAFeedType: true,
+      typesNamedWithoutOne: true,
+    });
+  });
+
+  /**
+   * The slice stops at the paragraph. `ACTIVITY_TYPE_TO_FEED_TYPE` is named in
+   * prose further down the page (the "give it one by adding the type to …"
+   * sentence); if that text is inside the slice, the reader ran past the blank
+   * line and is checking the wrong prose.
+   */
+  it('reads the transcription paragraph only, not the prose below it', () => {
+    const { lines } = readTranscription();
+    expect(lines.join(' ')).not.toContain('ACTIVITY_TYPE_TO_FEED_TYPE');
+  });
+
+  /**
+   * DIRECTION 1 — every key the map gives a feed type appears in the paragraph
+   * under THAT feed type. Expectation derived from the map; a missing key reads as
+   * `undefined` here and names itself in the diff.
+   */
+  it('lists every mapped activity type under the feed type the map gives it', () => {
+    const { pairs } = readTranscription();
+    const fromTheMap = Object.fromEntries(mappedKeys.map((key) => [key, ACTIVITY_TYPE_TO_FEED_TYPE[key]]));
+    const fromThePage = Object.fromEntries(mappedKeys.map((key) => [key, pairs.get(key)]));
+    expect(fromThePage).toEqual(fromTheMap);
+  });
+
+  /**
+   * DIRECTION 1, the other half — every `undefined` key is NAMED in the paragraph
+   * (as skipped / not record activity) and is NOT listed under any feed type.
+   * Naming them is the point: a reader who cannot find `login` on the page cannot
+   * tell "deliberately excluded" from "nobody has mapped it yet".
+   */
+  it('names every non-mapped activity type without putting it under a feed type', () => {
+    const { pairs, namedWithoutFeedType } = readTranscription();
+    const fromThePage = Object.fromEntries(
+      skippedKeys.map((key) => [
+        key,
+        { named: namedWithoutFeedType.has(key), underFeedType: pairs.get(key) },
+      ]),
+    );
+    const expected = Object.fromEntries(
+      skippedKeys.map((key) => [key, { named: true, underFeedType: undefined }]),
+    );
+    expect(fromThePage).toEqual(expected);
+  });
+
+  /**
+   * DIRECTION 2 — every activity type the paragraph names is a key of the map. A
+   * type deleted from the map but left on the page fails here.
+   *
+   * ⚠️ Bound: this reads types the prose spells in `backticks`, which is how the
+   * page spells every one of them today. A type added to the prose in bare words
+   * would escape this direction (direction 1 still covers deletions and moves).
+   */
+  it('names no activity type the map does not declare', () => {
+    const { pairs, namedWithoutFeedType } = readTranscription();
+    const named = [...new Set([...pairs.keys(), ...namedWithoutFeedType])].sort();
+    const undeclared = named.filter((type) => !(type in ACTIVITY_TYPE_TO_FEED_TYPE));
+    expect({ undeclared, checked: named.length > 0 }).toEqual({ undeclared: [], checked: true });
+  });
+});


### PR DESCRIPTION
Fixes #7876

Ruling A on the card, confirmed by triage `5557286492`: a **derived** transcription pin. One new test file; the page itself is untouched.

## What this closes, and what it does not

`content/docs/plugins/plugin-detail.mdx` restates `ACTIVITY_TYPE_TO_FEED_TYPE` in prose at `:221-225`, and **nothing read that sentence** — `check:doc-types` reads component type literals, `check:doc-snippets` reads fenced code blocks, `check:doc-fences` / `docs:check-links` / `check:docs-route-closure` read fence languages, links and route closure. None of them reads a sentence, which is how #6932 (PR #7871) came to find two `record:activity` statements on this page that were true when written and false on `main`.

⚠️ The **bound is written into the pin's docblock rather than sold past**: this covers the map transcription and **not** the free-prose behaviour statements — the class #6932 actually corrected. Card A's own words: it "is worth doing because the map is mechanically checkable; it should not be sold as closing the whole gap."

## How it works

- **Located structurally, never by line number.** The anchor is the paragraph's opening sentence (`` `sys_activity` rows map to feed items like this: ``); the slice runs to the next blank line. A missing or duplicated anchor throws with a stated reason, so a page restructure reds instead of vacuously passing.
- **Derived in both directions.** Every key with a feed type must appear under *that* feed type; every `undefined` key must be **named** in the paragraph and **not** listed under any feed type; and no activity type the paragraph names may be absent from the map.
- **Non-vacuity legs**: the map has ≥ 1 mapped key and ≥ 1 `undefined` key; the anchor matched exactly once; the paragraph yields ≥ 1 type under a feed type and ≥ 1 named without one. A separate leg asserts the slice stopped at the paragraph (the prose at `:239` naming the constant must not be inside it).

## Not the pin `recordActivityFeed.test.ts` forbids

That file bans deriving `PLATFORM_BUILTIN_ACTIVITY_TYPES` from the map — that list is the platform-**declared** vocabulary, hand-transcribed from upstream, so deriving it would compare the map with itself. The object here is different: prose on an `.mdx` page authored independently of the map, which is exactly what a derived expectation is for. Its neighbour `feedTypeProducerCensus-5877.test.ts` names the same page in order to declare it **out** of the producer census; this is the pin that reads it. Its `repoRoot` resolution is reused rather than re-invented. The map is read from `renderers/recordActivityFeed`, never from app-shell's separate `activityItemType.ts` mapping.

## Drift check on today's page

The prose and the map **agree** on `main`, so the page is not touched. Re-derived: `created` / `updated` / `deleted` / `assigned` / `shared` → `field_change`, `completed` → `task`, `scheduled` → `event`, `system` → `system`, and `commented` / `mentioned` / `login` / `logout` named as skipped / account events — the map's 12 keys exactly.

## Ablation — five legs, each mutating the page on disk, restored under a `trap` with absolute paths

Blob hashes recorded before and after every leg; each restore is `git checkout HEAD -- <abs path>` verified back to `a1b07f6…` with `git diff HEAD` exit 0.

| leg | mutation | pin exit | it named |
|---|---|---|---|
| A | `completed` → `task` becomes → `event` | **1** | `- "completed": "task" / + "completed": "event"` |
| B | delete `shared` from the mapped list | **1** | `- "shared": "field_change" / + "shared": undefined` |
| C | delete `mentioned` from the skip sentence | **1** | `- "named": true / + "named": false` |
| D | prose names `archived`, which the map does not declare | **1** | `undeclared: [ 'archived' ]` |
| E (live control) | the **same** `completed` → `task` pair where it appears **outside** the paragraph (`:229`) | **0**, as required | — |

Leg E is the ruling's "prose elsewhere on the page must not be read as the transcription", measured: the identical text moved outside the slice leaves the pin green. Leg A's first anchor attempt was rejected by the script because that text occurs twice on the page — which is how E got written.

## Gates, all pinned to `cb3ba202c` (the merged head)

`pnpm exec vitest run packages/plugin-detail/` → 133 files / 1205 tests passed · `pnpm --filter @object-ui/plugin-detail type-check` → 0, and `tsc -p tsconfig.test.json --listFiles` names the new file (so the type program is not vacuous over it) · `lint` → 0 errors, 0 findings in the new file · `check:control-bytes` → 0, plus a manual control-byte scan of both changed paths (no hits) · `node scripts/check-changeset-presence.mjs` → 0, empty frontmatter accepted as "releases nothing" · `check:governed-queue-guard --test` → **NOT GOVERNED** · `check:doc-types` → 0 · plus the derived set `check:doc-example-readers`, `check:published-tsconfig-exclude`, `check:unreferenced-sources`, `check:esm-specifiers`, `check:self-import` → all 0. Both files that name this page (`check-doc-component-types.mjs` and the census test) were run.

`origin/main` moved from `295804a63` to `c546cdfdd` mid-run; merged in and everything above was re-run on the merged head. The merge is disjoint from `packages/plugin-detail/**` and `content/docs/plugins/**`. `Live E2E (informational)` is red on every branch today for an upstream reason (#7990) — not this change.

Related, none of them addressed here: #6932 and its PR #7871 are the instance that motivated the card; #5877 owns the neighbouring census pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_