### PR TITLE
test(console): re-point the record:activity.types calibration control at the empty string

### DIFF
--- a/.changeset/8137-record-activity-calibration-repoint.md
+++ b/.changeset/8137-record-activity-calibration-repoint.md
@@ -1,0 +1,10 @@
+---
+---
+
+Re-point the `record:activity.types` member calibration control in
+`registry-inputs-spec-parity` from `'Account'` to `''` (objectui#8137).
+`@objectstack/spec` 17.3.0 made that vocabulary open —
+`z.array(z.union([FeedItemType, z.string().min(1)]))`, objectstack#11658
+executing the maintainer's 2026-08-24 ruling on objectstack#11507 — so the old
+probe now accepts, while `''` is still refused for its CONTENT via `.min(1)`.
+Test only; no package is released by this change.

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -3144,11 +3144,21 @@ describe('registry `inputs` vs `@objectstack/spec` ComponentPropsMap (repo-wide)
 
     // …and the second half of the calibration: a CONTENT refusal at the member
     // position is NOT a kind refusal, so the coarse-kind ceiling survives one
-    // level down exactly as it does at the top. `record:activity.types` is a
-    // spec enum of strings — a string member is refused as a VALUE, and reading
-    // that as "the string member declaration is invented" would condemn a
-    // declaration derived from the contract itself.
-    expect(specMemberVerdict('record:activity', 'types', 'array', 'Account')).toBe(
+    // level down exactly as it does at the top.
+    //
+    // `record:activity.types` was a CLOSED `z.enum([...])` of strings when this
+    // row was written, and it probed that enum with an unlisted word.
+    // `@objectstack/spec` 17.3.0 made the vocabulary OPEN —
+    // `z.array(z.union([FeedItemType, z.string().min(1)]))`, objectstack#11658
+    // executing the maintainer's 2026-08-24 ruling on objectstack#11507 — so no
+    // ordinary string is refused there any more and the unlisted word ACCEPTS.
+    // The widening kept exactly ONE content refusal, and it is the one this
+    // control needs: `''` IS a string, so the only check it fails is `.min(1)`
+    // and it raises no `invalid_type` anywhere — right KIND, wrong CONTENT.
+    // That is exactly the distinction from the `42` line below, which is
+    // refused for its KIND, and it is why the pair still discriminates.
+    // Re-pointed under the maintainer 2026-09-07 authorisation on objectui#8137.
+    expect(specMemberVerdict('record:activity', 'types', 'array', '')).toBe(
       'refuses-content',
     );
     expect(specMemberVerdict('record:activity', 'types', 'array', 42)).toBe('refuses-kind');


### PR DESCRIPTION
Fixes #8137

Re-points one member calibration control in
`apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` whose premise an
upstream contract change retired, and rewrites the comment that stated that
premise.

## Manual floor

Editing a calibration control is on the manual floor. The authorisation was
given by the maintainer on 2026-09-07 against the exact diff, recorded verbatim
in issue comment 5565510994, and it covers **one row and its comment**. This PR
carries exactly that and nothing else.

Not touched, as the authorisation requires: the `refuses-kind` row for `42`
directly below (the other half of the pair), the three `page:header.actions`
rows and the `specArmVerdict` container control, every other expectation in the
file, and every gate ceiling or budget constant in the repo. No expectation was
flipped to `accepts` and no row was deleted.

## Why the row was wrong

`@objectstack/spec` 17.3.0 made `RecordActivityProps.types` an **open**
vocabulary — `z.array(z.union([FeedItemType, z.string().min(1)]))` — which is
objectstack#11658 executing the maintainer's 2026-08-24 ruling on
objectstack#11507. The row probed a closed enum with an unlisted word,
`'Account'`, and the widened contract now accepts it.

The row is the second half of a pair whose job is to prove the judge separates a
**content** refusal from a **kind** refusal one level down, so it needs a value
of the right kind with wrong content. Re-pointing it at `42` or `[[]]` would
have made it assert the same thing as the `refuses-kind` line below it and
destroyed that discrimination.

## The change

```diff
-    expect(specMemberVerdict('record:activity', 'types', 'array', 'Account')).toBe(
+    expect(specMemberVerdict('record:activity', 'types', 'array', '')).toBe(
       'refuses-content',
     );
```

plus the comment above it, which said "`record:activity.types` is a spec enum of
strings" — false since 17.3.0. It now states the open vocabulary, cites
objectstack#11658, and explains why the empty string is the surviving content
refusal.

## Evidence — measured here, not inherited

**Contract**, `ComponentPropsMap['record:activity'].shape.types.safeParse`, both
pins, each resolving the repo's own zod 4.4.3:

```
=====  17.2.0  (what main installs today)  =====
["comment"]   ACCEPTS
["Account"]   refuses  invalid_value@[0]     invalid_type anywhere: false
[""]          refuses  invalid_value@[0]     invalid_type anywhere: false
[42]          refuses  invalid_value@[0]     invalid_type anywhere: false

=====  17.3.0  (what #7685 pins)  =====
["comment"]   ACCEPTS
["Account"]   ACCEPTS
[""]          refuses  too_small@[0]         invalid_type anywhere: false
[42]          refuses  invalid_union@[0]     invalid_type anywhere: true
[[]]          refuses  invalid_union@[0]     invalid_type anywhere: true
["  "]        ACCEPTS
```

**The judge itself**, which the card flagged as still unmeasured — the step from
"no `invalid_type`" to `refuses-content` was a derivation, and this closes it.
Printed by `specMemberVerdict` under the 17.3.0 artifact:

```
{"empty":"refuses-content","fortyTwo":"refuses-kind","account":"accepts","comment":"accepts"}
```

So `''` really does land as `refuses-content` and the `42` row really does stay
`refuses-kind`. The pair still discriminates.

**Both pins, whole file** (`pnpm exec vitest run` on the changed file, at
`37b3a94c3`):

| pin | before | after |
|---|---|---|
| 17.2.0 — what `main` installs | 198 passed (198) | **198 passed (198)** |
| 17.3.0 — artifact-swapped | 8 failed, 190 passed | **7 failed, 191 passed** |

The 17.3.0 leg used the artifact-swap method from #8226: registry 17.3.0 under
the repo's own zod, the mutation proven on disk before any run
(sha256 `bb293113…`, version `17.3.0`), and the restore proven by sha256 of
`dist/ui/index.mjs` returning to `021bb509…` — verified again after cleanup.

## One reading that needs stating plainly

The 17.3.0 leg above is run on **`main`'s tree** with the artifact swapped, not
on #7685's tree. `main`'s ledgers are calibrated for 17.2.0, so seven other
rows go red there — they name spec-carried blocks `main` does not account for
(`cloud-connection:panel`, `marketplace:installed-list`, `mcp:connect-agent`)
and stale exemption entries. **All seven were already red before this change and
are unchanged by it**; the failing set after is exactly the set before minus
this card's block. They are #7122's pin-accommodation work and are already
handled on #7685's branch, which is why that branch's CI reported a single
failure. Nothing else in the file went red during this work.

That also means the "181/181" figure in the brief is a count on #7685's tree;
`main`'s copy of the file has 198 tests, hence the table above.

## Gates

- `pnpm --filter @object-ui/console lint` — exit 0, 0 errors (208 pre-existing
  `no-explicit-any` warnings, none in this file; the file alone lints 0/0).
- `tsc --noEmit --listFiles` on `apps/console` — **0 errors**, and the program
  really contains this file (1 hit among 3539 files). Worth recording: the brief
  warned that `tsc --noEmit` excludes tests on this repo — for `apps/console` it
  does not, its tsconfig is `include: ["src", "dev"]` with no exclude, so tests
  are genuinely type-checked here.
- `node scripts/check-changeset-presence.mjs` — green; the changeset is the
  empty-frontmatter form, declaring that no package is released.
- `check:control-bytes`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`,
  `check:shell-escape-residue`, `check:unreferenced-sources` — all exit 0.
- `check-governed-queue-guard --test` on both changed paths — NOT GOVERNED.

The dependency closure was built first
(`pnpm --filter '@object-ui/console^...' build`, exit 0) so the typecheck read
real `dist/*.d.ts` rather than reporting 392 phantom missing-module errors.

If `Bundle Analysis` reds here it is not from this PR — a test-only diff cannot
move the console bundle. See #7848 and #8241.

PR #7685 is untouched; it picks this up on its next `main` merge.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114Ytxr5sM1vdW19Y9WAx6E

---
_Generated by [Claude Code](https://claude.ai/code/session_0114Ytxr5sM1vdW19Y9WAx6E)_