### PR TITLE
fix(app-shell,plugin-list): retire the invented gallery cover binding, and draw the switcher only when it can switch (objectui#7547)

### DIFF
--- a/.changeset/7547-forced-path-invented-bindings.md
+++ b/.changeset/7547-forced-path-invented-bindings.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/plugin-list': minor
+'@object-ui/app-shell': minor
+---
+
+Stop inventing a gallery cover binding, and offer the view switcher only when it
+can switch (objectui#7547).
+
+**The object page no longer floors `gallery.imageField` at `'image'`.** It used
+to supply that key for every object view, declared or not. The screen damage was
+small — `ObjectGallery` collapses the cover area when no record yields a cover —
+but the key fed `ListView`'s ADR-0047 capability gate, which reads
+`options.gallery.imageField`, so **Gallery was offered on every object view that
+whitelisted it**, with nothing behind the toggle. `galleryViewOptions` now
+forwards the view's own declared block (both legacy cover spellings still
+cross-fill each other, and `titleField` keeps its `'name'` display floor) and
+emits no cover key when the view declared none. Same class and same route as
+objectui#7029 (calendar) and objectui#7070 (gantt dates).
+
+⚠️ A view that whitelisted `gallery` without a `gallery:` block loses the Gallery
+toggle. That is the ADR-0047 rule working: it was only ever offered because this
+relay answered the gate on the author's behalf.
+
+**The visualization switcher is drawn for the resolved list, not the whitelist.**
+`showViewSwitcher` was computed from the LENGTH of
+`appearance.allowedVisualizations` — the whitelist BEFORE `ListView` intersects
+it with the capability gate — so a view whitelisting `['grid', 'timeline']` with
+no timeline block drew switcher chrome around a single Grid entry. The predicate
+now lives at the one site that holds both halves. Views whose whitelisted types
+all resolve are unaffected.

--- a/packages/app-shell/src/views/InterfaceListPage.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.tsx
@@ -479,6 +479,10 @@ export function InterfaceListPage({ page, className, onConfigChange, reserveEdit
       // Presentation policy — the page layer (ADR-0047).
       userFilters: cfg.userFilters ?? view.userFilters,
       appearance,
+      // The page author's INTENT, not the final predicate: `ListView` draws the
+      // chrome only when this whitelist INTERSECTED with its capability gate
+      // still has more than one entry (objectui#7547). Same note as the object
+      // page's twin — the whitelist is not the offer.
       showViewSwitcher: allowed.length > 1,
       showRecordCount: cfg.showRecordCount,
       // Add-record entry point (ListView gates the button on addRecord.enabled,

--- a/packages/app-shell/src/views/ObjectDataPage.tsx
+++ b/packages/app-shell/src/views/ObjectDataPage.tsx
@@ -336,6 +336,12 @@ export function ObjectDataPage({ dataSource, objects }: any) {
       gallery,
       userFilters,
       appearance: { allowedVisualizations },
+      // This surface's INTENT to offer a switcher, not the final predicate:
+      // `ListView` draws the chrome only when this whitelist INTERSECTED with
+      // its capability gate still has more than one entry (objectui#7547). The
+      // third face carrying this length count — the card named only the object
+      // page and the interface page; this one is found by enumerating the
+      // `ListView` render sites rather than grepping for the spelling.
       showViewSwitcher: allowedVisualizations.length > 1,
       // Full list capability — this surface trades the saved-view anchor for
       // the complete toolbar, NOT for a reduced one. (#2890: expressed as

--- a/packages/app-shell/src/views/ObjectView.calendarBinding-7029.test.tsx
+++ b/packages/app-shell/src/views/ObjectView.calendarBinding-7029.test.tsx
@@ -158,16 +158,26 @@ describe('no invented calendar field name survives in the source (objectui#7029)
 
   it('CONTROL (same class): the scan still sees a REMAINING fabricated field name', () => {
     // Can this filter see the specific thing it exists to hunt — a one-rung
-    // `|| 'literal'` field-name floor? Anchored on the gallery branch's
-    // `imageField: … || 'image'`, which is the same class, is still there, and
-    // is out of scope for both objectui#7029 and objectui#7070.
+    // `|| 'literal'` field-name floor?
     //
-    // ⚠️ TO WHOEVER RETIRES `'image'`: this going red is the mechanic working,
+    // RE-ANCHORED by objectui#7547, following this case's own instruction. It
+    // used to sit on the gallery branch's `imageField: … || 'image'`; #7547
+    // retired that literal, so the anchor moved rather than the case being
+    // dropped — a scan whose last live control is deleted is a test that passes
+    // over nothing, which is the class this whole card family is about.
+    //
+    // The new anchor is the CHART branch's measure floor
+    // (`chartConfig.yAxisFields[0] || 'value'`): the same one-rung class, still
+    // present, and deliberately left standing by #7547 — deleting it needs a
+    // refusal path `ObjectChart` does not have yet, so it is reported as its own
+    // card rather than decided here.
+    //
+    // ⚠️ TO WHOEVER RETIRES `'value'`: this going red is the mechanic working,
     // not a broken test. RE-ANCHOR it onto whatever fabrication legitimately
     // remains in this file — do not delete it, and do not weaken it to the
     // machinery control above. If nothing of this class remains anywhere in this
     // face, say so in the PR body and convert this case into the assertion that
     // NONE remains, so the scan keeps making a claim about the tree.
-    expect(CODE.filter((l) => l.includes("'image'")).length).toBeGreaterThan(0);
+    expect(CODE.filter((l) => /\|\| 'value'/.test(l)).length).toBeGreaterThan(0);
   });
 });

--- a/packages/app-shell/src/views/ObjectView.galleryBinding-7547.test.tsx
+++ b/packages/app-shell/src/views/ObjectView.galleryBinding-7547.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7547 — the object page must not invent a GALLERY cover binding.
+ *
+ * The third sibling of `ObjectView.calendarBinding-7029` (calendar) and
+ * `ObjectView.ganttBinding-7070` (gantt dates) next door, and the last member
+ * of that class this face still carried: `imageField` was floored at `'image'`
+ * for EVERY object view, declared or not.
+ *
+ * ⚠️ WHAT MAKES THIS ONE DIFFERENT, and why it still had to go. For calendar
+ * and gantt the fabrication produced a WRONG SCREEN — records piled onto
+ * today's cell, a chart drawn on names nobody wrote. Gallery does not:
+ * `ObjectGallery` resolves the cover per record and collapses the cover area
+ * when no record yields one, so the invented `'image'` degraded to a gallery of
+ * coverless cards. The defect is one layer up, in the GATE.
+ * `ListView.availableViews` asks `schema.options?.gallery?.imageField`, and a
+ * key this file always supplied made that check answer YES for every object
+ * view whitelisting `gallery` — so ADR-0047's whitelist ∩ resolvable, the
+ * mechanism that exists to stop a visualization being offered with nothing
+ * behind it, was answering about a name this face wrote. Gallery was offered
+ * without a block and looked fine only because the renderer degrades politely.
+ * A coincidence, not a design.
+ *
+ * ⚠️ THE PREMISE WAS MEASURED BEFORE THE DELETION — the discipline objectui#7070
+ * wrote down. #7029's mechanic is only correct where the read site's own answer
+ * is honest. `ObjectGallery` keeps its own `coverField … ?? 'image'` rung, and
+ * that is CORRECT there: it is the component's decision about an unconfigured
+ * record, and it is honest because the cover area collapses when the guess
+ * yields nothing (`ObjectGallery.tsx`, the `anyItemHasCover` memo). What this
+ * face must not do is pre-empt that decision and light the capability gate on
+ * the way past.
+ *
+ * REVERSE VERIFICATION — direction predicted before running, then observed:
+ * restore `imageField: viewDef.gallery?.imageField || viewDef.gallery?.coverField
+ * || 'image'` and the "invents NO cover field" cases below go RED (they read the
+ * fabricated name) while every declared-config CONTROL stays GREEN in either
+ * world — the fabricated value is only ever observable when the view declared
+ * nothing. That asymmetry is the point: a fix that emitted an empty config for
+ * EVERY view would also pass an absence-only test.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { galleryViewOptions } from './ObjectView';
+
+describe('galleryViewOptions — the object page forwards, it does not invent (objectui#7547)', () => {
+  it('invents NO cover field for a view that declares no gallery config', () => {
+    // THE DEFECT. This used to return `{ imageField: 'image', coverField:
+    // undefined, titleField: 'name' }` — a complete-looking cover binding for a
+    // view that configured nothing, which is what lit the Gallery toggle on
+    // every object view in the product.
+    expect(galleryViewOptions({})).toEqual({ titleField: 'name' });
+    expect(galleryViewOptions(undefined)).toEqual({ titleField: 'name' });
+    expect(galleryViewOptions({ label: 'All', columns: ['name'] })).toEqual({ titleField: 'name' });
+  });
+
+  it('invents no cover field for a view whose neighbouring blocks ARE declared', () => {
+    // A view bound for kanban/calendar must not acquire a gallery cover by
+    // proximity — the Gallery toggle it would light has nothing behind it.
+    const out = galleryViewOptions({
+      kanban: { groupByField: 'stage' },
+      calendar: { startDateField: 'start_date' },
+    });
+    expect(out).not.toHaveProperty('imageField');
+    expect(out).not.toHaveProperty('coverField');
+  });
+
+  it('invents no cover field for an EMPTY gallery block', () => {
+    // The half-written declaration: `allowedVisualizations: ['gallery']` with
+    // nothing under `gallery:`. It must stay half-written all the way down.
+    const out = galleryViewOptions({ gallery: {} });
+    expect(out).not.toHaveProperty('imageField');
+    expect(out).not.toHaveProperty('coverField');
+  });
+
+  it('invents no cover field for a gallery block that declares only PRESENTATION', () => {
+    // `cardSize` / `visibleFields` are gallery keys that say nothing about a
+    // cover binding. They must survive, and they must not answer the gate.
+    const out = galleryViewOptions({ gallery: { cardSize: 'large', visibleFields: ['name'] } });
+    expect(out).toMatchObject({ cardSize: 'large', visibleFields: ['name'] });
+    expect(out).not.toHaveProperty('imageField');
+    expect(out).not.toHaveProperty('coverField');
+  });
+
+  it('CONTROL: a declared `coverField` cross-fills the legacy `imageField`', () => {
+    // The spec spelling is `coverField`; `ObjectGallery` still consults the
+    // legacy `imageField`, and `ListView`'s gate reads `imageField` out of this
+    // bag. Cross-filling a DECLARED name is forwarding, not inventing.
+    const out = galleryViewOptions({ gallery: { coverField: 'photo' } });
+    expect(out.coverField).toBe('photo');
+    expect(out.imageField).toBe('photo');
+  });
+
+  it('CONTROL: a declared legacy `imageField` cross-fills `coverField`', () => {
+    const out = galleryViewOptions({ gallery: { imageField: 'logo' } });
+    expect(out.imageField).toBe('logo');
+    expect(out.coverField).toBe('logo');
+  });
+
+  it('CONTROL: both spellings declared — each keeps its own value', () => {
+    // The pre-#7547 precedence, unchanged: `imageField` prefers itself then
+    // `coverField`, `coverField` prefers itself then `imageField`. Only the
+    // `'image'` tail was removed, so a view declaring both is unaffected.
+    const out = galleryViewOptions({ gallery: { imageField: 'logo', coverField: 'photo' } });
+    expect(out.imageField).toBe('logo');
+    expect(out.coverField).toBe('photo');
+  });
+
+  it('CONTROL: forwards a fully declared block verbatim — every spec key survives', () => {
+    // A bare whitelist here would drop the presentation keys; the spread is
+    // load-bearing, the same way it is in `ganttViewOptions`.
+    const out = galleryViewOptions({
+      gallery: {
+        coverField: 'photo',
+        coverFit: 'contain',
+        cardSize: 'small',
+        visibleFields: ['name', 'owner'],
+        titleField: 'subject',
+      },
+    });
+    expect(out).toMatchObject({
+      coverField: 'photo',
+      imageField: 'photo',
+      coverFit: 'contain',
+      cardSize: 'small',
+      visibleFields: ['name', 'owner'],
+      titleField: 'subject',
+    });
+  });
+
+  it('keeps the `name` title floor — a display default is not a binding', () => {
+    // Deliberately NOT removed by this card, and the same rung
+    // `ganttViewOptions` and `timelineViewOptions` carry.
+    expect(galleryViewOptions({}).titleField).toBe('name');
+    expect(galleryViewOptions({ gallery: { titleField: 'subject' } }).titleField).toBe('subject');
+  });
+});
+
+describe('no invented gallery cover name survives in the source (objectui#7547)', () => {
+  const SOURCE = readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), 'ObjectView.tsx'),
+    'utf8',
+  );
+
+  /**
+   * Executable lines only. The prose above this file's own seams names
+   * `'image'` repeatedly — that is the record of what was deleted, and a scan
+   * that counted it would be red on a correct tree. Same filter, and same
+   * reason, as the objectui#7029 and objectui#7070 scans next door.
+   */
+  const CODE = SOURCE.split('\n').filter((l) => !/^\s*(\*|\/\*|\/\/)/.test(l));
+
+  it("the fabricated 'image' floor is gone from this face's CODE", () => {
+    // A structural tripwire, not a restatement of the cases above: this is what
+    // a copy-paste from a sibling branch would reintroduce, and it is invisible
+    // to a behavioural test on any object that happens to carry a real `image`
+    // field.
+    expect(CODE.filter((l) => l.includes("'image'"))).toEqual([]);
+  });
+
+  it('CONTROL (machinery): the scan can see a literal that IS there', () => {
+    // Anchored on `'name'`, which is DELIBERATELY permanent here — the
+    // display-name floor, not a fabricated binding, so no future card of this
+    // family retires it and this control cannot go red as a side effect.
+    expect(CODE.filter((l) => l.includes("'name'")).length).toBeGreaterThan(0);
+  });
+
+  it('CONTROL (same class): the scan still sees a REMAINING fabricated field name', () => {
+    // Can the filter see the specific thing it hunts — a one-rung `|| 'literal'`
+    // binding floor? Anchored on the CHART branch's measure floor
+    // (`chartConfig.yAxisFields[0] || 'value'`), which is the same class and is
+    // still there: retiring it needs a refusal path `ObjectChart` does not have,
+    // so #7547 measured it and reported it rather than deciding it here.
+    //
+    // ⚠️ TO WHOEVER RETIRES `'value'`: this going red is the mechanic working.
+    // RE-ANCHOR onto whatever fabrication legitimately remains — do not delete
+    // this case, and do not weaken it to the machinery control above. If nothing
+    // of this class remains in this face, convert it into the assertion that
+    // NONE remains, so the scan keeps making a claim about the tree.
+    expect(CODE.filter((l) => /\|\| 'value'/.test(l)).length).toBeGreaterThan(0);
+  });
+
+  it('CONTROL: the scan reads CODE, not the prose that records the deletion', () => {
+    // The filter's own correctness. The seam comments above `galleryViewOptions`
+    // name the deleted literal; if the filter ever stopped stripping comment
+    // lines, the case above would go red on a CORRECT tree and invite someone to
+    // weaken it.
+    expect(SOURCE.includes("`'image'`")).toBe(true);
+    expect(CODE.filter((l) => l.includes("'image'"))).toEqual([]);
+  });
+});

--- a/packages/app-shell/src/views/ObjectView.ganttBinding-7070.test.tsx
+++ b/packages/app-shell/src/views/ObjectView.ganttBinding-7070.test.tsx
@@ -141,13 +141,20 @@ describe('no invented gantt date name survives in the source (objectui#7070)', (
 
   it('CONTROL: the scan can still see a literal that IS there', () => {
     // Without this the case above is green on any tree where the filter simply
-    // matches nothing. `'image'` is the gallery branch's `imageField … ||
-    // 'image'` floor — the same one-rung class, still present, out of scope for
-    // this card. ⚠️ If you retire it, RE-ANCHOR this control onto whatever
-    // fabrication legitimately remains; do not delete it. (The twin of this
-    // control in `ObjectView.calendarBinding-7029.test.tsx` carries the same
-    // instruction, and explains why in full.)
-    expect(CODE.filter((l) => l.includes("'image'")).length).toBeGreaterThan(0);
+    // matches nothing.
+    //
+    // RE-ANCHORED by objectui#7547, following this control's own instruction:
+    // it sat on the gallery branch's `imageField … || 'image'` floor until #7547
+    // retired that literal. The anchor is now the CHART branch's measure floor
+    // (`chartConfig.yAxisFields[0] || 'value'`) — the same one-rung class, still
+    // present, and left standing by #7547 because deleting it needs a refusal
+    // path `ObjectChart` does not have yet.
+    //
+    // ⚠️ If you retire it, RE-ANCHOR this control onto whatever fabrication
+    // legitimately remains; do not delete it. (The twin of this control in
+    // `ObjectView.calendarBinding-7029.test.tsx` carries the same instruction,
+    // and explains why in full.)
+    expect(CODE.filter((l) => /\|\| 'value'/.test(l)).length).toBeGreaterThan(0);
   });
 
   it('CONTROL: the scan reads CODE, not the prose that records the deletion', () => {

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -341,7 +341,14 @@ export function galleryViewOptions(viewDef: any): Record<string, unknown> {
         ...(gallery || {}),
         ...(declaredImage ? { imageField: declaredImage } : {}),
         ...(declaredCover ? { coverField: declaredCover } : {}),
-        titleField: gallery?.titleField || 'name',
+        // Spelled through `viewDef` rather than the `gallery` local above, and
+        // that is load-bearing: `ObjectView.titleFieldConvergence.test.tsx`
+        // (objectui#6557) pins all six `titleField` / `labelField` seams to ONE
+        // expression shape — a chain of VIEW-declared rungs floored at 'name',
+        // with `viewDef` as the mechanical proxy for "view-declared". Reading
+        // the local here still resolves the same value but blinds that scan to
+        // the thing it hunts, so the seam keeps the family spelling.
+        titleField: viewDef?.gallery?.titleField || 'name',
     };
 }
 

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -2277,9 +2277,18 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                 : (viewDef.showDescription != null
                     ? { showDescription: viewDef.showDescription }
                     : listSchema.appearance),
-            // Offer the visualization switcher only when the author
-            // whitelisted more than one type; ListView intersects the
-            // whitelist with capability-resolvable types.
+            // The author's INTENT to offer a visualization switcher: more than
+            // one type whitelisted. Deliberately not the final predicate — this
+            // face counts the whitelist, and the whitelist is not the offer.
+            //
+            // `ListView` intersects it with the capability gate and draws the
+            // chrome only when the INTERSECTION has more than one entry
+            // (objectui#7547, `viewSwitcherOffered`). It has to be decided
+            // there: the gate that knows which types actually resolve lives in
+            // that component, so a view whitelisting `['grid', 'timeline']`
+            // with no timeline block reads as two here and one there. Counting
+            // this number alone is what drew switcher chrome around a single
+            // Grid entry.
             showViewSwitcher:
                 ((viewDef.appearance ?? listSchema.appearance)?.allowedVisualizations?.length ?? 0) > 1,
             // Toolbar policy — one vocabulary (#2890). Stored views may still

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -292,6 +292,60 @@ export function ganttViewOptions(viewDef: any): Record<string, unknown> {
 }
 
 /**
+ * The `options.gallery` config this page hands to `ListView`.
+ *
+ * objectui#7547 — the last surviving member of the objectui#7029 / #7070 /
+ * #7500 class on this face. It floored `imageField` at `'image'` for EVERY
+ * object view, declared or not: a cover binding no view had written, on a field
+ * name most objects do not carry.
+ *
+ * ⚠️ WHAT THAT LITERAL ACTUALLY DID, which is not what it looks like. The
+ * screen damage was small — `ObjectGallery` resolves the cover per record and
+ * COLLAPSES the cover area when no record yields one, so an invented `'image'`
+ * degraded to a gallery of coverless cards. The damage was to the GATE. This
+ * bag feeds `ListView.availableViews`, whose gallery check reads
+ * `schema.options?.gallery?.imageField`; a value that is always present makes
+ * that check answer YES for every object view that whitelists `gallery`, so
+ * ADR-0047's whitelist ∩ resolvable — the mechanism that exists to stop a
+ * visualization being offered with nothing behind it — was answering about a
+ * name this file wrote rather than one the author did. Gallery was offered
+ * without a block, and stayed watchable only because the renderer happens to
+ * degrade politely. That is a coincidence, not a design, and it is the same
+ * second-order effect objectui#7029 measured for `calendar` and objectui#7070
+ * for `gantt`.
+ *
+ * ⚠️ MEASURED BEFORE THE DELETION, the discipline objectui#7070 wrote down:
+ * #7029's mechanic — delete the literal, let the read site answer — is only
+ * correct where the read site's answer is honest. `ObjectGallery` floors its
+ * own `coverField` at `'image'` too, and that rung STAYS: it is the component's
+ * own decision about an unconfigured record, and it is honest because the cover
+ * area collapses when the guess yields nothing. What this face must not do is
+ * pre-empt that decision and light the capability gate on the way past.
+ *
+ * What stays here is the view's OWN declared block, spread whole so every spec
+ * key survives (`cardSize` / `visibleFields` / `coverFit` / …), the two legacy
+ * cover spellings cross-filled BUT ONLY WHEN ONE WAS DECLARED, and the
+ * `titleField` `'name'` floor — a display-name default, not a binding, exactly
+ * as `ganttViewOptions` above keeps it.
+ *
+ * Exported for the regression suite.
+ */
+export function galleryViewOptions(viewDef: any): Record<string, unknown> {
+    const gallery = viewDef?.gallery;
+    // `ObjectGallery` reads `coverField` and the legacy `imageField`; each
+    // spelling answers for the other, and NEITHER is invented. Both rungs are
+    // present or both absent, so the gate cannot be lit by half a declaration.
+    const declaredImage = gallery?.imageField || gallery?.coverField;
+    const declaredCover = gallery?.coverField || gallery?.imageField;
+    return {
+        ...(gallery || {}),
+        ...(declaredImage ? { imageField: declaredImage } : {}),
+        ...(declaredCover ? { coverField: declaredCover } : {}),
+        titleField: gallery?.titleField || 'name',
+    };
+}
+
+/**
  * THE record-detail URL this list surface builds — one route shape, one place.
  *
  * Derived from the LIST's own pathname rather than re-assembled from route
@@ -2443,16 +2497,12 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
                     zoom: viewDef.map?.zoom,
                     center: viewDef.map?.center,
                 },
-                gallery: {
-                    // Spread the full view-defined gallery first so spec
-                    // fields (cardSize, visibleFields, coverField, coverFit)
-                    // make it through; then layer legacy field aliases that
-                    // ObjectGallery still consults.
-                    ...(viewDef.gallery || {}),
-                    imageField: viewDef.gallery?.imageField || viewDef.gallery?.coverField || 'image',
-                    coverField: viewDef.gallery?.coverField || viewDef.gallery?.imageField,
-                    titleField: viewDef.gallery?.titleField || 'name',
-                },
+                // The gallery config the view DECLARED, title floored at
+                // 'name', and no invented cover field (objectui#7547). With no
+                // cover binding to forward, ListView's capability gate stops
+                // offering the Gallery toggle to a view that configured none.
+                // See `galleryViewOptions`.
+                gallery: galleryViewOptions(viewDef),
                 // The gantt config the view DECLARED, title floored at 'name' —
                 // never an invented date field (objectui#7070). With no date
                 // binding to forward, ListView's capability gate stops offering

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -2238,6 +2238,29 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     return resolvable;
   }, [schema.options, schema.viewType, schema.kanban, schema.calendar, schema.gantt, schema.gallery, schema.timeline, schema.map, (schema as any).tree, (schema as any).chart, schema.appearance?.allowedVisualizations]);
 
+  /**
+   * Whether the visualization switcher is actually WORTH drawing (objectui#7547).
+   *
+   * `showViewSwitcher` is the author's intent, and both faces that stamp it —
+   * `app-shell/ObjectView` and `app-shell/InterfaceListPage` — compute it from
+   * the LENGTH of `appearance.allowedVisualizations`, which is the whitelist
+   * BEFORE this component intersects it with `availableViews` above. Those two
+   * numbers are not the same number: a view whitelisting `['grid', 'timeline']`
+   * with no timeline block whitelists two and resolves one, so the toolbar drew
+   * switcher chrome — border, dropdown affordance and separator — around a
+   * single Grid entry that cannot switch to anything.
+   *
+   * Neither face can compute this: `availableViews` is the whitelist ∩ the
+   * capability gate, and the gate lives here. So the predicate is applied at
+   * the one site that holds both halves, which also means it covers BOTH doors
+   * at once and cannot drift from the list the dropdown is handed.
+   *
+   * ⚠️ NOT a second policy layer. An author who whitelists two RESOLVABLE types
+   * still gets the switcher, and an author who whitelists none still gets none;
+   * the only views this changes are the ones whose chrome offered no choice.
+   */
+  const viewSwitcherOffered = showViewSwitcher && availableViews.length > 1;
+
   // Sync view from props
   React.useEffect(() => {
      if (schema.viewType) {
@@ -3312,7 +3335,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           {/* Visualization switcher — compact dropdown (Airtable-style
               "List ▾"), first slot of the right tool cluster so the whole
               toolbar stays a single row. */}
-          {showViewSwitcher && (
+          {viewSwitcherOffered && (
             <>
               <ViewSwitcherDropdown
                 currentView={currentView}

--- a/packages/plugin-list/src/__tests__/ListView.switcherChrome-7547.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.switcherChrome-7547.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7547 — switcher chrome around a single entry.
+ *
+ * `showViewSwitcher` reaches this component already decided, and both faces
+ * that decide it compute the same wrong number: `app-shell/ObjectView` and
+ * `app-shell/InterfaceListPage` count the LENGTH of
+ * `appearance.allowedVisualizations`. That is the whitelist BEFORE this
+ * component intersects it with the ADR-0047 capability gate — so a view
+ * whitelisting `['grid', 'timeline']` with no timeline block whitelisted two,
+ * resolved one, and drew the border / dropdown / separator cluster around a
+ * Grid entry that could not switch to anything.
+ *
+ * Neither face can compute it: the gate that answers "does this type resolve?"
+ * lives here, in `availableViews`. So the predicate is applied at the one site
+ * holding both halves (`viewSwitcherOffered`), which is also why one change
+ * covers BOTH doors.
+ *
+ * ⚠️ THE DISCRIMINATING PAIR IS THE POINT. A fix that simply stopped drawing
+ * the switcher would pass every "no chrome" case below, so each of them is
+ * matched by a control that whitelists the SAME two types and DECLARES the
+ * second one's binding — chrome must still be drawn there. The two arms differ
+ * in exactly one thing: whether the whitelisted second type resolves.
+ *
+ * REVERSE VERIFICATION — direction predicted before running, then observed:
+ * restore `{showViewSwitcher && (` at the render site and the "no chrome" arms
+ * go RED (the cluster reappears around one entry) while every control stays
+ * GREEN in either world — a resolvable second type was always offered.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ListView } from '../ListView';
+import { SchemaRendererProvider } from '@object-ui/react';
+
+const makeDataSource = () =>
+  ({
+    find: vi.fn().mockResolvedValue([]),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue({ name: 'task', fields: {} }),
+  }) as any;
+
+const BASE = {
+  type: 'list-view',
+  objectName: 'task',
+  viewType: 'grid',
+  columns: ['name'],
+} as const;
+
+/**
+ * Is switcher chrome on the page, in EITHER of its two forms?
+ *
+ * `ViewSwitcherDropdown` renders a segmented control for 2–4 visualizations and
+ * a collapsed "List (chevron)" dropdown otherwise — which is why the one-entry
+ * case this card is about drew the DROPDOWN form: a menu affordance whose menu
+ * holds a single item. Asking for both forms is what keeps these cases about
+ * "was a switcher offered", not about which shape it took.
+ */
+const anySwitcher = () =>
+  screen.queryByTestId('view-switcher-segmented') ?? screen.queryByTestId('view-switcher-dropdown');
+
+/**
+ * Mount a view with the switcher ENABLED by the host — the state both app-shell
+ * faces stamp — and report whether the switcher chrome was drawn.
+ */
+const chromeDrawn = (view: Record<string, unknown>) => {
+  const dataSource = makeDataSource();
+  render(
+    <SchemaRendererProvider dataSource={dataSource}>
+      <ListView schema={{ ...BASE, ...view } as never} dataSource={dataSource} showViewSwitcher />
+    </SchemaRendererProvider>,
+  );
+  return Boolean(anySwitcher());
+};
+
+describe('the switcher is drawn for the RESOLVED list, not the whitelist (objectui#7547)', () => {
+  it('draws NO chrome for `[grid, timeline]` with no timeline block', () => {
+    // THE DEFECT, verbatim from the card. Two whitelisted, one resolvable.
+    expect(
+      chromeDrawn({ appearance: { allowedVisualizations: ['grid', 'timeline'] } }),
+    ).toBe(false);
+  });
+
+  it('CONTROL: the SAME whitelist WITH a declared timeline axis keeps its chrome', () => {
+    // The discriminating half. Nothing about this pair differs except whether
+    // the second whitelisted type resolves, so a fix that just stopped drawing
+    // the cluster cannot pass both.
+    expect(
+      chromeDrawn({
+        appearance: { allowedVisualizations: ['grid', 'timeline'] },
+        timeline: { startDateField: 'due_date' },
+      }),
+    ).toBe(true);
+  });
+
+  it('draws NO chrome for `[grid, kanban]` with no groupBy', () => {
+    expect(
+      chromeDrawn({ appearance: { allowedVisualizations: ['grid', 'kanban'] } }),
+    ).toBe(false);
+  });
+
+  it('CONTROL: the same whitelist WITH a declared kanban lane keeps its chrome', () => {
+    expect(
+      chromeDrawn({
+        appearance: { allowedVisualizations: ['grid', 'kanban'] },
+        kanban: { groupByField: 'stage' },
+      }),
+    ).toBe(true);
+  });
+
+  it('draws NO chrome when every whitelisted extra type is unbound', () => {
+    // Three whitelisted, still one resolvable — the length test read three.
+    expect(
+      chromeDrawn({ appearance: { allowedVisualizations: ['grid', 'kanban', 'calendar'] } }),
+    ).toBe(false);
+  });
+
+  it('CONTROL: chrome for two resolvable types is untouched by this card', () => {
+    expect(
+      chromeDrawn({
+        appearance: { allowedVisualizations: ['grid', 'kanban', 'calendar'] },
+        kanban: { groupByField: 'stage' },
+        calendar: { startDateField: 'due_date' },
+      }),
+    ).toBe(true);
+  });
+
+  it('CONTROL: the host can still switch the cluster OFF entirely', () => {
+    // `viewSwitcherOffered` narrows the author's intent; it never widens it.
+    const dataSource = makeDataSource();
+    render(
+      <SchemaRendererProvider dataSource={dataSource}>
+        <ListView
+          schema={
+            {
+              ...BASE,
+              appearance: { allowedVisualizations: ['grid', 'kanban'] },
+              kanban: { groupByField: 'stage' },
+            } as never
+          }
+          dataSource={dataSource}
+        />
+      </SchemaRendererProvider>,
+    );
+    expect(anySwitcher()).toBeNull();
+  });
+
+  it('draws NO chrome for a whitelist of one, as before', () => {
+    expect(chromeDrawn({ appearance: { allowedVisualizations: ['grid'] } })).toBe(false);
+  });
+});


### PR DESCRIPTION
Part of #7547.

⚠️ **This PR delivers two of the card's three in-scope items — the gallery cover binding and the switcher predicate. The third, the map / chart invented-axis pair, was measured, found to have no refusal path below it, and split into two sub-issues rather than decided here.** The reasoning is in "What is deliberately NOT here" below; it is the substance of this PR as much as the diff is, and a clean stop on a falsified route is the point rather than an apology for one.

## The class

objectui#7029 (calendar), #7070 (gantt dates) and #7500 (timeline) each removed one member of a family: a relay that invents a binding name the author never wrote, which downstream is indistinguishable from a real one. #7547 is the survivors. They live only on the FORCED path — an authored `type:` or an interface page's leading whitelist entry — because the switcher path already builds its offer from PRESENT bindings.

## Commit 1 — the switcher is drawn for the RESOLVED list, not the whitelist

`showViewSwitcher` reaches `ListView` already decided, and every face that decides it counts the LENGTH of `appearance.allowedVisualizations`. That is the whitelist BEFORE `availableViews` intersects it with the ADR-0047 capability gate. A view whitelisting `['grid', 'timeline']` with no timeline block whitelists two and resolves one, so the toolbar drew the collapsed switcher affordance, its separator and the border cluster around a single Grid entry that could not switch to anything.

Neither face can compute the right number — the gate lives in `ListView` — so the predicate is applied at the one site holding both halves (`viewSwitcherOffered`). One change, every door, and it cannot drift from the list the dropdown is handed. The relay sites keep their length test as the author's INTENT and each gains a note saying the whitelist is not the offer.

⭐ **There are THREE faces carrying that length count, not the two the card names.** Found by enumerating every `ListView` render site rather than grepping for the spelling — a population defined partly by *omission* (a site that passes nothing takes the default) cannot be measured by grepping the explicit form. The six real render sites:

| render site | opts in? |
|---|---|
| `app-shell/src/views/ObjectView.tsx` | `allowedVisualizations?.length ?? 0) > 1` |
| `app-shell/src/views/InterfaceListPage.tsx` | `allowed.length > 1` |
| **`app-shell/src/views/ObjectDataPage.tsx`** | **`allowedVisualizations.length > 1` — the third, unlisted anywhere** |
| `app-shell/src/views/studio-design/StudioDesignSurface.tsx` | omits it; spreads an authored slot schema that may carry it |
| `plugin-list/src/ListViewBlock.tsx` | omits it; forwards whatever the SDUI schema carries |
| `apps/console/src/sdui-workbench-preview.tsx` | omits it — takes the default |

All three are corrected by the single `ListView`-side predicate; `ObjectDataPage` gets the same INTENT note as its twins (comment only, no behaviour).

## Commit 2 — the object page forwards a gallery cover binding, never invents one

`options.gallery.imageField` was floored at `'image'` for every object view, declared or not.

⭐ **What that literal actually broke is the GATE, not the screen.** `ObjectGallery` resolves the cover per record and collapses the cover area when none resolves, so the invented name degraded to a gallery of coverless cards — which is why it survived three cards of this family. But `ListView.availableViews` asks `schema.options?.gallery?.imageField`, and a key this relay always supplied made that check answer YES for **every object view whitelisting `gallery`**. Whitelist ∩ resolvable — the mechanism that exists to stop a visualization being offered with nothing behind it — was answering about a name this file wrote rather than one the author did.

`galleryViewOptions` now mirrors `ganttViewOptions` next door: the view's own block spread whole, the two legacy cover spellings cross-filling each other **only when one was declared**, and `titleField` keeping its `'name'` display floor (a display default is not a binding — the same rung objectui#3129 and #6557 established and #7070 kept).

⚠️ **User-visible:** a view that whitelisted `gallery` without a `gallery:` block loses the Gallery toggle. That is ADR-0047 working; it was only ever offered because this relay answered the gate on the author's behalf.

⚠️ **The premise was measured BEFORE the deletion**, which is the discipline objectui#7070 wrote down ("#7029's mechanic is only correct where a refusal path exists"). `ObjectGallery` keeps its own cover guess and that is correct there: it is the component's decision about an unconfigured record, and it is honest because the cover area collapses when the guess yields nothing.

## Fixture triage — two positive controls RE-ANCHORED, not deleted

The source scans in `ObjectView.calendarBinding-7029.test.tsx` and `ObjectView.ganttBinding-7070.test.tsx` each carried a same-class positive control anchored on this PR's `'image'` literal, with an explicit instruction to whoever retired it: re-anchor, do not delete, do not weaken to the machinery control. Both are re-anchored onto the chart branch's `|| 'value'` measure floor — still present, same one-rung class, and deliberately left standing here. Both instructions are carried forward verbatim to whoever retires `'value'`.

## What is deliberately NOT here, and why

- ⛔ **chart `'name'` / `'value'`** at three faces. Filed as **#8168**. `ObjectChart` has NO refusal screen: `runAggregate` passes `groupBy` straight through with no guard, and the `find` leg buckets on `record[groupBy] ?? 'Unknown'`. Deleting the floors today produces a backend-dependent outcome, not an honest refusal — so it fails objectui#7070's stated precondition. The refusal screen landed as its own card for timeline (objectui#7459) before #7500 deleted the floors; this follows that shape.
- ⛔ **map `'location'`** at two faces. Filed as **#8169**, and it runs the OTHER WAY. `ObjectMap.getMapConfig` has a documented default branch guessing `latitude` / `longitude` / `location`, kept deliberately by objectui#5953 while that card removed the title guess from the same branch. The relay floor makes `getMapConfig` take its FLAT branch, which suppresses the lat/lng half — so deleting the relay floor would make the tree invent **three** names where it invents one today. Two faces holding opposite documented postures on one guess is a ruling, not a patch.
- ⛔ **gantt `'progress'` / `'dependencies'`** — objectui#7499's subject, in `pm:awaiting-maintainer`. Untouched.
- ⛔ **the interface-page calendar refusal-screen rider** — the highest-value user-visible piece left in the card, filed as **#8170**. It rewords a localized string and ten locale packs must follow; `packages/i18n/**` was held by two in-flight PRs. No locale pack is touched by this PR.

## Census re-measured on this branch

Re-measured independently rather than trusted from the card or triage; every line number in both had moved. Three corrections to the card's accounting:

- the chart class exists in **three** files (triage found the app-shell one), and the app-shell chart site carries **both** `'name'` and `'value'` — neither the card nor triage recorded the second;
- the `showViewSwitcher` length count has **three** faces, not two (table above);
- ⭐ **the gallery cover invention has exactly ONE site, not three.** The two sibling faces build their gallery block through `defaultGalleryFromObject`, which returns a cover only when the OBJECT declares an image-typed field and `undefined` otherwise — a derivation from the object definition, never a fabricated name, the same shape as `detectStatusField` under ADR-0085. Only `ObjectView`'s `|| 'image'` was inventing.

`titleField … || 'name'` is deliberately NOT in this class anywhere: it is the display-name floor objectui#3129 / #6557 established and #7070 explicitly kept ("a display-name default, not a date axis").

## Tests

**Everything `turbo ls --affected` names against `20316bac3`, in one run: 845 test files, 10256 tests, 1 skipped, 0 failures.** The affected set is 8 packages; the 5 that carry tests are `@object-ui/app-shell` (636), `@object-ui/console` (89), `@object-ui/plugin-list` (70), `@object-ui/example-schema-catalog` (29), `@object-ui/plugin-map` (20) and `@object-ui/example-console-starter` (1) — 845, which is the run's file count exactly. `@object-ui/example-byo-backend-console` and `@object-ui/site` carry none. Nothing in the affected set went unrun.

⚠️ **One real failure was found and corrected along the way, not explained away.** `ObjectView.titleFieldConvergence.test.tsx` (objectui#6557) pins all six `titleField` / `labelField` seams to ONE expression shape, using `viewDef` as the mechanical proxy for "view-declared". `galleryViewOptions` first read the rung off a local alias — same value, but it blinds that scan to exactly what it hunts. The pin was right and the code was wrong, so the code changed back to the family spelling; weakening the regex would have been the other way round.

New pins: `ListView.switcherChrome-7547.test.tsx` (8 cases) and `ObjectView.galleryBinding-7547.test.tsx` (13 cases). Every absence arm is paired with a control that whitelists the SAME types or declares the SAME block, so a fix that simply emitted nothing cannot pass both halves.

**Reverse verification — direction predicted before running, then observed.** Each mutation applied after committing; the anchor line printed before and after (not merely counted, since a no-op edit exits 0 and would read as a run); restore proved BY STATE, `git hash-object` equal to `git rev-parse HEAD:PATH`, plus `git diff HEAD` at 0 lines.

- Restore `{viewSwitcherOffered && (` to `{showViewSwitcher && (` — anchor 1 before, 1 injected, 0 left. **4 failed / 4 passed**: the reds are exactly the four arms asserting no chrome, the greens exactly the four controls.
- Restore the `|| 'image'` tail on the `declaredImage` rung — anchor 1 before, 1 injected. **6 failed / 7 passed**: the reds are exactly the four "invents no cover field" arms plus the two source-scan cases, the greens exactly the declared-config controls, which are unobservable in either world. That asymmetry is the point.

**Type-check** — `Done` for `@object-ui/app-shell`, `@object-ui/plugin-list`, `@object-ui/plugin-map` (rc 0), and for `@object-ui/console` once its dependency closure is built. The script is `tsc --noEmit && tsc -p tsconfig.test.json`: `tsconfig.json` EXCLUDES tests and a dedicated test project includes them, chained from `type-check` and enforced by `scripts/check-type-check-coverage.mjs`. **Proved by `--listFiles` rather than assumed:** all three app-shell pins appear in the 4425-file test program and the gallery pin appears 0 times in the 3685-file source program; the switcher pin appears in plugin-list's 1495-file test program.

**Lint** — `eslint --no-inline-config --format json` over the 7 changed source files: array length **7**, **0 errors**, 400 warnings, all pre-existing classes. Measured per-rule against the same files at `20316bac3` via `--stdin-filename`: `ListView.tsx` and `InterfaceListPage.tsx` have a **zero delta**; `ObjectView.tsx` is +2 (`no-explicit-any` 143 to 144 and `react-refresh/only-export-components` 13 to 14), both from the new `galleryViewOptions` export — exactly the two warnings each of its three sibling helpers already contributes. No new rule appears anywhere. The narrowing to changed files is a measurement, not a sample: `eslint.config.js` extends `tseslint.configs.recommended`, NOT the type-checked preset, and declares no `parserOptions.project` / `projectService`, so no rule reads cross-file type information and this diff cannot move the verdict on a file it does not contain.

**Gates** — `check-changeset-presence` (8 source files of 2 released packages, 1 changeset), `check-changeset-no-major`, `check:control-bytes`, `check:self-import`, `check:phantom-deps`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:unreferenced-sources`, and `check-governed-queue-guard --test` over all 9 changed paths (NOT GOVERNED) — all green. The repo-wide `pnpm lint` is CI's.

## Clause-② — assessed NO, and both traps checked explicitly

No declared type or schema member moves and no `@objectstack/spec` change; what changes is that a renderer stops inventing a binding name and a switcher predicate narrows. Nothing that was accepted is now rejected at a validation boundary — the same metadata still validates and still renders; it is simply no longer offered a toggle it had no binding for. Behaviour change on a published renderer, not an accept-set change.

- **(a) name already declared elsewhere?** `git grep galleryViewOptions` over the whole repo: the only non-test hits are its definition and its single call site, both in this file. No collision.
- **(b) `export *` widening the public face?** `packages/app-shell/src/index.ts` contains **zero** `export *` statements — every export is an explicit named list, and none of the four `*ViewOptions` helpers appears in it. The package's only entry is `./dist/index.js` from that file, and the sole `export * from` anywhere in the package's `src` is inside a test file. `galleryViewOptions` is module-scoped for its co-located regression suite and does not reach the published face — the same standing as `ganttViewOptions`, `calendarViewOptions` and `timelineViewOptions`.

No `needs:contract-review` label, on that measurement. ⚠️ Say so if you read it differently and I will attach it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_