### PR TITLE
fix(app-shell): stop emitting the third kanban lane spelling `groupBy`

### DIFF
--- a/.changeset/8213-objectview-kanban-groupby-retired.md
+++ b/.changeset/8213-objectview-kanban-groupby-retired.md
@@ -1,0 +1,37 @@
+---
+"@object-ui/app-shell": minor
+---
+
+**app-shell: the object page stops emitting `groupBy` in its view-level kanban config.**
+
+`ObjectView`'s `kanbanViewOptions` wrote two spellings of one concept into
+`options.kanban` — the spec's `groupByField`, and beside it `groupBy`. Measured
+against `@objectstack/spec` 17.3.0, the strict `KanbanConfigSchema` declares
+`groupByField` / `summarizeField` / `columns` and refuses `groupBy` **by name**
+(control on the same call: a bogus key is refused by name; `groupByField` alone
+is refused nothing). Upstream even knows the other legacy spelling by name —
+probing `groupField` answers "Did you mean `groupField` → `groupByField`?" — and
+knows nothing about `groupBy`. This repo was producing a third dialect for a key
+the contract already carries, which is exactly what AGENTS.md #0.1 forbids
+fixing at the renderer instead of the producer.
+
+**Breaking, in the sense worth stating explicitly** (shipped `minor`: this repo
+never declares `major`). A consumer reading `options.kanban.groupBy` off the
+schema this page builds loses that key. What such a consumer loses is nothing:
+the identical value is written by the same expression under `groupByField`, the
+capability gate resolves `groupByField || groupField` and never read `groupBy`,
+the kanban render branch resolves `groupByField || groupField ||
+detectStatusField(...)` and never read it either, and the one reader that did
+list it — `ListView`'s projection/expand collectors, which offer
+`v.groupByField, v.groupField, v.groupBy` as candidates for the same lane value
+— reads the canonical key first. A producer census over every tracked file found
+no other runtime writer of a view-level `groupBy` in this repo, and the sibling
+producer `defaultKanbanFromObject` has emitted `{ groupByField }` alone all
+along. Anyone who *did* author the key was already off-spec: the platform
+refuses it at authoring and publish time.
+
+Removing the write also takes away the only producer feeding a latent override:
+`ListView`'s kanban branch spreads the rest of the merged config **after** its
+own `groupBy: laneField`, so a surviving `groupBy` won over the lane the branch
+had just resolved. Both held the same value, so nothing was visibly wrong yet.
+The override itself is untouched here and is tracked separately.

--- a/packages/app-shell/src/views/ObjectView.kanbanGroupByRetired-8213.test.tsx
+++ b/packages/app-shell/src/views/ObjectView.kanbanGroupByRetired-8213.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8213 — the object page wrote a THIRD spelling of the kanban lane
+ * key into the view-level config it hands to `list-view`.
+ *
+ * `kanbanViewOptions` emitted `{ groupBy: lane, groupByField: lane }`: the
+ * spec's own `groupByField`, and beside it `groupBy`, which
+ * `@objectstack/spec`'s strict `KanbanConfigSchema` refuses BY NAME. Upstream
+ * already knows the OTHER legacy spelling by name — probing `groupField`
+ * answers "Did you mean `groupField` → `groupByField`?" — and knows nothing at
+ * all about `groupBy`. objectui#8193 had moved this producer onto the canonical
+ * key and deliberately left this half for a card of its own, because dropping
+ * it needed a census first.
+ *
+ * ⭐ WHAT THIS FILE ASSERTS, AND WHY IT IS NOT A SOURCE-TEXT SNAPSHOT. Every arm
+ * below RUNS the producer and asks `KanbanConfigSchema` about the object it
+ * actually returned. Nothing here greps `ObjectView.tsx`, so a reformat, a
+ * rename of the local `lane` variable, or a move of the expression cannot make
+ * these arms lie in either direction: the claim is about emitted KEYS, and the
+ * only way to satisfy it is to emit them.
+ *
+ * ⚠️ THE CLAIM IS NARROWER THAN "THE EMITTED BAG VALIDATES", and saying so is
+ * the point of the ratchet arm. The producer also emits `titleField` and
+ * `cardFields`, and `KanbanConfigSchema` — which declares exactly
+ * `groupByField` / `summarizeField` / `columns` — refuses BOTH of those by name
+ * as well. They are a different question and stay:
+ *   - `cardFields` is a DECLARED deprecated alias of the spec's `columns` in
+ *     this repo's own `KanbanConfig` mirror (`@object-ui/types`), i.e. drift
+ *     this repo has taken a documented position on;
+ *   - `titleField` is live and undeclared anywhere — `ListView` destructures it
+ *     out of the merged config and forwards it onto the generated
+ *     `object-kanban` node.
+ * Neither is a second spelling of a key this expression already writes
+ * correctly, which is all objectui#8213 was. So the honest assertion is not
+ * "nothing is refused" but "the refused set is EXACTLY the two known ones" —
+ * which reddens for a fourth undeclared key, and would have reddened for
+ * `groupBy`.
+ *
+ * ⚠️ NO ARM HERE ASSERTS THE `...restKanban` OVERRIDE, deliberately. `ListView`
+ * spreads the rest of the merged kanban config AFTER its own `groupBy:
+ * laneField`, so a surviving `groupBy` wins over the lane it just resolved.
+ * That override is real, but it cannot be pinned FROM THIS PRODUCER: every bag
+ * this producer can build has `groupBy` and `groupByField` holding the same
+ * value by construction, so an override row driven by it passes with or without
+ * the fix — a test that cannot fail. Distinguishing the two spellings needs a
+ * hand-built `plugin-list` fixture (`options.kanban.groupBy: 'a'` against
+ * `kanban.groupByField: 'b'`), which is a `plugin-list` change on its own card.
+ * What this deletion does is remove the only producer in this repo that fed the
+ * override; the override itself is untouched.
+ *
+ * REVERSE VERIFICATION — direction predicted before running, then observed:
+ * restore `{ groupBy: lane, groupByField: lane }` in `kanbanViewOptions` and
+ * the two discriminating arms plus the ratchet arm go RED by name, while every
+ * CONTROL (the schema refusing a bogus key, the schema accepting the canonical
+ * config, the lane still resolving) stays GREEN in both worlds. That asymmetry
+ * is what makes the controls worth their lines: an instrument that refused
+ * everything would satisfy the discriminating arms for the wrong reason.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { KanbanConfigSchema } from '@objectstack/spec/ui';
+import { kanbanViewOptions } from './ObjectView';
+
+/** An object whose lifecycle field the ADR-0085 detector finds by name. */
+const OBJECT_WITH_STAGE = {
+  name: 'deal',
+  fields: { name: { type: 'text' }, stage: { type: 'select' } },
+};
+
+/** Every spelling of the ONE lane concept this repo has ever produced. */
+const LANE_SPELLINGS = ['groupByField', 'groupField', 'groupBy'] as const;
+
+/**
+ * Key-level judgement only. The producer never emits the spec's REQUIRED
+ * `columns`, so a full parse of its output is red in every world; reading
+ * `unrecognized_keys` is what separates "this key is refused by name" from that
+ * orthogonal noise. Same discipline the card's own four probes used.
+ */
+const refusedKeys = (bag: Record<string, unknown>): string[] => {
+  const r = KanbanConfigSchema.safeParse(bag);
+  if (r.success) return [];
+  return r.error.issues
+    .flatMap((i: any) => (i.code === 'unrecognized_keys' ? (i.keys as string[]) : []))
+    .sort();
+};
+
+/** The lane keys actually PRESENT on a bag, by name, in sorted order. */
+const laneKeysOf = (bag: Record<string, unknown>) =>
+  LANE_SPELLINGS.filter((k) => k in bag).sort();
+
+/** The two keys the producer emits that the spec refuses and this card keeps. */
+const KNOWN_REFUSED_RESIDUAL = ['cardFields', 'titleField'];
+
+describe('the instrument can answer both ways on this exact call (objectui#8213)', () => {
+  it('CONTROL: the strict schema refuses an unknown key BY NAME on the producer output', () => {
+    // Fires. Without it, every empty refusal below is indistinguishable from a
+    // schema that has stopped judging this call shape at all.
+    const emitted = kanbanViewOptions({ kanban: { groupByField: 'stage' } }, OBJECT_WITH_STAGE);
+    expect(refusedKeys({ ...emitted, zzzBogusKey: 'x' })).toContain('zzzBogusKey');
+  });
+
+  it('CONTROL: the strict schema refuses NOTHING in a canonical config', () => {
+    // Accepts. Without it, "refused" could just mean "refuses everything".
+    expect(refusedKeys({ groupByField: 'stage', columns: ['name'] })).toEqual([]);
+  });
+
+  it('CONTROL: `groupBy` is still not a key the spec declares', () => {
+    // The premise tripwire. objectui#7685 moved the resolved spec pin while
+    // this card was open, so the measurement was re-run on the installed
+    // version — if a later bump ever DECLARES `groupBy`, this reddens first and
+    // every arm below stops meaning what it says.
+    expect(Object.keys((KanbanConfigSchema as any).shape)).not.toContain('groupBy');
+  });
+});
+
+describe('the object page emits ONE lane spelling — the spec\'s (objectui#8213)', () => {
+  // THE DISCRIMINATING ARMS. Each ran with `groupBy` in the emitted bag before
+  // this card, on every path that resolves a lane.
+  it('for a view that declared the canonical key', () => {
+    const emitted = kanbanViewOptions({ kanban: { groupByField: 'stage' } }, OBJECT_WITH_STAGE);
+    expect(laneKeysOf(emitted)).toEqual(['groupByField']);
+    expect(refusedKeys(emitted)).not.toContain('groupBy');
+  });
+
+  it('for a view that declared the LEGACY alias', () => {
+    // The alias READ is untouched by this card: the value arrives legacy and
+    // leaves canonical, and leaves under one key only.
+    const emitted = kanbanViewOptions({ kanban: { groupField: 'stage' } }, OBJECT_WITH_STAGE);
+    expect(laneKeysOf(emitted)).toEqual(['groupByField']);
+  });
+
+  it('for a lane the ADR-0085 detector supplied', () => {
+    // The commonest case in the product — a view with no kanban block at all.
+    const emitted = kanbanViewOptions({}, OBJECT_WITH_STAGE);
+    expect(laneKeysOf(emitted)).toEqual(['groupByField']);
+  });
+
+  it('and emits no lane key at all when no lane resolves', () => {
+    // Absence stays absence: a producer that always emitted a lane key — even
+    // an empty one — would light the capability gate for every object view.
+    const emitted = kanbanViewOptions({}, { name: 'note', fields: { body: { type: 'text' } } });
+    expect(laneKeysOf(emitted)).toEqual([]);
+  });
+});
+
+describe('the one reader of `groupBy` still gets the same value (objectui#8213)', () => {
+  it('carries the lane under `groupByField`, the rung the collectors read first', () => {
+    // The census question, stated as a property rather than as a claim about
+    // call sites. `ListView`'s two projection/expand collectors list
+    // `v.groupByField, v.groupField, v.groupBy` as candidates for the SAME lane
+    // value; deleting the third is only safe because the first carries it. If a
+    // future edit moved the value onto `groupBy` alone, this reddens.
+    expect(kanbanViewOptions({}, OBJECT_WITH_STAGE).groupByField).toBe('stage');
+  });
+
+  it('CONTROL: a lane really did resolve, so the arm above is not an empty agreeing with an empty', () => {
+    const emitted = kanbanViewOptions({}, OBJECT_WITH_STAGE);
+    expect(Object.keys(emitted).length).toBeGreaterThan(0);
+    expect(emitted.groupByField).toBeTruthy();
+  });
+});
+
+describe('the RATCHET on what the spec still refuses here (objectui#8213)', () => {
+  // ⭐ THE DURABLE ARM. Not "the emitted bag validates" — it does not, and this
+  // file's header says why. This is the exact refused SET, so `groupBy` cannot
+  // come back and a FOURTH undeclared key cannot join quietly.
+  it('refuses exactly the two known residual keys, and nothing else', () => {
+    const emitted = kanbanViewOptions({ kanban: { groupByField: 'stage' } }, OBJECT_WITH_STAGE);
+    expect(refusedKeys(emitted)).toEqual(KNOWN_REFUSED_RESIDUAL);
+  });
+
+  it('holds on the detector path and the no-lane path too', () => {
+    expect(refusedKeys(kanbanViewOptions({}, OBJECT_WITH_STAGE))).toEqual(KNOWN_REFUSED_RESIDUAL);
+    expect(
+      refusedKeys(kanbanViewOptions({}, { name: 'note', fields: { body: { type: 'text' } } })),
+    ).toEqual(KNOWN_REFUSED_RESIDUAL);
+  });
+
+  it('CONTROL: the residual set is what it says it is, and `groupBy` is not in it', () => {
+    // Guards the ratchet against being satisfied by a residual list that
+    // quietly grew to include the very key this card retired.
+    expect(KNOWN_REFUSED_RESIDUAL).not.toContain('groupBy');
+    expect(KNOWN_REFUSED_RESIDUAL.length).toBe(2);
+  });
+});

--- a/packages/app-shell/src/views/ObjectView.kanbanLane-8193.test.tsx
+++ b/packages/app-shell/src/views/ObjectView.kanbanLane-8193.test.tsx
@@ -36,11 +36,13 @@
  * is exactly why the sibling could drop the alias write. The arms below assert
  * what this face WRITES, never what any face reads.
  *
- * ⚠️ `groupBy` IS DELIBERATELY STILL WRITTEN, and this file records why rather
- * than asserting it away. Measured against the spec (below), `groupBy` is not a
- * declared key either — but it is read by `ListView`'s projection collectors,
- * so retiring it needs a producer census and got its own card: objectui#8213.
- * One atomic producer change per PR is what kept this one reviewable.
+ * ⚠️ `groupBy` WAS STILL WRITTEN WHEN THIS FILE LANDED, and is not any more:
+ * objectui#8213 ran the producer census this file deferred and retired the
+ * third spelling. The arms below that named it have been re-judged rather than
+ * spelling-swapped — the spec-refusal arm is still true and still here, the
+ * producer arm that asserted the write is gone, and the anti-fork arm no longer
+ * has to filter `groupBy` out before comparing the two producers. What that
+ * retirement asserts is pinned in `ObjectView.kanbanGroupByRetired-8213`.
  *
  * REVERSE VERIFICATION — direction predicted before running, then observed:
  * restore `return lane ? { groupBy: lane, groupField: lane } : {}` and the
@@ -138,7 +140,11 @@ describe('the two app-shell kanban producers speak ONE vocabulary (objectui#8193
     const viaObjectPage = kanbanViewOptions({}, OBJECT_WITH_STAGE);
     const viaInterfacePage = defaultKanbanFromObject(OBJECT_WITH_STAGE);
 
-    const objectPageLaneKeys = laneKeysOf(viaObjectPage).filter((k) => k !== 'groupBy');
+    // objectui#8213 removed the `.filter((k) => k !== 'groupBy')` that stood
+    // here. It existed only because this face emitted a third spelling the
+    // sibling never did; with the write gone the comparison is unfiltered, so
+    // re-introducing ANY lane spelling on either side now reddens this arm.
+    const objectPageLaneKeys = laneKeysOf(viaObjectPage);
     const interfacePageLaneKeys = laneKeysOf(
       viaInterfacePage as unknown as Record<string, unknown>,
     );
@@ -196,13 +202,15 @@ describe('the emitted lane key is the one `@objectstack/spec` declares (objectui
     expect(unrecognized(complete({ groupField: 'stage' }))).toContain('groupField');
   });
 
-  it('MEASURED, NOT FOLDED: the spec refuses `groupBy` too — objectui#8213', () => {
+  it('refuses `groupBy` by name too — the finding this file made, objectui#8213', () => {
     // The card's one explicitly unmeasured question, answered here so the
     // answer cannot be lost: `groupBy` is not a spec key at view level either.
-    // It is still written, because `ListView`'s projection collectors read it;
-    // retiring it needs a producer census and is objectui#8213, not this PR.
+    // ⚠️ The second half of this arm used to assert the producer STILL wrote it
+    // (`kanbanViewOptions({}, OBJECT_WITH_STAGE).groupBy === 'stage'`).
+    // objectui#8213 ran the census and deleted the write, so that half was
+    // replaced rather than re-spelled — asserting the retirement belongs with
+    // the rest of it, in `ObjectView.kanbanGroupByRetired-8213`.
     expect(unrecognized(complete({ groupBy: 'stage' }))).toContain('groupBy');
-    expect(kanbanViewOptions({}, OBJECT_WITH_STAGE).groupBy).toBe('stage');
   });
 
   it('declares exactly the three keys this file reasons about', () => {

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -383,11 +383,52 @@ export function galleryViewOptions(viewDef: any): Record<string, unknown> {
  * and objectui#7544 for `chart`. Pinned in `ObjectView.kanbanLane-8193` here
  * and in `ListView.kanbanOptionsBagCanonical-8193` in `plugin-list`.
  *
- * ⚠️ `groupBy` is kept VERBATIM and is deliberately not folded. It is not the
- * spec's key either — measured against `KanbanConfigSchema`, which declares
- * `groupByField` / `summarizeField` / `columns` and refuses `groupBy` by name —
- * but it is read by `ListView`'s projection collectors, so retiring it is a
- * separate change with its own census: objectui#8213.
+ * ⭐ `groupBy` IS RETIRED HERE (objectui#8213) — the THIRD spelling of the one
+ * concept this expression already writes canonically. Measured against
+ * `@objectstack/spec` 17.3.0's strict `KanbanConfigSchema`, which declares
+ * `groupByField` / `summarizeField` / `columns` and refuses `groupBy` BY NAME,
+ * on a call where one control fires (`zzzBogusKey` is refused by name) and
+ * another accepts (`groupByField` alone draws no `unrecognized_keys`). Upstream
+ * knows the OTHER alias by name — probing `groupField` answers "Did you mean
+ * `groupField` → `groupByField`?" — and knows nothing at all about `groupBy`.
+ *
+ * ⚠️ THE PRODUCER CENSUS THE CARD MADE A PRECONDITION, run before the deletion.
+ * A structural scan of every tracked file for a bare `groupBy` inside a
+ * view-level `kanban`/`calendar`/`gallery`/`timeline`/`gantt` object literal
+ * found NO runtime producer but this one; the lit control on the same
+ * instrument (`groupByField` in the same position) returned 58 sites, so the
+ * empty reading is a reading. The only other authors are FIXTURES: the two arms
+ * of `ListView.kanbanOptionsBagCanonical-8193` that pin this very bag, and one
+ * stale metadata payload in `data-objectstack`'s `updateView.draft.test.ts`.
+ * The sibling producer `defaultKanbanFromObject` emits `{ groupByField }` alone
+ * and always has.
+ *
+ * ⚠️ WHY THE ONE READER IS UNHARMED. `ListView`'s two projection/expand
+ * collectors list `v.groupByField, v.groupField, v.groupBy` as candidates for
+ * the same lane value, so `groupBy` did contribute a field NAME to the query
+ * projection — and this same expression writes that identical value under
+ * `groupByField`, which those collectors read first. The capability gate never
+ * read `groupBy` at all (it resolves `groupByField || groupField` on both
+ * nestings), and neither does the render branch (`groupByField || groupField ||
+ * detectStatusField(...)`).
+ *
+ * ⚠️ WHAT THIS CLOSES AND WHAT IT DOES NOT. `ListView`'s kanban branch
+ * destructures `columns`/`groupByField`/`groupField`/`cardFields`/`titleField`
+ * out of the merged config and spreads the REST *after* its own
+ * `groupBy: laneField`, so a surviving `groupBy` overrides the lane it just
+ * resolved. This deletion removes the only producer in this repo that fed that
+ * override — it does NOT remove the override, which stays reachable from
+ * author-written `kanban.groupBy` riding this repo's `.passthrough()` mirror
+ * and is a `plugin-list` change on its own card.
+ *
+ * ⚠️ `titleField` AND `cardFields` BELOW ARE ALSO OUTSIDE `KanbanConfigSchema`,
+ * and are deliberately NOT swept up here. `cardFields` is a DECLARED deprecated
+ * alias of the spec's `columns` in this repo's own `KanbanConfig` mirror
+ * (`@object-ui/types`), and `titleField` is live — `ListView` forwards it onto
+ * the generated node. Neither is a second spelling of a key this expression
+ * already writes correctly, which is the whole of objectui#8213. They are
+ * pinned as the KNOWN residual in `ObjectView.kanbanGroupByRetired-8213`, so a
+ * fourth undeclared key reddens instead of joining them quietly.
  *
  * ADR-0085: when the view doesn't pick a lane field, the object's declared
  * lifecycle (`stageField`) decides — including the strict `stageField: false`
@@ -404,7 +445,7 @@ export function kanbanViewOptions(viewDef: any, objectDef: any): Record<string, 
         detectStatusField(objectDef as any) ||
         undefined;
     return {
-        ...(lane ? { groupBy: lane, groupByField: lane } : {}),
+        ...(lane ? { groupByField: lane } : {}),
         titleField: viewDef?.kanban?.titleField || 'name',
         cardFields: viewDef?.kanban?.columns,
     };

--- a/packages/plugin-list/src/__tests__/ListView.kanbanOptionsBagCanonical-8193.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.kanbanOptionsBagCanonical-8193.test.tsx
@@ -101,7 +101,21 @@ describe('the capability gate resolves kanban from the CANONICAL key in the opti
   });
 
   it('offers Kanban for the bag ObjectView actually writes', () => {
-    // The end-to-end shape, `groupBy` included: the producer's real output.
+    // The end-to-end shape. ⚠️ This fixture used to carry `groupBy` and call
+    // itself "the producer's real output"; objectui#8213 retired that write, so
+    // the producer claim lives here and the `groupBy`-bearing bag moved to the
+    // arm below, as what it always really was — a robustness arm.
+    // ⛔ One `kanbanOffered` per test: it renders into the shared screen, and a
+    // second render in the same test makes every `queryByRole` ambiguous.
+    expect(
+      kanbanOffered({ options: { kanban: { groupByField: 'stage', titleField: 'name' } } }),
+    ).toBe(true);
+  });
+
+  it('CONTROL: a bag that ALSO carries a stray `groupBy` is answered the same', () => {
+    // Stored metadata written before objectui#8213 still carries the key, and
+    // this repo's `KanbanConfig` mirror is `.passthrough()`, so the gate must
+    // keep answering identically for a bag that has it and one that does not.
     expect(
       kanbanOffered({
         options: { kanban: { groupBy: 'stage', groupByField: 'stage', titleField: 'name' } },


### PR DESCRIPTION
Fixes #8213

`ObjectView.kanbanViewOptions` wrote `{ groupBy: lane, groupByField: lane }` into the view-level kanban config it hands to `list-view`. `groupBy` is a **third spelling** of one concept, and `@objectstack/spec`'s strict `KanbanConfigSchema` refuses it **by name**. This drops the write. PM ruling on the card's two options: **A**.

## The four probes, re-run on this branch's own base

Measured against the **installed** `@objectstack/spec` **17.3.0** (the card measured 17.2.0; objectui#7685 has since moved the pin, so the whole measurement was re-taken rather than quoted).

```
declared keys: groupByField, summarizeField, columns

SUBJECT  { groupByField, groupBy }     -> unrecognized_keys: ["groupBy"]
SUBJECT  { groupBy } alone             -> unrecognized_keys: ["groupBy"]
CONTROL  { groupByField, zzzBogusKey } -> unrecognized_keys: ["zzzBogusKey"]   (fires)
CONTROL2 { groupByField } alone        -> unrecognized_keys: []                (accepts)
BONUS    { groupField } alone          -> "Unrecognized key(s) ... `groupField`.
                                          Did you mean `groupField` -> `groupByField`?"
```

CONTROL fires and CONTROL2 accepts on the same call shape, so the refusal of `groupBy` carries information. Key recognition is read off `unrecognized_keys` only; the missing-required-`columns` `invalid_type` is present in **every** arm including CONTROL2 and is not a verdict. Upstream names the *other* alias by name and knows nothing about `groupBy`.

## The producer census (the card's binding precondition), sites printed

Instrument: a structural scan of all 6,628 tracked text files — balanced-brace extract of every `kanban`/`calendar`/`gallery`/`timeline`/`gantt` object literal, searched for a bare `groupBy` (negative lookahead, so `groupByField` and `groupBy2` do not match). Not a count: every hit printed and classified.

**Lit control on the same instrument** — `groupByField` in the same position: **58 sites**. The empty reading below is therefore a reading.

Real view-level `kanban` bag hits, all of them:

| site | what it is |
|---|---|
| `packages/app-shell/src/views/ObjectView.tsx:407` | **the subject** — the only runtime producer |
| `packages/plugin-list/src/__tests__/ListView.kanbanOptionsBagCanonical-8193.test.tsx:107,146` | fixtures pinning this very bag |
| `packages/data-objectstack/src/updateView.draft.test.ts:38` | a stale metadata payload in an *addressing* test; never reaches the collectors |

Everything else the raw grep returns is node-level `object-kanban.groupBy` (its own declared, required key), ObjectQL chart aggregates (`aggregate.groupBy`), the grid shorthand `schema.groupBy`, or i18n labels. The sibling producer `defaultKanbanFromObject` emits `{ groupByField }` alone and always has; `CreateViewDialog` emits `kanban: { groupByField }`.

**Verdict: the ruling survives the census.** No producer emits `groupBy` and nothing else, so the `v.groupBy` rung in `ListView`'s projection/expand collectors is covering nothing this repo writes — and the same expression writes the identical value under `groupByField`, which those collectors read first. The capability gate resolves `groupByField || groupField` on both nestings and never read it; the render branch resolves `groupByField || groupField || detectStatusField(...)` and never read it either.

## What the pin asserts, and why it is not a source-text snapshot

`packages/app-shell/src/views/ObjectView.kanbanGroupByRetired-8213.test.tsx`. Every arm **runs the producer** and hands the returned object to `KanbanConfigSchema`. Nothing greps `ObjectView.tsx`, so a reformat or a rename of the local `lane` cannot make it lie in either direction.

⚠️ **The claim had to be narrowed, and this is a correction against the brief.** The brief asked for a pin asserting *"the emitted config carries no key the spec refuses"*. That assertion is **unreachable**, and would be red after this change too: the producer also emits `titleField` and `cardFields`, and `KanbanConfigSchema` — which declares exactly `groupByField` / `summarizeField` / `columns` — refuses **both of those by name as well**:

```
producer output BEFORE -> unrecognized_keys: ["groupBy", "titleField", "cardFields"]
producer output AFTER  -> unrecognized_keys: ["titleField", "cardFields"]
```

So the pin asserts the honest form: **the refused set is EXACTLY the two known residuals**, plus, separately, that the lane keys present on the bag are exactly `['groupByField']`. That reddens for `groupBy` and for any *fourth* undeclared key, and it stays green for a key that becomes properly declared. The two residuals are a different question and stay: `cardFields` is a **declared** deprecated alias of the spec's `columns` in this repo's own `KanbanConfig` mirror; `titleField` is live and undeclared anywhere (filed separately — see below).

## The `...restKanban` override: measured, and NOT pinned from this producer

The brief warned that a naive override pin cannot fail here. It is worse than that — **no** override pin can be driven from this producer: every bag `kanbanViewOptions` can build has `groupBy` and `groupByField` holding the same value *by construction*, so the two spellings are indistinguishable from this side in every world.

A distinguishing fixture exists only one package over, and I built and ran it rather than reasoning about it. `options.kanban = { groupBy: 'LANE_FROM_STRAY_GROUPBY' }` against `kanban = { groupByField: 'LANE_FROM_CANONICAL' }`, captured off the generated `object-kanban` node:

```
MEASURED node.groupBy = "LANE_FROM_STRAY_GROUPBY"
AssertionError: expected 'LANE_FROM_STRAY_GROUPBY' to be 'LANE_FROM_CANONICAL'
```

The override is **real and active**, not merely latent — it is latent only in the sense that nothing was feeding it a differing value. ⚠️ So one line of the ruling needs correcting: dropping this write removes the only **producer** that fed the override; it does **not** remove the override, which stays reachable from author-written `kanban.groupBy` riding this repo's `.passthrough()` mirror. Filed as a `plugin-list` card. The probe file was deleted; nothing temporary is committed.

## Ablation — the read site, by state

Restored `{ groupBy: lane, groupByField: lane }`, proved it reached disk, ran, restored by state. Script carried `trap '<restore>' EXIT INT TERM` with absolute paths, from the committed implementation.

```
HEAD blob         : 5d66a9b5d638d6a5559a8f0e3f7482cf344d68ff
post-mutation hash: a03bdab5e92f87e8551c54cd6c3e5e547a4321a7   (differs -> mutation on disk)
fixed-text grep -c : 1 -> 0        mutated-text grep -c : 1
```

Six rows red, by name:

```
× ObjectView.kanbanGroupByRetired-8213 > for a view that declared the canonical key
× ObjectView.kanbanGroupByRetired-8213 > for a view that declared the LEGACY alias
× ObjectView.kanbanGroupByRetired-8213 > for a lane the ADR-0085 detector supplied
× ObjectView.kanbanGroupByRetired-8213 > refuses exactly the two known residual keys, and nothing else
× ObjectView.kanbanGroupByRetired-8213 > holds on the detector path and the no-lane path too
× ObjectView.kanbanLane-8193          > derive the same lane key from the same object

AssertionError: expected [ 'groupBy', 'groupByField' ] to deeply equal [ 'groupByField' ]
AssertionError: expected [ 'cardFields', 'groupBy', …(1) ] to deeply equal [ 'cardFields', 'titleField' ]
```

Every CONTROL stayed green in both worlds (21 passed under ablation) — the schema refusing a bogus key, the schema accepting the canonical config, `groupBy` still undeclared, a lane really resolving, absence staying absence. Restore proved **by state**, not by exit code:

```
restored hash : 5d66a9b5d638d6a5559a8f0e3f7482cf344d68ff   (== HEAD blob)
git diff HEAD --name-only: []
```

## Fixture triage, not a spelling sweep

- `ObjectView.kanbanLane-8193.test.tsx` — the `MEASURED, NOT FOLDED` arm asserted the producer **still wrote** `groupBy`. Replaced, not re-spelled: the spec-refusal half is still true and stays; the producer half moved to the new pin. Its anti-fork arm carried `.filter((k) => k !== 'groupBy')` before comparing the two producers — removed, which makes that arm *stronger* (it is one of the six rows the ablation reddens).
- `ListView.kanbanOptionsBagCanonical-8193.test.tsx` — its fixture called itself "the producer's real output" with `groupBy` in it. That claim is now false. The producer claim moved to the real shape and the `groupBy`-bearing bag became an explicit CONTROL (stored metadata written before this change still carries the key, and the mirror is `.passthrough()`). Split into two `it` blocks — a second `kanbanOffered` in one test renders twice into the shared screen and makes every `queryByRole` ambiguous; that is a real red I hit and fixed, not a theoretical one.

## Verification (all at `8c8ffb467`, clean tree)

| run | verdict line, quoted from the runner |
|---|---|
| `vitest run packages/app-shell/` | `Test Files  648 passed (648)` / `Tests  6246 passed | 1 skipped (6247)` |
| `vitest run packages/plugin-list/` | `Test Files  71 passed (71)` / `Tests  884 passed (884)` |
| `type-check` (both packages, incl. `tsconfig.test.json`) | `packages/app-shell type-check: Done` / `packages/plugin-list type-check: Done`, exit 0 |
| `lint` (package-scoped `eslint .`, both packages) | `✖ 2923 problems (0 errors, 2923 warnings)`, exit 0 — warnings are the pre-existing `no-explicit-any` baseline; the two on the new file match the pattern the sibling pin already uses |
| `check:control-bytes` | `✅ check-control-bytes: OK (scanned 6635 tracked text file(s); skipped 85 binary).` |
| `check:spec-symbols` | `✅ spec symbol derivation: 1353 files scanned against 5050 spec export names` |
| `check:unreferenced-sources` | `OK  Every shipped source file in every covered package is reachable.` |
| `check-changeset-presence` | `✅  4 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major` | `✅  No changeset declares a \`major\` bump.` |
| `check-governed-queue-guard --test <diff paths>` | `✅ NOT GOVERNED — 5 path(s) checked against 5 governed surface(s); none matched.` |

Dependency closures were built first (`pnpm --filter '@object-ui/app-shell^...' --filter '@object-ui/plugin-list^...' build`, exit 0), so the type-check reading is not the stale-`dist` signature.

## Changeset

`minor` (this repo never declares `major`; a breaking change ships `minor`). The changeset argues the removal explicitly: a consumer that *did* read `options.kanban.groupBy` loses the key, loses nothing by it — the identical value is written by the same expression under `groupByField`, no gate or render branch ever read it — and anyone who authored the key was already off-spec, since the platform refuses it at authoring and publish time.

## Out of scope, filed separately

1. **`plugin-list`: the `restKanban` spread overrides the lane the kanban branch just resolved** — measured above with a distinguishing fixture. `groupBy` is the one key the destructure does not strip.
2. **The view-level `titleField` is undeclared on both faces** — refused by the spec's `KanbanConfigSchema`, accepted only by this repo's `.passthrough()` mirror, and *live* (`ListView` forwards it onto the generated node). Unlike `cardFields` it is not declared as a deprecated alias anywhere. Either promote it upstream or declare it in the mirror the way `CalendarConfig.defaultView` is.
3. **`data-objectstack/src/updateView.draft.test.ts:38`** authors `kanban: { groupBy: 'status' }` in a draft-view payload fixture — off-spec metadata, inert for that test's subject, and no longer what any producer writes.

⚠️ GitHub's API was returning `API rate limit already exceeded` for issue **search** while this ran, so the dedup search these three need could not be completed. They are described in full in the report for the PM to file rather than filed unsearched — filing without the dedup read and filing nothing are both forbidden.

## Scope fence held

View-level `KanbanConfig` only. The node-level `ObjectKanbanSchema` tombstones (objectui#7322 / #8172 / #7742 / #7772 / #8174) are untouched, and the **live** view-level `groupField` alias objectui#8193 deliberately left in this same expression is untouched — its read and its write both stay. Branch cut from current `main` (`614d85b19`); nothing was carried over from a card's numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_