### PR TITLE
test(plugin-detail): pin the viewport in the #8350 dedupe pin, and cover the mobile branch

### DIFF
--- a/.changeset/issue-8399-dedupe-pin-pins-viewport.md
+++ b/.changeset/issue-8399-dedupe-pin-pins-viewport.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only change (objectui#8399): `record-details.dedupeEmptinessTrims-8350.test.tsx` now pins
+`window.innerWidth` instead of inheriting happy-dom's default, and covers the mobile branch of
+`DetailSection`'s auto-hide as a second case. No published behaviour changes.

--- a/packages/plugin-detail/src/renderers/__tests__/record-details.dedupeEmptinessTrims-8350.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.dedupeEmptinessTrims-8350.test.tsx
@@ -64,22 +64,71 @@
  * is therefore asserted by its LABEL, which for a bare-string entry is the
  * field name itself; a row that must drop is asserted by its VALUE.
  *
- * ## Why the whitespace rows are still on screen at all
+ * ## Why the whitespace rows are still on screen — and why this file now pins
+ * the viewport (objectui#8399)
  *
- * `DetailSection`'s auto-hide heuristic needs a section of at least 4 fields,
- * and its own emptiness test is raw — a whitespace-only value counts as FILLED
- * there. Both facts are measured, not assumed: every fixture below renders 3
- * rows after the dedupe, so auto-hide cannot fire and cannot be the reason a
- * row is missing. (That `DetailSection` has a THIRD, un-trimmed spelling of
- * emptiness is a real and separate divergence; it is not this card.)
+ * A row may only be missing below because the dedupe dropped it. `DetailSection`
+ * can also remove a row, through its auto-hide heuristic, and that heuristic is
+ * decided by TWO viewport-dependent constants (`DetailSection.tsx`, read through
+ * `useIsMobile`, breakpoint 768):
+ *
+ *   desktop — `AUTO_HIDE_MIN_FIELDS` 4, `AUTO_HIDE_RATIO` 0.25
+ *   mobile  — `AUTO_HIDE_MIN_FIELDS` 3, `AUTO_HIDE_RATIO` 0.2
+ *
+ * Measured on this base, after the dedupe, per fixture (rendered rows / of which
+ * empty): CONTRACT 2/1 · ACTIVITY 3/2 · PLAIN 2/1 · NON-REGRESSION 2/0. So on
+ * the DESKTOP branch nothing here can reach the 4-row minimum and auto-hide
+ * cannot fire — which is the condition every case below needs.
+ *
+ * ⚠️ This file used to state a second reason that is no longer true, and that
+ * is why the pin exists. `DetailSection`'s own emptiness test WAS raw, so a
+ * whitespace-only value counted as FILLED there and the ACTIVITY fixture read
+ * 0 empty rows. objectui#8376 made that definition TRIM — the same definition
+ * the dedupe ladder reads — so those two rows are EMPTY here now. The ACTIVITY
+ * fixture consequently sits EXACTLY at the mobile minimum (3 rows) with 2 of
+ * them empty (0.67 ≥ 0.2): on the mobile branch auto-hide fires and
+ * `WHITESPACE AT THE DERIVATION RUNG — HALF 2` reddens, reporting only that
+ * `contract_no` could not be found.
+ *
+ * The green was therefore resting on an ambient value this file never stated:
+ * happy-dom reports `innerWidth` 1024 (measured), which is the desktop branch.
+ * It is pinned below — and the branch is chosen, not inherited. DESKTOP is the
+ * branch these cases mean to exercise, because they assert WHICH ROW THE DEDUPE
+ * DROPS and that reading is only clean while no second mechanism can remove a
+ * row. The mobile branch is not swept under the rug by that choice: it is
+ * covered as a SECOND describe at the bottom of this file, never as a
+ * substitute, and what it pins is the distinction the choice above depends on —
+ * an auto-hidden row comes back, a deduped row does not.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import * as React from 'react';
 import { getRecordDisplayName } from '@object-ui/core';
 import { RecordContextProvider } from '@object-ui/react';
 import { RecordDetailsRenderer } from '../record-details';
+
+/**
+ * Viewport, pinned rather than inherited (objectui#8399) — see the docblock.
+ *
+ * `Object.defineProperty` rather than assignment: happy-dom's `innerWidth` is a
+ * getter, so `window.innerWidth = n` is silently a no-op. `configurable: true`
+ * is what lets the second describe re-pin it.
+ */
+const DESKTOP_WIDTH = 1280;
+const MOBILE_WIDTH = 375;
+const pinViewport = (width: number) => () => {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: width });
+};
+
+/**
+ * Presence read as a VALUE, so the `expect` message survives into the CI
+ * summary. `getByText` throws before `expect` runs, and its one-line summary
+ * ("Unable to find an element with the text: contract_no") is exactly the
+ * message that sent this card's reader to the dedupe ladder instead of to the
+ * auto-hide heuristic.
+ */
+const shown = (text: string) => screen.queryByText(text) !== null;
 
 /**
  * Declared pointer `contract_no`, held blank-but-not-empty on the record.
@@ -179,6 +228,11 @@ afterEach(() => {
 });
 
 describe('record:details dedupe — emptiness is the header\'s definition (#8350)', () => {
+  // DESKTOP on purpose: at these fixture sizes it is the only branch on which
+  // `DetailSection` auto-hide cannot fire, so a missing row can only be the
+  // dedupe's doing. See the docblock; the mobile branch is covered below.
+  beforeEach(pinViewport(DESKTOP_WIDTH));
+
   /**
    * The two halves are separate cases ON PURPOSE. Inside one `it` the first
    * failing expectation short-circuits the rest, so an ablation of the read
@@ -289,5 +343,93 @@ describe('record:details dedupe — emptiness is the header\'s definition (#8350
     // CONTROLS — the grid rendered, and the ordinary row is untouched.
     expect(screen.getByText('internal-name')).toBeInTheDocument();
     expect(screen.getByText('42')).toBeInTheDocument();
+  });
+});
+
+/**
+ * The MOBILE branch — an ADDITION, never a substitute (objectui#8399).
+ *
+ * The describe above pins DESKTOP because that is the branch its cases need.
+ * That choice is only honest if the other branch is stated rather than avoided,
+ * and here the other branch is not a null case: the ACTIVITY fixture's 3
+ * rendered rows sit EXACTLY at the mobile `AUTO_HIDE_MIN_FIELDS` (3) with 2 of
+ * them empty (0.67 ≥ `AUTO_HIDE_RATIO` 0.2), so `DetailSection` auto-hide
+ * fires. Measured, not argued: with the viewport at `MOBILE_WIDTH` and no other
+ * change, `WHITESPACE AT THE DERIVATION RUNG — HALF 2` above goes red.
+ *
+ * ## What these two cases pin, and why it is not just "the same rows again"
+ *
+ * A row the dedupe dropped and a row auto-hide hid are BOTH "not on screen".
+ * The describe above reads every absence as the dedupe's doing, and only the
+ * desktop thresholds make that reading sound. These cases pin the difference
+ * the reading rests on, on the branch where both mechanisms are live:
+ *
+ *   - auto-hide HIDES — `DetailSection` says so with `Show 2 empty fields`, and
+ *     the toggle brings both rows back;
+ *   - the dedupe REMOVES — `Acme Corporation`'s row is gone from the section
+ *     and no toggle resurrects it.
+ *
+ * ⇒ if auto-hide ever reaches the desktop branch too (a threshold change, a
+ * fixture change, another shift in what counts as empty), the describe above
+ * reddens with a bare "Unable to find … contract_no" while MOBILE HALF 2 stays
+ * green — and that pair of readings names auto-hide instead of the ladder.
+ */
+describe('record:details dedupe — on mobile the blank rows are HIDDEN, not deduped (#8399)', () => {
+  beforeEach(pinViewport(MOBILE_WIDTH));
+
+  it('MOBILE HALF 1 — auto-hide removes both blank rows, and DetailSection reports them as empty', () => {
+    renderBody(WHITESPACE_BOTH_RUNGS_RECORD, activitySchema, ACTIVITY_FIELDS);
+
+    expect(
+      shown('contract_no'),
+      'mobile auto-hide must fire on this fixture (3 rendered rows meets AUTO_HIDE_MIN_FIELDS 3, 2/3 empty clears AUTO_HIDE_RATIO 0.2) — this row is absent because it was HIDDEN, not because the dedupe took it',
+    ).toBe(false);
+    expect(
+      shown('activity_name'),
+      'the second blank row is hidden by the same heuristic, for the same reason',
+    ).toBe(false);
+
+    // CONTROL — the grid rendered at all. Every negative above is trivially
+    // true of a document that rendered nothing.
+    expect(shown('4'), 'the one filled row must still render').toBe(true);
+
+    // The count is the other half of the reading: a RAW emptiness test would
+    // see 0 empty rows here and offer no toggle at all, so this line also pins
+    // that `DetailSection` reads whitespace as empty (objectui#8376).
+    const toggle = screen.queryByRole('button', { name: /empty fields/i });
+    expect(
+      toggle === null ? 'NO TOGGLE RENDERED' : toggle.textContent,
+      'auto-hide must offer the reveal toggle, counting BOTH whitespace-only rows as empty',
+    ).toContain('Show 2 empty fields');
+  });
+
+  it('MOBILE HALF 2 — the toggle brings the hidden rows back; the DEDUPED row never comes back', () => {
+    renderBody(WHITESPACE_BOTH_RUNGS_RECORD, activitySchema, ACTIVITY_FIELDS);
+
+    const toggle = screen.queryByRole('button', { name: /empty fields/i });
+    expect(
+      toggle,
+      'without the reveal toggle there is nothing to reveal and this case measures nothing',
+    ).not.toBeNull();
+    fireEvent.click(toggle as HTMLElement);
+
+    expect(
+      shown('contract_no'),
+      'revealing empty fields must bring back a row that auto-hide hid',
+    ).toBe(true);
+    expect(
+      shown('activity_name'),
+      'revealing empty fields must bring back a row that auto-hide hid',
+    ).toBe(true);
+
+    // ⭐ The line between the two mechanisms. `label` carries `Acme Corporation`,
+    // the value this record's H1 shows; the dedupe removed that field from the
+    // section entirely, so no toggle can resurrect it. If this ever goes green,
+    // the rows above were auto-hidden rather than deduped and every absence
+    // asserted in the describe above is measuring the wrong mechanism.
+    expect(
+      shown('Acme Corporation'),
+      'the dedupe REMOVES the duplicate row — revealing empty fields must not resurrect it',
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #8399

`record-details.dedupeEmptinessTrims-8350.test.tsx` argued that a missing row could only be the dedupe's doing, because every fixture stayed below `DetailSection`'s auto-hide minimum. Both halves of that argument are viewport-dependent, and the file pinned neither value. It was green because happy-dom reports `innerWidth` **1024**.

## The margin, recounted on this base (`ca3942729`), not taken from the card

Rendered rows after the dedupe, and how many of them are empty **today** (post-#8396), measured at a pinned 1280 by counting rows in the container and `No value` placeholders by title:

| fixture | rendered rows | empty | mobile auto-hide fires? |
|---|---|---|---|
| `CONTRACT_FIELDS` | 2 | 1 | no — 2 is below the mobile minimum 3 |
| `ACTIVITY_FIELDS` | **3** | **2** | **yes** — 3 meets the minimum, 0.67 clears 0.2 |
| `PLAIN_FIELDS` | 2 | 1 | no |
| `NON-REGRESSION` | 2 | 0 | no |

The card said "3 rendered rows, 2 of them empty" for the ACTIVITY fixture and that is confirmed. Two things the card did not say, both of which come out of the recount:

- the **other three** fixtures render **2** rows, not 3. The file's own docblock said "every fixture below renders 3 rows after the dedupe" — that was never true of three of the four, and it is now corrected to the measured numbers.
- the thresholds re-read on this base are unchanged from the card: `AUTO_HIDE_MIN_FIELDS = isMobile ? 3 : 4`, `AUTO_HIDE_RATIO = isMobile ? 0.2 : 0.25` (`DetailSection.tsx:258-260`).

## The hazard is open — it is not a hypothetical, and it did not close

Ablation from the committed implementation, mutation proven on disk by `git hash-object` and restored by state (`git diff HEAD` empty **and** the hash back to `git rev-parse HEAD:PATH`), trap on `EXIT INT TERM` with absolute paths:

**Leg 1 — pin the existing describe to the mobile branch (1280 to 375):**

```
Tests  1 failed | 9 passed (10)
 × WHITESPACE AT THE DERIVATION RUNG — HALF 2: both blank rows survive
TestingLibraryElementError: Unable to find an element with the text: contract_no
```

Exactly the predicted failure, and note *what the message says*: nothing about auto-hide. That one line is the whole reason this card exists.

**Leg 2 — pin the new mobile describe to desktop (375 to 1280):**

```
Tests  2 failed | 8 passed (10)
 × MOBILE HALF 1 …
AssertionError: mobile auto-hide must fire on this fixture (3 rendered rows meets AUTO_HIDE_MIN_FIELDS 3, 2/3 empty clears AUTO_HIDE_RATIO 0.2) — this row is absent because it was HIDDEN, not because the dedupe took it
 × MOBILE HALF 2 …
AssertionError: without the reveal toggle there is nothing to reveal and this case measures nothing
```

The new cases are not vacuous, and the contrast between the two legs is itself the argument for reading presence through `queryByText` into `expect(value, message)`.

## What changed

1. **The viewport is pinned, and the branch is chosen out loud.** `DESKTOP_WIDTH` for the existing describe, with a comment saying *why*: these cases assert which row the dedupe drops, and that reading is only clean while no second mechanism can remove a row — which at these fixture sizes is true only on the desktop branch. Pinning desktop is the decision, not the accident.
2. **The docblock is corrected.** It claimed `DetailSection`'s emptiness test "is raw — a whitespace-only value counts as FILLED there". #8396 made that definition trim, which is precisely what turned this file's margin from comfortable into zero. The stale sentence is replaced by the measured table above and by the statement that the file now pins the viewport.
3. **The mobile branch is covered as a SECOND describe, never a substitute.** It does not re-assert the same rows; it pins the **distinction** the desktop choice rests on. A deduped row and an auto-hidden row are both "not on screen", and only one comes back: `MOBILE HALF 1` shows both blank rows hidden with `DetailSection` offering `Show 2 empty fields`, `MOBILE HALF 2` clicks that toggle, gets both rows back, and asserts that `Acme Corporation` — the row the dedupe removed — does **not** come back.

## Checks

- `pnpm exec vitest run packages/plugin-detail/src/renderers/__tests__/record-details.dedupeEmptinessTrims-8350.test.tsx` — `Test Files 1 passed (1) / Tests 10 passed (10)` (was 8).
- `pnpm --filter @object-ui/plugin-detail type-check` — exit 0. The test file is genuinely in that program: `tsc -p tsconfig.test.json --listFiles` lists it (1 hit, with `DetailSection.tsx` as the lit control).
- `pnpm exec eslint .` in `packages/plugin-detail` — exit 0, 0 errors, 901 pre-existing warnings; the two on this file are the pre-existing `no-explicit-any` on `renderBody`.
- Changeset — `node scripts/check-changeset-presence.mjs` verdict: `1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/issue-8399-dedupe-pin-pins-viewport.md.` `Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.` `check-changeset-no-major.mjs` also exit 0.
- No control bytes in either changed file (`grep -naP` for the control ranges, zero hits, with a lit control that fires on a file containing one).

## Out of scope, filed separately

#8444 — forcing `useIsMobile` to answer "mobile" turns **21 of 137** test files in this package red (77 of 1233 tests). Same class, one layer out. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_