### PR TITLE
fix(auth): workspace-admin reads the posture rung, not a name in positions[] (#8291)

### DIFF
--- a/.changeset/8291-workspace-admin-reads-the-rung.md
+++ b/.changeset/8291-workspace-admin-reads-the-rung.md
@@ -1,0 +1,38 @@
+---
+"@object-ui/auth": patch
+---
+
+`useWorkspaceAdminStatus` stops deriving platform-administrator standing from a NAME in the
+session's `positions[]`, and reads the ADR-0095 posture rung (`user.isPlatformAdmin`) instead.
+
+Framework objectstack#15948 (declared BREAKING) redefined that array: it used to be the
+`sys_user.role` scalar split on commas, and it is now built by `resolveUserAuthzGrants` from
+ADR-0057 D4 `sys_user_position` assignments. `sys_user_position` is `apiEnabled` with
+unconstrained `position` values, so a caller holding tenant-administration authority can mint a
+row spelling `platform_admin` for one of their own users — and the third leg of this hook, which
+scanned `positions[]` for any admin-sounding name, answered `true` for them. The server was
+already fixed (`platform-admin-gate.ts` dropped its positions leg and four evaluator sites moved
+to the rung), so what such a principal got was a Console painting platform-administrator surfaces
+while every underlying call was refused: misleading, in the direction that reveals platform
+structure to a tenant-controlled account.
+
+The array read is narrowed rather than deleted, name by name. `org_owner` and `org_admin` stay:
+`resolveUserAuthzGrants` emits exactly those from the ACTIVE organization's `sys_member.role`, a
+minted spelling of them claims authority inside the tenant that the minter already holds, and they
+are what lets a stamped tenant administrator resolve on the first frame (objectui#5619) instead of
+waiting for the member pipeline. `platform_admin` is dropped and replaced by the rung, which is
+byte-for-byte what the server's own `hasPlatformAdminStanding` returns. `owner`, `admin`,
+`super_admin`, `superadmin` and `system_admin` are dropped from the array read too — no server
+derivation emits any of them into `positions[]` (the membership leg normalizes `owner`/`admin` to
+`org_*` first), so a hit could only ever have been a tenant-written row. All five remain valid for
+the two scalar legs, where they are the raw membership role and the stored `user.role`.
+
+The docblock that argued AGAINST reading `user.isPlatformAdmin` — on the grounds that the server
+computed it as `'platform_admin' in positions`, "two spellings for one fact" — is rewritten rather
+than left standing. After #15948 the flag derives from the unscoped `admin_full_access` grant and
+the array does not, so they can disagree and the rung is right.
+
+No behaviour changes for a genuine administrator: a platform administrator on a single-tenant
+deployment still resolves through the flag (objectui#5389 stays green), a tenant administrator
+still resolves through the member row and through `org_owner`/`org_admin`, and the objectui#5619
+`isResolved` semantics are unchanged. Pinned by `__tests__/workspaceAdminRung-8291.test.tsx`.

--- a/packages/auth/src/__tests__/workspaceAdminRung-8291.test.tsx
+++ b/packages/auth/src/__tests__/workspaceAdminRung-8291.test.tsx
@@ -1,0 +1,375 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8291 — `useWorkspaceAdminStatus` may not read platform authority
+ * out of a NAME in `user.positions[]`.
+ *
+ * ## What changed under the hook
+ *
+ * Framework objectstack#15948 (declared BREAKING) redefined `positions[]`. It
+ * used to be the `sys_user.role` scalar split on commas; it is now built by
+ * `resolveUserAuthzGrants` and carries ADR-0057 D4 `sys_user_position`
+ * assignments. That table is `apiEnabled` with unconstrained `position`
+ * values, so a caller holding tenant-administration authority can mint a row
+ * spelling `platform_admin` for one of their own users, and the name lands on
+ * the session payload verbatim.
+ *
+ * The server's posture rung did NOT move with it: `customSession` sets
+ * `isPlatformAdmin` from `grants.posture === 'PLATFORM_ADMIN'`, which derives
+ * from an unscoped `admin_full_access` grant and nothing else. So the flag and
+ * the array can now disagree, and `resolve-authz-context.ts` says which one
+ * wins at `hasPlatformAdminStanding`: read the RUNG, never
+ * `positions.includes('platform_admin')`. The framework moved four server-side
+ * sites onto that rule; this file pins the client-side one.
+ *
+ * ## What each half of this file is for
+ *
+ * The FIRST describe is the defect: a payload that is exactly what a minted
+ * row produces — the name present, the rung false — must not yield
+ * `isAdmin: true`. It fails against the pre-#8291 hook.
+ *
+ * The SECOND and THIRD describes are the substitution guards, and they matter
+ * as much. The obvious "fix" for this card is to delete the array leg, which
+ * would regress objectui#5389 (a platform administrator on a single-tenant
+ * deployment has no member row and no admin scalar) and objectui#5619 (a
+ * tenant administrator whose session carries the org stamp resolves on the
+ * first frame instead of waiting for the member pipeline). Those two are
+ * pinned in their own files; what is pinned HERE is the narrower claim that
+ * distinguishes the real fix from the deletion — that the verdict for a
+ * platform administrator now comes from the FLAG, and that the two
+ * tenant-scoped names survive.
+ *
+ * The FOURTH describe walks the names that were dropped from the array
+ * vocabulary one at a time, because the decision was made name by name and a
+ * later reader is owed the record of it rather than a single set literal.
+ *
+ * These render the REAL `AuthProvider` against a client double, in the manner
+ * of `workspaceAdminPositions-5389.test.tsx`. A mocked `useAuth` could only
+ * restate the fixture; going through the provider measures the path the
+ * console actually takes from wire payload to boolean.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AuthProvider } from '../AuthProvider';
+import { useAuth } from '../useAuth';
+import { useWorkspaceAdminStatus } from '../useWorkspaceAdminStatus';
+import type { AuthClient, AuthUser } from '../types';
+
+const ORG = { id: 'org_1', name: 'Acme', slug: 'acme' };
+
+/**
+ * THE DEFECT'S PAYLOAD.
+ *
+ * An ordinary member of a tenant, for whom a `sys_user_position` row spelling
+ * `platform_admin` has been minted. Every field is what the server really
+ * emits for that principal:
+ *
+ *   - `positions` carries the minted name, because `resolveUserAuthzGrants`
+ *     pushes `sys_user_position.position` values through verbatim;
+ *   - `isPlatformAdmin` is FALSE, because the posture rung reads the unscoped
+ *     `admin_full_access` grant and this principal holds none;
+ *   - `role` stays better-auth's default, because the server no longer
+ *     overwrites it.
+ *
+ * Note what the array does NOT let a client see: `resolveUserAuthzGrants`
+ * pushes the built-in `platform_admin` only when it is not already present, so
+ * a genuine administrator and this principal produce a byte-identical
+ * `positions`. The array cannot answer this question; only the flag can.
+ */
+const TENANT_MINTED_PLATFORM_ADMIN = {
+  name: 'Minted Admin',
+  email: 'minted@tenant.example.com',
+  emailVerified: true,
+  image: null,
+  role: 'user',
+  id: 'u_minted',
+  positions: ['user', 'everyone', 'org_member', 'platform_admin'],
+  isPlatformAdmin: false,
+} as unknown as AuthUser;
+
+/**
+ * The genuine article, for contrast: the same shape with the rung set. This is
+ * the objectui#5389 deployment (single-tenant, adminship from the
+ * `admin_full_access` permission set) and its `isPlatformAdmin: true` is
+ * verbatim from the payload captured live there.
+ */
+const GENUINE_PLATFORM_ADMIN = {
+  name: 'PermSet Admin',
+  email: 'psadmin@example.com',
+  emailVerified: false,
+  image: null,
+  role: 'user',
+  id: 'u_genuine',
+  positions: ['user', 'platform_admin'],
+  isPlatformAdmin: true,
+} as unknown as AuthUser;
+
+function createMockClient(user: AuthUser, overrides: Partial<AuthClient> = {}): AuthClient {
+  return {
+    getSession: vi.fn().mockResolvedValue({ user, session: { token: 'tok-8291' } }),
+    signOut: vi.fn().mockResolvedValue(undefined),
+    listOrganizations: vi.fn().mockResolvedValue([]),
+    getActiveOrganization: vi.fn().mockResolvedValue(null),
+    setActiveOrganization: vi.fn().mockResolvedValue(null),
+    getActiveMember: vi.fn().mockResolvedValue(null),
+    ...overrides,
+  } as unknown as AuthClient;
+}
+
+/** The tenant the minted row lives in: an org whose member row says `member`. */
+function withOrdinaryMembership(userId: string): Partial<AuthClient> {
+  return {
+    listOrganizations: vi.fn().mockResolvedValue([ORG]),
+    getActiveOrganization: vi.fn().mockResolvedValue(ORG),
+    getActiveMember: vi.fn().mockResolvedValue({
+      id: 'mem_8291',
+      organizationId: ORG.id,
+      userId,
+      role: 'member',
+    }),
+  } as unknown as Partial<AuthClient>;
+}
+
+function AdminProbe() {
+  const { isAdmin, isResolved } = useWorkspaceAdminStatus();
+  const { user, activeMember, isMembershipResolved } = useAuth();
+  return (
+    <div>
+      <span data-testid="is-admin">{String(isAdmin)}</span>
+      <span data-testid="is-resolved">{String(isResolved)}</span>
+      <span data-testid="membership-resolved">{String(isMembershipResolved)}</span>
+      <span data-testid="user-id">{user?.id ?? 'none'}</span>
+      <span data-testid="member-role">{activeMember?.role ?? 'none'}</span>
+    </div>
+  );
+}
+
+const verdict = () => ({
+  isAdmin: screen.getByTestId('is-admin').textContent,
+  isResolved: screen.getByTestId('is-resolved').textContent,
+});
+
+/**
+ * Mount, wait for the session to have LANDED, and return the verdict.
+ *
+ * The wait is on the session's `user` arriving, never on the verdict itself:
+ * waiting for the verdict would make every negative case pass instantly
+ * against the pre-session state, where `user` is null and the answer is
+ * `false` for a reason that has nothing to do with what is being asserted.
+ */
+async function mountAndRead(
+  client: AuthClient,
+  opts: { expectMember?: string } = {},
+): Promise<string> {
+  render(
+    <AuthProvider authUrl="/api/v1/auth" client={client}>
+      <AdminProbe />
+    </AuthProvider>,
+  );
+  await waitFor(() => {
+    expect(screen.getByTestId('user-id').textContent).not.toBe('none');
+  });
+  if (opts.expectMember) {
+    await waitFor(() => {
+      expect(screen.getByTestId('member-role').textContent).toBe(opts.expectMember);
+    });
+  }
+  return screen.getByTestId('is-admin').textContent ?? '';
+}
+
+/** A session carrying exactly one extra `positions` entry and no other change. */
+function memberWithMintedPosition(position: string): AuthUser {
+  return {
+    name: 'Minted',
+    email: 'minted@tenant.example.com',
+    role: 'user',
+    id: `u_${position}`,
+    positions: ['user', 'everyone', 'org_member', position],
+    isPlatformAdmin: false,
+  } as unknown as AuthUser;
+}
+
+describe('useWorkspaceAdminStatus — a NAME in positions[] is not platform authority (#8291)', () => {
+  describe('the defect', () => {
+    it('a tenant-minted `platform_admin` with no `admin_full_access` grant does NOT confer admin', async () => {
+      const client = createMockClient(
+        TENANT_MINTED_PLATFORM_ADMIN,
+        withOrdinaryMembership('u_minted'),
+      );
+
+      expect(await mountAndRead(client, { expectMember: 'member' })).toBe('false');
+    });
+
+    it('the same payload on an org-less session does NOT confer admin either', async () => {
+      // Leg 1 cannot even be consulted here, so this isolates the array read
+      // from the membership row entirely.
+      expect(await mountAndRead(createMockClient(TENANT_MINTED_PLATFORM_ADMIN))).toBe('false');
+    });
+
+    it('the fixture really is the contradiction it claims to be', () => {
+      // Guards the fixture: if someone "tidies" it so the name and the flag
+      // agree, the two cases above stop measuring anything at all.
+      expect(TENANT_MINTED_PLATFORM_ADMIN.positions).toContain('platform_admin');
+      expect(TENANT_MINTED_PLATFORM_ADMIN.isPlatformAdmin).toBe(false);
+    });
+  });
+
+  describe('the replacement signal is the posture rung, not the name', () => {
+    it('a genuine platform administrator (rung set) still reads as admin', async () => {
+      // objectui#5389's viewer: no member row, `role` left at `user`. This is
+      // the case the naive "just delete the array leg" fix regresses.
+      expect(await mountAndRead(createMockClient(GENUINE_PLATFORM_ADMIN))).toBe('true');
+    });
+
+    it('the verdict follows the FLAG when the flag and the array disagree', async () => {
+      // The discrimination probe, and deliberately synthetic: today's server
+      // pushes the built-in name onto the array whenever the rung is set, so
+      // this exact payload is not one a shipping server emits. It is here
+      // because it is the only shape that can tell "read the flag" apart from
+      // "read the name" — the two agree on every other input, including both
+      // fixtures above.
+      const rungOnly = {
+        name: 'Rung Only',
+        email: 'rung@example.com',
+        role: 'user',
+        id: 'u_rung',
+        positions: ['user', 'everyone'],
+        isPlatformAdmin: true,
+      } as unknown as AuthUser;
+
+      expect(await mountAndRead(createMockClient(rungOnly))).toBe('true');
+    });
+
+    it('a session that publishes no `isPlatformAdmin` key at all admits nobody', async () => {
+      // Fail closed: the read is `=== true`, so an absent flag is "no platform
+      // standing" rather than a truthy unknown.
+      const noFlag = {
+        name: 'Old Server',
+        email: 'old@example.com',
+        role: 'user',
+        id: 'u_noflag',
+        positions: ['user', 'everyone'],
+      } as unknown as AuthUser;
+
+      expect(await mountAndRead(createMockClient(noFlag))).toBe('false');
+    });
+  });
+
+  describe('the tenant-scoped names survive — leg 3b was narrowed, not deleted', () => {
+    // These two are what `resolveUserAuthzGrants` derives from the ACTIVE
+    // organization's `sys_member.role` via `mapMembershipRole`. They are the
+    // reason objectui#5619's stamped tenant administrator resolves on the
+    // first frame, and a fix that deleted the array read would silently take
+    // that away — leaving them to wait on the member pipeline.
+    for (const position of ['org_owner', 'org_admin']) {
+      it(`\`${position}\` in positions still confers admin with the org pipeline still open`, async () => {
+        const stamped = {
+          name: 'Stamped Owner',
+          email: 'owner@example.com',
+          role: 'user',
+          id: `u_${position}`,
+          positions: ['user', 'everyone', position],
+          isPlatformAdmin: false,
+        } as unknown as AuthUser;
+
+        // `listOrganizations` never settles: if the verdict needed leg 1 this
+        // would hang at `false`.
+        const client = createMockClient(stamped, {
+          listOrganizations: vi.fn().mockReturnValue(new Promise(() => {})),
+          getActiveOrganization: vi.fn().mockReturnValue(new Promise(() => {})),
+        } as unknown as Partial<AuthClient>);
+
+        expect(await mountAndRead(client)).toBe('true');
+        expect(verdict()).toEqual({ isAdmin: 'true', isResolved: 'true' });
+        expect(screen.getByTestId('membership-resolved').textContent).toBe('false');
+      });
+    }
+  });
+
+  describe('the names dropped from the array vocabulary, one at a time', () => {
+    // Each of these was in `ADMIN_ROLES` and was honoured wherever it appeared
+    // in `positions[]`. None of them is emitted into that array by any server
+    // derivation: the membership leg normalizes `owner`/`admin` to `org_*`
+    // first, and `super_admin` / `superadmin` / `system_admin` are not
+    // built-in identity names in any framework vocabulary. So a hit could only
+    // ever have been a `sys_user_position` row — all exposure, no signal.
+    //
+    // They remain valid for legs 1 and 2, where they are the raw membership
+    // role and the stored `user.role` scalar; the case below each proves the
+    // narrowing did not reach those legs.
+    for (const position of ['platform_admin', 'super_admin', 'superadmin', 'system_admin', 'owner', 'admin']) {
+      it(`a minted \`${position}\` in positions does NOT confer admin`, async () => {
+        expect(await mountAndRead(createMockClient(memberWithMintedPosition(position)))).toBe('false');
+      });
+    }
+
+    it('but the same names on the MEMBER ROW (leg 1) still confer admin', async () => {
+      const plain = {
+        id: 'u_leg1', name: 'Leg One', email: 'leg1@example.com',
+        role: 'user', positions: ['user', 'everyone'], isPlatformAdmin: false,
+      } as unknown as AuthUser;
+      const client = createMockClient(plain, {
+        listOrganizations: vi.fn().mockResolvedValue([ORG]),
+        getActiveOrganization: vi.fn().mockResolvedValue(ORG),
+        getActiveMember: vi.fn().mockResolvedValue({
+          id: 'mem_leg1', organizationId: ORG.id, userId: 'u_leg1', role: 'owner',
+        }),
+      } as unknown as Partial<AuthClient>);
+
+      expect(await mountAndRead(client, { expectMember: 'owner' })).toBe('true');
+    });
+
+    it('and the same names on the `user.role` SCALAR (leg 2) still confer admin', async () => {
+      const scalarAdmin = {
+        id: 'u_leg2', name: 'Leg Two', email: 'leg2@example.com',
+        role: 'admin', positions: ['user', 'everyone'], isPlatformAdmin: false,
+      } as unknown as AuthUser;
+
+      expect(await mountAndRead(createMockClient(scalarAdmin))).toBe('true');
+    });
+  });
+
+  describe('objectui#5619 `isResolved` semantics are untouched', () => {
+    it('the minted principal settles to resolved-and-not-admin, never a permanent pending', async () => {
+      // The other way to make the defect case green is to answer
+      // `isResolved: false` forever, which holds every gate open instead of
+      // closing it. That reads as "still loading" to every caller and is not a
+      // fix; this is the case that fails for it.
+      const client = createMockClient(
+        TENANT_MINTED_PLATFORM_ADMIN,
+        withOrdinaryMembership('u_minted'),
+      );
+
+      render(
+        <AuthProvider authUrl="/api/v1/auth" client={client}>
+          <AdminProbe />
+        </AuthProvider>,
+      );
+
+      await waitFor(() => {
+        expect(verdict()).toEqual({ isAdmin: 'false', isResolved: 'true' });
+      });
+    });
+
+    it('a genuine platform administrator is resolved on the first frame, pipeline still open', async () => {
+      // The cost measurement objectui#5619 records for leg 3, carried over to
+      // the rung: this viewer never waits on the membership pipeline.
+      const client = createMockClient(GENUINE_PLATFORM_ADMIN, {
+        listOrganizations: vi.fn().mockReturnValue(new Promise(() => {})),
+        getActiveOrganization: vi.fn().mockReturnValue(new Promise(() => {})),
+      } as unknown as Partial<AuthClient>);
+
+      expect(await mountAndRead(client)).toBe('true');
+      expect(verdict()).toEqual({ isAdmin: 'true', isResolved: 'true' });
+      expect(screen.getByTestId('membership-resolved').textContent).toBe('false');
+    });
+  });
+});

--- a/packages/auth/src/useWorkspaceAdminStatus.ts
+++ b/packages/auth/src/useWorkspaceAdminStatus.ts
@@ -8,6 +8,20 @@
 
 import { useAuth } from './useAuth.js';
 
+/**
+ * The vocabulary of the two SCALAR legs — a membership row's `role` (leg 1)
+ * and the stored `user.role` (leg 2).
+ *
+ * Both are single values written by a path the tenant does not control: leg 1
+ * is better-auth's `sys_member.role`, capped at the issuer's own grade on
+ * every issuance path; leg 2 is `sys_user.role`, which framework ADR-0092 D2's
+ * identity write guard refuses under a user context. A name found in either is
+ * therefore evidence.
+ *
+ * ⛔ This set is NOT the vocabulary for `user.positions[]` — see
+ * {@link ADMIN_POSITION_NAMES} for the narrower one that leg 3b uses, and the
+ * hook's docblock for why the two had to be separated (objectui#8291).
+ */
 const ADMIN_ROLES = new Set([
   'owner',
   'admin',
@@ -15,23 +29,65 @@ const ADMIN_ROLES = new Set([
   'superadmin',
   'platform_admin',
   'system_admin',
-  // ADR-0068 canonical names, emitted into `user.positions[]` by the server's
-  // customSession (raw better-auth owner/admin are normalized to org_owner/
-  // org_admin). Accept both raw and canonical so admin detection survives the
-  // removal of the `user.role = 'admin'` overwrite footgun.
+  // ADR-0068 canonical names. `mapMembershipRole` normalizes raw better-auth
+  // owner/admin to org_owner/org_admin before they reach a session payload, so
+  // a membership role can arrive here in either spelling depending on which
+  // surface produced it. Accept both so admin detection survives the removal
+  // of the `user.role = 'admin'` overwrite footgun.
   'org_owner',
   'org_admin',
 ]);
 
 /**
- * One name from any of the three sources below — a membership role, the stored
- * `user.role` scalar, or an entry of `user.positions[]`. The three draw on one
- * vocabulary by design (ADR-0068 D2 maps a membership `owner`/`admin` onto the
- * canonical `org_owner`/`org_admin` that `positions[]` carries), so one
- * predicate serves all three.
+ * The vocabulary of leg 3b — the only names honoured when found in
+ * `user.positions[]`.
+ *
+ * Deliberately NOT {@link ADMIN_ROLES}. `positions[]` is a tenant-WRITABLE
+ * array (see the hook's docblock), so the question for each name is not "does
+ * it sound like an admin" but "does a trusted server derivation ever put it
+ * here". Decided name by name in objectui#8291:
+ *
+ *  - `org_owner`, `org_admin` — KEPT. `resolveUserAuthzGrants` emits exactly
+ *    these from the ACTIVE organization's `sys_member.role` through
+ *    `mapMembershipRole`, so a hit is usually the real membership row arriving
+ *    ahead of leg 1. A `sys_user_position` row CAN also spell them, but that
+ *    row is written by a caller who already holds tenant-administration
+ *    authority over the same organization (framework `DelegatedAdminGate`), so
+ *    what they mint is a second spelling of an authority they have — not a
+ *    crossing of any boundary. This is also the framework's own line: its
+ *    four-site sweep left every TENANT_ADMIN arm untouched and moved only the
+ *    platform ones.
+ *  - `platform_admin` — DROPPED, and replaced by leg 3a. It is the name a
+ *    tenant can mint to claim authority it does not have, and the array cannot
+ *    tell a minted one from a genuine one: `resolveUserAuthzGrants` pushes the
+ *    built-in name only when it is not already present, so both cases produce
+ *    a byte-identical array.
+ *  - `owner`, `admin`, `super_admin`, `superadmin`, `system_admin` — DROPPED.
+ *    No server derivation emits any of them into `positions[]` at all: the
+ *    membership leg normalizes `owner`/`admin` to `org_*` first, and the other
+ *    three are not built-in identity names in any framework vocabulary. A hit
+ *    on one could therefore ONLY be a `sys_user_position` row — all exposure,
+ *    no signal. They stay in {@link ADMIN_ROLES}, where they are the raw
+ *    scalars legs 1 and 2 legitimately read.
+ */
+const ADMIN_POSITION_NAMES = new Set([
+  'org_owner',
+  'org_admin',
+]);
+
+/**
+ * One name from either SCALAR source — a membership role or the stored
+ * `user.role` scalar. The two draw on one vocabulary by design (ADR-0068 D2
+ * maps a membership `owner`/`admin` onto the canonical `org_owner`/`org_admin`
+ * that {@link ADMIN_ROLES} also carries), so one predicate serves both.
  */
 function isAdminRole(role: unknown): boolean {
   return typeof role === 'string' && ADMIN_ROLES.has(role.toLowerCase());
+}
+
+/** One entry of `user.positions[]`, judged against the narrower vocabulary. */
+function isAdminPosition(position: unknown): boolean {
+  return typeof position === 'string' && ADMIN_POSITION_NAMES.has(position.toLowerCase());
 }
 
 /**
@@ -42,7 +98,7 @@ function isAdminRole(role: unknown): boolean {
  */
 export interface WorkspaceAdminStatus {
   /**
-   * True only when adminship is CONFIRMED by one of the three legs below.
+   * True only when adminship is CONFIRMED by one of the legs below.
    * While `isResolved` is false this is `false` because nothing has said
    * otherwise yet — NOT because the viewer is known not to be an admin.
    */
@@ -60,29 +116,76 @@ export interface WorkspaceAdminStatus {
  * has finished resolving.
  *
  * Sources considered (any one is sufficient):
- *  - The active organization member row (multi-tenant mode).
- *  - The top-level `user.role` scalar from the session — legacy deployments
- *    that still store an admin role on the user row.
- *  - `user.positions[]` from the session — the canonical identity/position
- *    names the server derives (ADR-0068 D1/D2, renamed from `roles` by
- *    ADR-0090 D3). This is the ONLY leg that sees a platform administrator
- *    whose adminship comes from the `admin_full_access` permission set: on a
- *    single-tenant deployment there is no member row to read (leg 1), and the
- *    server deliberately no longer overwrites `user.role` (leg 2), so
- *    `positions` carrying `platform_admin` is the whole signal. Measured on a
- *    live protocol-17 server in objectui#5389; pinned by
+ *  - LEG 1 — the active organization member row (multi-tenant mode).
+ *  - LEG 2 — the top-level `user.role` scalar from the session: legacy
+ *    deployments that still store an admin role on the user row.
+ *  - LEG 3a — `user.isPlatformAdmin` from the session: the server's ADR-0095
+ *    posture RUNG, and the ONLY leg that sees a platform administrator whose
+ *    adminship comes from the `admin_full_access` permission set. On a
+ *    single-tenant deployment there is no member row to read (leg 1) and the
+ *    server deliberately no longer overwrites `user.role` (leg 2), so this
+ *    flag is the whole signal for that viewer. Measured on a live protocol-17
+ *    server in objectui#5389 — the captured payload there carries
+ *    `isPlatformAdmin: true` — and pinned by
  *    `__tests__/workspaceAdminPositions-5389.test.tsx`.
+ *  - LEG 3b — `user.positions[]` from the session, judged against
+ *    {@link ADMIN_POSITION_NAMES} rather than {@link ADMIN_ROLES}: the
+ *    canonical TENANT-scoped identity names the server derives from the active
+ *    organization's membership row (ADR-0068 D1/D2, renamed from `roles` by
+ *    ADR-0090 D3). This is what lets a tenant administrator resolve on the
+ *    first frame instead of waiting for leg 1 (see the objectui#5619 section
+ *    below).
  *
- * `positions` is the ONE published spelling. It is deliberately not read
- * alongside the retired `roles` (ADR-0090 D3 renamed with no deprecation
- * window and bans resurrecting the old name as a fallback), and not alongside
- * the derived `user.isPlatformAdmin` either — that flag is computed by the
- * server as `'platform_admin' in positions` from the same expression, so
- * reading both would be two spellings for one fact with no way to disagree
- * usefully and every way to drift.
+ * ## Why 3a and 3b are two legs and not one (objectui#8291)
  *
- * In preview-mode / no-auth-enabled mode the provider seeds an admin user,
- * so this returns `isAdmin: true` for dev/demo setups.
+ * This docblock used to argue the opposite, and a future reader who finds that
+ * argument standing will re-introduce the defect it now describes. It said:
+ * do not read `user.isPlatformAdmin` alongside `positions`, because the server
+ * computes the flag as `'platform_admin' in positions` from the same
+ * expression, so reading both would be two spellings for one fact with no way
+ * to disagree usefully and every way to drift.
+ *
+ * **That was true and it is now false.** Framework objectstack#15948 (a
+ * declared BREAKING change) redefined what `positions[]` IS. It used to be the
+ * `sys_user.role` scalar split on commas; it is now built by
+ * `resolveUserAuthzGrants` and carries ADR-0057 D4 `sys_user_position`
+ * assignments. That table is `apiEnabled` and its `position` values are
+ * unconstrained, so a caller holding tenant-administration authority can mint
+ * a row spelling `platform_admin` for one of their own users — and the name
+ * lands on `positions[]` verbatim.
+ *
+ * The two therefore no longer say one thing:
+ *
+ *  - `isPlatformAdmin` is `grants.posture === 'PLATFORM_ADMIN'` — derived from
+ *    an UNSCOPED `admin_full_access` grant (or a verified email on the
+ *    deployment's declared administrator list) and from nothing else. It is
+ *    byte-for-byte what the server's own `hasPlatformAdminStanding` returns.
+ *  - `positions[]` is the security AXIS, which is a wider thing: it is the set
+ *    of names a request resolves to, including names a tenant wrote.
+ *
+ * They can now disagree, and when they do **the rung is right** — enforcement
+ * agrees with the rung, so the array's extra name buys nothing except a
+ * Console that paints platform-administrator surfaces at a principal every
+ * underlying call refuses. `resolve-authz-context.ts` states the rule at
+ * `hasPlatformAdminStanding`: read the RUNG, never
+ * `positions.includes('platform_admin')`. The framework moved four server-side
+ * sites onto it (`plugin-sharing`, `plugin-approvals`, `plugin-security`,
+ * `runtime`); this hook is the same read on the client side of the wire.
+ *
+ * ⛔ So: never put `platform_admin` back into {@link ADMIN_POSITION_NAMES},
+ * and never widen leg 3b back to {@link ADMIN_ROLES}. The name is not the
+ * authority. Every server that publishes `positions` publishes
+ * `isPlatformAdmin` beside it — `customSession` returns them in one object
+ * literal — so nothing is lost by reading the narrow one.
+ *
+ * `positions` also remains the ONE published spelling of the array itself. It
+ * is deliberately not read alongside the retired `roles` (ADR-0090 D3 renamed
+ * with no deprecation window and bans resurrecting the old name as a
+ * fallback).
+ *
+ * In preview-mode / no-auth-enabled mode the provider seeds an admin user
+ * (`role: 'admin'`, which leg 2 reads), so this returns `isAdmin: true` for
+ * dev/demo setups.
  *
  * ## Why this returns a pair and not a boolean (objectui#5619)
  *
@@ -98,18 +201,20 @@ export interface WorkspaceAdminStatus {
  * console chrome dropped and re-added a nav entry, and `AppContent` fired a
  * `<Navigate to="/home" replace>` that the later flip cannot undo.
  *
- * Legs 2 and 3 DO cover that viewer whenever the session was minted with an
+ * Legs 2 and 3b DO cover that viewer whenever the session was minted with an
  * active organization stamped on it — framework `auth-manager.ts` reads
  * `session.activeOrganizationId` and, when it is set, maps the member row into
- * `positions[]` as `org_owner`/`org_admin`. The window is therefore not "every
- * tenant admin" as first reported, but "every session that reaches the console
- * without that stamp", which is exactly the path `refreshOrganizations`'
- * ADR-0081 repair exists to serve.
+ * `positions[]` as `org_owner`/`org_admin`. Those two names are exactly why
+ * objectui#8291 kept leg 3b alive rather than deleting the array read
+ * outright. The window is therefore not "every tenant admin" as first
+ * reported, but "every session that reaches the console without that stamp",
+ * which is exactly the path `refreshOrganizations`' ADR-0081 repair exists to
+ * serve.
  *
  * `isResolved` is deliberately true the moment `isAdmin` is true: a confirmed
  * admin is a final answer, and the legs still in flight can only agree with it.
  * Callers therefore never wait on a verdict they already have — an admin
- * detected through `positions` pays nothing for this gate.
+ * detected through the rung or through `positions` pays nothing for this gate.
  */
 export function useWorkspaceAdminStatus(): WorkspaceAdminStatus {
   const { activeMember, user, isLoading, isMembershipResolved } = useAuth();
@@ -118,13 +223,16 @@ export function useWorkspaceAdminStatus(): WorkspaceAdminStatus {
   const isAdmin =
     isAdminRole(activeMember?.role) ||
     isAdminRole(user?.role) ||
-    (Array.isArray(positions) && positions.some(isAdminRole));
+    // Leg 3a — `=== true` on purpose. A session that never published the flag
+    // must read as "no platform standing", not as a truthy unknown.
+    user?.isPlatformAdmin === true ||
+    (Array.isArray(positions) && positions.some(isAdminPosition));
 
   if (isAdmin) return { isAdmin: true, isResolved: true };
 
-  // Legs 2 and 3 are settled once the session has landed (`isLoading`); leg 1
-  // is settled once the organization/member pipeline has reached a terminal
-  // state (`isMembershipResolved`). Both, because a viewer can be an admin
-  // through either.
+  // Legs 2, 3a and 3b are settled once the session has landed (`isLoading`);
+  // leg 1 is settled once the organization/member pipeline has reached a
+  // terminal state (`isMembershipResolved`). Both, because a viewer can be an
+  // admin through either.
   return { isAdmin: false, isResolved: !isLoading && isMembershipResolved };
 }


### PR DESCRIPTION
Fixes #8291

`useWorkspaceAdminStatus`'s third leg scanned `user.positions[]` for any admin-sounding name.
Framework objectstack#15948 (declared BREAKING) redefined that array: it used to be the
`sys_user.role` scalar split on commas, and it is now built by `resolveUserAuthzGrants` from
ADR-0057 D4 `sys_user_position` assignments. That table is `apiEnabled` with unconstrained
`position` values, so a caller holding tenant-administration authority can mint a row spelling
`platform_admin` for one of their own users — and the name lands on the session payload verbatim.

The server was already fixed, so this is not privilege escalation: what such a principal got was a
Console painting platform-administrator surfaces while every underlying call was refused. Worth
fixing anyway, on the card's two grounds — it is misleading in the direction that reveals platform
structure to a tenant-controlled account, and it is the exact pattern the framework banned by name.

## The replacement signal, verified against the framework tree

Read at `objectstack-ai/objectstack` `origin/main`, not taken from the card:

- `packages/core/src/security/resolve-authz-context.ts` — `hasPlatformAdminStanding` states the
  rule ("read the RUNG — never `positions.includes(...)`") and returns
  `grants.posture === 'PLATFORM_ADMIN'`.
- `packages/plugins/plugin-auth/src/auth-manager.ts` — `customSession` sets the payload's
  `isPlatformAdmin` from `grants.posture === 'PLATFORM_ADMIN'` and says so in its own comment.
  **This is what makes the old docblock obsolete**: the flag is the rung, not
  `'platform_admin' in positions`.
- `.changeset/positions-name-is-not-platform-authority.md` — the four server-side sites already
  moved this way, and the note that every TENANT_ADMIN arm was deliberately left unchanged.

So `user.isPlatformAdmin` is byte-for-byte what the server's own predicate returns, and the two
can now genuinely disagree. When they do, the rung is right.

## The comment was rewritten, not just bypassed

The docblock argued **against** reading `user.isPlatformAdmin` — the server computes it as
`'platform_admin' in positions`, so reading both would be "two spellings for one fact". That
reasoning was true and is now false, and a reader who found it standing would re-introduce the
scan. It is replaced by a section that names #15948, states what each of the two now derives from,
says which wins, and carries an explicit ⛔ against putting the name back.

## Judgment: each name in `ADMIN_ROLES`, decided separately

The set is split in two. `ADMIN_ROLES` stays as the vocabulary for the two **scalar** legs — a
membership row's `role` and the stored `user.role`, both written by paths a tenant does not
control. A new, narrower `ADMIN_POSITION_NAMES` is the vocabulary for the **array** leg. The
question for each name was not "does it sound like an admin" but "does a trusted server derivation
ever put it in `positions[]`":

| name | emitted into `positions[]` by a server derivation? | verdict for the array leg |
| --- | --- | --- |
| `org_owner`, `org_admin` | **Yes** — from the ACTIVE org's `sys_member.role` via `mapMembershipRole` | **Kept** |
| `platform_admin` | Yes when genuine, but indistinguishable from a minted row | **Dropped**, replaced by the rung |
| `owner`, `admin` | **No** — `mapMembershipRole` normalizes them to `org_*` first | **Dropped** |
| `super_admin`, `superadmin`, `system_admin` | **No** — not built-in identity names in any framework vocabulary | **Dropped** |

`org_owner` / `org_admin` are kept for three reasons stated together. They are the only two names a
trusted derivation actually emits. A minted spelling of them is written by a caller who already
holds tenant-administration authority over the same organization (framework `DelegatedAdminGate`),
so it is a second spelling of an authority they have rather than a crossing of any boundary — which
is also the line the framework drew when it left every TENANT_ADMIN arm alone. And they are what
lets a stamped tenant administrator resolve on the first frame instead of waiting for the member
pipeline (objectui#5619); deleting them would have been a silent UX regression on the nine consumer
surfaces that read `isAdmin` without `isResolved`.

`platform_admin` cannot be salvaged by any array read: `resolveUserAuthzGrants` pushes the built-in
name only when it is not already present, so a genuine administrator and a minted principal produce
a byte-identical `positions`.

The five dropped names remain valid on legs 1 and 2, and the new pin has a case each way to prove
the narrowing did not reach them.

## Verification

Reverse verification, run from the committed fix so there was a real restore point. Mutation =
`git checkout 3c6394cb2 -- packages/auth/src/useWorkspaceAdminStatus.ts` (the branch point, not
`origin/main`, which is shared and moves). Mutation confirmed on disk by hash before measuring
(`f0c971f0…` → `6ea7cf3f…`, plus a grep for the restored `positions.some(isAdminRole)`); restored
under a trap with absolute paths, and the restore proven by `git diff HEAD` empty **and** the
on-disk hash back to the HEAD blob. No rebuild was needed for this leg: the test imports the hook
by relative path, and `vitest.config.mts` aliases `@object-ui/auth` to `packages/auth/src`, so no
`dist` sits between the mutation and the measurement.

Result: **10 failed, 8 passed** against the pre-fix hook. The 10 are exactly the defect cases (both
minted-`platform_admin` shapes, the flag-vs-array discrimination probe, all six dropped names, and
the `isResolved` case). The 8 that stayed green are exactly the guards that must not move — the
genuine platform administrator, the two kept tenant names, legs 1 and 2, and the absent-flag case.

Everything below ran on tree `f1a91ebf` (commit `227753ca6`; the earlier gated commit `b6a1cc850`
was amended for its message only, and the two trees are identical):

| check | result |
| --- | --- |
| `@object-ui/auth` `test` | 25 files, **269 passed** (includes the 5389 / 5619 / 5719 pins and the 18 new cases) |
| `@object-ui/auth` `type-check` | exit 0 (`tsc --noEmit` + `tsc -p tsconfig.test.json`) |
| `@object-ui/auth` `lint` | 0 errors (26 pre-existing warnings, all in `AuthProvider.tsx` / `LoginForm.tsx` / `SocialSignInButtons.tsx` / `createAuthClient.ts` — none in either changed file) |
| eslint on the two changed files | 0 errors, 0 warnings |
| `@object-ui/app-shell` `test` | 644 files, **6201 passed**, 1 skipped |
| `@object-ui/app-shell` `type-check` | exit 0 |
| `@object-ui/console` `test` | 89 files, **1069 passed** |
| `@object-ui/console` `type-check` | exit 0 |
| `check:control-bytes` | OK (6598 files) |
| `check:comment-mask-corpus` | OK (4424 files) |
| `check:vi-mock-specifiers` / `check:vi-mock-inherit` | OK |
| `check:esm-specifiers` / `check:self-import` / `check:unreferenced-sources` | exit 0 |
| `check:side-effects-array` / `check:published-tsconfig-exclude` | exit 0 |
| `check:eager-closure` | exit 0 after building `apps/console` (it first reported a missing report, which is a broken gauge rather than a failure) |
| `check-changeset-presence` / `check-changeset-no-major` | exit 0 |

Consumers were checked rather than assumed. All thirteen call sites were read; every downstream
test mocks `useWorkspaceAdminStatus` and therefore pins the `{ isAdmin, isResolved }` contract,
which is unchanged. The one behaviour that moves is the verdict for a minted principal.

Two honest notes on scope. `positions` was swept for sibling defects and this hook is the only site
in the repo that read the `platform_admin` name. And no type was added for `isPlatformAdmin`: it
reads through `AuthUser`'s index signature as `unknown`, which typechecks under the `=== true`
comparison and matches the posture `expressionUser.ts` already states for the same field — the
strict comparison is what makes an absent flag fail closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
