### PR TITLE
test(scripts): cover `@object-ui/plugin-view` and `@object-ui/core` in the vi.mock inherit gate

### DIFF
--- a/scripts/check-vi-mock-inherit.mjs
+++ b/scripts/check-vi-mock-inherit.mjs
@@ -83,8 +83,11 @@
  *     nor a SUBPATH of one.** See below, and "A member covers its subpaths".
  *
  * `COVERED_SPECIFIERS` holds the workspace packages whose frozen sites have
- * actually been SWEPT to zero. Today that is nineteen, and each joined by sweep
- * rather than by judgement. Running this file's classifier over all 1,499
+ * actually been SWEPT to zero. Today that is twenty-one: nineteen joined by
+ * sweep, and the last two -- `@object-ui/plugin-view` and `@object-ui/core` --
+ * by a MEASUREMENT that found nothing to sweep, which is the degenerate case of
+ * the same precondition and not a second door (see "Slices 15 + 16" below).
+ * Running this file's classifier over all 1,499
  * `vi.mock` call sites in the tree at `9ce20233f`:
  *
  *     covered set = @object-ui/react (swept by PR #6847)  ->    1 frozen
@@ -883,22 +886,88 @@
  * 61 neighbours are local whole-module replacements, out of scope by
  * construction.
  *
- * ### What is left
+ * ### Slices 15 + 16 -- `@object-ui/plugin-view` and `@object-ui/core`, folded
  *
- * ⭐ **Nothing frozen is.** With this member added, running the classifier over
- * every workspace specifier ANY `vi.mock` call site in this tree names -- 21 of
- * them -- reads **660 judged, 660 inherit, 0 frozen**. Two specifiers are still
- * outside `COVERED_SPECIFIERS` (`@object-ui/plugin-view` at 10 sites,
- * `@object-ui/core` at 2), and objectui#6892 carries them as its remaining
- * slices, but both already read 10/10 and 2/2 INHERITING when judged. They are
- * membership flips, not sweeps -- which is why they are still owed a slice
- * each: the precondition below is a MEASUREMENT, and a specifier that reads
- * zero frozen today can carry a frozen factory tomorrow.
+ * The twentieth and twenty-first members, and the first two to join WITHOUT a
+ * sweep: both already read all-inheriting when judged, so this slice edits no
+ * test file at all. Re-derived on `d9788c141` by running this file's own
+ * `scan()` with a local `covered` override -- ⛔ never from the worklist's
+ * table, and never from slice 14's paragraph above, which recorded these same
+ * two figures a day earlier and is exactly the reading the ruling says to
+ * retake rather than inherit:
+ *
+ *     @object-ui/plugin-view   10 judged, 10 inheriting, 0 frozen
+ *     @object-ui/core           2 judged,  2 inheriting, 0 frozen
+ *
+ * with the tree-wide census moving `648 judged / 648 inherit / 12 other
+ * workspace` to `660 / 660 / 0`. Diffed PER SITE -- verdict AND reason string,
+ * across all 1,785 call sites the walk reports: exactly 12 rows changed, every
+ * one of them `workspace/unjudged -> covered/inherits`, and the other 1,773
+ * byte-identical. So this landed as a RATCHET, the shape objectui#8141 and
+ * objectui#8183 landed in, and the precondition below is met by MEASUREMENT
+ * because there was nothing to convert.
+ *
+ * ⭐ **A membership flip owes no STEP 0 barrel walk, and that is a property of
+ * the flip rather than an exemption.** Every previous slice measured its
+ * barrel's module-scope effects because converting a frozen factory makes the
+ * real barrel LOAD in each converted file. Nothing converts here: all twelve
+ * factories already spread the real module, so both barrels already load in
+ * exactly the files that load them today, and this diff cannot change what a
+ * single test executes. What moves is the gate's judgement, nothing else.
+ * ⛔ Do not read that as "flips are free" -- for a specifier that still carries
+ * a frozen factory the sweep, and its STEP 0, are owed in the same PR.
+ *
+ * ⚠️ `@object-ui/components/ui/sonner` is the one named specifier this slice
+ * deliberately did NOT add, and it is named here so the next reader refuses it
+ * on purpose rather than rediscovering it. It is a SUBPATH of the member slice
+ * 6 swept and has been judged by REACH since objectui#8141, so its 2 sites are
+ * already inside the 648. The constant names package ROOTS only and the gate's
+ * test pins that mechanically (`spec.split('/')` has length 2), so adding it
+ * would turn a green pin red while changing no verdict at all.
+ *
+ * ### What is left -- nothing, and what that does NOT mean
+ *
+ * ⭐ **The worklist is CLOSED.** With these two members added, every
+ * `@object-ui/*` specifier that any `vi.mock` or `vi.doMock` call site in this
+ * tree names is judged -- 22 distinct specifiers: 21 package roots, all
+ * members, plus one subpath covered by reach. The gate reads **660 judged, 660
+ * inherit, 0 frozen**, and `other workspace` reads **0**. That last figure is
+ * the one to watch, because it is the count of workspace call sites the gate
+ * declines to judge: the verdict line's claim and the population it was
+ * computed over are now the same set.
+ *
+ * ⛔ **That is a statement about today's tree, not a guarantee about
+ * tomorrow's.** Three things it does NOT promise, each of them measured
+ * somewhere on this worklist rather than argued:
+ *
+ *   - **`other workspace` does not stay 0 by itself.** A new package, or the
+ *     first `vi.mock` naming an existing one no test named before, lands as an
+ *     UNJUDGED site -- counted, never judged, verdict line still green. Slice 2
+ *     met exactly that: `@object-ui/plugin-charts` had no call site at all when
+ *     the worklist's table was taken, and the population GREW three consecutive
+ *     slices in a row while the worklist was being worked.
+ *   - **A member reading zero today can carry a frozen factory tomorrow.**
+ *     Membership is what makes the gate RED when that happens -- that is the
+ *     whole value of the flip. It buys nothing retroactively.
+ *   - **Zero frozen is not zero risk.** This gate judges the FACTORY's shape on
+ *     a covered specifier. A converted file can still die at COLLECTION for the
+ *     neighbouring reason slice 6 measured 15 times: a frozen THIRD-PARTY
+ *     factory (`lucide-react`), which this gate never judges by construction.
+ *
+ * ⇒ So the standing job after closure has exactly one shape: **a non-zero
+ * `other workspace` in the verdict line means a specifier is being mocked that
+ * nobody has swept.** Re-derive it with `scan()`, sweep it if it carries a
+ * frozen factory, and add it -- never floor it, never exempt it.
  *
  * **The precondition for widening is a sweep, not a judgement.** Convert a
  * specifier's frozen factories to the inheriting form, confirm this gate reads
  * zero for it, then add it to `COVERED_SPECIFIERS` in the same PR. The list only
- * ever grows. objectui#6892 carries the per-specifier worklist.
+ * ever grows. objectui#6892 carries the per-specifier worklist, and slices 15 +
+ * 16 close it. A specifier that ALREADY reads zero has an empty conversion set,
+ * so the confirmation -- a fresh `scan()` over the tree that ships, taken with a
+ * local `covered` override rather than by widening the constant first -- is then
+ * the whole of the evidence; it is not a lighter bar, it is the same bar with
+ * nothing to convert underneath it.
  *
  * ## A member covers its SUBPATHS (objectui#8141)
  *
@@ -1088,6 +1157,8 @@ export const COVERED_SPECIFIERS = Object.freeze([
   '@object-ui/plugin-list',
   '@object-ui/fields',
   '@object-ui/app-shell',
+  '@object-ui/plugin-view',
+  '@object-ui/core',
 ]);
 
 /** Files the walk reads at all. */


### PR DESCRIPTION
Fixes #6892

objectui#6892 slices 15 + 16, folded into one PR: `@object-ui/plugin-view` and
`@object-ui/core` join `COVERED_SPECIFIERS` in `scripts/check-vi-mock-inherit.mjs`,
and the file's header records the slice in the shape slices 5-14 used.

**No test file is edited.** Both specifiers were re-derived as already
all-inheriting, so these are membership flips rather than sweeps.

## Re-derivation (the gate's own `scan()`, local `covered` override)

Taken on `d9788c141` -- the base of this branch -- never from the worklist's
table and never from slice 14's paragraph in the header:

```
scan(ROOT, { covered: ['@object-ui/plugin-view'], floors: {} })
  -> 10 judged, 10 inheriting, 0 frozen, 0 unreadable
scan(ROOT, { covered: ['@object-ui/core'], floors: {} })
  ->  2 judged,  2 inheriting, 0 frozen, 0 unreadable
```

Nothing frozen turned up, so no sweep was folded in.

## Census, before and after

| | judged | inherit | frozen | other workspace |
|---|---|---|---|---|
| before (19 members) | 648 | 648 | 0 | 12 |
| after (21 members) | 660 | 660 | 0 | **0** |

Judged rose by exactly 12 = 10 + 2, and `other workspace` fell by the same
number. Diffed PER SITE -- verdict and reason string -- over all 1785 call
sites the walk reports: exactly 12 rows changed, every one of them
`workspace/unjudged` becoming `covered/inherits`, and the other 1773
byte-identical. No site moved the other way, so this lands as a ratchet.

## Why the closing keyword is correct here, and was not on the fourteen earlier slices

22 distinct `@object-ui/*` specifiers are named by some `vi.mock` / `vi.doMock`
call site in this tree. 19 were members; these 2 make 21 package roots, all
members; the 22nd is `@object-ui/components/ui/sonner`, a SUBPATH of the member
slice 6 swept, judged by reach since objectui#8141. So every specifier any call
site in this tree names is now judged and `other workspace` reaches 0 -- the
worklist has no remaining slice. Confirmed on this branch's own tree rather than
inherited from the dispatch.

## The one specifier deliberately NOT added

`@object-ui/components/ui/sonner`. It is already covered by reach, and the
constant names package ROOTS only -- the gate's test pins that mechanically
(every member's `spec.split('/')` has length 2), so adding it would turn a green
pin red while changing no verdict. Refused on purpose; the header now says so.

## No STEP 0 barrel walk is owed, and that is a property of the flip

Every earlier slice measured its barrel's module-scope effects because
converting a frozen factory makes the real barrel LOAD in each converted file.
Nothing converts here: all twelve factories already spread the real module, so
both barrels already load in exactly the files that load them today. This diff
cannot change what a single test executes -- only what the gate judges.

## Verification (real output)

```
$ node scripts/check-vi-mock-inherit.mjs        # EXIT=0
OK (4458 tracked source file(s), 2724 test-named; 616 carry a mock; 660 call
site(s) on ... @object-ui/app-shell, @object-ui/plugin-view, @object-ui/core and
their subpaths judged (660 inherit, 0 auto-mocked); 0 other workspace, 243
external, 879 local, 0 non-static, 3 embedded in a string literal)

$ pnpm exec vitest run scripts/__tests__/check-vi-mock-inherit.test.ts
Test Files  1 passed (1)
     Tests  84 passed (84)
(through scripts/pm/os-verify-lock.sh: VERDICT command-exit 0, held the lock 19s)

$ pnpm check:vi-mock-specifiers   # EXIT=0, sibling gate over the same population
$ pnpm check:control-bytes        # EXIT=0
$ pnpm check:entry-guard          # EXIT=0
$ pnpm check:comment-mask-corpus  # EXIT=0
$ pnpm check:doc-fences           # EXIT=0
$ pnpm exec eslint scripts/check-vi-mock-inherit.mjs   # EXIT=0, no output
```

The pin suite's 84 cases include the two this diff is exposed to: every member
names a real workspace package (`packages/plugin-view` and `packages/core` both
match), and every member is a package root.

## Changeset

Not owed, and measured rather than guessed:

```
$ node scripts/check-changeset-presence.mjs   # EXIT=0
Compared the working tree with d9788c141 (merge-base with origin/main): 1 file(s)
changed, 0 of them published source of a package the release covers ...
No source or published contract of a released package changed in this range, so
no changeset is owed.
```

The fourteen earlier slices each carried one because they edited test files under
a published package's `src/`; this one touches a single file under `scripts/`.

## Not measured locally

`pnpm check:readme-exports` exits 1 in this worktree with 532 lines of
"its type entry `./dist/index.d.ts` is not on disk -- run `pnpm build` first".
That is an unbuilt-workspace prerequisite, independent of this diff (which
touches no README and no package); CI builds first. Recorded as NOT MEASURED
rather than as a red gate.

Draft on purpose: CI convergence and the ready flip are the PM's read.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_