### PR TITLE
test(vi-mock): inherit the real @object-ui/app-shell surface in 23 vi.mock factories (objectui#6892 slice 14)

### DIFF
--- a/.changeset/vi-mock-inherit-slice14-app-shell.md
+++ b/.changeset/vi-mock-inherit-slice14-app-shell.md
@@ -1,0 +1,7 @@
+---
+---
+
+Test-only change: 23 `vi.mock` / `vi.doMock` factories in `@object-ui/console` now
+inherit the real `@object-ui/app-shell` export surface instead of freezing it, and
+the `check-vi-mock-inherit` gate covers that specifier. No published behaviour
+changes.

--- a/apps/console/src/__tests__/App.docsPortalLazy.test.tsx
+++ b/apps/console/src/__tests__/App.docsPortalLazy.test.tsx
@@ -84,7 +84,8 @@ vi.mock('../pages/DocPage', tracked('DocPage', 'doc-page'));
 vi.mock('../pages/SharedRecordPage', tracked('SharedRecordPage', 'shared-record-page'));
 
 // ── Everything else App.tsx imports but this card does not touch ──────────
-vi.mock('@object-ui/app-shell', () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   ConsoleShell: passthrough,
   ConsoleToaster: () => null,
   LoadingScreen: stub('loading-screen'),

--- a/apps/console/src/__tests__/internalFormShell.test.tsx
+++ b/apps/console/src/__tests__/internalFormShell.test.tsx
@@ -53,7 +53,8 @@ const { passthrough, stub } = vi.hoisted(() => ({
 // `DefaultHomeLayout` is the console's layout for app-INDEPENDENT authed pages
 // (`/home`, `/organizations` — and now the internal form). Its presence IS the
 // "nested inside the console shell" assertion.
-vi.mock('@object-ui/app-shell', () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   ConsoleShell: passthrough,
   ConsoleToaster: () => null,
   // Suspense fallback for App.tsx's lazy /docs routes (objectui#5467).

--- a/apps/console/src/__tests__/registerStudioComponents.builderDirect.test.tsx
+++ b/apps/console/src/__tests__/registerStudioComponents.builderDirect.test.tsx
@@ -57,7 +57,8 @@ const { registrations } = vi.hoisted(() => ({ registrations: [] as Registration[
 // exercised below is the production registration itself, not a re-creation.
 // `BuilderLanding` stands in for the real page: what this file measures is
 // WHEN it renders, which its internals cannot change.
-vi.mock('@object-ui/app-shell', () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   registerAppComponent: (entry: Registration) => {
     registrations.push(entry);
   },

--- a/apps/console/src/components/FormPage.predicateScope.test.tsx
+++ b/apps/console/src/components/FormPage.predicateScope.test.tsx
@@ -89,6 +89,14 @@ import { FormPage } from './FormPage';
  * (10s), narrower than the 15s it replaces. The specifier is unchanged, so this
  * is the same module and the same binding as the `await import()` was — only
  * loaded before the timed window instead of inside it.
+ *
+ * objectui#6892 slice 14 puts the barrel BACK into the factory — as an
+ * `importOriginal()` spread, so the mock inherits the real export surface
+ * instead of freezing it at the four names below. That is safe here for the
+ * reason this comment already gives: the module-scope import above is the
+ * first VALUE request for the specifier, so the factory — and the barrel load
+ * inside it — runs during the IMPORT phase, which no timeout bounds. Measured
+ * under objectui#8173: `hop1SessionPrincipal` 9ms -> 8ms.
  */
 import { InternalFormRoute } from './InternalFormRoute';
 
@@ -350,8 +358,9 @@ describe('#6110 controls — green before AND after the fix, by construction', (
 // below carry every name this file's graph reads from the barrel and cost a few
 // ms together: `ExpressionProvider`, `buildExpressionUser` (`expressionUser`)
 // and `resolveHostAppSegment` (`utils/`).
-vi.mock('@object-ui/app-shell', async () => {
+vi.mock('@object-ui/app-shell', async (importOriginal) => {
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     ...(await vi.importActual<Record<string, unknown>>(
       '../../../../packages/app-shell/src/providers/ExpressionProvider'
     )),

--- a/apps/console/src/components/RootLandingRedirect.route.test.tsx
+++ b/apps/console/src/components/RootLandingRedirect.route.test.tsx
@@ -87,7 +87,8 @@ const auth = vi.hoisted(() => ({
   value: { isAuthenticated: false, isLoading: false, user: null as any },
 }));
 
-vi.mock('@object-ui/app-shell', () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   // Chrome, stubbed to nothing — this file measures routing, not painting.
   ConnectedShell: passthrough,
   RequireOrganization: passthrough,

--- a/apps/console/src/components/SetupRoute.test.tsx
+++ b/apps/console/src/components/SetupRoute.test.tsx
@@ -75,7 +75,8 @@ vi.mock('../../../../packages/app-shell/src/providers/MetadataProvider', async (
 // reads from the barrel and cost ~2.0s together: `chrome/` has
 // `RedirectWithSplash`, `console/ConsoleShell` has `SetupRedirect`,
 // `SETUP_APP_PACKAGE_ID` and `SETUP_APP_NAME`.
-vi.mock('@object-ui/app-shell', async () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   ...(await vi.importActual<Record<string, unknown>>(
     '../../../../packages/app-shell/src/chrome/index'
   )),

--- a/apps/console/src/components/StudioRoute.test.tsx
+++ b/apps/console/src/components/StudioRoute.test.tsx
@@ -98,7 +98,8 @@ const designSurface = vi.fn();
 // `chrome/`, so the factory pulls that ONE submodule (**549ms**) instead.
 // `RedirectWithSplash` is the only real export left standing: `ProtectedRoute`
 // renders it for the unauthenticated case, which this file asserts.
-vi.mock('@object-ui/app-shell', async () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   ...(await vi.importActual<Record<string, unknown>>(
     '../../../../packages/app-shell/src/chrome/index'
   )),

--- a/apps/console/src/pages/developer/FlowRunsPage.test.tsx
+++ b/apps/console/src/pages/developer/FlowRunsPage.test.tsx
@@ -51,11 +51,12 @@ const { execute, ADAPTER, authFetch } = vi.hoisted(() => {
   return { execute, ADAPTER, authFetch };
 });
 
-vi.mock('@object-ui/app-shell', async () => {
+vi.mock('@object-ui/app-shell', async (importOriginal) => {
   // The runner itself is the real component — this test asserts it is mounted
   // AND that it resumes, so stubbing it would defeat the purpose.
   const { FlowRunner } = await import('../../../../../packages/app-shell/src/views/FlowRunner');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     useAdapter: () => ADAPTER,
     useMetadata: () => ({ objects: [] }),
     FlowRunner,

--- a/apps/console/src/pages/developer/PublicFormsPage.redirect.test.tsx
+++ b/apps/console/src/pages/developer/PublicFormsPage.redirect.test.tsx
@@ -79,7 +79,10 @@ const { saveItem, ADAPTER } = vi.hoisted(() => {
   return { saveItem, ADAPTER };
 });
 
-vi.mock('@object-ui/app-shell', () => ({ useAdapter: () => ADAPTER }));
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAdapter: () => ADAPTER,
+}));
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 // Imported AFTER the mocks so the page picks them up.

--- a/apps/console/src/pages/docs-portal.test.tsx
+++ b/apps/console/src/pages/docs-portal.test.tsx
@@ -47,7 +47,10 @@ const { ADAPTER } = vi.hoisted(() => {
   return { ADAPTER };
 });
 
-vi.mock('@object-ui/app-shell', () => ({ useAdapter: () => ADAPTER }));
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAdapter: () => ADAPTER,
+}));
 
 vi.mock('@object-ui/plugin-markdown', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),

--- a/apps/console/src/pages/system/ApprovalsInboxPage.cellIdentity.test.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.cellIdentity.test.tsx
@@ -120,7 +120,8 @@ vi.mock('@object-ui/auth', async (importOriginal) => {
   };
 });
 
-vi.mock('@object-ui/app-shell', () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useAdapter: () => ADAPTER,
   DeclaredActionsBar: () => null,
   isViaOverrideRow: () => false,

--- a/apps/console/src/pages/system/ApprovalsInboxPage.characterizationPins.test.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.characterizationPins.test.tsx
@@ -147,7 +147,8 @@ vi.mock('@object-ui/auth', async (importOriginal) => {
   };
 });
 
-vi.mock('@object-ui/app-shell', () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useAdapter: () => ADAPTER,
   DeclaredActionsBar: () => null,
   isViaOverrideRow: () => false,

--- a/apps/console/src/pages/system/ApprovalsInboxPage.hiddenFieldTrim.test.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.hiddenFieldTrim.test.tsx
@@ -143,7 +143,8 @@ vi.mock('@object-ui/auth', async (importOriginal) => {
   };
 });
 
-vi.mock('@object-ui/app-shell', () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useAdapter: () => ADAPTER,
   DeclaredActionsBar: () => null,
   isViaOverrideRow: () => false,

--- a/apps/console/src/pages/system/ApprovalsInboxPage.queueHiddenAmount.test.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.queueHiddenAmount.test.tsx
@@ -199,7 +199,8 @@ vi.mock('@object-ui/auth', async (importOriginal) => {
   };
 });
 
-vi.mock('@object-ui/app-shell', () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useAdapter: () => ADAPTER,
   DeclaredActionsBar: () => null,
   isViaOverrideRow: () => false,

--- a/apps/console/src/pages/system/ApprovalsInboxPage.rawPayloadGate.test.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.rawPayloadGate.test.tsx
@@ -122,7 +122,8 @@ vi.mock('@object-ui/auth', async (importOriginal) => {
   };
 });
 
-vi.mock('@object-ui/app-shell', () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useAdapter: () => ADAPTER,
   DeclaredActionsBar: () => null,
   isViaOverrideRow: () => false,

--- a/apps/console/src/pages/system/ApprovalsInboxPage.recordLink.test.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.recordLink.test.tsx
@@ -122,7 +122,8 @@ vi.mock('@object-ui/auth', async (importOriginal) => {
   };
 });
 
-vi.mock('@object-ui/app-shell', () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useAdapter: () => ADAPTER,
   DeclaredActionsBar: () => null,
   isViaOverrideRow: () => false,

--- a/apps/console/src/pages/system/ApprovalsInboxPage.stepProgressVertical.test.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.stepProgressVertical.test.tsx
@@ -156,7 +156,8 @@ vi.mock('@object-ui/auth', async (importOriginal) => {
   };
 });
 
-vi.mock('@object-ui/app-shell', () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useAdapter: () => ADAPTER,
   DeclaredActionsBar: () => null,
   isViaOverrideRow: () => false,

--- a/apps/console/src/pages/system/__tests__/AppManagementPage.i18n.test.tsx
+++ b/apps/console/src/pages/system/__tests__/AppManagementPage.i18n.test.tsx
@@ -53,7 +53,8 @@ vi.mock('sonner', () => ({
   toast: { success: toastSuccess, error: toastError },
 }));
 
-vi.mock('@object-ui/app-shell', () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useMetadata: () => ({ apps: apps.value, refresh }),
   useAdapter: () => ({ getClient: () => ({ meta: { saveItem, deleteItem } }) }),
 }));

--- a/apps/console/src/pages/system/__tests__/AppManagementPage.mutations.test.tsx
+++ b/apps/console/src/pages/system/__tests__/AppManagementPage.mutations.test.tsx
@@ -86,7 +86,8 @@ vi.mock('@object-ui/i18n', async (importOriginal) => ({
   }),
 }));
 
-vi.mock('@object-ui/app-shell', () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useMetadata: () => ({ apps: apps.value, refresh }),
   useAdapter: () => ({ getClient: () => ({ meta: { saveItem, deleteItem } }) }),
 }));
@@ -277,7 +278,8 @@ describe('Bulk toggle — issues one real mutation per selected app', () => {
 describe('no adapter — the control refuses instead of pretending', () => {
   it('⛔ never reports success when there is no metadata client to write through', async () => {
     vi.resetModules();
-    vi.doMock('@object-ui/app-shell', () => ({
+    vi.doMock('@object-ui/app-shell', async (importOriginal) => ({
+      ...(await importOriginal<Record<string, unknown>>()),
       useMetadata: () => ({ apps: apps.value, refresh }),
       useAdapter: () => null,
     }));

--- a/apps/console/src/pages/system/__tests__/AppManagementPage.search.test.tsx
+++ b/apps/console/src/pages/system/__tests__/AppManagementPage.search.test.tsx
@@ -65,7 +65,8 @@ vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
-vi.mock('@object-ui/app-shell', () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useMetadata: () => ({ apps: apps.value, refresh }),
   useAdapter: () => ({ getClient: () => ({ meta: { saveItem: vi.fn(), deleteItem: vi.fn() } }) }),
 }));

--- a/apps/console/src/pages/system/__tests__/SystemHubPage.counts.test.tsx
+++ b/apps/console/src/pages/system/__tests__/SystemHubPage.counts.test.tsx
@@ -123,7 +123,10 @@ const { state, ADAPTER, FRAMEWORK_OBJECT_NAMES } = vi.hoisted(() => {
   return { state, ADAPTER, FRAMEWORK_OBJECT_NAMES };
 });
 
-vi.mock('@object-ui/app-shell', () => ({ useAdapter: () => ADAPTER }));
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAdapter: () => ADAPTER,
+}));
 vi.mock('@object-ui/auth', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   useWorkspaceAdminStatus: () => ({ isAdmin: true, isResolved: true }),

--- a/apps/console/src/pages/system/__tests__/SystemHubPage.metadataCards.test.tsx
+++ b/apps/console/src/pages/system/__tests__/SystemHubPage.metadataCards.test.tsx
@@ -58,7 +58,8 @@ import { MemoryRouter, Routes, Route, useLocation, useParams } from 'react-route
 // The hub's only two data dependencies. `@object-ui/components` stays REAL so
 // the cards, their click handlers and their test ids are the ones the hub
 // actually renders.
-vi.mock('@object-ui/app-shell', () => ({
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useAdapter: () => ({ find: async () => ({ data: [] }) }),
 }));
 vi.mock('@object-ui/auth', async (importOriginal) => ({

--- a/scripts/check-vi-mock-inherit.mjs
+++ b/scripts/check-vi-mock-inherit.mjs
@@ -83,7 +83,7 @@
  *     nor a SUBPATH of one.** See below, and "A member covers its subpaths".
  *
  * `COVERED_SPECIFIERS` holds the workspace packages whose frozen sites have
- * actually been SWEPT to zero. Today that is eighteen, and each joined by sweep
+ * actually been SWEPT to zero. Today that is nineteen, and each joined by sweep
  * rather than by judgement. Running this file's classifier over all 1,499
  * `vi.mock` call sites in the tree at `9ce20233f`:
  *
@@ -817,11 +817,83 @@
  * under `packages/app-shell`. No file among the ten mocks `@object-ui/app-shell`,
  * so the parked specifier stays parked.
  *
- * The remaining 23 stay on objectui#6892, and they are now ONE specifier:
- * `@object-ui/app-shell` (23, ALL frozen, PARKED under objectui#8173 --
- * objectui#6892 and the closed objectui#6580 point opposite ways on that one
- * specifier and a seat does not decide it). Every other workspace specifier any
- * `vi.mock` call site in this tree names is covered and reads zero frozen.
+ * ### Slice 14 -- `@object-ui/app-shell`, the last specifier carrying frozen sites
+ *
+ * The nineteenth member, and the one slice 13 left PARKED. Re-derived on
+ * `fff250ff1` by running this file's own `scan()` with a local `covered`
+ * override -- ⛔ never from the worklist's table:
+ *
+ *     @object-ui/app-shell   23 judged, 0 inheriting, 23 frozen -> 0
+ *
+ * with the tree-wide census moving `625 judged / 625 inherit / 35 other
+ * workspace` to `648 / 648 / 12`: the covered count rose by exactly the
+ * converted sites and `other workspace` fell by the same number, so no site
+ * moved the other way and nothing joined the judged population except these.
+ *
+ * ⭐ THREE different counts were in circulation for this slice, and the way
+ * they reconcile is a property of THIS gate, so it is recorded here rather
+ * than left to be rediscovered:
+ *
+ *   - **22** -- objectui#6892's own Verification recipe greps `vi.mock` and
+ *     counts FILES. It can never reach 23:
+ *     `AppManagementPage.mutations.test.tsx` carries TWO call sites.
+ *   - **23** -- what `scan()` reports, and what this slice converted.
+ *   - **24** -- an unmasked regex over the same tree, matching `vi.mock` and
+ *     `vi.doMock` OCCURRENCES. The extra one is at
+ *     `FormPage.predicateScope.test.tsx:76` and it is **inside a block
+ *     comment** -- a doc comment that quotes the very call it documents.
+ *
+ * ⚠️ The 24th is NOT the `embedded` bucket, and guessing that it was would
+ * have been wrong in a way that reads plausible: `scanSource()` blanks
+ * comments BEFORE `CALL_RE` runs, so a commented occurrence never becomes a
+ * call site at all and is counted in NO bucket. `embedded` reads 3 tree-wide
+ * and every one of them names something else (two `@object-ui/react` samples
+ * in this file's own header, one `./dep` in an eslint-rule test). Measured:
+ * `comment[offset] = 1, literal[offset] = 0`.
+ *
+ * ⭐ **The odd site: a `vi.doMock` INSIDE a test.** Twenty-two of the 23 are
+ * module-scope `vi.mock` calls whose factory runs during the import phase.
+ * The twenty-third, `AppManagementPage.mutations.test.tsx:280`, is a
+ * `vi.doMock` inside a test body after `vi.resetModules()`, so its obtain sits
+ * in a BOUNDED window -- exactly the shape AGENTS.md's 测试纪律 section warns
+ * about. It was measured before conversion rather than argued about
+ * (objectui#8173): that test went 459ms -> 660ms against a 5000ms
+ * `testTimeout`, while `hop1SessionPrincipal` -- the 15000ms window
+ * objectui#6580 was fighting -- went 9ms -> 8ms. Harmless, but shaped
+ * differently from the other 22, and the next reader should not have to
+ * discover that.
+ *
+ * ⭐ **The cost question was settled by objectui#8173 in 11 vitest arms, and
+ * ⛔ no maintainer ruling is owed.** The blocker that parked this specifier
+ * was a `10s x 22 = 220s` extrapolation from objectui#6580. The per-file
+ * figure reproduces in isolation (~8.3s), but the cost is a ONE-TIME
+ * transform of the app-shell graph PER VITEST PROCESS, and ~67 of the console
+ * project's 89 test files already load the real barrel -- so a realistic
+ * shard has already paid it before the first converted file is transformed.
+ * The bound is **at most +4% of one shard**, and only in the pathological case
+ * where all 22 files land in one shard with no non-mocking console file beside
+ * them. Confirmed green over three replicates at 22/22 files, 150/150 tests,
+ * and the whole console project at 1069/1069.
+ *
+ * The neighbour reading found ZERO repairs owed. Across the 22 files the 28
+ * workspace neighbours are ALL already inheriting (16 `@object-ui/auth`, 11
+ * `@object-ui/i18n`, one `@object-ui/plugin-markdown`), and the only
+ * third-party factory is `sonner` (7) -- so the frozen `lucide-react`
+ * neighbour that killed 15 files in slice 6 cannot exist here. The remaining
+ * 61 neighbours are local whole-module replacements, out of scope by
+ * construction.
+ *
+ * ### What is left
+ *
+ * ⭐ **Nothing frozen is.** With this member added, running the classifier over
+ * every workspace specifier ANY `vi.mock` call site in this tree names -- 21 of
+ * them -- reads **660 judged, 660 inherit, 0 frozen**. Two specifiers are still
+ * outside `COVERED_SPECIFIERS` (`@object-ui/plugin-view` at 10 sites,
+ * `@object-ui/core` at 2), and objectui#6892 carries them as its remaining
+ * slices, but both already read 10/10 and 2/2 INHERITING when judged. They are
+ * membership flips, not sweeps -- which is why they are still owed a slice
+ * each: the precondition below is a MEASUREMENT, and a specifier that reads
+ * zero frozen today can carry a frozen factory tomorrow.
  *
  * **The precondition for widening is a sweep, not a judgement.** Convert a
  * specifier's frozen factories to the inheriting form, confirm this gate reads
@@ -1015,6 +1087,7 @@ export const COVERED_SPECIFIERS = Object.freeze([
   '@object-ui/plugin-designer',
   '@object-ui/plugin-list',
   '@object-ui/fields',
+  '@object-ui/app-shell',
 ]);
 
 /** Files the walk reads at all. */


### PR DESCRIPTION
Refs #6892 (slice 14)

Converts every frozen `vi.mock` / `vi.doMock` factory naming `@object-ui/app-shell`
to the inheriting form used by slices 1 to 13, and adds the specifier to
`COVERED_SPECIFIERS` in `scripts/check-vi-mock-inherit.mjs` in the same PR.

`@object-ui/app-shell` was the LAST specifier in this tree carrying frozen sites.

## FIRST: the count. Three numbers were in circulation; here is the reconciliation

The number this PR converted is **23**, and it is the one the gate's own exported
`scan()` reports. Command, run at `fff250ff1`:

```js
import { scan, COVERED_SPECIFIERS } from './scripts/check-vi-mock-inherit.mjs';
scan(ROOT, { covered: [...COVERED_SPECIFIERS, '@object-ui/app-shell'] });
// -> 23 sites naming the specifier, 23 frozen, 0 inheriting
```

| count | what it actually counts | why it differs |
|---|---|---|
| **22** | distinct FILES, from objectui#6892's own Verification recipe | `AppManagementPage.mutations.test.tsx` carries TWO sites, so a file count can never reach 23 |
| **23** | call SITES per `scan()` — **what this PR converts** | the gate's reading |
| **24** | `vi.mock` + `vi.doMock` OCCURRENCES from an unmasked regex | the extra one is at `FormPage.predicateScope.test.tsx:76` and it is **inside a block comment** |

The dispatch's hypothesis was that the 24th was a code SAMPLE inside a string
literal. **That is falsified.** It is a comment, and the difference is not
cosmetic: `scanSource()` blanks comments BEFORE `CALL_RE` runs, so a commented
occurrence never becomes a call site at all and is counted in **no** bucket. The
gate's `embedded` counter reads 3 tree-wide and every one of those three names
something else — two `@object-ui/react` samples inside the gate's own header, one
`./dep` in an eslint-rule test. Measured directly against the mask:
`comment[offset] = 1`, `literal[offset] = 0`.

## Before / after census

`node scripts/check-vi-mock-inherit.mjs`, exit 0 in both states:

| | judged | inherit | frozen | other workspace |
|---|---|---|---|---|
| `fff250ff1` (base) | 625 | 625 | 0 | 35 |
| this PR (`0d163da2a`) | **648** | **648** | **0** | **12** |

The covered count rose by exactly 23 and `other workspace` fell by exactly 23, so
no site moved the other way and nothing else joined the judged population.

## Name the odd site

Twenty-two of the 23 are module-scope `vi.mock` calls whose factory runs during the
import phase, which no timeout bounds.

The twenty-third — **`apps/console/src/pages/system/__tests__/AppManagementPage.mutations.test.tsx:280`**
— is a `vi.doMock` **inside a test body, after `vi.resetModules()`**. Its obtain
therefore sits in a **bounded window**, which is exactly the shape AGENTS.md's
测试纪律 section warns about. It was measured before conversion rather than argued
about (objectui#8173): that test went **459 ms to 660 ms against a 5000 ms
`testTimeout`**, while `hop1SessionPrincipal` — the 15000 ms window objectui#6580
was fighting — went **9 ms to 8 ms**. Harmless, but shaped differently from the
other 22, and the next reader should not have to rediscover that.

## The measured cost, carried forward so nobody re-derives it

objectui#8173 spent **11 vitest arms** establishing this. Summary, so this PR is
self-contained:

- The blocker that parked this specifier was a `10 s per file, times 22 files, equals 220 s`
  extrapolation from objectui#6580. **It does not survive.**
- objectui#6580's per-file figure reproduces in isolation (~8.3 s), but the cost is a
  **one-time transform of the app-shell graph per vitest process**, not a per-file
  cost — and **about 67 of the console project's 89 test files already load the real
  barrel**, so a realistic shard has already paid it before the first converted file
  is transformed.
- Bound: **at most +4 % of one shard**, and only in the pathological case where all 22
  files land in one shard with no non-mocking console file beside them.
- Green over three replicates: 22/22 files, 150/150 tests, and the whole console
  project at 1069/1069.

**No maintainer ruling is owed and none was sought.**

## What is left after this slice

With this member in, running the classifier over **every** workspace specifier any
`vi.mock` call site in this tree names — 21 of them — reads **660 judged, 660
inheriting, 0 frozen**. Two specifiers are still outside `COVERED_SPECIFIERS`:
`@object-ui/plugin-view` (10 sites) and `@object-ui/core` (2). **Both already read
all-inheriting when judged** (10/10 and 2/2), so their slices are membership flips
rather than sweeps. They are deliberately NOT folded in here — one specifier per
slice is this worklist's convention through thirteen landings, and it is what keeps
a regression bisectable.

## No assertion was edited or deleted

Every one of the **23 removed lines** in this diff is a factory line:

```
 15x  -vi.mock('@object-ui/app-shell', () => ({
  3x  -vi.mock('@object-ui/app-shell', () => ({ useAdapter: () => ADAPTER }));
  2x  -vi.mock('@object-ui/app-shell', async () => ({
  2x  -vi.mock('@object-ui/app-shell', async () => {
  1x  -    vi.doMock('@object-ui/app-shell', () => ({
```

One **purely additive** exception, declared rather than buried: `FormPage.predicateScope.test.tsx`
gains a paragraph inside an existing block comment. That comment documents the
module-scope import objectui#6580 added and states, as a load-bearing claim, that
"objectui#6580 took the barrel out of the factory". This PR puts the barrel back
in, so leaving the paragraph untouched would leave a comment asserting the opposite
of the code beside it. Nothing was removed from it; eight lines were appended.

## Neighbour reading — zero repairs owed

Across the 22 files, all **28** workspace neighbours already inherit (16
`@object-ui/auth`, 11 `@object-ui/i18n`, one `@object-ui/plugin-markdown`), and the
only third-party factory is `sonner` (7 sites). The frozen `lucide-react` neighbour
that killed 15 files in slice 6 **cannot exist here** — no file among the 22 mocks
it. The remaining 61 neighbours are local whole-module replacements, out of scope by
construction.

## Verification

Heavy runs went through the shared verify lock; every verdict below is the line the
tool printed, not a bare shell status.

| command | result |
|---|---|
| `pnpm exec vitest run` over the 22 converted files | `Test Files 22 passed (22)` / `Tests 150 passed (150)` — lock `VERDICT command-exit 0` |
| `pnpm exec vitest run apps/console/` | `Test Files 89 passed (89)` / `Tests 1069 passed (1069)` — lock `VERDICT command-exit 0` |
| `pnpm exec vitest run scripts/__tests__/check-vi-mock-inherit.test.ts …specifiers… …js-comment-mask-jsx-6891…` | `Test Files 3 passed (3)` / `Tests 146 passed (146)` |
| `node scripts/check-vi-mock-inherit.mjs` | exit 0, `648 judged (648 inherit)`, `12 other workspace` |
| `node scripts/check-vi-mock-specifiers.mjs` | exit 0 — the sibling gate on the same population |
| `node scripts/check-changeset-presence.mjs` | exit 0 — 22 published source files, 1 changeset, empty frontmatter |
| `node scripts/check-changeset-no-major.mjs` | exit 0 |
| `pnpm --filter @object-ui/console run type-check` | exit 0 (**after** `turbo run build --filter '@object-ui/console^...'`; without the dependency closure built it is TS2307-noise, i.e. NOT MEASURED, not red) |
| `turbo run lint --filter @object-ui/console` | exit 0 — `0 errors, 210 warnings`, all pre-existing |
| `eslint . --no-inline-config --format json` (whole tree, no narrowing) | 4456 files linted; 94 errors across 78 files, **all pre-existing and none in this diff**; the 12 warnings in changed files are all `no-explicit-any` on lines this PR did not write |
| control-character scan over the diff | no hits |

### Reverse verification (ablation)

Run from the committed tree, with a trap-restore on absolute paths, and proven on
disk rather than by an exit code. Reverting **one** converted factory
(`ApprovalsInboxPage.cellIdentity.test.tsx`) to the frozen form:

```
BEFORE  injected-spread count: 4   frozen-form count: 0
AFTER   injected-spread count: 3   frozen-form count: 1
        on-disk hash 673e5690… -> cef53498…   (HEAD blob 673e5690…)
GATE EXIT=1
  apps/console/…/ApprovalsInboxPage.cellIdentity.test.tsx:123 -- vi.mock("@object-ui/app-shell")
    the factory never obtains the real module
RESTORE  git diff HEAD empty: YES   on-disk hash back to 673e5690…   frozen-form count: 0
```

Worth recording: the **first** attempt at this ablation used a `perl -0pi -e`
substitution that silently matched nothing. It exited 0 and the file was
byte-identical to `HEAD`; only the on-disk marker count and the hash comparison
caught it. Had the run been read off the exit code, this PR would have reported a
green gate as evidence that the gate can fail.

## Changeset

`.changeset/vi-mock-inherit-slice14-app-shell.md`, empty frontmatter — 22 test files
under a published package changed, and the change releases nothing.
`check-changeset-presence` was run rather than guessed at.

## Scope fences honoured

- The scope resolver (`isCovered`, `coveredPrefixes`), `operandDenotes` and the
  verdict line are **untouched** — PR #8391 and PR #8406 are settled.
- The published `@object-ui/app-shell` barrel is **untouched**, including its 13 bare
  side-effect imports.
- **No** new public sub-path, **no** `dist` alias, **no** named exclusion.
- `@object-ui/plugin-view` and `@object-ui/core` are **not** folded in.
- objectui#8117 is **not** folded in.
- Governed surface (`.claude/`, `docs/adr/`, `skills/`, `AGENTS.md`, `CLAUDE.md`) and
  `content/docs/releases/` are untouched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_