### PR TITLE
feat(lint): reject a source line address inside a test name

### DIFF
--- a/.changeset/test-name-line-citation-gate-8047.md
+++ b/.changeset/test-name-line-citation-gate-8047.md
@@ -1,0 +1,6 @@
+---
+---
+
+Tooling and test-name only. Adds the `object-ui/no-line-address-in-test-name` ESLint rule
+(objectui#8047) and deletes the source line addresses from the test names it reports. No
+published behaviour, API surface or runtime code changes, so this releases nothing.

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -10,6 +10,7 @@ import noUnprefixedQueryParams from './no-unprefixed-query-params.js';
 import buttonHasType from './button-has-type.js';
 import noUnpairedBadgeColorClasses from './no-unpaired-badge-color-classes.js';
 import noUnusedImports from './no-unused-imports.js';
+import noLineAddressInTestName from './no-line-address-in-test-name.js';
 
 export default {
   rules: {
@@ -22,5 +23,6 @@ export default {
     'button-has-type': buttonHasType,
     'no-unpaired-badge-color-classes': noUnpairedBadgeColorClasses,
     'no-unused-imports': noUnusedImports,
+    'no-line-address-in-test-name': noLineAddressInTestName,
   },
 };

--- a/eslint-rules/no-line-address-in-test-name.js
+++ b/eslint-rules/no-line-address-in-test-name.js
@@ -1,0 +1,409 @@
+/**
+ * ObjectUI ESLint rule: no-line-address-in-test-name
+ *
+ * Bans a source LINE ADDRESS -- `SomeFile.tsx:123` -- from anything that
+ * becomes part of a resolved test name.
+ *
+ * ## The property, and why per-instance repair never closed it
+ *
+ * A line address inside a test name is read by NOTHING. It is not an
+ * assertion, no gate parses it, and the file it points at is never opened. So
+ * it cannot fail: it rots the first time a line is inserted above the thing it
+ * cites, and the rot stays invisible until a reader believes it. objectui#7853
+ * ruled the class -- CITE THE ASSERTION BY CONTENT, NOT BY LINE ADDRESS --
+ * and landed as `fa7d66c45`; #6548, #6998, #7289, #7913 and #8045 are the
+ * repairs that followed it, one instance at a time, and the class kept
+ * recurring. This rule is objectui#8047, the mechanical form of that ruling.
+ *
+ * ## Why a NAME-AGNOSTIC reading, and not a scan of `it(` lines
+ *
+ * The instrument matters more than the count here. Measured on `origin/main`
+ * at `868e82501`, over the 2454 test files under `packages/`:
+ *
+ *   - an enumeration anchored on the `it(` LINE finds 6 raw hits in 2 files
+ *     -- and one of those 6 is a false positive, a docblock-style sentence
+ *     ("...reads and draws it (PageHeader.tsx:123...")  that merely looks like
+ *     a test declaration;
+ *   - a name-agnostic scan of quoted addresses on non-comment lines finds 45
+ *     raw hits in 7 files -- and roughly 30 of those reach a resolved test
+ *     name through `it.each($src)` interpolation, from a case table that never
+ *     appears on an `it(` line at all.
+ *
+ * So the `it(`-anchored instrument under-counts the live population by about
+ * six-fold AND over-reports at the same time. That is not a sloppy regex; it
+ * is the class's defining property turned on its observer -- you cannot grep
+ * reliably for a citation that has no fixed syntactic home. A rule that read
+ * only `it(` string literals would reproduce the exact blind spot it exists to
+ * remove.
+ *
+ * ## Design question 1 -- resolved names, or strings that REACH a name
+ *
+ * Two designs answer the interpolation problem. The rejected one is to judge
+ * genuinely RESOLVED names by collecting them with the runtime
+ * (`vitest list --json`). It is disqualified twice over:
+ *
+ *   - in PRINCIPLE, collection EXECUTES every test module's top level, so a
+ *     syntax-only citation check would acquire the power to fail on an
+ *     unrelated runtime error, a missing DOM global or a slow transform. A
+ *     check on the text of a name must not depend on the suite booting.
+ *   - in COST, measured in this container: `vitest list --json` over ONE
+ *     `plugin-charts` file took 11.9s, and over ONE `app-shell` `dom` file it
+ *     had still emitted nothing after NINE MINUTES. There are 2454 test files.
+ *
+ * So this rule takes the other design: reject the address in any string that
+ * REACHES a test title, decided on the AST rather than on the `it(` line. The
+ * three legs are `Leg 1/2/3` below, and leg 3 exists so that "the rule could
+ * not tell" is never spelled the same way as "there is nothing here".
+ *
+ * ## Design question 2 -- where a line address is LEGITIMATE
+ *
+ * The population deliberately does NOT sprawl to every string in a test file.
+ * Three carve-outs, each with an instance measured in this tree today:
+ *
+ *   1. COMMENTS. A human reads them beside the code they annotate, and the
+ *      next reader of that code corrects a wrong one. This rule never reads a
+ *      comment: ESLint hands rules an AST, and nothing here inspects
+ *      `sourceCode.getAllComments()`.
+ *   2. ASSERTION AND FAILURE MESSAGES. A human reads these AT THE POINT OF
+ *      FAILURE, where the assertion that actually failed is the context. In
+ *      tree: `readme-app-shell-example.test.ts:231` and `:255`,
+ *      `guide-layout-sidebar-nav-doc.test.ts:490`, and the four `producer:`
+ *      fields in `gridNonAuthorKeys.test.tsx` that its line 229 splices into a
+ *      failure message. Not a title argument, not a case-table string, so not
+ *      reported.
+ *   3. DATA THE TEST ASSERTS ON. `page-header-authorable-keys.test.tsx`'s
+ *      `RENDERER_OWN_DECLARED` rationale carries an address and IS read --
+ *      line 227 asserts on that very string. Something checks it, so it is not
+ *      the unreadable class.
+ *
+ * The boundary is worth stating as a number, measured on `868e82501`: a rule
+ * over EVERY string in a test file reports 45 hits in 7 files; this rule
+ * reports 37 in 3. The 8 it drops are the carve-outs above, and dropping them
+ * is the point -- the remedy for a reported failure message is deleting useful
+ * provenance a human reads.
+ *
+ * The carve-out is drawn on the TITLE'S OWN REACH, not on a keyword list. For
+ * `it.each(ROWS)('the spec refuses $key ...')` only the `key` field of each
+ * row can arrive in the name, so a sibling `producer:` field carrying an
+ * address is data and is not reported -- that is `gridNonAuthorKeys.test.tsx`,
+ * four hits, and it is why leg 2 reads the title's `$path` set rather than the
+ * whole row. A POSITIONAL title (`%s`, `$0`) or a template title cannot say
+ * which field arrives, so those read the whole row: over-reporting is the safe
+ * direction here, silence is not.
+ *
+ * ## The residual gap, stated rather than papered over
+ *
+ * Leg 3 fires only for a NAMED title (`$src`) over a table the rule cannot
+ * resolve, because a named title is what says the rows are objects carrying
+ * fields -- the shape every recorded instance of this class has had. A
+ * POSITIONAL title over an opaque table (`it.each(covered)('%s declares ...')`
+ * in `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts`, the one
+ * in-tree instance) is therefore NOT covered. Reporting it would mean scanning
+ * that whole file and reporting a rationale record the test asserts on --
+ * carve-out 3, a false positive -- and the remedy offered would be to hoist a
+ * table computed from the live component registry, which cannot be hoisted.
+ * The gap is one site today; it is written here so the next reader does not
+ * mistake this rule's silence there for coverage.
+ *
+ * One shape is deliberately NOT reported, and it is the boundary's mirror: an
+ * address whose line number is COMPUTED from a live read of the cited file
+ * (`` `...layout.md:${fence.line}...` ``, real code in
+ * `guide-layout-sidebar-nav-doc.test.ts`) cannot rot -- it is derived, not
+ * cited. It is pinned as a valid case in this rule's tests.
+ *
+ * ## No autofixer, on purpose
+ *
+ * The repair at most sites is a DELETION -- the symbol or heading text is
+ * already in the name -- but not at all of them: where the address is the
+ * case's only identity (`it.each(CORPUS)('adopts $src ...')`) removing it
+ * merges names, and choosing the replacement identity is an authoring decision.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+
+/**
+ * File extensions that make `NAME.ext:NNN` a SOURCE ADDRESS rather than a
+ * coincidence. The list is explicit so the two known-negative shapes stay
+ * negative for a structural reason and not by luck: a version number (`1.2.3`)
+ * has no `:`, and a clock time (`12:30`) has no extension. A host:port
+ * (`http://example.com:3000`) is excluded the same way -- `com` is not here.
+ */
+const SOURCE_EXT = [
+  'ts', 'tsx', 'mts', 'cts', 'js', 'jsx', 'mjs', 'cjs',
+  'json', 'jsonc', 'md', 'mdx', 'yml', 'yaml',
+  'css', 'scss', 'html', 'vue', 'svelte', 'snap', 'sh', 'py', 'toml',
+];
+
+/**
+ * `NAME.ext:NNN`. The name part may carry directories (`views/ObjectView.tsx`)
+ * and scope characters, and must end in a word character so a trailing dot
+ * cannot start it. A leading boundary keeps `foo.mjs:12` from matching inside
+ * `barfoo.mjs:12`'s tail only -- the whole run is taken either way.
+ */
+const ADDRESS = new RegExp(
+  String.raw`[A-Za-z0-9_@$./-]*[A-Za-z0-9_$-]\.(?:${SOURCE_EXT.join('|')}):\d+`,
+);
+
+/**
+ * `$prop` / `$prop.nested` -- vitest splices the NAMED property of the case
+ * object into the title. `$#` is excluded on purpose: it is the case INDEX, so
+ * it carries no case string into the name.
+ */
+const NAMED_SUBSTITUTION = /\$([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)/g;
+
+/**
+ * Substitutions that splice case data POSITIONALLY, so the rule cannot say
+ * which field arrives: printf placeholders (`%s`, `%d`, ...) and `$0`-style
+ * tuple positions. `%%` is an escaped percent and carries nothing.
+ */
+const POSITIONAL_SUBSTITUTION = /%(?!%)[sdifjoO#]|\$\d/;
+
+/** Vitest/Jest declaration roots whose first argument names a test or a suite. */
+const DECLARATIONS = new Set(['it', 'test', 'describe', 'bench', 'suite']);
+
+/** Modifier chain allowed between the root and the call: `it.skip.each(...)`. */
+const MODIFIERS = new Set([
+  'each', 'for', 'skip', 'only', 'todo', 'fails', 'concurrent', 'sequential',
+  'runIf', 'skipIf', 'extend', 'scoped', 'shuffle',
+]);
+
+/** Array methods that return a subset/reshuffle, so the receiver over-approximates. */
+const ARRAY_DERIVATIONS = new Set([
+  'filter', 'map', 'slice', 'concat', 'flat', 'flatMap', 'reverse',
+  'toSorted', 'toReversed', 'sort', 'entries', 'values',
+]);
+
+/**
+ * Walks `it.skip.each` down to its root identifier, reporting the modifiers
+ * seen on the way. Returns null for anything that is not a declaration call --
+ * `foo.describe()` is somebody else's API.
+ */
+function classifyCallee(callee) {
+  const modifiers = [];
+  let node = callee;
+  while (node.type === 'MemberExpression' && !node.computed && node.property.type === 'Identifier') {
+    modifiers.unshift(node.property.name);
+    node = node.object;
+  }
+  if (node.type !== 'Identifier' || !DECLARATIONS.has(node.name)) return null;
+  if (!modifiers.every((m) => MODIFIERS.has(m))) return null;
+  return { root: node.name, isEach: modifiers.includes('each') || modifiers.includes('for') };
+}
+
+/** Every string this node contributes to a title, with the node to report on. */
+function titleStrings(node) {
+  if (!node) return [];
+  if (node.type === 'Literal' && typeof node.value === 'string') return [{ text: node.value, node }];
+  if (node.type === 'TemplateLiteral') return node.quasis.map((q) => ({ text: q.value.cooked ?? q.value.raw, node: q }));
+  return [];
+}
+
+/**
+ * How a title takes case data, which decides WHICH strings of a row can reach
+ * the name -- the difference between reporting a row's provenance field and
+ * reporting only the field the title actually names.
+ *
+ *   { kind: 'none' }      nothing from the row reaches the title.
+ *   { kind: 'named', paths } only these property paths reach it.
+ *   { kind: 'opaque' }    positional or computed -- any string in the row may.
+ */
+function titleSubstitution(node) {
+  // A template title splices an arbitrary expression: nothing static to name.
+  if (node && node.type === 'TemplateLiteral' && node.expressions.length > 0) return { kind: 'opaque' };
+  const chunks = titleStrings(node);
+  if (chunks.some((c) => POSITIONAL_SUBSTITUTION.test(c.text))) return { kind: 'opaque' };
+  const paths = new Set();
+  for (const chunk of chunks) {
+    NAMED_SUBSTITUTION.lastIndex = 0;
+    let m;
+    while ((m = NAMED_SUBSTITUTION.exec(chunk.text)) !== null) paths.add(m[1]);
+  }
+  return paths.size ? { kind: 'named', paths } : { kind: 'none' };
+}
+
+/**
+ * The strings a row contributes to the title. For a NAMED title only the named
+ * property paths are read -- a sibling field the title never mentions is data,
+ * not a name, and this is where the `producer:` fields of
+ * `gridNonAuthorKeys.test.tsx` stop being reported. Anything the walk cannot
+ * follow (a row that is not an object literal, a path that dead-ends in a
+ * computed key) falls back to the whole row, so the miss direction stays loud.
+ */
+function rowStringsForNamedPaths(row, paths) {
+  if (!row || row.type !== 'ObjectExpression') return collectStrings(row);
+  const out = [];
+  for (const path of paths) {
+    let node = row;
+    for (const segment of path.split('.')) {
+      if (!node || node.type !== 'ObjectExpression') { node = undefined; break; }
+      const prop = node.properties.find(
+        (pr) => pr.type === 'Property' && !pr.computed
+          && ((pr.key.type === 'Identifier' && pr.key.name === segment)
+            || (pr.key.type === 'Literal' && String(pr.key.value) === segment)),
+      );
+      node = prop ? prop.value : undefined;
+    }
+    if (node) out.push(...collectStrings(node));
+  }
+  return out;
+}
+
+/**
+ * Resolves an `each` case table to the array literal whose strings can reach
+ * the title. Deliberately OVER-approximates: `CORPUS.filter(fn)` resolves to
+ * all of `CORPUS`, because a filter can only drop rows, and over-reporting a
+ * row that will not run is loud while under-reporting is silent. Returns null
+ * when nothing static is reachable -- leg 3 then takes over, and the caller
+ * must not read null as "no addresses here".
+ */
+function resolveTable(node, scope) {
+  if (!node) return null;
+  if (node.type === 'ArrayExpression') return node;
+  if (node.type === 'TemplateLiteral') return node;
+  if (node.type === 'Identifier') {
+    let s = scope;
+    while (s) {
+      const variable = s.variables.find((v) => v.name === node.name);
+      if (variable) {
+        const defs = variable.defs.filter((d) => d.node && d.node.type === 'VariableDeclarator' && d.node.init);
+        if (defs.length !== 1) return null;
+        return resolveTable(defs[0].node.init, s);
+      }
+      s = s.upper;
+    }
+    return null;
+  }
+  if (node.type === 'TSAsExpression' || node.type === 'TSSatisfiesExpression') {
+    return resolveTable(node.expression, scope);
+  }
+  if (
+    node.type === 'CallExpression'
+    && node.callee.type === 'MemberExpression'
+    && !node.callee.computed
+    && node.callee.property.type === 'Identifier'
+    && ARRAY_DERIVATIONS.has(node.callee.property.name)
+  ) {
+    return resolveTable(node.callee.object, scope);
+  }
+  return null;
+}
+
+/** Every string literal / template chunk anywhere under `node`. */
+function collectStrings(node, out = [], seen = new Set()) {
+  if (!node || typeof node !== 'object' || seen.has(node)) return out;
+  seen.add(node);
+  if (Array.isArray(node)) {
+    for (const child of node) collectStrings(child, out, seen);
+    return out;
+  }
+  if (typeof node.type !== 'string') return out;
+  if (node.type === 'Literal' && typeof node.value === 'string') out.push({ text: node.value, node });
+  else if (node.type === 'TemplateElement') out.push({ text: node.value.cooked ?? node.value.raw, node });
+  for (const key of Object.keys(node)) {
+    if (key === 'parent' || key === 'loc' || key === 'range') continue;
+    collectStrings(node[key], out, seen);
+  }
+  return out;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Ban a source line address (`File.tsx:123`) from anything that becomes part of a test name — nothing reads it, so it cannot fail, and it rots on the next insertion above the line it cites (objectui#7853, objectui#8047).',
+    },
+    schema: [],
+    messages: {
+      inTitle:
+        'Test name cites `{{address}}` by LINE ADDRESS. Nothing reads a test name, so this citation cannot fail and rots on the next insertion above that line. Cite the assertion by CONTENT — the symbol, heading or text — per objectui#7853.',
+      inEachCase:
+        'This `each` case table carries the line address `{{address}}`, and the title interpolates case data, so the address reaches the test name. Nothing reads a test name, so it cannot fail and rots silently (objectui#7853). Cite the case by CONTENT.',
+      inUnresolvedTable:
+        'This `each` title interpolates case data from a table this rule cannot read statically, and `{{address}}` appears as a string in this file — so it may reach a test name unchecked. Hoist the cases to a `const` array literal so the citation check can see them, or cite by CONTENT instead of by line address (objectui#7853).',
+    },
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+
+    // Two `each` sites may share one case table (`CORPUS` and
+    // `CORPUS.filter(...)` in this tree), so the same string is reached twice.
+    // One report per (position, address) keeps the count a count of DEFECTS.
+    const alreadyReported = new Set();
+
+    /** Reports the FIRST address in `text`, if any, at `node`. */
+    const reportAddress = (messageId, text, node) => {
+      const m = ADDRESS.exec(text);
+      if (!m) return false;
+      const key = `${node.range[0]}:${node.range[1]}:${m[0]}`;
+      if (alreadyReported.has(key)) return true;
+      alreadyReported.add(key);
+      context.report({ node, messageId, data: { address: m[0] } });
+      return true;
+    };
+
+    return {
+      CallExpression(node) {
+        // `it('name', fn)` puts the declaration on `node.callee`; the `each`
+        // forms wrap it -- `it.each(TABLE)('name', fn)` is a call whose callee
+        // is itself a call, and `it.each\`…\`('name', fn)` a tagged template.
+        const outer = node.callee;
+        const decl = outer.type === 'CallExpression' ? outer.callee
+          : outer.type === 'TaggedTemplateExpression' ? outer.tag
+            : outer;
+        const kind = classifyCallee(decl);
+        if (!kind) return;
+
+        // Leg 1 — the title argument itself. For an `each` form the title is
+        // still argument 0 of the returned call, so this is the same read.
+        const title = node.arguments[0];
+        let reported = false;
+        for (const chunk of titleStrings(title)) {
+          if (reportAddress('inTitle', chunk.text, chunk.node)) reported = true;
+        }
+        if (!kind.isEach || reported) return;
+
+        // Legs 2 and 3 apply only when case data is actually spliced in. A
+        // fixed title cannot carry a row's string no matter what the table
+        // holds, and `$#` splices only the index.
+        const substitution = titleSubstitution(title);
+        if (substitution.kind === 'none') return;
+
+        const tableArg = outer.type === 'CallExpression' ? outer.arguments[0]
+          : outer.type === 'TaggedTemplateExpression' ? outer.quasi
+            : undefined;
+        if (tableArg === undefined) return;
+        const scope = sourceCode.getScope ? sourceCode.getScope(node) : context.getScope();
+        const table = resolveTable(tableArg, scope);
+
+        if (table) {
+          // Leg 2 — the resolved table, read through the title's own reach.
+          const rows = table.type === 'ArrayExpression' ? table.elements.filter(Boolean) : [table];
+          for (const row of rows) {
+            const chunks = substitution.kind === 'named'
+              ? rowStringsForNamedPaths(row, substitution.paths)
+              : collectStrings(row);
+            for (const chunk of chunks) reportAddress('inEachCase', chunk.text, chunk.node);
+          }
+          return;
+        }
+
+        // Leg 3 — the table is not statically legible. Silence here would be
+        // indistinguishable from "clean", which is the exact failure this rule
+        // exists to stop, so fall back to the whole file and say so. Confined
+        // to NAMED titles: `$src` says the rows are objects carrying fields, the
+        // shape every recorded instance of this class has had. The residual gap
+        // — a POSITIONAL title over an opaque table — is stated in the header
+        // rather than papered over.
+        if (substitution.kind !== 'named') return;
+        for (const chunk of collectStrings(sourceCode.ast)) {
+          reportAddress('inUnresolvedTable', chunk.text, tableArg);
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint-rules/no-line-address-in-test-name.test.js
+++ b/eslint-rules/no-line-address-in-test-name.test.js
@@ -1,0 +1,133 @@
+/**
+ * Pins `no-line-address-in-test-name` against BOTH directions, because the
+ * class this rule closes is defined by an instrument that fails in both.
+ *
+ * The `invalid` block carries every shape the address is known to arrive in —
+ * the five quote/modifier flavours of a literal name, and the INTERPOLATED
+ * form where the address lives in a case table and never appears on an `it(`
+ * line at all. A rule that only read `it(` string literals would pass the
+ * first group and silently miss the second, which is exactly how the sweeps
+ * before it under-counted the population six-fold.
+ *
+ * The `valid` block is the other half, and it is the answer to "where is a
+ * line address legitimate". Every entry is a real shape from this tree,
+ * reduced: an assertion message, a data field the title never names, a data
+ * field a test asserts ON, a comment, and an address whose line number is
+ * COMPUTED from a live read (derived, so it cannot rot). Without them the rule
+ * would be a rule against writing `.ts:` anywhere near a test.
+ */
+import { describe, it, afterAll } from 'vitest';
+import { RuleTester } from 'eslint';
+import rule from './no-line-address-in-test-name.js';
+
+RuleTester.afterAll = afterAll;
+RuleTester.it = it;
+RuleTester.describe = describe;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-line-address-in-test-name', rule, {
+  valid: [
+    // ── The carve-outs of design question 2 ──────────────────────────────
+    // An assertion message: a human reads it AT THE POINT OF FAILURE, where
+    // the assertion that failed is the context. Real shape:
+    // readme-app-shell-example.test.ts.
+    `it('AppShell declares every prop the README passes', () => {
+       expect(undeclared, 'AppShell destructures a fixed key list (AppShell.tsx:233-241)').toEqual([]);
+     });`,
+    // A case-table field the title never names. `$key` is spliced, `producer`
+    // is not, and `producer` is spliced into the FAILURE MESSAGE instead.
+    // Real shape: gridNonAuthorKeys.test.tsx.
+    `const KEYS = [{ key: 'columnState', producer: 'app-shell/src/views/ObjectView.tsx:1848' }];
+     it.each(KEYS)('the spec refuses $key as an unrecognized key', ({ key, producer }) => {
+       expect(refuse(key), \`written by \${producer}\`).toBe(true);
+     });`,
+    // Data the test asserts ON — something checks it, so it is not the
+    // unreadable class. Real shape: page-header-authorable-keys.test.tsx.
+    `const REASONS = { icon: 'reads and draws it (PageHeader.tsx:123), objectui#3829.' };
+     it('every renderer-own declaration says why', () => {
+       expect(/#\\d+/.test(REASONS.icon)).toBe(true);
+     });`,
+    // A comment. ESLint hands rules an AST and this rule never reads comments.
+    `// moved to SidebarNav.tsx:60 in objectui#4840
+     it('renders the nav', () => { expect(1).toBe(1); });`,
+    // Derived, not cited: the line number is COMPUTED from a live read of the
+    // file, so it cannot rot. Real shape: guide-layout-sidebar-nav-doc.test.ts.
+    'it(`the fence at layout.md:${fence.line} spells icon as a component`, () => { expect(1).toBe(1); });',
+    // `$#` is the case INDEX — no case string reaches the name.
+    `const ROWS = [{ src: 'a/b.ts:12' }];
+     it.each(ROWS)('case $# round-trips', ({ src }) => { expect(src).toBeTruthy(); });`,
+    // A fixed title cannot carry a row's string, whatever the table holds.
+    `const ROWS = [{ src: 'a/b.ts:12' }];
+     it.each(ROWS)('every corpus row round-trips', ({ src }) => { expect(src).toBeTruthy(); });`,
+
+    // ── The known-negative SHAPES: things that look like an address ───────
+    `it('pins the published range at 1.2.3', () => { expect(1).toBe(1); });`,      // version
+    `it('renders the 12:30 slot', () => { expect(1).toBe(1); });`,                  // clock
+    `it('reads layout.ts without opening it', () => { expect(1).toBe(1); });`,      // bare path
+    `it('proxies to http://localhost:3000/api', () => { expect(1).toBe(1); });`,    // host:port
+    // Somebody else's API — a member call that merely ends in `.it`.
+    `page.it('navigates to Foo.tsx:12', () => {});`,
+  ],
+
+  invalid: [
+    // ── Leg 1, the five literal flavours the earlier sweep enumerated ─────
+    {
+      code: `it('plugin-list ListView case chart legacy leg (ListView.tsx:2767-2768)', () => {});`,
+      errors: [{ messageId: 'inTitle', data: { address: 'ListView.tsx:2767' } }],
+    },
+    {
+      code: `it("app-shell ObjectView chart viewDef legacy leg (views/ObjectView.tsx:2218)", () => {});`,
+      errors: [{ messageId: 'inTitle', data: { address: 'views/ObjectView.tsx:2218' } }],
+    },
+    {
+      code: 'it(`DashboardRenderer widget with a provider aggregate (DashboardRenderer.tsx:620)`, () => {});',
+      errors: [{ messageId: 'inTitle' }],
+    },
+    {
+      code: `describe('the retired member at layout.ts:66', () => {});`,
+      errors: [{ messageId: 'inTitle', data: { address: 'layout.ts:66' } }],
+    },
+    {
+      code: `it.skip('cites tsconfig.typetests.json:12 by line', () => {});`,
+      errors: [{ messageId: 'inTitle' }],
+    },
+    {
+      code: `it.each([1, 2])('case %s at ObjectChart.tsx:41', () => {});`,
+      errors: [{ messageId: 'inTitle' }],
+    },
+
+    // ── Leg 2, the INTERPOLATED shape — the whole reason for the rule ─────
+    // The address is in a case table, twenty lines from any `it(` line.
+    {
+      code: `const CORPUS = [{ src: 'showcase/flows/index.ts:39', cel: 'a == b' }];
+             it.each(CORPUS)('adopts $src as structured rows', ({ cel }) => { expect(cel).toBeTruthy(); });`,
+      errors: [{ messageId: 'inEachCase', data: { address: 'showcase/flows/index.ts:39' } }],
+    },
+    // ...through a derivation, so a `.filter()` cannot hide a row.
+    {
+      code: `const CORPUS = [{ src: 'showcase/flows/index.ts:1696', parens: true }];
+             it.each(CORPUS.filter((c) => c.parens))('leaves $src on raw mode', () => {});`,
+      errors: [{ messageId: 'inEachCase', data: { address: 'showcase/flows/index.ts:1696' } }],
+    },
+    // ...and through a nested path, `$row.src`.
+    {
+      code: `const CASES = [{ row: { src: 'packages/react/README.md:224' } }];
+             it.each(CASES)('anchor for $row.src', () => {});`,
+      errors: [{ messageId: 'inEachCase', data: { address: 'packages/react/README.md:224' } }],
+    },
+    // A POSITIONAL title cannot say which field arrives, so the whole row is
+    // read — the safe direction, over-reporting rather than staying silent.
+    {
+      code: `it.each([['a', 'ListView.tsx:99']])('%s at %s', () => {});`,
+      errors: [{ messageId: 'inEachCase', data: { address: 'ListView.tsx:99' } }],
+    },
+
+    // ── Leg 3, "cannot tell" must not be spelled like "clean" ─────────────
+    {
+      code: `const ADDR = 'ObjectView.tsx:1848';
+             it.each(buildCases())('adopts $src', () => { use(ADDR); });`,
+      errors: [{ messageId: 'inUnresolvedTable', data: { address: 'ObjectView.tsx:1848' } }],
+    },
+  ],
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -268,6 +268,24 @@ export default tseslint.config({
     'object-ui/no-dynamic-import-in-test-hook': 'error',
   },
 }, {
+  // objectui#8047 ratchet — a `File.tsx:123` line address inside a test NAME is
+  // read by nothing: it is not an assertion, no gate parses it, the cited file
+  // is never opened. So it cannot fail, and it rots the first time a line is
+  // inserted above what it cites. objectui#7853 ruled the class (cite by
+  // CONTENT, not by line address) and five per-instance repairs followed it
+  // — #6548, #6998, #7289, #7913, #8045 — without closing it. Scoped to test
+  // files, because the property is "nothing reads a test name"; a line address
+  // in a comment, in an assertion message, or in data a test asserts ON is a
+  // human-read citation and is deliberately out of the population (the rule's
+  // own header carries the boundary and its measured false-positive cost).
+  // Error so a new one fails CI; the whole live population was converted in the
+  // same change, so this lints clean today.
+  files: ['**/*.test.{ts,tsx}', '**/__tests__/**/*.{ts,tsx}'],
+  plugins: { 'object-ui': objectUi },
+  rules: {
+    'object-ui/no-line-address-in-test-name': 'error',
+  },
+}, {
   // objectui#4045 ratchet — a `<button>` with no `type` is `type="submit"` per
   // HTML, so it submits any <form> it is composed into instead of running its
   // own handler. In an SDUI renderer that composition is a JSON metadata

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ConditionBuilder.subjectVocabulary.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ConditionBuilder.subjectVocabulary.test.tsx
@@ -117,23 +117,27 @@ function mount(value: string, vocab?: Record<string, unknown>) {
  *  parenthesised group. Extending the grammar is out of this card's scope, so
  *  those two are expected to stay on raw mode and are excluded from the
  *  round-trip denominator (counted separately, so the number stays honest). */
+/* `src` names the FILE only. It carried a line address until objectui#8047:
+ * `$src` is spliced into the case name below, nothing reads a test name, and a
+ * line in another repository's example app moves without anything here going
+ * red. `$#` restores the identity the address was carrying. */
 const CORPUS: Array<{ src: string; cel: string; parens?: true }> = [
-  { src: 'showcase/dynamic-approval.flow.ts:29', cel: 'title != previous.title' },
-  { src: 'showcase/flows/index.ts:39', cel: 'status == "done" && previous.status != "done"' },
-  { src: 'showcase/flows/index.ts:153', cel: 'assignee != previous.assignee' },
-  { src: 'showcase/flows/index.ts:212', cel: 'budget > 100000 && budget != previous.budget' },
-  { src: 'showcase/flows/index.ts:325', cel: 'status == "done" && previous.status != "done"' },
-  { src: 'showcase/flows/index.ts:438', cel: 'status == "done" && previous.status != "done"' },
-  { src: 'showcase/flows/index.ts:691', cel: 'status == "done" && previous.status != "done"' },
-  { src: 'showcase/flows/index.ts:808', cel: 'status == "completed" && previous.status != "completed"' },
-  { src: 'showcase/flows/index.ts:924', cel: 'status == "done" && previous.status != "done"' },
-  { src: 'showcase/flows/index.ts:1004', cel: 'status == "done" && previous.status != "done"' },
-  { src: 'showcase/flows/index.ts:1099', cel: 'status == "sent" && previous.status != "sent"' },
-  { src: 'showcase/flows/index.ts:1201', cel: 'health == "red" && previous.health != "red"' },
-  { src: 'showcase/flows/index.ts:1532', cel: 'status == "submitted" && previous.status != "submitted"' },
-  { src: 'showcase/flows/index.ts:1582', cel: 'status == "submitted" && previous.status != "submitted" && total_amount >= 5000' },
-  { src: 'showcase/flows/index.ts:1696', cel: "priority == 'urgent' && (previous == null || previous.priority != 'urgent')", parens: true },
-  { src: 'todo/task.flow.ts:183', cel: 'status == "completed" && previous.status != "completed"' },
+  { src: 'showcase/dynamic-approval.flow.ts', cel: 'title != previous.title' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts', cel: 'assignee != previous.assignee' },
+  { src: 'showcase/flows/index.ts', cel: 'budget > 100000 && budget != previous.budget' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "completed" && previous.status != "completed"' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "sent" && previous.status != "sent"' },
+  { src: 'showcase/flows/index.ts', cel: 'health == "red" && previous.health != "red"' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "submitted" && previous.status != "submitted"' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "submitted" && previous.status != "submitted" && total_amount >= 5000' },
+  { src: 'showcase/flows/index.ts', cel: "priority == 'urgent' && (previous == null || previous.priority != 'urgent')", parens: true },
+  { src: 'todo/task.flow.ts', cel: 'status == "completed" && previous.status != "completed"' },
   { src: '#6226 card body (HotCRM)', cel: 'contract_term_months > 24 && (previous == null || previous.contract_term_months <= 24)', parens: true },
 ];
 
@@ -142,7 +146,7 @@ const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
 describe('#6296 acceptance criterion — shipped flow-entry conditions round-trip into ROW mode', () => {
   const roundTrippable = CORPUS.filter((c) => !c.parens);
 
-  it.each(roundTrippable)('adopts $src as structured rows', ({ cel }) => {
+  it.each(roundTrippable)('adopts $src (corpus row $#) as structured rows', ({ cel }) => {
     const p = probe(mount(cel));
     expect(p.mode).toBe('row');
     // Structural, not textual: the rows exist as controls...

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.entryCondition.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.entryCondition.test.tsx
@@ -186,23 +186,27 @@ function mountField(opts: {
  * to stay on raw mode and are held out of the round-trip denominator instead of
  * flattering it.
  */
+/* `src` names the FILE only. It carried a line address until objectui#8047:
+ * `$src` is spliced into the case name below, nothing reads a test name, and a
+ * line in another repository's example app moves without anything here going
+ * red. `$#` restores the identity the address was carrying. */
 const CORPUS: Array<{ src: string; cel: string; parens?: true }> = [
-  { src: 'showcase/dynamic-approval.flow.ts:29', cel: 'title != previous.title' },
-  { src: 'showcase/flows/index.ts:39', cel: 'status == "done" && previous.status != "done"' },
-  { src: 'showcase/flows/index.ts:153', cel: 'assignee != previous.assignee' },
-  { src: 'showcase/flows/index.ts:212', cel: 'budget > 100000 && budget != previous.budget' },
-  { src: 'showcase/flows/index.ts:325', cel: 'status == "done" && previous.status != "done"' },
-  { src: 'showcase/flows/index.ts:438', cel: 'status == "done" && previous.status != "done"' },
-  { src: 'showcase/flows/index.ts:691', cel: 'status == "done" && previous.status != "done"' },
-  { src: 'showcase/flows/index.ts:808', cel: 'status == "completed" && previous.status != "completed"' },
-  { src: 'showcase/flows/index.ts:924', cel: 'status == "done" && previous.status != "done"' },
-  { src: 'showcase/flows/index.ts:1004', cel: 'status == "done" && previous.status != "done"' },
-  { src: 'showcase/flows/index.ts:1099', cel: 'status == "sent" && previous.status != "sent"' },
-  { src: 'showcase/flows/index.ts:1201', cel: 'health == "red" && previous.health != "red"' },
-  { src: 'showcase/flows/index.ts:1532', cel: 'status == "submitted" && previous.status != "submitted"' },
-  { src: 'showcase/flows/index.ts:1582', cel: 'status == "submitted" && previous.status != "submitted" && total_amount >= 5000' },
-  { src: 'showcase/flows/index.ts:1696', cel: "priority == 'urgent' && (previous == null || previous.priority != 'urgent')", parens: true },
-  { src: 'todo/task.flow.ts:183', cel: 'status == "completed" && previous.status != "completed"' },
+  { src: 'showcase/dynamic-approval.flow.ts', cel: 'title != previous.title' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts', cel: 'assignee != previous.assignee' },
+  { src: 'showcase/flows/index.ts', cel: 'budget > 100000 && budget != previous.budget' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "completed" && previous.status != "completed"' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "sent" && previous.status != "sent"' },
+  { src: 'showcase/flows/index.ts', cel: 'health == "red" && previous.health != "red"' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "submitted" && previous.status != "submitted"' },
+  { src: 'showcase/flows/index.ts', cel: 'status == "submitted" && previous.status != "submitted" && total_amount >= 5000' },
+  { src: 'showcase/flows/index.ts', cel: "priority == 'urgent' && (previous == null || previous.priority != 'urgent')", parens: true },
+  { src: 'todo/task.flow.ts', cel: 'status == "completed" && previous.status != "completed"' },
   { src: '#6226 card body (HotCRM)', cel: 'contract_term_months > 24 && (previous == null || previous.contract_term_months <= 24)', parens: true },
 ];
 
@@ -220,7 +224,7 @@ describe('#6226 acceptance — the flow Entry condition opens in ROW mode', () =
     expect(ROW_ELIGIBLE).toHaveLength(15);
   });
 
-  it.each(ROW_ELIGIBLE)('adopts $src as structured rows AT THE FLOW FIELD', ({ cel }) => {
+  it.each(ROW_ELIGIBLE)('adopts $src (corpus row $#) as structured rows AT THE FLOW FIELD', ({ cel }) => {
     const p = probe(mountField({ value: cel }));
     expect(p.mode).toBe('row');
     // The rows exist as controls…

--- a/packages/plugin-charts/src/ObjectChart.absentCategoryAxisRefusal-8168.test.tsx
+++ b/packages/plugin-charts/src/ObjectChart.absentCategoryAxisRefusal-8168.test.tsx
@@ -175,7 +175,7 @@ describe('ObjectChart — absent category axis refusal (objectui#8168)', () => {
  * theirs reach it exactly when the author declared nothing — which is the point.
  */
 describe('objectui#8168 stop condition — the refusal fires on NO producer that renders today', () => {
-  it('plugin-list ListView `case chart` legacy leg (ListView.tsx:2767-2768)', async () => {
+  it('plugin-list ListView `case chart` legacy leg', async () => {
     // `const valueField = chartBinding.valueField || 'value';`
     // `const categoryField = chartBinding.categoryField || 'name';`
     renderChart({
@@ -189,7 +189,7 @@ describe('objectui#8168 stop condition — the refusal fires on NO producer that
     await expectNoRefusal();
   });
 
-  it('plugin-view ObjectView `case chart` legacy leg (ObjectView.tsx:1535-1536)', async () => {
+  it('plugin-view ObjectView `case chart` legacy leg', async () => {
     renderChart({
       objectName: 'crm_opportunity',
       aggregate: { field: 'value', function: 'count', groupBy: 'name' },
@@ -200,7 +200,7 @@ describe('objectui#8168 stop condition — the refusal fires on NO producer that
     await expectNoRefusal();
   });
 
-  it('app-shell ObjectView chart viewDef legacy leg (views/ObjectView.tsx:2218/2220)', async () => {
+  it('app-shell ObjectView chart viewDef legacy leg', async () => {
     // `const categoryField = chartConfig.xAxisField || 'name';`
     // `const valueField = (Array.isArray(...yAxisFields) && ...[0]) || 'value';`
     renderChart({
@@ -214,7 +214,7 @@ describe('objectui#8168 stop condition — the refusal fires on NO producer that
     await expectNoRefusal();
   });
 
-  it('DashboardRenderer object-provider widget WITH a provider aggregate (DashboardRenderer.tsx:620)', async () => {
+  it('DashboardRenderer object-provider widget WITH a provider aggregate', async () => {
     // `const xAxisKey = options.xField || 'name';` — floored before the
     // provider is consulted, so this leg carries a category unconditionally.
     renderChart({
@@ -239,7 +239,7 @@ describe('objectui#8168 stop condition — the refusal fires on NO producer that
     await expectNoRefusal();
   });
 
-  it('DashboardGridLayout object-provider widget, both legs (DashboardGridLayout.tsx:241)', async () => {
+  it('DashboardGridLayout object-provider widget, both legs', async () => {
     renderChart({
       objectName: 'crm_opportunity',
       aggregate: { field: 'amount', function: 'sum', groupBy: 'stage' },


### PR DESCRIPTION
Fixes #8047

Adds `object-ui/no-line-address-in-test-name` to the local ESLint plugin, wires it at `error` over test files, and converts the whole live population so it lints clean on the day it lands — the same shape as every other `object-ui/*` ratchet in `eslint.config.js`.

A `File.tsx:123` address inside a test **name** is read by nothing: it is not an assertion, no gate parses it, and the cited file is never opened. So it cannot fail. It rots the first time a line is inserted above what it cites, and the rot is invisible until a reader believes it. objectui#7853 ruled the class — *cite the assertion by CONTENT, not by line address* — and five per-instance repairs followed it without closing it.

⚠️ Nothing is currently false. This PR does not repair a live falsehood; it closes a class that is waiting for its next insertion. That is why objectui#8047 is `priority:p3`.

---

## 1. The population, re-derived on `origin/main` at `868e82501`

⛔ The card's `3 / 5 more / 6` is **not** today's figure and was not carried forward. Both instruments were re-run over the **2454** test files under `packages/`, comments masked by the tree's own `scripts/js-comment-mask.mjs`:

| instrument | raw hits | files |
|---|---|---|
| anchored on the `it(` **line** | **6** | 2 |
| **name-agnostic** — a quoted address on any non-comment line | **45** | 7 |
| **this rule** — an address in a string that REACHES a test name | **37** | 3 |

Three readings the card did not have, and each one changes something:

1. **The narrow instrument also over-reports.** One of its 6 is a false positive: a rationale string in `page-header-authorable-keys.test.tsx` containing the words "reads and draws it (PageHeader.tsx:123", where `it (` merely looks like a declaration. So the `it(`-anchored sweep is wrong in **both** directions, not only short.
2. **The gap is not all defect.** 8 of the 45 are legitimate by the boundary in section 3 — assertion messages and data a test asserts on. A rule taking the name-agnostic scan wholesale would be about **22% false positive**, and its remedy would be deleting provenance a human reads at the point of failure.
3. **The class recurred again after the card was filed, in a new shape.** The two instances objectui#7913 and objectui#8045 were about are both repaired and gone. Today's 37 are: 5 literal `it(` names in `packages/plugin-charts/src/ObjectChart.absentCategoryAxisRefusal-8168.test.tsx`, and 32 addresses reaching names through `it.each(CORPUS)('adopts $src …')` in two `app-shell` metadata-admin inspector tests — a **different** interpolation shape from the card's worked example, and one the `it(`-anchored instrument sees **zero** of.

⇒ The card's central claim survives re-derivation and gets stronger: the narrow instrument misses **32 of 37**.

## 2. Design question 1 — interpolated names. Settled: strings that REACH a title, decided on the AST

The rejected alternative was to judge genuinely **resolved** names by collecting them with the runtime (`vitest list --json`). Disqualified twice:

- **In principle** — collection *executes* every test module's top level, so a syntax-only citation check would acquire the power to fail on an unrelated runtime error, a missing DOM global, or a slow transform. A check on the text of a name must not depend on the suite booting.
- **In cost, measured in this container** — `vitest list --json` over **one** `plugin-charts` file took **11.9 s**; over **one** `app-shell` `dom` file it had emitted **nothing after nine minutes**. There are 2454 test files.

So the rule reads the AST, in three legs:

| leg | what it reads | why it exists |
|---|---|---|
| 1 | the title argument itself — every quote flavour, every `it.skip` / `it.each` / `describe` chain | the literal shape |
| 2 | the strings of a statically-resolved `each` **case table**, when the title interpolates | **the blind spot the card is about** |
| 3 | when the table is not statically legible and the title names properties: the whole file, reported at the table | "the rule could not tell" must never be spelled the same way as "there is nothing here" |

Table resolution deliberately **over-approximates**: `CORPUS.filter(fn)` resolves to all of `CORPUS`, because a filter can only drop rows and over-reporting is loud where under-reporting is silent. That is not hypothetical — `ConditionBuilder.subjectVocabulary.test.tsx` has exactly that shape, and it is one of the 32.

**The worked example is caught.** `it.each(roundTrippable)('adopts $src as structured rows', …)` where `roundTrippable = CORPUS.filter((c) => !c.parens)` and `CORPUS` is a 17-row table of `{ src, cel }` — the addresses never appear on an `it(` line. Reported: 16 per file, 32 total. ⭐ And `src` there is read by **nothing else**: both call sites destructure `({ cel })` only, so the field exists solely to be spliced into a name.

## 3. Design question 2 — where a line address is legitimate. The boundary, and its cost

Drawn in the rule's own header, with the reason, and it is drawn on **the title's own reach** rather than on a keyword list. Three carve-outs, each with an instance measured in this tree today:

1. **Comments.** A human reads them beside the code they annotate, and the next reader of that code corrects a wrong one. This rule never reads a comment — nothing in it inspects `getAllComments`.
2. **Assertion and failure messages.** Read by a human *at the point of failure*, where the assertion that failed is the context. In tree: `readme-app-shell-example.test.ts:231` and `:255`, `guide-layout-sidebar-nav-doc.test.ts:490`, and the four `producer:` fields in `gridNonAuthorKeys.test.tsx` that its line 229 splices into a failure message.
3. **Data the test asserts ON.** `page-header-authorable-keys.test.tsx`'s `RENDERER_OWN_DECLARED` rationale carries an address and *is* read — line 227 asserts on that very string. Something checks it, so it is not the unreadable class.

The mechanism that makes carve-out 2 automatic: for `it.each(ROWS)('the spec refuses DOLLAR-key as an unrecognized key')` only the `key` field of a row can arrive in the name, so a sibling `producer:` field is data. A **positional** title (`%s`, `DOLLAR-0`) or a template title cannot say which field arrives, so those read the whole row.

⚠️ **The residual gap is stated, not papered over.** Leg 3 fires only for a **named** title over an unresolvable table. A **positional** title over an opaque table — `it.each(covered)('%s declares …')` in `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts`, the one in-tree instance — is **not** covered. Reporting it would mean flagging a rationale record that the same file asserts on (carve-out 3, a false positive), and the remedy offered would be to hoist a table computed from the live component registry, which cannot be hoisted. One site today, written into the rule header so the next reader does not mistake silence there for coverage.

## 4. Non-vacuity — the rule is proved able to fail, on each shape it claims

Every mutation was proved to have reached disk by **HEAD blob hash versus worktree hash plus a marker count, before any result was read**; every restore ran under an `EXIT INT TERM` trap with absolute paths and was proved **by state** (`git diff HEAD` empty), never by exit code.

**Rule ablation** (`eslint-rules/no-line-address-in-test-name.test.js`, 12 valid + 11 invalid cases):

| leg | mutation | expected | observed |
|---|---|---|---|
| A0 | none — control | green | `Tests 23 passed (23)`, exit 0 |
| A1 | delete leg 1, the title read | the six literal shapes red | `Tests 6 failed / 17 passed`, exit 1 |
| A2 | **reduce to an `it(`-anchored reader** (delete legs 2 and 3) | the interpolated shapes red | `Tests 5 failed / 18 passed`, exit 1 |
| A3 | drop the title-reach carve-out, read the whole row | the `producer:` carve-out red | `Tests 1 failed / 22 passed`, exit 1 |

⭐ **A2 is the one that matters.** It rebuilds precisely the instrument that under-counted this class and shows it failing five cases the shipped rule passes — the blind spot demonstrated rather than asserted.
⭐ **A3 proves the carve-outs are load-bearing**, not decoration: widening the rule breaks a legitimate in-tree shape.

**Tree-level ablation**, against real code rather than fixtures — the three repaired files reverted to `868e82501` and the rule re-run:

```
REPAIRED (HEAD)     0 hits in 0 files
UNREPAIRED (BASE)  37 hits in 3 files  {'inEachCase': 32, 'inTitle': 5}
restore proof: git diff HEAD --stat -> []   git status --short -> []
```

Every mutation's landing was proved before its result was read, e.g.
`LANDED plugin-charts/…-8168.test.tsx HEAD=4f70655867ef DISK=a01b3c097a1e addresses on disk: 5`.

## 5. The conversion — 37 sites, and one naming decision a reviewer should look at

- **`packages/plugin-charts/src/ObjectChart.absentCategoryAxisRefusal-8168.test.tsx`** — 5 names, **pure deletion**. The content is already in the name (`plugin-list ListView …`) and the cited source lines are already quoted verbatim in the comment under each `it(`. Names stay distinct.
- **`packages/app-shell/src/views/metadata-admin/inspectors/{ConditionBuilder.subjectVocabulary,FlowNodeConfigField.entryCondition}.test.tsx`** — 32 addresses. The `:NNN` half is deleted from each `src` value, which keeps the provenance file and drops the moving target; these point into **another repository's** example apps, so nothing here could ever have checked them.

  ⚠️ **The one judgement call in this PR, flagged for the `app-shell` reviewer.** `src` was the corpus rows' only distinguishing field, so deleting the line number alone would collapse twelve case names to one. `(corpus row DOLLAR-hash)` was added to the two `adopts` titles to carry the identity the address had been carrying. That is a **rewrite, not a deletion**, and it is the reason these two files were not treated as a mechanical in-scope repair without saying so.

## 6. Named consequences

- ⚠️ **objectui#8045 is CLOSED, not open.** The dispatch brief for this card carried it as *"open and `domain:spec`"*. It merged as `d9788c14` on 2026-09-07, and `packages/types/src/__tests__/text-value-retired-6951.test.ts` is clean today: **this rule does not red on it**, so the conflict the brief prepared for does not exist. Nothing in that file was touched here.
- **objectui#8478 filed** (`finding` label only, no assignee, no `domain:*`) for the reading objectui#8045 handed to this card: **27** published `.describe()` schema descriptions in `packages/types/src/zod/**` cite source line addresses. Ruled **out of scope** here — a `.describe()` string is a published schema description reaching the authorable surface, so editing it is contract-adjacent, not a test rename. ⚠️ Re-measured at 27, not the 16 on objectui#8045: `overlay.zod.ts` and `data-display.zod.ts` grew the count when objectui#8354 / objectui#8405 landed.
- The residual gap of section 3 is documented in the rule header rather than carded — it is a stated boundary with one site and no live defect.

## 7. Verification

All exit codes captured before any pipe. Heavy runs through the shared verify lock, quoting its own verdict line. Measured at `39044bb61`.

| check | reading |
|---|---|
| the new rule, tree-wide, **before** | `no-line-address-in-test-name: 37 hits in 3 files` |
| the new rule, tree-wide, **after** | `0 hits`; the census of every other rule's error count is unchanged (`130 -> 93`, delta only on this rule, `37 -> 0`) |
| wired where this repo wires rules | `eslint.config.js`, its own config object scoped `**/*.test.{ts,tsx}` and `**/__tests__/**/*.{ts,tsx}`, mirroring the `no-dynamic-import-in-test-hook` ratchet block |
| running there — CI shape (`turbo run lint` runs `eslint .` per package) | `packages/plugin-charts eslint exit=0` (0 errors) · `packages/app-shell eslint exit=0` (0 errors) |
| changed test files | `Test Files 4 passed (4)` · `Tests 114 passed (114)` · `VERDICT command-exit 0`, root vitest confirmed (`RUN v4.1.10 /home/user/objectui-issue-8047`) |
| pin tests that read `eslint.config.js` and `eslint-rules/**` | `Test Files 15 passed (15)` · `Tests 349 passed (349)` · `VERDICT command-exit 0` |
| `node scripts/check-changeset-presence.mjs` | first run exit 1, naming the three test files as published source; after the EMPTY-frontmatter changeset, **exit 0** with the gate printing its own exemption sentence |
| `node scripts/check-changeset-no-major.mjs` | exit 0 |
| `node scripts/check-lint-rule-coverage.mjs` | exit 0 — the new files fall under the existing `eslint-rules/**/*.js` ledger row |
| `node scripts/check-lint-coverage.mjs` | exit 0 — `46/46 packages linted, 0 with outstanding errors` |
| `node scripts/check-control-bytes.mjs` | exit 0 — 6706 tracked text files scanned |
| `node scripts/check-governed-queue-guard.mjs --test` (all 8 changed paths) | exit 0 — `NOT GOVERNED`; self-test `132 cases pass` |

⚠️ One instrument correction worth recording: the tree-wide census above was taken with `--no-inline-config`, which is **not** what `turbo run lint` runs. The 93 residual errors it shows are findings suppressed by in-file directives, not regressions — the CI-shaped per-package runs are 0 errors. The delta row is the load-bearing reading, and it is unaffected either way.

Affected packages read from `turbo ls --affected` against `868e82501`, not guessed. Only test files changed in those packages, so running exactly the changed test files is a **proved** narrowing rather than a skipped one; CI runs the farm.

---

## 四轴分析

**实际业务需求.** 服务的是真实场景,不是投机能力面。判据是实测而非"读起来有用":这个类在一条已有常设裁定(objectui#7853)之下仍然复发,今天在 `origin/main` 上有 **37** 处活体,分布在 **3** 个文件里,其中 `ObjectChart.absentCategoryAxisRefusal-8168.test.tsx` 是卡片提出之后才落地的**新增**复发。同时,人工/agent 普查在这个类上结构性欠数:窄仪器看不见 37 处里的 32 处。⇒ 需求是被测出来的,不是被推断出来的。

**项目长远合理性.** 契约优先,不是临时补丁。规则落在**已存在**的本地 ESLint 插件里,用**已存在**的接线(`eslint.config.js` 的 ratchet 段)和**已存在**的 RuleTester 约定,不新增 workflow、不新增 CI job、不新增 baseline 文件。⛔ 特别地:**没有引入 baseline/grandfather 名单** —— 全部 37 处在同一个改动里转换完毕,符合本仓每一条 `object-ui/*` ratchet 的既有措辞("existing sites pre-cleaned first, so the rule lints clean on the day it lands"),也符合维护者 2026-08-27「不设分阶段窗口」的裁定。

**防 AI 写代码犯错.** 这条轴给出最强的支持。行地址型引用正是 AI 批量写测试时最容易产出、也最不可能被发现的东西:它读起来精确、写起来便宜、而且**永远不会失败**。声明即强制 —— 规则把"这条引用没有任何东西在读"从一句人类要记住的规程(objectui#7853,五次复发)变成一次写入时的响亮拒绝。⛔ 反面做法(在消费端加宽容、或让规则对看不懂的表保持沉默)已被明确拒绝:leg 3 存在的全部理由就是"看不出来"不得和"这里很干净"拼成同一个字。

**创业阶段不扩散需求 —— 本轴默认反对新增门禁,必须正面回应.** 反对的理由成立:`p3`,今天没有任何东西是假的,新增守卫就是新增维护面。⇒ 逐条称重后仍然推荐落地,理由有三,且都是量出来的:① 边际维护成本近似为零 —— 一个规则文件加一个测试文件,复用既有插件、既有接线、既有测试框架,**没有**新 workflow、新 job、新脚本族、新 baseline;② 反对新增门禁的通常论据(没有实测成本、没有 population)在这里两条都不成立,分诊已经论证过,本轮重新取数后结论更强(37 处、复发仍在继续、窄仪器欠数 32/37);③ 本轴反对的是**能力扩张**,而这不是能力扩张 —— 它不新增任何可声明面、不新增任何可创作键、不给任何人新的东西可写,它只是把一条已经存在的裁定变得可执行。

**四轴冲突处的取舍,如实呈现给维护者:** 唯一的张力在第四轴与前三轴之间,而它落在"一个 p3 的类值不值一个新守卫"上。本席的推荐是**值**,理由是上面的 ①②③;若维护者读到的权衡不同,合理的替代不是弱化规则,而是**整个不落地**并把 objectui#8047 关成 `not_planned` —— ⛔ 不要保留一个把 leg 2/leg 3 拿掉的"轻量版",那正是 A2 消融证明会重新打开盲区的那个形状。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_