### PR TITLE
test(runner): pin the suite's timezone to UTC

### DIFF
--- a/.changeset/8366-vitest-timezone-pin.md
+++ b/.changeset/8366-vitest-timezone-pin.md
@@ -1,0 +1,7 @@
+---
+---
+
+Pin the test runner's timezone to UTC (objectui#8366). The date-face pin family
+asserts literal LOCAL-date faces built from fixed UTC instants, so the suite was
+green at exactly one offset and red on a contributor's laptop anywhere else.
+Test infrastructure only; no package is released by this change.

--- a/scripts/__tests__/vitest-timezone-pin-8366.test.ts
+++ b/scripts/__tests__/vitest-timezone-pin-8366.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * objectui#8366 — the suite's ambient timezone is UTC, pinned.
+ *
+ * ## What this guards
+ *
+ * `vitest.config.mts` sets `process.env.TZ = 'UTC'` in its module scope. A
+ * family of date pins asserts LITERAL local-date faces (`Jul 4, 2024`,
+ * `7/4/2024 7:00 am`) built from fixed UTC instants through LOCAL date parts,
+ * so without that line the face they render is a property of the
+ * contributor's laptop. Measured on `76573a184`, over the six files that carry
+ * the family, BEFORE the pin:
+ *
+ *   TZ=UTC              184 passed          TZ=Europe/Paris      7 failed
+ *   TZ=Asia/Shanghai      7 failed          TZ=America/New_York 31 failed
+ *   TZ=Etc/GMT+8         33 failed
+ *
+ * Green at exactly one offset — not merely "west of somewhere". A `07:00 AM`
+ * face pinned off an `07:00Z` instant is true at UTC+00:00 and nowhere else.
+ *
+ * ## Why a spawn and not just an in-process assertion
+ *
+ * CI runs in UTC. So `getTimezoneOffset() === 0`, asserted in this process, is
+ * green on CI whether or not the config still pins anything — it would catch a
+ * deleted pin only for the contributor it was written to protect, and stay
+ * silent in the one place that gates merges. That is the exact shape of the
+ * original defect, one level up.
+ *
+ * So the fact is measured where it can fail: a real vitest is spawned with
+ * `TZ=Etc/GMT+8` in its environment and asked to run the ambient-zone case
+ * below. It can only pass if the config overrode the inherited zone. Delete the
+ * line in `vitest.config.mts` and this case reds on CI.
+ *
+ * `Etc/GMT+8` is UTC-08:00 — POSIX inverts the sign — chosen because it is the
+ * zone the reporting contributor measured in.
+ *
+ * ## The live control
+ *
+ * A spawn-based pin has one silent failure: if `TZ` never reached the child at
+ * all, the child would read UTC for a reason that has nothing to do with the
+ * config, and the assertion would pass forever. `the child environment really
+ * carries TZ` measures that hand-off against a plain `node -e`, so a green
+ * spawn case is attributable.
+ *
+ * ## Recursion
+ *
+ * The child runs THIS file, filtered by `--testNamePattern` to the ambient-zone
+ * case, so the spawn cases are skipped there. `OBJECTUI_TZ_PIN_CHILD` is a
+ * second, independent belt: even an unfiltered child cannot spawn a grandchild.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const configPath = path.join(repoRoot, 'vitest.config.mts');
+const selfPath = path.relative(repoRoot, fileURLToPath(import.meta.url));
+
+/** UTC-08:00. POSIX `Etc/GMT+N` zones invert the sign; this is deliberate. */
+const WEST = 'Etc/GMT+8';
+const WEST_OFFSET_MINUTES = 480;
+
+/** The name the spawned child is filtered down to. Kept as one constant so the
+ *  filter and the `it()` title cannot drift apart. */
+const AMBIENT_CASE = 'the suite runs in UTC, whatever zone the contributor is in';
+
+const IS_CHILD = process.env.OBJECTUI_TZ_PIN_CHILD === '1';
+
+/** The vitest CLI entry, resolved rather than assumed at a `node_modules` path. */
+const vitestCli = (() => {
+  const require = createRequire(path.join(repoRoot, 'noop.js'));
+  const pkgPath = require.resolve('vitest/package.json');
+  const bin = (JSON.parse(fs.readFileSync(pkgPath, 'utf8')).bin as { vitest: string }).vitest;
+  return path.resolve(path.dirname(pkgPath), bin);
+})();
+
+describe('objectui#8366 — the runner pins the timezone', () => {
+  it(AMBIENT_CASE, () => {
+    // Read two independent surfaces: `Date`'s own offset, and the zone ICU
+    // resolves for a bare formatter — which is what every `toLocaleDateString`
+    // in the date-face family actually consults.
+    expect(new Date('2024-07-04T07:00:00.000Z').getTimezoneOffset()).toBe(0);
+    expect(new Intl.DateTimeFormat().resolvedOptions().timeZone).toBe('UTC');
+  });
+
+  it.skipIf(IS_CHILD)('control — the child environment really carries TZ', () => {
+    // Non-vacuity for the case below. Without this, a `TZ` that never reached
+    // the child would make the spawned run read UTC for a reason that has
+    // nothing to do with `vitest.config.mts`, and the pin would be inert.
+    const probe = spawnSync(
+      process.execPath,
+      ['-e', 'process.stdout.write(String(new Date("2024-07-04T07:00:00.000Z").getTimezoneOffset()))'],
+      { cwd: repoRoot, encoding: 'utf8', env: { ...process.env, TZ: WEST }, timeout: 60_000 },
+    );
+
+    expect(probe.status).toBe(0);
+    expect(probe.stdout.trim()).toBe(String(WEST_OFFSET_MINUTES));
+  });
+
+  it.skipIf(IS_CHILD)(
+    'a real vitest spawned under a non-UTC TZ still runs in UTC',
+    () => {
+      const env: NodeJS.ProcessEnv = { ...process.env };
+      // A fresh CLI, not a nested worker of this run.
+      for (const key of Object.keys(env)) if (key.startsWith('VITEST')) delete env[key];
+      env.TZ = WEST;
+      env.OBJECTUI_TZ_PIN_CHILD = '1';
+
+      const child = spawnSync(
+        process.execPath,
+        [vitestCli, 'run', selfPath, '--testNamePattern', AMBIENT_CASE],
+        { cwd: repoRoot, encoding: 'utf8', env, timeout: 300_000 },
+      );
+      const output = `${child.stdout ?? ''}${child.stderr ?? ''}`;
+
+      expect(output).toContain('1 passed');
+      expect(child.status).toBe(0);
+    },
+    360_000,
+  );
+
+  it.skipIf(IS_CHILD)('the pin is where the spawn says it is', () => {
+    // The cheap static half. It cannot replace the spawn — a line can be
+    // present and no longer take effect, which is the direction vitest could
+    // move under us — but it names the file and the spelling for whoever
+    // arrives here from a red spawn.
+    const source = fs.readFileSync(configPath, 'utf8');
+
+    expect(source).toContain("process.env.TZ = 'UTC'");
+    // Not `??=` / `||=`: a contributor's zone usually comes from
+    // `/etc/localtime`, not from `TZ`, so a conditional assignment would leave
+    // the reported population unfixed. See the comment at the assignment.
+    expect(source).not.toMatch(/process\.env\.TZ\s*(\?\?|\|\|)=/);
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -7,6 +7,54 @@ import { assertCanonicalVitestInvocation, cliHasTestFilters } from './scripts/vi
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+// ── The suite runs in UTC, always (objectui#8366) ───────────────────────────
+//
+// A family of pins asserts LITERAL local-date faces — `Jul 4, 2024`,
+// `Jul 4, '24`, `7/4/2024 7:00 am` — built from fixed UTC instants
+// (`2024-07-04T07:00:00.000Z` and friends) through LOCAL date parts. Nothing
+// pinned the runner's zone, so the face those pins render was a property of
+// the contributor's laptop. Measured on `76573a184` over the six files that
+// carry the family:
+//
+//   TZ=UTC              6 files passed              (184 tests, 0 failed)
+//   TZ=Europe/Paris     3 failed | 3 passed         (7 failed)
+//   TZ=Asia/Shanghai    3 failed | 3 passed         (7 failed)
+//   TZ=America/New_York 4 failed | 2 passed        (31 failed)
+//   TZ=Etc/GMT+8        4 failed | 2 passed        (33 failed)
+//
+// So the suite was green at EXACTLY ONE offset, not merely west of some
+// boundary: a `07:00 AM` face pinned off an `07:00Z` instant is true at
+// UTC+00:00 and nowhere else. CI is UTC, so the class was invisible there and
+// only ever cost a contributor — a wall of red that is not about the code.
+//
+// Why the zone and not the assertions: those literals are load-bearing ON
+// PURPOSE. `date-display.optionsStyle-7745.test.ts` says so in its own words —
+// its faces are "anchored by the two literals the card measured, so a redesign
+// that moved both sides together could not pass silently." Deriving the
+// expected face from the same formatter under test is what the two files that
+// ALREADY pass do (`dataset-format.date.test.ts`,
+// `DatasetWidget.dateMeasure.test.tsx`), and it is the right assertion where
+// the claim is "this surface shows what a list cell shows" — but on an anchor
+// it degrades to `formatDate(v) === formatDate(v)` and asserts nothing. Pinning
+// the offset the anchors were written against keeps them.
+//
+// This deletes no coverage: no test in this repo reads the ambient zone
+// (`process.env.TZ`, `getTimezoneOffset`, `resolvedOptions().timeZone` — zero
+// hits across every `*.test.ts`/`*.test.tsx`), and the one zone-aware surface
+// that exists takes its zone from METADATA, explicitly
+// (`GanttView.tsx`'s `tzOffsetMs(schema.timeZone, …)`). Non-UTC coverage, if
+// it is ever wanted, wants an explicit per-case zone — never the runner's
+// ambient one, which is the thing that made this silent.
+//
+// Unconditional on purpose: a contributor's zone usually comes from
+// `/etc/localtime` and not from `TZ`, so an `??=` would leave exactly the
+// reported population unfixed while pretending to fix it.
+//
+// Pinned by `scripts/__tests__/vitest-timezone-pin-8366.test.ts`, which spawns
+// a real vitest under a non-UTC `TZ` and asserts the run still sees UTC — so
+// deleting this line reds CI, where the ambient zone would otherwise hide it.
+process.env.TZ = 'UTC';
+
 // Refuse the two invocations that pass while running none of the tests the
 // caller asked for — a package-cwd run (objectui#3378) and a path filter that
 // never reaches Vitest (objectui#3288).


### PR DESCRIPTION
Fixes #8366

## The defect, re-measured on `origin/main` (`76573a184`)

The date-face pin family asserts **literal local-date faces** built from fixed
UTC instants through **local** date parts. Nothing pinned the runner's zone, so
the face those pins render was a property of the contributor's laptop.

All six files the card names, run together, one run per zone:

| `TZ` | offset | Test Files | Tests |
|---|---|---|---|
| `UTC` | +00:00 | 6 passed | 184 passed |
| `Europe/Paris` | +02:00 | 3 failed / 3 passed | 7 failed |
| `Asia/Shanghai` | +08:00 | 3 failed / 3 passed | 7 failed |
| `America/New_York` | −04:00 | 4 failed / 2 passed | 31 failed |
| `Etc/GMT+8` | −08:00 | 4 failed / 2 passed | 33 failed |

### Two corrections to the card

1. **The card says "red for any contributor west of UTC-07:00". Measurement
   says the suite is green at EXACTLY ONE offset.** It is red at `Europe/Paris`
   and `Asia/Shanghai` too — east of UTC, not west of anything. A face like
   `Jul 4, 2024, 07:00 AM`, pinned off an `07:00Z` instant, is true at UTC+00:00
   and nowhere else. Sample failures: `expected 'Jul 3, 2024, 11:00 PM' to be
   'Jul 4, 2024, 07:00 AM'`, `expected '7/3/2024 11:00 pm' to be '7/4/2024 7:00 am'`.
2. **The card's single-file reading has moved.** It reported `10 failed | 4 passed (14)`
   at base `411a132c0`; on `76573a184` the same file reads `11 failed | 4 passed (15)`
   — PR #8353 added a row. The defect is unchanged; only the count is.

The card's zeros reproduce exactly, each against a lit control:
`TZ` / `timeZone` = 0 in `vitest.config.mts`, `turbo.json`, `package.json` and
all six `vitest.setup.*`; `TZ:` = 0 workflows. Controls: `'environment'` in
`vitest.config.mts` = 8; `runs-on` = 34 workflows.

## The asymmetry the card asked to have explained

`dataset-format.date.test.ts` and `DatasetWidget.dateMeasure.test.tsx` pass in
every zone, and it is not luck. Both **derive** the expected face by calling the
same formatter the code under test calls, so the zone cancels:

```ts
expect(out).toBe(formatDateTime(ISO_DATETIME, { locale: EN }));
```

`DatasetWidget.dateMeasure.test.tsx` says so in a docblock headed *"Why the
expectations are DERIVED and not literal"* — and it was chosen for a different
reason entirely (a literal would pass just as well against a second date
convention, the objectui#4576 failure its ruling forbids).

## Why the zone and not the assertions — the fork, argued

The four failing files pin literals **on purpose**, and
`date-display.optionsStyle-7745.test.ts` states the purpose in prose: its faces
are *"anchored by the two literals the card measured, so a redesign that moved
both sides together could not pass silently."* Those literals sit next to
equivalence assertions of the form
`formatDate(V, undefined, { style }) === formatDate(V, style)`, which are
zone-independent already and which a redesign could move on both sides at once.
The literals are the anti-tautology anchor.

So rewriting them to derive the face is not a refactor — it turns the anchor
into `formatDate(v) === formatDate(v)` and deletes the thing the file was
written for. This repo already uses each form where it belongs; the fix should
not flatten them into one.

**Chosen: pin the runner's zone.** One line, in the one place that already owns
how this repo runs tests:

```ts
process.env.TZ = 'UTC';
```

`apps/console/vitest.config.ts` imports the root config, so its module scope runs
for that project too; the 11 remaining `packages/*/vite.config.ts` reach
`assertCanonicalVitestInvocation`, which refuses the package-cwd invocations that
could bypass it. Measured: with the pin, all six files are `184 passed` under
`Etc/GMT+8`, `America/New_York`, `Asia/Shanghai` and `UTC`.

**Unconditional, not `??=`.** A contributor's zone usually comes from
`/etc/localtime`, not from `TZ`, so a conditional assignment would leave exactly
the reported population unfixed while looking like a fix. The guard test forbids
the `??=` / `||=` spelling for that reason.

### It deletes no coverage — measured, not assumed

The card asks whether pinning hides a real zone bug. It does not:

- **Zero** tests in the repo read the ambient zone — `process.env.TZ`,
  `getTimezoneOffset`, `Intl.DateTimeFormat().resolvedOptions()` return 0 hits
  across every `*.test.ts` / `*.test.tsx`. Live control: the same
  `resolvedOptions()` pattern returns 5 hits elsewhere in the tree, so the grep
  fires.
- The one zone-aware production surface, `GanttView.tsx`'s `makeTzShift` /
  `tzOffsetMs`, takes its zone from **metadata** (`schema.timeZone`), and
  `GanttView.tzshift.test.ts` already tests it with **explicit per-case zones**
  (`Asia/Shanghai`, `America/New_York`, a DST pair). That is exactly the shape
  the card says non-UTC coverage should have, and it is unaffected.

### Costs of the options not taken

- **B — rewrite the pins.** Removes the same class, at roughly 50x the diff, and
  pays for it by converting four files' deliberate literal anchors into
  self-comparisons. `fields-date-widget-convention-8194.test.tsx` alone carries
  16 failing cases whose expected faces would become tautologies.
- **C — both, scoped.** Its incremental half over A is an inventory of "pins
  that would still be zone-dependent". That document has no consumer and no
  gate; the useful part of it is the guard below plus the asymmetry explanation
  above, both of which ship here.

## The pin is pinned — `scripts/__tests__/vitest-timezone-pin-8366.test.ts`

CI runs in UTC. So an in-process `getTimezoneOffset() === 0` would be green on CI
whether or not the config still pins anything — it would catch a deleted pin only
for the contributor it protects, and stay silent where merges are gated. That is
the original defect one level up.

So the guard **spawns a real vitest with `TZ=Etc/GMT+8`** and asserts the run
still sees UTC. Four cases: the ambient reading; a `node -e` live control proving
`TZ` actually reaches a child (without it, a broken env hand-off would make the
spawn pass forever); the spawn itself; and a static half that names the file and
forbids the conditional spelling.

### Ablation — direction predicted in writing before the run

Predicted: the spawn case and the static case go **RED**; the ambient case stays
**GREEN** (this box is UTC — which is the point), and the control stays green.

Mutation proven on disk before reading any result:

```
HEAD blob for vitest.config.mts = 89896da7cd4777abfb6bab7f66c04b1691600ed1
MARKER before: 1        MARKER after (expect 0): 0
INJECTED marker (expect 1): 1
on-disk blob now = 04beeb3449fc516137e3c824f98728b6647df7f8
MUTATION PROVEN ON DISK
```

Observed, matching the prediction:

```
 × a real vitest spawned under a non-UTC TZ still runs in UTC   1592ms
 × the pin is where the spawn says it is                           3ms
 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

and inside the spawned child, visible in the failure output — the direct reading
that the pin is what forces UTC:

```
+      × the suite runs in UTC, whatever zone the contributor is in
+ AssertionError: expected 480 to be +0
```

Restored under an `EXIT INT TERM` trap with absolute paths, via
`git checkout HEAD -- ...`, and proven **by state**: `git diff HEAD --stat`
printed nothing.

## Files touched outside `scripts/`

Per the card's scope fence — this fix touches **no other lane's test file**.
The four red files are fixed by the runner, not edited.

- `vitest.config.mts` — the pin plus its comment. Contents only: the
  `check-lint-rule-coverage` `UNREACHED_GROUPS` row that names this exact path
  (objectui#8337, PR #8467) is untouched, and `check:lint-rule-coverage` is green.
  Independently confirmed by measurement: the file appears **0 times** in
  `lint:root`'s 276-file population, which is what that row asserts.
- `.changeset/8366-vitest-timezone-pin.md` — empty frontmatter. Test
  infrastructure; no package is released by this change.

## Verification

| what | result |
|---|---|
| the six files x 5 zones, before | UTC green; 7 / 7 / 31 / 33 failures at +02:00 / +08:00 / −04:00 / −08:00 |
| the six files x 4 zones, after | `184 passed` in every one |
| `pnpm exec vitest run scripts/` | `122 passed (122)`, `3634 passed (3634)` — includes every test that reads `vitest.config.mts` |
| ablation | `2 failed \| 2 passed (4)`, matching the written prediction; restore proven by `git diff HEAD` empty |
| `node scripts/check-changeset-presence.mjs` | exit 0 — "no changeset is owed"; one added anyway, declaring no release |
| `node scripts/check-lint-rule-coverage.mjs` | exit 0 |
| `node scripts/check-governed-queue-guard.mjs --test ...` | exit 0 — NOT GOVERNED, 3 paths vs 5 governed surfaces |
| `check:control-bytes` · `check:vi-mock-inherit` · `check:vi-mock-specifiers` · `check:unreferenced-sources` | exit 0 |
| `type-check:scripts` · `type-check:coverage` · `type-check:vitest-config` | exit 0 |

**Lint, as a proven narrowing** (at `e1641f8e6`, the final commit):
`lint:root` — the repo's own root-lane invocation, so the receiving population is
read from ESLint's own config, not guessed — judged **276 files, 0 errors, 32
warnings, exit 0**, counted from `--format json`. The new test file is in that
population with 0/0. Invariance for the `packages/*` / `apps/*` lanes this
narrows away: `eslint.config.js` contains **0** occurrences of `projectService`,
`parserOptions` or `project:` (control: 10 occurrences of `rules` in the same
run), so no type-aware linting is enabled and this diff cannot move the verdict
on any file it did not touch — and it touches no file in those lanes.

Type-check is measured, not assumed: `tsc -p tsconfig.scripts.json --listFiles`
returns the new test file, so `type-check:scripts` really compiled it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_