### PR TITLE
docs(scripts): record the eager-closure cause as a standing baseline

### DIFF
--- a/scripts/check-eager-closure-budget.mjs
+++ b/scripts/check-eager-closure-budget.mjs
@@ -322,13 +322,29 @@ import { isEntrypoint } from './invoked-as.mjs';
  * accounted for. No chunk entered or left the closure; the eager chunk count is
  * unchanged.
  *
- * ⇒ ⭐ THE HONEST LONG-TERM FIX IS UPSTREAM, and this ceiling is the marker for
- * it, not the answer to it: a `describe()`-stripped browser build returns
- * ~292 KB to EVERY consumer of the spec, not just this console. Filed as
- * objectstack#16063. RESTORE CONDITION: when that lands, re-measure and bring
- * this ceiling and {@link BASELINE} back down together. ⛔ No other exemption
- * was added, no import was made lazy, and no other ceiling was moved — the
- * three per-chunk lines that still pass were left exactly as they are.
+ * ⇒ ⭐ THE UPSTREAM FIX WAS REFUSED, so these numbers are the STANDING
+ * BASELINE and not an exception awaiting reversal. Stripping the `describe()`
+ * prose out of the browser build would return ~292 KB to EVERY consumer of the
+ * spec, not just this console; that was filed as objectstack#16063, and it was
+ * ruled against. Maintainer verbatim 「16063 c」 — director-seat decision batch
+ * #59, recorded on objectui#7122 on 2026-09-06: the growth is accepted
+ * upstream, and neither a prose-stripped build nor a short-`describe`
+ * convention will land.
+ *
+ * ⛔ The objectstack#16063 citation therefore STAYS, and its sense is the one
+ * thing about it that changed — it is now the RECORDED CAUSE this ceiling
+ * rests on, where it used to be a condition to wait out. ⛔ Nothing is coming
+ * that would bring this ceiling and {@link BASELINE} back down together, so do
+ * not reinstate anything on its account and do not write a fresh condition in
+ * its place: a re-baseline that reads as temporary is one nobody ever
+ * re-measures. The next bump is measured against THIS number, knowing why it
+ * moved — the authorisation above (objectui#7122, decision batch 1 item 1 =
+ * "B + A") and the figures it bought landed together in objectui#7685,
+ * `639114c4d`.
+ *
+ * ⛔ No other exemption was added, no import was made lazy, and no other
+ * ceiling was moved — the three per-chunk lines that still pass were left
+ * exactly as they are.
  */
 export const MAX_EAGER_CLOSURE_GZIP_BYTES = 3_597_000;
 


### PR DESCRIPTION
Fixes #8283

Prose and provenance only — no executable line in the file changed (proof below).

The eager-closure budget's cause note pointed the next author at an upstream fix that is not coming: `RESTORE CONDITION: when that lands, re-measure and bring this ceiling and BASELINE back down together`, conditioned on `objectstack#16063`. That upstream fix was ruled against — maintainer verbatim 「16063 c」, director-seat decision batch #59, recorded on objectui#7122 on 2026-09-06. The condition could therefore never fire, and the numbers read as a temporary exception awaiting reversal when they are the standing baseline.

The note now says so. It keeps the `objectstack#16063` citation — the provenance the gate's own header requires — while stating that its sense changed from a condition to wait out into the recorded cause the ceiling rests on, forbids writing a fresh condition in its place, and names where the authorisation and figures landed (objectui#7122 decision batch 1 item 1 = "B + A"; objectui#7685, `639114c4d`).

## Verdict on the second sentence, `:575`

The card required a verdict on a second, similarly-shaped sentence — `re-measure and lower both numbers together`, at `:559` before this change and `:575` after. **It is a different note, it is correct as written, and it is deliberately left untouched.**

Four reasons, each re-derived rather than pattern-matched:

1. **Different constants.** `:575` closes the docblock attached to `PER_CHUNK_GZIP_CEILINGS` — heading `## Raising one` at `:564`, declaration at `:577`. Its "both numbers" are a per-chunk ceiling and its measurement in `PER_CHUNK_BASELINE` (`:681`), which the same paragraph names at `:568`. The note corrected here governs the aggregate pair, `MAX_EAGER_CLOSURE_GZIP_BYTES` and `BASELINE`.
2. **Different trigger.** Its condition is the landing of local payload-shrinking work, citing objectui#5324 as where the candidates are named. `objectstack#16063` appears nowhere in that block — its only three occurrences in the file are `:328`, `:329` and `:334`, all inside the aggregate note this PR rewrites.
3. **The trigger was not ruled against.** The 「16063 c」 ruling refuses an upstream prose-stripped `@objectstack/spec` browser build. It says nothing about this repo shrinking its own eager closure, and the same docblock already names a concrete local candidate at `:561` — taking the i18n catalogues out of the eager closure. If anything the ruling makes local shrink work the only remaining route, so this condition is more live, not less.
4. **Different sentence function.** `:570` is a ratchet guardrail: `Do not LOWER one below the measured figure to express an aspiration`. The trailing clause is its counterpart — it names the one legitimate route to lowering (do the real work, re-measure, move ceiling and baseline together). It makes no claim that today's numbers are temporary, which was the entire defect in the aggregate note. Rewriting it in this PR's idiom ("nothing is coming") would be false and would delete a correct rule.

Sweep for completeness rather than fixing only what was pointed at: grepping `re-measure|RESTORE CONDITION|when that lands|when it lands|awaiting|back down together|lower both` returns exactly two condition-shaped sentences in the file — the one rewritten here and `:574`-`:575`. The remaining hit at `:1067` is `evaluateHeadroomSensitivity`'s docblock describing when drift is detected, not a condition.

## The frozen numbers are byte-identical

The card's safety argument for touching this file at all. Verified two ways against the current `origin/main`, not asserted:

- **Every changed line is docblock prose.** All 30 changed lines (23 added, 7 removed — net +16, which is exactly the line-number shift) match `^[+-] \*`. The set of changed lines that are *not* docblock continuations is empty.
- **Comment-stripped content hashes identical.** Stripping every docblock and `//` line from both revisions and hashing the remainder gives `970db2bea4494c394f3ccb2562f93da7aa0e4423f5ba7d7ec0825ad456c8bf75` on both `origin/main` and this branch; `diff` of the two stripped files is empty.

The four frozen values as they now stand, all unmoved:

| | value | line |
|---|---|---|
| `MAX_EAGER_CLOSURE_GZIP_BYTES` | `3_597_000` | `:349` (was `:333`) |
| `BASELINE.gzipBytes` | `3_551_191` | `:378` (was `:362`) |
| `REGRESSION_THIS_GATE_MUST_CATCH_BYTES` | `89 * 1024` | `:390` (was `:374`) |
| `PER_CHUNK_GZIP_CEILINGS` | `1_254_000` / `455_000` / `71_000` / `399_000` | `:582`-`:585` |

Sensitivity re-derived rather than trusted, reading `89 * 1024` as the expression it is: `3,597,000 - 3,551,191 = 45,809`, and `45,809 / 91,136 = 0.503x` — against the docblock's own `H = REGRESSION / 2` requirement at `:90`. It holds.

## Gates

Exit codes captured before any pipe; verdict lines quoted from each gate's own output. All run after merging `origin/main`.

| gate | exit | verdict |
|---|---|---|
| the 5 test files referencing this gate, plus the `attached-docs` helper the two of them import | 0 | `Test Files 5 passed (5)` / `Tests 219 passed (219)` |
| `node scripts/check-control-bytes.mjs` | 0 | `check-control-bytes: OK (scanned 6596 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-changeset-presence.mjs` | 0 | `No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `node scripts/check-governed-queue-guard.mjs --self-test` | 0 | `OK check-governed-queue-guard self-test: 132 cases pass` |
| `node scripts/check-governed-queue-guard.mjs --test scripts/check-eager-closure-budget.mjs` | 0 | `NOT GOVERNED — 1 path(s) checked against 5 governed surface(s); none matched.` |

No changeset is added: the gate's own verdict line above says none is owed, this file being tooling rather than published source of a released package.

## A pin does read docblock prose — reported, as the card asked

The card asked whether any pin reads the note's text. One class does, and a phrase-grep does not find it: `scripts/__tests__/check-eager-closure-budget.test.ts` pins attached prose *structurally*, through `attachedDocs()` in `scripts/__tests__/helpers/attached-docs.ts`, which locates the JSDoc block preceding an `export const` without using line numbers.

What saves this change is not that no pin reads prose, but that those pins are scoped to **other constants' blocks**. They read `BASELINE` and `PER_CHUNK_BASELINE` only, and assert:

- every commit a baseline carries as data appears in its own attached prose;
- what each baseline carries as data, recorded so the pin above cannot go vacuous in silence (`BASELINE` carries exactly one commit, `PER_CHUNK_BASELINE` carries none);
- every "BASELINE carries X" claim in attached prose matches the live value — the objectui#6778 defect as an assertion;
- and a boundary assertion, `expect(perChunk.prose).not.toContain('## Raising one')`, which pins that the locator does not over-capture into the neighbouring `PER_CHUNK_GZIP_CEILINGS` block.

This PR rewrites the block attached to `MAX_EAGER_CLOSURE_GZIP_BYTES`, and leaves the block attached to `PER_CHUNK_GZIP_CEILINGS` alone. Neither is among the pinned pair, and the `## Raising one` heading the boundary assertion names is untouched. The suite is green.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_