### PR TITLE
i18n(gate): widen the defaults value-compare over the declared hand-rolled tables

### DIFF
--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -13,6 +13,7 @@
       "default": "./src/index.ts"
     },
     "./defaults-table-scan": "./src/defaults-table-scan.ts",
+    "./hand-rolled-tables": "./src/hand-rolled-tables.json",
     "./zod-wrapper-keys": "./src/zod-wrapper-keys.json"
   },
   "scripts": {

--- a/packages/test-support/src/defaults-table-scan.ts
+++ b/packages/test-support/src/defaults-table-scan.ts
@@ -74,6 +74,7 @@ import { createRequire } from 'node:module';
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import type * as TS from 'typescript';
+import handRolledTables from './hand-rolled-tables.json';
 
 const requireFrom = createRequire(import.meta.url);
 let compiler: typeof TS | null = null;
@@ -104,23 +105,55 @@ export const FACTORY_NAMES = new Set(['createSafeTranslation', 'createSafeTransl
  */
 export const NEEDLE_IN_SOURCE = ['.split(', '`{{', '${'].join('');
 
+/** One declared hand-rolled table: where it lives, and the `const` that holds it. */
+export interface HandRolledTable {
+  readonly file: string;
+  readonly name: string;
+}
+
 /**
- * The three tables whose packages re-implemented `fallbackT`'s literal needle
- * rather than taking the factory. Each file states its own reason for that;
- * none of them changes the grammar the needle accepts, so the rule is the same.
+ * The tables whose packages re-implemented `fallbackT`'s literal needle rather
+ * than taking the factory. Each file states its own reason for that; none of
+ * them changes the grammar the needle accepts, so the rule is the same.
  * `TIMELINE_DEFAULT_TRANSLATIONS` also reaches the factory — listed anyway, so
  * the registry mirrors the needle-file set objectui#3512's completeness case
  * pins. That deliberate double-listing is why a caller must de-duplicate on
  * `where` + `key` before reporting counts: its 21 rows are discovered twice.
+ *
+ * ## Why the DATA lives in `hand-rolled-tables.json` (objectui#7877)
+ *
+ * A second reader arrived that is not TypeScript:
+ * `scripts/check-i18n-call-site-keys.mjs` widened its `createSafeTranslation`
+ * value-compare over these tables (objectui#7567 Q2's B half). That gate is a
+ * bare `node scripts/check-*.mjs`, so it cannot import this module at all —
+ * `exports["./defaults-table-scan"]` resolves to TypeScript SOURCE with no build
+ * artefact. The shape here is the one objectui#6923 already ruled for exactly
+ * that wall, and `zod-wrapper-keys.json` is its first instance: the DATA moves
+ * to build-free JSON with its own `exports` subpath
+ * (`@object-ui/test-support/hand-rolled-tables`), `resolveJsonModule` types it
+ * for every TypeScript consumer, `node` reads the same bytes through the
+ * subpath, and this module keeps the prose JSON cannot carry.
+ *
+ * ⚠️ ONE declaration, not two pinned copies. The alternative — a second literal
+ * list inside the gate, pinned to this one by a test (the objectui#7310 /
+ * PR #8028 shape) — was available and is deliberately not what this is: two
+ * lists CAN disagree between the moment one is edited and the moment the pin
+ * runs, and the whole point of a registry that gates a scan population is that
+ * "0 drifted" must never be readable off a list that quietly lost an entry.
+ *
+ * ## The staleness ratchet lives in objectui#3512's completeness case
+ *
+ * A declared list rots when a table is added and not declared. What makes this
+ * one complete is not diligence, it is
+ * `packages/i18n/src/__tests__/fallback-placeholder-spelling-3512.test.ts`'s
+ * "covers the three hand-rolled interpolators, and no fourth exists": it asserts
+ * `scan.needle` — every runtime file carrying `NEEDLE_IN_SOURCE` — equals a
+ * pinned file list, and that every entry here contributes rows. A fourth
+ * hand-rolled `fallbackT` turns that case red naming its own file, instead of
+ * quietly serving an ungated table. Because the gate now reads THIS list rather
+ * than a copy, that one ratchet covers both readers.
  */
-export const HAND_ROLLED_TABLES: readonly { readonly file: string; readonly name: string }[] = [
-  { file: 'packages/plugin-gantt/src/useGanttTranslation.ts', name: 'GANTT_DEFAULT_TRANSLATIONS' },
-  { file: 'packages/plugin-grid/src/ImportWizard.tsx', name: 'IMPORT_DEFAULT_TRANSLATIONS' },
-  {
-    file: 'packages/plugin-timeline/src/useTimelineTranslation.ts',
-    name: 'TIMELINE_DEFAULT_TRANSLATIONS',
-  },
-];
+export const HAND_ROLLED_TABLES: readonly HandRolledTable[] = handRolledTables;
 
 /** One row of one discovered table, located precisely enough to fix. */
 export interface DefaultsRow {

--- a/packages/test-support/src/hand-rolled-tables.json
+++ b/packages/test-support/src/hand-rolled-tables.json
@@ -1,0 +1,8 @@
+[
+  { "file": "packages/plugin-gantt/src/useGanttTranslation.ts", "name": "GANTT_DEFAULT_TRANSLATIONS" },
+  { "file": "packages/plugin-grid/src/ImportWizard.tsx", "name": "IMPORT_DEFAULT_TRANSLATIONS" },
+  {
+    "file": "packages/plugin-timeline/src/useTimelineTranslation.ts",
+    "name": "TIMELINE_DEFAULT_TRANSLATIONS"
+  }
+]

--- a/scripts/__tests__/check-i18n-call-site-keys.test.ts
+++ b/scripts/__tests__/check-i18n-call-site-keys.test.ts
@@ -114,6 +114,30 @@ const realEn: unknown = (
  */
 const I18N_PKG = '@object-ui/i18n';
 
+/**
+ * ONE full-repo run, shared by every case below that asks about `main`.
+ *
+ * `analyze(repoRoot)` parses ~1600 files. Seven cases wanted that answer and
+ * each paid for its own walk, which held until objectui#7877 added two more
+ * and pushed the slowest case past vitest's 15s window under a full
+ * `pnpm exec vitest run scripts/__tests__/` — measured, not predicted. That is
+ * the shape AGENTS.md 测试纪律 names as the top cause of flaky tests here: an
+ * unbounded workload counted inside a bounded one. The fix it prescribes is
+ * this one — move the cost into the IMPORT phase, where no test or hook
+ * timeout applies — and NOT raising the timeout, which only hides the race.
+ *
+ * It is also the same per-root memoisation
+ * `packages/test-support/src/defaults-table-scan.ts` already does for its own
+ * walk, for the same reason. Safe to share: `analyze` is pure over
+ * (root, options) and no case below mutates what it returns — `applyBaseline`
+ * reads `findings` and builds new arrays.
+ *
+ * ⚠️ Only for the DEFAULT options. A case that injects its own registry
+ * (`{ families: [] }`, a synthetic `handRolled`) is asking a different
+ * question and must keep its own run.
+ */
+const REPO_ANALYSIS = analyze(repoRoot);
+
 /** Dotted leaf paths of a plain object — the shape the gate compares against. */
 function leafPaths(node: unknown, prefix = ''): string[] {
   return node !== null && typeof node === 'object'
@@ -1227,7 +1251,7 @@ export const A = (name: string) => {
     // The trap this rule's own card named: a coverage number that looks like
     // success and can be reached by judging nothing. The CLI exits non-zero
     // below 500; this pins the same floor where the counter is readable.
-    const { counters } = analyze(repoRoot);
+    const { counters } = REPO_ANALYSIS;
     expect(counters.spellingJudgedDefaults).toBeGreaterThan(500);
     // The residue route C could not reach is still IN the judged set, not
     // quietly dropped from it.
@@ -1464,7 +1488,7 @@ export const useBTranslation = createSafeTranslation({ ...ELSEWHERE }, 'common.s
     // distinct tables, 846 rows, 841 comparable, 0 drifted — objectui#7454's
     // instance having landed in objectui#7574 two days earlier. Both halves are
     // asserted, because "0 findings" and "0 rows compared" read identically.
-    const { counters } = analyze(repoRoot, { families: DYNAMIC_KEY_FAMILIES });
+    const { counters } = REPO_ANALYSIS;
     expect(factoryDriftOf(repoRoot)).toEqual([]);
     expect(counters.factoryTables).toBeGreaterThan(25);
     expect(counters.factoryComparedRows).toBeGreaterThan(500);
@@ -1638,7 +1662,7 @@ export const useXTranslation = createSafeTranslation(LOCAL_DEFAULTS, 'calendar.t
     // `packages/i18n/src/__tests__/fallback-placeholder-spelling-3512.test.ts`,
     // which asserts the needle-file set equals a pinned list; this is the other
     // direction — an entry that names something no longer there.
-    const { counters } = analyze(repoRoot);
+    const { counters } = REPO_ANALYSIS;
     expect(counters.handRolledDeclared).toBe(HAND_ROLLED_TABLES.length);
     expect(counters.handRolledUnreadableTables).toBe(0);
     for (const { file } of HAND_ROLLED_TABLES) {
@@ -1652,7 +1676,7 @@ export const useXTranslation = createSafeTranslation(LOCAL_DEFAULTS, 'calendar.t
     // registry that resolved nothing. The CLI exits non-zero below 150; this
     // pins the same floor where the counter is readable, and pins that 150 was
     // chosen to fail on losing EITHER table rather than only both.
-    const { counters } = analyze(repoRoot);
+    const { counters } = REPO_ANALYSIS;
     expect(counters.handRolledComparedRows).toBeGreaterThanOrEqual(150);
     expect(counters.handRolledTables).toBe(2);
     expect(counters.handRolledAlreadyFactoryCovered).toBe(1);
@@ -1925,7 +1949,7 @@ export const css = (v: string) => \`--oui.color.\${v}\`;
     // still pointed at the repo: if `toolTitleKey` is inlined, renamed into a
     // shape this leg cannot read, or moved behind a concatenation, the head
     // disappears here and `stale-dynamic-family` fails the gate.
-    const { dynamicHeads, counters, findings } = analyze(repoRoot);
+    const { dynamicHeads, counters, findings } = REPO_ANALYSIS;
     expect(counters.keyBuilderSites, 'the key-builder leg detects nothing on this tree').toBeGreaterThanOrEqual(1);
     expect(dynamicHeads.has('chatbot.tool.'), 'chatbot.tool. is no longer reached by any leg').toBe(true);
     expect(DYNAMIC_KEY_FAMILIES.some((f) => f.head === 'chatbot.tool.')).toBe(true);
@@ -1996,7 +2020,7 @@ describe('the checked-in registry describes this repo (objectui#4964)', () => {
   });
 
   it('the split is what the report says it is, and the check is not vacuous on `main`', () => {
-    const { counters, findings } = analyze(repoRoot);
+    const { counters, findings } = REPO_ANALYSIS;
     expect(counters.declaredFamilies).toBe(DYNAMIC_KEY_FAMILIES.length);
     expect(counters.enumerableFamilies + counters.notEnumerableFamilies).toBe(counters.declaredFamilies);
     // Measured on `main`: 18 of 25 families are exactly checkable. The number is
@@ -2022,7 +2046,7 @@ describe('the checked-in registry describes this repo (objectui#4964)', () => {
     expect(leaves.has('gantt.viewMode.day'), 'the fixture key this control rests on has moved').toBe(true);
     const viewMode = DYNAMIC_KEY_FAMILIES.find((f) => f.head === 'gantt.viewMode.');
     expect(readVocabulary(repoRoot, viewMode!.vocabulary!)).toContain('day');
-    expect(analyze(repoRoot).findings.filter((f: { detail: string }) => f.detail === 'gantt.viewMode.day')).toEqual([]);
+    expect(REPO_ANALYSIS.findings.filter((f: { detail: string }) => f.detail === 'gantt.viewMode.day')).toEqual([]);
   });
 });
 
@@ -2057,7 +2081,7 @@ describe('the baseline is a ratchet', () => {
     // landed, which is how a ratchet turns back into an allowlist.
     const baselineFile = path.join(repoRoot, 'scripts/i18n-call-site-key-baseline.json');
     const baseline = JSON.parse(fs.readFileSync(baselineFile, 'utf8'));
-    const { unexpected, stale } = applyBaseline(analyze(repoRoot).findings, baseline);
+    const { unexpected, stale } = applyBaseline(REPO_ANALYSIS.findings, baseline);
     expect(unexpected, `${unexpected.length} call site(s) not covered by the baseline`).toEqual([]);
     expect(stale, `${stale.length} stale baseline entr(y|ies)`).toEqual([]);
     for (const entry of Object.values(baseline.missingKeys) as Array<{ issue: string }>) {

--- a/scripts/__tests__/check-i18n-call-site-keys.test.ts
+++ b/scripts/__tests__/check-i18n-call-site-keys.test.ts
@@ -13,6 +13,7 @@ import {
   DYNAMIC_KEY_FAMILIES,
   EXTERNALLY_INTERPOLATED_HOLES,
   FACTORY_NAMES,
+  HAND_ROLLED_TABLES,
   holesOf,
   PACK_HOOK,
   readVocabulary,
@@ -1476,6 +1477,193 @@ export const useBTranslation = createSafeTranslation({ ...ELSEWHERE }, 'common.s
 
   it('the factory-name set is the one the objectui#3512 test uses, not a second opinion', () => {
     expect([...FACTORY_NAMES].sort()).toEqual(['createSafeTranslation', 'createSafeTranslationHook']);
+  });
+});
+
+describe('the hand-rolled tables are reached through a DECLARED registry (objectui#7877)', () => {
+  /**
+   * The B half of the ruling on objectui#7567 Q2. The class above takes its
+   * population from the SOURCE, which is why a 33rd factory needs nobody to
+   * remember it — and is also why it cannot see a table whose package
+   * re-implemented `fallbackT` instead of calling the factory: nothing in that
+   * source says which local function is the interpolator. Covering those takes
+   * a declaration, and a declaration is a second thing that rots.
+   *
+   * So three separate things are pinned here, and they fail for three different
+   * reasons:
+   *
+   *   1. The RULE — a declared table's rows are compared exactly as a factory
+   *      table's are, and a drifted row names itself under its own reason.
+   *   2. The DE-DUPLICATION — `TIMELINE_DEFAULT_TRANSLATIONS` is in the registry
+   *      AND reachable from the factory, so its rows must be counted once. A
+   *      census that double-counts is not a census.
+   *   3. The DECLARATION ITSELF — that the list this gate reads is the same
+   *      bytes `packages/test-support/src/defaults-table-scan.ts` reads, not a
+   *      copy of them, and that the collapse floor sits where losing a single
+   *      declared table fails rather than merely shrinking.
+   *
+   * ⛔ What is deliberately NOT pinned is an inferred population. Option C on
+   * objectui#7567 — matching identifier names, or every `Record<string, string>`
+   * that looks like a defaults map — was rejected there for inventing a
+   * heuristic where a declaration is available.
+   */
+
+  const EN_7877 = `const en = {
+  common: { save: 'Save', cancel: 'Cancel' },
+  calendar: { today: 'Today', allDay: 'All Day' },
+} as const;
+export default en;
+`;
+
+  /** A module that hand-rolls the interpolator: a table, and no factory call. */
+  function handRolledModule(table: string): string {
+    return `export const LOCAL_DEFAULTS: Record<string, string> = ${table};
+export const fallbackT = (key: string) => LOCAL_DEFAULTS[key] ?? key;
+`;
+  }
+
+  /** Widened-half findings as `key: en -> table @file:line`. */
+  function handRolledDriftOf(root: string, handRolled: { file: string; name: string }[]): string[] {
+    return analyze(root, { families: [], handRolled })
+      .findings.filter((f: { reason: string }) => f.reason === 'hand-rolled-default-drift')
+      .map(
+        (f: { detail: string; expected: string; actual: string; file: string; line: number }) =>
+          `${f.detail}: ${f.expected} -> ${f.actual} @${f.file}:${f.line}`,
+      )
+      .sort();
+  }
+
+  const REGISTRY = [{ file: 'packages/x/src/local.ts', name: 'LOCAL_DEFAULTS' }];
+
+  it('compares a declared table the factory walk cannot see, and stays silent when it matches', () => {
+    const root = repoWith({
+      'packages/i18n/src/locales/en.ts': EN_7877,
+      'packages/x/src/local.ts': handRolledModule(
+        `{ 'calendar.today': 'Today', 'calendar.allDay': 'All Day' }`,
+      ),
+    });
+    const { findings, counters } = analyze(root, { families: [], handRolled: REGISTRY });
+    expect(findings).toEqual([]);
+    // The factory half saw nothing at all here — which is the whole point of
+    // this class existing, and why its counters are separate.
+    expect(counters.factorySites).toBe(0);
+    expect(counters.factoryComparedRows).toBe(0);
+    expect(counters.handRolledDeclared).toBe(1);
+    expect(counters.handRolledTables).toBe(1);
+    expect(counters.handRolledComparedRows).toBe(2);
+    expect(counters.handRolledMatchingRows).toBe(2);
+  });
+
+  it('names the table, the key and both texts when a declared row drifts', () => {
+    const root = repoWith({
+      'packages/i18n/src/locales/en.ts': EN_7877,
+      'packages/x/src/local.ts': handRolledModule(
+        `{ 'calendar.today': 'Today', 'calendar.allDay': 'all-day' }`,
+      ),
+    });
+    expect(handRolledDriftOf(root, REGISTRY)).toEqual([
+      'calendar.allDay: All Day -> all-day @packages/x/src/local.ts:1',
+    ]);
+    const findings = analyze(root, { families: [], handRolled: REGISTRY }).findings;
+    // Its OWN reason, not the factory class's: the two halves are reached
+    // differently, and the hint that tells you how to fix one names a registry
+    // the other does not have.
+    expect(findings.map((f: { reason: string }) => f.reason)).toEqual(['hand-rolled-default-drift']);
+    expect(findings.map((f: { table: string }) => f.table)).toEqual([
+      'LOCAL_DEFAULTS (packages/x/src/local.ts)',
+    ]);
+  });
+
+  it('counts a declared table the factory ALSO reaches once, on the factory side', () => {
+    // `TIMELINE_DEFAULT_TRANSLATIONS` is the real instance: it is in the
+    // registry because that registry mirrors the needle-file set objectui#3512
+    // pins, and it takes the factory as well. Counting its rows in both halves
+    // would inflate both censuses and let the widened floor be satisfied by a
+    // table this class is not responsible for.
+    const root = repoWith({
+      'packages/i18n/src/locales/en.ts': EN_7877,
+      'packages/x/src/local.ts': `import { createSafeTranslation } from '${I18N_PKG}';
+export const LOCAL_DEFAULTS: Record<string, string> = { 'calendar.today': 'Today' };
+export const useXTranslation = createSafeTranslation(LOCAL_DEFAULTS, 'calendar.today');
+`,
+    });
+    const { counters } = analyze(root, { families: [], handRolled: REGISTRY });
+    expect(counters.factoryTables).toBe(1);
+    expect(counters.factoryComparedRows).toBe(1);
+    expect(counters.handRolledDeclared).toBe(1);
+    expect(counters.handRolledAlreadyFactoryCovered).toBe(1);
+    expect(counters.handRolledTables).toBe(0);
+    expect(counters.handRolledComparedRows).toBe(0);
+  });
+
+  it('counts a declaration that no longer resolves as an unreadable TABLE, not as zero rows', () => {
+    // The registry rotting in the direction nothing else would notice: the
+    // entry is still there, the file or the `const` is not. Silence here would
+    // be "0 drifted" over a table that left the surface.
+    const root = repoWith({ 'packages/i18n/src/locales/en.ts': EN_7877 });
+    const { findings, counters } = analyze(root, { families: [], handRolled: REGISTRY });
+    expect(findings).toEqual([]);
+    expect(counters.handRolledDeclared).toBe(1);
+    expect(counters.handRolledUnreadableTables).toBe(1);
+    expect(counters.handRolledComparedRows).toBe(0);
+  });
+
+  it('reads the SAME bytes as the test-support declaration — one list, not two', () => {
+    // objectui#6923's ruling, second instance. The gate is a bare
+    // `node scripts/check-*.mjs`, so it cannot import
+    // `@object-ui/test-support/defaults-table-scan` — that `exports` entry
+    // resolves to TypeScript source with no build artefact. The DATA therefore
+    // lives in JSON with its own subpath, and this asserts the gate really is
+    // reading it rather than a copy that can be stale for the window between
+    // two edits.
+    const declared = JSON.parse(
+      fs.readFileSync(
+        path.join(repoRoot, 'packages/test-support/src/hand-rolled-tables.json'),
+        'utf8',
+      ),
+    );
+    expect(HAND_ROLLED_TABLES).toEqual(declared);
+    // The subpath is what makes both readers reach one file; a package that
+    // stopped exporting it would send the gate to a resolution error rather
+    // than to a stale copy, and this says so out loud.
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, 'packages/test-support/package.json'), 'utf8'),
+    );
+    expect(pkg.exports['./hand-rolled-tables']).toBe('./src/hand-rolled-tables.json');
+  });
+
+  it('every declared entry names a file that exists and a const that resolves on main', () => {
+    // The staleness reading, this side of it. The ratchet that catches a table
+    // added and NOT declared lives in
+    // `packages/i18n/src/__tests__/fallback-placeholder-spelling-3512.test.ts`,
+    // which asserts the needle-file set equals a pinned list; this is the other
+    // direction — an entry that names something no longer there.
+    const { counters } = analyze(repoRoot);
+    expect(counters.handRolledDeclared).toBe(HAND_ROLLED_TABLES.length);
+    expect(counters.handRolledUnreadableTables).toBe(0);
+    for (const { file } of HAND_ROLLED_TABLES) {
+      expect(fs.existsSync(path.join(repoRoot, file)), `${file} left the tree`).toBe(true);
+    }
+  });
+
+  it('and main is measured, not merely green — the floor is above the LARGER table', () => {
+    // The objectui#7567 ⛔ #2 property, one level down: "0 drifted" and "0 rows
+    // compared" read identically, and the factory half's 841 rows would hide a
+    // registry that resolved nothing. The CLI exits non-zero below 150; this
+    // pins the same floor where the counter is readable, and pins that 150 was
+    // chosen to fail on losing EITHER table rather than only both.
+    const { counters } = analyze(repoRoot);
+    expect(counters.handRolledComparedRows).toBeGreaterThanOrEqual(150);
+    expect(counters.handRolledTables).toBe(2);
+    expect(counters.handRolledAlreadyFactoryCovered).toBe(1);
+    // The abstention counts are printed on every run for the reason
+    // objectui#7874 exists: a gate that hides its blind-spot size reads as 100%
+    // coverage forever. They are zero today, and zero is a READING here only
+    // because the compared count above says the scan had something to judge.
+    expect(counters.handRolledRowsNoEnKey).toBe(0);
+    expect(counters.handRolledUnjudgedRows).toBe(0);
+    expect(counters.handRolledUnreadableRows).toBe(0);
+    expect(counters.handRolledMatchingRows).toBe(counters.handRolledComparedRows);
   });
 });
 

--- a/scripts/check-i18n-call-site-keys.mjs
+++ b/scripts/check-i18n-call-site-keys.mjs
@@ -429,17 +429,40 @@
  *    dead row belongs. 0 such rows today; the abstention is what stops the first
  *    one being read as healthy.
  *
- *    WHAT THIS CLASS DOES NOT REACH, measured rather than assumed: three tables
- *    hand-roll `fallbackT` instead of taking the factory
- *    (`GANTT_DEFAULT_TRANSLATIONS`, `IMPORT_DEFAULT_TRANSLATIONS`, and
- *    `TIMELINE_DEFAULT_TRANSLATIONS`, which also reaches the factory and IS
- *    covered) — see the `HAND_ROLLED_TABLES` registry in the objectui#3512 test
- *    named above. Reaching them needs a declared registry, because nothing in
- *    the source says which local function is a `fallbackT`, and a registry is a
- *    second thing to keep from rotting. They were measured while this class was
- *    written: 215 rows, 215 comparable, 0 drifted. So the residue is real, named,
- *    and currently clean — which is the honest way to say "this covers the
- *    factory channel", rather than letting a coverage claim quietly round up.
+ *    THE OTHER HALF OF THE POPULATION — objectui#7877, the B half of the
+ *    ruling on objectui#7567 Q2. Three tables hand-roll `fallbackT`'s literal
+ *    needle instead of taking the factory, so the walk above cannot see them:
+ *    nothing in the source says which local function is a `fallbackT`. Two of
+ *    them are reachable no other way (`GANTT_DEFAULT_TRANSLATIONS`,
+ *    `IMPORT_DEFAULT_TRANSLATIONS`); the third,
+ *    `TIMELINE_DEFAULT_TRANSLATIONS`, also reaches the factory and is already
+ *    counted above.
+ *
+ *    Covering them takes a DECLARATION — which is why objectui#7567 shipped
+ *    the registry-free half first and split this out, and why the population
+ *    here is `packages/test-support/src/hand-rolled-tables.json` and not a
+ *    heuristic. Option C on that card (gate every `Record<string, string>`
+ *    that looks like a defaults map, inferred rather than declared) was
+ *    rejected for inventing a heuristic where a declaration is available.
+ *
+ *    The two halves keep SEPARATE counters, a separate collapse floor and a
+ *    separate summary line, and that separation is the point rather than
+ *    tidiness: the factory walk compares 841 rows, so a registry that stopped
+ *    resolving anything at all would be invisible inside a combined number,
+ *    and this half's verdict — also "0 drifted" — would be read off an empty
+ *    scan set. Its floor is 150 against a measured 215 (80 + 135), chosen to
+ *    sit above the LARGER of the two tables so that losing either one fails.
+ *
+ *    What keeps the declaration from rotting is not diligence and does not
+ *    live here:
+ *    `packages/i18n/src/__tests__/fallback-placeholder-spelling-3512.test.ts`
+ *    asserts that the set of runtime files carrying the hand-rolled needle
+ *    equals a pinned list, and that every declared entry contributes rows. A
+ *    fourth hand-rolled `fallbackT` turns that case red naming its own file.
+ *    Because this gate reads the SAME bytes that test reads rather than a
+ *    copy of them, that one ratchet covers both readers — the reason the data
+ *    moved to JSON on objectui#6923's ruling instead of being duplicated here
+ *    and pinned.
  *
  * ## Dynamic keys: the explicit policy
  *
@@ -529,6 +552,7 @@ import ts from 'typescript';
 import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { resolve, dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 import { isEntrypoint } from './invoked-as.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -547,6 +571,47 @@ export const PACK_HOOK = /^use[A-Za-z0-9_]*(Translation|Translate|T)$/;
  * in `packages/i18n/src/__tests__/`.
  */
 export const FACTORY_NAMES = new Set(['createSafeTranslation', 'createSafeTranslationHook']);
+
+/**
+ * The DECLARED hand-rolled tables — objectui#7877, the B half of the ruling on
+ * objectui#7567 Q2.
+ *
+ * Two tables re-implement `fallbackT` instead of taking the factory above, so
+ * the factory-resolved walk cannot see them: nothing in the source says which
+ * local function is a `fallbackT`, which is why covering them takes a
+ * declaration and why objectui#7567 shipped A (registry-free) first and split
+ * this out. Option C on that card — inferring the population by pattern-matching
+ * identifier names or every `Record<string, string>` — was REJECTED for
+ * inventing a heuristic where a declaration is available; if a future edit finds
+ * itself matching on names, it is building C.
+ *
+ * ⚠️ This is not a second list. It is the SAME BYTES
+ * `packages/test-support/src/defaults-table-scan.ts` reads, reached through the
+ * `exports` subpath objectui#6923 ruled for data that has to cross the
+ * `.mjs` / TypeScript boundary (`zod-wrapper-keys` is the first instance, read
+ * the same way by two other gates in this directory). A bare
+ * `node scripts/check-*.mjs` cannot import that module: its `exports` entry
+ * resolves to TypeScript source with no build artefact. Copying the list here
+ * and pinning the copies to each other was the alternative, and the reason it
+ * was not taken is written out in that module's header — a copy CAN be stale for
+ * the window between the two edits, and a scan population that quietly loses an
+ * entry reports "0 drifted" while judging nothing.
+ *
+ * `createRequire` rather than `import … with { type: 'json' }` for the reason
+ * `check-action-forward-parity.mjs` already records: this module is loaded both
+ * by `node` (the gate run) and by Vite's SSR transform (its pin tests in
+ * `scripts/__tests__/`), and under the latter an attributed JSON import yields
+ * no default export.
+ *
+ * The registry carries `TIMELINE_DEFAULT_TRANSLATIONS` too, because it mirrors
+ * the needle-file set objectui#3512's completeness case pins — but that table
+ * ALSO reaches the factory, so this class de-duplicates against the tables the
+ * factory walk already scanned rather than counting its rows twice. That
+ * overlap is reported, not swallowed.
+ */
+export const HAND_ROLLED_TABLES = createRequire(import.meta.url)(
+  '@object-ui/test-support/hand-rolled-tables',
+);
 
 /**
  * Annotations that mark a forwarded `t` as a translator. Only used to tell a
@@ -1839,16 +1904,22 @@ function resolveFactoryTable(root, source, argument, parseModule) {
 // ── the analysis ─────────────────────────────────────────────────────────────
 
 /**
- * `families` is injectable so the synthetic-repo tests can pin the registry
- * RULES against a registry they control. The real run always uses the module
- * constant — nothing in this file reads a registry from disk, so there is no
- * configuration path a call site could quietly narrow.
+ * `families` and `handRolled` are injectable so the synthetic-repo tests can pin
+ * the registry RULES against a registry they control. The real run always uses
+ * the module constants, and every CLI path below calls `analyze(root)` with no
+ * options at all — so there is no configuration path a call site could quietly
+ * narrow, which for `handRolled` is the same property its collapse floor exists
+ * to protect (objectui#7877).
  *
  * @returns {{ findings: Array, counters: Record<string, number>, enKeyCount: number,
  *   referencedKeys: Set<string>, referencedBranches: Set<string>, dynamicHeads: Set<string>,
  *   dynamicFamilies: Map<string, { tails: Set<string>, sites: Array, multiSubstitution: number }> }}
  */
-export function analyze(root, /** @type {{ families?: DynamicKeyFamily[] }} */ { families = DYNAMIC_KEY_FAMILIES } = {}) {
+export function analyze(
+  root,
+  /** @type {{ families?: DynamicKeyFamily[], handRolled?: { file: string, name: string }[] }} */
+  { families = DYNAMIC_KEY_FAMILIES, handRolled = HAND_ROLLED_TABLES } = {},
+) {
   const { leaves, branches, values } = collectEnKeys(root);
   const resolvesLeaf = (key) => leaves.has(key) || PLURAL_SUFFIXES.some((suffix) => leaves.has(key + suffix));
   // Materialised once, not inside the predicate: spreading a 2.6k-entry Set per
@@ -1939,6 +2010,23 @@ export function analyze(root, /** @type {{ families?: DynamicKeyFamily[] }} */ {
     factoryRowsNoEnKey: 0,
     factoryUnjudgedRows: 0,
     factoryUnreadableRows: 0,
+    // objectui#7877 — the widened half's own census, deliberately a SEPARATE
+    // set of counters rather than added into the factory numbers. Two reasons,
+    // both load-bearing: the collapse floor below has to be able to fail for
+    // this half alone (a factory walk of 841 rows would otherwise mask a
+    // registry that resolved nothing), and the abstention counts are what turn
+    // a blind spot into a card — objectui#7874 exists purely because the
+    // factory half printed its 5 abstaining rows instead of absorbing them.
+    handRolledDeclared: 0,
+    handRolledTables: 0,
+    handRolledAlreadyFactoryCovered: 0,
+    handRolledUnreadableTables: 0,
+    handRolledRows: 0,
+    handRolledComparedRows: 0,
+    handRolledMatchingRows: 0,
+    handRolledRowsNoEnKey: 0,
+    handRolledUnjudgedRows: 0,
+    handRolledUnreadableRows: 0,
   };
 
   // objectui#7567 — a table may be declared in a module the factory imports, so
@@ -1969,15 +2057,15 @@ export function analyze(root, /** @type {{ families?: DynamicKeyFamily[] }} */ {
    * because the row is where the fix goes — and for an imported table those are
    * in two different files.
    */
-  const scanFactoryTable = (literal, owner, tableName) => {
+  const scanDefaultsTable = (literal, owner, tableName, half) => {
     const ownerRel = relative(root, owner.fileName).split('\\').join('/');
     for (const property of literal.properties) {
-      counters.factoryRows += 1;
+      counters[`${half}Rows`] += 1;
       const { line, character } = owner.getLineAndCharacterOfPosition(property.getStart(owner));
       const at = { file: ownerRel, line: line + 1, column: character + 1 };
       if (!ts.isPropertyAssignment(property)) {
         // A spread or a shorthand: this reader cannot say which keys it brings.
-        counters.factoryUnreadableRows += 1;
+        counters[`${half}UnreadableRows`] += 1;
         continue;
       }
       const key =
@@ -1985,31 +2073,39 @@ export function analyze(root, /** @type {{ families?: DynamicKeyFamily[] }} */ {
           ? property.name.text
           : null;
       if (key === null) {
-        counters.factoryUnreadableRows += 1;
+        counters[`${half}UnreadableRows`] += 1;
         continue;
       }
       // NOT descended into — `fallbackT` indexes `defaults[key]` flat, so a
       // nested literal is a row nothing can ever read. See the header.
       const text = staticString(property.initializer, owner);
       if (text === null) {
-        counters.factoryUnreadableRows += 1;
+        counters[`${half}UnreadableRows`] += 1;
         continue;
       }
       if (!resolvesLeaf(key)) {
         // class 1's shape, and class 1 cannot reach it: it judges CALL SITES,
         // and a table row nothing calls has none. Counted, printed, never failed.
-        counters.factoryRowsNoEnKey += 1;
+        counters[`${half}RowsNoEnKey`] += 1;
         continue;
       }
       const enValue = values.get(key);
       if (enValue === undefined) {
         // A plural family, or an `en` leaf that is not a readable static string.
-        counters.factoryUnjudgedRows += 1;
+        counters[`${half}UnjudgedRows`] += 1;
         continue;
       }
-      counters.factoryComparedRows += 1;
-      if (enValue === text) counters.factoryMatchingRows += 1;
-      else findings.push({ reason: 'factory-default-drift', ...at, detail: key, expected: enValue, actual: text, table: tableName });
+      counters[`${half}ComparedRows`] += 1;
+      if (enValue === text) counters[`${half}MatchingRows`] += 1;
+      else
+        findings.push({
+          reason: half === 'factory' ? 'factory-default-drift' : 'hand-rolled-default-drift',
+          ...at,
+          detail: key,
+          expected: enValue,
+          actual: text,
+          table: tableName,
+        });
     }
   };
 
@@ -2028,7 +2124,7 @@ export function analyze(root, /** @type {{ families?: DynamicKeyFamily[] }} */ {
           if (!scannedTables.has(id)) {
             scannedTables.add(id);
             counters.factoryTables += 1;
-            scanFactoryTable(literal, owner, name);
+            scanDefaultsTable(literal, owner, name, 'factory');
           }
         }
       }
@@ -2058,6 +2154,44 @@ export function analyze(root, /** @type {{ families?: DynamicKeyFamily[] }} */ {
       ts.forEachChild(node, visit);
     };
     visit(source);
+  };
+
+  /**
+   * The widened half (objectui#7877): the DECLARED hand-rolled tables.
+   *
+   * Runs AFTER the file walk on purpose — `scannedTables` is only complete once
+   * every factory site has been resolved, and `TIMELINE_DEFAULT_TRANSLATIONS` is
+   * in the registry AND reachable from the factory. De-duplicating on the
+   * literal's own position (the same id the factory half keys on) is what keeps
+   * the row counts a census rather than a multiset; the overlap is counted and
+   * printed rather than silently dropped.
+   *
+   * A declared table that no longer resolves is an UNREADABLE TABLE, never a
+   * skip — that is the whole registry rotting in the direction nothing else
+   * would notice, and the floor below is what makes it fatal rather than quiet.
+   */
+  const scanHandRolledTables = () => {
+    for (const { file, name } of handRolled) {
+      counters.handRolledDeclared += 1;
+      const absolute = join(root, file);
+      const source = parseModule(absolute);
+      const initializer = source === null ? null : declaredConstant(source, name);
+      const literal = initializer === null ? null : unwrapExpression(initializer);
+      if (literal === null || !ts.isObjectLiteralExpression(literal)) {
+        counters.handRolledUnreadableTables += 1;
+        continue;
+      }
+      const id = `${source.fileName}#${literal.getStart(source)}`;
+      if (scannedTables.has(id)) {
+        // Declared here and reachable from the factory too. Its rows are already
+        // in the factory census; counting them again would inflate both halves.
+        counters.handRolledAlreadyFactoryCovered += 1;
+        continue;
+      }
+      scannedTables.add(id);
+      counters.handRolledTables += 1;
+      scanDefaultsTable(literal, source, `${name} (${file})`, 'handRolled');
+    }
   };
 
   for (const file of collectSourceFiles(root)) {
@@ -2381,6 +2515,8 @@ export function analyze(root, /** @type {{ families?: DynamicKeyFamily[] }} */ {
     visit(source);
   }
 
+  scanHandRolledTables();
+
   // ── the dynamic-family registry, evaluated (objectui#4964) ─────────────────
   //
   // Three rules, and the order matters: the two ratchet directions run over the
@@ -2596,6 +2732,16 @@ const HINTS = {
     ' today, and changing it makes `scripts/check-i18n-en-drift.mjs` demand the same change in' +
     ' the other nine packs. If the row is genuinely dead (no key in `en`, no caller), delete the' +
     ' row rather than inventing a pack entry for it.',
+  'hand-rolled-default-drift':
+    'Same failure as `factory-default-drift`, on the half that needs a DECLARED registry to be' +
+    ' seen at all (objectui#7877). This table hand-rolls `fallbackT` rather than taking' +
+    ' `createSafeTranslation`, so nothing in its source says it is a defaults table and the' +
+    ' factory-resolved walk cannot reach it; it is checked because' +
+    ' `packages/test-support/src/hand-rolled-tables.json` names it. The consequence is the' +
+    ' same and so is the fix: copy the `en` value into the TABLE byte-for-byte. Do NOT edit' +
+    ' `packages/i18n/src/locales/en.ts` to match the table — that changes what users read and' +
+    ' obliges the other nine packs through `scripts/check-i18n-en-drift.mjs`. If the row is' +
+    ' genuinely dead (no key in `en`, no caller), delete the row.',
   'interpolation-parity':
     'The arguments this call site passes are not the holes the `en` value has (objectui#3845).' +
     ' An INERT argument is one i18next drops on the floor — no hole to receive it, no warning,' +
@@ -2690,6 +2836,31 @@ if (invokedDirectly) {
     process.exit(1);
   }
 
+  // The widened half's OWN floor (objectui#7877). It is a separate threshold on
+  // a separate counter on purpose: `factoryComparedRows` is 841, so a registry
+  // that resolved nothing at all would sail through the guard above while this
+  // half reported "0 drifted" over 0 rows — the exact reading objectui#7567's
+  // ⛔ #2 forbids, one level down.
+  //
+  // How 150 was chosen, rather than picked: measured on this tree the two
+  // registry entries the factory walk cannot reach compare 80
+  // (`GANTT_DEFAULT_TRANSLATIONS`) and 135 (`IMPORT_DEFAULT_TRANSLATIONS`)
+  // rows, 215 together. The threshold sits ABOVE the larger of the two, so
+  // losing EITHER declared table — not just both — collapses the scan into a
+  // failure instead of a quieter green. A floor below 135 would let the bigger
+  // table carry the smaller one's disappearance.
+  if (counters.handRolledComparedRows < 150) {
+    console.error(
+      `The hand-rolled defaults scan collapsed: ${counters.handRolledComparedRows} row(s) compared over` +
+        ` ${counters.handRolledTables} table(s) from ${counters.handRolledDeclared} declared,` +
+        ` ${counters.handRolledUnreadableTables} table(s) unreadable.` +
+        ' Expected 200-odd — the registry in `packages/test-support/src/hand-rolled-tables.json`' +
+        ' names two tables the factory walk cannot reach, and a number this small means one of' +
+        ' them stopped resolving and this half is passing on an empty set.',
+    );
+    process.exit(1);
+  }
+
   const { unexpected, stale } = applyBaseline(findings, readBaseline(root));
 
   console.log(
@@ -2718,6 +2889,15 @@ if (invokedDirectly) {
       `${counters.factoryUnreadableRows} unreadable.`,
   );
   console.log(
+    `Hand-rolled defaults tables: ${counters.handRolledDeclared} declared, ` +
+      `${counters.handRolledTables} scanned here (${counters.handRolledAlreadyFactoryCovered} already ` +
+      `covered by the factory walk, ${counters.handRolledUnreadableTables} unreadable) — ` +
+      `${counters.handRolledComparedRows} row(s) compared against their en value, ` +
+      `${counters.handRolledMatchingRows} matching, ${counters.handRolledRowsNoEnKey} on a key en does not define, ` +
+      `${counters.handRolledUnjudgedRows} with no single comparable en value, ` +
+      `${counters.handRolledUnreadableRows} unreadable.`,
+  );
+  console.log(
     `Interpolation parity: ${counters.judgedInterpolation} call sites compared against their en value's holes, ` +
       `${counters.unjudgedInterpolation} with no single comparable en value, ${counters.opaqueOptions} with an ` +
       `unreadable option set, ${EXTERNALLY_INTERPOLATED_HOLES.length} key(s) whose holes are filled downstream.`,
@@ -2743,6 +2923,7 @@ if (invokedDirectly) {
   // introduce all three.
   const drift = unexpected.filter((finding) => finding.reason === 'default-value-drift');
   const factoryDrift = unexpected.filter((finding) => finding.reason === 'factory-default-drift');
+  const handRolledDrift = unexpected.filter((finding) => finding.reason === 'hand-rolled-default-drift');
   const parity = unexpected.filter((finding) => finding.reason === 'interpolation-parity');
   const siblings = unexpected.filter((finding) => finding.reason === 'dead-sibling-fallback');
   const spelling = unexpected.filter((finding) => finding.reason === 'unresolvable-default-spelling');
@@ -2761,6 +2942,7 @@ if (invokedDirectly) {
   const VALUE_CLASSES = new Set([
     'default-value-drift',
     'factory-default-drift',
+    'hand-rolled-default-drift',
     'interpolation-parity',
     'dead-sibling-fallback',
     'unresolvable-default-spelling',
@@ -2817,6 +2999,23 @@ if (invokedDirectly) {
         'console:',
     );
     for (const finding of factoryDrift) {
+      console.error(`  ${finding.file}:${finding.line}:${finding.column}  [${finding.reason}]  ${finding.detail}  (${finding.table})`);
+      console.error(`      en renders:      ${quote(finding.expected)}`);
+      console.error(`      defaults table:  ${quote(finding.actual)}`);
+    }
+  }
+
+  if (handRolledDrift.length > 0) {
+    const distinct = new Set(handRolledDrift.map((finding) => finding.detail));
+    console.error(
+      `\n${handRolledDrift.length} hand-rolled defaults row${handRolledDrift.length === 1 ? '' : 's'} ` +
+        `contradict${handRolledDrift.length === 1 ? 's' : ''} the en value of a key that EXISTS ` +
+        `(${distinct.size} distinct key${distinct.size === 1 ? '' : 's'}) — this table hand-rolls ` +
+        '`fallbackT`, so it is reached through the declared registry in ' +
+        '`packages/test-support/src/hand-rolled-tables.json` rather than through the factory; the ' +
+        'consequence on a provider-less host is identical:',
+    );
+    for (const finding of handRolledDrift) {
       console.error(`  ${finding.file}:${finding.line}:${finding.column}  [${finding.reason}]  ${finding.detail}  (${finding.table})`);
       console.error(`      en renders:      ${quote(finding.expected)}`);
       console.error(`      defaults table:  ${quote(finding.actual)}`);


### PR DESCRIPTION
Fixes #7877

The B half of the ruling on objectui#7567 Q2. PR objectui#7870 landed the
`createSafeTranslation` value-compare over the **factory-resolved** population —
every factory invocation, read from source with no registry. Two tables
hand-roll `fallbackT` instead of taking the factory, so nothing in their source
says they are defaults tables and that walk cannot reach them. Covering them
takes a declaration, which is why A went first and B was split out.

Head this was measured on: `924edd915`.

## The declaration: ONE list, not two pinned copies

`HAND_ROLLED_TABLES` already existed, in `packages/test-support` (it moved there
from the objectui#3512 test in objectui#7884). The gate is a bare
`node scripts/check-*.mjs` and cannot import it: `exports["./defaults-table-scan"]`
resolves to TypeScript source with no build artefact.

That wall already has a ruling — objectui#6923, whose first instance is
`zod-wrapper-keys.json` in the same package, read by two other `.mjs` gates in
`scripts/`. Same shape here: the DATA moves to `hand-rolled-tables.json` behind
its own `exports` subpath, `resolveJsonModule` types it for TypeScript,
`createRequire` reads the same bytes for `node`, and `defaults-table-scan.ts`
keeps the prose JSON cannot carry.

The alternative — a second literal list in the gate, pinned to this one by a test
(the objectui#7310 / PR objectui#8028 shape) — was available and deliberately
not taken: two lists can disagree for the window between one edit and the next
pin run, and the failure mode of a scan population that quietly loses an entry is
"0 drifted" over nothing. A shared declaration was measurable here, so it wins.

⛔ Option C on objectui#7567 (pattern-matching identifier names, or every
`Record` of strings that looks like a defaults map) is not built and is named as
rejected in both the gate header and the new pin block.

## The census, re-measured (not carried forward from the card)

```
Factory defaults tables: 32 createSafeTranslation site(s) over 32 distinct table(s) (0 unreadable) —
  841 row(s) compared against their en value, 841 matching, 0 on a key en does not define,
  0 with no single comparable en value, 0 unreadable.
Hand-rolled defaults tables: 3 declared, 2 scanned here (1 already covered by the factory walk,
  0 unreadable) — 215 row(s) compared against their en value, 215 matching,
  0 on a key en does not define, 0 with no single comparable en value, 0 unreadable.
```

Per table, measured by dropping one registry entry at a time (below):
`GANTT_DEFAULT_TRANSLATIONS` 80, `IMPORT_DEFAULT_TRANSLATIONS` 135. That matches
the card's 2026-09-06 baseline exactly. **Both read 0 drifted, so the widened
half ships blocking in this PR** rather than report-only.

⚠️ One correction to the card: it expected 5 abstaining rows on the factory half
(`timeline.relative.*`). Measured today that count is **0** — those rows were
retired in objectui#7887. The factory half's abstention counts are all zero on
this tree, and so are the widened half's. See the out-of-scope note at the end.

`TIMELINE_DEFAULT_TRANSLATIONS` is in the registry (it mirrors the needle-file
set objectui#3512 pins) **and** reaches the factory, so it is de-duplicated on
the literal's own position and reported as `1 already covered by the factory
walk` rather than counted twice.

## The collapse guard is not weakened

`factoryComparedRows < 500` at its original site is untouched. The widened half
gets its **own** counter and its **own** floor, `handRolledComparedRows < 150`.

How 150 was derived rather than picked: the two reachable-nowhere-else tables
compare 80 and 135 rows. The floor sits **above the larger of the two**, so
losing **either** table collapses the scan into a failure — not only losing both.
A floor below 135 would let the bigger table carry the smaller one's
disappearance. Demonstrated, one entry dropped at a time:

```
=== registry WITHOUT GANTT_DEFAULT_TRANSLATIONS ===
  VERDICT exit=1
  The hand-rolled defaults scan collapsed: 135 row(s) compared over 1 table(s) from 2 declared, ...
=== registry WITHOUT IMPORT_DEFAULT_TRANSLATIONS ===
  VERDICT exit=1
  The hand-rolled defaults scan collapsed: 80 row(s) compared over 1 table(s) from 2 declared, ...
```

Both legs restored under a `trap`, verified by blob hash (`git diff HEAD` = 0
bytes both times).

## (a) Positive control on the widened half

A real drift planted on disk in `GANTT_DEFAULT_TRANSLATIONS` — a table the
factory walk structurally cannot see. On-disk mutation proved by counting the
removed and injected text before and after (1/0, then 0/1) and by the blob hash
moving `33fe2321… -> a6a2fcec…`:

```
=== MUTATED RUN ===
VERDICT mutated-exit=1
Hand-rolled defaults tables: 3 declared, 2 scanned here (...) — 215 row(s) compared, 214 matching, ...
1 hand-rolled defaults row contradicts the en value of a key that EXISTS (1 distinct key) — ...
  packages/plugin-gantt/src/useGanttTranslation.ts:25:3  [hand-rolled-default-drift]  gantt.toolbar.jumpToToday  (GANTT_DEFAULT_TRANSLATIONS (packages/plugin-gantt/src/useGanttTranslation.ts))
      en renders:      "Jump to today"
      defaults table:  "Go to today"

=== RESTORED RUN ===
VERDICT restored-exit=0
Hand-rolled defaults tables: 3 declared, 2 scanned here (...) — 215 row(s) compared, 215 matching, ...
```

Restore proved by blob hash back to `33fe2321…` and `git diff HEAD` = 0 bytes.
The finding carries its **own** reason, `hand-rolled-default-drift`, with its own
hint — the two halves are reached differently and the fix for one names a
registry the other does not have.

## (b) The staleness reading on the registry — demonstrated, not asserted

A declared list rots when a table is added and **not** declared. What catches
that is not diligence and does not live in this gate:
`packages/i18n/src/__tests__/fallback-placeholder-spelling-3512.test.ts` asserts
the set of runtime files carrying the hand-rolled needle equals a pinned list.
Because the gate now reads the **same bytes** that test reads, that one ratchet
covers both readers.

Shown by planting an undeclared fourth hand-rolled `fallbackT`:

```
VERDICT intruder-exit=1
 FAIL  ... > covers the three hand-rolled interpolators, and no fourth exists
+   "packages/plugin-gantt/src/undeclaredFallback7877.ts"
Tests  1 failed | 17 passed (18)
```

Removed; restored run is `18 passed (18)`, exit 0.

The other direction — an entry that names a file or a `const` no longer there —
is covered here: a declaration that does not resolve is counted as an unreadable
**TABLE**, never skipped, and pinned both synthetically and against `main`.

## (c) The abstention counts are printed

The widened half prints its own summary line in the shape objectui#7870 prints
the factory half's, including all four abstention buckets. objectui#7874 exists
only because the factory half printed its blind spot instead of absorbing it.

## Also in this PR: one shared full-repo `analyze()` run in the pin file

`analyze(repoRoot)` parses about 1600 files. Seven cases in
`scripts/__tests__/check-i18n-call-site-keys.test.ts` each paid for their own
walk; the two new cases here took that to nine and pushed the slowest case past
vitest's 15s window under a full `scripts/__tests__/` run. AGENTS.md 测试纪律
names that shape and prescribes moving the cost into the import phase rather than
raising the timeout, so the default-options run is now computed once at module
scope. Cases that inject their own registry keep their own runs.

Measured either side, same 112 files / 3348 tests: **219.72s to 113.76s**. This
is the same failure objectui#8074 reports; that card is named here without a
closing keyword because this is a measured mitigation of its instance, not
necessarily the whole class it names — objectui#8074 stays open for a maintainer
to judge.

## Gates, all on `924edd915`

| gate | verdict |
|:--|:--|
| `pnpm check:i18n-keys` | exit=0 (both census lines quoted above) |
| `pnpm exec vitest run scripts/__tests__/check-i18n-call-site-keys.test.ts` | 137 passed |
| `pnpm exec vitest run scripts/__tests__/` | 112 files / 3351 tests passed, exit=0 |
| `packages/test-support/` + the 3512 test + the 4401 mirror test | 7 files / 104 tests passed |
| `pnpm --filter @object-ui/test-support type-check` / `lint` | exit=0 / exit=0 |
| `pnpm type-check:scripts` | exit=0 |
| `pnpm lint:root` | exit=0 |
| `pnpm check:i18n-drift` · `check:i18n-dead-keys` · `check:control-bytes` | exit=0 |
| manual control-byte scan of all 5 changed paths | no hits |
| `node scripts/check-changeset-presence.mjs` | exit=0 — no changeset owed |
| `node scripts/check-governed-queue-guard.mjs --test` (5 paths) | NOT GOVERNED |

Every exit code captured by redirect-then-capture, never across a pipe.

**Changeset, clause ② confirmed rather than assumed:** the checker reports
`0 of them published source of a package the release covers, 0 of them a manifest
whose published contract moved, 3 under a package changesets ignores`.
`@object-ui/test-support` is `private: true` and changesets ignores it; `scripts/`
publishes nothing. No published contract's accept/reject behaviour changes — a
gate's scan population widened.

**CI invocation unchanged:** `ci.yml:487` runs `pnpm check:i18n-keys`, the same
script name, untouched. Every reader of the gate found by
`git grep -l check-i18n-call-site-keys` over `scripts/__tests__`,
`.github/workflows` and `packages/i18n` was run.

`main` moved under this branch while it was in flight (PRs objectui#8081,
objectui#8082, objectui#8087 and two others); `origin/main` was merged in and
everything above was re-run on the merged head.

## Out of scope, filed separately

The class-8 header and one pin comment still say `timeline.relative.*` is five
abstaining rows on `main`; measured today it is zero. Not touched here — filed as
a `finding` rather than ridden in on this PR.

Back-links, none with a closing keyword: objectui#7567 · objectui#7870 ·
objectui#3512 · objectui#7874 · objectui#7454 · objectui#7574 · objectui#8028 ·
objectui#6923 · objectui#7884 · objectui#7887 · objectui#8074.

Drafted by the `domain:devx @ objectui` seat, session
`session_01FhBNJcLRZLe8M87VcUgpKr`, round R46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_