### PR TITLE
fix(plugin-chatbot): a confirm-gate preview is not the commit that settles the card before it (#8343)

### DIFF
--- a/.changeset/8343-apply-blueprint-awaiting-confirmation.md
+++ b/.changeset/8343-apply-blueprint-awaiting-confirmation.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/plugin-chatbot': patch
+---
+
+A confirm-gate preview no longer counts as the commit that settles the card before it
+(objectui#8343).
+
+`builtPlanIds` decided a proposed plan had been built from the tool NAME alone —
+`tool.toolName === 'apply_blueprint'`. On an iteration turn where the user did not say
+the magic phrase ("直接搭建" / "just build it"), `apply_blueprint` hits its own
+confirm gate and returns `{status:'awaiting_confirmation'}`: it built nothing and is
+itself waiting for the user. That still marked the earlier `propose_blueprint` card
+已搭建, collapsing its "Build it" button into an inert badge — and the
+`apply_blueprint` card carries no button of its own, so the turn was left with **no
+confirm affordance at all** while the assistant's prose asked the user to confirm one.
+The only way forward was guessing "确认" into the composer.
+
+A build now only counts when the invocation is not a confirm-gate preview
+(`!isProposalResult(tool.result)`) — the same fact the tool header already reads to say
+"Awaiting Approval". A still-running `apply_blueprint` (no result yet) keeps counting,
+so the objectui#432 guard against re-triggering an in-flight build is unchanged.
+
+The sibling `confirmedChangeIds` memo carried the same defect one level down: it
+inferred "this later call committed" from the ABSENCE of a rich `proposedChanges` card,
+and that detector additionally requires ≥1 parseable change row — so a later same-tool
+call that WAS a preview but produced no card (an empty `changes: []`) silently settled
+the pending 确认修改 card. It now reads the preview fact directly too.

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -1975,6 +1975,16 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
     // (not the rich `draftReview`, which a reloaded conversation strips), so the
     // done-state survives a refresh. Positional so a later, not-yet-built plan
     // (e.g. after "make it simpler") keeps its live button.
+    //
+    // objectui#8343 — the name alone is NOT enough. When the user didn't say the
+    // magic "直接搭建", `apply_blueprint` hits its own confirm gate and returns
+    // `{status:'awaiting_confirmation'}`: it built nothing and is itself waiting
+    // for the user. Counting that as a build collapsed the plan card to the inert
+    // 已搭建 badge and took its "Build it" button with it, while the
+    // apply_blueprint card has no button of its own — the turn was left with
+    // nothing to click and the only way out was guessing "确认" into the composer.
+    // So a build only counts when the invocation is not a confirm-gate preview,
+    // the same fact `getToolState` already reads to say "Awaiting Approval".
     const builtPlanIds = React.useMemo(() => {
       const ids = new Set<string>();
       const plans: Array<{ id: string; order: number }> = [];
@@ -1988,7 +1998,11 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
           if ((tool.proposedPlan || isUnstructuredBuildProposal(tool)) && tool.toolCallId) {
             plans.push({ id: tool.toolCallId, order });
           }
-          if (tool.toolName === 'apply_blueprint') lastBuildOrder = order;
+          // A still-running apply (no result yet) DOES count: the build is in
+          // flight, and a second "Build it" would re-trigger it (#432).
+          if (tool.toolName === 'apply_blueprint' && !isProposalResult(tool.result)) {
+            lastBuildOrder = order;
+          }
           order += 1;
         }
       }
@@ -2015,6 +2029,13 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
     // has been applied — i.e. a LATER invocation of the SAME tool committed (no
     // longer a changes_proposed preview). Positional + per-tool so an earlier
     // confirmed change doesn't silence a later still-pending one.
+    //
+    // objectui#8343 — "no longer a preview" was inferred from the ABSENCE of the
+    // rich `proposedChanges` card, which is a stricter thing: that detector also
+    // needs ≥1 parseable change row. So a later same-tool call that WAS a preview
+    // but produced no card (an empty `changes:[]`, an `awaiting_confirmation`)
+    // silently counted as the commit and settled the pending card — the same
+    // defect `builtPlanIds` had above. Read the preview fact directly instead.
     const confirmedChangeIds = React.useMemo(() => {
       const ids = new Set<string>();
       const proposals: Array<{ id: string; toolName: string; order: number }> = [];
@@ -2024,7 +2045,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
         for (const tool of message.toolInvocations ?? []) {
           if (tool.proposedChanges && tool.toolCallId) {
             proposals.push({ id: tool.toolCallId, toolName: tool.toolName ?? '', order });
-          } else if (tool.toolName) {
+          } else if (tool.toolName && !isProposalResult(tool.result)) {
             lastCommitByTool.set(tool.toolName, order);
           }
           order += 1;

--- a/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.awaitingConfirmBuild-8343.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.awaitingConfirmBuild-8343.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#8343 — an `apply_blueprint` that returned `awaiting_confirmation`
+ * built NOTHING, so the plan card before it must keep its live "Build it".
+ *
+ * `builtPlanIds` used to key on the tool NAME alone
+ * (`if (tool.toolName === 'apply_blueprint') lastBuildOrder = order`), which
+ * cannot tell "the build ran" from "the build refused to run and is itself
+ * waiting for the user". On the second (iteration) turn the build agent calls
+ * `apply_blueprint`, hits its own confirm gate and returns
+ * `{"status":"awaiting_confirmation", …}`. The earlier `propose_blueprint`
+ * card was then marked 已搭建, collapsing its "Build it" button away — while
+ * the `apply_blueprint` card itself has no button either. Measured in the
+ * browser: the whole turn had no confirm affordance at all, and the only way
+ * out was guessing the magic phrase "确认" into the composer.
+ *
+ * Both envelopes below are the real wire shapes, fed through the real mapper
+ * (`uiMessagesToChatMessages`) so the detector chain runs exactly as it does
+ * in the console.
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ChatbotEnhanced } from '../ChatbotEnhanced';
+import { uiMessagesToChatMessages } from '../mapMessages';
+
+/** `propose_blueprint` result — the plan the user is asked to confirm. */
+const BLUEPRINT_PROPOSED = {
+  status: 'blueprint_proposed',
+  summary: 'Add a vaccination-record table to the existing clinic app',
+  blueprint: {
+    objects: [
+      {
+        name: 'vaccination_record',
+        label: 'Vaccination record',
+        fields: [{ name: 'pet' }, { name: 'vaccine' }, { name: 'given_on' }],
+      },
+    ],
+  },
+  counts: { objects: 1, views: 1, dashboards: 0, seedData: 1 },
+  questions: [],
+  assumptions: [],
+};
+
+/**
+ * `apply_blueprint` result when the user did NOT say the magic "直接搭建" —
+ * the tool shows a confirm card and stops. Nothing was created.
+ */
+const AWAITING_CONFIRMATION = {
+  status: 'awaiting_confirmation',
+  message:
+    'A confirm card for this blueprint was just shown to the user — STOP and let them review it.',
+};
+
+/** `apply_blueprint` result when the build actually ran (ADR-0033 draft envelope). */
+const BUILD_DRAFTED = {
+  status: 'drafted',
+  summary: 'Created 1 object, 1 view',
+  drafted: [
+    { type: 'object', name: 'vaccination_record' },
+    { type: 'app', name: 'clinic' },
+  ],
+};
+
+/** The two-turn transcript: propose, then an apply_blueprint with `applyResult`. */
+function transcript(applyResult: unknown) {
+  return uiMessagesToChatMessages([
+    {
+      id: 'a1',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'tool-propose_blueprint',
+          toolCallId: 'plan-1',
+          state: 'output-available',
+          output: { type: 'text', value: JSON.stringify(BLUEPRINT_PROPOSED) },
+        },
+      ],
+    },
+    {
+      id: 'a2',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'tool-apply_blueprint',
+          toolCallId: 'apply-1',
+          state: 'output-available',
+          output: { type: 'text', value: JSON.stringify(applyResult) },
+        },
+        { type: 'text', text: 'Please confirm the plan card so the build can run.' },
+      ],
+    },
+  ]);
+}
+
+describe('ChatbotEnhanced — apply_blueprint that only asked for confirmation (#8343)', () => {
+  it('sanity: the transcript really produces a plan card the mapper recognised', () => {
+    const messages = transcript(AWAITING_CONFIRMATION);
+    expect(messages[0].toolInvocations?.[0].proposedPlan).toBeTruthy();
+    expect(messages[1].toolInvocations?.[0].toolName).toBe('apply_blueprint');
+    // The apply call carries no plan/changes card of its own — which is why
+    // the propose card is the ONLY confirm affordance in this turn.
+    expect(messages[1].toolInvocations?.[0].proposedPlan).toBeUndefined();
+    expect(messages[1].toolInvocations?.[0].proposedChanges).toBeUndefined();
+  });
+
+  it('keeps the plan card pending, with a live Build it button', () => {
+    render(<ChatbotEnhanced messages={transcript(AWAITING_CONFIRMATION)} onSendMessage={vi.fn()} />);
+
+    // The bug: this used to be the inert 已搭建 badge and the buttons were gone,
+    // leaving the whole turn with nothing to click.
+    expect(screen.queryByTestId('proposed-plan-built')).not.toBeInTheDocument();
+    expect(screen.getByTestId('proposed-plan-approve')).toBeInTheDocument();
+    expect(screen.getByTestId('proposed-plan-adjust')).toBeInTheDocument();
+  });
+
+  it('still collapses the plan card to Built once the build actually ran', () => {
+    render(<ChatbotEnhanced messages={transcript(BUILD_DRAFTED)} onSendMessage={vi.fn()} />);
+
+    // The #432 behaviour this fix must not regress: a plan whose build HAS run
+    // may not keep offering a button that re-triggers the whole build.
+    expect(screen.getByTestId('proposed-plan-built')).toBeInTheDocument();
+    expect(screen.queryByTestId('proposed-plan-approve')).not.toBeInTheDocument();
+  });
+
+  it('collapses to Built while the real build is still running (no result yet)', () => {
+    const messages = uiMessagesToChatMessages([
+      {
+        id: 'a1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-propose_blueprint',
+            toolCallId: 'plan-1',
+            state: 'output-available',
+            output: { type: 'text', value: JSON.stringify(BLUEPRINT_PROPOSED) },
+          },
+        ],
+      },
+      {
+        id: 'a2',
+        role: 'assistant',
+        parts: [
+          { type: 'tool-apply_blueprint', toolCallId: 'apply-1', state: 'input-available' },
+        ],
+      },
+    ]);
+    render(<ChatbotEnhanced messages={messages} onSendMessage={vi.fn()} />);
+
+    // An in-flight build is a build: the plan card must not offer a second
+    // "Build it" that would re-trigger it.
+    expect(screen.getByTestId('proposed-plan-built')).toBeInTheDocument();
+    expect(screen.queryByTestId('proposed-plan-approve')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * The sibling memo, `confirmedChangeIds`, was reported on the issue as already
+ * having the right shape. Measured: it does NOT. It inferred "this later call
+ * committed" from the ABSENCE of a rich `proposedChanges` card, and that
+ * detector needs a `changes_proposed` status AND ≥1 parseable change row — so a
+ * later same-tool call that WAS a preview but rendered no card settled the
+ * pending card just the same. Same defect, one memo down.
+ */
+const CHANGES_PROPOSED = {
+  status: 'changes_proposed',
+  applied: false,
+  summary: 'Confirm this change before it is applied.',
+  changes: [{ verb: 'add_field', object: 'task', field: 'priority', type: 'select' }],
+};
+
+function changeTranscript(secondResult: unknown) {
+  return uiMessagesToChatMessages([
+    {
+      id: 'c1',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'tool-update_metadata',
+          toolCallId: 'change-1',
+          state: 'output-available',
+          output: { type: 'text', value: JSON.stringify(CHANGES_PROPOSED) },
+        },
+      ],
+    },
+    {
+      id: 'c2',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'tool-update_metadata',
+          toolCallId: 'change-2',
+          state: 'output-available',
+          output: { type: 'text', value: JSON.stringify(secondResult) },
+        },
+      ],
+    },
+  ]);
+}
+
+describe('ChatbotEnhanced — a later preview is not a commit (#8343)', () => {
+  it('keeps the 确认修改 card pending when the later same-tool call was itself a preview', () => {
+    // `changes: []` — the shape `apply_edit` returns when the gate previewed an
+    // op list the row formatter could not turn into a card.
+    render(
+      <ChatbotEnhanced
+        messages={changeTranscript({ status: 'changes_proposed', applied: false, changes: [] })}
+        onSendMessage={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId('proposed-changes-confirmed')).not.toBeInTheDocument();
+    expect(screen.getByTestId('proposed-changes-confirm')).toBeInTheDocument();
+  });
+
+  it('still collapses the 确认修改 card once the same tool really committed', () => {
+    render(
+      <ChatbotEnhanced
+        messages={changeTranscript({ status: 'drafted', summary: 'Added task.priority' })}
+        onSendMessage={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('proposed-changes-confirmed')).toBeInTheDocument();
+    expect(screen.queryByTestId('proposed-changes-confirm')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Refs #8343.

## The dead end

`builtPlanIds` decided a proposed plan had been built from the tool NAME alone:

```js
if (tool.toolName === 'apply_blueprint') lastBuildOrder = order;
```

On an iteration turn where the user did not say the magic phrase ("直接搭建" / "just build it"), `apply_blueprint` hits its own confirm gate (cloud `blueprint-tools.ts`, `createApplyBlueprintHandler`) and returns:

```json
{"status":"awaiting_confirmation","message":"A confirm card for this blueprint was just shown to the user — STOP and let them review it. …"}
```

It built nothing and is itself waiting for the user. That still marked the earlier `propose_blueprint` card 已搭建, collapsing its "Build it" button into an inert badge — and the `apply_blueprint` card carries no button of its own. So the turn was left with **no confirm affordance at all** while the assistant's prose asked the user to confirm one. The only way forward was guessing "确认" into the composer.

## The fix

A build only counts when the invocation is not a confirm-gate preview — the same fact `getToolState` already reads to say "Awaiting Approval":

```js
if (tool.toolName === 'apply_blueprint' && !isProposalResult(tool.result)) { lastBuildOrder = order; }
```

A still-running `apply_blueprint` (no result yet) keeps counting, so the objectui#432 guard against a second "Build it" re-triggering an in-flight build is unchanged — pinned by its own test.

### Also: `confirmedChangeIds` had the same defect (contrary to the issue)

The issue reported the sibling memo as already the right shape. Measured, it is not. It inferred "this later call committed" from the ABSENCE of a rich `proposedChanges` card, and `detectProposedChanges` additionally requires `status === 'changes_proposed'` **and ≥1 parseable change row**. So a later same-tool call that WAS a preview but produced no card (an empty `changes: []` — reachable from the cloud gate's `changes: describeEditOps(args)` path) silently settled the pending 确认修改 card. It reads the preview fact directly now too.

Both memos are now one condition apart from `resolveProposalCardState`'s stated principle: "what actually happened" over "what was asked for".

## Tests

`packages/plugin-chatbot/src/__tests__/ChatbotEnhanced.awaitingConfirmBuild-8343.test.tsx` — the real two-turn wire envelopes fed through the real mapper (`uiMessagesToChatMessages`), so the whole detector chain runs as it does in the console. Six cases: the two regressions, plus positive controls that the card still collapses to 已搭建 / 已确认 on a real commit and on an in-flight build.

### Ablation (both conditions removed, then restored)

Removed:

```
Tests  2 failed | 4 passed (6)

FAIL  … > keeps the plan card pending, with a live Build it button
  expected document not to contain element, found <span data-testid="proposed-plan-built"> … Built </span>

FAIL  … > keeps the 确认修改 card pending when the later same-tool call was itself a preview
  expected document not to contain element, found <span data-testid="proposed-changes-confirmed"> … Confirmed </span>
```

Restored:

```
Tests  6 passed (6)
```

Whole package: `Test Files 40 passed (40) · Tests 467 passed (467)`. `packages/app-shell/`: `Test Files 647 passed (647) · Tests 6234 passed | 1 skipped`. `eslint` on the changed files: 0 errors.

## Not in this PR

The issue's tail note — the assistant says "请确认**下方**方案卡片" while the card renders **above** the prose. Grepped both repos: no such literal exists in objectui, and none in cloud either. It is the model's own improvised direction word; the nearest instruction that shapes that sentence is `packages/service-ai-studio/src/skills/solution-design-skill.ts:26` (cloud), which prescribes the one-line lead-in but says nothing about direction. Fixing it means constraining that prompt in **cloud**, not this repo.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)