### PR TITLE
feat(gate): census the code generators emit from template literals (report-only)

### DIFF
--- a/.github/workflows/doc-snippet-types.yml
+++ b/.github/workflows/doc-snippet-types.yml
@@ -128,5 +128,22 @@ jobs:
           esac
           pnpm exec turbo run build $FILTER_ARGS --concurrency=2
 
+      # REPORT-ONLY (objectui#7864). Code a generator EMITS from a template
+      # literal under `packages/*/src/**` is compiled by nothing: `tsc` sees a
+      # string, `tsup` copies it through, and this gate's own scan surface stops
+      # at `content/docs`, the per-app docs trees and the package READMEs. This
+      # step censuses that class through the same `compileSnippets()` the doc
+      # blocks go through, against the closure the step above just built.
+      #
+      # It runs BEFORE the blocking gate on purpose. The census is meant to be
+      # re-read on every run, and placed after it the number would be skipped on
+      # exactly the runs where the corpus moved. It exits 0 whatever it finds —
+      # one known member (objectui#7472) is an OPEN card — and non-zero only when
+      # the instrument itself is broken: a walk that collapsed, or a failed
+      # harness control. A check that runs, goes green and looked at nothing is
+      # the counterfeit the gate's own header is built against.
+      - name: Census the code emitted from template literals (report-only)
+        run: node scripts/check-doc-snippet-types.mjs --emit-census
+
       - name: Compile documentation snippets against the built types
         run: node scripts/check-doc-snippet-types.mjs

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -871,6 +871,30 @@ with a reason, so a new page is gated from the day it lands and opting one out i
 The ledger is debt with names: those documents are **not** compiled and **not** counted, which the
 script's header states plainly rather than letting a green run imply otherwise.
 
+**It also censuses the code this repository's generators EMIT — report-only.** A second step in the
+same job runs `node scripts/check-doc-snippet-types.mjs --emit-census`, against the same built
+closure. Code a generator writes out of a template literal under `packages/*/src/**` is compiled by
+nothing: `tsc` sees a **string**, `tsup` copies it through, and every doc gate's scan surface — this
+one's included — stops at `content/docs`, the per-app docs trees and the package READMEs
+([#7864](https://github.com/objectstack-ai/objectui/issues/7864)). The class already had two members
+when the census was written: `packages/vscode-extension/src/extension.ts` emitted a phantom
+`registerDefaultRenderers` import into every file its *Export to React* command ever wrote for a user
+(fixed by [#7863](https://github.com/objectstack-ai/objectui/issues/7863)), and
+`packages/cli/src/utils/app-generator.ts` is
+[#7472](https://github.com/objectstack-ai/objectui/issues/7472), still open. A template is recognised
+when its text carries an `import … from '…'` statement, or when it is opted in by a
+`/* doc-snippet: emits tsx */` comment — one vocabulary with the fragment marker above; each `${…}`
+hole is substituted by an identifier placeholder before the snippet is handed to the same
+`compileSnippets()` a documentation block goes through. It prints a census — files walked, templates
+recognised, what the recogniser cannot see, diagnostics, and the per-package split — and **exits 0
+regardless of what it finds**, so it can block no merge; it exits non-zero only when the instrument
+itself is broken, a walk that collapsed or a failed harness control, because a check that runs, goes
+green and looked at nothing is worse than none. Report-only is a ruling, not an oversight: #7472's
+site is an open card, and a blocking gate on this landing would go red on somebody else's work. The
+population is the deliverable — whether the corpus gets cleaned or gets a declared ledger is decided
+from those numbers on a follow-up card. The step is placed before the blocking one so the number is
+re-read on every run instead of being skipped exactly when the corpus moved.
+
 **If it fails:** each line is `file:line TS<code>: <message>`, addressed at the document rather than
 at the harness. Either fix what the snippet teaches, or — if the block is genuinely partial — declare
 it with a reason. Run it locally with `pnpm check:doc-snippets` (after building the packages it

--- a/scripts/__tests__/check-doc-snippet-emitted-census.test.ts
+++ b/scripts/__tests__/check-doc-snippet-emitted-census.test.ts
@@ -1,0 +1,449 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+import {
+  EMITTED_HOLE_DECLARATION,
+  EMITTED_HOLE_PLACEHOLDER,
+  EMITTED_IMPORT,
+  EMITTED_MARKER,
+  EMITTED_MARKER_EXAMPLE,
+  EXIT_CODES,
+  classifyEmittedDiagnostic,
+  compileSnippets,
+  declaresHolePlaceholder,
+  derivePackageTypePaths,
+  emittedCensus,
+  emittedCensusSummary,
+  emittingPackageOf,
+  listEmittedSources,
+  scanEmittedTemplates,
+} from '../check-doc-snippet-types.mjs';
+
+/**
+ * objectui#7864 — the emitted-code census.
+ *
+ * Code a generator EMITS from a template literal under `packages/NAME/src/**` is
+ * compiled by nothing: `tsc` sees a string, `tsup` copies it through, and every
+ * doc gate's scan surface stops short of `src/`. This file pins the instrument
+ * that measures the class, and the three properties the card's binding
+ * constraint turns on:
+ *
+ *   1. the recogniser is OPT-IN — an ordinary template literal is not compiled;
+ *   2. the walk is NON-VACUOUS on the real tree, so a green census is a
+ *      measurement rather than an empty set;
+ *   3. a diagnostic on a recognised template is REPORTED and the exit code
+ *      stays 0 — report-only is a ruling, and a census that could fail a build
+ *      would have to be red today on objectui#7472's open site.
+ */
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const SCRIPT = 'scripts/check-doc-snippet-types.mjs';
+const BACKTICK = '`';
+
+/**
+ * A `.ts` source whose exported function returns `body` from a template
+ * literal. `marker`, when given, is written on the line immediately above the
+ * template — where the census reads a declaration, the same place `scanFences`
+ * reads a fragment marker.
+ */
+const emitterSource = (body: string, marker = ''): string =>
+  `export function emit(): string {\n${marker ? `  ${marker}\n` : ''}  return ${BACKTICK}${body}${BACKTICK};\n}\n`;
+
+function tempTree(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'emitted-census-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(root, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  fs.mkdirSync(path.join(root, 'packages'), { recursive: true });
+  return root;
+}
+
+/**
+ * A tree holding one BUILT fixture package plus the four templates the ruling
+ * asks to be told apart: one that compiles, one that does not, one that is not
+ * recognised at all, and one hidden in a `TOOLING_FILE` path.
+ */
+function fixtureTree(): string {
+  return tempTree({
+    'package.json': JSON.stringify({ name: 'fixture-root' }),
+    'packages/emitter/package.json': JSON.stringify({
+      name: '@fixture/emitter',
+      exports: { '.': { types: './dist/index.d.ts' } },
+    }),
+    'packages/emitter/dist/index.d.ts': 'export declare const real: number;\n',
+    'packages/emitter/src/good.ts': emitterSource(
+      "import { real } from '@fixture/emitter';\nexport const value = real;\n",
+    ),
+    'packages/emitter/src/bad.ts': emitterSource(
+      "import { phantom } from '@fixture/emitter';\nexport const value = phantom;\n",
+    ),
+    'packages/emitter/src/plain.ts': emitterSource('SELECT * FROM users WHERE id = 1;\n'),
+    'packages/emitter/src/__tests__/hidden.test.ts': emitterSource(
+      "import { real } from '@fixture/emitter';\nexport const value = real;\n",
+    ),
+  });
+}
+
+/** The census, compiled the way the gate compiles it. */
+function runCensus(root: string) {
+  const census = emittedCensus({ root }) as unknown as {
+    files: string[];
+    excludedAsTooling: string[];
+    templatesSeen: number;
+    markerSeen: number;
+    markerOnly: { file: string }[];
+    moduleShapedMisses: string[];
+    recognised: { file: string; line: number; holes: number; byHeuristic: boolean; marked: boolean }[];
+    blocks: { doc: string; fenceLine: number; body: string }[];
+  };
+  const { paths } = derivePackageTypePaths(root) as unknown as { paths: Record<string, string[]> };
+  const run = compileSnippets({ root, compiled: census.blocks, paths, declaredSpecifiers: [] }) as unknown as {
+    semanticFailures: { block: { doc: string }; diagnostics: { code: number }[] }[];
+    parseFailures: { block: { doc: string } }[];
+    boundFailures: { block: { doc: string } }[];
+    semanticallyJudged: number;
+  };
+  return { census, run };
+}
+
+describe('the recogniser is opt-in — an ordinary template literal is not compiled', () => {
+  it('recognises the import-bearing templates and leaves the plain one alone', () => {
+    const { census } = runCensus(fixtureTree());
+    const sites = census.recognised.map((r) => r.file).sort();
+    expect(sites).toEqual(['packages/emitter/src/bad.ts', 'packages/emitter/src/good.ts']);
+    expect(
+      sites,
+      'a template with no import is not code this gate has any business compiling — without ' +
+        'this control the census would be judging the corpus SQL, CSS and prose',
+    ).not.toContain('packages/emitter/src/plain.ts');
+  });
+
+  it('excludes TOOLING_FILE paths by the rule check-phantom-dependencies.mjs already owns', () => {
+    const { census } = runCensus(fixtureTree());
+    expect(census.excludedAsTooling).toEqual(['packages/emitter/src/__tests__/hidden.test.ts']);
+    expect(census.recognised.map((r) => r.file)).not.toContain(
+      'packages/emitter/src/__tests__/hidden.test.ts',
+    );
+  });
+
+  it('counts the excluded population instead of dropping it — a member in a fixture is its own fact', () => {
+    const { census } = runCensus(fixtureTree());
+    expect(census.excludedAsTooling.length).toBe(1);
+  });
+
+  it('honours the marker, so a template the heuristic cannot see is opted in by one comment', () => {
+    const root = tempTree({
+      'package.json': JSON.stringify({ name: 'fixture-root' }),
+      'packages/emitter/package.json': JSON.stringify({ name: '@fixture/emitter' }),
+      'packages/emitter/src/marked.ts': emitterSource(
+        'export const emitted = 1;\n',
+        EMITTED_MARKER_EXAMPLE,
+      ),
+    });
+    const { census } = runCensus(root);
+    expect(census.recognised.map((r) => r.file)).toEqual(['packages/emitter/src/marked.ts']);
+    expect(census.markerOnly.map((r) => r.file)).toEqual(['packages/emitter/src/marked.ts']);
+    expect(
+      census.recognised[0].byHeuristic,
+      'this template carries no import — it is in the census because the marker put it there',
+    ).toBe(false);
+  });
+
+  it('keeps ONE vocabulary with the fragment marker', () => {
+    expect(EMITTED_MARKER_EXAMPLE).toContain('doc-snippet:');
+    expect(EMITTED_MARKER.test(EMITTED_MARKER_EXAMPLE)).toBe(true);
+    expect(EMITTED_MARKER.test('// doc-snippet: emits tsx')).toBe(true);
+    expect(EMITTED_MARKER.test('/* doc-snippet: fragment - a doc block, not an emitter */')).toBe(false);
+  });
+
+  it('bounds the heuristic, so a long template with no import does not find a distant `from`', () => {
+    expect(EMITTED_IMPORT.test("import { a } from 'b';")).toBe(true);
+    expect(EMITTED_IMPORT.test("import 'side-effect';")).toBe(true);
+    expect(EMITTED_IMPORT.test('import {\n  a,\n  b,\n} from "c";')).toBe(true);
+    expect(EMITTED_IMPORT.test('const x = 1;\n')).toBe(false);
+    expect(
+      EMITTED_IMPORT.test(`import java.util;\n${'// filler\n'.repeat(60)}const from = 'x';\n`),
+      'unbounded, the lazy search would reach a `from` hundreds of lines below an `import` that ' +
+        'is not one, and every long template in the corpus would recognise',
+    ).toBe(false);
+  });
+});
+
+describe('a diagnostic on a recognised template is REPORTED, and nothing fails', () => {
+  it('reports the phantom import and leaves the compiling one clean', () => {
+    const { run } = runCensus(fixtureTree());
+    expect(run.semanticFailures.map((f) => f.block.doc)).toEqual(['packages/emitter/src/bad.ts']);
+    expect(run.semanticFailures[0].diagnostics.map((d) => d.code)).toContain(2305);
+    expect(run.semanticallyJudged, 'both recognised templates reached the semantic phase').toBe(2);
+  });
+
+  it('points the diagnostic at the real source line, not one line past it', () => {
+    const root = fixtureTree();
+    const { census, run } = runCensus(root);
+    const bad = census.recognised.find((r) => r.file === 'packages/emitter/src/bad.ts');
+    const block = run.semanticFailures[0].block as unknown as { fenceLine: number };
+    expect(
+      block.fenceLine + 1,
+      "a fenced block's body starts on the line AFTER its fence; a template literal's starts ON " +
+        'its backtick, so the anchor is one line earlier and the printed number is the real line',
+    ).toBe(bad!.line);
+  });
+
+  it('exits 0 on findings and NEVER 1 — report-only is the card\'s ruling, not an oversight', () => {
+    // Both halves of the contract, and which one runs where. On a BUILT tree
+    // this is the positive control the ruling asks for: real diagnostics are
+    // printed and the status is still 0. In the unit-test job, which does not
+    // build this gate's closure, the run leaves through `couldNotRun` instead —
+    // which is the OTHER half worth pinning: an unbuilt tree is "I could not
+    // run", and neither state is ever `documentsFailed`.
+    const result = spawnSync('node', [SCRIPT, '--emit-census'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      timeout: 300_000,
+    });
+    expect(
+      result.status,
+      `the census may never exit ${EXIT_CODES.documentsFailed} ("I ran and found errors"): a finding ` +
+        'here is a census row, and objectui#7472\'s site is an OPEN card this PR may not fix.\n' +
+        `${result.stdout ?? ''}\n${result.stderr ?? ''}`,
+    ).not.toBe(EXIT_CODES.documentsFailed);
+    expect([EXIT_CODES.verified, EXIT_CODES.couldNotRun]).toContain(result.status);
+    if (result.status === EXIT_CODES.verified) {
+      expect(result.stdout).toContain('Emitted-code census (report-only, objectui#7864)');
+      expect(result.stdout).toContain('REPORT-ONLY');
+      expect(
+        result.stdout,
+        'on this corpus the census has findings; a run that printed none would mean the ' +
+          'recogniser stopped recognising, not that the corpus got clean',
+      ).toMatch(/\[(semantic|syntax|bound)]/);
+    }
+  }, 300_000);
+
+  it('leaves the documentation verdict untouched — the flag is the whole of the change', () => {
+    const source = fs.readFileSync(path.join(repoRoot, SCRIPT), 'utf8');
+    expect(source).toContain("argv.includes('--emit-census')");
+    expect(
+      source.indexOf("argv.includes('--emit-census')"),
+      'the census must run AFTER the precondition gate: it compiles against the same built ' +
+        'closure, so an unbuilt tree is "I could not run" for it too',
+    ).toBeGreaterThan(source.indexOf('const blocking = blockingPreconditions(state.findings);'));
+  });
+});
+
+describe('`${…}` holes are substituted by a stated placeholder', () => {
+  it('substitutes every hole and keeps the literal text around them', () => {
+    const templates = scanEmittedTemplates(
+      `const a = ${BACKTICK}const schema = \${json};\nexport class \${name}Plugin {}${BACKTICK};\n`,
+    ) as unknown as { text: string; holes: number }[];
+    expect(templates).toHaveLength(1);
+    expect(templates[0].holes).toBe(2);
+    expect(templates[0].text).toBe(
+      `const schema = ${EMITTED_HOLE_PLACEHOLDER};\nexport class ${EMITTED_HOLE_PLACEHOLDER}Plugin {}`,
+    );
+  });
+
+  it('uses an IDENTIFIER, because the corpus interpolates inside identifiers too', () => {
+    expect(
+      /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(EMITTED_HOLE_PLACEHOLDER),
+      'an expression-shaped placeholder (`null`, `0 as any`) is a syntax error in `${name}Plugin`',
+    ).toBe(true);
+  });
+
+  it('declares the placeholder with `var`, never a block-scoped binding', () => {
+    expect(EMITTED_HOLE_DECLARATION).toBe(`declare var ${EMITTED_HOLE_PLACEHOLDER}: any;`);
+    expect(
+      EMITTED_HOLE_DECLARATION,
+      'a block-scoped declaration read above its own line is TS2448 — a diagnostic the ' +
+        'instrument would have invented',
+    ).not.toMatch(/\b(const|let)\b/);
+  });
+
+  it('appends the declaration, so every diagnostic line number still points at the source', () => {
+    const root = tempTree({
+      'package.json': JSON.stringify({ name: 'fixture-root' }),
+      'packages/emitter/package.json': JSON.stringify({ name: '@fixture/emitter' }),
+      'packages/emitter/src/holes.ts': emitterSource("import 'x';\nconst schema = ${json};\n"),
+    });
+    const { census } = runCensus(root);
+    expect(census.blocks).toHaveLength(1);
+    expect(census.blocks[0].body.startsWith("import 'x';")).toBe(true);
+    expect(census.blocks[0].body.trimEnd().endsWith(EMITTED_HOLE_DECLARATION)).toBe(true);
+  });
+
+  it('skips the declaration when the placeholder is itself a declared name', () => {
+    // `export const ${vars.pascalName}` becomes `export const __hole__`, and a
+    // declaration beside it is TS2395 — measured on
+    // `packages/create-plugin/src/templates.ts` before this guard existed.
+    expect(declaresHolePlaceholder(`export const ${EMITTED_HOLE_PLACEHOLDER} = 1;\n`)).toBe(true);
+    expect(declaresHolePlaceholder(`export const value = ${EMITTED_HOLE_PLACEHOLDER};\n`)).toBe(false);
+    expect(
+      declaresHolePlaceholder('this is not typescript at all ### <<<\n'),
+      'a body that does not parse never reaches the semantic phase, so it needs no declaration',
+    ).toBe(true);
+  });
+
+  it('descends into a hole\'s expression, so a nested emitter is censused in its own right', () => {
+    const templates = scanEmittedTemplates(
+      `const a = ${BACKTICK}outer \${${BACKTICK}import 'inner';${BACKTICK}} end${BACKTICK};\n`,
+    ) as unknown as { text: string }[];
+    expect(templates).toHaveLength(2);
+    expect(templates.map((t) => t.text)).toContain("import 'inner';");
+  });
+});
+
+describe('the census reports what it cannot see, and separates its own artefacts', () => {
+  it('classifies an interpolated specifier, a sibling and a real diagnostic apart', () => {
+    const chain = (code: number, text: string) => ({ code, messageText: text });
+    expect(
+      classifyEmittedDiagnostic(
+        chain(2307, `Cannot find module './schemas/${EMITTED_HOLE_PLACEHOLDER}' or its corresponding type declarations.`),
+      ),
+    ).toBe('interpolated');
+    expect(classifyEmittedDiagnostic(chain(2307, "Cannot find module './App' or its corresponding type declarations."))).toBe(
+      'sibling',
+    );
+    expect(
+      classifyEmittedDiagnostic(chain(2882, "Cannot find module or type declarations for side-effect import of './index.css'.")),
+    ).toBe('sibling');
+    expect(classifyEmittedDiagnostic(chain(2307, "Cannot find module 'vite-plugin-dts'."))).toBe('code');
+    expect(
+      classifyEmittedDiagnostic(chain(2769, "No overload matches this call.")),
+      'anything that is not a module-not-found is a fact about the emitted code',
+    ).toBe('code');
+  });
+
+  it('prints the blind side beside the recognised count', () => {
+    const root = fixtureTree();
+    const { census, run } = runCensus(root);
+    const { packageDirOf } = derivePackageTypePaths(root) as unknown as {
+      packageDirOf: Record<string, string>;
+    };
+    const summary = (emittedCensusSummary(census, run, packageDirOf) as unknown as string[]).join('\n');
+    expect(summary).toContain('Walked');
+    expect(summary).toContain('Recognised');
+    expect(
+      summary,
+      'a census that cannot see what it excludes is not a census — the opt-in route\'s ' +
+        'population and the templates NEITHER route reaches are printed every run',
+    ).toContain('Blind side');
+    expect(summary).toContain('Judged');
+    expect(summary).toContain('Diagnostics');
+  });
+
+  it('keys the per-package split by DIRECTORY as well as name — on this tree they disagree', () => {
+    expect(
+      emittingPackageOf('packages/vscode-extension/src/extension.ts', {
+        'object-ui': 'packages/vscode-extension',
+      }),
+      'packages/vscode-extension publishes as `object-ui`; a split keyed on the name alone ' +
+        'prints a row nobody can find on disk',
+    ).toBe('packages/vscode-extension (object-ui)');
+  });
+});
+
+describe('on this repository — the walk is non-vacuous and reaches both known members', () => {
+  const census = emittedCensus({ root: repoRoot }) as unknown as {
+    files: string[];
+    excludedAsTooling: string[];
+    templatesSeen: number;
+    recognised: { file: string; line: number }[];
+    blocks: { doc: string }[];
+  };
+
+  it('walks a real population, so a green census is a measurement rather than an empty set', () => {
+    expect(
+      census.files.length,
+      'the walk collapsed — every count the census prints would be a zero that means nothing',
+    ).toBeGreaterThan(500);
+    expect(census.excludedAsTooling.length).toBeGreaterThan(100);
+    expect(census.templatesSeen).toBeGreaterThan(500);
+  });
+
+  it('recognises at least the two members objectui#7864 names', () => {
+    const sites = new Set(census.recognised.map((r) => r.file));
+    expect(
+      sites,
+      'PR objectui#7863 fixed this one; the census must still SEE it, or nothing would notice ' +
+        'the phantom import coming back',
+    ).toContain('packages/vscode-extension/src/extension.ts');
+    expect(
+      sites,
+      'objectui#7472 is the known UNFIXED member. The card requires the census to show it; ' +
+        'it does not permit this PR to fix it, and that is why the gate is report-only.',
+    ).toContain('packages/cli/src/utils/app-generator.ts');
+    expect(census.recognised.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('names objectui#7472\'s site at the path it actually occupies', () => {
+    // The card writes `packages/cli/src/app-generator.ts`; the file is one
+    // directory deeper. Pinned so the next reader does not re-derive it.
+    expect(fs.existsSync(path.join(repoRoot, 'packages/cli/src/utils/app-generator.ts'))).toBe(true);
+    expect(fs.existsSync(path.join(repoRoot, 'packages/cli/src/app-generator.ts'))).toBe(false);
+  });
+
+  it('lets no TOOLING_FILE path into the compiled set', () => {
+    for (const block of census.blocks) {
+      expect(block.doc).not.toMatch(/(^|\/)(__tests__|__mocks__|__benchmarks__)\//);
+      expect(block.doc).not.toMatch(/\.(test|spec|bench|stories)\.[cm]?[jt]sx?$/);
+    }
+  });
+
+  it('collects only source files under a package src/', () => {
+    const { files } = listEmittedSources(repoRoot) as unknown as { files: string[] };
+    for (const file of files.slice(0, 50)) {
+      expect(file).toMatch(/^packages\/[^/]+\/src\/.+\.tsx?$/);
+    }
+  });
+});
+
+describe('wiring — a census nothing runs is not a census', () => {
+  const workflow = fs.readFileSync(
+    path.join(repoRoot, '.github/workflows/doc-snippet-types.yml'),
+    'utf8',
+  );
+
+  it('runs the census in the workflow that already builds this gate\'s closure', () => {
+    expect(workflow).toContain('--emit-census');
+  });
+
+  it('runs it AFTER the build and BEFORE the blocking gate, so a red gate cannot hide the number', () => {
+    const build = workflow.indexOf('turbo run build');
+    const census = workflow.indexOf(`node ${SCRIPT} --emit-census`);
+    const gate = workflow.search(new RegExp(`run: node ${SCRIPT.replace(/[.\\/]/g, '\\$&')}\\s*$`, 'm'));
+    expect(build).toBeGreaterThan(-1);
+    expect(census).toBeGreaterThan(build);
+    expect(
+      census,
+      'the number is meant to be re-read on every run; placed after the blocking step it would ' +
+        'be skipped on exactly the runs where the corpus moved',
+    ).toBeLessThan(gate);
+  });
+
+  it('is written up on the page objectui#3653 pins, and declared report-only there', () => {
+    const doc = fs.readFileSync(path.join(repoRoot, 'content/docs/guide/ci-cd-pipeline.md'), 'utf8');
+    expect(doc).toContain('--emit-census');
+    const row = doc.split('\n').find((line) => line.includes('--emit-census'));
+    expect(row, 'the page must say what it runs').toBeDefined();
+    // The paragraph the command lives in, bounded by its own blank lines: a
+    // byte window would pass on a `report-only` belonging to another section.
+    const at = doc.indexOf('--emit-census');
+    const start = doc.lastIndexOf('\n\n', at);
+    const end = doc.indexOf('\n\n', at);
+    // Whitespace-normalised: this page hard-wraps, so a sentence that must be
+    // present is split across lines in the source and matches nothing verbatim.
+    const paragraph = doc
+      .slice(start, end === -1 ? doc.length : end)
+      .toLowerCase()
+      .replace(/\s+/g, ' ');
+    expect(
+      paragraph,
+      'a step the page does not declare report-only is a guardrail readers believe in',
+    ).toContain('report-only');
+    expect(paragraph).toContain('exits 0 regardless of what it finds');
+  });
+});

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -400,6 +400,7 @@ import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
 import { isEntrypoint } from './invoked-as.mjs';
+import { TOOLING_FILE } from './check-phantom-dependencies.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -1553,6 +1554,395 @@ export function compileSnippets({ root = repoRoot, compiled, paths, declaredSpec
   };
 }
 
+// ── Emitted-code census: what a generator WRITES into someone else's file ────
+
+/**
+ * A generator that emits `import` statements is a documentation surface, and
+ * nothing compiles it (objectui#7864).
+ *
+ * Code a generator emits from a template literal under `packages/NAME/src/**` is
+ * read by nothing: `tsc` sees a STRING, `tsup` copies it through, and every doc
+ * gate's scan surface — this one's `listDocuments()` included — stops at
+ * `content/docs`, the per-app docs trees and the package READMEs. The class has
+ * two known members. `packages/vscode-extension/src/extension.ts`'s
+ * `generateReactComponent()` emitted a phantom `registerDefaultRenderers`
+ * import into every file the *Export to React* command ever wrote for a user
+ * (fixed by PR objectui#7863, measured there as `tsc` exit 2 / TS2305 on the
+ * emitted file); `packages/cli/src/utils/app-generator.ts` is objectui#7472,
+ * still open and still unfixed.
+ *
+ * ⭐ REPORT-ONLY, and the CENSUS is the deliverable. The card's binding
+ * constraint, and the same posture `check-doc-expression-carriage.mjs` landed
+ * under: objectui#7472's site is a KNOWN UNFIXED member, so a blocking gate on
+ * first landing would go red on somebody else's card and turn one card into
+ * two. What the population is — how many code-emitting templates exist, how
+ * many diagnostics they produce, and how they split by package — is what
+ * decides clean-the-corpus versus build-a-ledger, and ⛔ this file does not
+ * make that decision.
+ *
+ * Report-only means it declines to fail on its FINDINGS, never that it passes
+ * without looking (objectstack#4928, objectui#4690). A failed harness control,
+ * an unbuilt closure or a walk that collapsed is the gate's own
+ * `EXIT_CODES.couldNotRun`, loudly — a check that runs, goes green and looked
+ * at nothing is the counterfeit this whole file is built against.
+ *
+ * ## The recogniser: the static heuristic, with the marker kept as its escape
+ *
+ * Ruling: compile a template only when something says it is code. Three routes
+ * were priced.
+ *
+ *   HEURISTIC  a template whose text contains an `import … from '…'` statement.
+ *              Sees the whole class without anybody opting in; can MISFIRE, and
+ *              on this corpus it does — `packages/create-plugin/src/templates.ts`
+ *              emits a README whose ```tsx fence carries an import, and emits
+ *              vite configs importing `vite` and `@vitejs/plugin-react`, which
+ *              no documented package declares. Under report-only a misfire
+ *              costs a reported line, never a red build.
+ *   MARKER     an opt-in comment on the template. Cannot see an unmarked
+ *              emitter — and that is disqualifying HERE, not merely weaker:
+ *              this card may not touch `app-generator.ts` (objectui#7472 is on
+ *              hold), so under a marker route the one site the ruling requires
+ *              the census to show RED could not be marked at all, and the
+ *              census would report one site and zero diagnostics. A census that
+ *              cannot see the member it was filed for measures nothing.
+ *   PATH LIST  a hand-kept list of emitting files. Rots silently in the
+ *              direction that produces a green over a file nobody added.
+ *
+ * ⇒ The heuristic is the recogniser. The marker is kept and HONOURED as its
+ * escape hatch — a template the heuristic cannot see (it emits a module that
+ * imports nothing, or builds its import line out of holes) is opted in by one
+ * comment, and the census reports how many templates arrive that way. Kept, and
+ * honoured, rather than merely counted: a marker the gate reads and does not
+ * act on is a declaration the runtime does not cash, which is the shape
+ * AGENTS.md commandment #0.1 refuses. It carries ONE vocabulary with the
+ * fragment marker above — `doc-snippet:` — because a second spelling of the
+ * same idea is the thing readers stop being able to keep straight.
+ *
+ * The blind side is reported rather than assumed, every run, because a census
+ * that cannot see what it excludes is not a census: the marker population (what
+ * the opt-in route alone would have reached) and the count of unrecognised
+ * templates that open a top-level `export` (what NEITHER route sees today) are
+ * both printed beside the recognised count.
+ *
+ * ## `${…}` holes, and the one transformation this makes
+ *
+ * A template's holes are substituted by the placeholder identifier
+ * `EMITTED_HOLE_PLACEHOLDER`, and a body that had any gets ONE appended line
+ * declaring it. Both halves are load-bearing and both are stated because the
+ * snippet compiled is then not byte-identical to what the generator writes:
+ *
+ *   - The placeholder is an IDENTIFIER because the corpus interpolates in
+ *     identifier position as often as in expression position — this repository's
+ *     generators write `${vars.pascalName}Plugin` and `const schema =
+ *     ${schemaJson};` in the same breath. An expression-shaped placeholder
+ *     (`null`, `0 as any`) is a syntax error in the first; an identifier is
+ *     legal in both.
+ *   - The declaration is APPENDED, never prepended, so every diagnostic's line
+ *     number still points at the real source line. `var`, not `const`: a
+ *     block-scoped declaration read above its own line is TS2448, which would
+ *     be a diagnostic this instrument invented.
+ *
+ * What the substitution therefore cannot judge, said out loud: whether the
+ * VALUE a hole interpolates type-checks where it lands. This census answers
+ * only whether the code AROUND the holes does.
+ *
+ * ## Where it walks
+ *
+ * `packages/NAME/src/**` — `.ts` and `.tsx` — minus `TOOLING_FILE`, imported from
+ * `check-phantom-dependencies.mjs` rather than copied, so tests, mocks,
+ * benchmarks and stories drop out by the same rule that file already enforces.
+ * The excluded population is COUNTED and printed: a member hiding in a test
+ * fixture is a different fact from no member at all.
+ *
+ * Each recognised template is then compiled through `compileSnippets()` — the
+ * same call, the same built `.d.ts` closure, the same root bound, the same
+ * controls — so an emitted snippet is judged EXACTLY the way a documentation
+ * block is. That is the whole argument for putting this here instead of in a
+ * per-package test: the harness already exists, and route B would have bought
+ * one template at the cost of real `devDependencies` in a package that builds
+ * in 23 ms (objectui#7864's own table).
+ */
+
+/** The tree the census walks: every workspace package's `src/`. */
+export const EMITTED_SOURCE_SUBDIR = 'src';
+
+/** Source extensions the walk collects. */
+const EMITTED_SOURCE_EXTENSION = /\.tsx?$/;
+
+/**
+ * THE RECOGNISER. A template literal whose text carries an `import` statement —
+ * either `import … from '…'` (single- or multi-line specifier list) or a bare
+ * side-effect `import '…'`.
+ *
+ * The `from` search is bounded to 300 characters and stops at a `;` on purpose:
+ * unbounded, a lazy `[\s\S]*?` would happily reach a `from` hundreds of lines
+ * further down a template that has no import at all, and every long template in
+ * the corpus would recognise.
+ */
+export const EMITTED_IMPORT = new RegExp(
+  [
+    String.raw`(?:^|\n)[ \t]*import[ \t\n][^;]{0,300}?\bfrom[ \t\n]*['"][^'"\n]+['"]`,
+    String.raw`(?:^|\n)[ \t]*import[ \t]+['"][^'"\n]+['"]`,
+  ].join('|'),
+);
+
+/**
+ * The opt-in escape, in the fragment marker's own `doc-snippet:` vocabulary.
+ * Written on the nearest non-blank line above the template, in either comment
+ * form a `.ts` file can carry. Honoured, not merely counted: a template it
+ * marks joins the census whether or not the heuristic saw it.
+ */
+export const EMITTED_MARKER =
+  /^[ \t]*(?:\/\/|\/\*)[ \t]*doc-snippet:[ \t]*emits[ \t]+(?:ts|tsx|typescript)\b/;
+
+/** The marker, spelled out — quoted as a string for the reason
+ *  `FRAGMENT_MARKER_EXAMPLES` gives: a block comment cannot quote one. */
+export const EMITTED_MARKER_EXAMPLE = '/* doc-snippet: emits tsx */';
+
+/**
+ * What an unrecognised template has to show for the census to report it as a
+ * thing NEITHER route sees: a top-level `export` on its own line. Deliberately
+ * narrow — this is a gauge printed beside the recognised count, never a
+ * recogniser, and a wide one would report the corpus's SQL, CSS and prose
+ * templates as missed code.
+ */
+const EMITTED_MODULE_SHAPED = /(?:^|\n)[ \t]*export[ \t]+(?:default|const|let|var|function|class|type|interface|async)\b/;
+
+/** The placeholder each `${…}` hole is substituted by. An identifier, because
+ *  the corpus interpolates inside identifiers as well as in expression
+ *  position. */
+export const EMITTED_HOLE_PLACEHOLDER = '__hole__';
+
+/** The one line appended to a body that had holes. `var`, and appended rather
+ *  than prepended — see this section's header. */
+export const EMITTED_HOLE_DECLARATION = `declare var ${EMITTED_HOLE_PLACEHOLDER}: any;`;
+
+/**
+ * Whether a substituted body already DECLARES the placeholder as a name of its
+ * own — `export const ${vars.pascalName}` becomes `export const __hole__`, and
+ * appending the declaration beside it is TS2395 ("individual declarations in a
+ * merged declaration must be all exported or all local"): a diagnostic this
+ * instrument would have invented, on a template that is fine.
+ *
+ * Read from the AST, and only when the body parses: a body that does not parse
+ * never reaches the semantic phase, so it needs no declaration either.
+ *
+ * @param {string} body a hole-substituted template body
+ */
+export function declaresHolePlaceholder(body) {
+  const sf = ts.createSourceFile('hole-probe.tsx', body, ts.ScriptTarget.ES2022, true, ts.ScriptKind.TSX);
+  if (sf.parseDiagnostics && sf.parseDiagnostics.length > 0) return true;
+  let found = false;
+  const visit = (node) => {
+    if (found) return;
+    const name = /** @type {{ name?: ts.Node }} */ (node).name;
+    if (name && ts.isIdentifier(name) && name.text === EMITTED_HOLE_PLACEHOLDER) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sf, visit);
+  return found;
+}
+
+/**
+ * Every `.ts`/`.tsx` file under a workspace package's `src/`, split by the rule
+ * `check-phantom-dependencies.mjs` already owns.
+ *
+ * @param {string} root
+ * @returns {{ files: string[], excludedAsTooling: string[] }}
+ */
+export function listEmittedSources(root = repoRoot) {
+  const files = [];
+  const excludedAsTooling = [];
+  const pkgDir = join(root, PACKAGES_DIR);
+  if (!existsSync(pkgDir)) return { files, excludedAsTooling };
+  for (const entry of readdirSync(pkgDir).sort()) {
+    const src = join(pkgDir, entry, EMITTED_SOURCE_SUBDIR);
+    if (!existsSync(src) || !statSync(src).isDirectory()) continue;
+    const walk = (dir) => {
+      for (const name of readdirSync(dir).sort()) {
+        const p = join(dir, name);
+        if (statSync(p).isDirectory()) {
+          walk(p);
+          continue;
+        }
+        if (!EMITTED_SOURCE_EXTENSION.test(name)) continue;
+        const rel = relative(root, p).split(sep).join('/');
+        (TOOLING_FILE.test(rel) ? excludedAsTooling : files).push(rel);
+      }
+    };
+    walk(src);
+  }
+  return { files, excludedAsTooling };
+}
+
+/**
+ * Every template literal in one source file, with its `${…}` holes already
+ * substituted — read from the AST, never from a regex over the text, for the
+ * same reason `moduleSpecifiersOf` is (objectui#7555): a backtick inside a
+ * string, a comment or another template is not a template.
+ *
+ * A hole's own EXPRESSION is descended into, so a code-emitting template nested
+ * inside another template's hole is censused in its own right rather than
+ * disappearing into its parent's placeholder.
+ *
+ * @param {string} source
+ * @param {string} fileName
+ * @returns {{ line: number, text: string, holes: number }[]}
+ */
+export function scanEmittedTemplates(source, fileName = 'source.tsx') {
+  const sf = ts.createSourceFile(fileName, source, ts.ScriptTarget.ES2022, true, ts.ScriptKind.TSX);
+  const templates = [];
+  const at = (node) => sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
+  const visit = (node) => {
+    if (ts.isNoSubstitutionTemplateLiteral(node)) {
+      templates.push({ line: at(node), text: node.text, holes: 0 });
+      return;
+    }
+    if (ts.isTemplateExpression(node)) {
+      let text = node.head.text;
+      for (const span of node.templateSpans) {
+        text += EMITTED_HOLE_PLACEHOLDER + span.literal.text;
+      }
+      templates.push({ line: at(node), text, holes: node.templateSpans.length });
+      // The literal parts are already consumed; the holes' expressions are not.
+      for (const span of node.templateSpans) visit(span.expression);
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sf, visit);
+  return templates;
+}
+
+/**
+ * The census: walk, recognise, substitute, and hand the result to the same
+ * `compileSnippets()` a documentation block goes through.
+ *
+ * Returns counts and blocks; it prints nothing and it decides nothing. The
+ * caller reports.
+ *
+ * @param {{ root?: string }} options
+ */
+export function emittedCensus({ root = repoRoot } = {}) {
+  const { files, excludedAsTooling } = listEmittedSources(root);
+  const recognised = [];
+  const markerOnly = [];
+  const moduleShapedMisses = [];
+  let templatesSeen = 0;
+  let markerSeen = 0;
+
+  for (const file of files) {
+    const source = readFileSync(join(root, file), 'utf8');
+    const lines = source.split('\n');
+    for (const template of scanEmittedTemplates(source, file)) {
+      templatesSeen++;
+      // The marker is the nearest non-blank line above the template's own line,
+      // read the way `scanFences` reads a fragment declaration.
+      let k = template.line - 2;
+      while (k >= 0 && lines[k].trim() === '') k--;
+      const marked = k >= 0 && EMITTED_MARKER.test(lines[k]);
+      if (marked) markerSeen++;
+      const byHeuristic = EMITTED_IMPORT.test(template.text);
+      if (byHeuristic || marked) {
+        const entry = { file, ...template, byHeuristic, marked };
+        recognised.push(entry);
+        if (marked && !byHeuristic) markerOnly.push(entry);
+        continue;
+      }
+      if (EMITTED_MODULE_SHAPED.test(template.text)) {
+        moduleShapedMisses.push(`${file}:${template.line}`);
+      }
+    }
+  }
+
+  const blocks = recognised.map((entry) => {
+    const substituted = entry.text;
+    const needsDeclaration = entry.holes > 0 && !declaresHolePlaceholder(substituted);
+    return {
+      doc: entry.file,
+      // `formatDiagnostic` prints `fenceLine + 1 + line`, because a FENCED
+      // block's body starts on the line after its fence. A template literal's
+      // body starts ON its backtick's line, so the anchor sits one line earlier
+      // and the printed number is the real source line.
+      fenceLine: entry.line - 1,
+      language: 'tsx',
+      quoteDepth: 0,
+      fragmentReason: null,
+      body: needsDeclaration ? `${substituted}\n${EMITTED_HOLE_DECLARATION}\n` : substituted,
+    };
+  });
+
+  return {
+    files,
+    excludedAsTooling,
+    templatesSeen,
+    markerSeen,
+    markerOnly,
+    moduleShapedMisses,
+    recognised,
+    blocks,
+  };
+}
+
+/**
+ * `packages/<dir>/…` -> `packages/<dir> (<manifest name>)`.
+ *
+ * Both halves, because on this corpus neither is enough on its own: the
+ * directory is what the walk collected and what a reader greps for, and the
+ * manifest name is what the rest of this gate's output is keyed by — and they
+ * disagree. `packages/vscode-extension` publishes under the name `object-ui`,
+ * so a split keyed on the name alone prints a row nobody can find on disk.
+ *
+ * @param {string} file
+ * @param {Record<string, string>} packageDirOf
+ */
+export function emittingPackageOf(file, packageDirOf = {}) {
+  const dir = file.split('/').slice(0, 2).join('/');
+  for (const [name, packageDir] of Object.entries(packageDirOf)) {
+    if (packageDir === dir) return `${dir} (${name})`;
+  }
+  return dir;
+}
+
+/**
+ * Which of three things a census diagnostic is. The split exists because a
+ * census whose headline number is dominated by artefacts of its own METHOD
+ * decides nothing, and deciding is the only reason this card exists.
+ *
+ *   `interpolated`  a module-not-found whose specifier still contains the hole
+ *                   placeholder: the emitted import TARGET is itself
+ *                   interpolated, so there is no specifier for any compiler to
+ *                   resolve. An artefact of the substitution, by construction.
+ *   `sibling`       a module-not-found on a RELATIVE specifier. The generators
+ *                   in this corpus write whole projects — `./App`,
+ *                   `./index.css`, `./theme-provider`, `./Layout` are files the
+ *                   same generator emits beside the one being judged, and no
+ *                   per-snippet compile can resolve a sibling that exists only
+ *                   after the generator has run. An artefact of the METHOD
+ *                   (isolation), which this gate inherits deliberately from the
+ *                   documentation rule "in isolation, as its own module".
+ *   `code`          everything else — the diagnostics that say something about
+ *                   the emitted code itself.
+ *
+ * ⚠️ It reads the diagnostic's MESSAGE for the quoted specifier, the only place
+ * a specifier survives into a `Diagnostic`. A TypeScript wording change moves
+ * these counts; it moves no verdict, because this gate publishes none.
+ *
+ * @param {{ code: number, messageText: string | ts.DiagnosticMessageChain }} diagnostic
+ * @returns {'interpolated' | 'sibling' | 'code'}
+ */
+export function classifyEmittedDiagnostic(diagnostic) {
+  if (diagnostic.code !== 2307 && diagnostic.code !== 2882) return 'code';
+  const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ');
+  const quoted = /'([^']+)'/.exec(message);
+  if (!quoted) return 'code';
+  if (quoted[1].includes(EMITTED_HOLE_PLACEHOLDER)) return 'interpolated';
+  return quoted[1].startsWith('.') ? 'sibling' : 'code';
+}
+
 // ── Reporting ────────────────────────────────────────────────────────────────
 
 function formatDiagnostic(diagnostic, block) {
@@ -1566,6 +1956,73 @@ function formatDiagnostic(diagnostic, block) {
     where = `${block.doc}:${block.fenceLine}`;
   }
   return `${where}  TS${diagnostic.code}: ${message}`;
+}
+
+/**
+ * The census summary, in this gate's own verdict style: what was walked, what
+ * was recognised, what the recogniser CANNOT see, what was judged, and the
+ * per-package split. Returned as lines rather than printed, so the shape is
+ * pinnable without spawning the gate.
+ *
+ * Every line is a count this run took. ⛔ None of them is a threshold: this
+ * census has no pass mark, and adding one is the decision objectui#7864's
+ * binding constraint reserves for the follow-up card.
+ *
+ * Typed structurally rather than as `ReturnType<typeof emittedCensus>`: the
+ * annotation then states exactly which fields the report READS, which is the
+ * half a reader needs, and a caller holding a narrower view of the census (a
+ * test) is not forced to restate fields nothing here touches.
+ *
+ * @param {{ files: string[], excludedAsTooling: string[], templatesSeen: number, markerSeen: number, markerOnly: unknown[], moduleShapedMisses: unknown[], recognised: { file: string, line: number, byHeuristic: boolean }[], blocks: unknown[] }} census
+ * @param {{ semanticFailures: { block: { doc: string } }[], parseFailures: { block: { doc: string } }[], boundFailures: { block: { doc: string } }[], semanticallyJudged: number }} run
+ * @param {Record<string, string>} packageDirOf
+ * @returns {string[]}
+ */
+export function emittedCensusSummary(census, run, packageDirOf = {}) {
+  const diagnosticsBySite = new Map();
+  const byClass = { interpolated: 0, sibling: 0, code: 0 };
+  for (const { block, diagnostics } of run.semanticFailures) {
+    diagnosticsBySite.set(`${block.doc}:${block.fenceLine + 1}`, diagnostics.length);
+    for (const d of diagnostics) byClass[classifyEmittedDiagnostic(d)] += 1;
+  }
+  const perPackage = new Map();
+  for (const entry of census.recognised) {
+    const name = emittingPackageOf(entry.file, packageDirOf);
+    const row = perPackage.get(name) ?? { sites: 0, diagnostics: 0, failed: 0 };
+    row.sites += 1;
+    const found = diagnosticsBySite.get(`${entry.file}:${entry.line}`) ?? 0;
+    row.diagnostics += found;
+    if (found > 0) row.failed += 1;
+    perPackage.set(name, row);
+  }
+  const totalDiagnostics = [...diagnosticsBySite.values()].reduce((n, d) => n + d, 0);
+
+  const lines = [
+    'Emitted-code census (report-only, objectui#7864) — a generator that emits `import`',
+    'statements is a documentation surface, and until now nothing compiled one.',
+    `  Walked        ${census.files.length} source file(s) under ${PACKAGES_DIR}/NAME/${EMITTED_SOURCE_SUBDIR}; ` +
+      `${census.excludedAsTooling.length} excluded as TOOLING_FILE (tests, mocks, benchmarks, stories).`,
+    `  Recognised    ${census.recognised.length} of ${census.templatesSeen} template literal(s): ` +
+      `${census.recognised.filter((e) => e.byHeuristic).length} by the import heuristic, ` +
+      `${census.markerOnly.length} by the \`doc-snippet: emits\` marker alone.`,
+    `  Blind side    ${census.markerSeen} template(s) carry the marker at all — the population an opt-in-only ` +
+      `route would have reached. ${census.moduleShapedMisses.length} unrecognised template(s) open a top-level ` +
+      '`export` and are seen by NEITHER route.',
+    `  Judged        ${run.semanticallyJudged} of ${census.blocks.length} recognised template(s) reached the ` +
+      `semantic phase; ${run.parseFailures.length} failed to parse, ${run.boundFailures.length} were refused by ` +
+      'the root bound. Neither of those is a pass.',
+    `  Diagnostics   ${totalDiagnostics} across ${diagnosticsBySite.size} site(s).`,
+    `  Of which      ${byClass.sibling} module-not-found on a sibling the same generator writes (an artefact of ` +
+      `judging one emitted file in isolation) and ${byClass.interpolated} on a specifier that is itself ` +
+      `interpolated (an artefact of the hole substitution). ${byClass.code} remain, and those are the only ` +
+      'ones that say anything about the emitted code.',
+  ];
+  for (const [name, row] of [...perPackage].sort()) {
+    lines.push(
+      `  ${name.padEnd(42)} ${row.sites} site(s), ${row.failed} with diagnostic(s), ${row.diagnostics} diagnostic(s).`,
+    );
+  }
+  return lines;
 }
 
 /**
@@ -1720,6 +2177,92 @@ function main() {
       `\n${scopedBuildNotice(state.neededPackages.size, Object.keys(state.packageDirOf).length)}`,
     );
     return EXIT_CODES.couldNotRun;
+  }
+
+  // ── the emitted-code census (objectui#7864) ───────────────────────────────
+  // REPORT-ONLY, and behind a flag: an existing caller's verdict and exit code
+  // do not move by one byte. It runs AFTER the precondition gate above on
+  // purpose — it compiles against the same built closure, so an unbuilt tree is
+  // "I could not run" here for exactly the reason it is there.
+  if (argv.includes('--emit-census')) {
+    const census = emittedCensus({ root: repoRoot });
+    if (census.files.length === 0) {
+      console.error(
+        `The emitted-code walk collected 0 file(s) under ${PACKAGES_DIR}/NAME/${EMITTED_SOURCE_SUBDIR}, so ` +
+          'every count below would be a zero that means nothing. A walk that collapsed is a verdict ' +
+          'about this instrument, never about the corpus.',
+      );
+      return EXIT_CODES.couldNotRun;
+    }
+
+    const censusRun = compileSnippets({
+      root: repoRoot,
+      compiled: census.blocks,
+      paths: state.paths,
+      declaredSpecifiers: state.declaredSpecifiers,
+    });
+
+    // The same controls the documentation verdict is gated on, for the same
+    // reason: a program resolving everything to `any` reports a clean census
+    // forever, and a clean census is precisely what this card must not
+    // manufacture.
+    const censusControls = [];
+    if (!censusRun.resolvedFileName || !/[\\/]dist[\\/].*\.d\.ts$/.test(censusRun.resolvedFileName)) {
+      censusControls.push(
+        `resolution did not land on a built artifact (${censusRun.resolvedFileName ?? 'unresolved'})`,
+      );
+    }
+    if (censusRun.srcLeaks.length > 0) {
+      censusControls.push(
+        `${censusRun.srcLeaks.length} source file(s) under a package's src/ entered the program, e.g. ${censusRun.srcLeaks[0]}`,
+      );
+    }
+    if (!censusRun.sentinelDiagnostics.map((d) => d.code).includes(2305)) {
+      censusControls.push("the planted sentinel produced no TS2305 — the program is resolving everything to 'any'");
+    }
+    if (censusRun.positiveDiagnostics.length > 0) {
+      censusControls.push(
+        `the positive control failed (${ts.flattenDiagnosticMessageText(censusRun.positiveDiagnostics[0].messageText, ' ')})`,
+      );
+    }
+    if (censusControls.length > 0) {
+      console.error('CENSUS HARNESS CONTROL FAILED — no count below is a fact about any emitter:');
+      for (const c of censusControls) console.error(`  - ${c}`);
+      console.error(
+        `\nThe census COULD NOT RUN (exit ${EXIT_CODES.couldNotRun}). Report-only means it declines to ` +
+          'fail on its FINDINGS, never that it passes without looking.',
+      );
+      return EXIT_CODES.couldNotRun;
+    }
+
+    for (const line of emittedCensusSummary(census, censusRun, state.packageDirOf)) console.log(line);
+    console.log('');
+
+    // The findings themselves. Printed on stdout, deliberately: they are a
+    // census, not a verdict, and nothing here fails the build.
+    for (const { block, diagnostics } of censusRun.parseFailures) {
+      for (const d of diagnostics) console.log(`  [syntax]    ${formatDiagnostic(d, block)}`);
+    }
+    for (const { block, diagnostics } of censusRun.semanticFailures) {
+      for (const d of diagnostics) console.log(`  [semantic]  ${formatDiagnostic(d, block)}`);
+    }
+    for (const { block, specifiers } of censusRun.boundFailures) {
+      console.log(
+        `  [bound]     ${block.doc}:${block.fenceLine + 1}  emits an import of ${specifiers
+          .map((s) => `'${s}'`)
+          .join(', ')}, which resolve only through this repository's ROOT package.json — not through ` +
+          'anything the emitted file\'s reader installs.',
+      );
+    }
+
+    console.log(
+      `\nREPORT-ONLY (exit ${EXIT_CODES.verified}) — objectui#7864 rules that the census IS the ` +
+        'deliverable and that no finding here may fail a build on this landing: one known member ' +
+        '(objectui#7472) is open and unfixed, so a blocking gate would go red on somebody else\'s ' +
+        'card. Whether this corpus gets cleaned or gets a declared ledger is decided from the ' +
+        'numbers above, on a follow-up card, and ⛔ not here.',
+    );
+    return EXIT_CODES.verified;
   }
 
   const run = compileSnippets({


### PR DESCRIPTION
Fixes #7864

Route C, as ruled on the card: `scripts/check-doc-snippet-types.mjs` — this repository's documentation-surface compiler, which already builds a scoped closure and compiles snippets against built `.d.ts` — now censuses the code this repository's generators **emit from template literals** under `packages/*/src/**`. **Report-only on first landing, and the census is the deliverable.**

## The recogniser, and its blind side

| route | taken? | why |
|:--|:--|:--|
| **static heuristic** — a template whose text carries an `import … from '…'` statement | ⭐ **yes** | Sees the class without anybody opting in. Misfires, and on this corpus it does (below) — under report-only a misfire costs a printed line, never a red build. |
| **marker** — an opt-in `/* doc-snippet: emits tsx */` comment | kept as the heuristic's **escape**, not as the route | **Disqualified as the primary route, not merely weaker.** The one site the card requires the census to show red — `packages/cli/src/utils/app-generator.ts`, objectui#7472 — sits in a file this PR may not touch. Under a marker-only route it could not be marked, so the census would report **1 site and 0 diagnostics**: a census that cannot see the member it was filed for measures nothing. |
| **path list** | no | Rots silently in the direction that produces a green over a file nobody added. |

The marker is **honoured**, not merely counted: a template it marks joins the census whether or not the heuristic saw it. Counting it without acting on it would be a declaration the runtime does not cash — the shape AGENTS.md commandment #0.1 refuses. It carries the **same `doc-snippet:` vocabulary** as the existing fragment marker; no second spelling was invented.

**The blind side is printed every run**, because a census that cannot see what it excludes is not a census:

- **0** templates carry the marker at all — the population an opt-in-only route would have reached today.
- **5** unrecognised templates open a top-level `export` and are seen by **neither** route.
- **2380** files under `packages/*/src/**` were excluded as `TOOLING_FILE` (regex imported from `scripts/check-phantom-dependencies.mjs`, not copied). Three of them do hold import-bearing templates: `packages/cli/src/__tests__/app-generator.test.ts`, `packages/types/src/__tests__/partial-schema-collapse-pin.test.ts`, `packages/vscode-extension/src/__tests__/export-to-react-compiles.test.ts`.

## The census

Measured at `1184533dc` on a built closure. Verbatim from `node scripts/check-doc-snippet-types.mjs --emit-census`:

```
  Walked        1414 source file(s) under packages/NAME/src; 2380 excluded as TOOLING_FILE (tests, mocks, benchmarks, stories).
  Recognised    20 of 3778 template literal(s): 20 by the import heuristic, 0 by the `doc-snippet: emits` marker alone.
  Blind side    0 template(s) carry the marker at all — the population an opt-in-only route would have reached. 5 unrecognised template(s) open a top-level `export` and are seen by NEITHER route.
  Judged        15 of 20 recognised template(s) reached the semantic phase; 1 failed to parse, 4 were refused by the root bound. Neither of those is a pass.
  Diagnostics   16 across 9 site(s).
  Of which      10 module-not-found on a sibling the same generator writes (an artefact of judging one emitted file in isolation) and 4 on a specifier that is itself interpolated (an artefact of the hole substitution). 2 remain, and those are the only ones that say anything about the emitted code.
  packages/cli (@object-ui/cli)              11 site(s), 6 with diagnostic(s), 10 diagnostic(s).
  packages/create-plugin (@object-ui/create-plugin) 8 site(s), 3 with diagnostic(s), 6 diagnostic(s).
  packages/vscode-extension (object-ui)      1 site(s), 0 with diagnostic(s), 0 diagnostic(s).
```

**The number that decides the follow-up card is `2`, not `16`.** The headline is dominated by artefacts of the census's own method, and they are separated out on their own line rather than left in the total:

| class | count | what it is |
|:--|--:|:--|
| `sibling` | 10 | Module-not-found on a **relative** specifier — `./App`, `./index.css`, `./theme-provider`, `./Layout`, `../app.json`, `./types`. These generators write whole projects; a per-snippet compile structurally cannot resolve a sibling that exists only after the generator has run. Inherited deliberately from the documentation rule *"in isolation, as its own module"*. |
| `interpolated` | 4 | Module-not-found on a specifier that is itself a `${…}` hole (`'./schemas/__hole__'`, `'./__hole__Impl'`). There is no specifier for any compiler to resolve — an artefact of the substitution, by construction. |
| `code` | **2** | Says something about the emitted code. See below. |

Plus **4 sites refused by the root bound** (they emit imports of `react-router-dom`, `@testing-library/react`, `vitest`, `@testing-library/jest-dom/vitest` — specifiers that resolve here only through this repository's own `package.json`, i.e. through nothing the emitted file's reader installs) and **1 parse failure**, which is a heuristic misfire: `packages/create-plugin/src/templates.ts:286` emits a **README**, and the `tsx` fence inside it carries an import.

**The two `code` diagnostics**, both in `packages/create-plugin/src/templates.ts`, both candidates for the PM to card:

- `:234` `TS2307: Cannot find module 'vite-plugin-dts'` — the emitted `vite.config.ts` imports a package no documented package declares.
- `:261` `TS2769: … 'test' does not exist in type 'UserConfigExport'` — the emitted vite config passes a `test:` block to `defineConfig` imported from `'vite'`. That is the real shape of the class this card is about.

**objectui#7472's site shows up**, as the ruling requires: `packages/cli/src/utils/app-generator.ts` carries 4 of the 11 `packages/cli` sites and 5 of its 10 diagnostics. ⛔ This PR does not address it — that card is `pm:on-hold`.

**PR objectui#7863's repair holds**: `packages/vscode-extension/src/extension.ts`, 1 site, **0 diagnostics**.

⚠️ One inherited path correction: the card writes `packages/cli/src/app-generator.ts`. The file is one directory deeper, at `packages/cli/src/utils/app-generator.ts`. Pinned in the test file so nobody re-derives it.

## The instrument

A separate walk over `packages/*/src/**/*.ts{,x}` minus `TOOLING_FILE`, extracting each recognised template **from the AST** (never a regex over the text — a backtick in a string or a comment is not a template), then handing each one to the gate's existing `compileSnippets()` with the same `paths`, the same `declaredSpecifiers` and the same four controls. An emitted snippet is judged **exactly** the way a documentation block is; that reuse is the whole argument for putting this here rather than in a per-package test.

**Holes.** Each `${…}` is substituted by the identifier `__hole__`, and a body that had any gets **one appended** line, `declare var __hole__: any;`. Both halves are stated in the source because the compiled snippet is then not byte-identical to what the generator writes:

- an **identifier**, because this corpus interpolates inside identifiers (`${vars.pascalName}Plugin`) as often as in expression position (`const schema = ${schemaJson};`) — an expression-shaped placeholder is a syntax error in the first;
- **appended**, so every diagnostic's line number still points at the real source line; `var`, not `const`, because a block-scoped binding read above its own line is TS2448 — a diagnostic the instrument would have invented;
- **skipped entirely** when the placeholder is itself a declared name (`export const ${vars.pascalName}` becomes `export const __hole__`). Measured: without that guard the census invented 2 TS2395s on `templates.ts`.

What the substitution therefore cannot judge, said out loud in the header: whether the **value** a hole interpolates type-checks where it lands.

**Behind a flag, per the seat's reading.** `--emit-census`. The documentation verdict and exit code do not move for existing callers, and `--build-filter`'s output was diffed against the base commit's copy of the script and is **byte-identical**. The census runs *after* the precondition gate (it needs the same built closure) and returns `EXIT_CODES.verified` on any finding; it returns `couldNotRun` only when the walk collapsed or a harness control failed — report-only means it declines to fail on its **findings**, never that it passes without looking.

## ⛔ Burn-down licence — objectui#5174 batch 26 re-baselines from here

This change **moves** the strictness region objectui#5174's batches pin byte-identical. Allowed for this card; the new baseline, for batch 26's dev:

| | line of the `Fence scanning` banner | sha256 of banner → EOF |
|:--|:--|:--|
| base `23933ae25` | 730 | `f46b5662ba336f026bca3a0003e0b7979789d48d0291fa5760be7d23c8ed0160` |
| this PR `1184533dc` | **731** | **`5dfcd1b876c044ef33b6b5fed8a57ec719622ddbb20ce0ab539e5c985a233017`** |

`UNGATED_DOCS` is **untouched** — no row added, none removed. If the census wants its own ledger, that is the follow-up card's decision, not this PR's.

## Tests — `scripts/__tests__/check-doc-snippet-emitted-census.test.ts`

27 tests, all green, covering the three properties the binding constraint turns on:

- **the recogniser is opt-in** — a fixture tree with a template that compiles, one that does not (a phantom import, TS2305), one plain template that is **not** recognised, and one hidden in a `__tests__/` path that is excluded and **counted**;
- **the walk is non-vacuous on the real tree** — 1414 files, 3778 templates, and both known members present by name;
- **a diagnostic is REPORTED and the exit code stays 0** — the census is spawned against this repository and the status asserted never to be `documentsFailed`; on a built tree (locally) the full positive control runs: real `[semantic]` lines printed, status 0.

Plus the hole substitution, the placeholder-collision guard, the diagnostic classifier, the marker vocabulary, the heuristic's bound, and the CI wiring.

**Reverse verification.** Committed first, then ablated: `const byHeuristic = EMITTED_IMPORT.test(template.text)` replaced by `false` on disk (anchor count 1 → 0, mutant count 1, blob `e84025fbb…` → `eecf59d63…`). **6 of 27 tests turned red**, including `recognises at least the two members objectui#7864 names` and the spawned exit-code control. Restored with `git checkout HEAD -- …`; `git diff HEAD` empty and the disk blob equal to the HEAD blob again.

## CI

One report-only step in `.github/workflows/doc-snippet-types.yml`, placed **after** the build and **before** the blocking gate — the number is meant to be re-read on every run, and after the blocking step it would be skipped on exactly the runs where the corpus moved. The matching write-up landed in `content/docs/guide/ci-cd-pipeline.md`'s *Documented Snippet Types* section, in the shape of the `check-doc-expression-carriage` entry: what it runs, that it exits 0 regardless of what it finds, and why report-only is a ruling rather than an oversight (objectui#3653 pins that page by command).

## Gates

All run at `1184533dc`, exit codes captured by redirect-then-capture:

| gate | exit | verdict line |
|:--|:--|:--|
| `pnpm check:doc-snippets` | 0 | `Every covered documentation snippet compiles against the built types.` (572 of 572 judged, 0 failed — unchanged) |
| `node scripts/check-doc-snippet-types.mjs --emit-census` | 0 | `REPORT-ONLY (exit 0)`, census as quoted above |
| `--build-filter` vs. base | 0 | `diff` empty against `23933ae25`'s copy of the script |
| `pnpm exec vitest run scripts/__tests__/check-doc-snippet-emitted-census.test.ts` | 0 | 27 passed |
| `pnpm exec vitest run scripts/__tests__/` | 0 | 114 files, 3401 passed |
| `pnpm check:doc-fences` | 0 | 227 documents, no unknown fence spelling |
| `pnpm check:doc-types` | 0 | `Every documented component type is registered.` |
| `pnpm type-check:scripts` | 0 | clean |
| `pnpm lint:root` | 0 | 0 errors, 32 warnings — none in the changed files |
| `pnpm check:control-bytes` | 0 | 6506 tracked text files |
| `grep -naP` self-scan of all 4 changed paths | 1 | no match |
| `pnpm check:entry-guard` | 0 | 70 scripts, no entry guard outside the baseline |
| `pnpm check:pre-install-import-graph` | 0 | 25 pre-install steps, every non-relative leaf a node builtin |
| `node scripts/check-changeset-presence.mjs` | 0 | `No source or published contract of a released package changed in this range` |
| `node scripts/check-governed-queue-guard.mjs --test` (4 paths) | 0 | `NOT GOVERNED — 4 path(s) checked against 5 governed surface(s); none matched.` |
| `pnpm type-check:coverage` | 0 | 45/46 |
| `node scripts/check-doc-links.mjs` | 0 | `Links are valid across 17 scan roots.` |

No changeset is owed: the diff is the gate, its test, one workflow and one doc page — nothing publishes from a package. `packages/vscode-extension` was **not** touched (the marker route was not taken), so the changeset the card warns about does not arise.

`Live E2E (informational)` is red on every branch today for an upstream reason (objectui#7990 / objectstack#16186) — not this PR's.

## What this PR deliberately does not decide

Whether the corpus gets cleaned or gets a declared ledger, and whether any rule here should ever block. That is what the numbers above are for, on a follow-up card the PM opens. ⛔ objectui#7472 is not addressed here and remains open.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_