### PR TITLE
docs(plugin-kanban): compile every README snippet, leave the UNGATED_DOCS ledger

### DIFF
--- a/packages/plugin-kanban/README.md
+++ b/packages/plugin-kanban/README.md
@@ -103,12 +103,23 @@ const schema: KanbanSchema = {
 ## Schema API
 
 ```typescript
-{
+import type { KanbanSchema } from '@object-ui/plugin-kanban';
+
+declare const columns: KanbanColumn[];
+
+// The board document. `type` is the only required member — `columns`,
+// `onCardMove` and `className` are all optional. The annotation is the type
+// this package ships, so the section below is compiled against it rather than
+// read as prose: an invented or renamed key, or a callback whose parameters
+// drift from the shipped signature, fails here.
+const board: KanbanSchema = {
   type: 'kanban',
-  columns?: KanbanColumn[],           // Array of columns
-  onCardMove?: (cardId, fromColumnId, toColumnId, newIndex) => void,
-  className?: string                  // Tailwind classes
-}
+  columns,                            // Array of columns
+  onCardMove: (cardId, fromColumnId, toColumnId, newIndex) => {
+    // see "Example with Callbacks" below
+  },
+  className: 'h-full',                // Tailwind classes
+};
 
 // Column structure
 interface KanbanColumn {
@@ -183,9 +194,13 @@ pnpm build
 ## Example with Callbacks
 
 ```typescript
-const schema = {
+import type { KanbanColumn, KanbanSchema } from '@object-ui/plugin-kanban';
+
+declare const columns: KanbanColumn[];
+
+const schema: KanbanSchema = {
   type: 'kanban',
-  columns: [...],
+  columns,
   onCardMove: (cardId, fromColumnId, toColumnId, newIndex) => {
     console.log(`Card ${cardId} moved from ${fromColumnId} to ${toColumnId} at index ${newIndex}`);
     // Update your backend or state here

--- a/packages/plugin-kanban/README.md
+++ b/packages/plugin-kanban/README.md
@@ -109,9 +109,12 @@ declare const columns: KanbanColumn[];
 
 // The board document. `type` is the only required member — `columns`,
 // `onCardMove` and `className` are all optional. The annotation is the type
-// this package ships, so the section below is compiled against it rather than
-// read as prose: an invented or renamed key, or a callback whose parameters
-// drift from the shipped signature, fails here.
+// this package ships, so each member below is compiled against it rather than
+// read as prose: a `columns` array of the wrong shape, or an `onCardMove`
+// whose parameters drift from the shipped signature, fails here. An unknown
+// key does not — `KanbanSchema` extends `BaseSchema`, whose index signature
+// deliberately accepts type-specific extensions, so the compiler is not what
+// catches a misspelt board key.
 const board: KanbanSchema = {
   type: 'kanban',
   columns,                            // Array of columns

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -716,8 +716,6 @@ const UNGATED_DOCS = {
     '5 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 1 unresolved-module diagnostic(s); plus TS17000x1 TS2322x1 — candidate real defects, un-triaged',
   'packages/plugin-editor/README.md':
     '6 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies',
-  'packages/plugin-kanban/README.md':
-    '6 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies',
   'packages/plugin-map/README.md':
     '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2322x1 — candidate real defects, un-triaged',
   'packages/plugin-markdown/README.md':


### PR DESCRIPTION
Part of #5174 — batch 26 of the `UNGATED_DOCS` burn-down.

`packages/plugin-kanban/README.md` leaves the ledger and every ts block on the
page now compiles against the built types. The gate file's only change is the
two lines of that one entry.

## Notation, read this first

This repository has measured that GitHub's body sanitizer deletes tag-shaped
fragments even inside backticks and fenced blocks. So generic parameters are
spelled out in words below — "an Array of badge objects", "the KanbanColumn
array" — rather than in their real angle-bracket form. The README itself
carries the real spellings; this page does not.

## Concurrency

`main` moved under this batch **once**, and it was absorbed by merging (never
rebasing, never force-pushing).

`535eb224f` to `21d7989fb` — one PR, #8143, the objectui#6892 slice 6 the
dispatch named: 27 test files, the vi-mock gate and a changeset. It touches no
`packages/**` source, so the built types this corpus is judged against did not
move; even so the forced build, the census, every gate, every test and the
load-bearing probes were re-run on the merged head, and every reading came back
byte-identical. `main` was re-checked after the merge and had not moved again at
push time, so no second cycle was needed and no gap is declared.

All 14 open pull requests' file lists were read over the REST files endpoint and
each count reconciled against that PR's own `changed_files`: 8144/2, 8143/29,
8142/4, 8109/1, 8104/2, 8091/1, 8090/1, 8076/6, 7749/4, 7685/69, 7058/24,
7054/2, 7053/2, 5400/1086. #5400's 1086-file list was paged to exhaustion
because the endpoint pages at 100 and a truncated list renders as a confident
absence. **No open PR touches `packages/plugin-kanban/README.md` or
`scripts/check-doc-snippet-types.mjs`.** The two open PRs that touch any package
README are both #7685, on `packages/auth/README.md` and
`packages/plugin-list/README.md` — the first is exactly the standing exclusion,
so it doubles as the positive control that this grep can find a hit at all.

`Live E2E (informational)` is red on every branch today for an upstream reason
(objectui#7990 / objectstack#16186), not because of this diff.

## Ledger arithmetic

Both rows MEASURED by a real gate run, never computed. Base row at the merged
base `21d7989fb` bytes (probe M0, both paths checked out to the main blobs and
proven equal by hash, restored under a trap); branch row at `b0ea6a7f8`.

| reading | base `21d7989fb` | branch `b0ea6a7f8` |
|:--|--:|--:|
| `UNGATED_DOCS` entries | 12 | **11** |
| covered documents | 215 | 216 |
| …of them holding a ts/tsx block | 113 | 114 |
| covered blocks | 730 | 735 |
| blocks to compile | 572 | 577 |
| declared fragments | 158 | **158** (zero new) |
| semantic failures | 0 | 0 |
| self-imports judged (`check:readme-exports`) | 499 | 502 |
| interface-pin keys compared both ways | 58 | 58 |

That last row is here because it is the one a reader would expect to move and it
does not: this repair adds **no** documented-type declaration for the pin to
compare (5 documented types in 4 blocks on both sides). What it adds is three
self-import bindings.

Programmatic diff of the two `UNGATED_DOCS` objects — both parsed as OBJECTS,
never diffed as text: removed = `['packages/plugin-kanban/README.md']`,
added = `[]`, reason-changed = `[]`, survivor key order preserved = true.
`git diff --numstat` on the gate file against the merge base is exactly `0 2`.
On the branch: kanban entries **0**, `packages/NAME/README.md` entries **10**
(from 11), control `'packages/auth/README.md'` **1**.

The strictness region — the `Fence scanning` banner line to EOF, 1720 lines on
both sides — hashes to
`5dfcd1b876c044ef33b6b5fed8a57ec719622ddbb20ce0ab539e5c985a233017` on the merge
base and on the branch. Re-measured here on both sides and not inherited, which
mattered this time: objectui#7864 (PR #8138) added a census mode to that region
hours before this batch, so the value batches 15 through 25 recorded
(`f46b5662…`) is no longer the right one.

**The removed entry's reason string was ACCURATE.** It claimed "6 parse
diagnostic(s) — blocks fenced `ts` that are bare object literals or elided
bodies". Measured by probe P2: exactly 6, all of them parse diagnostics, and
both offending blocks are exactly that shape — a bare object literal and an
elided `[...]`.

## Census and the rung that decided

Re-taken on this batch's own base through the gate's exported `analyze()` /
`compileSnippets()`, one document un-gated at a time, over every non-excluded
ledger candidate.

**Rung 1's first term decides outright: `packages/plugin-kanban/README.md` is
the only remaining candidate with 5 blocks; every other one has 4 or fewer.**
Batch 25 predicted exactly this, and the prediction held.

| document | blocks | diagnostics | distinct codes | codes |
|:--|--:|--:|--:|:--|
| **packages/plugin-kanban/README.md** | **5** | **6** | **2** | TS1109 x5, TS1011 x1 |
| packages/plugin-ai/README.md | 4 | 8 | 3 | TS2304 x4, TS2322 x3, TS2552 x1 |
| packages/providers/README.md | 4 | 8 | 2 | TS2304 x7, TS2741 x1 |
| packages/plugin-charts/README.md | 4 | 6 | 1 | TS1109 x6 |
| packages/plugin-editor/README.md | 4 | 6 | 1 | TS1109 x6 |
| packages/plugin-map/README.md | 4 | 2 | 2 | TS1005 x1, TS2304 x1 |
| packages/plugin-markdown/README.md | 4 | 2 | 2 | TS1005 x1, TS1109 x1 |
| packages/fields/README.md | 2 | 3 | 2 | TS7031 x2, TS2307 x1 |
| packages/plugin-tree/README.md | 1 | 3 | 2 | TS1005 x2, TS1109 x1 |

Assumption **A1 is CONFIRMED** — every block total, diagnostic total and
per-code figure matches batch 25's census exactly. Zero bound refusals on this
page.

Exclusions re-verified against GitHub on this base, not inherited: the root
`README.md` is not a `packages/NAME/README.md`; `packages/auth/README.md` is
held by open draft PR #7685; `packages/plugin-chatbot/README.md` is deferred by
the earlier ruling.

## The parse-debt decisions, block by block

This page is the first in the series whose debt is **entirely parse debt**, so
each block got a decision rather than a repair. Five blocks; three already
compiled and were not touched.

**Block at line 105, the Schema API — an interface-shaped props table.** This is
the block the ruling anticipated: a bare object literal fenced `ts`, carrying
`?` optionality markers and inline comments, that TypeScript cannot parse (4 of
the 5 TS1109 plus the TS1011 come from here). Three shapes were available:

- **Declare it a fragment.** Refused. A fragment's reason claims the block
  *cannot be checked*, and this one can — the page is documenting a type this
  package actually ships.
- **Rewrite it as the `interface` it pretends to be.** Refused, and this is the
  interesting refusal. The only honest name for it is `KanbanSchema`, which is
  an export of this package — so `check-readme-exports`'s interface pin would
  then compare it against the shipped declaration in **both** directions and
  report a stale-omission for each of the seventeen members the section does not
  document. Naming it something else instead (`KanbanBoardDocument`) would dodge
  the pin by teaching readers a type name that does not exist. Either way the
  rewrite buys a worse page.
- **Annotate a real binding against the shipped `KanbanSchema`.** Taken.

So the section is now `const board: KanbanSchema = { … }` with a real
self-import, and `columns` is supplied by a `declare const` stand-in typed
`KanbanColumn[]` — bound through **the page's own `KanbanColumn` interface**,
which is the load-bearing detail. That interface used to be a local declaration
inside a block that never even parsed; it now has to be assignable to the
shipped type or the gate goes red. Probe **P6** is what proves that.

The two `interface` declarations below it (`KanbanColumn`, `KanbanCard`) are
untouched and stay in the same fence. They still match the shipped types 7 keys
of 7 each, with 0 fabricated and 0 omitted, and `badges` keeps the `colorClass`
and `colorStyle` members PR #8134 landed there at 18:21Z.

**Block at line 185, Example with Callbacks — an elided body.** `columns: [...]`
is a spread with no operand: the sixth TS1109. The ruling's remedy for an elided
body is the smallest real value or a `declare const` stand-in typed from the
shipped surface; the stand-in is right here, because the point of the example is
that *your* columns go in that slot. Annotating the binding `KanbanSchema` does
a second thing worth naming: the four `onCardMove` parameters used to be
implicit `any` waiting to become TS7006 the moment the block parsed, and they
are now contextually typed by the shipped callback signature instead.

**Fragment count: 158 to 158.** No marker was written, so no new reason claims a
block cannot be checked.

## What the annotation actually checks — and the claim probe P4 falsified

Probe **P4** was predicted to go red and did not, and the correction it forced
is the most useful thing this batch measured.

`KanbanSchema` extends `BaseSchema`, which declares `[key: string]: any`
("This index signature allows type-specific extensions"). **So TypeScript's
excess-property check cannot fire on this type family at all** — adding
`swimlanes: []`, a key the shipped type does not declare, to the annotated board
literal leaves the gate green.

The first commit's comment claimed "an invented or renamed key … fails here".
That was false, and it would have shipped a promise of a check nobody performs
**inside the very block this batch was repairing** — the exact failure this gate
family exists to prevent. The second commit narrows it to what is measured: the
*type* of every member the shipped type declares is checked (probes P3, P5, P5b,
P6), and an unknown key is not, with the reason named so a reader knows where
the boundary is.

This bound is not new and nothing is filed for it: `check-readme-exports.mjs`
already states it in its own docblock — "`BaseSchema` carries an index signature
and its Zod mirror is passthrough, so no amount of type checking rejects an
invented schema key. That needs a third instrument, not a wider version of this
one."

## Probes — a base measurement and eight probes, each predicted in writing first

Predictions were written to the scratchpad before any probe ran and were not
amended: `5174-b26-PREDICTIONS.md` (md5 `bc4a0250f8e532120ab2cf6b10ff8421`) at
implementation commit `4a43188d9` with a clean tree. Every mutation is proven on
disk by occurrence counts of both the injected and the deleted text plus
`git hash-object` against the HEAD blob; every restore is proven by an empty
`git diff HEAD`; every leg runs under a `trap … EXIT INT TERM` with absolute
paths, restoring with `git checkout HEAD --` against an absolute path rather
than a bare checkout from the index. **No dist preflight is owed, and that is a
measurement rather than an omission:** both mutated paths are read from disk by
the gate itself, so no rebuild sits between a mutation and its reading.

| probe | mutation | predicted | observed |
|:--|:--|:--|:--|
| **M0** | both paths at merge-base bytes | exit 0; 215 covered / 12 ungated / 730 blocks / 572 to compile; readme-exports 499 | exactly that |
| **P1** | ledger entry restored ALONE | exit 0, coverage falls back to the base row | exactly that |
| **P2** | README restored ALONE | exit 1, exactly 6 diagnostics over exactly 2 codes | exactly that — TS1109 x5, TS1011 x1, at lines 108/108/109/109/110/188, matching the census row |
| **P3** | delete the Schema-API stand-in | exit 1, TS2304 "Cannot find name 'columns'" | **PREDICTION FALSIFIED IN ITS CODE.** exit 1 as predicted, but TS18004 "No value exists in scope for the shorthand property 'columns'" — the binding is written shorthand, so TypeScript reports the shorthand form, not the bare-name form |
| **P4** | add `swimlanes: []`, a key the shipped type lacks | exit 1, TS2353 "Object literal may only specify known properties" | **PREDICTION FALSIFIED IN ITS DIRECTION.** exit 0, no diagnostic — `BaseSchema`'s index signature disables excess-property checking. Re-run a second time with a clean anchor to be sure the first was not a no-op; same result. Drove the second commit |
| **P5** | retype the callbacks stand-in to a string array | exit 1, assignability error naming KanbanColumn | exactly that — TS2322 "Type 'string[]' is not assignable to type 'KanbanColumn[]'" at line 203 |
| **P5b** | retype the Schema-API stand-in to a string array | exit 1, the same, proving BOTH bindings are live | exactly that — the same TS2322 at line 120 |
| **P6** | rename `cards` to `items` in the README's OWN `interface KanbanColumn` | exit 1 on BOTH gates, reporting DIFFERENT things | exactly that — see below |
| **P7** | fabricate a self-import name | readme-exports 1 fabricated, naming this page | exactly that — 502 real / 1 fabricated at `packages/plugin-kanban/README.md:106` |

**P6 is the load-bearing one for this batch**, because it is what makes the
repair shape worth more than a fragment marker. Renaming one key in the README's
own interface turns **both** gates red, and they say different things:

- `check:doc-snippets` exit 1 — TS2322, "Property 'cards' is missing in type
  'KanbanColumn' but required in type … complex.KanbanColumn", at README line
  120. The page's own interface is now checked against the shipped type
  *through the annotated binding*. Before this batch it was a local declaration
  in a block that did not parse: it compiled green whatever it said.
- `check:readme-exports` exit 1 — the interface pin reports the rename as the
  pair its docblock says only the two directions together can see: `items` as a
  fabricated-key and `cards` as a stale-omission, both at line 128.

So the two gates now cover this declaration from two angles — names, and types.
That is strictly more than the ungated entry it replaces, which could have lost
either in silence.

**Two predictions were falsified, both reported above rather than smoothed**, and
P4's falsification is the reason the second commit exists. M0, P1, P2 and P6 were
re-run on the merged head and came back byte-identical.

## Gates — all at `b0ea6a7f8`, clean tree, nothing pushed after

Exit codes captured by redirect-then-capture, before any pipe; each row quotes
the gate's own verdict line. The build was forced first
(`pnpm exec turbo run build --filter=./packages/* --concurrency=2 --force`,
39 successful / 0 cached) and again inside the provenance gate (43 successful /
0 cached); every dist-sensitive gate was then re-run on that force-built dist.
Note the invocation: bare `turbo` is not on PATH in this container, so
`pnpm exec turbo` is what ran.

- `pnpm check:doc-snippets` exit 0 — "Scanned 227 document(s): 216 covered (114 of them hold a ts/tsx block), 11 ungated" / "Covered blocks: 735 — 577 to compile, 158 declared fragment(s)" / "Syntax phase: every block parsed, so every one of them reached the semantic phase" / "Root bound: no block imports a specifier that resolves only through this repository's ROOT manifest" / "Semantic phase: 577 of 577 block(s) judged, 0 failed" / "Every covered documentation snippet compiles against the built types."
- `pnpm check:readme-exports` exit 0 — "502 of them self-imports judged (502 real, 0 wrong-path, 0 fabricated)" / "58 key(s) compared both ways (0 fabricated, 0 stale omission(s)"
- `pnpm check:doc-fences` exit 0 — "every TypeScript block in 227 document(s) is fenced ts/tsx/typescript"
- `pnpm check:doc-types` exit 0 — "Every documented component type is registered."
- `node scripts/check-doc-links.mjs` exit 0 — "Links are valid across 17 scan roots."
- `pnpm check:doc-example-readers` exit 0 — "OK 80 documented symbol(s), 3947 call site(s)"
- `pnpm check:control-bytes` exit 0 — "OK (scanned 6509 tracked text file(s); skipped 85 binary)"
- `node scripts/check-node-esm-load.mjs --force-build` exit 0 — "Provenance leg: 37 of 37 gradable entries were built by this tree." Green on its first run, so no gate had to be re-run over a replayed sibling cache.
- `pnpm type-check:scripts` exit 0
- `node scripts/check-changeset-presence.mjs` exit 0 — "2 file(s) changed, 0 of them published source of a package the release covers … no changeset is owed." No `skip-changeset` label applied: this repository declares with an empty-frontmatter changeset rather than that label, and the presence gate says none is owed, so nothing was labelled at all by this seat.
- `node scripts/check-governed-queue-guard.mjs --test` on both paths exit 0 — "NOT GOVERNED — 2 path(s) checked against 5 governed surface(s); none matched"
- Owning package: `pnpm exec vitest run packages/plugin-kanban/` — "Test Files 24 passed (24) / Tests 126 passed (126)"; `pnpm --filter @object-ui/plugin-kanban type-check` exit 0, its output echoing `tsc --noEmit && tsc -p tsconfig.test.json`, so **A4 is confirmed** — the test tsconfig is genuinely included and the script really ran.
- Beyond the gate, a manual control-byte scan of both changed paths with `grep -naP` over the C0/DEL ranges found nothing (exit 1, zero output bytes).

**Lint, with the narrowing declared and its three evidence items.** `pnpm lint`
here is `turbo run lint` per package, so the repository-wide sweep is CI's run;
the narrowed run over exactly this diff is
`pnpm exec eslint --no-inline-config --format json` on both paths — 2 entries,
**0 errors**. eslint's own answer for the README is "File ignored because no
matching configuration was supplied", so the real lint surface of this diff is
the one `.mjs` at 0 errors and 0 warnings. (1) The population eslint would
otherwise judge is **4385 files** by its own count. (2) That run exits 1 with
**94 errors and 12223 warnings**, and the touched files carry **0 of them** —
measured, and reported rather than smoothed, because a reader must not mistake
the narrowing for a green repository. (3) `eslint.config.js` declares no
`project`, `projectService` or `parserOptions.project` (grep count 0), so
type-aware linting is off and this diff cannot move the verdict on any untouched
file. Both readings were taken on the final commit `b0ea6a7f8`.

## Readers of the changed paths

Derived with `git grep -l` on both paths on this head, not guessed — **17 test
files, 614 tests, all green** in one run, and the set was identical before and
after the merge.

**A2 is CONFIRMED and quantified.** The two named readers of the README are
`scripts/check-readme-exports.mjs` and `scripts/__tests__/check-readme-exports.test.ts`,
and the pin's own JSON output gives the numbers the assumption asked for:
`KanbanColumn` at line 125 and `KanbanCard` at line 136, both verdict `matches`,
both **7 documented of 7 shipped**, 0 fabricated, 0 omitted. A2's warning — that
rewriting a block as an `interface` may ADD an interface the pin then compares —
is exactly why the rewrite route was refused above; the pin still compares 5
documented types in 4 blocks and 58 keys, unchanged from the base. The remaining
15 readers read the **gate file**.

## Out of scope

**Nothing was filed, and that is a finding rather than an omission.** The one
candidate is the `BaseSchema` index signature that falsified probe P4. It is
deliberate and documented at the declaration ("This index signature allows
type-specific extensions"), and `check-readme-exports.mjs` already records the
consequence in its own docblock as a known bound needing a third instrument. So
this is the same class as batch 25's identity alias — intentional, documented
and already recorded — and filing it would have added noise to triage. It is
reported in the section above instead. No dedup search was run, because a search
with nothing to dedup is not a reading.

This PR is a DRAFT and stays a draft: this seat does not flip ready, does not
enable auto-merge, and touches no labels or assignee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_