### PR TITLE
test(core): pin the OUT-of-window precedence pair formatDate(V, 'relative', { style: 'short' })

### DIFF
--- a/.changeset/pin-relative-out-of-window-precedence-8262.md
+++ b/.changeset/pin-relative-out-of-window-precedence-8262.md
@@ -1,0 +1,7 @@
+---
+---
+
+Test-only: pin the OUT-of-window half of objectui#7745's precedence pair —
+`formatDate(v, 'relative', { style: 'short' })` on a years-old date renders the
+default absolute face, not the `options.style` face. No published behaviour
+changes.

--- a/packages/core/src/utils/__tests__/date-display.optionsStyle-7745.test.ts
+++ b/packages/core/src/utils/__tests__/date-display.optionsStyle-7745.test.ts
@@ -50,8 +50,20 @@
  *       falsifiable — neither mutation can turn both red.
  *   Dropping the `absoluteFallbackOptions` strip in `formatRelativeDate`
  *       RED: "`formatRelativeDate` still does not read `style`" (its
- *       out-of-window fallback would start honouring it) and the
- *       non-recursion case (`{ style: 'relative' }` blows the stack).
+ *       out-of-window fallback would start honouring it), the
+ *       non-recursion case (`{ style: 'relative' }` blows the stack), and —
+ *       since objectui#8262 — the OUT-of-window precedence case below.
+ *
+ * ── objectui#8262 — the out-of-window half of the sharpest pair ─────────────
+ * The pair at "beats it on the sharpest pair" was measured only INSIDE the
+ * ±7-day window, where `formatDate(v, 'relative', …)` produces the relative
+ * phrase locally and never reaches the absolute fallback. Outside the window
+ * the same call round-trips through `formatRelativeDate` and back into
+ * `formatDate`, carrying the shared bag — a second place the losing spelling
+ * could take effect, and the one `formatDate`'s own precedence pin could not
+ * see. "beats it OUT of window too" is that half; it is what keeps the #7745
+ * ruling two-sided if the strip is ever flipped (objectui#7816, ruled A —
+ * `formatRelativeDate` stays style-less — so nothing lands there today).
  */
 import { describe, it, expect } from 'vitest';
 
@@ -115,6 +127,36 @@ describe('the precedence between the two spellings is pinned: positional wins (#
     // options-wins would render the compact-year short face here.
     expect(formatDate(soon, 'relative', { style: 'short', locale: L })).toBe(
       formatRelativeDate(soon, { locale: L }),
+    );
+  });
+
+  it('beats it OUT of window too — on the delegated absolute face (#8262)', () => {
+    // The out-of-window sibling of the case above, and the reason it is a
+    // separate case: `V` is years old, so `formatDate(V, 'relative', …)` does
+    // NOT render its face here — it calls `formatRelativeDate`, which is past
+    // its ±7-day window and delegates BACK into `formatDate` for the absolute
+    // face, carrying the shared bag the whole way. That round trip is a second
+    // site at which the losing spelling could take effect, and the in-window
+    // case cannot reach it.
+    //
+    // Positional `'relative'` was the only face selector consulted, so what
+    // comes out is the default absolute face — stated as the equivalence
+    // first, because that half holds in any time zone.
+    expect(formatDate(V, 'relative', { style: 'short', locale: L })).toBe(
+      formatDate(V, undefined, { locale: L }),
+    );
+    // ⚠️ TZ is an INPUT here, not ambience: `V` is 07:00Z and every face in
+    // this module is built from LOCAL date parts, so the literal below reads
+    // `Jul 4` in UTC and in every zone from UTC-07:00 eastward, and `Jul 3`
+    // west of it. The repo pins no `TZ` (none in `vitest.config.mts`, none in
+    // any workflow); CI and this container both resolve `UTC`. The two
+    // equivalences around it are TZ-free and carry the property on their own.
+    expect(formatDate(V, 'relative', { style: 'short', locale: L })).toBe('Jul 4, 2024');
+    // The named loser, with its own lit control immediately before it — a
+    // `not.toBe` against a face that renders nothing would pass for free.
+    expect(formatDate(V, 'short', { locale: L })).toBe("Jul 4, '24");
+    expect(formatDate(V, 'relative', { style: 'short', locale: L })).not.toBe(
+      formatDate(V, 'short', { locale: L }),
     );
   });
 


### PR DESCRIPTION
Fixes #8262

Test-only. No source file changes, no rendered face moves.

## What the pin asserts

One new case in `packages/core/src/utils/__tests__/date-display.optionsStyle-7745.test.ts`, in the
existing `the precedence between the two spellings is pinned: positional wins (#7745)` describe:

> `formatDate(V, 'relative', { style: 'short', locale: 'en-US' })` on a years-old `V` renders the
> **default absolute face** (`Jul 4, 2024`) — byte-identical to `formatDate(V, undefined, { locale })`
> and *not* the `'short'` face `Jul 4, '24`.

Why that is a reading and not a snapshot: #7745's sharpest pair was measured only **inside** the
±7-day window, where `formatDate(v, 'relative', ...)` produces the phrase locally and never reaches
the absolute fallback. **Outside** the window the same call round-trips through `formatRelativeDate`
and back into `formatDate`, carrying the shared options bag the whole way — a second site at which
the losing spelling can take effect, and the one the in-window case structurally cannot see.

Assertion shape: the TZ-free equivalence first (`=== formatDate(V, undefined, { locale })`), then the
literal anchor, then the named loser with its own lit control immediately before it, so the
`not.toBe` cannot pass against a face that renders nothing.

## Ablation — two legs, both restored BY STATE

Every leg mutates the **read site** in `packages/core/src/utils/date-display.ts`, never the pin, and
runs from a committed implementation. Restore is `git checkout HEAD -- PATH` under a
`trap ... EXIT INT TERM` with absolute paths; proof is `git diff HEAD` empty **and** the blob hash
back to `git rev-parse HEAD:PATH`, never an exit code.

`HEAD` blob of `date-display.ts` (both legs): `6cbabb21ccb0eb105722aaaf87b5185b3bfebd2c`

### Leg C — drop the strip (`:152`, `absoluteFallbackOptions(options)` to `options`)

Mutated blob `e46f7f1fce2bdece1be4d9ccdcf493d22fd6970b`. On-disk proof: anchor count 1 to 0,
injected count 0 to 1. Verdict `Tests  4 failed | 11 passed (15)`. Red by name:

- `... > the options spelling IS the positional spelling, for every face` (RangeError, recursion)
- **`... > beats it OUT of window too — on the delegated absolute face (#8262)`** (new)
- `... > ignores it on the out-of-window ABSOLUTE fallback too`
- `... > does not recurse when the bag carries style: 'relative'`

`AssertionError: expected 'Jul 4, \'24' to be 'Jul 4, 2024'` — the leak, exactly as #7816 recorded it.
`... > beats it on the sharpest pair` (the in-window case) stays GREEN, which is the point.

### Leg P — invert the precedence (`:203`, `style ?? options?.style` to `options?.style ?? style`)

Mutated blob `3ae103e49dd4894f5788eb89e5241090da341a61`; same on-disk proof.
Verdict `Tests  4 failed | 11 passed (15)`. Red by name: the four cases of the precedence describe,
including the new one. The entire `formatRelativeDate still does not read style` describe stays
GREEN — the strip neutralises `style` before the delegated call, so those rows cannot see this half.

### The result the two legs give together

Leg C reds and leg P reds intersect in **exactly one** case: the new one. No existing row in the file
is red in both. That is the new case's whole claim — it is anchored to the *conjunction* of the
precedence and the strip, which is what "two-sided" means here, and it is the row that survives as a
trip-wire if #7816 is ever reopened and the strip flipped (the seat doing that legitimately rewrites
the `formatRelativeDate` rows; this one is not in that blast radius by name).

## Correction against the card

#8262's body says leg C makes the call render `Jul 4, '24` "and **no existing test goes red**".
**Measured false**: leg C turns **three existing** rows red on current `main`, and #7816's own body
already recorded that (`It turned three cases red`). The true and stronger statement is the
intersection above. The card's *conclusion* survives the correction; its stated evidence does not.

## Scope

- objectui#8194's `SCOPE FENCE` (`packages/fields/src/__tests__/fields-date-widget-convention-8194.test.tsx:285`)
  fences the two readonly **`datetime`** widget sites whose home is `formatDateTime`. This PR is
  `@object-ui/core`'s `formatDate` precedence and touches no `packages/fields` file and no
  `formatDateTime` face. Not crossed.
- objectui#8209 (unruled, same territory) is untouched.
- No display-convention choice was needed: the face asserted is the one `main` renders today, measured.

## Locale and timezone

`locale` is fixed explicitly in the fixture (`en-US`, the file's existing `L`).

**TZ is an input here and the repo pins none** — no `TZ` in `vitest.config.mts`, in any
`vitest.setup.*`, in `turbo.json`, in `package.json`, or in any workflow (zero hits; lit control on
the same corpus fires). CI and this container both resolve `UTC`. `V` is `07:00:00.000Z` and every
face in the module is built from **local** date parts, so the literal reads `Jul 4` in UTC and in
every zone from UTC-07:00 eastward, `Jul 3` west of it. The comment in the new case says exactly
this, and the two equivalences either side of the literal are TZ-free and carry the property alone.

This exposure is **pre-existing and out of scope here** — measured, not assumed: at the branch base
`411a132c0`, `TZ=Etc/GMT+8 pnpm exec vitest run <the pin file>` already gives
`Tests  10 failed | 4 passed (14)` **without** this PR's row. Reported to the PM as an out-of-scope
finding (6 files, 49 literal day-bearing assertions in the family) rather than filed: the session's
REST channel is gated 403 and the MCP pool returned `API rate limit already exceeded`, so the
mandatory de-duplication search could not be run, and filing unchecked is the worse failure.

## Verification (all quoted from the runner's own summary, at final HEAD `4aef6b774`)

| what | verdict line |
| --- | --- |
| the pin file | `Test Files  1 passed (1)` / `Tests  15 passed (15)` |
| `packages/core/` in full | `Test Files  122 passed (122)` / `Tests  2574 passed (2574)` |
| `packages/core` `type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`) |
| the new file is really in that program | `tsc -p tsconfig.test.json --listFiles` hits the pin file **1**; the main `tsc --noEmit` program hits it **0** — which is why the script runs both |
| `packages/core` `eslint .` | `✖ 517 problems (0 errors, 517 warnings)`; **0** of them name this file |
| `check-changeset-presence` | `✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/pin-relative-out-of-window-precedence-8262.md.` + `Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.` (its **first** run, before the changeset, was `❌ ... adds no changeset` — a test-only change under a released package's `src/` still owes the declaration) |
| `check:changeset-no-major` | `✅  No changeset declares a major bump.` |
| `check:control-bytes` | `✅  check-control-bytes: OK (scanned 6638 tracked text file(s); skipped 85 binary).` |
| `check:vi-mock-specifiers` / `check:vi-mock-inherit` | both `✅ ... OK` |
| `check-governed-queue-guard --test <the two paths>` | `✅ NOT GOVERNED — 2 path(s) checked against 5 governed surface(s); none matched.` (lit control: `--test AGENTS.md` fires the governed branch) |

Every exit code above was captured with `cmd > file 2>&1; EXIT=$?`, never through a pipe.

**Declared narrowing.** `turbo ls --affected` names 38 packages, because everything depends on
`@object-ui/core`. The diff is one file under `packages/core/src/**/__tests__/` plus a changeset:
`git grep optionsStyle-7745` across `packages apps examples scripts e2e` returns **zero** references
(lit control `absoluteFallbackOptions` returns 2), and `@object-ui/core`'s `files` is
`["dist","README.md","CHANGELOG.md","LICENSE"]`, so no other package can observe it. Everything
outside `packages/core/` is declared to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_