### PR TITLE
fix(app-shell,plugin-list): emit the spec-canonical kanban lane key, and let the capability gate see it (objectui#8193)

### DIFF
--- a/.changeset/8193-objectview-canonical-groupbyfield.md
+++ b/.changeset/8193-objectview-canonical-groupbyfield.md
@@ -1,0 +1,49 @@
+---
+'@object-ui/app-shell': minor
+'@object-ui/plugin-list': minor
+---
+
+Emit the spec-canonical kanban lane key from the object page, and teach the
+capability gate to recognize it (objectui#8193).
+
+`ObjectView` built the view-level kanban config it hands to `list-view` and wrote
+the deprecated alias `groupField` — never `groupByField`, the key
+`@objectstack/spec`'s `KanbanConfigSchema` actually declares — even though it
+already READ the canonical key first. Its sibling producer in the same package,
+`defaultKanbanFromObject` in `InterfaceListPage`, had migrated long before and
+left the reasoning next to itself ("that read-site now prefers the spec key, so
+one key is enough"); the twin was not carried along, so one producer surface
+spoke two vocabularies for one concept depending on which entry point you
+arrived through. `ObjectView` writes into `options.kanban`, which
+`normalizeListViewSchema`'s alias fold deliberately does not reach, so nothing
+corrected it downstream and the legacy spelling was what drove the lanes.
+
+The expression is now the exported `kanbanViewOptions`, the fifth member of the
+`timelineViewOptions` / `calendarViewOptions` / `ganttViewOptions` /
+`galleryViewOptions` family it had been the odd one out of.
+
+**`ListView`'s kanban capability gate changed with it, and had to.** The gate
+consulted the `options.kanban` bag for the LEGACY spelling only, so a producer
+writing the spec key into the bag was invisible to it while still rendering
+correctly — the render branch merges the bag and resolves
+`groupByField || groupField`, so the gate recognized strictly less than what
+renders. Measured before and after: a bag of `{groupBy, groupField}` offered
+Kanban and `{groupBy, groupByField}` did not, so shipping the producer change
+alone would have removed the Kanban toggle from every object view. The gate now
+reads both spellings out of the bag — the same one-question-two-sites repair
+objectui#5042 made for `map` and objectui#7544 for `chart`.
+
+**No alias READ was removed, and the alias is not retired.** Stored metadata
+still authors `groupField`, and every read site still resolves it; `ListView`
+already preferring the canonical key is precisely why the sibling producer could
+drop the alias write. What changed is only what this one face WRITES, plus one
+added rung on the gate.
+
+**Migration.** Nothing authored has to change. If you read
+`options.kanban.groupField` off the schema `ObjectView` produces, read
+`groupByField` (or both) instead — that bag now carries the spec spelling.
+
+The view-level `groupBy` in the same bag is untouched. It is not a spec key
+either — measured against the strict `KanbanConfigSchema`, which refuses it by
+name — but `ListView`'s projection collectors read it, so retiring it needs its
+own producer census and is filed as objectui#8213.

--- a/packages/app-shell/src/views/ObjectView.kanbanLane-8193.test.tsx
+++ b/packages/app-shell/src/views/ObjectView.kanbanLane-8193.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8193 — the object page emitted the DEPRECATED view-level kanban
+ * alias, into the one bag the alias fold is told not to reach.
+ *
+ * `ObjectView` built `options.kanban` and wrote `groupField` — never the
+ * spec-canonical `groupByField` — even though it already READ the canonical key
+ * first. Its sibling producer in this same package, `defaultKanbanFromObject`
+ * (`InterfaceListPage`), had migrated long before and left the reasoning in a
+ * comment: "that read-site now prefers the spec key, so one key is enough."
+ * The twin twelve hundred lines away was not carried along, so one producer
+ * surface spoke two vocabularies for one concept depending on which entry point
+ * the user arrived through.
+ *
+ * ⭐ THE ANTI-FORK ARM IS THE DURABLE HALF OF THIS CARD. Pinning only
+ * `kanbanViewOptions` would pin today's spelling; the defect was that the two
+ * producers DRIFTED. So the vocabulary of both is derived and compared here —
+ * whichever one a future edit moves, this file reddens.
+ *
+ * ⚠️ WHY `normalizeListViewSchema` CANNOT SAVE THIS. The alias fold maps
+ * `kanban.groupField` to `groupByField` on the DECLARED path only, and its own
+ * suite pins that boundary as intentional ("does not reach into the legacy
+ * `options.*` twin"). `ObjectView` writes into `options.kanban`, on the far
+ * side of that boundary, so nothing folded it and the alias read was
+ * load-bearing purely because of where this producer wrote.
+ *
+ * ⚠️ THE ALIAS IS NOT RETIRED AND NO ALIAS READ WAS TOUCHED. Stored metadata
+ * still authors `groupField`; `ListView` resolving `groupByField || groupField`
+ * is exactly why the sibling could drop the alias write. The arms below assert
+ * what this face WRITES, never what any face reads.
+ *
+ * ⚠️ `groupBy` IS DELIBERATELY STILL WRITTEN, and this file records why rather
+ * than asserting it away. Measured against the spec (below), `groupBy` is not a
+ * declared key either — but it is read by `ListView`'s projection collectors,
+ * so retiring it needs a producer census and got its own card: objectui#8213.
+ * One atomic producer change per PR is what kept this one reviewable.
+ *
+ * REVERSE VERIFICATION — direction predicted before running, then observed:
+ * restore `return lane ? { groupBy: lane, groupField: lane } : {}` and the
+ * canonical arms below go RED (the emitted bag loses `groupByField` and grows
+ * `groupField` back), while the ADR-0085 lane-RESOLUTION controls stay GREEN in
+ * either world — those read which FIELD was chosen, which the defect never
+ * changed. That asymmetry is the point: this defect was never about the value,
+ * only ever about the key it was filed under, so a test asserting the lane
+ * field alone would have passed against the unfixed producer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { KanbanConfigSchema } from '@objectstack/spec/ui';
+import { kanbanViewOptions } from './ObjectView';
+import { defaultKanbanFromObject } from './InterfaceListPage';
+
+/** An object whose lifecycle field the ADR-0085 detector finds by name. */
+const OBJECT_WITH_STAGE = {
+  name: 'deal',
+  fields: { name: { type: 'text' }, stage: { type: 'select' } },
+};
+
+/** The lane-bearing keys, in every spelling this repo has ever used. */
+const LANE_KEYS = ['groupByField', 'groupField', 'groupBy'] as const;
+const laneKeysOf = (bag: Record<string, unknown>) =>
+  LANE_KEYS.filter((k) => bag[k] !== undefined).sort();
+
+describe('the object page writes the SPEC lane key (objectui#8193)', () => {
+  // THE DISCRIMINATING ARM — the card's defect, stated directly. Before the fix
+  // this bag was `{ groupBy: 'stage', groupField: 'stage' }`: the canonical key
+  // the spec declares was the one spelling it never wrote.
+  it('emits `groupByField` for a view that declared the canonical key', () => {
+    const out = kanbanViewOptions({ kanban: { groupByField: 'stage' } }, OBJECT_WITH_STAGE);
+    expect(out.groupByField).toBe('stage');
+    expect(out).not.toHaveProperty('groupField');
+  });
+
+  it('emits `groupByField` for a view that declared the LEGACY alias', () => {
+    // Reading the alias is untouched — a view that authored `groupField` still
+    // resolves its lane. What changed is that the alias stops being propagated:
+    // the value comes in legacy and leaves canonical.
+    const out = kanbanViewOptions({ kanban: { groupField: 'stage' } }, OBJECT_WITH_STAGE);
+    expect(out.groupByField).toBe('stage');
+    expect(out).not.toHaveProperty('groupField');
+  });
+
+  it('emits `groupByField` for a lane the ADR-0085 detector supplied', () => {
+    // The commonest case in the product: a view that declared no kanban block
+    // at all, on an object whose lifecycle field the detector finds.
+    const out = kanbanViewOptions({}, OBJECT_WITH_STAGE);
+    expect(out.groupByField).toBe('stage');
+    expect(out).not.toHaveProperty('groupField');
+  });
+
+  it('emits NO lane key at all when no lane resolves', () => {
+    // The other half. A producer that always emitted `groupByField` — even
+    // empty — would pass every arm above and light the capability gate for
+    // every object view, which is the objectui#7547 defect one visualization
+    // over. Absence must stay absence.
+    const out = kanbanViewOptions({}, { name: 'note', fields: { body: { type: 'text' } } });
+    expect(laneKeysOf(out)).toEqual([]);
+  });
+
+  it('respects the strict `stageField: false` lane suppression', () => {
+    // ADR-0085: the object declared its status-shaped field non-linear, so the
+    // detector must not offer it as a lane. Pinned here because the rewrite
+    // moved this expression into a named function.
+    const out = kanbanViewOptions(
+      {},
+      { name: 'deal', stageField: false, fields: { stage: { type: 'select' } } },
+    );
+    expect(laneKeysOf(out)).toEqual([]);
+  });
+
+  it('keeps the non-lane forwards the inline expression carried', () => {
+    const out = kanbanViewOptions(
+      { kanban: { groupByField: 'stage', titleField: 'subject', columns: ['amount'] } },
+      OBJECT_WITH_STAGE,
+    );
+    expect(out.titleField).toBe('subject');
+    expect(out.cardFields).toEqual(['amount']);
+  });
+
+  it('floors `titleField` at `name`, as the four sibling faces do', () => {
+    expect(kanbanViewOptions({}, OBJECT_WITH_STAGE).titleField).toBe('name');
+  });
+});
+
+describe('the two app-shell kanban producers speak ONE vocabulary (objectui#8193)', () => {
+  // ⭐ THE ANTI-FORK PIN. This is the arm that would have caught the original
+  // drift, and the one that catches the next one: it names neither spelling,
+  // it asserts the two producers AGREE. `defaultKanbanFromObject` is the
+  // sibling that migrated first and whose comment set the precedent.
+  it('derive the same lane key from the same object', () => {
+    const viaObjectPage = kanbanViewOptions({}, OBJECT_WITH_STAGE);
+    const viaInterfacePage = defaultKanbanFromObject(OBJECT_WITH_STAGE);
+
+    const objectPageLaneKeys = laneKeysOf(viaObjectPage).filter((k) => k !== 'groupBy');
+    const interfacePageLaneKeys = laneKeysOf(
+      viaInterfacePage as unknown as Record<string, unknown>,
+    );
+
+    expect(interfacePageLaneKeys).toEqual(['groupByField']);
+    expect(objectPageLaneKeys).toEqual(interfacePageLaneKeys);
+  });
+
+  it('CONTROL: both actually resolved a lane, so the agreement is not two empties', () => {
+    // Without this, a future edit that made BOTH producers emit nothing would
+    // satisfy the arm above — two empty sets are equal. The agreement has to be
+    // an agreement about a value that exists.
+    expect(kanbanViewOptions({}, OBJECT_WITH_STAGE).groupByField).toBe('stage');
+    expect(defaultKanbanFromObject(OBJECT_WITH_STAGE)?.groupByField).toBe('stage');
+  });
+});
+
+describe('the emitted lane key is the one `@objectstack/spec` declares (objectui#8193)', () => {
+  /** Key-level judgement only: does the strict schema recognize this NAME? */
+  const unrecognized = (cfg: Record<string, unknown>): string[] => {
+    const r = KanbanConfigSchema.safeParse(cfg);
+    if (r.success) return [];
+    return r.error.issues.flatMap((i: any) => (i.code === 'unrecognized_keys' ? i.keys : []));
+  };
+
+  // A config complete enough to parse GREEN, so the arms below separate "this
+  // key is refused" from "this fixture is missing a required key".
+  const complete = (extra: Record<string, unknown>) => ({
+    groupByField: 'stage',
+    columns: ['name'],
+    ...extra,
+  });
+
+  it('CONTROL: the strict schema accepts the canonical config outright', () => {
+    // Establishes the schema can say YES on this exact call shape. Without it,
+    // every refusal below is indistinguishable from a schema that refuses all.
+    expect(KanbanConfigSchema.safeParse(complete({})).success).toBe(true);
+  });
+
+  it('CONTROL: the strict schema refuses a bogus key BY NAME on the same call', () => {
+    // Establishes the schema can say NO, and names what it refused. Without
+    // this arm, an acceptance below means nothing.
+    expect(unrecognized(complete({ zzzBogusKey: 'stage' }))).toContain('zzzBogusKey');
+  });
+
+  it('accepts the key this face now emits', () => {
+    const emitted = kanbanViewOptions({}, OBJECT_WITH_STAGE);
+    expect(emitted.groupByField).toBe('stage');
+    expect(unrecognized({ groupByField: emitted.groupByField as string, columns: ['name'] })).toEqual([]);
+  });
+
+  it('refuses the key this face used to emit, by name', () => {
+    // The spec-side statement of the whole card. Its own message even names the
+    // migration: "Did you mean `groupField` to `groupByField`?"
+    expect(unrecognized(complete({ groupField: 'stage' }))).toContain('groupField');
+  });
+
+  it('MEASURED, NOT FOLDED: the spec refuses `groupBy` too — objectui#8213', () => {
+    // The card's one explicitly unmeasured question, answered here so the
+    // answer cannot be lost: `groupBy` is not a spec key at view level either.
+    // It is still written, because `ListView`'s projection collectors read it;
+    // retiring it needs a producer census and is objectui#8213, not this PR.
+    expect(unrecognized(complete({ groupBy: 'stage' }))).toContain('groupBy');
+    expect(kanbanViewOptions({}, OBJECT_WITH_STAGE).groupBy).toBe('stage');
+  });
+
+  it('declares exactly the three keys this file reasons about', () => {
+    // A tripwire on the premise itself: if a future spec bump declares
+    // `groupBy` (or drops `groupByField`), the arms above stop meaning what
+    // they say and this reddens first. objectui#7685 is in flight to move the
+    // resolved spec version.
+    expect(Object.keys((KanbanConfigSchema as any).shape).sort()).toEqual([
+      'columns',
+      'groupByField',
+      'summarizeField',
+    ]);
+  });
+});

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -353,6 +353,64 @@ export function galleryViewOptions(viewDef: any): Record<string, unknown> {
 }
 
 /**
+ * The view-level KANBAN block this face forwards — the fifth member of the
+ * `timelineViewOptions` / `calendarViewOptions` / `ganttViewOptions` /
+ * `galleryViewOptions` family above, and the last one still inlined as an
+ * anonymous IIFE inside the schema literal (objectui#8193).
+ *
+ * ⭐ THE LANE KEY IS `groupByField`, THE SPEC'S OWN SPELLING. This used to emit
+ * the legacy `groupField` alias instead — never the canonical key, even though
+ * it already READ the canonical key first. The sibling producer
+ * `defaultKanbanFromObject` (`InterfaceListPage.tsx`) had migrated already and
+ * left the reasoning next to itself — "that read-site now prefers the spec key,
+ * so one key is enough" — but this twin twelve hundred lines away was not
+ * carried along, so ONE producer surface spoke two vocabularies for one concept
+ * depending on which entry point you arrived through.
+ *
+ * ⚠️ The alias is NOT retired and every alias READ stays exactly as it was:
+ * stored metadata still authors `groupField`, and `ListView` resolving
+ * `groupByField || groupField` is the whole reason the sibling could drop it.
+ * What changed is only what this face WRITES.
+ *
+ * ⚠️ WRITING THE CANONICAL KEY HERE REQUIRED THE GATE TO LEARN IT, and that is
+ * the half a reader will not guess from this file. `ListView.availableViews`
+ * consulted the `options.<kind>` bag for the LEGACY spelling only
+ * (`schema.options?.kanban?.groupField`), so emitting `groupByField` alone made
+ * the Kanban capability stop resolving and the toggle vanish from every object
+ * view — measured, not reasoned: `{groupBy, groupField}` offered Kanban, and
+ * `{groupBy, groupByField}` did not. The gate now reads both spellings out of
+ * the bag, the same one-question-two-sites repair objectui#5042 made for `map`
+ * and objectui#7544 for `chart`. Pinned in `ObjectView.kanbanLane-8193` here
+ * and in `ListView.kanbanOptionsBagCanonical-8193` in `plugin-list`.
+ *
+ * ⚠️ `groupBy` is kept VERBATIM and is deliberately not folded. It is not the
+ * spec's key either — measured against `KanbanConfigSchema`, which declares
+ * `groupByField` / `summarizeField` / `columns` and refuses `groupBy` by name —
+ * but it is read by `ListView`'s projection collectors, so retiring it is a
+ * separate change with its own census: objectui#8213.
+ *
+ * ADR-0085: when the view doesn't pick a lane field, the object's declared
+ * lifecycle (`stageField`) decides — including the strict `stageField: false`
+ * suppression (no default lanes; the status-shaped field is declared
+ * non-linear) and the shared name/type heuristic, which never invents a field
+ * the object doesn't have (the old hard-coded 'status' did).
+ *
+ * Exported for the pin test.
+ */
+export function kanbanViewOptions(viewDef: any, objectDef: any): Record<string, unknown> {
+    const lane =
+        viewDef?.kanban?.groupByField ||
+        viewDef?.kanban?.groupField ||
+        detectStatusField(objectDef as any) ||
+        undefined;
+    return {
+        ...(lane ? { groupBy: lane, groupByField: lane } : {}),
+        titleField: viewDef?.kanban?.titleField || 'name',
+        cardFields: viewDef?.kanban?.columns,
+    };
+}
+
+/**
  * THE record-detail URL this list surface builds — one route shape, one place.
  *
  * Derived from the LIST's own pathname rather than re-assembled from route
@@ -2467,25 +2525,9 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
             // #2890 — see the note at its single remaining computation)
             ...(viewDef.sort?.length ? { sort: viewDef.sort } : {}),
             options: {
-                kanban: {
-                    // ADR-0085: when the view doesn't pick a lane field, the
-                    // object's declared lifecycle (`stageField`) decides —
-                    // including the strict `stageField: false` suppression
-                    // (no default lanes; the status-shaped field is declared
-                    // non-linear) and the shared name/type heuristic, which
-                    // never invents a field the object doesn't have (the old
-                    // hard-coded 'status' did).
-                    ...(() => {
-                        const lane =
-                            viewDef.kanban?.groupByField ||
-                            viewDef.kanban?.groupField ||
-                            detectStatusField(objectDef as any) ||
-                            undefined;
-                        return lane ? { groupBy: lane, groupField: lane } : {};
-                    })(),
-                    titleField: viewDef.kanban?.titleField || 'name',
-                    cardFields: viewDef.kanban?.columns,
-                },
+                // The lane key is the spec's `groupByField`, not the legacy
+                // `groupField` this used to write. See `kanbanViewOptions`.
+                kanban: kanbanViewOptions(viewDef, objectDef),
                 // The calendar config the view DECLARED, or no calendar key at
                 // all — never an invented field name (objectui#7029). With the
                 // key absent, ListView's capability gate stops offering the

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -2162,7 +2162,24 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     const resolvable: ViewType[] = ['grid'];
 
     // Check for Kanban capabilities (spec config takes precedence)
-    if (schema.kanban?.groupByField || schema.kanban?.groupField || schema.options?.kanban?.groupField) {
+    //
+    // All FOUR spellings, because the lane can be bound in either nesting and
+    // in either vocabulary. The `options.kanban` bag was asked for the LEGACY
+    // `groupField` only, so a producer writing the SPEC key into the bag was
+    // invisible here while rendering perfectly — the render branch below merges
+    // the bag and resolves `groupByField || groupField`, so the gate recognized
+    // strictly less than what renders. That is objectui#5042 (`map`) and
+    // objectui#7544 (`chart`) a third time: the gate and the seam must answer
+    // one question. It went live with objectui#8193, which moved app-shell's
+    // `ObjectView` onto the canonical key — measured before and after, the
+    // Kanban toggle disappeared from every object view until this rung existed.
+    // ⛔ The alias rungs stay: stored metadata still authors `groupField`.
+    if (
+      schema.kanban?.groupByField ||
+      schema.kanban?.groupField ||
+      schema.options?.kanban?.groupByField ||
+      schema.options?.kanban?.groupField
+    ) {
       resolvable.push('kanban');
     }
 

--- a/packages/plugin-list/src/__tests__/ListView.kanbanOptionsBagCanonical-8193.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.kanbanOptionsBagCanonical-8193.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8193 — the kanban capability gate asked the `options` bag for the
+ * LEGACY lane spelling only.
+ *
+ * `availableViews` resolved kanban from three rungs: `schema.kanban`'s two
+ * spellings, and `schema.options.kanban.groupField`. There was no canonical
+ * rung for the bag — so a producer writing the SPEC key into `options.kanban`
+ * was invisible to the gate while rendering perfectly, because the render
+ * branch merges the bag and resolves `groupByField || groupField`. The gate
+ * recognized strictly LESS than what renders.
+ *
+ * ⚠️ THIS WAS LATENT UNTIL objectui#8193 MADE IT REACHABLE, which is why it is
+ * fixed alongside a producer change rather than on its own card. `app-shell`'s
+ * `ObjectView` writes the view-level kanban config into `options.kanban`, and
+ * it had always written the legacy `groupField` — so the missing rung cost
+ * nothing. Moving that producer onto the canonical key (the actual subject of
+ * objectui#8193) turned the hole into a regression: measured before and after,
+ * a bag of `{groupBy, groupField}` offered Kanban and `{groupBy, groupByField}`
+ * did not. The toggle would have disappeared from every object view in the
+ * product, silently, with the board still rendering correctly if you reached it
+ * another way.
+ *
+ * SAME SHAPE, THIRD TIME: objectui#5042 (`map`) and objectui#7544 (`chart`)
+ * were both "the gate and the seam must answer one question", and both were
+ * fixed by making the gate ask what the render branch asks. Kanban's render
+ * branch resolves `groupByField || groupField` off the MERGED config, so the
+ * gate now recognizes the same four combinations that merge.
+ *
+ * ⛔ NO ALIAS READ WAS REMOVED. All three original rungs are still there;
+ * stored metadata still authors `groupField`. This adds the canonical rung the
+ * bag never had.
+ *
+ * REVERSE VERIFICATION — direction predicted before running, then observed:
+ * drop the `schema.options?.kanban?.groupByField` rung and the canonical-bag
+ * arms below go RED while every legacy-bag and declared-path CONTROL stays
+ * GREEN — the gate keeps answering correctly for every input it already
+ * handled. That asymmetry is the point: a "fix" that pushed `kanban` whenever
+ * it was whitelisted would also pass the positive arms, so the refusal arms at
+ * the bottom are load-bearing.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ListView } from '../ListView';
+import { SchemaRendererProvider } from '@object-ui/react';
+
+const makeDataSource = () => ({
+  find: vi.fn().mockResolvedValue([]),
+  findOne: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  getObjectSchema: vi.fn().mockResolvedValue({ name: 'deal', fields: {} }),
+});
+
+// `viewType: 'grid'` on purpose: the gate has an "always allow switching back
+// to the schema's own viewType" rung, so a kanban-typed view would resolve
+// kanban for a reason that has nothing to do with the binding under test.
+const BASE = {
+  type: 'list-view',
+  objectName: 'deal',
+  viewType: 'grid',
+  columns: ['name'],
+} as const;
+
+const renderSwitcher = (view: Record<string, unknown>) => {
+  const dataSource = makeDataSource() as any;
+  render(
+    <SchemaRendererProvider dataSource={dataSource}>
+      <ListView schema={{ ...BASE, ...view } as never} dataSource={dataSource} showViewSwitcher />
+    </SchemaRendererProvider>,
+  );
+  const trigger = screen.queryByTestId('view-switcher-dropdown');
+  if (trigger) fireEvent.click(trigger);
+};
+
+/** Mirrors the helper in `ListView.chart-capability-7544.test.tsx`. */
+const queryViewOption = (name: string) =>
+  screen.queryByRole('tab', { name }) ?? screen.queryByRole('button', { name });
+
+/** Is `kanban` offered for a view whitelisting exactly `['grid', 'kanban']`? */
+const kanbanOffered = (view: Record<string, unknown>) => {
+  renderSwitcher({ appearance: { allowedVisualizations: ['grid', 'kanban'] }, ...view });
+  return Boolean(queryViewOption('Kanban'));
+};
+
+describe('the capability gate resolves kanban from the CANONICAL key in the options bag (objectui#8193)', () => {
+  // THE DISCRIMINATING ARM. This read `false` before the fix — and it is
+  // exactly the bag `app-shell`'s ObjectView now emits.
+  it('offers Kanban for `options.kanban.groupByField`', () => {
+    expect(kanbanOffered({ options: { kanban: { groupByField: 'stage' } } })).toBe(true);
+  });
+
+  it('offers Kanban for the bag ObjectView actually writes', () => {
+    // The end-to-end shape, `groupBy` included: the producer's real output.
+    expect(
+      kanbanOffered({
+        options: { kanban: { groupBy: 'stage', groupByField: 'stage', titleField: 'name' } },
+      }),
+    ).toBe(true);
+  });
+
+  it('CONTROL: still offers Kanban for the LEGACY `options.kanban.groupField`', () => {
+    // The rung that already worked. Stored metadata still authors this
+    // spelling, so this arm is what proves the fix ADDED a rung rather than
+    // swapping one out.
+    expect(kanbanOffered({ options: { kanban: { groupField: 'stage' } } })).toBe(true);
+  });
+
+  it('CONTROL: still offers Kanban for the declared `kanban.groupByField`', () => {
+    expect(kanbanOffered({ kanban: { groupByField: 'stage' } })).toBe(true);
+  });
+
+  it('CONTROL: still offers Kanban for the declared legacy `kanban.groupField`', () => {
+    expect(kanbanOffered({ kanban: { groupField: 'stage' } })).toBe(true);
+  });
+
+  // THE OTHER HALF. Pinning only the arms above would let the fix degrade into
+  // "offer kanban whenever whitelisted", which is worse than the bug: a board
+  // with no lane binding renders every card into one implicit column.
+  it('does NOT offer Kanban with no kanban block anywhere', () => {
+    expect(kanbanOffered({})).toBe(false);
+  });
+
+  it('does NOT offer Kanban for an options bag carrying no lane key', () => {
+    expect(kanbanOffered({ options: { kanban: { titleField: 'name' } } })).toBe(false);
+  });
+
+  it('does NOT offer Kanban for an empty declared block', () => {
+    expect(kanbanOffered({ kanban: {} })).toBe(false);
+  });
+
+  it('does NOT offer Kanban for `groupBy` alone', () => {
+    // `groupBy` is not a lane binding the gate recognizes in any nesting, and
+    // objectui#8213 measured that the spec does not declare it either. Pinned
+    // so the new canonical rung is not quietly widened into a third spelling.
+    expect(kanbanOffered({ options: { kanban: { groupBy: 'stage' } } })).toBe(false);
+  });
+});

--- a/packages/types/src/__tests__/object-kanban-group-by-limit-7322.test.ts
+++ b/packages/types/src/__tests__/object-kanban-group-by-limit-7322.test.ts
@@ -99,7 +99,19 @@ const READ_CONTROL_KEY = 'objectName';
  */
 const VIEW_LEVEL_ALIAS_SITES: ReadonlyArray<readonly [file: string, text: string]> = [
   ['packages/core/src/utils/normalize-list-view.ts', "kanban: { groupField: 'groupByField', cardFields: 'columns' }"],
-  ['packages/plugin-list/src/ListView.tsx', 'schema.kanban?.groupByField || schema.kanban?.groupField || schema.options?.kanban?.groupField'],
+  // Multi-line since objectui#8193, which added the CANONICAL rung for the
+  // `options` bag next to the legacy one (the gate had been asking that bag for
+  // the deprecated spelling only, so a producer writing the spec key into it was
+  // invisible while rendering fine). The alias rungs are untouched — this pin
+  // now covers four and reads the wider expression verbatim, indentation
+  // included, exactly as it read the one-line form before.
+  [
+    'packages/plugin-list/src/ListView.tsx',
+    `schema.kanban?.groupByField ||
+      schema.kanban?.groupField ||
+      schema.options?.kanban?.groupByField ||
+      schema.options?.kanban?.groupField`,
+  ],
   ['packages/plugin-view/src/ObjectView.tsx', 'kanbanCfg.groupField ||'],
 ];
 /** …and the same alias, still DECLARED on the view-level config in this very mirror file. */


### PR DESCRIPTION
Fixes #8193

Session: `session_01YBWFb5YgMU5dw8p2VKj16S` (in prose — a body edit downgrades the footer's session URL).

## What changed

`ObjectView` (app-shell) built the view-level kanban config it hands to its `list-view` and wrote the deprecated alias `groupField` — never `groupByField`, the key `@objectstack/spec`'s `KanbanConfigSchema` actually declares — even though it already READ the canonical key first. Its sibling producer in the same package, `defaultKanbanFromObject` in `InterfaceListPage`, had migrated long before and left the reasoning next to itself ("that read-site now prefers the spec key, so one key is enough"). The twin twelve hundred lines away was not carried along, so one producer surface spoke two vocabularies for one concept depending on which entry point you arrived through — and because `ObjectView` writes into `options.kanban`, which `normalizeListViewSchema`'s alias fold deliberately does not reach, nothing corrected it downstream.

The expression is now the exported `kanbanViewOptions`, the fifth member of the `timelineViewOptions` / `calendarViewOptions` / `ganttViewOptions` / `galleryViewOptions` family it had been the odd one out of. That is what makes both app-shell producers observable, which is what the anti-fork pin needs.

⛔ **No alias READ was removed and the alias is not retired.** Stored metadata still authors `groupField`; every read site still resolves it. `ListView` already preferring the canonical key is exactly why the sibling could drop the alias write.

## ⚠️ This is a two-part fix, and the second part is not optional

The card asked for a one-line producer change. Measurement said that alone ships a regression.

`ListView.availableViews` consulted the `options.kanban` bag for the **legacy spelling only** — `schema.options?.kanban?.groupField`, with no canonical twin. The render branch one screen down merges the bag and resolves `groupByField || groupField`, so the gate recognized strictly **less** than what renders. That hole cost nothing while the only producer writing into that bag wrote the alias. Moving the producer onto the canonical key turns it into a live defect.

Measured on the real component, before touching the gate — `viewType: 'grid'` so the "always allow the schema's own viewType" rung cannot mask it:

| emission into `options.kanban` | Kanban offered in the switcher? |
|---|---|
| `{groupBy, groupField}` — today | **true** |
| `{groupBy, groupByField}` — producer fix alone | **false** |
| neither lane key (negative control) | false |
| declared top-level `groupByField` (positive control) | true |

Both controls fire, so both readings carry information. Shipping only the producer change would have removed the Kanban toggle from **every object view in the product**, silently, with the board still rendering correctly if you reached it another way.

So the gate gains the canonical rung the bag never had. This is the same one-question-two-sites repair objectui#5042 made for `map` and objectui#7544 for `chart`, a third time. It is an **addition** — all three original rungs are untouched. **The PM has ruled this rung stays.**

### Clause-② — does this move an accept set?

Yes, and in both directions, which is why both halves are here. The producer change alone **narrows** the accept set (the table above). With the gate rung, the accept set **widens** by exactly one previously-unreachable combination: a canonical lane key in the `options` bag, which is precisely what the render branch has always been willing to render. Net effect on what the product offers: unchanged. What changed is that the gate and the seam now answer the same question, rather than the gate answering a narrower one by accident.

## ⚠️ Zone 2 — the card's explicitly unmeasured question, answered

The card said plainly it had **not** measured whether the spec's own kanban config declares the view-level `groupBy` the same expression writes, and asked for that before deciding whether it is a second alias or a legitimate key.

Measured at runtime against `KanbanConfigSchema` from `@objectstack/spec/ui` (strict), resolved version **17.2.0**, with a control on the same call:

```
declared keys: groupByField, summarizeField, columns

SUBJECT  { groupByField, groupBy }     -> unrecognized_keys: ["groupBy"]
CONTROL  { groupByField, zzzBogusKey } -> unrecognized_keys: ["zzzBogusKey"]
CONTROL2 { groupByField } alone        -> NO unrecognized_keys
```

CONTROL shows the schema can refuse an unknown key by name on this exact call shape; CONTROL2 shows it can accept one. So the refusal is about `groupBy` specifically. ⇒ **`groupBy` is not a spec key at view level.** The spec even names the other relationship itself — probing `{ groupField }` returns "Did you mean `groupField` to `groupByField`?", so upstream already treats the alias as an alias.

⛔ **Not folded here, exactly as the card directed.** `groupBy` is read by `ListView`'s projection collectors, so retiring it needs a producer census. Filed as objectui#8213 and left untouched in this PR. The measurement is pinned in the test suite so the answer cannot be lost, including a tripwire on the spec's declared key set (objectui#7685 is in flight to move the resolved spec version).

## CI follow-up — the objectui#7322 alias-site pin was a stale literal

CI run `34075243231` was red on one test: `packages/types/src/__tests__/object-kanban-group-by-limit-7322.test.ts`. That pin asserts, off disk, that `ListView.tsx` still reads the VIEW-LEVEL `groupField` alias — the objectui#7322 tombstone being node-local — and it does so by matching a **verbatim snapshot** of the capability-gate expression. The fourth rung above changed that expression's text, so the snapshot stopped occurring.

**Verified independently before touching the test.** The alias is still read in `ListView.tsx` at four sites — the two projection collectors (`:1536`, `:1890`), the preserved alias rung in the gate (`:2179`), and the render branch's lane resolution (`:2535`) — and the other two pinned sites (`normalize-list-view.ts`, `plugin-view/ObjectView.tsx`) are untouched. So this was a stale literal, not a regression.

The pin's own update note is **conditional**: *"If a site stops reading `groupField`, the retirement's stated boundary has moved and the docblocks on both faces are wrong: re-derive, do not widen the tombstone on the way past."* That antecedent is **false** here, so only the re-derivation applies — the boundary has not moved, the docblocks on both faces are still correct, and the tombstone is neither widened nor narrowed.

Re-derived, not weakened: the entry now matches the four-rung expression verbatim, indentation included. Both alias rungs remain inside the pinned text, so the pin still reddens if a site stops reading the alias — **proved by ablation, not assumed** (below).

## Measured vs claimed anchors

The card was written on `a915064e`; measured on `ecf8e726e`, with objectui#8188 landed into the target file since. Line numbers were treated as hints and matched on text.

| anchor | card | measured | premise |
|---|---|---|---|
| `ObjectView` producer | 2409-2415 | 2476-2485 | holds (drifted) |
| `InterfaceListPage` precedent comment | 157 | 157 | holds |
| `normalize-list-view` fold | 191 | 191 | holds — declared path only |
| fold-boundary pin test | 361 | 361 | holds |
| `ListView` lane resolution | 2495 | 2518 | holds (drifted) |
| `ListView` capability gate | 2165 | 2165 | holds |

All three Zone 2b premises confirmed: the fold still refuses the `options.*` twin, its pin still says so deliberately, and `ListView` still resolves `groupByField || groupField || detectStatusField(...)`.

## Reverse verification

Direction predicted before running, then observed. Every mutation was committed-then-mutated, proven to reach disk with anchored fixed-string counts in both directions, and restored **by state** (`git hash-object` equal to `git rev-parse HEAD:PATH`, empty `git diff HEAD`), never by an exit code.

- **Producer reverted to `groupField`** — canonical anchor 1 to 0, legacy 0 to 1. Pin: **6 failed / 9 passed**. The ADR-0085 lane-*resolution* arms and the spec controls stayed green in both worlds, because this defect never changed which field was chosen, only the key it was filed under. A test asserting the lane value alone would have passed against the unfixed producer.
- **Gate rung removed** — rung 1 to 0, legacy rung still 1. Pin: **2 failed / 7 passed**, exactly the two canonical-bag arms; every legacy-bag, declared-path and refusal control stayed green.
- **objectui#7322 pin, stale literal restored** — reproduces CI exactly: **1 failed / 28 passed**, failing test named `packages/plugin-list/src/ListView.tsx still reads the view-level alias`.
- **objectui#7322 pin, re-derived, with a real alias rung deleted from `ListView.tsx`** — legacy-bag rung 1 to 0, pin **1 failed / 28 passed**, failing **by name**. The re-derived literal can still fail for the reason it exists.

## Tests

- `pnpm exec vitest run packages/plugin-list/ packages/app-shell/` — **711 files, 7033 passed, 1 skipped, 0 failed** (pre-merge)
- `pnpm exec vitest run packages/types/` — **137 files, 2589 passed, 0 failed** (post-merge)
- `object-kanban-group-by-limit-7322.test.ts` — before **1 failed / 28 passed**, after **29 passed**
- Both new pins re-run post-merge alongside it — **3 files, 53 passed**
- `type-check` — green for app-shell, plugin-list and types (script is `type-check` with a hyphen; a `typecheck` filter matches zero scripts and exits 0)
- Gates: `check:control-bytes`, `check:spec-symbols`, `check:self-import`, `check:unreferenced-sources`, `check:changeset-presence`, `check:changeset-no-major`, `check:governed-queue-guard` — green (this diff is **not** governed surface)
- `check:readme-exports` — NOT MEASURED locally, a prerequisite failure rather than a red gate: it needs every package's `dist/*.d.ts` and reports "run `pnpm build` first" for 84 self-imports across packages this PR does not touch. It has its own CI workflow that builds first.

Two new pins, both of which redden against the unfixed code:

- `packages/app-shell/src/views/ObjectView.kanbanLane-8193.test.tsx` — 15 arms. ⭐ Includes the **anti-fork** arm, which names neither spelling and instead asserts the two app-shell producers *agree*, with a control proving the agreement is not two empty sets.
- `packages/plugin-list/src/__tests__/ListView.kanbanOptionsBagCanonical-8193.test.tsx` — 9 arms, including four refusal arms so the gate fix cannot degrade into "offer kanban whenever whitelisted", which would be worse than the bug.

`origin/main` merged in (merge, never rebase — the branch is pushed).

## Out of scope, deliberately

- objectui#8213 — the view-level `groupBy`, measured above and filed rather than folded.
- Not objectui#7773 (landed as `6712930f7`) and not objectui#7772; both concern the **retired node-level** key. This one is view-level and live.
- `packages/plugin-list/README.md` view-level config examples left alone — still valid.
- The brittleness of verbatim source-text pins as a *mechanism* is deliberately NOT addressed here; it is reported for the PM to file as its own card.

Draft on purpose: the PM lands this.
