### PR TITLE
test(metadata-admin): pin that a retired page-block i18n key leaves BOTH locale tables

### DIFF
--- a/.changeset/pageblock-retired-key-gate.md
+++ b/.changeset/pageblock-retired-key-gate.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: `block-config-i18n.test.ts` gains the retirement direction for
+`engine.inspector.pageBlock.*` — a key that left `BLOCK_CONFIG` must also leave
+BOTH metadata-admin locale tables. No published behaviour changes.

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config-i18n.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config-i18n.test.ts
@@ -60,10 +60,24 @@
  * What this file adds on top is the part a type cannot state: that the key side
  * is complete in both locales (with the rest of the walk), and that the literal
  * side is an inventory somebody has to argue with before "helpfully" translating
- * a JSON sample. The last describe holds that inventory.
+ * a JSON sample. The third describe holds that inventory.
+ *
+ * ## objectui#8368 — the other direction, and why it is the LAST describe
+ *
+ * Every assertion above answers "did the key ARRIVE?". None of them can answer
+ * "did the retired key LEAVE?" — a leftover key resolves in both locales, so it
+ * is green everywhere here by construction. Four renames in a row closed that
+ * half with a hand-written pin naming the one key they retired; the last
+ * describe replaces the convention with an instrument, scoped to exactly the
+ * subset where deadness is mechanically decidable. Its own header states the
+ * reader set it measured and, at equal length, what it deliberately does not
+ * cover.
  */
 
 import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { BLOCK_CONFIG, type BlockPropField, type PlaceholderSpec } from '../block-config';
 import { t } from '../../i18n';
 
@@ -443,5 +457,263 @@ describe('placeholders that must NOT be translated (#3979)', () => {
       (p) => `${p.where}: '${p.spec.literal}'`,
     );
     expect(keys).toEqual([]);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * objectui#8368 — the RETIREMENT direction.
+ *
+ * Everything above is the ARRIVAL half: a key BLOCK_CONFIG implies must exist
+ * in both locale tables. A designer rename owes a second half — the retired key
+ * must LEAVE both tables — and until this describe nothing measured it. The two
+ * repo-wide i18n gates cannot: `check:i18n-keys` and `check:i18n-dead-keys`
+ * both read `packages/i18n/src/locales/`, and `engine.inspector.pageBlock.*`
+ * lives only in `metadata-admin/i18n.ts` (which says so in its own header). So
+ * each of the four renames so far (objectui#3829, objectui#5212, objectui#8279,
+ * objectui#8278) shipped with a HAND-WRITTEN pin naming the one key it retired
+ * — a convention, not an instrument, and the fifth rename is one forgotten pin
+ * away from leaving dead vocabulary the next author reads as a live surface.
+ *
+ * ## What "retired" means here, operationally
+ *
+ * A key is retired when NOTHING CAN REACH IT — not when it merely looks unused.
+ * The reader set for this namespace was measured rather than assumed, and it
+ * has exactly two members:
+ *
+ *   1. BLOCK_CONFIG, through the positional derivation this file already
+ *      performs. Four families — `field.`, `add.`, `option.`, `placeholder.` —
+ *      are produced by nothing else: `SITES` above is the complete enumeration
+ *      of what the table can ask for, and the sibling assertions "stores
+ *      exactly the key its position implies" and "no label is left as display
+ *      text" are what make that enumeration exhaustive rather than a sample.
+ *   2. Literal `engine.inspector.pageBlock.…` strings in shipped source —
+ *      `PageBlockInspector.tsx`'s panel chrome and `PagePreview.tsx`'s outline
+ *      title. These have no position to derive from, so they are read back OUT
+ *      of the source, the same way `PageBlockInspector.i18n.test.tsx` reads its
+ *      own chrome key list rather than hand-copying it.
+ *
+ * Measured on this checkout: every one of the 171 `engine.inspector.pageBlock.*`
+ * keys in each table is covered by one of those two, and no key is constructed
+ * dynamically anywhere (`grep` for a template head under this prefix returns
+ * only prose in CHANGELOG.md and comments). That is what makes the namespace a
+ * CLOSED WORLD and therefore mechanically decidable.
+ *
+ * ## What this deliberately does NOT cover — say it loudly (objectui#8068)
+ *
+ * ONLY `engine.inspector.pageBlock.*`. The tables hold 1660 keys across three
+ * top-level namespaces (`engine.` 1371, `designer.` 178, `perm.` 111), and the
+ * rest of them are NOT a closed world: they are reached through dynamic
+ * construction (`engine.fieldType.<type>`, `engine.flowNode.<type>.label` via
+ * `translateNodeLabel`, `engine.diagnostics.severity.<level>`, …). Measured
+ * before scoping: a literal-footprint sweep over the whole `ENGINE_STRINGS_EN`
+ * table finds 226 of 1660 keys (13.6%) with no literal spelling in any non-test
+ * source — overwhelmingly LIVE keys the sweep cannot see. A gate over that
+ * corpus would cry wolf 226 times on a clean tree and be deleted rather than
+ * trusted, which is objectui#4658's own ruling for the pack-side sweep and
+ * objectui#8068's argument against instruments that claim more than they check.
+ * The honest scope is the subset that is exactly decidable, and it is stated
+ * here rather than implied by the assertion names.
+ *
+ * ## Why test files are excluded from the literal scan — load-bearing
+ *
+ * `block-config.test.ts` SPELLS the retired keys (`page:header.icon`,
+ * `page:accordion.title`, `object-kanban.groupField`) in its own negative pins.
+ * Counting test files as readers would make every key this gate exists to catch
+ * permanently reachable — the gate would be green by construction. A key read
+ * only by a test is not a key a user can see; the same argument
+ * `check-i18n-dead-keys.mjs` makes about test-only pack importers.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/** The four key families derived from a BLOCK_CONFIG POSITION, and therefore
+ *  judged against `SITES` alone — a literal spelling elsewhere (a comment, a
+ *  doc line) must not resurrect one. */
+const POSITIONAL_FAMILIES = new Set(['field', 'add', 'option', 'placeholder']);
+
+/** Repo root, found by walking UP to the workspace manifest rather than by
+ *  counting `..` segments, so moving this file retargets nothing silently. */
+function repoRoot(): string {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 12; i += 1) {
+    if (existsSync(path.join(dir, 'pnpm-workspace.yaml'))) return dir;
+    dir = path.dirname(dir);
+  }
+  throw new Error('could not locate the repo root (no pnpm-workspace.yaml above this file)');
+}
+
+const ROOT = repoRoot();
+const I18N_SOURCE_PATH = path.join(
+  ROOT,
+  'packages/app-shell/src/views/metadata-admin/i18n.ts',
+);
+
+interface EngineStringTable {
+  /** The `const` name, for assertion messages. */
+  name: string;
+  /** Every key the table declares, in file order. */
+  keys: string[];
+  /** 1-based line range of the object literal, for the disjointness guard. */
+  from: number;
+  to: number;
+}
+
+/**
+ * The KEYS of one `ENGINE_STRINGS_*` table, read out of the source by LINE
+ * RANGE rather than by scanning the whole file.
+ *
+ * Table membership is the whole question here: a key that MOVED from one locale
+ * table to the other reads as unchanged to a whole-file grep, which is exactly
+ * the mistake this direction has to be able to see. The range is bounded by the
+ * declaration line and the first column-0 `};` after it; keys are the entries at
+ * exactly two-space indent, so a multi-line VALUE (indented four) can never be
+ * mistaken for one.
+ */
+function engineStringTable(source: string, name: string): EngineStringTable {
+  const lines = source.split('\n');
+  const open = lines.findIndex((l) => l.startsWith(`const ${name}: Record<string, string> = {`));
+  if (open === -1) throw new Error(`${name}: declaration not found in i18n.ts — the extractor is stale`);
+  const close = lines.findIndex((l, i) => i > open && l === '};');
+  if (close === -1) throw new Error(`${name}: no column-0 '};' closes the table — the extractor is stale`);
+  const keys: string[] = [];
+  for (let i = open + 1; i < close; i += 1) {
+    const m = /^ {2}'((?:[^'\\]|\\.)*)':/.exec(lines[i]);
+    if (m) keys.push(m[1]);
+  }
+  return { name, keys, from: open + 1, to: close + 1 };
+}
+
+/**
+ * Every `engine.inspector.pageBlock.…` key spelled as a STRING LITERAL in
+ * shipped (non-test) source under `packages/` and `apps/`, mapped to the files
+ * that spell it.
+ *
+ * Scope is the whole workspace on purpose, not just `metadata-admin/`: `t()` is
+ * imported from `views/studio-design/**` and `views/*.tsx` today, so a chrome
+ * key could legitimately appear outside this directory tomorrow. Reading a key
+ * that no longer exists is not this gate's business (the sibling
+ * `every key resolves in …` assertions own that direction) — over-collecting
+ * here only ever costs a candidate, never a false red.
+ */
+function shippedLiteralKeys(): Map<string, string[]> {
+  const found = new Map<string, string[]>();
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (['node_modules', 'dist', 'build', 'coverage', '.turbo', '.next'].includes(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === '__tests__') continue;
+        walk(full);
+        continue;
+      }
+      if (!/\.(ts|tsx|js|jsx|mjs)$/.test(entry.name)) continue;
+      if (/\.(test|spec)\.[tj]sx?$/.test(entry.name)) continue;
+      if (full === I18N_SOURCE_PATH) continue; // the DEFINITION site, not a reader
+      const content = readFileSync(full, 'utf8');
+      if (!content.includes(PREFIX)) continue;
+      for (const m of content.matchAll(/['"`](engine\.inspector\.pageBlock\.[A-Za-z0-9_.:$-]+)['"`]/g)) {
+        const rel = path.relative(ROOT, full).split('\\').join('/');
+        const files = found.get(m[1]) ?? [];
+        if (!files.includes(rel)) files.push(rel);
+        found.set(m[1], files);
+      }
+    }
+  };
+  for (const top of ['packages', 'apps']) walk(path.join(ROOT, top));
+  return found;
+}
+
+const I18N_SOURCE = readFileSync(I18N_SOURCE_PATH, 'utf8');
+const EN_TABLE = engineStringTable(I18N_SOURCE, 'ENGINE_STRINGS_EN');
+const ZH_TABLE = engineStringTable(I18N_SOURCE, 'ENGINE_STRINGS_ZH');
+
+/** The keys `SITES` implies — the complete BLOCK_CONFIG-derived vocabulary. */
+const DERIVED = new Set(SITES.map((s) => s.derived));
+
+/** Literal chrome keys: spelled in shipped source AND not in a positional
+ *  family, so a stray mention of a positional key can never resurrect it. */
+const SHIPPED_LITERALS = shippedLiteralKeys();
+const CHROME = new Map(
+  [...SHIPPED_LITERALS].filter(
+    ([key]) => !POSITIONAL_FAMILIES.has(key.slice(PREFIX.length + 1).split('.')[0]),
+  ),
+);
+
+/** A table key nothing in the measured reader set can ask for. */
+function unreachable(table: EngineStringTable): string[] {
+  return table.keys.filter(
+    (key) => key.startsWith(`${PREFIX}.`) && !DERIVED.has(key) && !CHROME.has(key),
+  );
+}
+
+function pageBlockKeys(table: EngineStringTable): string[] {
+  return table.keys.filter((key) => key.startsWith(`${PREFIX}.`));
+}
+
+describe('a retired key leaves BOTH locale tables (objectui#8368)', () => {
+  it('reads two disjoint, non-empty tables out of i18n.ts', () => {
+    // The extractor is a source parser, so its silent failure mode is finding
+    // FEWER keys — which would make every assertion below vacuously green over
+    // an empty corpus. Ranges first: overlapping ones would mean the `};`
+    // scan ran past a table and both sets became the same set.
+    expect(EN_TABLE.to).toBeLessThan(ZH_TABLE.from);
+    expect(EN_TABLE.keys.length).toBeGreaterThan(1500);
+    expect(ZH_TABLE.keys.length).toBeGreaterThan(1500);
+    // No duplicates: a key declared twice would be a silent overwrite, and the
+    // set arithmetic below would hide it.
+    expect(EN_TABLE.keys.length).toBe(new Set(EN_TABLE.keys).size);
+    expect(ZH_TABLE.keys.length).toBe(new Set(ZH_TABLE.keys).size);
+  });
+
+  it('the extractor really sees the keys the derivation implies', () => {
+    // The strongest non-vacuity available: two INDEPENDENT channels for the
+    // same fact. `SITES` comes from walking BLOCK_CONFIG; these sets come from
+    // parsing the source text. A parser that silently stopped matching (a
+    // reformat, a changed indent) fails here by name, not by going quiet.
+    const enSet = new Set(EN_TABLE.keys);
+    const zhSet = new Set(ZH_TABLE.keys);
+    expect([...DERIVED].filter((k) => !enSet.has(k))).toEqual([]);
+    expect([...DERIVED].filter((k) => !zhSet.has(k))).toEqual([]);
+    expect(DERIVED.size).toBeGreaterThan(150);
+  });
+
+  it('the literal scan really finds the chrome call sites', () => {
+    // Same guard for the second reader. Named explicitly so a regex that stops
+    // matching fails here rather than quietly emptying the reachable set — an
+    // empty CHROME would report all 15 chrome keys as retired.
+    for (const key of [
+      `${PREFIX}.kind`,
+      `${PREFIX}.close`,
+      `${PREFIX}.list.add`,
+      `${PREFIX}.objectPlaceholder`,
+      `${PREFIX}.outlineLabel`,
+    ]) {
+      expect([...CHROME.keys()], `${key} is a live chrome call site`).toContain(key);
+    }
+    expect(CHROME.size).toBeGreaterThan(12);
+  });
+
+  it('en-US carries no pageBlock key nothing can reach', () => {
+    // The gate. A key here is one BLOCK_CONFIG no longer implies and no source
+    // file asks for — dead vocabulary the next author reads as a live surface.
+    // If a NEW reader shape appears (a dynamically built key), this reddens by
+    // name and the fix is to teach the reader set about it, not to delete the
+    // key. Loud is the correct direction to be wrong in.
+    expect(unreachable(EN_TABLE)).toEqual([]);
+  });
+
+  it('zh-CN carries no pageBlock key nothing can reach', () => {
+    // The half a rename actually forgets: `en` edited, `zh` left behind. The
+    // sibling `every key resolves in zh-CN` cannot see it — a LEFTOVER key
+    // resolves perfectly well.
+    expect(unreachable(ZH_TABLE)).toEqual([]);
+  });
+
+  it('both tables hold the same pageBlock key set', () => {
+    // "Left BOTH tables", stated directly. Asymmetry here is the signature of a
+    // half-applied retirement, and the message names which side kept the key.
+    const en = new Set(pageBlockKeys(EN_TABLE));
+    const zh = new Set(pageBlockKeys(ZH_TABLE));
+    expect([...en].filter((k) => !zh.has(k))).toEqual([]);
+    expect([...zh].filter((k) => !en.has(k))).toEqual([]);
+    expect(en.size).toBeGreaterThan(150);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config-i18n.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config-i18n.test.ts
@@ -697,14 +697,22 @@ describe('a retired key leaves BOTH locale tables (objectui#8368)', () => {
     // If a NEW reader shape appears (a dynamically built key), this reddens by
     // name and the fix is to teach the reader set about it, not to delete the
     // key. Loud is the correct direction to be wrong in.
-    expect(unreachable(EN_TABLE)).toEqual([]);
+    expect(
+      unreachable(EN_TABLE),
+      'ENGINE_STRINGS_EN keys under this prefix that BLOCK_CONFIG no longer implies and no ' +
+        'shipped source asks for — delete them, or teach the reader set about the new reader',
+    ).toEqual([]);
   });
 
   it('zh-CN carries no pageBlock key nothing can reach', () => {
     // The half a rename actually forgets: `en` edited, `zh` left behind. The
     // sibling `every key resolves in zh-CN` cannot see it — a LEFTOVER key
     // resolves perfectly well.
-    expect(unreachable(ZH_TABLE)).toEqual([]);
+    expect(
+      unreachable(ZH_TABLE),
+      'ENGINE_STRINGS_ZH keys under this prefix that BLOCK_CONFIG no longer implies and no ' +
+        'shipped source asks for — the half a rename forgets',
+    ).toEqual([]);
   });
 
   it('both tables hold the same pageBlock key set', () => {
@@ -712,8 +720,8 @@ describe('a retired key leaves BOTH locale tables (objectui#8368)', () => {
     // half-applied retirement, and the message names which side kept the key.
     const en = new Set(pageBlockKeys(EN_TABLE));
     const zh = new Set(pageBlockKeys(ZH_TABLE));
-    expect([...en].filter((k) => !zh.has(k))).toEqual([]);
-    expect([...zh].filter((k) => !en.has(k))).toEqual([]);
+    expect([...en].filter((k) => !zh.has(k)), 'in ENGINE_STRINGS_EN but not ZH').toEqual([]);
+    expect([...zh].filter((k) => !en.has(k)), 'in ENGINE_STRINGS_ZH but not EN').toEqual([]);
     expect(en.size).toBeGreaterThan(150);
   });
 });


### PR DESCRIPTION
Fixes #8368

## What this adds

`block-config-i18n.test.ts` only ever asserted the **arrival** half of a designer
rename: a key `BLOCK_CONFIG` implies must resolve in `en-US` and `zh-CN`. The
**retirement** half — the old key must leave *both* tables — had no instrument at
all, because `check:i18n-keys` and `check:i18n-dead-keys` both read
`packages/i18n/src/locales/` and `engine.inspector.pageBlock.*` lives only in
`metadata-admin/i18n.ts`. Four renames in a row (objectui#3829, objectui#5212,
objectui#8279 / PR #8325, objectui#8278 / PR #8359) each shipped a **hand-written
pin naming the one key it retired**. A convention, not an instrument.

One new describe closes that direction: `a retired key leaves BOTH locale tables
(objectui#8368)`, six assertions, in the same file as the forward direction so the
derivation cannot drift between them.

## What "retired" means here — the reader set was MEASURED, not assumed

A key is retired when **nothing can reach it**, never when it merely looks unused.
For `engine.inspector.pageBlock.*` the reader set has exactly two members, and
that is what makes the namespace a closed world:

1. **`BLOCK_CONFIG`, through positional derivation.** Four families — `field.`,
   `add.`, `option.`, `placeholder.` — are produced by nothing else. `SITES` (the
   walk this file already performs) is the complete enumeration, and the sibling
   assertions *stores exactly the key its position implies* and *no label is left
   as display text* are what make it exhaustive rather than a sample. A literal
   spelling elsewhere is deliberately **not** allowed to resurrect one of these,
   so a key surviving only in a comment still reads as dead.
2. **Literal `engine.inspector.pageBlock.…` strings in shipped source** —
   `PageBlockInspector.tsx`'s panel chrome (15 keys) and `PagePreview.tsx`'s
   outline title. These have no position to derive from, so the list is read back
   OUT of source, exactly as `PageBlockInspector.i18n.test.tsx` already reads its
   own chrome key list rather than hand-copying it.

Measured on this checkout: all **171** `engine.inspector.pageBlock.*` keys in each
table are covered by one of the two, and **nothing under the prefix is built
dynamically** (a grep for a template head under this prefix returns only prose in
`CHANGELOG.md` and comments).

**Test files are excluded from the literal scan, and that exclusion is
load-bearing.** `block-config.test.ts` *spells* the retired keys
(`page:header.icon`, `page:accordion.title`, `object-kanban.groupField`) inside its
own negative pins. Counting tests as readers would make every key this gate exists
to catch permanently reachable — green by construction.

## What it deliberately does NOT cover — stated loudly (objectui#8068)

**Only `engine.inspector.pageBlock.*`.** The two tables hold 1660 / 1715 keys
across three top-level namespaces (`engine.` 1371, `designer.` 178, `perm.` 111),
and the rest is **not** a closed world — it is reached through dynamic
construction. Measured before scoping, with the mechanism named rather than
guessed:

| measurement | value |
| --- | --- |
| `ENGINE_STRINGS_EN` keys | 1660 |
| …with **no** literal spelling in any non-test source | **226 (13.6%)** |
| `engine.inspector.pageBlock.*` keys | 171 |
| …with no literal spelling | **0** |

Those 226 are overwhelmingly **live** keys reached by template heads that exist
today — `engine.studio.access.explain.OP`, `engine.diagnostics.severity.LEVEL`,
`engine.layers.diff.STATUS`, `engine.list.col.KEY`, `engine.enum.FIELD.VALUE`,
`engine.flowNode.TYPE.label` via `translateNodeLabel`. A gate over that corpus
would cry wolf 226 times on a clean tree and be deleted rather than trusted —
objectui#4658's own ruling for the pack-side sweep, and objectui#8068's argument
against an instrument that claims more than it checks. The scope lives in the
describe's own header at the same length as the claim.

## The failing leg — built deliberately, because a gate that has only seen clean input has never been measured

Ablation ran from the **committed** implementation, with
`trap 'RESTORE' EXIT INT TERM` and absolute paths. The probe key is
`engine.inspector.pageBlock.field.object-grid.striped` — a **real** historical
field removed by objectui#4649 that **no existing pin names**, chosen over
`object-kanban.groupField` on purpose: a key some hand-written pin already covers
would not prove this gate sees anything new.

**Leg 1 — key re-added to `zh-CN` only.** On-disk proof first: the probe
declaration is at line 2120, and the recomputed table ranges put it inside
`ENGINE_STRINGS_ZH` (2119–4018), not merely somewhere in the file. Table
*membership* is read back, not whole-file spelling.

```
× zh-CN carries no pageBlock key nothing can reach
AssertionError: ENGINE_STRINGS_ZH keys under this prefix that BLOCK_CONFIG no longer
implies and no shipped source asks for — the half a rename forgets: expected [ Array(1) ] to deeply equal []
+ [ "engine.inspector.pageBlock.field.object-grid.striped" ]

× both tables hold the same pageBlock key set
AssertionError: in ENGINE_STRINGS_ZH but not EN: expected [ Array(1) ] to deeply equal []

Tests  2 failed | 19 passed (21)     vitest exit 1
```

**Leg 1 control — the pre-existing suites stay GREEN on the same mutated tree.**
`block-config.test.ts` + `PageBlockInspector.i18n.test.tsx`: `2 passed`,
`64 passed`, exit **0**. That is the gap this card describes, reproduced: without
this describe, a leftover retired key is invisible to everything.

**Leg 2 — key re-added to BOTH tables.** Declarations at lines 182 (EN range
181–2118) and 2121 (ZH range 2120–4019); both `en-US carries no pageBlock key
nothing can reach` and `zh-CN …` go red naming the key. `Tests 2 failed | 19
passed`, exit 1.

**Restore proved BY STATE after each leg, never by an exit code:**

```
git diff HEAD --name-only        -> []          (empty)
git hash-object …/i18n.ts        -> b254cece3e8550f9b116a69be797a1cee540b9ec
git rev-parse HEAD:…/i18n.ts     -> b254cece3e8550f9b116a69be797a1cee540b9ec
```

**Not trivially red:** on the unmutated tree the same file is `21 passed (21)`,
exit 0. There is no `dist` staleness surface — the test reads `i18n.ts` from disk
and imports `t` from source in the same package, so both channels see the mutation
directly.

## A real leftover found — OUTSIDE this gate's scope, reported and left alone

Four keys occur **nowhere in the repo except their own two definition lines**, in
both tables (lit control: `engine.directory.quickFind` has readers in
`DirectoryPage.tsx` and `StudioHomePage.tsx`):

- `engine.directory.allPackages` (i18n.ts:197 / :2136)
- `engine.directory.packageFilter` (i18n.ts:198 / :2137)
- `engine.list.allPackages` (i18n.ts:252 / :2191)
- `engine.list.packageFilter` (i18n.ts:254 / :2192)

They are `engine.directory.*` / `engine.list.*`, **not** `pageBlock`, so this gate
does not judge them and this PR does not touch them. Whether to delete them is a
separate call, filed separately.

## Verification

| check | result |
| --- | --- |
| `vitest run …/block-config-i18n.test.ts` | `21 passed (21)`, exit 0 |
| `vitest run packages/app-shell/src/views/metadata-admin` | `237 files, 2464 passed, 1 skipped`, exit 0 |
| `pnpm --filter @object-ui/app-shell type-check` | exit 0 (`tsc -p tsconfig.test.json --listFiles` confirms this test file is compiled, not excluded) |
| `eslint .` in `packages/app-shell` | exit 0, 0 errors; 0 lines mentioning this file |
| `check-changeset-presence` | `✅ … declares 1 changeset(s) … Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.` |
| `check-changeset-no-major` | `✅ No changeset declares a major bump.` |
| `check-control-bytes` | `✅ OK (scanned 6649 tracked text file(s))` |
| `check-type-check-coverage` | `✅ 42/42 packages compile their tests` |
| `check-lint-coverage` | `✅ 46/46 packages linted, 0 outstanding errors` |
| `check-governed-queue-guard --test PATHS` (the two changed paths) | `✅ NOT GOVERNED` |

Closure built first: `pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build`, exit 0.

## Corrections against the dispatch

- **The card's stated fix shape — "extend the dead-key report's corpus to the
  metadata-admin tables" — is the wrong instrument, and the numbers say so.**
  `scripts/check-i18n-dead-keys.mjs` is report-only by design, wired into no
  workflow, and its whole premise is a pack corpus with parity across ten locales.
  Pointing it at a 1660-key two-locale table with a 13.6% literal-unreachable floor
  produces a report nobody can act on and still enforces nothing — the card's own
  requirement ("the pin has to fail when a retired key is left behind") would remain
  unmet. A vitest pin over the exactly-decidable subset is already in CI, reddens by
  name, and claims only what it checks.
- **`skip-changeset` is not a mechanism in this repo.** No workflow or script reads
  such a label. The gate's documented answer for a change that releases nothing is
  the empty-frontmatter changeset, and its verdict line above is what settled it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_