### PR TITLE
feat(gate): bring the root docs/*.md pages into the doc-snippet walk

### DIFF
--- a/.github/workflows/doc-snippet-types.yml
+++ b/.github/workflows/doc-snippet-types.yml
@@ -131,7 +131,9 @@ jobs:
       # REPORT-ONLY (objectui#7864). Code a generator EMITS from a template
       # literal under `packages/*/src/**` is compiled by nothing: `tsc` sees a
       # string, `tsup` copies it through, and this gate's own scan surface stops
-      # at `content/docs`, the per-app docs trees and the package READMEs. This
+      # at the authored pages — `content/docs`, the per-app docs trees, the
+      # package READMEs, the root `README.md` (objectui#7115) and the top level
+      # of the root `docs/` tree (objectui#7856 card 1). This
       # step censuses that class through the same `compileSnippets()` the doc
       # blocks go through, against the closure the step above just built.
       #

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,8 +160,19 @@ Third-Party App
 
 ```tsx
 import { AppShell } from '@object-ui/app-shell';
+import type { AppShellProps } from '@object-ui/app-shell';
 import { ObjectView } from '@object-ui/plugin-view';
 import { DataSourceProvider, useDataSource } from '@object-ui/providers';
+import type { DataSourceProviderProps } from '@object-ui/providers';
+
+// The two things you bring. Both are typed from the surface these packages
+// ship, so this snippet compiles on its own: `myAPI` is your backend adapter
+// (the "Custom Data Source Interface" section below is the shape it needs at
+// runtime — `DataSourceProvider` declares the prop `any`, so the annotation
+// records where the value goes rather than checking it), and `MySidebar` is
+// your own component, returning whatever `AppShell` accepts for `sidebar`.
+declare const myAPI: DataSourceProviderProps['dataSource'];
+declare function MySidebar(): AppShellProps['sidebar'];
 
 function MyConsole() {
   return (
@@ -183,24 +194,29 @@ function ContactList() {
 
 ### Example 2: Next.js Integration
 
+`app/layout.tsx`:
+
 ```tsx
-// app/layout.tsx
 import { AppShell } from '@object-ui/app-shell';
+import type { AppShellProps } from '@object-ui/app-shell';
 import { ThemeProvider } from '@object-ui/providers';
 
-export default function RootLayout({ children }) {
+export default function RootLayout({ children }: { children: AppShellProps['children'] }) {
   return (
     <ThemeProvider>
       <AppShell>{children}</AppShell>
     </ThemeProvider>
   );
 }
+```
 
-// app/[object]/page.tsx
+`app/[object]/page.tsx`:
+
+```tsx
 import { ObjectView } from '@object-ui/plugin-view';
 import { useDataSource } from '@object-ui/providers';
 
-export default function Page({ params }) {
+export default function Page({ params }: { params: { object: string } }) {
   const dataSource = useDataSource();
   return <ObjectView schema={{ type: 'object-view', objectName: params.object }} dataSource={dataSource} />;
 }
@@ -211,6 +227,11 @@ export default function Page({ params }) {
 ```tsx
 import { ObjectView } from '@object-ui/plugin-view';
 import { DataSourceProvider, useDataSource } from '@object-ui/providers';
+import type { DataSourceProviderProps } from '@object-ui/providers';
+
+// Your backend adapter, as in Example 1 — declared here because every block on
+// this page compiles on its own.
+declare const myAPI: DataSourceProviderProps['dataSource'];
 
 function MyExistingApp() {
   return (
@@ -252,7 +273,9 @@ Example implementation:
 
 ```tsx
 const myDataSource = {
-  async find(objectName, params) {
+  // The parameter types are the ones the interface above declares; spelling
+  // them out is what lets this block be compiled rather than read.
+  async find(objectName: string, params?: any) {
     return fetch(`/api/${objectName}`, {
       method: 'POST',
       body: JSON.stringify(params),

--- a/scripts/__tests__/check-doc-fence-languages.test.ts
+++ b/scripts/__tests__/check-doc-fence-languages.test.ts
@@ -15,6 +15,8 @@ import {
 import {
   APP_DOCS as SNIPPET_APP_DOCS,
   listDocuments as snippetDocuments,
+  ROOT_DOCS as SNIPPET_ROOT_DOCS,
+  rootDocsPages as snippetRootDocsPages,
   ROOT_PAGES as SNIPPET_ROOT_PAGES,
   TS_FENCE_LANGUAGES as GATE_TS_FENCES,
 } from '../check-doc-snippet-types.mjs';
@@ -114,8 +116,61 @@ const MIN_HEADER_PROSE = 400;
  * place for those numbers.
  */
 describe('check-doc-fence-languages: the scan surface is check-doc-snippet-types’s', () => {
-  it('walks exactly the documents the snippet gate walks', () => {
-    expect(fenceDocuments(ROOT)).toEqual(snippetDocuments(ROOT));
+  /**
+   * objectui#7856 card 1 — the ONE place the two walks are allowed to differ,
+   * named rather than tolerated.
+   *
+   * That card brought the repository-root `docs/` tree, TOP LEVEL only, into
+   * `check-doc-snippet-types`' walk: an authored-documentation directory that no
+   * doc gate read, where three phantom-teaching sites (objectui#7838,
+   * objectui#7854) had already been found by hand. It moved THAT gate's
+   * population and no other, for a stated reason: the rest of the tree —
+   * `docs/adr/**`, a GOVERNED surface, and `docs/audits/**` — is card 2, whose
+   * pull request stops in draft for a human to merge, and `check:doc-fences`'
+   * own surface was not that card's to move.
+   *
+   * So the equality below subtracts exactly what the snippet gate exports as its
+   * leg, `rootDocsPages()`, rather than a hand-written list of today's two
+   * filenames: a page added to `docs/` tomorrow travels into BOTH sides of this
+   * comparison by itself, and a page added under `docs/adr/` travels into
+   * NEITHER. A hand-written list would have to be re-typed for the first case and
+   * would stay silently green for the second.
+   *
+   * ⛔ What this is not: a licence for the two walks to drift anywhere else. Any
+   * OTHER divergence still fails here, which is the whole point of keeping the
+   * comparison rather than deleting it.
+   */
+  it('walks exactly the documents the snippet gate walks, minus that gate’s docs/*.md leg', () => {
+    const legOnly = new Set(snippetRootDocsPages(ROOT));
+    expect(fenceDocuments(ROOT)).toEqual(snippetDocuments(ROOT).filter((d: string) => !legOnly.has(d)));
+  });
+
+  it('…and that subtraction is non-empty, so it is not silently subtracting nothing', () => {
+    const leg = snippetRootDocsPages(ROOT);
+    expect(leg.length).toBeGreaterThan(0);
+    // Every subtracted document really is on the snippet gate's side only.
+    for (const doc of leg) {
+      expect(snippetDocuments(ROOT), `${doc} is not in the snippet gate's walk`).toContain(doc);
+      expect(fenceDocuments(ROOT), `${doc} reached the fence guard's walk`).not.toContain(doc);
+    }
+  });
+
+  /**
+   * The card-2 boundary, pinned on the leg itself. `recursive: false` is a claim
+   * about where this surface stops, and a claim about a walk is only worth what
+   * a test that reads the tree says about it.
+   */
+  it('the docs/*.md leg stops at the top level — the governed subtrees stay out of both walks', () => {
+    expect(SNIPPET_ROOT_DOCS).toEqual({ dir: 'docs', recursive: false });
+    const nested = (docs: string[]) =>
+      docs.filter((d) => d.startsWith(`${SNIPPET_ROOT_DOCS.dir}/`) && d.slice(`${SNIPPET_ROOT_DOCS.dir}/`.length).includes('/'));
+    expect(nested(snippetDocuments(ROOT))).toEqual([]);
+    expect(nested(fenceDocuments(ROOT))).toEqual([]);
+    // Non-vacuous: the subdirectories this asserts are absent do hold pages.
+    expect(
+      fs.existsSync(path.join(ROOT, SNIPPET_ROOT_DOCS.dir, 'adr')),
+      'docs/adr no longer exists, so the exclusion above pins nothing',
+    ).toBe(true);
   });
 
   it('…and that is a non-empty set, so the comparison is not vacuous', () => {

--- a/scripts/__tests__/check-doc-snippet-types.test.ts
+++ b/scripts/__tests__/check-doc-snippet-types.test.ts
@@ -26,7 +26,9 @@ import {
   moduleSpecifiersOf,
   moduleSpecifiersOfBlock,
   resolvesOnlyThroughRootManifest,
+  ROOT_DOCS,
   rootDeclaredSpecifiers,
+  rootDocsPages,
   scanFences,
   scopedBuildNotice,
   specifierRoot,
@@ -619,6 +621,87 @@ describe('objectui#7115 — the root README is in the scan set', () => {
     const source = fs.readFileSync(path.join(repoRoot, 'scripts/check-doc-snippet-types.mjs'), 'utf8');
     expect(source).toContain('ROOT_PAGES');
     expect(source).toMatch(/for \(const name of ROOT_PAGES\) \{\n\s*if \(!existsSync\(join\(repoRoot, name\)\)\)/);
+  });
+});
+
+/**
+ * objectui#7856 card 1 — the repository-root `docs/` tree was in NO doc gate's
+ * scan set, and `lint:root` ignores it by name (`--ignore-pattern 'docs/**'`).
+ * The card measured what that bought: three phantom-teaching sites found in it by
+ * hand (objectui#7838, objectui#7854) and 11 diagnostics under `docs/*.md` that
+ * nothing reported.
+ *
+ * The rule this file's sibling states — "Widening a scan surface is the change
+ * that can be GREEN ABOUT NOTHING… Anything added here later is owed the same
+ * proof" — is why membership is pinned by name below, and why the leg's
+ * BOUNDARY is pinned too. `recursive: false` is not a performance note: the
+ * subtree it excludes is `docs/adr/**`, a governed surface whose pull requests
+ * stop in draft for a human, plus `docs/audits/**`, and both are card 2. A leg
+ * that grew into them by accident would put a governed-surface failure in front
+ * of a pull request that cannot land it.
+ */
+describe('objectui#7856 — the root docs/*.md pages are in the scan set, and only those', () => {
+  it('listDocuments reaches them', () => {
+    const documents = listDocuments(repoRoot);
+    for (const doc of rootDocsPages(repoRoot)) expect(documents).toContain(doc);
+    // Non-vacuous: the leg reaches a real page, not an empty directory.
+    expect(rootDocsPages(repoRoot)).toContain('docs/ARCHITECTURE.md');
+  });
+
+  it('the widening judges something — the leg contributes blocks to the compiled tier', () => {
+    // Being IN the walk is one fact; being compiled is the other, and this card
+    // delivered both (no `UNGATED_DOCS` entry was needed — the blocks were
+    // repaired). A leg whose pages all sat on the ledger would be visible to the
+    // accounting and judged by nothing, which is a weaker claim than this test
+    // makes.
+    const state = analyze({});
+    const leg = new Set(rootDocsPages(repoRoot));
+    expect((state.covered as string[]).filter((d) => leg.has(d)).sort()).toEqual([...leg].sort());
+    expect((state.compiled as { doc: string }[]).some((b) => leg.has(b.doc))).toBe(true);
+  });
+
+  it('stops at the top level: a page in a subdirectory is NOT collected', () => {
+    const root = tempTree({
+      'docs/PAGE.md': '# top level\n',
+      'docs/adr/0001-decision.md': '# governed, card 2\n',
+      'docs/audits/2026-07-audit.md': '# card 2\n',
+    });
+    try {
+      expect(rootDocsPages(root)).toEqual(['docs/PAGE.md']);
+      expect(listDocuments(root)).toEqual(['docs/PAGE.md']);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('collects files only, and only page extensions', () => {
+    const root = tempTree({
+      'docs/b.mdx': '# b\n',
+      'docs/a.md': '# a\n',
+      'docs/notes.txt': 'not a page\n',
+      'docs/screenshots/shot.png': 'not a page\n',
+    });
+    try {
+      expect(rootDocsPages(root)).toEqual(['docs/a.md', 'docs/b.mdx']);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('an absent docs/ tree yields nothing here, and a verdict is refused in main', () => {
+    const root = tempTree({ 'README.md': '# root\n' });
+    try {
+      // A throwaway fixture tree stays listable…
+      expect(rootDocsPages(root)).toEqual([]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+    // …while a REAL run refuses, the same way a dangling ROOT_PAGES name does.
+    // `main()` takes no `--root`, so this is pinned against the source for the
+    // same reason the ROOT_PAGES guard above is.
+    const source = fs.readFileSync(path.join(repoRoot, 'scripts/check-doc-snippet-types.mjs'), 'utf8');
+    expect(source).toMatch(/if \(!existsSync\(join\(repoRoot, ROOT_DOCS\.dir\)\)\) \{/);
+    expect(ROOT_DOCS).toEqual({ dir: 'docs', recursive: false });
   });
 });
 

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -370,7 +370,9 @@
  * be read off the collector:
  *
  *     every `.mdx` and `.md` page under `content/docs`, every
- *     `packages/<name>/README.md`, and the root `README.md`.
+ *     `packages/<name>/README.md`, every `.md` / `.mdx` page at the TOP LEVEL of
+ *     the repository-root `docs/` tree (objectui#7856 card 1 — not its
+ *     subdirectories), and the root `README.md`.
  *
  * Stating it here is objectui#5174's finding, and the finding was not the missing
  * extension — it was that a reader had to open `listDocuments` to learn that
@@ -484,6 +486,62 @@ export const ROOT_PAGES = ['README.md'];
  *  sidecars) holds no prose and is not a page. */
 const DOC_EXTENSIONS = ['.mdx', '.md'];
 
+/**
+ * The repository-root `docs/` tree, at its TOP LEVEL only (objectui#7856, card 1).
+ *
+ * objectui#7856 measured the hole the same way objectui#7115 measured the root
+ * `README.md`'s: `docs/` is an authored-documentation directory that NO doc gate
+ * read — not this one, not `check-doc-fence-languages`, not
+ * `check-doc-component-types`, and not `lint:root`, whose script literally passes
+ * `--ignore-pattern 'docs/**'`. Three phantom-teaching sites (objectui#7838,
+ * objectui#7854) were found in it by hand, which is the only instrument that was
+ * ever pointed at it.
+ *
+ * `recursive: false` is the whole design of this leg, and it is a boundary rather
+ * than an optimisation. The tree's SUBDIRECTORIES are a different review route:
+ * `docs/adr/**` is a GOVERNED surface (`GOVERNED_SURFACES` id `adr` in
+ * `check-governed-queue-guard.mjs`, so a pull request touching it stops in draft
+ * for a human to merge) and `docs/audits/**` travels with it as objectui#7856's
+ * card 2. A `**`-shaped walk here would pull 29 more diagnostics from those two
+ * trees into a gate whose failures a non-governed pull request is expected to
+ * fix (26 + 3, as objectui#7856 measured them on `8507a2283`) — which is how a
+ * widening turns into a change nobody can land. The same
+ * reasoning, in the same words, as `APP_DOCS`' "one level of app directory and no
+ * deeper": a scan surface says where it stops.
+ *
+ * So the enumeration below is by DIRECTORY ENTRY and filtered to FILES. Adding
+ * `docs/adr/**` later is then an edit to this file that a reviewer sees, never a
+ * side effect of a page being moved into a subdirectory.
+ *
+ * Exported — the constant and the enumerator both — so a sibling census can ask
+ * this gate what its leg contains instead of re-spelling it. That is what
+ * `check-doc-fence-languages.test.ts` does: `check-doc-fence-languages` does NOT
+ * carry this leg (its walk is `check:doc-fences`' own surface, and moving it is
+ * not objectui#7856 card 1), and that pin subtracts exactly this set rather than
+ * a hand-written list of the two filenames.
+ */
+export const ROOT_DOCS = { dir: 'docs', recursive: false };
+
+/**
+ * Every page at the top level of `ROOT_DOCS.dir`, in a stable order.
+ *
+ * An absent directory yields `[]` here so a throwaway fixture tree stays
+ * listable, exactly as `ROOT_PAGES` does; `main` refuses to publish a verdict
+ * when the directory is missing from a REAL run, because a leg that silently
+ * collects nothing is objectui#7115's defect one level up.
+ */
+export function rootDocsPages(root) {
+  const dir = join(root, ROOT_DOCS.dir);
+  if (!existsSync(dir) || !statSync(dir).isDirectory()) return [];
+  return readdirSync(dir)
+    .sort()
+    .filter(
+      (entry) =>
+        DOC_EXTENSIONS.some((ext) => entry.endsWith(ext)) && statSync(join(dir, entry)).isFile(),
+    )
+    .map((entry) => `${ROOT_DOCS.dir}/${entry}`);
+}
+
 /** Fence languages treated as compilable TypeScript. `js` / `jsx` are NOT in the
  *  set: they are not type-annotated, so a strict program judges them on rules
  *  their authors never opted into. */
@@ -502,6 +560,17 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  *   apps/<app>/docs/**              ✓        ✓       ✓     objectui#6600
  *   README.md                       ✓        ✓       ✓     objectui#7115
  *   packages/<name>/README.md       ✓        ✓       ✗     ships inside `files`
+ *   docs/*.md (top level only)      ✗        ✓       ✗     objectui#7856 card 1
+ *
+ * The `docs/*.md` row is the one leg THIS gate carries alone, and the asymmetry
+ * is deliberate rather than an oversight to be tidied up later: objectui#7856
+ * card 1 moves this gate's population only, so `check-doc-fence-languages` and
+ * `check-doc-component-types` keep the surface they had. `check-doc-fence-
+ * languages.test.ts` therefore no longer compares the two walks for equality
+ * flat — it subtracts exactly `rootDocsPages()` and compares the rest, so the
+ * divergence is named and bounded instead of being a list that silently drifted.
+ * ⛔ The subdirectories are NOT this row: `docs/adr/**` is governed and
+ * `docs/audits/**` travels with it (objectui#7856 card 2).
  *
  * `check-doc-component-types` does not read the package READMEs — it asks
  * whether a documented `type` literal is a registered component key, and a
@@ -512,7 +581,9 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * ⚠️ EVERYTHING ELSE authored in markdown is read by no doc gate at all. That is
  * a statement of what the roots are today, ⛔ not a plan and not a promise. In
  * descending order of size, the unscanned population is: non-README `.md` under
- * `packages/**` (by far the largest); `docs/**` (ADRs and audits); the PUBLISHED
+ * `packages/**` (by far the largest); `docs/adr/**` and `docs/audits/**` — the
+ * root `docs/` tree BELOW its top level, which objectui#7856 card 2 holds and
+ * card 1 deliberately left where it was; the PUBLISHED
  * `skills/objectui/**`; the root pages that are not `README.md` (`AGENTS.md`,
  * `CONTRIBUTING.md`, `ROADMAP.md` and the rest); `examples/**`; the `apps/**`
  * pages that are not under an `apps/<app>/docs/` tree; `.claude/**`;
@@ -532,7 +603,7 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * "which":
  *
  *     git ls-files '*.md' '*.mdx' \
- *       | grep -vE '^(content/docs/|apps/[^/]+/docs/|packages/[^/]+/README\.md$|README\.md$|\.changeset/)'
+ *       | grep -vE '^(content/docs/|apps/[^/]+/docs/|packages/[^/]+/README\.md$|README\.md$|docs/[^/]+\.mdx?$|\.changeset/)'
  *
  * ⛔ `skills/objectui/**` is NOT claimed by any gate here, and this line is the
  * opposite of a claim on it: it is a governed, published surface with its own
@@ -924,6 +995,10 @@ export function listDocuments(root = repoRoot) {
       if (existsSync(readme)) out.push(relative(root, readme).split(sep).join('/'));
     }
   }
+  // The root `docs/` tree, TOP LEVEL only (objectui#7856 card 1). Enumerated by
+  // directory entry and filtered to files by `rootDocsPages`, so `docs/adr/**`
+  // (governed) and `docs/audits/**` (card 2) cannot arrive here by accident.
+  out.push(...rootDocsPages(root));
   // Root pages last, by name. An absent one is dropped here so a throwaway
   // fixture tree stays listable; `main` refuses to publish a verdict when one is
   // missing from a real run, which is the only place that can bite.
@@ -2136,6 +2211,19 @@ function main() {
       );
       return EXIT_CODES.couldNotRun;
     }
+  }
+
+  // The same check for the other root leg, for the same reason (objectui#7856
+  // card 1): `rootDocsPages` returns [] for a directory that is not there, which
+  // keeps a fixture tree listable but would let a rename shrink the real surface
+  // back to what objectui#7856 found, with every count below still healthy.
+  if (!existsSync(join(repoRoot, ROOT_DOCS.dir))) {
+    console.error(
+      `ROOT_DOCS names \`${ROOT_DOCS.dir}/\`, which does not exist under ${repoRoot}. That directory is ` +
+        "part of this gate's stated scan surface (objectui#7856), so its absence silently narrows the " +
+        'surface. Re-point it at the tree\'s new path, or remove the leg deliberately.',
+    );
+    return EXIT_CODES.couldNotRun;
   }
 
   const state = analyze({});


### PR DESCRIPTION
Refs #7856 (card 1: docs/*.md). Card 2 (`docs/adr/**` + `docs/audits/**`, the governed half) stays open on that card for another seat — no closing keyword anywhere in this body on purpose.

Base: `origin/main` at `571b4870d` (carries batch 26 / PR #8147 and the `--emit-census` mode from PR #8138). Final HEAD: `f011733bf`.

## What this does

`scripts/check-doc-snippet-types.mjs`'s `listDocuments()` now carries a `docs/*.md` leg, **top level only**, in the same slot pattern the root `README.md` took for #7115:

- `export const ROOT_DOCS = { dir: 'docs', recursive: false }` — a named constant that states where the surface stops.
- `export function rootDocsPages(root)` — enumerates directory entries, filtered to **files** by `statSync`, so `docs/adr/**` (governed) and `docs/audits/**` cannot arrive by a page being moved into a subdirectory. Exported so a sibling census asks this gate what its leg holds instead of re-spelling it.
- `main()` refuses a verdict when `docs/` is missing, exactly as it already does for a dangling `ROOT_PAGES` name — a leg that silently collects nothing is #7115's defect one level up.
- The header's enumeration of the scan surface, the three-gate ownership table (new row `docs/*.md (top level only)`: fences ✗ · snippets ✓ · types ✗), the unscanned-population paragraph and its `git ls-files` recipe are all updated in the same stroke.

Document population: **227 → 229**. Covered blocks 735 → 741, compiled 577 → 583, declared fragments unchanged at **158**, `UNGATED_DOCS` unchanged at **11 entries**.

## Census — the gate's own analyzer, on this tree

Taken with the gate's exported `scanFences` / `derivePackageTypePaths` / `deriveDeclaredDependencyPaths` / `compileSnippets` (no hand-written regex), against the built closure (`pnpm exec turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter) --concurrency=2` — 34/34 tasks successful).

| file | ts/tsx blocks | diagnostics | by code | blind spots |
|---|---|---|---|---|
| `docs/ARCHITECTURE.md` | 5 (`tsx` at fence lines 161, 186, 211, 240, 253) | 11, all **semantic** | TS2552 x2, TS2304 x1, TS2323 x2, TS2393 x2, TS7031 x2, TS7006 x2 | 0 |
| `docs/CONSOLE-STREAMLINING-SUMMARY.md` | 0 | 0 | — | 0 |

**Blind spots: none.** Syntax phase: every block parsed, so all 5 reached the semantic phase; root-bound refusals 0; no fence the extractor could not read. The card's estimate for this half (11 diagnostics on `8507a2283`) re-measures **11** here; the per-code split differs from the card's tree-wide split because that one covered `docs/adr/**` and `docs/audits/**` too.

Both the card's and the claim comment's readings needed one correction: `docs/ARCHITECTURE.md` holds **5** `tsx` fences, at 161, 186, 211, 240 **and 253** — the claim's list of four omitted 253, which carries 2 of the 11 diagnostics. The 240 block (`interface DataSource`) is the one that already compiled clean.

## Ledger or repair, per block

**Repair, in all four cases. No `UNGATED_DOCS` entry was written and no fragment marker was added** — declared fragments stay at 158. Typed bindings before markers (batch 26 / PR #8147), no `@ts-expect-error` (no readonly or known-defect case here), no loosened type, no marker hiding a teaching defect.

| block | diagnostics | decision | why |
|---|---|---|---|
| fence 161 (Example 1) | TS2552 `myAPI`, TS2304 `MySidebar` | repair — `declare const` / `declare function` stand-ins annotated from the **shipped** `DataSourceProviderProps['dataSource']` and `AppShellProps['sidebar']` | The batch-26 idiom: the reader's two inputs become real bindings typed by the surface these packages ship, so the block is self-contained the way the gate compiles it (one block, one module). The comment states the bound honestly — `DataSourceProvider` declares that prop `any`, so the annotation records where the value goes, it does not check the value's shape. |
| fence 186 (Example 2, Next.js) | TS2323 x2, TS2393 x2, TS7031 x2 | repair — split into the two files it always was, then annotate the two props | The four duplicate-`default` diagnostics were not a defect in either example: one fence held **two** modules (`app/layout.tsx` and `app/[object]/page.tsx`), and the gate compiles a block in isolation, so the two `export default`s collided. One fence per file is what the page meant; the prop types come from `AppShellProps['children']` and the route's own `{ object: string }`. This is the +1 block (5 → 6). |
| fence 211 (Example 3) | TS2552 `myAPI` | repair — same stand-in as fence 161 | Same shape, same toolkit. |
| fence 240 (`interface DataSource`) | 0 | untouched | Already compiled. See the proposal below for what the gate cannot see about it. |
| fence 253 (example adapter) | TS7006 x2 | repair — spell the two parameter types | The implicit-any was the **absence** of an annotation, not a wrong one; the types written are the ones the page's own `DataSource` interface declares two paragraphs above, so nothing new is asserted. |

## Real teaching defects, named rather than papered over — proposals for their own cards

None of these produced a diagnostic; the gate structurally cannot see them. They are not filed as issues — this card's output goes here for the PM to route.

1. **The `DataSource` interface the page documents is not any package's exported contract, and `ObjectView` would reject it.** Measured through the gate's own `compileSnippets` (probe, not committed): annotate a stand-in with the page's verbatim 6-method interface and pass it to `ObjectView` and you get `TS2741: Property 'getObjectSchema' is missing in type 'DataSource' but required in type 'DataSource(OPT)'`. `@object-ui/types` exports a much larger `DataSource`; `@object-ui/app-shell` has a near-identical private one but does **not** export it. The only reason the page's examples type-check is that `useDataSource()` is declared `any` and `DataSourceProviderProps.dataSource` is `any` — the value is laundered between the provider and the renderer, so the page's central claim ("third-party systems implement this interface") is unchecked end to end by construction.
2. **The Next.js example has no `'use client'`.** `app/layout.tsx` renders `ThemeProvider` / `AppShell` and `app/[object]/page.tsx` calls the `useDataSource` hook; under the App Router both are server components by default, so a reader copying them literally gets a runtime error. The string appears nowhere on the page.

## Strictness region

The #5174 burn-down's byte-identical-strictness licence, re-baselined here because the leg lands **inside** the region (the `Fence scanning` banner to EOF):

| | sha256 |
|---|---|
| before, `571b4870d` | `5dfcd1b876c044ef33b6b5fed8a57ec719622ddbb20ce0ab539e5c985a233017` |
| after, `f011733bf` | `2749d53ae3a8df033a53b8d7a354fa7e22ee2d1a17f6ad0c3d61122e904e084b` |

Reason: **the scan population grew; no strictness rule moved.** Exactly two additions sit inside the region — the leg's call site in `listDocuments()` (4 lines, one of them code) and the missing-directory guard in `main()`. Fence languages read, fragment-marker semantics, the diagnostic filters and every failure classification are byte-identical.

## Pin resolution

The PM's reading held, and only one pin moved:

- `scripts/__tests__/check-doc-fence-languages.test.ts` — its `walks exactly the documents the snippet gate walks` assertion went red, as expected, because `check:doc-fences` does **not** gain this leg (its surface is not card 1's to move, and `check:doc-types` is #7896's). It now **records the divergence**: the equality subtracts exactly `rootDocsPages()` — the snippet gate's own export, not a hand-written list of today's two filenames, so a page added to `docs/` travels into both sides by itself and a page added under `docs/adr/` travels into neither. Two assertions added beside it: the subtraction is non-empty and every subtracted document really is on one side only; and the leg stops above `docs/adr/` and `docs/audits/` in **both** walks, with a non-vacuity check that `docs/adr` still exists.
- `scripts/__tests__/check-doc-expression-carriage.test.ts` — **untouched and green**. It pins the expression-carriage census against `check-doc-component-types`' constants, not this gate's, so this leg does not reach it.
- `scripts/__tests__/check-doc-snippet-types.test.ts` — gains the widening's own proof, the way #7115's leg has one: membership by name, that the leg contributes blocks to the **compiled** tier (a leg whose pages all sat on the ledger would be visible and judged by nothing), non-recursion on a fixture holding `docs/adr/` and `docs/audits/` pages, files-and-page-extensions only, and the missing-directory refusal.
- `check:doc-fences`, `check:doc-types`, `check:readme-exports` all exit 0 as controls that the siblings did not move.

⚠️ **Owed follow-up, outside this card's file surface.** `scripts/check-doc-fence-languages.mjs`'s header now says two things that stopped being true: "The scan surface is `check-doc-snippet-types`'s, exactly: …", and that the pin "fails if they ever return different document lists". The pin's own comment states the divergence and its reason, but that gate's prose should be corrected in a follow-up (this card's file surface named that gate's **test**, not the gate).

## Positive controls — both by state, under a trap, against the committed tree

**A. The gate really judges the new leg.** Injected `objectName: 42` into the Example 1 fence (`objectName` is `string` on `ObjectViewSchema`).

```
on-disk proof   anchor occurrences 2 -> 1, injected text 1   (blob 9e97fd3ce -> 6f9df8e96)
GATE_EXIT=1
  [semantic]  docs/ARCHITECTURE.md:190:48  TS2322: Type 'number' is not assignable to type 'string'.
Semantic phase: 583 of 583 block(s) judged, 1 failed.
restore         blob back to 9e97fd3ce24458f0d8a4e1a8705f8f7bdf8a9315 (= HEAD blob), `git diff HEAD -- docs/ARCHITECTURE.md` empty
```

**B. The silent-skip control.** Removed the leg's call site from `listDocuments()`:

```
on-disk proof   call-site occurrences 1 -> 0, marker 1   (HEAD blob 56aca37a18634e3c9ec138996ec6b9d76c010216)
documents WITH leg    : 229
documents WITHOUT leg : 227
drop                  : 2 = rootDocsPages(root).length
restore         blob back to 56aca37a1 (= HEAD blob), `git diff HEAD -- scripts/check-doc-snippet-types.mjs` empty
```

⚠️ **The instrument the brief named for control B does not measure documents.** `--emit-census` is #7864's **emitted-code** census: it walks `packages/NAME/src` through `listEmittedSources()` and never calls `listDocuments()`. Measured on both sides of control B — `Walked 1414 source file(s)` **with** the leg and `1414` **without** it. So the document-population reading is the gate's own `Scanned N document(s)` counter, above; the `--emit-census` numbers are the falsification, not the measurement.

## Gates, pinned to `f011733bf`

Exit codes captured by redirect-then-capture, never through a pipe.

| command | exit |
|---|---|
| `pnpm check:doc-snippets` | 0 — `Scanned 229 document(s): 218 covered (115 of them hold a ts/tsx block), 11 ungated` · `Covered blocks: 741 — 583 to compile, 158 declared fragment(s)` · `Semantic phase: 583 of 583 block(s) judged, 0 failed` |
| `pnpm exec vitest run` on the three sibling pins | 0 — 3 files, 160 tests (153 before) |
| `pnpm exec vitest run scripts/__tests__/` | 0 — 115 files, 3415 tests |
| `pnpm check:doc-fences` | 0 |
| `pnpm check:doc-types` | 0 |
| `pnpm check:readme-exports` | 0 (first run exited 1 on `@object-ui/plugin-ai`'s unbuilt `dist` — a precondition of the scoped build, not a verdict; 0 after building that package, and this diff holds no `packages/**` file) |
| `pnpm type-check:scripts` | 0 |
| `pnpm lint:root` | 0 (32 pre-existing warnings; full run, 11s — no narrowing) |
| `pnpm check:control-bytes` | 0, plus a `grep -naP` control-byte self-scan of all five changed paths: no match |
| `pnpm check:entry-guard` | 0 |
| `node scripts/check-changeset-presence.mjs` | 0 — nothing owed (a gate script, its tests, a workflow comment and a repo-root doc publish from no package) |
| `node scripts/check-governed-queue-guard.mjs --test` on all five changed paths | 0 — `NOT GOVERNED — 5 path(s) checked against 5 governed surface(s); none matched` |

`Live E2E (informational)` is red on every branch today for an upstream reason (#7990 / objectstack#16186) — not this change.

## Files

- `scripts/check-doc-snippet-types.mjs` — the leg, the constant, the enumerator, the `main()` guard, the header enumerations.
- `scripts/__tests__/check-doc-snippet-types.test.ts` — the widening's proof.
- `scripts/__tests__/check-doc-fence-languages.test.ts` — the divergence, recorded.
- `docs/ARCHITECTURE.md` — block repairs only.
- `.github/workflows/doc-snippet-types.yml` — one step comment that copied the gate's enumeration (it had already gone stale on #7115's root `README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_