### PR TITLE
types(QueryParams): close the `[key: string]: any` index signature (#7497)

### DIFF
--- a/.changeset/queryparams-closed-keys-7497.md
+++ b/.changeset/queryparams-closed-keys-7497.md
@@ -1,0 +1,44 @@
+---
+'@object-ui/types': minor
+---
+
+`QueryParams` (`@object-ui/types`) no longer carries the `[key: string]: any`
+index signature; its key set is now exactly the nine declared `$`-prefixed
+members — `$select`, `$filter`, `$orderby`, `$skip`, `$top`, `$expand`,
+`$search`, `$searchFields`, `$count` (objectui#7497).
+
+**What stops type-checking that type-checked before.** Any object literal
+assigned or passed as a `QueryParams` that carries a key outside those nine —
+the unprefixed spellings the readers silently dropped (`{ filter }` for
+`$filter`, `{ limit }` for `$top`, `{ options: { $top } }`), and any
+`$`-prefixed name that is not declared (`{ $limit }`). Reading an undeclared
+key off a `QueryParams` value (`params.filter`) is refused too. A published
+guide had taught `adapter.find('contacts', { filter: { active: true } })` and
+asserted the client saw that `filter`: it compiled, `convertQueryParams`
+dropped the key, and the assertion could never pass. That literal is now a
+compile error at the call site.
+
+**What does not change.** Every reader in this repository —
+`convertQueryParams` and `rawFindWithPopulate` in `@object-ui/data-objectstack`,
+`queryParamsToRecord` in `@object-ui/core`, `ValueDataSource.find` — reads only
+declared members, so nothing the runtime honoured is refused. A
+`Record<string, unknown>` or `Record<string, any>` VALUE (the shape
+`@objectstack/spec`'s `ViewData.params` parses to) still passes, as does a
+spread of one beside `$top` / `$skip`; a type assertion (`{ limit: 1 } as
+QueryParams`) still compiles because assertions skip excess-property checks,
+which is why `object-ui/no-unprefixed-query-params` keeps its typed cases.
+
+**Why `minor` and not `patch` or `major`.** Narrowing the accepted set of a
+published contract is a breaking change for any downstream caller that relied
+on the extra keys. The census behind the grade: across this repository's
+packages, apps, examples, e2e and scripts trees (4,362 files), zero `find` /
+`findOne` call sites or `QueryParams` literals carry a non-`$` key, and no
+adapter reads one — the signature carried nothing but typos. This repository
+records its own breaking changes as `minor` with the break spelled out; `major`
+is reserved for following `@objectstack` across a major (see AGENTS.md, version
+alignment). A `patch` would be wrong: this is a deliberate narrowing, not a
+fix inside the accepted set.
+
+Migration for a downstream caller that did pass an extra key: if an adapter of
+yours reads it, declare it on your own params type and widen at your adapter's
+boundary; if nothing reads it, it was already being dropped — delete it.

--- a/eslint-rules/no-query-params-under-options.js
+++ b/eslint-rules/no-query-params-under-options.js
@@ -11,11 +11,13 @@
  * `ApiDataSource` both read `params.$top` — so a cap written under `options`
  * never reaches the wire and the query silently runs unbounded.
  *
- * Nothing else catches this. `QueryParams` carries `[key: string]: any`, which
- * is deliberate (adapters accept adapter-specific params) but means the type
- * system accepts both spellings equally: `{ options: { $top: 100 } }`
- * type-checks exactly as well as `{ $top: 100 }`, and the two mean completely
- * different things — the first means nothing at all.
+ * When this rule landed nothing else caught it: `QueryParams` carried
+ * `[key: string]: any`, read as room for adapter-specific params, so the type
+ * system accepted both spellings equally — `{ options: { $top: 100 } }`
+ * type-checked exactly as well as `{ $top: 100 }`, and the two mean completely
+ * different things (the first means nothing at all). objectui#7497 closed the
+ * type, so a typed literal is now a `tsc` error too; this rule still reaches
+ * untyped sources, JS, and `as QueryParams` assertions, and fires at write time.
  *
  * Two live instances existed, written by different people at different times:
  *

--- a/eslint-rules/no-unprefixed-query-params.js
+++ b/eslint-rules/no-unprefixed-query-params.js
@@ -11,8 +11,13 @@
  * `$search`, `$searchFields`, `$count` — and `convertQueryParams` in
  * `@object-ui/data-objectstack` builds its outgoing options by copying exactly
  * those. An unprefixed key reaches no branch and is dropped: no throw, no
- * warning. `QueryParams` also carries `[key: string]: any`, so the type system
- * accepts both spellings equally and nothing rejects the dead one.
+ * warning. Until objectui#7497 `QueryParams` also carried `[key: string]: any`,
+ * so the type system accepted both spellings equally and nothing rejected the
+ * dead one; the index signature is gone, so a TYPED literal is now refused by
+ * `tsc` as well. This rule keeps its place for the sites `tsc` cannot judge —
+ * an `as any` / untyped data source, a JS file, and an `as QueryParams`
+ * assertion, which skips excess-property checking — and because it fires at
+ * write time with the canonical spelling in the message.
  *
  * The consequence for a dropped cap is an UNBOUNDED read, not a truncated one.
  * The platform's GET list route has no default page size — the pinned
@@ -49,11 +54,14 @@
  *
  * Two independent narrowings, both load-bearing:
  *
- *  1. **Only a KNOWN query-option name.** Not "any unprefixed key". The index
- *     signature exists because adapters legitimately take adapter-specific
- *     params, so flagging every unprefixed key would report the shape the type
- *     was written to allow — and a rule that cries wolf gets switched off. The
- *     list below is closed and every entry maps to a real `QueryParams` key.
+ *  1. **Only a KNOWN query-option name.** Not "any unprefixed key". When this
+ *     rule landed the index signature was read as room for adapter-specific
+ *     params, so flagging every unprefixed key would have reported the shape
+ *     the type was written to allow — and a rule that cries wolf gets switched
+ *     off. objectui#7497's census then found NO such params anywhere and closed
+ *     the type, so on a typed site every unprefixed key is now a `tsc` error;
+ *     the closed list still keeps this rule's report meaningful on the untyped
+ *     sites only it can see. Every entry maps to a real `QueryParams` key.
  *  2. **Only the second argument of a `find`/`findOne` CALL.** Unlike its
  *     sibling — whose `options`-holding-a-`$`-key signature is unmistakable
  *     anywhere — every name on the list (`top`, `limit`, `filter`, `sort`,
@@ -164,9 +172,10 @@ function calleeMethodName(callee) {
 /**
  * Look through the TypeScript wrappers that do not change the value, so a
  * params literal written `{ limit: 1 } as QueryParams` is still read as the
- * object literal it is. The index signature makes that cast compile, which is
- * exactly the population this rule exists for — an evasion by `as` would be
- * silent and would look deliberate.
+ * object literal it is. A type assertion skips excess-property checking, so
+ * that cast compiles even now that `QueryParams` has no index signature
+ * (objectui#7497) — exactly the population this rule exists for; an evasion by
+ * `as` would be silent and would look deliberate.
  */
 function unwrapExpression(node) {
   let current = node;
@@ -200,7 +209,7 @@ export default {
     schema: [],
     messages: {
       unprefixedQueryOption:
-        '`{{key}}` is not a `QueryParams` key — write `{{canonical}}`. `QueryParams` (@object-ui/types) declares every query option with a leading `$`, and `convertQueryParams` (@object-ui/data-objectstack) copies exactly those keys, so `{{key}}` reaches no branch and is dropped: no throw, no warning. Its `[key: string]: any` index signature exists for adapter-specific params, which is why the dead spelling type-checks. When the dropped key is a cap the read becomes UNBOUNDED rather than truncated — the platform GET list route has no default page size, so the query returns the whole match set and stays invisible until the object is large. See objectui#5458.',
+        '`{{key}}` is not a `QueryParams` key — write `{{canonical}}`. `QueryParams` (@object-ui/types) declares every query option with a leading `$`, and `convertQueryParams` (@object-ui/data-objectstack) copies exactly those keys, so `{{key}}` reaches no branch and is dropped: no throw, no warning. `QueryParams` has no index signature since objectui#7497, so a typed literal is refused by `tsc` too; this rule reaches the sites `tsc` cannot — untyped sources, JS, and `as QueryParams` assertions, which skip excess-property checks. When the dropped key is a cap the read becomes UNBOUNDED rather than truncated — the platform GET list route has no default page size, so the query returns the whole match set and stays invisible until the object is large. See objectui#5458.',
     },
   },
   create(context) {

--- a/eslint-rules/no-unprefixed-query-params.test.js
+++ b/eslint-rules/no-unprefixed-query-params.test.js
@@ -64,9 +64,11 @@ ruleTester.run('no-unprefixed-query-params', rule, {
     // …including the two-argument form, where `thisArg` is the second argument.
     `rows.find(function (r) { return r.id === id; }, { count: 0, limit: 1 });`,
 
-    // ── The adapter-specific params the index signature exists for. Flagging
-    //    these is what "any unprefixed key" would have done, and why it isn't
-    //    what this rule does.
+    // ── Keys off the closed list stay silent HERE. They were read as the
+    //    adapter-specific params the index signature existed for; objectui#7497
+    //    found none and closed the type, so on a typed site `tsc` refuses them
+    //    now. This rule still does not report them: "any unprefixed key" is
+    //    what it deliberately isn't.
     `adapter.find(objectName, { $top: 10, includeDeleted: true, tenant: 'acme' });`,
     `adapter.find(objectName, { $top: 10, cacheKey: key, signal: controller.signal });`,
 
@@ -214,8 +216,10 @@ tsRuleTester.run('no-unprefixed-query-params (typescript)', rule, {
     `adapter.find(o, { $top: 100 } as QueryParams);`,
   ],
   invalid: [
-    // The index signature is what makes all three of these compile — this is
-    // the population the rule exists for, so a cast must not be an escape.
+    // A type assertion skips excess-property checking, so the first two still
+    // compile with the index signature gone (objectui#7497); the third is an
+    // untyped source. This is the population the rule exists for, so a cast
+    // must not be an escape.
     {
       code: `adapter.find(o, { limit: 1 } as QueryParams);`,
       errors: [{ messageId: 'unprefixedQueryOption', data: { key: 'limit', canonical: '$top' } }],

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -1854,9 +1854,10 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
     // page size. The effect therefore did the opposite of what it says: it
     // downloaded EVERY row of the object, on every mount and every refresh of
     // every list view, to read one integer off the envelope. The dead spelling
-    // type-checked because `QueryParams` carries `[key: string]: any` for
+    // type-checked because `QueryParams` then carried `[key: string]: any` for
     // adapter-specific params; `object-ui/no-unprefixed-query-params` rejects it
-    // at write time now (objectui#5458).
+    // at write time now (objectui#5458), and the index signature itself is gone
+    // (objectui#7497), so `tsc` refuses it as well.
     //
     // `total` is the only field that can still answer the question, so the
     // row-counting fallbacks are gone rather than repointed. Once we ask for

--- a/packages/plugin-dashboard/src/DashboardFilterBar.tsx
+++ b/packages/plugin-dashboard/src/DashboardFilterBar.tsx
@@ -264,8 +264,9 @@ function SelectFilter({ def, value, onChange, dataSource }: { def: DashboardFilt
           // `QueryParams` declares, so BOTH unprefixed spellings here reached no
           // branch and were dropped: this "best-effort client-side dedupe (top
           // 200 records)" was in fact fetching every row AND every column of the
-          // source object. Nothing rejected it — the index signature exists for
-          // adapter-specific params, so both keys type-checked.
+          // source object. Nothing rejected it — the index signature that then
+          // stood for adapter-specific params let both keys type-check
+          // (retired in objectui#7497; `tsc` refuses them now).
           // Deduped: `valueField === labelField` is the common case (both
           // default to the same column), and this projection only started
           // reaching the wire when the key was corrected above — so a repeated

--- a/packages/types/src/__tests__/query-params-closed-keys-7497.test.ts
+++ b/packages/types/src/__tests__/query-params-closed-keys-7497.test.ts
@@ -1,0 +1,145 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7497 — `QueryParams` is a CLOSED key set. It carried
+ * `[key: string]: any` ("additional custom parameters") while every reader in
+ * the repository — `convertQueryParams` / `rawFindWithPopulate` in
+ * `@object-ui/data-objectstack`, `queryParamsToRecord` in `@object-ui/core`,
+ * `ValueDataSource.find` — copied exactly the declared `$`-prefixed members. So
+ * a misspelled key type-checked and was dropped on the floor: `{ filter }` for
+ * `$filter` (the published testing guide taught a test built on it, which could
+ * never pass), `{ limit }` for `$top` (objectui#5458, four live sites, one of
+ * which INVERTED "count only" into "fetch every row"), `{ options: { $top } }`
+ * (objectui#4734). A census at the closing commit found zero non-`$` keys in
+ * any `find` / `findOne` call or `QueryParams` literal across packages, apps,
+ * examples, e2e and scripts, and no reader of one — the signature carried
+ * nothing but typos.
+ *
+ * ## Why these pins are compile-time, and which one is load-bearing
+ *
+ * The defect never reached a runtime suite and could not: a dropped key changes
+ * the query, not the type of the result, and the mocks in this repo answer any
+ * params. So the regression signature is a `tsc` verdict, and this file is
+ * compiled by `tsc -p tsconfig.test.json` (the package's `type-check` script),
+ * where an unused `@ts-expect-error` is itself an error — every refusal below
+ * is therefore asserted in BOTH directions.
+ *
+ * The `keyof` identity pin is the one that cannot be fooled. Every
+ * `@ts-expect-error` pin goes red on a revert (the literal compiles again, the
+ * directive is unused), which is enough — but a *weaker* reopening, such as an
+ * index signature typed `unknown` or `never`, could keep some of them red for
+ * the wrong reason. `keyof` separates the declarations cleanly: with any string
+ * index signature it widens to `string | number`; closed, it is exactly the
+ * nine declared names. Adding a tenth query option changes that pin too — on
+ * purpose: a new member is only a member once every reader honours it, and the
+ * list here is the checklist for that.
+ *
+ * ## What is deliberately NOT changed by the closing
+ *
+ * A type ASSERTION still compiles — `{ limit: 1 } as QueryParams` — because
+ * assertions skip excess-property checking. That is not a hole this file can
+ * close; it is why `object-ui/no-unprefixed-query-params` keeps its typed test
+ * cases and runs at write time.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { QueryParams } from '../data';
+
+type Assert< T extends true > = T;
+/** Exact type identity — NOT mutual assignability. */
+type Equal< A, B > =
+  (< T >() => T extends A ? 1 : 2) extends (< T >() => T extends B ? 1 : 2) ? true : false;
+
+/** The nine members, spelled once here as the checklist a tenth must join. */
+type DeclaredKeys =
+  | '$select'
+  | '$filter'
+  | '$orderby'
+  | '$skip'
+  | '$top'
+  | '$expand'
+  | '$search'
+  | '$searchFields'
+  | '$count';
+
+/** A typed finder, the shape every `DataSource.find` implementation has. */
+declare function find(resource: string, params?: QueryParams): Promise<unknown>;
+
+describe('QueryParams — a closed key set (#7497)', () => {
+  it('is exactly the nine declared keys — no index signature (the load-bearing pin)', () => {
+    // With `[key: string]: any` present, `keyof QueryParams` is
+    // `string | number` and this line goes red. That is the whole regression
+    // in one assertion; the pins below say WHICH spellings that reopening
+    // would let back in.
+    type _Closed = Assert< Equal< keyof QueryParams, DeclaredKeys > >;
+    expect(true).toBe(true);
+  });
+
+  it('accepts every declared key together, with no cast', () => {
+    const params: QueryParams = {
+      $select: ['id', 'name'],
+      $filter: { active: true },
+      $orderby: { name: 'asc' },
+      $skip: 0,
+      $top: 50,
+      $expand: ['owner'],
+      $search: 'acme',
+      $searchFields: ['name'],
+      $count: true,
+    };
+    expect(Object.keys(params)).toHaveLength(9);
+  });
+
+  it('refuses the unprefixed spellings the readers drop', () => {
+    // The testing guide's Pattern 7 (objectui#7494 / PR #7496): compiled,
+    // dropped, and the assertion built on it could never pass.
+    // @ts-expect-error `filter` is not a QueryParams key — write `$filter`
+    const guide: QueryParams = { filter: { active: true } };
+    // objectui#5458 — `limit: 0` that turned "count only" into "fetch all".
+    // @ts-expect-error `limit` is not a QueryParams key — write `$top`
+    const cap: QueryParams = { $filter: { active: true }, limit: 0 };
+    // objectui#4734 — the cap nested under a key nothing reads. The lint rule
+    // written for that shape fires here as designed; this pin writes the dead
+    // shape on purpose, to prove `tsc` now refuses it too.
+    // @ts-expect-error `options` is not a QueryParams key
+    // eslint-disable-next-line object-ui/no-query-params-under-options
+    const nested: QueryParams = { options: { $top: 100 } };
+    expect([guide, cap, nested]).toHaveLength(3);
+  });
+
+  it('refuses a `$`-prefixed key nothing reads, too', () => {
+    // The closing is "declared = enforced", not "starts with a dollar sign": a
+    // `$`-prefixed template-literal key would have let this one compile and
+    // then dropped it, which is the same defect with a different spelling.
+    // @ts-expect-error `$limit` is not a QueryParams key — write `$top`
+    const params: QueryParams = { $limit: 5 };
+    expect(params).toBeDefined();
+  });
+
+  it('refuses the same spellings at a typed finder call site', () => {
+    // Excess-property checking applies to a literal passed straight to the
+    // parameter, so the call — the shape the guide taught — is refused where
+    // it is written. `find` is only DECLARED above (no runtime binding), so the
+    // call sits inside a function this test never invokes: the pin is the
+    // compile-time verdict, not the call.
+    // @ts-expect-error `filter` is not a QueryParams key — write `$filter`
+    const call = () => find('contacts', { filter: { active: true } });
+    expect(typeof call).toBe('function');
+  });
+
+  it('refuses reading an undeclared key off a QueryParams value (the reader side)', () => {
+    // An adapter cannot quietly grow a consumer of an extra key either: the
+    // read is refused, so a new option has to be declared here first.
+    const read = (p?: QueryParams) => {
+      // @ts-expect-error `filter` does not exist on QueryParams
+      return p?.filter;
+    };
+    expect(read({ $top: 1 })).toBeUndefined();
+  });
+});

--- a/packages/types/src/__tests__/query-params-filter-union.test.ts
+++ b/packages/types/src/__tests__/query-params-filter-union.test.ts
@@ -117,10 +117,11 @@ describe('QueryParams.$filter — declares the union it actually accepts (#3909)
   });
 
   it('still refuses a value that is neither shape', () => {
-    // The union documents; it must not have become `any` on the way. Note the
-    // slot sits on an interface that also carries `[key: string]: any` — these
-    // pins prove the declared property still wins over that index signature,
-    // which is the whole reason the declaration is worth anything.
+    // The union documents; it must not have become `any` on the way. When this
+    // was written the slot sat on an interface that also carried
+    // `[key: string]: any`, and these pins proved the declared property still
+    // won over that index signature; the signature is gone (objectui#7497 —
+    // see `query-params-closed-keys-7497.test.ts`), and the pins still hold.
     // @ts-expect-error a number is not a filter
     const bad: QueryParams = { $filter: 42 };
     // @ts-expect-error a string is not a filter

--- a/packages/types/src/data.ts
+++ b/packages/types/src/data.ts
@@ -39,6 +39,31 @@ export type { ExportJobStatus, ImportJobStatus, ImportWriteMode, ValidationError
 /**
  * Query parameters for data fetching.
  * Follows OData/REST conventions for universal compatibility.
+ *
+ * The key set is CLOSED: the nine `$`-prefixed members below are the whole
+ * contract. Every reader in this repository reads members of this set and
+ * nothing outside it — `convertQueryParams` and `rawFindWithPopulate`
+ * (`@object-ui/data-objectstack`), `queryParamsToRecord` (`@object-ui/core`'s
+ * `ApiDataSource`) and `ValueDataSource.find` — so a key outside the set
+ * reaches no branch and is dropped on the floor. The type refuses it instead
+ * (objectui#7497).
+ *
+ * Until objectui#7497 this interface also carried a `[key: string]: any`
+ * index signature described as "additional custom parameters". Nothing ever
+ * read one: a census of every `find` / `findOne` call site and every
+ * `QueryParams` literal across the packages, apps, examples, e2e and scripts
+ * trees found zero non-`$` keys, and every adapter above reads only declared
+ * members. What the signature DID do was make a misspelling compile —
+ * `{ filter }` for `$filter`, `{ limit }` for `$top`, `{ options: { $top } }`
+ * — and a published guide taught a test built on exactly that, which could
+ * never pass (objectui#4734, #5458, #7497). Declared = enforced: the type now
+ * says what the readers do, and `tsc` is the first gate a typo meets.
+ *
+ * ⛔ Do not reopen this with an index signature, a catch-all `extra` bag, or a
+ * `$`-prefixed template-literal key. No reader consumes such a key, so each of
+ * those is a declared-but-unenforced surface — the same defect in another
+ * spelling. A genuinely new query option is a named member here PLUS the
+ * branch in each reader that honours it, in the same change.
  */
 export interface QueryParams {
   /**
@@ -126,11 +151,6 @@ export interface QueryParams {
    * Total count of records (for pagination)
    */
   $count?: boolean;
-
-  /**
-   * Additional custom parameters
-   */
-  [key: string]: any;
 }
 
 /**


### PR DESCRIPTION
Fixes #7497

`QueryParams` (`packages/types/src/data.ts`) carried `[key: string]: any` while every reader in this repository copied exactly the nine declared `$`-prefixed members, so a misspelled key type-checked and was silently dropped. This PR removes the index signature: the key set is now closed and equal to what the readers honour. Clause-②: yes — a narrowing on a published contract; `needs:contract-review` stays on for the reviewable increment. (Attached 17:10:08Z; a later REST POST was idempotent. ⛔ An earlier note on this PR claimed the label had been stripped by the labeler — that was wrong and is retracted below.)

Session: `https://claude.ai/code/session_0114Ytxr5sM1vdW19Y9WAx6E` (os-dev seat; claim comment 5560603829 on the card). Base `7dcda9cd4`, head `ff27df82a`.

## Step 1 — census before the change (at base `7dcda9cd4`)

**Result: 0 consumers pass or read a non-`$` key through `QueryParams`.** Four instruments, each with a positive control:

1. **Literal level** — a purpose-built ESLint rule run over `packages`, `apps`, `examples`, `e2e`, `scripts` and `eslint-rules` (**4,362 files**). It reports every non-`$` static key at the top level of a `find()` second argument / `findOne()` third argument (skipping predicate-first `Array.prototype.find`), and of any literal annotated, asserted (`as`) or `satisfies`-checked as `QueryParams`. Control: a planted stdin file with `filter`, `includeDeleted`, `limit`, `populate` and a predicate `find` carrying `count` — the four keys reported, the predicate skipped (4/4). Real tree: **0 keys**. The 17 `...spread` sites it listed were read by hand: 15 are `...(cond ? { $expand | $orderby } : {})`, 1 spreads a `QueryParams` (`data-objectstack` `findOne`), 1 spreads a string-keyed record beside `$top` / `$skip` (`plugin-grid` `ObjectGrid.tsx:3610`) — see the probe below, it still passes.
2. **Reader level** — every non-`$` `params.KEY` read in the four readers (`convertQueryParams`, `rawFindWithPopulate`, `ApiDataSource.queryParamsToRecord`, `ValueDataSource.find`) plus `userState.ts`, `galleryDataSource.ts`, `mockDataSource.ts`, `useViewData.ts`, `LiveReportExporter.ts`, `recordReadability.ts`. Every hit is `aggregate()` reading `AggregateParams` (`field` / `function` / `groupBy` / `filter`) — a different type. `QueryParams` reads of an undeclared key: **0**. No `Object.keys` / `for-in` walk of a `QueryParams` anywhere.
3. **Prose and data** — markdown fences calling `find` with an unprefixed first key: 0 (control: the retired Pattern 7 line, 1/1). JSON `"params"` blocks opening with an unprefixed key: 0 (control 1/1). TS `params: {` blocks opening with an unprefixed key: 19, all action / navigation params, none a `QueryParams`.
4. **Zod mirror** — none in this repo. `ViewDataSchema` is re-exported from `@objectstack/spec` (17.2.0), whose `ViewData.params` is `z.record(z.string(), z.unknown())`; untouched, and a value of that shape still passes (probe line 6).

The card's three candidate shapes were weighed against that census: with zero readers of an extra key, a named `extra` bag or a `$`-prefixed template-literal key would each be a declared-but-unenforced surface (a `$limit` typo would still compile and drop). So the signature is closed, not replaced.

## What stops type-checking that type-checked before

Measured against both the source declaration and the rebuilt `dist/data.d.ts` (the `.d.ts` consumers resolve through `exports`), same six verdicts each time:

- `find('contacts', { filter: { active: true } })` — the published guide's Pattern 7 — TS2561 "did you mean `$filter`"
- `{ $top: 10, limit: 5 }` — the objectui#5458 shape — TS2353
- `{ options: { $top: 100 } }` — the objectui#4734 shape — TS2353
- `{ $limit: 5 }` — a `$`-prefixed key nothing reads — TS2353
- `{ top: 200 } satisfies QueryParams` — TS2561
- reading `params.filter` off a `QueryParams` value — TS2551 "did you mean `$filter`"

## What the runtime honours and is NOT refused

⚠️ **Three shapes this closure does not reach — named here because the card's defect is only partly closed and a reader should not assume otherwise.**

- **An object built elsewhere and passed by name** is excess-property-checked only if it shares *no* declared key. `const p = { $top: 10, limit: 5 }; find('x', p)` still compiles — TS's weak-type check fires only at zero shared keys (a pure typo object, `{ filter: … }`, is still caught as TS2559). `object-ui/no-unprefixed-query-params` reads **literal arguments only**, so it does not see this shape either. Six in-tree call sites pass a const by name today; all are `$`-only.
- **`<QueryParams>{ … }`** (angle-bracket assertion) compiles for the same reason `as QueryParams` does.
- **Values arriving as `Record<string, unknown>`** — the `ViewData.params` / SDUI JSON path — are not judged by this type at all.

⇒ What this PR closes is **hand-written TypeScript literals at typed sites**, which is where all three recorded incidents lived (the guide's Pattern 7, #5458's `limit: 0`, #4734's `options`). What rests on the lint rule is `as` / `<T>` assertions, and only for its closed name list in `find` / `findOne` argument position.


- every declared member, all nine together in one literal (probe line 26, and the new pin test)
- a `Record` keyed by string with `unknown` or `any` values passed as the params (probe lines 6 and 8) — the spec `ViewData.params` shape
- a spread of such a record beside `$top` / `$skip` (probe line 10 — the `ObjectGrid.tsx:3610` shape)
- `{ limit: 1 } as QueryParams` — a type assertion skips excess-property checking (probe line 20); this is why `object-ui/no-unprefixed-query-params` keeps its typed cases and stays load-bearing at write time

**Whole-repo verdict:** `turbo run type-check --continue --concurrency=2` at head — 81/81 tasks successful, 45 `type-check` tasks executed (cache miss), 0 `error TS` lines. Nothing in this repository newly fails to type-check; the census and the gate agree.

## Files changed (9)

- `packages/types/src/data.ts` — the index signature is removed; the interface doc states the closed contract, the census, and why it must not be reopened. `AggregateResult` (`:1264` to `:1265`) is untouched, per triage.
- `packages/types/src/__tests__/query-params-closed-keys-7497.test.ts` (new) — a `keyof` identity pin (goes red on ANY string index signature, including one typed `unknown`), `@ts-expect-error` pins for the guide / #5458 / #4734 / `$limit` spellings, a typed finder call, and the reader-side read; compiled by the package's `type-check` script (`tsc -p tsconfig.test.json`), so each refusal is enforced in both directions.
- Comment / message updates where the index signature was stated as fact — `eslint-rules/no-unprefixed-query-params.js` (header, scope note, cast note, and the user-facing message string), `eslint-rules/no-unprefixed-query-params.test.js`, `eslint-rules/no-query-params-under-options.js`, `packages/app-shell/src/views/ObjectView.tsx`, `packages/plugin-dashboard/src/DashboardFilterBar.tsx`, `packages/types/src/__tests__/query-params-filter-union.test.ts`. Non-comment changed lines: 0 in each, except the message string (2 lines) in the rule; its tests assert by `messageId`, and the one test asserting the message prefix is in the targeted run below.
- `.changeset/queryparams-closed-keys-7497.md` — `'@object-ui/types': minor`.

## Changeset grade: `minor`, not `patch`, not `major`

A narrowing of the accepted set of a published contract is breaking for any downstream caller that relied on the extra keys, so `patch` is wrong. This repo records its own breaking changes as `minor` with the break spelled out and reserves `major` for following `@objectstack` across a major (AGENTS.md, version alignment; `check-changeset-no-major` enforces it). The changeset body carries the census behind the grade and a migration note.

## Gates (exit codes captured before any pipe; all on the tree committed as `ff27df82a` — `git diff HEAD` is empty and no edit happened between the runs and the commit)

| gate | exit | evidence |
|---|---|---|
| `pnpm install` | 0 | Done in 5.5s |
| `turbo run build --filter '!@object-ui/site' --concurrency=2` (under the shared verify lock) | 0 | `Tasks: 43 successful, 43 total` |
| `turbo run type-check --continue --concurrency=2` (under the lock) | 0 | `Tasks: 81 successful, 81 total`; 45 type-check tasks executed; 0 `error TS` |
| `pnpm type-check:scripts` / `type-check:vitest-setup` / `type-check:vitest-config` | 0 / 0 / 0 | tsc silent |
| `pnpm exec vitest run` on the 6 runtime-reachable test files (under the lock) | 0 | `Test Files 6 passed (6)` / `Tests 130 passed (130)` |
| eslint via each package's own script on every changed file: `packages/types`, `app-shell`, `plugin-dashboard`; `eslint-rules/*` via the root config | 0 / 0 / 0 / 0 | 0 errors; warnings are pre-existing `no-explicit-any` |
| `check:doc-snippets` | 0 | 561 of 561 blocks judged, 0 failed |
| `check:skill-examples` | 0 | 13 of 13 ts fences, 70 json fences, 0 failed |
| `check-changeset-presence` / `check-changeset-fixed` / `check-changeset-no-major` | 0 / 0 / 0 | 4 source files of 3 released packages, 1 changeset declared |
| `check:control-bytes` + self-scan of the edited files | 0 / clean | 6,495 files scanned |
| reverse probe (source and dist) | 6 expected errors at the 6 planted lines, 0 at the 5 must-pass lines | tsc, `--strict` |

## Deviations, stated

- **The four `pnpm test --shard=N/4` were not run locally — declared narrowing.** The shared lock's ledger on this box puts one shard at 763 to 856 s (p50 of the recorded runs), past the ~600 s foreground cap, so a shard cannot complete in one call here. ⚠️ **The original evidence for this narrowing did not run.** It cited an esbuild comparison at "0 diff lines"; esbuild's postinstall is skipped in this container, so both sides of that comparison were the same `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "esbuild" not found` message — a zero that measured nothing. The premise is nonetheless **true**, re-measured at tier review with `ts.transpileModule` (the per-file emitter `tsc` and vitest share): `data.ts` emits **207 bytes → 207 bytes**, `export {};`, byte-identical, and `dist/data.js` matches. Five of the other files changed comment lines only (0 non-comment changed lines each, verified by token-stream diff), the rule's only non-comment change is its message string, and the new test file is the sixth. ⇒ **Moot in any case: CI shards 1–4 are green on `ff27df82a`.**
- Comment-only edits in five files outside the named `data.ts` surface: each stated the index signature as a present-tense fact, which this PR makes false. Listed above; 0 non-comment lines.
- `--concurrency=2` added to both turbo commands (shared box).

## Out of scope, filed separately

- `skills/objectui/guides/data-integration.md:74` still lists `[key: string]: any` on `QueryParams` with the comment "why an unprefixed `limit` type-checks — and is then dropped". Governed surface and the card excludes the guides; the fence is not `os:check`-marked so no gate goes red. Filed as a follow-up card, blocked by this one.
- `QueryParams.$count` is read by `ApiDataSource` only; both `ObjectStackDataSource` routes ignore it. Filed as a `finding`.

Not addressed here and still open by design: `$filter`'s own value type is #3909's axis; #6006 (guide taught unprefixed keys) stays closed.

⛔ Draft on purpose: not flipped ready, not enqueued, no auto-merge — the clause-② gate is the PM's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114Ytxr5sM1vdW19Y9WAx6E

---
_Generated by [Claude Code](https://claude.ai/code/session_0114Ytxr5sM1vdW19Y9WAx6E)_

---
_Generated by [Claude Code](https://claude.ai/code)_