### PR TITLE
fix(plugin-dashboard,core): resolve an object-bound chart's category axis through the aggregate

### DIFF
--- a/.changeset/8269-dashboard-category-axis-groupby.md
+++ b/.changeset/8269-dashboard-category-axis-groupby.md
@@ -1,0 +1,45 @@
+---
+'@object-ui/core': patch
+'@object-ui/plugin-dashboard': patch
+'@object-ui/plugin-charts': patch
+---
+
+Fix a dashboard chart widget that declares its category as `aggregate.groupBy` being
+refused for lacking a `name` column (objectui#8269).
+
+A widget bound to an object with `aggregate: { function: 'count', groupBy: 'status' }`
+and no `options.xField` rendered a refusal instead of a chart:
+
+> This chart cannot plot its category axis: no row has a `name` field.
+
+The author wrote `groupBy: 'status'`. Nothing on screen said `groupBy` was the key that
+had been ignored, and `name` appeared nowhere in their metadata — so the diagnostic sent
+them to debug the wrong layer.
+
+**Cause.** The two dashboard relays (`DashboardGridLayout`, `DashboardRenderer`) each
+floored the category binding on a literal — `options.xField || 'name'` — and handed it to
+the `object-chart` node without ever consulting the aggregate that decides it. An
+object-bound aggregate returns one row per group keyed by the raw `groupBy` field, so no
+row carried `name` and the category-axis guard (framework#4033) fired correctly on a
+binding that was already wrong when it arrived.
+
+**Fix.** `chartCategoryKey` is a new `@object-ui/core` export delegating to
+`chartAggregateCategoryKey` in `@objectstack/spec/ui` — the contract's own derivation of
+"the category column an object-bound aggregate produces", and the published sibling of the
+`chartAggregateValueKey` that objectui#8266 adopted for the measure axis. Both relays now
+consult it for the object-provider branch.
+
+**What moves on screen.** A widget that rendered a refusal now draws. Measured through
+`ChartRenderer` at 480x320 over the rows a fieldless count returns
+(`[{status:'open',count:2},{status:'paid',count:5}]`): the composed binding went from
+`xAxisKey: 'name'` — a `missing-category-key` refusal, 0 marks — to `xAxisKey: 'status'`,
+1 series and 2 marks with the category ticks drawn.
+
+**Unaffected.** A chart with no `aggregate` at all keeps the author's `xField` (its rows
+are raw records, so that key is the right one), an UNGROUPED aggregate keeps it too (it
+returns a single row with no category column), and the authored-literal-rows branch — the
+`chart` node composed after the object-provider check fails — keeps its floor unchanged.
+One authored key changes meaning, exactly as objectui#8266's `yField` did: an `xField`
+written on an object-bound chart that ALSO declares a `groupBy` no longer wins over the
+aggregate's own column — it named a record column a grouped aggregate never returns, so it
+produced the same refusal before.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,6 +76,11 @@ export * from './utils/chart-series.js';
 // projection and the series binding alike, delegated to the spec's own
 // derivation so the two cannot drift (objectui#8266).
 export * from './utils/chart-measure-key.js';
+// "Which result column carries the CATEGORY?" — the same move on the other
+// axis, delegated to the contract's own published derivation so a relay cannot
+// floor the x-axis binding on a literal the aggregate contradicts
+// (objectui#8269).
+export * from './utils/chart-category-key.js';
 // The AUTHORED half of a dataset-bound chart (objectui#4229's data/presentation
 // split), shared by the dashboard widget and the report's embedded chart so the
 // same spec keys are lowered identically on both (objectui#4877).

--- a/packages/core/src/utils/chart-category-key.test.ts
+++ b/packages/core/src/utils/chart-category-key.test.ts
@@ -1,0 +1,82 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8269 — the ONE answer to "which result column carries the category?".
+ *
+ * The regression arm is the FIRST one: a `groupBy` with no `options.xField`
+ * beside it, which is the whole authoring shape the card is about. The relays
+ * answered `'name'` there and the rows carry the raw groupBy field, so
+ * `hasNoCategoryKey` refused the widget by the name of a key nobody wrote.
+ *
+ * The fallback arms are the other half: a floor that fired too eagerly would
+ * take the caller's `xField` back over a `groupBy` the contract CAN answer for,
+ * or invent a category column for an UNGROUPED aggregate that returns exactly
+ * one row and has none.
+ */
+import { describe, it, expect } from 'vitest';
+import { chartCategoryKey } from './chart-category-key';
+
+describe('chartCategoryKey — the contract answers', () => {
+  it('is the raw groupBy field, never the caller floor', () => {
+    // THE REGRESSION. `options.xField || 'name'` answered 'name' here, and the
+    // rows carry 'status', so the chart refused, naming 'name'.
+    expect(chartCategoryKey({ function: 'count', groupBy: 'status' }, 'name')).toBe('status');
+  });
+
+  it('ignores a caller floor the author chose, when the groupBy answers', () => {
+    // An authored `xField` names a column of the RECORDS, and a grouped
+    // aggregate does not return records. Honouring it refuses the chart for
+    // exactly the same reason 'name' did.
+    expect(chartCategoryKey({ function: 'count', groupBy: 'status' }, 'stage')).toBe('status');
+  });
+
+  it('answers for a field-bearing aggregate the same way', () => {
+    expect(chartCategoryKey({ field: 'amount', function: 'sum', groupBy: 'stage' }, 'name')).toBe('stage');
+  });
+
+  it('reads a structured groupBy node by its FIELD', () => {
+    expect(
+      chartCategoryKey({ function: 'count', groupBy: { field: 'closed_at', dateGranularity: 'month' } }, 'name'),
+    ).toBe('closed_at');
+  });
+
+  it('prefers a structured groupBy ALIAS, because the alias renames the projected column', () => {
+    // The one place this seam and `plugin-charts`' `resolveChartCategoryField`
+    // deliberately disagree: that resolver answers "which FIELD?" (and returns
+    // `closed_at`, which is what a field-metadata probe needs), this one
+    // answers "which COLUMN do the rows carry?" — and `ObjectChart`'s own fetch
+    // path keys those rows `alias || field`.
+    expect(
+      chartCategoryKey({ function: 'count', groupBy: { field: 'closed_at', alias: 'month' } }, 'name'),
+    ).toBe('month');
+  });
+});
+
+describe('chartCategoryKey — the caller floor, only where the contract is silent', () => {
+  it('falls back when there is no aggregate at all', () => {
+    // A provider whose rows are raw records: the author's xField IS the key.
+    expect(chartCategoryKey(undefined, 'name')).toBe('name');
+    expect(chartCategoryKey(undefined, 'stage')).toBe('stage');
+  });
+
+  it('falls back for an UNGROUPED aggregate, which returns no category column', () => {
+    // One row, one number. There is no category to name, so the caller's floor
+    // is the only answer available — and refusing to invent one here is what
+    // keeps a single-value aggregate from being bound to a column that would
+    // never exist.
+    expect(chartCategoryKey({ field: 'amount', function: 'sum' }, 'name')).toBe('name');
+  });
+
+  it('falls back for a groupBy shape ChartGroupBySchema rejects', () => {
+    expect(chartCategoryKey({ function: 'count', groupBy: '' }, 'name')).toBe('name');
+    expect(chartCategoryKey({ function: 'count', groupBy: {} }, 'name')).toBe('name');
+    expect(chartCategoryKey({ function: 'count', groupBy: ['status'] }, 'name')).toBe('name');
+    expect(chartCategoryKey({}, 'name')).toBe('name');
+  });
+});

--- a/packages/core/src/utils/chart-category-key.ts
+++ b/packages/core/src/utils/chart-category-key.ts
@@ -1,0 +1,90 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * chart-category-key — the ONE answer to "which result column carries the
+ * CATEGORY?" for an object-bound chart (objectui#8269).
+ *
+ * The mirror of `chart-measure-key` (objectui#8266) on the other axis. That
+ * card landed `chartMeasureKey` over the contract's `chartAggregateValueKey`;
+ * the contract publishes a CATEGORY sibling in the same module —
+ * `chartAggregateCategoryKey` — and nothing in this repository read it.
+ *
+ * ## The disagreement this replaces
+ *
+ * Both dashboard relays composed the category binding as a LITERAL FLOOR:
+ *
+ *   const xAxisKey = options.xField || 'name';
+ *
+ * and handed it to the `object-chart` node without ever consulting the
+ * `aggregate` that decides it. An object-bound aggregate returns one row per
+ * group, keyed by the raw `groupBy` field, so a widget declaring
+ * `aggregate: { function: 'count', groupBy: 'status' }` and no `options.xField`
+ * bound `'name'` against rows keyed `'status'`.
+ *
+ * Unlike the measure half, this one is LOUD: `hasNoCategoryKey`
+ * (`plugin-charts/src/AdvancedChartImpl.tsx`, framework#4033) fires and the
+ * author reads "This chart cannot plot its category axis: no row has a `name`
+ * field." The diagnostic is wrong-CAUSE — it names a binding the author never
+ * wrote and never mentions the `groupBy` they did — so it points at the wrong
+ * layer. Being loud makes it a lesser harm than objectui#8266, not a
+ * non-defect: measured over the rows a fieldless count returns,
+ * `[{status:'open',count:2},{status:'paid',count:5}]`, an `xAxisKey` of
+ * `'name'` refuses under BOTH series bindings, i.e. objectui#8266's fix does
+ * not reach this authoring shape at all.
+ *
+ * ## Why the answer is delegated rather than restated
+ *
+ * Restating the rule here would make this file a second opinion of a question
+ * the contract already answers — the objectui#5042 / #7544 / #8193 / #8168
+ * drift shape that `chart-measure-key` exists to end. So the rule stays
+ * upstream in `@objectstack/spec/ui` and this is the seam objectui-side callers
+ * share.
+ *
+ * ## ⚠️ NOT the same function as `resolveChartCategoryField`
+ *
+ * `plugin-charts`' own `resolveChartCategoryField` (objectui#8168) reads
+ * `aggregate.groupBy` first too — which is exactly why `ObjectChart` does NOT
+ * refuse this shape at its own level, and then forwards `schema.xAxisKey`
+ * verbatim as the render binding anyway. But the two answer DIFFERENT
+ * questions and must not be collapsed:
+ *
+ *   - `resolveChartCategoryField` answers "which FIELD is the category?" — its
+ *     structured-`groupBy` leg returns `node.field`, because its two readers
+ *     are the refusal (does the author name a category at all?) and the
+ *     field-metadata probe that loads that field's option labels and colours.
+ *   - this function answers "which COLUMN do the returned rows carry it
+ *     under?" — `groupBy.alias ?? groupBy.field` per the contract, because an
+ *     `alias` (admitted by `ChartGroupBySchema`) renames the projected column.
+ *
+ * They coincide whenever no alias is written, which is why the distinction is
+ * easy to miss; conflating them would either bind an axis to a column the rows
+ * do not carry, or probe field metadata for a field that does not exist.
+ */
+
+import { chartAggregateCategoryKey, type ChartAggregateLike } from '@objectstack/spec/ui';
+
+/**
+ * The result column a chart's category axis / x-axis binding must name.
+ *
+ * `fallback` is the caller's own floor, used ONLY when the contract has no
+ * answer — a chart that declares no `aggregate` at all (its rows are raw
+ * records or authored literals, where the author's `xField` is the right key),
+ * an UNGROUPED aggregate (one row, no category column), or a `groupBy` shape
+ * `ChartGroupBySchema` already rejects. It is never a second opinion about an
+ * aggregate the contract CAN answer for.
+ *
+ * @param aggregate the chart's inline aggregate, or `undefined`
+ * @param fallback  the key to bind when the contract has no answer
+ */
+export function chartCategoryKey(
+  aggregate: ChartAggregateLike | undefined,
+  fallback: string,
+): string {
+  return chartAggregateCategoryKey(aggregate) ?? fallback;
+}

--- a/packages/plugin-charts/src/ObjectChart.categoryAxisKeyRender-8269.test.tsx
+++ b/packages/plugin-charts/src/ObjectChart.categoryAxisKeyRender-8269.test.tsx
@@ -1,0 +1,270 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8269, the RENDER half — what a category binding naming a column the
+ * rows do not carry actually draws, and what the fixed binding draws instead.
+ *
+ * `plugin-dashboard/src/__tests__/DashboardChart.categoryAxisKey-8269.test.tsx`
+ * pins which column the two dashboard relays name. That is necessary and not
+ * sufficient: the card's own bar is that "a widget that renders a refusal today
+ * would start drawing, so it needs a render measurement, not only a seam
+ * assertion". So this file renders the real chain — `ChartRenderer` →
+ * `normalizeChartSchema` → `AdvancedChartImpl` — over the rows a fieldless
+ * count actually returns, and reads the DOM.
+ *
+ * It lives here for the reason the objectui#8266 twin states: `recharts`
+ * resolves inside `plugin-charts` alone, so this is the only package that can
+ * mock `ResponsiveContainer` to a measured box and count marks at all.
+ * (Re-verified rather than inherited: `require.resolve('recharts')` from
+ * `packages/plugin-dashboard` is MODULE_NOT_FOUND.)
+ *
+ * ## The baseline this reproduces, measured on `origin/main` `3c6394cb2`
+ *
+ * Rows `[{status:'open',count:2},{status:'paid',count:5}]`, `ChartRenderer` at
+ * 480x320:
+ *
+ *   xAxisKey 'status' + dataKey 'value' -> surface, ticks open/paid, 0 marks,
+ *     no refusal                                        (that is objectui#8266)
+ *   xAxisKey 'status' + dataKey 'count' -> 2 marks, y ticks 0..8
+ *                                                 (objectui#8266, after PR 8272)
+ *   xAxisKey 'name'   + dataKey 'value' -> refusal `missing-category-key`
+ *   xAxisKey 'name'   + dataKey 'count' -> refusal `missing-category-key`
+ *
+ * The LAST row is this card: the binding both relays composed for a
+ * `groupBy`-only widget, AFTER objectui#8266's fix had already corrected the
+ * measure. It is the one the second block below shows changing.
+ *
+ * ⚠️ Mark counts are harness-bound (`ResponsiveContainer` is fixed at 480x320
+ * here); they are re-derived in this file and never carried in from another.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+
+// Recharts measures via ResizeObserver, which reports 0x0 under the headless
+// DOM, so nothing paints. Fix its size — the shim every render test in this
+// package uses.
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: 480, height: 320 }),
+  };
+});
+
+// `ChartRenderer` reaches the component under test through
+// `React.lazy(() => import('./AdvancedChartImpl'))`. Importing the SAME
+// specifier at module scope puts that load in the import phase, where no test
+// or hook timeout applies (AGENTS.md, the flaky-test rule): under a saturated
+// transform pipeline a first dynamic import can spend most of a `waitFor`
+// budget, and this file's assertions would then be racing the module loader.
+import './AdvancedChartImpl';
+import { ChartRenderer } from './ChartRenderer';
+import { ObjectChart, aggregateRecords } from './ObjectChart';
+import { chartCategoryKey, chartMeasureKey } from '@object-ui/core';
+
+afterEach(cleanup);
+
+/**
+ * Not transcribed — produced by the very builder the row projection uses, so a
+ * change to the projected column names lands in this fixture instead of leaving
+ * the pin asserting against a shape the product stopped emitting.
+ */
+const COUNT_ROWS = aggregateRecords(
+  [
+    { status: 'open' }, { status: 'open' },
+    { status: 'paid' }, { status: 'paid' }, { status: 'paid' }, { status: 'paid' }, { status: 'paid' },
+  ],
+  { function: 'count', groupBy: 'status' },
+);
+
+/** The aggregate the card's widget declares — its category named ONCE, as groupBy. */
+const AGGREGATE = { function: 'count', groupBy: 'status' } as const;
+
+/** The two literal floors the relays used to bind unconditionally. */
+const CATEGORY_FLOOR = 'name';
+const MEASURE_FLOOR = 'value';
+
+const readChart = (container: HTMLElement) => ({
+  marks: container.querySelectorAll('.recharts-rectangle').length,
+  series: container.querySelectorAll('.recharts-bar').length,
+  refusal: container.querySelector('[data-chart-error]')?.getAttribute('data-chart-error') ?? null,
+  refusalText: container.querySelector('[data-chart-error]')?.textContent ?? null,
+  emptyState: !!screen.queryByTestId('chart-empty-state'),
+  ticks: Array.from(container.querySelectorAll('.recharts-cartesian-axis-tick-value')).map((n) => n.textContent),
+});
+
+/**
+ * Wait for a TERMINAL state — a plot or a refusal. Either satisfies it, so a
+ * refusal is never mistaken for a timeout and a timeout is never read as "it
+ * drew nothing".
+ */
+const settleChart = async (container: HTMLElement) => {
+  await waitFor(() => {
+    if (!container.querySelector('.recharts-surface') && !container.querySelector('[data-chart-error]')) {
+      throw new Error('neither a plot nor a refusal');
+    }
+  }, { timeout: 5000 });
+  return readChart(container);
+};
+
+const drawWith = async (xAxisKey: string, dataKey: string) => {
+  const { container } = render(
+    <ChartRenderer
+      schema={{
+        chartType: 'bar',
+        data: COUNT_ROWS,
+        xAxisKey,
+        series: [{ dataKey }],
+        isAnimationActive: false,
+      } as any}
+    />,
+  );
+  return settleChart(container);
+};
+
+describe('the cardized baseline: which (xAxisKey, dataKey) pairs draw (objectui#8269)', () => {
+  it('is the shape the row builder emits — the premise the rest of the file rests on', () => {
+    expect(COUNT_ROWS).toEqual([
+      { status: 'open', count: 2 },
+      { status: 'paid', count: 5 },
+    ]);
+  });
+
+  it('status/count — the only pair that draws', async () => {
+    const drawn = await drawWith('status', 'count');
+    expect(drawn.refusal).toBeNull();
+    expect(drawn.series).toBe(1);
+    expect(drawn.marks).toBe(2);
+    expect(drawn.ticks).toEqual(expect.arrayContaining(['open', 'paid', '0', '2', '4']));
+  });
+
+  it('status/value — objectui#8266: a frame with the categories on it and nothing in it', async () => {
+    const drawn = await drawWith('status', MEASURE_FLOOR);
+    expect(drawn.ticks).toEqual(['open', 'paid']);
+    expect(drawn.marks).toBe(0);
+    expect(drawn.refusal).toBeNull();
+    expect(drawn.emptyState).toBe(false);
+  });
+
+  it.each([MEASURE_FLOOR, 'count'])(
+    'name/%s — refused, and the message names the key the author never wrote',
+    async (dataKey) => {
+      const drawn = await drawWith(CATEGORY_FLOOR, dataKey);
+      expect(drawn.refusal).toBe('missing-category-key');
+      // The wrong-CAUSE half of the defect: `name` is named, `status` is not.
+      expect(drawn.refusalText).toContain(CATEGORY_FLOOR);
+      expect(drawn.refusalText).not.toContain('status');
+      expect(drawn.marks).toBe(0);
+    },
+  );
+});
+
+describe('the binding the relays compose now draws (objectui#8269)', () => {
+  // Computed by the very seam the relays call, not transcribed: if
+  // `chartCategoryKey` stops answering for this aggregate, this file measures
+  // the binding that actually ships rather than a stale copy of it.
+  const composedCategory = chartCategoryKey(AGGREGATE, CATEGORY_FLOOR);
+  const composedMeasure = chartMeasureKey(AGGREGATE, MEASURE_FLOOR);
+
+  it('resolves the pair away from BOTH literal floors', () => {
+    expect(composedCategory).toBe('status');
+    expect(composedMeasure).toBe('count');
+  });
+
+  it('draws marks where the pre-fix binding rendered a refusal', async () => {
+    // Before: (name, count) — the last row of the baseline table, a refusal.
+    const before = await drawWith(CATEGORY_FLOOR, composedMeasure);
+    expect(before.refusal).toBe('missing-category-key');
+    expect(before.marks).toBe(0);
+
+    cleanup();
+
+    // After: the pair the relays compose today.
+    const after = await drawWith(composedCategory, composedMeasure);
+    expect(after.refusal).toBeNull();
+    expect(after.series).toBe(1);
+    expect(after.marks).toBe(2);
+    expect(after.ticks).toEqual(expect.arrayContaining(['open', 'paid']));
+  });
+});
+
+/**
+ * The ordering question the card raises, MEASURED rather than reasoned about:
+ *
+ * > `resolveGroupByLabels` rewrites the groupBy column in place — check the
+ * > resolved key is still valid at the point the axis reads it.
+ *
+ * A resolver returning the right key is worthless if a later pass renames the
+ * column under it. This block runs the WHOLE `ObjectChart` fetch pipeline —
+ * `runAggregate` → comparison merge → `resolveGroupByLabels` → `ChartRenderer`
+ * → `AdvancedChartImpl` — against a data source whose groupBy field carries
+ * picklist options, so the label pass really fires. Marks drawn UNDER
+ * HUMANIZED TICKS is the two-in-one reading: the rewrite happened (the ticks
+ * are the labels, not the raw enum values) AND the resolved key survived it
+ * (had the column been renamed, `hasNoCategoryKey` would refuse instead).
+ */
+describe('the resolved key survives the groupBy label rewrite (objectui#8269)', () => {
+  const OBJECT_SCHEMA = {
+    fields: {
+      status: {
+        type: 'select',
+        options: [
+          { value: 'open', label: 'Open cases' },
+          { value: 'paid', label: 'Paid cases' },
+        ],
+      },
+    },
+  };
+
+  beforeEach(() => {
+    // `ObjectChart` probes object metadata for option colours on the global
+    // fetch. Answered from a double so the render is offline and deterministic.
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({}) })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('draws the marks with the LABELS on the axis, not a refusal', async () => {
+    const dataSource = {
+      aggregate: vi.fn(async () => COUNT_ROWS.map((row) => ({ ...row }))),
+      getObjectSchema: vi.fn(async () => OBJECT_SCHEMA),
+    };
+
+    const { container } = render(
+      <ObjectChart
+        schema={{
+          objectName: 'crm_case',
+          chartType: 'bar',
+          aggregate: { ...AGGREGATE },
+          // Exactly what the relays compose for this widget.
+          xAxisKey: chartCategoryKey(AGGREGATE, CATEGORY_FLOOR),
+          series: [{ dataKey: chartMeasureKey(AGGREGATE, MEASURE_FLOOR) }],
+          isAnimationActive: false,
+        } as any}
+        dataSource={dataSource as any}
+      />,
+    );
+
+    const drawn = await settleChart(container);
+    expect(dataSource.getObjectSchema).toHaveBeenCalled();
+    expect(drawn.refusal).toBeNull();
+    expect(drawn.marks).toBe(2);
+    // The label pass ran…
+    expect(drawn.ticks).toEqual(expect.arrayContaining(['Open cases', 'Paid cases']));
+    // …and it replaced the VALUES, never the column name — the raw enums are
+    // gone from the axis, and the axis still found its key.
+    expect(drawn.ticks).not.toContain('open');
+    expect(drawn.ticks).not.toContain('paid');
+  });
+});

--- a/packages/plugin-dashboard/src/DashboardGridLayout.tsx
+++ b/packages/plugin-dashboard/src/DashboardGridLayout.tsx
@@ -6,7 +6,7 @@ import { Edit, GripVertical, Save, X, RefreshCw } from 'lucide-react';
 import { SchemaRenderer, useHasDndProvider, useDnd } from '@object-ui/react';
 import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import type { BaseSchema, DashboardComponentSchema, DashboardWidgetSchema } from '@object-ui/types';
-import { chartMeasureKey } from '@object-ui/core';
+import { chartCategoryKey, chartMeasureKey } from '@object-ui/core';
 import { isObjectProvider, deriveStaticTableColumns } from './utils';
 import { classifyWidgetType } from './widgetDispatch';
 import { LEGACY_RETIRED_WIDGET_SCHEMA, isLegacyRetiredWidget } from './legacyRetiredWidget';
@@ -245,12 +245,22 @@ export const DashboardGridLayout: React.FC<DashboardGridLayoutProps> = ({
         // the floor for a provider with NO aggregate, whose rows are raw
         // records — there the author's `yField` really is the key.
         const effectiveYField = chartMeasureKey(effectiveAggregate, yField);
+        // Which column carries the CATEGORY is the same question on the other
+        // axis, and this relay was answering it with a literal it never checked
+        // against the aggregate that decides it: `xField || 'name'` bound
+        // `'name'` against the rows a `groupBy: 'status'` aggregate returns, so
+        // `hasNoCategoryKey` refused the widget by the name of a key its author
+        // never wrote (objectui#8269). `xAxisKey` survives as the floor for the
+        // shapes the contract has no answer for — a provider with NO aggregate
+        // (rows are raw records) and an UNGROUPED one (a single row with no
+        // category column at all).
+        const effectiveXAxisKey = chartCategoryKey(effectiveAggregate, xAxisKey);
         return {
           type: 'object-chart',
           chartType: dispatch.chartType,
           objectName: widgetData.object,
           aggregate: effectiveAggregate,
-          xAxisKey: xAxisKey,
+          xAxisKey: effectiveXAxisKey,
           series: [{ dataKey: effectiveYField }],
           colors: CHART_COLORS,
           // Deterministic first paint inside the grid (#2756).

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -16,6 +16,7 @@ import {
   buildWidgetScopedFilter,
   mergeFilters,
   toDomProps,
+  chartCategoryKey,
   chartMeasureKey,
 } from '@object-ui/core';
 import { cn, Card, CardHeader, CardTitle, CardContent, Button, getLazyIcon } from '@object-ui/components';
@@ -623,13 +624,20 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
                     // while the dataKey did not: the legend read "Count" over a
                     // plot with nothing in it.
                     const effectiveYField = chartMeasureKey(effectiveAggregate, yField);
+                    // The CATEGORY half of the same gap — see the twin site in
+                    // `DashboardGridLayout` and objectui#8269. `xField ||
+                    // 'name'` bound a literal against rows keyed by the raw
+                    // `groupBy` field, and the refusal that produced named
+                    // `name`: a wrong-CAUSE diagnostic, since nothing on screen
+                    // named the `groupBy` that was actually ignored.
+                    const effectiveXAxisKey = chartCategoryKey(effectiveAggregate, xAxisKey);
                     return {
                         type: 'object-chart',
                         chartType: resolvedWidgetType,
                         objectName: widgetData.object,
                         aggregate: effectiveAggregate,
                         filter: widgetData.filter || widget.filter,
-                        xAxisKey: xAxisKey,
+                        xAxisKey: effectiveXAxisKey,
                         series: [{
                             dataKey: effectiveYField,
                             label: resolveSeriesLabel(widgetData.object, effectiveYField, effectiveAggregate?.function),

--- a/packages/plugin-dashboard/src/__tests__/DashboardChart.categoryAxisKey-8269.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DashboardChart.categoryAxisKey-8269.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8269 — the CATEGORY-axis binding both dashboard relays compose for
+ * an object-bound aggregate. The mirror of
+ * `DashboardChart.countSeriesKey-8266.test.tsx`, which pins the SERIES binding
+ * of the same two sites.
+ *
+ * ## What was measured before the fix (origin/main `3c6394cb2`)
+ *
+ * A widget with `provider: 'object'` and `aggregate: { function: 'count',
+ * groupBy: 'status' }` and NO `options.xField` — a perfectly ordinary way to
+ * author a grouped chart — composed `xAxisKey: 'name'` on BOTH relays, because
+ * each floored the binding on a literal:
+ *
+ *     const xAxisKey = options.xField || 'name';
+ *
+ * The rows an object-bound aggregate returns are keyed by the raw `groupBy`
+ * field, so no row carries `name`, and `hasNoCategoryKey`
+ * (`plugin-charts/src/AdvancedChartImpl.tsx`, framework#4033) refused the
+ * widget with "no row has a `name` field" — a key the author never wrote,
+ * while the `groupBy` they DID write went unmentioned.
+ *
+ * The picture that produced, and the picture the fix produces, is measured in
+ * `plugin-charts/src/ObjectChart.categoryAxisKeyRender-8269.test.tsx`: a seam
+ * assertion cannot tell a refusal from a plot, and `recharts` resolves inside
+ * `plugin-charts` alone (verified: `require.resolve('recharts')` from
+ * `packages/plugin-dashboard` is MODULE_NOT_FOUND, since it is a dependency of
+ * `plugin-charts` and pnpm does not hoist it).
+ *
+ * ## Why the recorder rather than the real chart
+ *
+ * The decision under test is which column the RELAY names, and it is spelled
+ * twice — `DashboardGridLayout` and `DashboardRenderer` each compose their own
+ * `object-chart` node. Registering a recorder for the two component types those
+ * nodes resolve to reads exactly that, from the real render path, for both
+ * surfaces.
+ *
+ * ## All FOUR `xAxisKey` consumers are settled here, not two
+ *
+ * Each relay's single `xAxisKey` local feeds TWO composed nodes
+ * (`DashboardGridLayout.tsx` 253 + 268, `DashboardRenderer.tsx` 632 + 658 on
+ * `3c6394cb2`). They are NOT one decision spelled twice:
+ *
+ *   - the object-provider node (the first of each pair) is reached with an
+ *     aggregate in hand and is what this file's first block fixes;
+ *   - the authored-literal node (the second) is reached only AFTER
+ *     `isObjectProvider` returns false, for a widget whose rows are a literal
+ *     array the author wrote. There is no aggregate to consult and the
+ *     author's `xField` names a column of their own rows, so the floor is
+ *     CORRECT there and must stay — which the last block pins, in both
+ *     directions, so a future "unify the two" refactor cannot quietly break it.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+import { ComponentRegistry } from '@object-ui/core';
+import '@object-ui/components';
+// Registers the real `object-chart` / `chart` entries this file then overrides,
+// so the override is measured against the production registration order rather
+// than against an empty registry.
+import '@object-ui/plugin-charts';
+import '../index';
+import { DashboardRenderer } from '../DashboardRenderer';
+
+/** Every composed chart node the relays handed the renderer, in order. */
+const composed: any[] = [];
+
+const recorder = (props: any) => {
+  composed.push(props.schema ?? props);
+  return null;
+};
+for (const type of ['object-chart', 'chart'] as const) {
+  ComponentRegistry.register(type, recorder as any, {
+    namespace: 'test',
+    label: 'recorder',
+    category: 'plugin',
+  } as any);
+}
+
+afterEach(cleanup);
+
+const dataSource = { aggregate: async () => [], find: async () => [] };
+
+/** Render one widget through a relay and return the node it composed. */
+const composeVia = async (surface: 'grid' | 'renderer', widget: Record<string, unknown>) => {
+  composed.length = 0;
+  render(
+    <SchemaRendererProvider dataSource={dataSource}>
+      {surface === 'grid' ? (
+        <SchemaRenderer schema={{ type: 'dashboard-grid', widgets: [widget] } as any} />
+      ) : (
+        <DashboardRenderer schema={{ widgets: [widget] } as any} />
+      )}
+    </SchemaRendererProvider>,
+  );
+  await waitFor(() => expect(composed.length).toBeGreaterThan(0));
+  const node = composed[composed.length - 1];
+  cleanup();
+  return node;
+};
+
+/**
+ * The card's authoring shape: `options` carries NO `xField`, which is the whole
+ * point — the category is declared once, as `aggregate.groupBy`.
+ */
+const objectWidget = (aggregate: unknown, options: Record<string, unknown> = {}) => ({
+  id: 'w1',
+  type: 'bar',
+  title: 'By status',
+  options,
+  data: { provider: 'object', object: 'crm_case', ...(aggregate ? { aggregate } : {}) },
+});
+
+const SURFACES = ['grid', 'renderer'] as const;
+
+describe.each(SURFACES)('%s relay — object-bound category axis key (objectui#8269)', (surface) => {
+  it('binds a groupBy-only widget to the column the rows carry, not to the name floor', async () => {
+    const node = await composeVia(surface, objectWidget({ function: 'count', groupBy: 'status' }));
+    // The regression: 'name' here, against rows keyed 'status' — and unlike
+    // objectui#8266 this one was LOUD, refusing the whole widget.
+    expect(node.xAxisKey).toBe('status');
+  });
+
+  it('ignores an authored xField that an object-bound aggregate cannot project', async () => {
+    // `xField` names a column of the RECORDS, and a grouped aggregate does not
+    // return records. Honouring it refuses the chart for exactly the same
+    // reason 'name' did, so the aggregate's own column wins — the same verdict
+    // objectui#8266 reached for `yField`.
+    const node = await composeVia(
+      surface,
+      objectWidget({ function: 'count', groupBy: 'status' }, { xField: 'title' }),
+    );
+    expect(node.xAxisKey).toBe('status');
+  });
+
+  it('binds a field-bearing aggregate to its groupBy just the same', async () => {
+    const node = await composeVia(surface, objectWidget({ function: 'sum', field: 'amount', groupBy: 'stage' }));
+    expect(node.xAxisKey).toBe('stage');
+  });
+
+  it('reads a structured groupBy node, and prefers its alias', async () => {
+    // `ChartGroupBySchema` admits both spellings; `ObjectChart`'s own fetch path
+    // keys the returned rows `alias || field`, so the binding must agree.
+    expect(
+      (await composeVia(surface, objectWidget({ function: 'count', groupBy: { field: 'closed_at', dateGranularity: 'month' } })))
+        .xAxisKey,
+    ).toBe('closed_at');
+    expect(
+      (await composeVia(surface, objectWidget({ function: 'count', groupBy: { field: 'closed_at', alias: 'month' } })))
+        .xAxisKey,
+    ).toBe('month');
+  });
+
+  it('keeps the xField floor for an object provider with NO aggregate', async () => {
+    // Rows are raw records here, so the author's xField really is the key —
+    // this is the arm a floor that fired too eagerly would have broken.
+    expect((await composeVia(surface, objectWidget(null))).xAxisKey).toBe('name');
+    expect((await composeVia(surface, objectWidget(null, { xField: 'title' }))).xAxisKey).toBe('title');
+  });
+
+  it('keeps the xField floor for an UNGROUPED aggregate, which has no category column', async () => {
+    // One row, one number: there is no category for the contract to name, so
+    // inventing one would bind an axis to a column that never exists.
+    const agg = { function: 'sum', field: 'amount' };
+    expect((await composeVia(surface, objectWidget(agg))).xAxisKey).toBe('name');
+    expect((await composeVia(surface, objectWidget(agg, { xField: 'title' }))).xAxisKey).toBe('title');
+  });
+
+  it('still composes the object node, and still names the measure column', async () => {
+    // The category fix rides on the same site objectui#8266 fixed; asserting
+    // both halves here means a regression in either is attributed correctly
+    // rather than showing up as an unexplained shape change.
+    const node = await composeVia(surface, objectWidget({ function: 'count', groupBy: 'status' }));
+    expect(node.type).toBe('object-chart');
+    expect(node.series[0].dataKey).toBe('count');
+  });
+});
+
+describe.each(SURFACES)('%s relay — the authored-rows branch is NOT the same decision', (surface) => {
+  const literalWidget = (options: Record<string, unknown>) => ({
+    id: 'w2',
+    type: 'bar',
+    title: 'Literal',
+    options,
+    data: [
+      { name: 'open', value: 2, bucket: 'a' },
+      { name: 'paid', value: 5, bucket: 'b' },
+    ],
+  });
+
+  it('binds the authored xField, because there is no aggregate to consult', async () => {
+    expect((await composeVia(surface, literalWidget({}))).xAxisKey).toBe('name');
+    expect((await composeVia(surface, literalWidget({ xField: 'bucket' }))).xAxisKey).toBe('bucket');
+  });
+
+  it('composes the literal `chart` node, not `object-chart`', async () => {
+    // The branch discriminator itself: these rows never reach the object path,
+    // which is why consulting an aggregate there would be meaningless.
+    const node = await composeVia(surface, literalWidget({ xField: 'bucket' }));
+    expect(node.type).toBe('chart');
+    expect(node.aggregate).toBeUndefined();
+    expect(Array.isArray(node.data)).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #8269

## The defect

A dashboard chart widget bound to an object whose category is declared **only** as
`aggregate.groupBy` — no `options.xField` — rendered a refusal instead of a chart:

> This chart cannot plot its category axis: no row has a `name` field.

The author wrote `groupBy: 'status'`. Nothing on screen said `groupBy` was the key that
had been ignored, and `name` appeared nowhere in their metadata, so the diagnostic sent
them to debug the wrong layer.

Both dashboard relays floored the category binding on a literal and handed it to the
`object-chart` node without consulting the aggregate that decides it:

```
DashboardGridLayout.tsx:227   const xAxisKey = options.xField || 'name';
DashboardRenderer.tsx:608     const xAxisKey = options.xField || 'name';
```

An object-bound aggregate returns one row per group keyed by the raw `groupBy` field, so
no row carried `name` and `hasNoCategoryKey` (framework#4033) fired correctly on a binding
that was already wrong when it arrived.

## The fix — the mirror of the measure half

`chartCategoryKey` is a new `@object-ui/core` export delegating to
`chartAggregateCategoryKey` in `@objectstack/spec/ui` — the contract's own published
derivation of "the category column an object-bound aggregate produces", and the sibling of
the `chartAggregateValueKey` that the measure axis adopted in PR #8272. Before this change
that category sibling had **0** readers in this repository while its measure twin had 7.

Not a literal repaired in place, and not a second local resolver: the authority stays
upstream of this repo, exactly as PR #8272 put it.

## All FOUR `xAxisKey` consumers, settled — two changed, two deliberately not

Each relay's single `xAxisKey` local feeds two composed nodes. They are **not** one
decision spelled twice:

| site (post-change line) | branch | verdict |
|---|---|---|
| `DashboardGridLayout.tsx:263` | object provider | **changed** — resolves through `chartCategoryKey` |
| `DashboardGridLayout.tsx:278` | authored literal rows | **floor kept** — correct as-is |
| `DashboardRenderer.tsx:640` | object provider | **changed** — resolves through `chartCategoryKey` |
| `DashboardRenderer.tsx:666` | authored literal rows | **floor kept** — correct as-is |

The two literal-rows sites are reached only after `isObjectProvider` returns false, for a
widget whose rows are an array the author wrote. There is no aggregate to consult and the
author's `xField` names a column of their own rows, so the floor is right there — the same
split PR #8272's author found for the series binding. Both verdicts are pinned, in both
directions, so a future "unify the two" refactor cannot quietly break either.

`DatasetWidget.tsx` also produces an `xAxisKey`, from `buildChartSeries` on the ADR-0021
dataset path. Different shape, different authority, explicitly carved out of the
object-bound refusal — untouched.

## Render measurement, not only a seam assertion

The card set that bar on itself, so both tables below are measured through
`ChartRenderer` at 480x320 with `ResponsiveContainer` mocked, over the rows a fieldless
count actually returns — `[{status:'open',count:2},{status:'paid',count:5}]`, produced by
`aggregateRecords` rather than transcribed.

**Baseline reproduced** (the card's own 4-row table, re-measured on `3c6394cb2`):

| `xAxisKey` | `dataKey` | marks | series | refusal | ticks |
|---|---|--:|--:|---|---|
| `status` | `value` | 0 | 0 | none | open, paid |
| `status` | `count` | 2 | 1 | none | open, paid, 0, 2, 4, 6, 8 |
| `name` | `value` | 0 | 0 | `missing-category-key` naming `name` | none |
| `name` | `count` | 0 | 0 | `missing-category-key` naming `name` | none |

**After** — the same chain driven end to end through the real `ObjectChart` fetch
pipeline (`runAggregate` to comparison merge to `resolveGroupByLabels` to `ChartRenderer`),
against a data source whose `status` field carries picklist options:

| composed `xAxisKey` | marks | series | refusal | ticks |
|---|--:|--:|---|---|
| `name` (what both relays composed before) | 0 | 0 | `missing-category-key` naming `name` | none |
| `status` (what they compose now) | 2 | 1 | none | Open cases, Paid cases, 0, 2, 4, 6, 8 |

**Clause 2, stated plainly: a widget that renders a refusal today starts drawing.** That
is the whole user-visible change.

## The ordering trap the card named — measured, not reasoned about

> `resolveGroupByLabels` rewrites the groupBy column **in place** — check the resolved key
> is still valid at the point the axis reads it.

It is. `resolveGroupByLabels` replaces the **values** under the existing key
(`row[groupByField] = label`) and stashes the raw value beside them under
a side-channel key spelled `__raw_` immediately followed by that same key name; it never
renames the column. The last row of the "after" table is the
measurement rather than the argument: marks drawn **under humanized ticks** is a
two-in-one reading — the rewrite really ran (the ticks are "Open cases"/"Paid cases", not
the raw enums) **and** the resolved key survived it (had the column been renamed,
`hasNoCategoryKey` would have refused instead of drawing).

One thing worth recording: `ObjectChart` already derived the label pass's own key as
`groupBy.alias || groupBy.field` (or the bare string), i.e. the same derivation this seam
now shares. So the label pass was always keyed correctly; the pre-change defect was purely
in the axis binding beside it.

## Ablation — every new pin proven able to fail, and to discriminate

Both legs mutate on disk (`grep -cF` counted before and after, injected line printed),
restore by state (`git diff HEAD` empty and `git hash-object` equal to
`git rev-parse HEAD:PATH`), never by an exit code, and carry a `trap ... EXIT INT TERM`.

**Leg A — neuter the seam** (`chart-category-key.ts` body to `return fallback;`):
16 failed / 18 passed.

- `chart-category-key.test.ts`: 5 failed (the contract-answers block), **3 passed** (the
  caller-floor block — a floor-only implementation still satisfies those).
- `ObjectChart.categoryAxisKeyRender-8269.test.tsx`: 3 failed, **5 passed** — the baseline
  matrix block hard-codes its pairs and is unaffected, which is what makes it a baseline.
- `DashboardChart.categoryAxisKey-8269.test.tsx`: 8 failed (4 object arms x 2 surfaces),
  **10 passed** (both floor arms, both literal-rows arms, and the measure-key arm).

**Leg B — revert only the relay wiring** (`xAxisKey: effectiveXAxisKey` back to
`xAxisKey: xAxisKey` at both object sites): 8 failed / 26 passed, and **only the
`plugin-dashboard` seam file failed**. The core unit file and the `plugin-charts` render
file stayed fully green, so the seam file is what pins the relay wiring and is not
redundant with the other two.

A leg that reddens everything discriminates nothing; these two redden disjoint, predicted
sets.

## Verification

- `pnpm exec vitest run packages/core/ packages/plugin-dashboard/ packages/plugin-charts/`
  — 270 files, 3936 tests, all passed.
- `turbo run type-check` for `@object-ui/core`, `@object-ui/plugin-dashboard`,
  `@object-ui/plugin-charts` — 16 tasks, all successful (it builds the dependency closure
  first, so the new export is verified present in `packages/core/dist/`).
- `eslint --no-inline-config` on the seven changed files — exit 0, 27 warnings, all of the
  same classes the surrounding files already carry. `lint.yml` sets no `--max-warnings`.
- Gates run green: `check:control-bytes`, `check:unreferenced-sources`, `check:self-import`,
  `check:spec-symbols`, `check:phantom-deps`, `check:vi-mock-specifiers`,
  `check:vi-mock-inherit`, `check:side-effects-array`, `changeset:check`,
  `check-changeset-presence.mjs`.
- `check:governed-queue-guard --test` on all eight changed paths: NOT GOVERNED.
- Two gates could not be measured locally, both for a missing prerequisite rather than a
  finding, and CI supplies both: `check:readme-exports` (378 findings, every one
  "type entry `./dist/index.d.ts` is not on disk — run `pnpm build` first", none of them
  naming any file in this diff) and `check:eager-closure` (needs
  `apps/console/dist/eager-closure.json`; it reports itself as a broken gauge).

## Changeset

`.changeset/8269-dashboard-category-axis-groupby.md`, `patch` for the three packages whose
`src/` changed. No `major`, per the version-alignment rule.

## Scope

The measure axis (objectui#8266, PR #8272) is done and is not revisited here. The literal
floors at the `ListView` / `plugin-view ObjectView` / `app-shell ObjectView` faces belong
to objectui#7547 and are untouched, as objectui#8244 deliberately left them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_