### PR TITLE
docs(ci-cd-pipeline): name both scan roots of check-skills-paths

### DIFF
--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -571,10 +571,10 @@ path filter at all**, for the same reason as the two sections above: this gate's
 is markdown, and `ci.yml` still lists `'**/*.md'` under the `paths-ignore` of its `push` trigger. It
 appears in the checks list as **Skill Guide Path Check**.
 
-Runs `scripts/check-skills-paths.mjs`, which reads every markdown file under `skills/` and asks, of
-each in-repo path the prose states inside a backtick code span, whether it exists on disk. Those
-guides are a direct input to every agent that writes code in this repository, and their prose gives
-paths as coordinates.
+Runs `scripts/check-skills-paths.mjs`, which reads every markdown file under `skills/` and
+`.claude/skills/` and asks, of each in-repo path the prose states inside a backtick code span,
+whether it exists on disk. Those guides are a direct input to every agent that writes code in this
+repository, and their prose gives paths as coordinates.
 
 **Why a dead coordinate costs more than its size suggests:** the symbol named next to it is usually
 real and only the location is wrong, so nobody gets a compile error — an agent gets "file not found"


### PR DESCRIPTION
Fixes #8006

## What changed

One sentence in the **Skill Guide Paths** section of `content/docs/guide/ci-cd-pipeline.md`. It said the gate "reads every markdown file under `skills/`"; it now says "under `skills/` and `.claude/skills/`". Four lines re-wrapped, no other bytes touched, and **no numeral appears anywhere in the new prose** — deliberately, so it cannot go stale the way a count would.

## Why

`SCAN_ROOTS` in `scripts/check-skills-paths.mjs` re-derived on this branch:

```
export const SCAN_ROOTS = ['skills', '.claude/skills'];
```

Re-derived gate verdict, run by me on today's tree (`node scripts/check-skills-paths.mjs`, exit 0):

```
check-skills-paths: OK (88/89 stated path(s) resolve across 20 guide file(s); 1 baselined).
    skills/ — 28/28 resolve across 16 file(s)
    .claude/skills/ — 60/61 resolve across 4 file(s)
```

The widening landed in `7c7729859` (objectui#7358, PR #7407); the doc sentence never followed. A reader taking it literally concludes the `.claude/skills/**` guides sit outside the gate — the exact wrong conclusion #7358 exists to prevent, since the untracked-surface state it repaired is what let 55 of 93 assertions leave the checked surface in one commit with nothing turning red.

The replacement phrasing is not invented here: the **Skill Examples** section immediately below already describes the same pair of roots as "markdown under `skills/` and `.claude/skills/`". This change makes the two neighbouring sections agree.

## No pin covers this sentence — verified, not assumed

`scripts/__tests__/ci-cd-pipeline-doc.test.ts` contains zero case-insensitive occurrences of "skill" (positive control on the same file: 30 occurrences of "ci-cd-pipeline", so the grep works). Independently confirmed by a mutation run on the committed tree: the sentence was replaced with an obvious falsehood, and the eleven test files that read this document stayed green.

| leg | pin suite | `check-doc-links` |
|---|---|---|
| implementation (this branch) | 11 files / 404 tests passed | exit 0 |
| sentence replaced by a falsehood | 11 files / 404 tests passed | exit 0 |

Observed direction is therefore **stays green**, not "turns red" — that is the finding, and it is exactly why the sentence could drift for as long as it did. Restore leg verified by blob hash against `HEAD` plus an empty `git diff HEAD`, not by an exit code.

## Gates run locally (real output in the report)

| command | result |
|---|---|
| `node scripts/check-skills-paths.mjs` | exit 0 — verdict quoted above |
| `node scripts/check-doc-links.mjs` | exit 0 — `Links are valid across 17 scan roots.` |
| `node scripts/check-doc-fence-languages.mjs` | exit 0 |
| `node scripts/check-control-bytes.mjs` | exit 0 — 6661 tracked text files scanned |
| `node scripts/check-changeset-presence.mjs` | exit 0 — "No source or published contract of a released package changed in this range, so no changeset is owed." |
| `pnpm exec vitest run` on the 11 doc-reading pin files | 11 passed / 404 tests |
| `node scripts/check-governed-queue-guard.mjs --test content/docs/guide/ci-cd-pipeline.md` | NOT GOVERNED |

**Changeset:** none, per the gate above rather than by guess. No `skip-changeset` label is applied — this repository has no such mechanism, and the pin in this very document asserts it is never wired in.

## Scope

Two neighbouring defects on this same file were left alone on purpose:

- The `main@6422aa891` measured-baseline sentence further down states its own measurement point; objectui#7965 ruled that form correct and that ruling stands. Untouched.
- The Lint section's pin gap is objectui#8015, serialised behind this card on this file and different in kind. Untouched here, and it rebases onto this change.

This PR stays **draft**; flipping it is the PM's read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_