### PR TITLE
fix(components): exclude test files from the published stylesheet's @source scan

### DIFF
--- a/.changeset/8446-components-css-excludes-test-sources.md
+++ b/.changeset/8446-components-css-excludes-test-sources.md
@@ -1,0 +1,48 @@
+---
+'@object-ui/components': minor
+---
+
+Stop scanning this package's own TEST files into the published stylesheet
+(objectui#8446).
+
+**The bloat was the mild half — this was a false-green generator.** Tailwind v4
+scans source *text*, not an import graph, and `src/index.css` declared
+`@source '../src/**/*.{ts,tsx}'` with no exclusion. All 243 test files under
+`src/**/__tests__/` were therefore sources for the published `dist/index.css`,
+so a class-shaped token written as a test's *expected value* compiled a real
+utility into the shipped bundle — meaning a test could create the production
+utility it was asserting on. Measured on #8435: `.\32 xl\:grid-cols-6` was
+present in the sheet with the *unfixed* renderer on disk, sourced entirely from
+assertion strings. Anyone reading "the class is in the stylesheet" as evidence
+the renderer worked would have been reading their own test back.
+
+Two `@source not` lines are added, matching the spelling already used by
+`fields`, `plugin-grid` and `plugin-kanban`.
+
+**Published bundle change — eight rules are removed**, measured by compiling
+`src/index.css` through this package's own postcss + `@tailwindcss/postcss`
+pipeline before and after, from the directory `pnpm build` runs in:
+
+    .flex-grow  .flex-nowrap  .h-[125px]  .isolate
+    .paused     .shrink       .text-green-500  .w-[250px]
+
+Nothing is added. Every one of the eight was named **only** by a test file:
+`.h-[125px]` / `.w-[250px]` are `<Skeleton>` fixture sizes in
+`snapshot-critical.test.tsx`, and `.flex-grow` came from a *prose sentence in a
+JSDoc comment* that mentions the CSS property `flex-grow: 50`. No non-test
+source in the package names any of them.
+
+**Who could notice.** A consumer running their own Tailwind build (as every
+example app here does) generates utilities from their own markup and is
+unaffected. Authoring these classes in runtime page metadata was already
+unsupported — the 2026-06-30 amendment to ADR-0080 under ADR-0065 states that a
+utility class in page source "produces CSS only if that exact class happens to
+already appear in objectui's own source", and `os validate` warns
+`page-source-className-tailwind`. That incidental "happens to appear" is exactly
+what is being removed. The narrow case that *can* regress is an app which
+imports only the prebuilt `@object-ui/components/style.css`, runs no Tailwind of
+its own, and hand-writes one of the eight in its own JSX; `.isolate`,
+`.shrink`, `.flex-nowrap` and `.text-green-500` are plausible there. Scored
+`minor` for that reason, not `patch`. `.flex-grow` and `.shrink` additionally
+have surviving canonical spellings — `.grow` and `.shrink-0` remain in the
+sheet, and this repo already migrated `flex-grow-N` → `grow-N` deliberately.

--- a/packages/components/src/__tests__/index-css-scan-excludes-tests.test.ts
+++ b/packages/components/src/__tests__/index-css-scan-excludes-tests.test.ts
@@ -1,0 +1,103 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `src/index.css` must not scan this package's own TEST files — objectui#8446.
+ *
+ * ## What was wrong
+ *
+ * Tailwind v4 scans source TEXT, not an import graph. `src/index.css` declared
+ * `@source '../src/**' + '/*.{ts,tsx}'` with no exclusion, so every one of the
+ * 243 test files under `src/**' + '/__tests__/` was a source for the PUBLISHED
+ * `dist/index.css`. A class-shaped token written as a test's expected value —
+ * even one sitting in a prose comment — therefore compiled a real utility into
+ * the shipped bundle, which means a test could create the very production
+ * utility it was asserting on. Measured on #8435: `.\32 xl\:grid-cols-6` was
+ * in the sheet with the UNFIXED renderer, sourced entirely from assertion
+ * strings.
+ *
+ * ## The instrument
+ *
+ * A sentinel token that exists nowhere else in the repository, written in THIS
+ * file — which lives under `__tests__/` and is therefore exactly the kind of
+ * file the exclusion must keep out of the scan. If the exclusions are removed,
+ * this file becomes a source, the sentinel compiles, and the negative
+ * assertion below goes red. The probe is live only because it is self-hosted:
+ * it does not depend on any other test continuing to name a fixture class.
+ *
+ * ## Why the positive assertion is not optional
+ *
+ * "No test-sourced rules" is satisfied by a stylesheet compiled from NOTHING —
+ * an implementation strictly worse than the fix (delete the `@source` line
+ * outright) would pass a negative-only test. The positive half pins a
+ * production-sourced utility and a floor on the rule count, so an empty or
+ * gutted sheet fails.
+ *
+ * ## Why `base` is passed explicitly
+ *
+ * `src/index.css` opens with a bare `@import 'tailwindcss'`, so Tailwind's
+ * automatic source detection is ON and resolves against the PROCESS CWD. Vitest
+ * runs from the repo root while `pnpm build` runs from this package directory,
+ * and the two produce different stylesheets from the same bytes (measured:
+ * 3430 rules vs 1385). Pinning `base` to the package root makes this reading
+ * reproduce the artifact the BUILD produces, from either working directory.
+ * The CWD dependence itself is out of scope here and reported separately.
+ */
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import postcss from 'postcss';
+import tailwindPostcss from '@tailwindcss/postcss';
+import { describe, expect, it } from 'vitest';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const entry = resolve(packageRoot, 'src/index.css');
+
+/**
+ * Deliberately absent from every other file in the repository, and an
+ * arbitrary-value utility so no production source can ever legitimately name
+ * it. Its ONLY occurrence is this line, in a file under `__tests__/`.
+ */
+const SENTINEL = 'mt-[3.7331px]';
+
+/**
+ * The part of the sentinel that Tailwind's selector escaping leaves alone
+ * (`.mt-\[3\.7331px\]` escapes the brackets and the dot, never the digits).
+ * Asserting on THIS rather than on a hand-escaped selector is what keeps the
+ * negative assertion from passing for the wrong reason.
+ */
+const SENTINEL_VALUE = '3.7331px';
+
+async function compilePublishedStylesheet(): Promise<{
+  css: string;
+  selectors: Set<string>;
+}> {
+  const source = await readFile(entry, 'utf8');
+  const result = await postcss([tailwindPostcss({ base: packageRoot })]).process(source, {
+    from: entry,
+  });
+  const selectors = new Set<string>();
+  postcss.parse(result.css, { from: entry }).walkRules((rule) => {
+    selectors.add(rule.selector);
+  });
+  return { css: result.css, selectors };
+}
+
+describe('packages/components/src/index.css @source scan', () => {
+  it('does not compile tokens that only test files name, and still compiles shipped ones', async () => {
+    const { css, selectors } = await compilePublishedStylesheet();
+
+    // POSITIVE — a sheet compiled from nothing must not pass.
+    expect(selectors.has('.flex-col')).toBe(true);
+    expect(selectors.size).toBeGreaterThan(800);
+
+    // NEGATIVE — this file is scanned only if the exclusions are gone.
+    expect(SENTINEL).toContain(SENTINEL_VALUE);
+    expect(css).not.toContain(SENTINEL_VALUE);
+  }, 60_000);
+});

--- a/packages/components/src/index.css
+++ b/packages/components/src/index.css
@@ -9,8 +9,24 @@
    centralized app-shell styles directly from their own index.css. */
 @custom-variant dark (&:where(.dark, .dark *));
 
-/* Scan sources for Tailwind classes */
+/* Scan sources for Tailwind classes.
+ *
+ * Only SHIPPED source. Tailwind v4 scans source TEXT, so any class-shaped
+ * token in a file that is scanned compiles a real rule into the published
+ * `dist/index.css` — including a token that only ever appears as a test's
+ * EXPECTED value. Without the exclusions below a test could therefore create
+ * the very production utility it asserts on, and a stylesheet reading would
+ * stop being evidence about the renderer (objectui#8446, hit live on #8435).
+ *
+ * The directory exclusion is the load-bearing one here: every test file in
+ * this package lives under a `__tests__/` directory, and two of them
+ * (`test-utils.tsx`, `page-header-action-ids.dist.spec.tsx`) are not named
+ * `*.test.*`. The filename exclusion carries no files today; it is kept to
+ * match the siblings (`fields`, `plugin-grid`, `plugin-kanban`) so a future
+ * co-located test is covered by construction rather than by luck. */
 @source '../src/**/*.{ts,tsx}';
+@source not './**/*.test.{ts,tsx}';
+@source not './**/__tests__/**';
 
 /* Tailwind plugin for animations */
 @plugin 'tailwindcss-animate';


### PR DESCRIPTION
Fixes #8446

Tailwind v4 scans source **text**, not an import graph. `packages/components/src/index.css`
declared `@source '../src/**/*.{ts,tsx}'` with no exclusion, so all **243** test files under
`src/**/__tests__/` were sources for the published `dist/index.css`. A class-shaped token
written as a test's *expected value* therefore compiled a real utility into the shipped
bundle — which is how a test can create the production utility it is asserting on.

The single cleanest instance found here is not a fixture but an assertion:

```
packages/components/src/renderers/basic/__tests__/icon-unresolvable-placeholder.test.tsx:146
    expect(svg?.getAttribute('class')).toContain('text-green-500');
```

`.text-green-500` shipped in `dist/index.css` **because that assertion names it.**

Two `@source not` lines are added, matching the spelling already used by `fields`,
`plugin-grid` and `plugin-kanban`.

---

## The measurement

`src/index.css` compiled through this package's own pipeline — `postcss([tailwindPostcss()])`,
i.e. step 2 of `packages/components/scripts/build-css.mjs` — and every `Rule` node collected
with its at-rule ancestry. Diffing rule **sets**, not counting them.

**File set on disk for both readings** (this is the step whose omission would make the table
dishonest — the compile is sensitive to what is on disk, not to what is committed):

- Working tree exactly `0b1ac58a66ee8ee0ddc59e0fa73301f8647ffbf6`; `git status --porcelain`
  over `packages/components/src` **empty** for the *before* reading.
- 453 `.ts`/`.tsx` files under `packages/components/src`, **243** of them test-shaped.
- *After* reading: the same tree plus this PR's two `@source not` lines. The new guard test
  file was added afterwards and **verified not to change the sheet** (byte-identical rule set),
  so it does not contaminate the table.

⚠️ **And the working directory, which turned out to matter more than the file set.**
`src/index.css` opens with a bare `@import 'tailwindcss'`, so Tailwind's automatic source
detection is ON and — as `packages/fields/src/index.css` already documents — resolves against
the **process CWD**. Same commit, same bytes, two artifacts:

| compiled from | rules | bytes | rules removed by this PR |
|---|---:|---:|---:|
| `packages/components` (**where `pnpm build` runs** — authoritative) | 1385 → 1377 | 159 827 → 159 481 | **8** |
| repo root | 3430 → 3427 | 438 435 → 438 319 | 3 |

A repo-root reading would have under-reported this PR's removal by **five of eight classes** —
they survive there only because *other* packages' sources also name them. The table below is
the package-CWD one.

## What disappears — the rule diff

**Removed (8). Added (0).**

```
@layer utilities || .flex-grow
@layer utilities || .flex-nowrap
@layer utilities || .h-\[125px\]
@layer utilities || .isolate
@layer utilities || .paused
@layer utilities || .shrink
@layer utilities || .text-green-500
@layer utilities || .w-\[250px\]
```

## Per-class verdict: does any non-test source name it?

The compile diff *defines* the answer — a rule that disappears when test files stop being
scanned is by construction sourced only from test files. The greps below say **which** text
produced it. All eight: **no production namer.**

| class | what actually produced it | production namer |
|---|---|---|
| `.text-green-500` | `icon-unresolvable-placeholder.test.tsx:141,146` — a `className` fixture **and the `toContain` expected value** | none |
| `.h-[125px]` | `snapshot-critical.test.tsx:321` — a `Skeleton` element with `className="h-[125px] w-[250px] …"` + committed snapshot | none |
| `.w-[250px]` | `snapshot-critical.test.tsx:309,321,323` + committed snapshot | none |
| `.flex-grow` | `form-field-panes.test.tsx:25` — **prose in a JSDoc comment** about the CSS *property* `flex-grow: 50` | none |
| `.flex-nowrap` | `page-header-title-width.test.tsx:6` — prose in a JSDoc comment | none |
| `.paused` | `dialog-popover-focus-scope.test.tsx:76` — a `//` code comment | none |
| `.isolate` | `__tests__` prose about Vitest's `isolate: true` | none |
| `.shrink` | `combobox-long-label.test.tsx:34,36` — a test title and a comment | none |

Four of the eight were compiled out of **English prose in comments**. None was ever authored
as styling.

### Does removing them bite anyone?

- **Apps that run their own Tailwind** — every example app here does (`apps/console`,
  `examples/console-starter`, `examples/byo-backend-console` all `@source` the package `src`
  dirs) — generate utilities from their own markup and are unaffected.
- **Authored runtime metadata** was already unsupported. The 2026-06-30 amendment to ADR-0080
  under ADR-0065 (`content/docs/guide/react-pages.md`) states a utility class in page source
  "produces CSS only if that exact class happens to already appear in objectui's own source",
  and `os validate` warns `page-source-className-tailwind`. That incidental "happens to
  appear" is precisely what is being removed.
- **The narrow case that can regress:** an app importing only the prebuilt
  `@object-ui/components/style.css`, running no Tailwind of its own, hand-writing one of the
  eight in its own JSX. `.isolate`, `.shrink`, `.flex-nowrap`, `.text-green-500` are plausible
  there. `.flex-grow` and `.shrink` also have surviving canonical spellings — `.grow` and
  `.shrink-0` stay in the sheet, and this repo already migrated `flex-grow-N` → `grow-N`
  deliberately.

That residual case is why the changeset is `minor` rather than `patch`.

## Proving the change can fail

The instrument is the compiled stylesheet, so the ablation restores the unrestricted
`@source` and recompiles. Run from the committed implementation (`336bd7a4`), tree clean,
with a `trap ... EXIT INT TERM` holding absolute paths.

**Mutation proven on disk, not by an exit code:** `@source not` lines 2 → 0; `git hash-object`
`50c2d90f` vs `git rev-parse HEAD:packages/components/src/index.css` = `75153ac5`.

Both legs fire:

1. **The rules come back** — all eight reappear in the recompiled sheet. So does a **ninth**,
   `.mt-\[3\.7331px\]`: the guard test's own sentinel. That is the defect reproducing live on
   this PR's own new test file, and it is what proves the probe is not inert.
2. **The guard test goes red** — `vitest` exits 1 on
   `AssertionError: expected '/*! tailwindcss v4.3.3 …' not to contain '3.7331px'`.

**Restore proven by state:** `git diff HEAD` empty, `git hash-object` back to `75153ac5`,
`@source not` lines back to 2 — then the guard test passes again.

No `dist/` rebuild is involved: the reading compiles `src/index.css` fresh each time, so there
is no stale-artifact leg to get wrong here.

## The guard test

`src/__tests__/index-css-scan-excludes-tests.test.ts` compiles the stylesheet and asserts
**both** directions, because a stylesheet compiled from **nothing** satisfies "no test-sourced
rules" — an implementation strictly worse than this fix (delete the `@source` line) would pass
a negative-only test.

- **Negative:** a sentinel arbitrary-value token (`mt-[3.7331px]`, absent everywhere else in
  the repo) is written **in that test file itself**, which lives under `__tests__/`. The probe
  is self-hosted: remove the exclusions and the sentinel compiles and the test goes red. It
  does not depend on any other test continuing to name a fixture class.
- **Positive:** `.flex-col` (production-sourced) must be present, and the sheet must hold more
  than 800 rules.

It passes `base: packageRoot` to `@tailwindcss/postcss` so the reading is CWD-independent —
otherwise Vitest (repo root) and `pnpm build` (package dir) would measure different artifacts,
per the table above.

## Out of scope — reported, not swept in (#8446 fences this to `components`)

`search_issues` was **rate-limited**, so per the dispatch these are reported rather than filed
unsearched. None is fixed here.

1. **The issue says `components` is the only one of three missing this. There are more.**
   Sweep of every `@source` in the repo: excluding correctly — `fields` (filename only),
   `plugin-grid` **(not mentioned in the issue)**, `plugin-kanban`. Missing exclusions
   entirely — `packages/runner/src/index.css`, `apps/console/src/index.css`,
   `apps/site/app/global.css`, and both `examples/*/src/index.css`.
2. **`packages/runner` is a published package that re-leaks these exact classes.** Its
   `index.css` scans `../../packages/components/src/**` with **no** test exclusion, so after
   this PR `@object-ui/runner`'s own published sheet still compiles the eight. Its line 10 also
   reads `@source './src/**/*.{ts,tsx}'`, which from `packages/runner/src/index.css` resolves
   to `packages/runner/src/src/` — **a directory that does not exist.**
3. **`components` lacks `source(none)`, so its published sheet is CWD-dependent** (1385 vs 3430
   rules, table above) and non-shipped text is a source. Measured: adding
   `source(none)` on top of this PR removes **23 further** rules, including `.flex-shrink-0`,
   `.bg-blue-500`, `.md:text-2xl`, `.hover:bg-blue-700:hover` and — from a doc comment —
   `.origin-[--radix-…]` with a literal Unicode ellipsis. `fields` calls its own `source(none)`
   "load-bearing, not tidiness" for exactly this reason. **This PR's two lines are a strict
   improvement but only a partial fix of the false-green generator**; the complete fix is
   sibling parity on `source(none)`, which is a materially larger bundle diff and its own card.
4. **`packages/components/CHANGELOG.md` is a Tailwind source for the published bundle.**
   Proven by injecting a unique token into it and recompiling. `.flex-shrink-0` — a deprecated
   v3 alias this repo deliberately migrated away from — ships today *solely because the
   changelog entry announcing its removal names it.*

## Changeset

`.changeset/8446-components-css-excludes-test-sources.md` — `@object-ui/components: minor`.

`node scripts/check-changeset-presence.mjs`:
> ✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)

Not empty-frontmatter: this changes published bundle contents. Not `patch`: it removes
behaviour a narrow consumer could depend on, and this repo labels its own breaking changes
`minor`. `major` is forbidden for the fixed group and
`scripts/check-changeset-no-major.mjs` passes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_