### PR TITLE
fix(types): correct the false "nothing reads AppComponentSchema.actions[]" changeset copy and widen its reader census

### DIFF
--- a/.changeset/7344-handler-string-any-mirrors.md
+++ b/.changeset/7344-handler-string-any-mirrors.md
@@ -29,7 +29,10 @@ reads a function, else `?: never`:
 - Runtime slots (callable kept): `DetailViewSchema.onBack` (now `() => void`, the prop
   `DetailView` invokes — it declared `string`), `DetailSchema.onBack`, `ActionSchema.onClick`,
   `CalendarViewSchema.onEventClick`.
-- Retired (`?: never`): `AppAction.onClick` (nothing reads `AppComponentSchema.actions[]`),
+- Retired (`?: never`): `AppAction.onClick` (no reader touches `onClick`, on the action
+  or on `items[]` — `AppComponentSchema.actions[]` itself IS read, by
+  `@object-ui/runner`'s `LayoutRenderer`, so the array being unread was never the
+  reason this key is inert; corrected at objectui#7721),
   `ReportBuilderSchema.onSave` / `.onCancel` (no `report-builder` renderer is registered),
   `CRUDDialogSchema.onClose` (no `crud-dialog` renderer is registered).
 

--- a/.changeset/7721-actions-reader-census.md
+++ b/.changeset/7721-actions-reader-census.md
@@ -1,0 +1,25 @@
+---
+---
+
+Correct a measured-false sentence in the pending objectui#7344 changeset, and widen the
+reader census that produced it (objectui#7721).
+
+`.changeset/7344-handler-string-any-mirrors.md` said `AppAction.onClick` retires because
+"nothing reads `AppComponentSchema.actions[]`". The array IS read — `@object-ui/runner`'s
+`LayoutRenderer` renders its `'button'` arm as toolbar buttons and its `'user'` arm as an
+avatar dropdown. The retirement itself is correct and unchanged: what no reader touches is
+`onClick`, on the action or on `items[]`. That sentence was future published
+`@object-ui/types` CHANGELOG copy, so it is corrected before the next release rather than
+after, when the CHANGELOG is history and no longer editable.
+
+The census in `handler-keys-string-any-mirrors-7344.test.ts` was the origin: it scoped to
+`@object-ui/layout`, `@object-ui/app-shell` and the console, which made it literally true
+and its conclusion false. It is now an assertion whose population is read off the tree, so
+a reader appearing in a package nobody listed fails the pin instead of narrowing the claim
+in silence.
+
+**Nothing published changes**: no accept set moves, no exported symbol changes, no
+TypeScript face moves. The edits are one parenthetical in an unreleased changeset and one
+pin's comment plus its new census — which is why this declares no bump. The `minor` the
+objectui#7344 changeset already declares for `@object-ui/types` is the release this copy
+belongs to.

--- a/packages/types/src/__tests__/handler-keys-string-any-mirrors-7344.test.ts
+++ b/packages/types/src/__tests__/handler-keys-string-any-mirrors-7344.test.ts
@@ -54,10 +54,29 @@
  *     `pickHostCallbacks` forwards it when it is a function
  *     (`calendar-view-renderer.tsx`), the sibling of `onViewChange`'s arm.
  *
- * RETIRED — nothing reads the key (`?: never` on the TypeScript face):
- *   - `app.zod.ts#AppActionSchema.onClick` — `AppComponentSchema.actions[]` has
- *     no reader in `@object-ui/layout`, `@object-ui/app-shell` or the console;
- *     zero references to `AppAction` outside `packages/types`.
+ * RETIRED — nothing reads the KEY (`?: never` on the TypeScript face). ⚠️ The
+ * subject is the KEY, never the array it sits in. This entry used to read
+ * "`AppComponentSchema.actions[]` has no reader in `@object-ui/layout`,
+ * `@object-ui/app-shell` or the console" — literally true, and true ONLY
+ * because of that hand-written three-package scope; `@object-ui/runner` was
+ * outside it and reads the array. Stripped of the scope it became the flat
+ * "nothing reads `AppComponentSchema.actions[]`" that the objectui#7344
+ * changeset was about to publish as `@object-ui/types` CHANGELOG copy
+ * (objectui#7721). Re-measured whole-tree:
+ *   - `app.zod.ts#AppActionSchema.onClick` — `AppComponentSchema.actions[]` IS
+ *     read, by exactly ONE package: `@object-ui/runner`, whose `LayoutRenderer`
+ *     renders the `'button'` arm as toolbar buttons and the `'user'` arm as an
+ *     avatar dropdown. What no reader touches is `onClick` itself — not on the
+ *     action, and no longer on `AppAction.items`, where that same renderer
+ *     reached one through an `as any` cast until objectui#6854 deleted it
+ *     (guarded from the renderer side by
+ *     `packages/runner/src/__tests__/LayoutRenderer.appActionItems-6854.test.tsx`).
+ *     The reader set is now ASSERTED rather than narrated: the census below
+ *     reads its population off the tree, so a reader appearing in a package
+ *     nobody thought to list fails loudly instead of narrowing the claim in
+ *     silence. `AppAction` is still imported nowhere outside `packages/types`
+ *     — the runner reaches the array structurally, through
+ *     `AppComponentSchema`.
  *   - `reports.zod.ts#ReportBuilderSchema.onSave` / `.onCancel` — no renderer is
  *     registered for `report-builder` (control on the same tree:
  *     `register('detail-view'` and `register('report-designer'` both resolve).
@@ -94,6 +113,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -162,7 +182,10 @@ const EVENT_NAME_KEYS: readonly Site[] = [
 ];
 const EVENT_NAME_WORDING = 'an event NAME, not a callback or a handler expression';
 
-const ZOD_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'zod');
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ZOD_DIR = join(HERE, '..', 'zod');
+/** `packages/types/src/__tests__` -> the workspace root. */
+const REPO_ROOT = join(HERE, '..', '..', '..', '..');
 /** EVERY mirror module — objectui#6182's close condition runs over the whole
  *  directory, not the nine files #7339's census listed (that list is what let
  *  these eight through). */
@@ -254,6 +277,160 @@ describe('census: the only on*: z.(function|string|any) lines left in packages/t
     // stays green through the very deletion it exists to catch.
     expect(objectOf(mirror, key).shape[key]).toBeDefined();
     expect(describeOf(mirror, key)).toContain('objectui#6124');
+  });
+});
+
+/* ── Census: WHO reads `AppComponentSchema.actions[]` (objectui#7721) ────── */
+
+/** The whole-tree reader set, measured on `origin/main` @ `951fa8e0d`: one file,
+ *  one package. The entry above used to carry this as a sentence naming three
+ *  packages, which is why it went stale silently — a hand-written scope cannot
+ *  fail when the tree grows a fourth package. Held as DATA so the failure names
+ *  the newcomer instead of leaving the next reader to re-derive the set. */
+const ACTIONS_READER_FILES = ['packages/runner/src/LayoutRenderer.tsx'] as const;
+const ACTIONS_READER_PACKAGES = ['@object-ui/runner'] as const;
+
+/** `packages/types` DECLARES the member and cannot render it (zero deps, no
+ *  React — AGENTS.md §3), so it is outside the reader population by
+ *  construction, not by convenience. `git grep` reads TRACKED files, so a
+ *  literal anchor also matches the two files that merely DESCRIBE the census;
+ *  those two are pinned below, so a third matching file inside `packages/types`
+ *  still turns this red rather than slipping through the exclusion. */
+const DECLARING_PACKAGE_PREFIX = 'packages/types/';
+const DECLARING_PACKAGE_PROSE = [
+  'packages/types/src/__tests__/handler-keys-string-any-mirrors-7344.test.ts',
+  'packages/types/src/app.ts',
+] as const;
+
+/** Two independent anchors, because a reader can reach the array two ways.
+ *  A — it NAMES `AppComponentSchema` and reads some `.actions` (how the one
+ *      known reader does it).
+ *  B — it reads `.actions` off an app-shaped receiver whatever it imports
+ *      (`app.actions`, `appConfig.actions`, …) — how a STRUCTURAL reader that
+ *      never mentions the type would surface. B is empty of new names today;
+ *      it is here for the tree that grows one. */
+const ANCHOR_NAMES_TYPE = 'AppComponentSchema';
+const ANCHOR_ACTIONS_READ = '\\.actions\\b';
+const ANCHOR_APP_SHAPED_READ = '\\bapp[A-Za-z0-9_$]*\\??\\.actions\\b';
+/** The scanned tree. `examples/` is in it because an example app is exactly
+ *  where a fourth reader would plausibly appear. */
+const SCAN_ROOTS = ['packages', 'apps', 'examples'] as const;
+
+/** File paths, relative to the workspace root, over TRACKED files only — an
+ *  untracked scratch file or a build artefact cannot move this census. */
+const gitGrepFiles = (args: readonly string[]): string[] => {
+  let out: string;
+  try {
+    out = execFileSync('git', ['grep', ...args, '--', ...SCAN_ROOTS], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+  } catch (err) {
+    // `git grep` exits 1 on "no matches", which here would mean a dead
+    // instrument, not an empty tree. Fall through with whatever it printed and
+    // let the emptiness controls below name it.
+    out = (err as { stdout?: string }).stdout ?? '';
+  }
+  return out.split('\n').filter(Boolean).sort();
+};
+
+const scan = () => {
+  const namesType = new Set(gitGrepFiles(['-l', '-F', ANCHOR_NAMES_TYPE]));
+  const readsActions = gitGrepFiles(['-l', '-E', ANCHOR_ACTIONS_READ]);
+  const anchorA = readsActions.filter((f) => namesType.has(f));
+  const anchorB = gitGrepFiles(['-l', '-E', '-i', ANCHOR_APP_SHAPED_READ]);
+  const readers = [...new Set([...anchorA, ...anchorB])]
+    .filter((f) => !f.startsWith(DECLARING_PACKAGE_PREFIX))
+    .sort();
+  return { namesType, readsActions, anchorA, anchorB, readers };
+};
+
+/** The owning package, read from its own manifest — never a hand-written map
+ *  from path to package name, which is the same kind of hand-written scope this
+ *  census exists to retire. */
+const packageNameOf = (file: string): string => {
+  const [top, dir] = file.split('/');
+  const manifest = JSON.parse(
+    readFileSync(join(REPO_ROOT, top, dir, 'package.json'), 'utf8'),
+  ) as { name: string };
+  return manifest.name;
+};
+
+describe('census: `AppComponentSchema.actions[]` IS read, by exactly one package, with the scope in the assertion (objectui#7721)', () => {
+  it('the scan is ALIVE and SELECTIVE — a large population that the anchors narrow, not an empty grep', () => {
+    const { namesType, readsActions, anchorA, anchorB } = scan();
+    // A filter over an empty scan passes vacuously, and "exactly one reader"
+    // is what a dead pattern renders as. Both directions get a counter-probe.
+    expect(readsActions.length, 'nothing in the tree reads `.actions` — the anchor is dead')
+      .toBeGreaterThan(20);
+    expect(namesType.size, 'nothing names `AppComponentSchema` — the anchor is dead')
+      .toBeGreaterThan(5);
+    expect(anchorA.length, 'anchor A matched nothing').toBeGreaterThan(0);
+    expect(anchorB.length, 'anchor B matched nothing').toBeGreaterThan(0);
+    // …and they must actually narrow, or the one-reader result is an artefact.
+    expect(anchorA.length).toBeLessThan(readsActions.length);
+    expect(anchorB.length).toBeLessThan(readsActions.length);
+  });
+
+  it('the three packages the OLD scope named were in the population and were rejected by the anchors — the negative is a reading, not an unvisited absence', () => {
+    // The control for a scan has to come from the POPULATION side: "no reader
+    // in `@object-ui/layout`" says nothing unless layout reached the grep at
+    // all. That is precisely how the sentence this card fixes stayed true.
+    const { readsActions, readers } = scan();
+    const OLD_SCOPE = ['packages/layout/', 'packages/app-shell/', 'apps/console/'] as const;
+    for (const prefix of OLD_SCOPE) {
+      expect(
+        readsActions.some((f) => f.startsWith(prefix)),
+        `${prefix} contributed no file to the population — it was never scanned`,
+      ).toBe(true);
+      expect(
+        readers.filter((f) => f.startsWith(prefix)),
+        `${prefix} now reads the array — the retirement rationale needs re-measuring`,
+      ).toEqual([]);
+    }
+  });
+
+  it('exactly one file reads the array, and its package is `@object-ui/runner`', () => {
+    const { readers } = scan();
+    expect(
+      readers,
+      'the reader set moved — widen ACTIONS_READER_FILES and re-check the '
+        + '`onClick` rationale before editing this expectation',
+    ).toEqual([...ACTIONS_READER_FILES]);
+    expect([...new Set(readers.map(packageNameOf))].sort()).toEqual([...ACTIONS_READER_PACKAGES]);
+  });
+
+  it('`packages/types` matches only as PROSE — the declaration and this census, and no third file', () => {
+    const { anchorA, anchorB } = scan();
+    const inTypes = [...new Set([...anchorA, ...anchorB])]
+      .filter((f) => f.startsWith(DECLARING_PACKAGE_PREFIX))
+      .sort();
+    expect(inTypes).toEqual([...DECLARING_PACKAGE_PROSE]);
+  });
+
+  it('the one reader renders BOTH arms and reads no `onClick` off an action — the real ground for the retirement', () => {
+    const src = readFileSync(join(REPO_ROOT, ACTIONS_READER_FILES[0]), 'utf8');
+    expect(src).toContain("app.actions?.filter(a => a.type === 'button')");
+    expect(src).toContain("app.actions?.filter(a => a.type === 'user')");
+    // The array is read; the KEY is not. That distinction is the whole card:
+    // `onClick?: never` is right, the reason given for it was wrong.
+    expect(src, 'a renderer now reads `onClick` off an action — `?: never` is no longer true')
+      .not.toMatch(/\b(?:action|userAction|a)\??\.onClick\b/);
+  });
+
+  it('`AppAction` is imported nowhere outside `packages/types` — the runner reaches the array through `AppComponentSchema`', () => {
+    const importers = gitGrepFiles(['-l', '-E', '^\\s*import[^;]*\\bAppAction\\b'])
+      .filter((f) => !f.startsWith(DECLARING_PACKAGE_PREFIX));
+    expect(importers).toEqual([]);
+    // An empty result needs a known-hit control, or it is indistinguishable
+    // from a dead pattern: the same anchor on the sibling type must find files.
+    const control = gitGrepFiles(['-l', '-E', '^\\s*import[^;]*\\bAppComponentSchema\\b'])
+      .filter((f) => !f.startsWith(DECLARING_PACKAGE_PREFIX));
+    expect(control.length, 'the import anchor found nothing at all').toBeGreaterThan(0);
+    // The symbol survives only as prose, and only in the reader's own package.
+    const mentions = gitGrepFiles(['-l', '-E', '\\bAppAction\\b'])
+      .filter((f) => !f.startsWith(DECLARING_PACKAGE_PREFIX));
+    expect([...new Set(mentions.map(packageNameOf))]).toEqual([...ACTIONS_READER_PACKAGES]);
   });
 });
 


### PR DESCRIPTION
Fixes #7721

A pending changeset carried a sentence that is measured false, and that changeset is
future published `@object-ui/types` CHANGELOG copy — so the correction had to land before
the next release, not after, when the CHANGELOG is history.

## The defect

`.changeset/7344-handler-string-any-mirrors.md:32` retired `AppAction.onClick` with the
parenthetical "nothing reads `AppComponentSchema.actions[]`". The array **is** read.
`@object-ui/runner`'s `LayoutRenderer` renders it: line 240 filters the `'button'` arm into
toolbar buttons, line 274 filters the `'user'` arm into an avatar dropdown.

The retirement itself is correct and untouched. What no reader touches is `onClick` — not
on the action, and no longer on `items[]`, where that same renderer reached one through an
`as any` cast until objectui#6854 deleted it. That is already the wording on
`packages/types/src/app.ts:771`, so this change reuses it rather than minting a third
version.

The origin was the census in `handler-keys-string-any-mirrors-7344.test.ts`, which scoped
to `@object-ui/layout`, `@object-ui/app-shell` and the console. It was literally true as
scoped; the scope was the defect. Stripped of the scope it became the flat sentence the
changeset published.

## The reader set, re-measured whole-tree

Measured on `origin/main` `951fa8e0d`, not taken from the card:

| | |
|---|---|
| Reader files | **1** — `packages/runner/src/LayoutRenderer.tsx` |
| Reader packages | **1** — `@object-ui/runner` |
| Files scanned that read some `.actions` | 105 |
| Files that name `AppComponentSchema` | 19 |

Two independent anchors, unioned, both derived from the tree rather than hand-listed:
(A) a file that names `AppComponentSchema` and reads some `.actions`; (B) a `.actions` read
on an app-shaped receiver whatever the file imports, which is how a structural reader that
never mentions the type would surface. Both return the same single file.

The three packages the old scope named contributed 2, 26 and 3 files respectively to the
scanned population and were rejected by the anchors — so their absence is a reading, not an
unvisited gap. `AppAction` is imported nowhere outside `packages/types`; the seven textual
mentions outside it are all comments and a test title, all inside `@object-ui/runner`.

The PM's assumption that `@object-ui/runner` is the only missing package **holds**. The
assumption that the changeset is unreleased **holds**: the sentence appears in no CHANGELOG
in the repo, and `@object-ui/types` is still at 17.6.0.

## The fix

Naming a fourth package would only move the trap one step, so the census is now an
assertion whose **population is read off the tree** — `git grep` over tracked files under
`packages`, `apps` and `examples` — pinned to the measured reader set. A reader appearing in
a package nobody thought to list now fails the pin by name instead of narrowing the claim in
silence. Six new tests: the anchors are alive and selective, the old scope's packages were
scanned and rejected, exactly one file and one package read the array (package name read
from its own manifest, never a hand-written path map), `packages/types` matches only as the
two prose files that describe the census, the reader renders both arms and reads no
`onClick` off an action, and `AppAction` stays unimported outside `packages/types` with a
known-hit control so that empty result is a reading.

## Reverse verification

Committed first, then mutated. Appended a structural reader
(`const ABLATION_PROBE_7721 = (app: AppComponentSchema) => app.actions?.length;`) to
`packages/layout/src/AppSchemaRenderer.tsx`, a package outside the ledger.

- Mutation confirmed on disk before the run: marker count 0 then 1; blob hash
  `bb80d37f` then `13268a77`.
- Predicted direction: RED. Observed: **RED**, exit 1, 2 failed / 55 passed, both failures
  naming the newcomer — "packages/layout/ now reads the array" and "the reader set moved".
- Restore leg: `git checkout HEAD -- FILE` with an absolute path from a trap; proven by
  `git diff HEAD` empty (exit 0) and the working-tree blob hash back to `bb80d37f`, equal to
  the HEAD blob. Re-run green, 57/57.

No build is involved — the pin reads source through `git grep` and `readFileSync`, with no
`dist` on the path — and the ablation also confirms `git grep` reads working-tree contents
of tracked files, so an uncommitted new reader is caught at author time.

## Gates, exit codes captured before any pipe

| Gate | Exit |
|---|---|
| `pnpm build --concurrency=2` (43/43 tasks) | 0 |
| `turbo run type-check --continue --concurrency=2` (81/81 tasks) | 0 |
| `pnpm exec vitest run` on the pin | 0 — 57/57 |
| `pnpm test --shard=1/4` | 0 — 649 files, 8509 passed, 1 skipped |
| `pnpm test --shard=2/4` | 0 — 649 files, 8571 passed |
| `pnpm test --shard=3/4` | 0 — 648 files, 8538 passed, 8 skipped |
| `pnpm test --shard=4/4` | 0 — 648 files, 7739 passed |
| `pnpm --filter @object-ui/types run lint` (its own script, `eslint .`) | 0 — 0 errors, 273 pre-existing warnings in files this PR does not touch |
| `eslint --format json` on the changed file | 0 — 1 file linted, 0 errors, 0 warnings |
| `node scripts/check-changeset-presence.mjs` | 0 |
| `node scripts/check-changeset-no-major.mjs` | 0 |
| `pnpm check:control-bytes` | 0 — 6471 tracked text files scanned |

Every row above was run against the final commit `e138415b6`, with a clean working tree
(`git diff HEAD` empty) — the four shards total 2594 test files and 33357 passing tests,
0 failures. Shards 2 to 4 went through the shared verify lock
(`scripts/pm/os-verify-lock.sh`); shards 3 and 4 report `VERDICT command-exit 0`, and
shard 2's own exit was captured into its log because that invocation's parts were
sequenced with a semicolon, which the lock warns cannot certify.

`@object-ui/types:type-check` was a cache **miss**, so it ran on this tree, and
`tsc -p tsconfig.test.json --listFiles` confirms the pin file is in its population — the
type-level `Expect` assertions were measured, not silently excluded.

## Changeset: owed, and declared as releasing nothing

`scripts/check-changeset-presence.mjs` counts `PKG/src/**` with no subtraction for tests, so
editing the pin under `packages/types/src/__tests__/` owes a declaration; editing an
existing pending changeset does not count as adding one (the gate reported "0 changeset(s)
added" and exit 1 before this was added).

A bumping changeset would be wrong: nothing published moves — no accept set, no exported
symbol, no TypeScript face — and the corrected copy already rides on the `minor` that the
objectui#7344 changeset declares for the same package. Declaring a second bump would
double-declare one release. So `.changeset/7721-actions-reader-census.md` carries an **empty
frontmatter**, the explicit first-class "releases nothing" form.

## Scope

Three files. `packages/runner` is read as evidence and not edited. No shape moves; the
`onClick?: never` retirement stands exactly as it was.

Draft on purpose — not flipped ready, not enqueued, no auto-merge.

Session: `session_0114Ytxr5sM1vdW19Y9WAx6E`

---
_Generated by [Claude Code](https://claude.ai/code/session_0114Ytxr5sM1vdW19Y9WAx6E)_