### PR TITLE
feat(plugin-kanban,plugin-calendar): declare the `filter` input both renderers read

### DIFF
--- a/.changeset/7712-kanban-calendar-filter-input.md
+++ b/.changeset/7712-kanban-calendar-filter-input.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/plugin-calendar': minor
+'@object-ui/plugin-kanban': minor
+---
+
+Declare the `filter` input on every `object-kanban` / `object-calendar`
+registration (objectui#7712) — the html tier stops reporting `unknown-prop` on a
+key the spec declares and both renderers read.
+
+`ObjectKanban.tsx` sends the authored key to the query as `$filter: schema.filter`
+and `ObjectCalendar.tsx` does the same, and `@objectstack/spec`'s
+`ComponentPropsMap` declares `filter` on both blocks (measured: `safeParse`
+accepts it, and refuses an undeclared key by name on the same call). But none of
+the four registrations that publish those two renderers listed `filter` in
+`inputs`, and `sdui-parser`'s `validateTree` reports `unknown-prop` for every key
+no `inputs` entry claims. So an author writing the one spelling that WORKS was
+told it was unknown — objectui#6678's shape, where a correct write draws the same
+diagnostic as a write that does nothing. That is worse than an inert key: it
+actively punishes the correct behaviour, and the honest response to it is to
+delete working metadata.
+
+ADR-0049 enforce-or-remove resolves toward **declare**, not remove: the key has
+live readers on both ends, so the registrations were the side that was wrong. The
+declaration is `type: 'array'` on all four, matching the `filter` that
+`object-grid`'s `GRID_QUERY_INPUTS` and `object-metric` already publish, and it is
+writable as one shape only because objectui#7711 landed first and retired the
+object-shaped `filter.calendar` spelling — `filter` is the query filter and
+nothing else.
+
+Declared per key against the spec rather than derived from the
+`ElementDataSourceMapping` sitting beside these registrations, even though that
+mapping already asserts `filter` is a live query key. Measured, that derivation
+would be wrong: the kanban mapping also carries `limit`, and the spec's strict
+`ComponentPropsMap['object-kanban']` **rejects** `limit` by name, so emitting it
+would publish a key the save gate refuses.
+
+⚠️ Note for whoever meets this class next: `check:react-blocks-declaration-parity`
+runs manifest → spec, one direction. A key the SPEC declares and the manifest
+omits is structurally outside what that ratchet measures, so fixing these four
+registrations does **not** make the next omission loud. Making that ratchet
+bidirectional is its own card.

--- a/content/docs/plugins/plugin-calendar.mdx
+++ b/content/docs/plugins/plugin-calendar.mdx
@@ -244,6 +244,7 @@ const schema: ObjectCalendarSchema = {
   staticData?: Array<any>,          // Static data array
   data?: ViewData,                  // Advanced data configuration
   calendar?: CalendarConfig,        // Calendar-specific configuration
+  filter?: ViewFilterRule[],        // Query filter, lowered to $filter
   onEventClick?: (record: any) => void,
   onDateClick?: (date: Date) => void,
   className?: string

--- a/content/docs/plugins/plugin-kanban.mdx
+++ b/content/docs/plugins/plugin-kanban.mdx
@@ -105,6 +105,7 @@ interface KanbanCard {
 | Property | Type | Description |
 |----------|------|-------------|
 | `columns` | KanbanColumn[] | Array of column definitions |
+| `filter` | ViewFilterRule[] | Query filter for an object-driven board, lowered to `$filter` |
 | `limit` | number | Rows fetched by an object-driven board (default 100) |
 | `onCardMove` | function | Callback when a card is moved |
 | `className` | string | Additional Tailwind CSS classes |

--- a/packages/plugin-calendar/package.json
+++ b/packages/plugin-calendar/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@object-ui/data-objectstack": "workspace:*",
+    "@object-ui/sdui-parser": "workspace:*",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
     "@vitejs/plugin-react": "^6.0.5",

--- a/packages/plugin-calendar/src/__tests__/filterIsDeclaredInput-7712.test.ts
+++ b/packages/plugin-calendar/src/__tests__/filterIsDeclaredInput-7712.test.ts
@@ -1,0 +1,144 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7712 — `filter` is DECLARED authoring surface on every tag
+ * `ObjectCalendarRenderer` is published under. Sibling of the file with the
+ * same name in `@object-ui/plugin-kanban`; same defect, same pin shape, the
+ * other half of the card.
+ *
+ * ## The defect this pins closed
+ *
+ * `ObjectCalendar.tsx:478` sends the authored key to the query as
+ * `$filter: schema.filter`, and `@objectstack/spec`'s
+ * `ComponentPropsMap['object-calendar']` declares `filter` — but neither of the
+ * two registrations that publish this renderer listed it in `inputs`. Since
+ * `sdui-parser`'s `validate.ts:76` reports `unknown-prop` for every key no
+ * `inputs` entry claims, the html tier told an author that the one spelling
+ * that WORKS is unknown, while the renderer honoured it (objectui#6678's
+ * shape). ADR-0049 enforce-or-remove resolves it toward DECLARE: the key has
+ * live readers on both ends, so the registrations were the side that was wrong.
+ *
+ * ## Its relation to objectui#7711, which landed first
+ *
+ * #7711 retired `getCalendarConfig`'s probe of `schema.filter` for a `calendar`
+ * key — the `filter.map` shape objectui#4034 closed, one view over. That left
+ * exactly one meaning for the key, which is what makes this declaration
+ * writable at all: `filter` is the query filter and nothing else, so it is
+ * declared here as `type: 'array'`, the same arm `object-grid` and
+ * `object-metric` publish. Had the object-shaped spelling survived, this
+ * declaration would have contradicted it — the two cards had to be decided in
+ * this order, and were.
+ *
+ * ## Why a gate did not catch it, and still will not catch the next one
+ *
+ * The framework's `check:react-blocks-declaration-parity` diffs the manifest
+ * `manifestFromConfigs` produces AGAINST the spec's zod schemas — manifest to
+ * spec, one direction. A key the SPEC declares and the manifest omits is
+ * structurally outside what that ratchet measures. This file is the per-key
+ * pin for one of the two instances objectui#7712 names; making the ratchet
+ * bidirectional is its own card.
+ *
+ * ## The rows, and what makes each a reading
+ *
+ * 1. THE HTML TIER ACCEPTS IT — the real validator over a manifest built from
+ *    the LIVE registry (never a hand-written one that could agree with itself),
+ *    on every tag the renderer is published under. Red on `origin/main`, green
+ *    here.
+ * 2. THE CONTROL, on the same call — a prop the component genuinely does not
+ *    declare is still reported, so row 1's empty array is a verdict rather than
+ *    a validator that reports nothing.
+ * 3. THE DECLARATION, read straight off the registry, with `objectName` as its
+ *    non-vacuity control.
+ * 4. THE CONTRACT AGREES — the spec accepts an authored `filter` on this block
+ *    (asserted as a KEY verdict: `filter` is absent from `unrecognized_keys`),
+ *    so declaring it restores `declared = enforced` rather than widening past
+ *    the contract.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ComponentRegistry } from '@object-ui/core';
+import { ComponentPropsMap } from '@objectstack/spec/ui';
+import { manifestFromConfigs, validateTree } from '@object-ui/sdui-parser';
+// Module scope, not a hook: this import IS the registration (AGENTS.md's
+// test-discipline section — an unbounded module load must not be billed to a
+// bounded window).
+import '../index';
+
+/** The two tags this one renderer is published under. */
+const CALENDAR_TAGS = [
+  { label: 'object-calendar', type: 'object-calendar', namespace: 'plugin-calendar' },
+  { label: 'view:calendar', type: 'calendar', namespace: 'view' },
+] as const;
+
+/** A filter in the JSON-rules form `ObjectCalendar` forwards as `$filter`. */
+const AUTHORED_FILTER = [{ field: 'status', operator: 'eq', value: 'confirmed' }];
+
+const declaredInputNames = (type: string, namespace?: string): string[] =>
+  ((ComponentRegistry.getConfig(type, namespace) as any)?.inputs ?? []).map((i: any) => i.name);
+
+/**
+ * A manifest built the way `gen-manifest.ts` and the JSX-page compiler build
+ * theirs — from the live registry — so these verdicts are the ones a real
+ * author gets, not the ones a fixture was written to produce.
+ */
+const liveManifest = () =>
+  manifestFromConfigs(
+    ComponentRegistry.getKnownTypes().map((type) => {
+      const meta = ComponentRegistry.getMeta(type);
+      return { type, namespace: meta?.namespace, isContainer: meta?.isContainer, inputs: meta?.inputs };
+    }) as unknown as Parameters<typeof manifestFromConfigs>[0],
+  );
+
+/** `unknown-prop` messages a one-node document draws for `props`. */
+const unknownProps = (type: string, props: Record<string, unknown>): string[] =>
+  validateTree({ type, objectName: 'event', ...props } as never, liveManifest())
+    .diagnostics.filter((d) => d.code === 'unknown-prop')
+    .map((d) => d.message);
+
+describe('objectui#7712 — object-calendar publishes the `filter` it reads', () => {
+  it.each(CALENDAR_TAGS)('$label — the html tier accepts an authored filter', ({ type }) => {
+    expect(
+      unknownProps(type, { filter: AUTHORED_FILTER }),
+      `<${type}> reports the spec-declared \`filter\` as unknown while ObjectCalendar.tsx sends it as $filter`,
+    ).toEqual([]);
+  });
+
+  it.each(CALENDAR_TAGS)('$label — control: a genuinely unknown prop is still reported', ({ type }) => {
+    expect(unknownProps(type, { bogusProp: AUTHORED_FILTER })).toEqual([
+      `<${type}> has no prop "bogusProp"`,
+    ]);
+  });
+
+  it.each(CALENDAR_TAGS)('$label — the registration declares it', ({ type, namespace }) => {
+    const declared = declaredInputNames(type, namespace);
+    // Non-vacuity: an empty read (wrong type/namespace) fails both lines rather
+    // than silently passing one.
+    expect(declared, `${type} inputs`).toContain('objectName');
+    expect(declared, `${type} inputs`).toContain('filter');
+  });
+
+  it('the spec accepts the key, so this declares rather than widens', () => {
+    const parsed = (ComponentPropsMap as Record<string, any>)['object-calendar'].safeParse({
+      objectName: 'event',
+      filter: AUTHORED_FILTER,
+    });
+    const unrecognized = parsed.success
+      ? []
+      : parsed.error.issues.flatMap((issue: any) => issue.keys ?? []);
+    expect(unrecognized).not.toContain('filter');
+    // The control for that zero: the same strict schema DOES refuse a key it
+    // never declared, so "not rejected" is a verdict and not a vacuous read.
+    const bogus = (ComponentPropsMap as Record<string, any>)['object-calendar'].safeParse({
+      objectName: 'event',
+      bogusProp: AUTHORED_FILTER,
+    });
+    expect(bogus.success).toBe(false);
+    expect(bogus.error.issues.flatMap((issue: any) => issue.keys ?? [])).toContain('bogusProp');
+  });
+});

--- a/packages/plugin-calendar/src/index.tsx
+++ b/packages/plugin-calendar/src/index.tsx
@@ -297,6 +297,7 @@ ComponentRegistry.register('object-calendar', ObjectCalendarRenderer, {
   inputs: [
     { name: 'objectName', type: 'string', required: true },
     { name: 'calendar', type: 'object', description: 'startDateField, endDateField, titleField, colorField' },
+    { name: 'filter', type: 'array', description: 'Filter criteria in JSON-rules form, narrowing the records the calendar fetches. Lowered to `$filter` on the query.' },
   ],
 });
 
@@ -304,8 +305,10 @@ ComponentRegistry.register('calendar', ObjectCalendarRenderer, {
   namespace: 'view',
   label: 'Calendar View',
   category: 'view',
+  // Same renderer as `object-calendar`, therefore the same declared surface.
   inputs: [
     { name: 'objectName', type: 'string', required: true },
     { name: 'calendar', type: 'object', description: 'startDateField, endDateField, titleField, colorField' },
+    { name: 'filter', type: 'array', description: 'Filter criteria in JSON-rules form, narrowing the records the calendar fetches. Lowered to `$filter` on the query.' },
   ],
 });

--- a/packages/plugin-kanban/package.json
+++ b/packages/plugin-kanban/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@object-ui/data-objectstack": "workspace:*",
+    "@object-ui/sdui-parser": "workspace:*",
     "@object-ui/test-support": "workspace:*",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/react": "19.2.18",

--- a/packages/plugin-kanban/src/__tests__/filterIsDeclaredInput-7712.test.ts
+++ b/packages/plugin-kanban/src/__tests__/filterIsDeclaredInput-7712.test.ts
@@ -1,0 +1,150 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7712 — `filter` is DECLARED authoring surface on every tag
+ * `ObjectKanbanRenderer` is published under.
+ *
+ * ## The defect this pins closed
+ *
+ * `ObjectKanban.tsx:363` sends the authored key to the query as
+ * `$filter: schema.filter`, and `@objectstack/spec`'s
+ * `ComponentPropsMap['object-kanban']` declares `filter` — but neither of the
+ * two registrations that publish this renderer listed it in `inputs`. Since
+ * `sdui-parser`'s `validate.ts:76` reports `unknown-prop` for every key no
+ * `inputs` entry claims, the html tier told an author that the one spelling
+ * that WORKS is unknown, while the renderer honoured it. That is objectui#6678's
+ * shape: a correct write drawing the same diagnostic as a write that does
+ * nothing, which trains authors (AI authors included) to delete working
+ * metadata and to dismiss the reports that are real.
+ *
+ * ADR-0049 enforce-or-remove resolves this toward DECLARE, not remove: a key
+ * with live readers on both ends is not dead, so the registrations were the
+ * side that was wrong.
+ *
+ * ## Why a gate did not catch it, and still will not catch the next one
+ *
+ * The framework's `check:react-blocks-declaration-parity` diffs the manifest
+ * `manifestFromConfigs` produces AGAINST the spec's zod schemas — manifest to
+ * spec, one direction. A key the SPEC declares and the manifest omits is
+ * structurally outside what that ratchet measures, so this whole class is in
+ * its blind spot. Making it bidirectional is its own card; this file is the
+ * per-key pin for the two instances objectui#7712 names.
+ *
+ * ## Why the declaration is hand-written and not derived from the mapping
+ *
+ * The `ElementDataSourceMapping` beside these registrations
+ * (`OBJECT_KANBAN_DATA_SOURCE`) already asserts `filter` is a live query key,
+ * which invites deriving `inputs` from it the way `register()` derives the
+ * `dataSource` input (objectui#6678). Measured, that derivation would be wrong
+ * here: the same mapping also carries `limit`, and
+ * `ComponentPropsMap['object-kanban']` is a STRICT object that does not declare
+ * `limit` — emitting it would publish a key the save gate refuses, turning the
+ * manifest-to-spec parity check red in the opposite direction. So `filter` is
+ * declared per key, against the spec, exactly as `object-grid`'s
+ * `GRID_QUERY_INPUTS` declares its own.
+ *
+ * ## The rows, and what makes each a reading
+ *
+ * 1. THE HTML TIER ACCEPTS IT — the real validator over a manifest built from
+ *    the LIVE registry (never a hand-written one that could agree with itself),
+ *    on every tag the renderer is published under. This row is red on
+ *    `origin/main` and green here.
+ * 2. THE CONTROL, on the same call — a prop the component genuinely does not
+ *    declare is still reported. Without it, row 1's empty array would also be
+ *    produced by a validator that reported nothing at all.
+ * 3. THE DECLARATION, read straight off the registry, with `objectName` as its
+ *    non-vacuity control.
+ * 4. THE CONTRACT AGREES — the spec accepts an authored `filter` on this block
+ *    (asserted as a KEY verdict: `filter` is absent from `unrecognized_keys`),
+ *    so declaring it restores `declared = enforced` rather than widening past
+ *    the contract.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ComponentRegistry } from '@object-ui/core';
+import { ComponentPropsMap } from '@objectstack/spec/ui';
+import { manifestFromConfigs, validateTree } from '@object-ui/sdui-parser';
+// Module scope, not a hook: this import IS the registration (AGENTS.md's
+// test-discipline section — an unbounded module load must not be billed to a
+// bounded window).
+import '../index';
+
+/** The two tags this one renderer is published under. */
+const KANBAN_TAGS = [
+  { label: 'object-kanban', type: 'object-kanban', namespace: 'plugin-kanban' },
+  { label: 'view:kanban', type: 'kanban', namespace: 'view' },
+] as const;
+
+/** A filter in the JSON-rules form `ObjectKanban` forwards as `$filter`. */
+const AUTHORED_FILTER = [{ field: 'stage', operator: 'eq', value: 'open' }];
+
+const declaredInputNames = (type: string, namespace?: string): string[] =>
+  ((ComponentRegistry.getConfig(type, namespace) as any)?.inputs ?? []).map((i: any) => i.name);
+
+/**
+ * A manifest built the way `gen-manifest.ts` and the JSX-page compiler build
+ * theirs — from the live registry — so these verdicts are the ones a real
+ * author gets, not the ones a fixture was written to produce.
+ */
+const liveManifest = () =>
+  manifestFromConfigs(
+    ComponentRegistry.getKnownTypes().map((type) => {
+      const meta = ComponentRegistry.getMeta(type);
+      return { type, namespace: meta?.namespace, isContainer: meta?.isContainer, inputs: meta?.inputs };
+    }) as unknown as Parameters<typeof manifestFromConfigs>[0],
+  );
+
+/** `unknown-prop` messages a one-node document draws for `props`. */
+const unknownProps = (type: string, props: Record<string, unknown>): string[] =>
+  validateTree({ type, objectName: 'task', ...props } as never, liveManifest())
+    .diagnostics.filter((d) => d.code === 'unknown-prop')
+    .map((d) => d.message);
+
+describe('objectui#7712 — object-kanban publishes the `filter` it reads', () => {
+  it.each(KANBAN_TAGS)('$label — the html tier accepts an authored filter', ({ type }) => {
+    expect(
+      unknownProps(type, { filter: AUTHORED_FILTER }),
+      `<${type}> reports the spec-declared \`filter\` as unknown while ObjectKanban.tsx sends it as $filter`,
+    ).toEqual([]);
+  });
+
+  it.each(KANBAN_TAGS)('$label — control: a genuinely unknown prop is still reported', ({ type }) => {
+    expect(unknownProps(type, { bogusProp: AUTHORED_FILTER })).toEqual([
+      `<${type}> has no prop "bogusProp"`,
+    ]);
+  });
+
+  it.each(KANBAN_TAGS)('$label — the registration declares it', ({ type, namespace }) => {
+    const declared = declaredInputNames(type, namespace);
+    // Non-vacuity: a registration that published nothing would satisfy no
+    // `toContain`, but an empty read (wrong type/namespace) would fail both
+    // lines rather than silently passing one.
+    expect(declared, `${type} inputs`).toContain('objectName');
+    expect(declared, `${type} inputs`).toContain('filter');
+  });
+
+  it('the spec accepts the key, so this declares rather than widens', () => {
+    const parsed = (ComponentPropsMap as Record<string, any>)['object-kanban'].safeParse({
+      objectName: 'task',
+      filter: AUTHORED_FILTER,
+    });
+    const unrecognized = parsed.success
+      ? []
+      : parsed.error.issues.flatMap((issue: any) => issue.keys ?? []);
+    expect(unrecognized).not.toContain('filter');
+    // The control for that zero: the same strict schema DOES refuse a key it
+    // never declared, so "not rejected" is a verdict and not a vacuous read.
+    const bogus = (ComponentPropsMap as Record<string, any>)['object-kanban'].safeParse({
+      objectName: 'task',
+      bogusProp: AUTHORED_FILTER,
+    });
+    expect(bogus.success).toBe(false);
+    expect(bogus.error.issues.flatMap((issue: any) => issue.keys ?? [])).toContain('bogusProp');
+  });
+});

--- a/packages/plugin-kanban/src/index.tsx
+++ b/packages/plugin-kanban/src/index.tsx
@@ -420,7 +420,8 @@ ComponentRegistry.register(
     category: 'view',
     inputs: [
       { name: 'objectName', type: 'string', required: true },
-      { name: 'columns', type: 'array' }
+      { name: 'columns', type: 'array' },
+      { name: 'filter', type: 'array', description: 'Filter criteria in JSON-rules form, narrowing the records the board fetches. Lowered to `$filter` on the query.' }
     ]
   }
 );
@@ -431,9 +432,11 @@ ComponentRegistry.register(
     namespace: 'view',
     label: 'Kanban Board',
     category: 'view',
+    // Same renderer as `object-kanban`, therefore the same declared surface.
     inputs: [
       { name: 'objectName', type: 'string', required: true },
-      { name: 'columns', type: 'array' }
+      { name: 'columns', type: 'array' },
+      { name: 'filter', type: 'array', description: 'Filter criteria in JSON-rules form, narrowing the records the board fetches. Lowered to `$filter` on the query.' }
     ]
   }
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1583,6 +1583,9 @@ importers:
       '@object-ui/data-objectstack':
         specifier: workspace:*
         version: link:../data-objectstack
+      '@object-ui/sdui-parser':
+        specifier: workspace:*
+        version: link:../sdui-parser
       '@types/react':
         specifier: 19.2.18
         version: 19.2.18
@@ -2265,6 +2268,9 @@ importers:
       '@object-ui/data-objectstack':
         specifier: workspace:*
         version: link:../data-objectstack
+      '@object-ui/sdui-parser':
+        specifier: workspace:*
+        version: link:../sdui-parser
       '@object-ui/test-support':
         specifier: workspace:*
         version: link:../test-support


### PR DESCRIPTION
Fixes #7712

ADR-0049 enforce-or-remove on `filter`, resolved toward **declare**. Both renderers read the key, `@objectstack/spec` declares it, and only the registrations were missing it — so the registrations are what moved.

## What changed

Four registration `inputs` lists gain one entry each, `{ name: 'filter', type: 'array', description: … }`:

- `packages/plugin-kanban/src/index.tsx` — `plugin-kanban:object-kanban` and `view:kanban`
- `packages/plugin-calendar/src/index.tsx` — `plugin-calendar:object-calendar` and `view:calendar`

Plus a pin per package, the `filter` row the two plugin doc pages omitted, `@object-ui/sdui-parser` declared in both packages' devDependencies (the pins import it; `tsc` caught that it was undeclared, `check:phantom-deps` agrees), and a changeset (`minor` on both packages — this repo forbids `major`).

## ⚠️ `needs:contract-review` (Clause-② = yes)

Adding an `inputs` entry changes what a published authoring tier **accepts**: a key rejected today stops being rejected. The label is attached and this PR stays **draft** — the PM lands it.

The narrower reading is on the record too, because it is what the measurements support: the spec already declares `filter` on both blocks, so this restores *declared = enforced* rather than widening past the contract. `ComponentPropsMap['object-kanban']` and `['object-calendar']` both `safeParse` an authored `filter` to `success: true`, while the same strict schemas refuse an undeclared control key by name on the same call.

## Premise verification — measured vs claimed

Everything in the card, its triage and the dispatch was re-measured on `origin/main` `9bfd618` before the first edit. The premise **holds**, with three corrections.

| # | Claim | Measured | Verdict |
|---|---|---|---|
| 1 | Both renderers read `schema.filter` | `ObjectKanban.tsx:363`, `ObjectCalendar.tsx:478` (dep arrays `:391` / `:514`) | ✅ confirmed |
| 2 | The spec declares it for both | Runtime `safeParse`, not the `.d.ts`: accepted on both; control key refused on the same call | ✅ confirmed |
| 3 | The html tier reports `unknown-prop` today | Reproduced before the fix — 4 failed / 3 passed, message `TAG has no prop "filter"` on both kanban tags | ✅ reproduced |
| 4 | Line numbers | Card said `ObjectKanban.tsx:263` / `ObjectCalendar.tsx:454`; measured **363** / **478**. Register-call anchors also moved (`:208 :313 :420 :434` to `:208 :307 :414 :427`; the `inputs:` lines are `:216 :348 :421 :434`, which is what the second seat measured) | ⚠️ **stale, corrected** |
| 5 | Zero-hit greps carry a control | Every absence here comes from an extraction that returns a non-empty set on the same call | ✅ |
| 6 | Do the two registrations differ? | Same cause and same fix — but the fix set is **4 tags, not 6** | ⚠️ **refined** |

**The `filter: true` trap did not catch this seat.** Measured on `9bfd618`: `plugin-kanban/src/index.tsx:390`, `plugin-calendar/src/index.tsx:66` and the `plugin-grid/src/index.tsx:76` that triage cited are all `ElementDataSourceMapping` constants, not registration `inputs`. The correct control is `plugin-grid/src/index.tsx:218` — `{ name: 'filter', type: 'array', description: … }` — and `plugin-dashboard/src/index.tsx:207` is a second one. The four entries added here are that shape.

**Correction to row 6, and why it matters.** `plugin-kanban/src/index.tsx` registers four tags, but only two are served by `ObjectKanbanRenderer`. `kanban-ui` and `kanban-enhanced` are the static-column board (`KanbanRenderer` and an inline renderer), which never read `schema.filter`, and `ComponentPropsMap` carries no row for either. Declaring `filter` there would publish a key nothing reads — this defect in the other direction. So the edit is 2 + 2 tags. The dispatch's "six registrations" is the count of registrations in the two files, not the count that reads the key.

## Why hand-declared, not derived from the mapping

The suggestion was to derive the `inputs` entry from the `ElementDataSourceMapping` beside these registrations, the way `register()` derives the `dataSource` input (objectui#6678). Measured, that derivation is wrong here: `OBJECT_KANBAN_DATA_SOURCE` also carries `limit`, and `ComponentPropsMap['object-kanban']` **refuses `limit` by name** (`unrecognized_keys: ["limit"]`). Emitting it would publish a key the save gate cannot store and put the manifest at odds with the manifest-to-spec parity check. So each key is declared against the spec, per key — which is what the per-key check asked for.

## Evidence

**Reproduction (before the fix)** — the kanban pin, 4 failed / 3 passed. The three that passed are the controls (a genuinely unknown prop is reported on both tags; the spec's key verdict), so the red rows were the declaration and nothing else.

**After the fix** — dependency-closure build exit 0; both full package suites green (`plugin-kanban` 26 files / 137 tests, `plugin-calendar` 26 files / 152 tests); `type-check` green in both packages, including each one's `tsconfig.test.json`, so the pins are compiled and not merely executed; the two pins re-run on the final HEAD, 2 files / 14 tests.

**Ablation** — with the fix committed, the `object-kanban` declaration was mutated on disk (`name: 'filter'` to `name: 'filterZZZ'`, first occurrence). The mutation was proved to have landed before anything was read: anchor counts 2 to 1 and 0 to 1, plus a changed `git hash-object` (`e2006771…` to `fe9930c2…`). The pin then went RED — 2 failed / 5 passed, and the two reds are exactly the `object-kanban` rows while `view:kanban` stayed green, which is what makes the pin per-tag rather than per-file. Restore was proved **by state**, not by an exit code: `git hash-object` equal to `git rev-parse HEAD:packages/plugin-kanban/src/index.tsx`, an empty `git diff HEAD`, and the anchors back at 2 / 0. That blob hash is still the one at this PR's HEAD, so the ablation is re-checkable against what you are reading.

No build is needed for any of that to be honest: the root `vitest.config.mts` aliases `@object-ui/*` to each package's `src`, so a stale `dist` cannot make the ablation falsely green.

**Left to CI, declared:** `check:doc-snippets` and `check:spec-floors` both need a whole-workspace build (`spec-floors` reports 12 `no-artifact` findings, every one of them a package this branch never built, none about this diff), and `check:sdui-registration-pins` weighs a built console bundle.

## ⭐ The blind spot this does NOT close (named, as the triage asked)

`check:react-blocks-declaration-parity` runs **manifest to spec**. A key the spec declares and the manifest omits is structurally outside what it ratchets, so fixing these four registrations does not make the next omission loud.

This PR adds a measurement the triage did not have: the console **does** carry the reverse direction (`apps/console/src/__tests__/registry-inputs-spec-parity.test.ts`, `undiscoverableSpecKeys` at `:387`), and it could not see this defect either. Its `covered` set is built from `ComponentRegistry.getConfig`, which reads loaded registrations only (`Registry.ts:649`), while the console registers every plugin block with `registerLazy` (`register-plugins.ts:107`-`:129`). So both blocks were unjudged *and* uncounted. Filed as #8176 with the one-line verification. ⛔ Not ridden on this PR.

## Out-of-scope findings, filed unassigned (⛔ not folded in)

- **#8171** — `object-calendar` omits `sort` on the same two registrations: spec-declared, renderer-read (`ObjectCalendar.tsx:479`), the same defect one key over. The positive half of the per-key measurement.
- **#8172** — kanban's `limit`: the docs (a whole section at `plugin-kanban.mdx:151`), `ObjectKanbanSchema` and the renderer all say yes; the spec's strict props schema refuses it by name. A contract decision, not a renderer patch. The negative half.
- **#8174** — `@object-ui/types` declares neither `filter` nor `sort` on `ObjectKanbanSchema` / `ObjectCalendarSchema` — the fourth declaration face, bounded honestly against #7927.
- **#8176** — the console parity gate's lazy-registration blind spot, above.

## Name-collision check

This change exports no new name: it adds object literals inside existing `inputs` arrays plus two test files. `filter` here is an input *name* in a registration — the same key `object-grid`, `object-metric`, `record:related_list` and `plugin-list` already publish — not an exported symbol, so there is no second authority to collide with, `export *` re-exports included.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S


---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_