### PR TITLE
feat(types)!: drop the `Cloud` namespace re-export from the root entry (objectui#8225)

### DIFF
--- a/.changeset/8225-drop-cloud-namespace-reexport.md
+++ b/.changeset/8225-drop-cloud-namespace-reexport.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/types': minor
+---
+
+**Breaking for `@object-ui/types` consumers:** the `Cloud` type namespace is
+REMOVED from the package's root entry. `export type * as Cloud from
+'@objectstack/spec/cloud'` is gone, so `import type { Cloud } from
+'@object-ui/types'` and every `Cloud.X` member access now fail to compile
+(TS2305 / TS2694). No alias and no deprecation window are left — the maintainer's
+standing posture is immediate removal (objectui#8225; step 2 of 3 of the
+objectstack#16325 ruling, option B: the cloud control-plane contracts leave
+`@objectstack/spec`, and the spec's `./cloud` subpath is deleted upstream once
+cloud and objectui stop importing it).
+
+The rest of the namespace family — `Data`, `UI`, `System`, `AI`, `API`,
+`Automation`, `Shared`, `QA`, `Kernel`, `Contracts`, `Integration`, `Studio`,
+`Identity`, `Security` (14 re-exports) — is unchanged; the gap in that block is
+deliberate and is marked in place.
+
+Measured in this repository at `289d14687`: zero consumers of the `Cloud`
+namespace across `packages/**` and `apps/**` (a `Cloud.` member-access census
+plus a named-import census, both 0 against a control of 15 namespace re-export
+lines in the same file), and zero imports of the spec's cloud subpath outside
+that one line — the three cloud-shaped types objectui does use
+(`PackageTranslation`, `resolvePackageL10n`'s result, `PackageManifest`) were
+already declared inline in `app-shell` rather than imported. No runtime
+behaviour changes; the emitted JavaScript is identical.

--- a/.changeset/8225-drop-cloud-namespace-reexport.md
+++ b/.changeset/8225-drop-cloud-namespace-reexport.md
@@ -19,8 +19,9 @@ deliberate and is marked in place.
 
 Measured in this repository at `289d14687`: zero consumers of the `Cloud`
 namespace across `packages/**` and `apps/**` (a `Cloud.` member-access census
-plus a named-import census, both 0 against a control of 15 namespace re-export
-lines in the same file), and zero imports of the spec's cloud subpath outside
+plus a named-import census over 4106 tracked ts/tsx files, both 0, with a
+firing control: the same PCRE pattern hits the consumed sibling namespaces
+`UI.` and `Data.`), and zero imports of the spec's cloud subpath outside
 that one line — the three cloud-shaped types objectui does use
 (`PackageTranslation`, `resolvePackageL10n`'s result, `PackageManifest`) were
 already declared inline in `app-shell` rather than imported. No runtime

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1117,7 +1117,9 @@ export type * as UI from './spec-ui-namespace.js';
 export type * as System from '@objectstack/spec/system';
 export type * as AI from '@objectstack/spec/ai';
 export type * as API from '@objectstack/spec/api';
-export type * as Cloud from '@objectstack/spec/cloud';
+// `Cloud` is deliberately absent from this family since objectui#8225: the
+// cloud control-plane contracts leave the spec's public surface (objectstack#16325,
+// option B), so nothing here re-exports that subpath and no consumer reads it.
 export type * as Automation from '@objectstack/spec/automation';
 export type * as Shared from '@objectstack/spec/shared';
 export type * as QA from '@objectstack/spec/qa';

--- a/scripts/__tests__/vite-objectstack-spec-dist.test.ts
+++ b/scripts/__tests__/vite-objectstack-spec-dist.test.ts
@@ -210,9 +210,14 @@ describe('objectui#4854: OBJECTSTACK_SPEC_DIST is subpath-aware', () => {
     const injection = inject(installedSpecDir)!;
     const specifiers = collectSpecSpecifiers();
 
-    // Anti-vacuity: the sweep found the measured surface (17 distinct
-    // specifiers, `/ui` and `/data` the heaviest), not an empty scan.
-    expect(specifiers.size).toBeGreaterThanOrEqual(17);
+    // Anti-vacuity: the sweep found the measured surface, not an empty scan.
+    // 16 distinct specifiers since objectui#8225 removed the repository's only
+    // `@objectstack/spec/cloud` literal (the `Cloud` namespace re-export in
+    // `packages/types/src/index.ts`; step 2 of the objectstack#16325 chain that
+    // deletes the `/cloud` subpath upstream) — 17 before that, `/ui` and `/data`
+    // the heaviest. A floor, so a specifier gained does not move it; one lost
+    // does, and the commit that loses it re-pins it here and says why.
+    expect(specifiers.size).toBeGreaterThanOrEqual(16);
     expect([...specifiers]).toContain(`${SPEC_PACKAGE_NAME}/ui`);
     expect([...specifiers]).toContain(SPEC_PACKAGE_NAME);
 


### PR DESCRIPTION
Fixes objectstack-ai/objectui#8225

Step 2 of 3 of the objectstack#16325 ruling (director batch #62, 2026-09-07, option B — maintainer verbatim, not translated: 「我一直觉得 cloud 的协议应该放在云端，没必要开源」): the cloud control-plane contracts leave `@objectstack/spec`, and the spec's `./cloud` subpath is deleted upstream once cloud and objectui stop importing it. Step 1 (objectstack-ai/cloud#2037) merged 2026-09-07T08:19Z; step 3 is objectstack#16325 itself and waits on this PR. Part of objectstack#16325.

## What changed

- `packages/types/src/index.ts`: `export type * as Cloud from '@objectstack/spec/cloud'` is removed — the only real import of that subpath in this repository. The gap in the namespace family (14 re-exports remain of 15) is marked in place with a comment so the next reader sees it as deliberate.
- `.changeset/8225-drop-cloud-namespace-reexport.md`: `@object-ui/types` minor with the break spelled out (this repo never declares major — AGENTS.md 版本号策略). No alias and no deprecation window (maintainer 2026-08-27, verbatim: 「项目在创业阶段，用户也很少，短期不考虑渐进。」).

Clause-② yes (a published type namespace is removed) — `needs:contract-review` is on this PR. No runtime behaviour changes; the emitted JavaScript is identical.

## Premise re-check on the tree I got (`origin/main` = `289d14687`, the branch base)

| PM assumption | Measured |
|---|---|
| A. one line, locate by content | line 1120, single occurrence (the card's `:1106` and the comment's `:1116` were both stale) |
| B. zero consumers, with a firing control | `Cloud.` member access: 0 hits over 4106 tracked ts/tsx files under `packages/**` + `apps/**` (PCRE). Bare `Cloud` identifier outside the declaring file: only lucide-react's `Cloud` icon, i18n strings, comments and `data-objectstack`'s unrelated `Cloud*` pin — nothing from `@object-ui/types`. Control: the same regex fires on the consumed siblings `UI.` (1 file) and `Data.` (4) and on a synthetic `Cloud.PackageManifest` line (1). ⚠️ The inherited control (15 export lines in the file) does not exercise the regex, and on this macOS host `git grep -E` has no `\b` at all (BSD regex): it returned 0 for every sibling too, so the census was redone with `-P`. |
| C. family of 15 | 15 before, 14 after. No test or comment asserts the family's completeness (the sibling subpaths appear in `__tests__`/`scripts` only as direct spec imports in parity tests; nothing enumerates the block). |
| D. other mentions are comments | True, and there are more than the three named: `packages/auth/README.md:220`, `packages/auth/src/createAuthenticatedFetch.ts:106`, `scripts/check-eager-closure-budget.mjs:109`, two test-fixture strings, one pending changeset — all prose, none an import. Untouched. |
| hotcrm (named in the card body) | `objectstack-ai/hotcrm` `package.json` carries no `@object-ui/*` dependency; code search for `@object-ui/types` in that repo: 0 (channel control: `objectstack` → 591 hits). No consumer there either. |
| star re-exports of `@object-ui/types` in other packages (surface inheritance) | 0 |

## The "surface pin regenerated with the repo tooling" acceptance item

There is no such pin for `@object-ui/types`. Searched: no api-extractor report; `docs:api` (typedoc) writes to an untracked `docs/api/` (only `content/docs/api/*.md` is tracked, and it does not mention `Cloud`); `packages/types/README.md` names no namespace; no test snapshots the root entry's export list. The nearest mechanisms are `check:dist-completeness` (runs inside the package `build`, green below) and `check:readme-exports` (see the gate table). A stated absence, not an invented regeneration.

## Verification (final commit `bdbdebf81`; the tree at every run below equals it)

**Declared narrowing — verification ran UNLOCKED.** `scripts/pm/os-verify-lock.sh`
could not take the shared verify lock on this host: no usable `flock`. The shared
verify lock is declared Linux-only (`flock` is util-linux, and a stock macOS does
not ship it), so the command below was run directly, without the lock —
a declared narrowing, not a silent one. No serialization guarantee held for this
run, nor for any sibling agent in this container while it ran.

    cd /Users/zhuangjianguo/Documents/GitHub/objectui-issue-8225 && NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @object-ui/types build

(The same disclosure applies to the `type-check`, `vitest` and reverse-verification runs below — every one went through that entry point and got the same `UNLOCKED (declared)` verdict.)

| Gate | Verdict |
|---|---|
| `pnpm --filter @object-ui/types build` (tsc + `check-dist-completeness`) | `VERDICT command-exit 0 · UNLOCKED (declared)` · 7s shared-box |
| `pnpm --filter @object-ui/types type-check` (src + examples + tests tsconfigs) | `VERDICT command-exit 0 · UNLOCKED (declared)` · 15s shared-box |
| `pnpm exec vitest run packages/types/` (repo root) | `Test Files 1 failed, 140 passed (141)`. The one red is `handler-keys-string-any-mirrors-7344.test.ts`, a host false-red: its anchors shell out to `git grep -E` with `\b`, which Apple Git 2.50.1's BSD regex does not support (`-E` → 0 files, `-P` → 97 files for the same `.actions` anchor; 0 vs 15 for the `AppComponentSchema` import anchor). The file is byte-identical to `origin/main` and reads nothing this PR touches; CI runs on Linux. Filed separately as a finding. |
| `pnpm --filter @object-ui/types lint` | exit 0 (pre-existing `no-explicit-any` warnings only) |
| `node scripts/check-changeset-presence.mjs` | ✅ 1 source file of 1 released package changed, 1 changeset declared |
| `node scripts/check-changeset-fixed.mjs` · `check-changeset-no-major.mjs` | ✅ · ✅ |
| `node scripts/check-spec-symbol-derivation.mjs` | ✅ 1353 files scanned against 5050 spec export names |
| `node scripts/check-control-bytes.mjs` | ✅ 6641 tracked text files |
| `node scripts/check-governed-queue-guard.mjs --test` on both paths | NOT GOVERNED |
| `node scripts/check-readme-exports.mjs` | NOT MEASURED locally: "the population COLLAPSED — this run proves nothing" (35 of 40 packages unbuilt in this worktree, floor 25). Narrowing evidence: `packages/types/README.md` has 7 self-import bindings and 0 mention `Cloud`, so this diff cannot move its verdict; CI builds first. |
| downstream consumer type-check (`pnpm --filter '...@object-ui/types' type-check`, i.e. the whole repo) | Declared narrowing, not run locally: a type-only namespace removal can only red a consumer that names `Cloud` from `@object-ui/types`, and that census is 0 with a firing control (table above). CI's `type-check` job runs the farm. |

### Reverse verification (two legs, run after the commit; restore proven by blob hash and an empty `git diff HEAD`)

A scratch consumer outside the tree imports `Cloud` and `System` from the rebuilt `packages/types/dist/index.d.ts`:

- leg 1, source restored to the base blob `b92fa6959`: dist has `as Cloud` 1 → probe **exit 0** (so `Cloud.PackageManifest` was a real member, and the probe reads the rebuilt d.ts rather than a cache)
- leg 2, source at the HEAD blob `06d971e8b`: dist has `as Cloud` 0 → probe **exit 2** with exactly `TS2305: Module '"@object-ui/types"' has no exported member 'Cloud'`; 0 errors mention `System` (control)

Direction: turned red, as expected.

## Not in this PR

- objectstack#16325 step 3 (deleting the subpath upstream) and the notification on landing belong to the PM's chain.
- objectui#7635 is in flight on `packages/types/**`; its declared sites are disjoint from this one line (measured in the PM claim), and nothing beyond `packages/types/src/index.ts` was touched inside `packages/types/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_f95e3874-e532-4748-a921-044aa2752a2b)_