### PR TITLE
fix(plugin-detail): record:details' dedupe shares the header's emptiness definition

### DIFF
--- a/.changeset/8350-dedupe-emptiness-shares-header-definition.md
+++ b/.changeset/8350-dedupe-emptiness-shares-header-definition.md
@@ -1,0 +1,48 @@
+---
+'@object-ui/plugin-detail': minor
+'@object-ui/core': minor
+---
+
+`record:details`' dedupe and the page H1 now share ONE definition of "this record
+has a value here" (objectui#8350).
+
+The renderer drops from the body grid the one field whose value the page H1 is
+already showing. objectui#8175 (PR #8349) made the two halves agree on **which
+field** — the ladder leads with the unified ADR-0079 resolver. They still
+disagreed on **what counts as a value**.
+
+**The user-visible defect.** The header half decides emptiness through
+`@object-ui/core`'s `recordDisplayValueAt`, which **trims**: a whitespace-only
+value is empty, so `getRecordDisplayName` walks on to the next rung. The ladder
+asked its own raw `undefined` / `null` / `''` question, which a whitespace-only
+value passes. So for a record whose title field held only spaces:
+
+- the H1 walked past that field and showed something else — say `Acme
+  Corporation`, resolved one rung further down;
+- the grid hid the blank field's row anyway, concluding it was the duplicate;
+- and the row that really did repeat the heading, `Acme Corporation`, stayed.
+
+A field disappeared from the grid to deduplicate against a heading that never
+displayed it. The failure is silent: nothing errors, a row is simply absent.
+
+**The change.** The ladder now calls `recordDisplayValueAt` — the very function
+every value-keyed rung of `getRecordDisplayName` uses — instead of re-spelling
+the test. `@object-ui/core` exports it for that purpose; it was the module-private
+`valueAt`, unchanged in behaviour and renamed only to be a defensible public
+name. One authority, not two implementations that agree today.
+
+**Behaviour change, deliberately — this is wider than trimming.** Sharing the
+definition also imports the two other things it decides, and both bring the grid
+into line with the heading:
+
+- an expanded/embedded reference object is **empty** when its Salesforce-style
+  display chain yields nothing, so a bare `{ id: 'u1' }` lookup payload no longer
+  claims the dedupe (the raw test read any object as a value — and so would a
+  bolted-on `.trim()`, which is why the fix is delegation rather than a trim);
+- non-strings are stringified, so `0` and `false` remain values, not blanks.
+
+In every case the new answer is the one the H1 was already giving.
+
+**New export.** `@object-ui/core` gains `recordDisplayValueAt(record, field)`.
+Additive: nothing imported the private `valueAt`, and `getRecordDisplayName`'s
+own answers are unchanged.

--- a/packages/core/src/utils/record-title.ts
+++ b/packages/core/src/utils/record-title.ts
@@ -430,8 +430,37 @@ const NAME_ISH_RECORD_KEYS = [
   'label',
 ] as const;
 
-/** Read a non-empty string-ish value off a record at `field`, else undefined. */
-function valueAt(record: any, field: string | undefined): string | undefined {
+/**
+ * Read a non-empty string-ish display value off a record at `field`, else
+ * `undefined`.
+ *
+ * THE definition of "this record has a value here" — the question every
+ * value-keyed rung of {@link getRecordDisplayName} asks, and the reason a
+ * whitespace-only field is not a title.
+ *
+ * ## Why this is exported (objectui#8350)
+ *
+ * A second reader existed. `record:details`' dedupe ladder in
+ * `@object-ui/plugin-detail` asks the same question about the same record for
+ * the same field, to decide which body-grid row duplicates the page H1 — and it
+ * asked it with a hand-written raw `undefined` / `null` / `''` test, which a
+ * whitespace-only value passes and this one does not. So for a record whose
+ * title field held only spaces the two halves disagreed about whether that
+ * field had a value at all: the H1 walked on to the next rung, while the grid
+ * hid the row anyway — a field vanished to deduplicate against a heading that
+ * never showed it. The ladder now calls THIS. One authority, not two
+ * implementations that agree today.
+ *
+ * ⛔ Do not re-spell this test at a call site, and do not "just add a trim"
+ * there: three things beyond the trim are part of the definition, and a second
+ * implementation drifts on each of them independently —
+ *   - an expanded/embedded reference object resolves through its Salesforce-
+ *     style display chain and is EMPTY when that yields nothing (a bare
+ *     `{ id }` lookup payload is not a title);
+ *   - non-strings are stringified, so `0` and `false` ARE values, not blanks;
+ *   - `null` and `undefined` are empty, and only those two.
+ */
+export function recordDisplayValueAt(record: any, field: string | undefined): string | undefined {
   if (!field || !record || typeof record !== 'object') return undefined;
   let v: any = record[field];
   if (v && typeof v === 'object') v = displayNameOfEmbeddedObject(v);
@@ -509,7 +538,7 @@ export function getRecordDisplayName(
   //    search-candidate paths) found none that does. Reading it was a
   //    consumer-side alias for an undeclared key (AGENTS.md Commandment #0.1),
   //    ranked ABOVE the `nameField` ADR-0079 Phase 2 made canonical.
-  const explicit = valueAt(record, options?.titleField);
+  const explicit = recordDisplayValueAt(record, options?.titleField);
   if (explicit) return explicit;
 
   // 1+2. Declared name field — the canonical `nameField` (ADR-0079 Phase 2),
@@ -519,7 +548,7 @@ export function getRecordDisplayName(
   //      if it also carries a stale `titleFormat`.
   //      The `??` chain itself lives in {@link declaredNameField} so the
   //      name-space {@link resolveNameField} reads the identical ladder.
-  const declared = valueAt(record, declaredNameField(objectDef));
+  const declared = recordDisplayValueAt(record, declaredNameField(objectDef));
   if (declared) return declared;
 
   // 3. titleFormat (LEGACY, render-only template). DEPRECATED by ADR-0079: the
@@ -535,7 +564,7 @@ export function getRecordDisplayName(
 
   // 4. Type-aware derivation from the object's fields.
   const derivedField = deriveTitleField(objectDef);
-  const derived = valueAt(record, derivedField);
+  const derived = recordDisplayValueAt(record, derivedField);
   if (derived) return derived;
 
   // 4b. Name-ish keys on the record itself — the safety net for when the
@@ -546,7 +575,7 @@ export function getRecordDisplayName(
   if (options?.deriveFromRecordKeys !== false && record && typeof record === 'object') {
     // (i) exact standard keys (name, full_name, title, …).
     for (const key of NAME_ISH_RECORD_KEYS) {
-      const v = valueAt(record, key);
+      const v = recordDisplayValueAt(record, key);
       if (v) return v;
     }
     // (ii) `*_name` / `*_title` / `name_*` AFFIX on the record's own keys.
@@ -559,7 +588,7 @@ export function getRecordDisplayName(
       const k = key.toLowerCase();
       if (k === 'id' || k === '_id' || k.endsWith('_id') || k.startsWith('_')) continue;
       if (k.endsWith('_name') || k.endsWith('_title') || k.startsWith('name_')) {
-        const v = valueAt(record, key);
+        const v = recordDisplayValueAt(record, key);
         if (v) return v;
       }
     }

--- a/packages/plugin-detail/src/renderers/__tests__/record-details.dedupeEmptinessTrims-8350.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.dedupeEmptinessTrims-8350.test.tsx
@@ -1,0 +1,293 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `record:details`' dedupe and the page H1 share ONE definition of "this record
+ * has a value here" (objectui#8350).
+ *
+ * ## The surface under test is the DEDUPE, not the title
+ *
+ * This renderer does not draw the H1. It draws the body grid and drops from it
+ * the one field whose value the H1 is already showing. The H1 is drawn a
+ * package away by `@object-ui/components`' `PageHeaderRenderer`, and its half
+ * of this is already green on `origin/main` with the defect fully present —
+ * `packages/components/src/__tests__/page-header-title.test.tsx` passes either
+ * way, because the two halves are decided in different packages. So every case
+ * below asserts which row RENDERS and which row DROPS. A title-only pin proves
+ * nothing here.
+ *
+ * ## The defect these cases pin
+ *
+ * objectui#8175 (PR #8349) made the two halves agree on WHICH FIELD: the ladder
+ * now leads with `resolveNameField` / `deriveTitleField`, the same ADR-0079
+ * resolver the header reads. They still disagreed on WHAT COUNTS AS A VALUE.
+ *
+ * The header decides emptiness through `@object-ui/core`'s
+ * `recordDisplayValueAt` (the function that was `valueAt`), which TRIMS: a
+ * whitespace-only value is empty, so `getRecordDisplayName` keeps walking to
+ * the next rung. The ladder asked its own raw `undefined` / `null` / `''`
+ * question, which `'   '` passes. ⇒ for a record whose title field holds only
+ * spaces the ladder concluded THAT field was what the H1 shows and hid its row,
+ * while the H1 had already moved on and was showing something else. A field
+ * disappeared from the grid to deduplicate against a heading that never
+ * displayed it, and nothing errored — a row was simply absent.
+ *
+ * ## Why every tier of the ladder is exercised
+ *
+ * The ladder is eight candidates: two resolver rungs (declared pointer, then
+ * the type-aware derivation) and the six-entry literal walk as the tail. The
+ * emptiness test is asked once per candidate, so a fix that reached only the
+ * first rung would leave the other two wrong. `WHITESPACE AT THE DERIVATION
+ * RUNG` and `WHITESPACE IN THE LITERAL WALK` are what make "all three tiers
+ * share the fixed test" a measurement rather than a claim.
+ *
+ * ## Every case carries a control, and one case IS a control
+ *
+ * `queryByText(...)` returning null is trivially true on a document that
+ * rendered nothing, so each case also asserts a surviving ordinary row BY
+ * VALUE. And `NON-REGRESSION` at the bottom pins that a real value still hides
+ * its row: without it, an "emptiness test" that answered EMPTY for everything —
+ * disabling the dedupe outright — would pass every other case in this file.
+ *
+ * ## What the rows are keyed by (objectui#8269's trap)
+ *
+ * The dedupe filters entries through `columnIdentity`, which is CANONICAL-first
+ * (`field` beats `name`), while `DetailSection` renders each row from
+ * `field.name`. All fixtures here use BARE STRING entries, where the two are
+ * the same string by construction — so a green cannot come from the resolver's
+ * answer accidentally matching a differently-keyed column. A row that survives
+ * is therefore asserted by its LABEL, which for a bare-string entry is the
+ * field name itself; a row that must drop is asserted by its VALUE.
+ *
+ * ## Why the whitespace rows are still on screen at all
+ *
+ * `DetailSection`'s auto-hide heuristic needs a section of at least 4 fields,
+ * and its own emptiness test is raw — a whitespace-only value counts as FILLED
+ * there. Both facts are measured, not assumed: every fixture below renders 3
+ * rows after the dedupe, so auto-hide cannot fire and cannot be the reason a
+ * row is missing. (That `DetailSection` has a THIRD, un-trimmed spelling of
+ * emptiness is a real and separate divergence; it is not this card.)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import * as React from 'react';
+import { getRecordDisplayName } from '@object-ui/core';
+import { RecordContextProvider } from '@object-ui/react';
+import { RecordDetailsRenderer } from '../record-details';
+
+/**
+ * Declared pointer `contract_no`, held blank-but-not-empty on the record.
+ * `deriveTitleField` lands on `name` (NAME_ISH_EXACT, first entry), which is
+ * exactly where the header's chain goes when the declared rung yields nothing —
+ * so `Acme Corporation` is what this record's H1 says, and its row is the
+ * duplicate.
+ */
+const contractSchema = {
+  name: 'contract',
+  label: 'Contract',
+  nameField: 'contract_no',
+  fields: {
+    contract_no: { type: 'text', label: 'Contract No' },
+    name: { type: 'text', label: 'Name' },
+    amount: { type: 'number', label: 'Amount' },
+  },
+};
+const CONTRACT_FIELDS = ['contract_no', 'name', 'amount'];
+const WHITESPACE_POINTER_RECORD = {
+  id: 'W1',
+  contract_no: '   ',
+  name: 'Acme Corporation',
+  amount: 42,
+};
+
+/**
+ * Both resolver rungs blank-but-not-empty at once: the declared pointer
+ * (`contract_no`) and the derivation (`activity_name`, via the `*_name` affix —
+ * no NAME_ISH_EXACT field is declared). The header therefore falls all the way
+ * to a record key, landing on `label`, the LAST literal-walk entry.
+ */
+const activitySchema = {
+  name: 'activity',
+  label: 'Activity',
+  nameField: 'contract_no',
+  fields: {
+    contract_no: { type: 'text', label: 'Contract No' },
+    activity_name: { type: 'text', label: 'Activity Name' },
+    amount: { type: 'number', label: 'Amount' },
+  },
+};
+const ACTIVITY_FIELDS = ['contract_no', 'activity_name', 'label', 'amount'];
+const WHITESPACE_BOTH_RUNGS_RECORD = {
+  id: 'W2',
+  contract_no: '   ',
+  activity_name: '\t\n ',
+  label: 'Acme Corporation',
+  amount: 4,
+};
+
+/**
+ * Neither resolver rung answers — `amount` is the only declared field and
+ * `number` is not title-eligible — so the ladder IS the literal walk here. Its
+ * first entry (`name`) is blank-but-not-empty; `title`, further down, is where
+ * both halves must land.
+ */
+const plainSchema = {
+  name: 'plain',
+  label: 'Plain',
+  fields: {
+    amount: { type: 'number', label: 'Amount' },
+  },
+};
+const PLAIN_FIELDS = ['name', 'title', 'amount'];
+const WHITESPACE_WALK_RECORD = { id: 'W3', name: '   ', title: 'Real Title', amount: 6 };
+
+function renderBody(record: any, schema: any, fields: string[]) {
+  return render(
+    <RecordContextProvider
+      objectName={schema?.name ?? 'contract'}
+      recordId={record.id}
+      data={record}
+      objectSchema={schema}
+    >
+      <RecordDetailsRenderer schema={{ fields } as never} />
+    </RecordContextProvider>,
+  );
+}
+
+beforeEach(() => {
+  // `useRecordEditable` probes `POST /api/v1/security/explain` for the
+  // ROW-level verdict; happy-dom resolves that relative URL to a REAL socket,
+  // which the repo's network-escape guard fails the file for (objectui#6640).
+  // Serve it from a double — its answer is orthogonal to which row is hidden.
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ allowed: true }),
+    text: async () => '{"allowed":true}',
+  })) as never);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('record:details dedupe — emptiness is the header\'s definition (#8350)', () => {
+  /**
+   * The two halves are separate cases ON PURPOSE. Inside one `it` the first
+   * failing expectation short-circuits the rest, so an ablation of the read
+   * site would redden "the duplicate survived" and say nothing at all about
+   * "an ordinary field vanished" — and that second half is half the defect.
+   * Split, an ablation names both by test name.
+   */
+  it('HALF 1 — a whitespace-only declared pointer does NOT claim the dedupe: the row the H1 really shows DROPS', () => {
+    renderBody(WHITESPACE_POINTER_RECORD, contractSchema, CONTRACT_FIELDS);
+
+    // `contract_no` holds only spaces, so the header walked past it to the
+    // derivation and this record's H1 reads `Acme Corporation`. That is the
+    // row that duplicates the heading, and the only row that may be hidden.
+    expect(screen.queryByText('Acme Corporation')).toBeNull();
+
+    // CONTROL — the grid rendered at all.
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('HALF 2 — the whitespace-only row SURVIVES (nothing vanishes for a heading that never showed it)', () => {
+    renderBody(WHITESPACE_POINTER_RECORD, contractSchema, CONTRACT_FIELDS);
+
+    // The raw test read `'   '` as a value and hid this row to deduplicate
+    // against an H1 that was showing something else entirely.
+    expect(screen.getByText('contract_no')).toBeInTheDocument();
+
+    // CONTROL — the grid rendered at all.
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('WHITESPACE AT THE DERIVATION RUNG — HALF 1: the walk continues past BOTH resolver rungs and the duplicate drops', () => {
+    renderBody(WHITESPACE_BOTH_RUNGS_RECORD, activitySchema, ACTIVITY_FIELDS);
+
+    // Fixing only the first rung is not enough: rung 2 (`activity_name`) is
+    // blank-but-not-empty too, and a raw test there would stop the walk before
+    // it reached `label` — leaving `Acme Corporation` printed under an H1 that
+    // already says `Acme Corporation`.
+    expect(screen.queryByText('Acme Corporation')).toBeNull();
+
+    // CONTROL — the grid rendered at all.
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+
+  it('WHITESPACE AT THE DERIVATION RUNG — HALF 2: both blank rows survive', () => {
+    renderBody(WHITESPACE_BOTH_RUNGS_RECORD, activitySchema, ACTIVITY_FIELDS);
+
+    expect(screen.getByText('contract_no')).toBeInTheDocument();
+    expect(screen.getByText('activity_name')).toBeInTheDocument();
+
+    // CONTROL — the grid rendered at all.
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+
+  it('WHITESPACE IN THE LITERAL WALK — HALF 1: the tail trims too, so the next entry down is what drops', () => {
+    renderBody(WHITESPACE_WALK_RECORD, plainSchema, PLAIN_FIELDS);
+
+    // Neither resolver rung answers for this object, so the six-entry tail IS
+    // the ladder. `name` is its first entry and holds only spaces; `title` is
+    // where the header lands, so `title`'s row is the duplicate.
+    expect(screen.queryByText('Real Title')).toBeNull();
+
+    // CONTROL — the grid rendered at all.
+    expect(screen.getByText('6')).toBeInTheDocument();
+  });
+
+  it('WHITESPACE IN THE LITERAL WALK — HALF 2: the blank `name` row survives', () => {
+    renderBody(WHITESPACE_WALK_RECORD, plainSchema, PLAIN_FIELDS);
+
+    expect(screen.getByText('name')).toBeInTheDocument();
+
+    // CONTROL — the grid rendered at all.
+    expect(screen.getByText('6')).toBeInTheDocument();
+  });
+
+  /**
+   * The OTHER half, measured here rather than cited.
+   *
+   * Everything above asserts the grid. This asserts what the header's own
+   * resolver actually answers for the same three records — so "the two halves
+   * now agree" is a reading in this file, not a cross-package promise. It is an
+   * ADDITION to the DOM cases, never a substitute: on its own it would be the
+   * title-only pin the docblock warns about, and it is green on `origin/main`
+   * with the defect fully present.
+   */
+  it('CROSS-CHECK — `getRecordDisplayName` names exactly the value each case drops', () => {
+    expect(getRecordDisplayName(contractSchema, WHITESPACE_POINTER_RECORD)).toBe('Acme Corporation');
+    expect(getRecordDisplayName(activitySchema, WHITESPACE_BOTH_RUNGS_RECORD)).toBe('Acme Corporation');
+    expect(getRecordDisplayName(plainSchema, WHITESPACE_WALK_RECORD)).toBe('Real Title');
+  });
+
+  /**
+   * NON-REGRESSION — the dedupe still dedupes.
+   *
+   * Every case above is satisfied by an emptiness test that answers EMPTY for
+   * everything, i.e. by deleting the dedupe. This is the case that goes red for
+   * that, and it is why the fix is "share the header's definition" rather than
+   * "be more willing to call things empty".
+   */
+  it('NON-REGRESSION: a real declared-pointer value still hides its own row', () => {
+    renderBody(
+      { id: 'W4', contract_no: 'HT-2026-001', name: 'internal-name', amount: 42 },
+      contractSchema,
+      CONTRACT_FIELDS,
+    );
+
+    expect(screen.queryByText('HT-2026-001')).toBeNull();
+
+    // CONTROLS — the grid rendered, and the ordinary row is untouched.
+    expect(screen.getByText('internal-name')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+});

--- a/packages/plugin-detail/src/renderers/__tests__/record-details.nameFieldDedupe-8175.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.nameFieldDedupe-8175.test.tsx
@@ -37,7 +37,7 @@
  * `nameField` wins outright and the type-aware derivation never runs. This
  * ladder is VALUE-keyed — the header's own chain re-tries the next rung when a
  * rung's value is empty on the record (`getRecordDisplayName` step 1+2 falls to
- * step 4 when `valueAt` comes back undefined). Delegating to `resolveNameField`
+ * step 4 when `recordDisplayValueAt` comes back undefined). Delegating to `resolveNameField`
  * alone would therefore lose the derivation rung for every record whose
  * declared pointer happens to be blank. The two rungs are listed separately so
  * the value-keyed walk can fall through exactly the way the H1's does.
@@ -169,7 +169,7 @@ describe('record:details dedupe — the declared `nameField` picks the hidden ro
 
   it('falls through to the literal walk when the declared pointer is EMPTY on the record', () => {
     // The H1's chain is value-keyed: `getRecordDisplayName` only takes the
-    // declared pointer when `valueAt` yields something, else it keeps walking.
+    // declared pointer when `recordDisplayValueAt` yields something, else it keeps walking.
     // With no `contract_no` value the H1 for this record is `Acme Corporation`,
     // so `name` is the row that has to go — not `contract_no`, which shows
     // nothing at all and duplicates no heading.

--- a/packages/plugin-detail/src/renderers/record-details.tsx
+++ b/packages/plugin-detail/src/renderers/record-details.tsx
@@ -15,7 +15,13 @@ import { useRecordContext, useHighlightFieldNames, useSafeFieldLabel } from '@ob
 import { useFieldPermissions, usePermissions } from '@object-ui/permissions';
 import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import type { RecordDetailsComponentProps } from '@object-ui/types';
-import { columnIdentity, deriveTitleField, isObjectInlineEditable, resolveNameField } from '@object-ui/core';
+import {
+  columnIdentity,
+  deriveTitleField,
+  isObjectInlineEditable,
+  recordDisplayValueAt,
+  resolveNameField,
+} from '@object-ui/core';
 import { DetailView } from '../DetailView';
 
 /** Normalize a field entry (string | {field} | {name}) to its machine name. */
@@ -226,8 +232,28 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
     'display_name',
     'label',
   ].filter((n): n is string => typeof n === 'string' && n.length > 0);
+  //
+  // ⚠️ EMPTINESS IS THE HEADER'S DEFINITION, NOT A LOCAL ONE (objectui#8350).
+  // `recordDisplayValueAt` is the very function every value-keyed rung of
+  // `getRecordDisplayName` uses to decide whether a rung resolved — imported,
+  // not re-spelled, because the two halves must agree about WHAT COUNTS AS A
+  // VALUE exactly as objectui#8175 made them agree about WHICH FIELD.
+  //
+  // This line used to be a raw `undefined` / `null` / `''` test. A
+  // whitespace-only value passes that and does NOT pass the header's, so on a
+  // record whose title field held only spaces the ladder concluded that field
+  // was what the H1 showed and hid its row, while the H1 had already walked on
+  // to the next rung and was showing something else. A field disappeared from
+  // the grid to deduplicate against a heading that never displayed it — silent,
+  // nothing errored, a row was simply absent.
+  //
+  // ⛔ Never "just add a `.trim()`" here. That is a SECOND implementation of the
+  // same test, which is the shape of the defect this line closes, one level
+  // down: it would still disagree with the header about an expanded lookup
+  // object whose display chain yields nothing (`{ id: 'u1' }` is not a title),
+  // which the raw test — and a trim of it — both read as a value.
   for (const candidate of titleCandidates) {
-    if (data[candidate] !== undefined && data[candidate] !== null && data[candidate] !== '') {
+    if (recordDisplayValueAt(data, candidate) !== undefined) {
       hideFieldNames.add(candidate);
       break;
     }


### PR DESCRIPTION
Fixes #8350

`record:details` drops from the body grid the one field whose value the page H1
is already showing. objectui#8175 (PR #8349) made the two halves agree on **which
field**. They still disagreed on **what counts as a value**.

## The defect

The header half decides emptiness through `@object-ui/core`'s `valueAt`, which
**trims** — a whitespace-only value is empty, so `getRecordDisplayName` walks on
to the next rung. The ladder asked its own raw `undefined` / `null` / `''`
question, which a whitespace-only value passes.

So for a record whose title field held only spaces, on an object declaring
`nameField: 'contract_no'` with `contract_no = '   '` and `name = 'Acme
Corporation'`:

| | before | after |
|---|---|---|
| what the H1 shows | `Acme Corporation` (walked past the blank pointer) | unchanged |
| `contract_no` row | **hidden** — a row the H1 never showed | rendered |
| `name` row | rendered — repeating the heading | **hidden** |

A field disappeared from the grid to deduplicate against a heading that never
displayed it. Silent: nothing errors, a row is simply absent.

## The change

The ladder now **calls** that function instead of re-spelling the test.
`@object-ui/core` exports it as `recordDisplayValueAt` — it was the
module-private `valueAt`, behaviour unchanged, renamed only to be a defensible
public name. One authority, not two implementations that agree today.

⚠️ **Wider than a trim, deliberately.** Sharing the definition also imports the
two other things it decides, and both bring the grid into line with the heading:
an expanded/embedded reference object is **empty** when its display chain yields
nothing (a bare `{ id: 'u1' }` lookup payload is not a title), and non-strings
are stringified so `0` and `false` stay values. A bolted-on `.trim()` would have
closed the whitespace half only — and would be the second implementation whose
drift is the shape of this very defect, one level down. In every case the new
answer is the one the H1 was already giving.

## The pin

`packages/plugin-detail/src/renderers/__tests__/record-details.dedupeEmptinessTrims-8350.test.tsx`
— 8 cases asserting the **dedupe outcome** (which row renders, which drops),
never the title. All three tiers of the ladder are exercised, because the
emptiness test is asked once per candidate and a fix reaching only the first rung
would leave the other two wrong:

- **declared-pointer rung** — `contract_no = '   '`;
- **derivation rung** — *both* resolver rungs blank at once (`contract_no = '   '`,
  `activity_name` = an escaped tab/newline/space), so the walk must reach `label`;
- **literal-walk tail** — an object neither rung answers for, `name = '   '`,
  the duplicate at `title`.

Each tier is split into two `it()`s (the duplicate that must drop / the ordinary
row that must survive) so a failure in one cannot short-circuit the other; each
case carries a control asserting a surviving row **by value**; all entries are
bare strings so `columnIdentity`'s canonical-first keying and `DetailSection`'s
`field.name` rendering coincide by construction (objectui#8269's trap). A
`NON-REGRESSION` case pins that a real value still hides its row — without it,
an emptiness test answering EMPTY for everything (i.e. deleting the dedupe)
would pass every other case in the file.

## Ablation — two legs, because the pin sits on a conjunction

Both from the committed implementation; each mutation proven on disk by
`git hash-object` differing from `git rev-parse HEAD:PATH`, each restored by
state (`git diff HEAD` empty **and** the hash equal again), `trap … EXIT INT TERM`
with absolute paths.

- **Leg A — the ladder's delegation** reverted to the raw check
  (`9d12fbf8…` → `9ec9e139…`): the **6** whitespace rows go red by name, at all
  three tiers.
- **Leg B — the shared definition's trim** removed in `@object-ui/core`
  (`1bb8bed1…` → `167304de…`): the same 6 rows, **plus** `CROSS-CHECK`.

**The red sets intersect on the 6 dedupe rows.** Leg B's extra red is the header
half — `CROSS-CHECK` asserts what `getRecordDisplayName` itself answers, which
Leg A does not touch. `NON-REGRESSION` is green in both legs, and the whole
objectui#8175 suite (7 cases) is green in both — that pin cannot see this defect,
which is why a new one was needed.

## Verification

Repo root, explicit positional paths, `--no-passWithNoTests`, at `422b2484b`:

- `pnpm exec vitest run packages/plugin-detail/src/renderers/__tests__/ packages/core/src/utils` → **84 files / 1363 tests passed**
- `pnpm exec vitest run packages/plugin-detail/` → **136 files / 1224 tests passed**
- `pnpm exec vitest run packages/core/ packages/components/src/__tests__/page-header-title.test.tsx` → **123 files / 2582 tests passed**
- the `getRecordDisplayName` consumers — `InterfaceListPage.mapConfig`,
  `ObjectView.titleFieldConvergence`, `components/src/renderers/layout/__tests__`
  → **3 files / 25 tests passed**
- `pnpm --filter '@object-ui/plugin-detail^...' build` → exit 0, then
  `type-check` on `@object-ui/core` and `@object-ui/plugin-detail` → both exit 0.
  Reverse-verified that the type instrument reads the **rebuilt** `.d.ts`: an
  imported symbol that does not exist produced `TS2305` naming
  `"@object-ui/core"`, and restoring returned it to exit 0.
- `eslint .` in both packages → **0 errors** (901 / 517 pre-existing warnings).
- `node scripts/check-changeset-presence.mjs` → exit 0.
- `node scripts/check-governed-queue-guard.mjs --test` on all five changed paths
  → `NOT GOVERNED`; control on `AGENTS.md` fires.

**Narrowing declared.** `turbo ls --affected` names ~30 packages, because
`@object-ui/core` is a root dependency of the workspace. Only `plugin-detail`
changes behaviour: the core edit is a rename of a **module-private** function
plus an `export`, and `git grep '\bvalueAt\b'` across the repo found no importer
— only the six call sites inside `record-title.ts`, two prose mentions in the
objectui#8175 pin (updated here), and the unrelated `valueAtPath` in
`app-shell`'s `clientValidation.ts`. `getRecordDisplayName`'s own answers are
byte-identical. The rest of the affected set is CI's.

## Changeset

`minor` on `@object-ui/plugin-detail` **and** `@object-ui/core`, matching PR
#8349's `minor` for the previous change to this same ladder. Same class of
change: a different row can now be hidden. `@object-ui/core` is declared too
because it gains a public export; both sit in the 40-package `fixed` group, so
the bump propagates either way — declaring both states which packages actually
moved. Not `major`: the repo forbids it. Not empty-frontmatter: this changes
behaviour on a released package, which is precisely the case that spelling is
*not* for.

Authored by the `domain:ui` dev seat, session `session_01YBWFb5YgMU5dw8p2VKj16S`
(recorded in prose because a footer link is not durable through this platform's
body rewrites).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_