### PR TITLE
fix(plugin-detail): DetailSection shares ONE definition of emptiness, and it trims

### DIFF
--- a/.changeset/8376-detailsection-emptiness-authority.md
+++ b/.changeset/8376-detailsection-emptiness-authority.md
@@ -1,0 +1,52 @@
+---
+'@object-ui/plugin-detail': minor
+---
+
+`DetailSection` now has ONE definition of emptiness, and it **trims**
+(objectui#8376).
+
+The component decided "is this field empty?" three times — the row filter behind
+`emptyCount`, the reader's "Show N empty fields" toggle and the auto-hide
+heuristic; the branch that draws the muted em-dash `No value` affordance; and
+the one that offers click-to-copy — each with its own raw
+`null | undefined | ''` test. None of them trimmed, while `@object-ui/core`'s
+`recordDisplayValueAt` — the definition the record page's H1 uses, and since
+objectui#8350 the definition `record:details`' dedupe ladder uses — does. A
+whitespace-only field value was therefore FILLED here and EMPTY everywhere else
+in the same render path.
+
+**The user-visible defect, in three widening steps.**
+
+- The row painted a **visually blank cell**. The em-dash affordance exists
+  precisely so a reader can tell "this field has nothing" from "this page failed
+  to render"; a value of `'   '` took the cell-renderer path instead and printed
+  the spaces.
+- It **escaped the counter**. `Show N empty fields` read one too low, and
+  revealing the empty rows did not reveal this one — it had never been hidden,
+  because it had never been counted.
+- ⭐ It could **arm auto-hide by itself**. `shouldAutoHideEmpty` requires only
+  `filledCount > 0`, and the all-empty case is deliberately reserved so a sparse
+  or brand-new record keeps its labels as a structural skeleton. A section whose
+  ONLY non-null value was `'   '` had `filledCount === 1`: the skeleton was
+  suppressed and **every genuinely empty row in that section** was hidden behind
+  a toggle — on a page a reader would describe as blank.
+
+**The change.** All three reads now go through one function, and its scalar
+answer is `recordDisplayValueAt`'s rather than a fourth hand-written test. A row
+that says `No value` is the same row the counter counts and the same row that no
+longer offers to copy its spaces.
+
+**Scoped to strings, deliberately — and this is narrower than objectui#8350's
+move.** `recordDisplayValueAt` answers "does this resolve to a NAME", so an
+object value runs through the Salesforce-style display chain and is empty when
+that yields nothing. That is right for a title and wrong for a CELL: here an
+object value is handed to a type-aware cell renderer that knows how to draw it —
+`{ latitude, longitude }` as coordinates, `{ street, city, … }` as a formatted
+postal address, an option array as badges, anything else as JSON. None of those
+carries a name-ish key, so delegating that half would have replaced populated
+cells with `No value` and let auto-hide bury them. An object is a value on this
+surface, exactly as before.
+
+The only values whose rendering changes are strings that contain nothing but
+whitespace. `0`, `false`, `''`, `null`, `undefined` and every object value are
+classified exactly as they were.

--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -26,6 +26,7 @@ import {
 } from '@object-ui/components';
 import { ChevronDown, ChevronRight, Copy, Check, Eye, EyeOff, Pencil } from 'lucide-react';
 import { SchemaRenderer, toRenderableSchema, useInlineEdit } from '@object-ui/react';
+import { recordDisplayValueAt } from '@object-ui/core';
 import { getCellRenderer, resolveCellRendererType } from '@object-ui/fields';
 import type { DetailViewSection as DetailViewSectionType, DetailViewField, FieldMetadata } from '@object-ui/types';
 import { applyDetailAutoLayout } from './autoLayout';
@@ -40,6 +41,69 @@ import {
   isComputedFieldType,
   isInlineExcludedDetailFieldType,
 } from './fieldEnrichment';
+
+/**
+ * Does this cell have anything to render? **THE** definition of emptiness on
+ * this surface (objectui#8376) — read by every one of the three places that
+ * used to spell it out for itself:
+ *
+ *  - `isEmptyValue`, the row filter behind `emptyCount`, the reader's
+ *    "Show N empty fields" toggle and the auto-hide heuristic;
+ *  - the `isEmpty` branch of `displayValue`, which draws the muted em-dash +
+ *    `No value` affordance;
+ *  - `canCopy`, which offers the copy affordance on the row.
+ *
+ * The three MUST agree. "Show N empty fields" means "N rows show the em-dash",
+ * the skeleton rule ("a section that is entirely empty keeps its labels") means
+ * "every row shows the em-dash", and a row that says `No value` must not also
+ * offer to copy that value. Three raw `null | undefined | ''` tests happened to
+ * agree; one definition cannot stop agreeing.
+ *
+ * ## Why the scalar half DELEGATES (objectui#8350's authority)
+ *
+ * All three tests were raw and none TRIMMED, so `'   '` counted as FILLED
+ * while `@object-ui/core`'s `recordDisplayValueAt` — the definition the page H1
+ * and the `record:details` dedupe ladder both read — calls it EMPTY. The
+ * consequences were not cosmetic: the row painted a visually blank cell (the
+ * exact UI the em-dash exists to prevent), it escaped `emptyCount` so the
+ * toggle read one too low, and because `shouldAutoHideEmpty` only needs
+ * `filledCount > 0` ONE such value suppressed the all-empty skeleton and hid
+ * every genuinely empty row in its section. So the scalar answer is not
+ * re-spelled here: it is the authority's, and a `.trim()` written at this call
+ * site would be the second implementation that drifts next.
+ *
+ * ## Why the OBJECT half does NOT delegate — measured, not assumed
+ *
+ * `recordDisplayValueAt` answers "does this resolve to a NAME", so an object
+ * value goes through `displayNameOfEmbeddedObject` and is EMPTY whenever that
+ * Salesforce-style chain yields nothing. That is right for a title and WRONG
+ * for a cell: here an object value is handed to a TYPE-AWARE cell renderer that
+ * knows how to draw it. `{ latitude, longitude }` renders as coordinates
+ * (`LocationCellRenderer`), `{ street, city, … }` as a formatted postal address
+ * (`AddressCellRenderer`, objectui#4037), `['alpha','beta']` as select badges,
+ * any other object as JSON — none of which carries a name-ish key, so
+ * delegating this half would replace populated cells with `No value`, drop them
+ * out of `filledCount`, and let auto-hide bury them. An object is therefore a
+ * VALUE here, exactly as it was before this change: this function moves
+ * whitespace-only strings and nothing else.
+ *
+ * Pinned end-to-end (DOM, not predicate) in
+ * `__tests__/DetailSection.emptinessAuthority-8376.test.tsx`, whose
+ * NON-REGRESSION cases are red for a wholesale delegation.
+ */
+function hasCellValue(value: unknown): boolean {
+  // Object/array values belong to the cell renderers, not to the display-name
+  // chain — see the docblock above. `typeof null === 'object'`, so null is
+  // excluded here and answered by the authority below.
+  if (value !== null && typeof value === 'object') return true;
+  // A one-key synthetic record is how a VALUE asks the authority its question:
+  // `recordDisplayValueAt` is keyed `(record, field)` because its callers read
+  // a field off a record, while this site's value has two sources (the record,
+  // then the authored `field.value` fallback) and is already resolved by the
+  // time emptiness is asked. Re-typing the test to take a value is precisely
+  // the extra implementation this function exists to remove.
+  return recordDisplayValueAt({ value }, 'value') !== undefined;
+}
 
 /**
  * Section-header icon. `fieldGroups[].icon` declares a Lucide name (spec),
@@ -160,10 +224,11 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
     });
   }, []);
 
-  // Identify empty fields once for both filtering and the toggle counter.
+  // Identify empty fields once for both filtering and the toggle counter —
+  // through `hasCellValue`, the ONE definition this file now shares with the
+  // em-dash affordance and the copy affordance (objectui#8376).
   const isEmptyValue = React.useCallback((field: DetailViewField) => {
-    const value = data?.[field.name] ?? field.value;
-    return value === null || value === undefined || value === '';
+    return !hasCellValue(data?.[field.name] ?? field.value);
   }, [data]);
 
   const emptyCount = React.useMemo(
@@ -277,7 +342,7 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
       if (displayWidget === 'permission-facet-link') {
         return <PermissionFacetLink value={value} field={enrichedField as any} />;
       }
-      const isEmpty = value === null || value === undefined || value === '';
+      const isEmpty = !hasCellValue(value);
       if (isEmpty) {
         return (
           <span
@@ -300,7 +365,11 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
       }
       return String(value);
     })();
-    const canCopy = value !== null && value !== undefined && value !== '';
+    // Same definition as the affordance above, deliberately: a row that says
+    // `No value` must not also offer to copy it. Before objectui#8376 both
+    // tests were raw and agreed by coincidence; fixing only the affordance
+    // would have put a copy button next to an em-dash that copies spaces.
+    const canCopy = hasCellValue(value);
     // An editable field surfaces the pencil (edit) affordance instead of the
     // copy affordance, and reserves single-click for text selection — so
     // click-to-copy only applies to non-editable fields.

--- a/packages/plugin-detail/src/__tests__/DetailSection.emptinessAuthority-8376.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailSection.emptinessAuthority-8376.test.tsx
@@ -1,0 +1,332 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `DetailSection` has ONE definition of emptiness, and it TRIMS (objectui#8376).
+ *
+ * ## The defect
+ *
+ * The file decided emptiness three times — `isEmptyValue` (the row filter behind
+ * `emptyCount`, the toggle and the auto-hide heuristic), the `isEmpty` branch of
+ * `displayValue` (the em-dash `No value` affordance) and `canCopy` — each with a
+ * raw `null | undefined | ''` test. None trimmed, while `@object-ui/core`'s
+ * `recordDisplayValueAt` (the page H1's definition, and since objectui#8350 the
+ * `record:details` dedupe ladder's) does. So a whitespace-only value was FILLED
+ * here and EMPTY everywhere else in the same render path.
+ *
+ * Three consequences, pinned below in order of how far they reach:
+ *   1. the row painted a visually blank cell instead of the affordance the
+ *      em-dash exists to provide;
+ *   2. it escaped `emptyCount`, so the toggle read one too low AND revealing the
+ *      empty rows did not reveal it (it was never hidden — never counted);
+ *   3. ⭐ `shouldAutoHideEmpty` only needs `filledCount > 0`, so ONE such value
+ *      suppressed the all-empty skeleton and hid EVERY genuinely empty row in
+ *      its section — on a page a reader would describe as blank.
+ *
+ * ## Why the fix delegates for scalars and does NOT for objects
+ *
+ * `recordDisplayValueAt` answers "does this resolve to a NAME": an object value
+ * goes through the Salesforce-style `displayNameOfEmbeddedObject` chain and is
+ * EMPTY when that yields nothing. Right for a title; wrong for a CELL, where an
+ * object is handed to a type-aware cell renderer that knows how to draw it.
+ * `NON-REGRESSION — object-valued cells` is that measurement: those two rows are
+ * populated on screen and carry no name-ish key, so they are exactly what a
+ * wholesale delegation would have turned into `No value`. That case is RED for a
+ * fix that delegates the object half, and it is why the fix delegates the scalar
+ * half only.
+ *
+ * ## Controls
+ *
+ * "The affordance is absent" and "the row is not on screen" are both trivially
+ * true of a document that rendered nothing, so every case asserts the section
+ * heading plus at least one row BY VALUE. `NON-REGRESSION — a real value is
+ * still a value` is the case that goes red for an emptiness test answering EMPTY
+ * for everything (i.e. for deleting the feature), which every other case here
+ * would otherwise accept.
+ *
+ * ## Reading the affordance
+ *
+ * `DetailSection`'s placeholder carries BOTH `aria-label` and `title`; the
+ * `EmptyValue` that field cell renderers draw carries `aria-label` only. So the
+ * count below is by TITLE — the same instrument
+ * `record-details.emptySectionDefault.test.tsx` uses — and it cannot pick up a
+ * cell renderer's own placeholder by accident.
+ *
+ * ## Interaction with objectui#8350's landed pin
+ *
+ * `record-details.dedupeEmptinessTrims-8350.test.tsx` deliberately keeps every
+ * fixture at ≤3 rendered rows so auto-hide CANNOT fire and confound it. These
+ * fixtures do the opposite on purpose (case 3 and case 4 run 4-row sections to
+ * drive `shouldAutoHideEmpty`), which is why they live in a separate file with
+ * their own thresholds asserted: nothing here changes the row count of any
+ * fixture there.
+ */
+
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import * as React from 'react';
+import { recordDisplayValueAt } from '@object-ui/core';
+import { DetailSection } from '../DetailSection';
+import type { DetailViewSection } from '@object-ui/types';
+
+/**
+ * Desktop thresholds — `AUTO_HIDE_MIN_FIELDS` 4 and `AUTO_HIDE_RATIO` 0.25.
+ * Pinned explicitly rather than inherited from happy-dom's default width,
+ * because the mobile variant (3 / 0.2) would change which fixtures below can
+ * fire auto-hide at all.
+ */
+beforeAll(() => {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1280 });
+});
+
+afterEach(cleanup);
+
+/** The placeholder `DetailSection` itself draws — by TITLE, see the docblock. */
+const affordances = () => screen.queryAllByTitle('No value');
+
+/** The row `<div>` a field label sits in (label div → row div). */
+const rowOf = (label: string) => screen.getByText(label).parentElement as HTMLElement;
+
+/**
+ * Presence as a VALUE rather than as a `getByText` throw.
+ *
+ * `getByText` raises `TestingLibraryElementError` before `expect` runs, so its
+ * one-line CI summary reads "Unable to find an element with the text: stage" and
+ * carries none of the reason. Measured on this file's own ablation: the ⭐
+ * amplification case reddened with exactly that line and said nothing about the
+ * skeleton. Read through `expect` instead and the summary is the message below.
+ */
+const shown = (text: string) => screen.queryByText(text) !== null;
+
+const objectSchema = {
+  fields: {
+    industry: { type: 'text', label: 'Industry' },
+    stage: { type: 'text', label: 'Stage' },
+    notes: { type: 'text', label: 'Notes' },
+    amount: { type: 'number', label: 'Amount' },
+    close_date: { type: 'text', label: 'Close Date' },
+    office_location: { type: 'location', label: 'Office Location' },
+    tags: {
+      type: 'multiselect',
+      label: 'Tags',
+      options: [
+        { value: 'alpha', label: 'Alpha' },
+        { value: 'beta', label: 'Beta' },
+      ],
+    },
+  },
+};
+
+const sectionOf = (fields: string[]): DetailViewSection =>
+  ({ title: 'Details', fields: fields.map((name) => ({ name })) }) as DetailViewSection;
+
+const renderSection = (fields: string[], data: Record<string, unknown>) =>
+  render(<DetailSection section={sectionOf(fields)} data={data} objectSchema={objectSchema} />);
+
+describe('DetailSection — one definition of emptiness, and it trims (#8376)', () => {
+  it('AFFORDANCE — a whitespace-only value draws the `No value` em-dash, not a blank cell', () => {
+    // 3 fields: below `AUTO_HIDE_MIN_FIELDS` (4), so nothing is hidden and the
+    // whitespace row is unambiguously ON SCREEN — an absence here could not be
+    // explained away by auto-hide.
+    const { container } = renderSection(['industry', 'notes', 'amount'], {
+      industry: 'Manufacturing',
+      notes: '   ',
+      amount: 42,
+    });
+
+    // CONTROLS — the section rendered, and both ordinary rows rendered by value.
+    expect(shown('Details'), 'CONTROL: the section heading rendered').toBe(true);
+    expect(shown('Manufacturing'), 'CONTROL: the filled text row rendered').toBe(true);
+    expect(shown('42'), 'CONTROL: the filled number row rendered').toBe(true);
+    // CONTROL — the whitespace row itself is present, so the assertion below is
+    // about what that row DRAWS and not about whether it exists.
+    expect(shown('notes'), 'CONTROL: the whitespace-only row is on screen at all').toBe(true);
+
+    expect(
+      rowOf('notes').querySelector('[title="No value"]'),
+      'the `notes` row must draw the `No value` affordance, not a blank cell',
+    ).not.toBeNull();
+    expect(affordances(), 'exactly the `notes` row is empty').toHaveLength(1);
+    // The blank cell the affordance exists to prevent: before the fix this row
+    // took the cell-renderer path and printed the raw spaces.
+    expect(
+      container.textContent,
+      'the raw whitespace must not reach the DOM as a rendered value',
+    ).not.toMatch(/ {3}/);
+  });
+
+  it('COPY AFFORDANCE — the row that says `No value` does not also offer to copy it', () => {
+    // `canCopy` was the THIRD raw spelling in this file. Fixing only the
+    // affordance would have put a copy button next to an em-dash whose click
+    // copies three spaces to the clipboard.
+    renderSection(['industry', 'notes', 'amount'], {
+      industry: 'Manufacturing',
+      notes: '   ',
+      amount: 42,
+    });
+
+    expect(shown('Details'), 'CONTROL: the section heading rendered').toBe(true);
+    // CONTROL — a genuinely filled row DOES offer the copy affordance, so the
+    // absence below is a decision about this value and not about the feature.
+    expect(
+      rowOf('industry').querySelector('[role="button"]'),
+      'a filled row still offers click-to-copy (control)',
+    ).not.toBeNull();
+
+    expect(
+      rowOf('notes').querySelector('[role="button"]'),
+      'the whitespace-only row must not offer click-to-copy',
+    ).toBeNull();
+  });
+
+  it('COUNTER — the whitespace-only row is counted among the empty fields, and revealing them reveals IT', () => {
+    // 4 fields, 2 of them empty once whitespace counts: `close_date` (absent)
+    // and `notes` ('   '). At/above both thresholds, so auto-hide fires and the
+    // toggle appears.
+    renderSection(['industry', 'stage', 'notes', 'close_date'], {
+      industry: 'Manufacturing',
+      stage: 'Won',
+      notes: '   ',
+    });
+
+    // CONTROLS — the section rendered and kept its filled rows.
+    expect(shown('Details'), 'CONTROL: the section heading rendered').toBe(true);
+    expect(shown('Manufacturing'), 'CONTROL: filled row 1 rendered').toBe(true);
+    expect(shown('Won'), 'CONTROL: filled row 2 rendered').toBe(true);
+
+    const toggle = screen.getByRole('button', { name: /empty fields/i });
+    expect(
+      toggle.textContent,
+      'the toggle must count the whitespace-only field: 2 empty fields, not 1',
+    ).toContain('Show 2 empty fields');
+
+    // It was hidden BECAUSE it was counted…
+    expect(
+      shown('notes'),
+      'the whitespace-only row is hidden along with the other empty rows',
+    ).toBe(false);
+
+    // …and revealing the empty fields brings it back, with the affordance.
+    fireEvent.click(toggle);
+    expect(shown('notes'), 'revealing the empty fields reveals the whitespace-only row').toBe(true);
+    expect(shown('close_date'), 'revealing the empty fields reveals the absent row').toBe(true);
+    expect(affordances(), 'both revealed rows draw the affordance').toHaveLength(2);
+  });
+
+  it('⭐ AMPLIFICATION — one whitespace-only value must not suppress the all-empty skeleton', () => {
+    // The consequence that reaches furthest. 4 fields, every one of them empty
+    // except `notes`, which holds only spaces. Under the raw test that was
+    // `filledCount === 1`, which is all `shouldAutoHideEmpty` needs: the section
+    // auto-hid its three genuinely empty rows and rendered a single blank cell.
+    renderSection(['notes', 'stage', 'amount', 'close_date'], { notes: '   ' });
+
+    // CONTROL — the section rendered at all (the early return for an all-empty
+    // section with nothing visible would have dropped it entirely).
+    expect(shown('Details'), 'CONTROL: the section heading rendered').toBe(true);
+
+    // The skeleton the heuristic reserves for an all-empty section: every label
+    // keeps its row, so the record reads as a structure waiting to be filled.
+    for (const label of ['notes', 'stage', 'amount', 'close_date']) {
+      expect(
+        shown(label),
+        `row \`${label}\` must survive the all-empty skeleton — one whitespace-only value must not arm auto-hide and bury the genuinely empty rows`,
+      ).toBe(true);
+    }
+    expect(affordances(), 'all four rows draw the `No value` affordance').toHaveLength(4);
+
+    // Nothing was hidden, so there is nothing to offer to reveal.
+    expect(
+      screen.queryByRole('button', { name: /empty fields/i }),
+      'no rows were hidden, so no show-empty toggle is offered',
+    ).toBeNull();
+  });
+
+  it('NON-REGRESSION — object-valued cells are still FILLED (the half that must NOT delegate)', () => {
+    // `recordDisplayValueAt` calls both of these EMPTY — neither carries a
+    // name-ish key for `displayNameOfEmbeddedObject` — yet both render real
+    // content through their type-aware cell renderer. Delegating the object half
+    // would replace them with `No value`, drop them out of `filledCount` and let
+    // auto-hide bury them. This case is that measurement, on the DOM.
+    const { container } = renderSection(['office_location', 'tags', 'industry'], {
+      office_location: { latitude: 30.2741, longitude: 120.1551 },
+      tags: ['alpha', 'beta'],
+      industry: 'Manufacturing',
+    });
+
+    expect(shown('Details'), 'CONTROL: the section heading rendered').toBe(true);
+    expect(shown('Manufacturing'), 'CONTROL: the ordinary filled row rendered').toBe(true);
+
+    expect(
+      container.textContent,
+      'a geolocation object renders as coordinates, not as `No value`',
+    ).toContain('30.2741, 120.1551');
+    expect(shown('Alpha'), 'a multiselect array renders its options, not `No value`').toBe(true);
+    expect(shown('Beta'), 'a multiselect array renders its options, not `No value`').toBe(true);
+
+    expect(
+      affordances(),
+      'NO row here is empty — an object value is a value on this surface',
+    ).toHaveLength(0);
+  });
+
+  it('NON-REGRESSION — a real value is still a value (`0`, `false`, and a plain string)', () => {
+    // The case that is RED for an emptiness test answering EMPTY for everything.
+    // Every other case in this file is satisfied by deleting the feature; this
+    // one is not, and `0` / `false` are the two the raw test got right and a
+    // careless rewrite (`!value`) would get wrong.
+    renderSection(['industry', 'amount', 'stage', 'close_date'], {
+      industry: 'Manufacturing',
+      amount: 0,
+      stage: false,
+    });
+
+    expect(shown('Details'), 'CONTROL: the section heading rendered').toBe(true);
+    expect(shown('Manufacturing'), 'a plain string is a value').toBe(true);
+
+    // 4 fields with exactly ONE empty row (`close_date`), so auto-hide fires and
+    // hides it: `0` and `false` are on the FILLED side of the count.
+    const toggle = screen.getByRole('button', { name: /empty fields/i });
+    expect(
+      toggle.textContent,
+      '`0` and `false` are values: exactly one field (`close_date`) is empty',
+    ).toContain('Show 1 empty fields');
+    expect(affordances(), 'no visible row draws the affordance').toHaveLength(0);
+    expect(shown('amount'), '`0` keeps its row and is not hidden as empty').toBe(true);
+    expect(shown('stage'), '`false` keeps its row and is not hidden as empty').toBe(true);
+  });
+
+  /**
+   * The measurement behind the split, asserted rather than cited.
+   *
+   * This is an ADDITION to the DOM cases above, never a substitute — on its own
+   * it is a predicate test, and the card is explicit that the pin has to assert
+   * the rendered outcome. It is green on `origin/main` with the defect fully
+   * present, because it measures `@object-ui/core`, not this component.
+   */
+  it('MEASUREMENT — the authority answers the cell\'s question for scalars and a DIFFERENT one for objects', () => {
+    // Scalars — exactly what this surface wants, which is why it delegates.
+    expect(recordDisplayValueAt({ value: '   ' }, 'value'), 'whitespace-only is EMPTY').toBeUndefined();
+    expect(recordDisplayValueAt({ value: '' }, 'value'), 'empty string is EMPTY').toBeUndefined();
+    expect(recordDisplayValueAt({ value: null }, 'value'), 'null is EMPTY').toBeUndefined();
+    expect(recordDisplayValueAt({ value: 0 }, 'value'), '`0` is a value').toBe('0');
+    expect(recordDisplayValueAt({ value: false }, 'value'), '`false` is a value').toBe('false');
+
+    // Objects — the authority answers "does this resolve to a NAME", so both of
+    // the populated fixtures used above come back EMPTY. That is correct for a
+    // title and wrong for a cell; it is the whole reason the object half is not
+    // delegated.
+    expect(
+      recordDisplayValueAt({ value: { latitude: 30.2741, longitude: 120.1551 } }, 'value'),
+      'a geolocation object has no display NAME — the authority calls it empty',
+    ).toBeUndefined();
+    expect(
+      recordDisplayValueAt({ value: ['alpha', 'beta'] }, 'value'),
+      'an option array has no display NAME — the authority calls it empty',
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #8376

`DetailSection` decided "is this field empty?" **three** times — the row filter behind `emptyCount` / the "Show N empty fields" toggle / the auto-hide heuristic, the branch that draws the em-dash `No value` affordance, and `canCopy` — each with its own raw `null | undefined | ''` test. None trimmed, while `@object-ui/core`'s `recordDisplayValueAt` (the page H1's definition, and since #8375 the `record:details` dedupe ladder's) does. All three now read one function, `hasCellValue`, whose scalar answer is the authority's.

`canCopy` was not in the card's scope but is folded in deliberately: it is the same raw spelling in the same function, and fixing only the affordance would have left a row that says `No value` sitting next to a copy button that copies three spaces. Before this change the invariant "em-dash implies no copy affordance" held by coincidence; converging it is what keeps it holding.

Session: `https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S` — written here as prose because a PATCH of this body degrades the attribution footer's session URL to the bare form (AGENTS.md, GitHub-rewrites-your-bytes, item 2), and this body has been PATCHed once to correct an ablation hash.

## ⚠️ A correction against the dispatch: the object half must NOT delegate

The card and the dispatch both prescribed converging on `recordDisplayValueAt` wholesale, on the grounds that "delegating is strictly more than a trim — an expanded reference object resolves through `displayNameOfEmbeddedObject` and is EMPTY when that chain yields nothing." That reasoning is correct for #8375's site and **measurably wrong here**, so this PR delegates the scalar half only.

`recordDisplayValueAt` answers *does this resolve to a NAME*. On this surface an object value is not a title — it is handed to a **type-aware cell renderer** that knows how to draw it, and none of those shapes carries a name-ish key:

| value | renders today as | `recordDisplayValueAt` says |
|---|---|---|
| `{ latitude, longitude }` | `30.2741, 120.1551` (`LocationCellRenderer`) | EMPTY |
| `{ street, city, … }` | a formatted postal address (`AddressCellRenderer`, #4037) | EMPTY |
| `['alpha','beta']` | option badges (`SelectCellRenderer`) | EMPTY |
| any other object | JSON (`JsonCellRenderer`) | EMPTY |

A wholesale delegation would have replaced those populated cells with `No value`, dropped them out of `filledCount`, and let auto-hide bury them. That is not an argument — it is ablation leg C below, which reddens exactly one case and prints the DOM text `Detailsoffice_location—tags—industryManufacturing`: two populated cells turned into em-dashes.

So: **one definition serves both consumers** (measured — see next section), and that definition is the authority for scalars plus the status quo for objects. The only values whose classification moves are strings containing nothing but whitespace.

## Do the two consumers want the same answer? Measured: yes, and they must

The card asked whether the counter/auto-hide read and the affordance read deserve different answers. They do not, and the coupling is stated in the code, not assumed:

- "Show N empty fields" **means** "N rows draw the em-dash". A row that shows the affordance but is not counted is exactly consequence 2 of the card.
- The skeleton rule the heuristic reserves — an entirely empty section keeps its labels — **means** "every row draws the em-dash". Consequence 3 is what happens when the two disagree about one row.
- A row that says `No value` must not offer to copy it.

Three readers, one question, one function.

## The three pins, plus the ones that keep them honest

`packages/plugin-detail/src/__tests__/DetailSection.emptinessAuthority-8376.test.tsx` — all assert the RENDERED outcome, never the predicate.

| case | asserts |
|---|---|
| **AFFORDANCE** | a whitespace-only value draws the `No value` affordance in its own row, and the raw spaces do not reach the DOM as a rendered value |
| **COPY AFFORDANCE** | that row offers no click-to-copy; a filled sibling still does (control) |
| **COUNTER** | the toggle reads `Show 2 empty fields`, the row is hidden **because** it was counted, and clicking the toggle reveals it with its affordance |
| ⭐ **AMPLIFICATION** | a 4-row section whose only non-null value is `'   '` keeps its all-empty skeleton: all four labels, four affordances, **no** toggle |
| **NON-REGRESSION — objects** | geolocation and multiselect cells still render their content and draw no affordance |
| **NON-REGRESSION — scalars** | `0` and `false` are values; exactly one field is counted empty |
| **MEASUREMENT** | what `recordDisplayValueAt` actually answers for each of those values — the reading behind the split, in-repo rather than cited |

Every case asserts the section heading plus a filled row **by value**, because "the affordance is absent" is trivially true of a document that rendered nothing. Presence is read through `screen.queryByText` and `expect(…, message)` rather than `getByText`, because `getByText` throws before `expect` runs and its CI summary line reads `Unable to find an element with the text: stage` and carries none of the reason — measured on this file's own first ablation, then rewritten.

## Ablation — three legs, each restored by state

Run from the committed implementation, `trap … EXIT INT TERM` with absolute paths, restore via `git checkout HEAD -- PATH` (never a bare `git checkout --`, which would take the mutation back out of the index and exit 0). Mutation-reached-disk proven by `git hash-object` differing from `git rev-parse HEAD:PATH`; restore proven by `git diff HEAD` empty **and** the hash equal again — never by an exit code. All three restores verified.

HEAD blob of `packages/plugin-detail/src/DetailSection.tsx`: `c8f72e5ed19be9a96796949fadeaffcaa8c2ea9b`.

**Leg A — the bug restored** (`return value !== null && value !== undefined && value !== '';`), mutated blob `68c2d1251d102bc24fa60cf2bfe36ed460f21640`: **4 failed / 3 passed**.
```
× AFFORDANCE …       AssertionError: the `notes` row must draw the `No value` affordance, not a blank cell: expected null not to be null
× COPY AFFORDANCE …  AssertionError: the whitespace-only row must not offer click-to-copy: expected a DIV element to be null
× COUNTER …          AssertionError: the toggle must count the whitespace-only field: 2 empty fields, not 1: expected 'Show 1 empty fields' to contain 'Show 2 empty fields'
× ⭐ AMPLIFICATION …  AssertionError: row `stage` must survive the all-empty skeleton — one whitespace-only value must not arm auto-hide and bury the genuinely empty rows: expected false to be true
```

**Leg B — an implementation strictly worse than the bug** (`return false;` — EMPTY for everything, i.e. deleting the feature), mutated blob `09e2e3ffb459388dc833fc16fdcd9fd539d4bff9`: **5 failed / 2 passed**. Both NON-REGRESSION cases and every control fire. ⚠️ Worth reading: **AMPLIFICATION passes under leg B** — an all-empty section is exactly what "empty for everything" produces. The ⭐ pin alone does not distinguish the fix from deleting the feature; the non-regression cases are what do.

**Leg C — the wholesale delegation the dispatch prescribed** (`return recordDisplayValueAt({ value }, 'value') !== undefined;`), mutated blob `df10431884cd97ad9340b37c92f85ffafdd25353`: **1 failed / 6 passed** — every whitespace case is green and only the object non-regression reddens.
```
× NON-REGRESSION — object-valued cells are still FILLED (the half that must NOT delegate)
  AssertionError: a geolocation object renders as coordinates, not as `No value`:
    Received: "Detailsoffice_location—tags—industryManufacturing"
```

## Interaction with #8375's landed pin

`record-details.dedupeEmptinessTrims-8350.test.tsx` deliberately keeps every fixture at 3 or fewer rendered rows so auto-hide cannot fire and confound it. These fixtures do the opposite on purpose (two of them run 4-row sections to drive `shouldAutoHideEmpty`), which is why they are a separate file.

Checked, not assumed. That file's largest fixture is `ACTIVITY_FIELDS` — 4 entries, one of which the dedupe drops, so `DetailSection` receives **3**. Two of those three are whitespace-only and become empty under this change, but 3 is below the desktop `AUTO_HIDE_MIN_FIELDS` of 4, so nothing hides. ⚠️ It would **not** be below the mobile minimum of 3, where 2/3 empty clears the 0.2 ratio and both `HALF 2` rows would vanish — that file relies on happy-dom's desktop `window.innerWidth`. The new file pins `innerWidth = 1280` explicitly for the same reason. All 6 cases of that pin are green; measured by running it, not by reading it.

## Changeset

`minor` on `@object-ui/plugin-detail` only, argued against #8375's `minor` on `plugin-detail` + `core`: same family (a rendered-behaviour change on `record:details`), one package rather than two because nothing in `@object-ui/core` moves — this consumes the export #8375 added rather than adding one. `major` is forbidden repo-wide.

`check-changeset-presence` verdict, quoted:
```
✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/8376-detailsection-emptiness-authority.md.
```
`check-changeset-no-major`: `✅  No changeset declares a major bump.` The `skip-changeset` label is a phantom in this repo and is not used here.

## Verification, at `b6ed5cdaf`

| check | result |
|---|---|
| `pnpm exec vitest run packages/plugin-detail/` | `Test Files 137 passed (137) · Tests 1231 passed (1231)` |
| `pnpm --filter @object-ui/plugin-detail type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | exit 0; `--listFiles` confirms the new `.test.tsx` is in the **test** program (1 hit) and not the src program (0 hits) |
| `pnpm exec eslint .` in `packages/plugin-detail` | `901 problems (0 errors, 901 warnings)` — 188 files linted; the new test file 0/0, `DetailSection.tsx` 0 errors / 12 warnings, all pre-existing classes |
| `check:control-bytes`, `check:i18n-keys`, `check:i18n-dead-keys`, `check:unreferenced-sources` | all exit 0 |
| `check-governed-queue-guard --test` on the 3 changed paths | `✅ NOT GOVERNED` (control: `AGENTS.md` returns `⛔ GOVERNED`, exit 3) |

**Declared narrowing.** `turbo ls --affected` names 11 packages; only `plugin-detail` was run locally. The blast radius outside it was measured rather than assumed: no source or test in any other affected package asserts on `No value`, `empty fields` or `showEmptyFields` (3 hits, all unrelated — a `designer.field.noValues` string, a prose comment, an error message), and no downstream fixture feeds a whitespace-only value into a detail row. The remaining suites are declared to CI.

## Findings filed (out of scope here)

- #8394 — four MORE un-trimmed spellings remain in this package (`HeaderHighlight.tsx:171`, `DetailView.tsx:979`, `RecordMetaFooter.tsx:82`, `HistoryTimeline.tsx:134`). The first two sit directly under/beside the same page H1, so on one screen the H1 and the body grid now agree and the highlight strip between them still does not.
- #8395 — `handleCopyField` writes `[object Object]` to the clipboard for every object-valued cell. Pre-existing and untouched by this change; `canCopy` classifies objects exactly as it did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S
