### PR TITLE
fix(runner): resolve every @source path and stop scanning test files

### DIFF
--- a/.changeset/8454-runner-stylesheet-source-set.md
+++ b/.changeset/8454-runner-stylesheet-source-set.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/runner': patch
+---
+
+Fix every `@source` path in the runner's Tailwind entry, and keep test files out
+of its published stylesheet (objectui#8454).
+
+`packages/runner/src/index.css` is a published input: this package is
+`private: false` with `files: ["dist"]`, so what it compiles to is bytes a
+consumer downloads and serves. All five of its `@source` lines were wrong by one
+path segment. Tailwind resolves a relative `@source` against the directory of the
+entry CSS — `packages/runner/src/` — so `./src/**` meant
+`packages/runner/src/src` and `../../packages/<pkg>/src` meant
+`packages/packages/<pkg>/src`. A glob whose base directory does not exist scans
+nothing and raises no error, so the file read as if it declared its inputs while
+declaring none: deleting all five lines produced a byte-identical artifact.
+
+What kept the sheet non-empty was Tailwind's automatic source detection, whose
+base defaults to the process CWD — `packages/runner`, where `pnpm build` runs.
+That covers this package's own tree and nothing else, so every utility belonging
+to `@object-ui/components`, `@object-ui/react`, `@object-ui/plugin-kanban` and
+`@object-ui/plugin-charts` was missing from the shipped app. Measured from the
+package directory, repairing the four sibling paths takes the compiled sheet from
+228 to 1456 selectors (21 kB to 136 kB): `bg-popover`, `bg-accent`,
+`bg-destructive`, `animate-out` and 1224 more had no source anywhere.
+
+The same automatic root also swept this package's own test files into the
+published bytes. Two `@source not` lines — the spelling
+`packages/plugin-kanban/src/index.css` already uses, anchored one level up
+because this entry scans four sibling packages — remove nine test-sourced
+classes, several of them ordinary English words lifted out of prose comments
+(`paused`, `invert`, `flex-nowrap`).
+
+`patch`: this package exposes no importable surface at all (no `main`, `module`,
+`types` or `exports` — it publishes a built application under `dist`), so nothing
+a consumer imports changes shape. The nine removed classes are unreachable from
+the app's own markup by construction, which is why the scan never had a shipped
+source for them.

--- a/packages/runner/src/__tests__/published-stylesheet-sources.test.ts
+++ b/packages/runner/src/__tests__/published-stylesheet-sources.test.ts
@@ -1,0 +1,180 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Pins the SOURCE SET of `@object-ui/runner`'s stylesheet (objectui#8454).
+ *
+ * This package is `private: false` with `files: ["dist"]`, so `src/index.css`
+ * compiles into bytes a consumer installs. Two things about it went wrong at
+ * once, and neither one produced any error at build time:
+ *
+ *  1. every `@source` path named a directory that does not exist. Tailwind
+ *     resolves a relative `@source` against `dirname(<entry css>)` — here
+ *     `packages/runner/src/` — so `./src/**` meant `packages/runner/src/src`
+ *     and `../../packages/<pkg>/src` meant `packages/packages/<pkg>/src`. A
+ *     glob whose base is missing scans nothing and is not an error: deleting
+ *     all five lines was measured byte-identical to keeping them.
+ *  2. nothing excluded test files. What kept the sheet non-empty was Tailwind's
+ *     automatic source detection, which roots at the PROCESS CWD (`base`
+ *     defaults to `process.cwd()`), i.e. `packages/runner` when `pnpm build`
+ *     runs — so runner's own tests were scanned and shipped, down to ordinary
+ *     English words picked out of prose comments.
+ *
+ * ## Why a naive assertion passes while broken
+ *
+ * "The published sheet contains no test-sourced class" is satisfied perfectly
+ * by a sheet compiled from NOTHING — which is exactly the state defect (1) put
+ * this package in for the four sibling trees. So the negative assertion below
+ * is paired with a positive one that a sheet compiled from nothing fails: a
+ * themed utility that ONLY `@object-ui/components`' shipped source can supply.
+ * And the negative is not a bare absence either — it is a DIFFERENCE against a
+ * second compile of the same entry with the `@source not` lines stripped, so an
+ * exclusion that silently stopped matching anything fails here rather than
+ * passing quietly.
+ *
+ * ## Why it compiles instead of reading `dist/`
+ *
+ * CI runs the suite on an unbuilt worktree, so `dist/` is legitimately absent
+ * and a test that read the artifact would pass vacuously — the same reasoning
+ * `scripts/__tests__/plugin-published-stylesheet.test.ts` records. It runs the
+ * real `@tailwindcss/postcss` over the real entry instead, with `base` pinned
+ * to the package root so the automatic-detection root is the one `pnpm build`
+ * uses no matter which directory the suite was launched from.
+ */
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import postcss from 'postcss';
+import tailwindPostcss from '@tailwindcss/postcss';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+/** `packages/runner` — what `process.cwd()` is when this package builds. */
+const PACKAGE_ROOT = resolve(HERE, '../..');
+const ENTRY = resolve(PACKAGE_ROOT, 'src/index.css');
+const ENTRY_DIR = dirname(ENTRY);
+
+const entryCss = readFileSync(ENTRY, 'utf8');
+
+/**
+ * Class names in a compiled selector, undoing Tailwind's CSS escapes.
+ * Mirrors `classesIn` in `scripts/build-plugin-stylesheet.mjs`; not imported
+ * from there because the root tsconfig sets `allowJs: false`, so a `.ts` test
+ * under `packages/` cannot pull in a plain `.mjs` helper.
+ */
+function classesIn(selector: string): string[] {
+  const found: string[] = [];
+  const re = /\.((?:\\.|[^\s.,>+~()[\]:#*'"\\])+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(selector))) {
+    found.push(
+      m[1]
+        .replace(/\\([0-9a-fA-F]{1,6})\s?/g, (_, hex: string) =>
+          String.fromCodePoint(parseInt(hex, 16)),
+        )
+        .replace(/\\(.)/g, '$1'),
+    );
+  }
+  return found;
+}
+
+/**
+ * Compile the entry the way this package's build does. `base` is the
+ * automatic-detection root and defaults to `process.cwd()` — pinning it to the
+ * package root is what makes this reading independent of where vitest started
+ * (from the repo root the same bytes scan the whole monorepo instead).
+ */
+async function compileClasses(css: string): Promise<Set<string>> {
+  const result = await postcss([tailwindPostcss({ base: PACKAGE_ROOT })]).process(css, {
+    from: ENTRY,
+  });
+  const classes = new Set<string>();
+  postcss.parse(result.css, { from: ENTRY }).walkRules((rule) => {
+    for (const selector of rule.selectors) for (const cls of classesIn(selector)) classes.add(cls);
+  });
+  return classes;
+}
+
+/** `@source` / `@source not` directives, in file order, params unquoted. */
+function sourceDirectives(css: string): { negated: boolean; pattern: string }[] {
+  const out: { negated: boolean; pattern: string }[] = [];
+  for (const line of css.split('\n')) {
+    const m = /^@source\s+(not\s+)?['"](.+)['"]\s*;/.exec(line.trim());
+    if (m) out.push({ negated: Boolean(m[1]), pattern: m[2] });
+  }
+  return out;
+}
+
+/** The literal directory prefix of a glob — everything before the first `*`. */
+function globBase(pattern: string): string {
+  const star = pattern.indexOf('*');
+  const literal = star === -1 ? pattern : pattern.slice(0, star);
+  return resolve(ENTRY_DIR, literal.replace(/\/[^/]*$/, ''));
+}
+
+// Cost paid at import time on purpose: module evaluation is bound by no test or
+// hook timeout, and each compile is ~0.6s. AGENTS.md's testing-discipline
+// section is explicit that a `beforeAll` would be the WORSE place for it:
+// `hookTimeout` (10s) is narrower than `testTimeout` (15s).
+const shipped = await compileClasses(entryCss);
+const withTestSources = await compileClasses(
+  entryCss
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('@source not '))
+    .join('\n'),
+);
+
+describe('@object-ui/runner published stylesheet — source set', () => {
+  it('resolves every @source path to a directory that exists', () => {
+    const directives = sourceDirectives(entryCss);
+    // Non-vacuity: the check above is trivially satisfied by a file with no
+    // `@source` at all, which is the shape this card had to rule out.
+    expect(directives.filter((d) => !d.negated).length).toBeGreaterThanOrEqual(5);
+
+    const missing = directives
+      .map((d) => ({ ...d, base: globBase(d.pattern) }))
+      .filter((d) => !existsSync(d.base));
+    expect(missing).toEqual([]);
+  });
+
+  it('the historical spellings really did point at nothing (control)', () => {
+    // Without this, the assertion above could be green because every path
+    // resolves to the package dir by accident rather than by being correct.
+    expect(existsSync(resolve(ENTRY_DIR, 'src'))).toBe(false);
+    expect(existsSync(resolve(ENTRY_DIR, '../../packages/components/src'))).toBe(false);
+  });
+
+  it('compiles utilities that only a dependency can supply', () => {
+    // `bg-popover` is used by ten shipped files under `packages/components/src`
+    // (popover, dropdown-menu, tooltip, select, …) and by nothing in this
+    // package's own `src`. It can therefore only come from the
+    // `../../components/src/**` line, and it is absent the moment that line
+    // stops resolving — which is what shipped before objectui#8454.
+    expect(shipped).toContain('bg-popover');
+    expect(readFileSync(resolve(PACKAGE_ROOT, 'src/LayoutRenderer.tsx'), 'utf8')).not.toContain(
+      'bg-popover',
+    );
+    // Lit control for the two assertions above: a class this package's OWN
+    // source supplies, so a compile that produced nothing cannot pass either.
+    expect(shipped).toContain('flex-col');
+  });
+
+  it('keeps test-sourced classes out of the published sheet', () => {
+    // `paused` reaches the candidate list only as an English word inside a
+    // prose comment in `packages/components/src/__tests__/`. It is a real
+    // Tailwind utility (`animation-play-state: paused`), so without the
+    // exclusions it compiles into bytes every consumer downloads.
+    expect(withTestSources).toContain('paused');
+    expect(shipped).not.toContain('paused');
+
+    // And the exclusions must still be subtracting something at all: an
+    // `@source not` that quietly stopped matching would otherwise leave every
+    // assertion in this file green.
+    const removed = [...withTestSources].filter((cls) => !shipped.has(cls));
+    expect(removed.length).toBeGreaterThan(0);
+    expect([...shipped].filter((cls) => !withTestSources.has(cls))).toEqual([]);
+  });
+});

--- a/packages/runner/src/index.css
+++ b/packages/runner/src/index.css
@@ -6,12 +6,57 @@
    shared styles entry. Keep in sync with packages/app-shell/src/styles.css. */
 @custom-variant dark (&:where(.dark, .dark *));
 
-/* Scan sources for Tailwind classes */
-@source './src/**/*.{ts,tsx}';
-@source '../../packages/components/src/**/*.{ts,tsx}';
-@source '../../packages/react/src/**/*.{ts,tsx}';
-@source '../../packages/plugin-kanban/src/**/*.{ts,tsx}';
-@source '../../packages/plugin-charts/src/**/*.{ts,tsx}';
+/*
+ * Scan sources for Tailwind classes.
+ *
+ * ⚠️ Every path below is resolved relative to THIS FILE's directory
+ * (`packages/runner/src/`) — not the package root, not the CWD.
+ * `@tailwindcss/postcss` compiles with `base = dirname(<entry css>)`, and the
+ * `@source` params are rewritten against that same base before the scanner ever
+ * sees them. All five lines used to get it wrong by exactly one `src` segment
+ * (`./src/**` -> `packages/runner/src/src`, `../../packages/<pkg>/src` ->
+ * `packages/packages/<pkg>/src`), so every one of them named a directory that
+ * does not exist and contributed nothing: measured on objectui#8454, deleting
+ * all five produced a byte-identical artifact.
+ *
+ * What kept this sheet non-empty was Tailwind's automatic source detection,
+ * which roots at the PROCESS CWD — `packages/runner`, where `pnpm build` runs.
+ * That covers runner's own tree and nothing else, so the utilities its
+ * dependencies need were simply missing from the published bundle: fixing the
+ * four sibling paths takes it from 228 to 1456 compiled selectors (21 kB ->
+ * 136 kB). The automatic root is still on (there is no `source(none)` here, and
+ * that parity question is objectui#8455), which is why the first line below is
+ * a no-op today and still belongs here: it is the declared intent, and it is
+ * what keeps runner's own source scanned the day the root moves.
+ */
+@source './**/*.{ts,tsx}';
+@source '../../components/src/**/*.{ts,tsx}';
+@source '../../react/src/**/*.{ts,tsx}';
+@source '../../plugin-kanban/src/**/*.{ts,tsx}';
+@source '../../plugin-charts/src/**/*.{ts,tsx}';
+
+/*
+ * Only shipped source. A `*.test.tsx` never reaches a consumer, and neither
+ * does a helper that lives beside one, so a utility used solely by tests must
+ * not become a published byte. Same two-line spelling as
+ * `packages/plugin-kanban/src/index.css`, anchored one level up because this
+ * entry scans four sibling packages instead of only its own tree — `../../`
+ * bases these on `packages/`, which contains every tree named above AND the
+ * automatic-detection root, so runner's own tests are covered by the same two
+ * lines (measured: negations do apply to files the automatic root found).
+ *
+ * Both lines earn their place. The file line removes nine test-sourced classes
+ * (`flex-grow`, `flex-nowrap`, `h-[125px]`, `h-[400px]`, `invert`, `paused`,
+ * `slide-in-from-bottom`, `text-green-500`, `w-[250px]` — several of them
+ * ordinary English words picked out of prose comments). The directory line
+ * removes nothing extra today, but it is the only thing covering the
+ * non-`*.test.*` sources under `packages/components/src/__tests__/`
+ * (`test-utils.tsx`, `page-header-action-ids.dist.spec.tsx`); ablated with a
+ * marker class injected into the first of those, the file line alone ships it
+ * and the pair does not.
+ */
+@source not '../../**/*.test.{ts,tsx}';
+@source not '../../**/__tests__/**';
 
 /* Tailwind plugin for animations */
 @plugin 'tailwindcss-animate';

--- a/packages/runner/tsconfig.test.json
+++ b/packages/runner/tsconfig.test.json
@@ -17,7 +17,14 @@
     // pulls `lib/MetadataLoader.ts` into this program, and that file calls
     // `import.meta.glob` — declared by `vite/client`, which the root config
     // this extends does not carry (it is not a Vite app).
-    "types": ["vite/client"]
+    //
+    // `node` joins it for `src/__tests__/published-stylesheet-sources.test.ts`,
+    // which reads and compiles this package's Tailwind entry through
+    // `node:fs` / `node:path` / `node:url`. Naming `types` at all switches off
+    // automatic `@types/*` inclusion, so the entry is required rather than
+    // implied; `@types/node` resolves from the workspace root, which is how
+    // `packages/components/tsconfig.test.json` gets it too.
+    "types": ["node", "vite/client"]
   },
   "include": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
Fixes #8454

`packages/runner/src/index.css` is a published input: this package is `private: false` with `files: ["dist"]`. The card reported two defects in it. Both are real, but **the first one is not what the card says it is**, and the second is five times larger than reported. Everything below was measured **from `packages/runner/`**, which is where `pnpm build` runs.

## What the measurement found

Tailwind resolves a relative `@source` against the directory of the entry CSS — `packages/runner/src/` — and `@tailwindcss/postcss` compiles with `base = dirname(path.resolve(opts.from))`. Under that arithmetic **all five** `@source` lines named a directory that does not exist, not just line 10:

| declared | resolved to | on disk |
|---|---|---|
| `./src/**/*.{ts,tsx}` | `packages/runner/src/src` | missing |
| `../../packages/components/src/**` | `packages/packages/components/src` | missing |
| `../../packages/react/src/**` | `packages/packages/react/src` | missing |
| `../../packages/plugin-kanban/src/**` | `packages/packages/plugin-kanban/src` | missing |
| `../../packages/plugin-charts/src/**` | `packages/packages/plugin-charts/src` | missing |

A glob whose base directory is missing scans nothing and raises no error. **Decisive reading:** deleting all five lines and rebuilding produced a **byte-identical** artifact — same content hash `index-BgwNVuMG.css`, same 20 969 bytes, same 219 rules.

So the sheet's only real input was Tailwind's **automatic source detection**, whose base defaults to the process CWD (`base?: string` — *"The base directory to scan for class candidates. Defaults to the current working directory"*, `@tailwindcss/postcss`'s own type declaration). That root is `packages/runner`, which covers this package's own tree and nothing else.

⇒ **The card's defect 1 is falsified as stated.** `components`' test-sourced classes were never reaching this sheet through the `../../packages/components/src/**` line, because that line was dead. What *was* leaking is this package's **own** tests, via the CWD root.

## The two deltas, separately

Readings are unique compiled selectors from `packages/runner/dist/assets/index-*.css`, produced by `pnpm build` **in `packages/runner/`**, from a clean `dist` each time. On-disk file set: the committed tree at `a407bd654` plus, for each row, only the stated edit to `src/index.css`.

**Delta 1 — repairing the paths ADDS.** `20 969 B / 219 rules / 228 selectors` → `136 310 B / 1553 rules / 1456 selectors`. **+1228 selectors, −0.** `bg-popover`, `bg-accent`, `bg-destructive`, `animate-out`, `aspect-square` and 1223 more had no source anywhere in the world: the published runner app was shipping without the utilities every one of its dependencies needs.

**Delta 2 — the exclusions REMOVE.** `136 310 B / 1553 rules / 1456 selectors` → `135 842 B / 1545 rules / 1447 selectors`. **−9, +0:** `flex-grow`, `flex-nowrap`, `h-[125px]`, `h-[400px]`, `invert`, `paused`, `slide-in-from-bottom`, `text-green-500`, `w-[250px]`. Several are ordinary English words lifted out of prose comments — `paused` comes from *"while its trap listeners stay active and `paused` is still false"*.

Applied to today's shipping bytes instead (broken paths kept, exclusions added), the removal is **−1**: `.block`, whose only source is the word "block" in the sentence *"the built-in 404 block instead of the ComponentRegistry"* in `src/App.navigation.test.tsx`. The shipped `md:block` is a different candidate and survives.

## ⚠️ Why the repo-root reading would have inverted the sign

The card warns that a repo-root reading under-reports. Here it does worse. Same two trees, built from the repo root (`pnpm exec vite build packages/runner`):

| reading | before | after | delta |
|---|---|---|---|
| **package dir** (authoritative — where `pnpm build` runs) | 228 selectors | 1447 | **+1228 / −9** |
| repo root | 3315 selectors | 3299 | **+0 / −16** |

From the repo root the automatic root has already scanned the whole monorepo, so the path repair adds nothing there and the change reads as a **pure removal**. A reviewer measuring from the repo root would never see that this PR restores 1228 missing utilities.

## Which sibling spelling applies, and why both lines

`plugin-kanban`'s two-line form, not `fields`' one-line form — anchored one level up (`../../`, base `packages/`) because this entry scans four sibling packages rather than only its own tree. Negations do reach files the automatic root found; that was measured, not assumed (adding only `@source not './**/...'` to the unrepaired tree removed `.block`, which the CWD root had supplied).

The card asked which line is load-bearing here rather than assuming. **Measured both ways:**

- The **file** line accounts for all nine removals. With only that line, the artifact is byte-identical to having both (`index-CLMWcOzp.css`, 135 842 B) — so today the directory line removes nothing extra.
- The **directory** line is nonetheless the only cover for `packages/components/src/__tests__/test-utils.tsx` and `page-header-action-ids.dist.spec.tsx` — non-`*.test.*` sources that the repaired `../../components/src/**` line reaches. **Ablated:** a marker class injected into `test-utils.tsx` compiles into the sheet with the file line alone (`.z-\[8454\]` present, lit control `.flex{` present) and is absent with both lines (marker 0, lit control still 1). Both files restored by state afterwards.

That is the condition the card named, so both lines stay.

## The guard test

`packages/runner/src/__tests__/published-stylesheet-sources.test.ts` compiles the real entry through the real `@tailwindcss/postcss`, with `base` pinned to the package root so the reading does not depend on where vitest started. It does not read `dist/` — CI runs the suite on an unbuilt worktree, where that would pass vacuously.

A sheet compiled from **nothing** satisfies "no test-sourced rules" perfectly — which is exactly the state defect 2 had put this package in. So the negative assertion is paired:

- **positive:** `bg-popover` is present. Ten shipped files under `packages/components/src` use it and nothing in this package does, so it can only arrive through the sibling `@source` line. Lit control: `flex-col`, from this package's own source.
- **negative:** taken as a **difference** against a second compile with the `@source not` lines stripped, so an exclusion that silently stopped matching fails here instead of passing quietly.
- **paths:** every `@source` glob base must exist, with a non-vacuity floor of five positive directives and a control asserting the two historical spellings really do resolve to nothing.

**Ablations, from the committed implementation, each restored by state (`git diff HEAD` empty and hash equal to `git rev-parse HEAD:PATH`):**

| mutation | on-disk hash | red |
|---|---|---|
| paths re-broken to `../../packages/...` | `6b7ec85c` vs HEAD `dd5f1a18` | `resolves every @source path…` + `compiles utilities that only a dependency can supply` (2 failed, 2 passed) |
| both `@source not` lines deleted | `e272958d` vs HEAD `dd5f1a18` | `keeps test-sourced classes out…` — `expected [ '@container', …(1387) ] to not include 'paused'` (1 failed, 3 passed) |

The new test file lives inside the scanned tree and is itself excluded: adding it left the artifact byte-identical (`index-CLMWcOzp.css`), despite carrying six class-shaped literals.

## Changeset

`node scripts/check-changeset-presence.mjs` before: *"❌ 1 source file(s) of 1 released package(s) changed, and this change adds no changeset"*. After: *"✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)"*. `check-changeset-no-major` ✅, `check-changeset-fixed` ✅, `check-changeset-overwrite` ✅.

**`patch`, argued from the diff:** this package exposes no importable surface at all — no `main`, `module`, `types`, `exports`, `sideEffects` or `peerDependencies`; it publishes a built application under `dist`. Nothing a consumer imports changes shape, and the nine removed classes are unreachable from the app's own markup by construction (that is precisely why the scan had no shipped source for them). `major` is forbidden repo-wide; `minor` would claim a surface change this package does not have.

## Verification

- `pnpm --workspace-concurrency=2 --filter '@object-ui/runner^...' build` — exit 0 (closure built before type-check).
- `pnpm --filter @object-ui/runner run type-check` — exit 0. `--listFiles` confirms the new test **is** in the program (1 hit; lit control `App.navigation.test.tsx` 1 hit; 1420 files), so this is a measurement and not an exclusion.
- `pnpm exec vitest run packages/runner/` from the repo root — **5 files, 21 tests passed**.
- `pnpm --filter @object-ui/runner run lint` — exit 0; 17 warnings, all pre-existing in files this PR does not touch.
- `turbo ls --affected` against the merge base: `@object-ui/runner`, one package.
- Gate families: `check:control-bytes` ✅ · `type-check:coverage` ✅ · `check:unreferenced-sources` ✅ · `check:phantom-deps` ✅ · `check:unused-deps` ✅ · `check:published-tsconfig-exclude` ✅ · `check:published-dist --all` ✅ (+ the four changeset gates above). The repo-wide `pnpm lint` / full `pnpm test` are left to CI.

## Out of scope — reported, not swept in

Per the fence, `packages/runner` only. A repo-wide `@source` resolution sweep (run after this fix) says **every** `@source` path in the repo now resolves — `packages/runner` was the sole offender. Two refinements for objectui#8455, whose census column is only "test exclusion":

1. Its table records `packages/fields/src/index.css` as *"✅ one line"*. That package has `src/__tests__/numberInputBrowserReadings.ts` — a non-`*.test.*` source inside its own scanned tree — so the missing directory line is actually leaking there, not merely stylistically absent. `@object-ui/fields` publishes a stylesheet consumers import.
2. A gate that only looks for `@source not` lines would have passed `packages/runner` while all five of its positive `@source` lines were dead. Whatever objectui#8455 builds needs a **second** assertion — every `@source` base resolves — and that half has zero current backlog, so it is cheap to add now.

`source(none)` for this entry is objectui#8455's option A and is deliberately **not** in this PR: the automatic root stays on, which is why the first `@source` line is a no-op today and still belongs there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_