### PR TITLE
docs(plugin-ai): compile the README's snippets against the shipped surface, retire its UNGATED_DOCS row

### DIFF
--- a/packages/plugin-ai/README.md
+++ b/packages/plugin-ai/README.md
@@ -22,41 +22,58 @@ npm install @object-ui/plugin-ai
 
 ## Quick Start
 
+Every component in this package takes exactly one schema object plus optional
+callbacks — `schema` carries the configuration, the callbacks carry the
+behaviour. The schema types ship from `@object-ui/types`.
+
 ```tsx
 import { AIFormAssist, AIRecommendations, NLQueryInput } from '@object-ui/plugin-ai';
+import type {
+  AIFormAssistSchema,
+  AIRecommendationItem,
+  AIRecommendationsSchema,
+  NLQuerySchema,
+} from '@object-ui/types';
+
+declare const recommendationsData: AIRecommendationItem[];
+
+const contactAssist: AIFormAssistSchema = {
+  type: 'ai-form-assist',
+  formId: 'new-contact',
+  objectName: 'Contact',
+  fields: ['name', 'email', 'company'],
+  showConfidence: true,
+};
 
 function SmartForm() {
   return (
     <div>
-      <AIFormAssist
-        formId="new-contact"
-        objectName="Contact"
-        fields={['name', 'email', 'company']}
-        showConfidence
-      />
+      <AIFormAssist schema={contactAssist} />
     </div>
   );
 }
 
+const productPicks: AIRecommendationsSchema = {
+  type: 'ai-recommendations',
+  objectName: 'Product',
+  maxResults: 5,
+  layout: 'grid',
+  recommendations: recommendationsData,
+};
+
 function RecommendationsPanel() {
-  return (
-    <AIRecommendations
-      objectName="Product"
-      maxResults={5}
-      layout="grid"
-      recommendations={recommendationsData}
-    />
-  );
+  return <AIRecommendations schema={productPicks} />;
 }
 
+const orderSearch: NLQuerySchema = {
+  type: 'nl-query',
+  objectName: 'Order',
+  placeholder: 'Ask a question about your orders...',
+  suggestions: ['Show orders from last week', 'Top customers by revenue'],
+};
+
 function SearchBar() {
-  return (
-    <NLQueryInput
-      objectName="Order"
-      placeholder="Ask a question about your orders..."
-      suggestions={['Show orders from last week', 'Top customers by revenue']}
-    />
-  );
+  return <NLQueryInput schema={orderSearch} />;
 }
 ```
 
@@ -64,50 +81,88 @@ function SearchBar() {
 
 ### AIFormAssist
 
-AI-powered form field suggestions and auto-fill:
+AI-powered form field suggestions and auto-fill. Props: `schema`, plus the
+optional `onApply` and `onRefresh` callbacks.
 
 ```tsx
-<AIFormAssist
-  formId="new-lead"
-  objectName="Lead"
-  fields={['name', 'email', 'phone']}
-  autoFill={false}
-  showConfidence
-  showReasoning={false}
-/>
+import { AIFormAssist } from '@object-ui/plugin-ai';
+import type { AIFormAssistSchema } from '@object-ui/types';
+
+const leadAssist: AIFormAssistSchema = {
+  type: 'ai-form-assist',
+  formId: 'new-lead',
+  objectName: 'Lead',
+  fields: ['name', 'email', 'phone'],
+  autoFill: false,
+  showConfidence: true,
+  showReasoning: false,
+};
+
+const assistPanel = (
+  <AIFormAssist
+    schema={leadAssist}
+    onApply={(suggestion) => console.log(suggestion.fieldName, suggestion.value)}
+  />
+);
 ```
 
 ### AIRecommendations
 
-Display AI-generated recommendations:
+Display AI-generated recommendations. Props: `schema`, plus the optional
+`onSelect` and `onDismiss` callbacks.
 
 ```tsx
-<AIRecommendations
-  objectName="Product"
-  recommendations={data}
-  maxResults={10}
-  layout="list"       // 'list' | 'grid' | 'carousel'
-  showScores={false}
-  emptyMessage="No recommendations available"
-/>
+import { AIRecommendations } from '@object-ui/plugin-ai';
+import type { AIRecommendationItem, AIRecommendationsSchema } from '@object-ui/types';
+
+declare const data: AIRecommendationItem[];
+
+const productPicks: AIRecommendationsSchema = {
+  type: 'ai-recommendations',
+  objectName: 'Product',
+  recommendations: data,
+  maxResults: 10,
+  layout: 'list', // 'list' | 'grid' | 'carousel'
+  showScores: false,
+  emptyMessage: 'No recommendations available',
+};
+
+const panel = (
+  <AIRecommendations schema={productPicks} onSelect={(item) => console.log(item.id)} />
+);
 ```
 
 ### NLQueryInput
 
-Natural language query input for data exploration:
+Natural language query input for data exploration. Props: `schema`, plus the
+optional `onSubmit` callback.
 
 ```tsx
-<NLQueryInput
-  objectName="Order"
-  placeholder="Ask anything..."
-  suggestions={['Recent orders', 'Revenue by month']}
-  showHistory={false}
-/>
+import { NLQueryInput } from '@object-ui/plugin-ai';
+import type { NLQuerySchema } from '@object-ui/types';
+
+const orderSearch: NLQuerySchema = {
+  type: 'nl-query',
+  objectName: 'Order',
+  placeholder: 'Ask anything...',
+  suggestions: ['Recent orders', 'Revenue by month'],
+  showHistory: false,
+};
+
+const searchBar = <NLQueryInput schema={orderSearch} onSubmit={(query) => console.log(query)} />;
 ```
 
-### Schema-Driven Usage
+## Schema-Driven Usage
 
-Components auto-register with `ComponentRegistry`:
+Components auto-register with `ComponentRegistry` on import. The registry key is
+the schema's `type`, and it is **not** always the component name — `NLQueryInput`
+registers as `nl-query`:
+
+| Component | Registry `type` | Schema type |
+|---|---|---|
+| `AIFormAssist` | `ai-form-assist` | `AIFormAssistSchema` |
+| `AIRecommendations` | `ai-recommendations` | `AIRecommendationsSchema` |
+| `NLQueryInput` | `nl-query` | `NLQuerySchema` |
 
 ```json
 {

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -779,8 +779,6 @@ const UNGATED_DOCS = {
     '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 15 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2741x1 — candidate real defects, un-triaged',
   'packages/fields/README.md':
     '2 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 1 unresolved-module diagnostic(s)',
-  'packages/plugin-ai/README.md':
-    '5 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2322x3 — candidate real defects, un-triaged',
   'packages/plugin-charts/README.md':
     '6 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies',
   'packages/plugin-chatbot/README.md':


### PR DESCRIPTION
Part of #5174 (batch 27: `packages/plugin-ai/README.md`)

Burns down the `packages/plugin-ai/README.md` row in `scripts/check-doc-snippet-types.mjs`'s `UNGATED_DOCS` ledger. The page's four `tsx` fences now compile against the built types, so the row is deleted rather than rewritten.

Base: `origin/main` `9bfd61848` (carries PR #8158, which re-baselined this gate's strictness region). `origin/main` moved to `967e5d803` mid-task and was merged in — never rebased — so every reading below is pinned to the merged head `61759cfcc`.

## Takeover

The first dev of this batch died at ~22:14Z (container restart) leaving one local, unpushed commit `80210b0d4` on a clean tree, no PR and no report. This PR inherits that commit rather than restarting; it was treated as an unreviewed patch and re-verified against every ruling before anything was added to it.

**What `80210b0d4` held:** `packages/plugin-ai/README.md` +103/−50 and `scripts/check-doc-snippet-types.mjs` −2.

**What was re-verified, independently:** the census on both sides was re-taken with the gate's own exported analyzer (`scanFences` / `analyze` / `compileSnippets`, never a hand-written regex); the per-key table below was re-derived from the schema declarations and the components' destructures; the strictness region was re-hashed on both sides; the ledger diff was confirmed to be the two entry lines and nothing else; and the positive control — the step the first dev died inside — was redone from scratch on a tree proven clean first (`git status --porcelain` empty, `git diff HEAD` zero bytes, so no half-applied injection survived the restart).

**What changed on top:** one merge commit for `origin/main` `967e5d803`. No fix-up commit was needed — `80210b0d4` violated no ruling. Nothing was amended and nothing was force-pushed.

## Census, before and after

Measured with the gate's own analyzer, with this page forced into the compiled tier and every other ledger row left ungated, so exactly one page is under measurement.

**Before — base `9bfd61848`, 8 diagnostics.** Reproduces the ledger row (`5 undefined-name … plus TS2322x3`) exactly:

| Fence | Diagnostics |
|---|---|
| 25 `tsx` | 4 — `TS2322`×3 (all three components' props), `TS2552` `Cannot find name 'recommendationsData'` |
| 69 `tsx` | 1 — `TS2304` `Cannot find name 'AIFormAssist'` |
| 84 `tsx` | 2 — `TS2304` `Cannot find name 'AIRecommendations'`, `TS2304` `Cannot find name 'data'` |
| 99 `tsx` | 1 — `TS2304` `Cannot find name 'NLQueryInput'` |

By code: `TS2322`×3, `TS2304`×4, `TS2552`×1.

**After — head `61759cfcc`, 0 diagnostics.** Fences moved to lines 29, 87, 114, 140; all four CLEAN. Four `tsx` fences before and after, zero fragment markers on either side.

### The blind spot: the ledger's `TS2322x3` was the visible half of six

The ledger counted 3 prop mismatches. There were **6**. An unresolved JSX tag name short-circuits the prop check on that same element, so fences 69, 84 and 99 — bare JSX with no import line — hid one `TS2322` each behind their `TS2304`. Measured by giving those fences, in memory only, the import line the page never wrote and an `any` stand-in for the two ambient names, touching nothing about the props: the count goes 3 → 6, one per fence, and no other code appears.

This is a property of TypeScript's diagnostic suppression, not a gate defect, but it means **any ledger row that mixes undefined-name diagnostics with type codes is a lower bound on that page's real debt**. Worth knowing for the remaining rows. The page pays down all 11 real diagnostics (5 undefined-name + 6 prop mismatches).

## What the repair was, and why the README moved rather than the components

All three exported components take exactly one `schema` prop plus callbacks — `AIFormAssistProps`, `AIRecommendationsProps`, `NLQueryInputProps` in `packages/plugin-ai/src/*.tsx`. Every README example passed flat props (`formId=`, `objectName=`, `fields=`, `maxResults=`, `layout=`, …). So the page taught an API the components do not have, against components that are right: **the README is what moves.** One typed binding per example from the schema type `@object-ui/types` exports, passed as `schema={…}`, with `declare const` stand-ins for the two ambient names the page never defined (typed as `AIRecommendationItem[]`, not `any`).

No `@ts-expect-error`, no fragment marker, no widened or loosened type, no edit to `packages/plugin-ai/src/**` or `packages/types/src/**`, no gate strictness change.

The registry `type` discriminators were read from the `ComponentRegistry.register` calls in `packages/plugin-ai/src/index.tsx`, not from the README — and one of them is **not** the component name: `NLQueryInput` registers as `nl-query`. The page now says so in a table, because that was undocumented and is exactly the kind of thing a metadata author guesses wrong.

The `Schema-Driven Usage` heading was promoted from `###` to `##`: it documents registry usage, not a component, so it did not belong inside the `Components` section.

## Per-key table (ruling 3 — the key-surface bound)

`BaseSchema` carries `[key: string]: any` at `packages/types/src/base.ts:398`, so a `BaseSchema`-derived annotation checks member **types** and never member **keys** (objectui#7927). Every key each example writes was therefore classified by hand against the schema type's own declaration — the compiler cannot do it.

**Result: all 14 keys the examples write are declared. Nothing was dropped, and no key is "undeclared but read at runtime".**

| Key (example) | Declared | Read at runtime | Verdict |
|---|---|---|---|
| `type` (all 3) | `ai.ts:92` / `:204` / `:316` | discriminant | keep |
| `formId` | `ai.ts:97` | **no** | keep (declared) — inert, see below |
| `objectName` (all 3) | `ai.ts:102` / `:209` / `:321` | **no** | keep (declared) — inert |
| `fields` | `ai.ts:107` | **no** | keep (declared) — inert |
| `autoFill` | `ai.ts:127` | dead destructure, `AIFormAssist.tsx:31` | keep (declared) — inert |
| `showConfidence` | `ai.ts:132` | `AIFormAssist.tsx:29` | keep |
| `showReasoning` | `ai.ts:137` | `AIFormAssist.tsx:30` | keep |
| `recommendations` | `ai.ts:224` | `AIRecommendations.tsx:28` | keep |
| `maxResults` | `ai.ts:229` | **no** | keep (declared) — inert |
| `showScores` | `ai.ts:234` | `AIRecommendations.tsx:29` | keep |
| `layout` | `ai.ts:239` | `AIRecommendations.tsx:30` | keep |
| `emptyMessage` | `ai.ts:259` | `AIRecommendations.tsx:32` | keep |
| `placeholder` | `ai.ts:326` | `NLQueryInput.tsx:26` | keep |
| `suggestions` (NLQuery) | `ai.ts:341` | `NLQueryInput.tsx:28` | keep |
| `showHistory` | `ai.ts:346` | `NLQueryInput.tsx:29` | keep |

**Finding proposal, filed as #8178, not fixed here.** Seven of those declared members are read by nothing: `formId`, `objectName` (all three schemas), `fields`, `maxResults`, and `autoFill` (destructured at `AIFormAssist.tsx:31` and never referenced again). `maxResults` is the sharp one — its doc comment says `Maximum number of results to display` and `AIRecommendations` renders every item with no slice anywhere. `grep -rn maxResults packages/*/src` returns exactly two hits, the declaration and the designer input metadata, and zero reads. Five of the seven are also advertised as authorable inputs by `ComponentRegistry.register` in `packages/plugin-ai/src/index.tsx`, so the designer offers keys the renderer ignores. That is the same class objectui#7742 already carries for `KanbanSchema`; enforce-or-remove is a maintainer call and #8178 does not pick one. It is out of scope for this PR under the ruling that declared keys are kept — the examples keep them, and the snippets compile, because the gate can see types and not inertness.

## Ledger decision

The page reads zero, so its row is **deleted**, not rewritten. The gate diff is exactly the two lines of that row (`git show 80210b0d4 -- scripts/check-doc-snippet-types.mjs`: `-2`, no additions). Package ledger rows: **11 → 10**. Gate counters on the head: 229 documents scanned, 219 covered, 10 ungated; compiled blocks 583 → **587** (this page's four fences joined the compiled tier); declared fragments **158 → 158** — no marker was added to buy a pass.

The `json` fence (now line 167) writes `type`, `formId`, `objectName`, `fields`, `showConfidence` — all declared, and no key was dropped under ruling 3, so it is left alone. It is read by `check:doc-types`, which is green.

## Strictness region

The region from the `Fence scanning` banner to EOF, sha256, re-baselined from PR #8158:

| Tree | sha256 | bytes |
|---|---|---|
| base `9bfd61848` | `2749d53ae3a8df033a53b8d7a354fa7e22ee2d1a17f6ad0c3d61122e904e084b` | 83711 |
| head `61759cfcc` | `2749d53ae3a8df033a53b8d7a354fa7e22ee2d1a17f6ad0c3d61122e904e084b` | 83711 |

Byte-identical. The deleted ledger row sits above the banner.

## Positive control

Redone from scratch against the committed tree, under a `trap … EXIT INT TERM` with absolute paths.

1. Tree proven clean first: `git status --porcelain` empty, `git diff HEAD` 0 bytes, README on disk `680ca1be68f88d4f658be017f244beca503c3978` = its HEAD blob.
2. Injected `showConfidence: 42` (was `true`) into the Quick Start fence. Landed on disk, proven by anchor counts (1 occurrence of the injected text, one fewer of the anchor) and by the blob hash moving to `4a3cd757a606cdff5fa987bc8506607244951179` — not by the editor's exit code.
3. `pnpm check:doc-snippets` → **exit 1**, naming the page and the line:
   `[semantic]  packages/plugin-ai/README.md:45:3  TS2322: Type 'number' is not assignable to type 'boolean | undefined'.`
4. Restore proven by **state**, not by exit code: `git diff HEAD -- packages/plugin-ai/README.md` 0 bytes, on-disk hash back to `680ca1be68f88d4f658be017f244beca503c3978` = HEAD blob, `git status --porcelain` empty.

So the page is genuinely in the compiled tier and the gate would catch a regression on it.

## Gates — all on head `61759cfcc`, exit codes captured by redirect-then-capture

| Gate | Exit |
|---|---|
| `pnpm check:doc-snippets` | 0 |
| `pnpm exec vitest run scripts/__tests__/check-doc-snippet-types.test.ts scripts/__tests__/check-doc-fence-languages.test.ts` | 0 — 2 files, 123 tests |
| `pnpm exec vitest run scripts/__tests__/` (whole directory) | 0 — 115 files, 3415 tests |
| `pnpm check:doc-types` | 0 |
| `pnpm check:readme-exports` | 0 (package built) |
| `pnpm check:doc-fences` | 0 |
| `pnpm type-check:scripts` | 0 |
| `pnpm lint:root` | 0 — 32 pre-existing warnings, 0 errors, none in either changed file |
| `pnpm check:control-bytes` | 0 |
| `grep -naP` control-byte self-scan of both changed paths | 1 (no match — clean) |
| `node scripts/check-changeset-presence.mjs` | 0 — "no changeset is owed" (0 of 2 changed files are published source or a moved contract) |
| `node scripts/check-governed-queue-guard.mjs --test` (both paths) | 0 — **NOT GOVERNED** |
| `pnpm check:entry-guard` | 0 |

Build closure rebuilt on the merged head before any measurement: `pnpm exec turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter) --concurrency=2` → exit 0, 35/35 tasks.

No changeset: `check-changeset-presence.mjs` is the authority and it says none is owed. No label was applied.

`Live E2E (informational)` is red on every branch today for an upstream reason (#7990 / objectstack#16186) — not from this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_