### PR TITLE
fix(console): reach the console vitest project by name, not by path filter

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -49,9 +49,9 @@
     "lint": "eslint .",
     "build:analyze": "pnpm build && echo 'Bundle analysis available at dist/stats.html'",
     "preview": "vite preview",
-    "test": "vitest run --root ../.. apps/console/",
-    "test:watch": "vitest --root ../.. apps/console/",
-    "test:ui": "vitest --ui --root ../.. apps/console/",
+    "test": "vitest run --root ../.. --project @object-ui/console --no-passWithNoTests",
+    "test:watch": "vitest --root ../.. --project @object-ui/console --no-passWithNoTests",
+    "test:ui": "vitest --ui --root ../.. --project @object-ui/console --no-passWithNoTests",
     "prepublishOnly": "pnpm build"
   },
   "devDependencies": {

--- a/scripts/__tests__/app-test-entry-8240.test.ts
+++ b/scripts/__tests__/app-test-entry-8240.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Plain-JS CI helper; its types are INFERRED by `tsconfig.scripts.json`
+// (`allowJs`), so no `@ts-expect-error` here — see objectui#3494.
+import { cliHasTestFilters, evaluateVitestInvocation, parseVitestArgv } from '../vitest-invocation-guard.mjs';
+
+/**
+ * objectui#8240 — `pnpm --filter @object-ui/console test` collected ZERO test
+ * files and exited 1, while the same 89 files were green from the repo root.
+ *
+ * ## The mechanism, measured at 0fa7a9c83
+ *
+ * The entry was `vitest run --root ../.. apps/console/`, i.e. the spelling
+ * objectui#3240 gave every `packages/*` entry, transplanted to an app. It works
+ * for packages and cannot work for an app, and the reason is NOT the `apps/**`
+ * line in the root config's `sharedExclude` (the card that reported this said it
+ * was; that is wrong, and the control below pins the refutation).
+ *
+ * Vitest matches a positional filter per project, against each test file's path
+ * RELATIVE TO THAT PROJECT'S OWN `dir`, and resolves a relative filter against
+ * `process.cwd()` — not against `--root`:
+ *
+ *     const testFile = relative(dir, t);
+ *     const relativePath = f.endsWith('/') ? join(relative(dir, f), '/') : relative(dir, f);
+ *     return testFile.includes(f) || testFile.includes(relativePath);
+ *
+ * For `packages/*` the files are collected by the ROOT-level projects, whose
+ * `dir` is the repo root, so `testFile` reads `packages/<pkg>/src/x.test.ts` and
+ * the literal `packages/<pkg>/` matches — cwd never enters into it.
+ *
+ * An app is different: it comes back through the root config's `projects` array
+ * as its OWN project rooted at the app directory, so `testFile` reads
+ * `src/x.test.tsx` and can never contain `apps/<app>/`. The only branch left is
+ * `relative(dir, f)`, and pnpm launches the script with the app directory as
+ * cwd, so `apps/console/` resolved to `apps/console/apps/console` — no match,
+ * zero files, exit 1.
+ *
+ * Measured, same head, same vitest root (`RUN v4.1.10 <repo root>` in both), the
+ * only variable being cwd:
+ *
+ *   cwd = apps/console  `vitest run --root ../.. apps/console/`  0 files, exit 1
+ *   cwd = repo root     `vitest run apps/console/`              89 files, exit 0
+ *   cwd = repo root     `vitest run --project @object-ui/console`
+ *                                              89 files, 1069 tests, exit 0
+ *
+ * ## Why the entry names a PROJECT and why it must also disable passWithNoTests
+ *
+ * There is no positional that is both cwd-stable and precise for an app, so the
+ * entry names the project instead. That trades one hazard for another, and the
+ * trade is only safe because both ends are closed:
+ *
+ *  - a project name that resolves to nothing is loud: vitest throws
+ *    `No projects matched the filter "..."` (measured: exit 1);
+ *  - but a project that resolves and then globs zero files is SILENT, because
+ *    the root config sets `passWithNoTests: !cliHasTestFilters(process.argv)`
+ *    and `--project` is a flag, not a positional — so an app entry gets
+ *    `passWithNoTests: true`. Measured in a sandbox on the same vitest 4.1.10:
+ *    with `passWithNoTests: true` in the config, `--project <empty project>`
+ *    exits **0**; adding `--no-passWithNoTests` makes the same run exit **1**.
+ *
+ * A script that exits 0 having run nothing is strictly worse than the loud
+ * exit 1 this card started from, so the negation is load-bearing, not decoration.
+ *
+ * Reverse verification: restore `"test": "vitest run --root ../.. apps/console/"`
+ * and the shape assertions here go red naming `apps/console`; drop just the
+ * `--no-passWithNoTests` and the false-green assertion goes red on its own.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const APPS_DIR = path.join(repoRoot, 'apps');
+const TEST_FILE = /\.test\.[cm]?[jt]sx?$/;
+
+type AppEntry = {
+  /** Repo-relative directory, e.g. `apps/console`. */
+  dir: string;
+  /** The app's package name, which is also its vitest project name. */
+  pkgName: string;
+  testScript: string;
+};
+
+function readAppEntriesWithTestScript(): AppEntry[] {
+  const entries: AppEntry[] = [];
+  for (const name of fs.readdirSync(APPS_DIR).sort()) {
+    const manifest = path.join(APPS_DIR, name, 'package.json');
+    if (!fs.existsSync(manifest)) continue;
+    const pkg = JSON.parse(fs.readFileSync(manifest, 'utf8')) as {
+      name?: string;
+      scripts?: Record<string, string>;
+    };
+    const testScript = pkg.scripts?.test;
+    if (!testScript || !pkg.name) continue;
+    entries.push({ dir: `apps/${name}`, pkgName: pkg.name, testScript });
+  }
+  return entries;
+}
+
+/** `process.argv` as pnpm hands it to a package script. */
+function argvForScript(script: string): string[] {
+  const tokens = script.trim().split(/\s+/);
+  return ['/usr/bin/node', '/bin/vitest', ...tokens.slice(1)];
+}
+
+/** The directory this script makes vitest's ROOT (cwd unless `--root` moves it). */
+function vitestRootOf(entry: AppEntry): string {
+  const { flags } = parseVitestArgv(argvForScript(entry.testScript));
+  const raw = flags['--root'] ?? flags['-r'];
+  const cwd = path.join(repoRoot, entry.dir);
+  return typeof raw === 'string' ? path.resolve(cwd, raw) : cwd;
+}
+
+/** Either accepted spelling of "do not go green on an empty collection". */
+function disablesPassWithNoTests(script: string): boolean {
+  const { flags } = parseVitestArgv(argvForScript(script));
+  return flags['--no-passWithNoTests'] === true || flags['--passWithNoTests'] === 'false';
+}
+
+function collectTestFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectTestFiles(abs));
+    else if (TEST_FILE.test(entry.name)) out.push(abs);
+  }
+  return out;
+}
+
+const appEntries = readAppEntriesWithTestScript();
+const rootConfig = fs.readFileSync(path.join(repoRoot, 'vitest.config.mts'), 'utf8');
+
+describe('objectui#8240 — apps/* test entries reach their project by NAME, never by path filter', () => {
+  it('finds at least one app test entry to check', () => {
+    // A zero-hit sweep and a clean sweep are the same output otherwise. The
+    // population was measured as exactly one (`apps/console`; `apps/site`
+    // declares no `test` script at all) — this fires if it ever empties out.
+    expect(appEntries.map((e) => e.dir)).toContain('apps/console');
+  });
+
+  for (const entry of appEntries) {
+    describe(entry.dir, () => {
+      it('is routed back into the repo-root config and passes the invocation guard', () => {
+        expect(vitestRootOf(entry)).toBe(repoRoot);
+        expect(
+          evaluateVitestInvocation({
+            argv: argvForScript(entry.testScript),
+            cwd: path.join(repoRoot, entry.dir),
+            repoRoot,
+          })
+        ).toBeNull();
+      });
+
+      it('names its own project instead of passing a positional path filter', () => {
+        const { positionals, flags } = parseVitestArgv(argvForScript(entry.testScript));
+
+        // The regression itself: a positional here is the objectui#8240 shape.
+        expect(positionals).toEqual([]);
+        // The project name vitest derives for an app is its package name.
+        expect(flags['--project']).toBe(entry.pkgName);
+      });
+
+      it('is declared as a project by the root config, so the name resolves', () => {
+        // `--project` naming nothing is loud (vitest throws), but a red CI run
+        // is a worse place to learn it than this file.
+        expect(rootConfig).toContain(`./${entry.dir}/vitest.config.ts`);
+        expect(fs.existsSync(path.join(repoRoot, entry.dir, 'vitest.config.ts'))).toBe(true);
+      });
+
+      it('cannot go green on an empty collection', () => {
+        // `--project` is a flag, so the root config's
+        // `passWithNoTests: !cliHasTestFilters(process.argv)` resolves to TRUE
+        // for this entry. That is precisely the case the explicit negation is
+        // here to cover; assert the premise as well as the remedy, so this stops
+        // asking for the flag if the premise ever changes.
+        expect(cliHasTestFilters(argvForScript(entry.testScript))).toBe(false);
+        expect(disablesPassWithNoTests(entry.testScript)).toBe(true);
+      });
+
+      it('has test files for that project to collect', () => {
+        expect(collectTestFiles(path.join(repoRoot, entry.dir)).length).toBeGreaterThan(0);
+      });
+
+      it('could not have been reached by a path filter, whatever the exclude list says', () => {
+        // The refutation of the reported mechanism. An app's project is rooted
+        // at the app directory, so its files' project-relative paths never
+        // contain `apps/<app>/` — the substring branch of vitest's filter match
+        // cannot fire, independently of `sharedExclude`. Removing `apps/**`
+        // from that list would therefore not have fixed anything, and is exactly
+        // what the card asked nobody to do.
+        const appDir = path.join(repoRoot, entry.dir);
+        const files = collectTestFiles(appDir);
+        expect(files.length).toBeGreaterThan(0);
+        for (const file of files) {
+          expect(path.relative(appDir, file)).not.toContain(`${entry.dir}/`);
+        }
+
+        // Control that fires: the same paths taken relative to the REPO ROOT do
+        // contain it, which is why the identical spelling works for packages/*.
+        for (const file of files) {
+          expect(path.relative(repoRoot, file)).toContain(`${entry.dir}/`);
+        }
+      });
+    });
+  }
+});


### PR DESCRIPTION
Fixes #8240

`pnpm --filter @object-ui/console test` collected zero test files and exited 1. It now runs the console suite: **89 files / 1069 tests**, exit 0 — the same set the repo-root spelling collects.

## ⚠️ The reported mechanism is wrong, and the correction matters

Both cards say the path filter fails because `apps/**` sits in the root config's `sharedExclude`. **Measured, that is not the cause**, and acting on it would have been wasted work in the one direction the cards told nobody to go.

Vitest matches a positional filter **per project**, against each test file's path **relative to that project's own `dir`**, and it resolves a relative filter against `process.cwd()` — not against `--root`:

```js
const testFile = relative(dir, t);
const relativePath = f.endsWith('/') ? join(relative(dir, f), '/') : relative(dir, f);
return testFile.includes(f) || testFile.includes(relativePath);
```

* For `packages/*` the files are collected by the **root-level** projects, whose `dir` is the repo root. `testFile` reads `packages/PKG/src/x.test.ts`, so the literal `packages/PKG/` matches on the first branch and cwd never enters into it. That is why the objectui#3240 spelling works there.
* An app is different. It comes back through the root config's `projects` array as **its own project rooted at the app directory**, so `testFile` reads `src/x.test.tsx` and can never contain `apps/console/`. Only the `relative(dir, f)` branch is left, and pnpm launches the script with the app directory as cwd — so `apps/console/` resolved to `apps/console/apps/console`, matching nothing.

Three runs on the same head, **same vitest root** (`RUN v4.1.10 <repo root>` printed by both), the only variable being cwd:

| cwd | command | result |
|---|---|---|
| `apps/console` | `vitest run --root ../.. apps/console/` | **0 files, exit 1** |
| repo root | `vitest run apps/console/` | 89 files, exit 0 |
| repo root | `vitest run --project @object-ui/console` | 89 files, 1069 tests, exit 0 |

The middle row is the refutation on its own: the identical filter string collects 89 files **while `apps/**` is still in that project's inherited exclude list** — visible in the failing run's own project dump. `apps/**` is scoped to the console project's own root, where it matches nothing. It is untouched here, as both cards asked.

## The fix

```
"test":       "vitest run --root ../.. --project @object-ui/console --no-passWithNoTests"
"test:watch": "vitest --root ../.. --project @object-ui/console --no-passWithNoTests"
"test:ui":    "vitest --ui --root ../.. --project @object-ui/console --no-passWithNoTests"
```

There is no positional that is both cwd-stable and precise for an app, so the entry names the project instead. `--root ../..` stays: it is what keeps the run under the repo-root config and under `scripts/vitest-invocation-guard.mjs`.

⚠️ **`test:ui` carried the same broken shape and is repaired too** — neither card mentions it; it was found by reading the manifest rather than the card.

## ⛔ Why `--no-passWithNoTests` is load-bearing, not decoration

Naming a project trades one hazard for another, and the trade is only safe because **both** ends are closed. A script that exits 0 having run nothing would be strictly worse than the loud exit 1 this started from.

* A project name that resolves to nothing is **loud**: vitest throws `No projects matched the filter "..."`. Measured against this repo: `--project @object-ui/does-not-exist` exits 1.
* A project that resolves and then globs **zero files** is **silent**, because the root config sets `passWithNoTests: !cliHasTestFilters(process.argv)` and `--project` is a flag, not a positional — so an app entry gets `passWithNoTests: true`.

Measured in a scratch project on the same vitest 4.1.10, with `passWithNoTests: true` in the config and a project whose include matches nothing:

| invocation | exit |
|---|---|
| `vitest run --project empty-proj` | **0** — the silent false green |
| `vitest run --project empty-proj --no-passWithNoTests` | **1** |
| `vitest run --project empty-proj --passWithNoTests=false` | **1** |

## The pin

`scripts/__tests__/app-test-entry-8240.test.ts` sweeps `apps/*` — not just console — so a future app cannot acquire the shape either. It asserts the entry keeps the repo root, passes the invocation guard, carries no positional, names a project equal to its own package name, is declared by the root config, has files to collect, and closes the empty-collection hole. Its last case pins the refutation above: an app's files are never reachable by a positional, with a live control showing the same paths taken from the repo root do contain `apps/console/`.

Reverse verification, each leg mutated on disk (anchor counts flipped, on-disk hash differing from the `HEAD` blob) and restored to a clean `git diff HEAD`:

| leg | pin result |
|---|---|
| restore the old positional shape | red — 2 of 7 fail |
| drop only `--no-passWithNoTests` | red — exactly 1 of 7 fails (the empty-collection case) |
| control, unmutated | green — 7/7, exit 0 |

## Verification

Run at `7b0dd64c7`.

| check | result |
|---|---|
| `pnpm --filter @object-ui/console test` | 89 files / **1069 tests**, exit 0 |
| `pnpm exec vitest run scripts/` | 116 files / 3422 tests, exit 0 |
| `tsc -p tsconfig.scripts.json` | exit 0; `--listFiles` confirms the new test is in the program (control: the sibling objectui#3746 pin is too) |
| `node scripts/check-control-bytes.mjs` | exit 0, 6578 files scanned |
| `pnpm run lint:root` | exit 0 (32 warnings, 0 errors); the new file is 0/0 under a full 4414-file `eslint .` sweep |
| `node scripts/check-changeset-presence.mjs` | exit 0 — **no changeset owed** (`scripts` is not one of the eight published-contract fields, and no published source moved) |
| `node scripts/check-governed-queue-guard.mjs --test` | NOT GOVERNED (control: `AGENTS.md` returns governed) |

Exit codes were captured before any pipe; the zero-hit control-character grep was validated with a control that fires.

## ⚠️ For the PM — two things this touches that I did not act on

1. **#8096 remains open and is the same defect**, filed a day earlier by another seat and never claimed. This PR makes it inoperative as a bug report, but which card is canonical is a triage call, so it is deliberately not referenced by a closing keyword here. Recommendation: close it as a duplicate when this lands. It has the same incorrect `apps/**` attribution.
2. **`AGENTS.md` is deliberately not edited.** Its test section still teaches only the `packages/PKG` spelling, and #8096's addendum asks that the fixing PR correct it. Two reasons not to, here: `AGENTS.md` is a **governed surface**, so touching it would park this whole PR behind a human approval; and that exact sentence is the subject of #7800, which remains open awaiting a maintainer. The mechanism is instead written into the pin test's docstring, where a revert makes it fail. A follow-up governed docs PR is the right home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_