### PR TITLE
docs(plugin-chatbot): compile the README's snippets against the shipped surface

### DIFF
--- a/packages/plugin-chatbot/README.md
+++ b/packages/plugin-chatbot/README.md
@@ -21,11 +21,17 @@ npm install @object-ui/plugin-chatbot
 
 ### Basic (Local/Demo Mode)
 
+`ChatMessage` is this package's runtime message contract, and `role` on it is
+the closed union `'user' | 'assistant' | 'system'`. Annotate the state with it:
+an unannotated array literal widens `role` to `string`, which `<Chatbot>` then
+refuses.
+
 ```tsx
-import { Chatbot } from '@object-ui/plugin-chatbot';
+import { useState } from 'react';
+import { Chatbot, type ChatMessage } from '@object-ui/plugin-chatbot';
 
 function App() {
-  const [messages, setMessages] = useState([
+  const [messages, setMessages] = useState<ChatMessage[]>([
     {
       id: '1',
       role: 'assistant',
@@ -34,7 +40,7 @@ function App() {
   ]);
 
   const handleSend = (content: string) => {
-    const newMessage = {
+    const newMessage: ChatMessage = {
       id: Date.now().toString(),
       role: 'user',
       content
@@ -344,20 +350,36 @@ of writing your own — they handle `parts: [{ type: 'text' | 'reasoning'
 | 'tool-*' | 'source-*' }]`, the streaming-cursor flag, and the legacy
 `msg.toolInvocations` fallback:
 
+> ⚠️ Today this call needs a cast on the reader's side. `uiMessagesToChatMessages`
+> declares its parameter as the package's own permissive `AnyUIMessage[]`, whose
+> `AnyPart.state` is typed as the tool-invocation state union — so a `TextUIPart`
+> carrying `state: 'streaming' | 'done'` is refused, and with it the whole
+> `UIMessage[]` that `useChat()` returns. The block below is what you should
+> write; it compiles once objectui#8214 widens that member. Nothing about the
+> mapper's runtime behaviour is affected.
+
+<!-- doc-snippet: fragment — `uiMessagesToChatMessages` declares its parameter as the package's own `AnyUIMessage[]`, whose `AnyPart.state` is the tool-invocation state union, so `@ai-sdk/react`'s `UIMessage` — whose text parts carry `state: 'streaming' | 'done'` — is refused at the very call this section is about (measured: TS2345 x1). objectui#8214 holds that parameter type; this block is what a reader should write and compiles the day it lands -->
+
 ```tsx
 import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport } from 'ai';
 import {
   ChatbotEnhanced,
   uiMessagesToChatMessages,
+  type ChatbotEnhancedProps,
 } from '@object-ui/plugin-chatbot';
 
+declare const handleSend: ChatbotEnhancedProps['onSendMessage'];
+
 function MyChat() {
-  const { messages, status } = useChat({ api: '/api/chat' });
+  const { messages, status } = useChat({
+    transport: new DefaultChatTransport({ api: '/api/chat' }),
+  });
   const isStreaming = status === 'streaming' || status === 'submitted';
   return (
     <ChatbotEnhanced
       messages={uiMessagesToChatMessages(messages, { isStreaming })}
-      onSend={/* … */}
+      onSendMessage={handleSend}
     />
   );
 }
@@ -375,11 +397,15 @@ chat routes can use `surface="plain"` to remove the outer panel border and let
 messages, controls, and the prompt input sit in a continuous workspace:
 
 ```tsx
+import { ChatbotEnhanced, type ChatMessage } from '@object-ui/plugin-chatbot';
+
+declare const messages: ChatMessage[];
+
 <ChatbotEnhanced
   messages={messages}
   surface="plain"
   hideClearBar
-/>
+/>;
 ```
 
 ### Agent process visibility
@@ -394,10 +420,14 @@ Use `processVisibility="debug"` for developer or admin trace surfaces that need
 the full reasoning panel, raw tool names, tool parameters, and tool results:
 
 ```tsx
+import { ChatbotEnhanced, type ChatMessage } from '@object-ui/plugin-chatbot';
+
+declare const messages: ChatMessage[];
+
 <ChatbotEnhanced
   messages={messages}
   processVisibility="debug"
-/>
+/>;
 ```
 
 Use `processVisibility="hidden"` when a host wants to suppress non-interactive

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -779,8 +779,6 @@ const UNGATED_DOCS = {
     '2 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 1 unresolved-module diagnostic(s)',
   'packages/plugin-charts/README.md':
     '6 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies',
-  'packages/plugin-chatbot/README.md':
-    '5 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 1 unresolved-module diagnostic(s); plus TS17000x1 TS2322x1 — candidate real defects, un-triaged',
   'packages/plugin-editor/README.md':
     '6 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies',
   'packages/plugin-map/README.md':


### PR DESCRIPTION
Part of #5174 (batch 30: `packages/plugin-chatbot/README.md`)

Base sha `590158122` (batch 29, PR #8206). `origin/main` advanced to `580b0fdf4` mid-task; merged in with a merge commit (never rebased) and every reading below is re-taken on the merged head `b1a383c75`.

Spelling note: generic type arguments are written as WORDS below, and element names bare, because GitHub's body sanitizer eats tag-shaped fragments — backticks and fenced code blocks included — and half of this page's story is about a generic.

## Census — two readings, both with the gate's own analyzer

Both readings use `analyze` / `compileSnippets` / `scanFences` exported from `scripts/check-doc-snippet-types.mjs`, with the target's row removed from `UNGATED_DOCS` and every other row left in place. No hand-written regex. Controls healthy on every run: `@object-ui/types` resolved to `packages/types/dist/index.d.ts`, sentinel 1, positive 0, undeclared 1, root-declared 1, 0 findings, 0 src leaks.

Eleven `tsx` fences on the base at lines 24, 61, 82, 145, 202, 271, 292, 316, 347, 377, 396.

### Reading 1 — ledger-literal, on the base

**9 diagnostics**, not the 8 the row claims. By code: TS2304 x3, TS2552 x2, TS2353 x1, TS2345 x1, TS2322 x1, TS17000 x1.

| fence | n | diagnostics |
|---|---|---|
| 24 | 1 | TS2304 `useState` |
| 61 | 0 | — |
| 82 | 0 | — |
| 145 | 0 | — |
| 202 | 0 | — |
| 271 | 0 | — |
| 292 | 0 | — |
| 316 | 0 | — |
| 347 | 4 | TS2353 `api` not in `UseChatOptions`; TS2345 mapper parameter; TS2322 `onSend`; TS17000 empty expression |
| 377 | 2 | TS2304 `ChatbotEnhanced`; TS2552 `messages` |
| 396 | 2 | TS2304 `ChatbotEnhanced`; TS2552 `messages` |

Against the row's own wording:

- `5 undefined-name` — **exact**. TS2304 x3 plus TS2552 x2 (`Did you mean 'onmessage'` is the same class, just with a suggestion).
- `1 unresolved-module` — **falsified, it is zero**. See the next section.
- `TS17000 x1`, `TS2322 x1` — present, but the TS2322 is not the one the brief predicted, and the count is a lower bound. See "Blind spot".
- **Two diagnostics the row never names**: TS2353 x1 and TS2345 x1, both in fence 347.

### Reading 2 — after adding only the missing imports and `declare` stand-ins, in memory

**5 diagnostics.** By code: TS2322 x2, TS2353 x1, TS2345 x1, TS17000 x1. This is the real debt, and the decisions below are made on it.

| fence | n | diagnostics |
|---|---|---|
| 24 | 1 | **TS2322 `role` widens to string** (new — was hidden) |
| 61, 82, 145, 202, 271, 292, 316 | 0 | — |
| 347 | 4 | unchanged from reading 1 |
| 377 | 0 | clean once imported and bound |
| 396 | 0 | clean once imported and bound |

What was added: `import { useState } from 'react'` to fence 24; `import type ChatMessage` plus `import ChatbotEnhanced` plus `declare const messages: ChatMessage[]` to fences 377 and 396. Nothing else — no prop touched, no type widened.

### Blind spot: 1

Batch 27's mechanism fired once, in a form neither batch 27 nor 28 had seen. Fence 24's `Chatbot` tag name **was** bound, so the element's prop check ran — but `messages` came from an unresolved `useState(...)` call, so its binding carried an error type and the check found nothing to complain about. Import `useState` and the element's real TS2322 appears.

⇒ A mixed ledger row understates type debt not only when a JSX tag name is unresolved (batch 27) but whenever an errored binding FEEDS a checked element. Real TS2322 count was 2, the row said 1.

Also note the row is an **upper bound in the total direction and a lower bound in the type-code direction at the same time**: 9 diagnostics collapsed to 5 real ones, and one type code went up.

## The unresolved module: the mechanism, measured

**There is no TS2307 on this page, and the gate can see the package's third-party dependency types.** Nothing to widen, no gate gap, nothing filed on this axis.

Measured with `derivePackageTypePaths` / `deriveDeclaredDependencyPaths` on the merged head:

- `@object-ui/plugin-chatbot` resolves from `packages/plugin-chatbot/dist/index.d.ts` (built, not source-typed).
- Because a compiled block imports it, it enters `neededPackages`, so `deriveDeclaredDependencyPaths` reads **its** manifest and probes each declared specifier from `packages/plugin-chatbot/`.
- `@ai-sdk/react` maps to `node_modules/.pnpm/@ai-sdk+react@4.0.68_react@19.2.8_zod@4.4.3/node_modules/@ai-sdk/react/dist/index.d.ts`, `declaredBy: @object-ui/plugin-chatbot`. It is **not** hoisted to the root `node_modules` (`ls node_modules/@ai-sdk/react` fails) and it does **not** need to be: pnpm links it under `packages/plugin-chatbot/node_modules/`, which is exactly where the probe file sits.
- `boundFailures` for this document: 0. `@ai-sdk/react` is in `paths`, so `resolvesOnlyThroughRootManifest` returns false for it.
- Same for `ai` (7.0.65), added by this PR to fence 347's imports: declared by `@object-ui/plugin-chatbot`, mapped, not bounded.

⇒ **PM mechanism assumption A2 is falsified in its second half.** A workspace package's third-party dependency types resolve *whether or not* they are hoisted, because the resolution probe runs from inside the owning package's directory. The whole run maps 91 specifiers from the declared dependencies of 34 imported packages; only 3 declared specifiers ship no types and stay unresolvable, and none of them is on this page.

Where the ledger's `1 unresolved-module` came from is not recoverable from this tree — it predates the current dependency-path derivation. What replaced it is real: the two diagnostics the row never named.

## TS17000 and TS2322, decided against the shipped surface

### TS2322 in fence 347 — `onSend` is a phantom prop. README defect, repaired.

Declarations read:

- `ChatbotEnhancedProps` at `packages/plugin-chatbot/src/ChatbotEnhanced.tsx:450` extends `React.HTMLAttributes` of `HTMLDivElement`. It declares `onSendMessage?: (message: string, files?: File[]) =` a void return at `:457`. **No `onSend`.**
- `ChatbotEnhanced.tsx` never READS `onSend` either — a grep for `onSend` not followed by `Message` in that file returns nothing.
- `onSend` is real, but somewhere else: it is `UseObjectChatOptions['onSend']` (`useObjectChat.ts:335`, `(content: string, messages: ObjectChatMessage[]) =` void) and an SDUI schema key the three renderers forward (`renderer.tsx:92`, `:281`, `:419`).

So this is **not** batch 28's other branch: the component does not read at runtime a prop the type omits. The type refuses a key nothing implements. README defect ⇒ repaired to `onSendMessage`, the prop that exists.

The page's own prose one section up already said `onSend(content, messages)` is "the callback fed from" `useObjectChat`'s messages — correct there, and the fence had promoted it to a component prop.

### TS17000 in fence 347 — elided body. Typed binding, no marker.

`onSend={/* … */}` is an empty JSX expression container. The brief's prescription was `declare const onSend: ChatbotEnhancedProps['onSend']`; that member does not exist, so the binding is spelled against the member that does:

```tsx
declare const handleSend: ChatbotEnhancedProps['onSendMessage'];
```

One edit removes both the TS17000 and the TS2322: the attribute becomes `onSendMessage={handleSend}`. Typed binding, not a fragment marker, per the brief's ordering.

### TS2322 in fence 24 — the Quick Start's untyped state. README defect, repaired.

This is the one the brief predicted, and it was invisible on the base (see "Blind spot"):

```
TS2322: Type '{ id: string; role: string; content: string; }[]' is not assignable to
type 'ChatMessage[]'. Types of property 'role' are incompatible.
Type 'string' is not assignable to type '"user" | "system" | "assistant"'.
```

`ChatbotProps.messages` is `ChatMessage[]` (`src/index.tsx:21`), and that `ChatMessage` is the runtime one re-exported from `./ChatbotEnhanced`, whose `role` is the closed union `'user' | 'assistant' | 'system'` (`ChatbotEnhanced.tsx:23`).

**What the page used to teach:** that an unannotated `useState([{ id, role: 'assistant', content }])` is a fine backing store for a typed prop. It is not — the array literal's `role` widens to `string`, and the element seven lines down refuses it. A reader copying the Quick Start whole got a red squiggle at the very first `Chatbot` element, which is the flagship example of the package. The same trap sat in `handleSend`'s `newMessage` literal.

Repaired with `useState` of `ChatMessage[]` plus a `ChatMessage` annotation on `newMessage`, and the imports both needed (`useState` from react, `type ChatMessage` from the package). Two sentences of prose above the fence now say why the annotation is there.

### TS2353 in fence 347 — a retired call shape. README defect, repaired.

`useChat({ api: '/api/chat' })` is refused: the installed `@ai-sdk/react@4.0.68` types `UseChatOptions` as a `chat` or `ChatInit` union intersected with throttle/resume options, and `ChatInit` (from `ai@7.0.65`) carries `transport`, not `api`. The package itself already writes the current shape — `useObjectChat.ts:12` imports `DefaultChatTransport` from `ai` and `:539` constructs one. Repaired to match, which is also what makes `ai` an import of this fence.

### TS2345 in fence 347 — package type defect. Not repairable here; filed as #8214.

`uiMessagesToChatMessages` declares its parameter as the package's own `AnyUIMessage[]`. `mapMessages.ts:19` writes `AnyPart` to be permissive but types one member tightly, `state?: ChatToolInvocation['state']` — the TOOL-invocation state set. A text part in the AI SDK's `UIMessagePart` union carries `state` of `'streaming' | 'done'`, which is not in that set, so the whole assignment fails. The interface written to be loose is, on that one property, stricter than the union it absorbs.

This is batch 28's second branch and it points at `src/`, which this batch may not touch:

- The export exists FOR this call — `mapMessages.ts`'s docblock says it is "Shared between `useObjectChat` … and apps that drive `useChat` themselves (e.g. Studio …)", and this README section documents the same use.
- Nothing caught it because the package's own call site is not type-checked: `useObjectChat.ts:683` destructures `chatResult as any`, and `__tests__/mapMessages.test.ts:135` calls the mapper with `msgs as never`. This README block is the first uncast caller in the repository.
- Runtime is fine — the mapper duck-types on `p.type === 'text'`.

Filed as #8214 with the mechanism, the three options and a recommendation. ⛔ Not repaired here, and no cast added to the page: a documented cast is the tolerant fallback AGENTS.md #0.1 refuses.

## Key-surface bound (objectui#7927)

Verified rather than assumed, per fence:

- `ChatbotProps` (`src/index.tsx:20`) extends `React.HTMLAttributes` of `HTMLDivElement`, **no index signature**, not `BaseSchema`-derived ⇒ the compiler judges keys itself. Fence 29 (Quick Start): `messages`, `onSendMessage`, `placeholder` all declared; zero after repair.
- `ChatbotEnhancedProps` (`ChatbotEnhanced.tsx:450`) same shape, same verdict ⇒ this is exactly how the `onSend` phantom was caught (JSX excess-property checking). Fences 363, 399, 422: `messages`, `surface`, `hideClearBar`, `processVisibility`, `onSendMessage` all declared; zero after repair.
- The runtime `ChatMessage` (`ChatbotEnhanced.tsx:21`) is a plain interface, **no index signature, not BaseSchema-derived** — so the `role` union is really enforced, which is why fence 29's TS2322 is a true positive rather than an artefact.
- The authoring `ChatMessage` from `@object-ui/types` (`complex.d.ts:785`) is likewise a plain interface with no index signature. **A5 confirmed**: two distinct types by design — the authoring one adds a `'tool'` role and allows a Date timestamp; fence 322 imports it under the alias the page already used.
- Schema-literal fences (67, 208) bind to no props type at all: they are `const` object literals with no annotation, so nothing is judged about their keys. Stated so the green is not read as more than it is.

## A4 — phantom exports

`check:readme-exports` is **green on the base and on the head** (exit 0 both times, package built). Both names the brief flagged are real exports of `packages/plugin-chatbot/dist/index.d.ts`: `uiMessagesToChatMessages` at `:98`, `toRuntimeMessages` at `:100`. So are the two type imports this PR adds, `ChatbotEnhancedProps` (`:63`) and `ChatMessage` (`:89`). No phantom, nothing to repair on this axis.

## The unlabeled fence at 251 (now 257)

It is an ASCII box-drawing architecture diagram. Both gates read it and both correctly decline it, for stated reasons:

- `check-doc-snippet-types` collects only `ts` / `tsx` / `typescript` info strings, so it never enters the compiled set.
- `check-doc-fence-languages` DOES read it: `scanFences` there filters nothing, its language is the empty string which is in `UNHIGHLIGHTED_SPELLINGS`, and `classifiesAsTypeScript` reads line 1 of the body literally — a box-drawing character, so it returns false and `classifyFence` returns null: "the block is nothing to this gate". `packages/plugin-chatbot/README.md` is not in that gate's `KNOWN_UNHIGHLIGHTED_TS_FENCES` ledger and does not belong there.

⛔ Not relabelled. The two `bash` fences (16, 183) are likewise correctly out of scope.

## Per-fence decision

| base fence | head fence | decision |
|---|---|---|
| 24 | 29 | repair — `useState` import, `useState` of `ChatMessage[]`, `ChatMessage` on the new-message literal, prose |
| 61 | 67 | untouched — compiled clean on the base |
| 82 | 88 | untouched — compiled clean |
| 145 | 151 | untouched — compiled clean |
| 202 | 208 | untouched — compiled clean |
| 271 | 277 | untouched — compiled clean |
| 292 | 298 | untouched — compiled clean |
| 316 | 322 | untouched — compiled clean |
| 347 | 363 | repair (api ⇒ transport, onSend ⇒ onSendMessage, typed binding) **and** declared fragment for the residual #8214 |
| 377 | 399 | repair — own imports plus `declare const messages` |
| 396 | 422 | repair — own imports plus `declare const messages` |

Ten fences compile in the covered tier. One is a declared fragment.

## Ledger decision

`UNGATED_DOCS` row **deleted** — the file reads zero, by the two honest routes the gate's own header names ("a block that should compile was made self-contained … and a block that genuinely cannot compile got a `FRAGMENT_MARKER` declaration with a written reason").

⚠️ **A judgment call the reviewer should see.** The brief's ruling 5 anticipated a residual and prescribed rewriting the row with the measured remainder. I did not, and here is why, with the alternative stated so it can be overruled cheaply:

- The debt is **block-granular**, not page-granular. A page-level row would describe 11 fences by the state of 1, and would leave the other 10 — including the Quick Start, the most-copied block in the package — permanently uncompiled and free to rot, which is the status quo this series exists to end.
- Ruling 7's positive control is only possible under this shape: an ungated page cannot be named by the gate at all.
- Every marker in this corpus today is about the reader's own code being absent or an excerpt being elided; this is the first one parked on a cross-package type incompatibility, and it is written to be removable in one line the day #8214 lands. The prose above the fence tells the reader the same thing in words, so nobody copies it without warning.

If you would rather keep the page in the ledger with `1 TS2345`, say so and it is a two-line change back.

Gate diff is exactly the two lines of the row, deletions only. Counters: 229 documents both ways; covered 221 ⇒ **222**; ungated 8 ⇒ **7**; blocks to compile 601 ⇒ **611** (this page's ten); declared fragments 158 ⇒ **159** (this page's one).

No pin enumerates this row: `scripts/__tests__/check-doc-snippet-types.test.ts:600` pins only the root `README.md` row and its `objectui#7417` reason, so no test file needed editing (batches 28 and 29 measured the same).

## Strictness region

The region from the `Fence scanning` banner to EOF, 83711 bytes:

- base `590158122`: `2749d53ae3a8df033a53b8d7a354fa7e22ee2d1a17f6ad0c3d61122e904e084b`
- head `b1a383c75`: `2749d53ae3a8df033a53b8d7a354fa7e22ee2d1a17f6ad0c3d61122e904e084b`

Identical. The deleted row sits above the banner. Nothing about this gate's strictness moved.

## Positive control

Run twice — on `a3cc79575` and again on the merged head `b1a383c75` — against a committed tree, under a `trap ... EXIT INT TERM` with absolute paths.

- Injection: `placeholder="Type your message..."` becomes `placeholder={42}` in the repaired Quick Start `Chatbot` element.
- Landing proven by observation, not by an editor's exit code: anchor grep count 1 ⇒ 0, injected grep count 0 ⇒ 1, and the blob moved.
- HEAD blob `0b607af3508916004f1d68cab40b8db81624e92c`; mutated blob `74a0f4fdba6c47689099c11b3047d48bc8c2d896`.
- Gate exit under injection: **1**, naming the page and the line: `[semantic]  packages/plugin-chatbot/README.md:55:7  TS2322: Type 'number' is not assignable to type 'string'. (611 of 611 judged, 1 failed)`
- Restore proven by STATE: disk blob back to `0b607af3508916004f1d68cab40b8db81624e92c`, `git diff HEAD` on the path 0 bytes, `git status --porcelain` empty.

## Gates — all pinned to `b1a383c75`

| gate | exit |
|---|---|
| `pnpm check:doc-snippets` | 0 |
| `pnpm exec vitest run scripts/__tests__/check-doc-snippet-types.test.ts scripts/__tests__/check-doc-fence-languages.test.ts` (123 tests) | 0 |
| `pnpm exec vitest run scripts/__tests__/` (115 files, 3415 tests) | 0 |
| `pnpm check:doc-types` | 0 |
| `pnpm check:readme-exports` (package built) | 0 |
| `pnpm check:doc-fences` | 0 |
| `pnpm type-check:scripts` | 0 |
| `pnpm lint:root` | 0 (32 pre-existing warnings, 0 errors) |
| `pnpm check:control-bytes` | 0 |
| `grep -naP` control-byte self-scan of both changed paths | 1 (no match — clean) |
| `node scripts/check-changeset-presence.mjs` | 0 — none owed |
| `node scripts/check-governed-queue-guard.mjs --test` on both paths | 0, **NOT GOVERNED** |
| `pnpm check:entry-guard` | 0 |
| `turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter) --concurrency=2` | 0 (35/35) |

Re-derived beyond the dispatched list, all 0: `check:doc-example-readers`, `lint:coverage`, `type-check:coverage`, `check:self-import`, `check:unreferenced-sources`, `check:esm-specifiers`, `check:shell-escape-residue`, `check:governed-queue-guard` self-test.

`check:node-esm-load` first exited 1 for the environmental reason the brief predicted — turbo shares one cache across worktrees and replayed 12 packages built in the sibling `objectui-issue-5174-b29` tree, which the provenance leg correctly refuses to grade. Re-run with `--force-build` as its own message instructs: **exit 0**, 34 of 39 published ESM entries evaluated.

Changeset: `check-changeset-presence.mjs` reports 2 files changed, 0 of them published source of a released package and 0 a manifest whose contract moved ⇒ none owed. No label applied, and no label written at all.

`Live E2E (informational)` is red on every branch today for the upstream reason tracked in #7990 / objectstack#16186 — not this branch's.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_