### PR TITLE
fix(app-shell): re-point saveAdvisoryToast's TranslateFn at its one authority

### DIFF
--- a/.changeset/8165-translatefn-one-authority.md
+++ b/.changeset/8165-translatefn-one-authority.md
@@ -1,0 +1,9 @@
+---
+---
+
+Re-point `saveAdvisoryToast`'s `TranslateFn` at its one authority,
+`writeWarningToast` (objectui#8165), and shrink the `KNOWN_COLLISIONS` baseline
+in `scripts/__tests__/one-authority-per-exported-name-6273.test.ts` by that
+site. Type-level only: the declaration was byte-identical to the one it now
+re-exports, the name is on no package's published face, and `export type { X }
+from '…'` erases at build — so no package is released by this change.

--- a/packages/app-shell/src/providers/saveAdvisoryToast.ts
+++ b/packages/app-shell/src/providers/saveAdvisoryToast.ts
@@ -38,9 +38,39 @@
  */
 
 import type { MetadataSaveAdvisoryEvent } from '@object-ui/data-objectstack';
+import type { TranslateFn } from './writeWarningToast.js';
 
-/** i18next's `t`, narrowed to what this module uses. */
-export type TranslateFn = (key: string, options?: Record<string, unknown>) => string;
+/**
+ * i18next's `t`, narrowed to what this module uses — RE-EXPORTED from
+ * `writeWarningToast`, never re-declared.
+ *
+ * This module carried its own byte-identical copy until objectui#8165. The
+ * objectui#6172 甲/A1 ruling is that every exported name has exactly one
+ * authority, and
+ * `scripts/__tests__/one-authority-per-exported-name-6273.test.ts` had been
+ * carrying `TranslateFn` as accepted debt across three files. The remedy that
+ * gate names is exactly this: `export type { X } from '<the-owner>'` is a
+ * re-export, not a second declaration, and the gate does not count it. ⛔ Its
+ * baseline is SHRINK-ONLY, so the entry lost this site in the same PR.
+ *
+ * Why `writeWarningToast` is the one pointed at — read off the tree rather
+ * than decided here:
+ *
+ *   - `AdapterProvider` is the single caller of all three emitters, and it
+ *     already imports `TranslateFn` from `./writeWarningToast.js` and passes
+ *     that one value into `emitSaveAdvisories` alongside the other two.
+ *   - `metadataReadWarningToast.ts` re-points at it for the same reason, and
+ *     `file-size-guard.ts` names it in its own docblock as the established
+ *     pattern it was copied from.
+ *
+ * ⚠️ The THIRD site — `packages/fields/src/widgets/file-size-guard.ts` — is
+ * deliberately NOT re-pointed and stays on the baseline. `@object-ui/app-shell`
+ * DEPENDS ON `@object-ui/fields`, so a re-export in that direction is a package
+ * cycle, and this name is on neither package's published face. Retiring that
+ * copy means moving the authority DOWN into a package both depend on — a
+ * different change, and one nobody has ruled on (objectui#8165 reports it).
+ */
+export type { TranslateFn } from './writeWarningToast.js';
 
 /**
  * Where the message goes. Structurally satisfied by sonner's `toast`, which is

--- a/scripts/__tests__/one-authority-per-exported-name-6273.test.ts
+++ b/scripts/__tests__/one-authority-per-exported-name-6273.test.ts
@@ -457,7 +457,27 @@ const KNOWN_COLLISIONS: ReadonlyMap<string, readonly string[]> = new Map([
   ['RecordDetailDrawerProps', ['packages/plugin-dashboard/src/RecordDetailDrawer.tsx', 'packages/plugin-detail/src/RecordDetailDrawer.tsx']],
   ['SchemaNode', ['packages/sdui-parser/src/types.ts', 'packages/types/src/base.ts']],
   ['ThemeProviderProps', ['packages/providers/src/types.ts', 'packages/react/src/context/ThemeContext.tsx']],
-  ['TranslateFn', ['packages/app-shell/src/providers/saveAdvisoryToast.ts', 'packages/app-shell/src/providers/writeWarningToast.ts', 'packages/fields/src/widgets/file-size-guard.ts']],
+  // `TranslateFn` lost its `packages/app-shell/src/providers/saveAdvisoryToast.ts`
+  // site in objectui#8165. All three declarations were BYTE-IDENTICAL when that
+  // was measured (86 bytes each, one sha256 across the three), so there was no
+  // shape to reconcile; and the authority did not need choosing, because
+  // `AdapterProvider` is the single caller of all three emitters and already
+  // imported the type from `./writeWarningToast.js`, passing that one value into
+  // each of them. `saveAdvisoryToast.ts` now re-exports it, which this gate does
+  // not count.
+  //
+  // ⚠️ The `packages/fields` site STAYS, and that is a measurement rather than an
+  // oversight. The re-export remedy is dependency-illegal there:
+  // `@object-ui/app-shell` DEPENDS ON `@object-ui/fields`, so pointing fields at
+  // app-shell is a package cycle — and `TranslateFn` is on neither package's
+  // published face (`app-shell/src/index.ts` names it nowhere and has no star
+  // re-export; `fields/src/index.tsx` stars 50-odd widget modules but not
+  // `file-size-guard.js`, and none of its three importers re-export the name), so
+  // there would be nothing to import either. Retiring the last copy means moving
+  // the authority DOWN into a package both depend on — the `KanbanSchema` route
+  // above — which publishes a new name from that package and is a decision
+  // nobody has made. objectui#8165 reports it instead of guessing.
+  ['TranslateFn', ['packages/app-shell/src/providers/writeWarningToast.ts', 'packages/fields/src/widgets/file-size-guard.ts']],
   ['UndoRedoState', ['packages/plugin-designer/src/hooks/useUndoRedo.ts', 'packages/types/src/ui-action.ts']],
   ['UserDataAdapter', ['packages/app-shell/src/context/UserStateAdapters.tsx', 'packages/data-objectstack/src/userState.ts']],
   // `ValidationFunction` sat here, colliding between


### PR DESCRIPTION
Part of #8165 — deliberately **not** a closing keyword: this lands two of the three sites and leaves the third open, for the reason measured below. #8165 stays open for re-triage.

## What changed

- `packages/app-shell/src/providers/saveAdvisoryToast.ts` — the local `export type TranslateFn = …` is gone; the module now `import type`s it from `./writeWarningToast.js` for its own two uses and re-exports it, so an import from `./saveAdvisoryToast.js` still resolves to the same type. Same shape as the two worked examples already in the tree (`orgRoleLabel.ts` re-exporting `OrgTranslate`, `resolveBulkActions.ts` re-exporting `NamedActionDef`) and as `metadataReadWarningToast.ts`, which took this exact route in #8152.
- `scripts/__tests__/one-authority-per-exported-name-6273.test.ts` — the `TranslateFn` `KNOWN_COLLISIONS` entry loses that site. Three files to two. ⛔ No line added; the baseline is SHRINK-ONLY by its own text.
- `.changeset/8165-translatefn-one-authority.md` — empty frontmatter (declares no release), see below.

## ⚠️ The measurement that had to come first

The card's own caution is the load-bearing one: the gate counts **declarations**, not **shapes**, so a re-export of a type that had quietly diverged would silently change two call sites' contracts with nothing noticing. Re-measured on `158d75bb3` before touching anything — the three declarations are **byte-identical**:

```
sha256 29f2f334f47b8ac55bd05fc5dcf7f0d769c303f0e2deb1c79aff6a9cd46e3762   (all three)
86 bytes each, identical `od -c` dumps
  packages/app-shell/src/providers/writeWarningToast.ts:26
  packages/app-shell/src/providers/saveAdvisoryToast.ts:43
  packages/fields/src/widgets/file-size-guard.ts:26
```

No shape to reconcile, so the re-point is safe on the two sites it touches.

The authority did not need choosing either: `AdapterProvider` is the single caller of all three emitters and already imported `TranslateFn` from `./writeWarningToast.js`, passing that one value into each of them (`:17`, `:81`, `:94`, `:107`).

## ⛔ Why the third site is NOT re-pointed — the card's remedy is dependency-illegal there

The card prescribed `export type { TranslateFn } from '<writeWarningToast>'` for **both** of the other two. That is not available in `packages/fields`:

- **`@object-ui/app-shell` DEPENDS ON `@object-ui/fields`** (`packages/app-shell/package.json`, `dependencies`), and `packages/fields` has zero real imports of `@object-ui/app-shell`. Pointing fields at app-shell is a package cycle.
- **`TranslateFn` is on neither package's published face**, so there is nothing to import either — see the next section.

⇒ retiring that copy means moving the authority **DOWN** into a package both depend on — the route the baseline's own `KanbanSchema` note records. That publishes a new name from a shared package and is a decision nobody has made, so this PR stops rather than guessing. Measured: all the packages carrying a copy of this shape depend on `@object-ui/i18n`; not all depend on `@object-ui/types`.

## Clause ② — is any of the three on a published face?

**No**, so this is not a public-face change and does not want `needs:contract-review`. Checked for star re-exports, not only the literal name:

- `packages/app-shell/src/index.ts` — 83 export statements, **zero** `export *` anywhere in the file, and no literal `TranslateFn`. The package's only entry is `.` (plus `./styles.css`).
- `packages/fields` has **no** `src/index.ts` — its entry is `src/index.tsx`, which does star 50 widget modules, but **not** `./widgets/file-size-guard.js`, and none of that file's three importers (`FileField`, `ImageField`, `LocationField`) re-exports the name.
- Decisive on the built artefact: `packages/fields/dist/index.d.ts` has **0** occurrences of `TranslateFn`, against a control (`FileField`, a name known to be starred) at 2.

## The gate's own verdict lines, before and after

```
BEFORE (base 158d75bb3, unmodified)
  Test Files  1 passed (1)
       Tests  11 passed (11)
  os-verify-lock: VERDICT command-exit 0

AFTER (this branch)
  Test Files  1 passed (1)
       Tests  11 passed (11)
  os-verify-lock: VERDICT command-exit 0
```

## Ablation — the gate still fails, in both directions

Both legs mutated on disk (proved by anchored fixed-string counts before and after), restored with `git checkout HEAD -- <abs path>`, and the restore proved **by state** (`git hash-object` == `git rev-parse HEAD:PATH`, empty `git diff HEAD`) rather than by an exit code. Run at `aa1114558`.

**Leg A — re-add a local declaration in `saveAdvisoryToast.ts`** (decl count 0 to 1, re-export 1 to 0). Gate exit 1:

```
× declares no name twice outside the named, shrinking baseline
  TranslateFn — a NEW site for a known collision
      packages/app-shell/src/providers/saveAdvisoryToast.ts:72 — type declaration
  ⛔ KNOWN_COLLISIONS is SHRINK-ONLY: adding a line is not a supported way to make this pass
```

**Leg B — put the three-site baseline entry back** while keeping the re-point (entry3 count 0 to 1, entry2 1 to 0). Gate exit 1, which is the proof the baseline edit was **owed**, not optional:

```
× declares no name twice outside the named, shrinking baseline
  KNOWN_COLLISIONS lists collisions that no longer exist …
  TranslateFn — no longer collides at:
      packages/app-shell/src/providers/saveAdvisoryToast.ts
```

Restore, both legs and final state:

```
RESTORE-PROOF OK  packages/app-shell/src/providers/saveAdvisoryToast.ts  disk=e7d158be2… == HEAD=e7d158be2…
RESTORE-PROOF OK  scripts/__tests__/one-authority-per-exported-name-6273.test.ts  disk=e6ddbd54b… == HEAD=e6ddbd54b…
git diff HEAD  →  empty
```

## Tests and gates run locally (all at `aa1114558` unless noted)

| run | result |
| :-- | :-- |
| `pnpm exec turbo run build --filter=@object-ui/app-shell^... --concurrency=2` | 28/28 successful — the dependency closure, without which type-check reports a wall of unrelated TS2307 |
| `pnpm --filter @object-ui/app-shell type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | `VERDICT command-exit 0`, zero `error TS` |
| `pnpm exec vitest run packages/app-shell/src/providers/ packages/app-shell/src/services/MetadataService.saveAdvisories.test.ts scripts/__tests__/one-authority-per-exported-name-6273.test.ts` | **20 files, 153 tests, all passed** |
| `node scripts/check-changeset-presence.mjs` | exit 0 — "declared as releasing nothing, which is the explicit exemption and a complete answer to this gate" |
| `node scripts/check-control-bytes.mjs` | exit 0 (6534 tracked text files) |
| `node scripts/check-governed-queue-guard.mjs --test <the 3 paths>` | exit 0 — "NOT GOVERNED — 3 path(s) checked against 5 governed surface(s); none matched" |
| `eslint --no-inline-config --format json` on the two changed source files | 2 files linted, 0 errors, 0 warnings |

**Declared narrowings**, so the omissions are visible rather than implied:

- The test run is scoped to `packages/app-shell/src/providers/` plus the one consumer suite that imports the type, not the whole 281-file package. The change is type-level and erases at build, so it has no runtime reach; the full package run is CI's.
- Lint was run on the two changed files rather than the repository. That is a measurement, not a skip: eslint's own config carries **no** type-aware linting (no `projectService`, no `project` in `eslint.config.js`, 337 lines, control grep on the same file fires), so this diff cannot move the verdict on any file it does not touch. Repo-wide `pnpm lint` is CI's.

## Changeset — why empty frontmatter

`packages/app-shell/src/**` changed, so a changeset is owed. It declares **no release**: the removed declaration was byte-identical to the one it now re-exports, `export type { X } from '…'` erases at build, and the name is on no package's published face, so nothing a consumer of `@object-ui/app-shell` can observe changed. `skip-changeset` is deliberately **not** applied — in this repository the changeset declaration is the mechanism and that label exempts nothing.

## Out-of-scope finding, filed not fixed

#8203 records what turned up while measuring this one: the same narrowed-`t` shape is declared 11 times across 6 packages under 9 different names, and 8 of those are structurally invisible to this gate, which matches on NAME and counts exported declarations only. Filed with the `finding` class label and no grading. ⛔ Nothing in `packages/fields` other than the untouched `file-size-guard.ts` was read or changed here, per the #8194 fence.

⛔ Left as **draft** on purpose — the PM lands it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_