### PR TITLE
fix(app-shell): render InspectorSelectField's placeholder, unreachable at all 45 call sites

### DIFF
--- a/.changeset/8450-inspector-select-placeholder.md
+++ b/.changeset/8450-inspector-select-placeholder.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Make `InspectorSelectField`'s `placeholder` reach the rendered trigger
+(objectui#8450). Every empty select in the metadata-admin designer drew a BLANK
+trigger instead of its hint.
+
+The field bridges a caller's `''` through an internal sentinel so a "— None —"
+option can exist at all (Radix `<Select.Item value="">` throws). That bridge also
+guaranteed the value handed to Radix was never `''` or `undefined` — the only two
+values for which Radix renders `SelectValue`'s placeholder — and a controlled
+value matching no `SelectItem` renders as nothing. So the declared `'—'` default
+was unreachable at all 45 call sites, none of which passes a placeholder of its
+own.
+
+The trigger now renders the placeholder itself, on the narrow state that means
+"nothing is selected": no value AND no option standing for none. Where the caller
+DOES offer a `''` row, that row is a selection and its label still wins,
+unchanged. A non-empty value matching no option also still renders blank —
+that is a stale value, not an empty one, and is out of this change's scope.
+
+Measured effect on the designer: 13 of the 45 call sites can be empty without
+offering a "none" row, and those now show `'—'` where they showed nothing — the
+flow-node config selects, the app-nav item type, the curated page-block props,
+the report dataset/chart-axis pickers and the action target/variant/mode/component
+pickers. The other 32 render exactly as before.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.declaredDefault.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.declaredDefault.test.tsx
@@ -15,10 +15,13 @@
  * The measurement, in four parts:
  *
  *  1. A declared default does NOT seed the control's value. An unset key draws
- *     an unchecked box / a blank select, whatever the table declares. The
- *     select is blank rather than showing a placeholder, because the field
- *     always passes a controlled value and Radix renders its placeholder only
- *     for an undefined one.
+ *     an unchecked box / a select on its PLACEHOLDER, whatever the table
+ *     declares. The placeholder is `InspectorSelectField`'s own em-dash, not
+ *     anything the table said — it means "nothing is selected", which is
+ *     precisely the point: the declared `'GET'` is nowhere on screen. (Until
+ *     objectui#8450 the trigger was blank instead: the sentinel the field
+ *     bridges `''` through kept Radix from ever recognising the empty state.
+ *     Blank and em-dash are the same fact about `defaultValue`, told twice.)
  *  2. That holds on BOTH writers of the property — the hand-written table here
  *     and the engine-published `configSchema` that `json-schema-to-fields`
  *     converts (`default: true` -> `defaultValue: 'true'`). Same dead end.
@@ -151,15 +154,16 @@ describe('a declared defaultValue does not reach the rendered control', () => {
 
     renderInspector(draftWith('http_request', { config: {} }));
 
-    // Measured, not assumed: the trigger is EMPTY — it shows neither the
-    // declared default nor `InspectorSelectField`'s own em-dash placeholder.
-    // Radix renders a placeholder only for an UNCONTROLLED/undefined value; the
-    // field always passes a controlled one (the `''` -> sentinel bridge), and a
-    // controlled value matching no `SelectItem` renders as nothing at all.
+    // Measured, not assumed: the trigger shows `InspectorSelectField`'s own
+    // em-dash placeholder — the "nothing is selected" mark — and NOT the
+    // declared default. (It rendered blank before objectui#8450, which fixed
+    // the placeholder's own unreachability in the shared primitive. That was a
+    // defect in the primitive, not evidence about `defaultValue`; this card's
+    // subject is the assertion below, which is unchanged either way.)
     expect(
       triggerText('Method'),
-      'the Method trigger renders empty — no declared default, not even the placeholder',
-    ).toBe('');
+      'the Method trigger renders its placeholder — the declared default seeds nothing',
+    ).toBe('—');
     expect(
       screen.queryByText('GET'),
       'the declared default "GET" reaches no part of the rendered inspector',
@@ -216,8 +220,9 @@ describe('the online writer of defaultValue hits the same dead end', () => {
 
     expect(
       triggerText('Method'),
-      'the server-derived default is not seeded into the control either',
-    ).toBe('');
+      'the server-derived default is not seeded into the control either — the ' +
+        'trigger sits on its placeholder, same as the hand-written half',
+    ).toBe('—');
     expect(screen.queryByText('POST'), 'the derived default reaches no rendered node').toBeNull();
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/_shared.select.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/_shared.select.test.tsx
@@ -1,11 +1,47 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * Regression: InspectorSelectField must accept an option whose value is
- * the empty string (a "— None —" choice). Radix `<Select.Item value="">`
- * throws on render; the field bridges "" through an internal sentinel.
- * This is exactly what the object field "Group" selector relies on once
- * field groups exist, so a regression here crashes the whole inspector.
+ * Two contracts of `InspectorSelectField`'s trigger, pinned together because
+ * they are the same question asked twice: what does the trigger render when the
+ * caller's value is EMPTY?
+ *
+ * 1. Regression: the field must accept an option whose value is the empty
+ *    string (a "— None —" choice). Radix `<Select.Item value="">` throws on
+ *    render; the field bridges "" through an internal sentinel. This is exactly
+ *    what the object field "Group" selector relies on once field groups exist,
+ *    so a regression here crashes the whole inspector.
+ *
+ * 2. objectui#8450: when the caller offers NO such option, the empty state must
+ *    draw the `placeholder`. It used not to. The sentinel that makes (1) work
+ *    is also what broke (2): Radix renders `SelectValue`'s placeholder only for
+ *    a value of `''` or `undefined` (`shouldShowPlaceholder`), the bridge
+ *    guarantees the value is neither, and a controlled value matching no
+ *    `SelectItem` renders as nothing at all. Measured across the tree: 45
+ *    non-test call sites, 0 of which passed an explicit `placeholder` — so what
+ *    never rendered was the declared `'—'` default, at every empty select in
+ *    the designer.
+ *
+ * ⚠️ The two pull against each other, which is why they live in one file. A
+ * repair that shows the placeholder whenever the value is empty breaks (1): the
+ * "— No group —" row IS a selection and its label must win. A repair that keeps
+ * quiet whenever the value is empty is the bug in (2). The predicate that
+ * satisfies both is narrow — no value AND no option standing for "none".
+ *
+ * ## The non-regression half (objectui#8350's lesson)
+ *
+ * Every positive case below is also satisfied by a field that renders the
+ * placeholder ALWAYS — an implementation strictly worse than the bug, since it
+ * would hide the selected value too. The two "does not render" cases are what
+ * fail on it, and they assert the trigger's exact text rather than the
+ * placeholder's absence, so an implementation that renders both also fails.
+ *
+ * ## Reverse verification
+ *
+ * Ablating the READ SITE — restoring `<SelectValue placeholder={placeholder} />`
+ * inside an unconditional trigger, i.e. the pre-fix source — turns the three
+ * `renders …` rows red and leaves the two `does not render …` rows green. That
+ * asymmetry is the point: the pin fails for the bug's own reason and for no
+ * other. Run recorded on the PR.
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -20,6 +56,16 @@ const OPTIONS = [
   { value: 'meta', label: 'Metadata' },
 ];
 
+/** The same roster minus the "none" row — the shape 35 of the 45 call sites use. */
+const NO_NONE_OPTIONS = OPTIONS.filter((o) => o.value !== '');
+
+/** The trigger Radix renders — `button[role=combobox]`, named by the `<Label>`. */
+function trigger(name = 'Group'): HTMLElement {
+  const el = screen.queryByRole('combobox', { name });
+  expect(el, `a combobox named "${name}" is rendered at all`).not.toBeNull();
+  return el as HTMLElement;
+}
+
 describe('InspectorSelectField — empty-value option', () => {
   it('renders with an empty-string option without throwing', () => {
     expect(() =>
@@ -27,14 +73,14 @@ describe('InspectorSelectField — empty-value option', () => {
         <InspectorSelectField label="Group" value="" options={OPTIONS} onCommit={vi.fn()} />,
       ),
     ).not.toThrow();
-    expect(screen.getByText('Group')).toBeInTheDocument();
+    expect(screen.queryByText('Group'), 'the field label is rendered').not.toBeNull();
   });
 
   it('shows the selected non-empty option label on the trigger', () => {
     render(
       <InspectorSelectField label="Group" value="profile" options={OPTIONS} onCommit={vi.fn()} />,
     );
-    expect(screen.getByText('Profile')).toBeInTheDocument();
+    expect(screen.queryByText('Profile'), 'the selected option label reaches the DOM').not.toBeNull();
   });
 
   it('displays the empty-valued option label when value is "" (round-trips through the sentinel)', () => {
@@ -47,10 +93,140 @@ describe('InspectorSelectField — empty-value option', () => {
         placeholder="Pick one"
       />,
     );
-    // value "" matches the "— No group —" option (both bridged to the
-    // sentinel), so the trigger surfaces that label rather than the
-    // placeholder — confirming the "" ⇄ none round-trip works.
-    expect(screen.getByText('— No group —')).toBeInTheDocument();
-    expect(screen.queryByText('Pick one')).not.toBeInTheDocument();
+    // ⚠️ The reason this case originally gave for the placeholder's absence was
+    // NOT the operative one. It read "value '' matches the — No group — option,
+    // so the trigger surfaces that label rather than the placeholder" — true of
+    // the first assertion, but the second one held for a different reason
+    // entirely: before objectui#8450 the placeholder was unreachable in EVERY
+    // state, matching option or not, so this case could not have told a working
+    // field from a broken one. It can now: with the roster below stripped of
+    // its "" row the very same props render "Pick one" (next describe), so this
+    // absence is the "" option winning, which is what it always claimed to be.
+    expect(
+      screen.queryByText('— No group —'),
+      'the "" option is a real selection and its label wins',
+    ).not.toBeNull();
+    expect(
+      screen.queryByText('Pick one'),
+      'a selection is showing, so the placeholder stays out of the DOM',
+    ).toBeNull();
+    expect(
+      trigger().textContent,
+      'the trigger shows the option label ALONE — not the label plus the placeholder',
+    ).toBe('— No group —');
+  });
+});
+
+describe('InspectorSelectField — placeholder (objectui#8450)', () => {
+  it('renders the declared "—" default when the value is undefined', () => {
+    render(
+      <InspectorSelectField label="Group" value={undefined} options={NO_NONE_OPTIONS} onCommit={vi.fn()} />,
+    );
+    expect(
+      trigger().textContent,
+      'an unset select draws its placeholder, not a blank trigger',
+    ).toBe('—');
+  });
+
+  it('renders the declared "—" default for an empty-string value', () => {
+    render(
+      <InspectorSelectField label="Group" value="" options={NO_NONE_OPTIONS} onCommit={vi.fn()} />,
+    );
+    expect(
+      trigger().textContent,
+      '"" with no "" option means the same thing as undefined: nothing is selected',
+    ).toBe('—');
+  });
+
+  it("renders the CALLER's placeholder — the prop that reached no output before", () => {
+    render(
+      <InspectorSelectField
+        label="Group"
+        value=""
+        options={NO_NONE_OPTIONS}
+        onCommit={vi.fn()}
+        placeholder="Pick one"
+      />,
+    );
+    expect(
+      screen.queryByText('Pick one'),
+      "the caller's placeholder reaches the DOM",
+    ).not.toBeNull();
+    expect(trigger().textContent, 'and it is the whole of what the trigger shows').toBe('Pick one');
+  });
+
+  it('does NOT render the placeholder when a value is selected', () => {
+    render(
+      <InspectorSelectField
+        label="Group"
+        value="profile"
+        options={NO_NONE_OPTIONS}
+        onCommit={vi.fn()}
+        placeholder="Pick one"
+      />,
+    );
+    // The half that fails on a field which renders the placeholder ALWAYS —
+    // an implementation strictly worse than the bug it replaces.
+    expect(screen.queryByText('Pick one'), 'the placeholder is not in the DOM').toBeNull();
+    expect(
+      trigger().textContent,
+      'the trigger shows the selected label and nothing else',
+    ).toBe('Profile');
+  });
+
+  it('does NOT render the placeholder when "" is itself an offered option', () => {
+    render(
+      <InspectorSelectField
+        label="Group"
+        value=""
+        options={OPTIONS}
+        onCommit={vi.fn()}
+        placeholder="Pick one"
+      />,
+    );
+    expect(screen.queryByText('Pick one'), 'the "none" row is the selection').toBeNull();
+    expect(trigger().textContent, 'so its label is what shows').toBe('— No group —');
+  });
+
+  it('flips both ways as the value comes and goes', () => {
+    const { rerender } = render(
+      <InspectorSelectField label="Group" value={undefined} options={NO_NONE_OPTIONS} onCommit={vi.fn()} />,
+    );
+    expect(trigger().textContent, 'empty at first').toBe('—');
+
+    rerender(
+      <InspectorSelectField label="Group" value="meta" options={NO_NONE_OPTIONS} onCommit={vi.fn()} />,
+    );
+    expect(
+      trigger().textContent,
+      'a value arriving replaces the placeholder with the option label — the Radix ' +
+        'item text still portals into SelectValue across the swap',
+    ).toBe('Metadata');
+
+    rerender(
+      <InspectorSelectField label="Group" value="" options={NO_NONE_OPTIONS} onCommit={vi.fn()} />,
+    );
+    expect(trigger().textContent, 'and clearing it brings the placeholder back').toBe('—');
+  });
+
+  it('carries Radix\'s own data-placeholder flag in the empty state only', () => {
+    // Not decoration: `data-[placeholder]:text-muted-foreground` on the Shadcn
+    // trigger is how the empty state is greyed, and Radix cannot derive the
+    // attribute itself while the sentinel keeps its value non-empty.
+    const { rerender } = render(
+      <InspectorSelectField label="Group" value="" options={NO_NONE_OPTIONS} onCommit={vi.fn()} />,
+    );
+    expect(
+      trigger().getAttribute('data-placeholder'),
+      'the empty trigger is flagged as showing a placeholder',
+    ).toBe('');
+
+    rerender(
+      <InspectorSelectField label="Group" value="profile" options={NO_NONE_OPTIONS} onCommit={vi.fn()} />,
+    );
+    expect(
+      trigger().getAttribute('data-placeholder'),
+      'a selected trigger is not',
+    ).toBeNull();
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/_shared.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/_shared.tsx
@@ -253,6 +253,31 @@ export function InspectorSelectField({
   // renders the real `button[role=combobox]`, which is a labelable element, so
   // one `for`/`id` pair names it (no second `aria-labelledby` channel needed).
   const id = React.useId();
+  // `SelectValue`'s own `placeholder` is unreachable here, and was at all 45
+  // call sites (objectui#8450). Radix shows it only when its value is `''` or
+  // `undefined`, and the sentinel bridge above guarantees the value is never
+  // either — a controlled value matching no `SelectItem` renders as nothing at
+  // all, so every empty select in the designer drew a BLANK trigger.
+  //
+  // The repair renders the placeholder here instead of handing Radix an
+  // `undefined` value. Passing `undefined` would work, but it makes the Radix
+  // `Select` UNCONTROLLED for exactly as long as the field is empty, so the
+  // first selection at every call site flips it back — measured: Radix logs
+  // `Select is changing from uncontrolled to controlled`, and the same flip
+  // fires with the value untouched when a late-arriving `options` list gains or
+  // loses its `''` row (async pickers: `useMetaOptions`, `datasetOptions`,
+  // `fieldOptions`). While uncontrolled, Radix also keeps its OWN value, so a
+  // pick the owner declines to persist stays on screen. Rendering the text is
+  // the same predicate with none of that.
+  //
+  // "No selection" is the narrow state: no value AND no option standing for
+  // none. When the caller DOES offer a `''` row (a "— None —" choice), `''` is
+  // a selection like any other and that row's label wins — the case pinned in
+  // `_shared.select.test.tsx`. A non-empty value matching no option keeps
+  // rendering blank, unchanged: that is a stale/unknown value, not an empty
+  // one, and the call sites that care already synthesise a visible row for it.
+  const hasNoneOption = options.some((o) => o.value === '');
+  const showPlaceholder = (value ?? '') === '' && !hasNoneOption;
   return (
     <div className="space-y-1">
       <Label htmlFor={id} className="text-xs text-muted-foreground">{label}</Label>
@@ -261,8 +286,17 @@ export function InspectorSelectField({
         onValueChange={(v) => onCommit(fromInner(v))}
         disabled={disabled}
       >
-        <SelectTrigger id={id} className="h-8 text-sm">
-          <SelectValue placeholder={placeholder} />
+        {/* `data-placeholder` is Radix's own trigger flag and the hook Shadcn's
+            `data-[placeholder]:text-muted-foreground` styles the empty state
+            with. Radix cannot derive it through the sentinel, and the trigger
+            spreads caller props AFTER its own attributes, so setting it here
+            restores the real placeholder styling instead of hand-rolling it. */}
+        <SelectTrigger
+          id={id}
+          className="h-8 text-sm"
+          data-placeholder={showPlaceholder ? '' : undefined}
+        >
+          {showPlaceholder ? <span>{placeholder}</span> : <SelectValue />}
         </SelectTrigger>
         <SelectContent>
           {options.map((o) => (


### PR DESCRIPTION
Fixes #8450

`InspectorSelectField` declares `placeholder = '—'` and hands it to
`SelectValue`. It could never render. The field bridges the caller's value
through `toInner(value ?? '')`, so empty/undefined becomes the sentinel
`__inspector_select_none__` — and Radix shows `SelectValue`'s placeholder for
exactly two values, `''` and `undefined` (`shouldShowPlaceholder`), neither of
which the bridge can produce. A controlled value matching no `SelectItem`
renders as nothing at all, so every empty select in the metadata-admin designer
drew a **blank trigger**.

Reproduced before changing anything, rendering the primitive directly:

| props | trigger `textContent` |
|---|---|
| `value={undefined}` | `""` |
| `value="" placeholder="PICKME"` | `""` |
| `value="profile"` (option exists) | `"Profile"` — the lit control: the field IS rendering |

## What contradicts the brief

**The call-site count is 45, not 61**, and 0 of them pass a placeholder.
Measured on `origin/main@c90395b20` with a brace-balanced JSX scan over every
`.tsx` in the repo: **51** JSX elements whose opening tag names `InspectorSelectField`, **45** outside test
files, in 15 files. The dispatch asked which call sites pass an explicit
`placeholder` — the answer is **none**: the only explicit placeholder anywhere in
the tree is `"Pick one"` inside `_shared.select.test.tsx` itself. So the sampling
question the brief posed ("which pass a placeholder / which rely on the default")
has a degenerate answer, and the useful split turned out to be a different one
(below). What was unreachable was the primitive's own `'—'` default, at all 45.

## Which repair, and the measured cost of each

Both candidates need the identical predicate (`does any option stand for
"none"?`), so they cost the same to write and change exactly the same set of call
sites. They differ on one thing, and it is decisive.

**A — hand Radix `undefined` when there is no value.** Works (the trigger draws
`'—'`, and Radix even sets `data-placeholder` itself). But `undefined` is how
Radix spells *uncontrolled*, so the field becomes uncontrolled for exactly as
long as it is empty. Measured against the real `Select`, with a `console.warn`
spy:

- empty → first selection (`undefined` → `"profile"`): **1** warning,
  `Select is changing from uncontrolled to controlled. …`. That is every call
  site's first interaction.
- **value untouched**, options arriving late and gaining a `""` row
  (`options=[]` → `[{value:''},…]` with `value=""` throughout): **1** warning,
  same text. The async pickers do this routinely — `useMetaOptions`,
  `datasetOptions`, `chartXOptions`, `fieldOptions` all populate after mount.
- While uncontrolled, `useControllableState` keeps Radix's *own* value
  (`setUncontrolledProp`), so a pick the owner declines to persist stays on
  screen. (Read from the installed source, not rendered.)

**B — keep the sentinel, render the placeholder outside `SelectValue`.** Same
measurements: **0** warnings on either transition, selected label still renders
across the empty→selected swap, `""`-option round trip intact.

They are **not** equivalent on cost — B is strictly cheaper — so **B is
implemented**. Two details B needs:

- The placeholder cannot go inside `SelectValue` as children: Radix's
  `SelectItemText` only portals the selected label into the value node when
  `!valueNodeHasChildren`, so giving `SelectValue` children would silence the
  selected label. It is rendered as the trigger's child *instead of*
  `SelectValue`.
- `data-placeholder=""` is set on the trigger in the empty state. Not decoration:
  `data-[placeholder]:text-muted-foreground` on the Shadcn trigger is how the
  empty state is greyed, Radix cannot derive the attribute through the sentinel,
  and `SelectPrimitive.Trigger` spreads caller props *after* its own attributes,
  so the override is legitimate rather than a fight.

The predicate is deliberately **narrow** — no value AND no option standing for
none. A non-empty value matching no option still renders blank; that is a stale
value, not an empty one, and calling it "—" would assert "nothing is stored"
about a field that is storing something. Filed separately as #8488.

## Representative sample, chosen by measurement

The 45 call sites were bucketed mechanically (value expression resolved through
its `const` initializer; `options` resolved to its array literal):

| bucket | count | what it is | effect of this PR |
|---|---|---|---|
| **A** | 10 | options offer a `""` row — empty IS a selection | unchanged |
| **B** | 13 | can be empty, no `""` row | **blank → `—`** |
| **C** | 22 | value always resolves to a non-empty key | unchanged |

(The static rule put 14 in B; `ActionDefaultInspector.tsx:530` is a false
positive — its `|| 'expression'` makes it never empty — and is counted in C by
hand. Four C members are "no literal fallback, empirically non-empty" rather than
provably so: `DatasetDefaultInspector` `d.type` / `m.aggregate`,
`ObjectFieldInspector:645`, `ViewColumnInspector:270`.)

The sample takes one site per bucket, and takes them through the **real
inspectors**, not the primitive — four inspector components, five triggers:

| bucket | call site | control | before | after |
|---|---|---|---|---|
| B | `FlowNodeConfigField.tsx:225` | `http_request` "Method", `config: {}` | `""` | `"—"` |
| B | `AppNavInspector.tsx:391` | nav item whose type infers `null` | `""` | `"—"` |
| B | `PageBlockInspector.tsx:545` | `object-form` "Mode" | `""` | `"—"` |
| B | `PageBlockInspector.tsx:545` | `object-form` "Layout" | `""` | `"—"` |
| A | `ObjectFieldInspector.tsx:911` | field "Group" with a `""` row | `"— No group —"` | `"— No group —"` |
| C | `FlowNodeInspector.tsx:401` | node "Node Type" | `"http_request"` | `"http_request"` |

The last two rows are the sample's own controls: A and C must not move, and did
not.

## `_shared.select.test.tsx` case 3 — reason corrected, case kept

Its two assertions were right and are unchanged. Its stated reason was not the
operative one: it read the placeholder's absence as "the `''` option matched",
but before this change the placeholder was absent in **every** state, matching
option or not — so the case could not have told a working field from a broken
one. The comment now says that, and points at the neighbouring case where the
very same props with the `""` row stripped render `"Pick one"`, which is what
makes this absence mean what it always claimed to mean. A third assertion was
added: the trigger text is the option label **alone**.

## Would an implementation strictly worse than the bug pass?

No. A field that renders the placeholder **always** satisfies every positive row,
and fails these two:

- `does NOT render the placeholder when a value is selected` — asserts
  `trigger.textContent === "Profile"`, not merely that the placeholder is absent,
  so an implementation rendering *both* also fails.
- `does NOT render the placeholder when "" is itself an offered option` —
  asserts `"— No group —"`.

Both live in the same describe as the positives and both stayed **green** under
the ablation below, which is the asymmetry that makes them load-bearing.

## Ablation — the pin can fail, and fails for the right reason

Ablated the **read site**: restored the pre-fix trigger (a bare
`SelectValue placeholder={placeholder}` element under an unconditional
`SelectTrigger`) on top of the committed implementation. Direction predicted before running.

Mutation proven on disk, hashes and both grep directions with the matched line:

```
HEAD blob                       ccdf0f887245e15fd17e16a12752a8582f65f069
on-disk before mutation         ccdf0f887245e15fd17e16a12752a8582f65f069   (equal - tree clean)
on-disk after  mutation         91998e75aa76c3c53bf440a0f33bb5d4627832a0   (differs)

removed marker `data-placeholder={showPlaceholder`
  before: 1   297:          data-placeholder={showPlaceholder ? '' : undefined}
  after : 0   (gone)
injected marker `SelectValue placeholder={placeholder}` (as an opening-tag span)
  before: 0   (absent)
  after : 1   line 295, an opening tag: SelectValue placeholder={placeholder}
```

No rebuild is involved and none is owed: the pins reach the mutated module by the
relative source import `from './_shared'`, not through a package `exports` entry,
so there is no `dist/` copy that could serve a stale green.

Result — `7 failed | 16 passed (23)`, red **by name**:

```
× _shared.select.test.tsx > placeholder (objectui#8450) > renders the declared "—" default when the value is undefined
× _shared.select.test.tsx > placeholder (objectui#8450) > renders the declared "—" default for an empty-string value
× _shared.select.test.tsx > placeholder (objectui#8450) > renders the CALLER's placeholder — the prop that reached no output before
× _shared.select.test.tsx > placeholder (objectui#8450) > flips both ways as the value comes and goes
× _shared.select.test.tsx > placeholder (objectui#8450) > carries Radix's own data-placeholder flag in the empty state only
× FlowNodeInspector.declaredDefault.test.tsx > a declared defaultValue … > select: an unset key draws the placeholder, not the declared "GET"
× FlowNodeInspector.declaredDefault.test.tsx > the online writer … > a server-published `default` is derived into the field and still not rendered
```

and green throughout on both `does NOT render …` rows and all three
`empty-value option` rows. Restored **by state**, not by an exit code:
`git hash-object` back to `ccdf0f887245e15fd17e16a12752a8582f65f069` (equal to
the HEAD blob) and `git diff HEAD` empty; re-run after restore `23 passed (23)`.
The script carried `trap … EXIT INT TERM` with absolute paths throughout.

## `FlowNodeInspector.declaredDefault.test.tsx`

Two rows read `'—'` where they read `''`. That file is objectui#6830's pin and
its subject — a declared `defaultValue` seeds no control — is untouched; the
`queryByText('GET') === null` / `queryByText('POST') === null` assertions carry it
and are unchanged. Only the mark for "nothing is selected" moved from blank to
the placeholder. **The select half of #6830's ruled direction A is deliberately
not implemented here** — this PR shows "nothing is selected", never the declared
default.

## objectui#3912

Read. **No collision, no pre-emption.** It is about `BlockPropField`'s `text`
branch in `previews/block-config.ts` carrying `placeholder` as its only
capability and wanting `pattern` / `validate` / `description` — a
`InspectorTextField` placeholder, which renders fine (the native
`placeholder` attribute on an `input` element) and is being asked to carry validation semantics it should not.
This PR touches neither `block-config.ts` nor `InspectorTextField`, and adds no
capability to `BlockPropField`. The one point of contact is that the `kind:
'select'` block props at `PageBlockInspector.tsx:545` now show `—` when unset —
which affects nothing #3912 proposes. It is `pm:on-hold`.

## Verification

Everything from the repo root with explicit positional paths.

- `pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build` — exit 0
- `pnpm exec vitest run packages/app-shell/` — **`Test Files 650 passed (650)` · `Tests 6281 passed | 1 skipped (6282)`**
- `pnpm exec vitest run apps/console/ examples/byo-backend-console/ examples/console-starter/` — **`Test Files 90 passed (90)` · `Tests 1078 passed (1078)`** (the other three packages `turbo ls --affected` reports; run from the root, never `--filter`-ed, because a filtered `examples/*` run relocates `process.cwd()`)
- `pnpm --filter @object-ui/app-shell run type-check` — exit 0 (it is `tsc --noEmit && tsc -p tsconfig.test.json`, so the new test file is type-checked too)
- `pnpm --filter @object-ui/app-shell run lint` (`eslint .`, package-scoped, no narrowing) — exit 0, `✖ 2925 problems (0 errors, 2925 warnings)`. The five `react-refresh/only-export-components` warnings on `_shared.tsx` are pre-existing and shifted, not new: the file's export list is byte-identical to `c90395b20` (15 exports, same names), and the warnings sit on `spliceArray` / `insertArray` / `appendArray` / `moveArray` / `uniqueId`.
- `node scripts/check-changeset-presence.mjs` — `✅  3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/8450-inspector-select-placeholder.md.`
- `node scripts/check-governed-queue-guard.mjs --test THE-4-PATHS` — `✅ NOT GOVERNED`
- Control-byte self-scan over the four changed files: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` → no hits (exit 1), with a lit control that fired on a planted `\x01`.

No assertion here depends on `window.innerWidth`: nothing opens the Radix content
(the popper is the only viewport-sensitive part), every reading is the closed
trigger's `textContent` or an attribute, and no responsive class is asserted.

## Changeset level

`patch`, for `@object-ui/app-shell`. `InspectorSelectField` is **not** exported
from any package index — it is internal to the metadata-admin designer, so no
published API moves. What changes is rendered output inside a shipped app
surface, which is what a patch-level fix is. `minor` would claim a new
capability; the `placeholder` prop was already declared and documented, it simply
never reached the DOM. (`major` is forbidden repo-wide — one fixed group.)
`skip-changeset` was not used: it is a phantom label here, and the gate above
names the real declaration.

---

⚠️ Every placeholder and JSX tag above is written as a capitalised word or with
its shape spelled out in prose, never as a literal short angle-bracket span:
the GitHub body sanitizer eats those, code fences included, and the eaten line
here would be the one carrying the ablation's injected marker. Session
attribution as durable prose, since footer blocks are rewritten on edit — this
PR was produced by the agent seat at
`https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_