### PR TITLE
fix(types,core,sdui-parser): type the framework-injected `binding` input instead of casting it in

### DIFF
--- a/.changeset/6950-binding-framework-injected-input.md
+++ b/.changeset/6950-binding-framework-injected-input.md
@@ -1,0 +1,17 @@
+---
+'@object-ui/types': minor
+'@object-ui/sdui-parser': minor
+'@object-ui/core': patch
+---
+
+`binding` on a component input is framework-set, not author-declared: `@object-ui/types` gains `InjectedComponentInput`, the `'field'` binding arm is retired from `@object-ui/sdui-parser`'s `RegistryConfigLike`, and the `as ComponentMeta` cast at the injection seam in `@object-ui/core` is gone (objectui#6950; maintainer ruling of 2026-09-07, director decision batch #69; ADR-0049 enforce-or-remove).
+
+**What was measured.** `binding` was published — the manifest serializer forwards it — and read — `validateTree` records a binding site for it — while `ComponentInput`, the authoring type every registration writes against, did not declare it. The one writer in the tree, `ELEMENT_DATA_SOURCE_INPUT`, therefore carried a hand-written inline type and reached a registration's `inputs` through `as ComponentMeta` in `Registry.register`. Declared narrower than enforced, on a published type — and `ComponentInput`'s own docblock listed `binding` among the forwarded per-input keys.
+
+**The ruling** answered the product question the card asked — may an ordinary registration declare a binding input? — with no. So:
+
+- **`@object-ui/types`** exports `InjectedComponentInput`, an `interface … extends ComponentInput` with the required marker `binding: 'object'`. `ComponentInput` itself does not change: no member is added, and authoring `binding` on a registration stays an excess-property `tsc` error — now on purpose and documented at the interface. The two tombstone docblocks that listed `binding` as a forwarded key now say it is forwarded from the framework's injected input, not authored.
+- **`@object-ui/core`** types `ELEMENT_DATA_SOURCE_INPUT` as `InjectedComponentInput` and splices it through a typed local; the cast is gone. Runtime behaviour is unchanged — the same key, `type`, `binding` and `description` reach the manifest, and `validateTree` still records the binding site.
+- **`@object-ui/sdui-parser`** narrows `RegistryConfigLike.inputs[].binding` from `'object' | 'field'` to `'object'`. The `'field'` arm had zero writers — every `binding:` literal in `packages/`, `apps/` and `examples/` is `'object'`, 7 of 7 at this change's merge-base — and nothing on either side of the manifest resolved a field binding. **Breaking, deliberately:** a config that feeds `manifestFromConfigs` a `binding: 'field'` input is now a type error instead of a manifest entry the server would never resolve. `ManifestInput.binding`, the manifest reader's vocabulary, is not narrowed by this change.
+
+If a real need for author-declared bindings is ever measured, it is filed as a widening of `ComponentInput` with the vocabulary decided then — not by putting the cast back.

--- a/packages/core/src/data-scope/element-data-source.ts
+++ b/packages/core/src/data-scope/element-data-source.ts
@@ -54,6 +54,7 @@
  * view and rendering a grid would be a silently wrong answer.
  */
 
+import type { InjectedComponentInput } from '@object-ui/types';
 import { mergeFilterNodes } from '../utils/filter-converter.js';
 import { resolveViewId } from '../utils/resolve-view-id.js';
 
@@ -323,13 +324,21 @@ export const ELEMENT_DATA_SOURCE_KEY = 'dataSource';
  * an object picker rather than a free-text blob. The `type` stays the coarse
  * `'object'` kind because the value is a record; the two words are unrelated and
  * both are correct here.
+ *
+ * ## Typed as the framework's injected input (objectui#6950)
+ *
+ * `binding` is not a `ComponentInput` member. The maintainer ruling of
+ * 2026-09-07 answered the card's product question — may an ordinary
+ * registration declare a binding input? — with no, so the ONE writer of the
+ * key is this constant, typed by `InjectedComponentInput` from
+ * `@object-ui/types`: a `ComponentInput` plus the marker. The hand-written
+ * inline type literal that used to sit here was the tell that the key had no
+ * authored home, and the splice in `Registry.register` reached the `inputs`
+ * array through an `as ComponentMeta` cast. Both are gone: the shape is now
+ * checked here and at the splice, and a registration that writes `binding`
+ * itself is an excess-property `tsc` error.
  */
-export const ELEMENT_DATA_SOURCE_INPUT: {
-  name: string;
-  type: 'object';
-  binding: 'object';
-  description: string;
-} = {
+export const ELEMENT_DATA_SOURCE_INPUT: InjectedComponentInput = {
   name: ELEMENT_DATA_SOURCE_KEY,
   type: 'object',
   binding: 'object',

--- a/packages/core/src/registry/Registry.ts
+++ b/packages/core/src/registry/Registry.ts
@@ -14,6 +14,10 @@ import type { ComponentMeta as CanonicalComponentMeta } from '@object-ui/types';
 // name. Two `import type` lines from one module is legal and costs nothing —
 // type imports are erased.
 import type { ComponentConfig } from '@object-ui/types';
+// A THIRD `import type` from the same module, for the same reason as the
+// second: the line above is the shape objectui#6298's pin reads, so the name
+// the splice below is typed with (objectui#6950) gets its own line.
+import type { InjectedComponentInput } from '@object-ui/types';
 import {
   ELEMENT_DATA_SOURCE_INPUT,
   isElementDataSourceBlock,
@@ -383,6 +387,19 @@ type LazyEntry = {
  * later must be able to say so without fighting this function.) Re-registering
  * the same component, which the registry allows and tests do constantly, is
  * likewise a no-op rather than a growing `inputs` array.
+ *
+ * ## Typed end to end — the cast is gone (objectui#6950)
+ *
+ * The spliced element is an `InjectedComponentInput` (`@object-ui/types`): a
+ * `ComponentInput` plus the framework-set `binding` marker, so it is a plain
+ * subtype of the array's element type and the return value type-checks as a
+ * `ComponentMeta` with no assertion. This used to read `as ComponentMeta`,
+ * because `ELEMENT_DATA_SOURCE_INPUT` carried a hand-written inline type and
+ * `binding` had no declared home — and a cast at the one place the key is
+ * written is exactly what would have hidden any later drift between the
+ * constant and the type. `packages/types/src/__tests__/injected-component-input-6950.test.ts`
+ * pins the cast's absence. Keep the local typed: if the shape ever stops
+ * fitting, this line is where the compiler should say so.
  */
 export function withElementDataSourceInput<T>(
   component: ComponentRenderer<T>,
@@ -391,7 +408,8 @@ export function withElementDataSourceInput<T>(
   if (!isElementDataSourceBlock(component)) return meta;
   const inputs: NonNullable<ComponentMeta['inputs']> = meta?.inputs ?? [];
   if (inputs.some((input) => input?.name === ELEMENT_DATA_SOURCE_INPUT.name)) return meta;
-  return { ...(meta ?? {}), inputs: [...inputs, { ...ELEMENT_DATA_SOURCE_INPUT }] } as ComponentMeta;
+  const injected: InjectedComponentInput = { ...ELEMENT_DATA_SOURCE_INPUT };
+  return { ...(meta ?? {}), inputs: [...inputs, injected] };
 }
 
 export class Registry<T = any> {

--- a/packages/sdui-parser/src/__tests__/injected-component-input-6950.test.ts
+++ b/packages/sdui-parser/src/__tests__/injected-component-input-6950.test.ts
@@ -1,0 +1,154 @@
+/**
+ * The runtime half of the objectui#6950 pin: the input the framework injects
+ * still SERIALISES `binding: 'object'` into the manifest, `validateTree` still
+ * RECORDS the binding site, and the serializer's boundary refuses the retired
+ * `'field'` arm. The type-level half — `InjectedComponentInput`, the authoring
+ * face's refusal, and the cast-free splice — is
+ * `packages/types/src/__tests__/injected-component-input-6950.test.ts`; it
+ * lives there because `@object-ui/types` may import neither this package nor
+ * `@object-ui/core`, while this package lists core as a devDependency
+ * (`render.test.tsx` already registers through it).
+ *
+ * ## Why the positive limbs are the half that matters
+ *
+ * "A registration that authors `binding` fails type-check" is satisfied by
+ * deleting the marker. What makes the ruling a shape and not a deletion is
+ * that the FRAMEWORK's write keeps working end to end: `Registry.register`
+ * splices `ELEMENT_DATA_SOURCE_INPUT` for a renderer marked by
+ * `elementDataSourceBlock()`, `manifestFromConfigs` forwards its `binding`,
+ * and `validateTree` turns the prop into a binding site the server resolves.
+ * The chain is driven through the real registry here — not a hand-built
+ * config — so a splice that stopped carrying the marker would be seen where
+ * it happens, not inferred from a fixture that never went through it.
+ *
+ * ## `'field'` (ADR-0049 enforce-or-remove)
+ *
+ * `RegistryConfigLike.inputs[].binding` was `'object' | 'field'`; every
+ * `binding:` literal in `packages/`, `apps/` and `examples/` is `'object'`
+ * (7 of 7 at the retiring merge-base) and nothing resolves a field binding.
+ * The arm is retired at the boundary a registry config feeds the serializer
+ * through; `ManifestInput.binding` (`types.ts`) is the manifest READER's
+ * vocabulary and is deliberately not narrowed here. The `@ts-expect-error`
+ * directives below are real enforcement — this package type-checks its tests
+ * through `tsconfig.test.json`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  ELEMENT_DATA_SOURCE_INPUT,
+  ELEMENT_DATA_SOURCE_KEY,
+  Registry,
+  elementDataSourceBlock,
+  type ComponentMeta,
+} from '@object-ui/core';
+import { manifestFromConfigs, validateTree, type RegistryConfigLike } from '../index.js';
+
+const NS = 'pin6950';
+const TYPE = `${NS}:probe`;
+
+/** A registry holding ONE gate-wrapping block, registered the way a plugin does it. */
+function registryWithProbe(): Registry {
+  const registry = new Registry();
+  const Probe = elementDataSourceBlock(() => null);
+  registry.register('probe', Probe, {
+    namespace: NS,
+    tier: 'public',
+    skipFallback: true,
+    inputs: [{ name: 'object', type: 'string', required: true }],
+  });
+  return registry;
+}
+
+describe("the injected input still serialises `binding: 'object'` into the manifest (objectui#6950)", () => {
+  it('reaches the manifest through the real registry, and survives JSON', () => {
+    const manifest = manifestFromConfigs(registryWithProbe().getAllConfigs());
+    const entry = manifest.components[TYPE];
+    expect(entry).toBeDefined();
+
+    const injected = entry.inputs.find((i) => i.name === ELEMENT_DATA_SOURCE_KEY);
+    expect(injected).toMatchObject({ name: ELEMENT_DATA_SOURCE_KEY, type: 'object', binding: 'object' });
+
+    // The artifact is JSON on disk — the marker must be a serialisable value,
+    // not a type-only fact.
+    const roundTripped = JSON.parse(JSON.stringify(manifest)) as typeof manifest;
+    expect(
+      roundTripped.components[TYPE].inputs.find((i) => i.name === ELEMENT_DATA_SOURCE_KEY)?.binding,
+    ).toBe('object');
+  });
+
+  it('the marker comes from the injection, not from the authored input beside it', () => {
+    const manifest = manifestFromConfigs(registryWithProbe().getAllConfigs());
+    const authored = manifest.components[TYPE].inputs.find((i) => i.name === 'object');
+    expect(authored).toBeDefined();
+    expect(authored?.binding).toBeUndefined();
+    // and the constant the splice copies is what carries it
+    expect(ELEMENT_DATA_SOURCE_INPUT.binding).toBe('object');
+  });
+});
+
+describe('`validateTree` still records the injected input as a binding site (objectui#6950)', () => {
+  it('reports the `dataSource` prop as an object binding, with no `unknown-prop` beside it', () => {
+    const manifest = manifestFromConfigs(registryWithProbe().getAllConfigs());
+    const value = { object: 'account', view: 'all_accounts' };
+    const result = validateTree(
+      { type: TYPE, object: 'account', [ELEMENT_DATA_SOURCE_KEY]: value },
+      manifest,
+    );
+
+    expect(result.bindings).toContainEqual({
+      tag: TYPE,
+      input: ELEMENT_DATA_SOURCE_KEY,
+      kind: 'object',
+      value,
+    });
+    // objectui#6678's defect was exactly this diagnostic on the one key that works.
+    expect(result.diagnostics.filter((d) => d.code === 'unknown-prop')).toEqual([]);
+    expect(result.requires).toEqual([NS]);
+  });
+});
+
+describe("the serializer's boundary accepts 'object' and refuses the retired 'field' arm (ADR-0049, objectui#6950)", () => {
+  it("forwards 'object' unchanged", () => {
+    const config: RegistryConfigLike = {
+      type: 'object-table',
+      namespace: 'plugin-grid',
+      inputs: [{ name: 'object', type: 'string', required: true, binding: 'object' }],
+    };
+    expect(manifestFromConfigs([config]).components['object-table'].inputs[0].binding).toBe('object');
+  });
+
+  it("is a type error on 'field'", () => {
+    const config: RegistryConfigLike = {
+      type: 'object-table',
+      inputs: [
+        {
+          name: 'field',
+          type: 'string',
+          // @ts-expect-error `'field'` had zero writers and is retired (ADR-0049, objectui#6950)
+          binding: 'field',
+        },
+      ],
+    };
+    expect(config.inputs).toHaveLength(1);
+  });
+});
+
+describe('a registration that authors `binding` itself fails type-check at the registration door (objectui#6950)', () => {
+  it("is an excess-property error on `register()`'s `meta.inputs`", () => {
+    const registry = new Registry();
+    const meta: ComponentMeta = {
+      namespace: NS,
+      skipFallback: true,
+      inputs: [
+        {
+          name: 'object',
+          type: 'string',
+          // @ts-expect-error `binding` is not a `ComponentInput` member — the framework injects it (objectui#6950)
+          binding: 'object',
+        },
+      ],
+    };
+    registry.register('authored', () => null, meta);
+    expect(registry.getAllConfigs()).toHaveLength(1);
+  });
+});

--- a/packages/sdui-parser/src/index.ts
+++ b/packages/sdui-parser/src/index.ts
@@ -87,7 +87,26 @@ export interface RegistryConfigLike {
     of?: string | string[];
     required?: boolean;
     enum?: Array<string | { value: unknown; label?: string }>;
-    binding?: 'object' | 'field';
+    /**
+     * The binding marker — exactly `'object'` (objectui#6950).
+     *
+     * `'field'` was declared beside it from the first draft of ADR-0080 §6.3
+     * and never written: every `binding:` literal in `packages/`, `apps/`
+     * and `examples/` is `'object'` (7 of 7, measured 2026-09-06 and
+     * re-measured at the retiring PR's merge-base), and nothing on either
+     * side of the manifest resolved a field binding. Retired under ADR-0049
+     * enforce-or-remove by the maintainer ruling of 2026-09-07 (decision
+     * batch #69): a config that spells the arm is a `tsc` error here rather
+     * than an entry the server would never resolve. `ManifestInput.binding`
+     * in `types.ts` is the manifest READER's vocabulary and still reads
+     * `'object' | 'field'`; only this boundary — what a registry config may
+     * feed the serializer — narrowed.
+     *
+     * Only the framework writes the key: `InjectedComponentInput` in
+     * `@object-ui/types`, spliced by `Registry.register`. `ComponentInput`
+     * itself has no `binding` member, deliberately.
+     */
+    binding?: 'object';
     description?: string;
   }>;
   /**

--- a/packages/types/src/__tests__/injected-component-input-6950.test.ts
+++ b/packages/types/src/__tests__/injected-component-input-6950.test.ts
@@ -1,0 +1,168 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `binding` is FRAMEWORK-SET, not author-declared (objectui#6950; maintainer
+ * ruling of 2026-09-07, director decision batch #69): the one input that
+ * carries it is typed by `InjectedComponentInput`, `ComponentInput` has no
+ * such member, and the seam that splices it in does so without a cast.
+ *
+ * ## The card, in one sentence
+ *
+ * `binding` was published (the manifest serializer forwards it), read
+ * (`validateTree` records a binding site), and undeclared on the authoring
+ * type — so its one writer, `ELEMENT_DATA_SOURCE_INPUT`, carried a
+ * hand-written inline type and reached `ComponentMeta.inputs` through an
+ * `as ComponentMeta` cast in `Registry.ts`. Declared narrower than enforced,
+ * on a published type. The ruling answered the product question (may an
+ * ordinary registration declare a binding input?) with **no**, which fixes
+ * the shape: the key stays OFF `ComponentInput`, and the framework's own
+ * write gets a type instead of a cast.
+ *
+ * ## The three limbs, and why the first alone is half a pin
+ *
+ * A registration that authors `binding` must FAIL type-check; the injected
+ * input must still SERIALISE `binding: 'object'` into the manifest; and
+ * `validateTree` must still RECORD the binding site. The first limb on its
+ * own would be satisfied by deleting the marker altogether. This file holds
+ * the type-level half (both directions) plus the source-text pins on the two
+ * write sites; `packages/sdui-parser/src/__tests__/injected-component-input-6950.test.ts`
+ * holds the runtime half, where the serializer and the validator live and
+ * where `@object-ui/core` is an importable devDependency (this package may
+ * import neither — `check:phantom-deps`, and it would be a cycle).
+ *
+ * The `@ts-expect-error` directives are REAL enforcement: this package
+ * type-checks its tests through `tsconfig.test.json`, so re-widening a
+ * declaration fails the build on the unused directive.
+ *
+ * ## Why two of the pins read SOURCE TEXT
+ *
+ * A cast is invisible to every runtime and every type-level assertion — that
+ * is what a cast is for. `as ComponentMeta` returning to the splice would
+ * compile, pass every runtime limb, and hide the next drift exactly as it hid
+ * this one. So the absence is read off the file, the way
+ * `packages/core/src/registry/__tests__/component-meta-derives-from-canonical.test.ts`
+ * reads its import line: a source-identity assertion is the only kind that
+ * can see a cast.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { ComponentInput, ComponentMeta, InjectedComponentInput } from '../base';
+
+const ROOT = resolve(__dirname, '../../../..');
+const read = (rel: string): string => readFileSync(resolve(ROOT, rel), 'utf8');
+
+/* ── type-level: the injected shape ───────────────────────────────────── */
+
+describe('`InjectedComponentInput` is a `ComponentInput` plus the framework-set marker (objectui#6950)', () => {
+  it('accepts the shape the framework writes, and is assignable to `ComponentInput`', () => {
+    const injected: InjectedComponentInput = {
+      name: 'dataSource',
+      type: 'object',
+      binding: 'object',
+      description: 'Per-element data binding',
+    };
+    // The splice's premise: an injected input is a plain subtype of the array
+    // element type, so `[...inputs, injected]` is a `ComponentInput[]` with no cast.
+    const asAuthored: ComponentInput = injected;
+    expect(asAuthored.name).toBe('dataSource');
+    expect(injected.binding).toBe('object');
+  });
+
+  it('requires the marker — an input without `binding` is not an injected input', () => {
+    // @ts-expect-error `binding` is required on the injected shape (objectui#6950)
+    const missing: InjectedComponentInput = { name: 'dataSource', type: 'object' };
+    expect(missing.name).toBe('dataSource');
+  });
+
+  it("the vocabulary is exactly 'object' — the zero-writer 'field' arm is retired (ADR-0049)", () => {
+    const fieldArm: InjectedComponentInput = {
+      name: 'dataSource',
+      type: 'object',
+      // @ts-expect-error `'field'` had zero writers and was retired with the ruling (objectui#6950)
+      binding: 'field',
+    };
+    expect(fieldArm.name).toBe('dataSource');
+  });
+});
+
+/* ── type-level: the authoring face refuses the key ────────────────────── */
+
+describe('an ordinary registration cannot author `binding` (objectui#6950, ruling: framework-set)', () => {
+  it('is an excess-property error on a `ComponentInput` literal', () => {
+    const input: ComponentInput = {
+      name: 'object',
+      type: 'string',
+      // @ts-expect-error `binding` is not a `ComponentInput` member — the framework injects it (objectui#6950)
+      binding: 'object',
+    };
+    expect(input.name).toBe('object');
+  });
+
+  it('is an excess-property error through the registration door, `ComponentMeta.inputs`', () => {
+    const meta: ComponentMeta = {
+      inputs: [
+        {
+          name: 'object',
+          type: 'string',
+          required: true,
+          // @ts-expect-error `binding` is not a `ComponentInput` member — the framework injects it (objectui#6950)
+          binding: 'object',
+        },
+      ],
+    };
+    expect(meta.inputs).toHaveLength(1);
+  });
+
+  it('`ComponentInput` has no `binding` key at all — not even as a tombstone', () => {
+    // A `?: never` tombstone would also refuse the write, but it would DECLARE
+    // the key, and the ruling's shape is "not a member": the key belongs to
+    // the injected type alone. Re-adding it here in any form flips this line.
+    type HasBinding = 'binding' extends keyof ComponentInput ? true : false;
+    const declared: HasBinding = false;
+    expect(declared).toBe(false);
+  });
+});
+
+/* ── source text: the two write sites carry the type, not a cast ───────── */
+
+describe('the write sites are typed by `InjectedComponentInput` and carry no cast (objectui#6950)', () => {
+  it('`ELEMENT_DATA_SOURCE_INPUT` is annotated with the injected type, not an inline literal', () => {
+    const src = read('packages/core/src/data-scope/element-data-source.ts');
+    expect(src).toContain('export const ELEMENT_DATA_SOURCE_INPUT: InjectedComponentInput = {');
+    expect(src).toMatch(/import type \{[^}]*\bInjectedComponentInput\b[^}]*\} from '@object-ui\/types';/);
+  });
+
+  it('the splice in `withElementDataSourceInput` names the type and has no `as ComponentMeta`', () => {
+    const src = read('packages/core/src/registry/Registry.ts');
+    const start = src.indexOf('export function withElementDataSourceInput<');
+    const end = src.indexOf('export class Registry<', start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const body = src.slice(start, end);
+    expect(body).toContain('const injected: InjectedComponentInput = { ...ELEMENT_DATA_SOURCE_INPUT };');
+    // The cast the card measured. Any `as` assertion here would hide drift
+    // between the constant and the type, which is the defect this closed.
+    expect(body).not.toMatch(/\bas\s+ComponentMeta\b/);
+    expect(body).not.toMatch(/\}\s*as\s+[A-Za-z]/);
+  });
+
+  it('the declaration extends `ComponentInput` rather than restating its members', () => {
+    const src = read('packages/types/src/base.ts');
+    expect(src).toContain('export interface InjectedComponentInput extends ComponentInput {');
+    // and the parent still has no `binding` member of its own (source-text
+    // twin of the `keyof` pin above, so a tombstone cannot slip in as prose).
+    const parentStart = src.indexOf('export interface ComponentInput {');
+    const parentEnd = src.indexOf('export interface InjectedComponentInput', parentStart);
+    expect(parentStart).toBeGreaterThan(-1);
+    expect(parentEnd).toBeGreaterThan(parentStart);
+    expect(src.slice(parentStart, parentEnd)).not.toMatch(/^\s+binding\??:/m);
+  });
+});

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -524,6 +524,13 @@ export type ComponentInputControlType =
 /**
  * Input field configuration for component metadata.
  * Describes what properties a component accepts in the designer/editor.
+ *
+ * `binding` is deliberately NOT a member. The manifest serializer forwards it
+ * and `validateTree` reads it, but no registration authors it: the key is set
+ * by the framework's injected input, {@link InjectedComponentInput}, at the
+ * one seam that splices it in (objectui#6950, maintainer ruling of
+ * 2026-09-07). Writing it here is therefore an excess-property `tsc` error,
+ * on purpose — see that declaration for the ruling and the measurement.
  */
 export interface ComponentInput {
   /**
@@ -685,7 +692,9 @@ export interface ComponentInput {
    * `ComponentMeta.inputs` was enumerated and none reads any of the three —
    * the serializer (`packages/sdui-parser/src/index.ts`) forwards a fixed key
    * list per input, `of` included since objectui#8067 (`name`, `type`, `of`,
-   * `required`, `enum`, `binding`, `description`), its boundary type has no slot for these, the registry's
+   * `required`, `enum`, `binding`, `description` — `binding` among them is
+   * not an authored key but the framework's, forwarded from
+   * {@link InjectedComponentInput}, objectui#6950), its boundary type has no slot for these, the registry's
    * data-source seam reads `name` only, and neither the designer nor the
    * app-shell inspectors consult registry `inputs` at all. The one
    * non-test touch was a WRITE (`WidgetRegistry` copying the widget-manifest
@@ -795,7 +804,9 @@ export interface ComponentInput {
    * retiring PR): no consumer reads any of the four, and the manifest
    * serializer (`packages/sdui-parser/src/index.ts`) forwards a fixed key list
    * per input — `name`, `type`, `of`, `required`, `enum`, `binding`,
-   * `description`, the last of them added by objectui#8067 —
+   * `description`, the last of them added by objectui#8067; `binding` is the
+   * framework's key, forwarded from {@link InjectedComponentInput} rather
+   * than authored (objectui#6950) —
    * so a value authored here could not reach the published
    * `sdui.manifest.json` even in principle. A structural census over every
    * `inputs:` array in the repository found ZERO authoring sites for the four
@@ -844,6 +855,63 @@ export interface ComponentInput {
    * @deprecated Not part of `ComponentInput`'s contract — the value was inert.
    */
   placeholder?: never;
+}
+
+/**
+ * The input the FRAMEWORK injects into a registration: a {@link ComponentInput}
+ * plus the `binding` marker — which is why `binding` is not a member of
+ * `ComponentInput` itself (objectui#6950; maintainer ruling of 2026-09-07,
+ * director decision batch #69: `binding` is framework-set, not
+ * author-declared).
+ *
+ * ## What the marker is, and who writes it
+ *
+ * `binding: 'object'` tells a consumer that the input names an OBJECT: the
+ * manifest serializer (`packages/sdui-parser/src/index.ts`) forwards it into
+ * `sdui.manifest.json`, `validateTree` records the prop as a binding site the
+ * server must resolve, and the designer offers an object picker. It is
+ * unrelated to `type: 'object'`, the coarse control KIND that sits one line
+ * above it in the same declaration — a record-shaped value and an
+ * object-naming input are two different facts, and the one writer states both.
+ *
+ * That writer is the framework: `ELEMENT_DATA_SOURCE_INPUT` in
+ * `@object-ui/core` (`data-scope/element-data-source.ts`), spliced into a
+ * registration's `inputs` by `Registry.register` for every renderer that
+ * passed through `elementDataSourceBlock()`. No registration authors the key.
+ * Measured before the ruling and re-measured at the retiring PR's merge-base:
+ * every `binding:` literal in `packages/`, `apps/` and `examples/` is
+ * `'object'` (7 of 7), and every one of them is either that constant or a
+ * fixture in `sdui-parser`'s own tests. The ruling answered the product
+ * question the card asked — may an ordinary registration declare a binding
+ * input? — with **no**, so `ComponentInput` refuses the key the ordinary way
+ * (an excess-property `tsc` error at the registration site) and the ONE place
+ * that may write it is typed by this declaration. Until objectui#6950 it was
+ * typed by a hand-written inline literal and reached the `inputs` array
+ * through an `as ComponentMeta` cast — a cast at the only write site is
+ * exactly what would have hidden any later drift between the constant and
+ * the type.
+ *
+ * ## Why `extends` and not the ruling's `&` sketch
+ *
+ * The ruling's example was `ComponentInput & { binding: 'object' }`. An
+ * `interface … extends` says the same thing and is checked at ITS declaration:
+ * if `ComponentInput` ever gains a `binding` member this one cannot extend
+ * (a `?: never` tombstone, say), that is a TS2430 on this line, where the
+ * relationship is stated — not a `never` quietly folded into a type expression
+ * that only surfaces at whichever use site first trips over it. Diagnostics
+ * also name `InjectedComponentInput` instead of an anonymous intersection.
+ * The reopen route the ruling names — a measured need for author-declared
+ * bindings, filed as a WIDENING of `ComponentInput` with the vocabulary
+ * decided then — lands on the parent, and this declaration follows it.
+ *
+ * The vocabulary is exactly `'object'`. The serializer's boundary type once
+ * also admitted `'field'`; that arm had zero writers and was retired with
+ * this declaration (ADR-0049 enforce-or-remove, objectui#6950) — see
+ * `RegistryConfigLike` in `packages/sdui-parser/src/index.ts`.
+ */
+export interface InjectedComponentInput extends ComponentInput {
+  /** The framework-set binding marker: this input names an object. */
+  binding: 'object';
 }
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -102,6 +102,9 @@ export type {
   SchemaNode,
   ComponentRendererProps,
   ComponentInput,
+  // The input the FRAMEWORK injects (`binding: 'object'`, objectui#6950) —
+  // `ComponentInput` plus the marker no registration may author.
+  InjectedComponentInput,
   // The arm vocabulary of `ComponentInput.type`, exported because that field
   // takes one arm OR an array of them (objectui#3832) and every declaration
   // site and reader needs the set by name rather than re-spelling it.


### PR DESCRIPTION
Fixes #6950

`binding` on a component input is framework-set, not author-declared — maintainer ruling of 2026-09-07 (director decision batch #69, card comment 5565503373; dispatch brief 5567557186). This PR executes the ruling's four notes. Measured on `origin/main` = `fc32921`; `origin/main` (`3c6394c`, a `scripts/`-only commit) merged before opening; head `e33cefd`.

## What changed

| Package | Change |
|---|---|
| `@object-ui/types` | New exported `InjectedComponentInput` — `interface … extends ComponentInput` with the required marker `binding: 'object'` — declared beside `ComponentInput` in `base.ts` and listed in the barrel. `ComponentInput`'s own member list is untouched (it has fourteen members on this tree: the card's thirteen plus `of`, which objectui#8067 added after the card was written). Its docblock now says why `binding` is deliberately absent, and the two tombstone docblocks that listed `binding` among the forwarded per-input keys now say it is forwarded from the framework's injected input, not authored. No Zod mirror: nothing parses an injected input through `ComponentInputSchema`, and the claim scoped `base.zod.ts` to "only if the new type needs a mirror". |
| `@object-ui/core` | `ELEMENT_DATA_SOURCE_INPUT` is typed `InjectedComponentInput` instead of a hand-written inline literal; `withElementDataSourceInput` splices it through a typed local and returns a `ComponentMeta` with **no cast** — the `as ComponentMeta` is gone. The injected input's runtime bytes are unchanged. |
| `@object-ui/sdui-parser` | `RegistryConfigLike.inputs[].binding` narrows from `'object' \| 'field'` to `'object'` (ADR-0049 enforce-or-remove; zero writers, see below). `ManifestInput.binding` is not touched — see 验收备注. |
| pins | `packages/types/src/__tests__/injected-component-input-6950.test.ts` — type-level in both directions (`@ts-expect-error` on an authored `binding` via a `ComponentInput` literal and via `ComponentMeta.inputs`; the injected type requires the marker, is assignable to `ComponentInput`, refuses `'field'`; a `keyof` pin that `ComponentInput` has no `binding` key at all) plus source-text pins on the two write sites. `packages/sdui-parser/src/__tests__/injected-component-input-6950.test.ts` — runtime, driven through a real `Registry`: the manifest still carries `binding: 'object'` and survives JSON, `validateTree` still records the binding site with no `unknown-prop` beside it, the boundary forwards `'object'` and refuses `'field'`, and `register()` refuses an authored `binding`. |
| changeset | `.changeset/6950-binding-framework-injected-input.md` — `@object-ui/types` minor (new export), `@object-ui/sdui-parser` minor (a retirement; the level objectui#3917's retirement used), `@object-ui/core` patch. |

## The reading the ruling rests on, re-derived at `fc32921`

`grep -rnE "binding:\s*'[^']*'" packages apps examples` over ts/tsx/js/mjs/json/md/mdx with `node_modules` and `dist` excluded: **7 occurrences, 7 of them `'object'`, 0 `'field'`** — three in `packages/core/src/data-scope/element-data-source.ts` (docblock, the old type literal, the value) and four in `sdui-parser` fixtures (`tier.test.ts`, `compile.test.ts`, `render.test.tsx`, `verify.ts`). A wider net — `binding` within 60 characters of `'field'` anywhere in the repo outside `node_modules`/`dist` — finds exactly two declaration sites: `packages/sdui-parser/src/index.ts` (retired here) and `packages/sdui-parser/src/types.ts` line 100 (the manifest face, see 验收备注). The premise holds.

## The shape, and why `interface … extends` rather than the ruling's `&` sketch

The ruling's example was `InjectedComponentInput = ComponentInput & { binding: 'object' }`, offered as an example. An `interface InjectedComponentInput extends ComponentInput { binding: 'object' }` says the same thing and is checked at its own declaration: if `ComponentInput` ever gains a `binding` member this one cannot extend (a `?: never` tombstone, say), that is TS2430 on the line where the relationship is stated, rather than a `never` quietly folded into a type expression that only surfaces at whichever use site first trips over it; diagnostics also name `InjectedComponentInput` instead of an anonymous intersection. The ruling's reopen route — a measured need for author-declared bindings, filed as a widening of `ComponentInput` with the vocabulary decided then — lands on the parent, and the child follows it. The splice types cleanly with it: the intersection was never needed for that.

`type: 'object'` and `binding: 'object'` stay two unrelated words (coarse control kind vs binding marker), exactly as `element-data-source.ts`'s docblock records; both are written by the one constant and nothing merges them.

## Why the pin is two files

`@object-ui/types` may import neither `@object-ui/core` nor `@object-ui/sdui-parser` (`check:phantom-deps`, and it would be a cycle), so the type-level half lives there with `../base` imports and the runtime half lives in `sdui-parser`, which already lists core as a devDependency (`render.test.tsx` registers through it). Both packages chain `tsconfig.test.json` in `type-check`, so every `@ts-expect-error` is live enforcement (ablation 1 and 3 below show the directives turning into TS2578).

## Gates — each exit captured to a file before any output was read

| Check | Reading |
|---|---|
| `check:element-data-source-declaration` | before, at `fc32921`: exit 0, `OK — 13 gate-consuming file(s) checked, 3 definition file(s) excluded`. After, at `e33cefd` (the merge changed `scripts/js-comment-mask.mjs`, which this gate imports): exit 0, same line. The gate asserts that a consumer of the runtime gate reaches `elementDataSourceBlock(` from core; it does not read the constant's type, so this change is not what it exists to prevent. |
| dependency closure build, `pnpm --workspace-concurrency=2 --filter '@object-ui/sdui-parser...' build` (types, core, i18n, data-objectstack, react, sdui-parser, test-support) | `VERDICT command-exit 0`, with `@object-ui/react` compiled as a downstream consumer of the new core/types. Not rebuilt after the merge: the merge touched no file in that closure (`git diff --stat HEAD^1 HEAD -- packages/…` empty). |
| `pnpm --workspace-concurrency=2 --filter @object-ui/types --filter @object-ui/core --filter @object-ui/sdui-parser run type-check` at `e33cefd` | exit 0 — all three `type-check: Done` |
| `pnpm exec vitest run --maxWorkers=2 packages/types/ packages/core/ packages/sdui-parser/ scripts/__tests__/one-authority-per-exported-name-6273.test.ts apps/console/src/__tests__/element-data-source-input-injection.test.tsx` at `e33cefd` | `Test Files 274 passed (274)`, `Tests 5390 passed (5390)` — 138 + 121 + 13 files plus the two consumer probes (the one-authority pin, because a name is added to a published barrel; the console injection probe, because it reads `.binding` off `manifestFromConfigs` against live registrations) |
| lint | `pnpm exec eslint --format json` over the 7 changed source/test files, invoked the way the package `lint` scripts do (`eslint .`, inline config honoured): 0 errors, 25 warnings — all `no-explicit-any` on lines this diff does not touch. Narrowing evidence, three parts: the population is read from `eslint.config.js` (`files: ['**/*.{ts,tsx}']`, ignores per that file); the file count (7) is read from the JSON output; and the config declares no `parserOptions.project`, so linting is not type-aware and this diff cannot move any untouched file's verdict. A first pass with `--no-inline-config` reported one `no-restricted-imports` error at `packages/types/src/index.ts:1293` — an untouched line under an existing `eslint-disable` block, and not the CI invocation. Repo-wide `pnpm lint` is CI's. |
| `check:control-bytes` at `e33cefd` | exit 0, `scanned 6599 tracked text file(s)`; plus a direct control-byte grep over the 8 files of this diff: clean |
| `check:self-import` · `check:spec-symbols` · `check:handler-key-reads` · `check:phantom-deps` | exit 0 each (`phantom-deps`: `Every in-scope import is declared by the package that publishes it` — the new cross-package test import is covered by sdui-parser's existing devDependency) |
| `node scripts/check-changeset-presence.mjs` at `e33cefd` | exit 0, `7 source file(s) of 3 released package(s) changed, and this change declares 1 changeset(s)` |
| `check:readme-exports` | NOT MEASURED locally: exit 1 with `424 self-import(s) could not be judged … ./dist/index.d.ts is not on disk — run pnpm build first`, every line naming a package outside the built closure (app-shell, auth, cli, collaboration, …); none names types, core or sdui-parser. A prerequisite failure, declared to CI. |
| `check:sdui-registration-pins` | not run: it weighs `apps/console/dist`, and this diff touches no `sideEffects` array and no registration module. Declared to CI. |

## Reverse verification — four mutations, each with a restore trap, each proven on disk (marker `grep -c` = 1) and restored to `HEAD` = `e33cefd` (blob hash equal to `HEAD`'s, `git diff HEAD` empty)

None of the mutated subjects resolves through `dist/`: the types pin imports `../base` relatively, the sdui-parser pin imports `../index.js` relatively, and the root vitest config aliases every `@object-ui` specifier to that package's `src/`. So no rebuild sits between a mutation and its reading.

1. **The refused disposition** — add `binding?: 'object' | 'field'` to `ComponentInput`: `tsc -p tsconfig.test.json` in `packages/types` exit 2 — `TS2578: Unused '@ts-expect-error' directive` at the `ComponentInput`-literal site and the `ComponentMeta.inputs` site, plus `TS2322: Type 'false' is not assignable to type 'true'` at the `keyof` pin; vitest on the types pin: 1 failed / 8 passed (the parent-has-no-`binding` source pin).
2. **The cast comes back** — `} as ComponentMeta` re-added to the typed splice: `tsc --noEmit` in `packages/core` exit **0**. A cast that adds nothing still compiles; that is the direction this limb was expected to take and the reason the pin reads source. vitest on the types pin: 1 failed / 8 passed (the no-cast pin).
3. **The `'field'` arm comes back** on `RegistryConfigLike`: `tsc -p tsconfig.test.json` in `packages/sdui-parser` exit 2 — `TS2578` at the `'field'` directive.
4. **The serializer stops forwarding `binding`** (`binding: i.binding,` removed from `manifestFromConfigs`): vitest on the sdui-parser pin: 3 failed / 3 passed — the manifest limb, the `validateTree` limb, and the `'object'`-forward control.

## 验收备注

- **`packages/sdui-parser/src/types.ts` line 100** — `ManifestInput.binding?: 'object' | 'field'`, and `ManifestValidationResult.bindings[].kind: 'object' | 'field'` a few lines below — still carry the `'field'` arm. The ruling and the claim name `RegistryConfigLike.binding` only, and `types.ts` is outside the declared file surface, so this PR narrows the boundary a registry config feeds the serializer through and leaves the manifest reader's vocabulary as it was. Reading for the seat: zero writers in objectui; `validateTree` forwards whatever a manifest says into `bindings[].kind`; objectstack has no reader of a `'field'` binding kind either — its only hits are a vendored sibling copy of this package (`objectstack/packages/sdui-parser/src/index.ts` and `types.ts`) carrying the same declarations. Noted, not filed: whether the manifest face and the vendored copy follow is a scope call.
- `ComponentInput` has fourteen members on this tree, not the thirteen the card and the brief count — `of` (objectui#8067) landed after the card. Nothing here depends on the number; the list is untouched.
- The eight `retirementTombstone()` messages in `ComponentInputSchema` (`base.zod.ts`) still say "the serializer forwards `name`/`type`/`of`/`required`/`enum`/`binding`/`description`" — true, but they list `binding` without saying it is not an authored key. That block is held by objectui#7493 items ② / ③ per the claim, so untouched. Noted, not filed.
- `packages/types/src/__tests__/component-input-retired-keys-7493.test.ts` carries a comment calling `binding` "objectui#6950's open question" — now ruled. A comment in a neighbour's pin; untouched. Noted, not filed.
- `ComponentMetaSchema` is a non-strict `z.object`, so a consumer that parsed a registration's meta after injection would silently strip `binding`. No non-test consumer does (`ComponentMetaSchema` / `ComponentInputSchema` are referenced only inside `packages/types`). Noted, not filed.

Route: draft, `needs:contract-review` (clause ② — a new exported type on a published package widens the public surface), reviewed in-seat; not flipped ready, not enqueued, no auto-merge. Session: `https://claude.ai/code/session_01QtGhnU3WnnWyiWeYQhw2aX`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtGhnU3WnnWyiWeYQhw2aX

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtGhnU3WnnWyiWeYQhw2aX)_