### PR TITLE
docs(guide): annotate objectos-integration's object-grid literal as ObjectGridSchema

### DIFF
--- a/content/docs/guide/objectos-integration.mdx
+++ b/content/docs/guide/objectos-integration.mdx
@@ -266,13 +266,14 @@ const sysUserView: ObjectViewSchema = {
 
 ```typescript
 import { ObjectStackAdapter } from '@object-ui/data-objectstack';
+import type { ObjectGridSchema } from '@object-ui/types';
 
 const dataSource = new ObjectStackAdapter({
   baseUrl: 'http://localhost:3000/api'
 });
 
 // ObjectQL queries are automatically handled
-const schema = {
+const schema: ObjectGridSchema = {
   type: 'object-grid',
   objectName: 'contact',
   dataSource,


### PR DESCRIPTION
Fixes #7972

`content/docs/guide/objectos-integration.mdx` declared its `object-grid` example as a bare `const schema = {`, so `check:doc-snippets` compiled the block against nothing: no declared type, therefore `ObjectGridSchema` was never consulted. objectui#7713 was exactly a wrong-shaped `filter` on this very block, and the gate was green on it for the whole interval.

## The diff — one page, two lines

````diff
 ```typescript
 import { ObjectStackAdapter } from '@object-ui/data-objectstack';
+import type { ObjectGridSchema } from '@object-ui/types';
 
 const dataSource = new ObjectStackAdapter({
   baseUrl: 'http://localhost:3000/api'
 });
 
 // ObjectQL queries are automatically handled
-const schema = {
+const schema: ObjectGridSchema = {
   type: 'object-grid',
   objectName: 'contact',
   dataSource,
````

That is the whole change: the type import joins the block's existing import group, and the literal is annotated. Nothing else in the block moves. It is the shape `packages/plugin-grid/README.md` already uses for its two `object-grid` examples (`const schema: ObjectGridSchema = {`).

## ⚠️ The honest ceiling — read this before quoting the change

`BaseSchema` ends with an index signature that maps any string key to `any` (measured by objectui#7927). ⛔ So this annotation does **not** catch a **misspelled** key on the example, and this PR must not be read as "the example's keys are now guarded". What the annotation catches is **a key whose declared TYPE is wrong** — which is the entire content of objectui#7713. That distinction is the point of the card; blurring it would leave the next reader believing the doc examples are held tighter than they are.

## Both controls, re-taken on this commit (`cb82bdb31`)

Each control ran under a `trap` with absolute paths; the mutation is proven on disk by anchor counts plus a `git hash-object` blob that differs from the `HEAD` blob, and the restore is proven by the blob equalling the `HEAD` blob and `git diff HEAD` being empty. Full logs are in the run's scratchpad.

**Control 1 — the block IS compiled** (so the old green was not "uncovered"). Injected `dataSource: zzzUndefinedIdent,` into the block:

```
HEAD_BLOB=8a1ce94a4e61a393e027af7de5b619c499cd22d6
anchor '  dataSource,'   page-wide 4 -> 3   (the block's one consumed)
anchor 'zzzUndefinedIdent'          0 -> 1
MUTATED_BLOB=c53faf4d0ea704c6f1651316915c5c39193d71b9   MUTATION PROVEN ON DISK
CONTROL1_GATE_EXIT=1
  [semantic]  content/docs/guide/objectos-integration.mdx:279:15  TS2304: Cannot find name 'zzzUndefinedIdent'.
Semantic phase: 567 of 567 block(s) judged, 1 failed.
RESTORED_BLOB=8a1ce94a4e61a393e027af7de5b619c499cd22d6   RESTORE PROVEN: blob == HEAD, git diff HEAD empty
```

**Control 2 — the annotation is load-bearing.** With the annotation committed, the `filter` value was reverted to the pre-objectui#7713 `and:`-keyed object (the exact seven lines PR objectui#7973 removed), leaving everything else in place:

```
HEAD_BLOB=8a1ce94a4e61a393e027af7de5b619c499cd22d6
anchor "operator: 'greater_than_or_equal'"  1 -> 0
anchor '    and: ['                         0 -> 1
MUTATED_BLOB=61ec5899cb5e37e4befb0feca3fa423fde46928f   MUTATION PROVEN ON DISK
annotation still in place: :276 const schema: ObjectGridSchema = {   :269 import type { ObjectGridSchema }
CONTROL2_GATE_EXIT=1
  [semantic]  content/docs/guide/objectos-integration.mdx:282:5  TS2353: Object literal may only specify known properties, and 'and' does not exist in type 'any[]'.
diagnostic count: 1
Semantic phase: 567 of 567 block(s) judged, 1 failed.
RESTORED_BLOB=8a1ce94a4e61a393e027af7de5b619c499cd22d6   RESTORE PROVEN: blob == HEAD, git diff HEAD empty
```

Exactly one diagnostic, on this page, naming the wrongly typed key — the same reading the card reported, reproduced on the post-objectui#7973 tree. That single line is the whole value of the change: the difference between a gate that reads the declared type and one that reads nothing.

The card's second claim also re-measures clean: with the annotation and the canonical array `filter` in place the gate is green, so `dataSource`, `objectName`, `filter` and `sort` are all already assignable and the annotation costs nothing today. `ObjectGridSchema.filter` is declared `any[]` (`packages/types/src/objectql.ts:679`), which is what makes the array form assignable and the `and:`-keyed object not.

## Gates (all pinned to `cb82bdb31`)

| gate | exit | verdict line |
| --- | --- | --- |
| `pnpm check:doc-snippets` | 0 | `Semantic phase: 567 of 567 block(s) judged, 0 failed.` · `Root bound: no block imports a specifier that resolves only through this repository's ROOT manifest.` · control `resolution   Module name '@object-ui/types' was successfully resolved to '.../objectui-issue-7972/packages/types/dist/index.d.ts'` |
| `pnpm check:doc-fences` | 0 | every TypeScript block in 227 document(s) is fenced ts/tsx/typescript |
| `pnpm check:doc-types` | 0 | Every documented component type is registered |
| `node scripts/check-doc-links.mjs` | 0 | Links are valid across 17 scan roots |
| `node scripts/check-doc-expression-carriage.mjs` | 0 | report-only census, unchanged by this diff |
| `pnpm check:control-bytes` | 0 | scanned 6497 tracked text file(s) |
| `node scripts/check-changeset-presence.mjs` | 0 | no changeset owed — 1 file changed, 0 published source |
| `node scripts/check-governed-queue-guard.mjs --test content/docs/guide/objectos-integration.mdx` | 0 | `NOT GOVERNED` — ordinary review and merge-queue route |

The snippet gate's closure was built first with its own `--build-filter` (34 turbo tasks, all cache hits), and the gate's `resolution` control confirms it typed against this worktree's `packages/types/dist`.

A direct `grep -naP` self-scan of the changed path for control bytes found none. `npx eslint --print-config` on the changed path prints `undefined`, i.e. eslint's own config resolution gives `.mdx` no configuration, so the repo-wide lint has no receiving population for this diff. No reader test names the page: `git grep -l objectos-integration` over `scripts/__tests__` and `packages` is empty; the only script that names it is `scripts/check-doc-component-types.mjs`'s exemption ledger, which is run above and green.

`Live E2E (informational)` is red on every branch today for an upstream reason (objectui#7990 / objectstack#16186), unrelated to this diff.

## Population re-count (requested by the dispatch, so the seat can decide on a census)

Counted with the triage comment's spelling, `git grep` over `content/docs`:

| | base `083343dff` | this head `cb82bdb31` |
| --- | --- | --- |
| bare `const schema = {` | 29 across 14 pages | 28 across 13 pages |
| annotated `const schema: ` | 22 across 9 pages | 23 across 10 pages |

Triage measured 30 across 15 / 21 across 9 at 05:26Z. The difference from that reading is accounted for: objectui#7778's sweep landed as PR objectui#8040 (`docs(plugin-gantt): annotate the four bare object-gantt literals`), moving `plugin-gantt.mdx` from the bare side to the annotated side. So the population is not growing between those two readings — one page was cleared, and this PR clears a second. 28 bare literals across 13 pages remain unswept; whether that becomes a census card is the scheduling seat's call, not this PR's.

⛔ Scope held to this one page: no other page is annotated here, no gate, no pin, no new scan population, nothing under `scripts/` or `packages/**`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_