### PR TITLE
ci: bound the six uncached jobs — four ceilings derived per job, two 360s accepted on the record

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,6 +25,48 @@ permissions:
 jobs:
   changelog:
     runs-on: ubuntu-latest
+
+    # ── NO job ceiling, and that is the DECISION, not its absence (objectui#7956) ──
+    # This job runs under GitHub's 360-minute default. objectui#7956 asked for a
+    # ceiling DERIVED from this job's own measured run-time distribution, in the
+    # shape objectui#7270 left beside `lint.yml::lint`. It is recorded here
+    # instead, because this job has no distribution to derive one from.
+    #
+    #   - Population: every run of this workflow, no status filter, whole
+    #     retained history — `GET /actions/workflows/changelog.yml/runs` reports
+    #     `total_count: 0`. Re-measured 2026-09-06T17:22Z.
+    #   - Control, so that zero is a reading rather than a broken query: the
+    #     identical call against `changeset-release.yml` reports a `total_count`
+    #     of 5010 completed runs. The endpoint answers; this workflow has never
+    #     produced a run for it to answer with.
+    #   - The header above already recorded this same zero once, measured before
+    #     2026-08-23 against the same endpoint while removing the dead `release`
+    #     trigger. It has not moved: this workflow is dispatch-only, and it has
+    #     never been dispatched.
+    #
+    # ⛔ Do NOT put a number here derived from another job, from the apparent
+    # cost of a checkout plus git-cliff, or from what these steps "should" take.
+    # A ceiling set under a job's honest slowest run converts a working job into
+    # a permanently red one (objectui#7048), and this job has produced no honest
+    # run to sit above; objectstack#16173 is the live counter-example, where a
+    # distribution mis-estimated by ~2.6x killed a test shard while the rollup
+    # read green. An invented ceiling is worse than the default it replaces,
+    # because it looks derived.
+    #
+    # ⚠️ The accepted cost, stated plainly: a hang in a dispatched run occupies
+    # a runner for six hours before reporting `cancelled`. That is the same
+    # exposure objectui#7956 closed on four of its six jobs. It is accepted here
+    # only because the alternative is a guess, and it is bounded in practice by
+    # the fact that nothing starts this workflow except a maintainer, who is by
+    # construction watching when they do.
+    #
+    # What would change this: one real dispatch. Measure that run the way
+    # `lint.yml::lint` documents, write the derivation here, and move this job
+    # out of the accept-360 table and into the `derived` table in
+    # `scripts/__tests__/workflow-cache-save-bound.test.ts` in the same commit —
+    # that pin holds this job's UNBOUNDED state deliberately, so adding a
+    # ceiling has to be an edit someone makes on purpose rather than a silent
+    # one.
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -261,6 +261,58 @@ jobs:
   lane:
     name: Decide lane
     runs-on: ubuntu-latest
+
+    # ── The job ceiling, DERIVED FOR THIS JOB (objectui#7956) ────────────
+    # Before this line the only backstop was GitHub's 360-minute default — on
+    # the job that gates every landing on `main`, sitting directly above
+    # `release`, which objectui#7270 bounded at 40. Two jobs in one file with
+    # two answers is what objectui#7956 was filed to close.
+    #
+    # ⚠️ The stakes here are NOT objectui#7270's. That card's argument leaned on
+    # two of its three jobs producing a REQUIRED context on a shared serial
+    # queue. Re-measured for this one on `GET /repos/objectstack-ai/objectui/
+    # rules/branches/main` at 2026-09-06T17:20Z, the required checks are `Lint`,
+    # `Type Check`, `Build & E2E`, `Test (shard 1/4)` through `(4/4)`,
+    # `Build Docs` and `Changeset Declaration` — this workflow produces none of
+    # them. What is left is the generic exposure: a wedged job holds a runner
+    # for six hours and then reports `cancelled`, a verdict the merge queue
+    # cannot tell from `failure`.
+    #
+    # ⛔ NOT inherited from `release`'s 40 directly below, and not from
+    # `ci.yml`'s 10/15/20/30/40 — objectui#7048 fences exactly that. The
+    # arithmetic below is this job's own.
+    #
+    #   - Population: the last 300 successful runs of this workflow, window
+    #     2026-09-02T14:14Z .. 2026-09-06T17:19Z, n=300 `Decide lane` jobs.
+    #     Per-job wall clock from the Actions jobs endpoint (`completed_at`
+    #     minus `started_at`), never the run's total. This job carries no `if:`,
+    #     so it runs on every run of the workflow and its sample is not thinned
+    #     the way `release`'s is by the skip-on-push branch.
+    #   - min 4s / median 6s / p95 8s / max 43s.
+    #   - By event: push n=297 (median 6s, max 43s), schedule n=3 (median 7s,
+    #     max 7s). No material difference, so one ceiling covers both.
+    #   - max/p95 = 5.3 — a fat tail, unlike `Lint`'s 1.25, and worth naming
+    #     because it is not WORK: on the three slowest runs the steps sum to 3
+    #     seconds while the job's wall clock is 41-43s, so the tail is runner
+    #     overhead that no step reports. It is still wall clock the ceiling has
+    #     to cover, which is why the max above is the job's and not the steps'.
+    #
+    # Ceiling = the smallest round number that is both >= 3x max (2.2min) and
+    # >= max + 15min (15.7min) => 20. That is ~28x the slowest run ever observed
+    # here, so it cannot fire on a healthy-but-slow runner; a wedge dies in 20
+    # minutes instead of 6 hours.
+    #
+    # ⚠️ Four of the six jobs objectui#7956 bounded land on 20 by this same
+    # arithmetic. That is NOT one number copied across them, which precondition
+    # ② of that card's triage forbids: for any job whose slowest run is under
+    # 7.5 minutes the additive term dominates the multiplicative one, so the
+    # rule puts every sub-minute job on the same rung. Each of the four carries
+    # its own sample and its own derivation beside its own key.
+    #
+    # ⛔ Raising this toward 360 is the ruled-out non-fix (objectui#6577,
+    # objectui#7048): the hang just runs longer and the gate still reports
+    # `cancelled`.
+    timeout-minutes: 20
     # Narrower than the workflow-level block deliberately: this job reads files
     # and writes nothing. Declaring any `permissions:` sets every unlisted scope
     # to `none`, which is the point — a new job on a workflow that can publish

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -63,6 +63,82 @@ on:
 jobs:
   check-links:
     runs-on: ubuntu-latest
+
+    # ── The job ceiling, DERIVED FOR THIS JOB (objectui#7956) ────────────
+    # Before this line the only backstop was GitHub's 360-minute default, on the
+    # one job in this repository that deliberately goes out over the network.
+    #
+    # ⚠️ The stakes here are NOT objectui#7270's. That card's argument leaned on
+    # two of its three jobs producing a REQUIRED context on a shared serial
+    # queue. Re-measured on `GET /repos/objectstack-ai/objectui/rules/branches/
+    # main` at 2026-09-06T17:20Z, the required checks are `Lint`, `Type Check`,
+    # `Build & E2E`, `Test (shard 1/4)` through `(4/4)`, `Build Docs` and
+    # `Changeset Declaration` — this job produces none of them, and the header
+    # above says it blocks nobody on purpose. What is left is the generic
+    # exposure: a sweep wedged on an unresponsive host holds a runner for six
+    # hours and then reports `cancelled`.
+    #
+    # ⛔ NOT inherited from `ci.yml`'s 10/15/20/30/40, nor from the ceilings
+    # objectui#7270 derived — objectui#7048 fences exactly that. The arithmetic
+    # below is this job's own.
+    #
+    # ⚠️ THE SAMPLE HAS TO BE CHOSEN, and the obvious choice is the wrong one.
+    # `status=success` returns a `total_count` of 217 for this workflow, and
+    # every single one of those runs is from 2026-01-24 .. 2026-01-28 on `push`
+    # and `pull_request` — triggers this workflow no longer declares, under the
+    # narrower scan scope it had before #3449. Those runs measure a different
+    # job wearing this job's name, and deriving from them would put the ceiling
+    # under today's honest slowest run, which is the hazard objectui#7048
+    # fenced. They are recorded here and NOT used.
+    #
+    #   - Population: every run under today's configuration —
+    #     `?event=schedule`, whose `total_count` is 5, window 2026-08-09T04:43Z
+    #     .. 2026-09-06T04:28Z. That is the entire population since the cron
+    #     landed, not a sample cut short; paging further buys the January runs
+    #     described above. Per-job wall clock from the Actions jobs endpoint
+    #     (`completed_at` minus `started_at`), never the run's total.
+    #   - min 15s / median 24s / p95 30s / max 31s.
+    #   - max/p95 = 1.03 — no fat tail inside the sample.
+    #   - ⚠️ All five ended `failure`, and that does NOT make them unusable: the
+    #     step conclusions show Lychee running 9s .. 24s and the job reaching its
+    #     post steps every time, so the failure is the sweep's own verdict
+    #     (`fail: true`, broken links found), not an abort partway through the
+    #     work. It is also the CONSERVATIVE side of the measurement — a link
+    #     that cannot be resolved is retried (`max_retries` in `lychee.toml`),
+    #     so a sweep that finds breakage does strictly more work than a clean
+    #     one. The max above therefore over-states a healthy run rather than
+    #     under-stating it.
+    #   - ⚠️ That every scheduled sweep so far has been red is a defect in its
+    #     own right and is filed as objectui#8126's sibling, objectui#8128. It
+    #     is deliberately NOT fixed by the same change that sets this ceiling:
+    #     the ceiling is about what happens when a sweep wedges, and the red is
+    #     about what the sweep found.
+    #
+    # Ceiling = the smallest round number that is both >= 3x max (1.6min) and
+    # >= max + 15min (15.5min) => 20. That is ~39x the slowest sweep observed
+    # under this configuration; a wedge dies in 20 minutes instead of 6 hours.
+    #
+    # ⚠️ The residual this does NOT bound, named rather than hidden:
+    # `lychee.toml` declares a per-request `timeout` and `max_retries` at a
+    # `max_concurrency` of 10, so a whole-run worst case scales with how much
+    # this workflow sweeps — and that size is exactly the number the header
+    # above forbids writing down, because it rots (objectui#7448,
+    # objectui#7825). The additive 15 minutes is where that residual is
+    # absorbed, not a proof against it. If a network-weather run ever does hit
+    # this ceiling, the cost is a `cancelled` weekly sweep that blocks nobody —
+    # which the header already accepts as this workflow's failure currency.
+    #
+    # ⚠️ Four of the six jobs objectui#7956 bounded land on 20 by this same
+    # arithmetic. That is NOT one number copied across them, which precondition
+    # ② of that card's triage forbids: for any job whose slowest run is under
+    # 7.5 minutes the additive term dominates the multiplicative one, so the
+    # rule puts every sub-minute job on the same rung. Each of the four carries
+    # its own sample and its own derivation beside its own key.
+    #
+    # ⛔ Raising this toward 360 is the ruled-out non-fix (objectui#6577,
+    # objectui#7048): the hang just runs longer and the gate still reports
+    # `cancelled`.
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/cross-repo-issue-closer.yml
+++ b/.github/workflows/cross-repo-issue-closer.yml
@@ -121,6 +121,60 @@ jobs:
     name: Close issues referenced in other repositories
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+
+    # ── The job ceiling, DERIVED FOR THIS JOB (objectui#7956) ────────────
+    # Before this line the only backstop was GitHub's 360-minute default.
+    #
+    # ⚠️ The stakes here are NOT objectui#7270's. That card's argument leaned on
+    # two of its three jobs producing a REQUIRED context on a shared serial
+    # queue. Re-measured on `GET /repos/objectstack-ai/objectui/rules/branches/
+    # main` at 2026-09-06T17:20Z, the required checks are `Lint`, `Type Check`,
+    # `Build & E2E`, `Test (shard 1/4)` through `(4/4)`, `Build Docs` and
+    # `Changeset Declaration` — this job produces none of them, and it runs on
+    # `pull_request_target: closed` where it blocks nothing. What is left is the
+    # generic exposure: a wedged job holds a runner for six hours and then
+    # reports `cancelled`.
+    #
+    # ⛔ NOT inherited from `ci.yml`'s 10/15/20/30/40, nor from the ceilings
+    # objectui#7270 derived — objectui#7048 fences exactly that. The arithmetic
+    # below is this job's own.
+    #
+    #   - Population: the last 300 successful runs of this workflow, window
+    #     2026-09-03T07:35Z .. 2026-09-06T17:19Z, n=300
+    #     `Close issues referenced in other repositories` jobs. Per-job wall
+    #     clock from the Actions jobs endpoint (`completed_at` minus
+    #     `started_at`), never the run's total.
+    #   - min 2s / median 4s / p95 5s / max 12s.
+    #   - Single event (`pull_request_target`, n=300), so there is no by-event
+    #     split to report.
+    #   - max/p95 = 2.4 — a mild tail at the high end, and one run in 300 at 12s
+    #     against a 4s median. Recorded rather than smoothed, because the max is
+    #     what the ceiling has to clear.
+    #   - ⚠️ One term is DECLARED and does not appear in the sample: the
+    #     github-script step below sets `retries: 3`, so a target answering
+    #     transiently is asked up to four times with octokit's backoff between
+    #     attempts, and the sample contains no run that spent that budget. The
+    #     additive 15 minutes below is where it is absorbed — the same reasoning
+    #     `changeset-release.yml::release` applies to its declared wait cap,
+    #     except that there the declared bound exceeded the multiplier and had
+    #     to be added explicitly, and here it does not come close.
+    #
+    # Ceiling = the smallest round number that is both >= 3x max (0.6min) and
+    # >= max + 15min (15.2min) => 20. That is ~100x the slowest run ever observed
+    # here, so it cannot fire on a healthy-but-slow runner; a wedge dies in 20
+    # minutes instead of 6 hours.
+    #
+    # ⚠️ Four of the six jobs objectui#7956 bounded land on 20 by this same
+    # arithmetic. That is NOT one number copied across them, which precondition
+    # ② of that card's triage forbids: for any job whose slowest run is under
+    # 7.5 minutes the additive term dominates the multiplicative one, so the
+    # rule puts every sub-minute job on the same rung. Each of the four carries
+    # its own sample and its own derivation beside its own key.
+    #
+    # ⛔ Raising this toward 360 is the ruled-out non-fix (objectui#6577,
+    # objectui#7048): the hang just runs longer and the gate still reports
+    # `cancelled`.
+    timeout-minutes: 20
     steps:
       - name: Close (or report) cross-repo closing keywords
         uses: actions/github-script@v9

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -24,6 +24,51 @@ permissions:
 jobs:
   label:
     runs-on: ubuntu-latest
+
+    # ── The job ceiling, DERIVED FOR THIS JOB (objectui#7956) ────────────
+    # Before this line the only backstop was GitHub's 360-minute default.
+    #
+    # ⚠️ The stakes here are NOT objectui#7270's. That card's argument leaned on
+    # two of its three jobs producing a REQUIRED context on a shared serial
+    # queue. Re-measured on `GET /repos/objectstack-ai/objectui/rules/branches/
+    # main` at 2026-09-06T17:20Z, the required checks are `Lint`, `Type Check`,
+    # `Build & E2E`, `Test (shard 1/4)` through `(4/4)`, `Build Docs` and
+    # `Changeset Declaration` — this job produces none of them, and it blocks
+    # nothing. What is left is the generic exposure: a wedged job holds a runner
+    # for six hours and then reports `cancelled`. This job runs on every push to
+    # every open pull request, so it is the most frequently started of the six
+    # objectui#7956 covers and the cheapest place for that exposure to be paid
+    # repeatedly.
+    #
+    # ⛔ NOT inherited from `ci.yml`'s 10/15/20/30/40, nor from the ceilings
+    # objectui#7270 derived — objectui#7048 fences exactly that. The arithmetic
+    # below is this job's own.
+    #
+    #   - Population: the last 300 successful runs of this workflow, window
+    #     2026-09-04T15:06Z .. 2026-09-06T17:19Z, n=300 `label` jobs. Per-job
+    #     wall clock from the Actions jobs endpoint (`completed_at` minus
+    #     `started_at`), never the run's total.
+    #   - min 3s / median 5s / p95 8s / max 13s.
+    #   - Single event (`pull_request`, n=300), so there is no by-event split to
+    #     report and one ceiling is all there is to set.
+    #   - max/p95 = 1.6 — no fat tail, so the multiplier is not widened.
+    #
+    # Ceiling = the smallest round number that is both >= 3x max (0.7min) and
+    # >= max + 15min (15.2min) => 20. That is ~92x the slowest run ever observed
+    # here, so it cannot fire on a healthy-but-slow runner; a wedge dies in 20
+    # minutes instead of 6 hours.
+    #
+    # ⚠️ Four of the six jobs objectui#7956 bounded land on 20 by this same
+    # arithmetic. That is NOT one number copied across them, which precondition
+    # ② of that card's triage forbids: for any job whose slowest run is under
+    # 7.5 minutes the additive term dominates the multiplicative one, so the
+    # rule puts every sub-minute job on the same rung. Each of the four carries
+    # its own sample and its own derivation beside its own key.
+    #
+    # ⛔ Raising this toward 360 is the ruled-out non-fix (objectui#6577,
+    # objectui#7048): the hang just runs longer and the gate still reports
+    # `cancelled`.
+    timeout-minutes: 20
     steps:
       - uses: actions/labeler@v7
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,6 +13,52 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
+
+    # ── NO job ceiling, and that is the DECISION, not its absence (objectui#7956) ──
+    # This job runs under GitHub's 360-minute default. objectui#7956 asked for a
+    # ceiling DERIVED from this job's own measured run-time distribution, in the
+    # shape objectui#7270 left beside `lint.yml::lint`. It is recorded here
+    # instead, because every run this job has to offer measures the wrong thing.
+    #
+    #   - Population: every completed run of this workflow, no status filter,
+    #     window 2026-01-16T01:14Z .. 2026-09-06T00:19Z, n=234, all `schedule`.
+    #     Measured 2026-09-06T17:24Z.
+    #   - `?status=success` returns a `total_count` of 0 over that same window.
+    #     This job has never once succeeded in the whole retained history.
+    #   - Wall clock, from the Actions jobs endpoint: min 1s / median 2s /
+    #     p95 4s / max 4s.
+    #   - ⚠️ Those seconds are NOT this job's work. Ten runs sampled evenly
+    #     across the window all report the same shape: a single step, `Set up
+    #     job`, with conclusion `failure` — the `actions/stale` step below never
+    #     starts. So the distribution above measures how fast this job fails to
+    #     begin, and says nothing whatever about how long it takes to sweep this
+    #     repository's issues and pull requests.
+    #
+    # ⛔ Do NOT derive 20-ish minutes from a 4-second maximum that belongs to a
+    # setup failure. That would be a ceiling with the look of provenance and
+    # none of the substance, sitting over a job whose real cost has never been
+    # observed — and `actions/stale` pages the issue and pull-request lists,
+    # which is the kind of work that grows with the repository. A ceiling set
+    # under a job's honest slowest run converts a working job into a permanently
+    # red one (objectui#7048); objectstack#16173 is the live counter-example,
+    # where a distribution mis-estimated by ~2.6x killed a test shard while the
+    # rollup read green. Here the mis-estimate would not be 2.6x, it would be
+    # unbounded, because the numerator has never been measured at all.
+    #
+    # ⚠️ Two separate things are true and only one of them is objectui#7956's:
+    # the exposure (no ceiling) is that card's, and the FAILURE (234 runs, 234
+    # failures, never a success) is objectui#8126's — filed separately, because
+    # bounding a job that cannot start would fix nothing and would hide the
+    # louder defect behind a tidy-looking diff.
+    #
+    # What would change this: fix the setup failure, let a few real sweeps run,
+    # then derive the number from THOSE the way `lint.yml::lint` documents,
+    # write the derivation here, and move this job out of the accept-360 table
+    # and into the `derived` table in
+    # `scripts/__tests__/workflow-cache-save-bound.test.ts` in the same commit —
+    # that pin holds this job's UNBOUNDED state deliberately, so adding a
+    # ceiling has to be an edit someone makes on purpose rather than a silent
+    # one.
     steps:
       - uses: actions/stale@e00e804f6792d3fedb5bd3a27df2761c5f86c981  # v9.0.0
         with:

--- a/scripts/__tests__/workflow-cache-save-bound.test.ts
+++ b/scripts/__tests__/workflow-cache-save-bound.test.ts
@@ -43,9 +43,32 @@ import { parse as parseYaml } from 'yaml';
  * ejects the next green pull request. Until objectui#7270 three of these jobs
  * declared no `timeout-minutes` at all, so the same stall held a required
  * context open against GitHub's 360-minute default instead; those three now
- * carry ceilings derived from their own run distributions, and the last pin in
- * this file is what keeps them. That is this repository's recurring "looks like
+ * carry ceilings derived from their own run distributions, and the last pins in
+ * this file are what keep them. That is this repository's recurring "looks like
  * enforcement, isn't" class (objectui#3009, #3181, #3494).
+ *
+ * ## The ceilings outgrew the cache (objectui#7956)
+ *
+ * objectui#7270 bounded the CACHED half of that exposure; objectui#7956 measured
+ * the other six jobs, which cache nothing at all, and closed them the same way.
+ * So the last three pins in this file are no longer about caching — they are
+ * about job ceilings, which is why they live beside the cache rules rather than
+ * in a new file: both are "a key whose deletion is invisible in every run", and
+ * splitting them would give a future reader two places to look for one rule.
+ *
+ * Those six divided in two, and BOTH halves are pinned, because both are
+ * decisions someone made:
+ *
+ *   - Four had a distribution to derive from, and carry a ceiling with the
+ *     derivation written beside the key.
+ *   - Two did not, and carry NO ceiling ON PURPOSE, with the reason written
+ *     beside the job. `changelog.yml::changelog` has never run at all;
+ *     `stale.yml::stale` has never succeeded, and every run it has fails in
+ *     `Set up job` before the marketplace action starts, so its seconds measure
+ *     a setup failure rather than the job's work. Pinning an ABSENCE reads
+ *     oddly until you notice the failure mode it catches: someone tidying up
+ *     the inconsistency by copying `20` onto them, which is precisely the
+ *     inherited number objectui#7048 fences and objectui#7956's triage forbade.
  *
  * ## Deliberately NOT asserted
  *
@@ -345,6 +368,148 @@ describe('every workflow cache save is bounded and non-fatal (objectui#7048)', (
         'reports `cancelled` (objectui#6577, objectui#7048). If a job genuinely got slower, ' +
         're-derive it from a fresh distribution, rewrite the comment beside the key, and move ' +
         'this pin in the same commit.',
+    ).toEqual([]);
+  });
+
+  it('bounds the four jobs objectui#7956 derived a ceiling for', () => {
+    // The uncached half of the same exposure. objectui#7270 scoped itself to
+    // jobs that cache; these six cache nothing, so the cache-save hazard above
+    // is absent and what they carried was the generic one: GitHub's 360-minute
+    // default and a `cancelled` verdict at the end of it.
+    //
+    // ⚠️ NONE of these four produces a required status check — re-measured on
+    // the `main` ruleset (`Lint`, `Type Check`, `Build & E2E`, the four `Test
+    // (shard n/4)`, `Build Docs`, `Changeset Declaration`). So objectui#7270's
+    // shared-serial-queue stakes do not carry over, and the numbers below are
+    // not carried over either.
+    //
+    // ⚠️ All four are 20 and that is NOT a shared constant, which is the exact
+    // thing objectui#7048 fences and objectui#7956's triage forbade in writing.
+    // Each was derived from its own sample by objectui#7270's rule — the
+    // smallest round number that is both >= 3x that job's max and >= that job's
+    // max + 15min — and the additive term dominates for every job whose slowest
+    // run is under 7.5 minutes, so the rule lands every sub-minute job on the
+    // same rung. Their measured maxima differ (43s, 31s, 13s, 12s); their
+    // ceilings coincide. The derivation beside each key is what makes that
+    // checkable, and moving any one of these numbers means rewriting the
+    // derivation beside it in the same commit.
+    const derived: Record<string, number> = {
+      'changeset-release.yml::lane': 20,
+      'check-links.yml::check-links': 20,
+      'cross-repo-issue-closer.yml::close-foreign-issues': 20,
+      'labeler.yml::label': 20,
+    };
+
+    const missing: string[] = [];
+    const raised: string[] = [];
+
+    for (const [key, ceiling] of Object.entries(derived)) {
+      const [file, jobKey] = key.split('::');
+      const entry = allJobs.find((e) => e.file === file && e.jobKey === jobKey);
+      expect(entry, `${file} must still define a \`${jobKey}:\` job`).toBeDefined();
+
+      const declared = entry!.job['timeout-minutes'];
+      if (typeof declared !== 'number') {
+        missing.push(`${file} :: job \`${jobKey}\``);
+      } else if (declared > ceiling) {
+        raised.push(`${file} :: job \`${jobKey}\` declares ${declared}, derived ${ceiling}`);
+      }
+    }
+
+    expect(
+      missing,
+      'these jobs declare no job-level `timeout-minutes`, so their only backstop is GitHub\'s ' +
+        '360-minute default again:\n' +
+        missing.map((o) => `  - ${o}`).join('\n') +
+        '\n\nNone of them blocks a pull request, so nothing goes red when this key disappears — ' +
+        'the only symptom is the next wedged run holding a runner for six hours. Restore the key ' +
+        'TOGETHER WITH the derivation comment beside it; a ceiling with no recorded provenance is ' +
+        "the next reader's excuse to guess at it (objectui#7270, objectui#7956).",
+    ).toEqual([]);
+
+    expect(
+      raised,
+      'these job ceilings are above the value derived for them:\n' +
+        raised.map((o) => `  - ${o}`).join('\n') +
+        '\n\nRaising a ceiling does not fix a hang — it buys a longer one and the gate still ' +
+        'reports `cancelled` (objectui#6577, objectui#7048). If a job genuinely got slower, ' +
+        're-derive it from a fresh distribution, rewrite the comment beside the key, and move ' +
+        'this pin in the same commit.',
+    ).toEqual([]);
+  });
+
+  it('keeps the two jobs objectui#7956 could not measure UNBOUNDED, with their reason recorded', () => {
+    // The other half of objectui#7956, and the half that is easy to undo by
+    // being helpful. Four of its six jobs got a ceiling; these two did not,
+    // because neither has a distribution that measures the job doing its work:
+    //
+    //   - `changelog.yml::changelog` — `total_count: 0` runs, ever. It is
+    //     dispatch-only and has never been dispatched. (Control on the same
+    //     endpoint: `changeset-release.yml` answers with thousands, so the zero
+    //     is a reading and not a broken query.)
+    //   - `stale.yml::stale` — 234 completed runs, 0 successful, over eight
+    //     months. Ten sampled evenly across that window all fail in `Set up
+    //     job`, before `actions/stale` starts, so their 1-4 seconds measure how
+    //     fast the job fails to begin. Its real cost has never been observed,
+    //     and it is the kind that grows with the repository.
+    //
+    // A number invented for either one would look derived and be a guess, and a
+    // ceiling under a job's honest slowest run converts a working job into a
+    // permanently red one — objectui#7048's fence, and objectstack#16173 is the
+    // live counter-example (a distribution mis-estimated by ~2.6x killed a test
+    // shard while the rollup read green).
+    //
+    // So this pin asserts an ABSENCE plus a RECORD, and the record is the point:
+    // the failure it catches is a future tidy-up that copies `20` off the four
+    // jobs above onto these two. Adding a real ceiling here is welcome — derive
+    // it from runs that did the work, write the derivation beside the key, and
+    // move the entry up into the `derived` table above in the same commit.
+    const accepted = ['changelog.yml::changelog', 'stale.yml::stale'];
+
+    const bounded: string[] = [];
+    const undocumented: string[] = [];
+
+    for (const key of accepted) {
+      const [file, jobKey] = key.split('::');
+      const entry = allJobs.find((e) => e.file === file && e.jobKey === jobKey);
+      expect(entry, `${file} must still define a \`${jobKey}:\` job`).toBeDefined();
+
+      if (typeof entry!.job['timeout-minutes'] === 'number') {
+        bounded.push(`${file} :: job \`${jobKey}\` now declares ${entry!.job['timeout-minutes']}`);
+      }
+
+      // The decision has to be READABLE at the job, not only in a merged pull
+      // request. Two stable tokens rather than a wording: the default being
+      // accepted, and the card that accepted it.
+      const prose = fs
+        .readFileSync(path.join(WORKFLOW_DIR, file), 'utf8')
+        .split('\n')
+        .filter((line) => /^\s*#/.test(line))
+        .join('\n');
+      if (!prose.includes('360') || !prose.includes('objectui#7956')) {
+        undocumented.push(`${file} (looked for \`360\` and \`objectui#7956\` in its comments)`);
+      }
+    }
+
+    expect(
+      bounded,
+      'these jobs were deliberately left at the 360-minute default and now declare a ceiling:\n' +
+        bounded.map((o) => `  - ${o}`).join('\n') +
+        '\n\nIf that number was DERIVED from runs in which the job actually did its work, this is ' +
+        'good news: write the derivation beside the key, move the entry into the `derived` table ' +
+        'above, and delete it from here — in this same commit. If it was copied from the four jobs ' +
+        'in that table, it is the inherited ceiling objectui#7048 fences: a number that looks ' +
+        "derived, sits over a cost nobody has measured, and reds a working job the first time it " +
+        'runs long (objectui#7956).',
+    ).toEqual([]);
+
+    expect(
+      undocumented,
+      'these jobs run under the 360-minute default with nothing beside them saying so on purpose:\n' +
+        undocumented.map((o) => `  - ${o}`).join('\n') +
+        '\n\nAn unbounded job that records WHY is a decision; one that records nothing is an ' +
+        'oversight, and the two are indistinguishable to the next reader — which is how ' +
+        'objectui#7956 came to be filed in the first place.',
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #7956

objectui#7270 bounded the three **cached** jobs that ran under GitHub's 360-minute default. The six here cache nothing, so its specific hazard — a runner-generated cache-save post step that no workflow syntax can bound — is absent, exactly as the card argued. What they carried is the generic exposure.

Four now carry a ceiling **derived from that job's own measured distribution**. Two carry none, on purpose, with the reason written beside the job. Both halves are pinned.

---

## Precondition ① — the required contexts, re-measured

Re-run rather than inherited, per the dispatch. `GET /repos/objectstack-ai/objectui/rules/branches/main` at 2026-09-06T17:20Z (readable with the session token; the legacy `branches/main/protection` endpoint answers 403 — verified again here):

```
Lint · Type Check · Build & E2E · Test (shard 1/4) · Test (shard 2/4)
Test (shard 3/4) · Test (shard 4/4) · Build Docs · Changeset Declaration
```

**None of the six jobs produces one of those.** Job display names checked per job, not per file: `changelog`, `Decide lane`, `check-links`, `Close issues referenced in other repositories`, `label`, `stale`.

⇒ **The consequence, stated so nobody re-derives it later**: objectui#7270's stakes argument — two of its three jobs being required contexts on a shared serial queue, so a wedge holds the queue for six hours — **does not apply here**. Nothing in this pull request blocks a merge, before or after. What these six carry is only the generic 360-minute exposure: a wedged job occupies a runner for six hours and then reports `cancelled`.

## Precondition ② — every ceiling derived per job, none inherited

The rule is objectui#7270's, written beside `lint.yml::lint`: **the smallest round number that is both at least 3x that job's max and at least that job's max + 15min.** Per-job wall clock throughout, from `/actions/runs/ID/jobs` (`completed_at` minus `started_at`), never the run's total. Channel: repo-scoped Actions REST with the session token (no MCP fallback needed; assumption A1 holds).

### `changeset-release.yml::lane` → 20

| | |
|:--|:--|
| population | last 300 successful runs, window 2026-09-02T14:14Z .. 2026-09-06T17:19Z, n=300 |
| distribution | min 4s / median 6s / **p95 8s** / **max 43s** |
| by event | push n=297 (median 6s, max 43s) · schedule n=3 (median 7s, max 7s) |
| tail | max/p95 = 5.3 |
| ceiling | max(3x43s = 2.2min, 43s + 15min = 15.7min) ⇒ **20** |

The tail is worth naming because it is **not work**: on the three slowest runs the step conclusions sum to 3 seconds while the job's wall clock is 41-43s. It is runner overhead no step reports — still wall clock the ceiling must cover, which is why the max above is the job's and not the steps'.

`release`'s `timeout-minutes: 40` directly below is **untouched** — verified structurally, see Gates.

### `check-links.yml::check-links` → 20

⭐ **The obvious sample is the wrong one.** `?status=success` answers with a `total_count` of 217, which reads like a healthy history — and every one of those runs is from **2026-01-24 .. 2026-01-28**, on `push` and `pull_request`, triggers this workflow no longer declares, under the scan scope it had before objectui#3449. They measure a different job wearing this job's name. Deriving from them (max 12s) would have put the ceiling under today's honest slowest run — the hazard objectui#7048 fenced. They are recorded in the comment and not used.

| | |
|:--|:--|
| population | `?event=schedule`, `total_count` 5 — the **entire** population since the cron landed, window 2026-08-09T04:43Z .. 2026-09-06T04:28Z |
| distribution | min 15s / median 24s / **p95 30s** / **max 31s** |
| tail | max/p95 = 1.03 |
| ceiling | max(3x31s = 1.6min, 31s + 15min = 15.5min) ⇒ **20** |

All five ended `failure`, and that does not make them unusable: step conclusions show Lychee running 9s .. 24s and the job reaching its post steps every time, so the failure is the sweep's own verdict (`fail: true`), not an abort partway through. It is also the **conservative** side — an unresolvable link is retried (`max_retries` in `lychee.toml`), so a red sweep does strictly more work than a clean one.

**The residual is named in the comment rather than hidden**: `lychee.toml` declares a per-request `timeout` and `max_retries` at a `max_concurrency` of 10, so a whole-run worst case scales with how much this workflow sweeps — and that size is exactly the number the file's header forbids writing down, because it rots (objectui#7448, objectui#7825). The additive 15 minutes absorbs it; it is not a proof against it. If network weather ever does hit this ceiling, the cost is a `cancelled` weekly sweep that blocks nobody, which the header already accepts as this workflow's failure currency.

### `cross-repo-issue-closer.yml::close-foreign-issues` → 20

| | |
|:--|:--|
| population | last 300 successful runs, window 2026-09-03T07:35Z .. 2026-09-06T17:19Z, n=300, single event `pull_request_target` |
| distribution | min 2s / median 4s / **p95 5s** / **max 12s** |
| tail | max/p95 = 2.4 |
| ceiling | max(3x12s = 0.6min, 12s + 15min = 15.2min) ⇒ **20** |

One declared term does not appear in the sample: the github-script step sets `retries: 3`, so a transiently-answering target is asked up to four times with backoff, and no sampled run spent that budget. Same reasoning `changeset-release.yml::release` applies to its declared wait cap — except that there the declared bound exceeded the multiplier and had to be **added** explicitly, and here it does not come close, so the additive 15 minutes absorbs it. Written into the comment.

### `labeler.yml::label` → 20

| | |
|:--|:--|
| population | last 300 successful runs, window 2026-09-04T15:06Z .. 2026-09-06T17:19Z, n=300, single event `pull_request` |
| distribution | min 3s / median 5s / **p95 8s** / **max 13s** |
| tail | max/p95 = 1.6 |
| ceiling | max(3x13s = 0.7min, 13s + 15min = 15.2min) ⇒ **20** |

The most frequently started of the six (every push to every open pull request), so the cheapest place for the exposure to be paid repeatedly.

### ⚠️ Why four numbers are the same, and why that is not one inherited number

Precondition ② forbids one number for six jobs. These four coincide **because the rule's additive term dominates its multiplicative one for any job whose slowest run is under 7.5 minutes**, so it lands every sub-minute job on the same rung. Their measured maxima differ — 43s, 31s, 13s, 12s — and each derivation stands beside its own key on its own sample. objectui#7270's pin says the same thing about its own two 25s: *"two of them being equal is a coincidence of the arithmetic."*

## The two jobs with no distribution to derive from — 360 accepted, on the record

Ruling 2's other branch. A number invented for either would look derived and be a guess, and a ceiling under a job's honest slowest run converts a working job into a permanently red one — objectui#7048's fence, with objectstack#16173 as the live counter-example (a distribution mis-estimated by ~2.6x killed a test shard while the rollup read green).

### `changelog.yml::changelog` — accept 360

`GET /actions/workflows/changelog.yml/runs`, no status filter, whole retained history ⇒ **`total_count: 0`**. Re-measured 2026-09-06T17:22Z.

**Control, so the zero is a reading rather than a broken query**: the identical call against `changeset-release.yml` answers with 5010 completed runs. The file's own header already recorded this same zero once, measured before 2026-08-23 while removing its dead `release` trigger — it has not moved. Dispatch-only, never dispatched.

⚠️ **A2 falsified here**: the dispatch expected `changelog.yml` to be schedule-driven. It declares `workflow_dispatch` only.

### `stale.yml::stale` — accept 360

| | |
|:--|:--|
| population | every completed run, no status filter, window 2026-01-16T01:14Z .. 2026-09-06T00:19Z, n=234, all `schedule` |
| `?status=success` | **`total_count: 0`** — never once succeeded in the whole retained history |
| wall clock | min 1s / median 2s / p95 4s / max 4s |

⚠️ **Those seconds are not this job's work.** Ten runs sampled evenly across the window all report one step — `Set up job`, conclusion `failure` — with `actions/stale` never starting. The distribution measures how fast the job fails to *begin*. Its real cost has never been observed, and it is the kind that grows with the repository, so a 20-ish minute ceiling derived from a 4-second maximum would have the look of provenance and none of the substance.

The **failure** is a separate defect from the **exposure** this card is about, and bounding a job that cannot start would fix nothing while hiding the louder problem behind a tidy diff. Filed on its own card — see below.

## The pin

`scripts/__tests__/workflow-cache-save-bound.test.ts`. **A3 partly falsified**: it holds no "exactly N unbounded jobs remain" count, so no count had to move. It is a table extension plus one new kind of assertion.

- `bounds the four jobs objectui#7956 derived a ceiling for` — presence and not-raised, the same shape as objectui#7270's own entry, kept as a sibling rather than folded into it (that one's failure text says "two of them are required contexts and one is the publish lane", which is false for these four).
- `keeps the two jobs objectui#7956 could not measure UNBOUNDED, with their reason recorded` — asserts the **absence** of a ceiling, plus two stable tokens (`360` and the card reference) in the workflow's comments so the decision is readable at the job and not only in a merged pull request. It is deliberately not a pinned wording. **The failure mode it catches** is a future tidy-up that copies `20` off the four jobs onto these two — the inherited ceiling objectui#7048 fences. Its message says what to do instead: derive from runs that did the work, write the derivation beside the key, and move the entry up into the table above in the same commit.

The file's header gained a section saying why job ceilings live beside cache rules rather than in a new file — both are "a key whose deletion is invisible in every run", and splitting them would give the next reader two places to look for one rule.

### Reverse verification — three legs, each proved on disk and restored

Run against the committed implementation, restore leg `git checkout HEAD -- PATH`, trap on `EXIT INT TERM`, mutation confirmed by an occurrence count in both directions before the run, and byte-identity confirmed after by comparing `git hash-object` against the HEAD blob.

| leg | mutation (on-disk proof) | result |
|:--|:--|:--|
| A | delete the ceiling from `labeler.yml::label` (`1 → 0` occurrences) | **red**, `these jobs declare no job-level ...` |
| B | copy `20` onto `stale.yml::stale` (`0 → 1`) | **red**, `these jobs were deliberately left at the 360-minute default ...` |
| C | strip the card reference from `changelog.yml` (`3 → 0`) | **red**, `these jobs run under the 360-minute default with nothing ...` |
| control | unmutated tree | 11 passed |

Three distinct messages, so each leg exercises a different branch. Final state: `git diff HEAD` empty; all three blobs hash-equal to HEAD.

## Gates

All pinned to final HEAD `b422e650d`, exit codes captured by redirect-then-capture (never across a pipe).

| gate | result |
|:--|:--|
| `pnpm exec vitest run scripts/__tests__/` | **exit 0** — 113 files, 3374 tests passed |
| `pnpm type-check:scripts` | exit 0 |
| `pnpm check:control-bytes` | exit 0 — "scanned 6499 tracked text file(s); skipped 85 binary" |
| `grep -naP` control-byte self-scan over the 7 changed paths | exit 1 (no hits) |
| `node scripts/check-changeset-presence.mjs` | exit 0 — "no changeset is owed" (0 published sources, 0 manifests) |
| `node scripts/check-governed-queue-guard.mjs --test` (7 changed paths) | exit 0 — **NOT GOVERNED**, ruling 6 confirmed mechanically |
| YAML parse of all six edited workflows | exit 0 — see below |

**The YAML check is structural, not cosmetic.** For each of the six it parses the file before (at base `cf1d29e2f`) and after, strips `timeout-minutes` from every job on both sides, and deep-compares:

```
changelog.yml                parses=OK  identical-ignoring-timeouts=true  added=[]                       pre-existing-changed=[]
changeset-release.yml        parses=OK  identical-ignoring-timeouts=true  added=[lane=20]                pre-existing-changed=[]
check-links.yml              parses=OK  identical-ignoring-timeouts=true  added=[check-links=20]         pre-existing-changed=[]
cross-repo-issue-closer.yml  parses=OK  identical-ignoring-timeouts=true  added=[close-foreign-issues=20] pre-existing-changed=[]
labeler.yml                  parses=OK  identical-ignoring-timeouts=true  added=[label=20]               pre-existing-changed=[]
stale.yml                    parses=OK  identical-ignoring-timeouts=true  added=[]                       pre-existing-changed=[]
```

`pre-existing-changed=[]` on `changeset-release.yml` is the machine-checked form of "ruling 5 honoured": `release`'s 40 did not move.

**Lint, narrowed and the narrowing measured.** One `.ts` file changed; ESLint does not read `.yml` (its config declares no YAML processor). `npx eslint --no-inline-config --format json` on it: **1 file linted** (from the JSON array length), 0 errors, 0 warnings. Invariance for untouched files: `eslint.config.js` extends `tseslint.configs.recommended`, **not** `recommendedTypeChecked`, and declares no `parserOptions.project` or `projectService` — type-aware linting is off, so this diff cannot move the verdict on any file it does not contain. The repo-wide run stays CI's.

`Live E2E (informational)` is red on every branch today for an upstream reason (#7990, objectstack#16186) — not this change.

## Out-of-scope findings, filed separately and ⛔ not touched here

Both surfaced while choosing samples; neither is a defect this change may fix without hiding it.

- **objectui#8126** — `stale.yml` has never succeeded: 234 scheduled runs, 234 failures, every one in `Set up job`. Every automation that file declares has been inert for at least eight months.
- **objectui#8128** — every scheduled `check-links` sweep since the cron landed is red (5 of 5), and the last green run predates objectui#3449's scope fix. The sweep is working; its answer reaches nobody.

Neither is closed or altered by this pull request; both remain open. Dedup: the delta of cards updated since 2026-09-06T16:01Z was read over repo-scoped REST (28 cards, no match), plus one MCP semantic search per finding, each validated by a known-hit control query on the same channel in the same session.

## Scope

Seven files: the six workflows (job-level `timeout-minutes` and its derivation comment, nothing else — proved above) and the one pin. Nothing under `packages/`, `content/docs/`, `scripts/*.mjs`, or the governed surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_