### PR TITLE
fix(test-infra): require the spread operand to BE the obtained module

### DIFF
--- a/scripts/__tests__/check-vi-mock-inherit.test.ts
+++ b/scripts/__tests__/check-vi-mock-inherit.test.ts
@@ -163,6 +163,45 @@ describe('the eleven — spellings the `importOriginal` grep mis-counted as brok
       ).verdict,
     ).toBe('inherits');
   });
+
+  // -- objectui#8183: what the OPERAND grammar has to keep accepting ---------
+  // The tightening in `the failing shape` below refuses a spread whose operand
+  // merely MENTIONS the obtained module. These are its accept-side
+  // counterweight: a false refusal reds correct code, and that is how a gate
+  // gets deleted rather than fixed.
+
+  it('a parenthesised binding — `...(actual)`', () => {
+    expect(
+      verdictOf(`async (importOriginal) => { const actual = await importOriginal(); return { ...(actual), X: Stub }; }`)
+        .verdict,
+    ).toBe('inherits');
+  });
+
+  it('nested parentheses around an asserted call — ObjectTree.rowCeiling-7210.test.tsx', () => {
+    // The one site in this tree that writes this shape, byte-for-byte.
+    expect(
+      verdictOf(
+        `async (importOriginal) => ({ ...((await importOriginal<any>()) as Record<string, unknown>), X: Stub })`,
+      ).verdict,
+    ).toBe('inherits');
+  });
+
+  it('a non-null assertion is transparent — `...actual!`', () => {
+    expect(
+      verdictOf(`async (importOriginal) => { const actual = await importOriginal(); return { ...actual!, X: Stub }; }`)
+        .verdict,
+    ).toBe('inherits');
+  });
+
+  it('a property read off the module still inherits — the interop shape', () => {
+    // `(await importOriginal()).default` freezes nothing: the key set is still
+    // one the real module OWNS, so it grows when the module grows. No site in
+    // this tree writes it today; refusing it would be a false refusal waiting
+    // for the first file that does.
+    const site = verdictOf(`async (importOriginal) => ({ ...(await importOriginal()).default, X: Stub })`);
+    expect(site.verdict).toBe('inherits');
+    expect(site.reason).toBe('...(await importOriginal()).default');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -215,6 +254,84 @@ describe('the failing shape — a factory that hand-lists the export surface', (
     const sites = findCallSites(mockCall(COVERED, `() => ({ X: Stub })`, 'doMock'), { covered: [COVERED] });
     expect(sites[0].fn).toBe('doMock');
     expect(sites[0].verdict).toBe('frozen');
+  });
+
+  // -- objectui#8183: an operand that merely MENTIONS the module -------------
+
+  /**
+   * Rows C and D of the recogniser table. Both obtain the real module, both
+   * spread, and both read `inherits` until objectui#8183 — the gate quoted the
+   * evasion back in its own reason line. The returned object carries exactly
+   * ONE inherited key (`_`), so the next export any module in the import graph
+   * reads at module scope still resolves to `undefined`: the #6849 failure,
+   * wearing the accepted spelling's clothes.
+   *
+   * NON-VACUITY. Each case is paired with the SAME fixture minus the object
+   * literal, and that twin must read `inherits`. The two differ by the wrapper
+   * alone, so a `frozen` verdict here cannot come from the gate bailing out
+   * early (`indirect`, `unreadable`, "never obtains the real module") — it can
+   * only come from the gate having READ the operand. The reason string is
+   * pinned for the same purpose: it is the one the gate emits after collecting
+   * spreads, not the one it emits before looking.
+   */
+  it('C — spreading an object literal that merely HOLDS the obtained module is frozen', () => {
+    const site = verdictOf(`async (importOriginal) => ({ ...({ _: await importOriginal() }), X: Stub })`);
+    expect(site.verdict).toBe('frozen');
+    expect(site.reason).toBe('the factory spreads something, but not the real module');
+
+    const twin = verdictOf(`async (importOriginal) => ({ ...(await importOriginal()), X: Stub })`);
+    expect(twin.verdict, 'the same fixture without the wrapper must still inherit').toBe('inherits');
+  });
+
+  it('D — the same evasion with the obtained value bound to a const first', () => {
+    const site = verdictOf(
+      `async (importOriginal) => { const actual = await importOriginal(); return { ...({ _: actual }), X: Stub }; }`,
+    );
+    expect(site.verdict).toBe('frozen');
+    expect(site.reason).toBe('the factory spreads something, but not the real module');
+
+    const twin = verdictOf(
+      `async (importOriginal) => { const actual = await importOriginal(); return { ...actual, X: Stub }; }`,
+    );
+    expect(twin.verdict, 'the same fixture without the wrapper must still inherit').toBe('inherits');
+  });
+
+  it('the nesting is refused one level up too — a BINDING that merely holds it', () => {
+    // `const wrapper = { _: await importOriginal() }` must not enter the
+    // inherited set, or C walks back in through the binding-propagation loop.
+    const site = verdictOf(
+      `async (importOriginal) => { const wrapper = { _: await importOriginal() }; return { ...wrapper, X: Stub }; }`,
+    );
+    expect(site.verdict).toBe('frozen');
+    expect(site.reason).toBe('the factory spreads something, but not the real module');
+
+    const twin = verdictOf(
+      `async (importOriginal) => { const wrapper = await importOriginal(); return { ...wrapper, X: Stub }; }`,
+    );
+    expect(twin.verdict, 'the same fixture without the wrapper must still inherit').toBe('inherits');
+  });
+
+  it('an ARRAY around the obtained module is refused for the same reason', () => {
+    const site = verdictOf(`async (importOriginal) => ({ ...[await importOriginal()], X: Stub })`);
+    expect(site.verdict).toBe('frozen');
+    expect(site.reason).toBe('the factory spreads something, but not the real module');
+  });
+
+  it('an object literal is refused even when its OWN contents would inherit', () => {
+    // Deliberate, and documented in the header rather than left to be read as
+    // an oversight: the nesting IS the evasion shape, and the one nesting that
+    // would be correct spells the same thing as `...actual`. No call site in
+    // this tree writes either.
+    expect(
+      verdictOf(`async (importOriginal) => { const actual = await importOriginal(); return { ...{ ...actual }, X: Stub }; }`)
+        .verdict,
+    ).toBe('frozen');
+  });
+
+  it('the callback spread without a CALL stays frozen under the operand grammar', () => {
+    // `...(importOriginal)` is a FUNCTION wearing parentheses. The grammar
+    // reaches the bare token and stops at the obtainer, which is not the module.
+    expect(verdictOf(`async (importOriginal) => ({ ...(importOriginal), X: Stub })`).verdict).toBe('frozen');
   });
 });
 

--- a/scripts/check-vi-mock-inherit.mjs
+++ b/scripts/check-vi-mock-inherit.mjs
@@ -872,6 +872,57 @@
  * wrong repair. An exemption means the recogniser called correct code broken;
  * fix the recogniser, or the specifier does not belong in the covered set yet.
  *
+ * ## The operand must BE the module, not merely MENTION it (objectui#8183)
+ *
+ * The spread recogniser asked whether the obtained token appeared ANYWHERE in
+ * the spread's text until objectui#8183, so a spread of an object literal that
+ * merely NESTS the obtained module satisfied it -- and the gate quoted the
+ * evasion back in its own reason line:
+ *
+ *     ...({ _: await importOriginal() })      read as `inherits`
+ *
+ * That object has exactly ONE key -- `_`, holding the module -- so the returned
+ * mock carries one inherited name, and the next export any module in the file's
+ * import graph reads AT MODULE SCOPE still resolves to `undefined`. It is the
+ * failure this whole file exists to stop, wearing the accepted spelling's
+ * clothes.
+ *
+ * The property is therefore the OPERAND, never a mention: the spread's operand
+ * has to DENOTE the obtained module. `operandDenotes` reads it as ONE whole
+ * expression through a deliberately small grammar, and the invariant every
+ * production preserves is that the operand's KEY SET is the real module's, so
+ * it still GROWS when the real module grows:
+ *
+ *   - `await`, parentheses, `as`/`satisfies` and `!` are transparent;
+ *   - calling the obtainer produces the module (`importOriginal()`,
+ *     `importOriginal<T>()`, `(orig as any)()`); the bare name does not;
+ *   - a property read keeps a key set the module owns
+ *     (`(await importOriginal()).default`, the CJS interop shape);
+ *   - `OBTAIN_TOKEN` already STANDS FOR a completed `vi.importActual(...)`.
+ *
+ * ⚠️ An object literal is refused even when its own contents would inherit
+ * (`...{ ...actual }`). Deliberate rather than an oversight: the nesting IS the
+ * evasion shape, the one nesting that would be correct spells the same thing as
+ * `...actual`, and no call site in this tree writes either. Pinned as such.
+ *
+ * ⛔ Tightening this recogniser carries the same precondition widening the
+ * covered set does, for the mirrored reason: a FALSE REFUSAL reds correct code,
+ * and that is how a gate gets deleted rather than fixed (see "The recogniser is
+ * SEMANTIC" above -- this one has been wrong in BOTH directions). Re-measured
+ * on `47053c9f6` by running this file's own `scan()` before and after and
+ * diffing PER SITE, verdict AND reason string:
+ *
+ *     625 judged, 625 inherit, 0 frozen   before
+ *     625 judged, 625 inherit, 0 frozen   after -- all 625 rows byte-identical
+ *
+ * so this landed as a RATCHET and no sweep was owed. The nine distinct operand
+ * shapes the tree actually writes -- `(await importOriginal<T>())` (367),
+ * `actual` (169), `(await importOriginal<typeof import(...)>())` (55), `mod`
+ * (22), `(await importActual<typeof import(...)>())` (6), `real` (2),
+ * `(await importOriginal())` (2), `(await importActual<any>())` (1) and
+ * `((await importOriginal<any>()) as Record<string, unknown>)` (1) -- are each
+ * pinned in this gate's test as its own case.
+ *
  * ## Green at rest, and what follows from that
  *
  * Once the one site above is converted this gate reads zero, and on any
@@ -1042,26 +1093,148 @@ function referencesName(text, name) {
   return new RegExp(`(?<![\\w$])${name.replace(/\$/g, '\\$')}(?![\\w$])`).test(text);
 }
 
+/** The index of the bracket closing the one at `open`, or -1. Plain text only. */
+function closingIndex(text, open) {
+  const pairs = { '(': ')', '[': ']', '{': '}', '<': '>' };
+  const close = pairs[text[open]];
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    const c = text[i];
+    if (c === text[open]) depth++;
+    else if (c === close && --depth === 0) return i;
+  }
+  return -1;
+}
+
+/** The index of the bracket opening the one at `close`, or -1. Plain text only. */
+function openingIndex(text, close) {
+  const pairs = { ')': '(', ']': '[', '}': '{', '>': '<' };
+  const open = pairs[text[close]];
+  let depth = 0;
+  for (let i = close; i >= 0; i--) {
+    const c = text[i];
+    if (c === text[close]) depth++;
+    else if (c === open && --depth === 0) return i;
+  }
+  return -1;
+}
+
+/** `f<Record<string, unknown>>` -> `f`. The list NESTS, so balance it. */
+function stripTypeArguments(text) {
+  const s = text.trimEnd();
+  if (!s.endsWith('>')) return text;
+  const open = openingIndex(s, s.length - 1);
+  return open < 0 ? text : s.slice(0, open);
+}
+
+/** `X as T` / `X satisfies T` at bracket depth 0 -> `X`, else `null`. */
+function beforeTypeAssertion(text) {
+  const re = /(?<![\w$])(?:as|satisfies)(?![\w$])/g;
+  let depth = 0;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (c === '(' || c === '[' || c === '{' || c === '<') depth++;
+    else if (c === ')' || c === ']' || c === '}' || c === '>') depth--;
+    else if (depth === 0) {
+      re.lastIndex = i;
+      const m = re.exec(text);
+      if (m && m.index === i) return text.slice(0, i);
+    }
+  }
+  return null;
+}
+
+/** `X.name` / `X?.name` at bracket depth 0 -> `X`, else `null`. */
+function beforeMemberAccess(text) {
+  const tail = /(\??\.)\s*[A-Za-z_$][\w$]*\s*$/.exec(text);
+  if (!tail) return null;
+  const at = tail.index;
+  let depth = 0;
+  for (let i = 0; i < at; i++) {
+    const c = text[i];
+    if (c === '(' || c === '[' || c === '{') depth++;
+    else if (c === ')' || c === ']' || c === '}') depth--;
+  }
+  return depth === 0 && at > 0 ? text.slice(0, at) : null;
+}
+
 /**
- * Does `text` hold the VALUE of the real module obtained through `token`?
+ * What does `expr` -- the WHOLE operand of a spread, or the WHOLE initialiser
+ * of a binding -- denote?
  *
- * For a callback parameter the reference is not enough -- the parameter is a
- * FUNCTION, and `...importOriginal` spreads the function rather than the module
- * it would have returned. That is a frozen factory wearing an inheriting one's
- * clothes, and it is the shape a green-at-rest gate is most likely to wave
- * through, so the call is required: the token has to be followed by a `(`
- * somewhere in the expression (`importOriginal()`, `importOriginal<T>()`,
- * `(orig as any)()` all qualify).
+ *   `'module'`   the real module obtained through `token`
+ *   `'obtainer'` the callback that would RETURN it, not the module itself
+ *   `null`       anything else
  *
- * `OBTAIN_TOKEN` is exempt because it already STANDS FOR a completed call --
- * the whole `vi.importActual(<specifier>)` expression, parentheses included,
- * was replaced by it.
+ * The grammar is deliberately small, and every production preserves the one
+ * property that makes a spread inherit: the operand's KEY SET is the real
+ * module's, so it grows when the real module grows. `await`, parentheses, a
+ * type assertion and a non-null assertion are all transparent; a call of the
+ * obtainer produces the module; a property read off the module keeps a key set
+ * the module still owns (`(await importOriginal()).default` -- the interop
+ * shape). Nothing else qualifies, and the exclusion that matters is the object
+ * literal: `{ _: await importOriginal() }` has the key set the AUTHOR typed
+ * (`_`), so spreading it inherits exactly one key and freezes the surface at
+ * that -- see "The operand must BE the module" in the header.
+ */
+function operandDenotes(expr, token, tokenIsValue) {
+  const s = expr.trim();
+  if (s === '') return null;
+
+  const awaited = /^await(?![\w$])/.exec(s);
+  if (awaited) return operandDenotes(s.slice(awaited[0].length), token, tokenIsValue);
+
+  if (s[0] === '(' && closingIndex(s, 0) === s.length - 1) {
+    return operandDenotes(s.slice(1, -1), token, tokenIsValue);
+  }
+
+  if (s.endsWith('!')) return operandDenotes(s.slice(0, -1), token, tokenIsValue);
+
+  if (s.endsWith(')')) {
+    const open = openingIndex(s, s.length - 1);
+    if (open > 0) {
+      const callee = stripTypeArguments(s.slice(0, open));
+      // Only calling the OBTAINER yields the module; calling the module does not.
+      return operandDenotes(callee, token, tokenIsValue) === 'obtainer' ? 'module' : null;
+    }
+    return null;
+  }
+
+  const asserted = beforeTypeAssertion(s);
+  if (asserted !== null) return operandDenotes(asserted, token, tokenIsValue);
+
+  const receiver = beforeMemberAccess(s);
+  if (receiver !== null) {
+    return operandDenotes(receiver, token, tokenIsValue) === 'module' ? 'module' : null;
+  }
+
+  if (!new RegExp(`^${token.replace(/\$/g, '\\$')}$`).test(s)) return null;
+  // A callback parameter is a FUNCTION until it is called; `OBTAIN_TOKEN`
+  // already STANDS FOR a completed `vi.importActual(<specifier>)` call, and a
+  // binding was resolved to the module before it entered `inherited`.
+  return tokenIsValue || token === OBTAIN_TOKEN ? 'module' : 'obtainer';
+}
+
+/**
+ * Is `text` -- read as ONE whole expression -- the real module obtained
+ * through `token`?
+ *
+ * ⛔ NOT "does `text` mention `token`". That was the recogniser until
+ * objectui#8183, and it judged the wrong thing: a spread of an object literal
+ * that merely NESTS the obtained module (`...({ _: await importOriginal() })`)
+ * satisfied it, so the gate read `inherits` and quoted the evasion back in its
+ * own reason line. See "The operand must BE the module" in the header.
+ *
+ * For a callback parameter the reference is not enough either -- the parameter
+ * is a FUNCTION, and `...importOriginal` spreads the function rather than the
+ * module it would have returned. That is a frozen factory wearing an
+ * inheriting one's clothes, so the call is required: `importOriginal()`,
+ * `importOriginal<T>()` and `(orig as any)()` all qualify, the bare name does
+ * not.
  */
 function holdsObtainedModule(text, token, tokenIsValue = false) {
   if (!referencesName(text, token)) return false;
-  if (tokenIsValue || token === OBTAIN_TOKEN) return true;
-  const at = text.search(new RegExp(`(?<![\\w$])${token.replace(/\$/g, '\\$')}(?![\\w$])`));
-  return text.indexOf('(', at + token.length) !== -1;
+  return operandDenotes(text, token, tokenIsValue) === 'module';
 }
 
 /**


### PR DESCRIPTION
Fixes #8183

Note on notation: generic argument lists and other angle-bracket shapes are written out in words below, because GitHub's body sanitizer eats tag-shaped fragments even inside backticks (objectui#6970).

## The defect

`holdsObtainedModule()` in `scripts/check-vi-mock-inherit.mjs` asked whether the obtained token appeared ANYWHERE inside the spread's text, not whether the module IS the thing being spread:

```js
if (!referencesName(text, token)) return false;
if (tokenIsValue || token === OBTAIN_TOKEN) return true;
const at = text.search(/* the token, whole-word */);
return text.indexOf('(', at + token.length) !== -1;
```

So a spread of an object literal that merely NESTS the obtained module satisfied it, and the gate quoted the evasion back in its own reason line:

```
inherits reason: ...({ _: await importOriginal() })
```

That object carries exactly ONE inherited key — `_`, holding the module object — so the next export any module in the file's import graph reads at module scope still resolves to `undefined`. The file dies during COLLECTION, the suite goes red with zero failed assertions and reads like flake. That is the failure objectui#6849 built this gate to stop, wearing the accepted spelling's clothes.

## Re-derivation FIRST — the table, on today's tree

Re-derived through the gate's own exported `findCallSites()` on `47053c9f6` (the post-merge tree, after objectui#8141 landed as PR #8391), not from the card's table:

| row | shape | before | after |
|---|---|---|---|
| A | spread the obtained module directly — `...(await importOriginal())` | `inherits` | `inherits` |
| B | obtain, bind, never spread | `frozen` (never spreads it) | `frozen` (never spreads it) |
| C | spread an object literal holding the obtained module — `...({ _: await importOriginal() })` | **`inherits`** ← false negative | `frozen` |
| D | same as C with the obtained value bound to a const first — `...({ _: actual })` | **`inherits`** ← false negative | `frozen` |

C and D are still false negatives on today's tree, so the brief's premise holds. The card's `576 judged / 0 using the C–D shape` is stale as the brief warned; today's baseline is stated below and measured, not inherited.

## The repair

`operandDenotes()` reads the spread's operand as ONE whole expression through a deliberately small grammar. The invariant every production preserves is the one that makes a spread inherit: the operand's KEY SET is the real module's, so it still GROWS when the real module grows.

- `await`, parentheses, `as`/`satisfies` and the non-null assertion are transparent;
- calling the obtainer produces the module (a bare call, a call with a generic argument list, `(orig as any)()`); the bare name does not — it is a FUNCTION;
- a property read keeps a key set the module owns (`(await importOriginal()).default`, the interop shape);
- `OBTAIN_TOKEN` already stands for a completed `vi.importActual` call;
- an object literal or an array does not qualify — that is the evasion.

The same function decides binding propagation, so `const wrapper = { _: await importOriginal() }` no longer enters the inherited set either; without that, C walks back in one level up.

⛔ Untouched, as the dispatch required: `isCovered`, `coveredPrefixes`, `COVERED_SPECIFIERS` and the verdict line — all of them objectui#8141's surface.

## Census — before and after, proved per site rather than by inspection

A false refusal reds correct code, which is how a gate gets deleted rather than fixed, so this is measured, not argued.

```
$ node scripts/check-vi-mock-inherit.mjs        # BEFORE (at 47053c9f6)
✅  check-vi-mock-inherit: OK (4457 tracked source file(s), 2723 test-named; 616 carry
    a mock; 625 call site(s) on ... and their subpaths judged (625 inherit, 0
    auto-mocked); 35 other workspace, 243 external, 879 local, 0 non-static, 3 embedded
    in a string literal -- all out of scope).
exit 0

$ node scripts/check-vi-mock-inherit.mjs        # AFTER
(the same line, byte-identical — `diff` of the two runs is empty)
exit 0
```

Per-site diff over all 625 judged sites, verdict AND reason string, base gate vs. patched gate driven from the same `scan()`:

```
625 /tmp/.../persite-before.tsv
625 /tmp/.../persite-after.tsv
$ diff persite-before.tsv persite-after.tsv
PER-SITE DIFF: EMPTY (625 sites byte-identical)
```

The nine distinct operand shapes the tree actually writes, each now pinned as its own case: a parenthesised awaited call with a generic argument list (367), a bare binding `actual` (169), the same with a `typeof import` generic (55), `mod` (22), the `importActual` parameter spelling (6), `real` (2), the plain `(await importOriginal())` (2), `(await importActual` with an `any` generic `())` (1), and one nested-parenthesis-plus-assertion form in `ObjectTree.rowCeiling-7210.test.tsx` (1). Population unmoved: **625 judged / 625 inherit / 0 frozen**, before and after. A ratchet — no sweep owed.

## Pins, and their non-vacuity control

`scripts/__tests__/check-vi-mock-inherit.test.ts` gains **10** cases: 6 in the POSITIVE control block (the file's own name for its "this must read frozen" block, which is where C and D belong by its own vocabulary — the brief called it the negative-control block) and 4 accept-side counterweights in the negative control block (`the eleven`). The suite goes 74 tests to 84.

Non-vacuity: each new refusal is paired with the SAME fixture minus the object-literal wrapper, and that twin must read `inherits`. The two differ by the wrapper alone, so a `frozen` verdict cannot come from the gate bailing out early (`indirect`, `unreadable`, "never obtains the real module") — it can only come from the gate having READ the operand. The reason string is pinned to the one the gate emits AFTER collecting spreads, for the same purpose.

## Ablation — the mutation is proved on disk before any result is read

The fix was committed first, then reverted in place (`holdsObtainedModule` restored byte-for-byte to its pre-fix body), with an `EXIT INT TERM` trap holding an absolute-path `git checkout HEAD --` restore:

```
== HEAD blob            : 0b79902cabf552a0a70d3a52ca4e9f576376de3a
== on disk before mutate: 0b79902cabf552a0a70d3a52ca4e9f576376de3a
python: replacement written
== on disk after mutate : a83202dbe23dea6cf48a7393146ce8751057571f
== removed-text count   : 0 (must be 0)
== injected-text count  : 1 (must be 1)
== MUTATION CONFIRMED ON DISK
== ABLATED PIN SUITE EXIT: 1
     × C — spreading an object literal that merely HOLDS the obtained module is frozen
     × D — the same evasion with the obtained value bound to a const first
     × the nesting is refused one level up too — a BINDING that merely holds it
     × an ARRAY around the obtained module is refused for the same reason
     × an object literal is refused even when its OWN contents would inherit
 Test Files  1 failed (1)
      Tests  5 failed | 79 passed (84)
== ABLATED GATE EXIT: 0
== on disk after restore: 0b79902cabf552a0a70d3a52ca4e9f576376de3a
== git diff HEAD (must be empty):
== RESTORE CONFIRMED (blob == HEAD blob, diff empty)
```

Two readings recorded as they came out rather than as a template predicts:

- **5 of the 6** new refusals are ablation-sensitive. The sixth — spreading the parenthesised callback, `...(importOriginal)` — was already `frozen` before this change, because the old mention test also required a `(` after the token and there is none. It is a regression guard against the new grammar losing that, not new-behaviour evidence, and is reported as such rather than counted in the ablation.
- **The gate itself still exits 0 under the ablation.** No call site in this tree writes the C or D shape, so the repo scan cannot see this defect at all; the pins are the only thing that can. That is the "green at rest" argument the file's own header makes, observed from the inside.

## Checks run

```
$ node scripts/check-vi-mock-inherit.mjs                 exit 0   (census above)
$ pnpm check:control-bytes                               exit 0   ✅ scanned 6655 tracked text file(s); skipped 85 binary
$ pnpm check:vi-mock-specifiers                          exit 0   ✅ 879 relative specifier(s) resolved, 903 bare
$ pnpm check:comment-mask-corpus                         exit 0   ✓ 4457 files, 1 disagree (the residue objectui#7882 holds open)
$ node scripts/check-changeset-presence.mjs              exit 0   ✅ no changeset owed (0 published source files changed)
$ node scripts/check-governed-queue-guard.mjs --test ... exit 0   ✅ NOT GOVERNED — 2 path(s), none matched
$ pnpm type-check:scripts                                exit 0
$ pnpm lint:root                                         exit 0   ✖ 32 problems (0 errors, 32 warnings) — all pre-existing, none in the two changed files
$ pnpm exec vitest run [the 5 files that read this gate] exit 0   Test Files 5 passed (5) / Tests 236 passed (236)
```

The five test files are every reader of `check-vi-mock-inherit` in the tree (`git grep -l`): its own pin suite, `check-readme-exports.test.ts`, `js-comment-mask-jsx-6891.test.ts`, `check-vi-mock-specifiers.test.ts` and `ConversationsSidebar.test.tsx`. Exit codes were captured before any pipe.

No changeset: the diff is `scripts/**` only, which publishes from no package — `check-changeset-presence.mjs` agrees and is the authority.

Session: `https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr`