### PR TITLE
docs(types): drop the shared `@default 'row'` on `FlexLayoutProps.direction` and state both consumers in prose

### DIFF
--- a/.changeset/layout-direction-default-jsdoc-7734.md
+++ b/.changeset/layout-direction-default-jsdoc-7734.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/types': patch
+---
+
+The published `@default` documentation on `FlexLayoutProps.direction` no longer states a value that only one of its two consumers applies. The member is declared once (objectui#6151) but `flex.tsx` reads `schema.direction || 'row'` while `stack.tsx` reads `schema.direction || 'col'` ("Default to column for Stack"), so the single `@default 'row'` was correct for `flex` and wrong for `stack` — whose own `defaultProps.direction` is `'col'`. The renderers are unchanged — they are the authority for what runs — so only the docblock moved: `direction` now names both consumers in prose, the same remedy objectui#7361 applied to the sibling `align`. `justify` is shared by the same two consumers and both read `|| 'start'`, so its tag is correct and stays: the criterion is a DIVERGENT shared member, not a shared one.

--- a/packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts
+++ b/packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts
@@ -1,27 +1,40 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * The `@default` documentation on two `layout.ts` members agrees with the value
- * the renderer actually applies (objectui#7361).
+ * The `@default` documentation on three `layout.ts` members agrees with the value
+ * the renderer actually applies (objectui#7361 rows 1-2, objectui#7734 row 3).
  *
- * Two published docblocks described a default no renderer ever applied:
+ * Three published docblocks described a default that at least one consuming
+ * renderer does not apply:
  *
- *   | member                     | tag said   | renderer applies                    |
- *   |----------------------------|------------|-------------------------------------|
- *   | `ContainerSchema.maxWidth` | `'lg'`     | `container.tsx`: `?? 'xl'`          |
- *   | `FlexLayoutProps.align`    | `'center'` | `flex.tsx`: `|| 'start'`,           |
- *   |                            |            | `stack.tsx`: `|| 'stretch'`         |
+ *   | member                      | tag said   | renderer applies                   |
+ *   |-----------------------------|------------|------------------------------------|
+ *   | `ContainerSchema.maxWidth`  | `'lg'`     | `container.tsx`: `?? 'xl'`         |
+ *   | `FlexLayoutProps.align`     | `'center'` | `flex.tsx`: `|| 'start'`,          |
+ *   |                             |            | `stack.tsx`: `|| 'stretch'`        |
+ *   | `FlexLayoutProps.direction` | `'row'`    | `flex.tsx`: `|| 'row'`,            |
+ *   |                             |            | `stack.tsx`: `|| 'col'`            |
  *
  * The renderers are the authority — they are what runs — so the tags moved, not
  * the reads. Changing the reads to match the tags would relayout every existing
  * page that omits either key, which is a behaviour change and a separate ruling.
  *
- * `FlexLayoutProps.align` is the structurally interesting half. The member is
- * declared ONCE (objectui#6151 — see the interface docblock for why `StackSchema`
- * cannot derive it with an `Omit`), but `flex` and `stack` deliberately diverge
- * on it: that divergence is most of what distinguishes the two component types.
- * So no single `@default` value can be correct there, and the fix is the absence
- * of a tag plus prose naming both consumers — not a second wrong single value.
+ * `FlexLayoutProps.align` and `FlexLayoutProps.direction` are the structurally
+ * interesting rows. Each member is declared ONCE (objectui#6151 — see the
+ * interface docblock for why `StackSchema` cannot derive them with an `Omit`),
+ * but `flex` and `stack` deliberately diverge on both: that divergence is most of
+ * what distinguishes the two component types. So no single `@default` value can
+ * be correct there, and the fix is the absence of a tag plus prose naming both
+ * consumers — not a second wrong single value. `direction` is the sharper case:
+ * its tag was not wrong for everybody the way `align`'s `'center'` was — `flex`
+ * really does apply `'row'` — which is exactly why "a shared member's tag is only
+ * conditionally true" is the defect, not "the value is wrong".
+ *
+ * The criterion is DIVERGENCE, not sharedness. `FlexLayoutProps.justify` is
+ * shared by the same two consumers and both read `|| 'start'`, so its tag is
+ * correct and must stay — it is pinned below as a negative control, and it is
+ * what stops this row-by-row fix from generalising into "shared members carry no
+ * tags".
  *
  * ## Why this pin reads both sides off disk
  *
@@ -55,6 +68,10 @@ const STACK = 'packages/components/src/renderers/layout/stack.tsx';
 const CONTAINER_MAXWIDTH = /schema\.maxWidth\s*\?\?\s*'([^']+)'/;
 const FLEX_ALIGN = /schema\.align\s*\|\|\s*'([^']+)'/;
 const STACK_ALIGN = /schema\.align\s*\|\|\s*'([^']+)'/;
+const FLEX_DIRECTION = /schema\.direction\s*\|\|\s*'([^']+)'/;
+const STACK_DIRECTION = /schema\.direction\s*\|\|\s*'([^']+)'/;
+const FLEX_JUSTIFY = /schema\.justify\s*\|\|\s*'([^']+)'/;
+const STACK_JUSTIFY = /schema\.justify\s*\|\|\s*'([^']+)'/;
 
 /** The body of a named `export interface`, so member lookups cannot stray. */
 function interfaceBody(src: string, name: string): string {
@@ -91,17 +108,25 @@ describe('layout.ts `@default` docs agree with the renderer fallbacks (objectui#
       expect(CONTAINER_MAXWIDTH.exec(read(CONTAINER))).not.toBeNull();
       expect(FLEX_ALIGN.exec(read(FLEX))).not.toBeNull();
       expect(STACK_ALIGN.exec(read(STACK))).not.toBeNull();
+      expect(FLEX_DIRECTION.exec(read(FLEX))).not.toBeNull();
+      expect(STACK_DIRECTION.exec(read(STACK))).not.toBeNull();
+      expect(FLEX_JUSTIFY.exec(read(FLEX))).not.toBeNull();
+      expect(STACK_JUSTIFY.exec(read(STACK))).not.toBeNull();
     });
 
     it('each extracted fallback is a member of the union the type declares', () => {
       const maxWidth = CONTAINER_MAXWIDTH.exec(read(CONTAINER))![1];
       const flexAlign = FLEX_ALIGN.exec(read(FLEX))![1];
       const stackAlign = STACK_ALIGN.exec(read(STACK))![1];
+      const flexDirection = FLEX_DIRECTION.exec(read(FLEX))![1];
+      const stackDirection = STACK_DIRECTION.exec(read(STACK))![1];
       const container = interfaceBody(types, 'ContainerSchema');
       const flexProps = interfaceBody(types, 'FlexLayoutProps');
       expect(container).toContain(`'${maxWidth}'`);
       expect(flexProps).toContain(`'${flexAlign}'`);
       expect(flexProps).toContain(`'${stackAlign}'`);
+      expect(flexProps).toContain(`'${flexDirection}'`);
+      expect(flexProps).toContain(`'${stackDirection}'`);
     });
   });
 
@@ -146,15 +171,53 @@ describe('layout.ts `@default` docs agree with the renderer fallbacks (objectui#
     });
   });
 
+  describe('row 3 — FlexLayoutProps.direction (shared member, two divergent consumers)', () => {
+    const flexDirection = FLEX_DIRECTION.exec(read(FLEX))![1];
+    const stackDirection = STACK_DIRECTION.exec(read(STACK))![1];
+
+    it('the two consumers really do diverge — the reason a single tag cannot be right', () => {
+      expect(flexDirection).not.toEqual(stackDirection);
+    });
+
+    it('publishes NO single-value `@default` block tag', () => {
+      const doc = docblockFor(interfaceBody(types, 'FlexLayoutProps'), 'direction');
+      expect(defaultTags(doc)).toEqual([]);
+    });
+
+    it('names BOTH consumers and the fallback each one applies', () => {
+      const doc = docblockFor(interfaceBody(types, 'FlexLayoutProps'), 'direction');
+      expect(doc).toContain('flex.tsx');
+      expect(doc).toContain('stack.tsx');
+      expect(doc).toContain(`'${flexDirection}'`);
+      expect(doc).toContain(`'${stackDirection}'`);
+    });
+
+    it('no longer publishes the value only ONE of the two consumers applies', () => {
+      const doc = docblockFor(interfaceBody(types, 'FlexLayoutProps'), 'direction');
+      expect(defaultTags(doc)).not.toContain(`'${flexDirection}'`);
+    });
+  });
+
   describe('negative controls — neighbouring `@default` tags are untouched', () => {
     it('ContainerSchema.centered still reads `@default true`', () => {
       const doc = docblockFor(interfaceBody(types, 'ContainerSchema'), 'centered');
       expect(defaultTags(doc)).toEqual(['true']);
     });
 
-    it('FlexLayoutProps.justify still reads `@default \'start\'`', () => {
+    /**
+     * The load-bearing control. `justify` is shared by the same two consumers as
+     * `align` and `direction`, so it is what makes the criterion DIVERGENCE and
+     * not sharedness: both renderers read `|| 'start'`, so one tag IS right for
+     * both and must stay. Derived off disk like the rows above, so it turns red
+     * if the consumers ever diverge here — at which point the tag becomes a
+     * fourth instance of this defect rather than a control.
+     */
+    it('FlexLayoutProps.justify keeps its tag — its two consumers AGREE', () => {
+      const flexJustify = FLEX_JUSTIFY.exec(read(FLEX))![1];
+      const stackJustify = STACK_JUSTIFY.exec(read(STACK))![1];
+      expect(flexJustify).toEqual(stackJustify);
       const doc = docblockFor(interfaceBody(types, 'FlexLayoutProps'), 'justify');
-      expect(defaultTags(doc)).toEqual(["'start'"]);
+      expect(defaultTags(doc)).toEqual([`'${flexJustify}'`]);
     });
 
     it('FlexLayoutProps.gap still reads `@default 2`', () => {

--- a/packages/types/src/layout.ts
+++ b/packages/types/src/layout.ts
@@ -286,8 +286,23 @@ export interface ContainerSchema extends BaseSchema {
  */
 export interface FlexLayoutProps {
   /**
-   * Flex direction
-   * @default 'row'
+   * Flex direction.
+   *
+   * Deliberately carries NO `@default` tag. The member is declared once here
+   * (see this interface's docblock and objectui#6151), but the two component
+   * types that consume it diverge on the value they apply when it is omitted:
+   * `flex.tsx` reads `schema.direction || 'row'`, `stack.tsx` reads
+   * `schema.direction || 'col'` ("Default to column for Stack"). One tag on a
+   * shared member cannot be right for both — it would publish a single default
+   * that only one consumer applies, which is the defect objectui#7734 records
+   * (the tag here used to read `'row'`, which `flex` applies and `stack`
+   * deliberately does not — a column is what the `stack` type is FOR). The
+   * per-type values are stated in prose so no parser reads a value that is only
+   * conditionally true.
+   *
+   * The criterion is a DIVERGENT shared member, not a shared one: the sibling
+   * `justify` keeps its `@default 'start'` because both consumers read
+   * `|| 'start'`, and that tag is correct for both.
    */
   direction?: 'row' | 'col' | 'row-reverse' | 'col-reverse';
   /**

--- a/packages/types/src/layout.ts
+++ b/packages/types/src/layout.ts
@@ -279,6 +279,12 @@ export interface ContainerSchema extends BaseSchema {
  * Types of property 'type' are incompatible.`). Lifting the shared members out
  * of the inheritance path is what keeps them nameable from both sides.
  *
+ * A member here carries an `@default` tag only when BOTH consumers apply the
+ * same value — the criterion is a DIVERGENT shared member, not a shared one:
+ * `align` and `direction` diverge and state their per-type values in prose
+ * instead, while `justify` keeps its `@default 'start'` because `flex.tsx` and
+ * `stack.tsx` both read `|| 'start'`.
+ *
  * Pinned by `__tests__/stack-schema-emitted-members.test.ts`, which asserts
  * against the EMITTED declaration rather than this source — a source-level
  * assertion passes while the emitted declaration is empty, and that gap is
@@ -299,10 +305,6 @@ export interface FlexLayoutProps {
    * deliberately does not — a column is what the `stack` type is FOR). The
    * per-type values are stated in prose so no parser reads a value that is only
    * conditionally true.
-   *
-   * The criterion is a DIVERGENT shared member, not a shared one: the sibling
-   * `justify` keeps its `@default 'start'` because both consumers read
-   * `|| 'start'`, and that tag is correct for both.
    */
   direction?: 'row' | 'col' | 'row-reverse' | 'col-reverse';
   /**


### PR DESCRIPTION
Fixes #7734

`FlexLayoutProps.direction` is declared once so `FlexSchema` and `StackSchema` can name it from both sides (objectui#6151), but its two consumers deliberately diverge on what they apply when the key is omitted. Every anchor below was re-located **by content** on `origin/main` `580b0fdf4` — the card measured on `b74a859` and triage on `0558e0f`, so their line numbers were stale:

| consumer | read | where |
|---|---|---|
| `flex.tsx` | `schema.direction \|\| 'row'` | `:16` |
| `stack.tsx` | `schema.direction \|\| 'col'` | `:22`, under its own `// Default to column for Stack` at `:21` |

The single published `@default 'row'` was therefore correct for `flex` and wrong for `stack` — whose registration agrees with its renderer (`defaultProps.direction: 'col'`, `stack.tsx:130`) and not with the tag.

## The remedy was already on this interface, two members down

objectui#7361 landed as `e546222b3` (#7736) and settled the identical case for `align`. It did **not** correct the value — it removed the tag and stated the per-type values in prose, on the stated ground that *"one tag on a shared member cannot be right for both … the per-type values are stated in prose so no parser reads a value that is only conditionally true."*

This PR copies that prose form structurally, deliberately: two sibling members on one interface written in two different styles would read as though they were two different situations. After the second commit the two member docblocks are parallel again — same shape, same voice, neither carrying anything the other lacks.

`direction` is the **sharper** instance of the same defect, and the docblock says so. `align`'s tag said `'center'`, which *neither* renderer applies, so it could be dismissed as merely a wrong value. `direction`'s `'row'` is what `flex` genuinely applies — the defect is that a shared member's tag is only *conditionally* true, not that its value is wrong.

## The control that keeps this from over-generalising

`justify` is shared by the same two consumers on the same interface, and **both** read `|| 'start'` (`flex.tsx:17`, `stack.tsx:23`). Re-verified here on `580b0fdf4`: unchanged since triage measured, no drift. Its `@default 'start'` is correct and stays.

The criterion is **a *divergent* shared member must not carry a tag**, not "shared members must not carry tags."

That criterion is stated once, on the **`FlexLayoutProps` interface docblock** — it is a claim about this interface, so on the interface docblock it reaches the reader of every member rather than one member's reader, and it keeps `align` and `direction` reading as two instances of one situation. It names all three shared members: `align` and `direction` diverge and state their per-type values in prose, `justify` keeps its tag because both consumers agree.

The same control also exists mechanically in the pin, where it was a literal `toEqual(["'start'"])`. This PR derives it off disk instead, so it turns red if those two reads ever part company — at which point `justify` stops being a control and becomes a fourth instance of this defect.

## Where the pin lands, and why not a new file

Row 3 of objectui#7361's census goes into objectui#7361's own pin, `packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts`, rather than a second card-numbered file. Same argument as the prose: rows 1-3 are one census, and the helpers that read both sides off disk already live there. Every expected value is extracted from the renderer source by a regex guarded by an explicit positive control, so the pin fails if **either** side moves.

**No pin assertion was touched or loosened by the relocation.** The interface docblock sits ahead of `export interface FlexLayoutProps`, which is exactly where `interfaceBody()` starts its slice, so no member-docblock lookup can see the moved text. All 15 assertions pass unchanged.

## Verification — every reading on the final commit `4317adc82`

| what | command | result |
|---|---|---|
| dependency-closure build | `pnpm --filter '@object-ui/types^...' build` | closure is **empty** — `@object-ui/types` has no internal workspace deps (`@objectstack/spec`, `zod` only). pnpm answered `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT None of the selected packages has a "build" script`, which is the measurement, not a failure |
| build | `pnpm --filter @object-ui/types build` | `✓ dist completeness: 1 package(s) complete (124 emitted files verified)` |
| affected package tests | `pnpm exec vitest run --project unit packages/types/src/__tests__/` | `Test Files 136 passed (136)` · `Tests 2561 passed (2561)` |
| the pin itself, named | same, one file, `--reporter=verbose` | `Tests 15 passed (15)`, including all four `row 3 — FlexLayoutProps.direction` assertions and the rewritten `FlexLayoutProps.justify keeps its tag — its two consumers AGREE` |
| type-check | `pnpm --filter @object-ui/types type-check` | pass (`tsc --noEmit` + `tsconfig.examples.json` + `tsconfig.test.json`) |
| package lint | `pnpm --filter @object-ui/types lint` | 202 files, 0 errors; 272 pre-existing warnings, **none in either edited file** (both measured at `err 0 warn 0`) |
| `check:control-bytes` | `pnpm check:control-bytes` | `✅ check-control-bytes: OK (scanned 6549 tracked text file(s); skipped 85 binary).` |
| changeset presence | `node scripts/check-changeset-presence.mjs` | `✅ 2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| changeset guards | `pnpm changeset:check` | `✅ All workspace packages are in the changeset fixed group.` · `✅ No changeset declares a 'major' bump.` |
| lint coverage | `pnpm lint:coverage` | `✅ lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |

Every verdict above is the line the gate printed itself; exit codes were captured before any pipe. The whole union was re-run on `4317adc82` after the relocation commit — nothing here is carried over from the first commit's run.

**Coverage was measured, not assumed.** `type-check` runs three `tsc` invocations, and only one of them contains the test file — so "typecheck is clean" could have been true while saying nothing about the new assertions. Counted with `--listFiles`:

| program | `src/layout.ts` | the pin test | files |
|---|---|---|---|
| `tsc --noEmit` | present | **absent** | 275 |
| `tsc -p tsconfig.test.json` | present | **present** | 597 |
| `tsc -p tsconfig.examples.json` | present | **absent** | 275 |

Both edited files are covered, via the test project.

### Reverse verification — two legs, direction predicted before running

The pin claims it turns red if *either* side moves, so both sides were mutated. Predicted first: leg A ⇒ 2 red, leg B ⇒ 1 red. Re-run in full on `4317adc82`, because leg A's mutation target is the very docblock the relocation commit edited.

| leg | mutation | confirmed on disk | predicted | observed |
|---|---|---|---|---|
| A | put `@default 'row'` back into the `direction` docblock | injected block-tag `grep -c` = 1; blob hash differs from the `HEAD` blob | 2 red | **`Tests 2 failed \| 13 passed`** — exactly `publishes NO single-value @default block tag` and `no longer publishes the value only ONE of the two consumers applies` |
| B | converge `stack.tsx` onto flex's fallback (`\|\| 'col'` → `\|\| 'row'`) | injected text `grep -c` = 1, removed text `grep -c` = 0 | 1 red | **`Tests 1 failed \| 14 passed`** — exactly `the two consumers really do diverge` |

Both legs matched the prediction. **No rebuild was needed and none is claimed**: this pin reads both sides as *source text* with `readFileSync` — no module resolution, no `dist` — so the stale-artifact hazard that makes an unbuilt ablation silently green does not apply here.

Each leg restored with `git checkout HEAD -- ABSOLUTE_PATH` (absolute paths, `HEAD` named so the mutated index cannot be the source), and the restore was **proven, not assumed**: both files' `git hash-object` compared byte-identical to their `HEAD` blob hashes, and `git diff HEAD` was empty. A control run on the restored tree returned `Tests 15 passed (15)`.

## Changeset: `@object-ui/types: patch` — measured, not guessed

`packages/types` publishes `dist` (`files: ["dist", …]`, not private), and `tsc` carries JSDoc into the emitted declaration. After building:

```
grep -c 'objectui#7734'            packages/types/dist/layout.d.ts   →  1
grep -c 'DIVERGENT shared member'  packages/types/dist/layout.d.ts   →  1
grep -c "@default 'row'"           packages/types/dist/layout.d.ts   →  0
```

The published `.d.ts` bytes change, so this ships something a consumer sees in their editor and every type-doc generator reads. It is a release, not an internal-only change — so a real `patch`, not an empty-frontmatter "no release" declaration. This matches the precedent exactly: objectui#7361 shipped `.changeset/layout-default-jsdoc-7361.md` declaring `'@object-ui/types': patch` for the same class of change, and that changeset is still pending release.

## Deliberately not touched

- **`packages/types/src/zod/layout.zod.ts`** — the mirror's `.default('lg')` still contradicts the JSDoc `maxWidth: 'xl'` that objectui#7361 landed. That contradiction is objectui#7735's reason for existing (`needs-user-decision`, p2). Aligning it here would be a published runtime behaviour change smuggled into a documentation card. My own view, for objectui#7735 rather than for here: the mirror is the runtime face and the JSDoc is not, so "align them" is the wrong frame — that card should rule on which face is authoritative first, because moving the mirror to `'xl'` changes what every existing container without an explicit `maxWidth` renders as.
- **`flex.tsx` / `stack.tsx`** — evidence, not edit targets. Not one line, other than the transient leg-B ablation mutation above, which was restored and proven restored.
- **The other 10 `@default` tags in `layout.ts`** — they declare a default no renderer applies as a fallback *at all*, so they are not comparable rather than wrong. Different question, needs its own card. The block-tag census on `layout.ts` went 23 → 22: exactly one tag removed.
- **`align`'s docblock** — untouched throughout, including by the relocation commit.

## Finding filed

**objectui#8229** — `flex.tsx` declares two different defaults for `align` in the same file: `defaultProps.align: 'center'` (`:132`) against its own renderer fallback `schema.align || 'start'` (`:18`). This is where the tag objectui#7361 retired most likely came from, and it is the third face that card did not reconcile. Bounded census in the issue: one disagreement out of eight comparable renderer-vs-`defaultProps` pairs across both files. Unassigned, unlabelled, left for triage; not acted on here.

Authored in Claude Code session `session_0114Ytxr5sM1vdW19Y9WAx6E`.