### PR TITLE
docs(plugin-calendar): rewrite the two object-calendar examples onto declared keys, and annotate them

### DIFF
--- a/packages/plugin-calendar/README.md
+++ b/packages/plugin-calendar/README.md
@@ -256,14 +256,29 @@ fields when they differ.
 
 ### With ObjectQL Integration
 
+Every key below is one `ObjectCalendarSchema` declares. Spelling the start-date
+key anything else is not a partial failure: `getCalendarConfig` gates the whole
+configuration on it, so a calendar whose title and end keys are spelled correctly
+still renders the "Calendar configuration required" refusal screen and never
+reads them.
+
 ```typescript
-const schema = {
+import type { ObjectCalendarSchema } from '@object-ui/types';
+
+// What this annotation buys, and what it does not - measured, objectui#7925.
+// It type-checks the VALUES of the declared keys: `defaultView: 'agenda'` and
+// `titleField: 42` are both compile errors, and `check:doc-snippets` re-runs
+// that check on every commit. It does NOT check key NAMES - this interface
+// extends `BaseSchema`, whose `[key: string]: any` admits any spelling, so a
+// misspelt key still compiles clean. Read the block as type-checked values,
+// never as a guarded key set.
+const schema: ObjectCalendarSchema = {
   type: 'object-calendar',
-  object: 'events',
+  objectName: 'events',
   titleField: 'name',
-  startField: 'startDate',
-  endField: 'endDate',
-  colorField: 'category.color'
+  startDateField: 'startDate',
+  endDateField: 'endDate',
+  defaultView: 'month'
 };
 ```
 
@@ -298,28 +313,34 @@ Authored JSON reacts to clicks through the node's action channel instead
 
 ## ObjectQL Integration
 
-When using with ObjectStack, the calendar can automatically fetch and display events:
+When using with ObjectStack, the calendar can automatically fetch and display
+events. The adapter is **not** a schema key: `ObjectCalendarRenderer` reads it
+from the renderer context that `SchemaRendererProvider` supplies. The schema
+names the object and its fields with the same flat keys as above - there is no
+`fields` container.
 
 ```typescript
 import { createObjectStackAdapter } from '@object-ui/data-objectstack';
+import type { ObjectCalendarSchema } from '@object-ui/types';
 
 const dataSource = createObjectStackAdapter({
   baseUrl: 'https://api.example.com',
   token: 'your-auth-token'
 });
 
-const schema = {
+// The annotation checks the values of the declared keys, not the key names -
+// see the note on the first `object-calendar` block above.
+const schema: ObjectCalendarSchema = {
   type: 'object-calendar',
-  dataSource,
-  object: 'calendar_events',
-  fields: {
-    title: 'title',
-    start: 'start_time',
-    end: 'end_time',
-    color: 'category_color'
-  }
+  objectName: 'calendar_events',
+  titleField: 'title',
+  startDateField: 'start_time',
+  endDateField: 'end_time',
+  defaultView: 'month'
 };
 ```
+
+Pass the adapter to `SchemaRendererProvider` to wire the fetch up.
 
 ## Customization
 


### PR DESCRIPTION
Fixes #7925

Both halves of the triage ruling ship here: the six wrong keys are replaced with the keys `ObjectCalendarSchema` declares, **and** both blocks are annotated so `check:doc-snippets` judges them instead of compiling bare literals against nothing.

## ⚠️ Re-derivation first — four coordinates on the card had drifted

The card was measured at `db2c20d08`; this branch is based on `868e82501`. Every coordinate was re-derived before a byte was touched. The defect is entirely real and unrepaired, but four numbers were stale, and one figure the card and its own triage comment disagreed about is now settled:

| the card said | measured at `868e82501` |
|:--|:--|
| `packages/types/src/objectql.ts:2672` | **`:2698`** |
| `getCalendarConfig` at `ObjectCalendar.tsx:119`, gate at `:131` | function at **`:155`**, gate at **`:162`** |
| README blocks at lines 262 / 314 | **261 / 312** |
| `schema.objectName` read at **26** sites | **19** occurrences — the triage comment's count was the correct one |

Also corrected: the brief predicted `UNGATED_DOCS` had reached `{}`. It holds **4** entries. `packages/plugin-calendar/README.md` is not among them — it is covered, so no entry was added and none was needed.

## The measurement, with its non-vacuity control

A zero read-site count means nothing without a term known to be present. Both halves come from the same run over `packages/plugin-calendar/src/ObjectCalendar.tsx`:

```
CONTROL   schema.objectName      19 occurrences   (present, as expected)
          schema.object           0              (excluding objectName)
          schema.startField       0
          schema.fields           0
          schema.dataSource       0
```

The control is non-zero in the same run, so the four zeros are readings rather than a broken matcher.

## The part of the card worth preserving: one wrong key silently disabled three correct ones

This is not six independent typos. `getCalendarConfig` gates the entire flat-property branch on the start-date spelling:

```ts
if ((schema as any).startDateField || (schema as any).dateField) {
```

Block 1 supplied `startField`. The gate was therefore false, `getCalendarConfig` returned `null`, and the block's **correctly spelled** `titleField` was never read either — the node rendered the "Calendar configuration required. Please specify startDateField and titleField." refusal screen (`ObjectCalendar.tsx:833`, pinned by `ObjectCalendar.unconfiguredRefusal-7029.test.tsx`). The prose now states that consequence, because it is the reason the key list is not a matter of taste.

## ⚠️ What the annotation buys — measured, and written into the file rather than implied

The card's own explanation of why three gates stayed green predicted that annotating would **not** have caught the key names either, because `ObjectCalendarSchema extends BaseSchema` and `BaseSchema` ends with an `[key: string]: any` index signature (`packages/types/src/base.ts:467`). That prediction was tested rather than assumed — a throwaway probe compiled against the built `dist/*.d.ts`:

| probe case | result |
|:--|:--|
| annotated literal carrying the undeclared `object` and `startField` | **0 diagnostics** — excess-property checking does not fire |
| annotated literal with `defaultView: 'agenda'` (a retired value) | TS2322 |
| annotated literal with `titleField: 42` | TS2322 |

So the annotation is live (two positive controls prove it is not vacuously `any`) but its reach is **values, not key names**. A reader who sees an annotation and assumes the key set is now guarded would be worse off than one who sees a bare literal, so the block says so in a comment rather than leaving the impression uncorrected.

## Ablation — proving the gate now actually judges these blocks

`check:doc-snippets` was green before and after, with identical block counts (632 compiled, 0 failed). That pair of greens on its own proves nothing about this change, since both blocks already compiled as bare literals. So the annotation was ablated from the committed state:

- mutation: block 1's `defaultView: 'month'` changed to `'agenda'`
- proven on disk before reading any result — blob hash `fcc26a3d…` moved to `dc3a8961…`, and the marker count for `defaultView: 'month'` fell from 2 to 1
- **result: the gate went red**, exit 1, `1 failed`:

```
[semantic]  packages/plugin-calendar/README.md:281:3  TS2322:
Type '"agenda"' is not assignable to type '"month" | "week" | "day" | undefined'.
```

The gate named this README, this line, and this annotation. Restored under an `EXIT INT TERM` trap with absolute paths, and the restore proven **by state** rather than by exit code: `git diff HEAD` empty, blob hash back to `fcc26a3d…`, `git status` clean.

## Verification

| check | result |
|:--|:--|
| `check:doc-snippets` before | exit 0 — `632 of 632 block(s) judged, 0 failed` |
| `check:doc-snippets` after | exit 0 — same, and now judging these two blocks (see ablation) |
| `check:doc-snippets` ablated | exit 1 — `1 failed`, naming this file |
| `check-doc-links` | exit 0 — `Links are valid across 17 scan roots` |
| `check-doc-component-types` | exit 0 — does not read package READMEs, run anyway |
| `check:readme-exports` | exit 0 — 43 READMEs, 0 fabricated, 0 wrong-path |
| `check:doc-fences` | exit 0 |
| `check:control-bytes` | exit 0 — 6704 tracked text files |
| `check:doc-example-readers` | exit 0 |
| `check-changeset-presence` | exit 0 — `0 of them published source of a package the release covers`, so none owed; run, not guessed |
| `check-governed-queue-guard --test` | `NOT GOVERNED` — 1 path, none of the 5 governed surfaces matched |

Exit codes were captured before any pipe, and each verdict line above is the gate's own printed text.

## 四轴分析

- **实际业务需求** — 实测,不是"读起来像有用"。这两个块是 `object-calendar` 在本包 README 里仅有的两个 ObjectQL 示例,而它们教的六个键渲染器一个都不读(上面的对照读数)。照抄 block 1 的读者拿到的不是"部分生效",是一整块拒绝渲染的屏幕。需求是真实的:文档是这个键集唯一的对外教学面。
- **项目长远合理性** — contract-first,no workarounds。修的是文档(生产者侧),不是渲染器。⛔ 没有在消费端加任何宽容:`startField` / `object` / `fields` 一律直接改成出厂拼写,不留双拼写、不加别名说明。别名去留是 objectui#8355 的题,triage 明确裁定两卡不得重叠,本 PR 不碰 `ObjectCalendar.tsx`,也不把别名问题写进 README 当搭车。
- **防 AI 写代码犯错(尤其元数据 app)** — 这是本卡的重心,也是标注为什么是交付物的一半。裸字面量对着任何东西都不编译,AI 批量生成的错拼永远不会被发现。加上标注,`check:doc-snippets` 每次提交重判一次值,消融已证明它能红。⚠️ 但收紧只到值这一层:索引签名让键名仍然不受检。所以这里同时做了第二件事 —— **把这个边界写进文件本身**。声明即强制的反面不只是"声明了不兑现",还包括"看起来被守住其实没有";留一个让读者误判覆盖面的标注,比留一个裸字面量更糟。键名那一层要真正关上,需要的是 objectui#8466 那类声明面收敛,不是这里再加一层看着像的东西。
- **创业阶段不扩散需求** — 从紧。本 PR 只动一个文件的两个块,不新增任何能力面、不新增门禁、不扩 `UNGATED_DOCS`。顺路量到的两个问题都按无 assignee 立单交 triage,⛔ 没有搭车修:objectui#8466(`colorField` / `allDayField` 被读却未声明)、objectui#8468(另外三个 README 仍把 adapter 写成 schema 键,与已关闭的 objectui#5098 同一类)。`colorField` 因此从 block 1 的示例里去掉而不是保留 —— 保留它等于在一个刚刚说明"键名不受检"的块里,示范一个未声明的键。

## Scope

⛔ Untouched, by triage's explicit fence: `packages/plugin-calendar/src/ObjectCalendar.tsx` and its alias ladder. That question is objectui#8355 and is not addressed here.

Related findings filed while working this card, both unassigned and bare: objectui#8466, objectui#8468.

Drafted by an automated development seat; session reference `https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr`. Left as a draft for the PM seat to flip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_