### PR TITLE
test(app-shell): pin that object-declared toolbar actions reach the DOM (objectui#7234)

### DIFF
--- a/.changeset/tidy-pans-repeat.md
+++ b/.changeset/tidy-pans-repeat.md
@@ -1,0 +1,8 @@
+---
+---
+
+Tests only (objectui#7234): pin that an object-declared `list_toolbar` action
+reaches the DOM from the served `/meta/object` payload, and that ADR-0066 D4's
+`requiredPermissions` capability gate — not the relay — is what hides a
+declared-but-ungranted action at every location. No runtime behaviour changes,
+so nothing is released.

--- a/packages/app-shell/src/views/ObjectView.objectBoundActions-7234.test.tsx
+++ b/packages/app-shell/src/views/ObjectView.objectBoundActions-7234.test.tsx
@@ -1,0 +1,337 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7234 — an object-declared action DOES reach the toolbar, and the
+ * thing that hides it is the capability gate, not the relay.
+ *
+ * ## What the card predicted, and what was measured
+ *
+ * #7234 reports that an action declared on `objectDef.actions[]` with valid
+ * `locations` renders at NO location, although the API serves the complete
+ * declaration — and points at the relay, on the shape of objectui#7199 (a
+ * per-view `description` served but never copied onto the ListView schema).
+ * The `(objectDef as any)?.actions` cast at the `rowActionDefs` rung reads like
+ * more of the same: a renderer casting its own object to reach a key.
+ *
+ * Measured on this tree, the relay is NOT the discard point. Case E below
+ * answers the card's exact wire payload from the client the provider actually
+ * calls (`meta.getItems('object')`) and walks it through `MetadataProvider`'s
+ * own `objects` getter — `extractItems` → `normalizeSchemaReferenceKeys` →
+ * `mergeViewsIntoObjects` → `attachInlineSubforms` — into this component's
+ * props. The button is in the DOM at the end of it. No hand-built `objects`
+ * array is involved in that case, which is what makes it evidence about the
+ * chain rather than about the fixture.
+ *
+ * ## What actually hides it: ADR-0066 D4, `requiredPermissions`
+ *
+ * `action:bar` filters its own set through `useCapabilityGate` before
+ * `actionRendersAt` ever runs, and so do the other two surfaces this card names
+ * (`page:header` for `record_header` / `record_more`, the grid's row menu for
+ * `list_item`) — one shared hook exactly so the three cannot drift apart. An
+ * action declaring a capability the viewer does not hold is filtered out, at
+ * every location at once, with no error and no 4xx. That is the reported
+ * symptom, and it is this gate rather than a dropped key.
+ *
+ * The gate fails OPEN on unknown (`systemPermissions` absent → the action
+ * shows) and CLOSED on a known array that lacks the capability — including the
+ * empty array, which means "holds nothing", not "unknown". Cases F/G/H pin all
+ * three readings, and F↔G are one differential: same payload, same code path,
+ * only the held set differs.
+ *
+ * ⚠️ This file therefore pins CURRENT, DELIBERATE behaviour. It is not a fix
+ * for #7234 and does not claim one. Whether a declared-but-ungranted action
+ * should stay silently invisible — or be surfaced some other way, since today
+ * nothing anywhere tells an author why their button is missing — is the open
+ * question left on the card.
+ *
+ * ## Reverse verification — direction predicted before running
+ *
+ * Predicted, then observed (measurements recorded on the PR):
+ *   • Deleting the `list_toolbar` gate's `objectDef.actions` read in
+ *     `ObjectView.tsx` turns every presence case RED (A, D, E, G, I) and
+ *     leaves every absence case GREEN (B, C, F, H) — an absence case asserts
+ *     absence, which a deleted renderer supplies for the wrong reason. That
+ *     asymmetry is why the presence cases carry the claim and the absence
+ *     cases are only controls. Measured: 5 failed / 4 passed.
+ *   • Making `useCapabilityGate` return `() => true` turns F and H RED and
+ *     leaves every other case GREEN, which is what holds the two mechanisms
+ *     apart: one ablation cannot redden both sets. Measured: 2 failed /
+ *     7 passed.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+/**
+ * The capabilities the host reports for the signed-in principal, per case.
+ * `undefined` is the "host never supplied them" reading the gate fails open on.
+ */
+let heldCapabilities: string[] | undefined;
+
+vi.mock('@object-ui/permissions', () => ({
+  usePermissions: () => ({
+    systemPermissions: heldCapabilities,
+    check: () => ({ allowed: true }),
+    checkField: () => true,
+    getFieldPermissions: () => [],
+    getRowFilter: () => undefined,
+    getObjectApiOperations: () => undefined,
+    roles: [],
+    isLoaded: true,
+    hasCapabilities: () => true,
+    can: () => true,
+    cannot: () => false,
+  }),
+  useFieldPermissions: () => ({ canRead: () => true, canWrite: () => true, permissions: [] }),
+}));
+
+vi.mock('@object-ui/auth', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAuth: () => ({ user: { id: 'u1', name: 'Ada' }, activeOrganization: null }),
+  useWorkspaceAdminStatus: () => ({ isAdmin: false, isResolved: true }),
+  createAuthenticatedFetch: () => vi.fn(),
+}));
+
+vi.mock('@object-ui/collaboration', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useRealtimeSubscription: () => ({ lastMessage: null }),
+  useConflictResolution: () => ({ hasConflicts: false, resolveAllConflicts: () => {} }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}));
+
+// Heavy children: orthogonal to the toolbar under test, and each drags in a
+// plugin bundle. Same posture as the sibling predicate suites in this dir.
+vi.mock('@object-ui/plugin-list', () => ({ ListView: () => null }));
+vi.mock('@object-ui/plugin-view', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ObjectView: () => null,
+  ViewTabBar: () => null,
+  ManageViewsDialog: () => null,
+}));
+vi.mock('./MetadataInspector', () => ({
+  MetadataPanel: () => null,
+  useMetadataInspector: () => ({ showDebug: false, toggle: () => {} }),
+}));
+vi.mock('./RecordDetailView', () => ({ RecordDetailView: () => null }));
+
+import { ObjectView } from './ObjectView';
+import { ExpressionProvider } from '../providers/ExpressionProvider';
+import { MetadataProvider, useMetadata } from '../providers/MetadataProvider';
+
+const OBJECT_NAME = 'duly_catalog_item';
+
+/**
+ * The card's served payload, verbatim: one valid location, and NO `visible`
+ * predicate — the reporter's sharpest case, since it removes the predicate
+ * layer from the explanation entirely.
+ */
+const APPLY_TO_PEOPLE = {
+  name: 'duly_catalog_apply_to_people',
+  objectName: OBJECT_NAME,
+  type: 'script',
+  label: 'Apply to people',
+  locations: ['list_toolbar'],
+};
+
+/** The same declaration as the app that found this ships it: capability-gated. */
+const APPLY_TO_PEOPLE_GATED = {
+  ...APPLY_TO_PEOPLE,
+  requiredPermissions: ['duly.catalog.apply'],
+};
+
+function objectsWithActions(actions: unknown) {
+  return [
+    {
+      name: OBJECT_NAME,
+      label: 'Catalog item',
+      fields: {
+        id: { type: 'text', label: 'Id' },
+        name: { type: 'text', label: 'Name' },
+      },
+      ...(actions === undefined ? {} : { actions }),
+    },
+  ];
+}
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async () => ({ data: [], total: 0 })),
+    findOne: vi.fn(async () => null),
+    create: vi.fn(async () => ({})),
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+  } as any;
+}
+
+const USER = { id: 'u1', name: 'Ada', profile: 'admin' };
+
+function renderList(objects: any[]) {
+  return render(
+    <ExpressionProvider user={USER}>
+      <MemoryRouter initialEntries={[`/apps/demo/${OBJECT_NAME}`]}>
+        <Routes>
+          <Route
+            path="/apps/:appName/:objectName"
+            element={<ObjectView dataSource={makeDataSource()} objects={objects} onEdit={() => {}} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </ExpressionProvider>,
+  );
+}
+
+/** The reporter's URL shape — the object's named list view, not the bare list. */
+function renderListAtView(objects: any[]) {
+  return render(
+    <ExpressionProvider user={USER}>
+      <MemoryRouter initialEntries={[`/apps/demo/${OBJECT_NAME}/view/list`]}>
+        <Routes>
+          <Route
+            path="/apps/:appName/:objectName/view/:viewId"
+            element={<ObjectView dataSource={makeDataSource()} objects={objects} onEdit={() => {}} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </ExpressionProvider>,
+  );
+}
+
+const toolbarButton = () => screen.queryByRole('button', { name: /Apply to people/ });
+
+/** Absence is only meaningful after the render has had a chance to settle. */
+async function settle() {
+  await new Promise((resolve) => setTimeout(resolve, 80));
+}
+
+describe('objectui#7234 — object-declared actions reach the list toolbar', () => {
+  beforeEach(() => {
+    heldCapabilities = undefined;
+    vi.clearAllMocks();
+  });
+  afterEach(() => cleanup());
+
+  it('A: draws the button when the objectDef carries the action', async () => {
+    renderList(objectsWithActions([APPLY_TO_PEOPLE]));
+    await waitFor(() => expect(toolbarButton()).toBeTruthy());
+  });
+
+  it('B (control): nothing is drawn when the object declares no actions', async () => {
+    renderList(objectsWithActions(undefined));
+    await settle();
+    expect(toolbarButton()).toBeNull();
+  });
+
+  it('C (control): the same action at record_header only is not on this toolbar', async () => {
+    renderList(objectsWithActions([{ ...APPLY_TO_PEOPLE, locations: ['record_header'] }]));
+    await settle();
+    expect(toolbarButton()).toBeNull();
+  });
+
+  it('D: draws it on the /view/:viewId route with a declared list view', async () => {
+    const objects = objectsWithActions([APPLY_TO_PEOPLE]);
+    (objects[0] as any).listViews = {
+      list: { name: 'list', label: 'All items', type: 'grid', columns: ['name'] },
+    };
+    renderListAtView(objects);
+    await waitFor(() => expect(toolbarButton()).toBeTruthy());
+  });
+
+  it('E: END TO END — the served /meta/object payload reaches the DOM', async () => {
+    // The client the provider actually calls, answering the card's payload.
+    // Nothing here hand-builds the `objects` array: it is whatever
+    // MetadataProvider's own getter produces from this response.
+    const adapter = {
+      clearCache: vi.fn(),
+      getClient: () => ({
+        meta: {
+          getItems: (type: string) =>
+            Promise.resolve({
+              type,
+              items:
+                type === 'object'
+                  ? [
+                      {
+                        name: OBJECT_NAME,
+                        label: 'Catalog item',
+                        fields: { id: { type: 'text' }, name: { type: 'text' } },
+                        actions: [APPLY_TO_PEOPLE],
+                      },
+                    ]
+                  : [],
+            }),
+          getItem: () => Promise.resolve({ item: null }),
+        },
+      }),
+    } as any;
+
+    function Host() {
+      const { objects } = useMetadata();
+      if (!objects.length) return null;
+      return <ObjectView dataSource={makeDataSource()} objects={objects} onEdit={() => {}} />;
+    }
+
+    render(
+      <MetadataProvider adapter={adapter}>
+        <ExpressionProvider user={USER}>
+          <MemoryRouter initialEntries={[`/apps/demo/${OBJECT_NAME}`]}>
+            <Routes>
+              <Route path="/apps/:appName/:objectName" element={<Host />} />
+            </Routes>
+          </MemoryRouter>
+        </ExpressionProvider>
+      </MetadataProvider>,
+    );
+
+    await waitFor(() => expect(toolbarButton()).toBeTruthy(), { timeout: 3000 });
+  });
+
+  // ── ADR-0066 D4: the gate that actually hides the app's actions ──────────
+  //
+  // F and G are ONE differential: identical payload, identical code path, only
+  // the held capability set differs. That is what identifies the gate as the
+  // cause rather than as a coincidence of the fixture.
+
+  it('F: a gated action is hidden from a viewer holding a different capability', async () => {
+    heldCapabilities = ['duly.task.update_status'];
+    renderList(objectsWithActions([APPLY_TO_PEOPLE_GATED]));
+    await settle();
+    expect(toolbarButton()).toBeNull();
+  });
+
+  it('G: the SAME payload is drawn once the viewer holds that capability', async () => {
+    heldCapabilities = ['duly.catalog.apply'];
+    renderList(objectsWithActions([APPLY_TO_PEOPLE_GATED]));
+    await waitFor(() => expect(toolbarButton()).toBeTruthy());
+  });
+
+  it('H: an empty held set is "holds nothing", not "unknown" — still hidden', async () => {
+    heldCapabilities = [];
+    renderList(objectsWithActions([APPLY_TO_PEOPLE_GATED]));
+    await settle();
+    expect(toolbarButton()).toBeNull();
+  });
+
+  it('I: unknown held set fails OPEN — the gated action is drawn', async () => {
+    heldCapabilities = undefined;
+    renderList(objectsWithActions([APPLY_TO_PEOPLE_GATED]));
+    await waitFor(() => expect(toolbarButton()).toBeTruthy());
+  });
+});


### PR DESCRIPTION
Part of #7234 — and deliberately **not** `Fixes`. This PR changes no runtime
behaviour: it records what was measured, because the card's premise did not
survive measurement. #7234 must stay open for re-triage; see "What is left" below.

## The card's premise is falsified

#7234 says an object-bound action "renders nowhere although the Console has
already fetched the complete declaration", and points at the relay — on the
shape of #7199, and on the `(objectDef as any)?.actions` cast at the
`rowActionDefs` rung, which reads like a key that is not on the declared type.

Measured on `origin/main` (`59a3a233d`): **the relay carries `actions` and the
button is drawn.** Case E in the new file answers the card's exact wire payload
from the client the provider actually calls (`meta.getItems('object')`) and lets
`MetadataProvider`'s own `objects` getter carry it — `extractItems` →
`normalizeSchemaReferenceKeys` → `mergeViewsIntoObjects` → `attachInlineSubforms`
— into `ObjectView`'s props. The control is in the DOM at the end of it. No
hand-built `objects` array is involved in that case, which is what makes it
evidence about the chain rather than about the fixture.

Two notes on the starting evidence, since both were reasonable and both were wrong:

* The `as any` cast is **noise, not a signal**. `ObjectView`'s props are
  annotated `any` (`function ObjectView({ dataSource, objects, … }: any)`), so
  `objectDef` is already `any` and the cast narrows nothing. Two of the three
  reads of the key on that component (`:1216`, `:2707`) have no cast at all.
* `packages/core/src/utils/normalize-list-view.ts` was correctly ruled out by
  triage, and so is every other rung in the chain above.

## What actually hides them: ADR-0066 D4, `requiredPermissions`

`action:bar` filters its own set through `useCapabilityGate` **before**
`actionRendersAt` runs, and so do the two other surfaces the card names
(`page:header` for `record_header`/`record_more`, the grid's row menu for
`list_item`) — one shared hook precisely so the three cannot drift apart. An
action declaring a capability the viewer does not hold is filtered out at every
location at once, with no error and no 4xx.

Every object-bound action in the app that found this declares one:

| action | capability | source |
|:--|:--|:--|
| `duly_catalog_apply_to_people` | `duly.catalog.apply` | inherited through the `...CatalogApplyAction` spread |
| `duly_task_complete` / `_undo` / `_skip` | `duly.task.update_status` | declared directly |

…and the app's own deployment guide says the sets that grant them are **not**
bound on a fresh install: *"a fresh install boots with three positions, three
permission sets and zero bindings, and every persona is denied until someone
does this"*, with `requiredPermissions` described as *"403 on the platform action
route and the MCP bridge, **mirrored as a UI hide**"*. A silent hide on a
capability nobody has been granted yet is the documented behaviour, and it
reproduces every measurement on the card: the payload is complete, the action
has no `visible` predicate, there are zero page errors and zero 4xx, all four
locations are dead at once, and the reporter's control still works — a
view-declared `bulkActionDefs` entry declares no capability, so it is never
gated.

Related and already settled, so not re-litigated here: #4656 made an *absent*
`systemPermissions` stay `undefined` (fail OPEN) instead of collapsing to `[]`.
Case I pins that reading; it is not what is happening in the report.

## What this PR adds

One test file, nine cases, no source change:

* **A, D, E, G, I** — presence. A (bare list route), D (the reporter's
  `/view/:viewId` URL), E (end to end from the served payload), G (gated action,
  viewer holds the capability), I (gate fails open on unknown).
* **B, C, F, H** — absence controls. B (no actions declared), C (same action at
  `record_header` only), F (gated, viewer holds a *different* capability), H
  (gated, viewer holds the empty set).

F↔G are one differential: identical payload, identical code path, only the held
set differs — which is what identifies the gate as the cause rather than as a
coincidence of the fixture.

## Reverse verification — direction predicted before running

| ablation | predicted | measured |
|:--|:--|:--|
| replace the `list_toolbar` gate's `objectDef.actions` read with `false` | every presence case red, every absence case green | **5 failed / 4 passed** — A, D, E, G, I red; B, C, F, H green |
| `useCapabilityGate` → `() => true` | F and H red, everything else green | **2 failed / 7 passed** — F, H red |

No single ablation reddens both sets, which is what holds the two mechanisms
apart. Both were run from the committed state and restored with
`git checkout HEAD -- <path>`, verified by an empty `git diff HEAD`. One
correction made in the open: the docblock's first prediction originally
enumerated "A, D, E and G" and omitted case I, which is also a presence case —
the enumeration was fixed to match the rule it states, not the other way round.

## Gates

| gate | result |
|:--|:--|
| `pnpm --filter @object-ui/app-shell test` (full suite) | **635 files, 6108 passed, 1 skipped, 0 failed**, exit 0 |
| `pnpm --filter @object-ui/app-shell type-check` | exit 0 |
| `pnpm lint` (repo-wide) | exit 0 — 0 errors, 2905 pre-existing warnings |
| `check:control-bytes` · `check:action-forward-parity` · `check:handler-key-reads` · `check:phantom-deps` · `check:published-tsconfig-exclude` · `check:published-dist` | all exit 0 |
| `check-changeset-presence` · `check-changeset-no-major` | exit 0 |

The new file is inside the type-checked set — `tsc -p tsconfig.test.json
--listFiles` matches it — so that is measured rather than assumed.

Changeset has **empty frontmatter**: tests only, nothing released. `skip-changeset`
is inert in this repo and was not applied.

## What is left, and why this is not a fix

The card's sharpest sentence survives its own diagnosis: *"the button does not
exist and nothing anywhere says so."* That remains true — it is just that the
silence comes from a deliberate capability hide rather than from a dropped key.
Whether a declared-but-ungranted action should stay invisible, or say something
to an admin or author, is a product decision on the `requiredPermissions`
contract and is **not** taken here. It is written up on the issue as the open
question, together with the one thing this run could not measure from here:
whether a platform admin whom the *server* would authorise can be hidden by the
client's stricter courtesy gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_