### PR TITLE
chore(components): drop the unused recharts declaration

### DIFF
--- a/.changeset/7625-drop-recharts-from-components.md
+++ b/.changeset/7625-drop-recharts-from-components.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/components': patch
+---
+
+`@object-ui/components` no longer declares `recharts`. The dependency became
+unused when objectui#7397 deleted `src/ui/chart.tsx`, which was its only
+consumer inside this package; `@object-ui/plugin-charts` declares its own
+`recharts` and remains the single implementation (objectui#7625).
+
+**No migration.** Nothing is added to or removed from the published surface, no
+type changes, no behaviour changes. Since objectui#7397 this package publishes
+no recharts-typed export at all, so there is no supported import that reaches
+`recharts` through `@object-ui/components`.
+
+**What actually changes** is the install graph: every consumer of
+`@object-ui/components` was resolving and installing a charting library it could
+not reach. AGENTS.md section 3 constrains this package — the Atoms layer — to
+"Shadcn primitives, zero heavy 3rd-party deps", and heavy widget dependencies
+belong in `@object-ui/plugin-*`; the declaration outlived the reason it existed.
+
+- **Why `patch` and not `minor`.** This repo ships its own breaking changes as
+  `minor` with the break spelled out (`scripts/check-changeset-no-major.mjs`),
+  so the bump has to state which of the two this is. Nothing breaks for a
+  supported consumer: the built output is byte-identical (this package's Vite
+  `external` predicate is path-based and never reads `dependencies`, so no
+  import graph, chunk or `.d.ts` moves), and the package exposes no recharts
+  surface to import. The one consumer this can reach is someone importing
+  `recharts` without declaring it and getting it hoisted out of this package's
+  dependency by a FLAT `node_modules` layout (npm/yarn). That is a phantom
+  dependency — undeclared, unsupported, and un-typed here since objectui#7397 —
+  and it is named rather than omitted so the trade is on the record.
+- **Not a bundle-size change.** `vendor-charts` stays eagerly reachable through
+  the plugins, so `check:eager-closure` is unaffected in both directions. The
+  cost this removes is install-graph weight, not shipped bytes.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -77,7 +77,6 @@
     "react-day-picker": "^10.0.1",
     "react-hook-form": "^7.85.0",
     "react-resizable-panels": "^4.12.2",
-    "recharts": "3.10.1",
     "sonner": "^2.0.8",
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1128,9 +1128,6 @@ importers:
       react-resizable-panels:
         specifier: ^4.12.2
         version: 4.12.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      recharts:
-        specifier: 3.10.1
-        version: 3.10.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-is@19.2.6)(react@19.2.8)(redux@5.0.1)
       sonner:
         specifier: ^2.0.8
         version: 2.0.8(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)


### PR DESCRIPTION
Fixes #7625

`packages/components/src/ui/chart.tsx` was the only consumer of `recharts` inside `@object-ui/components`, and objectui#7397 deleted it. One line leaves `dependencies`; the lockfile follows.

AGENTS.md section 3 constrains this package — the Atoms layer — to "Shadcn primitives, zero heavy 3rd-party deps", and routes heavy widget dependencies to `@object-ui/plugin-*`. The declaration outlived the reason it existed. `@object-ui/plugin-charts` keeps its own `recharts`, untouched — that is where the charting weight belongs.

## ⚠️ Overlap with dependabot #7058 — what to re-apply, and by whom

objectui#7058 (`lucide-react` 1.31.0 to 1.40.0) remains open and edits the same two files. It was neither rebased nor commented on by this PR. Whoever lands **second** re-applies this, and it is deliberately small:

| File | This PR's change | Line on `0c8dbc492` |
|---|---|---|
| `packages/components/package.json` | deletes the single line `"recharts": "3.10.1",` from `dependencies` | 80, between `react-resizable-panels` and `sonner` |
| `pnpm-lock.yaml` | drops the 3-line `recharts:` entry from the `packages/components` importer block | 1131-1133 |

- ⛔ **`lucide-react` is not touched by this PR** — it stays `^1.31.0` at line 75, exactly as objectui#7058 found it. The two edits are different entries about five lines apart in the same dependency block.
- **Re-applying by hand**: delete that one `package.json` line, then re-run `pnpm install` and commit the lockfile it regenerates. ⛔ Do not hand-merge the lockfile hunk — `pnpm install` produces the correct 3-line removal, and the lockfile is the likelier of the two conflicts since both changes land in the same importer block.

## Measured, before and after, with the control the card requires

A zero-hit grep is only a reading when a control fires beside it — the card is built on that rule, because objectui#7397's own body went wrong through a query shape that returned a zero nobody could check.

| Query (same command shape) | Before | After |
|---|---|---|
| `recharts` under `packages/components/src` | **0** files | **0** files |
| `lucide-react` under `packages/components/src` — **CONTROL** | **70** files | **70** files |

Triage's re-measure on `a472b07` claimed the declaration at `package.json:82` and the same 0-against-70. Re-measured on this branch's base `0c8dbc492`: **0 against 70 confirmed exactly**; the declaration had moved to **line 80**, not 82.

### The scope both prior greps left, now covered

The card's scan and triage's re-scan both covered `packages/components/src` only. Widened to the **whole package** — `__tests__`, configs, scripts, docs, fixtures, every tracked file:

    packages/components/package.json:80        "recharts": "3.10.1",        <- removed here
    packages/components/shadcn-components.json:373        "recharts",       <- left alone, deliberately

**Nothing in the tests imports `recharts`.** `packages/components/src/__tests__/` sits *inside* `src`, so it was in the prior greps' scope after all; the genuinely unscanned scope was the 13 non-`src` files, and the one hit there is the shadcn manifest.

That manifest hit is **not** a dependency declaration and is correctly left in place: `chart` is recorded under `customComponents` with `movedToPlugin: "@object-ui/plugin-charts"`, and its `dependencies` array is a record of what the moved component needed. That record is what stops `pnpm shadcn:update-all` resurrecting `src/ui/chart.tsx`, and `chart-primitives-removed-7397.test.ts` pins it — all three of its assertions ran and passed here. No script cross-checks manifest `dependencies` against `package.json`; the only readers log them.

## Clause ② — does this change what a consumer resolves?

Yes, and only in the one way that is the point of the card. Stated rather than assumed:

- **The published artifact does not change at all.** This package's Vite `external` predicate is path-based (`!/^[./]/.test(id)`) and never reads `dependencies`, so no import graph, chunk or `.d.ts` moves. `packages/components/dist/` contains **0** references to `recharts` (control on the same dist: `lucide-react`, **4** files). Nothing in the tarball mentioned it before this PR either.
- **In-repo, resolution changes for exactly one package.** After `pnpm install`: `packages/components/node_modules/recharts` is **gone**; `packages/plugin-charts/node_modules/recharts` **still exists**, and `packages/components/node_modules/lucide-react` still exists. The lockfile diff touches only the `packages/components` importer block. pnpm's strict layout is configured (no `shamefully-hoist`, no `public-hoist-pattern`), which is why this repo's own comments already say `recharts` "resolves inside plugin-charts alone".
- **The one consumer this could break** is someone importing `recharts` without declaring it and getting it hoisted out of this package's dependency by a **flat** `node_modules` layout (npm/yarn). That is a phantom dependency — undeclared, unsupported, and un-typed here since objectui#7397 removed every recharts-bearing export. Named rather than omitted, so the trade is on the record.

## Changeset: `patch`, and why

`.changeset/7625-drop-recharts-from-components.md`, `@object-ui/components: patch`.

**No gate demanded it.** `check-changeset-presence.mjs` reads an allowlist of eight publishing-contract fields and `dependencies` is deliberately not one; its verdict on this diff is `No changeset ... is owed`. Its header states the trade in as many words — a runtime dependency change "can be just as user-visible as any of the eight, and this gate still does not see it". So this changeset is an author's decision, the same route PR #6735 took.

It is written because **without it the fix never reaches anyone**: the card's benefit is install-graph weight for consumers of the *published* package, and only a version bump delivers that.

`patch` rather than `minor` because this repo ships its own breaking changes as `minor` with the break spelled out (`check-changeset-no-major.mjs`), so the bump has to say which this is — and nothing breaks for a supported consumer: identical published bytes, no export or type moved. The counter-case (the phantom import above) is named in the changeset rather than hidden. Note it rides the same unreleased train as objectui#7397's pending `minor`, whose entry is still in `.changeset/`, so the release carrying this tells chart consumers to move to `@object-ui/plugin-charts` anyway.

## Verification — the real instrument, since no gate watches this direction

`check:phantom-deps` judges imports-not-declared, so CI sees neither an unused declaration nor a wrongly removed one. Build and test are the only instruments. All run at `2d81f2041`:

| Run | Result |
|---|---|
| `pnpm --filter '@object-ui/components^...' build` (dependency closure first) | exit 0 |
| `pnpm --filter @object-ui/components --filter @object-ui/plugin-charts build` | exit 0 |
| `pnpm --filter @object-ui/components test` | **236 files, 2177 tests passed** |
| `chart-primitives-removed-7397.test.ts` alone, `--reporter=verbose` | 3/3 passed, names printed |
| `pnpm --filter @object-ui/components type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`, script name echoed) |
| `check:phantom-deps` · `check:control-bytes` · `changeset:check` · `check:unreferenced-sources` · `check:icon-record-names` | all exit 0 |

**Declared narrowing.** `turbo ls --affected` names 31 packages, because everything downstream depends on `@object-ui/components`. I ran `components` (the only package whose resolution changed) plus a `plugin-charts` build as the control that `recharts` still resolves where it belongs. The narrowing rests on the lockfile diff touching only the `packages/components` importer block under a strict-isolated layout. CI owns the full farm. No ESLint-relevant file is in this diff — the config matches `**/*.{ts,tsx}` and the three changed files are `.json`, `.yaml` and `.md`.

## Out of scope, filed separately

objectui#8198 — nothing gates a declared-but-never-imported dependency, the direction `check:phantom-deps` leaves open. Triage flagged it on the card and said explicitly it was not this card's work.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_