### PR TITLE
fix(live-e2e): pin the better-auth family so the lane boots, and guard the pin

### DIFF
--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -420,6 +420,21 @@ comment), so every promotion would stale a hand-copied enumeration here; it alre
 Backend pins live in `e2e/live/ci/backend.env` and must match the `@objectstack/spec` version in
 `pnpm-lock.yaml` — bump both in the same PR, or the run proves nothing.
 
+That file carries a **third** pin, `BETTER_AUTH_VERSION`, and it is a different kind of thing:
+not a matched-pair pin but a workaround for a break inside the published packages themselves.
+`@objectstack/plugin-auth` imports `createLocalAccountIssuer` from `@better-auth/core/db` and
+declares `@better-auth/core` with a caret; `@better-auth/core@1.7.3` removed that export in a
+**patch** release and is also `latest`, so a fresh install floats onto it, AuthPlugin fails to
+load, no `sys_*` table is ever created, the seeded sign-in never answers, and the lane dies on
+its 300-second readiness timeout having run zero specs (objectstack#16186, objectui#8084).
+`start-backend.sh` therefore writes an npm `overrides` block pinning that family, and — because
+pinning a dependency to turn a lane green is a gate weakening — `e2e/live/ci/better-auth-pin.mjs`
+runs on **every** start, cache hits included, and fails by name if the override was not declared,
+did not resolve, or resolved and still lacks the export. ⛔ It is not, and must not become, a
+repair of the two pins above: objectui#7689's triage forbids repairing this lane by moving those.
+Retire the pin and its guard together in the PR that bumps `OBJECTSTACK_VERSION` past the
+upstream fix.
+
 ## Internal Docs Links (`docs-links.yml`)
 
 **Triggers:** Push and PR to `main`/`develop`, plus manual dispatch — with **no path filter at

--- a/e2e/live/ci/backend.env
+++ b/e2e/live/ci/backend.env
@@ -22,3 +22,34 @@
 #   hand whenever the version above moves, from the tag's own commit.
 OBJECTSTACK_VERSION=17.2.0
 OBJECTSTACK_REF=e7d2cc67fdef7fee9d2c6d65d7363fe1c78ce6a4
+
+# BETTER_AUTH_VERSION — the version the whole floating `better-auth` family is
+#   pinned to in the backend's install path, via an npm `overrides` block that
+#   start-backend.sh writes into the showcase app's manifest.
+#
+#   Why: @objectstack/plugin-auth imports `createLocalAccountIssuer` from
+#   `@better-auth/core/db` and declares `@better-auth/core` with a CARET.
+#   @better-auth/core@1.7.3 removed that export in a PATCH release, and 1.7.3 is
+#   `latest`, so a fresh install of the pinned @objectstack/* floats onto it,
+#   AuthPlugin fails to load, no sys_* table is ever created, the seeded sign-in
+#   never answers and this lane times out at 300s having run zero specs.
+#   Root cause objectstack#16186; this pin decided on objectui#8084.
+#
+#   ⛔ This is NOT a repair of the two pins above and must never become one:
+#   objectui#7689's triage forbids repairing this lane by moving OBJECTSTACK_*,
+#   and those two values are unchanged. This pins a TRANSITIVE dependency of the
+#   published artifact to the version that artifact's own manifest was authored
+#   against. Retire it — this key and e2e/live/ci/better-auth-pin.mjs, together
+#   — in the PR that bumps OBJECTSTACK_VERSION past the upstream fix.
+#
+#   Enforced, not merely stated: e2e/live/ci/better-auth-pin.mjs runs on EVERY
+#   start (not just after a fresh install) and fails by name if the override was
+#   not declared, did not resolve, or resolved and still lacks the export. It
+#   also owns the list of package names — this file carries only the version.
+#
+#   ⚠️ It lives in THIS file rather than in start-backend.sh on purpose: the
+#   workflow caches the prepared fixture under
+#   `live-backend-<os>-<hashFiles(e2e/live/ci/backend.env)>`, so a pin that lives
+#   here changes the cache key and a pin change cannot be served a fixture built
+#   before it. start-backend.sh's own stamp carries it for the same reason.
+BETTER_AUTH_VERSION=1.7.2

--- a/e2e/live/ci/better-auth-pin.mjs
+++ b/e2e/live/ci/better-auth-pin.mjs
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The live-e2e backend's `better-auth` pin: it writes the override, and it
+ * refuses to let the override fail quietly.
+ *
+ *   node e2e/live/ci/better-auth-pin.mjs overrides VERSION
+ *   node e2e/live/ci/better-auth-pin.mjs verify APP_DIR VERSION
+ *
+ * Exit: 0 = the pinned world matches reality
+ *       1 = it does not, named by which of the three ways it stopped matching
+ *
+ * ## Why the pin exists (objectstack#16186)
+ *
+ * `@objectstack/plugin-auth` imports `createLocalAccountIssuer` from
+ * `@better-auth/core/db` and declares `@better-auth/core` with a CARET range
+ * (`^1.7.1` at 17.2.0, `^1.7.2` at 17.3.0). `@better-auth/core@1.7.3` REMOVED
+ * that public export — in a patch release, upstream better-auth#10909 — and
+ * 1.7.3 is both the top of the published `1.7.x` set and `latest`, so every
+ * caret in the family floats onto it and no range in the published manifest can
+ * protect against it. Measured in this lane's own install path: the import dies
+ * with `SyntaxError: The requested module '@better-auth/core/db' does not
+ * provide an export named 'createLocalAccountIssuer'`.
+ *
+ * What that costs is not one plugin. AuthPlugin fails to load, `auth` is
+ * reported as a missing core service, no `sys_*` table is ever created, the
+ * seeded sign-in never answers, and `start-backend.sh` times out at 300s — so
+ * the console is never built, Playwright never runs, and the lane's whole
+ * product (a console x published-backend integration reading) is lost on every
+ * PR. The backend does not refuse to start, which is the confusing part: it
+ * binds the port, loads 42 plugins and prints `Server is ready` while auth is
+ * absent (objectui#8084).
+ *
+ * ⛔ The pin is NOT a repair of `OBJECTSTACK_VERSION` / `OBJECTSTACK_REF`.
+ * objectui#7689's triage forbids repairing this lane by moving those, and this
+ * does not move them. It pins a TRANSITIVE dependency of the published artifact
+ * to the version that artifact's own manifest was authored against, restoring
+ * the resolution the publisher intended. When objectstack#16186 lands upstream
+ * — plugin-auth pinning `@better-auth/core` itself, or moving off the removed
+ * export — this file and the `BETTER_AUTH_VERSION` key in `backend.env` should
+ * be deleted in the same PR that bumps `OBJECTSTACK_VERSION` past the fix.
+ *
+ * ## Why `verify` exists, and why it runs on EVERY start
+ *
+ * Pinning a dependency to make a red lane green is a gate weakening, and it was
+ * taken deliberately (objectui#8084) on ONE condition: quieting the red must not
+ * quiet the information. A pin that stops applying must be LOUD, because the
+ * thing it decays into is precisely the outcome the lane exists to detect, minus
+ * the explanation — a 300-second timeout with no stated cause.
+ *
+ * Three ways the pinned world can stop matching reality, and this file names
+ * which one it is rather than reporting a single undifferentiated failure:
+ *
+ *   PIN-NOT-DECLARED   the `overrides` block never reached the manifest npm
+ *                      installed from. The classic silent failure: `overrides`
+ *                      is npm's spelling, `pnpm.overrides` is pnpm's, and each
+ *                      is INERT under the other package manager — no warning,
+ *                      no error, exit 0, a fully resolved tree that ignored the
+ *                      pin. This lane installs with `npm install`, so the npm
+ *                      spelling is the load-bearing one.
+ *   PIN-NOT-RESOLVED   the override was declared and the installed tree does
+ *                      not match it anyway (a stale cached fixture reused
+ *                      across a pin change, a nested copy npm declined to
+ *                      dedupe, a hand-edited manifest).
+ *   EXPORT-MISSING     the pinned version installed cleanly and the export the
+ *                      auth plugin needs is still not there. This is the check
+ *                      that survives the other two being satisfiable by a
+ *                      version number alone: it asks the question the plugin
+ *                      asks, with the resolver the plugin uses.
+ *
+ * ⚠️ EXPORT-MISSING is a CANARY, not a contract. It probes the one named import
+ * that broke. If `@objectstack/plugin-auth` grows a second import that a future
+ * `@better-auth/*` drops, this will not see it — the 300s readiness timeout
+ * will, in the way it always did. Widen `REQUIRED_IMPORTS` when that happens.
+ */
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * The packages the override pins, and the ONE list both halves of this file
+ * read — `overrides` writes exactly these names, `verify` checks exactly these
+ * names. Two lists would be a drift the lane could not see: pinning a name
+ * nothing checks, or checking a name nothing pins, both read as green.
+ *
+ * MEASURED against this lane's own install path at `@objectstack/*@17.2.0`
+ * rather than copied from the upstream workaround — every name below really is
+ * in the installed tree, all ten of them resolving to 1.7.3 before the pin:
+ *
+ *   node_modules/@better-auth/{core,drizzle-adapter,kysely-adapter,
+ *     memory-adapter,mongo-adapter,prisma-adapter,telemetry}
+ *   node_modules/@objectstack/plugin-auth/node_modules/{better-auth,
+ *     @better-auth/oauth-provider,@better-auth/sso}
+ *
+ * ⛔ TWO deliberate exclusions, each of which would be a bug to "fix" by adding:
+ *
+ *   `@better-auth/scim` — present, but `@objectstack/plugin-auth@17.2.0` pins it
+ *   EXACTLY at `1.7.0-rc.1`, not with a caret. It is therefore not floating,
+ *   it is not what broke, and overriding it to 1.7.2 would OVERRIDE THE
+ *   PUBLISHER rather than restore their intent — the opposite of this pin's
+ *   whole justification. The upstream workaround lists it; this lane measured
+ *   its own tree and left it alone.
+ *
+ *   `@better-auth/utils` — present at 0.4.2 and 0.5.0. A separate version line
+ *   that never had a 1.7.x, so pinning it to 1.7.2 would fail the install.
+ */
+const FAMILY = [
+  'better-auth',
+  '@better-auth/core',
+  '@better-auth/drizzle-adapter',
+  '@better-auth/kysely-adapter',
+  '@better-auth/memory-adapter',
+  '@better-auth/mongo-adapter',
+  '@better-auth/oauth-provider',
+  '@better-auth/prisma-adapter',
+  '@better-auth/sso',
+  '@better-auth/telemetry',
+];
+
+/**
+ * The named imports EXPORT-MISSING probes, as `[specifier, name]`. Exactly the
+ * one that broke; see the canary note in the header before adding to it.
+ */
+const REQUIRED_IMPORTS = [['@better-auth/core/db', 'createLocalAccountIssuer']];
+
+/** The package whose absence makes the whole pin pointless. */
+const KEYSTONE = '@better-auth/core';
+
+const ISSUE = 'objectstack#16186 (downstream: objectui#8084)';
+
+/** `overrides` object for the app manifest, in npm's top-level spelling. */
+function overridesFor(version) {
+  const out = {};
+  for (const name of FAMILY) out[name] = version;
+  return out;
+}
+
+function die(tag, lines) {
+  console.error(`[better-auth-pin] FAIL ${tag}`);
+  for (const line of lines) console.error(`[better-auth-pin]   ${line}`);
+  console.error(`[better-auth-pin]   root cause: ${ISSUE}`);
+  process.exit(1);
+}
+
+/**
+ * Every installed copy of a FAMILY package under `dir`, nested ones included.
+ *
+ * Walks `node_modules` by hand rather than shelling out to `npm ls`: the answer
+ * must be about what is ON DISK, which is the thing a restored cache can make
+ * disagree with any manifest.
+ */
+function installedCopies(appDir) {
+  const found = [];
+  const walk = (nodeModules) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(nodeModules, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+      const dirs = entry.name.startsWith('@')
+        ? fs
+            .readdirSync(path.join(nodeModules, entry.name), { withFileTypes: true })
+            .filter((e) => e.isDirectory())
+            .map((e) => path.join(nodeModules, entry.name, e.name))
+        : [path.join(nodeModules, entry.name)];
+      for (const pkgDir of dirs) {
+        const manifest = path.join(pkgDir, 'package.json');
+        if (fs.existsSync(manifest)) {
+          try {
+            const pkg = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+            if (FAMILY.includes(pkg.name)) {
+              found.push({ name: pkg.name, version: pkg.version, dir: path.relative(appDir, pkgDir) });
+            }
+          } catch {
+            /* an unreadable manifest is npm's business, not this gate's */
+          }
+        }
+        walk(path.join(pkgDir, 'node_modules'));
+      }
+    }
+  };
+  walk(path.join(appDir, 'node_modules'));
+  return found;
+}
+
+function verify(appDir, version) {
+  // ── PIN-NOT-DECLARED ────────────────────────────────────────────────────
+  const manifestPath = path.join(appDir, 'package.json');
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch (error) {
+    die('(PIN-NOT-DECLARED)', [
+      `could not read ${manifestPath}: ${error.message}`,
+      'start-backend.sh rewrites this manifest before installing; if it is not there,',
+      'the prepare step did not run or did not finish.',
+    ]);
+  }
+  const declared = manifest.overrides || {};
+  const wrong = FAMILY.filter((name) => declared[name] !== version);
+  if (wrong.length > 0) {
+    die('(PIN-NOT-DECLARED)', [
+      `${path.relative(appDir, manifestPath) || 'package.json'} does not declare the whole family at ${version}.`,
+      ...wrong.map((name) => `  ${name}: declared ${JSON.stringify(declared[name] ?? null)}, want ${JSON.stringify(version)}`),
+      manifest.pnpm && manifest.pnpm.overrides
+        ? 'NOTE: a `pnpm.overrides` block IS present. This app is installed with `npm install`,'
+        : 'The npm spelling is the top-level `overrides` key. `pnpm.overrides` is inert here:',
+      'npm reads `overrides`, pnpm reads `pnpm.overrides`, and each ignores the other silently.',
+    ]);
+  }
+
+  // ── PIN-NOT-RESOLVED ────────────────────────────────────────────────────
+  const copies = installedCopies(appDir);
+  // A zero-hit "everything matches" is not a reading. If the keystone is not
+  // installed at all, the loop below would pass over an empty set and this
+  // whole gate would be decorative.
+  if (!copies.some((c) => c.name === KEYSTONE)) {
+    die('(PIN-NOT-RESOLVED)', [
+      `no copy of ${KEYSTONE} is installed under ${appDir}/node_modules.`,
+      `That is either a broken install, or ${KEYSTONE} is no longer a dependency of`,
+      '@objectstack/plugin-auth at this OBJECTSTACK_VERSION. If it is the latter, the pin and',
+      'this guard have outlived their purpose: delete BETTER_AUTH_VERSION from backend.env and',
+      'delete this file, deliberately and in one PR. Do not leave a pin that pins nothing.',
+    ]);
+  }
+  const drifted = copies.filter((c) => c.version !== version);
+  if (drifted.length > 0) {
+    die('(PIN-NOT-RESOLVED)', [
+      `the override is declared at ${version} but the installed tree does not match it:`,
+      ...drifted.map((c) => `  ${c.name}@${c.version}  at ${c.dir}`),
+      'A restored fixture cache is the likeliest cause — the cache key is the hash of',
+      'backend.env, so a pin change must change that file, and start-backend.sh must not',
+      'reuse a stamped fixture across it.',
+    ]);
+  }
+
+  // ── EXPORT-MISSING ──────────────────────────────────────────────────────
+  // Asked with the resolver the plugin itself uses: a real ESM named import,
+  // resolved from the app directory. `--input-type=module -e` takes its
+  // resolution base from the cwd, so bare specifiers hit this app's tree.
+  for (const [specifier, name] of REQUIRED_IMPORTS) {
+    const probe = `import { ${name} } from '${specifier}'; if (typeof ${name} === 'undefined') { console.error('bound but undefined'); process.exit(3); }`;
+    const result = spawnSync(process.execPath, ['--input-type=module', '-e', probe], {
+      cwd: appDir,
+      encoding: 'utf8',
+    });
+    if (result.status !== 0) {
+      die('(EXPORT-MISSING)', [
+        `${specifier} does not provide a usable export named '${name}',`,
+        `even though the family installed cleanly at ${version}.`,
+        'This is the exact import @objectstack/plugin-auth makes; when it fails, AuthPlugin does',
+        'not load, no sys_* table is created, the seeded sign-in never answers, and this lane',
+        'times out after 300s having produced no Playwright run at all.',
+        `node exited ${result.status}:`,
+        ...String(result.stderr || '')
+          .trim()
+          .split('\n')
+          .slice(0, 6)
+          .map((l) => `  ${l}`),
+        `A NEW version pin will not necessarily fix this — check whether ${ISSUE} has landed`,
+        'upstream, and if it has, retire this pin instead of moving it.',
+      ]);
+    }
+  }
+
+  const shown = copies.map((c) => `${c.name}@${c.version}`).sort();
+  console.log(
+    `[better-auth-pin] ok: ${copies.length} installed copies pinned at ${version}, ` +
+      `${REQUIRED_IMPORTS.length} required import(s) resolved`,
+  );
+  console.log(`[better-auth-pin]   ${shown.join(', ')}`);
+}
+
+const [command, ...rest] = process.argv.slice(2);
+
+if (command === 'overrides') {
+  const version = rest[0];
+  if (!version) {
+    console.error('usage: better-auth-pin.mjs overrides VERSION');
+    process.exit(2);
+  }
+  process.stdout.write(JSON.stringify(overridesFor(version)));
+} else if (command === 'verify') {
+  const [appDir, version] = rest;
+  if (!appDir || !version) {
+    console.error('usage: better-auth-pin.mjs verify APP_DIR VERSION');
+    process.exit(2);
+  }
+  verify(path.resolve(appDir), version);
+} else {
+  console.error('usage: better-auth-pin.mjs overrides VERSION | verify APP_DIR VERSION');
+  process.exit(2);
+}

--- a/e2e/live/ci/start-backend.sh
+++ b/e2e/live/ci/start-backend.sh
@@ -8,8 +8,12 @@
 #   2. Rewrite its package.json: every `@objectstack/*` workspace dep -> the
 #      pinned published OBJECTSTACK_VERSION; dev-only tooling dropped.
 #   3. `npm install` (published tarballs only — nothing is built from source,
-#      so the lane tests the console against the released artifacts).
-#   4. `objectstack dev --seed-admin --fresh` on $LIVE_BACKEND_PORT with a
+#      so the lane tests the console against the released artifacts), with the
+#      floating `better-auth` family pinned to BETTER_AUTH_VERSION through an
+#      npm `overrides` block — see backend.env and better-auth-pin.mjs.
+#   4. Verify that pin actually took, ON EVERY RUN including cache hits, and
+#      fail by name if it did not (objectstack#16186 / objectui#8084).
+#   5. `objectstack dev --seed-admin --fresh` on $LIVE_BACKEND_PORT with a
 #      throwaway sqlite db, then poll the seeded sign-in until it answers.
 #
 # Env overrides:
@@ -29,7 +33,15 @@ PORT="${LIVE_BACKEND_PORT:-4010}"
 REPO_URL="${OBJECTSTACK_REPO_URL:-https://github.com/objectstack-ai/objectstack.git}"
 APP_DIR="$BACKEND_DIR/app"
 STAMP="$BACKEND_DIR/.prepared"
-WANT_STAMP="$OBJECTSTACK_REF $OBJECTSTACK_VERSION"
+# An absent pin is a hard stop, not a soft default: silently installing the
+# floating family is the exact outcome this pin exists to prevent, and it costs
+# 300 seconds to discover downstream (objectstack#16186).
+: "${BETTER_AUTH_VERSION:?backend.env must declare BETTER_AUTH_VERSION — see its header and objectstack#16186}"
+# The pin is IN the stamp: without it, a fixture prepared before a pin change
+# satisfies the reuse test and the new pin is never installed. The workflow's
+# fixture cache key is the hash of backend.env, which carries the pin for the
+# same reason.
+WANT_STAMP="$OBJECTSTACK_REF $OBJECTSTACK_VERSION better-auth@$BETTER_AUTH_VERSION"
 
 mkdir -p "$BACKEND_DIR"
 
@@ -54,15 +66,25 @@ prepare() {
   # workspace:* -> the pinned published version; drop dev tooling the server
   # doesn't need (playwright/vitest/typescript — the CLI loads the TS config
   # itself). Keep non-@objectstack runtime deps (e.g. @modelcontextprotocol/sdk).
+  #
+  # The third argument is the `better-auth` pin, as npm's TOP-LEVEL `overrides`
+  # object. Spelling matters and is not interchangeable: this app is installed
+  # with `npm install` below, npm reads `overrides`, pnpm reads
+  # `pnpm.overrides`, and each ignores the other with no warning and exit 0. The
+  # names come from better-auth-pin.mjs so the list that is pinned and the list
+  # that is checked cannot drift apart.
   node -e '
     const fs = require("fs");
     const file = process.argv[1], pin = process.argv[2];
+    const overrides = JSON.parse(process.argv[3]);
     const pkg = JSON.parse(fs.readFileSync(file, "utf8"));
     for (const k of Object.keys(pkg.dependencies || {}))
       if (k.startsWith("@objectstack/")) pkg.dependencies[k] = pin;
     pkg.devDependencies = { "@objectstack/cli": pin };
+    pkg.overrides = Object.assign({}, pkg.overrides, overrides);
     fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + "\n");
-  ' "$APP_DIR/package.json" "$OBJECTSTACK_VERSION"
+  ' "$APP_DIR/package.json" "$OBJECTSTACK_VERSION" \
+    "$(node "$SCRIPT_DIR/better-auth-pin.mjs" overrides "$BETTER_AUTH_VERSION")"
 
   (cd "$APP_DIR" && npm install --no-audit --no-fund --loglevel=error)
   echo "$WANT_STAMP" > "$STAMP"
@@ -110,4 +132,8 @@ start() {
 }
 
 prepare
+# Deliberately OUTSIDE prepare(): prepare is skipped on a stamp hit, and a
+# reused fixture is one of the ways the pin can stop being true. A check that
+# only runs when the thing it checks was just built is not a check.
+node "$SCRIPT_DIR/better-auth-pin.mjs" verify "$APP_DIR" "$BETTER_AUTH_VERSION"
 start


### PR DESCRIPTION
Part of #8084 — this PR takes **defect ① only** and deliberately does not close the card.

⚠️ **#8084's defect ② is NOT addressed here and remains open**: the workflow RUN reporting `success` while the JOB reports `failure`. Nothing below touches it, and it is what let ① run for a day unseen — so please do not read a merge of this PR as closing #8084.

## What was broken

The live-e2e backend installs published `@objectstack/*` at run time with **no lockfile**. `@objectstack/plugin-auth` imports `createLocalAccountIssuer` from `@better-auth/core/db` and declares `@better-auth/core` with a **caret**; `@better-auth/core@1.7.3` removed that export in a **patch** release and is also `latest`, so every fresh install floats onto it. Root cause: objectstack#16186.

Reproduced in this lane's own install path before changing anything:

```
SyntaxError: The requested module '@better-auth/core/db'
  does not provide an export named 'createLocalAccountIssuer'
```

⇒ AuthPlugin fails to load, no `sys_*` table is created, the seeded sign-in never answers, `start-backend.sh` dies on its 300-second readiness timeout — and every downstream step is skipped, so the console is never built and **Playwright never runs at all**.

## What this does

**1. The pin.** `start-backend.sh` writes an npm `overrides` block into the showcase app's manifest before installing, pinning the floating family to `BETTER_AUTH_VERSION` (new key in `backend.env`, `1.7.2`).

⛔ `OBJECTSTACK_VERSION` and `OBJECTSTACK_REF` are **unchanged, byte for byte** (`git diff --numstat` on `backend.env`: `31 0` — insertions only). objectui#7689's triage forbids repairing this lane by moving those, and this does not. It pins a *transitive* dependency of the published artifact to the version that artifact's own manifest was authored against.

**2. The guard, which is the half that makes the pin acceptable.** `e2e/live/ci/better-auth-pin.mjs` runs on **every** start — outside `prepare()`, so a stamp/cache hit does not skip it — and fails **by name** with one of three diagnoses, each naming objectstack#16186:

| tag | fires when |
|---|---|
| `PIN-NOT-DECLARED` | the `overrides` block never reached the manifest npm installed from |
| `PIN-NOT-RESOLVED` | declared, but the installed tree disagrees (stale fixture, undeduped nested copy) |
| `EXPORT-MISSING` | installed cleanly at the pinned version and the export is *still* absent |

It also owns the family list, which `start-backend.sh` reads to write the overrides — so what is pinned and what is checked cannot drift apart.

## Package manager and mechanism — verified, not assumed

The lane installs with **`npm install`** (`start-backend.sh`, unchanged line: `(cd "$APP_DIR" && npm install --no-audit --no-fund --loglevel=error)`). So the mechanism is npm's **top-level `overrides`**, not `pnpm.overrides` — under npm the pnpm spelling is inert with no warning and exit 0. Proven, not assumed: an ablation that writes `pnpm.overrides` instead is caught as `PIN-NOT-DECLARED`, and the guard's message calls out that exact confusion.

## Family membership — measured against this lane's real tree, and it differs from the brief

All ten pinned names are genuinely installed and were all at `1.7.3` before the pin. **Two names were deliberately left out**, each of which would be a bug to add:

- **`@better-auth/scim` — excluded.** It is present, but `@objectstack/plugin-auth@17.2.0` pins it **exactly** at `1.7.0-rc.1`, not with a caret. It is not floating, it is not what broke, and overriding it to `1.7.2` would *override the publisher* rather than restore their intent — the opposite of this pin's justification.
- **`@better-auth/utils` — excluded.** Present at `0.4.2` / `0.5.0`. A separate version line with no `1.7.x`; pinning it would fail the install.

## Evidence

Ablations. Each branch driven off the real installed baseline tree; the fixture was restored **by state** afterwards (`git hash-object` back to `874606d2…`, byte-identical).

| ablation | expected | observed |
|---|---|---|
| baseline tree, no overrides | `PIN-NOT-DECLARED` | exit 1, named, all 10 listed |
| `pnpm.overrides` instead of `overrides` | `PIN-NOT-DECLARED` + spelling note | exit 1, named, note printed |
| declared `1.7.2`, tree still `1.7.3` | `PIN-NOT-RESOLVED` | exit 1, named, all 10 drifted copies listed with paths |
| declared **and installed** `1.7.3` | `EXPORT-MISSING` | exit 1, named — checks 1 and 2 *pass*, the third still fires |

The fourth is the one that matters: it proves the guard is not satisfiable by a version number alone.

End-to-end, on the real script:

```
[better-auth-pin] ok: 10 installed copies pinned at 1.7.2, 1 required import(s) resolved
[live-backend] ready: seeded sign-in answered on :4084 (pid 2629)
```

1m14s total, against the 300s timeout it used to die on. In the backend log: `AuthPlugin failed to load` **0**, `no such table` **0**, control `Server is ready` **1**; `Plugins: 47 loaded` (was 42 — the five auth-family plugins now load); `POST /api/v1/auth/sign-in/email` returns **200** with a real session token.

**And the specs actually run.** Full `test:e2e:live:ci` allowlist against that backend and a `vite preview` console: **5 passed (23.0s)** — `action-modal`, `master-detail` (x2), `saved-view-filter`, `screen-flow`.

Gates: `check:control-bytes`, `check:bash32-floor`, `check:shell-escape-residue`, `check:doc-fences`, `check-doc-links`, `check-changeset-presence` — all exit 0. `scripts/__tests__/ci-cd-pipeline-doc.test.ts` + `bash32-floor-wiring.test.ts`: 53 passed. No changeset owed — the gate's own verdict, not a guess: *"No source or published contract of a released package changed in this range."*

## ⚠️ The dispatch's acceptance criterion is not reachable, and here is the measurement

The brief defined "the fix is real" as *the uploaded artifact's file count goes above 1 and a `playwright-report/` appears*. **The second half can never happen**, for a reason that has nothing to do with this fix: `playwright.live.config.ts` declares `reporter: [['list']]` and no HTML reporter, so `playwright-report/` is not produced in any outcome. Measured twice locally — after a run with **5 failures** and after a run with **5 passes**, `playwright-report/` was ABSENT both times, while `test-results/` held 6 files and 1 file respectively.

Two further corrections to the brief, both structural and readable off the workflow file:

- On a **green** lane there is no artifact at all: the upload step is gated `if: ${{ !cancelled() && failure() }}`. So no file count is observable on a run that passes.
- Today's single uploaded file is **`backend.log`**, not `console-preview.log`. `console-preview.log` is written by the `Serve console` step, which is *skipped* when `Start ObjectStack backend` fails — so it cannot be in the artifact of a run that failed at the backend step.

Filed as #8238 (the workflow header and `content/docs/guide/ci-cd-pipeline.md` both promise an uploaded Playwright report the config cannot produce). ⛔ Not fixed here.

**What replaces it as the acceptance check:** the `Run live E2E allowlist` step executing at all rather than being skipped, and its `list` reporter printing the pass count. That is already measured locally at 5 passed; on CI it is owed to the run of this PR.

## Owed to CI

- The lane running under GitHub's runner (my local run used a scratch config to point Playwright at the container's Chromium 1194, because this repo's `@playwright/test` wants revision 1234 and downloads are blocked here — the scratch config was deleted, `git status` clean).
- The fixture cache key changes with `backend.env`, so the first run after this lands does a full clone + install (~75s locally) rather than a cache hit. That is intended: a pin change must not be served a fixture built before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_