### PR TITLE
docs(i18n): state the import rule the placeholder-spelling suite actually obeys

### DIFF
--- a/.changeset/i18n-header-import-rule-8029.md
+++ b/.changeset/i18n-header-import-rule-8029.md
@@ -1,0 +1,4 @@
+---
+---
+
+Comment-only correction inside `packages/i18n/src/__tests__/fallback-placeholder-spelling-3512.test.ts` (objectui#8029): the header claimed the suite "imports nothing outside its own package" while importing `@object-ui/test-support/defaults-table-scan`, which arrived with objectui#7884. The paragraph now states the rule the file actually obeys — direction, not absence — as three checks a new import has to pass. No published behaviour changes: no runtime source, no assertion and no gate moved, and the edited file is a test under a directory this package's build `tsconfig.json` excludes from `dist`.

--- a/packages/i18n/src/__tests__/fallback-placeholder-spelling-3512.test.ts
+++ b/packages/i18n/src/__tests__/fallback-placeholder-spelling-3512.test.ts
@@ -112,14 +112,50 @@
  *
  * ## Why this file lives in `@object-ui/i18n` when two of its surfaces do not
  *
- * `defaults-maps-mirror-en-pack.test.ts` had to move to `app-shell` because it
- * IMPORTS three plugin maps, and every one of those packages depends on this
- * one — importing them back inverts the dependency. This file imports nothing
- * outside its own package: it READS the source files as text and parses them,
- * which is not a module dependency in either direction (same mechanism as
- * `forwardref-props-annotation.guard.test.ts`). So the rule can live beside the
- * fallback whose grammar it is enforcing, which is where the next person to
- * touch `useSafeTranslation.ts` will look.
+ * The rule is DIRECTION, not absence. This paragraph read "this file imports
+ * nothing outside its own package" until objectui#8029 — false since
+ * objectui#7884 added the `@object-ui/test-support` import below, and false in
+ * the load-bearing way, because this paragraph is the stated REASON the file may
+ * sit here: the next person deciding "may this suite import X?" would have been
+ * applying a rule the file itself breaks.
+ *
+ * `defaults-maps-mirror-en-pack.test.tsx` had to move to `app-shell` because it
+ * imports `@object-ui/plugin-detail`, `-list` and `-designer`, and each of those
+ * three declares `@object-ui/i18n` (two in `dependencies`, one as a peer) —
+ * importing them back inverts the dependency. What THIS file may import is
+ * anything that cannot import this package back. A new import belongs here only
+ * if it passes all three checks:
+ *
+ *   1. **Direction.** The imported package must not depend on `@object-ui/i18n`,
+ *      directly or transitively. `@object-ui/test-support` declares no
+ *      `@object-ui/*` dependency in any of its four fields — and is
+ *      `private: true`, never published — so no path back exists. Which is why
+ *      the SAME import also sits in the sibling: it is not what moved that file.
+ *   2. **Reach.** It must be a declared entry point of that package:
+ *      `@object-ui/test-support/defaults-table-scan` is an `exports` subpath, not
+ *      a deep path into another package's `src/__tests__/` — the shape
+ *      objectui#4325 ruled out, and the reason the walk lives in a third package
+ *      rather than in either caller.
+ *   3. **Ship.** It must not reach a consumer: declared in this package's
+ *      `devDependencies`, and imported from a file under `__tests__/`, a
+ *      directory this package's build `tsconfig.json` excludes
+ *      (`check:published-tsconfig-exclude`). That is the tooling tier
+ *      `check-phantom-dependencies.mjs` judges against dev dependencies instead
+ *      of runtime ones, on the ground that no consumer ever resolves such a file.
+ *
+ * What has NOT changed is the property that keeps the gated SURFACES out of the
+ * graph, and it is worth keeping separate from the three checks above: the packs
+ * are a same-package import, while the defaults tables and the needle files are
+ * READ as text and parsed, never imported — so gating them adds no module
+ * dependency in either direction (same mechanism as
+ * `forwardref-props-annotation.guard.test.ts`). Only the WALK that discovers
+ * them is an import, and it is the one the three checks are about. So the rule
+ * can live beside the fallback whose grammar it is enforcing, which is where the
+ * next person to touch `useSafeTranslation.ts` will look.
+ *
+ * ⛔ Nothing mechanical holds this paragraph to the import list above — comment
+ * accuracy is not gateable here, which is how the old sentence survived #7884
+ * for as long as it did. Re-read it when you add an import.
  *
  * ## Direction of the reverse verification, predicted before running (#4118)
  *


### PR DESCRIPTION
Fixes #8029

Comment-only. One paragraph of `packages/i18n/src/__tests__/fallback-placeholder-spelling-3512.test.ts`'s header, plus a changeset declaring no release. No assertion, no runtime source, no gate moved.

## The falsification, verified on `origin/main` at `4b5e07a53` before editing

The header's `## Why this file lives in @object-ui/i18n when two of its surfaces do not` said, of this file:

> This file imports nothing outside its own package: it READS the source files as text and parses them, which is not a module dependency in either direction.

The file's actual import list today (lines 136-143):

```
vitest
node:path
node:url
@object-ui/test-support/defaults-table-scan   <- outside its own package
./placeholder-spelling-rule                    (same package; arrived with objectui#7310)
../locales                                     (same package)
```

The `@object-ui/test-support` import arrived with objectui#7884, when the defaults-table walk moved there so this gate and objectui#4401's would ask their question of one population — which the same header already describes correctly a hundred lines further down. So the sentence was false, and self-contradicted within one document.

## What the file actually obeys, and how that was derived from the tree

The sentence is load-bearing: it is the stated reason this file may live in `@object-ui/i18n` rather than move to `app-shell` like `defaults-maps-mirror-en-pack.test.tsx`. So it is rewritten rather than deleted, and the invariant it now states is **direction, not absence**.

Derivation — four measurements on this tree:

1. **The sibling's imports are what moved it, and they are not the test-support one.** `packages/app-shell/src/__tests__/defaults-maps-mirror-en-pack.test.tsx` imports `@object-ui/plugin-detail`, `@object-ui/plugin-list`, `@object-ui/plugin-designer` — **and `@object-ui/test-support/defaults-table-scan`, the very same import**. The shared import is therefore provably not the discriminator.
2. **The three plugin packages each declare `@object-ui/i18n`**, so importing them from inside i18n inverts the dependency:
   - `plugin-detail` — `dependencies`
   - `plugin-designer` — `dependencies`
   - `plugin-list` — `peerDependencies` and `devDependencies`
3. **`@object-ui/test-support` declares no `@object-ui/*` dependency in any of its four fields**, and is `private: true`, never published — no path back to `@object-ui/i18n` exists. (`plugin-detail` and `plugin-list` themselves take it as a devDependency, which puts it below both.)
4. **The reach and ship conditions are already written down elsewhere in the tree**: `defaults-table-scan.ts`'s own header records that parking the walk in either caller "would either invert a dependency or force a deep subpath import into another package's `src/__tests__/`, the shape objectui#4325 ruled out"; `packages/i18n/tsconfig.json` excludes `**/__tests__/**` from the emitting program (`check:published-tsconfig-exclude`); and `check-phantom-dependencies.mjs` judges that same tooling tier against dev dependencies rather than runtime ones, "on the ground that no consumer ever resolves such a file".

⇒ The rewritten paragraph states it as three checks a new import has to pass — **direction** (the imported package must not depend on `@object-ui/i18n`, directly or transitively), **reach** (a declared `exports` subpath, never a deep path into another package's tests), **ship** (a devDependency, imported from a file under `__tests__/`) — and keeps separate the property that is still true and still load-bearing: the gated *surfaces* (defaults tables, needle files) are read as text and parsed, never imported. Only the *walk* that discovers them is an import.

## A premise in the card that did not survive contact with the tree

The card's "Shape of a fix" and the triage comment both name "`scripts/placeholder-spelling.mjs`-shaped helpers (since #7310)" as a second example of a dependency pointing away. **No such file exists.** objectui#7310 (PR #8028) put the rule in `packages/i18n/src/__tests__/placeholder-spelling-rule.ts` — inside this package — and `scripts/__tests__/placeholder-spelling-parity.test.ts` reaches *into* it by relative path. That file's own header records why the `scripts/`-side option was measured and rejected in both directions (TS2307 / ERR_MODULE_NOT_FOUND one way, TS7016 for lack of `allowJs` the other). The rewritten paragraph therefore does not cite it.

## ⛔ Not covered by any gate

Comment accuracy is not mechanically checkable here, which is how the old sentence survived objectui#7884 for as long as it did. This PR does not change that, and the paragraph now says so in its last line rather than leaving an implied "now covered". Adding a gate for it was not in scope and no obvious one exists.

## Changeset

`node scripts/check-changeset-presence.mjs` asks for one (the edited file is under a released package's `src/`), so `.changeset/i18n-header-import-rule-8029.md` carries an **empty frontmatter** — the explicit "releases nothing" declaration, which is a first-class pass, not a workaround. Not guessed: the gate went from `EXIT=1` to `EXIT=0` on adding it.

## Verification (real output; heavy runs through the shared lock)

`packages/i18n` — the package that owns the edited file:

```
os-verify-lock: VERDICT command-exit 0 - held the lock 15s - waited 0s
 Test Files  62 passed (62)
      Tests  1036 passed (1036)
```

Dependency-closure build + this package's type-check, whose `tsconfig.test.json` includes `src/**/*.test.ts`, so the edited file is a program input rather than merely adjacent to one:

```
os-verify-lock: VERDICT command-exit 0 - held the lock 23s - waited 0s
> @object-ui/i18n@17.6.0 type-check
> tsc --noEmit && tsc -p tsconfig.test.json
```

The four suites elsewhere in the tree that name this file, run explicitly rather than assumed unaffected:

```
os-verify-lock: VERDICT command-exit 0 - held the lock 22s - waited 1s
 Test Files  4 passed (4)
      Tests  160 passed (160)
```

Repo lint, run in full rather than narrowed:

```
os-verify-lock: VERDICT command-exit 0 - held the lock 186s (3m06s) - waited 0s
 Tasks:    47 successful, 47 total
```

Gates:

```
node scripts/check-changeset-presence.mjs      EXIT=0   (1 changeset, empty frontmatter)
node scripts/check-control-bytes.mjs           EXIT=0   (6662 tracked text files)
node scripts/check-governed-queue-guard.mjs    EXIT=0   NOT GOVERNED - 2 paths, 5 surfaces, none matched
pnpm check:published-tsconfig-exclude          EXIT=0   34 enforced packages carry the directory form
pnpm check:phantom-deps                        EXIT=0   40 packages, 20422 specifiers
```

The last two are not incidental: they are the two gates the new paragraph cites, re-run so the citations are true as of this commit. Exit codes captured before any pipe.

Every changed line in the `.ts` file is a block-comment line — measured, not asserted: `git diff HEAD~1 -- <that file> | grep -E '^[+-]' | grep -v '^[+-][+-][+-]' | grep -vcE '^[+-] \*'` returns **0**.

## Status

Stays **draft** by dispatch instruction; the governed-surface guard reports this diff as not governed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_