### PR TITLE
fix(test-infra): judge a subpath of a swept package in check-vi-mock-inherit

### DIFF
--- a/scripts/__tests__/check-vi-mock-inherit.test.ts
+++ b/scripts/__tests__/check-vi-mock-inherit.test.ts
@@ -287,6 +287,81 @@ describe('scope — narrow, and out of scope by construction rather than by exem
     expect(header.length).toBeLessThan(source.length);
     expect(header).toMatch(/whole-module replacement/i);
     expect(header).toMatch(/precondition for widening is a sweep/i);
+    // objectui#8141: the scope the resolver actually implements includes the
+    // subpaths of a member, so the header has to say so -- a verdict line that
+    // claims more than the prose explains is the same over-claim one level up.
+    expect(header).toMatch(/covers its SUBPATHS/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The subpath boundary (objectui#8141)
+// ---------------------------------------------------------------------------
+
+describe('a member covers its SUBPATHS — the boundary objectui#8141 moved', () => {
+  /**
+   * The resolver decided scope by EXACT equality until objectui#8141, so
+   * `@object-ui/components/ui/sonner` -- a subpath of the member slice 6 swept
+   * -- was counted in the "other workspace" bucket and never judged, while the
+   * verdict line named the package as covered. Measured on `b38014e82` with
+   * the gate's own `scan()`: 2 such sites in the tree, both already inheriting,
+   * so the prefix match landed as a ratchet (623 -> 625 judged, 37 -> 35 other
+   * workspace, 0 frozen either way).
+   */
+
+  const SUBPATH = `${COVERED}/testing`;
+
+  it('a SUBPATH of a covered member is JUDGED rather than bucketed as workspace', () => {
+    const site = verdictOf(`() => ({ SchemaRenderer: Stub })`, SUBPATH);
+    expect(site.scope).toBe('covered');
+    expect(site.verdict).toBe('frozen');
+  });
+
+  it('the same subpath in the inheriting form is green', () => {
+    const site = verdictOf(`async (importOriginal) => ({ ...(await importOriginal()), X: Stub })`, SUBPATH);
+    expect(site.scope).toBe('covered');
+    expect(site.verdict).toBe('inherits');
+  });
+
+  it('vi.importActual of the SUBPATH inherits it — the specifier match follows the subpath', () => {
+    const site = verdictOf(
+      `async () => ({ ...(await ${importActual(SUBPATH)}), X: Stub })`,
+      SUBPATH,
+    );
+    expect(site.verdict).toBe('inherits');
+  });
+
+  it('THE REGRESSION PIN: a frozen subpath factory makes the gate RED, not silently green', () => {
+    // This is the whole card in one case. Revert the resolver to exact
+    // equality and the site drops into `workspace`: `frozen` empties, the run
+    // reports OK, and the green claims a package the gate never checked.
+    const { root, files } = fixtureTree({
+      'packages/plugin-form/src/Toast.test.tsx': `${mockCall(SUBPATH, `() => ({ toast: Stub })`)}
+`,
+    });
+    const result = scanFixture(root, files);
+    expect(result.frozen.map((f: { specifier: string }) => f.specifier)).toEqual([SUBPATH]);
+    expect(result.census.covered).toBe(1);
+    expect(result.census.workspace).toBe(0);
+  });
+
+  it('a sibling package whose NAME starts with a member is NOT covered', () => {
+    // The separator is part of the prefix. `@object-ui/react-native` would be a
+    // different package with its own sweep to do, not a subpath of the member.
+    for (const spec of [`${COVERED}-native`, `${COVERED}ive`]) {
+      const site = verdictOf(`() => ({ X: Stub })`, spec);
+      expect(site.scope, `${spec} must not be swallowed by the prefix`).toBe('workspace');
+      expect(site.verdict).toBe('unjudged');
+    }
+  });
+
+  it('the constant still names package ROOTS only — reach widened, membership did not', () => {
+    // ⛔ The repair is NOT enumerating subpaths in the constant: that keeps the
+    // gap open per subpath forever, and a subpath member would also fail the
+    // package.json case above. A member joins only by sweep.
+    for (const spec of COVERED_SPECIFIERS) {
+      expect(spec.split('/'), `${spec} is not a package root`).toHaveLength(2);
+    }
   });
 });
 
@@ -661,6 +736,23 @@ describe('repo state — the gate is green on this tree', () => {
     for (const site of calendar) expect(site.scope).toBe('local');
   });
 
+  it('THE SUBPATH SITES, pinned against the real files — objectui#8141', () => {
+    // The on-disk half of the boundary. Both were `workspace` (counted, never
+    // judged) until objectui#8141 and both already inherited, which is why the
+    // prefix match was free; if a later edit re-freezes one, this reddens here
+    // as well as in the gate.
+    const subpathSites = ['packages/plugin-form/src/MasterDetailForm.outcomeToastSupersede.test.tsx', 'packages/plugin-form/src/WizardForm.outcomeToastSupersede.test.tsx'];
+    for (const file of subpathSites) {
+      expect(fs.existsSync(path.join(repoRoot, file)), `${file} moved — this control tests nothing`).toBe(true);
+      const sites = findCallSites(fs.readFileSync(path.join(repoRoot, file), 'utf8')).filter(
+        (s: { specifier: string }) => s.specifier.includes('/', s.specifier.indexOf('/') + 1),
+      );
+      const onAMember = sites.filter((s: { scope: string }) => s.scope === 'covered');
+      expect(onAMember.length, `${file} no longer mocks a subpath of a covered member`).toBeGreaterThan(0);
+      for (const site of onAMember) expect(site.verdict, `${file}:${site.line}`).toBe('inherits');
+    }
+  });
+
   it('puts the census in the verdict, so a reader sees the population', () => {
     // "OK" alone is what a gate that does nothing also prints.
     //
@@ -671,10 +763,14 @@ describe('repo state — the gate is green on this tree', () => {
     const named = COVERED_SPECIFIERS.join(', ');
     const line = summarise(result);
     expect(line).toMatch(/\d+ tracked source file\(s\)/);
-    expect(line).toMatch(new RegExp(`\\d+ call site\\(s\\) on ${escapeRe(named)} judged`));
+    // "and their subpaths" is load-bearing rather than decorative: the resolver
+    // judges a member AND its subpaths (objectui#8141), and a verdict line that
+    // named only the members would claim less than the run actually checked --
+    // the same over-claim in the other direction.
+    expect(line).toMatch(new RegExp(`\\d+ call site\\(s\\) on ${escapeRe(named)} and their subpaths judged`));
     const out = execFileSync('node', ['scripts/check-vi-mock-inherit.mjs'], { cwd: repoRoot, encoding: 'utf8' });
     expect(out).toMatch(/check-vi-mock-inherit: OK/);
-    expect(out).toContain(`${result.census.covered} call site(s) on ${named} judged`);
+    expect(out).toContain(`${result.census.covered} call site(s) on ${named} and their subpaths judged`);
   });
 
   it('needs no install and no build — it is a cheap-tier gate', () => {

--- a/scripts/check-vi-mock-inherit.mjs
+++ b/scripts/check-vi-mock-inherit.mjs
@@ -79,7 +79,8 @@
  *     fixed. Relative specifiers are counted here and never judged.
  *   - **Third-party packages.** `sonner`, `react-router-dom`, `lucide-react`
  *     and friends grow only on a deliberate version bump. Counted, never judged.
- *   - **Workspace specifiers not in `COVERED_SPECIFIERS`.** See below.
+ *   - **Workspace specifiers that are neither a `COVERED_SPECIFIERS` member
+ *     nor a SUBPATH of one.** See below, and "A member covers its subpaths".
  *
  * `COVERED_SPECIFIERS` holds the workspace packages whose frozen sites have
  * actually been SWEPT to zero. Today that is eighteen, and each joined by sweep
@@ -827,6 +828,46 @@
  * zero for it, then add it to `COVERED_SPECIFIERS` in the same PR. The list only
  * ever grows. objectui#6892 carries the per-specifier worklist.
  *
+ * ## A member covers its SUBPATHS (objectui#8141)
+ *
+ * The resolver decided scope by EXACT string equality against
+ * `COVERED_SPECIFIERS` until objectui#8141, so `@object-ui/components/ui/sonner`
+ * -- a subpath of the member slice 6 swept -- fell into the "other workspace"
+ * bucket: counted, never judged, while the verdict line above it named the
+ * package as covered. A gate that reports a verdict broader than what it
+ * checked hides the absence behind a green, and the defect it hides is the one
+ * this whole file exists to catch: the failure mechanism does not care whether
+ * the frozen stand-in stood in for a package root or for one of its subpaths.
+ * A subpath's export surface GROWS exactly the way the root's does.
+ *
+ * ⭐ That was not an exemption and not a recogniser bug -- the resolver did
+ * exactly what it said. It was a scope boundary drawn when the covered set had
+ * ONE member and no call site named a subpath.
+ *
+ * A member therefore covers `member` and `member/...`, and the separator is
+ * part of the prefix, so a sibling package whose NAME merely starts with a
+ * member's (`@object-ui/react-native`) is a different package and stays out.
+ * The constant keeps naming package ROOTS only, so "a member joins only by
+ * sweep" is unchanged: what widened is the reach of one membership, not the
+ * test for membership.
+ *
+ * ⚠️ Widening the resolver newly JUDGES sites nobody swept, so it carries the
+ * same precondition a new member does. Re-measured on `b38014e82` against
+ * today's EIGHTEEN members by running this file's own `scan()` -- ⛔ never from
+ * objectui#8141's own table, which was taken on `214d5d5a6` when the constant
+ * held eleven:
+ *
+ *     subpath call sites on a covered member  ->  2, both
+ *       `@object-ui/components/ui/sonner`, both in `packages/plugin-form`
+ *     the same 2, once the prefix match lands  ->  2 inherit, 0 frozen
+ *
+ * with the census moving 623 -> 625 judged and 37 -> 35 other-workspace, no
+ * site moving the other way and every other row byte-identical between the two
+ * runs. Zero frozen before and after, so this landed as a RATCHET -- the same
+ * "the tree is at zero" argument that scoped objectui#6849 -- and no sweep was
+ * owed. ⛔ A later re-measure that DOES turn up a frozen subpath factory sweeps
+ * it in the same PR: never a floor, never a per-site allowance.
+ *
  * ⛔ There is deliberately NO per-file exception list, and adding one is the
  * wrong repair. An exemption means the recogniser called correct code broken;
  * fix the recogniser, or the specifier does not belong in the covered set yet.
@@ -1233,8 +1274,9 @@ export function classifyFactory(masked, literal, start, end, specifier) {
 /**
  * Every mock call site in one file, classified.
  *
- * `scope` is `covered` (judged), `workspace` (a workspace package outside
- * `COVERED_SPECIFIERS`), `external` (a third-party package), `local` (a
+ * `scope` is `covered` (judged -- a `COVERED_SPECIFIERS` member OR a subpath of
+ * one), `workspace` (a workspace package that is neither), `external` (a
+ * third-party package), `local` (a
  * relative specifier -- whole-module replacement, out of scope by the ruling),
  * `dynamic` (an interpolated specifier) or `embedded` (the call token sits
  * inside a string, so it is a code SAMPLE -- see `check-vi-mock-specifiers.mjs`
@@ -1244,6 +1286,12 @@ export function findCallSites(source, { covered = COVERED_SPECIFIERS } = {}) {
   const { comment, literal } = scanSource(source);
   const masked = blank(source, comment);
   const coveredSet = new Set(covered);
+  // A member covers its own SUBPATHS too -- see "A member covers its subpaths"
+  // in the header. The separator is part of the prefix, so a sibling package
+  // whose NAME merely starts with a member's (`@object-ui/react-native`) is not
+  // swallowed; only a subpath of the member itself (`@object-ui/react/x`) is.
+  const coveredPrefixes = [...coveredSet].map((member) => `${member}/`);
+  const isCovered = (spec) => coveredSet.has(spec) || coveredPrefixes.some((prefix) => spec.startsWith(prefix));
 
   const sites = [];
   CALL_RE.lastIndex = 0;
@@ -1260,7 +1308,7 @@ export function findCallSites(source, { covered = COVERED_SPECIFIERS } = {}) {
       ? 'dynamic'
       : specifier === '.' || specifier === '..' || specifier.startsWith('./') || specifier.startsWith('../')
         ? 'local'
-        : coveredSet.has(specifier)
+        : isCovered(specifier)
           ? 'covered'
           : specifier.startsWith('@object-ui/')
             ? 'workspace'
@@ -1375,7 +1423,7 @@ export function summarise({ census, covered }) {
   return (
     `${census.sources} tracked source file(s), ${census.testFiles} test-named; ` +
     `${census.filesWithMocks} carry a mock; ` +
-    `${census.covered} call site(s) on ${covered.join(', ')} judged ` +
+    `${census.covered} call site(s) on ${covered.join(', ')} and their subpaths judged ` +
     `(${census.inherits} inherit, ${census.automock} auto-mocked); ` +
     `${census.workspace} other workspace, ${census.external} external, ` +
     `${census.local} local, ${census.dynamic} non-static, ` +


### PR DESCRIPTION
Fixes #8141

## The defect

`scripts/check-vi-mock-inherit.mjs` resolved scope by **exact string equality** against `COVERED_SPECIFIERS`. A subpath of an already-swept package therefore fell through to the `@object-ui/` branch and landed in the "other workspace" bucket: **counted, never judged** — while the verdict line printed above it named the package as covered.

That is the class this card is admitted under: **a gate that runs and reports a verdict broader than what it checked hides the absence behind a green.** The neighbouring card #8286 was closed as out-of-class precisely because no gate ran there at all — nothing was claimed, so nothing was over-claimed. #8286 is not addressed here.

⭐ This was **not an exemption and not a recogniser bug** — the resolver did exactly what it said. It was a scope boundary drawn when the covered set had ONE member and no call site named a subpath. The failure mechanism the gate exists to catch (a module-scope read of an export the frozen stand-in never listed, killing the file during COLLECTION with zero failed assertions) does not care whether the frozen stand-in stood in for a package root or for one of its subpaths: a subpath's export surface grows exactly the way the root's does.

## The route: option 1 (prefix match), and its precondition, taken first

A member now covers `member` and `member/...`. The separator is part of the prefix, so a sibling package whose NAME merely starts with a member's (`@object-ui/react-native`) is a different package and stays out. **The constant still names package ROOTS only** — what widened is the reach of one membership, not the test for membership, so "a member joins only by sweep" is unchanged.

Widening the resolver newly JUDGES sites nobody swept, so the population was re-measured **first**, on today's tree, with the gate's own exported `scan()` — never from the card's table, which was taken on `214d5d5a6` when the constant held eleven members:

```
node -e "import('./scripts/check-vi-mock-inherit.mjs').then(m => { const r = m.scan(process.cwd());
  console.log(r.sites.filter(s => s.scope === 'workspace' && m.COVERED_SPECIFIERS.some(c => s.specifier.startsWith(c + '/')))); })"
```

Measured on `b38014e82` against today's **eighteen** members:

| | before (exact match) | after (prefix match) |
| --- | --- | --- |
| judged call sites | 623 | **625** |
| other workspace | 37 | **35** |
| frozen | 0 | **0** |
| unreadable / vacuous | 0 / 0 | 0 / 0 |

The two newly-judged sites are both `@object-ui/components/ui/sonner`, both in `packages/plugin-form`:

```
packages/plugin-form/src/MasterDetailForm.outcomeToastSupersede.test.tsx:99
packages/plugin-form/src/WizardForm.outcomeToastSupersede.test.tsx:96
```

Both were **already inheriting** (`async (importOriginal) => ({ ...actual, toast: fakeToast })`), so **no sweep was owed and this lands as a RATCHET** — the same "the tree is at zero, so the gate starts as a ratchet" argument that scoped #6849. Every other row is byte-identical between the two runs and no site moved the other way. Had the re-measure turned up a frozen subpath factory it would have been SWEPT in this PR — never floored, never given a per-site allowance.

## What changed

- **The resolver** — `coveredSet.has(spec)` becomes `spec === member || spec.startsWith(member + '/')`.
- **The verdict line** — now reads `... call site(s) on A, B, ... and their subpaths judged`, so the line is true of what the run checked. The over-claim is the defect; a verdict that named only the members would be the same over-claim in the other direction.
- **The header prose** — a new section, "A member covers its SUBPATHS", records the boundary, why the separator is part of the prefix, the re-measured numbers above, and that a future re-measure turning up a frozen subpath factory sweeps it rather than flooring it.
- **The pins** (`scripts/__tests__/check-vi-mock-inherit.test.ts`) — six cases: a subpath is judged (frozen and inheriting shapes), `vi.importActual` of the subpath inherits it, the regression pin (a frozen subpath factory makes the gate RED rather than silently green), a sibling package sharing a name prefix is NOT swallowed, and `COVERED_SPECIFIERS` still holds package roots only.

## Verification

```
node scripts/check-vi-mock-inherit.mjs
  OK (4455 tracked source file(s), 2721 test-named; 615 carry a mock;
      625 call site(s) on ... and their subpaths judged (625 inherit, 0 auto-mocked);
      35 other workspace, 242 external, 879 local, 0 non-static, 3 embedded ...)
node scripts/check-vi-mock-specifiers.mjs   OK  (same population: 4455 / 615)
node scripts/check-control-bytes.mjs        OK  (6650 text files)
pnpm exec vitest run scripts/__tests__/     Test Files 120 passed | Tests 3598 passed
pnpm exec vitest run packages/plugin-form/src/{MasterDetailForm,WizardForm}.outcomeToastSupersede.test.tsx
                                            Test Files 2 passed | Tests 5 passed
pnpm exec eslint (both changed files)       exit 0
pnpm run type-check:scripts                 exit 0   (both files confirmed in the program via --listFiles)
```

**Ablation** — the resolver reverted to exact equality on a committed tree, the mutation proved on disk (marker counts 1 to 0, blob `7d02f51c` to `478fadc7`), then restored with `git checkout HEAD -- path` and proved byte-identical (blob back to `7d02f51c`, `git diff HEAD` empty):

- the pins go **RED**: `Tests 5 failed | 69 passed (74)` — the subpath is `workspace`/`unjudged` again, the regression pin's `frozen` list empties, and the on-disk pin finds no judged subpath site;
- **the gate itself still exits 0** and prints `37 other workspace`. That is the card in one line: nothing is red, the verdict just quietly stops being true of the package it names.

## Scope

Deliberately untouched: `holdsObtainedModule()` (#8183, serialized behind this card on the same file and rebasing onto this resolver change), #8117's pin-versus-prose issue in the same file, and `@object-ui/app-shell` (being measured under #8173) — it is not added to `COVERED_SPECIFIERS` here. No changeset is owed: `node scripts/check-changeset-presence.mjs` reports 0 published source files and 0 published contracts in this range.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_