### PR TITLE
fix(plugin-view,plugin-list): stop writing the retired `groupField` onto the generated object-kanban node

### DIFF
--- a/.changeset/7773-kanban-adapter-groupfield-write.md
+++ b/.changeset/7773-kanban-adapter-groupfield-write.md
@@ -1,0 +1,56 @@
+---
+'@object-ui/plugin-view': minor
+'@object-ui/plugin-list': minor
+---
+
+The two kanban adapters stop writing the retired `groupField` onto the
+`object-kanban` node they generate (objectui#7773). `groupBy` — the key the
+renderer actually reads — is unchanged and is now the only lane key emitted.
+
+**What was measured, on this branch's base (`a915064e`).** Both adapters emitted
+the key twice:
+
+```
+packages/plugin-view/src/ObjectView.tsx:1362   groupField: groupBy,
+packages/plugin-list/src/ListView.tsx:2500     groupField: laneField,
+```
+
+The `object-kanban` renderer never read it: `groupField` has ZERO hits anywhere
+under `packages/plugin-kanban/`, against a control of thirteen `schema.groupBy`
+read sites in `ObjectKanban.tsx` from the same query — so the zero is a reading,
+not a blind grep. The write was inert; the board grouped by `groupBy` and
+`groupField` rode along unread.
+
+**Why it is removed rather than tolerated.** objectui#7322 RETIRED
+`groupField` on this node on both published faces — `groupField?: never` on the
+TypeScript interface and a `retirementTombstone()` in the Zod mirror, which
+refuses an authored value BY NAME. So the adapters were producers emitting a
+node their own published contract rejects. That was harmless only because a
+generated node never reaches the mirror at runtime (`SchemaRenderer` runs the
+structural `validateSchema`, not `safeValidateSchema`) — but the CLI's
+`os check` / `os validate` DO run the mirror, so the identical node was already
+refused when authored by hand and admitted when generated. This closes that
+split.
+
+**What changes for a consumer.** Nothing on any documented path: the renderer's
+behaviour is byte-identical, because it never read the key. A host that
+registers its own `object-kanban` component and reads `props.schema.groupField`
+off the generated node now reads `undefined` — read `groupBy` instead, which
+carries the same value and always did. Graded `minor` rather than `patch` for
+exactly that narrowing, following the repo convention that objectui's own
+breaking changes ship as `minor` (AGENTS.md 版本号策略, mechanically enforced by
+`scripts/check-changeset-no-major.mjs`).
+
+**Who is NOT affected — the boundary is node-local.** Every VIEW-LEVEL
+`groupField` read is untouched and still live: it is a legacy alias of the
+spec's `groupByField` on the kanban *view config*, mapped by
+`normalize-list-view.ts`, and both adapters still resolve lanes through it
+(`ObjectView.tsx`'s `kanbanCfg.groupField ||`, `ListView.tsx`'s
+`groupByField || groupField`). Authoring `options.kanban.groupField` on a
+`list-view` or `object-view` keeps working exactly as documented in
+`packages/plugin-list/README.md`. `groupField` is dead only on the generated
+`object-kanban` NODE.
+
+The two tests that pinned the duplicate write are TURNED, not deleted — they now
+assert the key is absent, so restoring the write reddens them instead of being
+silently re-blessed by a missing assertion.

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -2493,11 +2493,28 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
         // vocabulary keys from the passthrough (mirrors plugin-view's adapter).
         const { columns: kanbanCardColumns, groupByField, groupField, cardFields, titleField, ...restKanban } = kanbanCfg as Record<string, any>;
         const laneField = groupByField || groupField || detectStatusField(objectDef) || undefined;
+        // `groupBy` is the lane key and the ONLY one written here. This node
+        // used to carry `groupField: laneField` alongside it — a duplicate the
+        // `object-kanban` renderer never read (zero `groupField` sites under
+        // `packages/plugin-kanban/`, against thirteen `schema.groupBy` reads in
+        // `ObjectKanban.tsx`). objectui#7322 retired the key on that node on
+        // both faces — `groupField?: never` on the TS interface and a
+        // `retirementTombstone()` in the zod mirror — so the write made this
+        // adapter emit a node the published contract refuses BY NAME. It was
+        // inert only because the generated node never reaches
+        // `safeValidateSchema` (SchemaRenderer runs the structural
+        // `validateSchema`); the CLI's `os check` / `os validate` do run the
+        // mirror, so the same node authored by hand was already rejected.
+        // ⛔ Do not restore it: the tombstone is the contract.
+        //
+        // ⚠️ NODE-LOCAL, and the distinction is the whole card: the VIEW-LEVEL
+        // `groupField` alias read just above (`groupByField || groupField`) is
+        // LIVE — a legacy spelling of the spec's `groupByField` — and is
+        // untouched. Only the write onto the generated node is dead.
         return {
           type: 'object-kanban',
           ...baseProps,
           groupBy: laneField,
-          groupField: laneField,
           ...(titleField ? { titleField } : {}),
           cardFields: cardFields || kanbanCardColumns || effectiveFields || [],
           ...(groupingConfig ? { grouping: groupingConfig } : {}),

--- a/packages/plugin-list/src/__tests__/ListView.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.test.tsx
@@ -2801,7 +2801,15 @@ describe('ListView — kanban config speaks the spec vocabulary', () => {
 
     const last = kanbanCalls.at(-1);
     expect(last?.schema?.groupBy).toBe('stage');
-    expect(last?.schema?.groupField).toBe('stage');
+    // TURNED, not deleted (objectui#7773). This line read
+    // `expect(last?.schema?.groupField).toBe('stage')` and pinned a duplicate
+    // write the `object-kanban` renderer never read — the key objectui#7322
+    // retired on that node (`groupField?: never` / `retirementTombstone()`).
+    // Kept in place and inverted so the history stays legible and so re-adding
+    // the write reddens here, rather than being silently re-blessed by a
+    // missing assertion. ⚠️ Node-local: the VIEW-LEVEL `kanban.groupField`
+    // alias is still live and still read — the two `it` blocks below pin it.
+    expect(last?.schema?.groupField).toBeUndefined();
   });
 
   it('still honors the deprecated `groupField` alias', async () => {

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -1355,11 +1355,28 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
         const kanbanConditionalFormatting =
           kanbanCfg.conditionalFormatting ??
           activeView?.conditionalFormatting;
+        // `groupBy` is the lane key and the ONLY one written here. This node
+        // used to carry `groupField: groupBy` alongside it — a duplicate the
+        // `object-kanban` renderer never read (zero `groupField` sites under
+        // `packages/plugin-kanban/`, against thirteen `schema.groupBy` reads in
+        // `ObjectKanban.tsx`). objectui#7322 retired the key on that node on
+        // both faces — `groupField?: never` on the TS interface and a
+        // `retirementTombstone()` in the zod mirror — so the write made this
+        // adapter emit a node the published contract refuses BY NAME. It was
+        // inert only because the generated node never reaches
+        // `safeValidateSchema` (SchemaRenderer runs the structural
+        // `validateSchema`); the CLI's `os check` / `os validate` do run the
+        // mirror, so the same node authored by hand was already rejected.
+        // ⛔ Do not restore it: the tombstone is the contract.
+        //
+        // ⚠️ NODE-LOCAL, and the distinction is the whole card: the VIEW-LEVEL
+        // `kanbanCfg.groupField` alias read above is LIVE (a legacy spelling of
+        // the spec's `groupByField`, mapped by `normalize-list-view.ts`) and is
+        // untouched. Only the write onto the generated node is dead.
         return {
           type: 'object-kanban',
           ...baseProps,
           groupBy,
-          groupField: groupBy,
           titleField: kanbanCfg.titleField || 'name',
           cardFields,
           ...restKanban,

--- a/packages/plugin-view/src/__tests__/ObjectView.kanbanConditionalFormatting.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.kanbanConditionalFormatting.test.tsx
@@ -168,7 +168,15 @@ describe('the kanban branch reads `conditionalFormatting` only where it is decla
       view: { kanban: { groupByField: 'stage', columns: ['name', 'amount'], titleField: 'name' } },
     });
     expect(node.groupBy).toBe('stage');
-    expect(node.groupField).toBe('stage');
+    // TURNED, not deleted (objectui#7773). This line read
+    // `expect(node.groupField).toBe('stage')` and pinned a duplicate write the
+    // `object-kanban` renderer never read — the key objectui#7322 retired on
+    // that node (`groupField?: never` / `retirementTombstone()`). Kept in place
+    // and inverted so the history stays legible and so re-adding the write
+    // reddens here, rather than being silently re-blessed by a missing
+    // assertion. ⚠️ Node-local: the VIEW-LEVEL `kanban.groupField` alias this
+    // very view could have been authored with is still live and still read.
+    expect(node.groupField).toBeUndefined();
     expect(node.titleField).toBe('name');
     expect(node.cardFields).toEqual(['name', 'amount']);
   });


### PR DESCRIPTION
Fixes #7773

Both kanban adapters stop writing the retired `groupField` onto the `object-kanban` node they generate. `groupBy` — the key the renderer actually reads — is unchanged and is now the only lane key emitted. The two tests that pinned the duplicate write are **turned, not deleted**: they now assert the key is absent.

## Anchors: measured vs claimed

The card was measured on `4dfdcc3c` and triaged on `0558e0f`; this branch's base is `a915064e`. **`plugin-view` drifted again since triage**, and in the worst possible way:

| Site | card | triage | measured on `a915064e` |
|---|---|---|---|
| `plugin-view/src/ObjectView.tsx` write | `:1279-1284` | `:1283` | **`:1362`** — drifted +79 |
| `plugin-view/.../ObjectView.kanbanConditionalFormatting.test.tsx` pin | `:165` | `:165` | **`:171`** — drifted +6 |
| `plugin-list/src/ListView.tsx` write | `:2412-2416` | `:2500` | `:2500` — matches triage |
| `plugin-list/src/__tests__/ListView.test.tsx` pin | `:2795` | `:2804` | `:2804` — matches triage |
| `plugin-view/src/ObjectView.tsx` live alias read | `:1234` | `:1234` | **`:1313`** |

⚠️ The trap this avoided: triage's instruction was "delete `ObjectView.tsx:1283`". On `a915064e` line 1283 is the `flatKeys` array — a **live** alias-read site. Following the anchor rather than the text would have deleted a live read and left the duplicate write in place. Every edit here was made against matched text, never a line number.

## Zone 2 — the mechanism claims, measured

1. **`groupField` is genuinely retired, and the validator refuses it by name.** Both halves are on disk: `packages/types/src/objectql.ts:2790` `groupField?: never;` and `packages/types/src/zod/objectql.zod.ts:1002` `groupField: retirementTombstone('RETIRED (objectui#7322) …')`, where `retirementTombstone` is `z.never({ error }).optional().describe(...)` (`zod/tombstone.zod.ts`). The refusal is exercised by `packages/types/src/__tests__/object-kanban-group-by-limit-7322.test.ts`, which asserts a `groupField`-authored node is refused **at** `groupField` by both `ObjectKanbanSchema.safeParse` and `safeValidateSchema`. Not merely undocumented — retired, on both faces, with a live refusal test.
2. **Both adapters really wrote it.** `plugin-view/src/ObjectView.tsx:1362` `groupField: groupBy,` and `plugin-list/src/ListView.tsx:2500` `groupField: laneField,`, each inside the `return { type: 'object-kanban', ...baseProps, … }` literal.
3. **There are exactly TWO pins — confirmed, and the count was checked for pins defined by omission too.** Explicit: the two named above. By omission: neither package contains any snapshot file or `toMatchSnapshot`/`toMatchInlineSnapshot`, and no whole-node `toEqual`/`toMatchObject` on an `object-kanban` node, so no third pin could hold the key without naming it. A **third, different** guard does read these two files — `object-kanban-group-by-limit-7322.test.ts`'s off-disk `VIEW_LEVEL_ALIAS_SITES` ledger, which asserts the *live view-level alias reads* are still present. It is untouched by this diff and stays green (run below). Worth flagging because it makes `packages/types` an affected package that `turbo ls --affected` cannot see: the dependency is a file read, not an import.
4. **The renderer really never reads it — zero, with a control that fires.** `git grep -n "groupField" -- packages/plugin-kanban` returns **zero hits** (exit 1). Same grep shape, same path, control key: `git grep -n "schema\.groupBy" -- packages/plugin-kanban/src/ObjectKanban.tsx` returns **13 matching lines**, printed rather than counted (`:701 :702 :713 :725 :726 :731 :740 :741 :749 :847 :937 :965 :995`). The control fires, so the zero is a reading. Checked for omission-shaped reads as well: no `schema[` dynamic access anywhere in `ObjectKanban.tsx`. The one `...schema` spread (`:757`) only forwards the node into `effectiveSchema`; it never reads the key.
5. **No new tombstone is owed.** The `retirementTombstone()` + `?: never` convention already carries `groupField` on this node, landed by objectui#7322. This PR references it rather than adding one — it is the *producer* half catching up to a declaration that already exists.
6. **Line numbers re-measured** — see the table above.

## What changed

- `plugin-view/src/ObjectView.tsx` — drop `groupField: groupBy,` from the generated node.
- `plugin-list/src/ListView.tsx` — drop `groupField: laneField,` from the generated node.
- Both pins turned to `toBeUndefined()`, kept in place with a note saying what they used to assert and why they were inverted.
- A changeset (`minor` for both packages).

⛔ Not touched, deliberately: every **view-level** `groupField` alias read (`ObjectView.tsx` `:1283` `flatKeys`, `:1313`, `:1323`; `ListView.tsx` `:1536`, `:1890`, `:2165`, `:2494`, `:2495`), the `KanbanConfig.groupField` declaration in the zod mirror, `normalize-list-view.ts`'s alias fold, the view-level alias behaviour tests, `plugin-list/README.md` `:126` / `:186` (both view-level config examples), and both CHANGELOGs.

## Docs (objectui#7070)

No doc restates the removed behaviour. The only `object-kanban` **node** authoring page, `content/docs/plugins/plugin-kanban.mdx`, already authors `groupBy` and is already pinned by objectui#7322's test to contain no `groupField`. The two `plugin-list/README.md` hits are view-level config, which is unchanged.

## Contract review — clause ② considered, and judged not to apply

Reported rather than assumed, because removing an emitted key is exactly where "removal is always safe" goes wrong:

- **No contract is edited.** `packages/types` is untouched; no schema, no validator, no accept set moves.
- **No published face widens.** This diff exports nothing — it is comments, two deleted object properties and two flipped assertions. Nothing new reaches an `index.ts` or an `export *`.
- **Direction of the accept/reject change.** The *generated artifact* moves from "would be rejected by `safeValidateSchema`" to "accepted". The validator did not move; the producer stopped emitting a key the validator already refused. Nothing that validated green now validates red.
- **The one real narrowing** is a host that registers its own `object-kanban` component and reads `props.schema.groupField` off the generated node: it now reads `undefined`. That is graded in the changeset as `minor`, and it is a read of a key the published type has declared `never` since objectui#7322.

If a reviewer reads the produced-artifact accept/reject shift as clause-② territory, `needs:contract-review` is the right label and I will attach it on request — I judged it out, and am saying so rather than staying quiet.

## Verification

All at `7644616c6`.

**Ablation — mutate, prove on disk, prove the pins redden, restore, prove the restore BY STATE.** Full record in the report comment on #7773.

- Green (committed fix): `3 test files / 183 tests passed`.
- Mutate: the duplicate write re-added to both adapters. Anchor `grep -c` `'groupField: groupBy,'` 0 → 1, `'groupField: laneField,'` 0 → 1; `git diff HEAD --stat` = `2 files changed, 2 insertions(+)`. An editor's exit code is not proof — the counts are.
- Red: `exit 1`, `2 failed | 181 passed`. **Both** turned pins reddened, each with `AssertionError: expected 'stage' to be undefined`. This is also the empirical answer to the spread question: in the green legs `toBeUndefined()` passes, so neither `...baseProps` nor `...restKanban` re-introduces the key.
- Restore: `git checkout HEAD -- PATH` (never a bare `git checkout --`, which reads the polluted index). Proven **by state**: `git hash-object` equals `git rev-parse HEAD:PATH` for both files (`c52b11b8…` / `a91b712774…`), and `git diff HEAD` reports 0 changed files. Not by an exit code.
- Green again: `183 tests passed`.

**Suites.** No rebuild was needed for any of this: the pins import the subject by relative path, and the root `vitest.config.mts` aliases every `@object-ui/*` specifier to that package's `src`, so the whole in-repo farm sees the source change directly.

| run | result |
|---|---|
| `vitest run packages/plugin-view/ packages/plugin-map/` | **56 files / 421 tests passed** |
| `vitest run packages/plugin-list/` | **69 files / 866 tests passed** |
| `vitest run …ObjectView.kanbanConditionalFormatting.test.tsx …ListView.test.tsx …object-kanban-group-by-limit-7322.test.ts` | **3 files / 183 tests passed** |
| `pnpm --filter @object-ui/plugin-view --filter @object-ui/plugin-list run type-check` | **exit 0**, `Scope: 2 of 47`, both echoing `tsc --noEmit && tsc -p tsconfig.test.json` |
| `node scripts/check-changeset-presence.mjs` | **exit 0** — "4 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)" |
| `node scripts/check-changeset-no-major.mjs` | **exit 0** — "No changeset declares a `major` bump" |
| `node scripts/check-control-bytes.mjs` | **exit 0** — 6527 tracked text files scanned |
| `node scripts/check-governed-queue-guard.mjs --test` (the 5 changed paths) | **exit 0** — "NOT GOVERNED" |

`type-check` really covers the edited tests, measured not assumed: `tsc -p tsconfig.test.json --listFiles` lists `ListView.test.tsx` and `ObjectView.kanbanConditionalFormatting.test.tsx` in their programs.

**Lint — a declared narrowing, with its three readings.** Run: `eslint --no-inline-config --format json` over the 4 changed files → **exit 0, 0 errors, 275 warnings**, every one pre-existing (`no-explicit-any`, `react-refresh/only-export-components`) on lines this diff does not touch. ① Population: the whole monorepo is governed by a single root `eslint.config.js` (`find . -name 'eslint.config.*'` outside `node_modules` returns exactly that one file). ② Count: 4, read from eslint's own `--format json` output, matching the 4 changed source files. ③ Invariance: type-aware linting is **not** enabled — `grep -n "projectService\|parserOptions\|project:" eslint.config.js` exits 1 — so each file's verdict depends only on its own bytes plus the unchanged shared config, and this diff cannot move the verdict on any file it did not touch. The repo-wide `turbo run lint` is CI's.

**Declared to CI, not run locally.** `turbo ls --affected` from `a915064e` names 9 packages; the 3 with source adjacency to this change (`plugin-view`, `plugin-list`, `plugin-map`) ran in full above. `app-shell` (637 test files), `console` (89) and the three examples plus `site` are left to CI. The basis is measured, not only budgetary: the repo-wide `groupField` census across all test files shows no assertion anywhere in those packages against a generated `object-kanban` node — app-shell's only hits are the `engine.inspector.pageBlock.field.object-kanban.groupField` i18n **key string**, which belongs to the page-block designer and is untouched here.

## Scope

Out of scope, filed separately, nothing folded in: #7772 (the page-block designer inspector half) and #7712 (in flight in `plugin-kanban` / `plugin-calendar` — disjoint packages; I did not reach into either). Related, and confirmed not duplicates: objectui#7322 (the declaration, landed) and objectui#2890 (the broad ListView legacy-vocabulary audit; this is one atomic write out of it, not the audit).

One out-of-scope finding surfaced while measuring and is filed as its own card rather than fixed here: `packages/app-shell/src/views/ObjectView.tsx:2414` still emits the deprecated **view-level** alias pair `{ groupBy, groupField }` into `options.kanban` instead of the spec-canonical `groupByField`, where its sibling `InterfaceListPage.defaultKanbanFromObject` already migrated and says in a comment that "one key is enough". That one is live, not inert — a different defect in a package this PR does not touch.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S


---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_