### PR TITLE
fix(types): declare `id` on the filter-builder condition so it stops being stripped

### DIFF
--- a/.changeset/8415-filter-builder-condition-id.md
+++ b/.changeset/8415-filter-builder-condition-id.md
@@ -14,8 +14,9 @@ STRIPS undeclared keys. So an author who correctly wrote `id` had it removed:
 `FilterBuilderConditionSchema.safeParse({ id: 'c1', field, operator, value })`
 returned `success: true` with an output whose keys were `field`, `operator`,
 `value` — no `id`. The document then validated and the row rendered, and from
-that point on it could never be edited or removed, because every affordance on
-the row matches on the identity that was no longer there.
+that point on the row had no individual identity: every affordance on it is
+handed `undefined`, so it acts on every OTHER id-less row along with it. The
+measurement is below.
 
 Re-derived from `packages/components/src/custom/filter-builder.tsx` rather than
 inherited: `id` has **sixteen** condition-side read sites — the four MATCH sites
@@ -23,8 +24,28 @@ that decide which row a mutation lands on (`removeCondition`'s
 `c.id !== conditionId`, `updateCondition`'s and `changeOperator`'s
 `c.id === conditionId`, `changeField`'s `c.id !== conditionId`), the React `key`
 on the row, and eleven call sites that hand `condition.id` to one of those four.
-Handed `undefined`, `removeCondition` deletes every OTHER row, `updateCondition`
-and `changeField` match none, and React keys the row `undefined`. The
+
+**What that does when `id` is stripped**, simulated on the four helper bodies
+transcribed verbatim, over three id-less rows and one `crypto.randomUUID()` row
+(the realistic mix: the mirror strips every AUTHORED row's `id`, while rows the
+user adds in-session are born with one). Both sides of every comparison are
+`undefined`, and `undefined === undefined` is TRUE, so each helper matches EVERY
+id-less row rather than none:
+
+- `removeCondition(undefined)` keeps only rows where `c.id !== undefined`, so it
+  deletes all three id-less rows in a single click — the clicked one included —
+  and leaves the uuid row standing. Measured: 3 of 4 rows removed.
+- `updateCondition(undefined, …)`, `changeOperator(undefined, …)` and
+  `changeField(undefined, …)` each apply the edit to all three at once.
+  Measured: 3 of 4 rows moved, each time.
+- `key={condition.id}` becomes `key={undefined}`, which React reads as NO key at
+  all rather than as a duplicate one. Measured on React 19.2.8: `element.key` is
+  `null` for every such row, the list falls back to index reconciliation, and
+  React logs `Each child in a list should have a unique "key" prop.`
+
+So the defect is **loss of individual identity** — every affordance acts on all
+the id-less rows en bloc, and a row cannot be edited or removed on its own. It
+is not "matches none", and it is the more severe of the two readings. The
 component's own exported `FilterBuilderCondition` has always declared
 `id: string`, and `addCondition` emits `crypto.randomUUID()`.
 
@@ -37,22 +58,49 @@ component's own exported `FilterBuilderCondition` has always declared
              "conditions": [{ "field": "a", "operator": "equals", "value": "x" }] } }
 ```
 
-now fails validation at `value.conditions.0.id`. **Migration:** give each
-condition a stable unique string — any value the rest of the document does not
-reuse; the component generates `crypto.randomUUID()` for rows the user adds.
+now fails validation. **Where it is REPORTED is not where it logically is.**
+`value.conditions.0.id` is the LOGICAL location — the concatenation of the paths
+down the arm tree. The issue `safeValidateSchema` actually reports is a single
+root `invalid_union` at `path: []`, across **13** arms; the `id` failure sits
+three nested unions further down, inside arm 8: `invalid_union` at `["value"]`
+→ arm 1 → `invalid_union` at `["conditions", 0]` → arm 0 → `invalid_type` at
+`["id"]`, *"Invalid input: expected string, received undefined"*. Parsed against
+`FilterBuilderConditionSchema` directly, the same refusal is reported flat, at
+`path: ["id"]`. Both are stated because a consumer that reads `issue.path` off
+the document-level result will not find `id` there.
+
+**The compile-time face, which lands before any document is parsed.** `id` is
+declared on the TypeScript interface as well, so a TypeScript author is refused
+by `tsc`, not only by the validator. An object literal typed
+`FilterBuilderCondition`, or `FilterGroup['conditions'][number]`, or a condition
+written inside a `FilterGroup` / `FilterBuilderSchema['value']` / `defaultValue`
+literal, now fails type-check with *"Property 'id' is missing in type … but
+required in type 'FilterBuilderCondition'"* — measured on all four spellings.
+The GROUP's own `id` stays optional, so `{ logic: 'and', conditions: [] }` still
+compiles. Stated explicitly for the reason objectui#7774 stated its compile-time
+face (`groupField?: never`, "refused at compile time"): it is the half a
+TypeScript author meets first, and a runtime-only description hides it.
+
+**Migration:** give each condition a stable unique string — any value the rest of
+the document does not reuse; the component generates `crypto.randomUUID()` for
+rows the user adds.
 
 ⭐ **The narrowing refuses only what was ALREADY broken.** A condition with no
-`id` renders today but can never be edited or removed, so nothing that works
-stops working; the state this refuses is *accepted-and-discarded*, the class
-objectui#6150 closed for `tree-view.title`. Measured across `apps/**`,
-`examples/**`, `content/**` and `packages/**`: **every** authored
-`filter-builder` condition in this repository already carries `id` — 7 of 7,
-across the three schema-catalog entries that author rows — so no shipped
-document in this repo changes verdict on this key.
+`id` renders today but cannot be edited or removed INDIVIDUALLY — as measured
+above, one click removes every id-less row at once and one edit fans out across
+all of them — so nothing that works stops working; the state this refuses is
+*accepted-and-discarded*, the class objectui#6150 closed for `tree-view.title`.
+Measured across `apps/**`, `examples/**`, `content/**` and `packages/**`:
+**every** authored `filter-builder` condition in this repository already carries
+`id` — 7 of 7, across the three schema-catalog entries that author rows — so no
+shipped document in this repo changes verdict on this key.
 
 **What else now refuses, and it is the second thing declaring a key buys:**
 `id: 42`. An UNDECLARED key gets no type check at all, so a wrong-typed identity
-parsed clean at base and was then dropped. It is now refused at its own path.
+parsed clean at base and was then dropped. It is now refused — reported flat at
+`path: ["id"]` on the condition schema (*"Invalid input: expected string,
+received number"*), and through the document at the same place in the arm tree
+as the missing key above.
 
 **Who is NOT affected.** ⛔ The GROUP's `id` is untouched and stays OPTIONAL
 (objectui#7560): `isValidGroup` never consults it, nothing reads

--- a/.changeset/8415-filter-builder-condition-id.md
+++ b/.changeset/8415-filter-builder-condition-id.md
@@ -1,0 +1,70 @@
+---
+'@object-ui/types': minor
+---
+
+**Breaking for authored metadata:** a `filter-builder` CONDITION must now declare
+`id` (objectui#8415). It is declared on both published faces — the TypeScript
+interface `FilterBuilderCondition` in `complex.ts` and the Zod mirror
+`FilterBuilderConditionSchema` in `zod/complex.zod.ts` — so a key the renderer
+has always required is finally validated instead of silently discarded.
+
+**What was measured, on this branch's base (`0203a29e`).** The mirror declared a
+condition as `{ field, operator, value? }` and it is a plain `z.object`, which
+STRIPS undeclared keys. So an author who correctly wrote `id` had it removed:
+`FilterBuilderConditionSchema.safeParse({ id: 'c1', field, operator, value })`
+returned `success: true` with an output whose keys were `field`, `operator`,
+`value` — no `id`. The document then validated and the row rendered, and from
+that point on it could never be edited or removed, because every affordance on
+the row matches on the identity that was no longer there.
+
+Re-derived from `packages/components/src/custom/filter-builder.tsx` rather than
+inherited: `id` has **sixteen** condition-side read sites — the four MATCH sites
+that decide which row a mutation lands on (`removeCondition`'s
+`c.id !== conditionId`, `updateCondition`'s and `changeOperator`'s
+`c.id === conditionId`, `changeField`'s `c.id !== conditionId`), the React `key`
+on the row, and eleven call sites that hand `condition.id` to one of those four.
+Handed `undefined`, `removeCondition` deletes every OTHER row, `updateCondition`
+and `changeField` match none, and React keys the row `undefined`. The
+component's own exported `FilterBuilderCondition` has always declared
+`id: string`, and `addCondition` emits `crypto.randomUUID()`.
+
+**Who is affected — a condition authored without `id`:**
+
+```json
+{ "type": "filter-builder", "name": "f",
+  "fields": [{ "value": "a", "label": "A", "type": "text" }],
+  "value": { "id": "root", "logic": "and",
+             "conditions": [{ "field": "a", "operator": "equals", "value": "x" }] } }
+```
+
+now fails validation at `value.conditions.0.id`. **Migration:** give each
+condition a stable unique string — any value the rest of the document does not
+reuse; the component generates `crypto.randomUUID()` for rows the user adds.
+
+⭐ **The narrowing refuses only what was ALREADY broken.** A condition with no
+`id` renders today but can never be edited or removed, so nothing that works
+stops working; the state this refuses is *accepted-and-discarded*, the class
+objectui#6150 closed for `tree-view.title`. Measured across `apps/**`,
+`examples/**`, `content/**` and `packages/**`: **every** authored
+`filter-builder` condition in this repository already carries `id` — 7 of 7,
+across the three schema-catalog entries that author rows — so no shipped
+document in this repo changes verdict on this key.
+
+**What else now refuses, and it is the second thing declaring a key buys:**
+`id: 42`. An UNDECLARED key gets no type check at all, so a wrong-typed identity
+parsed clean at base and was then dropped. It is now refused at its own path.
+
+**Who is NOT affected.** ⛔ The GROUP's `id` is untouched and stays OPTIONAL
+(objectui#7560): `isValidGroup` never consults it, nothing reads
+`filterGroup.id`, and deleting it from an authored group renders
+byte-identically — the opposite reading, on a member that looks identical.
+`{ logic: 'and', conditions: [] }` still validates. The renderer is unchanged;
+`FilterOperatorSchema`, `FilterFieldSchema` and `FilterBuilderSchema`'s own keys
+are byte-identical, so the three items parked on objectui#7562 and the operator
+vocabulary of objectui#7561 are neither addressed nor moved here.
+
+Graded `minor`, not `patch`: this narrows the accepted input set, which is
+breaking for any author who wrote a condition without an identity. It is not
+`major` per this repo's fixed-group convention (objectui's own breaking changes
+ship as `minor`; the group's major tracks `@objectstack` — AGENTS.md 版本号策略,
+mechanically enforced by `scripts/check-changeset-no-major.mjs`).

--- a/packages/types/src/__tests__/filter-builder-condition-id-8415.test.ts
+++ b/packages/types/src/__tests__/filter-builder-condition-id-8415.test.ts
@@ -12,9 +12,17 @@
  * The mirror declared a condition as `{ field, operator, value? }`. The
  * component's identity for a row is `id`, and because the mirror is a plain
  * `z.object`, an author who wrote `id` correctly had it STRIPPED in silence.
- * The document then validated and the row rendered — and no affordance could
- * ever reach it again, because all four mutation helpers match on `c.id` and
- * every one of them was handed `undefined`.
+ * The document then validated and the row rendered — and from then on the row
+ * had no individual identity. All four mutation helpers match on `c.id`, every
+ * one of them is handed `undefined`, and `undefined === undefined` is TRUE, so
+ * each matches EVERY id-less row: `removeCondition` deletes them all in one
+ * click (the clicked row included; only uuid-bearing rows survive), and
+ * `updateCondition` / `changeOperator` / `changeField` fan one edit out across
+ * all of them. `key={condition.id}` becomes `key={undefined}`, which React
+ * reads as no key at all rather than as a duplicate one.
+ *
+ * ⛔ Not "matches none" — the failure is EN BLOC, and it is the more severe of
+ * the two readings.
  *
  * Measured on the base commit, through `FilterBuilderConditionSchema.safeParse`:
  * a condition carrying `id` parsed successfully and the parsed OUTPUT did not
@@ -34,7 +42,8 @@
  *     source rather than quoting a count.
  *
  * ⭐ The narrowing therefore refuses only what is ALREADY broken: a condition
- * with no `id` renders today but can never be edited or removed. Nothing that
+ * with no `id` renders today but cannot be edited or removed INDIVIDUALLY —
+ * every affordance on it acts on all the id-less rows at once. Nothing that
  * works stops working.
  */
 import { describe, it, expect } from 'vitest';

--- a/packages/types/src/__tests__/filter-builder-condition-id-8415.test.ts
+++ b/packages/types/src/__tests__/filter-builder-condition-id-8415.test.ts
@@ -1,0 +1,182 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#8415 — `FilterBuilderConditionSchema` declares `id`.
+ *
+ * ## What was wrong
+ *
+ * The mirror declared a condition as `{ field, operator, value? }`. The
+ * component's identity for a row is `id`, and because the mirror is a plain
+ * `z.object`, an author who wrote `id` correctly had it STRIPPED in silence.
+ * The document then validated and the row rendered — and no affordance could
+ * ever reach it again, because all four mutation helpers match on `c.id` and
+ * every one of them was handed `undefined`.
+ *
+ * Measured on the base commit, through `FilterBuilderConditionSchema.safeParse`:
+ * a condition carrying `id` parsed successfully and the parsed OUTPUT did not
+ * carry the key. That is the `accepted-and-discarded` class objectui#6150
+ * closed for `tree-view.title`, not a refusal.
+ *
+ * ## Why REQUIRED, and why that is not the answer the GROUP got
+ *
+ * ⛔ The two `id`s look alike and take OPPOSITE answers — do not unify them.
+ *
+ *   - `FilterGroupSchema.id` is declared OPTIONAL (objectui#7560): `isValidGroup`
+ *     never consults it, nothing reads `filterGroup.id`, and deleting it from an
+ *     authored group renders byte-identically. Requiring it would invent a
+ *     refusal the renderer does not make.
+ *   - A CONDITION's `id` is the opposite reading. `assertion the four match
+ *     sites and the React key are live` below re-derives it from the component
+ *     source rather than quoting a count.
+ *
+ * ⭐ The narrowing therefore refuses only what is ALREADY broken: a condition
+ * with no `id` renders today but can never be edited or removed. Nothing that
+ * works stops working.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { FilterBuilderConditionSchema, FilterGroupSchema } from '../zod/complex.zod';
+import { safeValidateSchema } from '../zod/index.zod';
+import type { FilterBuilderCondition as TsCondition, FilterGroup as TsGroup } from '../complex';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..', '..', '..');
+const READER = 'packages/components/src/custom/filter-builder.tsx';
+const readerSource = readFileSync(join(REPO_ROOT, READER), 'utf8');
+
+const FIELDS = [{ value: 'a', label: 'A', type: 'text' }];
+const WELL_FORMED = { id: 'c1', field: 'a', operator: 'equals', value: 'x' };
+const NO_ID = { field: 'a', operator: 'equals', value: 'x' };
+const doc = (value: unknown) => ({ type: 'filter-builder', name: 'f', fields: FIELDS, value });
+const group = (conditions: unknown[]) => ({ id: 'root', logic: 'and', conditions });
+
+/* ── Type-level pins: the TS twin moved WITH the mirror ───────────────────── */
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+function expectType<T extends true>(_: T = true as T): void { /* compile-time only */ }
+
+expectType<Equal<TsCondition['id'], string>>();
+// `id` is REQUIRED, not merely typed `string`: an object that OMITS the key must
+// be rejected, and only this annotation proves it. The `@ts-expect-error` IS the
+// assertion — delete the `id` declaration and this line stops erroring, which
+// fails the compile.
+// @ts-expect-error `FilterBuilderCondition.id` is required (objectui#8415)
+const conditionWithoutId: TsCondition = { field: 'a', operator: 'equals' };
+// …and the GROUP's stayed optional, so the two faces cannot be "unified" by a
+// future editor without one of these two lines going red.
+const groupWithoutId: TsGroup = { logic: 'and', conditions: [] };
+
+describe('objectui#8415 — the condition `id` is DECLARED, so it is no longer stripped', () => {
+  it('the repair itself: `id` survives the parse output', () => {
+    // The base measurement this moves away from: `success` was already `true`,
+    // and the key was GONE from `.data`. Asserting only `success` would have
+    // been green before and after.
+    const parsed = FilterBuilderConditionSchema.safeParse(WELL_FORMED);
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && Object.keys(parsed.data as object).sort())
+      .toEqual(['field', 'id', 'operator', 'value']);
+    expect(parsed.success && (parsed.data as { id?: unknown }).id).toBe('c1');
+  });
+
+  it('REFUSES a condition with no `id`, on the direct arm and through a group', () => {
+    expect(FilterBuilderConditionSchema.safeParse(NO_ID).success).toBe(false);
+    expect(FilterGroupSchema.safeParse(group([NO_ID])).success).toBe(false);
+    expect(FilterGroupSchema.safeParse(group([{ id: 'g2', logic: 'or', conditions: [NO_ID] }])).success)
+      .toBe(false);
+  });
+
+  it('REFUSES it through the authored document too — both entry paths on `FilterBuilderSchema`', () => {
+    // `value` and `defaultValue` are each `union([condition, group])`, so a
+    // condition reaches the mirror two ways and the union must not launder it
+    // through the group arm.
+    expect(safeValidateSchema(doc(group([NO_ID]))).success).toBe(false);
+    expect(safeValidateSchema(doc(NO_ID)).success).toBe(false);
+    expect(safeValidateSchema({ type: 'filter-builder', name: 'f', fields: FIELDS, defaultValue: group([NO_ID]) }).success)
+      .toBe(false);
+  });
+
+  it('type-checks `id` now that it is declared — `id: 42` was ACCEPTED before', () => {
+    // The second thing declaring a key buys, and the one an author never sees:
+    // a `z.object` gives an UNDECLARED key no check at all, so `id: 42` parsed
+    // clean at base and was then dropped.
+    expect(FilterBuilderConditionSchema.safeParse({ ...WELL_FORMED, id: 42 }).success).toBe(false);
+  });
+});
+
+describe('objectui#8415 — the negative controls that must NOT have moved', () => {
+  it('still ACCEPTS a well-formed condition (anti-vacuity)', () => {
+    expect(FilterBuilderConditionSchema.safeParse(WELL_FORMED).success).toBe(true);
+    expect(FilterGroupSchema.safeParse(group([WELL_FORMED])).success).toBe(true);
+    expect(safeValidateSchema(doc(group([WELL_FORMED]))).success).toBe(true);
+    expect(safeValidateSchema(doc(group([]))).success).toBe(true);
+  });
+
+  it('still REFUSES a bad operator — and the fixture carries `id` so THIS is what refuses it', () => {
+    // Without the `id`, this assertion would stay green with
+    // `FilterOperatorSchema` deleted outright: the row would be refused for the
+    // missing key instead. Carrying `id` isolates the operator.
+    expect(FilterBuilderConditionSchema.safeParse({ ...WELL_FORMED, operator: 'not_a_real_operator' }).success)
+      .toBe(false);
+    expect(FilterBuilderConditionSchema.safeParse({ id: 'c1', operator: 'equals', value: 'x' }).success)
+      .toBe(false);
+  });
+
+  it('the GROUP `id` is UNTOUCHED — still optional, still type-checked (objectui#7560)', () => {
+    // ⛔ The trap this card was split out to avoid. The group's `id` has zero
+    // read sites; requiring it would refuse a document that renders perfectly.
+    expect(FilterGroupSchema.safeParse({ logic: 'and', conditions: [WELL_FORMED] }).success).toBe(true);
+    expect(FilterGroupSchema.safeParse({ id: 42, logic: 'and', conditions: [] }).success).toBe(false);
+    expect(FilterGroupSchema.safeParse({ operator: 'and', conditions: [] }).success).toBe(false);
+    expect(groupWithoutId.conditions).toEqual([]);
+    expect(conditionWithoutId.field).toBe('a');
+  });
+});
+
+describe('objectui#8415 — the enforcement the declaration now matches, re-derived from the reader', () => {
+  it('the four MATCH sites are live in the component', () => {
+    // Re-derived from source rather than quoted as a count: if a refactor moves
+    // a row's identity off `id`, this reddens and the REQUIRED declaration has
+    // to be re-argued rather than silently outliving its reason.
+    const matchSites = [
+      // removeCondition
+      'conditions: filterGroup.conditions.filter((c) => c.id !== conditionId)',
+      // updateCondition
+      'c.id === conditionId ? { ...c, ...updates } : c',
+      // changeOperator
+      'c.id === conditionId',
+      // changeField
+      'if (c.id !== conditionId) return c',
+    ];
+    for (const site of matchSites) expect(readerSource).toContain(site);
+  });
+
+  it('the React `key` on the row is the condition `id`', () => {
+    expect(readerSource).toContain('key={condition.id}');
+  });
+
+  it('a new row is BORN with an `id` — the producer agrees with the declaration', () => {
+    expect(readerSource).toContain('id: crypto.randomUUID(),');
+  });
+
+  it('the component declares `id` non-optional on its own condition type', () => {
+    // The renderer half of `declared = enforced`. `id?: string` here would mean
+    // the component tolerates its absence, and the required mirror would be
+    // narrower than the thing it mirrors.
+    expect(readerSource).toContain('export interface FilterBuilderCondition {\n  id: string\n');
+  });
+
+  it('anti-vacuity for the source probes: a spelling that is NOT there reads false', () => {
+    // The instrument above is `String.prototype.includes`; a probe that matches
+    // nothing would make every assertion in this block unfalsifiable.
+    expect(readerSource).not.toContain('c.zzzNotAKey === conditionId');
+    expect(readerSource.length).toBeGreaterThan(1000);
+  });
+});

--- a/packages/types/src/__tests__/zod-lazy-getter-identity-7918.test.ts
+++ b/packages/types/src/__tests__/zod-lazy-getter-identity-7918.test.ts
@@ -257,20 +257,28 @@ describe('objectui#7918 · z.lazy getter identity', () => {
     });
 
     it('FilterBuilderConditionSchema still accepts a condition and refuses a bad operator', () => {
+      // ⚠️ Both fixtures carry `id` since objectui#8415 declared it REQUIRED on
+      // the condition. The NEGATIVE one carries it for a reason that is not
+      // cosmetic: without it the row would be refused for the MISSING KEY, and
+      // this assertion — whose subject is `FilterOperatorSchema` — would stay
+      // green with the operator vocabulary deleted outright. Carrying `id`
+      // isolates the operator as the only thing left to refuse it.
       expect(FilterBuilderConditionSchema.safeParse(
-        { field: 'amount', operator: 'greater_than', value: 100 },
+        { id: 'c1', field: 'amount', operator: 'greater_than', value: 100 },
       ).success).toBe(true);
       expect(FilterBuilderConditionSchema.safeParse(
-        { field: 'amount', operator: 'not_a_real_operator' },
+        { id: 'c1', field: 'amount', operator: 'not_a_real_operator' },
       ).success).toBe(false);
     });
 
     it('FilterGroupSchema still nests conditions and sub-groups through the memoised arm', () => {
+      // The CONDITION rows carry `id` (required since objectui#8415); the
+      // sub-GROUP's `id` stays what it always was — declared but optional.
       const group = {
         id: 'g1', logic: 'and',
         conditions: [
-          { field: 'amount', operator: 'greater_than', value: 100 },
-          { id: 'g2', logic: 'or', conditions: [{ field: 'stage', operator: 'equals', value: 'won' }] },
+          { id: 'c1', field: 'amount', operator: 'greater_than', value: 100 },
+          { id: 'g2', logic: 'or', conditions: [{ id: 'c2', field: 'stage', operator: 'equals', value: 'won' }] },
         ],
       };
       expect(FilterGroupSchema.safeParse(group).success).toBe(true);

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -587,6 +587,22 @@ export type FilterBuilderOperator =
  */
 export interface FilterBuilderCondition {
   /**
+   * Row identity.
+   *
+   * REQUIRED, and deliberately asymmetric with `FilterGroup.id` below
+   * (objectui#8415). The group's `id` has zero read sites and is optional for
+   * that reason; a CONDITION's `id` is the identity every affordance on the row
+   * matches on — `removeCondition`, `updateCondition`, `changeOperator` and
+   * `changeField` in `packages/components/src/custom/filter-builder.tsx`, plus
+   * the React `key`. The component's own `FilterBuilderCondition` declares it
+   * `string`, and `addCondition` emits `crypto.randomUUID()`.
+   *
+   * Undeclared, it was STRIPPED by the `z.object` mirror in silence, so a
+   * correctly authored row validated and rendered and could then never be
+   * edited or removed. Declaring it is what makes `declared = enforced`.
+   */
+  id: string;
+  /**
    * Field to filter
    */
   field: string;

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -598,8 +598,12 @@ export interface FilterBuilderCondition {
    * `string`, and `addCondition` emits `crypto.randomUUID()`.
    *
    * Undeclared, it was STRIPPED by the `z.object` mirror in silence, so a
-   * correctly authored row validated and rendered and could then never be
-   * edited or removed. Declaring it is what makes `declared = enforced`.
+   * correctly authored row validated and rendered with no individual identity:
+   * every affordance is handed `undefined`, `c.id === conditionId` is TRUE for
+   * every id-less row, and so one click removes all of them at once — the
+   * clicked row included — while one edit fans out across all of them. A row
+   * cannot be edited or removed on its own. (Not "matches none"; the failure is
+   * en bloc.) Declaring it is what makes `declared = enforced`.
    */
   id: string;
   /**

--- a/packages/types/src/zod/complex.zod.ts
+++ b/packages/types/src/zod/complex.zod.ts
@@ -298,12 +298,23 @@ const FilterBuilderConditionObject = z.object({
   //
   // ⭐ The narrowing refuses only what is ALREADY broken. Because a plain
   // `z.object` STRIPS undeclared keys, an author who correctly wrote `id` had
-  // it discarded in silence: the document validated, the row rendered, and then
-  // no affordance could reach it — `removeCondition(undefined)` matches every
-  // OTHER row, `updateCondition(undefined)` matches none, and React keys the
-  // row `undefined`. Nothing that worked stops working; the state this refuses
-  // is accepted-and-discarded, the class objectui#6150 closed for
-  // `tree-view.title`.
+  // it discarded in silence: the document validated, the row rendered, and the
+  // row then had no individual identity. Both sides of every comparison listed
+  // above are `undefined`, and `undefined === undefined` is TRUE, so each
+  // helper matches EVERY id-less row rather than none:
+  //
+  //   - `removeCondition(undefined)` deletes them ALL in one click — the
+  //     clicked row included; only rows carrying a real id survive it;
+  //   - `updateCondition`, `changeOperator` and `changeField` fan a single
+  //     edit out across all of them;
+  //   - `key={condition.id}` becomes `key={undefined}`, which React reads as
+  //     NO key at all rather than as a duplicate one, so the rows reconcile by
+  //     index and React warns about the missing key.
+  //
+  // ⛔ Not "matches none": the failure is EN BLOC, and it is the more severe
+  // reading — a row cannot be edited or removed on its own. Nothing that worked
+  // stops working; the state this refuses is accepted-and-discarded, the class
+  // objectui#6150 closed for `tree-view.title`.
   id: z.string().describe('Row identity — matched by `removeCondition` / `updateCondition` / `changeOperator` / `changeField`, and the React key'),
   field: z.string().describe('Field name'),
   operator: FilterOperatorSchema.describe('Filter operator'),

--- a/packages/types/src/zod/complex.zod.ts
+++ b/packages/types/src/zod/complex.zod.ts
@@ -281,6 +281,30 @@ export const FilterOperatorSchema = z.enum([
  * — read that before "fixing" any of them to match this one.
  */
 const FilterBuilderConditionObject = z.object({
+  // REQUIRED, and the asymmetry with `FilterGroupSchema.id` below is the whole
+  // point of declaring it here (objectui#8415). The group's `id` has ZERO read
+  // sites and is optional for that reason; a CONDITION's `id` is the identity
+  // every affordance on the row matches on, measured in
+  // `packages/components/src/custom/filter-builder.tsx`:
+  //
+  //   - the four MATCH sites — `removeCondition` (`c.id !== conditionId`),
+  //     `updateCondition` and `changeOperator` (`c.id === conditionId`) and
+  //     `changeField` (`c.id !== conditionId`);
+  //   - the React `key` on the row;
+  //   - eleven call sites that hand `condition.id` to one of those four.
+  //
+  // The component's own exported `FilterBuilderCondition` declares it `string`,
+  // not `string | undefined`, and `addCondition` emits `crypto.randomUUID()`.
+  //
+  // ⭐ The narrowing refuses only what is ALREADY broken. Because a plain
+  // `z.object` STRIPS undeclared keys, an author who correctly wrote `id` had
+  // it discarded in silence: the document validated, the row rendered, and then
+  // no affordance could reach it — `removeCondition(undefined)` matches every
+  // OTHER row, `updateCondition(undefined)` matches none, and React keys the
+  // row `undefined`. Nothing that worked stops working; the state this refuses
+  // is accepted-and-discarded, the class objectui#6150 closed for
+  // `tree-view.title`.
+  id: z.string().describe('Row identity — matched by `removeCondition` / `updateCondition` / `changeOperator` / `changeField`, and the React key'),
   field: z.string().describe('Field name'),
   operator: FilterOperatorSchema.describe('Filter operator'),
   value: z.any().optional().describe('Filter value'),


### PR DESCRIPTION
Refs #8415

**`Clause-②: yes`** — this narrows a published accept set. `needs:contract-review` is hung on this PR and on the card. ⛔ Draft, unqueued, no auto-merge, no self-approval: parking green is the sanctioned resting state.

## The defect

`FilterBuilderConditionSchema` declared a condition as `{ field, operator, value? }` and its body is a plain `z.object`, which **strips** undeclared keys. So an author who correctly wrote `id` had it discarded in silence — the document validated, the row rendered, and from that point the row had **no individual identity** — every affordance on it is handed `undefined`, and `c.id === conditionId` is true for *every* id-less row, so each affordance acts on all of them at once. Measured under **Patch round** below.

Measured on this branch's base `0203a29e`, through `FilterBuilderConditionSchema.safeParse`:

| input | `success` at base | output keys at base |
|---|---|---|
| `{ id: 'c1', field: 'a', operator: 'equals', value: 'x' }` | `true` | `field`, `operator`, `value` — **no `id`** |

That is *accepted-and-discarded*, not refused — the class #6150 closed for `tree-view.title`.

## Patch round — the mechanism statement was INVERTED, and it shipped

A `CONTRACT_REVIEW_TIER` reviewer returned **FAIL** on this PR's own explanation of *what breaks when `id` is stripped*. The earlier wording said the row "could never be edited or removed", that `removeCondition` "deletes every OTHER row" and that `updateCondition` / `changeField` "match none". That is the opposite of what the code does, and two of the four surfaces carrying it are **published text**: the changeset reaches `CHANGELOG.md`, which is in the package's `files[]`; the zod comment survives into `dist/zod/complex.zod.js`; the TSDoc into `dist/complex.d.ts`.

**Re-read independently** from `packages/components/src/custom/filter-builder.tsx` — symbols `removeCondition`, `updateCondition`, `changeOperator`, `changeField`, and the row `key` — then simulated on the four helper bodies transcribed verbatim, over three id-less rows plus one `crypto.randomUUID()` row. That mix is the realistic one: the mirror strips every *authored* row's `id`, while rows the user adds in-session are born with one.

Both sides of every comparison are `undefined`, and `undefined === undefined` is **true**, so each helper matches **every** id-less row rather than none:

| helper | source predicate | measured on 3 stripped + 1 uuid row |
|---|---|---|
| `removeCondition(undefined)` | `conditions.filter((c) => c.id !== conditionId)` | **3 of 4 removed** — all three stripped rows, the clicked one included; only the uuid row survives |
| `updateCondition(undefined, …)` | `c.id === conditionId ? { ...c, ...updates } : c` | **3 of 4 edited at once** |
| `changeOperator(undefined, …)` | `c.id === conditionId ? { ...c, operator, value } : c` | **3 of 4 moved at once** |
| `changeField(undefined, …)` | `if (c.id !== conditionId) return c` | **3 of 4 moved at once** |

⇒ The defect is **loss of individual identity — every affordance acts on all the id-less rows en bloc**, and a row cannot be edited or removed on its own. It is **not** "matches none", and it is **more severe** than the old text claimed, not less.

**One correction to the reviewer's dictated wording**, because taking it verbatim would have shipped a second wrong mechanism. The instruction said React "keys them all `undefined`" / that the stripped rows "collide on a duplicate `undefined` React key". They do not collide: `key={condition.id}` on an id-less row is `key={undefined}`, which React reads as **no key at all**. Measured on React 19.2.8 through `react/jsx-runtime`, `element.key` is `null` for every such row, the list falls back to index reconciliation, and React logs `Each child in a list should have a unique "key" prop.` The published text now says that, not the duplicate-key version. Everything else in the reviewer's instruction reproduced exactly.

### The two additions the reviewer asked for, both measured

**The `invalid_union` path precision.** `value.conditions.0.id` is the **logical** location — the concatenation of the paths down the arm tree. The issue `safeValidateSchema` actually **reports** is a single root `invalid_union` at `path: []` across **13** arms, with the `id` leaf three nested unions further down, inside arm 8:

```
invalid_union @ []                                   (13 arms)
  arm 8  -> invalid_union @ ["value"]                 (2 arms)
    arm 1  -> invalid_union @ ["conditions", 0]       (2 arms)
      arm 0  -> invalid_type @ ["id"]
                "Invalid input: expected string, received undefined"
```

Parsed against `FilterBuilderConditionSchema` directly, the same refusal is reported flat at `path: ["id"]`. Both are now stated rather than one deleted, because a consumer that reads `issue.path` off the document-level result will not find `id` there.

**The compile-time consequence, stated explicitly** — it was only implicit before, and #7774 stated its compile-time face (`groupField?: never`, "refused at compile time"). Measured with `tsc --strict` against the built `dist/complex.d.ts`: four positive spellings and two negative controls, exit 0 with every `@ts-expect-error` consumed.

| literal | verdict |
|---|---|
| `FilterBuilderCondition` without `id` | **fails type-check** |
| `FilterGroup['conditions'][number]` without `id` | **fails type-check** |
| id-less condition inside a `FilterGroup` literal | **fails type-check** |
| id-less condition inside a `FilterBuilderSchema['value']` literal | **fails type-check** |
| negative control — `{ logic: 'and', conditions: [] }`, the group `id` still optional | compiles |
| negative control — a well-formed condition | compiles |

The message is `Property 'id' is missing in type '{ field: string; operator: "equals"; value: string; }' but required in type 'FilterBuilderCondition'`. Falsifiability checked: deleting one `@ts-expect-error` turns the run red (exit 2) with exactly that message.

### Comment-only — proved, not asserted

No executable text moved. **Method:** each `.ts` file is lexed with the **TypeScript parser** (`ts.createSourceFile`), and two independent readings are taken.

1. The **leaf-token stream** — `node.getText()` starts at `getStart()`, i.e. after leading trivia, so comments and whitespace never enter it. Joined and sha256'd. JSDoc subtrees are excluded: `getChildren()` folds a `/** … */` block into the tree as real nodes, so without that exclusion a JSDoc-only edit moves the hash while the token *count* holds. Measured — and it is why the first version of this prover was wrong.
2. The source with every **comment range erased** (`getLeadingCommentRanges` / `getTrailingCommentRanges`), then lines still holding non-whitespace counted and sha256'd.

Not a regex, and not the raw `ts.createScanner`: the scanner is context-free and cannot tell a backtick inside a single-quoted string from a template start. Measured on `complex.zod.ts`, whose `describe(...)` strings carry backticks, it desynced after 3 comment tokens and emitted a single 2396-character "template" token.

Readings across this round's own commit, `44b668f3` (before) to `c7150ca7` (after):

| file | token-stream sha256 | tokens | non-comment lines | non-comment lines sha256 |
|---|---|---|---|---|
| `packages/types/src/complex.ts` | `3aba1367…` **unchanged** | 1634 → 1634 | 336 → 336 | `35b464c7…` **unchanged** |
| `packages/types/src/zod/complex.zod.ts` | `033ec6d4…` **unchanged** | 5021 → 5021 | 479 → 479 | `9c24c106…` **unchanged** |
| `packages/types/src/__tests__/filter-builder-condition-id-8415.test.ts` | `f0787a35…` **unchanged** | 1114 → 1114 | 91 → 91 | `f4adf622…` **unchanged** |

The only reading that moved is `complex.zod.ts`'s comment-range count, **89 → 100** — one long `//` block split into a bulleted list, which is exactly what a comment-only edit is allowed to move.

**Prover falsifiability**, four scratch mutations of these same files: a JSDoc-text-only edit and a line-comment-only edit each leave both hashes at the post-edit values, while renaming one identifier (`field` → `fieldX`) and changing one string literal (`'Field name'` → `'Field NAME'`) each move both hashes.

**And the comments really are published** — checked in the built `dist/` at this head: `dist/zod/complex.zod.js` carries `// helper matches EVERY id-less row rather than none:`, and `dist/complex.d.ts` carries `en bloc.) Declaring it is what makes ...`.

⚠️ One residue that cannot be repaired: the **commit message** of `44b668f3` still carries the old wording. Amending a pushed commit is forbidden here, and this repo squashes on merge using the PR title and body — so the text that lands on `main` is this body, not that message.

### Gates for this round — head `997280e4`

Every exit code captured before any pipe (redirect to a log, capture `$?`, then read the log).

`origin/main` had moved (`ca394272` → `786bc91e`), so it was **merged in** — never rebased, nothing force-pushed or amended. The merge left all four surfaces byte-identical (`git diff c7150ca7 HEAD` over them is empty), and main had not touched them.

| gate | verdict |
|---|---|
| `pnpm --filter @object-ui/types type-check` | exit 0 — all three legs, incl. `tsc -p tsconfig.test.json` |
| `tsc -p tsconfig.test.json --listFiles` | the pin test **is** in the type-checked set (1 hit) — so its `@ts-expect-error` pins are really compiled |
| `pnpm --filter @object-ui/types build` | exit 0 — `dist completeness: 1 package(s) complete (124 emitted files verified)` |
| `node scripts/check-changeset-presence.mjs` | exit 0 — 1 changeset declared for 4 published source files |
| `node scripts/check-changeset-no-major.mjs` | exit 0 |
| `node scripts/check-changeset-fixed.mjs` | exit 0 |
| `node scripts/check-changeset-overwrite.mjs` | exit 0 — 0 pre-existing changesets modified or deleted |
| `pnpm check:control-bytes` | exit 0 — 6672 tracked text files scanned, 85 binary skipped |
| `pnpm check:comment-mask-corpus` | exit 0 — 4462 files; the single disagreement is pre-existing residue in a file this PR does not touch, at the ceiling #7882 holds open |
| `pnpm exec vitest run packages/types/src/__tests__/filter-builder-condition-id-8415.test.ts` | exit 0 — 12 passed |
| `pnpm exec vitest run packages/types/` | exit 0 — `Test Files 143 passed (143)` · `Tests 2724 passed (2724)` |

⛔ **No contract change in this round.** The `id` member's shape on both faces, the union, the accept set, the barrel, and every test assertion and fixture are byte-identical — which is precisely what the comment-only table proves. This round is wording only.

## Symbols, re-derived on `origin/main` (no line number copied from #8415 or #7562)

- `packages/types/src/zod/complex.zod.ts` — `FilterBuilderConditionObject`, the object the exported `z.lazy` returns. That is the edit target, **not** the `z.lazy` wrapper.
- `packages/types/src/complex.ts` — `FilterBuilderCondition`, the TypeScript twin. It omitted `id` too and moved with the mirror.

⛔ The `z.lazy` **shape** is untouched. The docblock directly above the edit point records that this one lazy can be memoised because its body is not recursive, and that seven other `z.lazy` exports on the same face cannot take that shape. Nothing here reshapes any lazy; `zod-lazy-getter-identity-7918.test.ts` stays green.

## The condition `id` vs the group `id` — the trap this card was split out to avoid

`.id` in `packages/components/src/custom/filter-builder.tsx` hits **17** (control: a bogus key hits 0). Disambiguated site by site rather than reported as a total:

| kind | count | sites |
|---|---|---|
| condition `id` — **MATCH** (decides which row a mutation lands on) | **4** | `removeCondition` `c.id !== conditionId`; `updateCondition` `c.id === conditionId`; `changeOperator` `c.id === conditionId`; `changeField` `if (c.id !== conditionId) return c` |
| condition `id` — React `key` on the row | **1** | `key={condition.id}` |
| condition `id` — call sites feeding one of the four | **11** | ten `updateCondition(condition.id, …)` / `changeField` / `changeOperator` calls, plus `removeCondition(condition.id)` |
| **group** `id` | **0** | none — confirms #7560's measurement |
| not a filter condition at all | **1** | `r?.[idField] ?? r?.id ?? r?._id` in the lookup option loader (a fetched record) |

⇒ **16 condition-side sites, 0 group-side.** The card's "four plus the React key" is right about the *match* sites and the key; the other eleven are call sites feeding them. The two `id`s take **opposite** answers and are not unified here: `FilterGroupSchema.id` stays **optional**, and a new pin holds them apart.

Three other faces already declared it required — the mirror was the only one that did not:

- the component's own exported `FilterBuilderCondition` declares `id: string`;
- `addCondition` emits `id: crypto.randomUUID()`;
- `content/docs/components/complex/filter-builder.mdx` publishes `id: string;  // Condition identifier`, with no `?`.

## Accept-set table, from source, both entry paths

`FilterBuilderSchema.value` and `.defaultValue` are each a union of condition and group, so a condition reaches the mirror two ways; conditions also nest inside a group's `conditions`.

| probe | base | after |
|---|---|---|
| P1 condition **with** `id` | ACCEPT | ACCEPT |
| P1 condition **without** `id` | ACCEPT | **REFUSE** |
| P1 `id: 42` (wrong type) | ACCEPT | **REFUSE** |
| P2 `group[cond without id]` | ACCEPT | **REFUSE** |
| P2 nested `subgroup[cond without id]` | ACCEPT | **REFUSE** |
| P3 doc `value = group[cond without id]` | ACCEPT | **REFUSE** |
| P3 doc `value = bare cond without id` | ACCEPT | **REFUSE** |
| P3 doc `defaultValue = group[cond without id]` | ACCEPT | **REFUSE** |
| **`id` survives the parse output** | **NO (stripped)** | **YES** |

Negative controls — refused before, still refused, so the narrowing did not swallow them: condition with no `field`; bad operator (with and without `id`); group spelled `operator`; group `id: 42`.

Positive controls — accepted before, still accepted: condition with `id`; empty group; **group without its own `id`**; nested subgroup with `id`; a document with no `value` at all; catalog `empty-filter-builder` and `user-filters`.

Unchanged and **not** this PR's business: catalog `product-search` and `with-conditions` refuse at base and still refuse, on the operator alias `eq` / `gt` / `lt` — that is #7561, deliberately not folded in. #7562's items 1–3 are untouched: `FilterOperatorSchema`, `FilterFieldSchema` and `FilterBuilderSchema`'s own keys are byte-identical.

## Corpus census, with a firing control

Instrument: a structural walker over `apps/**`, `examples/**`, `content/**`, `packages/**` (5027 files) — `JSON.parse` for JSON, fenced JSON in Markdown/MDX, and the TypeScript parser for object literals in TS/TSX. It reports every object carrying `field` and `operator` inside a `conditions` array.

**Authored metadata — the population the re-grade trigger asks about: 7 of 7 conditions carry `id`, 0 do not.** All in `examples/schema-catalog/src/schemas/components-complex-filter-builder/` — `product-search` 3/3, `search-interface` 2/2, `with-conditions` 2/2. (`empty-filter-builder` and `user-filters` author zero rows.) No document in `content/**` or `apps/**` authors a condition; the published doc renders the catalog entry rather than inlining one.

**Firing control** — a known-positive planted in both directions and then removed: totals moved `59 | 39 with / 20 without` → `61 | 40 / 21`, and the walker named the planted file and both of its rows (`control_positive` with an `id`, `control_negative` absent). Removal restored the exact baseline and left `git status` clean. So the zero above is a reading, not a blind walk.

**Radius, stated rather than implied:** this repository's working tree only. Authorship outside it — downstream applications built on `@object-ui/types` — is not measurable from here and is **not** covered by that zero.

## Parity: measured, not asserted

The instrument is `pnpm --filter @object-ui/types type-check`, whose third leg `tsc -p tsconfig.test.json` compiles the tests the package tsconfig excludes. ⚠️ `vitest run zod-mirror-parity.test.ts` is a **false green** here — the ledger is a type map and vitest does not typecheck.

**Proved live first**, before measuring anything: mirroring `ObjectViewSchema.listViews` (the key the ledger pins as unmirrored) reddened `tsc` with

```
src/__tests__/zod-mirror-parity.test.ts(2333,14): error TS2322: Type '"objectql.zod.ts#ObjectViewSchema"' is not assignable to type 'never'.
```

while the same mutated tree ran `vitest` **31/31 green** — the false green reproduced. Restore proven by blob hash back to HEAD.

**Result on this change: no ledger row and no header figure moves.** `type-check` is green. Mechanistically consistent with the ledger's own entry: `complex.zod.ts#FilterBuilderConditionSchema` sits in the not-compared half ("declared `z.ZodType` over `any`, which exposes no `.shape` to read"), and `FilterBuilderCondition` is not one of its paired TypeScript imports. ⇒ `zod-mirror-parity.test.ts`, held by parked PR #8354, is **not touched**.

## Fixture triage

`zod-lazy-getter-identity-7918.test.ts` had two condition fixtures without `id`. Both now carry one, and the **negative** fixture carries one for a reason that is not cosmetic: without it the row would be refused for the missing key, and an assertion whose subject is `FilterOperatorSchema` would have stayed green with the operator vocabulary deleted outright. Carrying `id` isolates the operator.

No other fixture in the mirror's consumer radius needed repair — verified by running the full suites of every package that validates documents through `safeValidateSchema`.

## Reverse verification

**Leg 1 — ablate the runtime declaration.** Blob `0e69e4d7` → `9a6473bb` on disk; anchored counts `1 → 0` for the condition `id` line and `1 → 1` for the group's optional one, so exactly the member this card added was removed. New pin: **4 failed / 8 passed** — the four failures are precisely the narrowing assertions, and the eight that stay green are the negative controls and the source-derived read-site probes, which must not move. Whole types suite under ablation: **exactly one file fails, mine** (1 failed / 141 passed). Restored: blob equal to HEAD, count back to 1, `git diff HEAD` empty.

**Leg 2 — ablate the TypeScript declaration** (`id: string` to `id?: string`). Anchored counts `6 → 5` required and `3 → 4` optional. `tsc -p tsconfig.test.json` exit 1 with both compile-time pins firing:

```
error TS2344: Type 'false' does not satisfy the constraint 'true'.
error TS2578: Unused '@ts-expect-error' directive.
```

Restored: blob equal to HEAD, count back to 6, `git diff HEAD` empty. Both ablation scripts carry an `EXIT INT TERM` trap restoring from `HEAD` by absolute path.

**Green control re-run after restore:** 142 files / 2707 tests pass, `type-check` green, `build` green.

## Gates — first round, head `44b668f3`

Every exit code captured before any pipe. These are the **first** round's readings, taken before `origin/main` was merged in; this round's gates, at head `997280e4`, are in **Patch round** above.

| gate | verdict |
|---|---|
| `pnpm exec vitest run --maxWorkers=2 packages/types/` | exit 0 — `Test Files 142 passed (142)` · `Tests 2707 passed (2707)` |
| `pnpm --filter @object-ui/types type-check` | exit 0 (all three legs) |
| `pnpm --filter @object-ui/types build` | exit 0 — `dist completeness: 1 package(s) complete (124 emitted files verified)` |
| `pnpm --filter @object-ui/types lint` | exit 0 — 0 errors, 273 warnings, none on changed lines |
| `node scripts/check-changeset-presence.mjs` | exit 0 — 1 changeset declared for 3 published source files |
| `node scripts/check-changeset-no-major.mjs` | exit 0 — `No changeset declares a major bump` |
| `filter-builder-condition-id-8415.test.ts` (new) | exit 0 — 12 passed |
| `zod-lazy-getter-identity-7918.test.ts` | exit 0 |
| consumers that validate documents — `examples/schema-catalog`, `packages/cli`, `packages/core` | exit 0 — `Test Files 167 passed` · `Tests 4910 passed` |
| `node scripts/check-governed-queue-guard.mjs --test` on all 5 paths | exit 0 — `NOT GOVERNED` |

Repo-wide `eslint .` is CI's run, not this PR's. One correction worth recording: an earlier free-hand `eslint . --no-inline-config` reported 5 errors in `packages/types`; all five were in files this PR does not touch and were an artifact of `--no-inline-config` stripping the `eslint-disable` directives those rule-demonstration pins rely on. objectui's own script is `eslint .` without that flag, and it exits 0.

## Grading input for the PM

The card is `priority:p3` with a written-down re-grade trigger: **p2 if authored conditions commonly carry `id`**, so the strip is hitting real documents rather than a theoretical author. Measured: **7 of 7 — 100% of authored conditions in this repository carry `id`**, and every one of them was having it discarded. My judgement is that the trigger fires and this is **p2**. The number is above; the call is the PM's.

## Verification notes

- ⛔ Nothing here touches `content/docs/releases/`, and no branch was force-pushed, rebased or amended after publication.
- ⛔ `FilterGroupSchema` and its optional `id` are byte-identical to base.
- The out-of-scope observations found while measuring are in the report, not filed as cards, and none of them is a fix in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtGhnU3WnnWyiWeYQhw2aX)_

---
_Generated by [Claude Code](https://claude.ai/code)_