### PR TITLE
docs(guide): make three drifted counts on ci-cd-pipeline.md self-maintaining

### DIFF
--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -778,9 +778,11 @@ the whole run to a checkout plus one `node` call. A registration whose key the d
 resolve **fails the gate** rather than being skipped: a key silently missing from the universe turns
 *correct* documentation red, which is the failure mode that gets gates deleted.
 
-**How a snippet is judged.** `type` is not one vocabulary in these pages — measured across 143 files
-and 558 literals, the corpus spells action schemas, block schemas, theme and report schemas, field
-and JSON-Schema data types, validation rules and navigation items all under the same key. A
+**How a snippet is judged.** `type` is not one vocabulary in these pages — measured across every
+`.md` and `.mdx` page under `content/docs`, a population the gate re-derives on every run and prints
+in its own verdict line beside the code-block and `type`-literal counts, the corpus spells action
+schemas, block schemas, theme and report schemas, field and JSON-Schema data types, validation rules
+and navigation items all under the same key — so that size is read off the run, never copied here. A
 structural discriminator was built and rejected on measurement (a TypeScript annotation reads exactly
 like an object key to a brace tracker, and `items` carries navigation entries on one page and
 renderable children on another, so any global rule is a silent false green somewhere). So the rule is
@@ -1079,9 +1081,10 @@ one that matches nothing. The verdict line therefore prints the **per-root popul
 fenced blocks for each of the five roots — rather than a bare `OK`, and the scan **fails when that
 population collapses**: a root that does not resolve, a root that walks to fewer documents than its
 floor, or a total fence count under the floor is a broken walk, not a clean tree. The document floors
-are **per root** and deliberately never a whole-surface total: on a day the four-file `.claude/skills`
-root reads zero, the other four still return 203 of today's 207 files, so a total floor stays green
-through the entire outage. A scan root that has
+are **per root** and deliberately never a whole-surface total: on a day the smallest root,
+`.claude/skills`, reads zero, the other four still return all but its handful of documents, so a
+total floor stays green through the entire outage — the relation is the argument, and each root's
+own population is printed on every run rather than copied here. A scan root that has
 moved or been mistyped is reported **by name**, because a mistyped root and a clean root produce
 identical output otherwise. The evidence that the gate works is the ablation in its test suite, which
 replants #5150's exact line in each root on a fixture tree.
@@ -1437,7 +1440,7 @@ remove. The validation is scoped to the surfaces the diff can move instead:
 |---|---|---|
 | `pnpm quick-reference:check` | `QUICK_REFERENCE.md` | ~1 s |
 | `pnpm check:control-bytes` | the 40 generated `CHANGELOG.md` | ~4 s |
-| `pnpm test scripts/__tests__` | 73 files / 1996 tests — every test that reads a manifest version, `QUICK_REFERENCE.md` or a `CHANGELOG.md` | ~50 s |
+| `pnpm test scripts/__tests__` | 112 test files / 3360 tests on `main@59a3a233d` — every test that reads a manifest version, `QUICK_REFERENCE.md` or a `CHANGELOG.md` | ~50 s |
 
 `check:spec-floors` and `check:published-dist` are deliberately **not** here: they read dependency
 ranges and built `dist/`, neither of which the version step moves, and `pnpm changeset:publish`


### PR DESCRIPTION
Fixes #7965

Three sentences on `content/docs/guide/ci-cd-pipeline.md` qualified a file/document population with a
copied numeral and no declared measurement point. Each numeral was re-taken from **that figure's own
gate verdict line** — never re-counted by hand — and each sentence was then rewritten so it stays
true as the tree moves, rather than being refreshed to today's number.

Base `59a3a233d` · head `6528b3fe4` · one file changed, 10 insertions / 7 deletions.

## The verdict lines these fixes rest on (verbatim, run on this branch)

`node scripts/check-doc-component-types.mjs` (exit 0):

```
Scanned 188 doc file(s) (.mdx + .md), 1105 code block(s), 889 `type` literal(s) against 658 registered key(s) derived from 143 source file(s) (240 resolved call site(s), 133 indirect, 2 open): 772 registered, 117 exempted; 4 key table(s), 24 row(s), 45 table key(s) judged (namespaced + bare), 45 registered.
✅  Every documented component type is registered.
```

`node scripts/check-shell-escape-residue.mjs` (exit 0):

```
✅  check-shell-escape-residue: OK (5/5 root(s) resolved -- AGENTS.md: 1 file(s), 15 fence(s); CLAUDE.md: 1 file(s), 0 fence(s); skills: 16 file(s), 210 fence(s); .claude/skills: 4 file(s), 20 fence(s); content/docs: 184 file(s), 1064 fence(s); 206 file(s) and 1309 fenced block(s) examined in total; 0 occurrence(s) outside a fence (counted, not judged); coverage -- .claude: 4/4; skills: 16/16 document(s) under a declared root).
```

`pnpm exec vitest run scripts/__tests__/` at head `6528b3fe4` (exit 0):

```
 Test Files  112 passed (112)
      Tests  3360 passed (3360)
   Duration  104.70s
```

**Difference from the card.** The card measured 206 files / 889 literals / 107 test files. Two of the
three still read the same today (206 total files with the four-file `.claude/skills` root inside it;
889 literals). The test population has moved again since the card was written: **112 test files and
3360 tests**, not 107. That movement inside one working day is itself the argument for not writing a
bare numeral here.

## The three sentences

### 1. `:782` — "measured across 143 files and 558 literals" → route (a), live reading

Before:

> **How a snippet is judged.** `type` is not one vocabulary in these pages — measured across 143 files
> and 558 literals, the corpus spells action schemas, block schemas, ...

After:

> **How a snippet is judged.** `type` is not one vocabulary in these pages — measured across every
> `.md` and `.mdx` page under `content/docs`, a population the gate re-derives on every run and prints
> in its own verdict line beside the code-block and `type`-literal counts, the corpus spells action
> schemas, ... — so that size is read off the run, never copied here.

**Why (a) and not (b).** The sentence's job is to say the corpus is large and mixed, not to state a
size, so the numeral was load-bearing for nothing — and the pairing was already wrong in a way a
refresh would have preserved: `143` is the gate's **source**-file count (the registry derivation),
while the literals come from the **doc** files it walks, which the same line reports as `188`. A
sentence reading "in these pages ... measured across 143 files" therefore pinned a doc-corpus claim
to a source-file count. Naming the population (`content/docs`, `.md` + `.mdx`) and pointing at the
verdict line removes both the drift and the mis-pairing. The trailing clause is deliberate: it tells
the next reader why there is no number here, so the sentence is not "repaired" back into one.

### 2. `:1083` — "the other four still return 203 of today's 207 files" → route (a), relation restated

Before:

> The document floors are **per root** and deliberately never a whole-surface total: on a day the
> four-file `.claude/skills` root reads zero, the other four still return 203 of today's 207 files, so
> a total floor stays green through the entire outage.

After:

> The document floors are **per root** and deliberately never a whole-surface total: on a day the
> smallest root, `.claude/skills`, reads zero, the other four still return all but its handful of
> documents, so a total floor stays green through the entire outage — the relation is the argument,
> and each root's own population is printed on every run rather than copied here.

**Why (a).** This paragraph's point is a RELATION — a per-root floor survives one root reading zero, a
total floor does not — and `203 of 207` was only an illustration of it. Restating the relation makes
the argument independent of any count, and the gate already prints the per-root census (`AGENTS.md: 1
file(s) ...; .claude/skills: 4 file(s) ...`) on every run, so a reader who wants the sizes gets
today's, not a copy. A measurement point (route b) would have worked here too but reads worse: it
would have anchored two numerals in a sentence whose whole force is that the numerals do not matter.

### 3. `:1440` — "73 files / 1996 tests" → route (b), declared measurement point

Before:

> \| `pnpm test scripts/__tests__` \| 73 files / 1996 tests — every test that reads a manifest version, `QUICK_REFERENCE.md` or a `CHANGELOG.md` \| ~50 s \|

After:

> \| `pnpm test scripts/__tests__` \| 112 test files / 3360 tests on `main@59a3a233d` — every test that reads a manifest version, `QUICK_REFERENCE.md` or a `CHANGELOG.md` \| ~50 s \|

**Why (b).** In a narrow table cell the route-(a) phrasing ("the run prints its own totals") displaces
the cell's actual job, which is to say what the command covers and roughly how big it is. A declared
measurement point keeps the sizing and makes the sentence permanently true, exactly the way `:576`'s
`Measured on main@6422aa891` does two sections up.

**Subject kept accurate.** This is a TEST-file population, not a document population. The cell now
says **"112 test files"**, not "112 files", so nobody reads it as a docs count later.

**What happened to the `~50 s` cell.** Nothing — it is untouched. It is a duration, not a count, and
only the middle cell was rewritten. Recorded for the reviewer: the two runs on this branch took
116.6 s and 104.7 s, but that is a shared container running several agents in parallel, so it is not a
measurement comparable with whatever produced the `~` figure. Changing it on this evidence would be a
guess, which is the failure mode this card exists to stop.

## The two correct neighbours did not move

Both declare the tree they measured, so both are still true and neither is a defect:

- `:576` — ``Measured on `main@6422aa891`: 18 guide files, 91 candidate spans ...``
- `:1658` — ``Across all 5281 first-parent commits on `main` ...``

Proof, and it is mechanical rather than a promise — the diff has exactly three hunks and none of their
ranges contains either line:

```
$ git diff -U0 59a3a233d..6528b3fe4 -- content/docs/guide/ci-cd-pipeline.md | grep '^@@'
@@ -781,3 +781,5 @@
@@ -1082,3 +1084,4 @@
@@ -1440 +1443 @@
```

Line 576 is untouched at 576; the neighbour formerly at 1658 is byte-identical and now sits at 1661,
shifted only by the three lines the second hunk added. Both were compared against
`59a3a233d:content/docs/guide/ci-cd-pipeline.md` directly and match.

## No gate, no pin, no new scan population

One file changed. No gate script, no workflow, no test, no other page, nothing under `packages/`. The
coverage-expansion work that would make this class fail loudly on `content/docs` is objectui#7966's
family and is deliberately not started here.

## Gates (all at head `6528b3fe4`, exit codes captured by redirect-then-capture)

| Gate | Exit | Verdict |
|---|---|---|
| `pnpm exec vitest run scripts/__tests__/ci-cd-pipeline-doc.test.ts` (before and after) | 0 | `Test Files 1 passed (1)` · `Tests 44 passed (44)` — the page's pins stay green, none of them reads one of the three sentences |
| `pnpm exec vitest run scripts/__tests__/` | 0 | `Test Files 112 passed (112)` · `Tests 3360 passed (3360)` |
| `node scripts/check-doc-component-types.mjs` / `pnpm check:doc-types` | 0 | `✅ Every documented component type is registered.` |
| `node scripts/check-shell-escape-residue.mjs` | 0 | `✅ check-shell-escape-residue: OK (5/5 root(s) resolved ...)` |
| `pnpm check:doc-fences` | 0 | `✅ check:doc-fences — every TypeScript block in 227 document(s) is fenced ts/tsx/typescript ...` |
| `pnpm check:doc-snippets` | 0 | `Semantic phase: 561 of 561 block(s) judged, 0 failed.` (after the scoped build the gate itself prescribes — `turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter) --concurrency=2`, 34/34 tasks successful) |
| `node scripts/check-doc-links.mjs` | 0 | `Links are valid across 17 scan roots.` |
| `node scripts/check-doc-expression-carriage.mjs` | 0 | census, report-only |
| `node scripts/check-docs-route-eager-closure.mjs` | 0 | clean |
| `node scripts/check-skills-paths.mjs` | 0 | `skills/ — 28/28 resolve across 16 file(s)` |
| `node scripts/check-bash32-floor.mjs` | 0 | `✓ check-bash32-floor: 12 tracked shell file(s) ...` |
| `pnpm check:control-bytes` | 0 | `✅ check-control-bytes: OK (scanned 6495 tracked text file(s); skipped 85 binary).` |
| `grep -naP` control-byte self-scan of the changed path | 1 (no match) | no control byte in the edited file |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅ No source or published contract of a released package changed in this range, so no changeset is owed.` — so no changeset is added |
| `node scripts/check-governed-queue-guard.mjs --test content/docs/guide/ci-cd-pipeline.md` | 0 | `✅ NOT GOVERNED — 1 path(s) checked against 5 governed surface(s); none matched.` |

The gate list was re-derived against the actual diff rather than taken from the dispatch: every
script under `scripts/` that reads `content/docs` was enumerated and run, which is where the last
four doc gates in the table came from.

`Live E2E (informational)` is red on every branch today for an upstream reason unrelated to this
change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_