### PR TITLE
test(scripts): read the vi.mock anti-exemption pin over the comment-blanked gate, and name the offending line

### DIFF
--- a/scripts/__tests__/check-vi-mock-inherit.test.ts
+++ b/scripts/__tests__/check-vi-mock-inherit.test.ts
@@ -370,7 +370,13 @@ function offendingLines(code: string, re: RegExp, original: string = code) {
   const all = new RegExp(re.source, re.flags.includes('g') ? re.flags : `${re.flags}g`);
   const out: string[] = [];
   for (let m = all.exec(code); m; m = all.exec(code)) {
-    const n = code.slice(0, m.index).split('\n').length;
+    // Count to the first NON-WHITESPACE byte of the match, not to `m.index`.
+    // `EXEMPTION_DECLARATION_RE` opens with `^\s*`, and `\s` matches a newline:
+    // against a declaration with a blank line above it the match STARTS on that
+    // blank line, so the naive offset reported `1853: ` — an empty line, one
+    // above the carve-out, which is worse than useless in a failure message.
+    const at = m.index + /^\s*/.exec(m[0])![0].length;
+    const n = code.slice(0, at).split('\n').length;
     out.push(`${n}: ${lines[n - 1].trim()}`);
     if (all.lastIndex === m.index) all.lastIndex += 1;
   }
@@ -446,6 +452,18 @@ describe('scope — narrow, and out of scope by construction rather than by exem
     // the docblock's file: prose above it does not shelter the code below it.
     const both = `${prose}\n${array}`;
     expect(offendingLines(maskComments(both), EXEMPTION_ENTRY_RE, both)).toEqual([`4: ${array}`]);
+  });
+
+  it('a reported line is the DECLARATION, never the blank line above it', () => {
+    // Measured, not hypothetical: the first draft of `offendingLines` counted to
+    // `m.index`, and `EXEMPTION_DECLARATION_RE` opens with `^\s*` where `\s`
+    // matches a newline. Appending a carve-out to the gate with a blank line
+    // before it therefore reported `1853: ` — an empty line, one above the
+    // declaration. A failure message that names the wrong line is the defect
+    // objectui#8117 is about, one level down, so it gets its own case.
+    const decl = "const KNOWN_BAD = ['packages/x/src/A.test.tsx'];";
+    const withBlankLineAbove = `const ok = 1;\n\n${decl}\n`;
+    expect(offendingLines(withBlankLineAbove, EXEMPTION_DECLARATION_RE)).toEqual([`3: ${decl}`]);
   });
 
   it('the covered set is non-empty and names only real workspace packages', () => {

--- a/scripts/__tests__/check-vi-mock-inherit.test.ts
+++ b/scripts/__tests__/check-vi-mock-inherit.test.ts
@@ -15,7 +15,7 @@ import {
   scan,
   summarise,
 } from '../check-vi-mock-inherit.mjs';
-import { scanSource } from '../js-comment-mask.mjs';
+import { maskComments, scanSource } from '../js-comment-mask.mjs';
 
 /**
  * objectui#6849 — the test for `scripts/check-vi-mock-inherit.mjs`.
@@ -54,6 +54,9 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../
 
 /** A quote, from its code point — see "Fixture discipline" above. */
 const Q = String.fromCharCode(39);
+
+/** A backtick, from its code point — same discipline as `Q`. */
+const BT = String.fromCharCode(96);
 
 const COVERED = '@object-ui/react';
 
@@ -339,6 +342,41 @@ describe('the failing shape — a factory that hand-lists the export surface', (
 // Scope — the narrow gate triage ruled for, and what it must NOT touch
 // ---------------------------------------------------------------------------
 
+/**
+ * The shape a hand-written array of exempt file paths declares itself with.
+ *
+ * Named rather than inlined so a failure can point at THE pattern instead of
+ * asking the reader to copy one out of an expectation by hand (objectui#8117).
+ */
+const EXEMPTION_DECLARATION_RE = /^\s*(export )?const (ALLOW|EXEMPT|IGNORE|SKIP|KNOWN)[A-Z_]*\s*=/m;
+
+/** The shape one ENTRY of such an array has: a quoted test file, then `,` or `]`. */
+const EXEMPTION_ENTRY_RE = /\.test\.tsx?['"`]\s*[,\]]/;
+
+/**
+ * Every line of `code` that matches `re`, as `<line number>: <source line>`.
+ *
+ * ## Why not `expect(src).not.toMatch(re)` (objectui#8117)
+ *
+ * `not.toMatch` over this gate prints its ~1850-line source as the "received"
+ * value and never says WHERE the match was; locating it needed a separate
+ * `grep -nP` with the pattern copied out of this file by hand. The assertion
+ * below is the same assertion — zero matches — reported so its failure names
+ * the offending line. `line` is looked up in `original`, which is the raw
+ * source: `maskComments` preserves byte offsets, so the numbering is shared.
+ */
+function offendingLines(code: string, re: RegExp, original: string = code) {
+  const lines = original.split('\n');
+  const all = new RegExp(re.source, re.flags.includes('g') ? re.flags : `${re.flags}g`);
+  const out: string[] = [];
+  for (let m = all.exec(code); m; m = all.exec(code)) {
+    const n = code.slice(0, m.index).split('\n').length;
+    out.push(`${n}: ${lines[n - 1].trim()}`);
+    if (all.lastIndex === m.index) all.lastIndex += 1;
+  }
+  return [...new Set(out)];
+}
+
 describe('scope — narrow, and out of scope by construction rather than by exemption', () => {
   it('a RELATIVE specifier is never judged — whole-module replacement is legitimate', () => {
     // `plugin-calendar/src/registration.test.tsx` replaces `./ObjectCalendar`
@@ -365,8 +403,49 @@ describe('scope — narrow, and out of scope by construction rather than by exem
     // Triage: ⛔ 不要顺手加例外白名单. An exemption means the recogniser called
     // correct code broken — the repair is the recogniser, not a carve-out.
     const src = fs.readFileSync(path.join(repoRoot, 'scripts/check-vi-mock-inherit.mjs'), 'utf8');
-    expect(src).not.toMatch(/^\s*(export )?const (ALLOW|EXEMPT|IGNORE|SKIP|KNOWN)[A-Z_]*\s*=/m);
-    expect(src).not.toMatch(/\.test\.tsx?['"`]\s*[,\]]/);
+    // objectui#8117: the ENTRY pattern is read over the COMMENT-BLANKED source,
+    // the gate's own "only text the language would EXECUTE is judged" rule
+    // turned on the gate's own file. The header docblock is this sweep's
+    // per-slice logbook by construction, so recording a sweep means naming test
+    // files — and a backticked filename followed by a comma is byte-identical
+    // to one entry of the array this pin exists to catch. It reddened twice on
+    // running prose (#8116, #8207 at `e104c509d`), and both times the repair
+    // was to reword the sentence: a tax on every future slice author, paid to a
+    // pin whose failure text points at a regex while the only "fix" it suggests
+    // is the carve-out the comment above forbids. Blanking costs the pin
+    // nothing — a real exemption array is a string LITERAL, which the shared
+    // masker leaves intact; the sibling case below drives both directions.
+    //
+    // The DECLARATION pattern still reads the raw source: it cannot match a
+    // docblock line (`^\s*` reaches the ` * ` prefix and stops), so it has no
+    // false red to fix and narrowing it would buy nothing.
+    expect(offendingLines(src, EXEMPTION_DECLARATION_RE)).toEqual([]);
+    expect(offendingLines(maskComments(src), EXEMPTION_ENTRY_RE, src)).toEqual([]);
+  });
+
+  it('that pin reads CODE, and the header prose it used to redden on is intact', () => {
+    // Both legs are needed: on a tree whose header already avoids the comma,
+    // an empty reading proves only that today's prose dodges the pattern, not
+    // that the pin stopped judging prose. The RAW assertions are the control —
+    // each fixture MUST match before masking, or the leg below measures nothing.
+    const entry = (file: string) => `${Q}packages/x/src/${file}${Q},`;
+    const array = `const ALLOWLIST = [${entry('A.test.tsx')} ${entry('B.test.ts')}];`;
+    // The exact shape #8116 measured: one sweep record naming a swept file.
+    const prose = `/**\n *     ${BT}ObjectView.expandFls-7429.test.tsx${BT}, landed by objectui#7429\n */`;
+
+    expect(EXEMPTION_ENTRY_RE.test(array), 'the positive fixture is matchable at all').toBe(true);
+    expect(EXEMPTION_ENTRY_RE.test(prose), 'the prose fixture is matchable BEFORE masking').toBe(true);
+
+    // A real exemption array survives the mask — the pin keeps every tooth.
+    expect(offendingLines(maskComments(array), EXEMPTION_ENTRY_RE, array)).toEqual([
+      `1: ${array}`,
+    ]);
+    // The header record does not — that is the false red, and it is gone.
+    expect(offendingLines(maskComments(prose), EXEMPTION_ENTRY_RE, prose)).toEqual([]);
+    // And the same masking must not blind the pin to an array written INSIDE
+    // the docblock's file: prose above it does not shelter the code below it.
+    const both = `${prose}\n${array}`;
+    expect(offendingLines(maskComments(both), EXEMPTION_ENTRY_RE, both)).toEqual([`4: ${array}`]);
   });
 
   it('the covered set is non-empty and names only real workspace packages', () => {


### PR DESCRIPTION
Fixes #8117

Head `2a10ce4e1`, base `1706d8be4`. Session `session_01FhBNJcLRZLe8M87VcUgpKr`.

## The defect, re-derived on today's tree

`scripts/__tests__/check-vi-mock-inherit.test.ts` carries the assertion that keeps the
exemption swamp out of `scripts/check-vi-mock-inherit.mjs`. It read the gate's **raw** source
and asserted it does not match the pattern below — one entry of a hand-written array of exempt
file paths (the character class holds a single quote, a double quote and a backtick):

```
/\.test\.tsx?['"`]\s*[,\]]/
```

That gate's leading docblock is 1128 lines and is, by construction, the per-slice logbook
objectui#6892 writes every sweep record into. Recording a sweep means naming test files, and a
backticked filename followed by a comma is **byte-identical** to one entry of the array the pin
exists to catch.

Measured on this branch's base (`1706d8be4`), before any edit:

| reading | raw source | comment-blanked source |
|---|---|---|
| the pin's ENTRY pattern, today's gate | 0 hits | 0 hits |
| backticked test filenames in the header | 13 | — |
| of those, followed by a comma | 0 | — |
| **+ one sweep record naming a swept file, with a comma** | **1 hit, line 1128** | **0 hits** |
| + a real exemption array, as CODE | 2 hits | **2 hits** |
| + the same array commented out | 2 hits | 0 hits |

The card's diagnosis reproduces exactly. Note row 3: the header already carries 13 backticked
test filenames and **none** is followed by a comma — that green reading is not evidence the pin
is sound, it is the tax the two previous repairs paid by rewording prose (objectui#8116 at 69
of 69, objectui#8207 at `caf312b93`). Without the injected control, the zero would have meant
nothing.

## What changed

One file, `scripts/__tests__/check-vi-mock-inherit.test.ts`, +99 / -4.

1. **The ENTRY pattern is read over `maskComments(src)`** — the gate's own rule ("only text the
   language would EXECUTE is judged") turned on the gate's own file. The shared masker leaves
   string literals, templates and regex literals intact, so a real exemption array survives it
   whole; only prose goes. The pin keeps every tooth and the docblock becomes unreachable.
2. **The DECLARATION pattern still reads the raw source.** Its `^\s*` anchor reaches a docblock
   line's ` * ` prefix and stops, so that half has no false red to fix, and blanking it would
   narrow an assertion for nothing. Leg 6 below measures that claim rather than asserting it.
3. **The failure names the offending LINE.** `not.toMatch` printed the whole ~1850-line gate as
   the "received" value and never said where the match was; locating it needed a separate
   `grep -nP` with the pattern copied out of the test by hand. Both patterns are now named
   constants and both assertions go through one `offendingLines()` helper reporting
   `LINE NUMBER: source line`. Measured below: 101417 bytes of failure report became 1336.
4. **Three sibling cases pin the repair itself**, each with the raw match as its control — a
   zero-hit reading on a tree whose prose already dodges the comma would otherwise mean nothing.

⛔ No exemption was added, and none of `isCovered` / `coveredPrefixes` / `operandDenotes` /
`COVERED_SPECIFIERS` was touched. `scripts/check-vi-mock-inherit.mjs` is **not** in this diff.

## A premise of the card is falsified

Both the card body and the triage comment prescribe "the masking helper the gate already
exports (`deJsxClosingTags` plus the shared `js-comment-mask`)". `deJsxClosingTags` was
**retired by objectui#7883** and survives only as three lines of historical prose (gate line
1115, test lines 544 and 568). It is not a function, not an export, not callable. The other
half is live and is what the gate itself uses at `check-vi-mock-inherit.mjs:1603-1604`, so the
repair stands — but on `js-comment-mask` alone.

Two smaller corrections: the card describes the pin as one assertion, and it is two, only one
of which has the false red; and the dispatch brief quotes `660 judged / 660 inherit` where the
tree reads **663 / 663** today.

## Ablation — six legs, every mutation proved on disk before any result was read

Each leg prints the HEAD blob hash, the on-disk blob hash and a marker count **before** the run
is read; an empty hash exits 9 rather than reading as "nothing to compare". Restore is proved
by state — `git diff HEAD` empty and both blobs equal to HEAD — never by an exit code. Both
scripts carry `trap RESTORE EXIT INT TERM` with absolute paths from `git rev-parse --show-toplevel`.

| leg | mutation (on-disk proof) | predicted | observed |
|---|---|---|---|
| 1 | header gains one sweep record with a comma; pin reverted to `origin/main` (gate `08a986a0af5f` to `bf2f4a5611c9`, marker 1; pin `3bd7dd19b060` to `650fd8eba6cb`, marker 2) | RED | **RED** — 1 failed / 83 skipped. Report **1880 lines, 101417 bytes**, never names line 1128 |
| 2 | same header mutation, pin restored to HEAD (gate still `bf2f4a5611c9`, pin identical to HEAD) | GREEN | **GREEN** — the false red is gone |
| 3 | positive: an unanchored inline carve-out list as CODE (`673f3fab6ba4`, marker 1) | RED, naming the line | **RED** — report **35 lines, 1336 bytes**, naming `1854: const PER_FILE_CARVE_OUTS = [...]` |
| 4a | pre-fix pin, the sentence with a **comma** (`bf2f4a5611c9`, marker 1) | RED | **RED** |
| 4b | pre-fix pin, **the same sentence, comma to em dash, nothing else** (`f84a6483cf9f`, commas after that filename now 0) | GREEN | **GREEN** — punctuation is the only input that flips the pre-fix pin |
| 5 | positive: the anchored declaration shape `const KNOWN_BAD = [...]` as CODE (`adb4fbcdf8bb`, marker 1) | RED | **RED** — `1854: const KNOWN_BAD = ['packages/x/src/A.test.tsx', 'packages/y/src/B.test.ts'];` |
| 6 | the same declaration written as docblock PROSE (`f29e3bf3762d`, marker 1) | GREEN | **GREEN** — both halves decline prose |

Restore after each script: 0 paths differing from HEAD, gate blob and pin blob both equal to
their HEAD blobs.

### Leg 5 found a defect in the repair, and it is fixed in `2a10ce4e1`

The anchored positive control is the reason the dispatch note asked for two positive shapes
rather than one. The pin went red as it must, but the line it named was

```
[ "1853: " ]
```

an **empty line, one above the declaration**. `EXEMPTION_DECLARATION_RE` opens with `^\s*` and
`\s` matches a newline, so against a declaration with a blank line above it the match *starts*
on that blank line, and counting to the match offset reported the blank line. A failure message
that names the wrong line is the defect this branch is about, one level down. `offendingLines`
now counts to the first non-whitespace byte of the match, and a dedicated case pins it. Leg 5
re-run on the fix reports `1854:` with the declaration's own text, as the table shows.

## Census unmoved

`node scripts/check-vi-mock-inherit.mjs`, exit 0, before and after — byte-identical lines:

```
✅  check-vi-mock-inherit: OK (4480 tracked source file(s), 2746 test-named; 625 carry a mock;
663 call site(s) on … and their subpaths judged (663 inherit, 0 auto-mocked); 0 other
workspace, 244 external, 886 local, 0 non-static, 3 embedded in a string literal)
```

## Commands, with real output

All heavy runs through the shared `os-verify-lock.sh` (slot `issue-8117-vi-mock`), verdicts read
from its own `VERDICT` line rather than a bare exit status. Head `2a10ce4e1`, tree clean.

| command | result |
|---|---|
| `vitest run scripts/__tests__/check-vi-mock-inherit.test.ts` | exit 0 — `Test Files 1 passed (1)`, `Tests 86 passed (86)` (84 before this PR) |
| `node scripts/check-vi-mock-inherit.mjs` | exit 0 — census above, unmoved |
| `node scripts/check-vi-mock-specifiers.mjs` | exit 0 |
| `node scripts/check-control-bytes.mjs` | exit 0 — 6699 tracked text files, 85 binary skipped |
| `node scripts/check-comment-mask-corpus.mjs` | exit 0 — 4480 files, 1 disagrees, within the residue objectui#7882 holds open; unchanged by this PR |
| `tsc -p tsconfig.scripts.json` | exit 0 — and `--listFiles` confirms the program contains the changed file (count 1), so this is a measurement, not a NOT MEASURED reading |
| `pnpm run lint:root` | exit 0 — whole lane, not a narrowed run: 275 files read from eslint's own config via `--format json`, **0 errors**, 32 pre-existing warnings, 0 in the changed file (control: another file does appear in that output) |
| `node scripts/check-changeset-presence.mjs` | exit 0 — "No source or published contract of a released package changed in this range, so no changeset is owed". Measured, not guessed |
| `grep -naP` for control bytes on the changed file | 0 hits, with a positive control file proving the grep fires |
| `node scripts/check-governed-queue-guard.mjs --test …` | NOT GOVERNED |

Bare objectui#8202 was filed for the second instance and a maintainer already marked it a
duplicate of this card. It is mentioned for history only and needs nothing from this PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr