### PR TITLE
docs(vscode-extension): the page describes the shortcuts, commands and menus the manifest actually contributes

### DIFF
--- a/content/docs/utilities/vscode-extension.mdx
+++ b/content/docs/utilities/vscode-extension.mdx
@@ -46,19 +46,19 @@ code --install-extension object-ui-<version>.vsix
 
 Access commands via Command Palette (Ctrl+Shift+P / Cmd+Shift+P):
 
-### `ObjectUI: Preview Schema`
+### `Object UI: Open Preview`
 
-Opens a live preview of your schema in a side panel.
+Opens a live preview of your schema in the first editor column. Its sibling
+`Object UI: Open Preview to the Side` opens the same panel beside the editor
+instead.
 
 **Usage:**
 1. Open a `.json` or `.objectui.json` file
 2. Press `Ctrl+Shift+P` (Windows/Linux) or `Cmd+Shift+P` (Mac)
-3. Type "ObjectUI: Preview Schema"
-4. Preview opens in side panel
+3. Type "Object UI: Open Preview"
+4. Preview opens in a panel
 
-**Keyboard Shortcut:** `Ctrl+Alt+P` (Windows/Linux) or `Cmd+Alt+P` (Mac)
-
-### `ObjectUI: Validate Schema`
+### `Object UI: Validate Schema`
 
 Validates the current schema against ObjectUI schema definitions.
 
@@ -67,9 +67,7 @@ Validates the current schema against ObjectUI schema definitions.
 2. Run command
 3. View validation errors in Problems panel
 
-**Keyboard Shortcut:** `Ctrl+Alt+V` (Windows/Linux) or `Cmd+Alt+V` (Mac)
-
-### `ObjectUI: Export to React`
+### `Object UI: Export to React Component`
 
 Converts the schema to a React component.
 
@@ -115,7 +113,7 @@ export default function GeneratedComponent() {
 }
 ```
 
-### `ObjectUI: Format Schema`
+### `Object UI: Format Schema`
 
 Formats the schema JSON with consistent indentation and ordering.
 
@@ -124,15 +122,13 @@ Formats the schema JSON with consistent indentation and ordering.
 2. Run command
 3. Schema is auto-formatted
 
-**Keyboard Shortcut:** `Ctrl+Alt+F` (Windows/Linux) or `Cmd+Alt+F` (Mac)
-
-### `ObjectUI: Create New Schema`
+### `Object UI: Create New Schema`
 
 Creates a new schema file from a template.
 
 **Usage:**
 1. Run command
-2. Select template (Dashboard, Form, Grid, etc.)
+2. Select a template — `Empty Schema`, `Simple Form`, `Dashboard`, `Card Layout` or `Data Table`
 3. New file is created with template content
 
 ## Language Support
@@ -366,18 +362,15 @@ Create `.vscode/settings.json` in your project:
 
 ## Keyboard Shortcuts
 
-Default keyboard shortcuts:
+**The extension ships no default keyboard shortcuts.** Its manifest has no
+`contributes.keybindings` block, so no command arrives bound to a chord — run them
+from the Command Palette or the context menus above, or bind the ones you use.
 
-| Command | Windows/Linux | Mac |
-|---------|--------------|-----|
-| Preview Schema | `Ctrl+Alt+P` | `Cmd+Alt+P` |
-| Validate Schema | `Ctrl+Alt+V` | `Cmd+Alt+V` |
-| Format Schema | `Ctrl+Alt+F` | `Cmd+Alt+F` |
-| Export to React | `Ctrl+Alt+E` | `Cmd+Alt+E` |
+### Bind a command yourself
 
-### Custom Shortcuts
-
-Customize via Keyboard Shortcuts editor (Ctrl+K Ctrl+S):
+Open the Keyboard Shortcuts editor (Ctrl+K Ctrl+S / Cmd+K Cmd+S), search for the
+command by its name, and assign a chord. To write the binding by hand instead, open
+`keybindings.json` from that editor and add an entry naming the command id:
 
 ```json
 {
@@ -387,21 +380,31 @@ Customize via Keyboard Shortcuts editor (Ctrl+K Ctrl+S):
 }
 ```
 
+Every command the extension contributes, with the id to bind:
+
+| Command | Command id |
+|---------|------------|
+| Object UI: Open Preview | `objectui.preview` |
+| Object UI: Open Preview to the Side | `objectui.previewToSide` |
+| Object UI: Validate Schema | `objectui.validate` |
+| Object UI: Format Schema | `objectui.format` |
+| Object UI: Export to React Component | `objectui.exportToReact` |
+| Object UI: Create New Schema | `objectui.newSchema` |
+
 ## Context Menus
 
-Right-click on a schema file to access:
+Right-click a `.objectui.json` or `.oui.json` file to access — the entries are
+contributed for those two extensions only:
 
 ### Editor Context Menu
 
-- **Preview Schema** - Open live preview
-- **Validate Schema** - Run validation
-- **Export to React** - Convert to React component
-- **Format Schema** - Auto-format
+- **Object UI: Open Preview** - Open live preview
+- **Object UI: Validate Schema** - Run validation
+- **Object UI: Export to React Component** - Convert to React component
 
 ### Explorer Context Menu
 
-- **Preview Schema** - Preview selected file
-- **Create Schema** - Create new schema in folder
+- **Object UI: Open Preview** - Preview selected file
 
 ## Preview Features
 
@@ -420,10 +423,10 @@ The preview panel includes:
 
 1. **Create Schema** - Use snippet or command
 2. **Edit Schema** - IntelliSense helps with completion
-3. **Preview** - Open live preview (Ctrl+Alt+P)
-4. **Validate** - Check for errors (Ctrl+Alt+V)
+3. **Preview** - Open live preview
+4. **Validate** - Check for errors
 5. **Test** - Interact with preview
-6. **Export** - Convert to React (Ctrl+Alt+E)
+6. **Export** - Convert to React
 
 ### Tips
 


### PR DESCRIPTION
Fixes #8113

One file: `content/docs/utilities/vscode-extension.mdx`. **Nothing in `contributes` changes** — the manifest is what ships, the page describes it, and this PR only makes the page true. Whether any of the four chords the page used to claim *should* ship is a product decision and a separate card; it is not taken here.

## The manifest's real contribution set, re-derived on today's tree

Read off `packages/vscode-extension/package.json` at `4b4d35a7d` rather than copied from the card:

```
contributes keys: ["languages","grammars","commands","menus","snippets","jsonValidation","configuration"]
contributes.keybindings: undefined   (hasOwnProperty -> false)
```

Seven keys. `keybindings` is not one of them, so **the extension contributes zero keyboard shortcuts.** A grep for any keybinding contribution or any documented chord over the whole package returns 0 lines:

```
$ git grep -rniE 'keybinding|ctrl\+alt|cmd\+alt' -- packages/vscode-extension
(0 lines)
$ git grep -rn '"keybindings"' -- '*.json'      # repo-wide
(0 lines)
```

**Positive control, same corpus and same tool**, so the zero is a reading and not a broken search — the things the manifest *does* contribute come back:

```
$ git grep -rn 'exportToReact' -- packages/vscode-extension
packages/vscode-extension/DESIGN.md:127
packages/vscode-extension/package.json:91
packages/vscode-extension/package.json:124
packages/vscode-extension/src/extension.ts:97
packages/vscode-extension/src/extension.ts:100
packages/vscode-extension/src/extension.ts:197
```

Six commands (`objectui.preview`, `previewToSide`, `validate`, `format`, `exportToReact`, `newSchema`), three menu groups, snippets, a grammar, a language, JSON validation and five settings — all contributed, all reachable. Only the chords were fictional.

## The card was right about its own subject, with one correction to its count

Its title says *five* shortcuts. There are **four distinct chords** — `Ctrl+Alt+P` / `V` / `F` / `E` — asserted across **six sites** on the page, not five: the card's own body says "five places" and then adds the Development Workflow hand-off (`:407`) as a sixth in the next paragraph. The manifest contributes zero of them either way, so the card's substance holds; only the number in its title is loose.

The card's line numbers had drifted, as with the two previous stale-documentation cards on this page. Card vs. today's tree: `:59` → `:59` ✓, `:70` → `:70` ✓, `:108` → **`:127`**, `:348` → **`:367`**, `:357` → **`:376`**, `:407` → **`:426`**. Every site was re-located by content, not by line number.

## ⚠️ What re-deriving falsified: the card and its triage are wrong that the rest of the page is correct

Both the card and the triage comment state that the six commands are "reachable from the Command Palette and the context menus, **which the page also documents correctly**", and the chosen route is to keep those and point the reader at them. Measured against the manifest, three of those claims are false — so writing "use the Command Palette or the context menu instead" without touching them would have routed the reader through a broken replacement. Each is corrected here because the new text depends on it:

**1. Command Palette names.** The page taught `ObjectUI: …`; the manifest's `title` fields say `Object UI: …`, and two differ in more than the prefix.

| page said | manifest `title` |
|---|---|
| `ObjectUI: Preview Schema` | `Object UI: Open Preview` |
| `ObjectUI: Validate Schema` | `Object UI: Validate Schema` |
| `ObjectUI: Export to React` | `Object UI: Export to React Component` |
| `ObjectUI: Format Schema` | `Object UI: Format Schema` |
| `ObjectUI: Create New Schema` | `Object UI: Create New Schema` |

There is no `category` on any command, so the palette shows the `title` verbatim. Second control that the page is the drifted artifact and not the manifest: `packages/vscode-extension/README.md:114-119` already lists all six commands spelled exactly as the manifest spells them, including `Open Preview to the Side` and `Export to React Component`.

**2. Context menus.** `contributes.menus` is:

```
editor/title     objectui.preview, objectui.previewToSide
editor/context   objectui.preview, objectui.validate, objectui.exportToReact
explorer/context objectui.preview
```

The page listed a fourth editor-context entry (**Format Schema**) and a second explorer-context entry (**Create Schema**). Neither is contributed. Both are removed. Every entry's `when` restricts it to `.objectui.json` / `.oui.json`, which the page did not say and now does.

**3. Preview column.** `objectui.preview` calls `showPreview(uri, false)` and the provider maps that to `ViewColumn.One`; `objectui.previewToSide` passes `true` and gets `ViewColumn.Beside` (`packages/vscode-extension/src/providers/PreviewProvider.ts:25-37`). The page described `Open Preview` as opening "in a side panel" — that is `previewToSide`'s behaviour. Corrected, and the sibling command is now named.

These three sit inside the scope fence rather than outside it: same page, same defect class (a published claim about the extension the manifest does not back), mechanical fixes whose shape is pinned by the manifest, no other claim on the file, no new verification surface. They are declared here rather than folded in silently.

Also folded in, as the triage directed: `createNewSchema()` offers `Empty Schema`, `Simple Form`, `Dashboard`, `Card Layout`, `Data Table` (`packages/vscode-extension/src/extension.ts:249-255`). The page said `Dashboard, Form, Grid, etc.` — **`Grid` is not among them**.

## Result

Zero `Ctrl+Alt` / `Cmd+Alt` occurrences remain on the page. Every chord still named is a stock VS Code binding, not an extension contribution: `Ctrl+Shift+X` (Extensions), `Ctrl+Shift+P` (Command Palette), `Ctrl+,` (Settings), `Ctrl+K Ctrl+S` (Keyboard Shortcuts editor), `Ctrl+R` (Reload Window). The `Keyboard Shortcuts` section now states that the extension binds nothing, keeps the Keyboard Shortcuts editor route the page already documented, and adds the six real command ids so a reader can bind what they want.

The `keybindings.json` example is left **byte-identical** on purpose — changing its key means choosing a chord, which this card is fenced away from. It has its own problem and its own card: #8424.

## Nothing pins this page — measured, with a control

Only two things in the tree name this file at all, and neither compares it to the manifest: `scripts/check-doc-component-types.mjs:704` (a two-key exemption table for `ajax` / `api`) and `scripts/__tests__/check-doc-component-types.test.ts:706` (asserts `"type": "h1"` is present and `"type": "heading"` is not).

**Ablation** — re-inject the deleted `Default keyboard shortcuts:` table into the page and re-run everything that reads it:

```
mutation landed on disk: Ctrl+Alt+P count 0 -> 1; replaced text count 1 -> 0
  check:doc-types           exit=0
  check:doc-fences          exit=0
  docs:check-links          exit=0
  check:doc-snippets        exit=0
  check:doc-examples        exit=0
  doc-expression-carriage   exit=0
  body-dialect-census       exit=0
  check:control-bytes       exit=0
  vitest (5 files)          Test Files 5 passed (5) · Tests 212 passed (212)
```

All green with the false table restored. **Control leg**, so that green is a reading and not a harness that never fires — mutate `"type": "h1"` to `"type": "heading"` in the same file:

```
CONTROL-LEG exit=1
AssertionError: content/docs/utilities/vscode-extension.mdx still teaches the unregistered `heading` type
 Test Files  1 failed (1) · Tests  2 failed | 54 passed (56)
```

The harness reads this file and can fail on it. It has no comparison between the page's prose and the extension's manifest. Both legs restored and verified by blob hash, not by exit code: on-disk `9f4c34f4…` = `HEAD:…` `9f4c34f4…`, `git diff HEAD` empty.

**Judgement on whether a pin is warranted, without building one:** not on this card, and probably not as a bespoke gate. A guard that re-derived `contributes.keybindings` and the six command `title` strings against this one page would be a new gate surface built for a single document, and the startup-focus axis is against speculative ones. The general shape — a document mirroring something no tool re-derives — is already the cluster #7976 / #7974 / #7837 name, and if it earns a gate it should be that generic one over the whole `content/docs` corpus, decided on its own card with a maintainer, not accreted here.

## Verification

All through `scripts/pm/os-verify-lock.sh`. Every gate below printed its own verdict line; exit codes captured before any pipe.

```
✅  No source or published contract of a released package changed in this range, so no changeset is owed.
✅  check:doc-fences — every TypeScript block in 227 document(s) is fenced ts/tsx/typescript …
✅  Every documented component type is registered.   (188 files, 1106 blocks, 890 type literals)
✅  check-control-bytes: OK (scanned 6662 tracked text file(s); skipped 85 binary).
    Links are valid across 17 scan roots.
    Scanned 244 document(s): 240 covered … Covered blocks: 790 — 632 to compile
✅  Controls pass: this gate can see the class it is looking for, and does not cry wolf.
✅  Dialect blind spot: none …  ✅  Blind spot: none …
os-verify-lock: VERDICT command-exit 0 · held the lock 38s
```

```
Test Files  5 passed (5)
      Tests  212 passed (212)
os-verify-lock: VERDICT command-exit 0 · held the lock 12s
```

`check:doc-snippets` and `check:doc-examples` first returned **exit 2, `PRECONDITION NOT MET`** — not a failed measurement, they need the packages built. The scoped build the gate names was run (`turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter) --concurrency=2` — 34 packages, `Tasks: 35 successful, 35 total`, `VERDICT command-exit 0 · held the lock 188s`) and both gates then ran green in the `&&` chain above. So both are real measurements, not narrowings.

For the record, the narrowing they would have needed had the build not been affordable: all **18** fenced code blocks in the file are byte-identical before and after this diff — `sha256` of the concatenated fenced content is `ea31adcc5229acf3…` on both sides — and those two gates read only fenced blocks.

**Changeset:** none owed, and this is `check-changeset-presence`'s own verdict, not a guess — the diff is one `content/docs` file, no published source and no publish-contract field moved. No label applied (this repo's `skip-changeset` label object is inert; the changeset gate is the mechanism).

**Governed surface:** `node scripts/check-governed-queue-guard.mjs --test content/docs/utilities/vscode-extension.mdx` → `✅ NOT GOVERNED — 1 path(s) checked against 5 governed surface(s); none matched.` The PR nonetheless stays **draft**: the dispatch withheld the self-merge clause for this card.

## Out of scope, filed not fixed

- #8424 — the page's `keybindings.json` example rebinds `ctrl+shift+p` over the Command Palette under `when: editorLangId == json`, i.e. in exactly the files the same page tells you to use the palette in; plus `Object UI: Open Preview to the Side` still has no `Usage` block of its own. Filed unassigned, no labels, for triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_