### PR TITLE
test(plugin-dashboard): pin the chart x LOCAL-select cell — objectui#7696's premise is measured false

### DIFF
--- a/.changeset/7696-chart-local-select-cell-measured.md
+++ b/.changeset/7696-chart-local-select-cell-measured.md
@@ -1,0 +1,15 @@
+---
+---
+
+Test-only change: pin the objectui#7696 cell — a LOCAL select dimension on a dataset
+CHART widget — with the card's own fixture, plus a control that fires. No published
+behaviour changes; nothing outside `packages/plugin-dashboard/src/__tests__/` is touched.
+
+The card modelled the analytics option-label coverage as a 2x2 and reported the
+chart/local-select cell as left open by both objectui#4030 (PR #4324) and objectui#4330
+(PR #4388). Measured on `origin/main`, that cell was closed by PR #4324 itself: a chart
+has always resolved EVERY dimension (PR #4388's `dottedOnly = isTable` removal widened
+the TABLE path, not the chart one), and `buildDimensionLabelMap` keys the AUTHORED label
+beside the stored value, which is what re-translates a row the server already resolved.
+The pin added here says so in the card's own terms so the next reader of the 2x2 gets an
+answer from `git grep 7696` instead of re-deriving it.

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.chartLocalSelectI18n.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.chartLocalSelectI18n.test.tsx
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#7696 — MEASUREMENT of the card's claimed-open 2x2 cell: a LOCAL
+ * select dimension on a CHART widget. The card's own fixture, verbatim:
+ * `duly_duty_register` on `duly_duty`, one local `form` dimension (a select
+ * with three options), a pie with `showLegend: true`, and rows arriving
+ * SERVER-RESOLVED to the object's authored ENGLISH labels (ADR-0021) — the
+ * exact bytes the card measured off
+ * `POST /api/v1/analytics/dataset/query`.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { I18nProvider } from '@object-ui/i18n';
+import { DatasetWidget } from '../DatasetWidget';
+
+/** Capture what the widget hands the chart renderer (jsdom lays out no SVG). */
+let capturedChartProps: any = null;
+beforeAll(() => {
+  ComponentRegistry.register('chart', (props: any) => {
+    capturedChartProps = props;
+    return null;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  capturedChartProps = null;
+  vi.restoreAllMocks();
+});
+
+const FORM_OPTIONS = [
+  { value: 'one_off', label: 'One-off' },
+  { value: 'recurring', label: 'Recurring' },
+  { value: 'standing', label: 'Standing' },
+];
+
+/** The card's object. */
+const DUTY = { name: 'duly_duty', fields: { form: { type: 'select', options: FORM_OPTIONS } } };
+/** The SAME object with the option LIST absent — the control (see below). */
+const DUTY_NO_OPTIONS = { name: 'duly_duty', fields: { form: { type: 'select' } } };
+
+const ZH_BUNDLE = {
+  zh: {
+    duly: {
+      fields: { duly_duty: { form: '形式' } },
+      fieldOptions: {
+        duly_duty: { form: { one_off: '一次性', recurring: '周期性', standing: '常设' } },
+      },
+    },
+  },
+};
+
+function installMetaRouter(docs: Record<string, unknown>) {
+  const requested: string[] = [];
+  global.fetch = vi.fn(async (input: unknown) => {
+    const url = String(input);
+    const m = /\/api\/v1\/meta\/object\/(.+)$/.exec(url);
+    const name = m ? decodeURIComponent(m[1]) : '';
+    requested.push(name);
+    const doc = docs[name];
+    if (!doc) return { ok: false, json: async () => ({}) };
+    return { ok: true, json: async () => ({ item: doc }) };
+  }) as any;
+  return { requested };
+}
+
+const sourceOf = (result: unknown) => ({ queryDataset: vi.fn(async () => result) });
+
+/** The card's measurement: `rows[].form` carries the authored ENGLISH label. */
+const serverResolvedPie = () =>
+  sourceOf({
+    rows: [
+      { form: 'One-off', duty_count: 5 },
+      { form: 'Recurring', duty_count: 3 },
+      { form: 'Standing', duty_count: 2 },
+    ],
+    fields: [
+      // `type: 'string'` — what a select dimension is on the wire.
+      { name: 'form', type: 'string', label: '形式' },
+      { name: 'duty_count', type: 'number', label: '数量' },
+    ],
+    object: 'duly_duty',
+    dimensionFields: { form: 'form' },
+    drillRawRows: [{ form: 'one_off' }, { form: 'recurring' }, { form: 'standing' }],
+  });
+
+const PIE_WIDGET = {
+  type: 'pie',
+  dataset: 'duly_duty_register',
+  dimensions: ['form'],
+  values: ['duty_count'],
+  chartConfig: { showLegend: true },
+};
+
+function renderIn(language: string, ui: React.ReactElement) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false, resources: ZH_BUNDLE }}>
+      {ui}
+    </I18nProvider>,
+  );
+}
+
+/**
+ * The pie's categories, as the chart renderer receives them. A pie legend is
+ * painted from exactly this: `AdvancedChartImpl`'s pie branch builds
+ * `pieConfig[String(row[xAxisKey])] = { label: String(row[xAxisKey]) }` and
+ * hands it to `ChartLegendContent nameKey={xAxisKey}`, so the legend text IS
+ * the category string in these rows.
+ */
+const categories = () => (capturedChartProps?.schema?.data ?? []).map((r: any) => r.form);
+
+describe('objectui#7696 — a LOCAL select dimension on a CHART widget', () => {
+  it('renders the zh-CN option labels as the pie categories', async () => {
+    const { requested } = installMetaRouter({ duly_duty: DUTY });
+    renderIn('zh', <DatasetWidget widget={PIE_WIDGET} dataSource={serverResolvedPie()} />);
+    await waitFor(() => expect(categories()).toContain('周期性'));
+    expect(categories()).toEqual(['一次性', '周期性', '常设']);
+    // The authored English label must not survive beside the translation.
+    expect(categories()).not.toContain('Recurring');
+    // ONE read, on the dataset's base object — a local path walks no relationship.
+    expect(requested).toEqual(['duly_duty']);
+  });
+
+  it('CONTROL — with the option LIST absent the categories stay English', async () => {
+    // A control that FIRES. `resolveDimensionFieldMeta` yields an entry only
+    // for a terminal field that carries `options`, so removing them is the one
+    // change that starves the seam while leaving every other input identical:
+    // same rows, same bundle, same widget, same locale, same read. It is what
+    // makes the assertion above a reading rather than a coincidence — the
+    // fixture CAN produce English, and does, exactly when the option list the
+    // locale bundle is keyed against is missing.
+    const { requested } = installMetaRouter({ duly_duty: DUTY_NO_OPTIONS });
+    renderIn('zh', <DatasetWidget widget={PIE_WIDGET} dataSource={serverResolvedPie()} />);
+    await waitFor(() => expect(requested).toEqual(['duly_duty']));
+    expect(categories()).toEqual(['One-off', 'Recurring', 'Standing']);
+  });
+
+  it('BOUNDARY — under `en` the chart reads the authored labels', async () => {
+    installMetaRouter({ duly_duty: DUTY });
+    renderIn('en', <DatasetWidget widget={PIE_WIDGET} dataSource={serverResolvedPie()} />);
+    await waitFor(() => expect(capturedChartProps).not.toBeNull());
+    expect(categories()).toEqual(['One-off', 'Recurring', 'Standing']);
+  });
+});


### PR DESCRIPTION
Part of #7696 — deliberately **not** `Fixes`. This PR changes no production code and does not explain the downstream symptom #7696 reports, so merging it must not close that card. What it leaves open: why the reporter's `duly` console renders English (see "What is still open" below). What it closes: the coverage question the card asked, answered as a measurement and pinned.

## The card's premise, and the measurement that falsifies it

#7696 models the analytics option-label coverage as a 2x2 and reports the **chart x LOCAL-select** cell as left open by both #4030 (PR #4324) and #4330 (PR #4388). Measured on `origin/main` = `a915064`, that cell was never open.

**PR #4324 already resolved EVERY dimension on a chart.** The `dottedOnly` gate it left behind reads, in its own diff:

```
const dottedOnly = isTable;
const resolveDims = dottedOnly ? dimensions.filter((d) => fieldOf(d).includes('.')) : dimensions;
```

The chart arm of that ternary is the `false` arm — every dimension, dotted or local. PR #4388 removed the gate, and its own commit message says which half it was widening ("Table, pivot and `DatasetReportRenderer` now take that one read"). So #4388 widened the **table** path; the chart path did not need widening.

**`buildDimensionLabelMap` is what re-translates a server-resolved row**, which is the card's measured shape (`rows[].form` byte-identical across locales, carrying the object's authored English label):

```
if (display !== vl.value) byValue[vl.value] = display;
if (display !== vl.label) byAuthoredLabel[vl.label] = display;
```

The second key is the authored label. A row arriving as `Recurring` therefore lands on the same translated display as a row arriving as `recurring`.

**The cell is already pinned, too**, under a name that does not mention it — which is plausibly how the card came to be written. `packages/plugin-dashboard/src/__tests__/DatasetWidget.optionLabelI18n.test.tsx` carries `re-translates a chart the SERVER already resolved to the English label`: a LOCAL `competitor_name` dimension (`dimensionFields: { competitor_name: 'competitor_name' }`, no dot), rows carrying `Orion Engineered Carbons`, asserted to plot `欧励隆`. That is the card's cell, green since PR #4324.

## What this PR adds

One test file, `DatasetWidget.chartLocalSelectI18n.test.tsx`, restating the measurement in the card's own fixture so the next reader of the 2x2 gets an answer from `git grep 7696`:

| case | asserts | direction |
|---|---|---|
| `zh` | `duly_duty_register`, local `form` select, pie + `showLegend`, rows server-resolved to `One-off / Recurring / Standing`, plots `['一次性','周期性','常设']`, one metadata read | the card's cell |
| CONTROL | the same fixture with the option LIST removed from the object document plots `['One-off','Recurring','Standing']` | fires |
| BOUNDARY | under `en`, the authored labels survive | green both ways |

The control is what makes the first case a reading rather than a coincidence: `resolveDimensionFieldMeta` yields an entry only for a terminal field carrying `options`, so removing them is the one change that starves the seam with every other input held identical — same rows, same bundle, same widget, same locale, same read.

The pie's categories are read off the schema handed to the chart renderer, and that is the legend: `AdvancedChartImpl`'s pie branch builds `pieConfig[String(row[xAxisKey])] = { label: String(row[xAxisKey]) }` and hands it to `ChartLegendContent nameKey={xAxisKey}`, so the painted legend text IS the category string in those rows.

## Ablation

Mutation and restore both proven by state, never by an exit code:

```
=== [2] MUTATION — drop the chart branch's relabel ===
before: anchor hits = 1  marker hits = 0
after : anchor hits = 0  marker hits = 1
 packages/plugin-dashboard/src/DatasetWidget.tsx | 2 +-

=== [3] ABLATED RUN ===
     x renders the zh-CN option labels as the pie categories 1054ms
      Tests  1 failed | 2 passed (3)

=== [4] RESTORE, proven BY STATE ===
HEAD blob = 9bc7cc2ca0ad0360bfaf3756ef8395a02b04f0de
disk blob = 9bc7cc2ca0ad0360bfaf3756ef8395a02b04f0de
git diff HEAD -- target is empty: YES
```

Replacing `const chartRows = relabelDimensions(state.rows, dimensionLabels)` with `state.rows` reddens the `zh` case **alone**; the control and the `en` boundary stay green, which is the direction a pin on this seam should have.

## What is still open (for #7696's re-triage)

The reporter's console really does render English, and nothing here explains that. All three analytics chart producers relabel — enumerated as every non-test `buildChartSeries` call site rather than grepped for the seam's spelling:

| producer | relabels |
|---|---|
| `plugin-dashboard/src/DatasetWidget.tsx:1407` | `:1388` |
| `plugin-report/src/DatasetReportRenderer.tsx:1026` | `:1027` |
| `plugin-charts/src/ObjectChart.tsx:891` | `:892` |

So the English must come from one of the five ways this best-effort net starves, each of which is one step to measure in the live app:

1. the analytics response omits `object` — `useDatasetDimensionMeta` bails before reading;
2. `GET /api/v1/meta/object/duly_duty` fails or is unauthorized — the catch sets meta null (#4121's shape: a bearer-token console whose `apiFetch` never reached the context);
3. `duly_duty.fields.form` carries no inline `options` on the metadata document (options behind a shared option set);
4. the zh bundle's app namespace is not discoverable in the dashboard's i18n scope, so `fieldOptionLabel` returns the authored label and no map key is emitted;
5. no `I18nProvider` in scope, so `useSafeFieldLabel` degrades to authored labels.

(3) and (2) fit the report best: both leave the list view beside the dashboard correct, since it resolves options through a different path.

## Checks

- `pnpm exec turbo run type-check --filter=@object-ui/plugin-dashboard` — 14/14 tasks successful. Its second leg is `tsc -p tsconfig.test.json`, so the new file is inside the typechecked set, not excluded with the rest of the tests.
- `pnpm exec vitest run --maxWorkers=2 packages/plugin-dashboard/` — 95 files, 849 tests, all passing, at `1738297c7`.
- `check:control-bytes`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:unreferenced-sources` — all exit 0.
- `check-governed-queue-guard.mjs --test` on both changed paths: `NOT GOVERNED — 2 path(s) checked against 5 governed surface(s); none matched.`
- Narrowing declared: `turbo ls --affected` names 7 packages, six of them downstream consumers of `plugin-dashboard`. The diff adds one file under `plugin-dashboard/src/__tests__/` that nothing imports and that ships in no bundle, so no consumer can observe it; their suites are left to CI.
- Clause-2: no contract accept/reject behaviour changes and no published face widens. The diff exports no name — it adds one test module and one changeset. No `needs:contract-review`.
- Changeset present with empty frontmatter (test-only, publishes nothing) — the objectui form; the `skip-changeset` label is deliberately not applied.

## Out of scope, filed separately

#8187 — the metadata-admin dataset PREVIEW chart (`app-shell/src/views/metadata-admin/previews/DatasetPreview.tsx`) is a fourth analytics chart that never calls `buildChartSeries` and hands `state.rows` to `ChartRenderer` unrelabeled, so a dotted dimension plots raw stored values there. Measured while enumerating the producers above; not touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_