### PR TITLE
fix(plugin-kanban): ObjectKanbanComponentProps.schema names both registered node types (objectui#7322 item ②)

### DIFF
--- a/.changeset/7322-object-kanban-component-props.md
+++ b/.changeset/7322-object-kanban-component-props.md
@@ -1,0 +1,55 @@
+---
+'@object-ui/plugin-kanban': minor
+---
+
+`ObjectKanbanComponentProps.schema` names both node types the component is registered for
+(objectui#7322 item ②, following the objectui#5903 / #5018 land shape).
+
+`ObjectKanbanRenderer` is registered under two keys — `'object-kanban'` and `'kanban'` —
+and the two keys have different declared node types: `ObjectKanbanSchema` (`type:
+'object-kanban'`, `objectName` and `groupBy` required) and `KanbanSchema` (`type:
+'kanban'`, both optional). The prop named `KanbanSchema` alone, so **no `object-kanban`
+node was assignable to the component that renders it**, and the discriminants are disjoint
+string literals, so no cast-free annotation existed for half the boards this component
+serves. It is now the union of the two.
+
+## What settled it: the read set
+
+`ObjectKanban` reads thirteen keys off `schema`. Neither declaration covers them; the two
+TOGETHER cover twelve, and each arm is load-bearing:
+
+- `objectName`, `groupBy`, `limit`, `cardFields` — declared on both;
+- `columns`, `cardTitle`, `swimlaneField`, `grouping` — `KanbanSchema` only;
+- `titleField` — `ObjectKanbanSchema` only (which is why that read was spelled
+  `(schema as any).titleField`);
+- `data`, `bind`, `className` — `BaseSchema`;
+- `filter` — declared by **neither** face, still riding `BaseSchema`'s index signature.
+  Measured and reported, **not** changed here: this card moves the prop, not the two
+  published schema faces.
+
+So naming `ObjectKanbanSchema` alone — the remedy the original card implied — would have
+been wrong in the other direction: it drops four declared reads and the `'kanban'`
+registration.
+
+## Not affected
+
+Widening a member of an exported prop type is additive: every caller that passed a
+`KanbanSchema` still compiles, and the union claims exactly the accept set the registry
+dispatches to this component — a third node type is still turned away. The runtime is
+untouched; `ObjectKanbanRenderer` still takes `schema: any`, so no shape is turned away
+there either (the objectui#5903 disposition, restated). The view-level `kanban.groupField`
+alias, `BaseSchema`'s index signature, and `@object-ui/types` are all untouched.
+
+## Casts this removes
+
+Inside `ObjectKanban.tsx`, three schema-key reads drop their `as any`: `titleField` (two
+sites, now honest because the `object-kanban` arm declares it) and `cardFields` /
+`cardTitle` (already declared; the casts were redundant). `(schema as any).navigation`
+**stays** — `navigation` is declared on neither face, so removing the cast would change
+nothing but the spelling of an index-signature read.
+
+Four of the six in-package fixtures that mount an `object-kanban` board drop their
+`as never` escape for a real `satisfies ObjectKanbanSchema`. The other two are static
+boards (`columns` + inline `data`, no fetch) that author no `objectName`, which
+`ObjectKanbanSchema` declares required — objectui#7780's subject; their casts stay, now
+carrying the reason and the card number.

--- a/packages/plugin-kanban/src/ObjectKanban.markedRefusalToast.test.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.markedRefusalToast.test.tsx
@@ -51,7 +51,7 @@ import '@testing-library/jest-dom';
 import { registerAllFields } from '@object-ui/fields';
 import { toast } from '@object-ui/components';
 import { normaliseClientError } from '@object-ui/data-objectstack';
-import type { DataSource } from '@object-ui/types';
+import type { DataSource, ObjectKanbanSchema } from '@object-ui/types';
 import { ObjectKanban } from './ObjectKanban';
 
 // Pay the board's lazy chunk at import time rather than racing it against a
@@ -112,7 +112,7 @@ const schema = {
     { id: 'backlog', title: 'Backlog' },
     { id: 'in_progress', title: 'In Progress' },
   ],
-} as never;
+} satisfies ObjectKanbanSchema;
 
 const serverRecords = () => [{ id: 't1', title: CARD, status: 'backlog' }];
 

--- a/packages/plugin-kanban/src/ObjectKanban.navWidthDefault.test.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.navWidthDefault.test.tsx
@@ -45,6 +45,7 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import type { ObjectKanbanSchema } from '@object-ui/types';
 import { ObjectKanban } from './ObjectKanban';
 
 // Pay the board's lazy chunk at import time, not inside a `findBy` budget
@@ -84,7 +85,7 @@ async function openDrawer(navigation?: Record<string, unknown>) {
         columns: [{ id: 'todo', title: 'To Do' }],
         data: cards,
         ...(navigation ? { navigation } : {}),
-      } as never}
+      } satisfies ObjectKanbanSchema}
     />,
   );
   const card = await screen.findByText('On the board');

--- a/packages/plugin-kanban/src/ObjectKanban.overlayTitleI18n.test.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.overlayTitleI18n.test.tsx
@@ -96,6 +96,15 @@ function renderKanbanIn(language: string, schemaExtra: Record<string, unknown>) 
           columns: [{ id: 'todo', title: 'To Do' }],
           data: cards,
           ...schemaExtra,
+        // ⚠️ Still escaped, and NOT by oversight (objectui#7322 item ②). This
+        // board is STATIC — `columns` plus inline `data`, no fetch — so it
+        // authors no `objectName`, which `ObjectKanbanSchema` declares REQUIRED.
+        // That requiredness is objectui#7780's subject (the renderer reads inline
+        // `data` ahead of the fetch and never needs the object name for a board
+        // like this one); until it is answered, no declared type accepts this
+        // node. The other four in-package fixtures that mount an `object-kanban`
+        // board dropped their `as never` for a real `satisfies ObjectKanbanSchema`
+        // in objectui#7322 — when #7780 lands, this one follows.
         } as never}
       />
     </I18nProvider>,

--- a/packages/plugin-kanban/src/ObjectKanban.overlayTitleNoProviderFallback.test.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.overlayTitleNoProviderFallback.test.tsx
@@ -68,6 +68,15 @@ function renderKanban(schemaExtra: Record<string, unknown>) {
         columns: [{ id: 'todo', title: 'To Do' }],
         data: cards,
         ...schemaExtra,
+      // ⚠️ Still escaped, and NOT by oversight (objectui#7322 item ②). This
+      // board is STATIC — `columns` plus inline `data`, no fetch — so it
+      // authors no `objectName`, which `ObjectKanbanSchema` declares REQUIRED.
+      // That requiredness is objectui#7780's subject (the renderer reads inline
+      // `data` ahead of the fetch and never needs the object name for a board
+      // like this one); until it is answered, no declared type accepts this
+      // node. The other four in-package fixtures that mount an `object-kanban`
+      // board dropped their `as never` for a real `satisfies ObjectKanbanSchema`
+      // in objectui#7322 — when #7780 lands, this one follows.
       } as never}
     />,
   );

--- a/packages/plugin-kanban/src/ObjectKanban.rejectedMoveRollback.test.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.rejectedMoveRollback.test.tsx
@@ -50,7 +50,7 @@ import { render, screen, within, act, cleanup, waitFor } from '@testing-library/
 import '@testing-library/jest-dom';
 import { registerAllFields } from '@object-ui/fields';
 import { toast } from '@object-ui/components';
-import type { DataSource } from '@object-ui/types';
+import type { DataSource, ObjectKanbanSchema } from '@object-ui/types';
 import { ObjectKanban } from './ObjectKanban';
 
 // Pay the board's lazy chunk at import time rather than racing it against a
@@ -105,7 +105,7 @@ const schema = {
     { id: 'backlog', title: 'Backlog' },
     { id: 'in_progress', title: 'In Progress' },
   ],
-} as never;
+} satisfies ObjectKanbanSchema;
 
 /** Server truth: the card is in `backlog` and the server never moves it. */
 const serverRecords = () => [{ id: 't1', title: CARD, status: 'backlog' }];

--- a/packages/plugin-kanban/src/ObjectKanban.requiredWhenPrompt.test.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.requiredWhenPrompt.test.tsx
@@ -68,7 +68,7 @@ import { render, screen, within, act, cleanup, waitFor, fireEvent } from '@testi
 import '@testing-library/jest-dom';
 import { registerAllFields } from '@object-ui/fields';
 import { toast } from '@object-ui/components';
-import type { DataSource } from '@object-ui/types';
+import type { DataSource, ObjectKanbanSchema } from '@object-ui/types';
 import { ObjectKanban } from './ObjectKanban';
 
 // Pay the board's lazy chunk at import time rather than racing it against a
@@ -127,7 +127,7 @@ const schema = {
     { id: 'negotiation', title: 'Negotiation' },
     { id: 'closed_won', title: 'Closed Won' },
   ],
-} as never;
+} satisfies ObjectKanbanSchema;
 
 const records = (winReason: unknown = null) => [
   { id: 'o1', name: DEAL, stage: 'negotiation', win_reason: winReason },

--- a/packages/plugin-kanban/src/ObjectKanban.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useEffect, useState, useMemo } from 'react';
-import type { DataSource } from '@object-ui/types';
+import type { DataSource, ObjectKanbanSchema } from '@object-ui/types';
 import {
   useDataScope,
   useNavigationOverlay,
@@ -141,7 +141,60 @@ export function resolveKanbanCardFields(
  * no importer breaks. Tripwire: `__tests__/spec-symbol-4650.test.ts`.
  */
 export interface ObjectKanbanComponentProps {
-  schema: KanbanSchema;
+  /**
+   * The board node. A UNION of the two declared node types this component is
+   * registered for (objectui#7322 item ②) — `KanbanSchema` (`type: 'kanban'`)
+   * and `ObjectKanbanSchema` (`type: 'object-kanban'`).
+   *
+   * ## Why a union and not either type alone
+   *
+   * `index.tsx` registers ONE component under TWO keys —
+   * `ComponentRegistry.register('object-kanban', ObjectKanbanRenderer, …)` and
+   * `ComponentRegistry.register('kanban', ObjectKanbanRenderer, …)`, and
+   * `kanban-plugin-dialect-authoritative-7664.test.ts` pins that they resolve to
+   * the same renderer. The two keys have DIFFERENT declared node types, and the
+   * discriminants are disjoint literals, so naming one of them makes the prop
+   * lie about the other half of the nodes this component serves. That is the
+   * defect this member carried: it named `KanbanSchema` alone, so no
+   * `object-kanban` node was assignable to it, and every in-package test that
+   * mounts one had to escape the prop with `as never`.
+   *
+   * ## The read set that settled it (measured on `origin/main` `21d7989fb`)
+   *
+   * `ObjectKanban` reads thirteen keys off `schema`. Neither declaration covers
+   * them; the two TOGETHER cover twelve:
+   *
+   * | key | `BaseSchema` | `KanbanSchema` | `ObjectKanbanSchema` |
+   * |---|---|---|---|
+   * | `objectName`, `groupBy`, `limit`, `cardFields` | — | yes | yes |
+   * | `columns`, `cardTitle`, `swimlaneField`, `grouping` | — | yes | — |
+   * | `titleField` | — | — | yes |
+   * | `data`, `bind`, `className` | yes | — / yes | — |
+   * | `filter` | — | — | — |
+   *
+   * So each arm is load-bearing: dropping `ObjectKanbanSchema` loses the
+   * `titleField` read at `:350` / `:1024` (which is why that read was spelled
+   * `(schema as any).titleField` before this card), and dropping `KanbanSchema`
+   * loses four reads AND the `'kanban'` registration. `filter` (`:310`,
+   * `$filter` on the fetch) is declared by NEITHER face and still rides
+   * {@link BaseSchema}'s `[key: string]: any` — measured, filed, and NOT fixed
+   * here: this card moves the prop, not the two published schema faces.
+   *
+   * ## What the union does and does not claim
+   *
+   * It claims exactly the accept set the registry dispatches to this component,
+   * no wider: a node of some third type is still turned away. Every key above
+   * that only one arm declares reads as `any` on the union (through the other
+   * arm's index signature) — the same resolution it had before, so no read
+   * changes meaning. Widening a member of an exported prop type is additive:
+   * every caller that passed a `KanbanSchema` still compiles.
+   *
+   * ⛔ Do not narrow this back to one arm without first removing a
+   * registration. `__tests__/object-kanban-component-props-7322.test.ts`
+   * derives the registered key set from `index.tsx` off disk and goes red if
+   * the two ever stop agreeing.
+   */
+  schema: KanbanSchema | ObjectKanbanSchema;
   dataSource?: DataSource;
   className?: string; // Allow override
   /** Pre-fetched records passed by a parent (e.g. ListView). When provided, skips internal data fetching. */
@@ -347,7 +400,7 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
     // Support cardTitle property from schema (passed by ObjectView)
     // Fallback to legacy titleField for backwards compatibility
     const explicitTitleField: string | undefined =
-      schema.cardTitle || (schema as any).titleField;
+      schema.cardTitle || schema.titleField;
 
     // Title is resolved per-item below via:
     //   1. explicit titleField (schema.cardTitle / schema.titleField), if it
@@ -481,7 +534,7 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
       // semantic role (ADR-0085); `[]` drops to the legacy heuristic below.
       // (See `resolveKanbanCardFields` for the full priority contract.)
       const explicitCardFields: string[] = resolveKanbanCardFields(
-        (schema as any).cardFields,
+        schema.cardFields,
         objectDef,
       );
       // The field used as the card title is implicit (resolved above). Don't
@@ -1021,7 +1074,7 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
         const rec = navigation.selectedRecord as Record<string, any>;
         const recordId = rec.id ?? rec._id;
         if (!objectName || recordId == null) return null;
-        const titleField = (schema as any).cardTitle ?? (schema as any).titleField;
+        const titleField = schema.cardTitle ?? schema.titleField;
         const titleText = titleField && rec[titleField]
           ? String(rec[titleField])
           : detailTitle;

--- a/packages/plugin-kanban/src/__tests__/kanban-plugin-dialect-authoritative-7664.test.ts
+++ b/packages/plugin-kanban/src/__tests__/kanban-plugin-dialect-authoritative-7664.test.ts
@@ -73,8 +73,25 @@ type _RegistryEntryIsThisFace = Assert<Equal<SchemaRegistry['kanban'], KanbanSch
 
 // 3. The renderers' props type-check against the declared schema:
 //    - `ObjectKanban` (behind `ObjectKanbanRenderer`, registered for `'kanban'`
-//      AND `'object-kanban'`) takes exactly the declared face as its `schema`;
-type _ObjectKanbanTakesTheDeclaredFace = Assert<Equal<ObjectKanbanComponentProps['schema'], KanbanSchema>>;
+//      AND `'object-kanban'`) ACCEPTS the declared face as its `schema`.
+//
+//      ⚠️ This leg read `Equal<…, KanbanSchema>` until objectui#7322 item ②.
+//      Identity was never what the ruling claimed — the ruling's words are that
+//      "the four registered renderers' props still type-check against the
+//      declared schema", i.e. assignability, which is the same form the
+//      `kanban-ui` leg below already uses and for the same reason. Identity was
+//      merely the shape the prop happened to have while it named ONE arm, and
+//      that was itself the defect objectui#7322 item ② filed: the same renderer
+//      is registered for `'object-kanban'` too, whose declared node type is
+//      `ObjectKanbanSchema`, and no such node was assignable to the prop. The
+//      prop is now the union of the two registered keys' declared types, so the
+//      ruling's claim holds on this arm and now holds on the other one as well.
+//      The union's own honesty is pinned in
+//      `object-kanban-component-props-7322.test.ts`, which derives the
+//      registered key set from `../index` off disk; this leg keeps guarding
+//      what objectui#7664 asserted — that THIS declaration is the one the
+//      renderer consumes.
+type _ObjectKanbanTakesTheDeclaredFace = Assert<KanbanSchema extends ObjectKanbanComponentProps['schema'] ? true : false>;
 //    - `KanbanRenderer` (`'kanban-ui'`) accepts a declared board — its inline
 //      prop schema is a looser projection (`columns?: Array<any>`), so the
 //      claim is assignability, not identity;

--- a/packages/plugin-kanban/src/__tests__/object-kanban-component-props-7322.test.ts
+++ b/packages/plugin-kanban/src/__tests__/object-kanban-component-props-7322.test.ts
@@ -1,0 +1,143 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ObjectKanbanComponentProps.schema` names EVERY node type the component is
+ * registered for, and nothing else (objectui#7322 item ②).
+ *
+ * ## The defect this pins closed
+ *
+ * `ObjectKanbanRenderer` is registered under two keys — `'object-kanban'` and
+ * `'kanban'` — and the two keys have different declared node types
+ * (`ObjectKanbanSchema`, `type: 'object-kanban'`; `KanbanSchema`,
+ * `type: 'kanban'`). The prop named `KanbanSchema` alone, so no
+ * `object-kanban` node was assignable to the component that renders it. The
+ * cost was visible and paid in this package: five of the six in-package
+ * fixtures that mount an `object-kanban` board escaped the prop with
+ * `as never`, and the `titleField` read inside `ObjectKanban.tsx` was spelled
+ * `(schema as any).titleField` because the named arm does not declare it.
+ *
+ * ## Why the derivation, and not a list of two strings
+ *
+ * A hand-written pair of keys is exactly what the defect survived under: the
+ * second registration was added and the prop never followed, and no assertion
+ * anywhere related the two. So suite 2 EXTRACTS the registered keys from
+ * `../index.tsx` off disk and requires that set to equal the arms of the
+ * union — a third registration, or a re-key of an existing one, turns it red
+ * naming the key, and the fix is to move the prop rather than the test.
+ *
+ * ## The instrument
+ *
+ * Suite 1 is compile-time. Vitest strips types without checking them, so a
+ * green run proves nothing on its own: the assertions are read by
+ * `tsc -p packages/plugin-kanban/tsconfig.test.json`, chained off this
+ * package's `type-check` script. That project sets `"paths": {}`, so
+ * `@object-ui/types` resolves through the workspace dependency to
+ * `packages/types/dist/index.d.ts` — BUILD `@object-ui/types` before believing
+ * either colour suite 1 reports. Suite 2 is a real runtime assertion and needs
+ * no build.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ComponentRegistry } from '@object-ui/core';
+import type { KanbanSchema, ObjectKanbanSchema, ObjectGridSchema } from '@object-ui/types';
+import type { ObjectKanbanComponentProps } from '../ObjectKanban';
+import { ObjectKanbanRenderer } from '../index';
+import '../index';
+
+/* -------------------------------------------------------------------------- */
+/* Suite 1 — compile-time, read by tsconfig.test.json.                         */
+/* -------------------------------------------------------------------------- */
+
+type Assert<T extends true> = T;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+type Prop = ObjectKanbanComponentProps['schema'];
+
+// Non-vacuity controls. `any` anywhere below would satisfy every `extends`
+// while checking nothing — and `any` is precisely what this member would have
+// been widened to by the lazy fix.
+type _PropIsNotAny = Assert<Equal<IsAny<Prop>, false>>;
+type _KanbanArmIsReal = Assert<Equal<IsAny<KanbanSchema>, false>>;
+type _ObjectKanbanArmIsReal = Assert<Equal<IsAny<ObjectKanbanSchema>, false>>;
+
+// 1. Both registered node types are accepted. The second leg is the one this
+//    card added; the first is what objectui#7664 already required and must not
+//    regress.
+type _AcceptsTheKanbanNode = Assert<KanbanSchema extends Prop ? true : false>;
+type _AcceptsTheObjectKanbanNode = Assert<ObjectKanbanSchema extends Prop ? true : false>;
+
+// 2. And nothing else. `ObjectGridSchema` is the control: a sibling
+//    `@object-ui/types` node type, declared in the same file as
+//    `ObjectKanbanSchema`, registered to a DIFFERENT renderer. If this ever
+//    reads `true` the prop has been widened to something structural (or to
+//    `any`) rather than to the two declared arms.
+type _RejectsAnUnregisteredNode = Assert<Equal<ObjectGridSchema extends Prop ? true : false, false>>;
+
+// 3. The discriminant carries exactly the two registered keys. This is the
+//    claim suite 2 checks the other half of: here, what the TYPE says; there,
+//    what `index.tsx` actually registers.
+type _DiscriminantIsTheTwoKeys = Assert<Equal<Prop['type'], 'kanban' | 'object-kanban'>>;
+
+/* -------------------------------------------------------------------------- */
+/* Suite 2 — runtime, derived from the read site.                              */
+/* -------------------------------------------------------------------------- */
+
+const INDEX_TSX = join(dirname(fileURLToPath(import.meta.url)), '..', 'index.tsx');
+
+/** Every key `index.tsx` registers `ObjectKanbanRenderer` under. */
+function registeredKeys(): string[] {
+  const src = readFileSync(INDEX_TSX, 'utf8');
+  const keys: string[] = [];
+  const re = /ComponentRegistry\.register\(\s*'([^']+)'\s*,\s*ObjectKanbanRenderer\b/g;
+  for (const m of src.matchAll(re)) keys.push(m[1]);
+  return keys.sort();
+}
+
+describe('ObjectKanbanComponentProps.schema names every registered node type (objectui#7322)', () => {
+  it('is pinned at compile time', () => {
+    expect(true).toBe(true);
+  });
+
+  it('index.tsx registers ObjectKanbanRenderer under exactly the two keys the prop union names', () => {
+    // Red when a third registration is added, or an existing key is renamed,
+    // without moving `ObjectKanbanComponentProps['schema']` to match. The
+    // literals here are the union's arms restated: `KanbanSchema['type']` is
+    // `'kanban'` and `ObjectKanbanSchema['type']` is `'object-kanban'`, which
+    // suite 1's `_DiscriminantIsTheTwoKeys` holds to the prop.
+    expect(registeredKeys()).toEqual(['kanban', 'object-kanban']);
+  });
+
+  it('the extraction is lit — it finds the reader it claims to read, and no other renderer', () => {
+    // Anti-vacuity for the assertion above: a regex that matched nothing would
+    // return `[]` and a same-shaped `toEqual` against `[]` would pass forever.
+    const keys = registeredKeys();
+    expect(keys.length).toBeGreaterThan(0);
+    // `'kanban-ui'` and `'kanban-enhanced'` are registered in the same file to
+    // OTHER renderers — the control that the pattern discriminates on the
+    // component, not merely on the word `register`.
+    expect(keys).not.toContain('kanban-ui');
+    expect(keys).not.toContain('kanban-enhanced');
+    expect(ComponentRegistry.has('kanban-ui')).toBe(true);
+    expect(ComponentRegistry.has('kanban-enhanced')).toBe(true);
+  });
+
+  it('every extracted key resolves to that renderer in the live registry', () => {
+    // Ties the off-disk reading to the running registry, so a key that is
+    // registered in a source form this regex cannot see still has to show up
+    // through `ComponentRegistry` — and a key it read from a comment or a dead
+    // branch would fail here.
+    for (const key of registeredKeys()) {
+      expect(ComponentRegistry.get(key), `\`${key}\` does not resolve to ObjectKanbanRenderer`).toBe(ObjectKanbanRenderer);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #7322 (item ②; item ① landed as PR #7774 on 2026-09-05)

`ObjectKanbanRenderer` is registered under **two** keys — `'object-kanban'` (`index.tsx:416`)
and `'kanban'` (`:429`), and `kanban-plugin-dialect-authoritative-7664.test.ts` already pins
that both resolve to the same renderer. The two keys have **different declared node types**:

| key | declared type | `type` literal | `objectName` / `groupBy` |
|---|---|---|---|
| `'object-kanban'` | `ObjectKanbanSchema` (`objectql.ts`) | `'object-kanban'` | required / required (after item ①) |
| `'kanban'` | `KanbanSchema` (`complex.ts`, moved down by #7743) | `'kanban'` | optional / optional |

`ObjectKanbanComponentProps.schema` named `KanbanSchema` alone. The discriminants are
disjoint string literals, so **no `object-kanban` node was assignable to the component that
renders it**, and the prop lied about half the nodes it serves.

## The measurement that settled union-vs-single-type

The dispatch said measure first, choose second, and to stop and report if no single type can
serve both registrations. It can't — and the reason is not just the discriminant.
`ObjectKanban` reads **thirteen** keys off `schema`. Neither declaration covers them; the two
together cover twelve:

| key(s) | `BaseSchema` | `KanbanSchema` | `ObjectKanbanSchema` |
|---|---|---|---|
| `objectName`, `groupBy`, `limit`, `cardFields` | — | yes | yes |
| `columns`, `cardTitle`, `swimlaneField`, `grouping` | — | **yes** | — |
| `titleField` | — | — | **yes** |
| `data`, `bind`, `className` | yes | (`data`, `className`) | — |
| `filter` | — | — | — |

Each arm is load-bearing, in both directions:

* naming **`ObjectKanbanSchema` alone** (the original card's implied remedy) drops four
  declared reads *and* the `'kanban'` registration — it is wrong in the other direction;
* naming **`KanbanSchema` alone** (the status quo) drops `titleField` — which is exactly why
  `ObjectKanban.tsx` spelled that read `(schema as any).titleField`.

⇒ the honest type is the **union**, `KanbanSchema | ObjectKanbanSchema`. It claims exactly the
accept set the registry dispatches to this component and no more: an unregistered node type is
still turned away (pinned). This is the same land shape #7311 already took for the calendar
(`ObjectCalendarComponentProps.schema: ObjectGridSchema | CalendarSchema`).

`filter` (`:310`, the real `$filter` on the fetch) is declared by **neither** face and still
rides `BaseSchema`'s index signature. Measured and reported, **not** changed here — this card
moves the prop, not the two published schema faces. See "Findings" below.

## What the change costs the tree — the visible payoff

Five of the six in-package fixtures that mount an `object-kanban` board were escaping the prop
with `as never`. Four of them now carry a real `satisfies ObjectKanbanSchema`:

* `ObjectKanban.rejectedMoveRollback.test.tsx`
* `ObjectKanban.requiredWhenPrompt.test.tsx`
* `ObjectKanban.markedRefusalToast.test.tsx`
* `ObjectKanban.navWidthDefault.test.tsx`

The other two (`overlayTitleI18n`, `overlayTitleNoProviderFallback`) are **static** boards —
`columns` plus inline `data`, no fetch — so they author no `objectName`, which
`ObjectKanbanSchema` declares required. That requiredness is **#7780**'s subject; their casts
stay, now carrying the reason and the card number instead of being silent.

Three `as any` casts drop out of `ObjectKanban.tsx`: `titleField` at `:350` / `:1024` (honest
now that the `object-kanban` arm declares it) and `cardFields` / `cardTitle` (already declared;
the casts were redundant). Measured with eslint on the same file before and after: **28 → 24**
`@typescript-eslint/no-explicit-any` findings, i.e. exactly the four `any` tokens removed.

`(schema as any).navigation` at `:789` **stays**: `navigation` is declared on neither face, so
removing the cast would change the spelling of an index-signature read and nothing else — the
#5903 disposition, restated.

### `index.tsx:395`'s `schema: any` — the "if and only if" answered NO

The dispatch authorised cleaning it up *iff* the measurement makes an honest type available
there. It does not, on two readings: `ComponentRegistry.register`'s component parameter is
untyped, so an annotation there is a claim about registry dispatch that nothing enforces; and
`registration.test.tsx:32` renders a deliberately minimal `{ type: 'object-kanban' }`, which no
declared type accepts while #7780 is open. #5903 took the same disposition for the same reason
("the registered renderer still passes `schema: any`, so no runtime shape is turned away").

## The pin, and the pin it amends

**New** — `packages/plugin-kanban/src/__tests__/object-kanban-component-props-7322.test.ts`.
Suite 1 (compile-time, read by `tsc -p tsconfig.test.json`): both arms accepted, an
unregistered node type (`ObjectGridSchema`) refused, the discriminant equal to
`'kanban' | 'object-kanban'`, with `IsAny` controls so a widening to `any` cannot pass. Suite 2
(runtime): the registered key set is **extracted from `index.tsx` off disk** and required to
equal the union's arms — a hand-written pair of strings is exactly what this defect survived
under, so a third registration or a re-key goes red naming the key, and the fix is to move the
prop rather than the test. Anti-vacuity: the extraction must be non-empty, must **not** pick up
`'kanban-ui'` / `'kanban-enhanced'` (registered in the same file to other renderers), and every
key it finds must resolve to `ObjectKanbanRenderer` in the live registry.

**Amended** — `kanban-plugin-dialect-authoritative-7664.test.ts`, leg 3's first bullet, from
an `Equal` identity assertion between the prop's `schema` member and `KanbanSchema`, to
assignability. Identity was never what objectui#7664's ruling claimed; its words are that
*"the four registered renderers' props still type-check against the declared schema"* — the
same assignability form leg 3's own `kanban-ui` bullet already uses, and for the same reason.
Identity was merely the shape the prop happened to have while it named one arm, which was
itself this card's defect.

## Verification

All on `25907cd70`; every exit code captured before any pipe; build/test through the shared
verify lock.

| command | exit | verdict |
|---|---|---|
| `pnpm --filter @object-ui/plugin-kanban type-check` (`tsc --noEmit` + `tsconfig.test.json`) | 0 | no `error TS` line |
| `pnpm exec vitest run --maxWorkers=2 packages/plugin-kanban/` | 0 | `Test Files 25 passed (25) · Tests 130 passed (130)` |
| `turbo run type-check --filter=@object-ui/runner --filter=@object-ui/app-shell` | 0 | `Tasks: 31 successful, 31 total` (the two package-level consumers) |
| `pnpm --filter @object-ui/plugin-kanban lint` | 0 | `✖ 121 problems (0 errors, 121 warnings)`; 0 new on touched files |
| `pnpm --filter @object-ui/plugin-kanban build` | 0 | `Declaration files built in 4378ms` |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅ 8 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-control-bytes.mjs` | 0 | `✅ OK (scanned 6511 tracked text file(s))` |
| `pnpm check:spec-symbols` | 0 | `✅ no comment cites a key its spec symbol does not declare` |
| `pnpm check:element-data-source-declaration` | 0 | `OK — 13 gate-consuming file(s) checked` |
| `pnpm check:unreferenced-sources` | 0 | `OK  Every shipped source file … is reachable` |
| `pnpm check:vi-mock-specifiers` / `check:vi-mock-inherit` / `check:self-import` / `check:phantom-deps` | 0 | all `✅` |
| `pnpm check:sdui-registration-pins` | **NOT MEASURED** | `❌ No console build to weigh at apps/console/dist/assets` — a prerequisite complaint, not a red gate. Narrowing declared: this diff adds and removes **no** registration, which is that gate's whole subject. CI runs it with a real console build. |

`turbo ls --affected` from the merge-base names 8 packages; the two with a real source-level
dependency on this one (`runner`, `app-shell`) are type-checked above, the rest are apps and
examples that reach this package only through plugin registration and are CI's.

### Reverse verification at the package boundary

A widening is invisible unless the consumer really reads the rebuilt `.d.ts`. A scratch probe
assigning an `ObjectKanbanSchema`-typed value into the prop's `schema` member, importing
through `dist/index`:

* against the rebuilt `.d.ts` → **exit 0**;
* with that one line in `dist/ObjectKanban.d.ts` reverted to the single arm (mutation proven by
  md5, restored and re-proven) → **exit 2**, `TS2322: Type 'ObjectKanbanSchema' is not
  assignable to type 'KanbanSchema'`.

So the green is a reading of this change, not of a cache.

### Ablation — both halves of the new pin, red-first

Run from the committed state, mutation proven by blob hash on disk, restored under
`trap … EXIT INT TERM` with `git checkout HEAD --` and `git diff HEAD` empty afterwards. No
`dist` is on the pin's own resolution path (`../ObjectKanban` and `../index` are source imports;
`tsconfig.test.json` sets `"paths": {}` only for the `@object-ui/*` workspace deps, which this
change does not touch).

**Leg A — prop reverted to the single arm** (the union member replaced by `schema: KanbanSchema`;
anchors counted 1→0 and 0→1, blob `48bd449d` → `fba3ea76`).
Predicted red on the two new type legs and on the four `satisfies` fixtures. Observed:
`tsc -p tsconfig.test.json` **exit 2, 6 errors** — `TS2344` at
`object-kanban-component-props-7322.test.ts(77,43)` and `(89,41)` (`_AcceptsTheObjectKanbanNode`,
`_DiscriminantIsTheTwoKeys`) plus `TS2322` on all four fixtures. One refinement on the
prediction: the fixtures fail at the **JSX prop assignment** (`TS2322`), not at the `satisfies`
clause (`TS1360`) — the literals still satisfy `ObjectKanbanSchema`; it is the prop that stops
accepting them, which is the more exact statement of the defect.

**Leg B — one registration re-keyed** (`'kanban'` → `'kanban2'` in `index.tsx`; blob
`4e354382` → `c01425be`). Predicted exactly one red assertion with the anti-vacuity legs
staying green. Observed: vitest **exit 1**, `Tests 1 failed | 3 passed (4)`,
`AssertionError: expected [ 'kanban2', 'object-kanban' ] to deeply equal [ 'kanban', 'object-kanban' ]`.
⚠️ Leg B's `grep -c` echo lines were mangled by quoting inside the script's heredoc and printed
no usable count; the mutation's arrival on disk is carried instead by the blob-hash inequality
**and** by the assertion message itself, which quotes the mutated key back. Two independent
readings, so the leg stands; the broken echo is a script defect, reported rather than papered
over.

Restore proven on both legs: blobs equal `HEAD` again, `git diff HEAD` empty.

## Findings — reported, not filed, to avoid a fourth card on this family

The dispatch flagged that #7772 / #7773 / #7780 already sit on the `object-kanban` family and
this card must not duplicate them. Two measurements fall inside cards that already exist:

* **`filter` and `navigation` are declared on neither kanban face** while `ObjectKanban` reads
  both. #7742 is already the enforce-or-remove ledger card for `KanbanSchema`'s
  declared-vs-read set (it names the undeclared `titleField` read), and #7712 covers `filter`
  from the registration-`inputs` angle. `navigation` is named by neither; it is added as a
  comment on #7742 rather than as a new card.
* ⚠️ **This PR moves #7742's premise.** Its `titleField` half reads "the board reads an
  undeclared `titleField`" — after this change that read is declared (on the `object-kanban`
  arm) and cast-free, while still undeclared on `KanbanSchema`. Its taker should re-measure
  from this commit.

## Not touched

The four view-level `groupField` alias sites (`normalize-list-view.ts`, `ListView.tsx`,
`ObjectView.tsx`), `BaseSchema`'s index signature (#5155), and `packages/types` — read-only
here, as dispatched (slot 3/5 is editing `complex.ts`'s `ChatbotSchema` region concurrently).
Nothing under `content/docs/releases/`.

## Governance

`node scripts/check-governed-queue-guard.mjs --test` on this diff's paths:
`✅ NOT GOVERNED — 3 path(s) checked against 5 governed surface(s); none matched.`
Held **draft** with `needs:contract-review` per Clause-② (this widens a member of a prop type
exported from a published package). ⛔ Does not enqueue while that label is on it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_