### PR TITLE
fix(metadata-admin): page-block object-kanban inspector authors groupBy, not the retired groupField (objectui#7772)

### DIFF
--- a/.changeset/7772-page-block-kanban-group-by-control.md
+++ b/.changeset/7772-page-block-kanban-group-by-control.md
@@ -1,0 +1,47 @@
+---
+'@object-ui/app-shell': minor
+---
+
+**Breaking for the page designer's output:** the page-block inspector's `object-kanban`
+panel now authors `groupBy` (the key the board reads) instead of `groupField` (the key it
+never read), and offers the `limit` control the schema has declared since objectui#7322.
+
+**What was measured, on this branch's base (`0c8dbc49`).** `BLOCK_CONFIG['object-kanban']`
+offered exactly four controls — `objectName` / `groupField` / `titleField` / `cardFields`.
+`ObjectKanbanSchema.groupBy` is REQUIRED on both published faces (`objectql.ts:2765
+groupBy: string`, no `?`; `objectql.zod.ts:1001 groupBy: z.string()`, no `.optional()`) and
+had **no control at all**, while `groupField` — the only control able to set grouping — has
+been a `retirementTombstone()` on the Zod face and `?: never` on the TS face since
+objectui#7322. `ObjectKanban.tsx` reads `schema.groupBy` at thirteen sites and `groupField`
+at zero (control: those same thirteen hits in the one query, so the zero is a reading).
+
+Run against the node those four controls produced, `ObjectKanbanSchema.safeParse` reported
+**two** issues, not one: `groupBy` "expected string, received undefined", and `groupField`
+carrying the retirement guidance verbatim. So this panel could not author a valid
+`object-kanban` node however it was filled in, and the board it produced grouped nothing
+with no diagnostic on any face. Both halves are now pinned against the schema itself rather
+than against a spelling, in `previews/__tests__/block-config.test.ts` —
+`scripts/check-designer-field-key-parity.mjs` judges `PAYLOAD_SHAPES` and does not read
+`BLOCK_CONFIG`, so nothing mechanical was watching this table.
+
+`limit` is not polish: `ObjectKanban.tsx` sends it as a real `$top`
+(`$top: schema.limit ?? DEFAULT_KANBAN_LIMIT`) and renders every fetched record into a lane
+with no pagination, so a board over 100 records was silently truncated with no way to widen
+it. The new number box states `100` — `DEFAULT_KANBAN_LIMIT`, read from the renderer's own
+source by its pin — as the value that applies while it is empty.
+
+**Stored pages.** Documents saved by every released build since
+`@object-ui/app-shell@17.5.0` can carry `properties.groupField` on an `object-kanban` block.
+The inspector's read door now strips it (`stripRetiredBlockProps`, keyed to
+`RETIRED_BLOCK_PROP_KEYS`), so an edit-and-save round-trip comes out without the retired
+key — no migration pass, and no blanket unknown-key purge: every other key the designer
+does not render still survives. It is a strip and **not** a migration into `groupBy` on
+purpose: reading the old spelling into the new box would be a second de-facto alias
+(AGENTS.md #0.1) for a value no board ever acted on.
+
+The **view-level** `kanban.groupField` alias (`core/src/utils/normalize-list-view.ts`) is
+live and untouched — node-level retirement and the view-level alias are different things.
+
+The two locale entries move with the control (`engine.inspector.pageBlock.field.object-kanban.groupBy`,
+plus a new `.limit`); the English wording is unchanged, so the panel reads the same as it
+always did.

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -608,9 +608,15 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.pageBlock.field.object-metric.prefix': 'Prefix',
   'engine.inspector.pageBlock.field.object-metric.suffix': 'Suffix',
   'engine.inspector.pageBlock.field.object-kanban.objectName': 'Object',
-  'engine.inspector.pageBlock.field.object-kanban.groupField': 'Group by field',
+  // `…object-kanban.groupField` was renamed to `…groupBy` with the control it
+  // labels (objectui#7772): the lane picker wrote a key `ObjectKanban.tsx`
+  // never reads and objectui#7322 retired by name, while the REQUIRED `groupBy`
+  // had no control. The English text is deliberately unchanged — the box means
+  // exactly what it always meant; only the key its position implies moved.
+  'engine.inspector.pageBlock.field.object-kanban.groupBy': 'Group by field',
   'engine.inspector.pageBlock.field.object-kanban.titleField': 'Title field',
   'engine.inspector.pageBlock.field.object-kanban.cardFields': 'Card fields',
+  'engine.inspector.pageBlock.field.object-kanban.limit': 'Limit',
   'engine.inspector.pageBlock.field.grid.columns': 'Columns',
   'engine.inspector.pageBlock.field.grid.gap': 'Gap',
   'engine.inspector.pageBlock.field.element:text.content': 'Content',
@@ -2462,9 +2468,10 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.pageBlock.field.object-metric.prefix': '前缀',
   'engine.inspector.pageBlock.field.object-metric.suffix': '后缀',
   'engine.inspector.pageBlock.field.object-kanban.objectName': '对象',
-  'engine.inspector.pageBlock.field.object-kanban.groupField': '分组字段',
+  'engine.inspector.pageBlock.field.object-kanban.groupBy': '分组字段',
   'engine.inspector.pageBlock.field.object-kanban.titleField': '标题字段',
   'engine.inspector.pageBlock.field.object-kanban.cardFields': '卡片字段',
+  'engine.inspector.pageBlock.field.object-kanban.limit': '条数上限',
   'engine.inspector.pageBlock.field.grid.columns': '列数',
   'engine.inspector.pageBlock.field.grid.gap': '间距',
   'engine.inspector.pageBlock.field.element:text.content': '内容',

--- a/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.retiredBlockProps.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.retiredBlockProps.test.tsx
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#7772 — the `object-kanban` panel on screen: the lane picker now
+ * writes `groupBy`, `limit` is authorable, and a stored `groupField` is gone
+ * from both the panel and the next save.
+ *
+ * The sibling `previews/__tests__/block-config.test.ts` pins the TABLE and the
+ * strip function. That is a fact about data. This file pins the fact about the
+ * screen, and they are different for the reason
+ * `PageBlockInspector.sectionName.test.tsx` states: `BLOCK_CONFIG` is data, and
+ * what an author gets is whatever `renderField` and the generic "Advanced"
+ * section do with it. Two of the three facts below are only reachable here:
+ *
+ *   - a retired key that is no longer a curated field falls into ADVANCED,
+ *     whose editor can set a value but has no delete — so "not offered as a
+ *     curated control" and "not on screen at all" are different claims, and
+ *     only the second one is the fix;
+ *   - `blockProps` is the single value every property write spreads from, so
+ *     whether the retired key rides back out is decided by a real commit, not
+ *     by reading the strip in isolation.
+ *
+ * ## NOT pinned here, deliberately: page-schema rejection
+ *
+ * Measured against the pinned `@objectstack/spec`: `PageSchema.safeParse` does
+ * not look inside a block's `properties` at all — a page carrying
+ * `properties: { zzzTotallyBogusKey: 1 }` parses green, so a poisoned kanban
+ * block was never blocked at the designer's save gate. The refusal is on the
+ * NODE face (`ObjectKanbanSchema`, `@object-ui/types/zod`), which is where the
+ * sibling suite asserts it. Pinning "the committed draft parses" here would be
+ * a green light that means nothing.
+ *
+ * FIXTURE DISCIPLINE (#3216's method, as in the sibling suites): the page is
+ * authored the way a user does and fed through `PageSchema.parse`, so the
+ * fixture cannot drift from the spec.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { PageSchema } from '@objectstack/spec/ui';
+
+// objectui#4697 — see PageBlockInspector.i18n.test.tsx for the full mechanism;
+// same STABLE stub, short-circuiting useObjectFields/useObjectOptions's
+// mount-time fetch instead of letting it escape to the real network. No
+// assertion here reads the fetched object list or its fields.
+const state = vi.hoisted(() => ({
+  metadataClient: { get: vi.fn(async () => undefined), list: vi.fn(async () => [] as unknown[]) },
+}));
+vi.mock('../useMetadata', () => ({
+  useMetadataClient: () => state.metadataClient,
+}));
+
+import { PageBlockInspector } from './PageBlockInspector';
+
+afterEach(cleanup);
+
+const BLOCK_PATH = 'regions[0].components[0]';
+
+/** A record page carrying one `object-kanban` block with the given properties. */
+function pageDraft(properties: Record<string, unknown>): Record<string, unknown> {
+  return PageSchema.parse({
+    name: 'opportunity_record',
+    label: 'Opportunity',
+    type: 'record',
+    object: 'opportunity',
+    template: 'default',
+    regions: [
+      { name: 'main', components: [{ type: 'object-kanban', id: 'b1', properties }] },
+    ],
+  }) as unknown as Record<string, unknown>;
+}
+
+function renderInspector(draft: Record<string, unknown>, onPatch = vi.fn()) {
+  render(
+    <PageBlockInspector
+      type="page"
+      name="opportunity_record"
+      draft={draft}
+      selection={{ kind: 'block', id: BLOCK_PATH }}
+      onPatch={onPatch}
+      onClearSelection={() => {}}
+      readOnly={false}
+      locale={'en-US' as never}
+    />,
+  );
+  return onPatch;
+}
+
+/** The block's `properties` as the inspector last committed them. */
+function committedProps(onPatch: ReturnType<typeof vi.fn>): Record<string, unknown> {
+  const patch = onPatch.mock.calls.at(-1)![0] as any;
+  return patch.regions[0].components[0].properties as Record<string, unknown>;
+}
+
+/* ─────────────────── the controls the schema actually declares ───────────── */
+
+describe('object-kanban inspector · the declared controls are on screen (objectui#7772)', () => {
+  it('offers the lane picker and the row cap', () => {
+    renderInspector(pageDraft({ objectName: 'opportunity' }));
+    // The lane picker kept its wording and changed the key underneath it, so
+    // the label is the same string it always was — the rename is invisible to
+    // an author, which is the intended cost of it.
+    expect(screen.getByLabelText('Group by field')).toBeTruthy();
+    expect(screen.getByLabelText('Limit')).toBeTruthy();
+  });
+
+  it('the row cap states DEFAULT_KANBAN_LIMIT while it is empty, and commits a number', () => {
+    const onPatch = renderInspector(pageDraft({ objectName: 'opportunity' }));
+    const box = screen.getByLabelText('Limit') as HTMLInputElement;
+    // Empty box, and the placeholder says what applies anyway.
+    expect(box.value).toBe('');
+    expect(box.placeholder).toBe('100');
+
+    fireEvent.change(box, { target: { value: '250' } });
+    expect(committedProps(onPatch)).toEqual({ objectName: 'opportunity', limit: 250 });
+  });
+});
+
+/* ────────────────────── the stored retired key, on screen ────────────────── */
+
+describe('object-kanban inspector · a stored `groupField` (objectui#7772)', () => {
+  /** A block saved by a released build: the lane value under the retired key. */
+  const poisoned = () =>
+    pageDraft({
+      objectName: 'opportunity',
+      groupField: 'stage',
+      titleField: 'name',
+      // A key the designer does not curate and never retired. It is the
+      // NON-VACUITY control for every "not on screen" assertion below: the
+      // Advanced section must still be rendering, or their zeroes would be a
+      // reading about the section rather than about the key.
+      somePluginKey: 'kept',
+    });
+
+  it('renders no box for it — not curated, and not in Advanced either', () => {
+    renderInspector(poisoned());
+    // Advanced IS rendering: the control key has a box, labelled by its raw name.
+    expect(screen.getByLabelText('somePluginKey')).toBeTruthy();
+    // The retired key has none, under either spelling it could appear as.
+    expect(screen.queryByLabelText('groupField')).toBeNull();
+    expect(screen.queryByDisplayValue('stage')).toBeNull();
+  });
+
+  it('does not ride back out on the next save', () => {
+    const onPatch = renderInspector(poisoned());
+    // Any property edit rewrites `properties` from the read door's value.
+    fireEvent.change(screen.getByLabelText('somePluginKey'), { target: { value: 'edited' } });
+
+    const committed = committedProps(onPatch);
+    expect('groupField' in committed).toBe(false);
+    // Everything else survives — this is a tombstone-keyed strip, not a
+    // blanket unknown-key purge (AGENTS.md #0.1).
+    expect(committed).toEqual({
+      objectName: 'opportunity',
+      titleField: 'name',
+      somePluginKey: 'edited',
+    });
+  });
+
+  it('leaves the lane picker empty rather than reading the retired value into it', () => {
+    // Deliberate, and the opposite of the `formula` -> `expression` carry-over
+    // (objectui#6526 option B): reading `groupField` into the `groupBy` box
+    // would be a second de-facto spelling for the key, and it would invent an
+    // intent the board never acted on — `ObjectKanban.tsx` reads `groupBy` at
+    // thirteen sites and `groupField` at none, so no card was ever placed by
+    // this value. Nothing on screen changes when it goes.
+    renderInspector(poisoned());
+    const picker = screen.getByLabelText('Group by field') as HTMLElement;
+    expect(picker.textContent ?? '').not.toContain('stage');
+  });
+
+  it('an untouched block with only live keys is committed verbatim', () => {
+    // Non-vacuity for the strip itself: it must not be quietly rewriting
+    // properties on every read.
+    const onPatch = renderInspector(
+      pageDraft({ objectName: 'opportunity', groupBy: 'stage', somePluginKey: 'kept' }),
+    );
+    fireEvent.change(screen.getByLabelText('somePluginKey'), { target: { value: 'edited' } });
+    expect(committedProps(onPatch)).toEqual({
+      objectName: 'opportunity',
+      groupBy: 'stage',
+      somePluginKey: 'edited',
+    });
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/PageBlockInspector.tsx
@@ -26,7 +26,13 @@ import {
   InspectorEmptyState,
   moveArray,
 } from './_shared.js';
-import { BLOCK_CONFIG, blockHasConfig, type BlockPropField, type PlaceholderSpec } from '../previews/block-config.js';
+import {
+  BLOCK_CONFIG,
+  blockHasConfig,
+  stripRetiredBlockProps,
+  type BlockPropField,
+  type PlaceholderSpec,
+} from '../previews/block-config.js';
 import { ColorVariantPicker } from '../color-variant-field.js';
 import { ConditionBuilder } from './ConditionBuilder.js';
 import { expressionSource, writeExpressionSource } from './expression-envelope.js';
@@ -445,7 +451,20 @@ export function PageBlockInspector({ selection, draft, onPatch, onClearSelection
   // Per-block configurable properties (spec `properties`). The renderer hoists
   // `properties.*` to the top level, so we read from either and always write
   // back to `properties` (the canonical shape).
-  const blockProps = (block.properties as Record<string, unknown>) || {};
+  //
+  // Read through `stripRetiredBlockProps` (objectui#7772): a key a released
+  // designer build wrote that the block's node schema now refuses BY NAME is
+  // dropped HERE, which is the only place it can be dropped without a migration
+  // pass. This is the single value every property write spreads from
+  // (`patchProp` below), and it is also what `advancedKeys` enumerates — so a
+  // retired key neither rides back out on the next save nor shows up in the
+  // generic "Advanced" editor, which can set a value but never delete one. The
+  // criterion for membership, and why this is a strip rather than a migration,
+  // are on the constant itself.
+  const blockProps = stripRetiredBlockProps(
+    block.type as string | undefined,
+    (block.properties as Record<string, unknown>) || {},
+  );
   // The record page's bound object — drives `field-picker`/`field-list` with
   // objectFrom:'page'. (objectFrom:'self' reads a sibling block property.)
   const pageObject = typeof (draft as any)?.object === 'string' ? ((draft as any).object as string) : undefined;

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config-i18n.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config-i18n.test.ts
@@ -280,7 +280,7 @@ describe('en-US labels are unchanged by the key migration (#3913)', () => {
     'engine.inspector.pageBlock.field.element:image.src': 'Source URL',
     'engine.inspector.pageBlock.field.element:button.action': 'Action',
     'engine.inspector.pageBlock.field.object-metric.colorVariant': 'Color',
-    'engine.inspector.pageBlock.field.object-kanban.groupField': 'Group by field',
+    'engine.inspector.pageBlock.field.object-kanban.groupBy': 'Group by field',
     // string-list / array container
     'engine.inspector.pageBlock.field.record:quick_actions.actionNames': 'Action names',
     'engine.inspector.pageBlock.field.record:details.sections': 'Sections',
@@ -369,20 +369,27 @@ describe('placeholders that must NOT be translated (#3979)', () => {
       because: 'a JSON sample the author copies — translated keys would fail InlineActionSchema',
     },
     'record:related_list.limit': { literal: '10', because: 'a row limit' },
+    'object-kanban.limit': {
+      literal: '100',
+      because: "a row limit — DEFAULT_KANBAN_LIMIT, the board's fetch cap when the box is empty",
+    },
     'record:details.sections.columns': { literal: '2', because: 'a column count' },
   };
 
-  it('collects all 17 placeholders — 7 keyed, 10 literal', () => {
+  it('collects all 18 placeholders — 7 keyed, 11 literal', () => {
     // Guards the walk: if placeholder collection silently found nothing, every
     // assertion here would pass over an empty list.
     //
     // 18 / 8 / 10 until objectui#3829: the canonical `page:header` icon box was
     // a KEYED placeholder, and it went with the field when objectstack#6946 /
-    // PR objectstack#7115 retired `PageHeaderProps.icon`. The literal half is
-    // untouched, which is what this split says.
-    expect(PLACEHOLDERS.length).toBe(17);
+    // PR objectstack#7115 retired `PageHeaderProps.icon`. Then 17 / 7 / 10
+    // until objectui#7772 gave `object-kanban` the `limit` control its schema
+    // has declared since objectui#7322 — a VALUE placeholder (`100`,
+    // `DEFAULT_KANBAN_LIMIT`), so it lands on the literal side and the keyed
+    // half is what stays untouched this time.
+    expect(PLACEHOLDERS.length).toBe(18);
     expect(PLACEHOLDERS.filter((p) => p.spec.key !== undefined).length).toBe(7);
-    expect(PLACEHOLDERS.filter((p) => p.spec.literal !== undefined).length).toBe(10);
+    expect(PLACEHOLDERS.filter((p) => p.spec.literal !== undefined).length).toBe(11);
   });
 
   it('every placeholder declares exactly one of key / literal', () => {

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   ACTION_LOCATIONS,
   PageAccordionProps,
@@ -14,7 +17,19 @@ import {
   resolvePropsShape,
   shapeMemberTypeName,
 } from '@object-ui/test-support';
-import { BLOCK_CONFIG, blockHasConfig, type PlaceholderSpec } from '../block-config';
+// The NODE face of the block vocabulary — `object-kanban`'s own schema, where
+// objectui#7322 declared `groupBy` REQUIRED and tombstoned `groupField`. The
+// spec imports above cover the PAGE face; the two are different contracts and
+// this file now reads both.
+import { ObjectKanbanSchema } from '@object-ui/types/zod';
+import {
+  BLOCK_CONFIG,
+  RETIRED_BLOCK_PROP_KEYS,
+  blockHasConfig,
+  stripRetiredBlockProps,
+  type BlockPropField,
+  type PlaceholderSpec,
+} from '../block-config';
 import { BLOCK_TYPE_META, PALETTE_EXCLUSIONS } from '../block-types';
 import { t } from '../../i18n';
 
@@ -478,6 +493,245 @@ describe('page:accordion `title` / items `value` — dead designer inputs (#5212
     ]) {
       expect(t(key, 'en-US')).toBe(key);
       expect(t(key, 'zh-CN')).toBe(key);
+    }
+  });
+});
+
+/**
+ * `object-kanban` — the panel that could not author a valid board (objectui#7772).
+ *
+ * Same PUBLISH-FACE-with-no-parity-gate reasoning as the two describes above,
+ * and this block is where that gap cost the most.
+ * `scripts/check-designer-field-key-parity.mjs` judges `PAYLOAD_SHAPES` — the
+ * field / object / permission payloads — and does not read `BLOCK_CONFIG` at
+ * all, so nothing mechanical compared this panel's four fields against
+ * `ObjectKanbanSchema`. What that hid was not one stale key but a matched pair:
+ *
+ *   - the ONLY control able to set grouping wrote `groupField`, which
+ *     `ObjectKanban.tsx` reads at zero sites (`schema.groupBy` at thirteen in
+ *     the same query, so that zero is a reading) and which objectui#7322
+ *     retired BY NAME — `retirementTombstone()` on the zod face, `?: never` on
+ *     the TS one;
+ *   - `groupBy`, which the same card declared REQUIRED, had no control at all.
+ *
+ * So the panel stably emitted a node that was missing a required key AND
+ * carrying a name-retired one, and rendered a board that grouped nothing with
+ * no diagnostic anywhere. `limit` is the third declared key it never offered:
+ * `ObjectKanban.tsx` sends it as a real `$top`, so a board over
+ * `DEFAULT_KANBAN_LIMIT` records was silently truncated with no way to widen it.
+ *
+ * The parse probes below are the instrument this surface otherwise lacks: they
+ * read the CONTRACT rather than a spelling, so the next control added here is
+ * measured against the schema instead of against a reviewer's memory.
+ */
+describe('object-kanban — the required `groupBy` control, and the retired `groupField` (objectui#7772)', () => {
+  const fieldNames = () => BLOCK_CONFIG['object-kanban'].map((f) => f.name);
+
+  /** A block node as the canvas hoists it: `properties.*` at the top level. */
+  const nodeFrom = (properties: Record<string, unknown>) => ({
+    type: 'object-kanban' as const,
+    id: 'k1',
+    ...properties,
+  });
+
+  // POSITIVE half, for the reason the two describes above state: without it the
+  // negative pin would pass just as happily on a panel that lost every field.
+  it('offers exactly the five controls, in panel order', () => {
+    expect(fieldNames()).toEqual(['objectName', 'groupBy', 'titleField', 'cardFields', 'limit']);
+  });
+
+  it('does NOT offer the retired `groupField`', () => {
+    expect(fieldNames().length, 'field list is empty — the pin would be vacuous').toBeGreaterThan(0);
+    expect(fieldNames()).not.toContain('groupField');
+  });
+
+  /* ── the contract, read rather than spelled ───────────────────────────── */
+
+  /** A value of the shape the control commits, chosen by its declared kind. */
+  const sampleFor = (f: BlockPropField): unknown => {
+    switch (f.kind) {
+      case 'number':
+        return 1;
+      case 'boolean':
+        return true;
+      case 'field-list':
+      case 'string-list':
+        return ['name'];
+      default:
+        return 'name';
+    }
+  };
+
+  it('every control writes a key `ObjectKanbanSchema` accepts', () => {
+    // Membership, not absence: a field whose name the schema refuses (retired,
+    // or never declared) fails here without anyone having to name it in
+    // advance — which is the coverage `check-designer-field-key-parity.mjs`
+    // gives the payload shapes and does not give this table.
+    const refused = BLOCK_CONFIG['object-kanban']
+      .filter(
+        (f) =>
+          !ObjectKanbanSchema.safeParse(
+            nodeFrom({ objectName: 'opportunity', groupBy: 'stage', [f.name]: sampleFor(f) }),
+          ).success,
+      )
+      .map((f) => f.name);
+    expect(refused).toEqual([]);
+
+    // Non-vacuity: the probe must be able to say no. A key this block never
+    // declared has to be refused by the very same call shape.
+    expect(
+      ObjectKanbanSchema.safeParse(
+        nodeFrom({ objectName: 'opportunity', groupBy: 'stage', groupField: 'stage' }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it('the node this panel can now author PARSES', () => {
+    const result = ObjectKanbanSchema.safeParse(
+      nodeFrom({
+        objectName: 'opportunity',
+        groupBy: 'stage',
+        titleField: 'name',
+        cardFields: ['amount'],
+        limit: 50,
+      }),
+    );
+    expect(result.success, JSON.stringify(result.error?.issues)).toBe(true);
+  });
+
+  // FALSIFICATION for the probe above — the pre-fix control set, verbatim. A
+  // green "it parses" means nothing unless the node this panel used to emit
+  // goes red, and it must go red TWICE: once for the key that is missing and
+  // once for the key that is refused by name. Either issue alone would be a
+  // different, smaller defect.
+  it('the node the pre-fix panel emitted is refused twice — missing `groupBy`, named `groupField`', () => {
+    const result = ObjectKanbanSchema.safeParse(
+      nodeFrom({ objectName: 'opportunity', groupField: 'stage', titleField: 'name' }),
+    );
+    expect(result.success).toBe(false);
+    const byPath = Object.fromEntries(
+      (result.error?.issues ?? []).map((i) => [i.path.join('.'), i]),
+    );
+    expect(Object.keys(byPath).sort()).toEqual(['groupBy', 'groupField']);
+    // The required key, absent.
+    expect(byPath.groupBy.code).toBe('invalid_type');
+    // The retired key, refused BY NAME — the tombstone's guidance reaches the
+    // author verbatim, which is the whole point of `retirementTombstone()` over
+    // a silent strip. Asserted on the message because `invalid_type` alone
+    // cannot tell a tombstone from an ordinary type mismatch.
+    expect(byPath.groupField.message).toContain('RETIRED (objectui#7322)');
+    expect(byPath.groupField.message).toContain('author `groupBy`');
+  });
+
+  /* ── the placeholder states the real default ──────────────────────────── */
+
+  it("`limit`'s placeholder is DEFAULT_KANBAN_LIMIT, read from the renderer", () => {
+    // The box is empty by default and the board still caps the fetch, so the
+    // hint is only honest while it equals the constant `ObjectKanban.tsx`
+    // actually falls back to. Read from source rather than imported: the
+    // constant is not on `@object-ui/plugin-kanban`'s barrel, and a deep
+    // cross-package import would be a worse coupling than a regex.
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const src = readFileSync(
+      path.resolve(here, '../../../../../../plugin-kanban/src/ObjectKanban.tsx'),
+      'utf8',
+    );
+    const declared = /export const DEFAULT_KANBAN_LIMIT = (\d+)/.exec(src)?.[1];
+    expect(declared, 'could not read DEFAULT_KANBAN_LIMIT from ObjectKanban.tsx').toBeTruthy();
+
+    const limit = BLOCK_CONFIG['object-kanban'].find((f) => f.name === 'limit');
+    expect(limit?.kind).toBe('number');
+    expect((limit as { placeholder?: PlaceholderSpec }).placeholder).toEqual({ literal: declared });
+  });
+
+  /* ── the i18n side ────────────────────────────────────────────────────── */
+
+  // The two repo-wide i18n gates do NOT reach this table — `check:i18n-keys`
+  // and `check:i18n-dead-keys` both read `packages/i18n/src/locales/en.ts`, and
+  // `engine.inspector.pageBlock.*` lives only in `metadata-admin/i18n.ts`
+  // (which says so in its own header). So the renamed key's two halves are
+  // pinned here, in the same file as the field it labels: the sibling
+  // `block-config-i18n.test.ts` derives the NEW key from this table's position
+  // and demands both locales define it, and this pin is the other direction —
+  // a key kept past its field is dead vocabulary the next author reads as a
+  // live surface.
+  it('has no leftover translation for the retired key in either locale', () => {
+    const retired = 'engine.inspector.pageBlock.field.object-kanban.groupField';
+    expect(t(retired, 'en-US')).toBe(retired);
+    expect(t(retired, 'zh-CN')).toBe(retired);
+    // Non-vacuity: `t()` returning the key unchanged is also what a broken
+    // table would do, so a live neighbour must still resolve to real text.
+    const live = 'engine.inspector.pageBlock.field.object-kanban.groupBy';
+    expect(t(live, 'en-US')).toBe('Group by field');
+    expect(t(live, 'zh-CN')).toBe('分组字段');
+  });
+});
+
+/**
+ * `stripRetiredBlockProps` — the read-door half of objectui#7772.
+ *
+ * The rename above stops the panel WRITING `groupField`; documents saved by
+ * every released build before it still carry the key, and after the rename it
+ * is no longer a curated field, so it lands in `PageBlockInspector`'s generic
+ * "Advanced" section — an editor that can set a value but has no delete. These
+ * pin the door itself; `PageBlockInspector.retiredBlockProps.test.tsx` pins
+ * what an author sees and what the next save commits.
+ */
+describe('stripRetiredBlockProps (objectui#7772)', () => {
+  it('drops the retired key and keeps everything else', () => {
+    const out = stripRetiredBlockProps('object-kanban', {
+      objectName: 'opportunity',
+      groupField: 'stage',
+      groupBy: 'stage',
+      titleField: 'name',
+      // An unknown key the designer does not render still survives: this is a
+      // tombstone-keyed strip, never a blanket unknown-key purge (AGENTS.md
+      // #0.1) — a plugin-registered key would be lost by the blanket version.
+      somePluginKey: 1,
+    });
+    expect(Object.keys(out).sort()).toEqual(
+      ['groupBy', 'objectName', 'somePluginKey', 'titleField'].sort(),
+    );
+  });
+
+  it('is scoped to the block type that retired the key', () => {
+    // `groupField` is NODE-LOCAL to `object-kanban`. Any other block carrying a
+    // key of that name keeps it — and so does the view-level `kanban.groupField`
+    // alias, which is live (`core/src/utils/normalize-list-view.ts`) and is not
+    // a page block at all.
+    const props = { groupField: 'stage' };
+    expect(stripRetiredBlockProps('object-grid', props)).toEqual({ groupField: 'stage' });
+    expect(stripRetiredBlockProps(undefined, props)).toEqual({ groupField: 'stage' });
+  });
+
+  it('returns the very same object when there is nothing to strip', () => {
+    // Identity, not equality: the caller memoises on this value, so allocating a
+    // fresh object per read would churn every consumer downstream of it.
+    const props = { objectName: 'opportunity', groupBy: 'stage' };
+    expect(stripRetiredBlockProps('object-kanban', props)).toBe(props);
+  });
+
+  it('every registered key really is one the block schema refuses BY NAME', () => {
+    // The membership criterion, mechanical: a key the schema ACCEPTS must never
+    // be listed here, because stripping an accepted key deletes authored
+    // metadata. Only `object-kanban` is registered today, and this walks
+    // whatever the registry holds rather than that one literal.
+    for (const [type, keys] of Object.entries(RETIRED_BLOCK_PROP_KEYS)) {
+      expect(type, 'only object-kanban has a schema probe here').toBe('object-kanban');
+      for (const key of keys) {
+        const result = ObjectKanbanSchema.safeParse({
+          type: 'object-kanban',
+          id: 'k1',
+          objectName: 'opportunity',
+          groupBy: 'stage',
+          [key]: 'anything',
+        });
+        expect(result.success, `${type}.${key} is still accepted`).toBe(false);
+        expect(
+          (result.error?.issues ?? []).some((i) => i.path.join('.') === key),
+          `${type}.${key} was not refused at its own path`,
+        ).toBe(true);
+      }
     }
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/block-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/block-config.ts
@@ -219,9 +219,26 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
   ],
   'object-kanban': [
     { name: 'objectName', label: 'engine.inspector.pageBlock.field.object-kanban.objectName', kind: 'object-picker' },
-    { name: 'groupField', label: 'engine.inspector.pageBlock.field.object-kanban.groupField', kind: 'field-picker', objectFrom: 'self', objectProp: 'objectName' },
+    // `groupBy`, not `groupField` (objectui#7772). This lane picker wrote
+    // `groupField` from #1831 until here — the one key `ObjectKanban.tsx` never
+    // reads (thirteen `schema.groupBy` sites, zero `groupField`), and since
+    // objectui#7322 a `retirementTombstone()` on the zod face and `?: never` on
+    // the TS one, so the node it produced was refused BY NAME. The other half
+    // was worse and unnamed: `ObjectKanbanSchema.groupBy` is REQUIRED and had
+    // no control at all, so this panel could not author a valid board however
+    // it was filled in. Measured on the node these four fields produce:
+    // `ObjectKanbanSchema.safeParse` reported BOTH — `groupBy` "expected
+    // string, received undefined" and `groupField` carrying the retirement
+    // message. Pinned in `__tests__/block-config.test.ts`.
+    { name: 'groupBy', label: 'engine.inspector.pageBlock.field.object-kanban.groupBy', kind: 'field-picker', objectFrom: 'self', objectProp: 'objectName' },
     { name: 'titleField', label: 'engine.inspector.pageBlock.field.object-kanban.titleField', kind: 'field-picker', objectFrom: 'self', objectProp: 'objectName' },
     { name: 'cardFields', label: 'engine.inspector.pageBlock.field.object-kanban.cardFields', kind: 'field-list', objectFrom: 'self', objectProp: 'objectName' },
+    // The board's fetch window, not a page size: `ObjectKanban.tsx` sends it as
+    // a real `$top` (`$top: schema.limit ?? DEFAULT_KANBAN_LIMIT`) and renders
+    // every fetched record into a lane with no pagination, so an author with
+    // more than 100 records had no way to widen it. `{ literal: '100' }` is
+    // `DEFAULT_KANBAN_LIMIT`, the value that applies when the box is empty.
+    { name: 'limit', label: 'engine.inspector.pageBlock.field.object-kanban.limit', kind: 'number', placeholder: { literal: '100' } },
   ],
 
   // ── Layout grid ───────────────────────────────────────────────────────────
@@ -523,4 +540,74 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
 /** Block types that expose a configurable property panel. */
 export function blockHasConfig(type: string | undefined): boolean {
   return !!type && Array.isArray(BLOCK_CONFIG[type]) && BLOCK_CONFIG[type].length > 0;
+}
+
+/**
+ * Per block type, the `properties` keys a SHIPPED designer build wrote that the
+ * block's own node schema now refuses BY NAME — stripped where the inspector
+ * READS a block (objectui#7772).
+ *
+ * ## Membership criterion: evidence, never defence
+ *
+ * A key belongs here only when BOTH hold, the same bar
+ * `previews/object-fields-io.ts`'s `RETIRED_FIELD_KEYS` sets for the object
+ * designer and `PermissionAdvancedFacets`' `RETIRED_RLS_KEYS` for the RLS one:
+ *
+ *   1. a control in {@link BLOCK_CONFIG} above really wrote it in a RELEASED
+ *      build, so stored documents can carry it — never a defensive guess at
+ *      what an author might have typed;
+ *   2. the node schema refuses the key BY NAME rather than ignoring it, so the
+ *      strip cannot lose anything a consumer would have honoured.
+ *
+ * `object-kanban.groupField` meets both: the lane picker wrote it from #1831
+ * (released — `@object-ui/app-shell@17.5.0` and later) until objectui#7772
+ * renamed that control to `groupBy`, and `ObjectKanbanSchema.groupField` is a
+ * `retirementTombstone()` on the zod face and `?: never` on the TS one since
+ * objectui#7322.
+ *
+ * ## Why a strip and not a migration into `groupBy`
+ *
+ * Reading a stored `groupField` into the new `groupBy` box would be a second
+ * de-facto spelling for the key — AGENTS.md #0.1, the renderer-side alias this
+ * repo does not accrete — and it would invent an intent the board never acted
+ * on: `ObjectKanban.tsx` reads `schema.groupBy` at thirteen sites and
+ * `groupField` at none, so the value has never placed a single card in a lane.
+ * Nothing on screen changes when it goes. The `formula` -> `expression`
+ * carry-over (objectui#6526 option B) is the opposite case and stays the
+ * opposite case: there a live editor MIGRATES the value and the authored source
+ * text would be destroyed by a strip.
+ *
+ * ## Why on READ, and why here rather than a data migration
+ *
+ * After the rename `groupField` is no longer a curated field, so it falls into
+ * `PageBlockInspector`'s generic "Advanced" section — whose editor can SET a
+ * value but has no delete, leaving an author with a key the contract refuses
+ * and no control to clear it with. `blockProps` there is the single value every
+ * property write spreads from, so one strip on read makes an edit-and-save
+ * round-trip of an already-poisoned block come out clean, with no migration
+ * pass over stored documents.
+ *
+ * NODE-LOCAL, exactly as the tombstone is: the VIEW-LEVEL `kanban.groupField`
+ * alias (`core/src/utils/normalize-list-view.ts`) is live and is not a page
+ * block, so nothing here reaches it.
+ */
+export const RETIRED_BLOCK_PROP_KEYS: Readonly<Record<string, readonly string[]>> = {
+  'object-kanban': ['groupField'],
+};
+
+/**
+ * Drop the block type's {@link RETIRED_BLOCK_PROP_KEYS} from one block's
+ * `properties`. Returns the input untouched when there is nothing to strip, so
+ * a caller's identity-keyed memo does not churn on every read.
+ */
+export function stripRetiredBlockProps(
+  type: string | undefined,
+  props: Record<string, unknown>,
+): Record<string, unknown> {
+  const retired = (type && RETIRED_BLOCK_PROP_KEYS[type]) || [];
+  const present = retired.filter((k) => k in props);
+  if (present.length === 0) return props;
+  const next = { ...props };
+  for (const k of present) delete next[k];
+  return next;
 }


### PR DESCRIPTION
Fixes #7772

## The defect, as measured — bigger than the card's framing

The card says "an inspector writes a key the renderer ignores". Triage's §2 corrected that, and I re-measured every anchor before touching anything.

`BLOCK_CONFIG['object-kanban']` offered four controls — `objectName` / `groupField` / `titleField` / `cardFields` — while `ObjectKanbanSchema` declared:

| | measured on `origin/main` `0c8dbc49` |
|:--|:--|
| `groupBy` | **REQUIRED** — `packages/types/src/objectql.ts:2765 groupBy: string;` (no `?`), `zod/objectql.zod.ts:1001 groupBy: z.string()` (no `.optional()`). **No control at all.** |
| `groupField` | `zod/objectql.zod.ts:1002 groupField: retirementTombstone(...)`, `?: never` on the TS face (objectui#7322). **The only control able to set grouping.** |
| renderer reads | `schema.groupBy` at 13 sites in `plugin-kanban/src/ObjectKanban.tsx`, `groupField` at **0** (`git grep` exit 1; control: those same 13 hits in the one query, so the zero is a reading) |

So this panel could not author a valid board however it was filled in. Run against the node those four controls produce, `ObjectKanbanSchema.safeParse` reports **two** issues, not one:

```
{ code: 'invalid_type', path: ['groupBy'],    message: 'Invalid input: expected string, received undefined' }
{ code: 'invalid_type', path: ['groupField'], message: 'RETIRED (objectui#7322) - `groupField` is not read by
                                                        the object-kanban renderer; author `groupBy`. ...' }
```

Both halves are now pinned against the schema itself rather than against a spelling.

## What changed

1. **`block-config.ts`** — the lane picker's `name` and `label` become `groupBy` (same `field-picker` kind, same `objectFrom`/`objectProp`).
2. **`limit`** — a new `number` control. Not polish: `ObjectKanban.tsx` sends it as a real `$top` (`$top: schema.limit ?? DEFAULT_KANBAN_LIMIT`) and renders every fetched record into a lane with no pagination, so a board over 100 records was silently truncated with no way to widen it. The placeholder is `{ literal: '100' }`, and its pin reads `DEFAULT_KANBAN_LIMIT` out of `ObjectKanban.tsx` rather than hard-coding it, so the hint cannot drift from the fallback it describes.
3. **i18n** — both locale entries move with the control, plus a new `.limit` in each. The English wording is unchanged (`Group by field`): the box means what it always meant, only its key moved.
4. **Saved documents** — `RETIRED_BLOCK_PROP_KEYS` + `stripRetiredBlockProps` in `block-config.ts`, applied where `PageBlockInspector` reads `block.properties`. This is triage §4's instruction: copy the established `RETIRED_FIELD_KEYS` pattern (`previews/object-fields-io.ts`, `PermissionAdvancedFacets`' `RETIRED_RLS_KEYS`) with a same-shaped but independent list — the existing registry is field-key specific and says so ("Every key in this registry is refused by the installed `FieldSchema`").

### Why a strip on read, and not a migration into `groupBy`

Reading a stored `groupField` into the new box would be a second de-facto spelling for the key (AGENTS.md #0.1), and it would invent an intent the board never acted on — the renderer has never read it, so the value has not placed a single card in a lane. Nothing on screen changes when it goes. The `formula` -> `expression` carry-over (objectui#6526 option B) is the opposite case and stays the opposite case: there a live editor MIGRATES the value, and a strip would destroy authored source text.

Evidence for membership, not defence — the criterion the precedent sets. The control landed 2026-06-21 (objectui#1831) and ships in `@object-ui/app-shell@17.5.0` and every build since (`git tag --contains`), so stored pages really can carry the key; and the node face refuses it BY NAME rather than ignoring it, so the strip cannot lose anything a consumer would have honoured.

Why the read door: after the rename `groupField` is no longer a curated field, so it falls into the generic **Advanced** section, whose `GenericPropField` can set a value but has no delete — the "no UI path left to clear the key" shape the precedent names. `blockProps` is the single value every property write spreads from, so one strip there makes an edit-and-save round-trip come out clean with no migration pass.

## Clause-② — does any accept set move?

**No.** Stated rather than assumed, because renaming an inspector control changes what the designer *emits*.

- **Node face**: untouched. `ObjectKanbanSchema` already required `groupBy` and already refused `groupField`; nothing here widens or narrows it. What moved is the producer, toward the contract (declared = enforced).
- **Page face**: measured, and it never had an opinion. `PageSchema.safeParse` does not descend into a block's `properties` — a page carrying `properties: { zzzTotallyBogusKey: 1 }` parses green (control run in the same script). So no draft that parsed before fails now, and none that failed passes.
- **The strip** is keyed to a tombstone list, not a blanket unknown-key purge: every other key the designer does not render still survives, pinned.

## Zone 2 — anchors re-measured, drift reported

Line numbers were treated as hints and matched on text.

| anchor | claimed | measured | |
|:--|:--|:--|:--|
| `block-config.ts` lane control | `:222` | `:222` | exact |
| en i18n | `:611` | `:611` | exact |
| zh i18n | `:2465` (card said `:2454`) | `:2465` | triage's correction confirmed; `:2454` is `option.colorVariant.purple` |
| i18n pin | `block-config-i18n.test.ts:283` | `:283` | exact |
| TS `groupBy: string;` | `objectql.ts:2765` | `:2765` | exact |
| zod `groupBy` / `groupField` | `objectql.zod.ts:995` / `:996` | **`:1001` / `:1002`** | drift +6 |
| `schema.limit` read | `ObjectKanban.tsx:264` | **`:364`** (and `:391` deps) | drift +100 |

**Pins defined by omission** — the class a grep for the key cannot see. `toMatchSnapshot` / `toMatchInlineSnapshot` / `.snap`: **zero** anywhere under `packages/app-shell` (control: the pattern does fire — `packages/components/src/__tests__/snapshot-critical.test.tsx` and two `.snap` files repo-wide). What the enumeration *did* find is three exact counts my change had to move, none of which name `groupField` or `limit`: `PLACEHOLDERS.length` 17 -> 18, the literal half 10 -> 11, and the `INVARIANT` literal inventory, which is asserted whole (`expect(actual).toEqual(expected)`) and now carries `object-kanban.limit` with its reason.

## The i18n trap, measured — and it is not where the dispatch expected

The order warned that `check:i18n-keys` and `check:i18n-dead-keys` would each go half-red if the three sites moved apart. **Measured, that premise is false**: both gates read `packages/i18n/src/locales/en.ts` (the ten locale packs), and `engine.inspector.pageBlock.*` is not in them — `git grep -c` over `packages/i18n/src/locales/` returns zero for that prefix while the control (`filterBuilder`) returns a hit, and `metadata-admin/i18n.ts`'s own header says it "is NOT one of those packs". `check:i18n-drift` confirms it from the other side: it reports **0 en values changed** on a diff that renames a key in this table.

**The conclusion is unchanged and the coupling is real** — it is just enforced by a different instrument. `block-config-i18n.test.ts` derives every key from `BLOCK_CONFIG`'s own structure and asserts both locales define it, and its `orphans` check asserts every sampled key is one the table still reaches. Moving any one of the three sites without the others reddens it, which the ablation below demonstrates rather than asserts. Since no repo-wide gate watches the retired key's *absence* here, that direction is pinned explicitly in `block-config.test.ts`, in the house shape objectui#3829 and objectui#5212 established.

## Scope fences honoured

- ⛔ No controls added for `quickAdd` / `coverImageField` / `allowCollapse` / `conditionalFormatting` — triage's product-decision call.
- ⛔ The **view-level** `kanban.groupField` alias is untouched, and I confirmed it is live rather than assuming: `plugin-list/src/ListView.tsx:2165` reads `schema.options?.kanban?.groupField` today, and `core/src/utils/normalize-list-view.ts:191` maps it. `stripRetiredBlockProps` is keyed by block type, and a pin asserts a `groupField` on any other block survives.
- ⛔ Did not widen into the gate-coverage question. Filed separately, unassigned: **objectui#8216**.

One note on a near-miss: `plugin-view/src/ObjectView.tsx` and `plugin-list/src/ListView.tsx` still write `groupField` onto a generated `object-kanban` node **in this branch's tree**, which looks like a live sibling defect. It is not — PR #8191 (objectui#7773) landed that fix at 00:21, one hour after this branch's base at 23:22. Verified by ancestry with a control leg on a non-shallow checkout (`--is-ancestor` of base: exit 1; control commit: exit 0). Branch facts are not tree facts.

## Verification

All heavy runs through the container's shared verify lock; every verdict read from the wrapper's own `VERDICT command-exit` line, never a bare `$?`. Final commit `f0e6f3f7c`.

**Tests** — green, and the counts are before/after on the same command:

| run | result |
|:--|:--|
| the two `block-config` suites, baseline (pre-edit) | 2 files, **45 passed** |
| the same two, after | 2 files, **56 passed** (+11) |
| new `PageBlockInspector.retiredBlockProps.test.tsx` | 1 file, **6 passed** |
| `packages/app-shell/src/views/` (incl. all of metadata-admin) | 388 files, **3708 passed**, 1 skipped |
| `packages/app-shell/src/` outside `views/` | 251 files, **2431 passed** |
| `apps/console/` | 89 files, **1052 passed** |

Affected set read from `TURBO_SCM_BASE=0c8dbc49 turbo ls --affected`: `@object-ui/app-shell`, `@object-ui/console`, and two examples (no test scripts). Not guessed from which packages the diff touches.

**Type-check** — `pnpm --filter @object-ui/app-shell run type-check`, exit 0. Note the objectui spelling is `type-check` (hyphen), and it is `tsc --noEmit && tsc -p tsconfig.test.json`, so the new test file is really covered rather than excluded.

**Gates** — all exit 0, each redirected to a file before the exit code was captured (never read across a pipe): `check:control-bytes` · `check:i18n-keys` · `check:i18n-dead-keys` · `check:i18n-drift` · `check:designer-field-key-parity` · `check:vi-mock-specifiers` · `check:vi-mock-inherit` · `check:phantom-deps` · `check:self-import` · `check:unreferenced-sources` · `check-changeset-presence.mjs` · `check-changeset-no-major.mjs`. Plus a manual control-byte sweep over the seven changed files (`grep -naP` over the C0 range, exit 1 = clean).

**Lint** — not a narrowing, the whole population: `eslint --no-inline-config .` at the repo root, **4396 files**, count read from `--format json`. My six changed files: **0 errors** (35 warnings, all pre-existing rule classes — `no-explicit-any` in tests, `react-refresh` in the inspector, carried unchanged from the file each was copied from). The 94 errors the run reports live in 78 files none of which this diff touches, and they cannot be attributable to it: `eslint.config.js` enables no type-aware linting (no `project`, `projectService` or `tsconfigRootDir` anywhere in it), so no rule reads types across files and this diff cannot move the verdict on a file it does not contain. `--no-inline-config` makes this run strictly stricter than CI's per-package `eslint .`.

**Ablation** — two legs, each: mutate one anchored line, prove it reached disk, run the pins, restore via `trap ... EXIT INT TERM`, prove the restore BY STATE. No build step needed and that is measured, not assumed: `vitest.config.mts:411` aliases `@object-ui/types/zod` to `packages/types/src/zod/index.zod.ts`, and the app-shell suites reach `block-config` by relative path, so every file under test resolves to `src`.

**Leg A** — the lane control reverted to `groupField`. Anchor `name: 'groupBy'` 1 -> 0, `name: 'groupField'` 0 -> 1, blob hash changed. Result: **9 tests failed across all three files**, exactly the claimed set —

- `offers exactly the five controls, in panel order`
- `does NOT offer the retired groupField`
- `every control writes a key ObjectKanbanSchema accepts`
- `every key resolves in en-US` / `in zh-CN` / `zh-CN is actually translated` / `every sampled key is one the table really reaches`
- `offers the lane picker and the row cap` / `leaves the lane picker empty rather than reading the retired value into it`

The four i18n failures are the coupling the dispatch was worried about, demonstrated: move `block-config.ts` without the two locale entries and the pin goes red in both directions at once.

**Leg B** — the `stripRetiredBlockProps` call replaced by the raw read. Anchor 1 -> 0, blob hash changed. Result: **exactly 2 failed, 4 passed** — `renders no box for it` and `does not ride back out on the next save`. The other four stayed green, which is correct: they do not depend on the strip. A leg that reddened everything would mean the pins are not separable.

Restore proven by state in both legs, not by exit code: `git checkout HEAD -- <abs path>`, then `git hash-object` equal to `git rev-parse HEAD:<path>` and `git diff HEAD` empty. Working tree clean at the final commit.

**Direction reported as observed**: both legs turn RED. Neither was a diagnostics-count change nor a reversal.

## Not done, deliberately

- ⛔ Not flipped ready, not merged, not enqueued — draft for the PM to land.
- No `skip-changeset` label: this repo declares with a changeset file, and its same-named label is inert (pinned). The changeset declares `@object-ui/app-shell: minor` — a new authoring control plus a behaviour change in what the designer emits, and this repo ships breaking as `minor` (`check-changeset-no-major.mjs`, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_