### PR TITLE
fix(core): lower $and / $or to real AST group nodes in convertFiltersToAST

### DIFF
--- a/.changeset/filter-ast-combinators-6948.md
+++ b/.changeset/filter-ast-combinators-6948.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/core': minor
+'@object-ui/data-objectstack': patch
+---
+
+`convertFiltersToAST` lowers the `$and` / `$or` combinators to real ObjectQL AST
+group nodes (objectui#6948).
+
+`FilterCondition` declares `$and` / `$or` / `$not`, and this repo's one lowering
+had no branch for any of them. `$and` / `$or` fell through to the
+simple-equality branch and became a leaf naming a field literally called `$and`
+/ `$or`. That leaf reached the server intact — `parseFilterAST` reads
+`['$or', '=', [...]]` back as a real `$or`, so the wire condition was correct
+and is unchanged by this release — but it is a well-formed *comparison* node, so
+every AST evaluator in this repo read `$or` as a field name, found no such key
+on any record, and returned an EMPTY list with no error. Producers that reach
+this today include `mergeFilters` (dashboard scope broadcast, dataset report
+blocks), `FilterConditionField`, and `Field.relatedListFilter`.
+
+`minor` rather than `patch`: shipped results move. A list filtered by a
+combinator through any in-process data source went from zero rows to the rows
+the author asked for, and an unknown or refused operator *inside* a combinator
+branch — which used to travel to the wire unchecked inside the leaf's value slot
+— is now refused at the same door as every other operator.
+
+`$not` is refused with an accurate message instead of translated: the AST has no
+negation keyword (`FILTER_ARRAY_LOGIC_KEYWORDS` is `['and', 'or']`) and several
+operators it carries have no negated counterpart, so a rewrite would be silently
+partial. It threw before this change too, naming the author's own nested field
+as a bogus operator; the verdict is unchanged, only the diagnostic.

--- a/packages/core/src/utils/__tests__/filter-combinators-6948.test.ts
+++ b/packages/core/src/utils/__tests__/filter-combinators-6948.test.ts
@@ -1,0 +1,345 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `$and` / `$or` / `$not` through the repo's ONE lowering — objectui#6948.
+ *
+ * ## What this file asserts, and why it is row sets and not source shape
+ *
+ * The card asked for a branch. A branch existing is not the property that
+ * matters, so nothing here greps the source: every assertion is either the node
+ * that REACHES THE WIRE, put through the spec's own doors (`isFilterAST` /
+ * `parseFilterAST`, `@objectstack/spec/data`), or the ROW SET a real
+ * `ValueDataSource` returns for it.
+ *
+ * Both halves are pinned in both directions, because each half alone passes on
+ * an implementation strictly worse than the bug:
+ *
+ *   - an assertion that a combinator is PRESENT passes on a builder that emits
+ *     everything;
+ *   - an assertion that a row set is EMPTY passes on a converter that emits
+ *     nothing at all — `$filter: undefined` returns EVERY row, and a node no
+ *     evaluator reads returns NONE.
+ *
+ * So every row-set case names the exact ids, and {@link ALL_IDS} is asserted to
+ * be neither of them.
+ *
+ * ## What was actually wrong — NOT what the card said
+ *
+ * The card stated that the pre-fix emission for `$and` / `$or` — a leaf naming a
+ * field literally called `$and` / `$or` — was refused by the server with `400
+ * INVALID_FILTER`. Re-measured against `@objectstack/spec` 17.3.0 that is FALSE,
+ * and this repo already knew: `data-objectstack/src/filter-entry-translation.test.ts`
+ * pins the same round trip with the note "verified". `parseFilterAST` lowers
+ * `['$or', '=', [...]]` to `{ $or: [...] }` — the FilterCondition the author
+ * wrote — because a `[field, '=', value]` node becomes `{ [field]: value }` and
+ * `$or` is a legal FilterCondition key. So the combinator DID reach the wire and
+ * WAS interpreted correctly there. {@link WIRE_UNMOVED} pins that it still is.
+ *
+ * The real defect is one door further in, and it is silent: `['$or', '=', [...]]`
+ * is a well-formed COMPARISON node, so every AST evaluator in this repo reads
+ * `$or` as a field name. `ValueDataSource`'s matcher looks up `record['$or']`,
+ * finds nothing, and excludes every row — no error, no console line, an empty
+ * list where the author asked for a union. That is the failure this file fixes
+ * in place, and {@link PRE_FIX_OR_NODE} is the control that it really did.
+ *
+ * ## `$not` is refused, and that is an open contract question
+ *
+ * The ObjectQL AST has no negation: `FILTER_ARRAY_LOGIC_KEYWORDS` is
+ * `['and', 'or']`. Rewriting the negation inward is not available either —
+ * `startswith`, `endswith`, `between` and `icontains` have no negated
+ * counterpart in `VALID_AST_OPERATORS`, so a De Morgan lowering would be
+ * silently partial, and `$not` is NULL-safe by ruling (objectstack#5146), which
+ * a partial rewrite would quietly drop. So `$not` is refused with an accurate
+ * message instead of translated. It threw before this card too — with a message
+ * naming a nonsense operator — so this changes the diagnostic, not the verdict;
+ * whether the AST should GAIN a negation is a spec decision, not this file's.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isFilterAST, parseFilterAST } from '@objectstack/spec/data';
+import { convertFiltersToAST, mergeFilterNodes } from '../filter-converter';
+import { ValueDataSource } from '../../adapters/ValueDataSource';
+
+// ---------------------------------------------------------------------------
+// Fixture — one row per branch of the combinators under test
+// ---------------------------------------------------------------------------
+
+const ROWS = [
+  { id: 'open-active', status: 'open', is_active: true, age: 30 },
+  { id: 'blocked-idle', status: 'blocked', is_active: false, age: 20 },
+  { id: 'done-active', status: 'done', is_active: true, age: 40 },
+  { id: 'null-status', status: null, is_active: null, age: null },
+  { id: 'no-status-key' },
+];
+
+/** What "no filter reached the evaluator" looks like. Never an expected answer. */
+const ALL_IDS = ['open-active', 'blocked-idle', 'done-active', 'null-status', 'no-status-key'];
+
+async function selectedIds(filter: unknown): Promise<string[]> {
+  const ds = new ValueDataSource({ items: ROWS });
+  const result = await ds.find('tasks', { $filter: filter as any });
+  return result.data.map((r: any) => r.id as string);
+}
+
+/** The authored filter of the card: a two-branch union. */
+const AUTHORED_OR = { $or: [{ status: 'open' }, { status: 'blocked' }] };
+
+/** Its emission BEFORE this card — a comparison node on a field named `$or`. */
+const PRE_FIX_OR_NODE = ['$or', '=', [{ status: 'open' }, { status: 'blocked' }]];
+
+// ---------------------------------------------------------------------------
+// 1. The lowering — the node that reaches the wire
+// ---------------------------------------------------------------------------
+
+describe('objectui#6948 — the lowering', () => {
+  it('lowers $or to an AST group node, children lowered recursively', () => {
+    expect(convertFiltersToAST(AUTHORED_OR)).toEqual([
+      'or',
+      ['status', '=', 'open'],
+      ['status', '=', 'blocked'],
+    ]);
+  });
+
+  it('lowers $and the same way, and lowers operator children too', () => {
+    expect(convertFiltersToAST({ $and: [{ status: 'open' }, { age: { $gte: 18 } }] })).toEqual([
+      'and',
+      ['status', '=', 'open'],
+      ['age', '>=', 18],
+    ]);
+  });
+
+  it('nests, so a combinator inside a combinator survives as a group', () => {
+    expect(
+      convertFiltersToAST({
+        $and: [{ $or: [{ status: 'open' }, { status: 'done' }] }, { is_active: true }],
+      }),
+    ).toEqual([
+      'and',
+      ['or', ['status', '=', 'open'], ['status', '=', 'done']],
+      ['is_active', '=', true],
+    ]);
+  });
+
+  it('AND-combines a combinator with the sibling fields of its own object', () => {
+    expect(convertFiltersToAST({ is_active: true, ...AUTHORED_OR })).toEqual([
+      'and',
+      ['is_active', '=', true],
+      ['or', ['status', '=', 'open'], ['status', '=', 'blocked']],
+    ]);
+  });
+
+  it('survives mergeFilterNodes, so a parent scope still NARROWS it', () => {
+    // The related-list / line-items shape: a parent scope AND the list's own
+    // filter. The union must stay one child of the `and`, never spread into it.
+    expect(mergeFilterNodes({ task_version: 'tv-1' }, AUTHORED_OR)).toEqual([
+      'and',
+      ['task_version', '=', 'tv-1'],
+      ['or', ['status', '=', 'open'], ['status', '=', 'blocked']],
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The wire door — the spec's own predicate and lowering
+// ---------------------------------------------------------------------------
+
+/**
+ * The FilterCondition the server sees. Identical before and after this card —
+ * the pre-fix leaf round-tripped correctly, which is why the defect was invisible
+ * from the wire and why the changeset argues its level from the EVALUATOR side.
+ */
+const WIRE_UNMOVED = { $or: [{ status: 'open' }, { status: 'blocked' }] };
+
+describe('objectui#6948 — what the wire receives', () => {
+  it('emits a node the spec accepts AS A GROUP, which the old leaf was not', () => {
+    const node = convertFiltersToAST(AUTHORED_OR);
+    expect(isFilterAST(node)).toBe(true);
+    // Control that fires: the pre-fix node also passed `isFilterAST` — as a
+    // COMPARISON. Passing that gate was never the property in question, which
+    // is why this file does not stop here.
+    expect(isFilterAST(PRE_FIX_OR_NODE)).toBe(true);
+    expect(node).not.toEqual(PRE_FIX_OR_NODE);
+  });
+
+  it('lowers to the FilterCondition the author wrote', () => {
+    expect(parseFilterAST(convertFiltersToAST(AUTHORED_OR))).toEqual(WIRE_UNMOVED);
+  });
+
+  it('does not move the wire: the old leaf lowered to the SAME condition', () => {
+    expect(parseFilterAST(PRE_FIX_OR_NODE)).toEqual(WIRE_UNMOVED);
+    expect(parseFilterAST(convertFiltersToAST(AUTHORED_OR))).toEqual(parseFilterAST(PRE_FIX_OR_NODE));
+  });
+
+  it('keeps the parent scope AROUND the union once merged', () => {
+    expect(parseFilterAST(mergeFilterNodes({ task_version: 'tv-1' }, AUTHORED_OR) as any)).toEqual({
+      $and: [{ task_version: 'tv-1' }, WIRE_UNMOVED],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Row sets — both directions, one fixture
+// ---------------------------------------------------------------------------
+
+describe('objectui#6948 — row sets through ValueDataSource', () => {
+  it('the pre-fix node selected NOTHING — the control this repair is measured against', async () => {
+    // Silently: `matchesComparisonNode` reads `$or` as a field, `record['$or']`
+    // is undefined, no row equals the array. No throw, no console line.
+    expect(await selectedIds(PRE_FIX_OR_NODE)).toEqual([]);
+  });
+
+  it('INCLUDES both branches of the union — not empty', async () => {
+    expect(await selectedIds(convertFiltersToAST(AUTHORED_OR))).toEqual([
+      'open-active',
+      'blocked-idle',
+    ]);
+  });
+
+  it('EXCLUDES the rows outside the union — not everything', async () => {
+    const kept = await selectedIds(convertFiltersToAST(AUTHORED_OR));
+    for (const excluded of ['done-active', 'null-status', 'no-status-key']) {
+      expect(kept).not.toContain(excluded);
+    }
+  });
+
+  it('so the answer is neither of the two failure shapes', async () => {
+    const kept = await selectedIds(convertFiltersToAST(AUTHORED_OR));
+    // A converter that emits nothing usable leaves `$filter` unread: every row.
+    expect(kept).not.toEqual(ALL_IDS);
+    // A converter that emits a node no evaluator reads: no row. That is the bug.
+    expect(kept).not.toEqual([]);
+    // And the fixture is not trivially the answer either way.
+    expect(ALL_IDS.length).toBeGreaterThan(kept.length);
+    expect(await selectedIds(undefined)).toEqual(ALL_IDS);
+  });
+
+  it('$and intersects, both directions', async () => {
+    const node = convertFiltersToAST({ $and: [{ status: 'open' }, { is_active: true }] });
+    expect(await selectedIds(node)).toEqual(['open-active']);
+    expect(await selectedIds(node)).not.toEqual(ALL_IDS);
+  });
+
+  it('a parent scope still narrows a union it wraps', async () => {
+    const scoped = mergeFilterNodes({ is_active: true }, AUTHORED_OR);
+    // `blocked-idle` is in the union but fails the scope; `done-active` passes
+    // the scope but is outside the union. Both directions in one assertion.
+    expect(await selectedIds(scoped)).toEqual(['open-active']);
+  });
+
+  it('nested combinators evaluate as written', async () => {
+    const node = convertFiltersToAST({
+      $and: [{ $or: [{ status: 'open' }, { status: 'done' }] }, { is_active: true }],
+    });
+    expect(await selectedIds(node)).toEqual(['open-active', 'done-active']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. The boolean identities (#5322) — the boundary of the new branch
+// ---------------------------------------------------------------------------
+
+describe('objectui#6948 — empty and vacuous combinators', () => {
+  it('drops `$and: []` — the TRUE identity constrains nothing', async () => {
+    // NOT `['and']`: measured, `isFilterAST(['and'])` is false and
+    // `parseFilterAST(['and'])` is `undefined`, i.e. NO filter — every row. A
+    // TRUE conjunct must disappear, never become an empty group.
+    expect(isFilterAST(['and'])).toBe(false);
+    expect(parseFilterAST(['and'] as any)).toBeUndefined();
+    expect(convertFiltersToAST({ $and: [], status: 'open' })).toEqual(['status', '=', 'open']);
+    expect(await selectedIds(convertFiltersToAST({ $and: [], status: 'open' }))).toEqual([
+      'open-active',
+    ]);
+  });
+
+  it('keeps the pre-existing leaf for `$or: []` — FALSE is not expressible', async () => {
+    // The OR identity is FALSE (#5322) and the AST has no contradiction literal.
+    // The leaf answers FALSE at BOTH consumers, which no group node does.
+    const node = convertFiltersToAST({ $or: [] });
+    expect(node).toEqual(['$or', '=', []]);
+    expect(parseFilterAST(node)).toEqual({ $or: [] });
+    expect(await selectedIds(node)).toEqual([]);
+  });
+
+  it('lets a `{}` disjunct absorb its `$or`, and drops it from an `$and`', () => {
+    // #5322: `{}` is TRUE, so it absorbs an OR and vanishes from an AND. The
+    // absorbed OR must not leave an object in AST child position — that makes
+    // `isFilterAST` false for the whole filter.
+    expect(convertFiltersToAST({ $and: [{}, { status: 'open' }] })).toEqual([
+      'and',
+      ['status', '=', 'open'],
+    ]);
+    const absorbed = convertFiltersToAST({ $or: [{}, { status: 'open' }], is_active: true });
+    expect(absorbed).toEqual(['is_active', '=', true]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Refusals — envelope, not a bare throw
+// ---------------------------------------------------------------------------
+
+/** Assert the data-API refusal envelope (ADR-0112 / objectui#3066), not just that it threw. */
+function expectRefusal(run: () => unknown, messageMatch: RegExp): void {
+  expect(run).toThrow();
+  try {
+    run();
+  } catch (e: any) {
+    expect(e.code).toBe('INVALID_FILTER');
+    expect(e.httpStatus).toBe(400);
+    expect(String(e.message)).toMatch(messageMatch);
+  }
+}
+
+describe('objectui#6948 — refusals', () => {
+  it('refuses $not, naming the missing AST negation rather than a nonsense operator', () => {
+    // Before this card the message read "Unknown filter operator 'status' for
+    // field '$not'" — the author's own nested field name reported as an
+    // operator. It threw then and it throws now; only the diagnostic moved.
+    expectRefusal(
+      () => convertFiltersToAST({ $not: { status: 'done' } }),
+      /'\$not' filter combinator cannot be lowered/,
+    );
+    expect(() => convertFiltersToAST({ $not: { status: 'done' } })).not.toThrow(
+      /Unknown filter operator 'status'/,
+    );
+  });
+
+  it('refuses $not nested inside a combinator too', () => {
+    expectRefusal(
+      () => convertFiltersToAST({ $or: [{ status: 'open' }, { $not: { status: 'done' } }] }),
+      /'\$not' filter combinator cannot be lowered/,
+    );
+  });
+
+  it('refuses a combinator whose value is not an array', () => {
+    expectRefusal(
+      () => convertFiltersToAST({ $or: { status: 'open' } as any }),
+      /'\$or' filter combinator takes an ARRAY/,
+    );
+  });
+
+  it('refuses a non-object member', () => {
+    expectRefusal(
+      () => convertFiltersToAST({ $or: ['open' as any] }),
+      /Every member of '\$or' must be a filter condition OBJECT/,
+    );
+  });
+
+  it('runs the unknown-operator guard on combinator children, which used to escape it', () => {
+    // Pre-fix the whole array travelled to the wire verbatim inside the leaf's
+    // value slot, so a typo inside a `$or` branch was never checked here.
+    expectRefusal(
+      () => convertFiltersToAST({ $or: [{ status: { $bogus: 1 } as any }] }),
+      /Unknown filter operator '\$bogus'/,
+    );
+    expectRefusal(
+      () => convertFiltersToAST({ $or: [{ name: { $regex: 'a.c' } as any }] }),
+      /\$regex/,
+    );
+  });
+});

--- a/packages/core/src/utils/filter-converter.ts
+++ b/packages/core/src/utils/filter-converter.ts
@@ -81,6 +81,115 @@ export function convertOperatorToAST(operator: string): string | null {
 }
 
 /**
+ * The `FilterCondition` combinators this lowering can carry, and the AST
+ * keyword each becomes.
+ *
+ * The vocabulary is the spec's, not a second list: `FILTER_ARRAY_LOGIC_KEYWORDS`
+ * (`@objectstack/spec/data`) is `['and', 'or']` — measured — and those two are
+ * exactly the heads `isFilterAST` opens a group on. `$not` is absent from it,
+ * which is why it has no row here and is refused below rather than translated.
+ */
+const AST_LOGIC_KEYWORD: Record<string, 'and' | 'or'> = {
+  $and: 'and',
+  $or: 'or',
+};
+
+/**
+ * Lower ONE `$and` / `$or` group to an AST group node.
+ *
+ * Returns `undefined` when the group is the TRUE identity and therefore
+ * constrains nothing, so the caller drops it instead of emitting a childless
+ * `['and']` — which is NOT the same thing. Measured against the spec's own
+ * doors: `isFilterAST(['and'])` is `false` and `parseFilterAST(['and'])` is
+ * `undefined`, i.e. NO FILTER — every row. A combinator that reduces to "no
+ * constraint" must therefore disappear at THIS level; emitting an empty group
+ * would widen the result set, which is the one failure direction this file
+ * exists to avoid.
+ *
+ * `#5322` (maintainer ruling 2026-08-04, recorded on `FilterConditionSchema`)
+ * fixes the identities: `{ $and: [] }` is TRUE, `{ $or: [] }` is FALSE, and a
+ * `{}` disjunct is TRUE and ABSORBS its `$or`. TRUE is expressible here — it is
+ * the absence of a constraint. FALSE is not: the AST has no contradiction
+ * literal, so `{ $or: [] }` keeps the emission it already had (see
+ * {@link falseIdentityLeaf}).
+ */
+function lowerLogicalGroup(
+  field: string,
+  keyword: 'and' | 'or',
+  value: unknown,
+): FilterNode | undefined {
+  if (!Array.isArray(value)) {
+    throw new FilterOperatorError(
+      `[ObjectUI] The '${field}' filter combinator takes an ARRAY of conditions. ` +
+      `Received ${typeof value === 'object' ? 'an object' : typeof value}: ` +
+      `${JSON.stringify(value)}. Spec: FilterCondition declares ` +
+      `'${field}?: FilterCondition[]' (data/filter.zod.ts).`
+    );
+  }
+
+  if (value.length === 0) {
+    return keyword === 'and' ? undefined : falseIdentityLeaf(field, value);
+  }
+
+  const children: FilterNode[] = [];
+  for (const child of value) {
+    if (child === null || typeof child !== 'object' || Array.isArray(child)) {
+      throw new FilterOperatorError(
+        `[ObjectUI] Every member of '${field}' must be a filter condition OBJECT. ` +
+        `Received ${JSON.stringify(child)}. Spec: FilterCondition declares ` +
+        `'${field}?: FilterCondition[]' (data/filter.zod.ts).`
+      );
+    }
+    const lowered = convertFiltersToAST(child as Record<string, any>);
+    if (!Array.isArray(lowered)) {
+      // `convertFiltersToAST` hands back the ORIGINAL OBJECT when the child
+      // produced no conditions — a `{}` disjunct, or one holding only
+      // null/undefined values. That child is the TRUE identity (#5322), so it
+      // absorbs an `$or` outright and drops out of an `$and`. It must not be
+      // pushed as a child either way: an object in AST child position makes
+      // `isFilterAST` false (measured), and the wire face answers `400
+      // INVALID_FILTER` for the whole filter.
+      if (keyword === 'or') return undefined;
+      continue;
+    }
+    children.push(lowered as FilterNode);
+  }
+
+  // Every conjunct reduced to TRUE, so the `$and` constrains nothing.
+  if (children.length === 0) return undefined;
+
+  // A one-child group is emitted as a group, not unwrapped. `['or', node]` is
+  // accepted by `isFilterAST` (length >= 2 = keyword + one condition) and
+  // `parseFilterAST` reduces it to the child, so the extra hop costs nothing
+  // and keeps this function's output shape a function of the INPUT shape.
+  return [keyword, ...children] as FilterNode;
+}
+
+/**
+ * `{ $or: [] }` — FALSE, the OR identity (#5322) — as the leaf this file has
+ * always emitted for it.
+ *
+ * Deliberately unchanged, and deliberately not a group node. Three measurements
+ * against `@objectstack/spec` 17.3.0 and this repo's own evaluator decide it:
+ *
+ *   - `parseFilterAST(['$or', '=', []])` is `{ $or: [] }` — the FilterCondition
+ *     the author wrote, which every backend reduces to zero rows. Correct.
+ *   - `ValueDataSource`'s matcher reads it as a comparison on a field named
+ *     `$or`, which no record has, so it excludes every row. Also correct, and
+ *     the same answer.
+ *   - `['or']` — the "obvious" empty group — is `isFilterAST` FALSE and
+ *     `parseFilterAST` `undefined`: no filter at all, i.e. EVERY row. That is
+ *     the widening direction, on a filter whose whole purpose is to hide rows
+ *     (#5134), so it is the one shape that must not be emitted.
+ *
+ * A leaf naming `$or` as a field is not a shape to be proud of; it is the shape
+ * that answers FALSE at both consumers, which the alternatives do not.
+ */
+function falseIdentityLeaf(field: string, value: unknown[]): FilterNode {
+  return [field, '=', value] as FilterNode;
+}
+
+/**
  * Convert object-based filters to ObjectStack FilterNode AST format.
  * Converts MongoDB-like operators to ObjectStack filter expressions.
  * 
@@ -101,15 +210,49 @@ export function convertOperatorToAST(operator: string): string | null {
  * // Multiple conditions
  * convertFiltersToAST({ age: { $gte: 18, $lte: 65 }, status: 'active' })
  * // => ['and', ['age', '>=', 18], ['age', '<=', 65], ['status', '=', 'active']]
- * 
- * @throws {Error} If an unknown operator is encountered
+ *
+ * @example
+ * // Logical combinators (objectui#6948) — children lower recursively
+ * convertFiltersToAST({ $or: [{ status: 'open' }, { status: 'blocked' }] })
+ * // => ['or', ['status', '=', 'open'], ['status', '=', 'blocked']]
+ *
+ * @throws {FilterOperatorError} If an unknown operator is encountered, or if
+ * `$not` is used — see the `$not` arm for why the AST cannot carry it.
  */
 export function convertFiltersToAST(filter: Record<string, any>): FilterNode | Record<string, any> {
   const conditions: FilterNode[] = [];
   
   for (const [field, value] of Object.entries(filter)) {
     if (value === null || value === undefined) continue;
-    
+
+    // Logical combinators are read BEFORE the field/operator machinery below,
+    // because they are not fields and their value is not an operator map.
+    // Without this arm `$and` / `$or` reached the simple-equality branch (their
+    // value is an array, so the operator loop was skipped) and became a leaf
+    // naming a field literally called `$and` / `$or`, while `$not` entered the
+    // operator loop with its OWN nested object's keys read as operator names.
+    const logicKeyword = AST_LOGIC_KEYWORD[field];
+    if (logicKeyword) {
+      const group = lowerLogicalGroup(field, logicKeyword, value);
+      if (group !== undefined) conditions.push(group);
+      continue;
+    }
+
+    if (field === '$not') {
+      throw new FilterOperatorError(
+        `[ObjectUI] The '$not' filter combinator cannot be lowered to the ObjectQL ` +
+        `filter AST. '@objectstack/spec' declares it on FilterCondition, but the AST ` +
+        `this layer emits has no negation keyword (FILTER_ARRAY_LOGIC_KEYWORDS is ` +
+        `['and', 'or']), and rewriting the negation inward is not available either — ` +
+        `'startswith', 'endswith', 'between' and 'icontains' have no negated ` +
+        `counterpart in VALID_AST_OPERATORS, so the rewrite would be silently ` +
+        `partial. Express the negation with a negated operator instead ($ne, $nin, ` +
+        `$notContains); note those follow each operator's own answer for a missing ` +
+        `value rather than $not's NULL-safe rule (objectstack#5146). ` +
+        `Value: ${JSON.stringify(value)}.`
+      );
+    }
+
     // Check if value is a complex operator object
     if (typeof value === 'object' && !Array.isArray(value)) {
       // Handle operator-based filters

--- a/packages/data-objectstack/src/filter-entry-translation.test.ts
+++ b/packages/data-objectstack/src/filter-entry-translation.test.ts
@@ -22,7 +22,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { isFilterAST } from '@objectstack/spec/data';
+import { isFilterAST, parseFilterAST } from '@objectstack/spec/data';
 import { ObjectStackAdapter, clearSharedDiscoveryCache, isMalformedFilterError } from './index';
 
 function makeAdapter() {
@@ -309,12 +309,37 @@ describe('an OBJECT filter reaches the same predicate on both routes', () => {
   );
 
   bothRoutes(
-    'leaves a top-level Mongo logical node alone',
-    // `mergeFilters` (dashboard scope filters) produces this. It survives as a
-    // `['$and', '=', [...]]` comparison that `parseFilterAST` reads back as a
-    // real `$and` — verified, and the reason this is NOT rewritten here.
+    'lowers a top-level Mongo logical node to an AST group',
+    // `mergeFilters` (dashboard scope filters) produces this, and it used to go
+    // out as a `['$and', '=', [...]]` comparison — a leaf naming a field
+    // literally called `$and`. The note this case carried was accurate about the
+    // WIRE and that half still holds: `parseFilterAST` reads that leaf back as a
+    // real `$and`, so nothing was ever refused there, and the assertion below
+    // pins that the lowered form reaches the same FilterCondition.
+    //
+    // What the note did not cover is the consumer one door in. The leaf is a
+    // well-formed COMPARISON node, so every AST evaluator in this repo — the
+    // matcher in `@object-ui/core`'s `ValueDataSource` above all — reads `$and`
+    // as a FIELD NAME, finds no such key on any record, and returns an EMPTY
+    // list with no error. objectui#6948 taught `convertFiltersToAST` the group
+    // spelling the spec's own `FILTER_ARRAY_LOGIC_KEYWORDS` declares, so the
+    // node is now executable as well as parseable.
     { $and: [{ a: 1 }, { b: 2 }] },
-    (wire) => expect(wire).toEqual(['$and', '=', [{ a: 1 }, { b: 2 }]]),
+    (wire) => expect(wire).toEqual(['and', ['a', '=', 1], ['b', '=', 2]]),
+  );
+
+  bothRoutes(
+    'and the wire CONDITION is unchanged by that lowering',
+    // The half of the old note that still holds, kept as an assertion rather
+    // than a sentence: both spellings lower to the same `FilterCondition`, so
+    // the server's answer to this filter did not move.
+    { $and: [{ a: 1 }, { b: 2 }] },
+    (wire) => {
+      expect(parseFilterAST(wire as any)).toEqual({ $and: [{ a: 1 }, { b: 2 }] });
+      expect(parseFilterAST(wire as any)).toEqual(
+        parseFilterAST(['$and', '=', [{ a: 1 }, { b: 2 }]] as any),
+      );
+    },
   );
 
   for (const route of ['plain', 'expand'] as const) {


### PR DESCRIPTION
Fixes #6948

## The card's premise is half wrong, and that changes what this PR is

Re-derived on `ca3942729` (the branch base) against `@objectstack/spec` **17.3.0** — the card measured `packages/core/dist` at `40c479af2`.

**Still holds, byte for byte.** Composing each condition with a parent scope, `mergeFilterNodes({task_version:'tv-1'}, f)` on the base commit reproduces every emission the card printed:

```
$or    ->  ["and",["task_version","=","tv-1"],["$or","=",[{"status":"open"},{"status":"blocked"}]]]
$and   ->  ["and",["task_version","=","tv-1"],["$and","=",[{"status":"open"},{"is_active":true}]]]
$not   ->  THROWS FilterOperatorError: Unknown filter operator 'status' for field '$not'.
plain  ->  ["and",["task_version","=","tv-1"],["status","!=","archived"]]
```

The file, the three functions and the two mechanisms (array value skips the operator loop; `$not`'s own nested keys read as operators) all hold. `filter-converter.ts` has not moved on `main` since `2a9513d81`.

**Falsified.** The card says the `$and` / `$or` leaf is *"a well-formed AST node carrying a nonsense field, so the server refuses it (`400 INVALID_FILTER`)"*. Measured against the spec's own doors:

```
isFilterAST(['$or','=',[{status:'open'},{status:'blocked'}]])   -> true
parseFilterAST(['$or','=',[{status:'open'},{status:'blocked'}]]) -> {$or:[{status:'open'},{status:'blocked'}]}
```

A `[field, '=', value]` node lowers to `{ [field]: value }`, and `$or` is a legal `FilterCondition` key — so the leaf round-trips into a *real* combinator and the server was never refusing anything. This repo already knew: `data-objectstack/src/filter-entry-translation.test.ts` pinned that exact round trip with the note "verified, and the reason this is NOT rewritten here."

**So the failure mode being fixed is neither "never reaches the wire" nor "reaches it and is ignored."** It is: *reaches the wire and is interpreted correctly there, and is mis-evaluated — silently, to zero rows — by every AST evaluator inside this repo.* `['$or','=',[...]]` is a well-formed **comparison** node, so `ValueDataSource`'s `matchesComparisonNode` reads `$or` as a field name, looks up `record['$or']`, finds nothing, and excludes every row. No throw, no console line, an empty list where the author asked for a union.

## Reachability — which consumers the claim covers

The card called this sink-level rather than related-list-level. That holds and is stronger than stated: `$and` has live in-repo producers today, not only the newly-typed `Field.relatedListFilter`.

| producer | shape emitted |
|---|---|
| `core/src/utils/merge-filters.ts` `mergeFilters` | `{ $and: [a, b] }` |
| `plugin-dashboard/src/DashboardRenderer.tsx:851,858` | via `mergeFilters` (scope-filter broadcast) |
| `plugin-report/src/DatasetReportRenderer.tsx:1429,1447` | via `mergeFilters` (report / block runtime filter) |
| `plugin-dashboard/src/ObjectMetricWidget.tsx:413`, `DrillDownDrawer.tsx:106` | `{ $and: [existing, resolved] }` |
| `fields/src/widgets/FilterConditionField.tsx:209,213` | `{ $or: [...] }` / `{ $and: [...] }` |

The only in-repo AST **evaluator** is `ValueDataSource`'s `matchesASTFilter` (grep for `node[0]`); every other consumer forwards the node to a `DataSource`.

## The change

`$and` / `$or` lower to `['and'|'or', ...children]` — the spelling the spec's own `FILTER_ARRAY_LOGIC_KEYWORDS` declares — with children lowered recursively. The wire condition is **unchanged** (pinned both ways); what changes is that the node is executable as well as parseable, and that operators inside a combinator branch now meet the same guard every other operator meets (a `$bogus` or a `$regex` inside a `$or` branch used to travel to the wire unchecked inside the leaf's value slot).

Boolean identities (objectstack#5322) are handled at the boundary of the new branch, because a new branch has to decide them:

- `{ $and: [] }` is TRUE, so it **drops out**. Not `['and']`: measured, `isFilterAST(['and'])` is `false` and `parseFilterAST(['and'])` is `undefined` — no filter at all, i.e. **every row**, the one direction that must never happen.
- `{ $or: [] }` is FALSE, which the AST cannot spell, so it **keeps the leaf it already had** — measured to answer zero rows at the wire (`{$or: []}`) *and* in the in-memory matcher. Documented in place, with the alternatives and why each is worse.
- A `{}` disjunct is TRUE and absorbs its `$or`; a `{}` conjunct drops out of its `$and`.

## `$not` is refused, and it is an open contract question

The ObjectQL AST has **no negation**: `FILTER_ARRAY_LOGIC_KEYWORDS` is `['and','or']` and `VALID_AST_OPERATORS.has('not')` is `false` (measured, 53 members). Rewriting the negation inward is not available either — `startswith`, `endswith`, `between` and `icontains` have no negated counterpart in that set, so a De Morgan lowering would be silently partial and would quietly drop the NULL-safe rule of objectstack#5146.

So `$not` throws with an accurate message instead of one naming the author's own nested field as a bogus operator. **It threw before this change too, so the verdict is unchanged and only the diagnostic moved** — this PR does not decide the contract. Whether the AST should gain a negation, or whether this sink may hand a `FilterCondition` object to the wire when a `$not` is present, is raised on the card for the maintainer.

## The pin — row sets, both directions, and what a worse implementation would do

`packages/core/src/utils/__tests__/filter-combinators-6948.test.ts` (24 cases). Nothing greps the source; every assertion is either the node that reaches the wire put through `isFilterAST` / `parseFilterAST`, or the row set a real `ValueDataSource` returns.

Both halves are asserted because each alone passes on something worse than the bug:

- **inclusion half** — `selectedIds(...)` is `['open-active','blocked-idle']`, exactly. A converter that emits nothing usable leaves `$filter` unread and returns **every** row (`selectedIds(undefined)` is asserted equal to `ALL_IDS` as the lit control).
- **exclusion half** — `done-active`, `null-status`, `no-status-key` are absent. A converter emitting a node no evaluator reads returns **no** row — which is the bug itself, pinned as `PRE_FIX_OR_NODE` selecting `[]`.
- a case asserting the answer is neither `ALL_IDS` nor `[]`, and that the fixture is not trivially either.
- a scoped case where one row is in the union but fails the scope and another passes the scope but is outside the union — both directions in one assertion.

Refusals assert the `INVALID_FILTER` / `400` envelope plus the message clause, never a bare `toThrow()`.

## Ablation — the read site, from the committed implementation

Removed the combinator dispatch block from `convertFiltersToAST` (the read site, not the helper), proved it reached disk, ran, restored by state.

```
HEAD blob = 5f99be95293258673b88816bdffa2004d8deec6f
disk blob = aec6ab2b7d1cc723422658edfc677bbe12fca336   (differs -> mutation on disk)
anchor 'const logicKeyword = AST_LOGIC_KEYWORD[field];'  BEFORE 1 -> AFTER 0
marker 'ABLATED objectui#6948' AFTER 1, at line 234
```

**19 named red rows across both packages**, including `lowers $or to an AST group node`, `INCLUDES both branches of the union — not empty`, `$and intersects, both directions`, `a parent scope still narrows a union it wraps`, `nested combinators evaluate as written`, `drops $and: [] — the TRUE identity constrains nothing`, `runs the unknown-operator guard on combinator children`, and both routes of `lowers a top-level Mongo logical node to an AST group`.

Two rows deliberately stayed **green** under ablation and that is the point: `EXCLUDES the rows outside the union` (the ablated converter excludes *everything*, so it trivially excludes those) and `the pre-fix node selected NOTHING` (a control on a literal node, independent of the implementation). That is exactly why the inclusion half exists.

The `data-objectstack` pin going red under a `packages/core` source edit is also the proof that **no rebuild leg is owed**: the root `vitest.config.mts` aliases `@object-ui/core` to `packages/core/src`, so there is no `dist` hop to stale.

Restore verified by state, not by exit code: `git diff HEAD` empty and `hash-object` equal to `rev-parse HEAD:path`.

## Changeset

`.changeset/filter-ast-combinators-6948.md` — `@object-ui/core: minor`, `@object-ui/data-objectstack: patch`. Verdict line:

```
✅  2 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s): .changeset/filter-ast-combinators-6948.md.
```

`minor` because shipped results move: a list filtered by a combinator through any in-process data source goes from zero rows to the rows the author asked for, and an unknown operator inside a combinator branch is now refused rather than shipped. Same shape as the landed precedent PR #8437. `major` is forbidden here (fixed group); `check-changeset-no-major.mjs` exits 0. `skip-changeset` deliberately not applied — it is a phantom label in this repo.

## Verification run

At `df25f4b1a`:

| command | result |
|---|---|
| `pnpm exec vitest run packages/core/ packages/data-objectstack/ packages/fields/ packages/plugin-dashboard/ packages/plugin-report/` | `VERDICT command-exit 0` — 429 files, 6775 tests |
| `pnpm exec vitest run <the two pins> packages/plugin-list/ packages/plugin-grid/ packages/plugin-detail/ packages/plugin-form/ packages/plugin-view/` | `VERDICT command-exit 0` — 442 files, 4360 passed / 1 skipped |
| `pnpm exec vitest run packages/components/ packages/react/` | `VERDICT command-exit 0` — 313 files, 3100 tests |
| `pnpm --filter '@object-ui/core' --filter '@object-ui/data-objectstack' type-check` | exit 0 (both test files proven in-program via `--listFiles`, with a lit and a dark control) |
| `pnpm --filter '@object-ui/core' --filter '@object-ui/data-objectstack' lint` | exit 0 — 0 errors |
| `node scripts/check-control-bytes.mjs` | `✅ OK (6668 tracked text files)` |
| `node scripts/check-governed-queue-guard.mjs --test <the 4 paths>` | `✅ NOT GOVERNED` |

**Declared narrowing:** 1184 test files run locally, covering every direct consumer of the sink and every in-repo producer of `$and` / `$or` enumerated above. `app-shell`, `console`, `site`, the examples and the remaining plugins are declared to CI — their `$and` references (`ObjectFieldInspector`, `datasetFilterCondition`) are metadata-authoring conversions that never reach `convertFiltersToAST`.

**Merge note.** `ValueDataSource.ts` moved on `main` after this branch was cut (objectui#7379: text-operator case sensitivity). The pin here uses only `=` and `>=` on non-string and string-equality fields, so it touches none of the drifted arms; `filter-converter.ts` itself is unmoved since `2a9513d81`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_