### PR TITLE
test(scripts): hoist the doc-links corpus walk out of the timed window

### DIFF
--- a/scripts/__tests__/check-doc-links.test.ts
+++ b/scripts/__tests__/check-doc-links.test.ts
@@ -2017,35 +2017,89 @@ describe('in-page and cross-document anchors are resolved — objectui#7644', ()
   });
 });
 
-describe('the anchor rule is the renderers’ own, not this gate’s — objectui#7644', () => {
-  // `scripts/github-slug.mjs` is a COPY of github-slugger, because this gate runs
-  // before `pnpm install` and may not import a package (see
-  // `check-pre-install-import-graph.mjs --list`). A copy is only safe while
-  // something proves it still equals the original — that is what this block is.
-  // Both truth sources are resolved from the workspace package that DECLARES
-  // them, so neither is a phantom dependency of the repo root:
-  //   fumadocs-core  — declared by `apps/site`, the docs renderer itself
-  //   github-slugger — declared by `@object-ui/plugin-markdown`
-  const siteRequire = createRequire(path.join(repoRoot, 'apps/site/package.json'));
-  const markdownRequire = createRequire(path.join(repoRoot, 'packages/plugin-markdown/package.json'));
+// `scripts/github-slug.mjs` is a COPY of github-slugger, because this gate runs
+// before `pnpm install` and may not import a package (see
+// `check-pre-install-import-graph.mjs --list`). A copy is only safe while
+// something proves it still equals the original — that is what the describe below
+// is. Both truth sources are resolved from the workspace package that DECLARES
+// them, so neither is a phantom dependency of the repo root:
+//   fumadocs-core  — declared by `apps/site`, the docs renderer itself
+//   github-slugger — declared by `@object-ui/plugin-markdown`
+const siteRequire = createRequire(path.join(repoRoot, 'apps/site/package.json'));
+const markdownRequire = createRequire(path.join(repoRoot, 'packages/plugin-markdown/package.json'));
 
-  const loadToc = async (): Promise<(content: string, plugins: unknown[]) => Promise<{ url: string; title: string }[]>> =>
-    (await import(pathToFileURL(siteRequire.resolve('fumadocs-core/content/toc')).href)).getTableOfContents;
-  const loadSlugger = async (): Promise<new () => { slug(value: string): string }> =>
-    (await import(pathToFileURL(markdownRequire.resolve('github-slugger')).href)).default;
-  const loadMdx = async (): Promise<unknown> => (await import('remark-mdx')).default;
+const loadToc = async (): Promise<(content: string, plugins: unknown[]) => Promise<{ url: string; title: string }[]>> =>
+  (await import(pathToFileURL(siteRequire.resolve('fumadocs-core/content/toc')).href)).getTableOfContents;
+const loadSlugger = async (): Promise<new () => { slug(value: string): string }> =>
+  (await import(pathToFileURL(markdownRequire.resolve('github-slugger')).href)).default;
+const loadMdx = async (): Promise<unknown> => (await import('remark-mdx')).default;
 
-  /** The document body fumadocs-mdx hands the remark pipeline: frontmatter gone. */
-  function documentBody(raw: string): string {
-    const lines = raw.split('\n');
-    if (!/^---\s*$/.test(lines[0] ?? '')) return raw;
-    for (let index = 1; index < lines.length; index += 1) {
-      // Blank the frontmatter rather than dropping it, so line numbers survive.
-      if (/^(?:---|\.\.\.)\s*$/.test(lines[index])) return '\n'.repeat(index + 1) + lines.slice(index + 1).join('\n');
-    }
-    return raw;
+/** The document body fumadocs-mdx hands the remark pipeline: frontmatter gone. */
+function documentBody(raw: string): string {
+  const lines = raw.split('\n');
+  if (!/^---\s*$/.test(lines[0] ?? '')) return raw;
+  for (let index = 1; index < lines.length; index += 1) {
+    // Blank the frontmatter rather than dropping it, so line numbers survive.
+    if (/^(?:---|\.\.\.)\s*$/.test(lines[index])) return '\n'.repeat(index + 1) + lines.slice(index + 1).join('\n');
   }
+  return raw;
+}
 
+/** One scanned file, parsed ONCE by the renderer both corpus tests compare against. */
+interface CorpusEntry {
+  readonly file: string;
+  readonly rule: string;
+  readonly raw: string;
+  readonly body: string;
+  readonly toc: { url: string; title: string }[];
+}
+
+/**
+ * The whole-corpus walk, performed ONCE at MODULE SCOPE — objectui#8062.
+ *
+ * The two corpus tests at the bottom of this file each walked every
+ * `SCAN_ROOTS` entry and handed all 273 files to fumadocs' own
+ * `getTableOfContents`. Measured on this tree (2.5 MB of markdown): that remark
+ * parse is 2.7-3.1 s per pass, while everything those two tests actually ASSERT
+ * adds up to 27 ms. So an UNBOUNDED corpus walk sat inside vitest's BOUNDED
+ * 15 s window — twice, over identical inputs — and both tests timed out under
+ * container load (idle they were 4429 ms and 3792 ms, i.e. 3.4x of headroom,
+ * and this file is measurably ~1.6x slower on a contended box).
+ *
+ * The repair is the one AGENTS.md prescribes under its test-discipline rule
+ * ("flaky tests: look for the race, do not raise the timeout"), and it is NOT a
+ * raised timeout: move the unbounded work OUT of the bounded window. Module
+ * scope is the only home that qualifies — the cost lands in the import phase,
+ * which no `testTimeout` governs, and unlike a `beforeAll` it does not trade
+ * the 15 s budget for the NARROWER 10 s `hookTimeout`. Each `it()` below now
+ * times its own assertion, and the shared parse is paid once, not twice.
+ *
+ * ⚠ Whatever else you do to this block, keep the parse here: this is the
+ * property that makes the timeout question moot rather than merely deferred.
+ */
+const ANCHOR_CORPUS: CorpusEntry[] = await (async () => {
+  const [getTableOfContents, remarkMdx] = await Promise.all([loadToc(), loadMdx()]);
+  const entries: CorpusEntry[] = [];
+  for (const row of SCAN_ROOTS as ScanRoot[]) {
+    const files = collectFiles(
+      path.join(repoRoot, row.path),
+      row.exclude ? new Set(row.exclude) : undefined,
+      row.collect ? new Set(row.collect) : undefined,
+    ) as string[];
+    for (const file of files) {
+      const raw = fs.readFileSync(file, 'utf8');
+      const body = documentBody(raw);
+      // `.mdx` is parsed with `remark-mdx` exactly as `fumadocs-mdx` compiles
+      // it; without it a JSX element followed by a heading with no blank line
+      // between them is one HTML block, and four real files here have that shape.
+      const toc = await getTableOfContents(body, file.endsWith('.mdx') ? [remarkMdx] : []);
+      entries.push({ file, rule: row.rule, raw, body, toc });
+    }
+  }
+  return entries;
+})();
+
+describe('the anchor rule is the renderers’ own, not this gate’s — objectui#7644', () => {
   it('reproduces github-slugger exactly, over every non-surrogate code point', async () => {
     // The tempting shortcut — `/[^\p{L}\p{M}\p{N}\p{Pc}\- ]/gu` — is not
     // equivalent, and this is the assertion that says so: it disagrees on the
@@ -2079,38 +2133,28 @@ describe('the anchor rule is the renderers’ own, not this gate’s — objectu
     // The corpus check, and the reason the hand-written flattener in
     // `check-doc-links.mjs` is safe to hand-write. Truth per rule:
     //   docs — fumadocs' own `getTableOfContents`, MDX-parsed for `.mdx` exactly
-    //          as `fumadocs-mdx` compiles it. Without `remark-mdx` a JSX element
-    //          followed by a heading with no blank line between them is one HTML
-    //          block, and four real files here have that shape.
+    //          as `fumadocs-mdx` compiles it (see `ANCHOR_CORPUS`, which is where
+    //          that parse now happens — once, for both tests, objectui#8062).
     //   disk — GitHub, i.e. the real `github-slugger` run over the same flattened
     //          heading titles, in document order.
-    const [getTableOfContents, Slugger, remarkMdx] = await Promise.all([loadToc(), loadSlugger(), loadMdx()]);
+    const Slugger = await loadSlugger();
     const disagreeing: string[] = [];
     let docsFiles = 0;
     let diskFiles = 0;
 
-    for (const row of SCAN_ROOTS as ScanRoot[]) {
-      const files = collectFiles(
-        path.join(repoRoot, row.path),
-        row.exclude ? new Set(row.exclude) : undefined,
-        row.collect ? new Set(row.collect) : undefined,
-      ) as string[];
-      for (const file of files) {
-        const raw = fs.readFileSync(file, 'utf8');
-        const toc = await getTableOfContents(documentBody(raw), file.endsWith('.mdx') ? [remarkMdx] : []);
-        let expected: Set<string>;
-        if (row.rule === 'docs') {
-          docsFiles += 1;
-          expected = new Set(toc.map((item) => item.url.slice(1)));
-        } else {
-          diskFiles += 1;
-          const slugger = new Slugger();
-          expected = new Set(toc.map((item) => slugger.slug(item.title)));
-        }
-        const actual = headingAnchors(raw, { customId: row.rule === 'docs' }) as Set<string>;
-        const only = [...expected].filter((id) => !actual.has(id)).concat([...actual].filter((id) => !expected.has(id)));
-        if (only.length > 0) disagreeing.push(`${path.relative(repoRoot, file)}: ${only.join(', ')}`);
+    for (const { file, rule, raw, toc } of ANCHOR_CORPUS) {
+      let expected: Set<string>;
+      if (rule === 'docs') {
+        docsFiles += 1;
+        expected = new Set(toc.map((item) => item.url.slice(1)));
+      } else {
+        diskFiles += 1;
+        const slugger = new Slugger();
+        expected = new Set(toc.map((item) => slugger.slug(item.title)));
       }
+      const actual = headingAnchors(raw, { customId: rule === 'docs' }) as Set<string>;
+      const only = [...expected].filter((id) => !actual.has(id)).concat([...actual].filter((id) => !expected.has(id)));
+      if (only.length > 0) disagreeing.push(`${path.relative(repoRoot, file)}: ${only.join(', ')}`);
     }
 
     expect(disagreeing).toEqual([]);
@@ -2119,29 +2163,19 @@ describe('the anchor rule is the renderers’ own, not this gate’s — objectu
     expect(diskFiles).toBeGreaterThan(50);
   });
 
-  it('has no setext headings, which the ATX-only scan would not see', async () => {
+  it('has no setext headings, which the ATX-only scan would not see', () => {
     // `Title` over `---` is a heading too, and `headingAnchors()` does not read
     // one. Nothing in this tree writes them; this is what says so out loud, so
     // the day someone does the answer is a red test rather than a missing anchor.
-    const getTableOfContents = await loadToc();
-    const remarkMdx = await loadMdx();
+    // The renderer's own reading of each file is `ANCHOR_CORPUS` (objectui#8062);
+    // what this test computes is the ATX count it compares that against.
     const setext: string[] = [];
-    for (const row of SCAN_ROOTS as ScanRoot[]) {
-      const files = collectFiles(
-        path.join(repoRoot, row.path),
-        row.exclude ? new Set(row.exclude) : undefined,
-        row.collect ? new Set(row.collect) : undefined,
-      ) as string[];
-      for (const file of files) {
-        const raw = fs.readFileSync(file, 'utf8');
-        const body = documentBody(raw);
-        const lines = body.split('\n');
-        const toc = await getTableOfContents(body, file.endsWith('.mdx') ? [remarkMdx] : []);
-        // Every heading fumadocs found must have been written in ATX form; the
-        // TOC carries no position, so compare counts against the ATX scan.
-        const atx = lines.filter((line, index) => /^#{1,6}\s+\S/.test(line) && !inFence(lines, index)).length;
-        if (toc.length > atx) setext.push(`${path.relative(repoRoot, file)}: ${toc.length} headings, ${atx} ATX`);
-      }
+    for (const { file, body, toc } of ANCHOR_CORPUS) {
+      const lines = body.split('\n');
+      // Every heading fumadocs found must have been written in ATX form; the
+      // TOC carries no position, so compare counts against the ATX scan.
+      const atx = lines.filter((line, index) => /^#{1,6}\s+\S/.test(line) && !inFence(lines, index)).length;
+      if (toc.length > atx) setext.push(`${path.relative(repoRoot, file)}: ${toc.length} headings, ${atx} ATX`);
     }
     expect(setext).toEqual([]);
   });


### PR DESCRIPTION
Fixes #8062

## What was measured, and on what box

Every run below went through the shared heavy-verify lock
(`../objectstack/scripts/pm/os-verify-lock.sh`, the convention recorded as objectui#8403),
and each one printed its own `VERDICT command-exit 0` line. **The lock was held for every
number in this PR.** The lock excludes other locked runs, not unlocked sibling work, so
treat the absolutes as shared-box seconds and the ratios as the durable part.

Re-derived first, before changing anything —
`pnpm exec vitest run scripts/__tests__/check-doc-links.test.ts --reporter=verbose`:

| test | before | after |
| --- | ---: | ---: |
| `agrees with the real renderers on every heading in the scan surface` | 3964 ms | 25 ms |
| `has no setext headings, which the ATX-only scan would not see` | 3659 ms | 35 ms |
| whole file, 121 tests | 10.32 s | 6.10 s |

The card's idle figures (4429 ms / 3792 ms) reproduced, so the premise still holds. Against
vitest's 15000 ms default the headroom goes from **3.8x and 4.1x** to **600x and 428x**, and
the file as a whole gets 4.2 s faster because the walk is now paid once instead of twice.

## Which of the two shapes this is: shape 2, with the split measured

The work had drifted into a bounded window; it does not belong there. A standalone profile of
the identical walk (plain node, no vitest, under the lock) splits the cost:

```
files 273 · bytes 2,550,739
collect            29 ms
read               12 ms
getTableOfContents  pass 1 3138 ms · pass 2 2746 ms
assertion work (github-slugger + headingAnchors)   27 ms
```

So ~99% of each test's window was fumadocs' remark parse of the whole corpus, and **both
tests parsed the same 273 files** — the hint in the card is right: it was shared work paid
twice over identical inputs. Everything the two tests actually assert adds up to 27 ms.

No timeout was raised. Nothing was skipped, quarantined or narrowed.

## The repair

`ANCHOR_CORPUS` is now built **once at module scope**: collect the `SCAN_ROOTS` files, read
each one, strip frontmatter with the existing `documentBody()`, and hand it to fumadocs'
`getTableOfContents` with `remark-mdx` for `.mdx` — byte for byte the same call the two tests
each used to make. Each `it()` then measures only its own assertion.

Module scope is the only home that qualifies, and AGENTS.md's test-discipline rule is the
reason for both halves of that:

- the cost lands in the **import phase**, which no `testTimeout` governs (vitest's own summary
  moves it there: `import 225ms` before, `import 4.22s` after);
- it is deliberately **not** a `beforeAll`, which would trade the 15 s `testTimeout` for the
  narrower 10 s `hookTimeout` — moving the problem, not fixing it.

The two `loadToc` / `loadSlugger` / `loadMdx` helpers and `documentBody()` moved out of the
describe body to module scope unchanged (a describe callback is synchronous, so the top-level
await could not live inside it). `loadSlugger()` is still awaited inside the tests that use it;
the github-slugger parity tests are untouched.

## Proof that nothing asserted changed

1. **Not one assertion line moved.** `git diff origin/main..HEAD -- scripts/__tests__/check-doc-links.test.ts | grep -E '^[-+].*expect\('` prints **nothing** — no `expect(` line was added, removed or edited anywhere in the diff.
2. **Both tests still go red on a real corpus change.** Ablation: append a setext H2 to `ROADMAP.md` (a genuinely scanned file), proven on disk by `git hash-object` moving `e022b5d1` to `ec9e1df5` and by a `grep -c` of the injected text. Result — both corpus tests **FAIL** (`Tests 2 failed | 119 passed (121)`), in 36 ms and 37 ms, so the fixture really does feed both assertions. Restore leg proven by state: hash back to `e022b5d1`, `git diff HEAD` empty.
3. **The corpus is not narrower than it was.** A temporary assertion printed `ANCHOR_CORPUS.length 273 · docsFiles 184 · diskFiles 89`, identical to an independent walk of `SCAN_ROOTS` outside the test (`{"total":273,"docs":184,"disk":89}`). The file's own lit-instrument assertions (`docsFiles` over 150, `diskFiles` over 50) are unchanged and still pass. That mutation was restored the same way, hash and empty `git diff HEAD`.

## Checks run, with real verdicts

| command | result |
| --- | --- |
| `pnpm exec vitest run scripts/__tests__/check-doc-links.test.ts --reporter=verbose` | `Test Files 1 passed (1)` · `Tests 121 passed (121)` |
| `pnpm exec vitest run scripts/` | `Test Files 121 passed (121)` · `Tests 3615 passed (3615)` · 93.34 s |
| `pnpm lint` | `Tasks: 47 successful, 47 total`, exit 0 (0 errors; the warning counts are pre-existing) |
| `pnpm type-check:scripts` | exit 0 — and `tsc --listFiles` confirms it really includes this test file, so that green is a measurement |
| `node scripts/check-changeset-presence.mjs` | exit 0 — *"No source or published contract of a released package changed in this range, so no changeset is owed."* Checked, not guessed; no changeset added. |
| `pnpm check:control-bytes` | OK, 6661 tracked text files |
| `pnpm check:lint-rule-coverage` · `check:vi-mock-specifiers` · `check:vi-mock-inherit` · `check:pre-install-import-graph` | all exit 0 |

Scope fences respected: the corpus, `SCAN_ROOTS`, the renderers and the github-slugger parity
test are all untouched. One file changed.

---

Drafted by an agent seat, session `session_01FhBNJcLRZLe8M87VcUgpKr`; stays in draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_