### PR TITLE
fix(plugin-chatbot): accept the AI SDK's UIMessage in the exported mappers

### DIFF
--- a/.changeset/8214-chatbot-anypart-state-widen.md
+++ b/.changeset/8214-chatbot-anypart-state-widen.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/plugin-chatbot': minor
+---
+
+`uiMessagesToChatMessages` / `uiMessageToChatMessage` now accept `@ai-sdk/react`'s
+`UIMessage[]` — the exact input the exported mappers are documented for
+(objectui#8214).
+
+**Not breaking.** The parameter type only got looser: every argument that compiled
+before still compiles. `minor` rather than `patch` because a published signature
+accepts input it refused before, which is a capability a consumer can newly rely on.
+
+`mapMessages.ts`'s local `AnyPart` is written to absorb whatever a producer hands the
+mapper — every other member is `string` / `unknown` — but `state` was typed against the
+OUTPUT contract (`ChatToolInvocation['state']`, the tool-invocation lifecycle). The AI
+SDK's own text and reasoning parts carry `state: 'streaming' | 'done'`, which is not in
+that union, so the deliberately-permissive input interface was on that one property
+STRICTER than the union it exists to absorb and the whole `UIMessage[]` assignment was
+refused (TS2345). An app that followed the README and drove `useChat()` itself had to
+add an `as never` / `as any` of its own, permanently disabling checking on that seam.
+
+`AnyPart.state` is now `string`, and the one read site narrows through an `isToolState`
+guard whose table is a `Record` over `ChatToolInvocation['state']` — so the output stays
+exactly as checked as before, and the table cannot drift from the union it guards.
+
+Small behaviour fix that falls out of the guard: a part carrying an unrecognized state
+string (an AI SDK v4 snapshot's `'result'`, say) used to pass through verbatim into
+`ChatToolInvocation.state`, fall past every branch in `getToolState`, and render a
+finished call as "Running" forever. It now normalizes to `undefined`, which is the
+documented "infer from `errorText` / `result`" case.

--- a/packages/plugin-chatbot/README.md
+++ b/packages/plugin-chatbot/README.md
@@ -350,16 +350,6 @@ of writing your own — they handle `parts: [{ type: 'text' | 'reasoning'
 | 'tool-*' | 'source-*' }]`, the streaming-cursor flag, and the legacy
 `msg.toolInvocations` fallback:
 
-> ⚠️ Today this call needs a cast on the reader's side. `uiMessagesToChatMessages`
-> declares its parameter as the package's own permissive `AnyUIMessage[]`, whose
-> `AnyPart.state` is typed as the tool-invocation state union — so a `TextUIPart`
-> carrying `state: 'streaming' | 'done'` is refused, and with it the whole
-> `UIMessage[]` that `useChat()` returns. The block below is what you should
-> write; it compiles once objectui#8214 widens that member. Nothing about the
-> mapper's runtime behaviour is affected.
-
-<!-- doc-snippet: fragment — `uiMessagesToChatMessages` declares its parameter as the package's own `AnyUIMessage[]`, whose `AnyPart.state` is the tool-invocation state union, so `@ai-sdk/react`'s `UIMessage` — whose text parts carry `state: 'streaming' | 'done'` — is refused at the very call this section is about (measured: TS2345 x1). objectui#8214 holds that parameter type; this block is what a reader should write and compiles the day it lands -->
-
 ```tsx
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';

--- a/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/mapMessages.test.ts
@@ -7,6 +7,7 @@
  * `@ai-sdk/react`'s `useChat()` directly (e.g. Studio's chat panel).
  */
 import { describe, it, expect } from 'vitest';
+import type { UIMessage } from '@ai-sdk/react';
 import {
   uiMessageToChatMessage,
   uiMessagesToChatMessages,
@@ -120,7 +121,7 @@ describe('uiMessageToChatMessage', () => {
   });
 
   it('uiMessagesToChatMessages: only the streaming tail keeps a tool Running; prior messages terminalize', () => {
-    const msgs = [
+    const msgs: UIMessage[] = [
       {
         id: 'm-prior',
         role: 'assistant',
@@ -132,7 +133,7 @@ describe('uiMessageToChatMessage', () => {
         parts: [{ type: 'tool-add_field', toolCallId: 'c2', state: 'input-available', input: {} }],
       },
     ];
-    const out = uiMessagesToChatMessages(msgs as never, { isStreaming: true });
+    const out = uiMessagesToChatMessages(msgs, { isStreaming: true });
     expect(out[0].toolInvocations?.[0]?.state).toBe('output-available'); // prior turn → terminalized
     expect(out[1].toolInvocations?.[0]?.state).toBe('input-available');  // live tail → still Running
   });

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -27,7 +27,18 @@ interface AnyPart {
   args?: unknown;
   result?: unknown;
   errorText?: string;
-  state?: ChatToolInvocation['state'];
+  /**
+   * Free-form on purpose. `AnyPart` absorbs whatever a producer hands the
+   * mapper, and `state` is NOT one namespace: a tool part carries the
+   * tool-invocation lifecycle, while `@ai-sdk/react`'s text and reasoning
+   * parts carry `'streaming' | 'done'`. Typing this member against the
+   * OUTPUT contract made the deliberately-permissive input interface
+   * stricter than the union it exists to absorb, so the SDK's own
+   * `UIMessage[]` — the documented input of the exported mappers — was
+   * refused outright (objectui#8214). `isToolState` below is what keeps the
+   * output checked; this stays open.
+   */
+  state?: string;
   url?: string;
   href?: string;
   title?: string;
@@ -42,6 +53,35 @@ interface AnyUIMessage {
   content?: unknown;
   toolInvocations?: ChatToolInvocation[];
   metadata?: unknown;
+}
+
+/**
+ * The tool-invocation lifecycle states as a runtime value. Declared as a
+ * `Record` over the union so the compiler rejects a typo here AND requires a
+ * row when `ChatToolInvocation['state']` grows: the table cannot drift from
+ * the type it guards.
+ */
+const TOOL_STATES: Record<NonNullable<ChatToolInvocation['state']>, true> = {
+  'input-streaming': true,
+  'input-available': true,
+  'approval-requested': true,
+  'approval-responded': true,
+  'output-available': true,
+  'output-error': true,
+  'output-denied': true,
+};
+
+/**
+ * Narrows a part's free-form `state` to the tool-invocation lifecycle. Any
+ * other spelling (a text/reasoning part's `'streaming' | 'done'`, an AI SDK v4
+ * snapshot's `'result'`) is not a tool state and maps to `undefined` — which is
+ * the documented "infer from `errorText` / `result`" case in
+ * `ChatbotEnhanced.getToolState`, not a loss: an unrecognized string used to
+ * pass through verbatim and fall past every branch there, rendering a finished
+ * call as "Running" forever.
+ */
+function isToolState(state: string | undefined): state is NonNullable<ChatToolInvocation['state']> {
+  return state !== undefined && state in TOOL_STATES;
 }
 
 function extractText(msg: AnyUIMessage, parts: AnyPart[]): string {
@@ -631,7 +671,7 @@ function extractToolInvocations(
       //      ENDED, so it cannot still be running, output-snapshot or not.
       // Only the actively-streaming trailing assistant message (`liveTail`)
       // may legitimately keep a tool spinning; everything else is history.
-      const persistedState = p.state;
+      const persistedState = isToolState(p.state) ? p.state : undefined;
       const isDanglingInput =
         persistedState === 'input-available' || persistedState === 'input-streaming';
       const baseState: ChatToolInvocation['state'] =


### PR DESCRIPTION
Fixes #8214

> Spelling note, same reason the card gives: generic type arguments are written as WORDS below (`UIMessage of unknown, UIDataTypes, UITools`), because GitHub's body sanitizer eats tag-shaped fragments — backticks and fences included.

## The defect

`packages/plugin-chatbot/src/mapMessages.ts` declares a deliberately **permissive** local `AnyPart` — every member is `string` / `unknown` — but typed one member against the **output** contract:

```ts
state?: ChatToolInvocation['state'];   // the TOOL-invocation lifecycle
```

`@ai-sdk/react`'s text and reasoning parts carry `state: 'streaming' | 'done'`, which is not in that union. So the interface written to absorb the SDK's part union was, on that one property, **stricter** than the union it exists to absorb, and the whole `UIMessage[]` assignment failed — at the exact call the docblock and the README export the mappers for.

## The fix (PM ruling: option A)

`AnyPart.state` is now `string`, and the file's single read site narrows through a guard:

```ts
// a Record keyed by (NonNullable of ChatToolInvocation's state), valued true
const TOOL_STATES = { 'input-streaming': true, /* … the other 6 rows … */ };

// a type predicate narrowing to (NonNullable of ChatToolInvocation's state)
function isToolState(state) { return state !== undefined && state in TOOL_STATES; }

// the one read site, was: const persistedState = p.state;
const persistedState = isToolState(p.state) ? p.state : undefined;
```

**Why `string` and not the union of both known state sets.** Both widens cost the same at the read site — neither one lets `p.state` flow into `ChatToolInvocation['state']` without an explicit narrowing, because `AnyPart` is a flat interface and the `p.type` filter above does not narrow a sibling property. Given equal cost, `string` is the one consistent with the ruling: it is a purely local widening. Enumerating one dependency's *current* literals inside a published parameter type keeps the type coupled to `@ai-sdk/react@4.0.68` without the SDK's type as the source of truth — the coupling of option B with none of its authority — and re-creates this identical defect on the next SDK bump. `string` matches every sibling member of `AnyPart` and ends the class.

**Cost at the read sites.** `mapMessages.ts` has exactly one read of `p.state` (line 634 on the base; the other four `state` occurrences in `extractToolInvocations` are locals). It pays one guard call. The `Record` over the union is what keeps the guard honest in both directions: a typo in the table is a compile error, and a state added to `ChatToolInvocation['state']` fails here until a row is added.

**Behaviour fix that falls out of it.** An unrecognized state string (an AI SDK v4 snapshot's `'result'`, say) used to pass through verbatim into `ChatToolInvocation.state`, then fall past every branch in `getToolState` and render a finished call as "Running" forever. It now normalizes to `undefined`, which is that function's documented "infer from `errorText` / `result`" case. The output type is now *true* at runtime instead of merely asserted.

## Evidence

Instrument is the package's own `type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`), not vitest — vitest transpiles types away. `tsconfig.test.json` was confirmed to actually read the test file (`--listFiles`, 1876 files, `src/__tests__/mapMessages.test.ts` present; a made-up filename control returns 0 hits).

| leg | verdict |
|---|---|
| base, cast in place | `type-check` **exit 0** |
| base, cast removed (lit control) | **exit 2** — `TS2345` at `mapMessages.test.ts(136,42)`, the card's exact chain down to `Type '"done"' is not assignable to …` |
| after the widen, cast removed | `type-check` **exit 0** |
| ablation: narrow `state` restored on the committed implementation | **exit 2**, same `TS2345` by name |
| dependents (`--filter '...@object-ui/plugin-chatbot'`) | **exit 0**, `Scope: 7 of 47 workspace projects`, all 7 `Done`, 0 errors |
| `pnpm --filter @object-ui/plugin-chatbot test` | 39 files / 461 tests passed |
| `eslint .` (package-scoped) | 0 errors, 90 warnings (all pre-existing, none in a touched file) |

Ablation discipline: mutation proved on disk by `git hash-object` differing from `git rev-parse HEAD:PATH`, restore proved by state (`git diff HEAD` empty **and** the hashes equal again), `trap … EXIT INT TERM` with absolute paths, from a committed implementation. A separate positive control confirms the vitest case is really executed: an injected failing expectation turns that exact file and test name red, then is restored by state.

## The two load-bearing casts

- **`mapMessages.test.ts:135` `msgs as never` — removed.** The fixture is now declared `UIMessage[]` imported from `@ai-sdk/react`, so the pin is about the dependency's real shape rather than a hand-rolled literal. Note the cast was doing more than the card's diagnostic: the untyped literal also had `role: string`, so the cast was hiding two things. The SDK type fixes both, and nothing else in the fixture had to change.
- **`useObjectChat.ts:683` `chatResult as any` — measured, left in place.** With the widen applied, removing it leaves **exactly one** diagnostic, and it has nothing to do with this card: `TS2322` at `useObjectChat.ts:803` — the hook's own returned `setMessages` is declared `(messages: unknown[]) => void` while the SDK's is `(messages: UIMessage[] | updater) => void`, which is contravariantly incompatible. Out of scope here; reported rather than chased.

That measurement also **substantiates the card's central claim** rather than repeating it. With the narrow `state` restored *and* the `as any` removed, the mapper call in production source goes red too: `TS2345` at `useObjectChat.ts(701,69)`. So the widen fixes the package's own call site, not just the test — the `as any` had been masking this defect as well as the unrelated one.

## README

The `doc-snippet: fragment` marker **does** exist on this base (`packages/plugin-chatbot/README.md`, line 361), so batch 30's PR #8228 has landed. It is removed here, and the doc-snippet gate is the instrument that proves the block now compiles:

| run | verdict line |
|---|---|
| marker present (before) | `Covered blocks: 790 — 631 to compile, 159 declared fragment(s).` / `Semantic phase: 631 of 631 block(s) judged, 0 failed.` — **exit 0** |
| marker removed (after) | `Covered blocks: 790 — 632 to compile, 158 declared fragment(s).` / `Semantic phase: 632 of 632 block(s) judged, 0 failed.` — **exit 0** |
| control: marker removed, `dist` rebuilt from the **ablated** source | **exit 1** — `[semantic] packages/plugin-chatbot/README.md:371:42 TS2345 …` |

Exit 1 is "I ran and found errors", not the exit 2 "PRECONDITION NOT MET" a fresh worktree gives before its closure is built; that closure (34 filters, from the gate's own `--build-filter`) was built for every one of these runs.

**One addition beyond the brief:** the seven-line prose blockquote directly above the marker — "Today this call needs a cast on the reader's side…" — is removed with it. It documents the defect as a live constraint on the reader; leaving it would keep the page telling readers to write a cast the compiler no longer wants, which is the same over-claim in prose that the marker was in metadata.

## Changeset

`minor` on `@object-ui/plugin-chatbot`. **Not breaking**: the parameter type only got looser, so every argument that compiled before still compiles (verified — `dist/mapMessages.d.ts` now emits `state?: string;`). `minor` rather than `patch` because a published signature accepts input it previously refused, which is a capability a consumer can newly depend on. The repo forbids `major`; `pnpm` gate `check-changeset-no-major` is green, as are `check-changeset-presence` / `-fixed` / `-overwrite`.

## Other gates run

`check:control-bytes`, `check:readme-exports`, `check:doc-fences`, `check:doc-types`, `check:phantom-deps`, `check:unused-deps` — all exit 0. `check-governed-queue-guard --test` on the four changed paths: `NOT GOVERNED — 4 path(s) checked against 5 governed surface(s); none matched.`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_