### PR TITLE
docs(skills): teach BaseSchema in the two published node fences

### DIFF
--- a/skills/objectui/guides/architecture.md
+++ b/skills/objectui/guides/architecture.md
@@ -18,15 +18,15 @@ integration package to install. Day-to-day schema authoring is
 Every node in the UI tree follows this shape — enforce it on every input.
 
 ```typescript
-// @object-ui/types
-interface UIComponent {
+// @object-ui/types — abridged; the full BaseSchema member list is packages/types/src/base.ts
+interface BaseSchema {
   /** The unique identifier for the renderer registry (e.g., 'input', 'grid', 'card') */
   type: string;
 
   /** Unique ID for DOM accessibility and event targeting */
   id?: string;
 
-  /** Visual properties (mapped directly to Shadcn props) */
+  /** Config envelope — read only by element:* renderers; see rules/protocol.md */
   props?: Record<string, any>;
 
   /** Data binding path (e.g., 'user.address.city') */
@@ -36,14 +36,14 @@ interface UIComponent {
   className?: string;
 
   /** Dynamic Behavior */
-  hidden?: string; // Expression: "${data.role != 'admin'}"
-  disabled?: string; // Expression
+  hidden?: boolean | ExpressionWire; // e.g. "${data.role != 'admin'}"
+  disabled?: boolean | ExpressionWire; // same wire as hidden
 
   /** Event Handlers */
-  events?: Record<string, ActionDef[]>; // onClick -> [Action1, Action2]
+  events?: Record<string, ActionSchema[]>; // onClick -> [Action1, Action2]
 
   /** Layout Slots */
-  children?: UIComponent[];
+  children?: BaseSchema[]; // object half; the real slot also admits primitives
 }
 ```
 
@@ -73,7 +73,7 @@ How the schema tree becomes React:
 
 ```typescript
 // packages/react/src/SchemaRenderer.tsx
-export const SchemaRenderer = ({ schema }: { schema: UIComponent }) => {
+export const SchemaRenderer = ({ schema }: { schema: BaseSchema }) => {
   const Component = resolveComponent(schema.type);
   const { isHidden } = useExpression(schema.hidden);
 

--- a/skills/objectui/rules/protocol.md
+++ b/skills/objectui/rules/protocol.md
@@ -46,7 +46,7 @@ These top-level schema fields are passed as raw strings:
 Every UI component node MUST follow this shape:
 
 ```typescript
-interface UIComponent {
+interface BaseSchema {       // abridged — full member list: packages/types/src/base.ts
   type: string;              // Required: component type identifier
   id?: string;               // Optional: unique identifier
   properties?: Record<string, any>; // Optional: spec config bag, hoisted onto
@@ -55,10 +55,10 @@ interface UIComponent {
                                // general bag. See "Rule: Keys Live on the Node".
   bind?: string;             // Optional: data binding path
   className?: string;        // Optional: Tailwind CSS classes
-  hidden?: string;           // Optional: visibility expression
-  disabled?: string;         // Optional: disabled expression
-  events?: Record<string, ActionDef[]>; // Optional: event handlers
-  children?: UIComponent[];  // Optional: nested components
+  hidden?: boolean | ExpressionWire;   // Optional: visibility predicate
+  disabled?: boolean | ExpressionWire; // Optional: disabled predicate
+  events?: Record<string, ActionSchema[]>; // Optional: event handlers
+  children?: BaseSchema[];   // Optional: object nodes; real slot is wider
 }
 ```
 


### PR DESCRIPTION
Fixes #8065

The published `skills/objectui` tree taught `UIComponent` — a name `@object-ui/types` exports nowhere — in five places. Each becomes `BaseSchema`, the maintainer's ruled name for "a component node" (ruling 5556352576 on objectui#7434). The two fenced interface blocks additionally take the option-2 ruling recorded on objectui#8092 **as amended**: the test for a member is not "is it on the TS interface" but "does a real reader accept it on the wire", so a member a reader accepts stays with a comment naming the node kind, and the abridged rest is pointed at `packages/types/src/base.ts`.

⚠️ **Generic parameters are spelled in WORDS below (e.g. "array-of-BaseSchema"), never in angle-bracket shape.** This repo's `AGENTS.md` records that GitHub's body sanitizer eats tag-shaped fragments even inside backticks and fenced blocks; this PR is entirely about type declarations, so a literal rendering would collapse both columns of the tables into the same string and a table written to show a change would read as "nothing changed".

## Surface

| file | lines before | lines after | governed |
|---|---:|---:|---|
| `skills/objectui/guides/architecture.md` | 94 | 94 | yes |
| `skills/objectui/rules/protocol.md` | 332 | 332 | yes |

**Line- or token-pinned in this repo? Measured: no.** No ratchet or budget script names either file — the four scripts that mention them (`check-doc-links.mjs`, `check-skills-paths.test.ts`, `check-doc-component-types.mjs`, `check-skill-eval-tokens.mjs`) count neither lines nor tokens of them, and `scripts/check-skill-eval-tokens.mjs` measures eval `must_contain` tokens against the bundle, not file size. Every edit is a one-line-for-one-line replacement anyway, so both files are line-neutral in fact as well as by budget.

Governed verdict, quoted from the gate:

```
$ node scripts/check-governed-queue-guard.mjs --test skills/objectui/guides/architecture.md skills/objectui/rules/protocol.md
⛔ GOVERNED — 2 of 2 path(s) are on a governed surface:
   skills/** x2 — the published skills catalog
   One governed path governs the WHOLE pull request — proportion is not a question.
   ⛔ Do not flip it ready, enqueue it, or arm auto-merge. Park it as a DRAFT and leave the merge
      to the maintainer; a human merge IS the review record for a governed surface.
exit 3
```

⇒ This PR stays a **draft**. ⛔ Not flipped ready, not enqueued, no auto-merge, no approval sought.

## 改前 → 改后 — `skills/objectui/guides/architecture.md`, fence at 21-47

| line | 改前 | 改后 | the reader / authority that justifies it |
|---|---|---|---|
| 21 | `// @object-ui/types` | same, plus `— abridged; the full BaseSchema member list is packages/types/src/base.ts` | the one abridged note this fence owes; the fourteen absent members stay absent |
| 22 | `interface UIComponent` | `interface BaseSchema` | `packages/types/src/base.ts:70` exports `BaseSchema`; `UIComponent` is exported by nothing (0 files under `packages/types/src`, live control: `BaseSchema` in 98) |
| 23-27 | `type` / `id` | unchanged | `base.ts` declares both identically |
| 29 | comment `Visual properties (mapped directly to Shadcn props)` | comment `Config envelope — read only by element:* renderers; see rules/protocol.md` | **kept, node kind named.** Reader: `packages/components/src/renderers/basic/readProps.ts:69` reads `schema.props` for the `element:*` family, called at `elements.tsx:76 · 142 · 201 · 369`. The other half is stated in the renderer's own source at `packages/react/src/SchemaRenderer.tsx:1519-1528`: those keys "are spread as React props and never hoisted onto the node, so a renderer that reads its config from `schema` — every family except `element:*`'s `readProps()` — drops them without a word." The old comment taught the opposite and was the trap; the key itself is real |
| 32-36 | `bind` / `className` | unchanged | `base.ts:248` (`bind`), and `className` identical |
| 39 | `hidden?: string` | `hidden?: boolean OR ExpressionWire` | `packages/types/src/base.ts:376` — spelled the way that file spells it. `ExpressionWire` is a real export (`packages/types/src/index.ts:119`, declared `packages/types/src/expression.ts:67` as a string OR the CEL envelope object), so the taught line is now a superset-free restatement rather than a narrowing |
| 40 | `disabled?: string` | `disabled?: boolean OR ExpressionWire` | `packages/types/src/base.ts:412` |
| 43 | element type `ActionDef` | element type `ActionSchema` | `ActionDef` is `@object-ui/core`'s (declared `packages/core/src/actions/ActionRunner.ts:113`), **not** `@object-ui/types`' — and this fence names `@object-ui/types`. `ActionSchema` is exported from there: `packages/types/src/crud.ts:40`, barrel `packages/types/src/index.ts:383`. ⛔ The line's semantics are untouched: whether the `events` bag is the action system at all is objectui#7945's open question and is not pre-empted here |
| 46 | `children?: array-of-UIComponent` | `children?: array-of-BaseSchema` plus comment `object half; the real slot also admits primitives` | the node-slot rule restated three times on objectui#7434: `BaseSchema` for node-slot positions, `SchemaNode` only where the union is genuinely correct. **`SchemaNode` is written nowhere new** — neither file introduces the name today (`git grep -n SchemaNode -- skills/` is empty), so the fence keeps the object half and the comment plus the abridged note carry the fact that the real slot (`packages/types/src/base.ts:260`) is wider |
| 76 | renderer example `schema: UIComponent` | `schema: BaseSchema` | the real prop is declared `schema: BaseSchema | string | null | undefined` at `packages/react/src/SchemaRenderer.tsx:500-502`, so the example keeps that declaration's object half |

## 改前 → 改后 — `skills/objectui/rules/protocol.md`, fence at 48-62

| line | 改前 | 改后 | the reader / authority that justifies it |
|---|---|---|---|
| 49 | `interface UIComponent` | `interface BaseSchema` plus trailing `abridged — full member list: packages/types/src/base.ts` | as above; this fence's one abridged note rides the interface line, so the block stays line-neutral |
| 52-53 | `properties` plus its hoisting comment | unchanged — **kept** | `packages/react/src/SchemaRenderer.tsx:1057-1068` hoists every key of a config-bag `properties` onto the node (`type` / `id` excepted) before the renderer runs, so **every** namespace reads it — not a narrower node kind. This file's own 「Rule: Keys Live on the Node」 documents it with a measured table, which is the second half of the amended test |
| 54-55 | `props` plus its `element:*` comment | unchanged — **kept** | same readers as the architecture fence above; the existing comment already names the node kind (`element:* config envelope — NOT a general bag`) and the same rule in this file documents it |
| 58 | `hidden?: string` | `hidden?: boolean OR ExpressionWire` | `packages/types/src/base.ts:376` |
| 59 | `disabled?: string` | `disabled?: boolean OR ExpressionWire` | `packages/types/src/base.ts:412` |
| 60 | element type `ActionDef` | element type `ActionSchema` | as above; semantics untouched |
| 61 | `children?: array-of-UIComponent` | `children?: array-of-BaseSchema` plus comment `object nodes; real slot is wider` | as above |

The prose above each fence — "Every node in the UI tree follows this shape — enforce it on every input." and "Every UI component node MUST follow this shape:" — stays, and is now true of the lines shown.

### Every kept member type-checks as written

Compiled against the **built** `@object-ui/types` d.ts (`pnpm exec tsc --ignoreConfig --noEmit --strict --skipLibCheck --moduleResolution bundler`), a program that assigns every member both fences keep onto a real `BaseSchema` — `type` · `id` · `properties` · `props` · `bind` · `className` · `hidden: true` · `disabled` as a template string · `children` — plus an `ExpressionWire` in both its string and its CEL-envelope form and a Record from event name to array-of-`ActionSchema`: **exit 0**. (`props` and `properties` are admitted by `BaseSchema`'s index signature at `packages/types/src/base.ts:464`, which is the TS-side half of why the wire test, not the interface test, is the right one.)

The reverse direction is deliberately **not** claimed, and the compiler says why: assigning a real `BaseSchema` to the fence's shape fails with `Type 'SchemaNode | SchemaNode[]' is not assignable to type 'BaseSchema[] | undefined' — Type 'null' is not assignable`. That is the measured narrowing the `children` comment and the abridged note both declare.

## Gates — every exit captured before any pipe, on head `d999e94b`

| gate | verdict line |
|---|---|
| `pnpm check:skill-examples` | exit 0 — `Marked: 13 ts fence(s) (floor 13), 70 json fence(s) (floor 70)` · `Semantic phase: 13 of 13 ts fence(s) judged, 0 failed` · `JSON phase: 70 fence(s) parsed, 0 failed`. **Marked-fence count before this change: 13 ts / 70 json. After: 13 ts / 70 json — unchanged.** Neither edited fence carries the opt-in marker, and none was added (see below) |
| `pnpm check:skill-eval-tokens` | exit 0 — `Red under the chosen oracle: 0 (0 beyond the baseline)`. **No eval names `UIComponent`**: over all 99 distinct `must_contain` tokens in the 11 eval files, that token does not appear, so this rename edits nothing an eval grades. Reported, not edited, per the dispatch |
| `pnpm check:skills-paths` | exit 0 — `88/89 stated path(s) resolve across 20 guide file(s); 1 baselined` (unchanged; the new `packages/types/src/base.ts` mentions sit inside fences, which that gate reads by design as worked examples rather than prose claims — and the path exists either way) |
| `pnpm check:doc-fences` | exit 0 — `every TypeScript block in 227 document(s) is fenced ts/tsx/typescript` |
| `node scripts/check-governed-queue-guard.mjs --test PATH PATH` | **exit 3 — GOVERNED**, quoted in full above |
| `node scripts/check-changeset-presence.mjs` | exit 0 — `2 file(s) changed, 0 of them published source of a package the release covers … ✅ No source or published contract of a released package changed in this range, so no changeset is owed.` This repo has no `skip-changeset` label; the gate's own verdict is followed, so no changeset file is added |
| `pnpm exec vitest run scripts/__tests__/component-node-vocabulary-7434.test.ts` | exit 0 — `Test Files 1 passed (1) · Tests 4 passed (4)`. **`skills/**` is outside that pin's corpus today**: its scan surface is `DOCS_ROOT = 'content/docs'` plus each `packages/NAME/README.md` (`scripts/__tests__/component-node-vocabulary-7434.test.ts:78 · 93`), and its docblock names only `docs/**` and `AGENTS.md` as the load-bearing exclusions. ⛔ Not extended here — that is objectui#8093's subject |
| whole-repo `pnpm lint` (through the shared verify lock, acquired once, held 4m18s, waited 0s) | `Tasks: 47 successful, 47 total` — exit 0. Warnings only, all pre-existing `no-explicit-any` in package source |

Every one of the above was captured as `cmd > FILE 2>&1; EXIT=$?` — no exit code was read through a pipe.

### Why no opt-in marker was added to either fence

The dispatch permits adding one only if the block compiles against the built d.ts and that is shown. It does not, and the measurement is the reason to leave it alone: `node scripts/check-skill-examples.mjs --measure` (which judges every candidate, marked or not) reports both fences `FAIL` on **both** trees, because each is a bare interface fragment that imports nothing — before this change with `TS2304: Cannot find name 'ActionDef'` and `'UIComponent'`, after it with `TS2304: Cannot find name 'ExpressionWire'` and `'ActionSchema'`. The difference matters and is the point of the change: the pre-change names could not be imported from `@object-ui/types` at all, while all three post-change names are real exports of it and resolve the moment an import line exists. Adding that import line to earn a marker would be a net-positive-lines expansion of a governed file, which this flight is not scoped to make.

The pre-change measurement was taken by restoring both files to `d3499b31` under a `trap`-guarded restore, confirming the mutation on disk by anchored counts (`UIComponent` 3 + 2, `ActionDef` 1 + 1), running the measurement, and restoring with `git checkout HEAD -- ABSOLUTE_PATH`; the restore is proven by `git diff HEAD` being empty and both blob hashes matching the HEAD blobs (`dfb1bd49`, `3d5cf0fa`), not by the command's exit code.

## 验收备注

Noted and deliberately **not** filed — none clears the admission threshold on its own, and each belongs to a card that already exists:

1. **`ActionSchema` is marked `@deprecated`** in its own docblock (`packages/types/src/crud.ts`, "Use `UIActionSchema` … for new code"). The ruling named `ActionSchema` explicitly and this PR follows it verbatim; the alternative (`UIActionSchema`) is a semantics choice about what the `events` bag *is*, which is objectui#7945's question. Recorded so whoever rules that card sees the trade rather than rediscovering it.
2. **The `events` shape has no reader at all**, re-measured on this tree: `git grep -nE '\??\.events\b' -- 'packages/*/src' 'apps/*/src'` returns nothing, and the only `events` member declared anywhere in `packages/types` is `EventableSchema.events` (`packages/types/src/api-types.ts:282`), which is an **array of `UIEventHandler`** — not a Record keyed by event name at all. Both readings are objectui#7945's subject and it is `pm:awaiting-maintainer`; ⛔ this flight does not pre-empt it, and the line's shape is left exactly as it was apart from the element type.
3. **The claim comment on the card (5560223433, 15:26Z) says "drop `props`, `events` and any `ActionDef` reference".** The dispatch's ruling section, written at 15:3xZ after the objectui#8092 amendment, replaces that with the reader test — a member a reader accepts stays with the node kind named. This PR follows the later text. Recorded here so the two do not read as a contradiction in six weeks.
4. **`packages/types/README.md` and `content/docs/api/schema-reference.md`** were already repaired by PR #8064 and are untouched here.

Filed, because it *does* clear the threshold and is outside this PR's ruled file surface:

- **objectui#8103** — `skills/objectui/guides/plugin-development.md:219-228` teaches a plugin node interface that hand-rolls `BaseSchema`'s members instead of extending it and declares `hidden` / `disabled` as plain strings, so a copied declaration refuses `hidden: true` and the CEL envelope that the shipped renderer accepts. Same class, fourth surface. Unassigned, `finding` only; dedup run over 383 open issues with a live control.

## 维护者速读(草稿)

我们发布给客户和 AI 的技能包里,有两段"每个 UI 节点长什么样"的接口示例。它们教的接口名 `UIComponent` 在真实代码里根本不存在——`@object-ui/types` 从来没有导出过这个名字。也就是说,任何人(尤其是 AI)照着抄,写出来的类型是编译不过去的,而这份技能包恰恰是模型在写 ObjectUI 页面时实际读的那一份。

这次把五处名字改成 `BaseSchema`——维护者在 objectui#7434 上已经拍板的正式名字,也是代码里真实导出的那一个。同时按 objectui#8092 上记录的裁定,把两段接口块里"写着但不成立"的行改成成立的:`hidden` / `disabled` 原来写成纯字符串,而渲染器实际接受布尔值和 CEL 表达式对象;`events` 里引用的元素类型是另一个包的私有名字,换成了 `@object-ui/types` 真正导出的那个。

有两个键被**留下**了,而不是删掉:`props` 和 `properties`。判据不是"TS 接口上有没有",而是"线上有没有真实的读取方"——`properties` 由渲染器逐键提升到节点上、所有命名空间都读得到;`props` 只有 `element:*` 这一族读,其余全族静默丢弃。这两个事实都在代码里逐行核实过(PR 正文列了文件行号),并且把"哪一族读它"写进了注释,所以照抄的人不会再掉进"卡片渲染成空框"那个坑。

**没有做**的三件事,都是刻意的:不动 `events` 这个通道到底是不是动作系统(那是 objectui#7945,正等维护者裁);不把接口扩写成全部二十一个成员(没有门禁看着的接口副本就是漂移发生器,这正是这一族卡要防的事),只加一句"这是节选,完整清单在 `packages/types/src/base.ts`";不给这两段代码块加编译门禁标记(实测它们作为片段编译不过,加标记要先加 import 行,那是给受管文件净增行数)。两个文件都是**行数中性**的,一行换一行。

风险面很小:改的是纯文档,没有任何运行时代码,门禁全绿(含全仓 lint 47/47)。因为命中受管面 `skills/**`,这个 PR **停在 draft 等人工合并**,没有翻 ready、没有入队、没有挂 auto-merge。顺手量到并另立了一张卡(objectui#8103):同一个技能包的插件开发指南里,还有第三段同类的接口示例。

**席位意见:**

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox

---
_Generated by [Claude Code](https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox)_