### PR TITLE
fix(plugin-detail): record:details dedupe asks the ADR-0079 resolver which row to hide

### DIFF
--- a/.changeset/8175-record-details-namefield-dedupe.md
+++ b/.changeset/8175-record-details-namefield-dedupe.md
@@ -1,0 +1,49 @@
+---
+'@object-ui/plugin-detail': minor
+---
+
+`record:details`' dedupe now asks the unified ADR-0079 resolver which row to hide
+(objectui#8175).
+
+The renderer drops from the body grid the one field whose value the page H1 is
+already showing, so a record page does not print `Contract No: HT-2026-001`
+directly under an H1 reading `HT-2026-001`. It picked that field with a six-entry
+literal walk — `name`, `full_name`, `title`, `subject`, `display_name`, `label` —
+which is the **tail** of the chain `PageHeaderRenderer` uses to draw the H1 a
+package away, with no equivalent of the ADR-0079 resolver rung that sits above it
+in that chain.
+
+**The user-visible defect.** For an object whose declared `nameField` names a
+field the literal walk does not know, *both halves of the dedupe were wrong at
+once*. On an object declaring `nameField: 'contract_no'`, for a record carrying
+both `contract_no` and an ordinary `name`:
+
+- the H1 showed `contract_no`'s value (correct — that half was already right);
+- the grid still showed the `contract_no` row, repeating the heading;
+- and the grid dropped the `name` row, a field the heading never showed.
+
+**The change.** The candidate list now leads with `resolveNameField` and
+`deriveTitleField` from `@object-ui/core` — the same ADR-0079 resolver
+`getRecordDisplayName` reads to produce the H1's *value*, and the one
+`resolveTitleField` in this package already delegates to. The literal walk stays
+as the tail, unchanged, for records whose object definition resolves nothing.
+
+**Breaking, deliberately — a different row can now be hidden.** This is a
+behaviour change for any object the resolver answers for and the literal walk did
+not, which includes objects with no name-ish field at all: there the resolver's
+type-aware derivation lands on the first title-eligible field by declaration
+order, and that field *is* what the page H1 shows, so the grid stops repeating it.
+Authors who want a field back can keep it out of the dedupe the way they always
+could — the ladder only ever hides a field whose value is non-empty on the record.
+
+The rung is spelled as **two** candidates rather than one `resolveNameField` call.
+That call returns a single answer and short-circuits: a declared pointer wins
+outright and the derivation never runs. This ladder is value-keyed, and so is the
+header's own chain — when the declared pointer is blank on a record,
+`getRecordDisplayName` keeps walking and lands on the derivation. Listing both
+rungs is what lets the same fall-through happen here.
+
+Two rungs of the header chain are deliberately **not** mirrored, because neither
+names a field and so neither has a row to hide: `page:header`'s own `schema.title`
+(which this package cannot see) and `objectSchema.titleFormat` (a render-only
+template the header ranks above the declared pointer).

--- a/packages/plugin-detail/src/__tests__/recordDetailsBodySource.test.tsx
+++ b/packages/plugin-detail/src/__tests__/recordDetailsBodySource.test.tsx
@@ -42,13 +42,28 @@ import { RecordContextProvider } from '@object-ui/react';
 import { RecordDetailsRenderer } from '../renderers/record-details';
 
 /**
- * No `name` / `title` / `display_name` in the data on purpose: the renderer
- * drops the page-H1 title field from the body (`titleCandidates`), and a
- * fixture that tripped that would make an absence assertion below pass for the
- * wrong reason.
+ * No `name` / `title` / `display_name` VALUE in the data on purpose: the
+ * renderer drops the page-H1 title field from the body (`titleCandidates`), and
+ * a fixture that tripped that would make an absence assertion below pass for
+ * the wrong reason.
+ *
+ * ⚠️ Keeping that property took a change when the dedupe ladder gained the
+ * ADR-0079 resolver rung (objectui#8175). The ladder is no longer six literal
+ * names: it asks `deriveTitleField` first, and that walk ends in "the first
+ * title-eligible field by DECLARATION ORDER" — which on the old fixture was
+ * `phone`, so `555-0100` (asserted below) started disappearing from the grid.
+ * That was the ladder working correctly: with no name-ish field declared, the
+ * page H1 for this record IS the phone number, because `PageHeaderRenderer`
+ * resolves it through the very same derivation.
+ *
+ * So `name` is DECLARED here and left UNSET on the record. The derivation
+ * prefers it (name-ish exact beats declaration order), the record has no value
+ * there, and the value-keyed ladder therefore hides nothing — which is what
+ * this file wanted all along, now stated as a field rather than as an absence.
  */
 const objectSchema = {
   fields: {
+    name: { type: 'text', label: 'Name' },
     phone: { type: 'text', label: 'Phone' },
     email: { type: 'text', label: 'Email' },
     industry: { type: 'text', label: 'Industry' },

--- a/packages/plugin-detail/src/renderers/__tests__/record-details.emptySectionDefault.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.emptySectionDefault.test.tsx
@@ -59,6 +59,14 @@ import { RecordDetailsRenderer } from '../record-details';
  */
 const objectSchema = {
   fields: {
+    // DECLARED and left UNSET on every record below, so the `record:details`
+    // dedupe ladder resolves its H1 candidate to `name`, finds no value there
+    // and hides nothing (objectui#8175). Without it the ladder's ADR-0079
+    // derivation rung ends in "first title-eligible field by declaration
+    // order" — `industry` — and every `Manufacturing` assertion in this file
+    // would be measuring the dedupe instead of the empty-section heuristic
+    // these cases exist to pin.
+    name: { type: 'text', label: 'Name' },
     industry: { type: 'text', label: 'Industry' },
     stage: { type: 'text', label: 'Stage' },
     amount: { type: 'text', label: 'Amount' },

--- a/packages/plugin-detail/src/renderers/__tests__/record-details.nameFieldDedupe-8175.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.nameFieldDedupe-8175.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `record:details`' dedupe asks the ADR-0079 resolver WHICH ROW to hide
+ * (objectui#8175).
+ *
+ * ## The surface under test is the DEDUPE, not the title
+ *
+ * This renderer does not draw the H1. It draws the body grid and drops from it
+ * the one field whose value the page H1 is already showing. The H1 is drawn a
+ * package away by `@object-ui/components`' `PageHeaderRenderer`, whose chain
+ * ends with the unified ADR-0079 resolver and only then the same six-name
+ * literal walk this ladder used to be. So a TITLE-only pin passes while this
+ * ladder is wrong — the two halves are decided in different packages, and
+ * `packages/components/src/__tests__/page-header-title.test.tsx` (case
+ * `nameField wins over a record-level 'name' value`) is already green on
+ * `origin/main` with this defect fully present. Every case below therefore
+ * asserts which row RENDERS and which row DROPS.
+ *
+ * ## The defect these cases pin
+ *
+ * The ladder had no equivalent of the resolver rung, so for an object whose
+ * declared `nameField` names a field the six-entry literal walk does not know,
+ * BOTH halves of the dedupe were wrong at once: the duplicate row survived
+ * (`contract_no`, the value the H1 shows) and an ordinary field disappeared
+ * instead (`name`, a row the H1 never showed).
+ *
+ * ## Why the resolver rung is UNROLLED into two candidates
+ *
+ * `resolveNameField` returns ONE answer and short-circuits: a declared
+ * `nameField` wins outright and the type-aware derivation never runs. This
+ * ladder is VALUE-keyed — the header's own chain re-tries the next rung when a
+ * rung's value is empty on the record (`getRecordDisplayName` step 1+2 falls to
+ * step 4 when `valueAt` comes back undefined). Delegating to `resolveNameField`
+ * alone would therefore lose the derivation rung for every record whose
+ * declared pointer happens to be blank. The two rungs are listed separately so
+ * the value-keyed walk can fall through exactly the way the H1's does.
+ *
+ * ## What the rows are keyed by (objectui#8269's trap, measured here)
+ *
+ * The dedupe filters entries through `columnIdentity`, which is CANONICAL-first
+ * (`field` beats `name`/`fieldName`), while `DetailSection` renders each row
+ * from `field.name`. For the shapes these fixtures use — bare strings — the two
+ * are the same string, so "the resolver's answer" and "the column the row
+ * carries" cannot coincide by accident. A deliberately conflicting entry
+ * (`{ field, name }` disagreeing) is a different, pre-existing defect shape that
+ * `hasConflictingColumnIdentity` already names; it is NOT pinned here.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import * as React from 'react';
+import { RecordContextProvider } from '@object-ui/react';
+import { RecordDetailsRenderer } from '../record-details';
+
+/**
+ * An object whose declared `nameField` is `contract_no` — a name the six-entry
+ * literal walk (`name`, `full_name`, `title`, `subject`, `display_name`,
+ * `label`) does not know. `name` is an ORDINARY field here, and the two carry
+ * different values, so "which row is hidden" is answerable from the DOM alone.
+ */
+const contractSchema = {
+  name: 'contract',
+  label: 'Contract',
+  nameField: 'contract_no',
+  fields: {
+    contract_no: { type: 'text', label: 'Contract No' },
+    name: { type: 'text', label: 'Name' },
+    amount: { type: 'number', label: 'Amount' },
+  },
+};
+
+const CONTRACT_FIELDS = ['contract_no', 'name', 'amount'];
+
+function renderBody(record: any, schema: any, fields: string[]) {
+  return render(
+    <RecordContextProvider
+      objectName={schema?.name ?? 'contract'}
+      recordId={record.id}
+      data={record}
+      objectSchema={schema}
+    >
+      <RecordDetailsRenderer schema={{ fields } as never} />
+    </RecordContextProvider>,
+  );
+}
+
+beforeEach(() => {
+  // `useRecordEditable` probes `POST /api/v1/security/explain` for the
+  // ROW-level verdict; happy-dom resolves that relative URL to a REAL socket,
+  // which the repo's network-escape guard fails the file for (objectui#6640).
+  // Serve it from a double — its answer is orthogonal to which row is hidden.
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ allowed: true }),
+    text: async () => '{"allowed":true}',
+  })) as never);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('record:details dedupe — the declared `nameField` picks the hidden row (#8175)', () => {
+  it('drops the declared `nameField` row and KEEPS the ordinary `name` row', () => {
+    renderBody(
+      { id: 'C1', contract_no: 'HT-2026-001', name: 'internal-name', amount: 42 },
+      contractSchema,
+      CONTRACT_FIELDS,
+    );
+
+    // Half 1 — the duplicate must NOT survive. `HT-2026-001` is exactly what
+    // the H1 shows for this record (pinned in `page-header-title.test.tsx`),
+    // so repeating it in the grid is the duplication this dedupe exists for.
+    expect(screen.queryByText('HT-2026-001')).toBeNull();
+
+    // Half 2 — the ordinary field must NOT disappear. `internal-name` is a row
+    // the H1 never showed; the literal walk took it out because `name` is its
+    // first entry and the record has a value there.
+    expect(screen.getByText('internal-name')).toBeInTheDocument();
+
+    // CONTROL — the grid rendered at all. Without this, both assertions above
+    // are satisfied by a build that rendered nothing: "queryByText is null" is
+    // trivially true on an empty document, and this is the row that proves the
+    // component produced a grid rather than a placeholder or a crash.
+    // (the row LABEL is `amount`, not `Amount`: `DetailSection` labels a row
+    // from the entry's own `label`, and these entries are bare strings.)
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('amount')).toBeInTheDocument();
+  });
+
+  it('honours the deprecated `displayNameField` alias the same way', () => {
+    renderBody(
+      { id: 'C2', contract_no: 'HT-2026-002', name: 'internal-name-2', amount: 7 },
+      { ...contractSchema, nameField: undefined, displayNameField: 'contract_no' },
+      CONTRACT_FIELDS,
+    );
+
+    expect(screen.queryByText('HT-2026-002')).toBeNull();
+    expect(screen.getByText('internal-name-2')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument(); // CONTROL: grid rendered
+  });
+
+  it('falls through to the literal walk when the declared pointer is EMPTY on the record', () => {
+    // The H1's chain is value-keyed: `getRecordDisplayName` only takes the
+    // declared pointer when `valueAt` yields something, else it keeps walking.
+    // With no `contract_no` value the H1 for this record is `Acme Corporation`,
+    // so `name` is the row that has to go — not `contract_no`, which shows
+    // nothing at all and duplicates no heading.
+    renderBody(
+      { id: 'C3', name: 'Acme Corporation', amount: 11 },
+      contractSchema,
+      CONTRACT_FIELDS,
+    );
+
+    expect(screen.queryByText('Acme Corporation')).toBeNull();
+    expect(screen.getByText('11')).toBeInTheDocument(); // CONTROL: grid rendered
+  });
+
+  it('uses the type-aware derivation rung when nothing is declared', () => {
+    // No `nameField`, and no key the literal walk knows. `deriveTitleField`
+    // picks `activity_name` off the `*_name` affix, which is exactly what the
+    // H1 resolves to — so before this fix the grid repeated the heading and
+    // the dedupe dropped nothing at all.
+    renderBody(
+      { id: 'A1', activity_name: 'Kickoff call', amount: 5 },
+      {
+        name: 'activity',
+        label: 'Activity',
+        fields: {
+          activity_name: { type: 'text', label: 'Activity Name' },
+          amount: { type: 'number', label: 'Amount' },
+        },
+      },
+      ['activity_name', 'amount'],
+    );
+
+    expect(screen.queryByText('Kickoff call')).toBeNull();
+    expect(screen.getByText('5')).toBeInTheDocument(); // CONTROL: grid rendered
+  });
+
+  it('re-tries the derivation rung when a DECLARED pointer is blank on the record', () => {
+    // The case a single `resolveNameField()` call cannot answer: it returns
+    // `contract_no` (declared wins, derivation never runs), that field is empty
+    // here, and the H1 therefore falls to the derivation — `activity_name`.
+    // A ladder that consulted only `resolveNameField` would hide nothing and
+    // leave `Kickoff call` printed directly under an H1 reading `Kickoff call`.
+    renderBody(
+      { id: 'A2', activity_name: 'Kickoff call', amount: 3 },
+      {
+        name: 'activity',
+        label: 'Activity',
+        nameField: 'contract_no',
+        fields: {
+          contract_no: { type: 'text', label: 'Contract No' },
+          activity_name: { type: 'text', label: 'Activity Name' },
+          amount: { type: 'number', label: 'Amount' },
+        },
+      },
+      ['contract_no', 'activity_name', 'amount'],
+    );
+
+    expect(screen.queryByText('Kickoff call')).toBeNull();
+    expect(screen.getByText('3')).toBeInTheDocument(); // CONTROL: grid rendered
+  });
+
+  /**
+   * CONTROL — the literal walk is still the tail of the ladder.
+   *
+   * Without this, deleting the resolver rungs AND the literal walk together
+   * would pass every case above that only asserts a row survives. This is the
+   * case that goes red for a ladder that resolves nothing.
+   */
+  it('CONTROL: an undeclared object still dedupes via the literal walk', () => {
+    renderBody(
+      { id: 'P1', name: 'Acme Corporation', amount: 99 },
+      {
+        name: 'plain',
+        label: 'Plain',
+        fields: {
+          name: { type: 'text', label: 'Name' },
+          amount: { type: 'number', label: 'Amount' },
+        },
+      },
+      ['name', 'amount'],
+    );
+
+    expect(screen.queryByText('Acme Corporation')).toBeNull();
+    expect(screen.getByText('99')).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-detail/src/renderers/__tests__/record-details.nameFieldDedupe-8175.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.nameFieldDedupe-8175.test.tsx
@@ -110,31 +110,49 @@ afterEach(() => {
 });
 
 describe('record:details dedupe — the declared `nameField` picks the hidden row (#8175)', () => {
-  it('drops the declared `nameField` row and KEEPS the ordinary `name` row', () => {
+  /**
+   * The two halves are separate cases ON PURPOSE. Asserting both inside one
+   * `it` makes the first failure short-circuit the second, so an ablation of
+   * the read site reddens the duplicate half and says nothing at all about the
+   * vanishing half — and "an ordinary field disappears" is half the defect.
+   * Split, the ablation names both.
+   */
+  it('HALF 1 — DROPS the declared `nameField` row (the duplicate must not survive)', () => {
     renderBody(
       { id: 'C1', contract_no: 'HT-2026-001', name: 'internal-name', amount: 42 },
       contractSchema,
       CONTRACT_FIELDS,
     );
 
-    // Half 1 — the duplicate must NOT survive. `HT-2026-001` is exactly what
-    // the H1 shows for this record (pinned in `page-header-title.test.tsx`),
-    // so repeating it in the grid is the duplication this dedupe exists for.
+    // `HT-2026-001` is exactly what the H1 shows for this record (pinned in
+    // `@object-ui/components`' `page-header-title.test.tsx`, case `nameField
+    // wins over a record-level 'name' value`), so repeating it in the grid is
+    // the duplication this dedupe exists for.
     expect(screen.queryByText('HT-2026-001')).toBeNull();
 
-    // Half 2 — the ordinary field must NOT disappear. `internal-name` is a row
-    // the H1 never showed; the literal walk took it out because `name` is its
-    // first entry and the record has a value there.
-    expect(screen.getByText('internal-name')).toBeInTheDocument();
-
-    // CONTROL — the grid rendered at all. Without this, both assertions above
-    // are satisfied by a build that rendered nothing: "queryByText is null" is
-    // trivially true on an empty document, and this is the row that proves the
-    // component produced a grid rather than a placeholder or a crash.
-    // (the row LABEL is `amount`, not `Amount`: `DetailSection` labels a row
-    // from the entry's own `label`, and these entries are bare strings.)
+    // CONTROL — the grid rendered at all. Without it this case is satisfied by
+    // a build that rendered nothing: "queryByText is null" is trivially true on
+    // an empty document. (The row LABEL is `amount`, not `Amount` —
+    // `DetailSection` labels a row from the entry's own `label`, and these
+    // entries are bare strings.)
     expect(screen.getByText('42')).toBeInTheDocument();
     expect(screen.getByText('amount')).toBeInTheDocument();
+  });
+
+  it('HALF 2 — KEEPS the ordinary `name` row (no field may vanish in its place)', () => {
+    renderBody(
+      { id: 'C1', contract_no: 'HT-2026-001', name: 'internal-name', amount: 42 },
+      contractSchema,
+      CONTRACT_FIELDS,
+    );
+
+    // `internal-name` is a row the H1 never showed. The literal walk took it
+    // out anyway, because `name` is its first entry and the record has a value
+    // there — so the grid lost a field AND kept the duplicate, both at once.
+    expect(screen.getByText('internal-name')).toBeInTheDocument();
+
+    // CONTROL — the grid rendered at all.
+    expect(screen.getByText('42')).toBeInTheDocument();
   });
 
   it('honours the deprecated `displayNameField` alias the same way', () => {

--- a/packages/plugin-detail/src/renderers/record-details.tsx
+++ b/packages/plugin-detail/src/renderers/record-details.tsx
@@ -15,7 +15,7 @@ import { useRecordContext, useHighlightFieldNames, useSafeFieldLabel } from '@ob
 import { useFieldPermissions, usePermissions } from '@object-ui/permissions';
 import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import type { RecordDetailsComponentProps } from '@object-ui/types';
-import { columnIdentity, isObjectInlineEditable } from '@object-ui/core';
+import { columnIdentity, deriveTitleField, isObjectInlineEditable, resolveNameField } from '@object-ui/core';
 import { DetailView } from '../DetailView';
 
 /** Normalize a field entry (string | {field} | {name}) to its machine name. */
@@ -160,8 +160,37 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
   // non-empty because a row with no value is not duplicating a heading.
   // The H1 itself is drawn a package away, by `@object-ui/components`'
   // `PageHeaderRenderer` (`page:header`, synthesized by
-  // `buildDefaultPageSchema`) — the names below mirror the tail of THAT
-  // chain, which is why a change to either half must re-read the other.
+  // `buildDefaultPageSchema`) — the names below mirror THAT chain, which is
+  // why a change to either half must re-read the other.
+  //
+  // ⭐ The first two candidates are the unified ADR-0079 resolver, in NAME
+  // space (objectui#8175). Before them this list was the six literal names
+  // alone — the TAIL of the header's chain with no equivalent of the resolver
+  // rung above it — so an object declaring `nameField: 'contract_no'` got BOTH
+  // halves of the dedupe wrong at once: the duplicate survived (`contract_no`,
+  // the value the H1 was showing) and an ordinary field disappeared instead
+  // (`name`, the literal walk's first entry, a row the H1 never showed).
+  // Pinned in `__tests__/record-details.nameFieldDedupe-8175.test.tsx`, which
+  // asserts which row RENDERS and which row DROPS — never the heading, which
+  // this package does not draw.
+  //
+  // ⚠️ The resolver rung is UNROLLED into two candidates on purpose, and
+  // `resolveNameField` alone is NOT enough. It returns ONE answer and
+  // short-circuits: a declared pointer wins outright and `deriveTitleField`
+  // never runs. This ladder is VALUE-keyed, and so is the header's — when the
+  // declared pointer is blank on a record, `getRecordDisplayName` keeps
+  // walking and lands on the derivation (step 4). Listing both rungs is what
+  // lets the fall-through happen here too. When nothing is declared the two
+  // return the same name and the first one simply wins.
+  //
+  // ⚠️ Two disagreements with the header chain are KNOWN and deliberately NOT
+  // repaired here — both are rungs that name no FIELD, so there is no row to
+  // hide for either, and closing them is a separate ruling:
+  //   - `page:header`'s own `schema.title`, which this package cannot see;
+  //   - `objectSchema.titleFormat`, a render-only template the header ranks
+  //     ABOVE the declared pointer (pinned in `@object-ui/components`'
+  //     `__tests__/page-header-title.test.tsx`, "titleFormat still outranks
+  //     nameField"), interpolating any number of fields.
   //
   // ⛔ `objSchema?.primaryField` used to top this list, and it is gone
   // (objectui#7586). It is a `DetailViewSchema` key (`@object-ui/types`
@@ -182,9 +211,21 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
   // asserts the DEDUPE outcome (which row the grid hides), not the title.
   const objSchema: any = (ctx as any).objectSchema;
   const data: any = ctx.data ?? {};
-  // No `.filter(…): n is string` guard any more: it existed solely to drop the
-  // `objSchema?.primaryField` entry when the key was absent, which was always.
-  const titleCandidates = ['name', 'full_name', 'title', 'subject', 'display_name', 'label'];
+  // The `.filter(…): n is string` guard is back, for a different reason than
+  // the one objectui#7586 retired: it used to drop an `objSchema?.primaryField`
+  // entry that was absent always, and now it drops the two resolver rungs when
+  // an object declares and derives nothing — `string | undefined` is those
+  // functions' real return type, not a stand-in for a key nothing can produce.
+  const titleCandidates = [
+    resolveNameField(objSchema),
+    deriveTitleField(objSchema),
+    'name',
+    'full_name',
+    'title',
+    'subject',
+    'display_name',
+    'label',
+  ].filter((n): n is string => typeof n === 'string' && n.length > 0);
   for (const candidate of titleCandidates) {
     if (data[candidate] !== undefined && data[candidate] !== null && data[candidate] !== '') {
       hideFieldNames.add(candidate);


### PR DESCRIPTION
Fixes #8175

## What was wrong

`record:details` drops from the body grid the one field whose value the page H1 is already showing, so a record page does not print `Contract No: HT-2026-001` directly under an H1 reading `HT-2026-001`. It picked that field with a six-entry literal walk — `name`, `full_name`, `title`, `subject`, `display_name`, `label`.

That list is the **tail** of the chain `PageHeaderRenderer` uses to draw the H1 a package away. The rung above it in that chain — the unified ADR-0079 resolver — had no equivalent here, so for an object whose declared `nameField` names a field the literal walk does not know, **both halves of the dedupe were wrong at once**.

Measured on `origin/main` (`dacb98f3b`), object `nameField: 'contract_no'`, record `{ id: 'C1', contract_no: 'HT-2026-001', name: 'internal-name', amount: 42 }`:

```
MEASURE grid-renders-contract_no(H1 duplicate survives): true
MEASURE grid-drops-name(ordinary field vanished):        true
MEASURE control-row-amount-present:                      true
MEASURE H1 value the header resolves:                    HT-2026-001
```

The duplicate survived **and** an ordinary field disappeared in its place, with the control row proving the grid rendered at all.

## The fix

The candidate list now leads with `resolveNameField` and `deriveTitleField` from `@object-ui/core` — the same ADR-0079 resolver `getRecordDisplayName` reads to produce the H1's *value*, and the one `resolveTitleField` in this very package already delegates to (objectui#7287 / PR #7585). The literal walk stays as the tail, byte-identical.

## ⚠️ Correction against the dispatch's suggested shape

The card suggested "ask `resolveNameField` first, then fall through to the literal walk". **Measurement says that single call is not enough**, and the rung is spelled as **two** candidates instead:

```
resolveNameField(contractSchema)                 -> contract_no   (declared wins, derivation never runs)
deriveTitleField(contractSchema)                 -> name
resolveNameField(declared-blank-activity-object) -> contract_no   (still short-circuits)
deriveTitleField(declared-blank-activity-object) -> activity_name (the rung the H1 actually lands on)
```

`resolveNameField` returns ONE answer and short-circuits. This ladder is **value-keyed** — and so is the header's: `getRecordDisplayName` re-tries the next rung when `valueAt` comes back empty on the record, so a declared pointer that is blank falls through to the type-aware derivation (step 4). A single `resolveNameField()` call would silently lose that rung. Pinned by the case *"re-tries the derivation rung when a DECLARED pointer is blank on the record"*, which is red under the ablation.

## ⚠️ What the rows are keyed by (objectui#8269's trap, measured)

```
MEASURE columnIdentity(bare string "contract_no"):     contract_no
MEASURE columnIdentity({field:"a",name:"b"}) [filter]: a
```

`DetailSection` renders each row from `field.name`, while the dedupe filters entries through `columnIdentity`, which is **canonical-first** (`field` beats `name`/`fieldName`). The two answers diverge for a deliberately conflicting entry. Every fixture in the new pin uses **bare strings**, where the two are the same string — so the pin cannot be green because a resolver answer accidentally matched a differently-keyed column. The conflicting-entry shape is a pre-existing defect class `hasConflictingColumnIdentity` already names; it is **not** touched here.

## The pin asserts the DEDUPE, never the title

`packages/plugin-detail/src/renderers/__tests__/record-details.nameFieldDedupe-8175.test.tsx`, shaped after `record-details.primaryFieldRetired-7586.test.tsx`. The H1 half is already green on `origin/main` and proves nothing about this defect, so every case asserts which row RENDERS and which row DROPS, and every case carries a control row proving the grid rendered at all.

The two halves are **separate cases** on purpose: inside one `it` the first failure short-circuits the second, so an ablation would redden the duplicate half and say nothing about the vanishing half.

## Ablation — the read site, not the pin

Reverted the delegation (bare literal walk back), from the committed implementation, restore proven **by state**, trap on EXIT INT TERM with absolute paths:

```
HEAD_BLOB      = e6c1d21871bfa0f213d5da25465286012f31a822
AFTER(disk)    = 3cdf19d67cd0734c5dd043f39010e8a23bea100c   MUTATION REACHED DISK
anchors after  : resolveNameField(objSchema) 0 | deriveTitleField(objSchema) 0 | bare walk 1
RESTORED(disk) = e6c1d21871bfa0f213d5da25465286012f31a822   == HEAD_BLOB
git diff HEAD --stat: 0 lines
```

Red rows, by name — every one a DEDUPE assertion (`queryByText(...).toBeNull()` / `getByText(...)`), no title assertion involved:

```
× HALF 1 — DROPS the declared `nameField` row (the duplicate must not survive)
× HALF 2 — KEEPS the ordinary `name` row (no field may vanish in its place)
× honours the deprecated `displayNameField` alias the same way
× uses the type-aware derivation rung when nothing is declared
× re-tries the derivation rung when a DECLARED pointer is blank on the record
Tests  5 failed | 2 passed (7)
```

The **2 that stay green** are the controls that must: *"falls through to the literal walk when the declared pointer is EMPTY on the record"* and *"CONTROL: an undeclared object still dedupes via the literal walk"* — they describe behaviour this change does not alter, and their staying green is what makes the five reds a measurement of the new rungs rather than of the ladder's absence.

No `dist` is involved: the root vitest config aliases `@object-ui/core` to `packages/core/src`, and the pin imports `../record-details` by relative path.

## Fixture triage — two files were written around the old ladder

Both are **updated, not re-verdicted**. Each declares a `name` field and leaves it **unset** on every record, so the ladder resolves its candidate to `name`, finds no value, and hides nothing:

- `recordDetailsBodySource.test.tsx` — its docstring already said "no `name`/`title`/`display_name` in the data on purpose … a fixture that tripped that would make an absence assertion pass for the wrong reason". With no name-ish field declared, the derivation ends in *first title-eligible field by declaration order* — `phone` — so `555-0100` started disappearing. That was the ladder working correctly: the page H1 for that record **is** the phone number, because `PageHeaderRenderer` resolves it through the very same derivation.
- `record-details.emptySectionDefault.test.tsx` — same cause on `industry`; every `Manufacturing` assertion would have been measuring the dedupe instead of the empty-section heuristic those cases exist to pin. Placeholder counts and section verdicts are **unchanged**.

## ⚠️ Reported, deliberately NOT repaired — two remaining disagreements

Neither names a FIELD, so neither has a row to hide, and closing either is a product ruling rather than a repair:

1. **`page:header`'s own `schema.title`** — an author-set heading this package cannot see. The ladder hides a row regardless.
2. **`objectSchema.titleFormat`** — a render-only template the header ranks **above** the declared pointer (pinned in `@object-ui/components`' `__tests__/page-header-title.test.tsx`, *"titleFormat still outranks nameField"*), and which can interpolate any number of fields. Note this is itself a divergence between the header and `getRecordDisplayName`, whose documented step order puts `titleFormat` **below** the declared pointer.

A third, smaller one: the header's `valueAt` trims strings (so a whitespace-only value is "empty"), while this ladder's non-empty test does not. Pre-existing for all six literal entries; not changed here.

## Verification

All at `b0a4df615` unless noted. Every run through the container's shared heavy-verify lock; verdicts quoted from the runner's own summary.

| run | verdict |
|:--|:--|
| `vitest run packages/plugin-detail/` | `Test Files  135 passed (135)` · `Tests  1216 passed (1216)` |
| `vitest run apps/console/` | `Test Files  89 passed (89)` · `Tests  1069 passed (1069)` |
| `vitest run packages/app-shell/ --shard=1/3` | `Test Files  216 passed (216)` · `Tests  2094 passed \| 1 skipped (2095)` |
| `vitest run packages/app-shell/ --shard=2/3` | `Test Files  216 passed (216)` · `Tests  1921 passed (1921)` |
| `vitest run packages/app-shell/ --shard=3/3` | `Test Files  215 passed (215)` · `Tests  2219 passed (2219)` |
| `vitest run` calendar+gantt+kanban+runner+schema-catalog+console-starter | `Test Files  153 passed (153)` · `Tests  2958 passed (2958)` |
| `pnpm --filter @object-ui/plugin-detail run type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`) |
| `eslint .` in `packages/plugin-detail` | exit 0 — `899 problems (0 errors, 899 warnings)`, all pre-existing `no-explicit-any`; the two on the new pin are the same `renderBody(record: any, schema: any)` shape the `#7586` harness already ships |
| `check:control-bytes` | `OK (scanned 6628 tracked text file(s))` |
| `check:phantom-deps` · `check:unused-deps` · `check:self-import` | all `✅` |
| `check:unreferenced-sources` · `check:vi-mock-specifiers` · `check:vi-mock-inherit` | all OK |
| `check:changeset-presence` · `check:changeset-no-major` | `✅ 4 source file(s) … declares 1 changeset(s)` · `✅ No changeset declares a major bump` |
| `check:governed-queue-guard --test` | `✅ NOT GOVERNED — 5 path(s) checked` |

The package test set was chosen from `TURBO_SCM_BASE=dacb98f3b turbo ls --affected` (11 packages); `examples/byo-backend-console` and `apps/site` carry no test files.

**Declared narrowings, left to CI:** `check:sdui-registration-pins` returned its `PREREQUISITE NOT MET` exit 2 ("build the console first") — a NOT-MEASURED, not a red; this diff changes no `ComponentRegistry.register` call. The repo-wide `pnpm lint` and the remaining `check:*` farm are CI's run.

## Notes

Session for this work: `https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S`

Scope fence honoured: objectui#7586 removed the `primaryField` rung from these same lines and nothing here restores it — this is an **addition** to the ladder. Its pin, `record-details.primaryFieldRetired-7586.test.tsx`, is untouched and still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_