### PR TITLE
docs(providers): compile every README snippet against the shipped surface

### DIFF
--- a/packages/providers/README.md
+++ b/packages/providers/README.md
@@ -12,12 +12,24 @@ pnpm add @object-ui/providers
 
 ## Providers
 
+Every example below compiles against this package's built types. The values your
+own app supplies are written as `declare const` stand-ins so each block stands
+alone, and each stand-in is typed from the prop it is passed to — so the bound
+the example teaches is the bound the package actually declares.
+
 ### DataSourceProvider
 
 Generic data source context that decouples ObjectUI from ObjectStack.
 
 ```tsx
-import { DataSourceProvider } from '@object-ui/providers';
+import type { ReactNode } from 'react';
+import { DataSourceProvider, type DataSourceProviderProps } from '@object-ui/providers';
+
+// `DataSourceProviderProps['dataSource']` is declared `any` today, so this
+// stand-in inherits `any`: the compiler checks nothing about the adapter's
+// shape here (objectui#8160, objectui#7912 track that laundering).
+declare const myCustomDataSource: DataSourceProviderProps['dataSource'];
+declare const App: () => ReactNode;
 
 <DataSourceProvider dataSource={myCustomDataSource}>
   <App />
@@ -29,7 +41,13 @@ import { DataSourceProvider } from '@object-ui/providers';
 Schema/metadata management for objects, fields, and views.
 
 ```tsx
-import { MetadataProvider } from '@object-ui/providers';
+import type { ReactNode } from 'react';
+import { MetadataProvider, type MetadataProviderProps } from '@object-ui/providers';
+
+// `MetadataProviderProps['metadata']` is declared `any` today — same bound as
+// `dataSource` above, so nothing about this object's shape is checked here.
+declare const myMetadata: MetadataProviderProps['metadata'];
+declare const App: () => ReactNode;
 
 <MetadataProvider metadata={myMetadata}>
   <App />
@@ -40,8 +58,14 @@ import { MetadataProvider } from '@object-ui/providers';
 
 Theme management with system theme detection.
 
+`defaultTheme` takes a `ThemePreference` (`auto | light | dark | system`); both
+props are optional.
+
 ```tsx
+import type { ReactNode } from 'react';
 import { ThemeProvider } from '@object-ui/providers';
+
+declare const App: () => ReactNode;
 
 <ThemeProvider defaultTheme="system" storageKey="my-app-theme">
   <App />
@@ -50,15 +74,31 @@ import { ThemeProvider } from '@object-ui/providers';
 
 ## Usage Example
 
+`DataSourceProvider` and `MetadataProvider` both declare `children` as required,
+so each one needs a real element inside it — a placeholder comment is not a
+child.
+
 ```tsx
-import { DataSourceProvider, MetadataProvider, ThemeProvider } from '@object-ui/providers';
+import type { ReactNode } from 'react';
+import {
+  DataSourceProvider,
+  MetadataProvider,
+  ThemeProvider,
+  type DataSourceProviderProps,
+  type MetadataProviderProps,
+} from '@object-ui/providers';
+
+declare const myDataSource: DataSourceProviderProps['dataSource'];
+declare const myMetadata: MetadataProviderProps['metadata'];
+// Your own component tree goes here.
+declare const AppContent: () => ReactNode;
 
 function App() {
   return (
     <ThemeProvider>
       <DataSourceProvider dataSource={myDataSource}>
         <MetadataProvider metadata={myMetadata}>
-          {/* Your app components */}
+          <AppContent />
         </MetadataProvider>
       </DataSourceProvider>
     </ThemeProvider>

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -789,8 +789,6 @@ const UNGATED_DOCS = {
     '2 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies',
   'packages/plugin-tree/README.md':
     '3 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies',
-  'packages/providers/README.md':
-    '7 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2741x1 — candidate real defects, un-triaged',
 };
 
 // ── Fence scanning ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Part of #5174 (batch 29: `packages/providers/README.md`)

`packages/providers/README.md` leaves the `UNGATED_DOCS` ledger in `scripts/check-doc-snippet-types.mjs` and joins the compiled tier of `check:doc-snippets`. The page reads zero after repair, so its entry is deleted rather than rewritten.

- Base: `158d75bb322e4697e28a6ae3d870cc3555f7d237` (carries PR #8189, batch 28).
- `origin/main` advanced to `d80447d4e` mid-task (three unrelated PRs; `git diff --name-only` over that range against both of my paths is empty). Merged in with a merge commit, never a rebase, per the brief. Every reading below is pinned to the merged head `678609876`.
- Files changed: `packages/providers/README.md`, `scripts/check-doc-snippet-types.mjs` (the ledger row only). No changeset owed. Nothing under `packages/providers/src/**` or `packages/types/src/**` touched.

Note on spelling: JSX tag-shaped and generic-shaped fragments are written as prose names below, because GitHub's body sanitizer silently eats them — see AGENTS.md.

## Census — two readings, with the gate's own analyzer

Both readings drive the gate's exported `analyze` / `compileSnippets` (no hand-written regex), with the page forced into the compiled tier and every other ledger row left ungated. Harness controls healthy on both runs: resolution landed on `packages/types/dist/index.d.ts`, sentinel 1 diagnostic, positive 0, undeclared 1, zero package-`src` leaks, zero analyzer findings.

### Reading 1 — ledger-literal, on the base

Total **8**: `TS2304` x7, `TS2741` x1. Matches the ledger row's own wording exactly.

| fence (base line) | count | diagnostics |
|---|---|---|
| 19 DataSourceProvider | 2 | TS2304 `myCustomDataSource`; TS2304 `App` |
| 31 MetadataProvider | 2 | TS2304 `myMetadata`; TS2304 `App` |
| 43 ThemeProvider | 1 | TS2304 `App` |
| 53 Usage Example | 3 | TS2304 `myDataSource`; TS2304 `myMetadata`; TS2741 `children` |

**Assumption A1 is falsified in one place, and this is the exact split it asked for.** The brief expected `App` four times, one per fence — which would be eight mentions carried by seven diagnostics, and it flagged that arithmetic itself. The resolution is neither of the two the brief offered: `App` is an ambient name in **three** fences only, because the Usage Example *declares* `function App()` itself, so that name is bound inside its own block. Split: `App` x3, `myMetadata` x2, `myCustomDataSource` x1, `myDataSource` x1 = 7. Nothing is counted once that appears twice, and no fence compiles `App` differently.

### Reading 2 — after adding only the missing `declare` stand-ins, in memory

Prefixed to each fence body: type-only imports plus `declare const` lines, nothing else. Every fence already carried its own value import, so no value import line was added and no prop was touched.

Total **1**: `TS2741` x1, fence 53. Fences 19, 31 and 43 read zero.

**Blind-spot count: 0.** Batches 27 and 28 both found a mixed ledger row understating type debt, and the mechanism is specific: an *unresolved JSX tag name* short-circuits the prop check on its own element. That mechanism cannot fire here — every provider tag name is imported and bound in every fence, and all seven undefined names sit in ordinary value positions (`dataSource={…}`, `metadata={…}`, and an `App` element that takes no props). So this row was **exact** in the type-code direction. The other direction from batch 28 does hold, strongly: 7 of the 8 diagnostics were ambient names, 1 was a real defect.

The ledger-or-repair decision is made on reading 2, per the batch-28 carry-forward.

### Reading 3 — the page as committed

Total **0** across all four fences, measured through the same harness. `pnpm check:doc-snippets` agrees: 601 of 601 blocks judged, 0 failed.

## Per-fence decision

All four fences: **repair**. Nothing ledgered, nothing declared a fragment.

| fence | decision | what changed |
|---|---|---|
| DataSourceProvider | repair | `myCustomDataSource` and `App` become `declare const` stand-ins |
| MetadataProvider | repair | `myMetadata` and `App` become stand-ins |
| ThemeProvider | repair | `App` becomes a stand-in |
| Usage Example | repair | `myDataSource` / `myMetadata` stand-ins, and the MetadataProvider element is given a real child |

The first three fences are bare JSX expression statements. That shape is kept, and the gate's parse phase never objected to it — before and after, its syntax line reads "every block parsed, so every one of them reached the semantic phase". No fragment marker, no `@ts-expect-error`, no widened type, no loosened prop anywhere in the diff.

Stand-in types, all read off the shipped surface: `DataSourceProviderProps['dataSource']`, `MetadataProviderProps['metadata']`, and `() => ReactNode` for the component stand-ins.

## The TS2741, decided against the exported props type

Declarations cited from `packages/providers/src/types.ts` (byte-identical in the built `packages/providers/dist/types.d.ts`):

- `:4` `DataSourceProviderProps` — `:5` `dataSource: any`, `:6` `children: ReactNode` **required**
- `:9` `MetadataProviderProps` — `:10` `metadata?: any`, `:11` `children: ReactNode` **required**
- `:43` `ThemeProviderProps` — `:44` `defaultTheme?: ThemePreference`, `:45` `storageKey?: string`, `:46` `children: ReactNode` **required**

**Assumption A2 confirmed.** The diagnostic is on the Usage Example's MetadataProvider, exactly where the brief predicted:

> Property 'children' is missing in type '{ metadata: any; }' but required in type 'MetadataProviderProps'.

**Verdict: README defect, repaired to the shipped surface.** This is batch 28's shape again — the type refuses nothing the page passes; it *requires* something the page omits. So it takes the first branch of the brief's rule, not the type-defect branch, and the ledger keeps no count.

What the page used to teach: that a placeholder comment satisfies a required `children` prop. The element's entire content was a JSX expression container holding a comment and nothing else, which is no child at all — a reader copying the one example the page presents as the complete wiring gets a red build on it. It now nests an `AppContent` stand-in, and the prose above the fence states that both providers declare `children` required, so the next author does not re-introduce the placeholder.

The other two providers in that same fence were never at issue: ThemeProvider and DataSourceProvider each already had a real element inside them.

## The `any` bound, recorded rather than invented

`dataSource` and `metadata` are declared `any` (`types.ts:5` and `:10`). No stronger type was invented for either: each stand-in is typed *through the prop it is passed to*, so it inherits `any`, and the fence comment says out loud that the compiler therefore checks nothing about those objects' shape. That laundering is a known, declared one — objectui#8160 and objectui#7912 already name it — so it is cited here and not re-filed.

## Key surface (objectui#7927)

Verified rather than assumed: none of `DataSourceProviderProps`, `MetadataProviderProps` or `ThemeProviderProps` extends anything, none is `BaseSchema`-derived, and none carries an index signature — a grep of `packages/providers/src/types.ts` for `extends`, `BaseSchema` and index-signature syntax returns no hits. So the compiler judges the keys itself through JSX excess-property checking, and the per-key table collapses to its verdict per fence:

- DataSourceProvider fence — one key, `dataSource`; compiler judges; zero.
- MetadataProvider fence — one key, `metadata`; compiler judges; zero.
- ThemeProvider fence — `defaultTheme` and `storageKey`, both declared and both optional; `"system"` is a member of `ThemePreference`; zero.
- Usage Example — `dataSource`, `metadata`, and `children` on all three elements; zero after the repair.

## Strictness region

The region from the `Fence scanning` banner to EOF, byte-identical as the licence requires:

| tree | sha256 | bytes |
|---|---|---|
| base `158d75bb3` | `2749d53ae3a8df033a53b8d7a354fa7e22ee2d1a17f6ad0c3d61122e904e084b` | 83711 |
| head `678609876` | `2749d53ae3a8df033a53b8d7a354fa7e22ee2d1a17f6ad0c3d61122e904e084b` | 83711 |

Identical. The gate diff is exactly the two lines of this page's `UNGATED_DOCS` row, deletions only (`2 --`, no additions).

## Ledger

The page reads zero, so its entry is **deleted**, per the ledger contract. Rows 9 to 8. No pin enumerates it — `scripts/__tests__/check-doc-snippet-types.test.ts` pins only the root `README.md` row at `:600`/`:601` — so no test file needed editing.

Counters on the head: 229 documents; covered 220 to **221** (118 of them hold a ts/tsx block); ungated 9 to **8**; blocks to compile 597 to **601**, exactly this page's four fences; declared fragments 158 to 158, unchanged.

## Positive control

Injected `defaultTheme={42}` into the repaired ThemeProvider fence (`ThemePreference` is a string union), against the committed tree, inside a `trap` whose restore path is absolute.

- **clean before**: `git diff HEAD` on the path 0 bytes; disk blob equals the HEAD blob `3e986a6de1e0a19f75fadefeaa5e1611ba983c81`
- **injection landed on disk**, proven by anchor counts (anchor 1 to 0, injected 0 to 1) plus the blob moving to `67d0e621beebeb119777193a84c548b38ae3d933` — not by an editor's exit code
- **gate exit under injection: 1**, naming the file and the line:
  `[semantic]  packages/providers/README.md:70:16  TS2322: Type 'number' is not assignable to type 'ThemePreference | undefined'.`
  and its semantic line reads `601 of 601 block(s) judged, 1 failed`
- **restore proven by STATE**, not by exit code: disk blob back to `3e986a6de1e0a19f75fadefeaa5e1611ba983c81`, `git diff HEAD` on the path 0 bytes, `git status --porcelain` empty

Run twice with identical results — once on the pre-merge commit `5bf697c60`, once on the merged head.

## Gates, every reading pinned to `678609876`

Exit codes captured by redirect-then-capture, never across a pipe.

| gate | exit |
|---|---|
| `pnpm check:doc-snippets` | 0 |
| `pnpm exec vitest run scripts/__tests__/check-doc-snippet-types.test.ts scripts/__tests__/check-doc-fence-languages.test.ts` | 0 (123 tests) |
| `pnpm exec vitest run scripts/__tests__/` | 0 (115 files, 3415 tests) |
| `pnpm check:doc-types` | 0 |
| `pnpm check:readme-exports` | 0 (package built) |
| `pnpm check:doc-fences` | 0 |
| `pnpm type-check:scripts` | 0 |
| `pnpm lint:root` | 0 |
| `pnpm check:control-bytes` | 0 |
| `grep -naP` control-byte self-scan, both changed paths | 1 (no match, clean) |
| `node scripts/check-changeset-presence.mjs` | 0 — no changeset owed |
| `node scripts/check-governed-queue-guard.mjs --test` both paths | 0 — NOT GOVERNED |
| `pnpm check:entry-guard` | 0 |
| turbo build closure (`--build-filter`, `--concurrency=2`) | 0 (35/35) |

Re-derived beyond the brief's list against the actual diff, all 0: `check:doc-example-readers`, `check:esm-specifiers`, `check:shell-escape-residue`, `lint:coverage`, `type-check:coverage`, `check:self-import`, `check:unreferenced-sources`, `check-doc-links.mjs`, `check-doc-component-types.mjs`, `check-doc-expression-carriage.mjs`, and `check:node-esm-load`.

`check:node-esm-load` first exited 1 for the environmental reason the brief predicted: turbo shares one cache across every worktree of a checkout, so one package replayed an artefact built in a sibling worktree and the gate correctly refused to grade another tree's output. Re-run with `--force-build`, as its own message instructs, it exits 0 with 34 of 39 published ESM entries imported and evaluated.

`Live E2E (informational)` is red on every branch today for an upstream reason (#7990, objectstack#16186) and is not this branch's.

This PR is draft, base `main`, and the work was published from Claude Code session `session_01FhBNJcLRZLe8M87VcUgpKr`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_