### PR TITLE
fix(components, plugin-detail): drop the last two `primaryField` reads off an object def

### DIFF
--- a/.changeset/7586-primary-field-consumer-reads.md
+++ b/.changeset/7586-primary-field-consumer-reads.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/components': minor
+'@object-ui/plugin-detail': minor
+---
+
+The last two consumer-side reads of `primaryField` off an OBJECT def are gone (objectui#7586).
+
+`primaryField` is a `DetailViewSchema` key (`@object-ui/types` `views.ts`) — a **view** key,
+which `DetailView.resolveDisplayTitle` reads off `schema` and is welcome to. Read off an
+**object** def it is undeclared: `@objectstack/spec`'s object schema is a `strictObject`
+answering `unrecognized_keys: ['primaryField']`, and `ObjectSchema.create()` throws.
+`primaryField` appears in **zero** files of the shipped `@objectstack/spec@17.2.0` dist,
+against 68 for the canonical `nameField`. objectstack#6326 removed the identical read from
+two lint rules; objectui#7287 / PR #7585 removed it from `resolveTitleField`. These two
+survived it — and three of this repo's own changelogs already called the probe *"not a spec
+property — always undefined"* while the code kept honouring it.
+
+**They are two different repairs, not one patch applied twice.**
+
+`@object-ui/components` — `PageHeaderRenderer`'s record-chip chain ranked
+`objectSchema.primaryField` directly under `schema.title` and **above** the unified ADR-0079
+resolver, on the surface that renders the **actual H1** of a synthesized record page. The
+rung is deleted, so the heading now comes from `titleFormat` → the ADR-0079 resolver
+(`nameField` → `displayNameField` → type-aware derivation) → the record-key walk, the same
+precedence `DetailView`'s own header uses.
+
+`@object-ui/plugin-detail` — `record:details`' dedupe ladder decides **which row the body
+grid hides**, so that the field already shown as the H1 is not repeated underneath it. That
+is a different question from "what is the title", and `primaryField` was its *first*
+candidate. The rung is deleted; the ladder is the literal display-name walk that mirrors the
+tail of the header chip's chain. Its docstring, which had described the chip as resolving
+"from objectSchema.primaryField", went stale when PR #7585 landed and now describes the chip
+as it is.
+
+**User-visible, deliberately.** A payload that carries the off-spec key anyway changes in two
+ways: the H1 of its record page stops being `primaryField`'s value, and a different row
+survives the detail grid. Nothing spec-legal can reach either path.
+
+`DetailViewSchema.primaryField` is untouched, and so is `ObjectDefLike.primaryField` in
+`buildDefaultPageSchema` — a deliberate declaration (not a read) that keeps an external
+caller's object literal type-checking.

--- a/apps/console/src/__tests__/record-block-record-reach.test.tsx
+++ b/apps/console/src/__tests__/record-block-record-reach.test.tsx
@@ -138,7 +138,10 @@ const RECORD_B = {
 const PROBE_OBJECT_SCHEMA = {
   name: PROBE_OBJECT,
   label: 'Probe Object',
-  primaryField: 'name',
+  // `nameField`, not `primaryField`: the latter is a `DetailViewSchema` key
+  // that `@objectstack/spec`'s `strictObject` object schema refuses on an
+  // object def, and no renderer reads it off one any more (objectui#7586).
+  nameField: 'name',
   fields: [
     { name: 'id', label: 'ID', type: 'text' },
     { name: 'name', label: 'Name', type: 'text' },

--- a/packages/components/src/__tests__/page-header-title.test.tsx
+++ b/packages/components/src/__tests__/page-header-title.test.tsx
@@ -108,3 +108,125 @@ describe('PageHeaderRenderer — record title resolution', () => {
     expect(screen.getByText(/Audit Log abcdefgh/)).toBeTruthy();
   });
 });
+
+/**
+ * `objectSchema.primaryField` is NOT a rung of this chain (objectui#7586).
+ *
+ * `primaryField` is a `DetailViewSchema` key (`@object-ui/types` `views.ts`) —
+ * a VIEW key a view author sets, which `DetailView.resolveDisplayTitle` reads
+ * off `schema` and is welcome to. It was ALSO read here off the OBJECT def,
+ * and ranked ABOVE the unified ADR-0079 resolver that ADR-0079 Phase 2 made
+ * the single pointer to a record's identity.
+ *
+ * No producer can put it on an object: `@objectstack/spec`'s object schema is
+ * a `strictObject` that answers `unrecognized_keys: ['primaryField']`, which
+ * is why objectstack#6326 deleted the identical read from two lint rules and
+ * objectui#7287 / PR #7585 deleted it from `resolveTitleField`. Three of this
+ * repo's own changelogs already describe the probe as "not a spec property —
+ * always undefined" while the code kept honouring it.
+ *
+ * ⚠️ These cases are about RANKING, not about the key being unreadable. Each
+ * object below carries `primaryField` AND a legitimate declaration, and the
+ * assertion is that the legitimate one wins — so deleting the rung turns them
+ * green and re-adding it anywhere above the resolver turns them red again.
+ * A case with `primaryField` alone would pass on a chain that had merely
+ * demoted it, which is not what this pins.
+ */
+describe('PageHeaderRenderer — `objectSchema.primaryField` is not a rung (#7586)', () => {
+  it('does not let `primaryField` outrank the declared `nameField`', () => {
+    const { container } = renderHeader({
+      objectSchema: {
+        name: 'contract',
+        label: 'Contract',
+        nameField: 'contract_no',
+        // Off-spec: a DetailViewSchema key sitting on an OBJECT def.
+        primaryField: 'ref_no',
+        fields: {
+          contract_no: { type: 'text', label: 'Contract No' },
+          ref_no: { type: 'text', label: 'Ref No' },
+        },
+      },
+      record: { id: 'rec-1', contract_no: 'HT-2026-001', ref_no: 'R-999' },
+    });
+
+    // The ACTUAL H1 of the synthesized record page, not a prediction of it.
+    expect(container.querySelector('h1')?.textContent).toBe('HT-2026-001');
+    expect(screen.queryByText('R-999')).toBeNull();
+  });
+
+  it('does not let `primaryField` outrank `titleFormat`', () => {
+    const { container } = renderHeader({
+      objectSchema: {
+        name: 'contact',
+        label: 'Contact',
+        titleFormat: '{first_name} {last_name}',
+        primaryField: 'ref_no',
+        fields: {
+          first_name: { type: 'text' },
+          last_name: { type: 'text' },
+          ref_no: { type: 'text' },
+        },
+      },
+      record: { id: 'rec-2', first_name: 'Ada', last_name: 'Lovelace', ref_no: 'R-999' },
+    });
+
+    expect(container.querySelector('h1')?.textContent).toBe('Ada Lovelace');
+    expect(screen.queryByText('R-999')).toBeNull();
+  });
+
+  it('does not let `primaryField` outrank the type-aware derivation', () => {
+    const { container } = renderHeader({
+      objectSchema: {
+        name: 'task',
+        label: 'Task',
+        // Nothing declared: the ADR-0079 resolver derives `subject` from the
+        // field types, the rung this chain used to jump over.
+        primaryField: 'ref_no',
+        fields: {
+          subject: { type: 'text', label: 'Subject' },
+          ref_no: { type: 'text', label: 'Ref No' },
+        },
+      },
+      record: { id: 'rec-3', subject: 'Fix the widget', ref_no: 'R-999' },
+    });
+
+    expect(container.querySelector('h1')?.textContent).toBe('Fix the widget');
+    expect(screen.queryByText('R-999')).toBeNull();
+  });
+
+  /**
+   * Non-vacuity for the three above, and the case that measures the DELETED
+   * RUNG directly rather than a re-ranking of it.
+   *
+   * ⚠️ Written the obvious way first, and the obvious way cannot fail:
+   * `primaryField: 'ref_no'` over a TEXT `ref_no` still produced `R-999` after
+   * the rung was gone, because the ADR-0079 type-aware derivation picks
+   * `ref_no` on its own — the only title-typed field on the object. Measured,
+   * not assumed. A pin written that way would have gone green against a
+   * `primaryField` rung that was still there.
+   *
+   * `autonumber` is the type that separates the two readings: it is in core's
+   * `NON_TITLE_TYPES`, so the resolver REFUSES `ref_no` (an autonumber is a
+   * record's number, never its name), the record-key walk below never looks at
+   * `ref_no` either, and every remaining rung declines. Only the deleted
+   * `primaryField` rung could put `R-999` in this heading. The chain lands on
+   * the `${objectLabel} ${id}` floor instead.
+   */
+  it('a `primaryField` the resolver refuses does not title the record at all', () => {
+    const { container } = renderHeader({
+      objectSchema: {
+        name: 'ledger_entry',
+        label: 'Ledger Entry',
+        primaryField: 'ref_no',
+        fields: {
+          ref_no: { type: 'autonumber', label: 'Ref No' },
+          posted_at: { type: 'datetime' },
+        },
+      },
+      record: { id: 'abcdefgh-rest-of-id', ref_no: 'R-999', posted_at: '2026-07-04' },
+    });
+
+    expect(container.querySelector('h1')?.textContent).toMatch(/^Ledger Entry abcdefgh/);
+    expect(screen.queryByText('R-999')).toBeNull();
+  });
+});

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -1868,11 +1868,25 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   //   2. Author hasn't opted out via `recordChrome: false`.
   // When both pass, we resolve the chip title from (in order):
   //   - explicit `schema.title` (interpolated against data),
-  //   - `objectSchema.primaryField` / `titleFormat` (author overrides),
+  //   - `objectSchema.titleFormat` (the author override),
   //   - the unified ADR-0079 resolver (`nameField` → `displayNameField` →
   //     type-aware derivation) — same precedence as DetailView's own header,
   //   - common display fields on the record (`name`, `title`, `display_name`),
   //   - `${objectLabel} ${id}` as a last-resort.
+  //
+  // ⛔ `objectSchema.primaryField` is NOT a rung and must not become one again
+  // (objectui#7586). It used to sit directly under `schema.title`, ABOVE the
+  // unified resolver — on the surface that renders the ACTUAL H1 of a
+  // synthesized record page, so it decided the heading a user reads. It is a
+  // `DetailViewSchema` key (`@object-ui/types` `views.ts`): a VIEW key, which
+  // `DetailView.resolveDisplayTitle` reads off `schema` and is welcome to. On
+  // an OBJECT def it is undeclared — `@objectstack/spec`'s object schema is a
+  // `strictObject` answering `unrecognized_keys: ['primaryField']` and
+  // `ObjectSchema.create()` throws — which is why objectstack#6326 deleted the
+  // identical read from two lint rules and objectui#7287 / PR #7585 deleted it
+  // from `resolveTitleField`. This package's own CHANGELOG already described
+  // the probe as "not a spec property — always undefined" while this line kept
+  // honouring it. Pinned in `__tests__/page-header-title.test.tsx`.
   const hasRecord = !!(ctx?.data && (ctx as any)?.objectSchema);
   if (hasRecord && !disableRecordChrome) {
     const data: any = ctx!.data;
@@ -1882,7 +1896,6 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
     const objectLabel: string | undefined = rawObjectName
       ? tObjectLabel({ name: rawObjectName, label: fallbackLabel })
       : fallbackLabel || undefined;
-    const primaryField: string | undefined = objSchema?.primaryField;
     // Honor objectSchema.titleFormat (e.g. `{first_name} {last_name}`).
     // Mirrors DetailView.resolveDisplayTitle's behaviour so default and
     // synthesized record pages produce the same title.
@@ -1912,7 +1925,6 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
     })();
     const resolvedTitle =
       explicitTitle ||
-      (primaryField && data?.[primaryField]) ||
       (interpolatedTitleFormat && !interpolatedTitleFormat.includes('{') ? interpolatedTitleFormat : '') ||
       unifiedTitle ||
       data?.name ||

--- a/packages/plugin-detail/src/renderers/__tests__/record-details.primaryFieldRetired-7586.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.primaryFieldRetired-7586.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `record:details` no longer asks `objectSchema.primaryField` WHICH ROW to
+ * hide (objectui#7586).
+ *
+ * ## The surface under test is the DEDUPE, not the title
+ *
+ * This renderer does not draw the H1. It draws the body grid, and drops from
+ * it the one field whose value the page H1 is already showing — otherwise
+ * every record page repeats itself ("客户名称: Acme Corporation" directly under
+ * an H1 reading "Acme Corporation"). The ladder that picks that field was
+ * topped by `objSchema?.primaryField`, so the question these cases answer is
+ * **which row disappears**, never what the heading says. A title-only pin
+ * passes while this ladder is still wrong, because the two are decided in
+ * different packages: `@object-ui/components`' `PageHeaderRenderer` renders
+ * the H1, this file renders the grid under it.
+ *
+ * ## Why the rung had to go
+ *
+ * `primaryField` is a `DetailViewSchema` key (`@object-ui/types` `views.ts`) —
+ * a VIEW key, which `DetailView.resolveDisplayTitle` legitimately reads off
+ * `schema`. Read off an OBJECT def it is undeclared: `@objectstack/spec`'s
+ * object schema is a `strictObject` answering `unrecognized_keys:
+ * ['primaryField']`, and `ObjectSchema.create()` throws. objectstack#6326
+ * removed the identical read from two lint rules; objectui#7287 / PR #7585
+ * removed it from `resolveTitleField`. Three of this repo's changelogs
+ * already call the probe "not a spec property — always undefined" while the
+ * code kept honouring it.
+ *
+ * ⚠️ Its removal is a real BEHAVIOUR change for a payload that carries the key
+ * anyway — a different row survives the grid — which is why it is pinned here
+ * rather than waved through as a dead-code deletion.
+ *
+ * ⚠️ The docstring this ladder carried ("the header chip resolves the title
+ * from objectSchema.primaryField → …") went stale the moment PR #7585 landed;
+ * it now describes the chip as it actually is.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import * as React from 'react';
+import { RecordContextProvider } from '@object-ui/react';
+import { RecordDetailsRenderer } from '../record-details';
+
+/**
+ * An object whose identity field is `ref_no`, spelled the ONE way no producer
+ * can spell it. `name` is an ordinary field here, and the two carry different
+ * values so "which row is hidden" is answerable from the DOM alone.
+ */
+const objectSchema = {
+  name: 'contract',
+  label: 'Contract',
+  primaryField: 'ref_no',
+  fields: {
+    ref_no: { type: 'text', label: 'Ref No' },
+    name: { type: 'text', label: 'Name' },
+    amount: { type: 'number', label: 'Amount' },
+  },
+};
+
+const FIELDS = ['ref_no', 'name', 'amount'];
+
+function renderBody(record: any, schema: any = objectSchema) {
+  return render(
+    <RecordContextProvider
+      objectName="contract"
+      recordId={record.id}
+      data={record}
+      objectSchema={schema}
+    >
+      <RecordDetailsRenderer schema={{ fields: FIELDS } as never} />
+    </RecordContextProvider>,
+  );
+}
+
+beforeEach(() => {
+  // `useRecordEditable` probes `POST /api/v1/security/explain` for the
+  // ROW-level verdict; happy-dom resolves that relative URL to a REAL socket,
+  // which the repo's network-escape guard fails the file for (objectui#6640).
+  // Serve it from a double — its answer is orthogonal to which row is hidden.
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ allowed: true }),
+    text: async () => '{"allowed":true}',
+  })) as never);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('record:details dedupe — `primaryField` no longer picks the hidden row (#7586)', () => {
+  it('hides the row the H1 actually shows, not the `primaryField` row', () => {
+    renderBody({ id: 'C1', ref_no: 'HT-2026-001', name: 'Acme Corporation', amount: 42 });
+
+    // `name` is what the header chip resolves to for this record, so `name` is
+    // the row that goes. Before this fix `primaryField` took `ref_no` out
+    // instead, leaving the grid repeating the H1 and hiding a field nothing
+    // else showed.
+    expect(screen.queryByText('Acme Corporation')).toBeNull();
+    expect(screen.getByText('HT-2026-001')).toBeInTheDocument();
+
+    // An ordinary row is untouched — the dedupe drops ONE field, it does not
+    // filter the grid down.
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('hides nothing when `primaryField` names the only value on the record', () => {
+    // Nothing in the literal display-name walk has a value here. Before the
+    // fix `ref_no` was hidden and the body grid rendered a single `amount`
+    // row; the H1 for this record is the `${objectLabel} ${id}` floor, which
+    // no grid row duplicates, so nothing should be dropped.
+    renderBody({ id: 'C2', ref_no: 'HT-2026-002', amount: 7 });
+
+    expect(screen.getByText('HT-2026-002')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  /**
+   * CONTROL — the dedupe still runs.
+   *
+   * Without this, deleting the whole dedupe block would pass both cases above:
+   * "the `ref_no` row survives" is satisfied by a renderer that hides nothing
+   * at all. This is the case that goes red for that, and it is the reason the
+   * two cases above are readable as a measurement of the LADDER rather than of
+   * its absence.
+   */
+  it('CONTROL: the H1 field is still dropped from the grid', () => {
+    renderBody(
+      { id: 'C3', ref_no: 'HT-2026-003', name: 'Acme Corporation', amount: 42 },
+      { ...objectSchema, primaryField: undefined },
+    );
+
+    expect(screen.queryByText('Acme Corporation')).toBeNull();
+    expect(screen.getByText('HT-2026-003')).toBeInTheDocument();
+  });
+
+  /**
+   * CONTROL — `primaryField` on a VIEW schema is a different key and stays.
+   *
+   * `DetailViewSchema.primaryField` is declared (`packages/types/src/views.ts`)
+   * and `DetailView.resolveDisplayTitle` reads it as rung 1. Nothing in this
+   * card touches that; a change that deleted the key everywhere rather than
+   * only where it sits on an OBJECT def turns this red.
+   */
+  it('CONTROL: the declared VIEW-level `primaryField` is untouched', async () => {
+    const { DetailView } = await import('../../DetailView');
+
+    render(
+      <DetailView
+        schema={
+          {
+            type: 'detail-view',
+            objectName: 'contract',
+            primaryField: 'ref_no',
+            data: { id: 'C4', ref_no: 'HT-2026-004', name: 'Acme Corporation' },
+            fields: ['name'],
+            showHeader: true,
+          } as never
+        }
+      />,
+    );
+
+    expect(screen.getByText('HT-2026-004')).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-detail/src/renderers/__tests__/record-details.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.test.tsx
@@ -76,7 +76,11 @@ const BOUND_CTX = {
   data: { id: 'rec_1', name: 'Acme' },
   dataSource: { update: async () => ({}) },
   refresh: async () => {},
-  objectSchema: { primaryField: 'name' },
+  // `nameField` is the canonical, spec-declared way an object says which field
+  // titles its records. This fixture spelled it `primaryField` — a
+  // `DetailViewSchema` key an object def cannot carry (objectui#7586), and one
+  // nothing in this hook-ordering suite ever read.
+  objectSchema: { nameField: 'name' },
 };
 
 beforeEach(() => {

--- a/packages/plugin-detail/src/renderers/record-details.tsx
+++ b/packages/plugin-detail/src/renderers/record-details.tsx
@@ -148,25 +148,43 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
   for (const n of liveHighlightNames) hideFieldNames.add(n);
 
   // Phase P.0: also hide the field that's already shown as the page H1
-  // title. The header chip resolves the title from objectSchema.primaryField
-  // → common display fields (name/full_name/title/subject/display_name).
-  // Repeating that same value in the body grid is pure duplication —
+  // title. Repeating that same value in the body grid is pure duplication —
   // every record detail page used to show "客户名称: Acme Corporation"
   // immediately below an H1 that said "Acme Corporation". Authors who
   // want the field anyway can override via the schema (we only add it
   // when the field exists in the data and the dedup wouldn't empty the
   // section).
+  //
+  // ⚠️ This ladder is a DEDUPE, not a title resolver: the question it answers
+  // is "which ROW disappears", and it is keyed on the record value being
+  // non-empty because a row with no value is not duplicating a heading.
+  // The H1 itself is drawn a package away, by `@object-ui/components`'
+  // `PageHeaderRenderer` (`page:header`, synthesized by
+  // `buildDefaultPageSchema`) — the names below mirror the tail of THAT
+  // chain, which is why a change to either half must re-read the other.
+  //
+  // ⛔ `objSchema?.primaryField` used to top this list, and it is gone
+  // (objectui#7586). It is a `DetailViewSchema` key (`@object-ui/types`
+  // `views.ts`) — a VIEW key, read here off an OBJECT def, where nothing can
+  // declare it: `@objectstack/spec`'s object schema is a `strictObject`
+  // answering `unrecognized_keys: ['primaryField']`, and
+  // `ObjectSchema.create()` throws. objectstack#6326 removed the identical
+  // read from two lint rules; objectui#7287 / PR #7585 removed it from
+  // `resolveTitleField`, and the same removal from the header chain above is
+  // what keeps the two halves agreeing. `DetailView.resolveDisplayTitle`
+  // still reads `schema.primaryField` off the VIEW schema and is welcome to.
+  //
+  // ⚠️ The docstring here used to name `objectSchema.primaryField` as the
+  // chip's first source. That stopped being true when PR #7585 landed, and
+  // this ladder outlived the sentence describing it — hence the rewrite
+  // above rather than a one-line deletion. Pinned in
+  // `__tests__/record-details.primaryFieldRetired-7586.test.tsx`, which
+  // asserts the DEDUPE outcome (which row the grid hides), not the title.
   const objSchema: any = (ctx as any).objectSchema;
   const data: any = ctx.data ?? {};
-  const titleCandidates = [
-    objSchema?.primaryField,
-    'name',
-    'full_name',
-    'title',
-    'subject',
-    'display_name',
-    'label',
-  ].filter((n): n is string => typeof n === 'string' && n.length > 0);
+  // No `.filter(…): n is string` guard any more: it existed solely to drop the
+  // `objSchema?.primaryField` entry when the key was absent, which was always.
+  const titleCandidates = ['name', 'full_name', 'title', 'subject', 'display_name', 'label'];
   for (const candidate of titleCandidates) {
     if (data[candidate] !== undefined && data[candidate] !== null && data[candidate] !== '') {
       hideFieldNames.add(candidate);


### PR DESCRIPTION
Fixes #7586

`primaryField` is a `DetailViewSchema` key (`@object-ui/types` `views.ts`) — a **view** key, which `DetailView.resolveDisplayTitle` reads off `schema` and is welcome to. Two consumers also read it off an **object** def, where nothing can declare it. objectstack#6326 removed the identical read from two lint rules; objectui#7287 / PR #7585 removed it from `resolveTitleField`. These two survived it — while three of this repo's own changelogs (`packages/components/CHANGELOG.md:5613`, `app-shell/CHANGELOG.md:11119`, `plugin-detail/CHANGELOG.md:2786`) already called the probe *"not a spec property — always undefined"*.

## Premise re-measured here, with a lit control

Structural, not census. `@objectstack/spec@17.2.0`'s object schema is a `strictObject`:

```
primaryField on an object def -> success: false
  { code: 'unrecognized_keys', keys: ['primaryField'], path: ['objects', 0] }
CONTROL nameField on the same object def -> no unrecognized_keys issue at all
```

Both legs were parsed through the same probe and both carry the same unrelated `fields`-shape error, so the query shape demonstrably CAN produce `unrecognized_keys` — it just does not for the declared key. And in the shipped `dist/`: `primaryField` in **0** files against **68** for `nameField`.

**Read-site census, measured on this branch's base: two, not three.** `git grep primaryField` over `packages/**/src` and `apps/**/src` returns 38 lines. Ranked by what they are:

| site | verdict |
|:--|:--|
| `components/src/renderers/layout/containers.tsx:1885, :1915` | **live read off an object def** — fixed here |
| `plugin-detail/src/renderers/record-details.tsx:162` | **live read off an object def** — fixed here |
| `plugin-detail/src/DetailView.tsx:86` | reads `schema.primaryField` off the **VIEW** schema — declared, legitimate, untouched |
| `plugin-detail/src/synth/buildDefaultPageSchema.ts:70` | a deliberate **declaration** on `ObjectDefLike`, not a read — untouched (see the reasoning at `:65`) |
| `types/src/views.ts:557` | the declaration itself, on `DetailViewSchema` |
| the rest | comments, and two fixtures (below) |

⚠️ Line drift from the card: it cites `:1886` / `:1916`; on this base they are `:1885` / `:1915`. `:162` is exact.

## Two different repairs, not one patch applied twice

**Site 1 — `@object-ui/components`, a ranking bug.** `PageHeaderRenderer`'s record-chip chain ranked `objectSchema.primaryField` directly under `schema.title` and **above** the unified ADR-0079 resolver, on the surface that renders the **actual H1** of a synthesized record page — not a prediction of the title, the title. The rung is deleted, so the heading comes from `titleFormat` then the ADR-0079 resolver (`nameField` then `displayNameField` then type-aware derivation) then the record-key walk: the precedence `DetailView`'s own header already uses.

**Site 2 — `@object-ui/plugin-detail`, a dedupe.** `record:details`' ladder decides **which ROW the body grid hides**, so the field already shown as the H1 is not repeated under it. That is a different question from "what is the title", it is keyed on the record value being non-empty, and `primaryField` was its *first* candidate. The rung is deleted and the `.filter(): n is string` guard with it — that guard existed only to drop the `primaryField` entry when the key was absent, which was always. Its docstring, which described the header chip as resolving *"from objectSchema.primaryField"*, went stale the moment PR #7585 landed and now describes the chip as it is.

**User-visible on purpose.** A payload carrying the off-spec key anyway gets a different H1 and a different surviving grid row. Nothing spec-legal reaches either path. The changeset says so.

## The pins, and the ablation that proves they are lit

Two disjoint pin sets, one per site, run as **two independent ablation legs** — because one leg cannot tell two repairs apart.

**Leg A** — re-add the rung to the header chain (on-disk proof: rung `0 -> 1`, decl `0 -> 1`):

```
Tests  4 failed | 9 passed (13)
FAIL page-header-title.test.tsx > does not let `primaryField` outrank the declared `nameField`
FAIL page-header-title.test.tsx > does not let `primaryField` outrank `titleFormat`
FAIL page-header-title.test.tsx > does not let `primaryField` outrank the type-aware derivation
FAIL page-header-title.test.tsx > a `primaryField` the resolver refuses does not title the record at all
```

The plugin-detail pin file stayed **green** through Leg A.

**Leg B** — re-add `primaryField` as the ladder's first candidate (on-disk proof: candidate `0 -> 1`, literal list `1 -> 0`):

```
Tests  2 failed | 11 passed (13)
FAIL record-details.primaryFieldRetired-7586.test.tsx > hides the row the H1 actually shows, not the `primaryField` row
FAIL record-details.primaryFieldRetired-7586.test.tsx > hides nothing when `primaryField` names the only value on the record
```

The components pin file stayed **green** through Leg B, and so did both of the site-2 file's own CONTROL cases — correct, since neither measures the mutated rung.

Each leg restored under a `trap ... EXIT INT TERM` with absolute paths, `git checkout HEAD -- path` (never the bare form, which restores the mutation back out of the index with exit 0), and the restore proven by **state**: blob hash equal to the HEAD blob plus an empty `git diff HEAD`, never by an exit code. Mutations were proven on disk by anchored before/after counts, never by an editor's exit code.

⭐ **One pin was measured wrong first, and the measurement is why it is right now.** The site-1 non-vacuity case originally gave `primaryField` a **text** `ref_no` and expected the `${objectLabel} ${id}` floor. It failed — because the ADR-0079 type-aware derivation picks `ref_no` on its own when it is the only title-typed field, so that case would have gone green against a `primaryField` rung that was still there. It now types `ref_no` as `autonumber`, which core's `NON_TITLE_TYPES` refuses, so only the deleted rung could put that value in the heading. The comment in the test records this.

## Fixture triage

Two fixtures spelled the key on an **object** def; neither suite ever read its effect. Both now spell the canonical `nameField`, which the spec's object schema accepts:

- `packages/plugin-detail/src/renderers/__tests__/record-details.test.tsx` (a rules-of-hooks suite)
- `apps/console/src/__tests__/record-block-record-reach.test.tsx` (a binding-reach probe; its own docstring is about labels, picklists and actions)

## Verification

| run | result |
|:--|:--|
| `vitest run packages/components/` | **236 files / 2177 tests passed** |
| `vitest run packages/plugin-detail/` | **134 files / 1209 tests passed** |
| `vitest run apps/console/` | **89 files / 1052 tests passed** |
| `type-check` — components, plugin-detail | Done, 0 errors (each also compiles its `tsconfig.test.json`, so the new tests are covered) |
| `type-check` — console, after `--filter '@object-ui/console^...' build` | **0 errors** |
| `eslint .` repo-wide, `--format json` | **4386 files resolved from eslint's own config, 0 errors** (all six changed files in that population, 0 errors each) |
| gates | `check:control-bytes` · `check:lint-coverage` · `check:vi-mock-specifiers` · `check:vi-mock-inherit` · `check:unreferenced-sources` · `check:handler-key-reads` · `check:governed-queue-guard` · `check:shell-escape-residue` · `check-changeset-presence` · `check-changeset-no-major` · `check-changeset-fixed` · `check-changeset-overwrite` — all exit 0 |

No lint narrowing to declare: the repo-wide scan ran in full (220s) at `648193c63`, the final commit. Not governed — `check-governed-queue-guard --test` on all six paths: *"NOT GOVERNED — 6 path(s) checked against 5 governed surface(s); none matched."*

⚠️ One reading worth not repeating: `apps/console`'s type-check first reported 29 `TS2307` / `TS2882` "cannot find module" errors naming files this PR never touches. That was an unbuilt-dependency artifact, not this diff — building `@object-ui/console^...` first takes it to 0.

## Filed, not fixed here

objectui#8175 — the same ladder hides the **wrong row** when the object declares a `nameField` the literal walk does not know: the H1 shows `contract_no` while the grid drops `name` and keeps `contract_no`. Measured as byte-identical before and after this change (the rung this PR removes was never populated), so it is an addition to the ladder rather than this removal, and it is out of scope here. objectui#8175 is not addressed by this pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S


---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_