### PR TITLE
docs(disclosure): collapsible.mdx documents the `content` slot the renderer reads

### DIFF
--- a/content/docs/components/disclosure/collapsible.mdx
+++ b/content/docs/components/disclosure/collapsible.mdx
@@ -13,7 +13,13 @@ description: "Toggle visibility of content"
 interface CollapsibleSchema {
   type: 'collapsible';
   trigger: SchemaNode | SchemaNode[];
-  children: SchemaNode[];
+  content: SchemaNode | SchemaNode[];
   defaultOpen?: boolean;
 }
 ```
+
+The body is authored under `content`, not `children`: the renderer reads
+`schema.content` inside `CollapsibleContent`, with no `children` fallback of any
+kind, and the registration's `defaultProps` ships `content` too. A collapsible
+that puts its body under `children` is refused by the zod twin — `content` is
+required — and paints an empty body wherever nothing validates it.


### PR DESCRIPTION
Fixes #8197

The `## Schema` block on `content/docs/components/disclosure/collapsible.mdx`
published `children: SchemaNode[];` as a **required** member. No such member
exists. `packages/types/src/disclosure.ts:113` declares the content slot as
`content: SchemaNode | SchemaNode[];` — required — and `children` reaches
`CollapsibleSchema` only through `BaseSchema` (`packages/types/src/base.ts:260`)
as `children?: SchemaNode | SchemaNode[]`: optional, and a different union. The
`collapsible` renderer reads `renderChildren(schema.content)` inside
`CollapsibleContent` with no `children` fallback of any kind, and the
registration's `defaultProps` ships `content`, not `children`. So the page named
a key nothing consumes and omitted the only key that works.

The row is now the declared one, and a short prose note below the fence names
the trap for anyone who already followed the old row.

## The judgement the card left open: NO row for the inherited `children`

The card deliberately did not rule on whether the inherited **optional**
`children` deserves a row of its own. It does not, for three reasons.

**1. The fence's membership rule is "what this component reads", not "what it
inherits".** The block lists four members and stops. It carries no `id`,
`visible`, `className`, `testId`, `bind` or `body` — all equally inherited from
`BaseSchema`. Admitting `children` and nothing else would make the selection
arbitrary. This page has no "Base properties" section to hold it either (the
`scroll-area` page has one; this one does not).

**2. The two same-class precedents document `children` because their renderers
READ it — that is the discriminator, not inheritance.** Measured on this base:

- `packages/components/src/renderers/complex/scroll-area.tsx:34` is
  `renderChildren(schema.children)` — the only content channel, and
  `scroll-area.mdx` carries a `children` row. (objectui#6805)
- `packages/components/src/renderers/layout/aspect-ratio.tsx:33` is
  `renderChildren(schema.children || schema.body)`, and `aspect-ratio.mdx`
  carries a `children` row. (objectui#6773)

`collapsible.tsx:28` is `renderChildren(schema.content)`. Applying the same rule
to this page yields: no `children` row. Giving it one would re-document a key
the renderer provably ignores — the exact defect this PR removes, merely
downgraded from "required" to "optional". A member list is read as "this is how
you author it here"; a row for an inert key is a trap, not a completeness win.

**3. The repo already has a shape for an inherited-but-unread key that authors
are actively getting wrong: prose below the fence, not a member row.**
`content/docs/components/overlay/tooltip.mdx:24-27` does exactly this for its
own `children` (objectui#6939). The evidence that authors get it wrong *here* is
this card itself — a doc row that had been telling them to write `children`. So
the note is added in tooltip's shape and the fence stays a list of read keys.

## Landing control — before/after, with a lit control

All three legs measured with `grep -cF` (fixed-string: a regex grep would read
the `|` as alternation).

| leg | before | after | required |
|---|--:|--:|--:|
| `children: SchemaNode[];` | 1 | **0** | 0 |
| `content: SchemaNode \| SchemaNode[];` | 0 | **1** | 1 |
| lit control — `SchemaNode` on any line | 2 | **2** | non-zero |

Bidirectional on purpose: deleting the row alone would satisfy leg 1 and is not
the fix. The two legs are each other's firing control — leg 1 returned 1 before,
leg 2 returns 1 after, so neither grep is silently matching nothing.

## The defect demonstrated end-to-end, not just measured as text

Two nodes identical except for the content key, both `defaultOpen: true`.

**Zod twin** (`packages/types/src/zod/disclosure.zod.ts`, `safeParse`):

- authored per the OLD row (`children`) — `success = false`:
  `{ "code": "invalid_type", "expected": "nonoptional", "path": ["content"],
  "message": "Invalid input: expected nonoptional, received undefined" }`
- authored per the NEW row (`content`) — `success = true`

**Render** (`renderComponent` from `packages/components/src/__tests__/test-utils`,
jsdom, real renderer registration). Both roots came back `data-state="open"`,
`aria-expanded="true"`, so both were genuinely expanded:

- OLD row: the content div (`id="radix-_r_0_"`) ends immediately after its own
  attributes — **empty body**, no `BODY-MARKER` text node anywhere in the tree.
- NEW row: the content div (`id="radix-_r_2_"`) holds the text node
  `BODY-MARKER` — content painted.

The NEW leg is the firing control for the OLD leg's negative reading: the same
harness does paint the marker when the key is right.

These were throwaway probes, run and then deleted; the tree carries only the
docs change (`git status` clean at `4b9be5954`).

## Gates: they all pass, and NONE of them judges this deliverable

Stated plainly because a green CI is not evidence for this row.

- `check:doc-types` — exit 0. Reads only `type` string literals out of doc code
  blocks (889 literals scanned); it never judges a member row.
- `check:doc-snippets` — **exit 2, PRECONDITION NOT MET**. It did not run (five
  packages unbuilt). It is also structurally incapable of judging this block:
  `TS_FENCE_LANGUAGES` at `scripts/check-doc-snippet-types.mjs:548` is
  `{ts, tsx, typescript}`, and this file has **0** such fences and **1**
  `plaintext` fence (measured here, not taken from the card). Read as NOT
  MEASURED, neither green nor red.
- `check:doc-fences` — exit 0 (227 documents).
- `docs:check-links` — exit 0, "Links are valid across 17 scan roots."
- `check:control-bytes` — exit 0 (6556 tracked text files). Plus a direct scan of
  the changed file for the C0/C1 set: no hits.
- `check:doc-example-readers` — exit 0. `check:docs-route-closure` — exit 0.
  `check-doc-expression-carriage` — exit 0 (report-only by design).
- `node scripts/check-changeset-presence.mjs` — exit 0: "No source or published
  contract of a released package changed in this range, so no changeset is
  owed." So no `.changeset/*.md`, and no label is applied.
- Affected packages: `turbo ls --affected` against the merge base returns **0
  packages** — `content/` is outside every workspace package, so no package test
  or typecheck is owed here.
- Repo-wide `eslint` has nothing to say about this diff, measured from eslint's
  own config resolution rather than assumed: `eslint --format json` on the
  changed file returns `"File ignored because no matching configuration was
  supplied."` Every config block in `eslint.config.js` targets `**/*.{ts,tsx}`.
- `fumadocs-mdx` regenerates cleanly (exit 0), so the page still parses as MDX.

⇒ the verification for the row itself is the before/after measurement and the
render demonstration above, not any gate.

## Other rows in the same fence, checked against the declaration

- `type: 'collapsible';` — matches `disclosure.ts:93`. Correct.
- `trigger: SchemaNode | SchemaNode[];` — objectui#7767's row, already correct on
  main via objectui#8199. Untouched, per the scope fence.
- `defaultOpen?: boolean;` — matches `disclosure.ts:118`, and the renderer reads
  it. Correct.
- Missing from the fence: `open?: boolean` and `onOpenChange`. Omitting
  `onOpenChange` is **right** — it is a runtime slot whose zod twin refuses the
  key by name (`handlerKeyRefusal(..., 'runtime-slot')` is a `z.custom` arm
  whose predicate always returns false), so it is not authorable. Omitting
  `open` is defensible for a different reason and is **not** folded in: the
  renderer never reads `schema.open`, so it is a declaration-side question,
  filed separately.

## Out-of-scope findings — filed, not repaired here

Three, none touched by this PR:

- **objectui#8234** — `scroll-area.mdx` documents a `content?` member that
  `ScrollAreaSchema` does not declare and `ui:scroll-area` does not read, and
  labels `children?` (the only channel) "Alternative content prop". Exact mirror
  of this card on another page; objectui#6805 addressed that component's demos,
  not its reference page.
- **objectui#8235** — census: component reference pages document `on*` handler
  rows their zod twins refuse by name. 3 confirmed on top-level schemas
  (`accordion`, `toggle-group`, `pagination`), 14 further rows left unclassified
  rather than overclaimed.
- **objectui#8236** — `CollapsibleSchema.open` is declared on both faces,
  validates, and is read by no renderer. Deliberately not documented on this
  page: a row for an inert key is the trap this PR removes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S


---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_