### PR TITLE
fix(components): ui:grid renders the 2xl breakpoint its columns map accepts

### DIFF
--- a/.changeset/7097-grid-2xl-breakpoint.md
+++ b/.changeset/7097-grid-2xl-breakpoint.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/components': patch
+---
+
+`ui:grid` renders the `2xl` breakpoint its `columns` map has always accepted
+(objectui#7097).
+
+`columns: { xs: 1, '2xl': 6 }` type-checked, passed `GridSchema`'s zod mirror, emitted
+**no class**, and rendered at the `xs` count on every screen — no error, no warning.
+Measured through a real `SchemaRenderer` render:
+
+| authored `columns` | before | after |
+|---|---|---|
+| `{ xs: 1, '2xl': 6 }` | `grid grid-cols-1 gap-4` | `grid grid-cols-1 2xl:grid-cols-6 gap-4` |
+| `{ xs: 1, xl: 5 }` | `grid grid-cols-1 xl:grid-cols-5 gap-4` | unchanged |
+| `4` | `grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4` | unchanged |
+
+`2xl` is a full member of the repo's breakpoint vocabulary everywhere else —
+`BreakpointName` in `@object-ui/types`, `BREAKPOINTS` / `BREAKPOINT_ORDER` in
+`@object-ui/mobile`, `BreakpointColumnMap` in `@object-ui/layout`, whose
+`ResponsiveGrid` already emits `2xl:grid-cols-*`. Only this consumer stopped at five.
+
+**The drop was in two layers, and both are fixed.** `grid.tsx` had neither a `2xl` read
+arm nor a `GRID_COLS_2XL` static class map. Adding the read arm alone would have
+produced a class name Tailwind never compiles — Tailwind v4 finds utilities by scanning
+source text, so a `2xl:grid-cols-${n}` assembled at runtime is not a utility that
+exists, and the node would have rendered unstyled while a unit test went green. The
+twelve literal class strings are what make the class real; measured against the
+package's own Tailwind build, `.2xl\:grid-cols-6` is absent from `dist/index.css` before
+this change and present after it.
+
+Nothing that rendered before renders differently: the other five tiers, the bare-number
+mobile-first ramp, and the designer's flat `smColumns`…`xlColumns` channel are
+unchanged.

--- a/.changeset/7097-grid-2xl-breakpoint.md
+++ b/.changeset/7097-grid-2xl-breakpoint.md
@@ -26,8 +26,8 @@ produced a class name Tailwind never compiles — Tailwind v4 finds utilities by
 source text, so a `2xl:grid-cols-${n}` assembled at runtime is not a utility that
 exists, and the node would have rendered unstyled while a unit test went green. The
 twelve literal class strings are what make the class real; measured against the
-package's own Tailwind build, `.2xl\:grid-cols-6` is absent from `dist/index.css` before
-this change and present after it.
+package's own Tailwind build, the `2xl:grid-cols-*` rules go from **0 to 12** in the
+compiled stylesheet, with the twelve `xl:grid-cols-*` rules unchanged as the control.
 
 Nothing that rendered before renders differently: the other five tiers, the bare-number
 mobile-first ramp, and the designer's flat `smColumns`…`xlColumns` channel are

--- a/packages/components/src/__tests__/grid-breakpoint-columns-7097.test.tsx
+++ b/packages/components/src/__tests__/grid-breakpoint-columns-7097.test.tsx
@@ -116,7 +116,13 @@ type _GateIsLive = _UncoveredBreakpoint;
 
 const classOf = (schema: unknown): string => {
   const { container } = render(<SchemaRenderer schema={schema as never} />);
-  return (container.firstElementChild as HTMLElement).className;
+  const el = container.firstElementChild as HTMLElement | null;
+  // Checked, not asserted away. A renderer that produced no element at all would
+  // otherwise throw a bare `Cannot read properties of null` here, BEFORE any
+  // `expect` ran — the failure summary would name a TypeError instead of the
+  // node that failed to render. This turns that case into a named assertion.
+  expect(el, `SchemaRenderer produced no element for ${JSON.stringify(schema)}`).not.toBeNull();
+  return (el as HTMLElement).className;
 };
 
 /** `xs` is the base tier: its class carries no variant prefix. */

--- a/packages/components/src/__tests__/grid-breakpoint-columns-7097.test.tsx
+++ b/packages/components/src/__tests__/grid-breakpoint-columns-7097.test.tsx
@@ -92,14 +92,27 @@ import { SchemaRenderer } from '@object-ui/react';
 const ALL_BREAKPOINTS = ['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const;
 
 /**
- * Exhaustiveness gate. If `BreakpointName` grows a member that is not in
- * `ALL_BREAKPOINTS`, `Exclude<...>` stops being `never` and this declaration
- * fails to compile — the new tier cannot be added to the vocabulary without
- * this file being updated to cover it.
+ * Exhaustiveness gate, both directions.
+ *
+ * Forward: if `BreakpointName` grows a member that `ALL_BREAKPOINTS` does not
+ * list, `Exclude<...>` stops being `never`, stops satisfying `T extends never`,
+ * and this alias fails to compile — the new tier cannot join the vocabulary
+ * without this file being updated to cover it. (An `Uncovered[]` variable would
+ * NOT do: `const x: '2xl'[] = []` type-checks happily, so the empty-array
+ * spelling of this gate is inert. This one was verified to redden by deleting a
+ * member from `ALL_BREAKPOINTS`.)
+ *
+ * Reverse: a member listed here that is NOT a `BreakpointName` fails at the
+ * `expectedClassFor(bp, …)` call below, whose parameter is typed `BreakpointName`.
+ *
+ * Both are checked by `pnpm --filter @object-ui/components type-check`, whose
+ * second program is `tsconfig.test.json`.
  */
-type _UncoveredBreakpoint = Exclude<BreakpointName, (typeof ALL_BREAKPOINTS)[number]>;
-const _breakpointsAreExhaustive: _UncoveredBreakpoint[] = [];
-void _breakpointsAreExhaustive;
+type _AssertNever<T extends never> = T;
+type _UncoveredBreakpoint = _AssertNever<
+  Exclude<BreakpointName, (typeof ALL_BREAKPOINTS)[number]>
+>;
+type _GateIsLive = _UncoveredBreakpoint;
 
 const classOf = (schema: unknown): string => {
   const { container } = render(<SchemaRenderer schema={schema as never} />);

--- a/packages/components/src/__tests__/grid-breakpoint-columns-7097.test.tsx
+++ b/packages/components/src/__tests__/grid-breakpoint-columns-7097.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ui:grid` renders every breakpoint its `columns` map is authored with —
+ * all SIX of the repo's breakpoint vocabulary, not the first five
+ * (objectui#7097).
+ *
+ * ## What was wrong
+ *
+ * `grid.tsx` carried one static Tailwind class map per breakpoint (`GRID_COLS`,
+ * `GRID_COLS_SM` … `GRID_COLS_XL`) and one read arm per breakpoint. Both stopped
+ * at `xl`. `2xl` — a full member of `BreakpointName` (`@object-ui/types`), of
+ * `@object-ui/mobile`'s `BREAKPOINTS` / `BREAKPOINT_ORDER`, and of
+ * `@object-ui/layout`'s `BreakpointColumnMap`, whose `ResponsiveGrid` already
+ * emits `2xl:grid-cols-*` — had no arm and no map here. Measured on the base
+ * commit through this same harness:
+ *
+ * ```
+ * authored { xs: 1, '2xl': 6 }  ->  "grid grid-cols-1 gap-4"
+ * ```
+ *
+ * The entry type-checked, survived `GridSchema`'s zod mirror, emitted no class,
+ * and the grid rendered at its `xs` count on every screen. No error, no warning
+ * — the declared-but-not-read shape `skills/objectui/rules/protocol.md` warns
+ * authors about, inside the layout key that section uses as its own example.
+ *
+ * ## Which layer dropped it, and why that decides the fix
+ *
+ * BOTH layers, and this is the load-bearing measurement. Adding a `2xl` read arm
+ * alone would have produced the string `2xl:grid-cols-6` from a template — and a
+ * Tailwind class that no static source literal spells is a class Tailwind's
+ * scanner never sees, so it is never compiled. The node would carry a class name
+ * with no rule behind it: GREEN in this file and unstyled in the browser. That
+ * is precisely what the `GRID_COLS_*` maps exist for — their own comment says
+ * "Helper maps to ensure Tailwind classes are scanned and included". The fix
+ * therefore adds the sixth static map (`GRID_COLS_2XL`, twelve literal class
+ * strings) as well as the sixth read arm. `packages/components/src/index.css`
+ * scans `../src/**` and this repo defines no `--breakpoint-*` override in any
+ * `@theme` block, so Tailwind v4's default `2xl` (96rem / 1536px — the same
+ * 1536 `BREAKPOINTS['2xl']` carries) is the variant those literals compile to.
+ *
+ * ## What this file observes, and why that observation is sound
+ *
+ * The EMITTED CLASS STRING, compared whole. Not `getComputedStyle`: these are
+ * CSS-only Tailwind responsive variants, and happy-dom does not compile Tailwind
+ * or resolve `@media (width >= 96rem)` the way a browser does, so a computed
+ * `grid-template-columns` here would measure the harness, not the renderer. The
+ * class string is the renderer's entire output on this path — `grid.tsx` reads
+ * no window, no matchMedia, no ResizeObserver — so nothing is lost by observing
+ * it, and `renders-identically-at-any-viewport` below pins that width
+ * independence explicitly rather than assuming it (a viewport-dependent pin that
+ * is green only on an unpinned desktop default is the failure this repo has been
+ * bitten by).
+ *
+ * ## Why every case compares the WHOLE string
+ *
+ * `toContain('2xl:grid-cols-6')` would also pass for an implementation that
+ * emits the `2xl` class and drops `xl`, or that emits all six classes at the
+ * same column count. Whole-string equality makes the other five breakpoints
+ * non-regression assertions of this file, so a change that trades one
+ * breakpoint for another reddens here. An implementation strictly WORSE than the
+ * bug — one that emits no responsive classes at all, the "delete the feature"
+ * shape — fails every case below rather than satisfying them.
+ *
+ * ## Why the case list is derived, not typed out
+ *
+ * `ALL_BREAKPOINTS` is checked for exhaustiveness against `BreakpointName` at
+ * the type level, so a seventh member of the vocabulary makes this file a
+ * COMPILE error (`pnpm --filter @object-ui/components type-check`, which covers
+ * `tsconfig.test.json`) instead of silently leaving the new tier untested. That
+ * is the durable half of this card: the gap survived because nothing compared
+ * the breakpoint vocabulary against the keys this renderer actually reads.
+ *
+ * Module-scope import of the renderers, not `beforeAll` (AGENTS.md §测试纪律).
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import type { BreakpointName } from '@object-ui/types';
+import '../renderers';
+import { SchemaRenderer } from '@object-ui/react';
+
+/**
+ * The breakpoint vocabulary, smallest first — the same six and the same order as
+ * `@object-ui/mobile`'s `BREAKPOINT_ORDER`.
+ */
+const ALL_BREAKPOINTS = ['xs', 'sm', 'md', 'lg', 'xl', '2xl'] as const;
+
+/**
+ * Exhaustiveness gate. If `BreakpointName` grows a member that is not in
+ * `ALL_BREAKPOINTS`, `Exclude<...>` stops being `never` and this declaration
+ * fails to compile — the new tier cannot be added to the vocabulary without
+ * this file being updated to cover it.
+ */
+type _UncoveredBreakpoint = Exclude<BreakpointName, (typeof ALL_BREAKPOINTS)[number]>;
+const _breakpointsAreExhaustive: _UncoveredBreakpoint[] = [];
+void _breakpointsAreExhaustive;
+
+const classOf = (schema: unknown): string => {
+  const { container } = render(<SchemaRenderer schema={schema as never} />);
+  return (container.firstElementChild as HTMLElement).className;
+};
+
+/** `xs` is the base tier: its class carries no variant prefix. */
+const expectedClassFor = (bp: BreakpointName, cols: number): string =>
+  bp === 'xs' ? `grid-cols-${cols}` : `${bp}:grid-cols-${cols}`;
+
+describe('ui:grid emits a column class for every breakpoint in the vocabulary (#7097)', () => {
+  it('a fully authored six-breakpoint map emits all six classes, in order', () => {
+    expect(
+      classOf({
+        type: 'grid',
+        columns: { xs: 1, sm: 2, md: 3, lg: 4, xl: 5, '2xl': 6 },
+        gap: 4,
+      }),
+    ).toBe(
+      'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-4',
+    );
+  });
+
+  it('the reported node — { xs: 1, "2xl": 6 } — now emits its 2xl class', () => {
+    // The card's measured row. Before the fix this was "grid grid-cols-1 gap-4".
+    expect(classOf({ type: 'grid', columns: { xs: 1, '2xl': 6 }, gap: 4 })).toBe(
+      'grid grid-cols-1 2xl:grid-cols-6 gap-4',
+    );
+  });
+
+  it.each(ALL_BREAKPOINTS)(
+    'a map naming only %s emits that tier and no other tier',
+    (bp) => {
+      const authored = classOf({ type: 'grid', columns: { [bp]: 6 }, gap: 4 });
+      // Whole-string equality: this is simultaneously the presence assertion for
+      // `bp` and the absence assertion for the other five.
+      const base = bp === 'xs' ? 'grid-cols-6' : 'grid-cols-1';
+      const expected =
+        bp === 'xs' ? `grid ${base} gap-4` : `grid ${base} ${expectedClassFor(bp, 6)} gap-4`;
+      expect(authored, `authored { "${bp}": 6 } rendered: ${authored}`).toBe(expected);
+    },
+  );
+
+  it('the two rows that already worked keep working', () => {
+    // Non-regression on the shapes the card measured as CORRECT, so a fix that
+    // moves the 2xl tier in by breaking one of them cannot pass this file.
+    expect(classOf({ type: 'grid', columns: { xs: 1, xl: 5 }, gap: 4 })).toBe(
+      'grid grid-cols-1 xl:grid-cols-5 gap-4',
+    );
+    // A bare number keeps its mobile-first ramp (baseCols collapses to 1).
+    expect(classOf({ type: 'grid', columns: 4, gap: 4 })).toBe(
+      'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4',
+    );
+  });
+
+  it('an unmapped 2xl column count emits no 2xl class, exactly as xl behaves', () => {
+    // The static maps cover 1-12. Out-of-range counts fall out of BOTH the xl and
+    // the 2xl map the same way — the sixth tier is not given a lenient path the
+    // other five do not have.
+    expect(classOf({ type: 'grid', columns: { xs: 1, xl: 99 }, gap: 4 })).toBe(
+      'grid grid-cols-1 gap-4',
+    );
+    expect(classOf({ type: 'grid', columns: { xs: 1, '2xl': 99 }, gap: 4 })).toBe(
+      'grid grid-cols-1 gap-4',
+    );
+  });
+});
+
+describe('the emitted class is viewport-independent, which is why reading it is sound (#7097)', () => {
+  const originalInnerWidth = window.innerWidth;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: originalInnerWidth,
+    });
+  });
+
+  it('renders identically at a phone width and at a 2xl desktop width', () => {
+    const node = { type: 'grid', columns: { xs: 1, xl: 5, '2xl': 6 }, gap: 4 };
+
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 375 });
+    const atPhone = classOf(node);
+
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1600 });
+    const atWideDesktop = classOf(node);
+
+    // Equal, and equal to the full six-class-per-authored-tier string: the
+    // renderer emits every tier's class unconditionally and lets CSS pick. A
+    // pin that only held at one viewport would be measuring happy-dom's default
+    // window size instead of the renderer.
+    expect(atPhone).toBe('grid grid-cols-1 xl:grid-cols-5 2xl:grid-cols-6 gap-4');
+    expect(atWideDesktop, `phone=${atPhone} desktop=${atWideDesktop}`).toBe(atPhone);
+  });
+});

--- a/packages/components/src/renderers/layout/grid.tsx
+++ b/packages/components/src/renderers/layout/grid.tsx
@@ -42,6 +42,27 @@ const GRID_COLS_XL: Record<number, string> = {
   9: 'xl:grid-cols-9', 10: 'xl:grid-cols-10', 11: 'xl:grid-cols-11', 12: 'xl:grid-cols-12'
 };
 
+// `2xl` is the sixth and last member of the breakpoint vocabulary — `BreakpointName`
+// in `@object-ui/types`, `BREAKPOINTS` / `BREAKPOINT_ORDER` in `@object-ui/mobile`,
+// and `BreakpointColumnMap` in `@object-ui/layout`, whose `ResponsiveGrid` already
+// emits `2xl:grid-cols-*`. This map stopped at `xl`, and so did the read arm below,
+// so an authored `columns: { '2xl': 6 }` validated, emitted nothing, and rendered at
+// the `xs` count on every screen (objectui#7097).
+//
+// The map is not decoration: it is what makes these class names EXIST. Tailwind v4
+// finds utilities by scanning source text (`@source '../src/**/*.{ts,tsx}'` in
+// `packages/components/src/index.css`), so a `2xl:grid-cols-${n}` built at runtime
+// from a template would never be compiled and the node would render unstyled — green
+// in a unit test, wrong in the browser. Spelling all twelve out is the same reason
+// the five maps above are spelled out. The variant itself is Tailwind's default
+// `2xl` (96rem / 1536px, matching `BREAKPOINTS['2xl']`); no `@theme` block in this
+// repo overrides `--breakpoint-*`.
+const GRID_COLS_2XL: Record<number, string> = {
+  1: '2xl:grid-cols-1', 2: '2xl:grid-cols-2', 3: '2xl:grid-cols-3', 4: '2xl:grid-cols-4',
+  5: '2xl:grid-cols-5', 6: '2xl:grid-cols-6', 7: '2xl:grid-cols-7', 8: '2xl:grid-cols-8',
+  9: '2xl:grid-cols-9', 10: '2xl:grid-cols-10', 11: '2xl:grid-cols-11', 12: '2xl:grid-cols-12'
+};
+
 const GAPS: Record<number, string> = {
   0: 'gap-0', 1: 'gap-1', 2: 'gap-2', 3: 'gap-3', 4: 'gap-4', 
   5: 'gap-5', 6: 'gap-6', 8: 'gap-8', 10: 'gap-10', 12: 'gap-12'
@@ -52,18 +73,21 @@ ComponentRegistry.register('grid',
     // Determine columns configuration
     // Supports detailed object configuration from schema
     let baseCols = 2;
-    let smCols, mdCols, lgCols, xlCols;
+    let smCols, mdCols, lgCols, xlCols, xxlCols;
 
     if (typeof schema.columns === 'number') {
       baseCols = schema.columns;
     } else if (typeof schema.columns === 'object' && schema.columns !== null) {
-      // Handle responsive object: { xs: 1, sm: 2, md: 3, lg: 4 }
+      // Handle responsive object: { xs: 1, sm: 2, md: 3, lg: 4, xl: 5, '2xl': 6 }
       // Note: 'xs' corresponds to base (mobile-first)
       baseCols = schema.columns.xs ?? 1;
       smCols = schema.columns.sm;
       mdCols = schema.columns.md;
       lgCols = schema.columns.lg;
       xlCols = schema.columns.xl;
+      // `xxlCols` because `2xlCols` is not a legal identifier; the authored key
+      // is and stays `'2xl'`.
+      xxlCols = schema.columns['2xl'];
     }
 
     // Fallback to legacy flat props if provided (from designer)
@@ -76,6 +100,12 @@ ComponentRegistry.register('grid',
     // overrides) collapses on small screens so an N-across row doesn't render
     // as unreadable slivers on a phone. Authors who pass a responsive object
     // or sm/md/lg/xlColumns keep full control.
+    //
+    // `xxlCols` is deliberately NOT in this condition. It is only ever set from
+    // the responsive-object branch above, which this arm cannot have taken
+    // (`typeof schema.columns === 'number'`), and there is no `xxlColumns`
+    // legacy flat prop — the designer's flat channel stays at the five it
+    // declares in `inputs` below. Add it here if that ever changes.
     if (
       typeof schema.columns === 'number' && baseCols > 1 &&
       smCols === undefined && mdCols === undefined && lgCols === undefined && xlCols === undefined
@@ -97,6 +127,7 @@ ComponentRegistry.register('grid',
       mdCols && GRID_COLS_MD[mdCols],
       lgCols && GRID_COLS_LG[lgCols],
       xlCols && GRID_COLS_XL[xlCols],
+      xxlCols && GRID_COLS_2XL[xxlCols],
       // Gap
       GAPS[gap] || `gap-[${gap * 0.25}rem]`, // Fallback for arbitrary values if not in map
       className


### PR DESCRIPTION
Fixes #7097

`ui:grid` renders the `2xl` breakpoint its `columns` map has always accepted.

## Re-measured on today's tree — two of the card's numbers no longer hold

The card was written against `@objectstack/spec` 17.2.0. This repo now pins **17.3.0**, and that changes the accept surface it names.

| the card says | today, base `34510e0c3` |
|---|---|
| accept surface is `BreakpointColumnMapSchema` in `@objectstack/spec/ui`, a strict six-key object | **gone.** objectstack#11027 (ADR-0049 D2) retired the whole `ui/responsive` vocabulary. `node -e "require('@objectstack/spec/ui')"` exports exactly one `Breakpoint*`/`Responsive*` symbol: `ResponsiveStylesSchema`. The removal note is in the package's own `src/ui/responsive.zod.ts`. |
| "the spec accepts six breakpoints" | the accept surface is objectui's own `GridSchema.columns`, typed **`number` or an open string-keyed record of numbers** (`packages/types/src/layout.ts:385`, mirrored in `zod/layout.zod.ts:223` as `z.record(z.string(), z.number())`). Not six — **unbounded**. |
| "the grid renderer reads five" | **still exactly right.** `grid.tsx` had five read arms and five class maps, `xs` through `xl`. |
| the three rendered-class rows | **all three reproduced verbatim** through a real `SchemaRenderer` render (see below). |

The six-member vocabulary is still real, just no longer spec-side: `BreakpointName` (`packages/types/src/mobile.ts:69`), `BREAKPOINTS` / `BREAKPOINT_ORDER` (`packages/mobile/src/breakpoints.ts`, pinned at `breakpoints.test.ts:31`), and `BreakpointColumnMap` (`packages/layout/src/ResponsiveGrid.tsx:53`, re-homed from the retired schema by objectui#7580, maintainer ruling 2026-09-04 option A). So the card's conclusion survives its premise: the vocabulary is six everywhere, and only this consumer stopped at five.

## Which layer dropped it — the load-bearing measurement

**Both**, and that decides the diff. `grid.tsx` had no `2xl` read arm *and* no `GRID_COLS_2XL` static class map. Adding the read arm alone would have emitted a class name Tailwind never compiles — v4 finds utilities by scanning source text, so a `2xl:grid-cols-` count assembled from a template is not a utility that exists. Green in a unit test, unstyled in the browser.

Measured by compiling `packages/components/src/index.css` through the package's own pipeline (`postcss` + `@tailwindcss/postcss`, the same two lines as `packages/components/scripts/build-css.mjs`), varying **only** `grid.tsx`:

| `grid.tsx` on disk | compiled `2xl:grid-cols-*` rules | control: `xl:grid-cols-*` rules |
|---|---|---|
| base `34510e0c3` blob `11835179a` (no map, no arm) | **0** | 12 |
| this branch blob `62b735f9c` (map + arm) | **12** | 12 |

Escape-form note, because it is a trap: Tailwind emits these selectors as `.\32 xl\:grid-cols-6`, not `.2xl\:grid-cols-6` — a CSS identifier cannot start with a digit. Grepping the literal spelling returns zero on a stylesheet that contains all twelve.

The class then survives to the DOM. Emitted `className` on the rendered `div`, read through `SchemaRenderer`:

| authored `columns` | before | after |
|---|---|---|
| `{ xs: 1, "2xl": 6 }` | `grid grid-cols-1 gap-4` | `grid grid-cols-1 2xl:grid-cols-6 gap-4` |
| `{ xs: 1, xl: 5 }` | `grid grid-cols-1 xl:grid-cols-5 gap-4` | unchanged |
| `4` | `grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4` | unchanged |

**Not a deliberate five.** The escalation fence does not fire: `2xl` has a Tailwind equivalent in this setup (default theme, no `--breakpoint-*` override in any `@theme` block, so `2xl` is 96rem/1536px — the same 1536 `BREAKPOINTS['2xl']` carries), and `@object-ui/layout`'s `ResponsiveGrid` already emits `2xl:grid-cols-*` from its own class table. One consumer in this repo shipped the sixth tier; the other did not.

## Sibling responsive readers — the triage's "before closing" step

Swept, and there is no second instance. `grid.tsx:87` is the **only** site in `packages/**` or `apps/**` that reads `.xl` off a responsive object. The other two consumers of the vocabulary are keyed by `BREAKPOINT_ORDER` or by `Object.entries`, so they carry all six by construction: `resolveResponsiveValue` / `ResponsiveContainer` (`@object-ui/mobile`) and `resolveColumnClasses` (`@object-ui/layout`).

## What the pin observes, and why that is sound

`packages/components/src/__tests__/grid-breakpoint-columns-7097.test.tsx` asserts the **whole emitted class string**, not a parse and not `getComputedStyle`. happy-dom does not compile Tailwind or evaluate `@media (width >= 96rem)` as a browser does, so a computed `grid-template-columns` here would measure the harness. The class string is the renderer's entire output on this path — `grid.tsx` reads no `window`, no `matchMedia`, no `ResizeObserver` — and one case pins that width-independence explicitly by rendering the same node at `innerWidth` 375 and 1600 and requiring identical output, rather than being green by accident on happy-dom's default desktop width.

The class reader asserts its element with a message before reading `className`: a renderer that produced nothing would otherwise throw `Cannot read properties of null` before any `expect` ran, and the summary would name a TypeError instead of the node that failed to render (commit 4).

**Would an implementation strictly worse than the bug pass it?** No. Every case is whole-string equality, so the other five tiers are non-regression assertions of the same file: a change that emits the `2xl` class and drops `xl` reddens, and so does "delete the feature" (no responsive classes at all), which fails all eleven cases.

The case list is **derived**, not typed out: `ALL_BREAKPOINTS` is checked against `BreakpointName` by an `_AssertNever` alias, so a seventh member of the vocabulary makes this file a compile error instead of silently leaving the new tier untested. That is the durable half of the card, scoped to what still exists — with the spec-side `Breakpoint*Map` schemas retired, a repo-wide "compare a strict breakpoint map's member set against its renderer's reads" gate has no remaining subject.

## Prove the pin can fail — three ablations, restored by state

Each from the committed implementation, with a `trap ... EXIT INT TERM` and absolute paths; each restore verified by `git hash-object` equality **and** an empty `git diff HEAD`, never by an exit code.

1. **Read site.** Deleted only the `cn()` arm, leaving the class map, so the read layer is isolated. HEAD blob `62b735f9c` -> on-disk `eede06b1c`. `4 failed | 7 passed`, red rows by name: *a fully authored six-breakpoint map emits all six classes, in order* · *the reported node — { xs: 1, "2xl": 6 } — now emits its 2xl class* · *a map naming only 2xl emits that tier and no other tier* · *renders identically at a phone width and at a 2xl desktop width*.
2. **Class-map layer.** Kept the read arm, replaced the twelve literals with a runtime template. On-disk `ed665c2e0`. The DOM pin goes to `1 failed | 10 passed` — it catches this only incidentally, through the out-of-range case, while the compiled stylesheet loses all twelve rules. **Stated plainly: the DOM pin alone does not cover the class-map layer for in-range counts.** The table above is what covers it, and it is why the diff adds the map rather than a template.
3. **Exhaustiveness gate.** Dropped `'2xl'` from `ALL_BREAKPOINTS`; `type-check` exits 2 with `grid-breakpoint-columns-7097.test.tsx(113,3): error TS2344: Type '"2xl"' does not satisfy the constraint 'never'`. The gate's first spelling was **inert** (`const x: Uncovered[] = []` type-checks whether `Uncovered` is `never` or `'2xl'`); commit 2 replaces it and this ablation is what caught that.

## Verification

- `pnpm --filter @object-ui/components test` — `Test Files 241 passed (241)`, `Tests 2235 passed (2235)`.
- `pnpm --filter @object-ui/components type-check` — exit 0, both programs (`tsc --noEmit && tsc -p tsconfig.test.json`, so the exhaustiveness gate is covered).
- `pnpm --workspace-concurrency=2 --filter '@object-ui/components^...' build` — exit 0, run first so type-check reads fresh `.d.ts`.
- `pnpm exec eslint .` in `packages/components` — exit 0, 0 errors. The one warning on `grid.tsx` is the pre-existing `[key: string]: any` on the register signature, present at base. The new test file draws none.
- `node scripts/check-changeset-presence.mjs` — `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/7097-grid-2xl-breakpoint.md.`
- `node scripts/check-changeset-no-major.mjs` — `No changeset declares a major bump.`
- `node scripts/check-governed-queue-guard.mjs --test` on the three changed paths — `NOT GOVERNED — 3 path(s) checked against 5 governed surface(s); none matched.`
- `check:control-bytes`, `check:unreferenced-sources`, `check:self-import`, `check:esm-specifiers`, `check:vi-mock-specifiers` — all exit 0.
- `check:sdui-registration-pins` — exit 0: `All 16 registration(s) a sideEffects array promises are present in the built console (518 chunks weighed; the 3 ruled control(s) are in the derived set).` It first exited 2 with a prerequisite message (it reads the console bundle at BUNDLE time); `pnpm --workspace-concurrency=2 --filter '@object-ui/console...' build` — exit 0 — supplied it, so this is measured, not narrowed.

No authored node in any corpus changes: `grep -rn '"2xl"'` across every JSON/YAML in the tree returns **zero** hits (control: `"type": "grid"` hits five catalog files). The fix is additive for future authors and explains why nobody noticed.

## Two findings, reported not filed

`search_issues` returned `API rate limit already exceeded for user ID 323634890` on the second query, and the first query's zero-result read has no lit control to certify it, so per the dispatch contract these are reported in full rather than filed unsearched.

1. **`packages/components/src/index.css` scans its own test files into the published stylesheet.** Its `@source '../src/**/*.{ts,tsx}'` carries no exclusion, while the siblings do — `packages/plugin-kanban/src/index.css:91-92` has `@source not './**/*.test.{ts,tsx}'` and `@source not './**/__tests__/**'`, and `packages/fields/src/index.css:44` has the first of those. Two consequences. Bloat is the mild one. The sharp one is that a class literal written as a test's *expected value* compiles a real utility into `dist/index.css`, so a test can make the production utility it is checking for exist — measured live here: with this PR's pin file on disk and base `grid.tsx`, the stylesheet contains `.\32 xl\:grid-cols-6` and nothing else in the family, sourced entirely from the test's own assertion strings. The table in this PR is honest only because the measurement was re-run with the pin file removed. Fix is two lines copied from the siblings; it changes published bundle contents, so it wants its own PR and changeset.
2. **`GridSchema.columns` accepts any string key, not six.** `packages/types/src/layout.ts:385` types it `number` or an open string-keyed record of numbers, mirrored as `z.record(z.string(), z.number())`. `columns: { banana: 3 }` type-checks, parses, emits nothing — the same silent-drop shape as this card, one level more general. Narrowing to a partial record keyed by `BreakpointName` would close it, but that is a narrowing of a published accept surface across `@object-ui/types` plus its zod mirror and the `zod-mirror-parity` pin, so it wants a ruling rather than a patch. Related and minor: the `GridSchema.columns` docblock example still reads `{ xs: 1, sm: 2, md: 3, lg: 4 }`, four of six — illustrative rather than wrong, and it sits under `layout-default-jsdoc-7361.test.ts`, so it was left alone.

## Out of scope, deliberately

The designer's legacy flat channel (`smColumns` … `xlColumns`) gains no sixth member. Naming it and declaring a sixth designer `input` is a product surface decision, and this card is about the `columns` breakpoint object. A comment at the mobile-first ramp records why `xxlCols` is absent from that condition, so it does not read as an oversight.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_