### PR TITLE
fix(plugin-chatbot): make useObjectChat's setMessages honest and drop the chatResult cast

### DIFF
--- a/.changeset/setmessages-honest-surface-8342.md
+++ b/.changeset/setmessages-honest-surface-8342.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/plugin-chatbot': minor
+---
+
+`useObjectChat().setMessages` now keeps the promise its declaration makes, and the
+`chatResult as any` that was hiding the gap is gone (objectui#8342).
+
+The member is declared `(messages: unknown[]) => void` and the hook returned
+`@ai-sdk/react`'s own `setMessages`, which accepts only its `UIMessage[]`.
+Parameters are contravariant, so that assignment is unsound — `tsc` reported it as
+a TS2322 the moment the cast came off, and the declared type was telling every
+consumer they could hand over an arbitrary array when the function underneath
+could not take one. Nothing broke only because no caller had yet taken the type at
+its word; one who did got a runtime failure the compiler had blessed.
+
+The parameter stays `unknown[]`. This package does not republish the SDK's pinned
+`UIMessage` on its own surface — the same call objectui#8214 made one file over
+for `AnyPart.state`, and typing this member against the SDK would re-break it on
+the next dependency bump. Instead the hook now wraps the SDK function and checks
+every element first: an object with a string `id`, a `'user' | 'assistant' |
+'system'` role, and a `parts` array — exactly the three members `UIMessage`
+requires. `parts` is checked for array-ness only, because the part union is open
+(a `data-*` part carries an author-defined payload) and restating it is the
+coupling this change exists to avoid.
+
+**Behaviour change, and the reason this is not a patch.** A value that is not a
+chat message is now REFUSED, not filtered and not passed on: the call throws a
+`TypeError` naming the offending index, and the SDK's store is left untouched
+because the whole array is validated before anything is written. Filtering was
+rejected deliberately — this is a re-hydration path where the caller's statement
+is "the thread is now exactly these messages", so dropping the failures would
+install a shorter thread that the `void` return makes undetectable. The declared
+TYPE does not move, so nothing that compiled stops compiling; what narrows is the
+set of values a consumer can successfully pass at runtime, which is the opposite
+direction from objectui#8214's widen.
+
+`@object-ui/app-shell`'s `useReconcileOnError` is the one in-repo consumer. Its
+payload comes from `toUIMessages`, which emits exactly `id` / `role` / `parts`, so
+it passes the check unchanged; and it already calls through a `try`/`catch` that
+falls back to the ordinary error banner, so a future malformed server payload
+degrades to "show the error" rather than to a quietly-truncated transcript.

--- a/packages/plugin-chatbot/src/__tests__/useObjectChat.setMessagesHonest-8342.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/useObjectChat.setMessagesHonest-8342.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `useObjectChat().setMessages` — the deliberately-loose member tells the truth
+ * (objectui#8342).
+ *
+ * The hook declared `setMessages?: (messages: unknown[]) => void` and returned
+ * the AI SDK's own function, which accepts only its `UIMessage[]`. Parameters
+ * are CONTRAVARIANT, so that assignment is unsound and `tsc` said so — the one
+ * thing suppressing it was a `chatResult as any` at the destructure. The fix
+ * keeps the loose parameter (this package does not republish `@ai-sdk/react`'s
+ * pinned `UIMessage`) and narrows INSIDE the hook, so the promise on the
+ * surface is one the implementation keeps.
+ *
+ * Two halves, and they only mean something together:
+ *
+ *   - the COMPILE-TIME block pins the declaration. It is erased by vitest, so
+ *     `pnpm test` proves nothing about it; only
+ *     `pnpm --filter @object-ui/plugin-chatbot type-check` can, and this
+ *     package's `tsconfig.test.json` is the project that reads this file.
+ *   - the RUNTIME blocks pin what the declaration is now a statement ABOUT.
+ *     Pinning either alone reproduces exactly the blindness that shipped: a
+ *     declaration that disagreed with the values flowing through it.
+ *
+ * The contract under test on a non-surviving element is REFUSE LOUDLY, not
+ * filter and not pass through. See the member's doc comment in
+ * `useObjectChat.ts` for why; the assertions below are what stops a later
+ * change from quietly picking one of the other two.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { useObjectChat, type UseObjectChatReturn } from '../useObjectChat';
+
+const API = 'https://example.test/api/v1/ai/agents/build/chat';
+
+const { sdkSetMessages } = vi.hoisted(() => ({ sdkSetMessages: vi.fn() }));
+
+vi.mock('@ai-sdk/react', () => ({
+  useChat: () => ({
+    messages: [],
+    status: 'ready',
+    error: undefined,
+    sendMessage: vi.fn(),
+    regenerate: vi.fn(),
+    stop: vi.fn(),
+    setMessages: sdkSetMessages,
+  }),
+}));
+
+/** A thread as the server persists it — `id` / `role` / `parts`, the three members `UIMessage` requires. */
+const HYDRATED = [
+  { id: 'm1', role: 'user', parts: [{ type: 'text', text: 'build me an app' }] },
+  {
+    id: 'm2',
+    role: 'assistant',
+    parts: [
+      { type: 'text', text: 'Built your app.' },
+      // An open `data-*` part: author-defined payload, no closed union to check
+      // against. It must survive — the guard checks `parts` for array-ness only.
+      { type: 'data-build-progress', id: 'bp-1', data: { phase: 'done' } },
+    ],
+  },
+];
+
+function renderApiMode() {
+  return renderHook(() => useObjectChat({ api: API, conversationId: 'c1' }));
+}
+
+beforeEach(() => {
+  sdkSetMessages.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// Compile-time: the declaration itself. Erased at runtime — `type-check` reads
+// these, vitest does not.
+// ---------------------------------------------------------------------------
+type Assert<T extends true> = T;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+
+type Published = UseObjectChatReturn['setMessages'];
+
+// Probe hygiene first: an `any` anywhere on this member would make every
+// assertion below answer whatever it is asked.
+type _NotAny = Assert<Equal<IsAny<Published>, false>>;
+type _NotAnyParam = Assert<Equal<IsAny<Parameters<NonNullable<Published>>[0]>, false>>;
+
+// Optional, because local mode does not expose it at all.
+type _StillOptional = Assert<Equal<undefined extends Published ? true : false, true>>;
+
+// The card, as a type. `(messages: unknown[]) => void` and nothing else:
+// re-narrowing this to the SDK's `UIMessage[]` is option A, which the ruling
+// declined precisely so a dependency bump cannot move the published surface.
+type _HonestSignature = Assert<Equal<NonNullable<Published>, (messages: unknown[]) => void>>;
+
+// The parameter really is the top array type — a caller may hand over anything
+// an `unknown[]` can hold, and the compiler must not object.
+type _AcceptsUnknownArray = Assert<
+  Equal<Parameters<NonNullable<Published>>[0], unknown[]>
+>;
+
+describe('the returned setMessages belongs to the hook, not to the SDK', () => {
+  it('is a wrapper, so what the declaration promises is enforced somewhere', () => {
+    const { result } = renderApiMode();
+    // Lit control for the negative below: the member is present and callable.
+    expect(typeof result.current.setMessages).toBe('function');
+    // The whole shape of the fix. Before it, this WAS the SDK's function and
+    // the declared parameter was a promise nothing kept.
+    expect(result.current.setMessages).not.toBe(sdkSetMessages);
+  });
+});
+
+describe('a well-formed thread passes through untouched', () => {
+  it('forwards every element, in order, by identity', () => {
+    const { result } = renderApiMode();
+
+    act(() => {
+      result.current.setMessages?.(HYDRATED);
+    });
+
+    expect(sdkSetMessages).toHaveBeenCalledTimes(1);
+    const [forwarded] = sdkSetMessages.mock.calls[0] as [unknown[]];
+    // Not filtered, not re-shaped: same length, same elements, same order.
+    expect(forwarded).toHaveLength(HYDRATED.length);
+    expect(forwarded[0]).toBe(HYDRATED[0]);
+    expect(forwarded[1]).toBe(HYDRATED[1]);
+    // The open `data-*` part survived — `parts` is checked for array-ness only.
+    expect((forwarded[1] as { parts: unknown[] }).parts).toHaveLength(2);
+  });
+});
+
+describe('a non-message element is REFUSED, not filtered and not passed on', () => {
+  it('throws a TypeError naming the offending index', () => {
+    const { result } = renderApiMode();
+
+    expect(() => result.current.setMessages?.([HYDRATED[0], { oops: true }])).toThrow(TypeError);
+    expect(() => result.current.setMessages?.([HYDRATED[0], { oops: true }])).toThrow(
+      /index 1/,
+    );
+  });
+
+  it('writes NOTHING — the store never sees a truncated thread', () => {
+    const { result } = renderApiMode();
+
+    expect(() => result.current.setMessages?.([HYDRATED[0], { oops: true }])).toThrow();
+
+    // The anti-FILTER pin, and the reason the check runs over the whole array
+    // before anything is handed on. A filtering implementation would have
+    // called the SDK exactly once here, with the single surviving message —
+    // installing a shorter thread that the `void` return makes undetectable.
+    expect(sdkSetMessages).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['a null hole', null],
+    ['a primitive', 'not a message'],
+    ['no id', { role: 'user', parts: [] }],
+    ['a non-string id', { id: 7, role: 'user', parts: [] }],
+    ['an unknown role', { id: 'm', role: 'tool', parts: [] }],
+    ['no parts', { id: 'm', role: 'user' }],
+    ['a non-array parts', { id: 'm', role: 'user', parts: { type: 'text' } }],
+  ])('refuses %s', (_label, bad) => {
+    const { result } = renderApiMode();
+    expect(() => result.current.setMessages?.([bad])).toThrow(TypeError);
+    expect(sdkSetMessages).not.toHaveBeenCalled();
+  });
+
+  it('refuses a non-array argument too', () => {
+    const { result } = renderApiMode();
+    // A JS host can reach a published surface with anything. The declared type
+    // says `unknown[]`; the implementation says so out loud.
+    const setMessages = result.current.setMessages as unknown as (m: unknown) => void;
+    expect(() => setMessages(null)).toThrow(TypeError);
+    expect(sdkSetMessages).not.toHaveBeenCalled();
+  });
+});
+
+describe('the in-hook caller still works through the wrapper', () => {
+  it('clear() empties the thread — an empty array survives the narrowing', () => {
+    const { result } = renderApiMode();
+
+    act(() => {
+      result.current.clear();
+    });
+
+    expect(sdkSetMessages).toHaveBeenCalledTimes(1);
+    expect(sdkSetMessages).toHaveBeenCalledWith([]);
+  });
+});

--- a/packages/plugin-chatbot/src/useObjectChat.ts
+++ b/packages/plugin-chatbot/src/useObjectChat.ts
@@ -356,7 +356,41 @@ export interface UseObjectChatReturn {
   reload: () => void;
   /** Clear all messages */
   clear: () => void;
-  /** ADR-0013 D2: re-hydrate the thread (API mode only); undefined in local mode. */
+  /**
+   * ADR-0013 D2: re-hydrate the thread (API mode only); undefined in local mode.
+   *
+   * Deliberately loose, and — since objectui#8342 — honest about it. The
+   * parameter stays `unknown[]` because this package will not republish
+   * `@ai-sdk/react`'s pinned `UIMessage` on its own surface; that is the same
+   * call objectui#8214 made one file over for `AnyPart.state`. Parameters are
+   * CONTRAVARIANT, so this declaration used to be a lie: the value handed out
+   * was the SDK's own `setMessages`, which accepts only its `UIMessage[]`, and
+   * the only thing stopping `tsc` from saying so was a `chatResult as any`
+   * inside the hook.
+   *
+   * What the implementation now guarantees, which is what makes the
+   * declaration a promise it keeps: the hook wraps the SDK function and CHECKS
+   * every element before handing the array on. A value that is not a chat
+   * message — not an object, or missing a string `id`, a
+   * `'user' | 'assistant' | 'system'` role, or a `parts` array — is REFUSED
+   * LOUDLY: the call throws a `TypeError` naming the offending index, and the
+   * SDK's store is left untouched, because the whole array is checked before
+   * anything is written.
+   *
+   * Refusing rather than FILTERING is the contract, on purpose. This is a
+   * re-hydration path: the caller's statement is "the thread is now exactly
+   * these messages". Dropping the elements that failed would install a SHORTER
+   * thread with no way for the caller to notice — the return type is `void` —
+   * which is the same silent-deletion failure objectui#4424 was graded on. The
+   * one in-repo consumer, `@object-ui/app-shell`'s `useReconcileOnError`,
+   * already calls this inside a `try`/`catch` that falls through to the
+   * ordinary error banner, so a refusal degrades to "show the error" instead of
+   * to a quietly-truncated transcript.
+   *
+   * Note the surface accepts an ARRAY only. The SDK's own `setMessages` also
+   * takes an updater callback; this member never advertised one and still
+   * does not.
+   */
   setMessages?: (messages: unknown[]) => void;
   /** Whether the hook is operating in API (streaming) mode */
   isApiMode: boolean;
@@ -395,6 +429,70 @@ function normalizeMessages(msgs?: OuiChatMessage[]): ObjectChatMessage[] {
     streaming: msg.streaming,
     toolInvocations: msg.toolInvocations,
   }));
+}
+
+/**
+ * The message element the PINNED `@ai-sdk/react` `setMessages` accepts,
+ * DERIVED from that function rather than restated. No SDK type is named here,
+ * so a version bump that moves `UIMessage` moves this alias with it and the
+ * published `UseObjectChatReturn['setMessages']` never has to move at all —
+ * which is precisely why objectui#8342 was ruled option B and not option A.
+ */
+type SdkChatMessage = Extract<
+  Parameters<ReturnType<typeof useChat>['setMessages']>[0],
+  readonly unknown[]
+>[number];
+
+/**
+ * Is `value` a chat message the SDK's store can hold?
+ *
+ * Checks exactly the three members `UIMessage` REQUIRES and every SDK read
+ * path dereferences: a string `id`, one of the three roles, and a `parts`
+ * array. `parts` is checked for array-ness only, NOT element by element — the
+ * part union is open (a custom `data-...` part carries an author-defined
+ * payload, `UIDataTypes = Record<string, unknown>`), so there is no closed set
+ * to check against and restating the union would be exactly the SDK-coupling
+ * objectui#8342's ruling declined. `mapMessages.ts`'s `AnyPart` is the same
+ * decision on the inbound side; this is its outbound mirror.
+ */
+function isSdkChatMessage(value: unknown): value is SdkChatMessage {
+  if (typeof value !== 'object' || value === null) return false;
+  const msg = value as { id?: unknown; role?: unknown; parts?: unknown };
+  return (
+    typeof msg.id === 'string' &&
+    (msg.role === 'user' || msg.role === 'assistant' || msg.role === 'system') &&
+    Array.isArray(msg.parts)
+  );
+}
+
+/**
+ * Narrow an arbitrary `unknown[]` to what the SDK's `setMessages` takes, or
+ * refuse loudly — see {@link UseObjectChatReturn.setMessages} for why refusing
+ * beats filtering on this path. The array is fully checked BEFORE the caller's
+ * value can reach the store, so a refusal leaves the thread exactly as it was.
+ *
+ * The result is built by pushing values the type predicate has already
+ * narrowed; there is deliberately no assertion here, because an `as` would
+ * just move objectui#8342's defect one line over.
+ */
+function narrowToSdkChatMessages(messages: unknown[]): SdkChatMessage[] {
+  if (!Array.isArray(messages)) {
+    throw new TypeError(
+      `useObjectChat: setMessages expects an array of chat messages, received ${typeof messages}.`,
+    );
+  }
+  const narrowed: SdkChatMessage[] = [];
+  messages.forEach((message, index) => {
+    if (!isSdkChatMessage(message)) {
+      throw new TypeError(
+        `useObjectChat: setMessages received a value at index ${index} that is not a chat ` +
+          `message (it needs a string \`id\`, a 'user' | 'assistant' | 'system' \`role\` and ` +
+          `a \`parts\` array). Nothing was written; the thread is unchanged.`,
+      );
+    }
+    narrowed.push(message);
+  });
+  return narrowed;
 }
 
 /**
@@ -619,6 +717,11 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
               cur.length > 0 &&
               cur[cur.length - 1]?.role === 'user'
             ) {
+              // The SDK's own `setMessages`, reached through `chatRef` — NOT
+              // the narrowed wrapper the hook returns (objectui#8342). The
+              // value is the SDK's own live `messages` minus its last element,
+              // so it is already `UIMessage[]`; re-checking it here would only
+              // pay for a guarantee the source already carries.
               chat.setMessages(cur.slice(0, -1));
             }
             // A rejected send (esp. a 429 quota block) means the usage picture
@@ -680,8 +783,8 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
     sendMessage: aiSendMessage,
     regenerate,
     stop,
-    setMessages,
-  } = chatResult as any;
+    setMessages: aiSetMessages,
+  } = chatResult;
 
   const isLoading = status === 'submitted' || status === 'streaming';
 
@@ -718,6 +821,19 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
       onSend?.(trimmed, nextMessages);
     },
     [aiSendMessage, onSend, apiMessages],
+  );
+
+  // objectui#8342 — the honest half of the deliberately-loose surface. The
+  // published member takes `unknown[]`; the SDK's own `setMessages` takes only
+  // its `UIMessage[]`, and parameters are contravariant, so passing the SDK
+  // function straight out advertised a capability it does not have. The
+  // narrowing happens HERE, which is what turns the declaration into a promise
+  // the implementation keeps.
+  const setMessages = useCallback(
+    (messages: unknown[]) => {
+      aiSetMessages(narrowToSdkChatMessages(messages));
+    },
+    [aiSetMessages],
   );
 
   const clear = useCallback(() => {
@@ -797,9 +913,11 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
       stop,
       reload: regenerate,
       clear,
-      // ADR-0013 D2: expose the underlying useChat setMessages so the host can
-      // re-hydrate the thread from the server after a stream-transport failure
-      // (the reply may already be persisted server-side — reconcile, don't re-run).
+      // ADR-0013 D2: let the host re-hydrate the thread from the server after
+      // a stream-transport failure (the reply may already be persisted
+      // server-side — reconcile, don't re-run). This is the NARROWING wrapper
+      // above, not the SDK function itself: the declared parameter is
+      // `unknown[]` and the wrapper is what makes that true (objectui#8342).
       setMessages,
       isApiMode: true,
       input: apiInput,


### PR DESCRIPTION
Fixes #8342

Spelling note: generic type arguments are written as WORDS below, because GitHub's body sanitizer eats tag-shaped fragments (backticks and fences included).

## The defect

`useObjectChat` declares

```
setMessages?: (messages: unknown[]) => void;
```

and returned `@ai-sdk/react`'s own `setMessages`, which accepts only its `UIMessage` array (or an updater). Parameters are **contravariant**, so that assignment is unsound: the published type promised every consumer they could hand over an arbitrary `unknown[]` when the function underneath could not take one. The only thing keeping `tsc` quiet was `} = chatResult as any;` at the destructure.

Re-measured on this branch's base (`37149ec4f`, i.e. after objectui#8214 / PR #8341 landed). Removing the cast alone leaves **exactly one** diagnostic, the chain the card quotes, now at `:803`:

```
src/useObjectChat.ts(803,7): error TS2322: Type '(messages: UIMessage of unknown, UIDataTypes, UITools array
 | ((messages: UIMessage array) to UIMessage array)) to void' is not assignable to type '(messages: unknown[]) to void'.
  Types of parameters 'messages' and 'messages' are incompatible.
    Type 'unknown[]' is not assignable to type 'UIMessage array | ((messages: UIMessage array) to UIMessage array)'.
      Type 'unknown[]' is not assignable to type 'UIMessage array'.
        Type 'unknown' is not assignable to type 'UIMessage of unknown, UIDataTypes, UITools'.
```

(One correction to the card: the measured chain has **five** levels, not four — the card elided the `unknown[]` is-not-assignable-to `UIMessage array` step between the union and the element.)

## The fix — ruling B, and why it does not collapse into A

The declared parameter **stays** `unknown[]`. This package does not republish the SDK's pinned `UIMessage` on its own surface; that is the same call objectui#8214 made one file over for `AnyPart.state`. The hook now wraps the SDK function and narrows internally.

The narrowing target is **derived from the SDK function, not restated**:

```
type SdkChatMessage = Extract(
  Parameters(ReturnType(typeof useChat)['setMessages'])[0],
  readonly unknown[]
)[number];
```

(spelled with parentheses above for the sanitizer; the source uses the real bracket syntax)

No SDK type is named in a type position anywhere on this path — the alias is derived from `useChat`, which the hook already imports as a value — so a dependency bump moves this internal alias and the published surface never has to move. **B therefore does not collapse into A**, and the package already made the mirror-image call on the inbound side — `mapMessages.ts`'s `AnyPart` / `AnyUIMessage` are locally-owned structural types for exactly this reason.

Verified on the emitted declaration: `dist/useObjectChat.d.ts:265` is still `setMessages?: (messages: unknown[]) => void;`, and every `UIMessage` occurrence in that file is inside a doc comment, never a type position. `SdkChatMessage` is module-private and does not appear at all.

## What happens to an element that does not survive: REFUSE LOUDLY

The three available contracts are refuse / filter / pass through, and they are genuinely different. This picks **refuse**:

- a value that is not a chat message throws a `TypeError` naming the offending index;
- **nothing is written** — the whole array is validated before anything reaches the SDK, so a refusal leaves the thread exactly as it was.

Grounds: this is a re-hydration path whose return type is `void`. The caller's statement is "the thread is now exactly these messages", so **filtering** would install a silently *shorter* thread with no way to notice — the same silent-deletion class objectui#4424 was graded on. Pass-through is the status quo the card rejects.

The check is exactly the three members `UIMessage` requires: a string `id`, a `'user' | 'assistant' | 'system'` role, and a `parts` array. `parts` is checked for array-ness **only** — the part union is open (a `data-` prefixed part carries an author-defined payload, `UIDataTypes` being a `Record` of string to unknown), so there is no closed set to check against, and restating it would be exactly the coupling this change exists to avoid. That residual is stated in the guard's doc comment rather than papered over.

Pinned by `packages/plugin-chatbot/src/__tests__/useObjectChat.setMessagesHonest-8342.test.tsx` — 13 cases, including the explicit anti-filter pin ("writes NOTHING — the store never sees a truncated thread"), plus a compile-time block that fails if anyone later takes option A.

## The two internal callers — only one goes through the wrapper

- `:724 setMessages([])` (`clear`) — now routed through the wrapper. An empty array survives trivially; pinned.
- `:622 chat.setMessages(cur.slice(0, -1))` — **not** affected. It reaches the SDK function through `chatRef.current` (typed `any`), not through the returned member, and its value is the SDK's own live `messages` minus the last element, i.e. already the right shape. Left as-is with a comment saying so.

## The one real downstream consumer

`@object-ui/app-shell`'s `useReconcileOnError` declares its sink as `(m: unknown[]) => void` and calls `setMessagesRef.current(ui as unknown[])` — it takes the published type at its word, which is precisely the consumer the card's Reachability section describes. Its payload comes from `toUIMessages`, which emits exactly `id` / `role` / `parts`, so it passes the check unchanged. And the call already sits inside a `try`/`catch` that falls through to the ordinary error banner, so a future malformed server payload degrades to "show the error" rather than to a quietly-truncated transcript. `pnpm --filter @object-ui/app-shell test`: 647 files, 6234 passed, 1 skipped.

## Ablation — four legs, run from the committed implementation

Every leg proved the mutation reached disk (`git hash-object` differs from `git rev-parse HEAD:PATH`) and restored **by state** (`git diff HEAD` empty AND the blob equal again), under a `trap ... EXIT INT TERM` with absolute paths.

| leg | mutation | `tsc --noEmit` | `tsc -p tsconfig.test.json` | vitest |
|---|---|---|---|---|
| 1 | wrapper removed (cast stays off) | **RED** TS2322 at `916,7`, full chain by name | **RED** same | **RED** 11/13 |
| 2 | wrapper removed **and** `chatResult as any` restored — the exact pre-fix hook body | green | green | **RED** 11/13 |
| 3 | `chatResult as any` restored, wrapper kept | green | green | green |
| 4 | declaration re-narrowed to the SDK message type (the option-A counterfactual) | green | **RED** TS2344 at `(103,32)` and `(108,3)` | not run |

The red sets of legs 1 and 2 **intersect at vitest**: the behavioural pin catches the regression whether or not someone re-introduces the cast to silence `tsc`. Their union covers both instruments.

Two results worth reading closely, because they correct the brief's model of this change:

- **Leg 3 is all green.** After the fix the `as any` is no longer load-bearing at all — the wrapper is what makes the assignment sound, so the cast becomes merely redundant. Removing it is therefore a *consequence* of the fix, not a second half of it, and it cannot be half of an ablation pair.
- **Leg 4 is red only in the test program.** `tsc --noEmit` stays green under option A because the compile-time pins live in a `*.test.tsx` file, which `tsconfig.json` excludes by directory. That is a direct measurement of why `type-check` runs both projects.

`--listFiles` proof that both of my files are in the programs that read them:

- test project: `src/useObjectChat.ts` **and** `src/__tests__/useObjectChat.setMessagesHonest-8342.test.tsx` are both listed.
- main project: `src/useObjectChat.ts` is listed; zero test files are (lit control: the same regex matches 39 entries in the test project's list).

## Verification

| what | result |
|---|---|
| `pnpm --filter '@object-ui/plugin-chatbot^...' build` | exit 0 (run first — without it `type-check` reports TS2307/TS2882, the stale-`dist` signature) |
| `pnpm --filter @object-ui/plugin-chatbot type-check` | exit 0 |
| `pnpm --filter @object-ui/plugin-chatbot test` | exit 0 — 40 files, 474 passed; all 13 new cases named in the verbose run |
| `pnpm --filter '...@object-ui/plugin-chatbot' type-check` | exit 0 — `Scope: 7 of 47 workspace projects`; plugin-chatbot, examples/schema-catalog, app-shell, examples/console-starter, examples/byo-backend-console, apps/site, apps/console — every one `Done`, 0 `error TS` |
| `eslint .` in `packages/plugin-chatbot` | exit 0, 0 errors, 89 warnings — all pre-existing; 0 in the new test file, and the 6 in `useObjectChat.ts` are the pre-existing `react-hooks/refs` sites at 542/590/627/629/637/736, none in the new code |
| code-level `as any` in `useObjectChat.ts` | 4 to 3; `:684 } = chatResult as any;` is the one removed (the whole-file `grep -c` still reads 4 because the new doc comment names the cast in prose — not a reading) |

## Changeset: `minor`, and the direction

`.changeset/setmessages-honest-surface-8342.md` declares `@object-ui/plugin-chatbot: minor`.

The **declared type does not move**, so nothing that compiled stops compiling. What narrows is the set of values a consumer can successfully pass **at runtime**: a call that used to hand junk to the SDK now throws. That is the opposite direction from objectui#8214's widen, and it is an observable behaviour change on a published member — so `minor` under this repo's "breaking ships minor, never major" rule.

Two things for the reviewer to weigh, stated rather than decided here:

1. The alternative reading is `patch`: no caller loses a capability it actually *had*, since passing a non-message array was undefined behaviour that merely happened not to throw at the call site. If the maintainer prefers that reading, the changeset is a one-word edit.
2. `plugin-chatbot` sits in the `fixed` version group in `.changeset/config.json`, so a `minor` here bumps the entire `@object-ui/*` line 17.6.x to 17.7.0. That is a real consequence of the level, not a reason to under-report it — flagging it so the choice is made with the cost visible.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_