### PR TITLE
test(console): make the registry/spec parity gate judge its lazily-registered blocks

### DIFF
--- a/.changeset/parity-gate-lazy-registrations.md
+++ b/.changeset/parity-gate-lazy-registrations.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change to the console's registry/spec parity gate (`apps/console/src/__tests__/registry-inputs-spec-parity.test.ts`): it now loads the two spec-carried plugin blocks the console registers lazily, and asserts its own coverage so a block can no longer fall out of the judged population silently. No published behaviour changes — no renderer, registration or runtime file is touched.

--- a/.changeset/parity-gate-lazy-registrations.md
+++ b/.changeset/parity-gate-lazy-registrations.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Test-only change to the console's registry/spec parity gate (`apps/console/src/__tests__/registry-inputs-spec-parity.test.ts`): it now loads the two spec-carried plugin blocks the console registers lazily, and asserts its own coverage so a block can no longer fall out of the judged population silently. No published behaviour changes — no renderer, registration or runtime file is touched.
+Test-only change to the console's registry/spec parity gate (`apps/console/src/__tests__/registry-inputs-spec-parity.test.ts`): it now loads the two spec-carried plugin blocks the console registers lazily, and asserts its own coverage so a block can no longer fall out of the judged population silently. Also adds one member pin next to the renderer it constrains (`packages/plugin-kanban/src/__tests__/ObjectKanban.filterMembersReachTheWire-8176.test.tsx`), so the `filter` key objectui#8186 declared is answered with a pin rather than with an exemption. No published behaviour changes — no renderer, registration or runtime file is touched.

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -254,11 +254,47 @@ import {
   tombstonedShapeKeys,
 } from '@object-ui/test-support';
 
-// The two graphs whose registrations this file reads, at module scope rather
-// than in a hook: their cold transform is billed to the import phase, which has
-// no test/hook timeout (AGENTS.md §测试纪律, objectui#3010).
+// The graphs whose registrations this file reads, at module scope rather than
+// in a hook: their cold transform is billed to the import phase, which has no
+// test/hook timeout (AGENTS.md §测试纪律, objectui#3010).
 import '@object-ui/components';
 import '../register-plugins';
+
+// ── objectui#8176: the blocks `register-plugins` alone cannot show this gate ──
+//
+// `register-plugins` is the console's REAL block layer, and importing it is what
+// makes this gate read the registrations the console ships rather than a
+// hand-copied list. It is not sufficient on its own, and the gap was silent for
+// as long as this file existed.
+//
+// Most of that module's plugin blocks are registered with
+// `ComponentRegistry.registerLazy`, which files a STUB carrying only the meta
+// `registerLazy` was handed — no `inputs`, until the chunk loads. `getConfig`,
+// which `declaredInputEntries` below calls, is loaded-only BY DESIGN (its own
+// docblock: it answers "can I render this right now", and callers read
+// `.component` off the result). So for a lazily-registered block `getConfig`
+// returned `undefined`, `declaredInputs` returned `null`, and the block landed
+// in neither `covered` (filter: `length > 0`) nor `registeredWithoutInputs`
+// (filter: `length === 0`, which `null` does not satisfy). Unjudged AND
+// uncounted — the gate reported green over a population it never read.
+//
+// MEASURED on `origin/main` `0c8dbc492` before this import existed: 42 blocks in
+// `ComponentPropsMap`, 27 judged, 7 counted as propless, and 8 in neither set.
+// Two of those 8 — `object-calendar` and `object-kanban` — are spec-carried
+// blocks this repo registers WITH inputs, hidden only by the lazy stub. That is
+// the structural reason objectui#7712 (a spec-declared `filter` published by
+// neither registration) was invisible to this direction.
+//
+// Loading the two plugin packages here is the fix, and the import is the whole
+// of it: their top-level `ComponentRegistry.register()` calls replace the stubs
+// with real registrations, `getConfig` answers, and both blocks enter `covered`.
+// The cost is import-phase transform, which is the right place for it (the same
+// note as above). `no spec-carried block is registered but unloaded` below is
+// what keeps this list correct: a future plugin block that reaches
+// `ComponentPropsMap` while the console registers it lazily fails there, by
+// name, instead of quietly rejoining the blind spot.
+import '@object-ui/plugin-kanban';
+import '@object-ui/plugin-calendar';
 
 /** This block's spec props schema, or `undefined` when this pin has none. */
 const specSchema = (type: string): unknown => (ComponentPropsMap as Record<string, unknown>)[type];
@@ -393,9 +429,22 @@ function undiscoverableSpecKeys(type: string): string[] {
 
 /**
  * The blocks this gate judges: an entry of `ComponentPropsMap` that this repo
- * registers with at least one `inputs` entry. A block with no `inputs` — or one
- * present only as a `registerLazy` stub, which has none yet — has no declaration
- * to be wrong.
+ * registers with at least one `inputs` entry. A block with no `inputs` has no
+ * declaration to be wrong.
+ *
+ * ⚠️ This set is a PARTITION MEMBER, not a standalone reading, and objectui#8176
+ * is why the distinction is written down. Every `ComponentPropsMap` entry must
+ * land in exactly one of three places — here, in `registeredWithoutInputs`
+ * below, or in `UNJUDGED_SPEC_BLOCKS` with a reason — and
+ * `accounts for every spec-carried block` asserts it. Before that assertion the
+ * three sets did not have to add up, so a block could be absent from all of
+ * them: not judged, and not counted as unjudged either. Eight were.
+ *
+ * The comment this docblock replaces said a block "present only as a
+ * `registerLazy` stub, which has none yet — has no declaration to be wrong."
+ * That reading was the defect stated as if it were the design: a lazy stub's
+ * emptiness says nothing about the registration behind it, and for
+ * `object-calendar` / `object-kanban` there WAS a declaration, and it WAS wrong.
  */
 const covered = Object.keys(ComponentPropsMap)
   .filter((type) => (declaredInputs(type) ?? []).length > 0)
@@ -511,8 +560,31 @@ const PINNED_EXPECTED_COVERED = [
  * current `main`, and hard-coding only the eighteen fails the day the pin moves;
  * both readings are correct facts about different installed contracts.
  */
+/**
+ * The two spec-carried blocks the console registers ONLY with `registerLazy`,
+ * newly judged by objectui#8176.
+ *
+ * Pin-INDEPENDENT, unlike the two groups above: `@objectstack/spec` has carried
+ * both since well before the GA line, and this repo has registered both with
+ * `inputs` for just as long (`plugin-kanban/src/index.tsx:208`+,
+ * `plugin-calendar/src/index.tsx:293`/`:303`). Nothing about either side moved.
+ * What moved is this FILE — it now loads the two plugin packages (see the import
+ * block at the top), so `getConfig` answers for them and the reverse direction
+ * reaches them for the first time.
+ *
+ * Kept as its own group rather than folded into `PINNED_EXPECTED_COVERED` so the
+ * transition stays legible: a reader asking "why did this gate's population
+ * change without a pin bump" gets the answer from the name and this docblock,
+ * not from `git log`.
+ */
+const LAZY_REGISTERED_BLOCKS = [
+  'object-calendar',
+  'object-kanban',
+];
+
 const EXPECTED_COVERED = [
   ...PINNED_EXPECTED_COVERED,
+  ...LAZY_REGISTERED_BLOCKS,
   ...(specCarriesGaBlocks ? GA_ONLY_BLOCKS : []),
   ...(specCarries171Blocks ? MINOR_17_1_BLOCKS : []),
 ].sort();
@@ -543,6 +615,57 @@ const EXPECTED_WITHOUT_INPUTS = [
   'nav:breadcrumb',
   'nav:menu',
 ];
+
+/**
+ * The third and last place a `ComponentPropsMap` entry may land: blocks this
+ * gate CANNOT judge, each with the reason it cannot (objectui#8176).
+ *
+ * ## Why a ledger and not an absence
+ *
+ * "Not judged" used to be spelled as absence — a block simply failed both
+ * filters and vanished from every set this file computes. Absence is the one
+ * state a gate cannot report on, and it is how eight blocks stayed outside this
+ * gate unnoticed for its whole life, two of them (`object-calendar`,
+ * `object-kanban`) with a real, wrong declaration behind a lazy stub. Fixing
+ * those two by loading them (see the import block) closes the instance; this
+ * ledger plus `accounts for every spec-carried block` closes the CLASS, because
+ * a block can no longer leave the judged population without a line here saying
+ * so and a diff someone reviews.
+ *
+ * ## Two classes, each mechanically checked so an entry cannot rot
+ *
+ * `every unjudged-block ledger entry still describes a block this gate cannot
+ * judge` asserts the reason, not just the name:
+ *
+ *   - EMPTY SPEC SHAPE — `ComponentPropsMap[type]` accepts no top-level key at
+ *     all, so neither direction has a question to ask. Whether this repo happens
+ *     to register the block is irrelevant to that, which is why it is the
+ *     recorded reason even for the two the app shell does register. Asserted as
+ *     `specTopLevelKeys(type).length === 0`, so the day upstream gives one of
+ *     these blocks props, this entry goes red and the block gets judged.
+ *   - NOT REGISTERED, DELIBERATELY — this repo renders no such block on purpose,
+ *     and the refusal is written at the site that refuses. Asserted as absent
+ *     from `ComponentRegistry.getKnownTypes()` (lazy stubs INCLUDED, so the
+ *     assertion cannot be satisfied by the very stub-blindness objectui#8176 is
+ *     about), so registering one of them forces this entry out.
+ *
+ * `aria` is not a member of the empty-shape reasoning: it is a key on non-empty
+ * shapes and has its own uniform cover in `GLOBALLY_UNPUBLISHED_SPEC_KEYS`.
+ */
+const UNJUDGED_SPEC_BLOCKS: Record<string, string> = {
+  'ai:chat_window':
+    'NOT REGISTERED, DELIBERATELY. `packages/components/src/renderers/placeholders.tsx` omits it from `PROTOCOL_COMPONENTS` in so many words — the floating chat overlay (plugin-chatbot) is the canonical entry point, an inline page-level chat window is not a supported surface, and a page schema referencing it should raise a loud unknown-type error rather than draw a placeholder. `app-shell/src/views/metadata-admin/previews/block-types.ts` records the same refusal. objectui#8176.',
+  'app:launcher':
+    'EMPTY SPEC SHAPE. `ComponentPropsMap[app:launcher]` declares no props at all, so there is nothing for either direction to judge. It IS registered — `app-shell/src/views/app-launcher-renderer.tsx` registers it propless for exactly this reason, and says so — but by `@object-ui/app-shell`, which this file does not import; the empty shape is the load-bearing half either way. objectui#8176.',
+  'element:filter':
+    'EMPTY SPEC SHAPE. The pin declares no top-level key for it, and no package in this repo registers the tag. Nothing to judge on either count. objectui#8176.',
+  'element:form':
+    'NOT REGISTERED, DELIBERATELY. `app-shell/src/views/metadata-admin/previews/block-types.ts` records the reason verbatim: no renderer, use the object-bound `object-form` block, which IS registered and IS judged here. objectui#8176.',
+  'global:notifications':
+    'EMPTY SPEC SHAPE. Same shape and same reasoning as `app:launcher` above: `app-shell/src/views/global-notifications-renderer.tsx` registers it propless because the spec shape is empty, and that registration is not in this file\'s import graph. objectui#8176.',
+  'user:profile':
+    'EMPTY SPEC SHAPE. Declared by the spec with no top-level key; in this repo it exists only as a `PROTOCOL_COMPONENTS` placeholder name, which is a scaffold rather than a renderer and publishes no authoring surface. objectui#8176.',
+};
 
 /*
  * `SPEC_SHAPE_EMPTY_ON_THE_PIN` — DELETED on the @objectstack/spec 17.0.0-rc.6
@@ -841,6 +964,60 @@ const UNPUBLISHED_EXEMPTIONS: Record<string, string> = {
     '@deprecated in ObjectGridSchema ("Moved to top-level resizable"); GA describes it as the "Alternate spelling of `resizable`". Read as back-compat, deliberately not published — the canonical `resizable` IS declared. Same ruled carve-out class as the five the ruling enumerated, measured on this branch — objectui#4648 (maintainer 2026-08-16).',
   'object-grid.title':
     '@deprecated in ObjectGridSchema ("Use label instead"); GA describes it as the "Fallback for `label` (the renderer reads `label || title`)". Read as back-compat, deliberately not published — the canonical `label` IS declared. Same ruled carve-out class as the five the ruling enumerated, measured on this branch — objectui#4648 (maintainer 2026-08-16).',
+
+
+  // ── objectui#8176: the two lazily-registered blocks, judged for the first ──
+  //     time. Eighteen keys, three owners, every one of them A DECLARATION
+  //     SOMEONE OWES (the arm this map's docblock above says must name itself).
+  //
+  //     These are NOT a new divergence. The registrations and the spec entries
+  //     are unchanged; what changed is that this file now loads the two plugin
+  //     packages, so `getConfig` answers for them and the reverse direction
+  //     reaches them at all. Eighteen is the "dozens" case this file already
+  //     owns a route for (see the member-pin transition note below): list them
+  //     BY NAME, cite the issue that owns each, and let the existing dangling
+  //     and stale checks force their deletion the moment a key is declared.
+  //     `the objectui#8176 backlog has a ceiling` below stops the list growing.
+  //
+  //     ⛔ Not a licence to keep them unpublished — the bar is unchanged. A key
+  //     the renderer honours gets DECLARED at its registration site, and the
+  //     entry goes stale in the same change.
+  'object-kanban.filter':
+    'Read by the renderer and declared by the spec, published by neither the four `plugin-kanban` registrations nor the two `plugin-calendar` ones. objectui#7712 is open on exactly this key on exactly these two blocks and owns the declaration; this entry is its cover while it is open. Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8176.',
+  'object-calendar.filter':
+    'The `object-calendar` half of the same key and the same card: objectui#7712 measured both renderers reading `schema.filter` while neither registration publishes it. Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8176.',
+  'object-calendar.sort':
+    'objectui#8171 is open on exactly this key — `ObjectCalendar` reads `schema.sort` and the spec declares it, one key over from objectui#7712. That card owns the declaration and its landing deletes this entry. Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8176.',
+  'object-kanban.groupBy':
+    'Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8201 owns that question and its answer deletes this entry. objectui#8176.',
+  'object-kanban.data':
+    'Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8201 owns that question and its answer deletes this entry. objectui#8176.',
+  'object-kanban.cardTitle':
+    'Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8201 owns that question and its answer deletes this entry. objectui#8176.',
+  'object-kanban.titleField':
+    'Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8201 owns that question and its answer deletes this entry. objectui#8176.',
+  'object-kanban.cardFields':
+    'Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8201 owns that question and its answer deletes this entry. objectui#8176.',
+  'object-kanban.swimlaneField':
+    'Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8201 owns that question and its answer deletes this entry. objectui#8176.',
+  'object-kanban.grouping':
+    'Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8201 owns that question and its answer deletes this entry. objectui#8176.',
+  'object-kanban.quickAdd':
+    'Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8201 owns that question and its answer deletes this entry. objectui#8176.',
+  'object-kanban.coverImageField':
+    'Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8201 owns that question and its answer deletes this entry. objectui#8176.',
+  'object-kanban.conditionalFormatting':
+    'Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8201 owns that question and its answer deletes this entry. objectui#8176.',
+  'object-calendar.defaultView':
+    'Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8201 owns that question and its answer deletes this entry. objectui#8176.',
+  'object-calendar.data':
+    'Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8201 owns that question and its answer deletes this entry. objectui#8176.',
+  'object-calendar.staticData':
+    'Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8201 owns that question and its answer deletes this entry. objectui#8176.',
+  'object-calendar.locale':
+    'Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8201 owns that question and its answer deletes this entry. objectui#8176.',
+  'object-calendar.loading':
+    'Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8201 owns that question and its answer deletes this entry. objectui#8176.',
 
   // ── record:reference_rail.entries — a nested collection, newly JUDGED ──────
   //                                                                   (1 key)
@@ -1618,6 +1795,17 @@ const MULTI_KIND_MEMBER_CONTRACTS: Record<string, string> = {
 // set: 77 array/object-armed inputs across 22 blocks, of which 19 already have a
 // pin that meets both the criterion and the locator. 58 do not.
 //
+// ⚠️ THAT CENSUS WAS TAKEN OVER AN INCOMPLETE POPULATION — objectui#8176. Two
+// spec-carried blocks were missing from `covered` because `getConfig` is
+// loaded-only and the console registers plugin blocks with `registerLazy`, so
+// 77/22/58 was never the whole tree. Re-measured over the corrected population:
+// 81 array/object-armed inputs across 24 blocks, 19 pinned, 62 not. The four
+// that moved are `object-calendar.calendar` / `.dataSource` and
+// `object-kanban.columns` / `.dataSource` — pre-existing declarations, named in
+// `NEWLY_JUDGED_UNPINNED_MEMBERS`, and the reason
+// `MEMBER_PIN_EXEMPTION_CEILING` reads 62. objectui#8071's work is unchanged in
+// kind and four keys longer in extent.
+//
 // 58 is the transition case, and this file already owns the pattern for it —
 // `OFF_SPEC_EXEMPTIONS` / `UNPUBLISHED_EXEMPTIONS` / `OFF_SPEC_ARM_EXEMPTIONS`
 // are explicit, reasoned, issue-backed, and go RED once stale. This is the same
@@ -1806,6 +1994,27 @@ const AWAITING_A_PIN =
   'delete this entry in the same change that registers it.';
 
 /**
+ * The reason the four keys objectui#8176 brought INTO this population carry.
+ *
+ * Separate from `AWAITING_A_PIN` on purpose, because the two say different
+ * things about how the key got here and a reader must be able to tell them
+ * apart. An `AWAITING_A_PIN` key was in objectui#8068's measured 77. These four
+ * were not — not because anything about them changed, but because their blocks
+ * were outside this file's `covered` set entirely while the console's
+ * `registerLazy` stubs hid them from `getConfig`. The declarations are older
+ * than the measurement that missed them.
+ *
+ * Same owner and same exit as their 58 neighbours: objectui#8071 writes the pin,
+ * and the entry is deleted in the change that registers it.
+ */
+const AWAITING_A_PIN_NEWLY_JUDGED =
+  'No per-block member pin today, and NOT one of objectui#8068\'s measured 77: this key was ' +
+  'invisible to that measurement because its block sat outside `covered` behind a `registerLazy` ' +
+  'stub until objectui#8176 loaded it. The declaration is older than the census that missed it, ' +
+  'so this is a correction to the measured population and not a newly added array key. ' +
+  'objectui#8071 owns writing the pin; delete this entry in the same change that registers it.';
+
+/**
  * Array/object-armed inputs accepted WITHOUT a member pin for now, each with the
  * reason. Key format: `BLOCK.INPUT`.
  *
@@ -1910,7 +2119,31 @@ const MEMBER_PIN_EXEMPTIONS: Record<string, string> = {
   'record:related_list.dataSource': AWAITING_A_PIN,
   'record:related_list.filter': AWAITING_A_PIN,
   'record:related_list.sort': AWAITING_A_PIN,
+
+  // objectui#8176 — the four this direction could not see. See
+  // `NEWLY_JUDGED_UNPINNED_MEMBERS` below, which pins them BY NAME so the
+  // ceiling correction cannot absorb anything else.
+  'object-calendar.calendar': AWAITING_A_PIN_NEWLY_JUDGED,
+  'object-calendar.dataSource': AWAITING_A_PIN_NEWLY_JUDGED,
+  'object-kanban.columns': AWAITING_A_PIN_NEWLY_JUDGED,
+  'object-kanban.dataSource': AWAITING_A_PIN_NEWLY_JUDGED,
 };
+
+/**
+ * The four ids the ceiling below moves for, named so the move is auditable.
+ *
+ * A ceiling that goes up is worth exactly as much as the account of why, and
+ * "+4, trust me" is not an account. Pinning the four by name means the
+ * correction admits four SPECIFIC pre-existing keys and nothing else: a fifth
+ * entry cannot hide inside the same headroom, because `the member-pin exemption
+ * list only ratchets DOWN` still reads the total.
+ */
+const NEWLY_JUDGED_UNPINNED_MEMBERS = [
+  'object-calendar.calendar',
+  'object-calendar.dataSource',
+  'object-kanban.columns',
+  'object-kanban.dataSource',
+];
 
 /**
  * How many keys may be exempt. Ratchet: this number may only ever go DOWN.
@@ -1919,8 +2152,37 @@ const MEMBER_PIN_EXEMPTIONS: Record<string, string> = {
  * cheapest way to green a newly added array-typed input is an exemption entry
  * with the same reason as its 58 neighbours — which is exactly the "voluntary"
  * state this direction was built to end, one entry further in.
+ *
+ * ## 58 -> 62, and why that is a CORRECTION rather than a loosening
+ *
+ * ⚠️ The one number in this file that has gone UP. It is the judgement call in
+ * objectui#8176's change and it is written out here rather than left in a diff,
+ * because a reviewer who disagrees with the reading should be able to find it
+ * without reading the whole card.
+ *
+ * The 58 was measured "over this file's own `covered` set" — and objectui#8176
+ * is the finding that `covered` was wrong: it held 27 of the 42 spec-carried
+ * blocks, because `getConfig` is loaded-only and the console registers plugin
+ * blocks with `registerLazy`. `object-calendar` and `object-kanban` were never
+ * offered to objectui#8068's census. Over the corrected population the same
+ * measurement, by the same method, yields 81 array/object-armed inputs across 24
+ * blocks, 19 pinned and 62 not.
+ *
+ * So this raise admits no new key. It admits four PRE-EXISTING declarations that
+ * the census could not see, named individually in
+ * `NEWLY_JUDGED_UNPINNED_MEMBERS` above and asserted by name below. Nothing
+ * about what the ratchet forbids changes: a genuinely new array-typed input
+ * still cannot be absorbed, because 62 is now the true measured floor and the
+ * count may still only go down from it.
+ *
+ * ⛔ The reading a future edit must not take from this: that a ceiling may be
+ * raised to fit a list. The ONLY thing that licensed it here is that the
+ * population itself was mis-measured, and that fact is independently asserted —
+ * if `states the size of the population it judges` and
+ * `no spec-carried block is registered but unloaded` ever stop holding, this
+ * paragraph stops being true and the number owes a re-derivation, not a bump.
  */
-const MEMBER_PIN_EXEMPTION_CEILING = 58;
+const MEMBER_PIN_EXEMPTION_CEILING = 62;
 
 /**
  * Every test file a member pin can live in, as LAZY `?raw` loaders.
@@ -2017,6 +2279,149 @@ describe('registry `inputs` vs `@objectstack/spec` ComponentPropsMap (repo-wide)
 
   it('pins the spec-carried blocks that are registered with no inputs', () => {
     expect(registeredWithoutInputs).toEqual(EXPECTED_WITHOUT_INPUTS);
+  });
+
+  it('accounts for every spec-carried block — judged, propless, or ledgered', () => {
+    // THE ASSERTION objectui#8176 EXISTS FOR, and the one that turns this gate's
+    // population from an accident into a statement.
+    //
+    // Every other assertion in this file is generated from `covered`. That makes
+    // `covered` the gate's whole reach, and until this test there was nothing
+    // anywhere saying what SHOULD be in it — only `EXPECTED_COVERED`, which
+    // pins the set it happens to hold. A block that fell out of `covered` and
+    // out of `registeredWithoutInputs` fell out of both pins at once and left no
+    // trace: not judged, not counted as unjudged, not reported. Eight did,
+    // measured on `origin/main` `0c8dbc492`.
+    //
+    // The three sets are now required to PARTITION `ComponentPropsMap`, so
+    // absence is no longer expressible. A block leaving the judged population
+    // has exactly one way to do it: a `UNJUDGED_SPEC_BLOCKS` entry, written by
+    // hand, with a reason, in a diff someone reviews.
+    const specBlocks = Object.keys(ComponentPropsMap).sort();
+    const accounted = [
+      ...covered,
+      ...registeredWithoutInputs,
+      ...Object.keys(UNJUDGED_SPEC_BLOCKS),
+    ].sort();
+    expect(
+      specBlocks.filter((type) => !accounted.includes(type)),
+      'spec-carried blocks this gate neither judges nor accounts for — add a ' +
+        'UNJUDGED_SPEC_BLOCKS entry with the reason, or make them judgeable',
+    ).toEqual([]);
+    // …and the converse, so the ledger cannot name a block the spec dropped.
+    expect(
+      accounted.filter((type) => !specBlocks.includes(type)),
+      'accounted for a block ComponentPropsMap does not carry',
+    ).toEqual([]);
+    // Exactly once each: a block may not be both judged and ledgered.
+    expect(accounted, 'a block is accounted for twice').toEqual(specBlocks);
+  });
+
+  it('states the size of the population it judges', () => {
+    // The census, in one place, as one readable object. Redundant with the exact
+    // membership pins above BY CONSTRUCTION and kept anyway: the failure mode
+    // objectui#8176 is about was never a wrong name, it was a population nobody
+    // could see the size of. A reader (and a diff) gets all four numbers here.
+    expect({
+      specCarried: Object.keys(ComponentPropsMap).length,
+      judged: covered.length,
+      registeredPropless: registeredWithoutInputs.length,
+      ledgeredUnjudgeable: Object.keys(UNJUDGED_SPEC_BLOCKS).length,
+    }).toEqual({
+      specCarried: 42,
+      judged: 29,
+      registeredPropless: 7,
+      ledgeredUnjudgeable: 6,
+    });
+    // Non-vacuity, stated rather than implied by the numbers above.
+    expect(covered.length).toBeGreaterThan(0);
+  });
+
+  it('no spec-carried block is registered but unloaded', () => {
+    // The MECHANISM behind objectui#8176, asserted so it cannot come back
+    // silently — and the reason the two eager plugin imports at the top of this
+    // file are not merely a convenience.
+    //
+    // `getConfig` is loaded-only by design, so a block present only as a
+    // `registerLazy` stub reads exactly like a block nobody registered: both
+    // answer `undefined`. `hasLazy` is what tells them apart, and it is the one
+    // question this file never asked. A block that answers YES here has a
+    // declaration this gate is not reading — which is the whole defect, and the
+    // reason objectui#7712 was invisible to a direction written to catch it.
+    //
+    // The remedy is an eager import, never a ledger entry: the declaration
+    // exists and is reachable, so `UNJUDGED_SPEC_BLOCKS` would be a false
+    // statement about it. `assertFullyLoaded` in `sdui-parser` makes the same
+    // demand of manifest generation for the same reason.
+    const registeredButUnloaded = Object.keys(ComponentPropsMap)
+      .filter((type) => ComponentRegistry.hasLazy(type))
+      .filter((type) => ComponentRegistry.getConfig(type) === undefined)
+      .sort();
+    expect(
+      registeredButUnloaded,
+      'these blocks are registered lazily and this file has not loaded them, so ' +
+        'their `inputs` are invisible to both directions — add an eager import ' +
+        'of the owning plugin package alongside the two at the top of this file',
+    ).toEqual([]);
+  });
+
+  it('every unjudged-block ledger entry still describes a block this gate cannot judge', () => {
+    // The ledger's own rot check. An entry states WHY the block is unjudgeable,
+    // and both reasons it may state are mechanically decidable — so an entry
+    // that stops being true fails here instead of quietly excusing a block that
+    // became judgeable.
+    expect(Object.keys(UNJUDGED_SPEC_BLOCKS).length).toBeGreaterThan(0);
+    for (const [type, reason] of Object.entries(UNJUDGED_SPEC_BLOCKS)) {
+      expect(reason, `${type}'s ledger reason cites no issue`).toMatch(/#\d+/);
+      expect(
+        Object.keys(ComponentPropsMap),
+        `${type} is ledgered but the spec no longer carries it — delete the entry`,
+      ).toContain(type);
+      if (reason.startsWith('EMPTY SPEC SHAPE')) {
+        expect(
+          specTopLevelKeys(type),
+          `${type} is ledgered as having an empty spec shape, and it does not — ` +
+            'it now has an authoring surface, so it must be judged',
+        ).toEqual([]);
+      } else {
+        // NOT REGISTERED, DELIBERATELY. `getKnownTypes` includes pending lazy
+        // stubs on purpose: a stub is a registration, and satisfying this
+        // assertion with one would be the exact blindness objectui#8176 is about.
+        expect(
+          ComponentRegistry.getKnownTypes(),
+          `${type} is ledgered as deliberately unregistered, and something ` +
+            'registers it — judge it instead',
+        ).not.toContain(type);
+      }
+    }
+  });
+
+  it('the two lazily-registered blocks are judged, with a real declaration behind them', () => {
+    // The instance pin behind the mechanism pin above.
+    //
+    // ⚠️ It deliberately does NOT assert `hasLazy` on these two, and the reason
+    // is the same registry behaviour that makes the mechanism assertion exact:
+    // `register()` DELETES the matching `lazyEntries` keys, so a stub that has
+    // been loaded stops answering `hasLazy` at all. Measured, not assumed —
+    // both answer false here, precisely because the eager imports at the top of
+    // this file replaced their stubs. That is also why
+    // `registeredButUnloaded` above can never name a loaded block: the two
+    // conditions it ANDs are only ever true together for a stub still pending.
+    //
+    // What is asserted instead is the fact the blind spot hid: there is a real
+    // declaration behind each of these names, with inputs, being judged. If a
+    // future change drops the eager imports, the console's `registerLazy` stubs
+    // come back, `hasLazy` starts answering true again, and the mechanism
+    // assertion above reddens by name — which is the guard this instance pin
+    // does not need to duplicate.
+    for (const type of LAZY_REGISTERED_BLOCKS) {
+      expect(
+        (declaredInputs(type) ?? []).length,
+        `${type} is registered without inputs, or its plugin package stopped ` +
+          'being loaded by this file',
+      ).toBeGreaterThan(0);
+      expect(covered, `${type} is not being judged`).toContain(type);
+    }
   });
 
   it('resolves a non-empty accepted key set for each covered block', () => {
@@ -2338,6 +2743,37 @@ describe('registry `inputs` vs `@objectstack/spec` ComponentPropsMap (repo-wide)
         return !undiscoverableSpecKeys(type).includes(specKey);
       });
     expect(stale).toEqual([]);
+  });
+
+  it('the objectui#8176 backlog has a ceiling — it may shrink, never grow', () => {
+    // The transition list's other half, and the reason a "dozens" case is
+    // survivable at all. The stale check above forces an entry OUT once its key
+    // is declared; without a ceiling nothing stops the cheap move in the other
+    // direction — greening a fresh divergence on these two blocks by writing a
+    // nineteenth entry instead of declaring the input.
+    //
+    // Eighteen is the MEASURED backlog at the moment these blocks entered the
+    // population (objectui#8176), not a budget: eleven undiscoverable keys on
+    // `object-kanban`, seven on `object-calendar`. Landing objectui#8201 /
+    // objectui#7712 / objectui#8171 lowers it. A new divergence on these blocks
+    // is a plain defect and gets declared, exactly as it would on any other
+    // covered block.
+    const backlog = Object.keys(UNPUBLISHED_EXEMPTIONS).filter((key) =>
+      LAZY_REGISTERED_BLOCKS.includes(splitExemptionKey(key)[0]),
+    );
+    expect(
+      backlog.length,
+      'a new unpublished-key exemption was added on a block objectui#8176 newly ' +
+        'judged — declare the input at its registration site instead; the ' +
+        'backlog list is shrink-only',
+    ).toBeLessThanOrEqual(18);
+    // Lower it here when the owning cards land, so the ceiling keeps ratcheting
+    // rather than banking the headroom their fixes free up.
+    expect(
+      backlog.length,
+      'the objectui#8176 backlog shrank — lower the ceiling above to match, in ' +
+        'the same change that declared the input',
+    ).toBe(18);
   });
 
   it('the eight tombstoned keys are recognised, not exempted — and not published either', () => {
@@ -3021,10 +3457,41 @@ describe('registry `inputs` vs `@objectstack/spec` ComponentPropsMap (repo-wide)
 
   it('the member-pin exemption list only ratchets DOWN', () => {
     // The other half. A new array-typed key must be answered with a pin, not
-    // with a 59th entry carrying the same reason as its neighbours — that move
+    // with a 63rd entry carrying the same reason as its neighbours — that move
     // is what made the discipline voluntary in the first place, one layer in.
     expect(Object.keys(MEMBER_PIN_EXEMPTIONS).length).toBeLessThanOrEqual(
       MEMBER_PIN_EXEMPTION_CEILING,
     );
+  });
+
+  it('the ceiling correction admits exactly the four keys objectui#8176 made visible', () => {
+    // The audit of the one number in this file that went up. The ceiling moved
+    // 58 -> 62 because the population it was measured over was wrong, not
+    // because four keys needed room — and the difference between those two
+    // sentences is only checkable if the four are named.
+    //
+    // Both directions are asserted. Every named key must really be exempt (so
+    // the list cannot claim credit for headroom it does not use), and every
+    // exemption on a newly judged block must be one of the four (so a fifth
+    // cannot ride in on the same correction).
+    for (const id of NEWLY_JUDGED_UNPINNED_MEMBERS) {
+      expect(
+        Object.keys(MEMBER_PIN_EXEMPTIONS),
+        `${id} is named as part of the objectui#8176 ceiling correction but is ` +
+          'not exempt — delete it from the list and lower the ceiling',
+      ).toContain(id);
+      expect(
+        MEMBER_PIN_EXEMPTIONS[id],
+        `${id} carries the generic reason; it was not in objectui#8068's census`,
+      ).toBe(AWAITING_A_PIN_NEWLY_JUDGED);
+    }
+    const onNewlyJudgedBlocks = Object.keys(MEMBER_PIN_EXEMPTIONS).filter((id) =>
+      LAZY_REGISTERED_BLOCKS.includes(splitExemptionKey(id)[0]),
+    );
+    expect(
+      onNewlyJudgedBlocks.sort(),
+      'a member-pin exemption was added on a block objectui#8176 newly judged ' +
+        'that is not part of the measured correction — it needs a pin, not room',
+    ).toEqual([...NEWLY_JUDGED_UNPINNED_MEMBERS].sort());
   });
 });

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -967,8 +967,17 @@ const UNPUBLISHED_EXEMPTIONS: Record<string, string> = {
 
 
   // ── objectui#8176: the two lazily-registered blocks, judged for the first ──
-  //     time. Eighteen keys, three owners, every one of them A DECLARATION
+  //     time. Sixteen keys, two owners, every one of them A DECLARATION
   //     SOMEONE OWES (the arm this map's docblock above says must name itself).
+  //
+  //     ⚠️ IT STARTED AT EIGHTEEN, and the two that left are the ledger doing
+  //     its job rather than a correction to it. `object-kanban.filter` and
+  //     `object-calendar.filter` were objectui#7712's two keys; objectui#8186
+  //     landed that declaration on all six registrations while this branch was
+  //     open, which made both entries STALE — `carries no stale unpublished-key
+  //     exemption` named them by name and stayed red until they were deleted
+  //     here. That is the documented exit written into the ⛔ note below,
+  //     observed on a real landing: a declaration retires its own cover.
   //
   //     These are NOT a new divergence. The registrations and the spec entries
   //     are unchanged; what changed is that this file now loads the two plugin
@@ -982,10 +991,23 @@ const UNPUBLISHED_EXEMPTIONS: Record<string, string> = {
   //     ⛔ Not a licence to keep them unpublished — the bar is unchanged. A key
   //     the renderer honours gets DECLARED at its registration site, and the
   //     entry goes stale in the same change.
-  'object-kanban.filter':
-    'Read by the renderer and declared by the spec, published by neither the four `plugin-kanban` registrations nor the two `plugin-calendar` ones. objectui#7712 is open on exactly this key on exactly these two blocks and owns the declaration; this entry is its cover while it is open. Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8176.',
-  'object-calendar.filter':
-    'The `object-calendar` half of the same key and the same card: objectui#7712 measured both renderers reading `schema.filter` while neither registration publishes it. Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8176.',
+  // `object-kanban.filter` and `object-calendar.filter` stood here until
+  // objectui#8186 declared them. Deleted, not updated — see the ⚠️ note above.
+  // ⚠️ THE RIDER objectui#8223 OWES, spelled out here so it is not discovered
+  //    in a merge-queue rebuild. objectui#8171's PR declares `sort` on both
+  //    `plugin-calendar` registrations as `{ name: 'sort', type: 'array' }` and
+  //    does not touch this file. Landing it AFTER this change reddens three
+  //    assertions at once, and all three are this ledger working: (1) this
+  //    entry goes stale, so delete it; (2) `the objectui#8176 backlog has a
+  //    ceiling` is exact, so lower 16 to 15 in the same change; (3) `sort`
+  //    becomes an array-armed input on a newly judged block with no member pin,
+  //    so it needs a `MEMBER_PINS` entry — NOT an exemption, which `the ceiling
+  //    correction admits exactly the four keys objectui#8176 made visible`
+  //    refuses by name. The calendar's `filter` pin next door is the shape to
+  //    copy: `sort` is the same kind of pass-through key
+  //    (`ObjectCalendar.tsx` hands it to the query), so the member claim is the
+  //    same identity-forwarding one. Landing objectui#8223 BEFORE this change
+  //    is the other legal order and moves the same three edits here.
   'object-calendar.sort':
     'objectui#8171 is open on exactly this key — `ObjectCalendar` reads `schema.sort` and the spec declares it, one key over from objectui#7712. That card owns the declaration and its landing deletes this entry. Newly JUDGED rather than newly missing: the console registers this block with `registerLazy`, so it sat outside the population of this gate entirely until objectui#8176 loaded it. A DECLARATION SOMEONE OWES, not a ruled carve-out — nobody has yet asked, per key, against the read sites in the renderer, whether it should be published or carved out. objectui#8176.',
   'object-kanban.groupBy':
@@ -1806,6 +1828,17 @@ const MULTI_KIND_MEMBER_CONTRACTS: Record<string, string> = {
 // `MEMBER_PIN_EXEMPTION_CEILING` reads 62. objectui#8071's work is unchanged in
 // kind and four keys longer in extent.
 //
+// ⚠️ THE POPULATION THEN GREW BY TWO, and they were answered with PINS rather
+// than with room. objectui#8186 landed objectui#7712's declaration while this
+// branch was open, so `object-calendar.filter` and `object-kanban.filter`
+// became array-armed inputs on newly judged blocks — exactly the case this
+// ceiling exists to refuse absorbing. Both are in `MEMBER_PINS` below: the
+// calendar's is the file objectui#7711 already left behind, the kanban's was
+// written for this change. 83 array/object-armed inputs across 24 blocks, 21
+// pinned, 62 not — and the ceiling does NOT move. A genuinely new array key
+// gets a pin, which is the whole rule, now demonstrated rather than only
+// asserted.
+//
 // 58 is the transition case, and this file already owns the pattern for it —
 // `OFF_SPEC_EXEMPTIONS` / `UNPUBLISHED_EXEMPTIONS` / `OFF_SPEC_ARM_EXEMPTIONS`
 // are explicit, reasoned, issue-backed, and go RED once stale. This is the same
@@ -1922,9 +1955,17 @@ const MEMBER_PINS: Record<string, MemberPin> = {
     file: 'packages/components/src/__tests__/text-input-inputs-spec-parity.test.ts',
     pins: 'The I18nLabel trio — see `element:text_input.description` (objectui#5717).',
   },
+  'object-calendar.filter': {
+    file: 'packages/plugin-calendar/src/__tests__/ObjectCalendar.filterIsNotAConfigSlot-7711.test.tsx',
+    pins: 'The members are ObjectQL `$filter` elements, and this renderer adds nothing to that contract and subtracts nothing from it: the authored value reaches `dataSource.find` as `$filter` BY IDENTITY (`toBe`, so a normalising rewrite cannot pass), and the retired `filter.calendar` member spelling yields NO configuration — one authored key read twice with two incompatible meanings is the member-level defect objectui#7711 closed here and objectui#4034 closed on the map. Both member forms are covered (the object form and the array-of-arrays form). The spec side cannot supply this: the `object-calendar` `filter` row is `z.unknown()`, so the wire is the only member contract there is (objectui#7711, registered as a pin by objectui#8176 once objectui#8186 declared the key).',
+  },
   'object-grid.data': {
     file: 'packages/plugin-grid/src/__tests__/gridDataInputContract.test.ts',
     pins: 'The `object` arm is `ViewDataSchema` discriminated on `provider`: each of the four providers parses, none of them is an array, the declaration is one shape across both registered tags so the alias cannot drift, and it is pinned at compile time too (objectui#5090).',
+  },
+  'object-kanban.filter': {
+    file: 'packages/plugin-kanban/src/__tests__/ObjectKanban.filterMembersReachTheWire-8176.test.tsx',
+    pins: 'The `object-kanban` twin of `object-calendar.filter` above, written for this change because the board had no equivalent: the authored array reaches `$filter` BY IDENTITY, a condition on a field named `columns` (this block\'s own configuration key) stays a filter and never reaches a configuration read, both member forms pass through identically, and an unauthored `filter` arrives as `undefined` rather than as a fabricated default — the control that keeps the other three from reading as a coincidence. Same reasoning as the calendar entry: the spec row is `z.unknown()`, so the wire is the whole member contract (objectui#8176).',
   },
   'page:card.title': {
     file: 'apps/console/src/__tests__/component-input-union-specimens.test.ts',
@@ -2199,7 +2240,7 @@ const MEMBER_PIN_EXEMPTION_CEILING = 62;
  * LAZY on purpose. `eager: true` would inline the raw text of every test file in
  * the repo — 2,000+ files, ~3 MB — into this module on every run of a gate that
  * already loads the whole registration graph. Lazy hands back loaders, so the
- * cost is the glob itself plus one read per REGISTERED pin (19 today).
+ * cost is the glob itself plus one read per REGISTERED pin (21 today).
  */
 const PIN_SOURCES = import.meta.glob(
   [
@@ -2752,12 +2793,19 @@ describe('registry `inputs` vs `@objectstack/spec` ComponentPropsMap (repo-wide)
     // direction — greening a fresh divergence on these two blocks by writing a
     // nineteenth entry instead of declaring the input.
     //
-    // Eighteen is the MEASURED backlog at the moment these blocks entered the
-    // population (objectui#8176), not a budget: eleven undiscoverable keys on
-    // `object-kanban`, seven on `object-calendar`. Landing objectui#8201 /
-    // objectui#7712 / objectui#8171 lowers it. A new divergence on these blocks
-    // is a plain defect and gets declared, exactly as it would on any other
-    // covered block.
+    // Sixteen is the MEASURED backlog today, not a budget: ten undiscoverable
+    // keys on `object-kanban`, six on `object-calendar`. It was EIGHTEEN when
+    // these blocks entered the population; objectui#7712's declaration landed
+    // as objectui#8186 while this branch was open and took its two `filter`
+    // entries with it, which is the first observed round-trip of the exit this
+    // ceiling is paired with. Landing objectui#8201 / objectui#8171 lowers it
+    // again. A new divergence on these blocks is a plain defect and gets
+    // declared, exactly as it would on any other covered block.
+    //
+    // ⚠️ The `toBe` below is EXACT in both directions on purpose, so the card
+    // that lands a declaration must lower this number in the same change. That
+    // is a rider objectui#8171's PR objectui#8223 owes if it lands after this
+    // one — see the note on `object-calendar.sort` in `UNPUBLISHED_EXEMPTIONS`.
     const backlog = Object.keys(UNPUBLISHED_EXEMPTIONS).filter((key) =>
       LAZY_REGISTERED_BLOCKS.includes(splitExemptionKey(key)[0]),
     );
@@ -2766,14 +2814,14 @@ describe('registry `inputs` vs `@objectstack/spec` ComponentPropsMap (repo-wide)
       'a new unpublished-key exemption was added on a block objectui#8176 newly ' +
         'judged — declare the input at its registration site instead; the ' +
         'backlog list is shrink-only',
-    ).toBeLessThanOrEqual(18);
+    ).toBeLessThanOrEqual(16);
     // Lower it here when the owning cards land, so the ceiling keeps ratcheting
     // rather than banking the headroom their fixes free up.
     expect(
       backlog.length,
       'the objectui#8176 backlog shrank — lower the ceiling above to match, in ' +
         'the same change that declared the input',
-    ).toBe(18);
+    ).toBe(16);
   });
 
   it('the eight tombstoned keys are recognised, not exempted — and not published either', () => {

--- a/packages/plugin-kanban/src/__tests__/ObjectKanban.filterMembersReachTheWire-8176.test.tsx
+++ b/packages/plugin-kanban/src/__tests__/ObjectKanban.filterMembersReachTheWire-8176.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8176 — the MEMBER shape of `object-kanban`'s `filter` is ObjectQL's,
+ * and this board neither reads inside it nor rewrites it.
+ *
+ * ## Why this file exists
+ *
+ * objectui#8186 declared `filter` on the four `plugin-kanban` registrations
+ * (`{ name: 'filter', type: 'array' }`), which is the DECLARATION half of
+ * objectui#7712 and is pinned next door in `filterIsDeclaredInput-7712.test.ts`.
+ * That file asserts the key is discoverable — the html tier accepts it, the
+ * registry publishes it, and `ComponentPropsMap` does not reject it. It says
+ * nothing whatever about what is INSIDE the array, and it cannot: its spec row
+ * is a KEY verdict (`filter` is absent from `unrecognized_keys`), which is the
+ * right assertion for a discoverability claim and the wrong one for a member
+ * claim.
+ *
+ * The member direction is the one objectui#8068 built and objectui#8176 turned
+ * on for this block. Its criterion: some file must constrain the member shape
+ * the RENDERER READS, so that a registration declaring `array` while the code
+ * reads members as something else goes red. This is that file.
+ *
+ * ## What the member contract actually is here, measured
+ *
+ * `@objectstack/spec`'s `ComponentPropsMap['object-kanban'].filter` is
+ * `z.unknown().optional()` — the contract constrains the VALUE not at all, and
+ * so it cannot be the thing a member pin compares against. What constrains the
+ * members is the wire: `ObjectKanban.tsx:363` passes the authored value to
+ * `dataSource.find` as `$filter`, verbatim, and nothing between the schema and
+ * that call reads a member key. The member contract of `filter` is therefore
+ * ObjectQL's `$filter` element contract, and this block's entire obligation is
+ * to add nothing to it and subtract nothing from it.
+ *
+ * A pass-through is a member claim, not the absence of one. Its negation is
+ * concrete and this repo has shipped it TWICE:
+ *
+ *   - objectui#4034 — `ObjectMap` probed `schema.filter` for a `map` key and
+ *     returned it as configuration. `'map' in filter` is TRUE for every ARRAY
+ *     (`Array.prototype.map`), so authors writing the correct member shape were
+ *     silently reconfigured.
+ *   - objectui#7711 — `ObjectCalendar` did the same with a `calendar` key, one
+ *     view over, and the same authored object still went to `$filter`: one key
+ *     read twice with two incompatible meanings.
+ *
+ * Both were defects INSIDE the members of an array-armed input that every other
+ * direction of the parity gate reads as green. The calendar twin of this file
+ * (`plugin-calendar/src/__tests__/ObjectCalendar.filterIsNotAConfigSlot-7711.test.tsx`)
+ * is the pin objectui#7711 left behind and is registered as
+ * `object-calendar.filter`'s member pin. `object-kanban` had no equivalent,
+ * which is the gap this file closes rather than a defect it fixes: the board is
+ * correct today and these rows are what keep it correct.
+ *
+ * ## The rows, and what makes each a reading
+ *
+ *   1. IDENTITY — the array the author wrote is the array that reaches
+ *      `$filter`, `toBe` and not merely `toEqual`. Identity is the assertion
+ *      that catches a rewrite no deep-equal can see: a normalising pass that
+ *      rebuilt equal members would satisfy `toEqual` and would mean this block
+ *      HAD a member contract of its own after all.
+ *   2. OPAQUE MEMBERS — a condition on a field literally named `columns`
+ *      (this block's own configuration key) is still a filter. That is
+ *      objectui#7711's core case transposed: the member is not offered to any
+ *      configuration read, and the board renders from its declared `columns`.
+ *   3. BOTH MEMBER FORMS — the triple-object form the query builders emit and
+ *      the array-of-arrays form objectui#4034 measured on the map both survive
+ *      identically, so the pass-through is not accidentally shape-specific.
+ *   4. THE CONTROL — an absent `filter` reaches the wire as `undefined` rather
+ *      than as a fabricated default. Without it, every `$filter` assertion above
+ *      could be satisfied by a board that always forwards whatever it is given
+ *      including nothing, and the reader could not tell a pass-through from a
+ *      coincidence.
+ *
+ * Every row waits for a REAL `find` call before asserting, so "zero queries"
+ * can never read as success here — the same non-vacuity discipline
+ * `fetchGate.objectDef-6271.test.tsx` states next door.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+// Registers `object-kanban`. Module scope, not a hook: the import IS the
+// registration (AGENTS.md's test-discipline section).
+import '../index';
+// The board renders inside `KanbanRenderer`'s `React.lazy` boundary; importing
+// the chunk at module scope bills the cold transform to the import phase
+// instead of racing a `waitFor` budget (objectui#3010), same specifier as
+// `index.tsx`'s factory so ESM's module cache resolves it immediately.
+import '../KanbanImpl';
+
+afterEach(cleanup);
+
+const OBJECT = 'deal';
+
+const DEAL_SCHEMA = {
+  name: OBJECT,
+  label: 'Deal',
+  fields: {
+    name: { type: 'text', label: 'Name' },
+    status: { type: 'text', label: 'Status' },
+    // A field whose NAME collides with this block's own configuration key, so
+    // row 2 can put a legitimate condition on it.
+    columns: { type: 'text', label: 'Columns' },
+  },
+};
+
+const ROWS = [{ id: 'd1', name: 'Q3 renewal', status: 'open' }];
+
+function makeAdapter(): Record<string, any> {
+  return {
+    find: vi.fn(async () => ({ data: ROWS })),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async () => DEAL_SCHEMA),
+  };
+}
+
+/** The declared board configuration, identical across every case below. */
+const BOARD = {
+  type: 'object-kanban',
+  objectName: OBJECT,
+  groupBy: 'status',
+  columns: [{ id: 'open', title: 'Open' }],
+};
+
+function renderBoard(adapter: Record<string, any>, filter?: unknown) {
+  return render(
+    <SchemaRendererProvider dataSource={adapter as any}>
+      <SchemaRenderer
+        schema={(filter === undefined ? BOARD : { ...BOARD, filter }) as any}
+      />
+    </SchemaRendererProvider>,
+  );
+}
+
+/** The query parameters of the most recent `find`, after waiting for one. */
+async function lastFindParams(adapter: Record<string, any>): Promise<any> {
+  await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+  const calls = adapter.find.mock.calls;
+  return calls[calls.length - 1][1] ?? {};
+}
+
+describe('objectui#8176 — `object-kanban`\'s `filter` members reach `$filter` untouched', () => {
+  it('forwards the authored array BY IDENTITY, not merely by value', async () => {
+    const adapter = makeAdapter();
+    const authoredFilter = [{ field: 'status', operator: 'eq', value: 'open' }];
+
+    renderBoard(adapter, authoredFilter);
+    const params = await lastFindParams(adapter);
+
+    // `toBe`, deliberately. A normalising pass that rebuilt equal members would
+    // satisfy `toEqual` while meaning this block reads its members after all —
+    // which is the claim this pin exists to refuse.
+    expect(params.$filter).toBe(authoredFilter);
+    expect(adapter.find.mock.calls[0][0]).toBe(OBJECT);
+  });
+
+  it('treats a condition on a field named `columns` as a FILTER, never as configuration', async () => {
+    // objectui#7711's core case, transposed to this block: one authored key
+    // must not be read twice with two meanings. `columns` is `object-kanban`'s
+    // own configuration key, so a probe that looked inside members for it would
+    // have exactly the retired `filter.calendar` / `filter.map` shape.
+    const adapter = makeAdapter();
+    const authoredFilter = [{ field: 'columns', operator: 'eq', value: 'team' }];
+
+    const { container } = renderBoard(adapter, authoredFilter);
+    const params = await lastFindParams(adapter);
+
+    expect(params.$filter).toBe(authoredFilter);
+    // The configuration half: the board still reads its DECLARED `columns`, so
+    // the filter member was never offered to a configuration read.
+    await waitFor(() => expect(container.textContent).toContain('Open'));
+  });
+
+  it('passes the array-of-arrays member form through identically — the shape objectui#4034 measured', async () => {
+    const adapter = makeAdapter();
+    const authoredFilter = [['status', '=', 'open']];
+
+    renderBoard(adapter, authoredFilter);
+    const params = await lastFindParams(adapter);
+
+    expect(params.$filter).toBe(authoredFilter);
+  });
+
+  it('CONTROL: an unauthored `filter` reaches the wire as `undefined`, not as a fabricated default', async () => {
+    // Without this row the three above could all be satisfied by a board that
+    // forwards whatever it holds — including a default it invented — and the
+    // pass-through claim would not be distinguishable from a coincidence.
+    const adapter = makeAdapter();
+
+    renderBoard(adapter);
+    const params = await lastFindParams(adapter);
+
+    expect(params.$filter).toBeUndefined();
+    // Non-vacuity for the line above: the call really happened and really
+    // carried the row cap, so `undefined` is a verdict about `$filter` rather
+    // than a read of an empty parameter object.
+    expect(params.$top).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Fixes #8176

## ⚠️ Read this first — the branch was rebuilt on a `main` that moved under it

The original commit was authored against base `fb1a60663`. While it sat, **objectui#8186 landed objectui#7712's declaration** (`0ead1f62a`): `filter` is now a declared `{ type: 'array' }` input on the four `plugin-kanban` and two `plugin-calendar` registrations. `origin/main` is merged in (merge commit, never a rebase — AGENTS.md §9), and this widened gate is the first thing in the repo that can see those two keys, so it went **red four ways** on the merged tree.

Measured here, on the merged tree, before anything was changed — `Tests 4 failed | 194 passed (198)`:

| assertion | verdict |
|---|---|
| `carries no stale unpublished-key exemption — a published key must lose its entry` | `expected [ 'object-kanban.filter', 'object-calendar.filter' ] to deeply equal []` |
| `judges a non-vacuous member-shape census — every covered block, every array/object input` | `expected [ 'object-calendar.filter', 'object-kanban.filter' ] to deeply equal []` |
| `object-calendar pins the member shape of every array/object input it declares` | `expected [ 'object-calendar.filter' ] to deeply equal []` |
| `object-kanban pins the member shape of every array/object input it declares` | `expected [ 'object-kanban.filter' ] to deeply equal []` |

Both halves of the ledger fired, and that is the finding worth recording: the **stale-exemption** direction and the **member-pin** direction each caught the same landing from their own side. Nothing was silent.

## What that red is, and what it is answered with

`object-kanban.filter` / `object-calendar.filter` moved from "undeclared, with an exemption naming objectui#7712 as its cover" to "declared, array-armed, with no member pin". Two different obligations came due at once and both are discharged:

**1. The two `UNPUBLISHED_EXEMPTIONS` entries are deleted.** This file's own rule — *"a key the renderer honours gets DECLARED at its registration site, and the entry goes stale in the same change"* — and the first time it has been observed round-tripping on a real landing rather than only asserted. The `objectui#8176 backlog has a ceiling` assertion ratchets with them: **18 to 16**, in both directions (it is a `toBe`, deliberately, so a landing card cannot bank the headroom its own fix frees).

**2. Both keys get a REAL MEMBER PIN — route (a), not more ceiling.** The alternative was to raise `MEMBER_PIN_EXEMPTION_CEILING` again and extend the exemption set, and it is refused on this PR's own terms: the assertion `the ceiling correction admits exactly the four keys objectui#8176 made visible` exists precisely so a fifth and sixth cannot ride in on that headroom, and `filter` is a key **declared after** objectui#8068's census rather than one it could not see. So `MEMBER_PIN_EXEMPTION_CEILING` is **unchanged at 62** and `NEWLY_JUDGED_UNPINNED_MEMBERS` is unchanged at four. The population grew by two and both were answered with pins:

| key | pin | why that file is a member pin and not just a mention |
|---|---|---|
| `object-calendar.filter` | `packages/plugin-calendar/src/__tests__/ObjectCalendar.filterIsNotAConfigSlot-7711.test.tsx` (already on disk) | Asserts the authored value reaches `dataSource.find` as `$filter` **by identity** (`toBe`), and that the retired `filter.calendar` member spelling yields NO configuration. That is a constraint on what is read INSIDE the members. |
| `object-kanban.filter` | `packages/plugin-kanban/src/__tests__/ObjectKanban.filterMembersReachTheWire-8176.test.tsx` (**new**) | The board had no equivalent. Four rows: identity forwarding; a condition on a field named `columns` (this block's own configuration key) stays a filter; both member forms pass through identically; and a control — an unauthored `filter` arrives as `undefined`, not as a fabricated default. |

### Why "pass-through" is a member claim rather than the absence of one

Measured, not assumed: `ComponentPropsMap['object-kanban'].filter` and `['object-calendar'].filter` are both `z.unknown().optional()`. The **contract constrains the value not at all**, so it cannot be what a member pin compares against. What constrains the members is the wire — `ObjectKanban.tsx:363` and `ObjectCalendar.tsx` hand the authored value to the query as `$filter`, verbatim. The member contract of `filter` is therefore ObjectQL's `$filter` element contract, and each block's whole obligation is to add nothing to it and subtract nothing from it.

The negation is concrete and this repo has shipped it **twice**: objectui#4034 (`ObjectMap` probed members for a `map` key — true for every array, via `Array.prototype.map`) and objectui#7711 (`ObjectCalendar` did it with `calendar`, while the same object still went to `$filter`: one authored key read twice with two incompatible meanings). Both are defects INSIDE the members of an array-armed input that every other direction of this gate reads as green — which is exactly the class objectui#8068 built this direction for.

The neighbouring `filterIsDeclaredInput-7712.test.ts` files do **not** cover this and could not: their spec row is a KEY verdict (`filter` is absent from `unrecognized_keys`), which is the right assertion for discoverability and the wrong one for a member claim.

## Ablation — both pins are proven able to fail

Two legs, each mutating one line of renderer source, each proven on disk before the run by an anchored count plus a `git hash-object` that differs from the HEAD blob (never by an editor's exit code), each restored **by state**.

**A — the new kanban pin.** `$filter: schema.filter` becomes a normalising copy (`Array.isArray(...) ? [...schema.filter] : ...`): members equal, array not the same object.

- RED, by name: `forwards the authored array BY IDENTITY, not merely by value` / `treats a condition on a field named columns as a FILTER, never as configuration` / `passes the array-of-arrays member form through identically`, all three `AssertionError: ... to be ... // Object.is equality`.
- The fourth row stayed GREEN — it is the control, and a control that dies with the thing it controls is not one. `Tests 3 failed | 1 passed (4)`.
- This is also the receipt for choosing `toBe` over `toEqual`: a `toEqual` pin would have passed the mutation.

**B — the registered calendar pin.** objectui#7711's retired arm is reintroduced into `getCalendarConfig` (probe `schema.filter` for a `calendar` key, return it as the `CalendarConfig`).

- RED, by name: `refuses a schema whose only calendar config is stashed under filter.calendar` / `does not let filter.calendar shadow the canonical calendar container` / `passes filter: { calendar: ... } to $filter untouched and reads config from calendar`. `Tests 3 failed | 4 passed (7)`.
- So the file registered as `object-calendar.filter`'s pin really constrains member reads; it does not merely contain the words the locator greps for.

Restore, both legs: `git hash-object` equal to `git rev-parse HEAD:PATH`, `git diff HEAD` empty, `git status --short` empty. Each script carried `trap '...' EXIT INT TERM` with absolute paths. No build stands between either mutation and the code under test: `vitest.config.mts:420`/`:425` still alias `@object-ui/plugin-kanban` and `@object-ui/plugin-calendar` to their `src`.

## The assertion count did NOT move, and that is checkable

**198 passed (198)**, the same number this PR stated before the rebuild. It is not a coincidence and not a stale figure: this gate's test count is `covered.length` (the `it.each` legs) plus its fixed assertions, and this change moves neither. `covered` is unchanged at 29; what changed is ledger **data** — two exemption entries deleted, two `MEMBER_PINS` entries added, one ceiling constant lowered. A change that added or removed a judged block would move the number; this one cannot.

The **member-shape population** did move, and its prose is corrected at the constant: 81 array/object-armed inputs across 24 blocks with 19 pinned and 62 exempt becomes **83 across 24, 21 pinned, 62 exempt**. 21 + 62 = 83, and the exemption count — the one the ceiling reads — is untouched.

## Defects the widened gate now sees — recorded, NOT fixed here

**Corrected.** The previous revision of this section said the two `filter` keys were *"objectui#7712, already open on exactly them"*. That is **no longer true**: objectui#7712's declaration landed as objectui#8186 while this PR was open, which is what made those two entries stale. The backlog is now **16 keys, two owners**:

- `object-kanban` — 13 spec keys, **3 discoverable** (`objectName` `columns` `filter`), ten not: `groupBy` `data` `cardTitle` `titleField` `cardFields` `swimlaneField` `grouping` `quickAdd` `coverImageField` `conditionalFormatting`
- `object-calendar` — 9 spec keys, **3 discoverable** (`objectName` `calendar` `filter`), six not: `defaultView` `sort` `data` `staticData` `locale` `loading`

(The previous revision wrote these as "publishes 3 of 13 / 3 of 9" with eleven and seven not published — arithmetic that did not close on either line. It closes now: 3 + 10 = 13 and 3 + 6 = 9, and the split is the one the 16 ledger entries actually spell.)

Ownership: `object-calendar.sort` is objectui#8171. The remaining fifteen are objectui#8201. Each entry still says **"a declaration someone owes"** rather than "a ruled carve-out", and the stale check is what deletes it — now demonstrated end to end.

## ⚠️ objectui#8223 (objectui#8171) — the ordering verdict, and the rider it owes

objectui#8223 declares `{ name: 'sort', type: 'array' }` on the same two `plugin-calendar` registrations and its diff (measured: 4 files) **does not touch this gate file**. So it cannot land for free in second position, in either direction:

- **objectui#8223 lands AFTER this PR** — legal, and it owes a three-part rider in `registry-inputs-spec-parity.test.ts`, spelled out in a comment above the `object-calendar.sort` entry so nobody discovers it in a merge-queue rebuild: (1) delete the now-stale `object-calendar.sort` exemption; (2) lower the backlog ceiling 16 to 15 (it is a `toBe`); (3) add a `MEMBER_PINS` entry for `object-calendar.sort` — **not** an exemption, which `the ceiling correction admits exactly the four keys objectui#8176 made visible` refuses by name. `sort` is the same pass-through kind of key as `filter`, so the calendar pin next door is the shape to copy.
- **objectui#8223 lands BEFORE this PR** — also legal, and it moves the same three edits into this branch instead. Today's `main` gate is blind to `object-calendar`, so objectui#8223 is green on it as written.
- **This PR cannot pre-absorb it.** A `MEMBER_PINS` entry for an undeclared key dangles, and `every member pin names a key that is still array/object-armed on a covered block` reddens on it. The rider has to travel with the declaration.

Recommendation: **land objectui#8223 first**, then re-merge `main` here and absorb `sort` in the PR that owns the ledger — it keeps a small feature PR free of console-gate edits. Either order works as long as it is chosen rather than discovered.

## ⚠️ One number went UP — unchanged from the previous revision, and it did NOT go up again

`MEMBER_PIN_EXEMPTION_CEILING` still reads **58 to 62**, with the full argument at the constant: the 58 was measured *"over this file's own `covered` set"*, and this card is the finding that `covered` was wrong, so the raise admits four PRE-EXISTING declarations the census could not see (`object-calendar.calendar` / `.dataSource`, `object-kanban.columns` / `.dataSource`) and nothing else. That is the judgement call to review, and this paragraph is where to object.

What this rebuild adds is a demonstration rather than another exception: two genuinely new array keys arrived, and they got **pins**, not room. The ceiling is the same 62 it was.

## Where the fix belongs — gate, registration surface, or both

**Mostly the gate, and now one pin beside a renderer.** The console's `registerLazy` calls are correct (they are why the heavy `object-*` chunks stay out of the initial bundle) and `getConfig` is correct (its docblock is explicit that it answers "can I render this right now"). Neither is the defect; the defect was a test that built its population from whatever happened to be loaded. No runtime, renderer, registration or spec file is modified — the one new file is a test.

## Verification

Everything below was run on the merged tree, at `4020372` unless stated.

- `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` — **198 passed (198)**, `VERDICT command-exit 0` under the shared verify lock.
- **The full `@object-ui/console` vitest project — 89 files, 1069 passed (1069).** This closes the previous revision's declared narrowing: the earlier run could not get the lock, this one did. (Note for the next reader: `pnpm --filter @object-ui/console test` finds zero test files, because every project's `exclude` carries `apps/**`; the working spelling is `pnpm exec vitest run --project @object-ui/console` from the root. That is a pre-existing repo quirk, loud rather than silent — it exits 1.)
- `packages/plugin-kanban` full suite — **27 files, 141 passed (141)**, with the new pin in it.
- `pnpm --filter @object-ui/console run type-check` — exit 0; `pnpm --filter @object-ui/plugin-kanban run type-check` — exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`). Both after `turbo run build` over the two dependency closures (**34 successful, 34 total**). Proven to COVER the edited files rather than assumed to: `tsc --listFiles` names each of them in its own program.
- `pnpm --filter @object-ui/console run lint` — exit 0, 0 errors (208 warnings, pre-existing). `pnpm --filter @object-ui/plugin-kanban run lint` — exit 0, 0 errors (133 warnings). The new file carries 6 `no-explicit-any` warnings, the same idiom as its neighbour `fetchGate.objectDef-6271.test.tsx`.
- **Lint narrowing, declared with its three measurements** rather than merely taken: population read from the repo's own config by `node scripts/check-lint-coverage.mjs` — *"46/46 packages linted, 0 with outstanding errors (0 total)"*; file counts read from `eslint . --no-inline-config --format json` in each changed package — console 191 files, plugin-kanban 41 files, **both changed files 0 errors**; and invariance — `eslint.config.js` extends `tseslint.configs.recommended` with no `parserOptions.project` / `projectService`, so type-aware linting is off and this diff cannot move the verdict on any file it does not contain. (That harsher invocation surfaces 3 pre-existing `react-hooks/static-components` errors in `apps/console/src/pages/settings/`, in files this PR does not touch; CI runs `turbo run lint`, which is the 0-error reading above.)
- `node scripts/check-changeset-presence.mjs` — exit 0, and it now sees **2** released packages' source files against 1 empty-frontmatter changeset, which it accepts by name.
- `check:control-bytes` · `check:phantom-deps` (`@object-ui/react` is a declared dependency of `plugin-kanban`) · `check:self-import` · `check:side-effects-array` · `check:unreferenced-sources` · `check:vi-mock-specifiers` · `check:vi-mock-inherit` — all exit 0. Plus a self-scan for control bytes over the three changed files, with a control that fires.
- `node scripts/check-type-check-coverage.mjs` — exit 0 (42/42 packages compile their tests). `node scripts/check-lint-coverage.mjs` — exit 0.
- `check:eager-closure` and `check:sdui-registration-pins` — first exit **2** (`PREREQUISITE NOT MET`, read as NOT MEASURED rather than as red), then **exit 0 both** against a real `pnpm --filter @object-ui/console build`. 518 chunks weighed, all 16 promised registrations present.
- `node scripts/check-governed-queue-guard.mjs --test` on both changed paths — **NOT GOVERNED**.
- **Not run locally, declared:** the other six `turbo ls --affected` packages (`app-shell`, `runner`, `site`, three examples). They are affected at PACKAGE granularity only — neither changed file is imported anywhere, proven by an import-statement grep over the tree returning zero with a control grep that fires on a file that IS imported. CI runs the full farm.

## Accept-set note (clause 2)

Unchanged in kind from the previous revision: `specTopLevelKeys`, `authorableShapeKeys` and every schema-reading helper are untouched, and no renderer, registration or spec file is modified. What moved is the population those unchanged readers are applied to, plus the ledger entries that population requires. The one new file is a test that pins existing, correct behaviour — it fixes nothing and is not a behaviour change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S