### PR TITLE
docs(auth): compile every README snippet against the shipped surface

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -25,16 +25,18 @@ npm install @object-ui/auth
 ## Quick Start
 
 ```tsx
-import { AuthProvider, useAuth, AuthGuard } from '@object-ui/auth';
-import { createAuthClient } from '@object-ui/auth';
+import type { ReactNode } from 'react';
+import { AuthProvider, AuthGuard, createAuthClient, useAuth } from '@object-ui/auth';
 
-const authClient = createAuthClient({
-  baseURL: 'https://api.example.com/auth',
-});
+// Your app supplies the sign-in page shown to unauthenticated visitors.
+declare const LoginPage: () => ReactNode;
+
+const authUrl = 'https://api.example.com/auth';
+const authClient = createAuthClient({ baseURL: authUrl });
 
 function App() {
   return (
-    <AuthProvider client={authClient}>
+    <AuthProvider authUrl={authUrl} client={authClient}>
       <AuthGuard fallback={<LoginPage />}>
         <Dashboard />
       </AuthGuard>
@@ -57,12 +59,21 @@ function Dashboard() {
 
 ### AuthProvider
 
-Wraps your application with authentication context:
+Wraps your application with authentication context. `authUrl` is **required**;
+`client` is optional, and when you pass one it is used instead of the client
+`AuthProvider` would otherwise build from `authUrl`:
 
 ```tsx
-<AuthProvider client={authClient}>
+import type { ReactNode } from 'react';
+import { AuthProvider } from '@object-ui/auth';
+import type { AuthClient } from '@object-ui/auth';
+
+declare const authClient: AuthClient;
+declare const App: () => ReactNode;
+
+<AuthProvider authUrl="/api/v1/auth" client={authClient}>
   <App />
-</AuthProvider>
+</AuthProvider>;
 ```
 
 ### useAuth
@@ -70,6 +81,8 @@ Wraps your application with authentication context:
 Hook for accessing auth state and methods:
 
 ```tsx
+import { useAuth } from '@object-ui/auth';
+
 const {
   user,
   session,
@@ -100,9 +113,14 @@ const {
 Protects children from unauthenticated access:
 
 ```tsx
+import type { ReactNode } from 'react';
+import { AuthGuard, LoginForm } from '@object-ui/auth';
+
+declare const ProtectedContent: () => ReactNode;
+
 <AuthGuard fallback={<LoginForm />}>
   <ProtectedContent />
-</AuthGuard>
+</AuthGuard>;
 ```
 
 ### LoginForm / RegisterForm / ForgotPasswordForm
@@ -110,9 +128,13 @@ Protects children from unauthenticated access:
 Pre-built authentication form components:
 
 ```tsx
-<LoginForm onSuccess={() => navigate('/dashboard')} />
-<RegisterForm onSuccess={() => navigate('/welcome')} />
-<ForgotPasswordForm onSuccess={() => navigate('/check-email')} />
+import { ForgotPasswordForm, LoginForm, RegisterForm } from '@object-ui/auth';
+
+declare const navigate: (to: string) => void;
+
+<LoginForm onSuccess={() => navigate('/dashboard')} />;
+<RegisterForm onSuccess={() => navigate('/welcome')} />;
+<ForgotPasswordForm onSuccess={() => navigate('/check-email')} />;
 ```
 
 ### UserMenu
@@ -120,7 +142,9 @@ Pre-built authentication form components:
 Displays current user info with avatar and sign-out:
 
 ```tsx
-<UserMenu />
+import { UserMenu } from '@object-ui/auth';
+
+<UserMenu />;
 ```
 
 ### createAuthenticatedFetch
@@ -129,6 +153,8 @@ Creates a fetch wrapper that injects the stored Bearer token (plus
 `X-Tenant-ID` and `Accept-Language`) into API requests:
 
 ```tsx
+import { createAuthenticatedFetch } from '@object-ui/auth';
+
 const authedFetch = createAuthenticatedFetch();
 
 // For fetches whose target URL comes from view metadata (`provider: 'api'`
@@ -330,7 +356,10 @@ This feature aligns with the `PreviewModeConfig` from `@objectstack/spec/kernel`
 ### Usage
 
 ```tsx
+import type { ReactNode } from 'react';
 import { AuthProvider, PreviewBanner } from '@object-ui/auth';
+
+declare const Dashboard: () => ReactNode;
 
 function App() {
   return (
@@ -377,6 +406,8 @@ import { PreviewBanner } from '@object-ui/auth';
 Use the `useAuth` hook to check if the app is in preview mode:
 
 ```tsx
+import { useAuth } from '@object-ui/auth';
+
 function MyComponent() {
   const { isPreviewMode, previewMode } = useAuth();
 

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -775,8 +775,6 @@ const UNGATED_DOCS = {
     'diagnostic(s) (TS2420, TS2355) — a `DataSource` implementation written as `// ... other ' +
     'methods`. This entry read 9 until objectui#7417 paid down the three TS2305s it carried; ' +
     'what is left is fragment shape, and no gate reads this page\'s import names.',
-  'packages/auth/README.md':
-    '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 15 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2741x1 — candidate real defects, un-triaged',
   'packages/fields/README.md':
     '2 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 1 unresolved-module diagnostic(s)',
   'packages/plugin-charts/README.md':


### PR DESCRIPTION
Part of #5174 (batch 28: packages/auth/README.md)

Burns down the `packages/auth/README.md` row of `UNGATED_DOCS` in `scripts/check-doc-snippet-types.mjs`. The page's ten `tsx` fences now compile in the gate's covered tier instead of being ledgered.

- Base: `origin/main` `153d43237` (carries PR #8180, batch 27). Head: `7293545be`. One commit, no amend, no force-push.
- Files: `packages/auth/README.md` (+45/-16) and `scripts/check-doc-snippet-types.mjs` (-2, the two lines of the ledger row and nothing else).

## Census — two readings

Both taken with the gate's own exported analyzer (`analyze` / `compileSnippets`), the target forced into the compiled tier and every other ledger row left ungated. No hand-written regex.

### Reading 1 — ledger-literal, on the base

17 diagnostics, matching the ledger row exactly: 1 parse + 15 undefined-name + TS2741 x1.

| Fence (base line) | Diagnostics | By code |
| --- | --- | --- |
| 27 Quick Start | 2 | TS2741 `authUrl` missing on the AuthProvider element; TS2304 `LoginPage` |
| 62 AuthProvider | 4 | TS2304 `AuthProvider` x2, `authClient`, `App` |
| 72 useAuth | 1 | TS2304 `useAuth` |
| 102 AuthGuard | 4 | TS2304 `AuthGuard` x2, `LoginForm`, `ProtectedContent` |
| 112 forms | 1 | PARSE TS2657 "JSX expressions must have one parent element" |
| 122 UserMenu | 1 | TS2304 `UserMenu` |
| 131 createAuthenticatedFetch | 2 | TS2304 `createAuthenticatedFetch` x2 |
| 332 preview usage | 1 | TS2304 `Dashboard` |
| 368 PreviewBanner | 0 | clean already |
| 379 detecting preview | 1 | TS2304 `useAuth` |
| **total** | **17** | parse TS2657 x1, TS2304 x15, TS2741 x1 |

The ledger's canned wording for the parse diagnostic is wrong on this page: it says "blocks fenced `ts` that are bare object literals or elided bodies". This page has no `ts` fence and no object-literal fence. The single parse failure is three sibling JSX elements written as one expression (fence 112). Moot now that the row is deleted, recorded because the wording is shared with other rows.

### Reading 2 — after imports and stand-ins, in memory

Only the missing import lines plus `declare` stand-ins for names the page never defines were added, and fence 112 was given a JSX parent so its parse failure stopped hiding the element checks behind it. Nothing about any prop was touched.

| Fence | Diagnostics after imports |
| --- | --- |
| 27 | 1 — TS2741 `authUrl` missing |
| 62 | 1 — TS2741 `authUrl` missing |
| 72, 102, 112, 122, 131, 332, 368, 379 | 0 |
| **total** | **2** |

**This is the reading the ledger-or-repair decision was made on.** The real type debt is 2, not 1: fence 62's `AuthProvider` tag was unresolved, and an unresolved JSX tag name short-circuits the prop check on its own element, so it hid a second TS2741 behind its TS2304 — the same mechanism batch 27 measured and wrote into the worklist. The other 15 diagnostics were import shape, not defects.

Reading it the other way round: the ledger row's 17 overstated the page's real debt (15 of the 17 were missing imports) while its `TS2741x1` understated the type debt by exactly one. Both halves of a mixed row are unreliable, in opposite directions.

Measured, not assumed: fence 112's parse failure hid **no** prop defect. With a parent element added and nothing else changed, the fence reads zero — `onSuccess` is a real prop on all three form components.

## Per-fence decision

Every fence got a typed binding; no fragment marker was added anywhere on this page (0 before, 0 after), and no type was loosened.

| Fence | Decision |
| --- | --- |
| 27 Quick Start | Repaired. `authUrl` added beside `client`; `LoginPage` typed as `declare const LoginPage: () =` a `ReactNode` returner; the URL hoisted to a `const` so the client's `baseURL` and the prop are visibly the same string rather than two copies. |
| 62 AuthProvider | Continuation fence: own import line, `declare const authClient: AuthClient` (the exported type), `declare const App` stand-in, `authUrl` added. Prose above it now states that `authUrl` is required and `client` optional. |
| 72 useAuth | Continuation fence: own import line. |
| 102 AuthGuard | Continuation fence: own import line plus a `ProtectedContent` stand-in. |
| 112 forms | Repaired parse failure: the three elements are now separate statements. Own import line plus a `navigate` stand-in typed `(to: string) =` void. |
| 122 UserMenu | Continuation fence: own import line. |
| 131 createAuthenticatedFetch | Continuation fence: own import line. |
| 332 preview usage | Continuation fence: `Dashboard` stand-in. Its `previewMode` object literal was already clean. |
| 368 PreviewBanner | Untouched — it compiled on the base and still does. |
| 379 detecting preview | Continuation fence: own import line. |

Stand-in spelling is the one already established on this corpus (`packages/app-shell/README.md:59`): `import type { ReactNode } from 'react'` plus a `declare const`.

## The TS2741 decision — README defect, repaired

Decided against the exported type, as ruled.

- `AuthProviderProps` — `packages/auth/src/AuthProvider.tsx:119` — `extends AuthProviderOptions`, adding `children`, `enabled?`, `previewMode?: PreviewModeOptions`.
- `AuthProviderOptions` — `packages/auth/src/types.ts:513` — declares `authUrl: string` (**required**, line 515), `client?: AuthClient` (**optional**, line 517), `onAuthStateChange?`, `redirectTo?`.

So the dispatch's framing (that the type refuses one of `client` / `authUrl`) does not hold: **both are members**. The type refuses nothing the page passed; it *requires* something the page omitted. The Quick Start and the AuthProvider example passed `client` alone, and `authUrl` is required.

**Verdict: README defect, branch A — repaired to the shipped surface.** The page used to teach that `client` alone configures the provider. Every call site in this repository writes both, including the published skill guide `skills/objectui/guides/auth-permissions.md:29` and `:328`, `skills/objectui/guides/testing.md:201`, the component's own three JSDoc examples (`AuthProvider.tsx:144`, `:151`, `:157`), and 20-plus tests under `packages/auth/src/__tests__/`. The README was the only place teaching the one-prop form.

**Separate observation, offered as a finding proposal rather than filed** (the runtime read is cited, per the dispatch's rule that a type/runtime divergence found by this batch belongs in the PR body and the PM opens its card):

`authUrl` is required by the type but dead at runtime whenever `client` is supplied. The only read is `AuthProvider.tsx:171` — `externalClient ?? createAuthClient({ baseURL: authUrl })` — and `authUrl` appears nowhere else in the component (greps at `:163`, `:171`, `:172` only). A caller who already has a client must still pass a URL that is never used. Contract-first would express this as a discriminated union (`client` XOR `authUrl`) so a declaration cannot promise a value the runtime ignores. Out of scope here twice over: it is a `packages/auth/src/**` change this batch may not make, and the README compiles correctly without it. No card filed by me.

## Ruling 4 — key surface

**The bound does not bite anywhere on this page.** No binding here is `BaseSchema`-derived, so objectui#7927's hand-classification does not apply and the table collapses to the compiler's own verdict, per fence:

| Fence | Binding | Who judges keys |
| --- | --- | --- |
| 27, 62, 332 | `AuthProviderProps` (`AuthProvider.tsx:119`) extending `AuthProviderOptions` (`types.ts:513`) | The compiler. Neither interface carries an index signature, and JSX attributes are excess-property-checked, so an undeclared prop is a diagnostic rather than a silent pass. |
| 332 `previewMode` value | `PreviewModeOptions` (`types.ts:411`) | The compiler. No index signature; the literal is contextually typed, so its four keys (`simulatedRole`, `simulatedUserName`, `readOnly`, `bannerMessage`) are excess-checked. All four are declared (`:415`, `:417`, `:419`, `:423`). |
| 102, 112, 122, 368 | `AuthGuardProps`, `LoginFormProps` / `RegisterFormProps` / `ForgotPasswordFormProps`, `UserMenuProps`, `PreviewBannerProps` | The compiler, same reason. |
| 72, 131, 379 | No props object — a hook destructure and two function calls | Not a key question. |

A2 confirmed for both types named in the dispatch: `AuthProviderProps` and `PreviewModeOptions` are plain props interfaces with no index signature.

Consistency check done while here: the `useAuth` table (9 rows) and the `PreviewModeOptions` table (6 rows) both match their declarations exactly, and fence 72 destructures all 9 names with zero diagnostics.

## Ledger decision

The page reads **zero** after the repairs, so its `UNGATED_DOCS` entry is **deleted**, not rewritten. The gate diff is exactly those two lines and nothing else.

Counters on the head, from the gate's own summary:

| | base `153d43237` | head `7293545be` |
| --- | --- | --- |
| documents scanned | 229 | 229 |
| covered | 219 | 220 |
| ungated rows | 10 | 9 |
| blocks to compile | 587 | 597 |
| declared fragments | 158 | 158 |

The 10 new compiled blocks are exactly this page's 10 fences. No pin enumerates this row: `scripts/__tests__/check-doc-snippet-types.test.ts` pins only the root `README.md` row (`:600`, `:601`), so no test file needed editing.

## Strictness region

The region from the `Fence scanning` banner to EOF, 83711 bytes, the ledger sitting above it:

| | sha256 |
| --- | --- |
| base `153d43237` | `2749d53ae3a8df033a53b8d7a354fa7e22ee2d1a17f6ad0c3d61122e904e084b` |
| head `7293545be` | `2749d53ae3a8df033a53b8d7a354fa7e22ee2d1a17f6ad0c3d61122e904e084b` |

Byte-identical, and identical to the PR #8158 baseline.

## Positive control

Run against the committed tree, under a `trap` with absolute paths.

- Clean first: `git diff HEAD -- packages/auth/README.md` 0 bytes; disk blob equals the HEAD blob `8e7c95fd2ec32b9aa07443d9f556880e3c1b6bbf`.
- Injection: `authUrl={authUrl}` to `authUrl={123}` in the Quick Start fence. Landing proved by anchor counts (anchor 1 to 0, injected text 0 to 1) plus the blob move to `d705be3ed1fef0345b4e1f0ddb88dc342b472c85` — not by an editor's exit code.
- Gate under injection: **exit 1**, naming the file and the line: `[semantic]  packages/auth/README.md:39:19  TS2322: Type 'number' is not assignable to type 'string'.`
- Restore proved **by state**: `git diff HEAD -- path` 0 bytes AND disk blob back to `8e7c95fd2ec32b9aa07443d9f556880e3c1b6bbf` (the HEAD blob), `git status --porcelain` empty.

## Gates

All pinned to head `7293545be` on a clean tree. Exit codes captured by redirect-then-capture, never through a pipe.

| Gate | Exit |
| --- | --- |
| `pnpm check:doc-snippets` | 0 — every covered snippet compiles; page in the compiled tier |
| `pnpm exec vitest run scripts/__tests__/check-doc-snippet-types.test.ts scripts/__tests__/check-doc-fence-languages.test.ts` | 0 (123 tests) |
| `pnpm exec vitest run scripts/__tests__/` (whole directory) | 0 (115 files, 3415 tests) |
| `pnpm check:doc-types` | 0 |
| `pnpm check:readme-exports` | 0 (516 self-imports judged, 0 fabricated) |
| `pnpm check:doc-fences` | 0 |
| `pnpm type-check:scripts` | 0 |
| `pnpm lint:root` | 0 (32 pre-existing warnings, 0 errors) |
| `pnpm check:control-bytes` | 0 |
| `grep -naP` control-byte self-scan, both changed paths | 1 (no match — clean) |
| `node scripts/check-changeset-presence.mjs` | 0 — no changeset owed (0 of 2 files are published source or a moved manifest contract) |
| `node scripts/check-governed-queue-guard.mjs --test` (both paths) | 0 — NOT GOVERNED |
| `pnpm check:entry-guard` | 0 |
| turbo build closure (`--build-filter`, `--concurrency=2`) | 0 (35 tasks) |

Re-derived against the actual diff (a markdown page plus one `scripts/*.mjs`), beyond the dispatched list — all 0: `check-doc-component-types.mjs`, `check-doc-expression-carriage.mjs`, `check-doc-links.mjs`, `check-doc-snippet-types.mjs --emit-census`, `check-shell-escape-residue.mjs`, `check-lint-coverage.mjs`, `check-type-check-coverage.mjs`, `check:doc-example-readers`, `check:esm-specifiers`, `check:node-esm-load`.

One note on the last of those. `pnpm check:node-esm-load` first exited **1**, and the reason was environmental, not this diff: turbo shares one cache across every worktree of a checkout, so six packages replayed artifacts built in `/home/user/objectui-issue-5174-b27` (batch 27's worktree) and the gate correctly refused to grade another tree's output. Re-run with `--force-build`, as the gate's own message instructs, it exits **0** with 37 of 37 gradable entries built by this tree. Worth knowing for any batch that runs it next to a sibling worktree.

`Live E2E (informational)` is red on every branch today for an upstream reason (#7990 / objectstack#16186) and is not this PR's.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_