### PR TITLE
fix(components): combobox honours options[].disabled

### DIFF
--- a/.changeset/7687-combobox-option-disabled.md
+++ b/.changeset/7687-combobox-option-disabled.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/components': minor
+---
+
+Honour `options[].disabled` on a `combobox` node (objectui#7687).
+
+**User-visible behaviour change, deliberately — hence `minor`, not `patch`.** The
+member was already declared by `@object-ui/types` (`ComboboxOption.disabled`) and
+already validated by the zod mirror (`ComboboxOptionSchema`, pinned as `boolean`
+on both faces by the objectui#7087 twin-symmetry ruling), but the component never
+read it: `Combobox` mapped each option to a `CommandItem` carrying `key`, `value`
+and `onSelect` only. So an option authored `{ value, label, disabled: true }`
+passed `safeValidateSchema`, type-checked against the published `ComboboxSchema`,
+and then rendered as an ordinary, fully selectable option — a declared key with no
+read site behind it, the class the enforce-or-remove ledgers exist to close.
+
+An author who already writes `disabled: true` today gets a different combobox
+after this change: that option now renders dimmed and can no longer be chosen, by
+click or by keyboard. That is the intended repair — declared and validated should
+mean enforced — but it is a change in what existing metadata does, not a silent
+internal fix, so it is priced as a behaviour change rather than a patch.
+
+The alternative remedy, retiring `disabled` from `ComboboxOption` and the zod
+mirror, was weighed and **not** adopted: it narrows a published surface and would
+require the objectui#7087 twin-symmetry pin to be changed, where honouring the key
+restores declared = enforced at the cost of one prop. The spelling follows the
+sibling select renderer, which already sets `disabled={opt.disabled}` on its
+`SelectItem`.
+
+Nothing else moves. The whole-control `disabled` prop (the one forwarded to the
+trigger button) is untouched, `@object-ui/types` is untouched, and no new key is
+introduced — this release only starts reading one that was already published.

--- a/.changeset/7687-combobox-option-disabled.md
+++ b/.changeset/7687-combobox-option-disabled.md
@@ -28,5 +28,15 @@ sibling select renderer, which already sets `disabled={opt.disabled}` on its
 `SelectItem`.
 
 Nothing else moves. The whole-control `disabled` prop (the one forwarded to the
-trigger button) is untouched, `@object-ui/types` is untouched, and no new key is
-introduced — this release only starts reading one that was already published.
+trigger button) is untouched, no key is added to `@object-ui/types`, and no new
+key is introduced — this release only starts reading one that was already
+published.
+
+`@object-ui/types` is deliberately **not** given its own bump. The one file that
+changes there is a test, `component-docs-disabled-inherited-7239.test.ts`: its
+census over `content/docs/components` counts every documented `disabled?:` row,
+and documenting the member adds a legitimate row that the ledger now claims as
+INDEPENDENT (the shipped `ComboboxOption` declares `disabled` itself and does not
+extend `BaseSchema`, so the narrow `boolean` spelling is correct for it). No
+shipped type or value moves in that package, so there is no behaviour there to
+version.

--- a/content/docs/components/form/combobox.mdx
+++ b/content/docs/components/form/combobox.mdx
@@ -28,6 +28,7 @@ The Combobox component combines a text input with a dropdown list, allowing user
 interface ComboboxOption {
   value: string;
   label: string;
+  disabled?: boolean;             // Option renders dimmed and cannot be selected
 }
 
 interface ComboboxSchema {

--- a/packages/components/src/__tests__/combobox-option-disabled.test.tsx
+++ b/packages/components/src/__tests__/combobox-option-disabled.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7687 — `options[].disabled` on a `combobox` node must be READ.
+ *
+ * The member was declared (`@object-ui/types` `ComboboxOption.disabled`),
+ * validated (`ComboboxOptionSchema` in the zod mirror, pinned as `boolean` on
+ * both faces by `disabled-twin-symmetry-7087.test.ts`) and never read: the
+ * component mapped each option to a `CommandItem` with `key` / `value` /
+ * `onSelect` only, so an option authored `disabled: true` passed validation,
+ * type-checked against the published `ComboboxSchema`, and rendered as an
+ * ordinary selectable option — a declared key with no read site behind it.
+ *
+ * ⛔ An attribute-only pin is not enough here: it passes on "styled disabled
+ * but still clickable", which is the exact defect this card is about. So the
+ * behaviour is pinned too — a disabled option must not fire `onValueChange`.
+ * The third test is the CONTROL that keeps that negative from being vacuous:
+ * without it, a popover that never opened would satisfy "not called".
+ */
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Combobox } from '../custom/combobox';
+
+const OPTIONS = [
+  { value: 'alpha', label: 'Alpha' },
+  { value: 'beta', label: 'Beta', disabled: true },
+  { value: 'gamma', label: 'Gamma', disabled: false },
+];
+
+function openDropdown() {
+  fireEvent.click(screen.getByRole('combobox'));
+}
+
+describe('Combobox honours options[].disabled (objectui#7687)', () => {
+  it('marks an option authored `disabled: true` as disabled in the DOM', () => {
+    render(<Combobox options={OPTIONS} value="" onValueChange={vi.fn()} />);
+    openDropdown();
+
+    const beta = screen.getByRole('option', { name: /Beta/ });
+    // `data-disabled` is what the CommandItem wrapper's className already
+    // styles (`data-[disabled=true]:opacity-50 …:pointer-events-none`);
+    // `aria-disabled` is what assistive tech and cmdk's own valid-item
+    // selector read.
+    expect(beta).toHaveAttribute('data-disabled', 'true');
+    expect(beta).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('refuses to select a disabled option — no onValueChange', () => {
+    const onValueChange = vi.fn();
+    render(<Combobox options={OPTIONS} value="" onValueChange={onValueChange} />);
+    openDropdown();
+
+    fireEvent.click(screen.getByRole('option', { name: /Beta/ }));
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('refuses the keyboard path too — Enter on a search narrowed to the disabled option selects nothing', () => {
+    const onValueChange = vi.fn();
+    render(<Combobox options={OPTIONS} value="" onValueChange={onValueChange} />);
+    openDropdown();
+
+    // A separate code path from the click above: cmdk keeps disabled items out
+    // of the valid-item selector its arrow keys and its auto-select walk, and
+    // never registers the `cmdk-item-select` listener Enter dispatches. With
+    // the list narrowed to `Beta` alone there is nothing left to select.
+    const search = screen.getByPlaceholderText('Search...');
+    fireEvent.change(search, { target: { value: 'bet' } });
+    expect(screen.getByRole('option', { name: /Beta/ })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /Alpha/ })).toBeNull();
+
+    fireEvent.keyDown(search, { key: 'Enter' });
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL — options without `disabled: true` stay selectable', () => {
+    const onValueChange = vi.fn();
+    render(<Combobox options={OPTIONS} value="" onValueChange={onValueChange} />);
+    openDropdown();
+
+    // Omitted (`alpha`) and explicitly `false` (`gamma`) are both enabled.
+    const alpha = screen.getByRole('option', { name: /Alpha/ });
+    const gamma = screen.getByRole('option', { name: /Gamma/ });
+    expect(alpha).toHaveAttribute('data-disabled', 'false');
+    expect(gamma).toHaveAttribute('data-disabled', 'false');
+
+    fireEvent.click(alpha);
+    expect(onValueChange).toHaveBeenCalledWith('alpha');
+  });
+
+  it('CONTROL — the keyboard path still selects an enabled option', () => {
+    const onValueChange = vi.fn();
+    render(<Combobox options={OPTIONS} value="" onValueChange={onValueChange} />);
+    openDropdown();
+
+    const search = screen.getByPlaceholderText('Search...');
+    fireEvent.change(search, { target: { value: 'gam' } });
+    fireEvent.keyDown(search, { key: 'Enter' });
+    expect(onValueChange).toHaveBeenCalledWith('gamma');
+  });
+});

--- a/packages/components/src/custom/combobox.tsx
+++ b/packages/components/src/custom/combobox.tsx
@@ -115,6 +115,19 @@ export function Combobox({
                 <CommandItem
                   key={option.value}
                   value={option.value}
+                  // objectui#7687 — `options[].disabled` is declared by
+                  // `@object-ui/types` and validated by the zod mirror, so it
+                  // has to be READ; the sibling select renderer already spells
+                  // it this way (`disabled={opt.disabled}` on `SelectItem`).
+                  // cmdk 1.1.1 needs nothing more than the prop: a disabled
+                  // `Command.Item` renders with `onClick` undefined, never
+                  // registers the `cmdk-item-select` listener Enter
+                  // dispatches, and is excluded from the valid-item selector
+                  // the arrow keys walk — so an extra refusal inside
+                  // `onSelect` below would be unreachable. Measured, and the
+                  // behaviour half of `combobox-option-disabled.test.tsx`
+                  // keeps that measurement honest.
+                  disabled={option.disabled}
                   onSelect={(currentValue) => {
                     onValueChange?.(currentValue === value ? "" : currentValue)
                     setOpen(false)

--- a/packages/types/src/__tests__/component-docs-disabled-inherited-7239.test.ts
+++ b/packages/types/src/__tests__/component-docs-disabled-inherited-7239.test.ts
@@ -78,6 +78,33 @@
  * That last pair is the point of the control: a failure that reddened the
  * independent rows too would mean the sweep was indiscriminate, not that the
  * inherited rows were wrong.
+ *
+ * ## Amendments
+ *
+ * The population is a ledger, not a constant: it moves when a page gains or
+ * loses a real `disabled` row. Each move is recorded here with its cause, so a
+ * later reader can tell a deliberate claim from a number someone bumped to get
+ * back to green.
+ *
+ *   - **22 -> 23 rows, INDEPENDENT 8 -> 9 (objectui#7687).** `ComboboxOption`
+ *     joins the independent table. Its `disabled` was always DECLARED by
+ *     `packages/types/src/form.ts` and validated by `ComboboxOptionSchema`, but
+ *     the combobox component never read it, so an option authored
+ *     `disabled: true` rendered selectable; #7687 makes the component honour it
+ *     and documents the member on `form/combobox.mdx`, which is the row this
+ *     census then measured. It classifies INDEPENDENT on this file's own
+ *     criterion, not by resemblance to its neighbours: the shipped
+ *     `ComboboxOption` declares `disabled` itself and does NOT extend
+ *     `BaseSchema`, so the narrow `boolean` is the correct spelling and the
+ *     second INDEPENDENT assertion holds for it unchanged.
+ *
+ *     ⚠️ Note for the class, since the #7687 card recorded the opposite: that
+ *     page's `interface` block sits in a `plaintext` fence and the card
+ *     concluded no CI gate could see it. True of the doc-type gates named
+ *     above, and false overall — THIS census reads those `.mdx` files as text
+ *     and caught the new row. A doc edit under `content/docs/components` that
+ *     touches a `disabled` row is answerable to `packages/types`, so a run
+ *     narrowed to the package the code fix lives in cannot see it.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -184,6 +211,8 @@ const INDEPENDENT = [
   { page: 'basic/button-group.mdx', iface: 'ButtonGroupButton', shippedName: 'ButtonGroupButton' },
   { page: 'disclosure/accordion.mdx', iface: 'AccordionItem', shippedName: 'AccordionItem' },
   { page: 'disclosure/toggle-group.mdx', iface: 'ToggleGroupItem', shippedName: 'ToggleGroupItem' },
+  // Added by objectui#7687, which made the member real — see `## Amendments`.
+  { page: 'form/combobox.mdx', iface: 'ComboboxOption', shippedName: 'ComboboxOption' },
   { page: 'form/form.mdx', iface: 'FormField', shippedName: 'FormField' },
   { page: 'form/radio-group.mdx', iface: 'RadioOption', shippedName: 'RadioOption' },
   // Doc-local names; the shipped shape they illustrate is `MenuCommandItem`.
@@ -246,7 +275,7 @@ describe('the two tables account for every documented `disabled` row (objectui#7
 
   it('sees exactly the population this card measured', () => {
     expect({ rows: ROWS.length, inherited: INHERITED.length, independent: INDEPENDENT.length }).toEqual(
-      { rows: 22, inherited: 14, independent: 8 },
+      { rows: 23, inherited: 14, independent: 9 },
     );
   });
 });


### PR DESCRIPTION
Fixes #7687

## What was wrong

`options[].disabled` on a `combobox` node was **declared** (`@object-ui/types` `ComboboxOption.disabled`), **validated** (`ComboboxOptionSchema` in the zod mirror, pinned as `boolean` on both faces by the objectui#7087 twin-symmetry ruling) and **never read**. The component mapped each option to a `CommandItem` carrying `key`, `value` and `onSelect` only, so an option authored `{ value, label, disabled: true }` passed `safeValidateSchema`, type-checked against the published `ComboboxSchema`, and rendered as an ordinary, fully selectable option.

Reproduced before touching anything — the pin in this PR, run against the base tree `5b09821ed`, fails exactly there:

```
× marks an option authored `disabled: true` as disabled in the DOM
    Expected the element to have attribute: data-disabled="true"
    Received:                               data-disabled="false"
× refuses to select a disabled option — no onValueChange
    expected "vi.fn()" to not be called at all, but actually been called 1 times
    1st vi.fn() call: Array [ "beta" ]
```

## The fix — one prop, the house spelling

`disabled={option.disabled}` on the `CommandItem`, which is what the sibling select renderer already does on its `SelectItem` (`packages/components/src/renderers/form/select.tsx`). The styling needed no work: the `CommandItem` wrapper's className already carried `data-[disabled=true]:opacity-50` and `data-[disabled=true]:pointer-events-none`, so only the read was missing.

**Remedy chosen: honour the key, not retire it.** Retiring `disabled` from `ComboboxOption` and the zod mirror would narrow a published surface and would require the objectui#7087 twin-symmetry pin to be changed; honouring it restores declared = enforced for the cost of one prop. **No declared type or value moves** — `ComboboxOption` and the zod mirror are exactly as they were; the only `packages/types` file in this diff is a census test, described below.

## Measured: the `onSelect` guard would have been dead code

The card left open whether cmdk needs a refusal inside `onSelect` in addition to the `disabled` prop. Measured against cmdk 1.1.1 rather than assumed — a disabled `Command.Item`:

- renders with `onClick` **undefined**, so a click reaches no handler;
- never registers the `cmdk-item-select` listener that Enter dispatches;
- is excluded from the valid-item selector the arrow keys and the auto-select walk use (`aria-disabled="true"` is filtered out).

So the prop alone suppresses selection on both the pointer and the keyboard path, and an extra guard in `onSelect` would be unreachable. It is not added. The reasoning is recorded at the change site so the next reader does not re-open the question, and the behaviour legs of the pin are what keep the measurement honest.

## The pin asserts behaviour, not just the attribute

⛔ An attribute-only pin passes on "styled disabled but still clickable", which is the exact failure this card is about. `packages/components/src/__tests__/combobox-option-disabled.test.tsx` has five legs:

| leg | asserts |
|---|---|
| attribute | the disabled option carries `data-disabled` and `aria-disabled` |
| behaviour, pointer | clicking it fires no `onValueChange` |
| behaviour, keyboard | narrowing the search to it and pressing Enter fires no `onValueChange` |
| CONTROL | options with `disabled` omitted and with `disabled: false` are both `data-disabled="false"`, and clicking one DOES fire `onValueChange` |
| CONTROL | the keyboard path still selects an enabled option |

The two controls exist because both negatives are vacuous without them — a popover that never opened would satisfy "not called" just as well.

**Reverse verification**, run from the committed state (mutation proven on disk by a marker count `1 → 0` and a blob-hash mismatch against the `HEAD` blob, restored with `git checkout HEAD -- ...` and proven clean by an empty `git diff HEAD`): removing the one-line read turns **all three** assertion legs red and leaves **both** control legs green. That is the shape it has to have — the controls measure the surrounding machinery, not the fix.

## The docs row, and the census that claims it

`content/docs/components/form/combobox.mdx` documented `ComboboxOption` as value-plus-label, missing `disabled`. Only that interface block is touched; the rest of the page is untouched, and `content/docs/releases/` is not touched at all.

⚠️ **Correcting a belief this card carried.** The card recorded that the block's `plaintext` fence means no CI gate could see it. That is true of the doc-TYPE gates — `check-doc-component-types` reads only `type` string literals, and `check-doc-snippet-types` compiles `ts`/`tsx` fences, not `plaintext` — and **false overall**: `packages/types/src/__tests__/component-docs-disabled-inherited-7239.test.ts` is a census that reads those `.mdx` files as text, counts every documented `disabled?:` row, and pins the population. It caught the new row, red, on `Test (shard 4/4)`.

So the second commit claims the row deliberately. ⛔ Not a count bump: the row is classified on the criterion that file states — the shipped `ComboboxOption` declares `disabled` itself and does **not** extend `BaseSchema`, so it is INDEPENDENT and the narrow `boolean` spelling on the page is the correct one. Counts move consistently: rows 22 to 23, independent 8 to 9, inherited unchanged at 14. A new `## Amendments` section in that file records why the ledger moved, so a later reader can tell a deliberate claim from a number bumped to get back to green.

`@object-ui/types` is deliberately not given its own changeset bump: no shipped type or value moves there, only that test.

## Why `minor`

Making a previously ignored key take effect **is** a user-visible behaviour change. An author who already writes `disabled: true` today gets a different combobox after this lands. The changeset body says so and records why the retire remedy was not taken. (`major` is forbidden in this repo; a deliberately breaking change ships `minor`.)

## Gates

Re-run at `b0a6b3c8b`, after the census fix.

| gate | result |
|---|---|
| `vitest run packages/types/src/__tests__/component-docs-disabled-inherited-7239.test.ts` | exit 0 — 46 passed; verbose output confirms **both** new `ComboboxOption` assertions ran, so the row is claimed for the right reason |
| `vitest run packages/types/` | exit 0 — 133 files, 2500 tests |
| `vitest run packages/components/` | exit 0 — 236 files, 2173 tests (at `6ff473171`; the second commit touches no file this package reads) |
| every test under `scripts/__tests__` that reads `content/docs` (24 files) | exit 0 — 1085 tests |
| every test in the other packages that reads `content/docs` (25 files) | exit 0 — 263 tests |
| `packages/types` and `packages/components` `type-check` | exit 0 each |
| `pnpm lint` (full, `turbo run lint`) | exit 0, 47/47 tasks, every package reporting 0 errors |
| `check:control-bytes` | exit 0, plus a direct scan of the changed files |
| `check:published-dist` · `check:published-tsconfig-exclude` · `check:handler-key-reads` | exit 0 |
| `check:doc-fences` · `check:doc-snippets` · `check:doc-types` · `check:docs-route-closure` · `check-doc-links` | exit 0 |
| `check:changeset-presence` · `check-changeset-no-major` · `check-changeset-fixed` · `check-changeset-overwrite` | exit 0 |

The doc-reading population above was enumerated by measurement (grep for the tests that read `content/docs`) rather than guessed, because a scope narrowed to the package the code fix lives in is exactly what could not see the census failure. A full local `pnpm test` does not fit the container's foreground limit — it is a 4-way shard job on CI — so that enumeration is the declared substitute.

Known reds that are not from this branch: `Live E2E (informational)` is advisory and red on `main` itself (carded objectui#8084), and a `Build and E2E` death at roughly 11s at `pnpm --version` is a corepack download flake.

## Scope

⛔ No change to the declared surface: `ComboboxOption`, `ComboboxOptionSchema` and the objectui#7087 twin-symmetry pin are untouched (narrowing them is the retire remedy's territory). ⛔ Not folded into objectui#6349 batch 3 / PR #7691, which deliberately changes no behaviour. ⛔ objectui#7697, the root-barrel export gap, is adjacent and surface-only and is **not addressed here** — it stays open.

Out-of-scope finding filed unassigned while working this card: objectui#8140 — the combobox renderer never reads `ComboboxSchema.defaultValue`, `.name` or `.description`, while the sibling select and input renderers read theirs. Same defect class, different member set, deduped against a search whose control fired. ⛔ Not fixed here.

⛔ Left as a draft deliberately: CI convergence and landing belong to the dispatching PM.