### PR TITLE
feat(types): widen `CollapsibleSchema.trigger` to the node array its mirror, runtime and shipped default already accept (objectui#7767)

### DIFF
--- a/.changeset/7767-collapsible-trigger-union.md
+++ b/.changeset/7767-collapsible-trigger-union.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/types': minor
+---
+
+**`CollapsibleSchema.trigger` now declares the node array its Zod mirror, its runtime and its own shipped default already accept** (objectui#7767).
+
+`trigger` on `CollapsibleSchema` widens from `string | SchemaNode` to `SchemaNode | SchemaNode[]` on the TypeScript face, and stays required. The dropped `string |` half was redundant rather than an extra: `SchemaNode` is `BaseSchema | string | number | boolean | null | undefined`, so `string | SchemaNode` already denoted exactly `SchemaNode` — a bare string trigger type-checks before and after. `SchemaNode` itself is unchanged.
+
+This is a **widening**, not a replacement: every singular `trigger` keeps type-checking unchanged. The Zod mirror is untouched — `zod/disclosure.zod.ts` already spelled this key `z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)])` — and so is the runtime: `renderers/disclosure/collapsible.tsx` hands `schema.trigger` to `renderChildren`, whose `Array.isArray` branch has served the array form all along, and that same registration's `defaultProps.trigger` ships as an array. What changes is that the TypeScript face stops under-reporting an accept set that already ships: copying the renderer's own default into a typed document is no longer a type error against the type that shipped it. The docs page's `trigger` row follows the declaration.
+
+This is the eighth member of the change objectui#7081 made to the overlay family, carried out under the same ruling (2026-09-03 on that card): the validator's accept set does not move, so this is a declaration catching up with what ships rather than a new capability. Per this repository's version-alignment convention, a widening of a published type surface ships as `minor` with the semantics spelled out here rather than as `major` (see AGENTS.md, "版本号策略").

--- a/content/docs/components/disclosure/collapsible.mdx
+++ b/content/docs/components/disclosure/collapsible.mdx
@@ -12,7 +12,7 @@ description: "Toggle visibility of content"
 ```plaintext
 interface CollapsibleSchema {
   type: 'collapsible';
-  trigger: SchemaNode;
+  trigger: SchemaNode | SchemaNode[];
   children: SchemaNode[];
   defaultOpen?: boolean;
 }

--- a/packages/types/src/__tests__/overlay-trigger-union-7081.test.ts
+++ b/packages/types/src/__tests__/overlay-trigger-union-7081.test.ts
@@ -160,12 +160,30 @@ export const singularStaysSingular: SingularSlot = {
   trigger: [{ type: 'button', label: 'Open' }],
 };
 
-// The one in-repo `trigger` OUTSIDE the family with the same asymmetry,
-// recorded rather than resolved (`disclosure.ts`: `string | SchemaNode` on the
-// TS face, the union in `disclosure.zod.ts`, an array in `collapsible.tsx`'s
-// `defaultProps`). Fenced out of objectui#7081 and filed as objectui#7767; the
-// day it widens, this leg goes red and the pin is re-derived deliberately.
-export type _CollapsibleStillSingular = Expect<Equal<AdmitsArray<CollapsibleSchema['trigger']>, false>>;
+// The one in-repo `trigger` OUTSIDE the family that carried the same asymmetry
+// (`disclosure.ts`: `string | SchemaNode` on the TS face, the union in
+// `disclosure.zod.ts`, an array in `collapsible.tsx`'s `defaultProps`). It was
+// fenced out of objectui#7081 and filed as objectui#7767, and stood here as
+// `_CollapsibleStillSingular` -- `AdmitsArray<...>` equal to `false` -- under
+// the note that "the day it widens, this leg goes red and the pin is re-derived
+// deliberately".
+//
+// objectui#7767 IS that day, and it is not a second decision: it carries the
+// 2026-09-03 ruling recorded above -- "The TS face only. The validator's accept
+// set does not move" -- onto this eighth member, whose mirror, renderer and
+// shipped `defaultProps` all already served the array. So the leg is TURNED,
+// not deleted. It is a pin and not a formality: compiled against the pre-#7767
+// declaration this assertion errors (TS2344, `false` does not satisfy `true`),
+// and so does `shippedCollapsible` below (TS2322).
+//
+// The redundant `string |` half went with the widening. `_SchemaNodeUntouched`
+// above pins `SchemaNode` as `BaseSchema | string | ...`, and the leg below
+// spells the consequence out: `string | SchemaNode` denoted `SchemaNode` all
+// along, so dropping it moved nothing.
+export type _CollapsibleTrigger = Expect<Equal<CollapsibleSchema['trigger'], Union>>;
+export type _CollapsibleAdmitsArray = Expect<Equal<AdmitsArray<CollapsibleSchema['trigger']>, true>>;
+export type _CollapsibleRequired = Expect<Equal<IsOptionalKey<CollapsibleSchema, 'trigger'>, false>>;
+export type _StringSchemaNodeCollapses = Expect<Equal<string | SchemaNode, SchemaNode>>;
 
 /**
  * The `defaultProps.trigger` each overlay registration ships, copied VERBATIM
@@ -199,6 +217,16 @@ export const shippedDropdownMenu: DropdownMenuSchema = {
   items: [],
 };
 
+// The same complaint on the eighth member (objectui#7767), copied VERBATIM from
+// `packages/components/src/renderers/disclosure/collapsible.tsx`'s
+// `defaultProps`. Red on the pre-#7767 declaration: `string | SchemaNode`
+// refused the array its own registration ships.
+export const shippedCollapsible: CollapsibleSchema = {
+  type: 'collapsible',
+  trigger: [{ type: 'button', label: 'Toggle', variant: 'outline' }],
+  content: [{ type: 'text', content: 'Collapsible content goes here' }],
+};
+
 // A widening, not a replacement: every singular `trigger` keeps type-checking.
 const SINGLE = { type: 'button', label: 'Open' };
 export const singleDialog: DialogSchema = { type: 'dialog', trigger: SINGLE };
@@ -208,6 +236,10 @@ export const singleDrawer: DrawerSchema = { type: 'drawer', trigger: SINGLE };
 export const singlePopover: PopoverSchema = { type: 'popover', trigger: SINGLE, content: [] };
 export const singleHoverCard: HoverCardSchema = { type: 'hover-card', trigger: SINGLE, content: [] };
 export const singleDropdownMenu: DropdownMenuSchema = { type: 'dropdown-menu', trigger: SINGLE, items: [] };
+export const singleCollapsible: CollapsibleSchema = { type: 'collapsible', trigger: SINGLE, content: [] };
+// ... and so does the bare `string` the dropped `string |` half used to name --
+// it is a `SchemaNode`, which is why that half was redundant (objectui#7767).
+export const stringCollapsible: CollapsibleSchema = { type: 'collapsible', trigger: 'Toggle', content: [] };
 
 /* -- Readers (the objectui#7082 shape) -- */
 

--- a/packages/types/src/disclosure.ts
+++ b/packages/types/src/disclosure.ts
@@ -92,9 +92,21 @@ export interface AccordionSchema extends BaseSchema {
 export interface CollapsibleSchema extends BaseSchema {
   type: 'collapsible';
   /**
-   * Trigger content/label
+   * Trigger content/label -- a node OR a node array.
+   *
+   * READ SITE: `packages/components/src/renderers/disclosure/collapsible.tsx:25`
+   * -- `renderChildren(schema.trigger)` inside `CollapsibleTrigger`, whose
+   * `Array.isArray` branch (`packages/components/src/lib/utils.tsx:23`) serves
+   * the array form, and the registration's own `defaultProps.trigger` in that
+   * same file SHIPS that array. The same spelling the overlay family's
+   * `trigger` declares since objectui#7081, carried onto this eighth member by
+   * objectui#7767.
+   *
+   * The `string |` this used to carry was redundant, not an extra: `SchemaNode`
+   * (`./base`) is `BaseSchema | string | number | boolean | null | undefined`,
+   * so `string | SchemaNode` collapses to `SchemaNode`.
    */
-  trigger: string | SchemaNode;
+  trigger: SchemaNode | SchemaNode[];
   /**
    * Collapsible content
    */


### PR DESCRIPTION
Fixes #7767

Widens `CollapsibleSchema.trigger` from `string | SchemaNode` to `SchemaNode | SchemaNode[]` on the TypeScript face — the eighth member of the change objectui#7081 made to the overlay family, under the same 2026-09-03 ruling recorded on that card: **the TS face only; the validator's accept set does not move.** The mirror, the runtime and the component's own shipped `defaultProps` all already served the array; only the published type was under-reporting itself.

## Triage's four deliverables, ticked

| # | deliverable | done |
| --- | --- | --- |
| 1 | `packages/types/src/disclosure.ts` → `trigger: SchemaNode | SchemaNode[];`, redundant `string |` dropped, docblock copied from the `overlay.ts` sibling block (READ SITE + `renderChildren` / `utils.tsx:23`) | ✅ |
| 2 | the pin's `_CollapsibleStillSingular` leg **TURNED**, not deleted, with the comment above it naming this card as the follow-through of the objectui#7081 ruling | ✅ |
| 3 | ⚠️ `content/docs/components/disclosure/collapsible.mdx` `trigger` row re-derived — **no gate reddens if this is missed** | ✅ **ticked explicitly** |
| 4 | ⛔ `collapsible.tsx:47` `defaultProps` and `disabled-verdict-one-carrier.test.tsx:184` **not touched** | ✅ untouched (`git diff --name-only` is the 4 files below and nothing else) |

Deliverable 3 in full, since nothing mechanical guards it: `check:doc-types` reads only `type` string literals out of doc code blocks, and `check:doc-snippets` compiles only `ts` / `tsx` / `typescript` fences (`TS_FENCE_LANGUAGES`) while this block is fenced `plaintext`. Measured: that document holds one fence, `plaintext`, and zero fences of the snippet gate's population. The row was changed by hand and is verified by reading the file, not by a green check.

## Zone 2 — every anchor re-measured before the first edit

Triage measured 8/8 verbatim at `origin/main` `0558e0f`. Re-measured here at this branch's base `daf9d576d`:

| anchor | measured vs claimed |
| --- | --- |
| `types/src/disclosure.ts:97` | ✅ verbatim |
| `types/src/zod/disclosure.zod.ts:52` | ✅ verbatim |
| `components/.../collapsible.tsx:51` | ⚠️ **line drift only** — the text is verbatim but now at **:47**. Cause: `c6198c27b` (ADR-0049 tombstones) removed the `label:` entries from this registration's `inputs`, shifting `defaultProps` up 4 lines. Confirmed the card's `:51` was correct at `0558e0f`. No semantic drift; a ⛔ do-not-touch site either way. |
| `docs/.../collapsible.mdx:15` | ✅ verbatim |
| `collapsible.tsx:25` | ✅ verbatim |
| `components/src/lib/utils.tsx:23` | ✅ verbatim |
| `disabled-verdict-one-carrier.test.tsx:184` | ✅ verbatim |
| pin `overlay-trigger-union-7081.test.ts:168` | ✅ verbatim |

**objectui#7081 really landed as described** — `overlay.ts:56` and `:117` both read `trigger?: SchemaNode | SchemaNode[];`, and so do all seven widened members plus the two already-union controls. The Zone 1 basis stands.

**The `string |` collapse, proven rather than assumed.** `base.ts:483` is `SchemaNode = BaseSchema | string | number | boolean | null | undefined`. Compiled: the type-level `Equal` of `string | SchemaNode` against `SchemaNode` passes, while its control — the same `Equal` against bare `string` — errors TS2344 (angle brackets spelled out in words here on purpose: GitHub's body sanitizer eats tag-shaped fragments, in fenced code as readily as in prose) — so the silence on the first is a reading, not a vacuum. That leg now ships permanently as `_StringSchemaNodeCollapses`, alongside `stringCollapsible`, a typed document authoring a bare string trigger, which type-checks before and after.

## The pin turn is a real pin

Ablation, on the committed fix. Mutation = the declaration reverted to its pre-#7767 bytes; anchors are `grep -cxF` whole-line fixed strings.

```
BEFORE   fixed spelling = 1   pre-7767 spelling = 0
MUTATE   fixed spelling = 0   pre-7767 spelling = 1   →  109:  trigger: string | SchemaNode;
MUTATED LEG  tsc -p tsconfig.test.json  MUTATED_EXIT=2
  test.ts(183,42) TS2344  _CollapsibleTrigger        Type 'false' does not satisfy the constraint 'true'.
  test.ts(184,46) TS2344  _CollapsibleAdmitsArray    ← the TURNED leg
  test.ts(226,3)  TS2322  shippedCollapsible.trigger not assignable to type 'SchemaNode'
RESTORE  git checkout HEAD -- ABSOLUTE_PATH
  git hash-object     = 88141b40b0bad1108cfa8ec11fda4445d655c286
  git rev-parse HEAD: = 88141b40b0bad1108cfa8ec11fda4445d655c286   MATCH
  git diff HEAD byte count = 0 ; anchored recount fixed=1 pre-7767=0
RESTORED LEG  RESTORED_EXIT=0
```

The three reddening legs are exactly the three that assert the widening. The controls stayed green under the mutation and are the reason this is a widening rather than a swap: `_CollapsibleRequired` (185), `_StringSchemaNodeCollapses` (186), `singleCollapsible` (241), `stringCollapsible` (242), plus the file's existing `_SingularRefusesArray` counter-control, which still shows `AdmitsArray` can say `false`.

⚠️ **Correction, recorded rather than hidden:** the first ablation run used `grep -cE` with a pattern containing a literal `|` — in ERE that is alternation, so it also matched the two `content:` rows and read 3 where 1 was expected. The mutation itself did reach disk (its line was printed), but the count was not a reading. Re-run with `grep -cxF` fixed-string anchors, plus a control proving they discriminate; the block above is the corrected run.

No `dist` round-trip is involved: the pin imports the declaration relatively (`from '../disclosure'`) and `tsconfig.test.json` sets `"paths": {}`, so the compiler reads `src/`, never `dist/`. `dist/` was not rebuilt during the ablation and still carries the fix.

## Verification

Run at final commit `2bfbefc01`.

| command | result |
| --- | --- |
| `pnpm --filter @object-ui/types type-check` | **EXIT 0** — echoed `tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json` (the type-level legs are compiled here, so they are enforced) |
| `pnpm --filter '@object-ui/components^...' build` | **EXIT 0** — rebuilt the closure; `packages/types/dist/disclosure.d.ts:104` verified to carry the widened spelling, so the next row read the new declaration and not a stale one |
| `pnpm --filter @object-ui/components type-check` | **EXIT 0** — the one downstream read site |
| `pnpm exec vitest run` on the 4 `packages/types` pins | **EXIT 0** — 4 files, **470 tests passed** (`overlay-trigger-union-7081`, `zod-mirror-parity`, `disabled-twin-symmetry-7087`, `handler-keys-json-refusal-6124`) |
| `pnpm check:doc-types` | **EXIT 0** |
| `pnpm check:doc-fences` | **EXIT 0** |
| `pnpm check:control-bytes` | **EXIT 0** (6532 tracked text files) |

Baseline discipline: `tsc -p tsconfig.test.json` was **EXIT 0 on the unmodified tree** before any edit, so the reddening above is attributable to this change and nothing else.

**Declared narrowings, for CI to cover:**

- `pnpm check:doc-snippets` returned exit **2**, which that gate itself prints as *"I could not run", NOT "I ran and found errors"* — it needs a 34-package scoped build. Not run locally. It cannot move on this diff: measured, the one document touched has zero `ts`/`tsx`/`typescript` fences.
- `pnpm lint` repo-wide is CI's run. Scoped instead: eslint `--no-inline-config --format json` over the 2 changed source files — **2 files linted, 0 errors, 2 warnings**, and those 2 are the pre-existing `no-explicit-any` pair on the same line of the pin file at base (line 279 → 311), unchanged in rule and count. Population read from eslint's own config via `--print-config` (all 4 changed paths are in it, so the scoping is not hiding a file). Invariance: `eslint.config.js` enables no type-aware linting (no `projectService`, `parserOptions.project`, or `recommendedTypeChecked`), so a type declaration change cannot move any untouched file's verdict.
- Everything downstream of `@object-ui/types` is "affected" by turbo, i.e. the whole tree. Narrowed on evidence: the only site outside `packages/types` that reads this member is `collapsible.tsx:25`, and it hands the value to `renderChildren(children: any)`; the only typed authors of a `collapsible` node in the repo are inside `packages/types`' own tests, all compiled by the run above. The one in-repo array author (`disabled-verdict-one-carrier.test.tsx:184`) is an untyped literal — which is precisely the card's complaint, and is left untouched per deliverable 4.

## Files

- `packages/types/src/disclosure.ts` — the declaration and its docblock
- `packages/types/src/__tests__/overlay-trigger-union-7081.test.ts` — the turned leg plus `_CollapsibleTrigger`, `_CollapsibleRequired`, `_StringSchemaNodeCollapses`, `shippedCollapsible`, `singleCollapsible`, `stringCollapsible`
- `content/docs/components/disclosure/collapsible.mdx` — deliverable 3
- `.changeset/7767-collapsible-trigger-union.md` — `@object-ui/types: minor` (a widening; this repo ships breaking as `minor`, and this one is not even breaking)

## Scope

Zone 3 respected: the `zod-mirror-parity.test.ts` one-directional census is **not** widened here.

One out-of-scope finding, filed separately and unlabelled, not addressed in this PR: objectui#8197 — the same docs fence's `children: SchemaNode[]` row names a key `collapsible.tsx` never reads while omitting the required `content` it does read. Dedup-searched before filing (the search returned objectui#7767 itself and two same-class cards, so it was not returning an empty set).

⚠️ Held as a **draft** deliberately. The PM lands it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_