### PR TITLE
fix(plugin-detail): copy object-valued cells as JSON, not `[object Object]`

### DIFF
--- a/.changeset/8395-detail-copy-object-values.md
+++ b/.changeset/8395-detail-copy-object-values.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/plugin-detail': minor
+---
+
+`DetailSection`'s click-to-copy no longer writes `[object Object]` for object-valued
+cells (objectui#8395).
+
+The copy affordance built its payload with `String(value)`, and `String()` of an object
+is the literal text `[object Object]`. Because the affordance is offered for every
+non-empty value — objects included — a reader clicking the copy button, the row, or
+pressing Enter on an **address**, **geolocation**, **JSON**, **file/attachment**,
+**expanded lookup**, **repeater** or **image** cell silently got that placeholder on the
+clipboard, while the cell beside the button rendered the same value correctly. Nothing
+errored; it was noticed only on paste.
+
+Objects are now serialized with `JSON.stringify`, so those cells copy the stored value
+losslessly and parseably.
+
+**Non-objects are byte-identical.** A number still copies `16` (not the rendered
+`16.00`), a currency `1234.5` (not `1,234.50`), a percent `0.123` (not `12%`), a date
+`2026-03-04` (not `Mar 4`), and a select its stored `won` (not `Closed Won`). Copying
+the *rendered* text was measured and rejected: it is the worse contract for 9 of 17
+field types and loses data silently.
+
+**One payload moves without having been broken:** a multiselect stored as
+`['alpha','beta']` copied `alpha,beta` and now copies `["alpha","beta"]` — an array is
+an object. The new form is lossless where the old one was ambiguous for any value
+containing a comma.
+
+The JSON blob is a **defensible default, not a settled contract**. What an object cell
+*should* copy (a formatted postal address, `lat, lng`, a filename) is a per-kind product
+question tracked separately as objectui#8395's option B; the read site says so in place
+so the default is not mistaken for the answer. The `password` / `secret` branch of the
+same handler is untouched here — it is its own open card.

--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -216,8 +216,62 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
    */
   const serverFieldErrors = useInlineEdit()?.fieldErrors ?? null;
 
+  /**
+   * What the copy affordance WRITES (objectui#8395).
+   *
+   * `String(value)` on an object is the literal text `[object Object]`, so
+   * every object-valued cell — address, geolocation, JSON, file, expanded
+   * lookup, repeater — silently put a placeholder on the clipboard, while the
+   * cell BESIDE the button rendered that same value correctly. Objects are
+   * serialized as JSON here instead: lossless, parseable, never
+   * `[object Object]`.
+   *
+   * ## The JSON blob is a DEFENSIBLE DEFAULT, NOT A SETTLED CONTRACT
+   *
+   * What an object cell *should* put on the clipboard is a product question
+   * with several defensible answers per kind — the formatted postal address
+   * the reader can see, `lat, lng` for a geolocation, a filename for a file,
+   * the option labels or the stored values for a multiselect. That contract is
+   * objectui#8395's OPTION B (a shared value-to-text formatter that REUSES the
+   * cell renderers' own formatters — `formatAddress`, objectui#4037 — rather
+   * than re-spelling them), and it is a SEPARATE, still-unspecified card.
+   * ⛔ Do not read this line as the answer to it.
+   *
+   * ## Two shapes were measured and REJECTED — do not reach for them
+   *
+   * Copying the cell's RENDERED text is the worse contract for 9 of 17 field
+   * types and loses data silently: `date` renders `Mar 4` (the year is gone),
+   * `percent` renders `12%` against a stored `0.123` (a different quantity),
+   * `datetime` concatenates to an unparseable `3/4/20265:06 am`, and `image`
+   * and `boolean` render no text at all — so it would copy the empty string,
+   * which is strictly worse than the defect it set out to fix. And withdrawing
+   * the affordance from text-less cells would narrow `canCopy` away from
+   * `hasCellValue`, whose three readers MUST agree (see its docblock above).
+   *
+   * ## The non-regression half
+   *
+   * Non-objects keep `String(value)` BYTE-FOR-BYTE: a number still copies
+   * `16`, never the rendered `16.00`; a select still copies its stored `won`,
+   * never the rendered `Closed Won`. Pinned per kind — both halves — in
+   * `__tests__/DetailSection.copyObjectValues-8395.test.tsx`.
+   */
   const handleCopyField = React.useCallback((fieldName: string, value: any) => {
-    const textValue = value !== null && value !== undefined ? String(value) : '';
+    let textValue: string;
+    if (value === null || value === undefined) {
+      textValue = '';
+    } else if (typeof value === 'object') {
+      // The same guard `JsonCellRenderer` already applies to this exact
+      // operation on this exact value: a structure `JSON.stringify` cannot
+      // represent (a cycle) keeps today's string form rather than throwing out
+      // of a click handler, and the row stays consistent with its own cell.
+      try {
+        textValue = JSON.stringify(value);
+      } catch {
+        textValue = String(value);
+      }
+    } else {
+      textValue = String(value);
+    }
     navigator.clipboard.writeText(textValue).then(() => {
       setCopiedField(fieldName);
       setTimeout(() => setCopiedField(null), 2000);

--- a/packages/plugin-detail/src/__tests__/DetailSection.copyObjectValues-8395.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailSection.copyObjectValues-8395.test.tsx
@@ -1,0 +1,370 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * What `DetailSection`'s click-to-copy WRITES, per field kind (objectui#8395).
+ *
+ * ## The defect
+ *
+ * `handleCopyField` built its payload with `String(value)`, and `String()` of an
+ * object is the literal text `[object Object]`. The affordance is offered for
+ * every non-empty value (`canCopy` is `hasCellValue`, objectui#8376) — objects
+ * included — so a reader clicking the copy button, the row, or pressing Enter on
+ * an address, geolocation, JSON, file, expanded-lookup, repeater or image cell
+ * got a placeholder on the clipboard **while the cell beside the button rendered
+ * that same value correctly**. Nothing errors; it is noticed only on paste.
+ *
+ * ## What this file pins — BOTH halves
+ *
+ * 1. **The fix.** Every object-valued kind copies parseable JSON of the STORED
+ *    value. Each such case also asserts the cell RENDERED its value, because
+ *    "the payload is not `[object Object]`" is satisfied by a cell that rendered
+ *    nothing and copied nothing — an implementation strictly worse than the bug.
+ *    Nothing here asserts a negation; every row asserts its exact payload.
+ * 2. ⭐ **The non-regression.** The scalar kinds that were already correct stay
+ *    BYTE-IDENTICAL, and each of those cases asserts the rendered text too, so
+ *    the pin is red for any future "just copy what the cell renders" rewrite.
+ *    That shape was measured and rejected on this card: it is the worse contract
+ *    for 9 of 17 field types (`date` renders `Mar 4` — the year is gone;
+ *    `percent` renders `12%` against a stored `0.123`; `image` and `boolean`
+ *    render no text at all, so they would copy the empty string).
+ *
+ * ## The contract status of the JSON blob
+ *
+ * A JSON blob is a DEFENSIBLE DEFAULT, not a settled contract — see the read
+ * site's docblock. The per-kind contract (a formatted postal address, `lat,
+ * lng`, a filename …) is objectui#8395's option B, a separate card. These cases
+ * pin today's answer so a future option-B change is a deliberate edit here.
+ *
+ * ## Instruments
+ *
+ * - What is observed is the ARGUMENT to `navigator.clipboard.writeText`, spied
+ *   through `Object.defineProperty(navigator, 'clipboard', …)` — the pattern
+ *   `app-shell/src/console/organizations/__tests__/acceptInvitationLink.mount.test.tsx`
+ *   already uses. There is no `execCommand` fallback on this path.
+ * - ⚠️ The clickable row is found by `[role="button"]`, NEVER by
+ *   `querySelector('button')`: `BooleanCellRenderer` renders a Radix Checkbox,
+ *   which IS a `button` element, so that selector matches the checkbox instead
+ *   of the copy button and the click copies nothing. Pinned below.
+ * - `window.innerWidth` is 1280: `DetailSection` has mobile and desktop row
+ *   shapes and an `isMobile` auto-hide threshold.
+ * - Presence is read through `queryByText` into `expect(value, message)`, never
+ *   `getByText`, so a missing row fails with the reason rather than with
+ *   `TestingLibraryElementError` before `expect` runs.
+ *
+ * ## Deliberately NOT pinned here
+ *
+ * The `password` / `secret` branch of this same handler — copy writes the raw
+ * secret while the cell renders the mask — is objectui#8440, in the maintainer's
+ * decision box. This card leaves that path exactly as it found it, and asserts
+ * nothing about it, so whichever way #8440 is answered no case here turns red.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import * as React from 'react';
+import { DetailSection } from '../DetailSection';
+import type { DetailViewSection } from '@object-ui/types';
+
+let writeText: ReturnType<typeof vi.fn>;
+
+beforeAll(() => {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1280 });
+});
+
+beforeEach(() => {
+  writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+});
+
+afterEach(cleanup);
+
+const objectSchema = {
+  fields: {
+    // — object-valued kinds: the defect —
+    billing_address: { type: 'address', label: 'Billing Address' },
+    office_location: { type: 'location', label: 'Office Location' },
+    payload: { type: 'json', label: 'Payload' },
+    contract: { type: 'file', label: 'Contract' },
+    owner_ref: { type: 'lookup', label: 'Owner', reference_to: 'account' },
+    attachments: { type: 'file', label: 'Attachments', multiple: true },
+    line_items: { type: 'repeater', label: 'Line Items' },
+    logo: { type: 'image', label: 'Logo' },
+    tags: {
+      type: 'multiselect',
+      label: 'Tags',
+      options: [
+        { value: 'alpha', label: 'Alpha' },
+        { value: 'beta', label: 'Beta' },
+      ],
+    },
+    // — scalar kinds: already correct, must not move —
+    amount: { type: 'number', label: 'Amount', scale: 2 },
+    price: { type: 'currency', label: 'Price' },
+    ratio: { type: 'percent', label: 'Ratio' },
+    due: { type: 'date', label: 'Due' },
+    stage: {
+      type: 'select',
+      label: 'Stage',
+      options: [{ value: 'won', label: 'Closed Won' }],
+    },
+    name: { type: 'text', label: 'Name' },
+    active: { type: 'boolean', label: 'Active' },
+  },
+};
+
+/**
+ * Stored values. The geolocation carries MORE precision than the cell displays
+ * (the cell rounds to 4 decimals) so the payload assertions below cannot be
+ * satisfied by re-deriving the payload from the rendered text.
+ */
+const DATA: Record<string, unknown> = {
+  billing_address: {
+    // `postalCode`, the spec spelling (objectstack#5143). `formatAddress` reads
+    // that key and the legacy `zipCode` only, so an off-spec `postal_code`
+    // would be dropped from the RENDERED line while still riding along in the
+    // JSON payload — which would make the control below weaker than it looks.
+    street: '1 Main St',
+    city: 'Springfield',
+    state: 'IL',
+    postalCode: '62704',
+    country: 'USA',
+  },
+  office_location: { latitude: 30.2741567, longitude: 120.1551234 },
+  payload: { a: 1, b: ['x', 'y'] },
+  contract: { name: 'contract.pdf', url: 'https://cdn.example.com/contract.pdf' },
+  owner_ref: { id: 'acct-1', name: 'Acme Corp' },
+  attachments: [{ name: 'a.pdf' }, { name: 'b.pdf' }],
+  line_items: [{ label: 'one' }, { label: 'two' }],
+  logo: { name: 'logo.png', url: 'https://cdn.example.com/logo.png' },
+  tags: ['alpha', 'beta'],
+  amount: 16,
+  price: 1234.5,
+  ratio: 0.123,
+  due: '2026-03-04',
+  stage: 'won',
+  name: 'Plain String Value',
+  active: true,
+};
+
+/**
+ * The row LABEL is the section field's own `label` (`field.label || field.name`
+ * at the render site), so it is spelled here rather than inherited from
+ * `objectSchema` — which supplies the TYPE and the options, not the label.
+ */
+const section = {
+  title: 'Details',
+  fields: Object.entries(objectSchema.fields).map(([name, def]) => ({
+    name,
+    label: (def as { label: string }).label,
+  })),
+} as DetailViewSection;
+
+const renderAll = () =>
+  render(<DetailSection section={section} data={DATA} objectSchema={objectSchema} />);
+
+/**
+ * The clickable row for a field, located by its LABEL and taken by
+ * `[role="button"]` — see the docblock on why not `querySelector('button')`.
+ */
+const rowOf = (label: string): HTMLElement => {
+  const labelEl = screen.queryByText(label);
+  expect(labelEl, `CONTROL: a row labelled "${label}" is on screen`).not.toBeNull();
+  const row = (labelEl as HTMLElement).parentElement!.querySelector('[role="button"]');
+  expect(row, `the "${label}" row offers the copy affordance`).not.toBeNull();
+  return row as HTMLElement;
+};
+
+/** Click the row and return the exact argument handed to `writeText`. */
+const copyFrom = (label: string): unknown => {
+  writeText.mockClear();
+  fireEvent.click(rowOf(label));
+  expect(
+    writeText.mock.calls.length,
+    `clicking the "${label}" row wrote to the clipboard exactly once`,
+  ).toBe(1);
+  return writeText.mock.calls[0][0];
+};
+
+describe('DetailSection copy payloads — object cells copy JSON, scalars are unchanged (#8395)', () => {
+  /**
+   * The seven object-valued kinds whose cell renders TEXT. `rendered` is the
+   * control: it proves the cell drew the value, so no row here can pass on a
+   * cell that rendered nothing.
+   */
+  const OBJECT_KINDS = [
+    {
+      label: 'Billing Address',
+      rendered: '1 Main St, Springfield, IL 62704, USA',
+      clipboard:
+        '{"street":"1 Main St","city":"Springfield","state":"IL","postalCode":"62704","country":"USA"}',
+    },
+    {
+      label: 'Office Location',
+      rendered: '30.2742, 120.1551',
+      clipboard: '{"latitude":30.2741567,"longitude":120.1551234}',
+    },
+    {
+      label: 'Payload',
+      rendered: '{"a":1,"b":["x","y"]}',
+      clipboard: '{"a":1,"b":["x","y"]}',
+    },
+    {
+      label: 'Contract',
+      rendered: 'contract.pdf',
+      clipboard: '{"name":"contract.pdf","url":"https://cdn.example.com/contract.pdf"}',
+    },
+    {
+      label: 'Owner',
+      rendered: 'Acme Corp',
+      clipboard: '{"id":"acct-1","name":"Acme Corp"}',
+    },
+    {
+      label: 'Attachments',
+      rendered: '2 files',
+      clipboard: '[{"name":"a.pdf"},{"name":"b.pdf"}]',
+    },
+    {
+      // The repeater cell prints a COUNT. Only the count is asserted: the label
+      // beside it is a hardcoded Chinese string (objectui#8441), and pinning
+      // that spelling here would turn this file red when #8441 fixes it.
+      label: 'Line Items',
+      rendered: '2',
+      clipboard: '[{"label":"one"},{"label":"two"}]',
+    },
+  ];
+
+  it.each(OBJECT_KINDS)(
+    'OBJECT — $label copies parseable JSON of the stored value, not `[object Object]`',
+    ({ label, rendered, clipboard }) => {
+      renderAll();
+      const row = rowOf(label);
+
+      // CONTROL — the cell drew the value. Without this, the payload assertion
+      // below would also pass for a cell that rendered and copied nothing.
+      expect(
+        row.textContent,
+        `CONTROL: the "${label}" cell rendered its value`,
+      ).toContain(rendered);
+
+      expect(copyFrom(label), `"${label}" copies the stored value as JSON`).toBe(clipboard);
+      // Parseability is the property the JSON default was chosen for, so it is
+      // asserted rather than implied by the string above.
+      expect(() => JSON.parse(clipboard), `"${label}"'s payload parses`).not.toThrow();
+    },
+  );
+
+  it('OBJECT — an image cell copies its JSON even though it renders no text', () => {
+    // The image cell renders an <img>, so its `textContent` is ''. Its control
+    // is therefore the element, not text — and it is exactly the row that would
+    // copy the EMPTY STRING under a "copy the rendered text" rewrite.
+    renderAll();
+    const row = rowOf('Logo');
+
+    expect(
+      row.querySelector('img'),
+      'CONTROL: the "Logo" cell rendered an <img> for its value',
+    ).not.toBeNull();
+    expect(row.textContent, 'the "Logo" cell renders no text at all').toBe('');
+
+    expect(copyFrom('Logo'), '"Logo" copies the stored file object as JSON').toBe(
+      '{"name":"logo.png","url":"https://cdn.example.com/logo.png"}',
+    );
+  });
+
+  it('OBJECT — a multiselect copies its stored values as a JSON array', () => {
+    // ⚠️ DECLARED MOVE. An array is an object, so this payload changes from
+    // `alpha,beta` (`String(['alpha','beta'])`) to a JSON array. It is the one
+    // kind whose payload moves without having been `[object Object]` today: the
+    // new form is lossless where the old one was ambiguous for any value
+    // containing a comma. The LABELS ("Alpha", "Beta") are deliberately NOT what
+    // is copied — the stored values are.
+    renderAll();
+    const row = rowOf('Tags');
+
+    expect(row.textContent, 'CONTROL: the "Tags" cell rendered its option badges').toBe(
+      'AlphaBeta',
+    );
+    expect(copyFrom('Tags'), '"Tags" copies the stored values, not the labels').toBe(
+      '["alpha","beta"]',
+    );
+  });
+
+  /**
+   * ⭐ The non-regression half. `rendered` here is what the reader SEES and
+   * `clipboard` is what they GET — the two differ on purpose for four of these
+   * five rows, which is why "copy the rendered text" is not the contract.
+   */
+  const UNCHANGED_SCALARS = [
+    { label: 'Amount', rendered: '16.00', clipboard: '16' },
+    { label: 'Price', rendered: '1,234.50', clipboard: '1234.5' },
+    { label: 'Ratio', rendered: '12%', clipboard: '0.123' },
+    { label: 'Due', rendered: 'Mar 4', clipboard: '2026-03-04' },
+    { label: 'Stage', rendered: 'Closed Won', clipboard: 'won' },
+    { label: 'Name', rendered: 'Plain String Value', clipboard: 'Plain String Value' },
+  ];
+
+  it.each(UNCHANGED_SCALARS)(
+    'SCALAR — $label still copies its stored value byte-for-byte',
+    ({ label, rendered, clipboard }) => {
+      renderAll();
+      const row = rowOf(label);
+
+      expect(
+        row.textContent,
+        `CONTROL: the "${label}" cell rendered its value as ${rendered}`,
+      ).toContain(rendered);
+
+      expect(copyFrom(label), `"${label}" copies the STORED value, not the rendered one`).toBe(
+        clipboard,
+      );
+    },
+  );
+
+  it('SCALAR — a boolean copies `true`, and the copy target is not the row\'s first button', () => {
+    // ⚠️ The instrument pin. `BooleanCellRenderer` renders a Radix Checkbox,
+    // which IS a `button`, so `querySelector('button')` in this row returns the
+    // checkbox and clicking it copies nothing. Anyone writing a copy test for
+    // this surface must click `[role="button"]`, as `rowOf` does.
+    renderAll();
+    const row = rowOf('Active');
+
+    const firstButton = row.querySelector('button');
+    expect(firstButton, 'CONTROL: the boolean row does contain a `button` element').not.toBeNull();
+    expect(
+      firstButton!.getAttribute('role'),
+      'that first `button` is the checkbox, NOT the copy button',
+    ).toBe('checkbox');
+
+    expect(copyFrom('Active'), 'the boolean row copies its stored value').toBe('true');
+  });
+
+  it('a value JSON cannot represent keeps its string form instead of throwing', () => {
+    // NOT a payload contract — the guard `JsonCellRenderer` applies to the same
+    // operation on the same value. A cycle cannot be serialized; retaining
+    // today's `[object Object]` for it keeps the click handler from throwing,
+    // and it is the ONLY input for which that text is still written.
+    const cyclic: Record<string, unknown> = { self: null };
+    cyclic.self = cyclic;
+
+    render(
+      <DetailSection
+        section={
+          { title: 'Details', fields: [{ name: 'payload', label: 'Payload' }] } as DetailViewSection
+        }
+        data={{ payload: cyclic }}
+        objectSchema={objectSchema}
+      />,
+    );
+
+    expect(() => copyFrom('Payload'), 'clicking must not throw out of the handler').not.toThrow();
+    expect(writeText.mock.calls[0][0], 'an unserializable value keeps its string form').toBe(
+      '[object Object]',
+    );
+  });
+});


### PR DESCRIPTION
Fixes #8395

`DetailSection`'s click-to-copy built its payload with `String(value)`, and `String()` of an object is the literal text `[object Object]`. The affordance is offered for every non-empty value — objects included (`canCopy` is `hasCellValue`, objectui#8376) — so a reader clicking the copy button, the row, or pressing Enter on an address, geolocation, JSON, file, expanded-lookup, repeater or image cell silently got a placeholder on the clipboard **while the cell beside the button rendered that same value correctly**. Nothing errors; it is noticed only on paste.

**The change is one read site**: objects are serialized with `JSON.stringify`, everything else keeps `String()`.

## Per-kind payloads — measured, not reasoned

Rendered via a real `DetailSection` at `innerWidth` 1280; the observed value is the ARGUMENT handed to `navigator.clipboard.writeText`.

| field kind | the cell renders | clipboard BEFORE | clipboard AFTER |
|---|---|---|---|
| address | `1 Main St, Springfield, IL 62704, USA` | `[object Object]` | `{"street":"1 Main St","city":"Springfield","state":"IL","postalCode":"62704","country":"USA"}` |
| geolocation | `30.2742, 120.1551` | `[object Object]` | `{"latitude":30.2741567,"longitude":120.1551234}` |
| json | `{"a":1,"b":["x","y"]}` | `[object Object]` | `{"a":1,"b":["x","y"]}` |
| file (single) | `contract.pdf` | `[object Object]` | `{"name":"contract.pdf","url":"https://cdn.example.com/contract.pdf"}` |
| lookup (expanded) | `Acme Corp` | `[object Object]` | `{"id":"acct-1","name":"Acme Corp"}` |
| file (array) | `2 files` | `[object Object],[object Object]` | `[{"name":"a.pdf"},{"name":"b.pdf"}]` |
| repeater | a count | `[object Object],[object Object]` | `[{"label":"one"},{"label":"two"}]` |
| image | an `img` element, no text | `[object Object]` | `{"name":"logo.png","url":"https://cdn.example.com/logo.png"}` |
| multiselect | `AlphaBeta` | `alpha,beta` | `["alpha","beta"]` |

⚠️ **One payload moves without having been broken** — the multiselect. An array IS an object, so `['alpha','beta']` now copies as a JSON array. The new form is lossless where the old one was ambiguous for any value containing a comma. It is called out here rather than buried: it is the only row whose BEFORE column was not already a placeholder.

## ⭐ The non-regression half

Every correct-today scalar payload is **byte-identical**, and the pin asserts the rendered text beside it, so it is red for any later "just copy what the cell renders" rewrite:

| field kind | the reader SEES | the clipboard GETS (unchanged) |
|---|---|---|
| number (scale 2) | `16.00` | `16` |
| currency | `1,234.50` | `1234.5` |
| percent | `12%` | `0.123` |
| date | `Mar 4` | `2026-03-04` |
| select | `Closed Won` | `won` |
| text | `Plain String Value` | `Plain String Value` |
| boolean | (a checkbox, no text) | `true` |

## What this deliberately does NOT decide

- ⚠️ **The JSON blob is a defensible default, not a settled contract.** The read site now says so in place, naming objectui#8395's **option B** — a shared value-to-text formatter reusing the cell renderers' own formatters (`formatAddress`, objectui#4037) — as where the real per-kind contract gets decided. That needs product answers that do not exist yet (address under which locale, geolocation at stored precision or displayed rounding, json compact or pretty, file filename or list or URL, multiselect labels or values, lookup name or id, image URL or filename) and is a separate card.
- ⛔ **Copying the rendered text (option A) was measured and rejected.** It is the worse contract for 9 of 17 field types and loses data silently: `date` renders `Mar 4` (the year is gone), `percent` renders `12%` against a stored `0.123` (a different quantity), `datetime` concatenates to an unparseable `3/4/20265:06 am`, `image` and `boolean` render no text at all — so those two would copy the EMPTY STRING, an implementation strictly worse than the defect. It would also make the payload display-locale dependent.
- ⛔ **Withdrawing the affordance from text-less cells (option D) stays out**: it would narrow `canCopy` away from `hasCellValue`, whose three readers must agree per objectui#8376's docblock.
- ⛔ **objectui#8440 is not addressed here** and its code path is byte-for-byte untouched: the `password` / `secret` branch of this same handler (copy writes the raw secret while the cell renders the mask) is in the maintainer's decision box. The pin asserts nothing about it on purpose, so whichever way that card is answered, no case in this file turns red. That card remains open.

## The one addition beyond the literal one-liner

`JSON.stringify` throws on a cycle, and this runs inside a click handler. The stringify is therefore wrapped in the SAME `try` / `catch` that `JsonCellRenderer` already applies to this exact operation on this exact value, falling back to today's string form. It is pinned (a self-referencing value still copies `[object Object]` and the click does not throw) and is the only input for which that text is still written. Strike it if you would rather have the bare call.

## Ablation — proof the pin can fail

Run from the committed implementation, restoring the copy handler's bare `String(value)`. ⚠️ There is a SECOND `String(value)` in this file — `displayValue`'s no-renderer fallback — which is NOT this defect; the mutation is anchored on the handler body and that second site is asserted unmoved.

```
HEAD blob            014ec9dc9f356d7c2f0267c5c4f1389cfca70324
on disk, mutated     6f5bde22876b224f753718e4a028eb41a9d932c3   ⇒ the mutation reached disk
anchors  JSON.stringify(value)                1 -> 0
         bare one-liner (copy handler)        0 -> 1
         '      return String(value);' (L420) 1 -> 1   (the OTHER site, unmoved)
result   Tests 9 failed | 8 passed (17)
restore  on-disk hash == HEAD blob AND `git diff HEAD` empty   ⇒ restored BY STATE, not by an exit code
```

The nine red rows, by name — every one an object-valued kind, each failing on its payload (`Received: "[object Object]"`) while its rendered-value CONTROL still passed, so the failure is about what was copied and never about a blank cell:

```
OBJECT — 'Billing Address' / 'Office Location' / 'Payload' / 'Contract' /
         'Owner' / 'Attachments' / 'Line Items' copies parseable JSON …
OBJECT — an image cell copies its JSON even though it renders no text
OBJECT — a multiselect copies its stored values as a JSON array
```

The eight that stayed green under the mutation are exactly the ones that must: the six scalars, the boolean, and the unserializable-value case.

## Verification

| what | verdict |
|---|---|
| the pin | `pnpm exec vitest run packages/plugin-detail/src/__tests__/DetailSection.copyObjectValues-8395.test.tsx` — `Tests 17 passed (17)`, lock `VERDICT command-exit 0` |
| whole affected package | `pnpm exec vitest run packages/plugin-detail/` — `Test Files 138 passed (138)`, `Tests 1248 passed (1248)`, lock `VERDICT command-exit 0` |
| types (incl. tests) | closure build then `pnpm --filter @object-ui/plugin-detail type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) — lock `VERDICT command-exit 0` |
| lint | package-scoped `eslint .` in `packages/plugin-detail` — exit 0, `901 problems (0 errors, 901 warnings)`, identical to the pre-change baseline and none in the changed files |
| governed surface | `check-governed-queue-guard --test` on all three changed paths — `NOT GOVERNED — 3 path(s) checked against 5 governed surface(s); none matched.` |
| control bytes | `grep -naP` over the changed files: zero hits, with a lit control that fires |

No downstream package asserts this payload: of the nine test files in the repo that touch `clipboard`, the only two that render this surface are in `packages/plugin-detail`.

## Changeset

`minor`, on `@object-ui/plugin-detail` — this moves a shipped clipboard payload, which is user-visible behaviour; the landed precedent for a `record:details` behaviour change is PR #8396. The repo forbids `major`. Gate verdicts, quoted:

```
✅  2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/8395-detail-copy-object-values.md.
✅  No changeset declares a `major` bump.
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_