### PR TITLE
docs(complex): scroll-area.mdx publishes the four rows the declaration has

### DIFF
--- a/content/docs/components/complex/scroll-area.mdx
+++ b/content/docs/components/complex/scroll-area.mdx
@@ -29,15 +29,14 @@ interface ScrollAreaSchema {
   type: 'scroll-area';
   
   // Dimensions
-  height?: string;                      // Container height (e.g., '200px', '50vh')
-  width?: string;                       // Container width (default: '100%')
+  height?: string | number;             // Container height ('200px', '50vh', or 200 = px)
+  width?: string | number;              // Container width ('100%', '50vw', or 300 = px)
   
   // Configuration
   orientation?: 'vertical' | 'horizontal' | 'both';  // Scroll direction (default: 'vertical')
   
   // Content
-  content?: SchemaNode | SchemaNode[];  // Scrollable content
-  children?: SchemaNode | SchemaNode[]; // Alternative content prop
+  children?: SchemaNode | SchemaNode[]; // Scrollable content (the only content channel)
   
   // Styling
   className?: string;                   // Tailwind CSS classes
@@ -48,6 +47,18 @@ interface ScrollAreaSchema {
   testId?: string;
 }
 ```
+
+The scrollable body is authored under `children`, and only under `children`:
+the renderer reads `renderChildren(schema.children)` and nothing else, and the
+registration's `defaultProps` ships `children` too. A scroll area that puts its
+body under `content` is not refused anywhere — `content` is not a member of
+`ScrollAreaSchema`, but the zod twin extends a `.passthrough()` base, so it
+validates, survives parsing, and reaches the DOM as a stray attribute on an
+otherwise empty scroll box.
+
+`height` and `width` take a number as well as a CSS length; a bare number is
+applied as pixels (`height: 200` renders `height: 200px`). Neither has a
+render-time default — omitting one leaves the container unsized in that axis.
 
 ## Examples
 


### PR DESCRIPTION
Fixes #8234

## What was wrong — five things, not two

The `Schema` fence on `content/docs/components/complex/scroll-area.mdx` was re-derived **member by member** against the declaration, as the claim comment asked. The card named two wrong rows, the PM found two more while verifying, and the full re-derivation turned up a fifth that nobody had flagged.

| fence row, before | the declaration says |
|---|---|
| `content?: SchemaNode \| SchemaNode[];  // Scrollable content` | `ScrollAreaSchema` (`packages/types/src/layout.ts:505`) declares no `content` member. Neither does `BaseSchema`. |
| `children?: …  // Alternative content prop` | `children` is the **only** content channel: `packages/components/src/renderers/complex/scroll-area.tsx:34` is `renderChildren(schema.children)`, the single content read in the renderer, and the registration's `defaultProps` ships `children`. |
| `height?: string;` | `layout.ts:510` — `height?: string \| number;` |
| `width?: string;` | `layout.ts:514` — `width?: string \| number;` |
| `width?: …  // Container width (default: '100%')` | **NEW — not in the card or the claim comment.** There is no render-time default. `'100%'` exists only in the registration's *designer* `defaultProps` (`scroll-area.tsx:50`), which the renderer never applies. Measured: omit `width` and the rendered `style` attribute carries no `width` at all. |

Every other row was checked and is correct, so it is untouched: `type: 'scroll-area'` (`layout.ts:506`); `orientation` including its `(default: 'vertical')` annotation, which **is** a real render-time default (`scroll-area.tsx:24`, `const orientation = schema.orientation || 'vertical'`); `className` (`base.ts:171`); and the three Base-properties rows (see the ruling below).

## Ruling on the "Base properties" section: keep it, unchanged

The card left this to the implementer, so here is the argument rather than a silent default.

**1. Every row in it is true against the declaration.** `id?: string` = `base.ts:81`. `testId?: string` = `base.ts:424`. And `visible?: boolean | string | { dialect?: string; source: string }` is the *exact* structural expansion of `base.ts:292`'s `visible?: boolean | ExpressionWire`, since `ExpressionWire = string | { dialect?: string; source: string }` (`packages/types/src/expression.ts:67`). All three arms were measured working end to end — boolean `false`, the predicate string `${1 === 2}`, and the CEL envelope `{ dialect: 'cel', source: 'false' }` each render nothing at all (innerHTML length 0), which is what that key promises.

**2. A curated subset is the right shape; the two alternatives are worse.** `BaseSchema` has 21 members. Making the section exhaustive would add 18 rows to this page and to every other component page, several of them inert here (`bind`, `data`, `placeholder`, `label` on a scroll box). Deleting the section would remove the only thing on the page that explains why `id` / `visible` / `testId` are absent from `ScrollAreaSchema` itself.

**3. It is the repo's existing block, not a local invention.** The same three rows with the same `visible` expansion appear verbatim on 16 component pages (`carousel`, `resizable`, `data-table`, `box`, `page`, `calendar`, …). Rewriting it here would fork a convention across 16 files for a defect that is not this page's.

**4. Read-ness points the same way for two of three, and the third is not this PR's to fix.** Following objectui#8197's discriminator — read-ness, not inheritance — `id` and `visible` are read: `id` reaches the DOM as `id="…"` plus `data-obj-id`, and `visible` gates rendering. `testId` is the one row where read-ness and the declaration disagree: nothing in the repo reads `schema.testId` (the only two mentions are `schema-builder.ts:84`, which *writes* it, and its own test), it falls through `SchemaRenderer`'s metadata destructure, and React writes the raw prop to the DOM as a lowercase `testid="…"` attribute — so `[data-testid="…"]` finds nothing, contradicting `base.ts:421`'s own *"Rendered as data-testid attribute"*. That is a producer-side defect in `packages/types` or in the renderer, it is repo-wide, and per AGENTS.md #0.1 the fix belongs at the producer. Deleting the row here would make this page disagree with the declaration in order to route around a defect somewhere else — the exact lenient-fallback shape that rule forbids. Reported to the PM as a separate finding instead.

## Demonstrated end to end, not by grep

Three throwaway probe files were run from the repo root (`pnpm exec vitest run …`), read, and deleted; nothing from them is in this diff. Raw readings:

**A. The zod twin does NOT refuse the old authoring — and that matters.**

```
LEG A: safeParse({type:'scroll-area', content:[…]}) success = true
LEG A: parsed data = {"type":"scroll-area","orientation":"vertical","content":[{"type":"text",…}]}
LEG A: issues = null
```

⚠️ **This is a correction to the brief.** objectui#8197's demonstration had a zod `safeParse` *refusing* the old authoring, and the claim comment asked for the same here. It does not reproduce, for a structural reason: `CollapsibleSchema` declares `content` as **required**, so omitting it fails — whereas `ScrollAreaSchema.children` is optional and the zod `BaseSchema` is `.passthrough()` (`packages/types/src/zod/base.zod.ts:241`), so an unknown `content` key validates *and is preserved in the parsed output*. Nothing anywhere rejects it. That makes the doc row more dangerous than #8197's, not less, and it is why the page now says so in prose.

**B. `height: 200` is valid, exactly as the declaration says.**

```
LEG B: safeParse({height:200,width:300,children:[…]}) success = true, issues = null
LEG E: root style attr = position: relative; …; height: 200px; width: 300px;
LEG F (control, string): root style attr = position: relative; …; height: 200px;
```

A bare number and `'200px'` produce the identical style. The page's `string`-only rows would have told an author this is invalid.

**C. The failure mode the card describes, rendered.**

```
LEG C (authored per the OLD page, `content`):  body text present = false
LEG C: container.textContent = "[data-radix-scroll-area-viewport]{scrollbar-width:none;…}"   ← Radix's own style tag; no body
LEG D (authored per the NEW page, `children`): body text present = true
LEG D: container.textContent = "…{display:none}PROBE-8234-BODY"
```

Through `SchemaRenderer` the phantom key does not merely do nothing — it is not stripped as metadata, so it is spread as a React prop and lands on the element:

```
content: outerHTML head = DIV dir="ltr" class="relative overflow-hidden" style="…" content="[object Object]" data-obj-type="scroll-area"
                          (opening tag; angle brackets written out as DIV so the body survives GitHub's sanitizer)
```

**D. The `(default: '100%')` claim, measured.**

```
omit width → style = position: relative; --radix-scroll-area-corner-width: 0px; --radix-scroll-area-corner-height: 0px;
```

No `width`. The annotation named a default that does not exist.

## Landing control (`grep -cF`, fixed-string)

| leg | required | before | after |
|---|--:|--:|--:|
| `content?: SchemaNode` | 0 | 1 | **0** |
| `Alternative content prop` | 0 | 1 | **0** |
| `height?: string;` | 0 | 1 | **0** |
| `width?: string;` | 0 | 1 | **0** |
| lit control — `SchemaNode`, any line | non-zero | 2 | **1** |

The lit control stays lit: the corrected `children?: SchemaNode | SchemaNode[];` row is still there, so the four zeroes are a deletion of the wrong rows and not of the fence.

## Gates — reported as what they are

⚠️ **No gate confirms the rows above, by construction, so none of these is offered as evidence for them.** `check:doc-types` reads only `type` string literals and never judges a member row. `check:doc-snippets` compiles only `ts`/`tsx`/`typescript` fences (`TS_FENCE_LANGUAGES`, `scripts/check-doc-snippet-types.mjs:548`); this block is `plaintext`. The measurements in the section above are the verification.

| gate | verdict |
|---|---|
| `check:doc-fences` | exit 0 — "every TypeScript block in 227 document(s) is fenced ts/tsx/typescript, except 80 declared file(s) carrying 89 block(s)" |
| `check:doc-types` | exit 0 — "Every documented component type is registered" (188 docs, 1105 blocks, 889 `type` literals) |
| `check:doc-snippets` | exit 0 — "618 of 618 block(s) judged, 0 failed", with its own sentinel control firing (1 diagnostic for a deliberately bad import). Needed the scoped 34-package build first; the bare run is exit **2** = `PRECONDITION NOT MET`, which is "could not run", not a failure. |
| `docs:check-links` | exit 0 — "Links are valid across 17 scan roots" |
| `check:control-bytes` | exit 0 — 6577 tracked text files scanned |
| `check:doc-example-readers` | exit 0 |
| `check:docs-route-closure` | exit 0 |
| `check:changeset-presence` | exit 0 — "No source or published contract of a released package changed in this range, so no changeset is owed" |
| `check:governed-queue-guard --test` | "NOT GOVERNED — 1 path(s) checked against 5 governed surface(s); none matched" |

**No changeset**, on the gate's own verdict line plus the landed precedent: PR #8237 (objectui#8197) and #8036 were both single-file `content/docs/**` changes and neither carried one.

## Scope

Only the one `.mdx` file. `packages/components/src/renderers/complex/scroll-area.tsx` is untouched — the renderer is correct, the page was wrong. objectui#6805 (the demo catalog) is a different, closed card and is not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_