### PR TITLE
refactor(plugin-chatbot): drop the inert blanket cast on useChat's options object

### DIFF
--- a/.changeset/issue-8378-usechat-options-cast.md
+++ b/.changeset/issue-8378-usechat-options-cast.md
@@ -1,0 +1,11 @@
+---
+---
+
+Removes the inert blanket `as any` on `useChat`'s options object in
+`useObjectChat` (objectui#8378). Publishes nothing: the assertion lives inside a
+function body whose export already carries an explicit return-type annotation, so
+it is erased at emit. Measured rather than assumed — building
+`@object-ui/plugin-chatbot` from this branch and from the merge-base produced a
+byte-identical `dist` across all 34 published artifacts (`.d.ts`, `.js`, `.cjs`,
+`.css`), and the comparison was proved live by a control mutation to an emitted
+string literal, which the same comparison reported as differing.

--- a/packages/plugin-chatbot/src/useObjectChat.ts
+++ b/packages/plugin-chatbot/src/useObjectChat.ts
@@ -701,6 +701,14 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
   const chatRef = useRef<any>(null);
   const chatResult = useChat({
     transport,
+    // The `as any` here is the LIVE suppression on this call, and it is the only
+    // one: `aiInitialMessages` builds `parts` as `Record<string, unknown>[]`, which
+    // is not a `UIMessagePart` union, so dropping this cast turns the call red with
+    // TS2322 (measured, objectui#8378). The blanket `as any` that used to sit on the
+    // whole options object was removed there because it hid nothing this one does not
+    // already absorb — but it also switched off checking of `transport`, `onError`
+    // and excess properties. Fix the builder before deleting this cast; do NOT
+    // re-widen the call by casting the options object again.
     messages: isApiMode && aiInitialMessages.length > 0 ? (aiInitialMessages as any) : undefined,
     onError: isApiMode
       ? (err: Error) => {
@@ -732,7 +740,7 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
           onError?.(err);
         }
       : undefined,
-  } as any);
+  });
   chatRef.current = chatResult;
 
   // ADR-0057 #8 — refresh the AI usage indicator when a turn finishes. On the


### PR DESCRIPTION
Fixes #8378

Removes `useChat({...} as any)` in `packages/plugin-chatbot/src/useObjectChat.ts`, and records in a comment what the measurement actually found.

Spelling note: generic type arguments are written as WORDS where they appear, because GitHub's body sanitizer eats tag-shaped fragments.

## The site, re-derived

The brief said the file had moved twice and not to trust `:735`. Re-derived by content, not by line number: `grep -n 'as any'` returns four hits, of which one (`:368`) is a doc comment naming the cast objectui#8342 removed and one (`:808`) is an unrelated metadata read. The site is `packages/plugin-chatbot/src/useObjectChat.ts:735`, the line `  } as any);`, unique in the file.

⚠️ **Contradicts the brief:** `:735` was still correct. PR #8377 landed above the site but the intervening edits were net line-neutral at this point in the file. I re-derived it independently rather than trusting it, and the base read below confirms the line number as well as the content — but the dispatch's expectation that the number had moved was wrong.

Base side read with a **literal sha** (`fadf6cd7317e1ac8a011f4e6b986187223c7fdba`), interrogated in both directions so it cannot be an index read of my own work:

| question the base copy must answer | answer |
|---|---|
| contains `  } as any);` | yes, printed at line 735 |
| contains `SdkChatMessage` (PR #8377 landed marker) | 6 |
| contains this PR's new comment token | 0 |
| branch HEAD contains that comment token | 1 |
| branch HEAD contains `  } as any);` | 0 |
| a token present in neither (negative control) | 0 |

Base blob `ff06f46f94c81cda552f741484e36e36c5df08fe`, branch blob `0c3c0da6259ba6725ccb6540a1185428d16a0372`.

## ⚠️ This is a narrowing, not an elimination — read this before approving

The card asked whether the outer cast is inert on its own merits, or only because the nested `(aiInitialMessages as any)` absorbs the mismatch. Measured as a 2x2, each leg mutated on disk (hash proven to differ from the HEAD blob), each restored by state:

| outer cast | nested cast | `tsc --noEmit` | `tsc -p tsconfig.test.json` |
|---|---|---|---|
| present | present (base) | exit 0, 0 diagnostics | exit 0, 0 diagnostics |
| **removed** | present (**this PR**) | exit 0, 0 diagnostics | exit 0, 0 diagnostics |
| present | removed | exit 0, 0 diagnostics | exit 0, 0 diagnostics |
| removed | removed | **exit 2, TS2322** | **exit 2, TS2322** |

The bottom row is the answer:

```
src/useObjectChat.ts(704,5): error TS2322: Type '{ id: string; role: "user" | "assistant" | "system";
parts: Record<string, unknown>[]; }[] | undefined' is not assignable to type
'UIMessage<unknown, UIDataTypes, UITools>[] | undefined'.
  ... Type 'Record<string, unknown>' is not assignable to type 'UIMessagePart<UIDataTypes, UITools>'.
```

So the outer cast **is** inert only because the nested one is absorbing a real mismatch. **The suppression count on this call goes 2 to 1, not 2 to 0.** The card's headline — "this cast is DEAD" — is true only conditionally, and the condition is that the nested cast stays. Row 3 shows the converse: with the nested cast gone the outer one would have been load-bearing.

It is still worth landing, for a reason that is about scope rather than count. The outer cast widened the **entire** options argument to `any`: `transport`, `onError`, excess-property checking and the generic instantiation all went unchecked. The nested cast suppresses exactly one property. Removing the outer restores compiler checking of everything except `messages`. That is real checking newly acquired, not zero — but it is a different claim from the one the card makes, and the card should be re-read in that light.

## Which instantiation results

The card asked this explicitly. Probed with the TypeScript compiler API against the real program (no mutation), before and after:

|  | resolved `chatResult` type | argument type |
|---|---|---|
| with the cast | `UseChatHelpers<UIMessage<unknown, UIDataTypes, UITools>>` | `any` |
| without the cast | `UseChatHelpers<UIMessage<unknown, UIDataTypes, UITools>>` | `{ transport: DefaultChatTransport<UIMessage<unknown, UIDataTypes, UITools>> or undefined; messages: any; onError: ((err: Error) => void) or undefined; }` |

Identical, in both the main and the test program. Inference does start running, and it lands on exactly the type the default already supplied, so nothing downstream of `chatResult` moves.

## The declaration-level argument — and where it stops

`useChat` is declared `useChat<UI_MESSAGE extends UIMessage = UIMessage>(options?: UseChatOptions<UI_MESSAGE>): UseChatHelpers<UI_MESSAGE>`, and `UseChatOptions` is `({ chat: Chat<UI_MESSAGE> } | ChatInit<UI_MESSAGE>) & { throttle?; experimental_throttle?; resume? }`. Only three properties are passed, and each contributes to `UI_MESSAGE` inference as follows:

- **`onError`** is declared `ChatOnErrorCallback`, and that is `type ChatOnErrorCallback = (error: Error) => void` — **no type parameter occurs in it at all**. This one is genuinely declaration-level and permanent: whatever is passed, this property can never produce an inference candidate for `UI_MESSAGE`.
- **`messages`** is `any` at the call, and an `any` source contributes no inference candidate (it carries none of the object/intersection flags the inference walk requires). Declaration-level as a rule of the algorithm, but **contingent on the nested cast staying**.
- **`transport`** is therefore the sole inference source, and it is `DefaultChatTransport<UIMessage<unknown, UIDataTypes, UITools>>` — itself pinned there because `new DefaultChatTransport({ ... })` at :637 supplies no explicit type argument and no candidate either, leaving its own `UI_MESSAGE` to fall back to its constraint.

**I cannot make the strong claim.** "This cast is a no-op for every possible instantiation" is not true here, and saying it would be dressing the result up. The honest claim is the weaker one the brief asks for:

> The cast is inert **today**, and precisely what would make it load-bearing is: deleting the nested `(aiInitialMessages as any)` without first fixing the `parts` builder. That is not hypothetical — it is row 4 of the table above, measured red in both programs. Secondarily, an excess or misspelled property on the options object, or a `transport` narrowed to a custom `UI_MESSAGE`, would also be caught now and were hidden before.

That weakness is why the deletion ships with a comment rather than silently: the next reader who removes the nested cast expecting the last suppression to fall away needs to know what they will hit, and needs to not "fix" it by re-widening the call.

## Instrument discipline

**Both projects, with membership proof.** `type-check` for this package is `tsc --noEmit && tsc -p tsconfig.test.json`; both were run separately for every leg. `tsconfig.json` excludes tests by directory, and `tsconfig.test.json` includes only `*.test.ts(x)`, so membership was not assumed:

- main program `--listFiles | grep -c 'src/useObjectChat\.ts$'` = **1**; lit control (a made-up filename on the same instrument) = **0**
- test program, same two readings = **1** and **0** (pulled in transitively by six `useObjectChat.*` suites, named in the run)

The instrument is not merely present but demonstrably able to fail: row 4 turned **both** programs red on this exact file.

**Restore-integrity / instrument-liveness control.** Re-inserting the cast onto the implementation returns both projects to exit 0. Reported as what it is — evidence the tree is unbroken and the harness restores correctly — **not** as a second reading about the cast, since it restores code `main` keeps green by construction.

**Dependents, downstream direction.** `pnpm --workspace-concurrency=2 --filter '...@object-ui/plugin-chatbot' type-check`, after building the full closure first so a stale `dist` could not masquerade as a verdict (the TS2307/TS2882 signature objectui#8342 hit).

```
Scope: 7 of 47 workspace projects
```

Zero `error TS` across the run; per package: `packages/plugin-chatbot` Done, `packages/app-shell` Done, `apps/console` Done, `apps/site` Done, `examples/schema-catalog` Done, `examples/console-starter` Done, `examples/byo-backend-console` Done.

**Vitest.** Run from the repo root as AGENTS.md requires (`pnpm exec vitest run packages/plugin-chatbot/`), which reports `RUN v4.1.10 /home/user/objectui-issue-8378` — the repo root, not a package dir. **40 test files passed, 474 tests passed.** `vitest list` names all six `useObjectChat.*` suites and shows zero `apps/console` files, so this is not the objectui#3378 false green. As the brief notes, vitest transpiles types away and can never see a type-level change; it is here to show nothing moved.

**Lint** is the package-scoped `eslint .`: exit 0, `88 problems (0 errors, 88 warnings)`. Against the base copy of the same file on the same instrument: `89 problems (0 errors, 89 warnings)`, with `no-explicit-any` hits going **13 to 12**. The deleted cast was a real reported `any`, and exactly one warning went away.

**Mutation hygiene.** Every leg: absolute-path `trap ... EXIT INT TERM`, mutation proved on disk by `git hash-object` differing from `git rev-parse HEAD:PATH` (empty hash guarded as failure), anchor counted in both directions (deleted text 1 to 0, injected text 1 to 2), restore verified **by state** — hash equal again **and** `git diff HEAD` empty — never by an exit code. The ablation legs ran from a committed implementation.

## Changeset

`node scripts/check-changeset-presence.mjs` decided it, and its verdict line is:

```
✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s):
    .changeset/issue-8378-usechat-options-cast.md.
    Every one of them has an EMPTY frontmatter — declared as releasing nothing, which
    is the explicit exemption and a complete answer to this gate.
```

Empty frontmatter, argued the way PR #8389 argued it — from a measurement, not by feel. Building `@object-ui/plugin-chatbot` from this branch and from the merge-base produced a **byte-identical `dist` across all 34 published artifacts** (`.d.ts`, `.js`, `.cjs`, `.css`, compared by `sha256sum` manifest).

That "identical" verdict was itself proved live, because a comparison that can only ever say "identical" is not a measurement: a control mutation to an emitted string literal in the same file, verified to have reached `dist/index.js` before the comparison ran, made the same manifest report differing hashes for `index.js` and `index.umd.cjs`. A first control attempt — an unused local const — was **tree-shaken away and never reached `dist`**, and is reported here as void rather than as a dead instrument.

`scripts/check-changeset-no-major.mjs`: `✅  No changeset declares a 'major' bump.` No `skip-changeset` label was applied; it is a phantom label in this repo and a labelled bypass was declined twice.

`pnpm check:control-bytes`: `✅  check-control-bytes: OK (scanned 6653 tracked text file(s); skipped 85 binary)`, plus a direct `grep -naP` control-byte scan of the edited file with a firing lit control.

All readings above were re-taken at the final head `4a134d170` with a clean working tree.

## Out of scope, and not filed — needs the PM

The nested `(aiInitialMessages as any)` is now **measured live**, not merely suspected: it hides a genuine TS2322, because the `aiInitialMessages` builder at :545 constructs `parts` as `Record<string, unknown>[]`, which is not a `UIMessagePart` union. The real fix is at the producer (build real `UIMessagePart` values), not a wider cast at the consumer — contract-first, AGENTS.md #0.1.

I could not file it as its own card: dedupe search was unavailable this session (MCP `search_issues` returned `API rate limit already exceeded` on two attempts; repo-scoped REST returns 403 `GitHub access is not enabled for this session`, an app-installation policy rather than a quota, while `/rate_limit` itself answers 200). Filing without a dedupe read is not allowed, and dropping the finding silently is not allowed either, so it goes to the PM in the report to file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_