### PR TITLE
test(types): cite `TextSpanSchema.value` by symbol, not by `layout.ts:66`

### DIFF
--- a/.changeset/text-value-retired-citations-8045.md
+++ b/.changeset/text-value-retired-citations-8045.md
@@ -1,0 +1,7 @@
+---
+---
+
+Test-only change: the two `TextSpanSchema.value` control cases in
+`text-value-retired-6951.test.ts` now cite their subject by SYMBOL alone,
+dropping a `layout.ts:66` line address that nothing read. No published
+behaviour, no declaration face and no exported symbol changes.

--- a/packages/types/src/__tests__/text-value-retired-6951.test.ts
+++ b/packages/types/src/__tests__/text-value-retired-6951.test.ts
@@ -173,7 +173,7 @@ describe('the retirement narrows exactly `value` and nothing else (objectui#6951
     expect(result.error.issues.find((i) => i.path[0] === 'content')).toBeTruthy();
   });
 
-  it('control: `TextSpanSchema.value` — the sibling member at `layout.ts:66` — is still ACCEPTED and survives', () => {
+  it('control: `TextSpanSchema.value` — the sibling member — is still ACCEPTED and survives', () => {
     // `value?: string` appears on three interfaces in `layout.ts`; only
     // `TextSchema`'s is retired. The `span` renderer still reads its own
     // `value` (`basic/span.tsx`), so this member must keep parsing — the pin
@@ -339,7 +339,7 @@ describe('TextSchema.value is RETIRED — the TS half of the tombstone (objectui
     expect(document.type).toBe('text');
   });
 
-  it('control: `TextSpanSchema.value` (`layout.ts:66`) still type-checks — retired by symbol, not by grep', () => {
+  it('control: `TextSpanSchema.value` still type-checks — retired by symbol, not by grep', () => {
     const span: TextSpanSchemaTS = { type: 'span', value: 'inline' };
     expect(span.value).toBe('inline');
   });


### PR DESCRIPTION
Refs #8045

Two `it(` names in `packages/types/src/__tests__/text-value-retired-6951.test.ts` cited their subject by LINE ADDRESS. objectui#7853's standing ruling is to cite the assertion by CONTENT, not by line address.

## The diff — a deletion, not a rewrite

```diff
-  it('control: `TextSpanSchema.value` — the sibling member at `layout.ts:66` — is still ACCEPTED and survives', () => {
+  it('control: `TextSpanSchema.value` — the sibling member — is still ACCEPTED and survives', () => {
```

```diff
-  it('control: `TextSpanSchema.value` (`layout.ts:66`) still type-checks — retired by symbol, not by grep', () => {
+  it('control: `TextSpanSchema.value` still type-checks — retired by symbol, not by grep', () => {
```

The symbol text `TextSpanSchema.value` was already in both names and in both assertions, so the address clause is deleted outright. Every other word is kept.

## ⚠️ This is NOT a falsehood repair

Both citations were **accurate**. Re-measured BY SYMBOL on this branch's own merge-base `fff250ff1` — deliberately not copied from the card's `06761b351`:

`TextSpanSchema` is declared at `layout.ts:61`, and its `value?: string;` member is line 66.

The defective property is that **the address is read by nothing, so it can never fail**. It rots silently on the first insertion above it, and `TextSpanSchema` begins only five lines higher.

## The name-agnostic scan, its radius, and its control

The `it(`-line regex the card used structurally under-counts: a name built from DATA does not carry the address on the `it(` line. So a second, name-agnostic scan was run over `packages/types` for quoted `PATH.EXT:LINE` addresses on non-comment lines.

**Radius, stated explicitly.** It walks git-tracked files under `packages/types` (217 paths enumerated from git's index, the same tree that is read; 217 text files, 79,818 lines). It does **not** walk: untracked files; anything outside `packages/types`; comment lines (first non-space is a slash-slash, a star, or a slash-star); or an address split across an interpolation boundary leaving no path text on the line.

**Control that fires.** A data-built known-positive (`probe-fixture.tsx:1234`, in an array literal far from any `it(` line) was planted into a tracked in-radius file. This instrument reported it (32 → 33); the card's narrow `it(`-line regex reported **0** on that same planted probe — so the control shows the instrument reaches the blind-spot shape, not merely that a search ran. Three known-negatives (`1.2.3`, `12:30`, a bare `layout.ts`) produced no hits. The plant was proven on disk by a moved blob hash plus anchored counts, and the restore by a blob hash equal to HEAD with an empty `git diff HEAD`. Every stop-and-report path was separately confirmed present in the walked set.

**The count is 30, not 2** (32 before this change). The two repaired here are gone; the remaining 30 are a different surface and are **not** touched by this PR:

| Where | Hits | Disposition |
|---|---|---|
| `zod/overlay.zod.ts` | 8 | held by a parked PR — reported, not edited |
| `zod/data-display.zod.ts` | 3 | held by a parked PR — reported, not edited |
| `zod/form.zod.ts` | 8 | `.describe()` prose, not a test name — out of scope |
| `zod/complex.zod.ts` | 6 | `.describe()` prose — out of scope |
| `zod/objectql.zod.ts` | 1 | `.describe()` prose — out of scope |
| `zod/layout.zod.ts` | 1 | `.describe()` prose — out of scope |
| `CHANGELOG.md` | 3 | generated release history — out of scope |

These are published schema description strings citing renderer source addresses — a different class from test names, and a different blast radius. They are handed back to the PM rather than widened into this PR. Closing the class mechanically is objectui#8047, which this PR deliberately does not attempt.

## Reverse verification

A renamed test never seen fail is a transcription, not a pin. Both renamed cases were mutated at their assertion's actual subject, with the mutation proven on disk and the restore proven by blob hash plus an empty `git diff HEAD`.

- **Runtime half** — mutated the Zod subject (`TextSpanSchema.value` from `z.string()` to `z.number()`). The renamed case turned RED by name: `× control: TextSpanSchema.value — the sibling member — is still ACCEPTED and survives`, `Tests 1 failed | 17 passed`. Restored, blob equal to HEAD.
- **Type half** — mutated the TS subject (`value?: string;` to `value?: number;`). Type-check exit 2 with `src/__tests__/text-value-retired-6951.test.ts(343,52): error TS2322: Type 'string' is not assignable to type 'number'`, which is inside the renamed case. Restored, blob equal to HEAD.
- **Green control re-run** after both legs: 18 passed, type-check exit 0, worktree clean.

⚠️ **One measured limit worth recording.** The type-half control pins the member's TYPE, not its EXISTENCE. `BaseSchema` carries `[key: string]: any` (`base.ts:467`), so deleting or renaming `TextSpanSchema.value` outright is absorbed by the index signature and this case still passes — a first mutation leg that renamed the member produced no error in this file at all (only `zod-mirror-parity.test.ts` caught it). That is pre-existing and out of scope here; it is reported for triage, not adjusted.

## Gates

| Gate | Verdict |
|---|---|
| `pnpm exec vitest run --maxWorkers=2 packages/types/` | `Test Files 141 passed (141)`, `Tests 2695 passed (2695)`, exit 0 |
| `pnpm --filter @object-ui/types type-check` | exit 0 (script name echoed; all three `tsc` passes incl. `tsconfig.test.json`) |
| `node scripts/check-changeset-presence.mjs` | ✅ exit 0 |
| `node scripts/check-changeset-no-major.mjs` | ✅ exit 0 |

All measured at the final commit `d7480259`. Every exit code was captured before any pipe.

**Changeset.** The gate initially exited 1: this test file lives under `src/` of a released package, so it counts as published source. The gate names the legal answer for a test-only diff verbatim — *"If this change really should release nothing, say so — that is a pass, not a workaround"* — so `.changeset/text-value-retired-citations-8045.md` declares an EMPTY frontmatter. No `skip-changeset` label is applied; that label is inert in this repo.

## Landing

Stays in **draft**. Not enqueued, no auto-merge, not self-approved. This session's GitHub identity is also a `GOVERNED_APPROVER` and the author here, which is exactly why none of that is done from this seat.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtGhnU3WnnWyiWeYQhw2aX)_