### PR TITLE
chore(scripts): retire the deJsxClosingTags workaround in check-vi-mock-inherit

### DIFF
--- a/scripts/__tests__/check-vi-mock-inherit.test.ts
+++ b/scripts/__tests__/check-vi-mock-inherit.test.ts
@@ -11,7 +11,6 @@ import { fileURLToPath } from 'node:url';
 import {
   COVERED_SPECIFIERS,
   FLOORS,
-  deJsxClosingTags,
   findCallSites,
   scan,
   summarise,
@@ -335,10 +334,10 @@ describe('only text the language would execute', () => {
 });
 
 // ---------------------------------------------------------------------------
-// The JSX mask — a real mis-mask in the shared scanner, measured
+// The JSX mask — a real mis-mask in the shared scanner, since fixed
 // ---------------------------------------------------------------------------
 
-describe('deJsxClosingTags — the shared masker USED to read `</div>` as a regex literal', () => {
+describe('a JSX closing tag — the shared masker USED to read `</div>` as a regex literal', () => {
   /**
    * `js-comment-mask` opened a regex when a `/` followed something that is not
    * a value. In `</div>` that something is `<`, so a PHANTOM regex opened and
@@ -346,11 +345,22 @@ describe('deJsxClosingTags — the shared masker USED to read `</div>` as a rege
    * `)` that closes a `vi.mock` call. Measured on this tree at the time: SEVEN
    * call sites could not be delimited at all, one of them a covered site.
    *
-   * Fixed in the shared module by objectui#6891, whose own pin
-   * (`scripts/__tests__/js-comment-mask-jsx-6891.test.ts`) now holds the
-   * scanner. `deJsxClosingTags` stays: it is still correct, still length-
-   * preserving, and removing it belongs to whoever owns THIS gate's source.
-   * The first case below is what makes that a decision rather than a guess.
+   * That is history. The shared masker handles `</tag>` itself since
+   * objectui#6891, whose own pin
+   * (`scripts/__tests__/js-comment-mask-jsx-6891.test.ts`) holds the scanner,
+   * and THIS gate rewrites nothing before masking any more — objectui#7883
+   * retired the local `deJsxClosingTags` workaround and its two unit cases
+   * with it.
+   *
+   * The three cases below are what say the retirement changed nothing: the
+   * first reads the mask directly on the RAW source, and the two behavioural
+   * ones drive the gate end to end on a factory that returns JSX. They pass
+   * with no rewrite in the gate at all.
+   *
+   * ⛔ Not a claim that the masker is correct on JSX: objectui#6891 closed
+   * only the `<` `/` half, and a `/` after `}` or `>` still opens a phantom
+   * (objectui#7882, still open). The retired rewrite never covered that half
+   * either, so nothing was lost with it.
    */
 
   const jsxFactory = `({ open, children }: any) => (open ? <div>{children}</div> : null)`;
@@ -363,10 +373,11 @@ describe('deJsxClosingTags — the shared masker USED to read `</div>` as a rege
     // whose immediately preceding byte is `<` opens nothing, and this case
     // has been turned over to pin the fix instead.
     //
-    // `deJsxClosingTags` is deliberately NOT removed in that change — it is a
-    // second gate's source, outside that card's file surface. It is now a
-    // no-op-in-effect on this shape, and the assertions below are what say so:
-    // the raw source, WITHOUT the rewrite, already masks correctly.
+    // `deJsxClosingTags` was deliberately NOT removed in that change — it was
+    // a second gate's source, outside that card's file surface. objectui#7883
+    // then retired it, and these assertions are what made that a decision
+    // rather than a guess: the raw source, with no rewrite anywhere, already
+    // masks correctly.
     const src = `const C = ${jsxFactory};\n`;
     const { literal } = scanSource(src);
     const inside = src.indexOf('</div>') + 2;
@@ -377,26 +388,11 @@ describe('deJsxClosingTags — the shared masker USED to read `</div>` as a rege
     expect(literal[src.lastIndexOf(')')]).toBe(0);
   });
 
-  it('neutralises the tag while PRESERVING LENGTH, so every offset still holds', () => {
-    const src = 'a</div>b</>c</Foo.Bar>z';
-    const out = deJsxClosingTags(src);
-    expect(out).toHaveLength(src.length);
-    expect(out).toBe('a<____>b<_>c<________>z');
-    // Every offset past the rewrite still indexes the same byte, which is what
-    // lets the mask's flags be read against the ORIGINAL source.
-    expect(out.indexOf('z')).toBe(src.indexOf('z'));
-  });
-
-  it('leaves a `/` that is not a closing tag alone — a regex, a path, a division', () => {
-    for (const src of ['const re = /<x>/;', 'const p = "a/b";', 'const q = a / b;', 'x.replace(/</g, "&lt;");']) {
-      expect(deJsxClosingTags(src)).toBe(src);
-    }
-  });
-
   it('THE CONSEQUENCE: a covered factory returning JSX is READ, not skipped', () => {
-    // Without the workaround this call site is `unreadable`. `unreadable` fails
-    // the gate, so the mis-mask would not have been silent — but it would have
-    // reddened five innocent files instead of judging them.
+    // Under the mis-mask this call site was `unreadable`. `unreadable` fails
+    // the gate, so the defect would not have been silent — but it would have
+    // reddened five innocent files instead of judging them. This case is now
+    // the load-bearing half: it goes red if the shared masker ever regresses.
     const site = verdictOf(`async (importOriginal) => ({ ...(await importOriginal()), C: ${jsxFactory} })`);
     expect(site.verdict).toBe('inherits');
   });

--- a/scripts/check-vi-mock-inherit.mjs
+++ b/scripts/check-vi-mock-inherit.mjs
@@ -302,32 +302,35 @@
  * the shared `js-comment-mask.mjs`, exactly as the sibling gate does it, and
  * for the same reasons (this file's own header quotes the defect in prose).
  *
- * ## `js-comment-mask` reads a JSX closing tag as a regex literal
+ * ## `js-comment-mask` USED to read a JSX closing tag as a regex literal
  *
- * The shared masker decides a `/` opens a regex when the preceding character is
- * not a value. In `</div>` the preceding character is `<`, so it opens a
- * PHANTOM regex that runs to the end of the line and swallows whatever is
+ * Kept as measured history: it is why the shared module was fixed, and the two
+ * behavioural cases in this gate's test still pin the outcome.
+ *
+ * The shared masker decided a `/` opens a regex when the preceding character is
+ * not a value. In `</div>` the preceding character is `<`, so it opened a
+ * PHANTOM regex that ran to the end of the line and swallowed whatever was
  * there -- including the `)` that closes a `vi.mock` call.
  *
- * That is not hypothetical here: measured on this tree, SEVEN `vi.mock` call
- * sites in five files could not have their argument list delimited at all
- * because of it, one of them a covered `@object-ui/react` site
+ * That was not hypothetical here: measured on this tree at the time, SEVEN
+ * `vi.mock` call sites in five files could not have their argument list
+ * delimited at all because of it, one of them a covered `@object-ui/react` site
  * (`plugin-dashboard/src/__tests__/ObjectDataTable.cells.test.tsx`). The sibling
  * gate never noticed because it only reads the specifier; this gate reads the
- * factory BODY, so it cannot.
+ * factory BODY, so it could not.
  *
- * `deJsxClosingTags` neutralises it, and the shape of the fix is what keeps it
- * safe: a JSX closing tag is rewritten to the SAME NUMBER OF BYTES
- * (`</div>` -> `<____>`) before masking, so every offset the mask returns still
- * indexes the original source, and the only bytes that change are slashes that
- * cannot be part of a spread, an identifier, or a specifier. A `</` inside a
- * string or a regex is rewritten too and does not matter: it is literal content
- * either way, and its quotes are untouched, so nothing structural moves.
- * Measured: the seven unreadable sites become zero, and no site changes verdict.
- *
- * This is a LOCAL workaround in this gate, not a change to the shared masker --
- * that module is used by many gates and its JSX behaviour is filed separately
- * as objectui#6891.
+ * This gate carried a LOCAL workaround for it -- `deJsxClosingTags`, a
+ * length-preserving rewrite of every closing tag applied before masking. The
+ * shared masker itself was then fixed by objectui#6891 (CLOSED, PR #7880),
+ * which taught `scanSource` that a `/` whose immediately preceding byte is `<`
+ * opens nothing. Re-measured on the fixed masker, the raw source with the
+ * rewrite NOT applied has ZERO undelimitable sites and the gate's verdict is
+ * byte-identical either way, so the workaround was retired by objectui#7883.
+ * ⛔ That is not "the masker is correct on JSX": objectui#6891 closed only the
+ * `<` `/` half. A `/` after `}` or `>` -- a self-closing tag, a `/` in JSX text
+ * -- still opens a phantom; that half is objectui#7882 and is still open. The
+ * retired rewrite never covered it either (its pattern matched closing tags
+ * only), which is why removing it lost no coverage.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -381,18 +384,6 @@ export const FLOORS = Object.freeze({
   testFiles: 1000,
   covered: 50,
 });
-
-/** A JSX closing tag: `</div>`, `</Foo.Bar>`, `</>`. */
-const JSX_CLOSING_TAG = /<\/([A-Za-z_$][\w$.:-]*)?\s*>/g;
-
-/**
- * `source` with the slash of every JSX closing tag replaced, PRESERVING LENGTH,
- * so offsets from the mask still index the original. See the header section on
- * `js-comment-mask` for the measurement that made this necessary.
- */
-export function deJsxClosingTags(source) {
-  return source.replace(JSX_CLOSING_TAG, (m) => `<${'_'.repeat(m.length - 2)}>`);
-}
 
 /** 1-based line number of `offset` in `source`. */
 function lineOf(source, offset) {
@@ -682,9 +673,8 @@ export function classifyFactory(masked, literal, start, end, specifier) {
  * for the instance that made this distinction necessary).
  */
 export function findCallSites(source, { covered = COVERED_SPECIFIERS } = {}) {
-  const dejsxed = deJsxClosingTags(source);
-  const { comment, literal } = scanSource(dejsxed);
-  const masked = blank(dejsxed, comment);
+  const { comment, literal } = scanSource(source);
+  const masked = blank(source, comment);
   const coveredSet = new Set(covered);
 
   const sites = [];


### PR DESCRIPTION
Fixes #7883

Retires the local `deJsxClosingTags` workaround in `scripts/check-vi-mock-inherit.mjs`, now that the shared masker `scripts/js-comment-mask.mjs` decides for itself that a SLASH whose immediately preceding byte is LT opens no regex (objectui#6891, PR #7880).

⚠️ **Spelling note.** GitHub deletes tag-shaped fragments from issue and PR bodies, backticks and fenced blocks included, so this body writes `LT`, `GT` and `SLASH` for the bracket characters. "the LT-SLASH half" means a slash immediately preceded by a left angle bracket; "a JSX closing tag" is the six-byte `LT SLASH div GT` form.

## 1. The two re-measurements, re-taken on this base

Base `origin/main` `e920343de`, both readings taken **before** any edit, because the card's figure was measured on `cf7f2af6e` and a premise older than the merge is unverified.

**(a) Raw-mask walk.** Two copies of the gate were made outside the tree — one pristine, one with the single line `const dejsxed = deJsxClosingTags(source);` replaced by `const dejsxed = source;` — and every `vi.mock` call site in the tree was walked through the gate's own `findCallSites`, with the full set of observed specifiers passed as `covered` so that every site reaches the delimiter walk:

| variant | sites walked | argument list does not balance |
|:--|--:|:--|
| rewrite applied (today's `main`) | 1763 in 4380 tracked sources | **0** |
| rewrite **NOT** applied (raw mask) | 1763 in 4380 tracked sources | **0** |
| raw mask **+ a copy of the masker with objectui#6891's rule reverted** (non-vacuity control) | 1763 in 4380 tracked sources | **6, in 6 files** |

The third row is the control that makes the second row a reading rather than a broken walk. Its six sites are five `@object-ui/components` mocks under `packages/app-shell/src/console/organizations/__tests__/` plus `packages/plugin-dashboard/src/__tests__/ObjectDataTable.cells.test.tsx` at line 24 — the covered `@object-ui/react` site the gate's header names by name. The header's historical figure was SEVEN in five files; the tree has moved since, so the header keeps its own number in the past tense and today's control reading is reported here rather than written over it.

**(b) The gate's verdict, with and without the rewrite.**

```
pnpm check:vi-mock-inherit > gate-before.txt 2>&1   # on e920343de, exit 0
pnpm check:vi-mock-inherit > gate-after.txt  2>&1   # after the removal, exit 0
cmp gate-before.txt gate-after.txt                   # -> BYTE-IDENTICAL, diff empty (0 bytes)
```

Both runs print, verbatim:

```
check-vi-mock-inherit: OK (4380 tracked source file(s), 2655 test-named; 602 carry a mock; 437 call site(s) on @object-ui/react, @object-ui/i18n, @object-ui/plugin-markdown, @object-ui/data-objectstack, @object-ui/plugin-report, @object-ui/plugin-charts, @object-ui/plugin-dashboard, @object-ui/auth, @object-ui/collaboration, @object-ui/plugin-form judged (437 inherit, 0 auto-mocked); 217 other workspace, 235 external, 871 local, 0 non-static, 3 embedded in a string literal -- all out of scope).
```

## 2. The removal

Gone from `scripts/check-vi-mock-inherit.mjs`: the `JSX_CLOSING_TAG` constant, the `deJsxClosingTags` export and its docblock, and the call in `findCallSites`.

The call site was a **pure substitution**, traced before deleting: `dejsxed` had exactly three uses, all adjacent — `scanSource(dejsxed)` and `blank(dejsxed, comment)`. It was never returned, never used for an offset of its own, and nothing downstream indexes it; the rewrite was length-preserving precisely so that `masked` kept indexing the original. So the three lines collapse to `scanSource(source)` / `blank(source, comment)`.

`COVERED_SPECIFIERS` is untouched, and no other logic in the gate moved. A repo-wide `git grep` for both names now returns only three prose mentions, all deliberately past tense.

## 3. The test split

`scripts/__tests__/check-vi-mock-inherit.test.ts`:

- **Removed with the function**: its two unit cases, `neutralises the tag while PRESERVING LENGTH...` and `leaves a SLASH that is not a closing tag alone...`, plus the import of `deJsxClosingTags`.
- **Kept, and passing with no rewrite in the gate at all**: `THE CONSEQUENCE: a covered factory returning JSX is READ, not skipped` and `...and a FROZEN factory returning JSX is still caught`. These two are the evidence that the removal changed nothing, so deleting them would have thrown away the removal's own proof.
- **Also kept**: the turned-over pin `the mis-mask is GONE...`, which reads the mask directly on the raw source.
- The `describe` title and its docblock now describe the present — the shared masker handles a JSX closing tag itself, this gate rewrites nothing before masking, and these three cases pin that. The pin's "written the other way up ... has been turned over" history stays, in the past tense.

## 4. The header rewrite

The section `## js-comment-mask reads a JSX closing tag as a regex literal` (heading spelled with backticks in the source) becomes `## js-comment-mask USED to read a JSX closing tag as a regex literal`, rewritten to the past tense as measured history. ⛔ Nothing was deleted from it: the seven undelimitable sites in five files, one of them a covered `@object-ui/react` site, and the reason the shared module was fixed all stay. Its closing pointer now marks objectui#6891 as CLOSED and cites its pull request, number 7880, instead of pointing at it as an open filing. (Written that way round on purpose: a closing keyword sitting immediately before a hash-number reference is what the merge-time parser acts on, and only the first line of this body is meant to close anything.)

**objectui#8117** was checked, since it is a reader of exactly this rewrite: the anti-exemption pin reddens on a quoted string ending in a test-file extension followed by a comma or a closing bracket, backticks included. The header's one such name is still in parentheses, so the pin is unaffected — re-run explicitly (`there is NO per-file exception list anywhere in the gate`, 1 passed) and the pin's own pattern applied by hand to the new gate source returns no match. ⛔ The pin's assertion is not touched here.

⚠️ One consequence for objectui#8117 worth recording there: its "shape of the repair" paragraph offers `deJsxClosingTags` as an already-exported helper for blanking comments before running the pin's pattern. That helper no longer exists after this PR. The rest of that paragraph is unaffected — the shared `js-comment-mask` is what actually does comment blanking, and it is still exported.

## 5. Positive control — the two behavioural cases are still load-bearing

With the workaround gone, are those two cases still pinning anything, or do they now pass for free? Mutated `scripts/js-comment-mask.mjs` in the working tree so the objectui#6891 rule stops firing (probe only — that file is not in this PR's diff):

```
before mutation: occurrences of the objectui#6891 rule anchor = 1
after  mutation: original rule text = 0, injected marker = 1     (the mutation is proven on disk, not by an exit code)
HEAD blob 08c990d1753e9e35dec21be28c68445c1211bd7f -> mutated blob 0bdf88f43b9a7e401bca9691ada00d83f8757b10
```

Result, running only those two cases:

```
FAIL  THE CONSEQUENCE: a covered factory returning JSX is READ, not skipped
      AssertionError: expected 'unreadable' to be 'inherits'
FAIL  ...and a FROZEN factory returning JSX is still caught
      AssertionError: expected 'unreadable' to be 'frozen'
Test Files  1 failed (1)   Tests  2 failed | 65 skipped (67)
```

Both RED, both for the right reason: the phantom regex swallows the closing parenthesis, so the call site cannot be delimited. Restore was performed under a `trap ... EXIT INT TERM` with absolute paths and is proven, not assumed:

```
BACK_BLOB = 08c990d1753e9e35dec21be28c68445c1211bd7f   (identical to the HEAD blob)
restored: original rule text = 1, injected marker = 0
git diff HEAD  -> empty
git status --porcelain -> empty
```

Re-run after restore: the same two cases, `2 passed | 65 skipped`, exit 0.

## 6. The caveat — ⛔ this PR does **not** claim the masker is correct on JSX

objectui#6891 closed only the LT-SLASH half. A slash after a right brace or after GT still opens a phantom — the self-closing tag, and a slash in JSX text. That half is **objectui#7882 and is still open**. The retired rewrite never covered it either (its pattern matched closing tags only), which is exactly why removing it loses no coverage — not because the problem is gone. That statement is now written into the gate's header and into the test's docblock as well, so the next reader of either file gets it without needing this PR.

## 7. Gates

All run on the final HEAD, `038c5afee`. Exit codes captured by redirect-then-capture, never through a pipe.

| gate | exit | reading |
|:--|--:|:--|
| `pnpm check:vi-mock-inherit` | 0 | verdict line quoted in section 1(b); byte-identical before and after |
| `pnpm exec vitest run scripts/__tests__/check-vi-mock-inherit.test.ts scripts/__tests__/js-comment-mask-jsx-6891.test.ts scripts/__tests__/check-vi-mock-specifiers.test.ts` | 0 | `Test Files 3 passed (3)`, `Tests 129 passed (129)` |
| `pnpm exec vitest run scripts/__tests__/` | 0 | `Test Files 113 passed (113)`, `Tests 3370 passed (3370)` |
| `pnpm check:vi-mock-specifiers` | 0 | OK, 4380 tracked sources |
| `pnpm type-check:scripts` | 0 | clean |
| `pnpm lint:root` | 0 | 32 problems, **0 errors**, 32 pre-existing warnings — none in either changed file |
| `pnpm check:control-bytes` | 0 | 6500 tracked text files scanned |
| `grep -naP` control-byte self-scan of both changed paths | 1 (no match) | clean |
| `node scripts/check-changeset-presence.mjs` | 0 | "no changeset is owed" — 2 files changed, 0 of them published source |
| `node scripts/check-governed-queue-guard.mjs --test` on both paths | 0 | **NOT GOVERNED** — ordinary review and merge-queue route |
| `pnpm check:entry-guard` | 0 | 70 scripts files; 63 export bindings, 63 inert on import, 0 known-unsafe |
| `pnpm check:unreferenced-sources` | 0 | every shipped source file reachable — the deleted export leaves no dangling reference |

`Live E2E (informational)` is red on every branch today for an upstream reason (objectui#7990 / objectstack#16186) and is not this PR's.

Session reference, as prose so it survives a body edit: `session_01FhBNJcLRZLe8M87VcUgpKr`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_