### PR TITLE
fix(metadata-admin): page:tabs designer item control writes `value`

### DIFF
--- a/.changeset/8278-page-tabs-item-value.md
+++ b/.changeset/8278-page-tabs-item-value.md
@@ -1,0 +1,49 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Fix the page designer's `page:tabs` item control, which wrote a key the spec
+refuses by name and the tabs renderer never reads (objectui#8278).
+
+**Every tab strip built in the page designer carried no stable per-tab value.**
+`BLOCK_CONFIG['page:tabs']` named its identifier item control `key`;
+`PageBlockInspector` writes an item key verbatim (`next[i] = { ...itemObj, [n]: v }`),
+so an author who filled that box produced `properties.items[i].key`. Three faces
+disagreed with that spelling, all three measured on `@objectstack/spec@17.3.0`:
+
+- `ComponentPropsMap['page:tabs'].safeParse` returns `success: false` with
+  `unrecognized_keys` naming `key` at `items.0` — and 17.3.0's own message now
+  spells the remedy out, "Did you mean `key` -> `value`?";
+- `PageTabsRenderer` builds `itemsWithValue` from `it.value` and reads `it.key`
+  nowhere, so the tab falls back to the index-derived `tab-IDX`;
+- `PageTabsProps.items[].value` is a real, declared schema member, which this
+  repo's own `block-config.test.ts` already stated in prose.
+
+So every designer-built tab was addressed by INDEX — exactly the failure
+objectui#2257 dealt with for the URL-addressable active tab (`?tab=`): the deep
+link silently points at a different tab as soon as the item list changes. The
+author DID supply a stable identifier; it landed under a key nothing reads, and
+nothing reported it (`PageComponent.properties` is an open bag, so the page parse
+stays green).
+
+The control is renamed to `value` on the producer side — AGENTS.md #0.1 and the
+rule stated in `block-config.ts`'s own file header ("keep each field `name`
+aligned with the property name the corresponding renderer reads"). Teaching the
+renderer a second spelling would have been the lenient-fallback shape that rule
+forbids. The field `name` is the last segment of the i18n key, so both locale
+tables move with it in this one commit and the retired key leaves both, the
+objectui#3829 / objectui#5212 pattern.
+
+objectui#8216's parity gate carried this key as a LEDGER row. That row is
+deleted here: the gate is a two-way ratchet, and a resolved key that leaves its
+row behind is as red as an unledgered violation.
+
+**Stored documents are left as they are, deliberately.** A tab strip saved by a
+released build carries `items[].key`, which was unread before this change and is
+unread after it — it already fell back to `tab-IDX`, so nothing regresses, and a
+newly-authored strip is now correct. It is not carried over into `value` either:
+that would be a permanent second spelling with no retirement path. It is not
+stripped either, and that half is a real gap rather than a decision this change
+could make — `RETIRED_BLOCK_PROP_KEYS` is a `Record<blockType, string[]>` of
+TOP-LEVEL keys, so a nested `items[].key` cannot be expressed in it at all.
+Tracked separately; see the follow-up card referenced from objectui#8278.

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -685,7 +685,7 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.inspector.pageBlock.field.page:card.bordered': 'Bordered',
   'engine.inspector.pageBlock.field.page:tabs.items': 'Tabs',
   'engine.inspector.pageBlock.add.page:tabs.items': 'Add tab',
-  'engine.inspector.pageBlock.field.page:tabs.items.key': 'Key',
+  'engine.inspector.pageBlock.field.page:tabs.items.value': 'Value',
   'engine.inspector.pageBlock.field.page:tabs.items.label': 'Label',
   // `…field.page:accordion.title` and `…field.page:accordion.items.value`
   // retired with their designer fields (objectui#5212): neither is read by
@@ -2584,7 +2584,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.inspector.pageBlock.field.page:card.bordered': '显示边框',
   'engine.inspector.pageBlock.field.page:tabs.items': '标签页',
   'engine.inspector.pageBlock.add.page:tabs.items': '添加标签页',
-  'engine.inspector.pageBlock.field.page:tabs.items.key': '键',
+  'engine.inspector.pageBlock.field.page:tabs.items.value': '值',
   'engine.inspector.pageBlock.field.page:tabs.items.label': '标签',
   // `…field.page:accordion.title` / `…items.value` retired with their designer
   // fields — see the matching note in the `en` table above. Removed from BOTH

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config-schema-parity-8216.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config-schema-parity-8216.test.ts
@@ -188,14 +188,6 @@ const LEDGER: ReadonlyArray<{ block: string; path: string; face: OracleFace; car
       'The renderer honours it — ObjectKanban.tsx sends `$top: schema.limit ?? DEFAULT_KANBAN_LIMIT` — and both @object-ui/types faces declare it, but ComponentPropsMap[object-kanban] does not. The producer side is upstream, so removing the control would delete a working affordance to satisfy a schema that is behind it.',
   },
   {
-    block: 'page:tabs',
-    path: 'items[].key',
-    face: 'spec',
-    card: 'objectui#8278',
-    why:
-      'PageTabsProps items declare `value`, which the tabs renderer reads (containers.tsx `itemsWithValue`, falling back to an index-derived value); `key` is read nowhere and refused by name. The resolution is a control rename, which also moves the field i18n key in both locale tables and needs a read-door decision for stored documents.',
-  },
-  {
     block: 'object-form',
     path: 'formType',
     face: 'node',
@@ -386,11 +378,21 @@ describe('BLOCK_CONFIG ↔ node-schema parity — the ratchet (objectui#8216)', 
     }
   });
 
-  it('the two SPEC-face ledger rows are real parser refusals, named', () => {
+  it('every SPEC-face ledger row is a real parser refusal, named', () => {
     // The ledger's own non-vacuity. A row recorded from a key-set comparison
     // would look identical to a row recorded from nothing, so each spec-face
     // entry is re-measured through `safeParse` — the verdict the platform's
     // component-props lint actually reaches.
+    //
+    // SELF-DELETING, like the EXEMPT rows above: the probes below are written
+    // out one per row, so this guard is what stops a future spec-face row from
+    // being ledgered with no probe behind it. `page:tabs::items[].key` was the
+    // second row until objectui#8278 renamed that control to `value`; its
+    // measurement moved WITH it, to `page-tabs-item-value-8278.test.tsx`.
+    expect(LEDGER.filter((r) => r.face === 'spec').map(ledgerId)).toEqual([
+      'object-kanban::limit@spec',
+    ]);
+
     const kanban = SPEC_ORACLES['object-kanban'] as { safeParse: (v: unknown) => any };
     const withLimit = kanban.safeParse({ objectName: 'opportunity', groupBy: 'stage', limit: 50 });
     expect(withLimit.success).toBe(false);
@@ -398,15 +400,6 @@ describe('BLOCK_CONFIG ↔ node-schema parity — the ratchet (objectui#8216)', 
     expect(
       kanban.safeParse({ objectName: 'opportunity', groupBy: 'stage' }).success,
       'the base kanban must parse clean, or the refusal above proves nothing',
-    ).toBe(true);
-
-    const tabs = SPEC_ORACLES['page:tabs'] as { safeParse: (v: unknown) => any };
-    const withKey = tabs.safeParse({ items: [{ key: 'a', label: 'A', children: [] }] });
-    expect(withKey.success).toBe(false);
-    expect(withKey.error.issues.flatMap((i: any) => i.keys ?? [])).toContain('key');
-    expect(
-      tabs.safeParse({ items: [{ value: 'a', label: 'A', children: [] }] }).success,
-      'the same item with the DECLARED spelling must parse clean',
     ).toBe(true);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
@@ -225,8 +225,9 @@ describe('record:details sections ↔ spec section-entry coverage (#3819)', () =
   });
 
   it('lists `name` before `label` — the entry identity comes first', () => {
-    // Matches `page:tabs` (`key`), where the stable identifier precedes the
-    // human label. `page:accordion` items no longer have an identifier field
+    // Matches `page:tabs` (`value` — named `key` until objectui#8278 renamed
+    // it to the member the spec declares), where the stable identifier
+    // precedes the human label. `page:accordion` items no longer have an identifier field
     // to compare against — its `value` was removed as dead input (#5212): the
     // renderer derives the panel id and never reads what was authored.
     const order = (sectionsField?.itemFields ?? []).map((f) => f.name);
@@ -462,8 +463,11 @@ describe('page:header `icon` — the designer field retired with the spec key (#
  *     who writes it by hand to remove the key.
  *
  * Neither is symmetric with `page:tabs`: one component over, an authored
- * `items[].value` (designer field name `key`) IS read, with a `tab-${idx}`
- * fallback only when absent (`itemsWithValue` for `page:tabs`, same file).
+ * `items[].value` IS read, with a `tab-${idx}` fallback only when absent
+ * (`itemsWithValue` for `page:tabs`, same file) — and the designer control
+ * there is NAMED `value` since objectui#8278, which is what makes the two
+ * comparable; until then it was named `key`, so the tabs panel wrote a key
+ * the spec refuses by name and the renderer never reads.
  * `PageTabsProps.items[].value` is a real, declared schema member. The
  * accordion's panel id is unconditionally derived; the tabs one is genuinely
  * live — this suite touches the accordion only.

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/page-tabs-item-value-8278.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/page-tabs-item-value-8278.test.tsx
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#8278 — the designer's `page:tabs` item control writes the key the
+ * spec declares and the tabs renderer actually reads.
+ *
+ * ## What was broken
+ *
+ * `BLOCK_CONFIG['page:tabs']` named its identifier item control `key`;
+ * `PageBlockInspector.renderField`'s array branch writes an item key VERBATIM
+ * (`next[i] = { ...itemObj, [n]: v }`), so an author who filled that box got
+ * `properties.items[i].key`. Three faces disagreed with that spelling:
+ *
+ *   - `ComponentPropsMap['page:tabs']` is strict and refuses `key` BY NAME at
+ *     `items.0` (`unrecognized_keys`) — measured below, not asserted from prose;
+ *   - `PageTabsRenderer` (`renderers/layout/containers.tsx`) builds
+ *     `itemsWithValue` from `it.value` and reads `it.key` nowhere, so an item
+ *     without `value` falls back to the index-derived `tab-${idx}`;
+ *   - `PageTabsProps.items[].value` is a real, declared schema member, which
+ *     `block-config.test.ts`'s `page:accordion` suite already states in prose.
+ *
+ * The consequence is the failure objectui#2257 exists to prevent: a tab strip
+ * built in Studio carries no stable per-tab value, so `?tab=` addresses tabs by
+ * INDEX and silently points at a different tab once the item list changes. The
+ * author supplied a stable identifier; it landed under a key nothing reads.
+ *
+ * ## Why this file measures the round trip rather than the table
+ *
+ * A pin that grepped `BLOCK_CONFIG` for the string `value` would pass on a
+ * table whose control name no renderer honours — the exact defect being fixed,
+ * one rename later. So neither end is hard-coded: the key comes out of
+ * `BLOCK_CONFIG` itself and the item is assembled the way `PageBlockInspector`
+ * assembles it, then that item is put to BOTH judges — the spec's parser and
+ * the registered renderer's DOM. A future rename on either face turns this red
+ * instead of quietly re-opening the defect.
+ *
+ * The spec-face half also carries the ledger measurement that
+ * `block-config-schema-parity-8216.test.ts` used to hold: this key was a LEDGER
+ * row in objectui#8216's parity gate, and that row was deleted in this change
+ * because the violation it recorded is resolved.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { ComponentPropsMap } from '@objectstack/spec/ui';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope, not a hook: the package's barrel registers the renderers as a
+// side effect and the cost belongs to the import phase (AGENTS.md §测试纪律,
+// object-ui/no-dynamic-import-in-test-hook).
+import '@object-ui/components';
+import { BLOCK_CONFIG, type BlockPropField } from '../block-config';
+
+const BLOCK = 'page:tabs';
+
+/** The `items` array field, read out of the designer table itself. */
+function itemsField(): Extract<BlockPropField, { kind: 'array' }> {
+  const f = (BLOCK_CONFIG[BLOCK] ?? []).find((x) => x.name === 'items');
+  if (!f || f.kind !== 'array') throw new Error(`${BLOCK} has no \`items\` array field`);
+  return f;
+}
+
+/** The item-object keys a designer build writes — the producer's own answer. */
+const DESIGNER_ITEM_KEYS = itemsField().itemFields.map((f) => f.name);
+
+/**
+ * Build one item exactly as `PageBlockInspector.renderField`'s array branch
+ * does — `next[i] = { ...itemObj, [n]: v }`, one commit per control, in table
+ * order. Assembling it rather than writing a literal is what makes every row
+ * below measure the PRODUCER instead of this file's opinion of it.
+ */
+function authorItem(values: readonly string[]): Record<string, unknown> {
+  let item: Record<string, unknown> = {};
+  DESIGNER_ITEM_KEYS.forEach((name, i) => {
+    item = { ...item, [name]: values[i] };
+  });
+  return item;
+}
+
+/**
+ * `children` is REQUIRED by `PageTabsProps.items[]` and is NOT one of these two
+ * controls' business — a tab's contents come from the canvas's nested sub-block
+ * editor, addressed as `…components[0].properties.items[0].children[0]`. It is
+ * supplied here as the rest of the document supplies it, so the parse verdicts
+ * below are about the two keys these controls DO write.
+ */
+const withChildren = (item: Record<string, unknown>) => ({ ...item, children: [] });
+
+const tabsProps = ComponentPropsMap[BLOCK] as { safeParse: (v: unknown) => any };
+const refusedKeys = (r: any): string[] =>
+  r.success ? [] : r.error.issues.flatMap((i: any) => i.keys ?? []);
+
+/**
+ * `PageTabsRenderer` reads `schema.items` / `schema.defaultTab` at the TOP
+ * level; `SchemaRenderer` hoists `properties.*` onto the schema before it gets
+ * there (the renderer's own comment on the `alwaysShowStrip` dual read says so).
+ * Rendering the registered component directly skips that hoist, so the flat
+ * form is what a real page delivers either way.
+ */
+function renderTabs(items: unknown[], extra: Record<string, unknown> = {}) {
+  const Component = ComponentRegistry.get(BLOCK);
+  if (!Component) throw new Error(`Component "${BLOCK}" is not registered`);
+  return render(<Component schema={{ type: BLOCK, items, ...extra }} />);
+}
+
+afterEach(cleanup);
+
+describe('page:tabs — the designer item control writes a key the SPEC accepts (objectui#8278)', () => {
+  it('CONTROL — the parser CAN refuse an item key by name, so an accept below means something', () => {
+    // Without this row, "the authored item parses clean" could be true of a
+    // schema that had quietly become passthrough and would read identically.
+    const refused = tabsProps.safeParse({ items: [withChildren({ zzzNotAKey: 1, label: 'A' })] });
+    expect(refused.success).toBe(false);
+    expect(refusedKeys(refused)).toContain('zzzNotAKey');
+  });
+
+  it('CONTROL — the RETIRED spelling `key` is still refused, at `items.0`, by name', () => {
+    // The defect's own measurement, kept so the rename cannot be read as "the
+    // spec relaxed". `key` is refused today exactly as it was before.
+    const refused = tabsProps.safeParse({ items: [withChildren({ key: 'overview', label: 'Overview' })] });
+    expect(refused.success).toBe(false);
+    expect(refusedKeys(refused)).toContain('key');
+    expect(
+      refused.error.issues.some(
+        (i: any) => i.code === 'unrecognized_keys' && i.path.join('.') === 'items.0',
+      ),
+    ).toBe(true);
+  });
+
+  it('CONTROL — an item carrying no identifier at all parses clean', () => {
+    // So the refusal above is about the KEY, not about the item shape.
+    expect(tabsProps.safeParse({ items: [withChildren({ label: 'Overview' })] }).success).toBe(true);
+  });
+
+  it('the item an author builds through the designer table is ACCEPTED by the spec', () => {
+    const parsed = tabsProps.safeParse({ items: [withChildren(authorItem(['overview', 'Overview']))] });
+    expect(refusedKeys(parsed), 'a designer-authored tab item is refused by name').toEqual([]);
+    expect(parsed.success).toBe(true);
+  });
+});
+
+describe('page:tabs — the authored identifier reaches the RENDERER as the tab value (objectui#8278)', () => {
+  const authored = () => [
+    withChildren(authorItem(['overview', 'Overview'])),
+    withChildren(authorItem(['history', 'History'])),
+  ];
+
+  it('CONTROL — the harness renders a tab strip at all', () => {
+    // Without this row every assertion below could fail for a broken harness
+    // (renderer unregistered, DOM not mounted) and read as the key defect.
+    const { getAllByRole, queryByText } = renderTabs(authored());
+    expect(getAllByRole('tab')).toHaveLength(2);
+    expect(queryByText('Overview')).toBeTruthy();
+    expect(queryByText('History')).toBeTruthy();
+  });
+
+  it('CONTROL — an item WITHOUT the identifier really does fall back to `tab-IDX`', () => {
+    // The defect's signature, and what makes the row below a measurement: if
+    // the fallback did not exist, honouring an authored value would be
+    // indistinguishable from honouring nothing.
+    const onTabChange = vi.fn();
+    const { getAllByRole } = renderTabs(
+      [withChildren({ label: 'Overview' }), withChildren({ label: 'History' })],
+      { onTabChange },
+    );
+    fireEvent.mouseDown(getAllByRole('tab')[1], { button: 0 });
+    expect(onTabChange).toHaveBeenCalledWith('tab-1');
+  });
+
+  it('reports the AUTHORED value on tab change — not the index-derived one', () => {
+    const onTabChange = vi.fn();
+    const { getAllByRole } = renderTabs(authored(), { onTabChange });
+    fireEvent.mouseDown(getAllByRole('tab')[1], { button: 0 });
+    expect(onTabChange).toHaveBeenCalledWith('history');
+    expect(onTabChange).not.toHaveBeenCalledWith('tab-1');
+  });
+
+  it('is URL-ADDRESSABLE by the authored value — the objectui#2257 consequence', () => {
+    // `?tab=` restores the active tab through `defaultTab`. This is the whole
+    // reason the key has to be one the renderer reads: an index value silently
+    // points at a different tab once the item list changes.
+    const { getAllByRole } = renderTabs(authored(), { defaultTab: 'history' });
+    const selected = getAllByRole('tab').filter((el) => el.getAttribute('data-state') === 'active');
+    expect(selected).toHaveLength(1);
+    expect(selected[0].textContent).toContain('History');
+  });
+
+  it('CONTROL — `defaultTab` naming the RETIRED spelling selects nothing, so the row above is live', () => {
+    // A document saved by a released build carries `items[].key`; addressing a
+    // tab by that value has never worked and still does not. Without this row,
+    // the assertion above could pass merely because the first tab is the
+    // default whatever `defaultTab` says.
+    const { getAllByRole } = renderTabs(authored(), { defaultTab: 'no-such-tab' });
+    const selected = getAllByRole('tab').filter((el) => el.getAttribute('data-state') === 'active');
+    expect(selected[0].textContent).toContain('Overview');
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/block-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/block-config.ts
@@ -410,7 +410,7 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
       kind: 'array',
       addLabel: 'engine.inspector.pageBlock.add.page:tabs.items',
       itemFields: [
-        { name: 'key', label: 'engine.inspector.pageBlock.field.page:tabs.items.key', kind: 'text' },
+        { name: 'value', label: 'engine.inspector.pageBlock.field.page:tabs.items.value', kind: 'text' },
         { name: 'label', label: 'engine.inspector.pageBlock.field.page:tabs.items.label', kind: 'text' },
       ],
     },
@@ -427,8 +427,11 @@ export const BLOCK_CONFIG: Record<string, BlockPropField[]> = {
   //     `itemsWithValue = items.map((it, idx) => ({ ...it, value:
   //     \`panel-${idx}\` }))` — so an authored value never reaches the Radix
   //     item. This is NOT the `page:tabs` case one component over: there, an
-  //     authored `items[].value` (designer field name `key`) really is read,
-  //     with a `tab-${idx}` fallback only when absent. The accordion's panel id
+  //     authored `items[].value` really is read, with a `tab-${idx}` fallback
+  //     only when absent — and the designer control is NAMED `value` since
+  //     objectui#8278, which is what makes the two cases comparable at all.
+  //     Until then it was named `key`, so the tabs panel wrote a key the spec
+  //     refuses by name and the renderer never reads. The accordion's panel id
   //     is unconditionally derived; the tabs one is genuinely live. The spec
   //     mirrors the asymmetry — `PageAccordionProps.items[]` deliberately does
   //     not declare `value` and carries a `guidance` prescription pointing an


### PR DESCRIPTION
Fixes #8278

The page designer's `page:tabs` item control was named `key`.
`PageBlockInspector.renderField`'s array branch writes an item key VERBATIM
(`next[i] = { ...itemObj, [n]: v }`), so an author who filled that box produced
`properties.items[i].key` — a key three faces disagree with.

## Measured on my own base, not quoted from the card

Base `33b507365`; installed `@objectstack/spec` is **17.3.0** (the card measured
17.2.0). `ComponentPropsMap['page:tabs'].safeParse`, four legs in one run —
`children` is supplied throughout because the item shape requires it and it is
not one of these two controls' business:

| leg | input item | `success` | `unrecognized_keys` |
| --- | --- | --- | --- |
| DEFECT | `{ key, label, children }` | `false` | `["key"]` at `items.0` |
| CONTROL A — a probe key IS refused | `{ zzzNotAKey, label, children }` | `false` | `["zzzNotAKey"]` |
| CONTROL B — the declared spelling is ACCEPTED | `{ value, label, children }` | **`true`** | `[]` |
| CONTROL C — base parses clean | `{ label, children }` | **`true`** | `[]` |

A and B together are the point: the parser can refuse at `items.0`, and it
accepts the same item shape under `value`, so the refusal is about the NAME.

⭐ **New since the card was written:** 17.3.0's own message now spells the
remedy out — "Unrecognized key(s) on this `page:tabs` item: `key`. Did you mean
`key` → `value`? …". Upstream already encodes this rename.

`PageTabsRenderer` (`renderers/layout/containers.tsx`) builds `itemsWithValue`
from `it.value` and reads `it.key` nowhere, falling back to `tab-IDX`. So every
designer-built tab strip was addressed by INDEX — the failure objectui#2257
deals with for `?tab=`: the deep link points at a different tab as soon as the
item list changes. Nothing reported it, because `PageComponent.properties` is an
open bag and the page parse stays green.

## What ships

- the control renamed `key` → `value` (producer side, AGENTS.md #0.1 and the
  rule `block-config.ts`'s own file header states);
- the i18n key moved in **both** locale tables, retired spelling gone from both
  (the objectui#3829 / objectui#5212 pattern) — `'Value'` / `'值'`, the wording
  the sibling `record:path.stages.value` box already uses;
- objectui#8216's LEDGER row for this key **deleted** — see below;
- three prose sites that named the old designer spelling, updated;
- a round-trip pin, and a `patch` changeset.

## The ledger row was not a courtesy — the gate demanded it

objectui#8216's parity gate ledgers this key and is a two-way ratchet. With the
rename landed and the row still in place it failed **twice, by name**:

```
× every ledger row still applies — a resolved key may not leave one behind
    AssertionError: stale LEDGER rows: expected [ Array(1) ] to deeply equal []
× every ledger row names a control that still exists, and carries a card
    AssertionError: LEDGER names 'items[].key': expected [ 'value', 'label' ] to include 'key'
```

That gate's spec-face probe test hard-coded "the two SPEC-face ledger rows" and
carried a `page:tabs` probe for the row being retired. It is now
`every SPEC-face ledger row is a real parser refusal, named`, and it asserts the
spec-face row set explicitly, so a future row cannot be ledgered with no
`safeParse` measurement behind it. The tabs measurement moved WITH the key, into
the new pin.

## Verification

| what | result |
| --- | --- |
| `packages/app-shell/` + the `page:tabs` renderer suite | **649 files, 6249 passed**, 1 skipped, 0 failed |
| `pnpm --filter @object-ui/app-shell type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`; `--listFiles` confirms the new pin is IN the program) |
| `pnpm exec eslint .` in `packages/app-shell` | **0 errors**, 2923 pre-existing warnings; the 4 in the new file are the `no-explicit-any` idiom its siblings use |
| `check:i18n-keys` · `check:i18n-drift` · `check:i18n-dead-keys` · `check:control-bytes` · `check:designer-field-key-parity` | all exit 0 |
| `check-changeset-presence` · `check-changeset-no-major` | exit 0 |
| `check-governed-queue-guard --test` on this exact file list | `NOT GOVERNED — 6 path(s) checked against 5 governed surface(s); none matched` |

Run from the repo root with explicit positional paths, per AGENTS.md.

## Ablation — the change can fail

The READ SITE was ablated, not the pin: the control line put back to `name: 'key'`
from the committed implementation, with an `EXIT INT TERM` trap on an absolute path.

- mutation reached disk — HEAD blob `b35c31bab…`, mutated blob `8efe702b2…`; the
  two anchor counts inverted (new 1→0, old 0→1);
- **four rows went red, by name:**

```
× no control writes a name its oracle refuses or tombstones          (the 8216 gate)
    unledgered BLOCK_CONFIG field names refused by their schema
× the item an author builds through the designer table is ACCEPTED by the spec
    a designer-authored tab item is refused by name: expected [ 'key' ] to deeply equal []
× reports the AUTHORED value on tab change — not the index-derived one
× is URL-ADDRESSABLE by the authored value — the objectui#2257 consequence
```

- the CONTROL rows stayed green throughout — including
  `CONTROL — the harness renders a tab strip at all`, so a red row above is the
  key and not a dead fixture (18 passed / 4 failed of 22);
- restored **BY STATE**, never by an exit code: on-disk blob equal to the HEAD
  blob again, `git diff HEAD` empty, `git status` empty; re-run 22/22 green.

The mutated module is imported by RELATIVE path from the tests, so it resolves
to source — there is no dist leg to rebuild for the mutation to be live.

### A second ablation, because the i18n half is the one most likely done partially

Reverting **only** the ZH row and leaving EN renamed — a half-done rename — is
caught mechanically, which is worth recording because I had assumed it was not:

```
× block-config-i18n.test.ts > block-config labels are translation keys (#3913) > every key resolves in zh-CN
    expected [ Array(1) ] to deeply equal []
    +   "engine.inspector.pageBlock.field.page:tabs.items.value"
```

⚠️ But the enforcement is **one-directional**. That test proves the NEW key is
present in both tables; nothing proves the RETIRED key LEFT them.
`check-i18n-dead-keys.mjs` reads only `packages/i18n/src/locales/`, so it does
not see `metadata-admin/i18n.ts`'s tables at all. The four table-membership
readings below are the only guard for that half — recorded here rather than in a
comment, because that is a real coverage gap:

| reading | table | before | after |
| --- | --- | --- | --- |
| retired key | `ENGINE_STRINGS_EN` | PRESENT | **ABSENT** |
| retired key | `ENGINE_STRINGS_ZH` | PRESENT | **ABSENT** |
| new key | `ENGINE_STRINGS_EN` | ABSENT | **PRESENT** (`'Value'`) |
| new key | `ENGINE_STRINGS_ZH` | ABSENT | **PRESENT** (`'值'`) |

Read by extracting each table's line range and grepping inside it — table
MEMBERSHIP, not whole-file spelling occurrence, so a key that MOVED tables could
not read as unchanged. Lit control: `…page:tabs.items.label` is PRESENT in both,
before and after.

## Qualified counts in `block-config.ts`

The blunt form lies here, so both forms are reported:

| matcher | before | after |
| --- | --- | --- |
| `page:tabs.items.key` (qualified) | 1 — line 413 | **0** |
| `page:tabs.items.value` (qualified) | 0 | **1** — line 413 |
| `name: 'value'` (blunt) | 1 | 2 |
| `items.value` (blunt) | 0 | 1 |

The blunt `name: 'value'` count moves 1→2 only because `record:path.stages.value`
(line 520) shares the spelling — it says nothing about `page:tabs`. Lit control
for the qualified matcher: `page:tabs.items.label` = 2 hits, unchanged.

## Stored documents — untouched, deliberately, per the PM ruling

`items[].key` was unread before this change and is unread after it; every stored
strip already fell back to `tab-IDX`, so nothing regresses and newly-authored
strips are correct. It is NOT carried over into `value` (that would be a
permanent second spelling with no retirement path) and it is NOT stripped.

Two things I measured rather than assumed, both supporting the ruling:

- `RETIRED_BLOCK_PROP_KEYS` is a Record keyed by BLOCK TYPE whose values are
  readonly string arrays (spelled out in words, not in angle brackets, because
  GitHub eats tag-shaped fragments even inside backticks). Those are TOP-LEVEL
  keys only, so a nested `items[].key` cannot be expressed in it at all. This is
  structural, not an omission.
- objectui#7772's read door admits a key only when the schema refuses it BY NAME.
  `page:tabs items[].key` **meets** that criterion (unlike objectui#8279's
  definition-list keys, which had no schema at all) — so this is the first key
  that qualifies for the strip and cannot be written into its ledger's shape.

⚠️ One consequence I did not find anticipated anywhere, reported for triage
rather than acted on here: after this rename the orphan is unreachable from
**every** inspector control — `advancedKeys` is `Object.keys(blockProps)`, so a
nested key never reaches the Advanced section, and the `value` box does not read
it. An author who repairs a stored strip through the new box therefore still
ships an item the component-props lint refuses by name. That verdict is
**unchanged** by this PR (refused before, refused after), so the ruling's
no-regression claim holds — but the follow-up is worth its own card. Details in
the report on objectui#8278; not filed here because the dedup search channel was
rate-limited and filing without dedup is worse than deferring.

## objectui#3912

Read first, as instructed. It asks for a `pattern` / `validate` / `description`
capability bit on the `BlockPropField` union, and lists this very box as one of
three identifier-valued fields with no mechanical enforcement. No collision: it
adds a capability to the union TYPE, this changes one field's `name`. It is not
pre-empted either — an identifier box still has no pattern affordance. One
knock-on: that card's prose names `page:tabs` 的 `items[].key`, which is now the
stale spelling. Its issue body is left alone.

## Changeset — `patch`, matching the landed precedent

PR #8325 (objectui#8279) renamed two designer item controls in **this same file**
and took `'@object-ui/app-shell': patch`. Same class, same package, same i18n
key-removal shape, so this matches it. The repo forbids `major` and ships
breaking changes as `minor`; this is not breaking in the sense that rule guards —
no exported type moves (`BlockPropField`'s shape is untouched), and `BLOCK_CONFIG`
is data. What changes is what the designer EMITS going forward, which is the bug
being repaired, and the changeset says so in full.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_