### PR TITLE
fix(combobox): honour `description`, retire `defaultValue`, pin the `name` delivery

### DIFF
--- a/.changeset/8140-combobox-schema-members.md
+++ b/.changeset/8140-combobox-schema-members.md
@@ -1,0 +1,64 @@
+---
+'@object-ui/types': minor
+'@object-ui/components': minor
+---
+
+Combobox: honour `description`, retire `defaultValue`, pin the `name` delivery
+that was already there (objectui#8140).
+
+`ComboboxSchema` declares eight authorable members and the `combobox` node
+renderer forwarded four. The three the card named as unread got three different
+verdicts, because the measurement did not give them the same answer.
+
+**`description` — now honoured.** It renders as a paragraph below the control
+and is tied to the trigger with `aria-describedby`, so it is the control's
+accessible DESCRIPTION rather than loose decoration next to it (the shape
+objectui#5735 established for `element:text_input`). The published
+`ComboboxProps` is unchanged: help text sits below the control, so it belongs to
+the node renderer's own output and not to the button `<Combobox>` renders. A node
+that authors no `description` renders exactly the DOM it rendered before —
+including no `aria-describedby`, since an attribute naming an absent element is
+worse than none. An `aria-describedby` the author put on the node is COMPOSED
+with, never overwritten.
+
+**`name` — was never missing.** There is no `schema.name` read site in the
+renderer and there should not be one: `SchemaRenderer` spreads every non-metadata
+top-level schema key as a React prop, and `name` is one of the two keys the
+form-control DOM pass-through adds to the SDUI baseline for exactly this class of
+host, so an authored `name` already lands on the focusable `role="combobox"`
+trigger. A grep for the spelling says otherwise; the DOM says this. Behaviour is
+unchanged and now pinned, so it cannot regress as silently as an unread key
+would.
+
+**`defaultValue` — RETIRED (ADR-0049), breaking, deliberately.** Authoring it is
+now a `tsc` error and a named `safeValidateSchema` refusal whose message carries
+the remedy: write `value`. It was retired rather than implemented to match the
+sibling `select` renderer, because the two differ in the property that makes a
+"default value" mean anything distinct from a value:
+
+- `combobox` is a **standalone node type only**. It is not a built-in form field
+  type and no `field:combobox` widget is registered, so a form field authored
+  `type: "combobox"` (or `field:combobox`, or `ui:combobox`) never reaches this
+  renderer at all — it renders a plain text input. On the form-field path, which
+  is where "a default the user then edits" is a real concept, the form's own
+  value plumbing already supplies the default and never consults this key.
+- On the node path the selection is **frozen**: the renderer passes no
+  `onValueChange` and the DOM pass-through forwards neither `onChange` nor
+  `onValueChange`, so no host can supply one. Selecting a different option leaves
+  the trigger unchanged. `select`'s renderer does pass a change handler, which is
+  precisely why `defaultValue` is a real initial value there.
+
+On a control whose selection cannot change, honouring the key could only have
+made it a second spelling of `value` — the consumer-side alias AGENTS.md #0.1
+forbids. It is kept declared and unwritable rather than deleted because the
+mirror extends the passthrough `BaseSchema`: a deleted member parses green and is
+ignored, trading one silent no-op for another.
+
+**Migration.** Replace `defaultValue` with `value` on any `combobox` node. No
+occurrence exists in this repository's corpus — the schema catalog's five
+combobox examples and the published docs' schema block never carried the key,
+and the docs block never documented it.
+
+⛔ Not part of this change: `label` and `error`, which are also declared on
+`ComboboxSchema` and also unrendered by this renderer. They were fenced out of
+the card and were not measured on the node path, so they are untouched here.

--- a/content/docs/components/form/combobox.mdx
+++ b/content/docs/components/form/combobox.mdx
@@ -64,7 +64,7 @@ interface ComboboxSchema {
 
 ## Help Text
 
-```plaintext
+```json
 {
   "type": "combobox",
   "name": "country",

--- a/content/docs/components/form/combobox.mdx
+++ b/content/docs/components/form/combobox.mdx
@@ -35,15 +35,45 @@ interface ComboboxSchema {
   type: 'combobox';
   options: ComboboxOption[];     // Available options
   value?: string;                 // Selected value
-  
+  name?: string;                  // Form-serialization key, placed on the trigger button
+
   // Text
   placeholder?: string;           // Button placeholder
-  
+  description?: string;           // Help text below the control, announced via aria-describedby
+
   // States
   disabled?: boolean | string | { dialect?: string; source: string };   // boolean, predicate expression, or CEL envelope
   
   // Styling
   className?: string;
+}
+```
+
+<Callout type="warn">
+  There is no `defaultValue` on a combobox — authoring it is refused by name,
+  on both the TypeScript face and `safeValidateSchema`. Write `value`.
+
+  A combobox node shows the option named by `value` and its selection does not
+  change, so "the value it starts at" and "the value it shows" are one question;
+  the key was retired under ADR-0049 rather than turned into a second spelling of
+  `value`. A `select` node does take `defaultValue`, because it hands the control
+  a change handler and so has a selection that can move away from its default —
+  and unlike `combobox`, `select` is also a built-in **form field** type, where
+  the form supplies the default itself.
+</Callout>
+
+## Help Text
+
+```plaintext
+{
+  "type": "combobox",
+  "name": "country",
+  "description": "Where the account is billed.",
+  "placeholder": "Select country...",
+  "options": [
+    { "value": "us", "label": "United States" },
+    { "value": "de", "label": "Germany" }
+  ]
 }
 ```
 

--- a/packages/components/src/__tests__/combobox-schema-members-8140.test.tsx
+++ b/packages/components/src/__tests__/combobox-schema-members-8140.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The three `ComboboxSchema` members objectui#8140 measured, each pinned in the
+ * state the measurement put it in — and the two facts the third one's
+ * RETIREMENT rests on, so the retirement cannot quietly outlive its premise.
+ *
+ * ## Why the card's count of three unread keys was itself a count, not a reading
+ *
+ * The card reported `name`, `defaultValue` and `description` as having "0 read
+ * sites on the combobox path", derived from grepping this renderer for
+ * `schema.<key>`. That spelling is absent for all three. Only two of them are
+ * actually undelivered:
+ *
+ *  - `name` ALREADY REACHES THE DOM. `SchemaRenderer` spreads every
+ *    non-metadata top-level schema key as a React prop, and `name` is one of
+ *    the two keys `FORM_CONTROL_DOM_PASS_THROUGH_KEYS` adds to the SDUI
+ *    baseline for exactly this class of host. It survives
+ *    `toFormControlDomProps` and lands on the focusable trigger. The remedy for
+ *    a key that is delivered by a mechanism instead of by a spelling is a PIN,
+ *    not a second carrier — adding `name={schema.name}` would be the
+ *    two-carriers-for-one-question shape objectui#7238 removed for `disabled`.
+ *  - `description` was genuinely undelivered and is honoured here, wired with
+ *    `aria-describedby` rather than left as a loose paragraph (objectui#5735).
+ *  - `defaultValue` was genuinely undelivered and is RETIRED on both faces
+ *    (`@object-ui/types`' `combobox-default-value-retired-8140.test.ts` pins
+ *    the contract). The two premises that decision rests on are measured here.
+ *
+ * ⛔ `label` and `error` are NOT in scope and must not be swept in: they are
+ * declared on `ComboboxSchema` and unrendered here too, but for a reason this
+ * card did not measure and did not settle.
+ *
+ * ## The negatives all carry controls
+ *
+ * "No `aria-describedby`" and "no combobox rendered" both pass on a build that
+ * rendered nothing at all, so every negative below is paired with a positive on
+ * the same instrument.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import React from 'react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SchemaRenderer } from '@object-ui/react';
+// Module scope, not a hook — the cold transform must not be billed to
+// `hookTimeout` (object-ui/no-dynamic-import-in-test-hook, objectui#3010).
+import '../renderers';
+
+afterEach(cleanup);
+
+const OPTIONS = [
+  { value: 'cn', label: 'China' },
+  { value: 'us', label: 'United States' },
+];
+
+const renderNode = (node: Record<string, unknown>) =>
+  render(<SchemaRenderer schema={{ type: 'combobox', options: OPTIONS, ...node } as any} />);
+
+/** The focusable trigger — the element a user and their screen reader touch. */
+const trigger = (): HTMLElement => screen.getByRole('combobox');
+
+/**
+ * The description relationship resolved the way assistive tech resolves it:
+ * read `aria-describedby`, look every id up, return the resolved text. A
+ * DANGLING id throws rather than being skipped — an attribute naming an element
+ * that does not exist is worse than no attribute (objectui#5735's discipline).
+ */
+function describedTexts(el: HTMLElement): string[] {
+  const ids = (el.getAttribute('aria-describedby') ?? '').split(/\s+/).filter(Boolean);
+  return ids.map((id) => {
+    const found = el.ownerDocument.getElementById(id);
+    if (!found) throw new Error(`aria-describedby names "${id}", which is not in the document`);
+    return found.textContent ?? '';
+  });
+}
+
+/* ── `name` — delivered already, pinned so it cannot regress silently ─────── */
+
+describe('`name` reaches the trigger (objectui#8140)', () => {
+  it('lands on the focusable `role="combobox"` button', () => {
+    renderNode({ id: 'cb', name: 'country' });
+    expect(trigger()).toHaveAttribute('name', 'country');
+  });
+
+  it('CONTROL — a node that authors no `name` has no `name` attribute, so the assertion above is about the key', () => {
+    renderNode({ id: 'cb' });
+    expect(trigger().hasAttribute('name')).toBe(false);
+  });
+});
+
+/* ── `description` — newly honoured, and ASSOCIATED ───────────────────────── */
+
+describe('`description` is rendered and announced (objectui#8140)', () => {
+  it('renders the help text below the control', () => {
+    renderNode({ id: 'cb', description: 'Where you live' });
+    expect(screen.getByText('Where you live')).toBeInTheDocument();
+  });
+
+  it('ties it to the trigger, so it is the control‘s accessible DESCRIPTION and not loose decoration', () => {
+    renderNode({ id: 'cb', description: 'Where you live' });
+    expect(describedTexts(trigger())).toEqual(['Where you live']);
+    expect(trigger()).toHaveAccessibleDescription('Where you live');
+  });
+
+  it('leaves NO `aria-describedby` when no description is authored — a dangling id is worse than none', () => {
+    renderNode({ id: 'cb' });
+    expect(trigger().hasAttribute('aria-describedby')).toBe(false);
+  });
+
+  it('COMPOSES with an author-supplied `aria-describedby` instead of overwriting it', () => {
+    render(
+      <>
+        <p id="authored-note">Read the policy first</p>
+        <SchemaRenderer
+          schema={{ type: 'combobox', id: 'cb', options: OPTIONS, description: 'Where you live', 'aria-describedby': 'authored-note' } as any}
+        />
+      </>,
+    );
+    expect(describedTexts(trigger())).toEqual(['Read the policy first', 'Where you live']);
+  });
+
+  it('CONTROL — the author-supplied id survives on its own when no description is authored', () => {
+    render(
+      <>
+        <p id="authored-note">Read the policy first</p>
+        <SchemaRenderer schema={{ type: 'combobox', id: 'cb', options: OPTIONS, 'aria-describedby': 'authored-note' } as any} />
+      </>,
+    );
+    expect(describedTexts(trigger())).toEqual(['Read the policy first']);
+  });
+
+  it('keeps the designer handles and the trigger where they were — the wrapper is for the paragraph, not a relocation', () => {
+    renderNode({ id: 'cb', description: 'Where you live' });
+    expect(trigger()).toHaveAttribute('data-obj-id', 'cb');
+    expect(trigger()).toHaveAttribute('data-obj-type', 'combobox');
+  });
+});
+
+/* ── The two premises `defaultValue`'s retirement rests on ────────────────── */
+
+describe('the premises behind retiring `defaultValue` (objectui#8140)', () => {
+  /**
+   * ⚠️ A red here does NOT mean delete this case. It means a `combobox` has
+   * acquired a form-FIELD path, or a selectable one, and the retirement of
+   * `defaultValue` has to be re-argued before either lands.
+   */
+  it('PREMISE 1 — no form-field spelling reaches this renderer, so the field path never needed this key', () => {
+    for (const type of ['combobox', 'field:combobox', 'ui:combobox']) {
+      const { container, unmount } = render(
+        <SchemaRenderer
+          schema={{
+            type: 'form',
+            showSubmit: false,
+            showCancel: false,
+            fields: [{ name: 'country', type, options: OPTIONS }],
+          } as any}
+        />,
+      );
+      // CONTROL first: the form DID render a control, so the negative below is
+      // not "nothing rendered".
+      expect(container.querySelector('input')).toBeTruthy();
+      expect(container.querySelector('[role="combobox"]')).toBeNull();
+      unmount();
+    }
+  });
+
+  it('PREMISE 2 — the standalone node’s selection is frozen: choosing another option changes nothing', () => {
+    renderNode({ id: 'cb', value: 'cn' });
+    const el = trigger();
+    expect(el).toHaveTextContent('China');
+
+    fireEvent.click(el);
+    // CONTROL: the dropdown really opened and the other option really is
+    // clickable, so "nothing changed" is not "nothing happened".
+    const other = screen.getByRole('option', { name: /United States/ });
+    expect(other).toBeInTheDocument();
+
+    fireEvent.click(other);
+    expect(trigger()).toHaveTextContent('China');
+  });
+});

--- a/packages/components/src/renderers/form/combobox.tsx
+++ b/packages/components/src/renderers/form/combobox.tsx
@@ -6,13 +6,63 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import React from 'react';
 import { ComponentRegistry } from '@object-ui/core';
 import type { ComboboxSchema } from '@object-ui/types';
 import { Combobox } from '../../custom';
 import { toFormControlDomProps } from '../../lib/form-control-dom-props';
 
-ComponentRegistry.register('combobox', 
-  ({ schema, disabled: hostDisabled, ...props }: { schema: ComboboxSchema; disabled?: boolean; [key: string]: any }) => {
+/**
+ * The `combobox` NODE renderer (objectui#8140).
+ *
+ * ## What this node is, measured — and what that decides
+ *
+ * `combobox` is a STANDALONE node type only. It is registered in the `ui`
+ * namespace, it is not in `renderFieldComponent`'s `BUILTIN_FIELD_TYPES`
+ * (`input` / `textarea` / `checkbox` / `switch` / `select`), and no
+ * `field:combobox` widget exists anywhere in the tree — so a form FIELD
+ * authored `type: 'combobox'` (or `field:combobox`, or `ui:combobox`) never
+ * reaches this file at all: it falls to that switch's `default:` arm and
+ * renders a plain text `<input>`. Measured on this branch's base, all three
+ * spellings.
+ *
+ * That is why `ComboboxSchema.defaultValue` is an ADR-0049 RETIREMENT TOMBSTONE
+ * rather than a key this renderer forwards. The reasoning is written out at the
+ * tombstone (`@object-ui/types` `packages/types/src/form.ts`); the half that
+ * belongs HERE is the mechanism it rests on: this renderer passes no
+ * `onValueChange`, and `toFormControlDomProps` forwards neither `onChange` nor
+ * `onValueChange`, so no host can supply one either. A standalone combobox
+ * node's selection is therefore FROZEN at `schema.value` — measured by
+ * selecting a different option and reading the trigger back unchanged. On a
+ * control the user cannot change, "the value it starts at" and "the value it
+ * shows" are the same question, and `defaultValue` could only ever have been a
+ * second spelling of `value` (AGENTS.md #0.1 — one contract, not two dialects).
+ *
+ * ## `name` is delivered ALREADY — do not add a second carrier
+ *
+ * There is no `schema.name` read site in this file and there must not be one. A
+ * grep for that spelling reports the key unread, and it is not: `SchemaRenderer`
+ * spreads every non-metadata top-level schema key as a React prop, and `name`
+ * is one of the two keys `FORM_CONTROL_DOM_PASS_THROUGH_KEYS` adds to the SDUI
+ * baseline precisely so that form controls keep it. It arrives in
+ * `comboboxProps`, survives `toFormControlDomProps`, and lands on the focusable
+ * `role="combobox"` trigger. Measured: an authored `name: 'country'` renders
+ * `<button … name="country">` today, with this file unchanged. Spelling
+ * `name={schema.name}` on top would be the two-carriers-for-one-question shape
+ * `input.tsx` writes out for `disabled` (objectui#7238). The delivery is pinned
+ * in `__tests__/combobox-schema-members-8140.test.tsx` so it cannot regress
+ * silently the way an unread key would.
+ *
+ * ## `description` is rendered here, not by `<Combobox>`
+ *
+ * Help text sits BELOW the control, so it belongs to the node's own output and
+ * not to the button `<Combobox>` renders — no widening of the published
+ * `ComboboxProps` is involved. It is wired with `aria-describedby` rather than
+ * left as a loose paragraph, the shape objectui#5735 established for
+ * `element:text_input`: an unassociated `<p>` is decoration a screen reader
+ * moving to the control never announces.
+ */
+const ComboboxRenderer = ({ schema, disabled: hostDisabled, ...props }: { schema: ComboboxSchema; disabled?: boolean; [key: string]: any }) => {
   // `hostDisabled` is `SchemaRenderer`'s EVALUATED verdict on `disabled` /
   // `disabledOn`, not the raw authored key — which may be a predicate STRING,
   // truthy however it evaluates (objectui#7238, precedent objectui#6169).
@@ -22,19 +72,67 @@ ComponentRegistry.register('combobox',
         style,
         ...comboboxProps
     } = props;
-    
-    return (
+
+    // Minted per instance and NOT derived from `schema.id`, for the reason
+    // `element:text_input` states (objectui#5735): the id `aria-describedby`
+    // needs sits on the PARAGRAPH, an element this renderer wholly owns, so the
+    // association must not inherit the author's obligation to supply an `id` —
+    // and two nodes sharing an authored id would publish two paragraphs sharing
+    // one, resolving both fields to whichever came first in the document.
+    const instanceId = React.useId();
+    // Emitted only when a paragraph is actually rendered: an `aria-describedby`
+    // that outlives an absent description is a DANGLING reference, which
+    // assistive tech reports as broken rather than falling through.
+    const descriptionId = schema.description ? `${instanceId}-description` : undefined;
+
+    // COMPOSED, never overwritten. `aria-describedby` is authorable on any node
+    // (`AriaPropsSchema`) and `SchemaRenderer` injects it into these props, so
+    // assigning ours would silently drop whatever the author pointed at. HTML
+    // takes a space-separated id list; both descriptions get announced.
+    //
+    // Read off `comboboxProps` rather than off the filtered bag: the filter
+    // keeps the whole `aria-*` family, so the two carry the same value, and
+    // `FormControlDomProps<P>` narrows to `{}` for this renderer's open `P`
+    // (`Extract<string, \`aria-${string}\`>` is `never`) — a bag you cannot
+    // index without widening the prop type.
+    const authoredDescribedBy = comboboxProps['aria-describedby'];
+    const describedBy = [authoredDescribedBy, descriptionId].filter(Boolean).join(' ') || undefined;
+
+    const trigger = (
     <Combobox 
         options={schema.options || []}
         placeholder={schema.placeholder}
         value={schema.value}
         disabled={hostDisabled}
-        className={schema.className} 
+        className={schema.className}
         {...toFormControlDomProps(comboboxProps)}
+        aria-describedby={describedBy}
         {...{ 'data-obj-id': dataObjId, 'data-obj-type': dataObjType, style }}
     />
   );
-  },
+
+    // No description authored ⇒ the node's DOM is byte-for-byte what it was
+    // before this card. The wrapper exists ONLY to give the paragraph a home,
+    // so it is not paid for by nodes that render no paragraph — and the
+    // designer's handles (`data-obj-id` / `data-obj-type`) and the authored
+    // `style` stay on the trigger in BOTH arms, where this renderer has always
+    // put them. Relocating them onto a wrapper the way `input` / `select` do is
+    // a change to the designer's hit target, not to this card's subject.
+    if (!descriptionId) return trigger;
+
+    return (
+      // `grid gap-1.5` deliberately without the siblings' `w-full`: their
+      // controls are `w-full` themselves, whereas the combobox trigger is a
+      // fixed `w-[200px]`, so `w-full` here would stretch the node's footprint
+      // in a flex parent to serve the paragraph alone.
+      <div className="grid gap-1.5">
+        {trigger}
+        <p id={descriptionId} className="text-sm text-muted-foreground">{schema.description}</p>
+      </div>
+    );
+};
+
+ComponentRegistry.register('combobox', ComboboxRenderer,
   {
     namespace: 'ui',
     label: 'Combobox',
@@ -42,7 +140,13 @@ ComponentRegistry.register('combobox',
       { name: 'placeholder', type: 'string' },
       { name: 'value', type: 'string' },
       { name: 'disabled', type: 'boolean' },
-      { name: 'className', type: 'string' }
+      { name: 'className', type: 'string' },
+      // Declared here because both are READ on this path: `name` by the
+      // form-control DOM pass-through (see the docblock above), `description`
+      // by this renderer. `defaultValue` is deliberately absent — it is a
+      // retirement tombstone on both faces of `ComboboxSchema`.
+      { name: 'name', type: 'string' },
+      { name: 'description', type: 'string' }
     ],
     defaultProps: {
       placeholder: 'Select option...',

--- a/packages/types/src/__tests__/combobox-default-value-retired-8140.test.ts
+++ b/packages/types/src/__tests__/combobox-default-value-retired-8140.test.ts
@@ -1,0 +1,122 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ComboboxSchema.defaultValue` is an ADR-0049 RETIREMENT TOMBSTONE on both
+ * faces, the refusal is LOUD and BY NAME, and the remedy it carries is `value`
+ * (objectui#8140).
+ *
+ * ## What was measured, and why the sibling `select` is not a precedent
+ *
+ * The card that named this key listed `select.tsx`'s `defaultValue` read as the
+ * sibling the combobox renderer should match. It is not, and the difference is
+ * mechanical rather than stylistic:
+ *
+ *  - `combobox` is a STANDALONE node type only. It is absent from
+ *    `renderFieldComponent`'s `BUILTIN_FIELD_TYPES`, and no `field:combobox`
+ *    widget is registered in the tree, so a form field authored
+ *    `type: 'combobox'` / `field:combobox` / `ui:combobox` renders a plain text
+ *    `<input>` from that switch's `default:` arm. All three spellings measured.
+ *  - On the node path the selection is FROZEN: the renderer passes no
+ *    `onValueChange` and `toFormControlDomProps` forwards neither `onChange`
+ *    nor `onValueChange`, so no host can make one arrive. `select`'s renderer
+ *    DOES pass a change handler, which is what makes an initial-then-edited
+ *    value a distinct concept there.
+ *
+ * On a control whose selection cannot change, honouring the key would have made
+ * it a second spelling of `value` — the consumer-side alias AGENTS.md #0.1
+ * forbids. The behavioural half of the measurement lives with the renderer, in
+ * `@object-ui/components`' `combobox-schema-members-8140.test.tsx`; this file
+ * pins the CONTRACT.
+ *
+ * ## Why a tombstone and not a deletion
+ *
+ * `ComboboxSchema`'s mirror extends the passthrough `BaseSchema`, so a DELETED
+ * member is not refused — it rides through unvalidated and is ignored, which is
+ * the same silent no-op the retirement exists to end. The controls below prove
+ * that directly rather than asserting it: an undeclared key on the very same
+ * fixture parses GREEN, while `defaultValue` is refused by name.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ComboboxSchema as TsComboboxSchema } from '../form';
+import { ComboboxSchema } from '../zod/form.zod';
+
+/** The fixture every case below varies — valid on its own, so a red is the key. */
+const BASE = {
+  type: 'combobox' as const,
+  options: [
+    { value: 'cn', label: 'China' },
+    { value: 'us', label: 'United States' },
+  ],
+};
+
+const shapeOf = (schema: unknown): Record<string, unknown> =>
+  (schema as { shape: Record<string, unknown> }).shape;
+
+describe('the TypeScript face refuses `defaultValue` (objectui#8140)', () => {
+  it('makes authoring it a `tsc` error at a real node shape', () => {
+    const node: TsComboboxSchema = {
+      ...BASE,
+      // @ts-expect-error `defaultValue` is a retirement tombstone (objectui#8140) — write `value`
+      defaultValue: 'us',
+    };
+    // The directive above is the assertion; this keeps the binding used and
+    // proves the object still constructs with everything else on it.
+    expect(node.type).toBe('combobox');
+  });
+
+  it('CONTROL — `value` and `description` are still writable', () => {
+    const node: TsComboboxSchema = { ...BASE, value: 'us', description: 'Where you live', name: 'country' };
+    expect([node.value, node.description, node.name]).toEqual(['us', 'Where you live', 'country']);
+  });
+});
+
+describe('the Zod twin refuses `defaultValue` BY NAME (objectui#8140)', () => {
+  it('rejects an authored value', () => {
+    const result = ComboboxSchema.safeParse({ ...BASE, defaultValue: 'us' });
+    expect(result.success).toBe(false);
+  });
+
+  it('names the key in the issue path, so the refusal is addressed', () => {
+    const result = ComboboxSchema.safeParse({ ...BASE, defaultValue: 'us' });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues.map((i) => i.path.join('.'))).toContain('defaultValue');
+  });
+
+  it('carries the remedy in the message an author actually reads', () => {
+    const result = ComboboxSchema.safeParse({ ...BASE, defaultValue: 'us' });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const message = result.error.issues.find((i) => i.path.join('.') === 'defaultValue')?.message ?? '';
+    // Not a substring of the generic zod text — the remedy and the reason.
+    expect(message).toMatch(/Write `value` instead/);
+    expect(message).toMatch(/RETIRED \(objectui#8140, ADR-0049\)/);
+  });
+
+  it('publishes the same one string as schema metadata, so docs cannot drift', () => {
+    const described = (shapeOf(ComboboxSchema).defaultValue as { description?: string }).description ?? '';
+    const result = ComboboxSchema.safeParse({ ...BASE, defaultValue: 'us' });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const message = result.error.issues.find((i) => i.path.join('.') === 'defaultValue')?.message ?? '';
+    expect(described).toBe(message);
+  });
+
+  it('CONTROL — the fixture itself parses green, so the red above is the key', () => {
+    expect(ComboboxSchema.safeParse(BASE).success).toBe(true);
+    expect(ComboboxSchema.safeParse({ ...BASE, value: 'us' }).success).toBe(true);
+    expect(ComboboxSchema.safeParse({ ...BASE, description: 'Where you live' }).success).toBe(true);
+    expect(ComboboxSchema.safeParse({ ...BASE, name: 'country' }).success).toBe(true);
+  });
+
+  it('CONTROL — an UNDECLARED key on the same fixture parses green, which is why deleting the member would not refuse anything', () => {
+    expect(ComboboxSchema.safeParse({ ...BASE, notAKeyAnyoneDeclared: 'us' }).success).toBe(true);
+  });
+});

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -1443,15 +1443,51 @@ export interface ComboboxSchema extends BaseSchema {
    */
   options?: ComboboxOption[];
   /**
-   * Default selected value
+   * ADR-0049 RETIREMENT TOMBSTONE (objectui#8140) — `defaultValue` on a
+   * `combobox`. Write {@link ComboboxSchema.value} instead.
+   *
+   * Retired, rather than implemented to match the sibling `select` renderer,
+   * because the two nodes differ in the one property that gives a "default
+   * value" a meaning distinct from a value. MEASURED on the retiring PR's base,
+   * not inherited from the card that named it:
+   *
+   *  - `combobox` is a STANDALONE node type only. It is absent from
+   *    `renderFieldComponent`'s `BUILTIN_FIELD_TYPES` and no `field:combobox`
+   *    widget is registered anywhere in the tree, so a form field authored
+   *    `type: 'combobox'` — or `field:combobox`, or `ui:combobox` — takes that
+   *    switch's `default:` arm and renders a plain text `<input>`. The node
+   *    renderer is never on the form-field path, and on the form-field path a
+   *    field's `defaultValue` is already honoured by the form's own value
+   *    plumbing, which reads the field metadata and never this key.
+   *  - On the node path the selection is FROZEN. The renderer passes no
+   *    `onValueChange`, and `toFormControlDomProps` forwards neither `onChange`
+   *    nor `onValueChange`, so no host can supply one: selecting a different
+   *    option leaves the trigger showing `value`. `select` is not a precedent
+   *    here — its renderer DOES pass a change handler, which is exactly why
+   *    `select.tsx`'s `defaultValue` is a real initial value there.
+   *
+   * On a control whose selection cannot change, "what it starts at" and "what
+   * it shows" are one question, so honouring this key could only have added a
+   * second spelling of `value` — the consumer-side alias AGENTS.md #0.1 forbids.
+   * Kept declared and unwritable rather than deleted, for the reason every
+   * tombstone in this package states: `BaseSchema` is a passthrough mirror, so a
+   * DELETED member parses green and is silently ignored — one silent no-op
+   * traded for another. `?: never` makes authoring it a `tsc` error here, and
+   * `retirementTombstone()` on the Zod twin (`zod/form.zod.ts`) makes it a NAMED
+   * parse refusal carrying this remedy.
+   *
+   * @deprecated Not part of this contract — write `value`.
    */
-  defaultValue?: string;
+  defaultValue?: never;
   /**
    * Controlled value
    */
   value?: string;
   /**
-   * Help text or description
+   * Help text or description — rendered as a paragraph BELOW the control and
+   * tied to the trigger with `aria-describedby`, so assistive tech announces it
+   * with the field (objectui#8140, the shape objectui#5735 established for
+   * `element:text_input`). Omitted entirely when the key is absent.
    */
   description?: string;
   /**

--- a/packages/types/src/zod/form.zod.ts
+++ b/packages/types/src/zod/form.zod.ts
@@ -17,7 +17,7 @@
  */
 
 import { z } from 'zod';
-import { handlerKeyRefusal } from './tombstone.zod.js';
+import { handlerKeyRefusal, retirementTombstone } from './tombstone.zod.js';
 import { SelectOptionSchema as SpecSelectOptionSchema } from '@objectstack/spec/data';
 import { BaseSchema, SchemaNodeSchema } from './base.zod.js';
 // The predicate wire shape (`string | { dialect?, source }`, #2212) was a
@@ -405,9 +405,23 @@ export const ComboboxSchema = BaseSchema.extend({
   label: z.string().optional().describe('Combobox label'),
   placeholder: z.string().optional().describe('Placeholder text'),
   options: z.array(ComboboxOptionSchema).describe('Combobox options'),
-  defaultValue: z.string().optional().describe('Default value'),
+  defaultValue: retirementTombstone(
+    'Default value — RETIRED (objectui#8140, ADR-0049). Write `value` instead. `combobox` is a ' +
+      'standalone node type only: it is not a built-in form field type and no `field:combobox` ' +
+      'widget exists, so a form field authored `type: "combobox"` never reaches this renderer, ' +
+      'and on the node path the selection is frozen — the renderer passes no change handler and ' +
+      'the DOM pass-through forwards none, so an option cannot be selected. On a control whose ' +
+      'selection cannot change, a default value and a value are the same thing, and this key ' +
+      'could only ever have been a second spelling of `value`.',
+  ),
   value: z.string().optional().describe('Controlled value'),
-  description: z.string().optional().describe('Help text'),
+  description: z
+    .string()
+    .optional()
+    .describe(
+      'Help text — rendered as a paragraph below the control and tied to the trigger with ' +
+        '`aria-describedby`, so assistive tech announces it with the field (objectui#8140).',
+    ),
   error: z.string().optional().describe('Error message'),
   onChange: handlerKeyRefusal('onChange', 'retired', 'Change handler'),
 });


### PR DESCRIPTION
Fixes #8140

`ComboboxSchema` declares eight authorable members; the `combobox` node renderer forwarded four. The card named three as unread. **They did not get the same verdict, because they did not get the same measurement.**

## The measurement the card asked for, first

The card fenced one premise as unverified and decision-relevant: *does a `combobox` used as a form FIELD already receive its default through the form's own value plumbing?* Measured on this branch's base, and the answer is stronger than either option the card anticipated:

**A `combobox` has no form-field path at all.** It is registered in the `ui` namespace, it is absent from `renderFieldComponent`'s `BUILTIN_FIELD_TYPES` (`input` / `textarea` / `checkbox` / `switch` / `select`), and no `field:combobox` widget is registered anywhere in the tree. A form field authored `type: "combobox"` — measured for all three spellings, `combobox`, `field:combobox`, `ui:combobox` — falls to that switch's `default:` arm and renders a plain text input. The node renderer is never reached.

The same measurement showed the form-field path *does* already supply both a default and help text for a field it recognises: an equivalent field rendered `value="us"` from the form's own `defaultValues` and a `FormDescription` paragraph, without consulting the node renderer. So the gap is standalone-node-only, exactly as the card suspected — but not because the field path already covers combobox; because there is no field path for combobox to be on.

A second measurement decided the remedy: **a standalone combobox node's selection is frozen.** The renderer passes no `onValueChange`, and `toFormControlDomProps` forwards neither `onChange` nor `onValueChange`, so no host can supply one either. Opening the dropdown and selecting a different option leaves the trigger showing the same option.

## Per-key verdicts

| key | verdict | why |
|---|---|---|
| `description` | **honour** | genuinely undelivered; purely presentational, so freezing is irrelevant |
| `name` | **already honoured** — pin only | it reaches the DOM today; the card's "0 read sites" is a grep result, not a reading |
| `defaultValue` | **retire** (ADR-0049) | on a control whose selection cannot change it could only be a second spelling of `value` |

### `description` — honoured

Rendered as help text below the control and tied to the trigger with `aria-describedby`, so it is the control's accessible DESCRIPTION rather than a loose paragraph beside it. That follows objectui#5735's shape for `element:text_input` rather than `input.tsx:67`'s older unassociated paragraph — #5735 already ruled that an unassociated paragraph is decoration a screen reader never announces.

Three properties worth naming:

* A node that authors no `description` renders **byte-identical DOM to before**, including no `aria-describedby` — an attribute naming an absent element is worse than none. The wrapper element exists only to give the paragraph a home, and the designer handles (`data-obj-id` / `data-obj-type`) and the authored `style` stay on the trigger in both arms, where this renderer has always put them.
* An `aria-describedby` the author put on the node is **composed with, never overwritten**. It is authorable via `AriaPropsSchema` and `SchemaRenderer` injects it, so assigning ours would have silently dropped whatever the author pointed at.
* ⚠️ **Correction to the brief:** honouring `description` does **not** widen the published `ComboboxProps`. Help text sits below the control, so it belongs to the node renderer's own output, not to the button the `Combobox` component renders — the sibling `input` and `select` renderers place it the same way. Clause ② therefore applies to rendered output only. No published props type moved in this PR.

### `name` — was never missing

There is no `schema.name` read site in this renderer and there should not be one. `SchemaRenderer` spreads every non-metadata top-level schema key as a React prop, and `name` is one of the two keys `FORM_CONTROL_DOM_PASS_THROUGH_KEYS` adds to the SDUI baseline **precisely so form controls keep it**. It survives the filter and lands on the focusable `role="combobox"` trigger.

Measured with this file unchanged: a node authoring `name: "country"` already rendered a trigger button carrying `name="country"`. Spelling `name={schema.name}` on top would be the two-carriers-for-one-question shape objectui#7238 removed for `disabled`. Behaviour is unchanged; the delivery is now **pinned**, so a key delivered by a mechanism rather than by a spelling cannot regress as silently as an unread key would.

⚠️ **Correction to the card:** the count of genuinely-unread keys is **two**, not three. The card's own warning — that a count is not a reading — applied to one of its own three rows.

### `defaultValue` — retired under ADR-0049

`?: never` on the TypeScript face (a `tsc` error at the authoring site) and `retirementTombstone()` on the Zod twin (a named parse refusal whose message carries the remedy: write `value`).

`select.tsx:52` is not the precedent the card took it for. The two renderers differ in the one property that makes a "default value" mean anything distinct from a value: `select`'s renderer **passes a change handler**, so its selection can move away from its default; the combobox node's cannot. Honouring the key would have made it a `??` alias for `value` — the consumer-side tolerance AGENTS.md #0.1 forbids.

Kept declared and unwritable rather than deleted, because the mirror extends the passthrough `BaseSchema`: a deleted member parses green and is ignored — one silent no-op traded for another. Pinned with a control that demonstrates exactly that (an undeclared key on the same fixture parses green while `defaultValue` is refused).

**Migration:** replace `defaultValue` with `value` on any combobox node. Zero occurrences exist in this repository's corpus: the schema catalog's five combobox examples and the published docs' schema block never carried the key.

## ⛔ Not in this PR

`label` and `error` — fenced by the card and untouched here. objectui#7687 and objectui#7697 are not folded in.

## Evidence

Every new pin was ablated, and each turned red **by name** with the state restored by hash comparison (`git hash-object` == `git rev-parse HEAD:PATH`) and an empty `git diff HEAD`, never by an exit code:

| ablation | instrument | result |
|---|---|---|
| description paragraph removed | vitest | 3 named cases red |
| `aria-describedby` overwritten instead of composed | vitest | 2 named cases red |
| `name` dropped before the pass-through | vitest | 1 named case red |
| TS tombstone reverted to `defaultValue?: string` | `tsc` | `TS2578: Unused '@ts-expect-error' directive` in the pin, plus `zod-mirror-parity` red |
| Zod tombstone reverted | vitest | 4 named cases red |

⚠️ The TS-face ablation is listed against `tsc` on purpose. Run against **vitest** the same mutation is GREEN — vitest transpiles types away, so that green is NOT a measurement of anything. The enforcing channel is `packages/types`' own `type-check`, which includes `tsconfig.test.json`.

Run on the final commit (`6ca4b43c4`):

* `pnpm exec vitest run packages/types/` — 139 files, 2642 tests, pass
* `pnpm exec vitest run packages/components/` — 238 files, 2206 tests, pass
* `pnpm exec turbo run type-check --concurrency=2` — **81/81 tasks**, whole tree including `@object-ui/site`
* `pnpm exec turbo run lint --concurrency=2` — **47/47 tasks**, 0 errors (warnings are pre-existing debt). Whole farm, not a narrowing. ⛔ No `--no-inline-config`.
* `check:control-bytes`, `check:doc-types`, `check:doc-fences`, `check:doc-snippets` (after its scoped build; its own verdict line: 631/631 blocks judged, 0 failed), `check:handler-key-reads`, `check:doc-example-readers`, `check-changeset-presence`, `check-changeset-no-major`, `pnpm check` — all green on their own verdict lines
* `check-governed-queue-guard --test` on all 7 changed paths: `NOT GOVERNED — 7 path(s) checked against 5 governed surface(s); none matched`

Changeset: `minor` on `@object-ui/types` and `@object-ui/components`. No `major`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_