### PR TITLE
refactor(app-shell): drop the redundant unknown[] assertion in useReconcileOnError

### DIFF
--- a/.changeset/issue-8379-reconcile-redundant-assertion.md
+++ b/.changeset/issue-8379-reconcile-redundant-assertion.md
@@ -1,4 +1,6 @@
 ---
 ---
 
-Internal type-only change in `@object-ui/app-shell`: `useReconcileOnError` no longer asserts `ui as unknown[]` when handing the rehydrated thread to `setMessages`. `toUIMessages` already returns an array, which widens to the sink's `unknown[]` on its own, so the assertion converted nothing. Measured: the emitted JavaScript is byte-identical with and without it, so nothing is published and no consumer can observe this.
+Internal type-only change in `@object-ui/app-shell`: `useReconcileOnError` no longer asserts `ui as unknown[]` when handing the rehydrated thread to `setMessages`. `toUIMessages` already returns an array, which widens to the sink's `unknown[]` parameter on its own, so the assertion converted nothing.
+
+Measured against the base commit with two real package builds: the published `.d.ts` is byte-identical, and the published `.js` differs only by the four explanatory comment lines this change adds -- there is no code delta (with comments stripped both emits are 1584 bytes and identical). Nothing a consumer of the tarball can observe changes, so this declares no release.

--- a/.changeset/issue-8379-reconcile-redundant-assertion.md
+++ b/.changeset/issue-8379-reconcile-redundant-assertion.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal type-only change in `@object-ui/app-shell`: `useReconcileOnError` no longer asserts `ui as unknown[]` when handing the rehydrated thread to `setMessages`. `toUIMessages` already returns an array, which widens to the sink's `unknown[]` on its own, so the assertion converted nothing. Measured: the emitted JavaScript is byte-identical with and without it, so nothing is published and no consumer can observe this.

--- a/packages/app-shell/src/hooks/useReconcileOnError.ts
+++ b/packages/app-shell/src/hooks/useReconcileOnError.ts
@@ -71,7 +71,11 @@ export function useReconcileOnError(opts: {
         const conv = await fetchConversation(aiBase, conversationId);
         const ui = toUIMessages(conv?.messages);
         if (isReconcilableCompletedTurn(ui) && setMessagesRef.current) {
-          setMessagesRef.current(ui as unknown[]);
+          // No assertion here: `toUIMessages` returns `HydratedUIMessage[]`, which
+          // widens to the sink's `unknown[]` on its own. Asserting would erase the
+          // diagnostic on this exact seam if either side is ever tightened
+          // (objectui#8379; the class of objectui#4424 / #8342).
+          setMessagesRef.current(ui);
           setErrorSuppressed(true);
           return;
         }


### PR DESCRIPTION
Fixes #8379

`useReconcileOnError` handed the rehydrated thread to the chat sink as
`setMessagesRef.current(ui as unknown[])`. Both sides of that call are already compatible, so the
assertion converted nothing:

| side | declaration | where |
| --- | --- | --- |
| producer | `toUIMessages(rows): HydratedUIMessage[]` | `packages/app-shell/src/hooks/useChatConversation.ts:479` |
| sink (published boundary) | `setMessages?: (messages: unknown[]) => void` | `packages/plugin-chatbot/src/useObjectChat.ts:360` |
| the ref app-shell wires it through | `React.MutableRefObject` parameterised with `((m: unknown[]) => void) OR undefined` | `packages/app-shell/src/hooks/useReconcileOnError.ts:36` |

An array of anything already widens to `unknown[]`. Site re-derived on this branch's own base
(`ab03bffae`), not trusted from the card: still line 74, one hit, lit control (a made-up type name on
the same instrument) 0.

Note on spelling: the generic parameter above is written in words rather than in angle brackets
because GitHub silently eats tag-shaped fragments from stored bodies, including inside backticks —
a table written to show a type would otherwise render as if nothing were there.

## Why this is not a tidy-up

A redundant assertion and a load-bearing one look identical in the source, so the deletion is only
worth making if you can show which one this is — that proof is the content of this PR.

And it is worth making. This assertion sits on **exactly the seam objectui#8342 was about**: the one
real in-repo consumer of that hook member, on a published-package boundary. It costs nothing today
and it is precisely the thing that would swallow the signal tomorrow — if `toUIMessages`'s return
type is ever narrowed, or if the sink's parameter is ever tightened (which is what option A on
objectui#8342 would have done), `as unknown[]` erases the diagnostic that should fire at this exact
line. That is the failure class of objectui#4424, where a cast on this same seam deleted capability
with the compiler agreeing, and it is how objectui#8342's own defect stayed invisible behind
`chatResult as any` until someone removed it.

Deleting it makes the compiler answer the question instead of being told not to.

## Evidence: inert in both directions

The instrument is `type-check`, not vitest — vitest transpiles types away and can never see this.
app-shell's `type-check` script is `tsc --noEmit && tsc -p tsconfig.test.json`, and **both** projects
were run separately (so neither hides behind the other's short-circuit), with the dependency closure
built first (`pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build`, exit 0).

| leg | src project (`tsconfig.json`) | test project (`tsconfig.test.json`) |
| --- | --- | --- |
| baseline, before any edit | exit 0, **0** `error TS` lines | exit 0, **0** `error TS` lines |
| removal (assertion gone) | exit 0, **0** `error TS` lines | exit 0, **0** `error TS` lines |
| reverse (assertion put back) | exit 0, **0** `error TS` lines | exit 0, **0** `error TS` lines |

All six runs produced zero lines of output at all, not merely zero matches. The reverse leg is what
makes this a reading rather than a tolerance: the assertion is inert in both directions, not merely
tolerated in one.

Both legs were mutated and restored **by state**, from a committed implementation, under a
`trap ... EXIT INT TERM` with absolute paths:

- mutation reached disk — old spelling 0 hits / new spelling 1 hit, and `git hash-object` differed
  from `git rev-parse HEAD:PATH` (`7f5b89c9f` vs `a1c6bcce5`)
- restored — `git hash-object` equal to `git rev-parse HEAD:PATH` again **and** `git diff HEAD`
  empty. Never by an exit code.

### The files being quoted are actually in the programs being quoted

This matters here specifically: `tsconfig.json` excludes `__tests__/` **by directory**, and this
hook's only test lives at `src/hooks/__tests__/useReconcileOnError.test.ts`. objectui#8342 measured a
case that was red only in the test program for exactly that reason, so a claim quoted from one
project alone would not be a reading.

| project | program size | hits for `src/hooks/useReconcileOnError.ts` | lit control (made-up filename, same instrument) |
| --- | --- | --- | --- |
| `tsconfig.json` | 3692 files | 1 | 0 |
| `tsconfig.test.json` | 4450 files | 1 | 0 |

Both hits are non-zero, so they are self-validating; the made-up filename returning 0 on the same
instrument confirms the matcher discriminates rather than matching everything.

### Nothing moved at runtime

- app-shell suite, run from the repo root as AGENTS.md requires
  (`pnpm exec vitest run packages/app-shell/ --no-passWithNoTests`):
  `Test Files 649 passed (649)`, `Tests 6255 passed | 1 skipped (6256)`, exit 0. A type-only deletion
  should move nothing, and it moved nothing. (649 files, not the 22 that the
  wrong-cwd false green reports.)
- `eslint .` for the package: exit 0, `2925 problems (0 errors, 2925 warnings)` — all pre-existing
  `no-explicit-any` warnings in other files.

### What the published tarball actually gains

Measured with two real package builds (`tsc`), base file swapped in and out under the same trap:

- published `.d.ts` — **byte-identical**. The change is entirely inside a function body.
- published `.js` — the **only** delta is the four explanatory comment lines this change adds. With
  comments stripped, both emits are 1584 bytes and identical, so there is no code delta: the
  assertion is erased by the compiler either way.

## Changeset

`node scripts/check-changeset-presence.mjs` verdict, quoted:

```
✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/issue-8379-reconcile-redundant-assertion.md.
    Every one of them has an EMPTY frontmatter — declared as releasing nothing, which
    is the explicit exemption and a complete answer to this gate.
```

Argued both ways, since the empty spelling should be reasoned to rather than felt:

- **for a `minor`** — this is `src/` of a package the release covers, which is the gate's own trigger;
  and a `minor` is cheap right now, since `main` already carries hundreds of pending `minor`
  changesets in the same 40-package `fixed` group, so one more costs nothing incremental.
- **for the empty frontmatter (chosen)** — the gate's header says the criterion is whether the change
  releases anything, and names the empty spelling "a pass, not a workaround". Here that is measured,
  not asserted: identical `.d.ts`, zero code delta in `.js`. A release-note line saying "removed a
  redundant type assertion" would be noise in the platform's notes, which read this repo's declared
  changesets verbatim. Declaring "this releases nothing" is the true statement.

`scripts/check-changeset-no-major.mjs`: `✅  No changeset declares a major bump.`

`node scripts/check-governed-queue-guard.mjs --test <the two changed paths>`:
`✅ NOT GOVERNED — 2 path(s) checked against 5 governed surface(s); none matched.`

## One correction against my own working notes

While measuring the emit delta I first wrote `git show "$BASE":path` in a shell where `$BASE` was
unset. That expands to `git show :path`, which reads the **index** — it exits 0 and prints a real
file, so the comparison silently became implementation-vs-itself and reported "identical" for the
comments-preserved emit too. Caught by asking the base copy a question it had to answer (`as unknown[]`
must appear exactly once in it; it appeared zero times). Every base-side read in this PR now names the
literal sha. The corrected measurement is the one in the table above, and it changed the conclusion:
the comments-preserved emit is **not** identical, which is why the changeset wording was revised in a
second commit rather than left as first written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_