### PR TITLE
fix(fields): an empty array is not a cell value in the shared read renderers

### DIFF
--- a/.changeset/8481-empty-array-is-not-a-cell-value.md
+++ b/.changeset/8481-empty-array-is-not-a-cell-value.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/fields': minor
+---
+
+An empty array is no longer a cell value in the shared read renderers (objectui#8481).
+
+Three renderers in `@object-ui/fields` open a multi-value container and map their
+entries into it. Their opening guards tested only `null` / `undefined` / `''`, so `[]`
+passed and each mapped over zero entries — the renderer's entire output was a
+**childless container**: no glyph, no `aria-label`, a visually blank cell.
+
+| field types | renderer | output for `[]` before |
+|---|---|---|
+| `select`, `status`, `multiselect`, `radio`, `checkboxes`, `tags` | `SelectCellRenderer` | a flex-wrap DIV with no children |
+| `lookup`, `master_detail`, `tree` | `LookupCellRenderer` | a flex-wrap DIV with no children |
+| `user` | `UserCellRenderer` | an avatar-stack DIV with no children |
+
+All ten types now render the shared `EmptyValue` affordance — the muted em-dash with a
+`No value` accessible name — exactly as they already did for `null`.
+
+**Why this is user-visible on multiple surfaces.** `@object-ui/plugin-detail` already
+carried two private upstream pre-checks against this (objectui#8474's `hasCellValue`
+and `RelatedList`'s `isValueEmpty` from objectui#8459), so the record page was already
+protected. Every consumer that does not pre-check reached the renderer directly:
+`ObjectGrid` (both the desktop table and the sub-768px card layout), `ObjectGallery`
+and `ObjectKanban` were each verified by rendering to paint the blank cell before this
+change and the affordance after it.
+
+**Deliberately narrow.** This is not a package-wide emptiness predicate and the helper
+is not exported. Measured by rendering every registered field type against `[]`, these
+renderers hold at least seven different private answers to "is this empty", and several
+of the disagreements are intentional: `JsonCellRenderer` draws the two-character array
+literal (measured and kept by objectui#8474) and `FileCellRenderer` states `0 files`.
+Neither moves, and both are pinned as the declared boundary of this change. `{}` is
+untouched everywhere — the test is `Array.isArray`, so an object cannot reach it.

--- a/packages/fields/src/__tests__/cellRenderers.emptyArray-8481.test.tsx
+++ b/packages/fields/src/__tests__/cellRenderers.emptyArray-8481.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8481 — an empty array is not a cell value, and the SHARED renderer
+ * is where that has to be said.
+ *
+ * Three renderers in `@object-ui/fields` open a multi-value container and map
+ * their entries into it. Their opening guards tested only `null`/`undefined`/
+ * `''`, so `[]` passed and each mapped over zero entries — the renderer's
+ * whole output was a childless container:
+ *
+ * | field types                                          | renderer             | output for `[]` on `7cf6f38fb` |
+ * |------------------------------------------------------|----------------------|--------------------------------|
+ * | select, status, multiselect, radio, checkboxes, tags | `SelectCellRenderer` | a DIV classed `flex flex-wrap gap-1`, no children |
+ * | lookup, master_detail, tree                          | `LookupCellRenderer` | a DIV classed `flex flex-wrap gap-1`, no children |
+ * | user                                                 | `UserCellRenderer`   | a DIV classed `flex -space-x-2`, no children |
+ *
+ * `@object-ui/plugin-detail` had already grown two private upstream
+ * pre-checks against this (objectui#8474, objectui#8459). Every consumer that
+ * does not pre-check reached the renderer directly. The consumer half of the
+ * evidence lives in `plugin-grid`'s `emptyArrayCell-8481.test.tsx`.
+ *
+ * ── Why the POPULATED cases are the load-bearing ones ─────────────────────
+ * An implementation that answered "empty" for EVERY value would satisfy every
+ * `[]`-renders-the-affordance case in this file, including the ones that read
+ * most convincingly. What refuses it is the four NON-REGRESSION cases below —
+ * a populated multiselect drawing its badges, a populated lookup its chips, a
+ * populated user field its avatars, and a scalar select value its single
+ * badge. That is objectui#8474's measured lesson applied here: the vivid
+ * assertion is rarely the discriminating one.
+ *
+ * ── Why the fix is NOT a package-wide emptiness predicate ─────────────────
+ * Measured, by rendering every registered field type against `[]`: the
+ * renderers in this package hold at least seven different private answers to
+ * "is this empty", and several of the disagreements are deliberate.
+ * `JsonCellRenderer` draws the two-character literal for `[]` (objectui#8474
+ * measured that and kept it) and `FileCellRenderer` states "0 files" — both
+ * pinned below as the declared boundary of this change, so widening it later
+ * has to delete an assertion rather than merely forget a consideration.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { getCellRenderer, resolveCellRendererType } from '../index';
+
+afterEach(() => cleanup());
+
+const OPTIONS = [
+  { value: 'alpha', label: 'Alpha' },
+  { value: 'beta', label: 'Beta' },
+];
+
+/** Resolve + render exactly the way a consumer builds a read-mode cell. */
+function renderCell(type: string, value: unknown, field: Record<string, unknown> = {}) {
+  const Renderer = getCellRenderer(resolveCellRendererType({ type }) || type);
+  return render(
+    <Renderer value={value as any} field={{ type, name: type, ...field } as any} />,
+  );
+}
+
+/** The shared "No value" affordance — a muted glyph carrying an aria-label. */
+const affordance = (root: HTMLElement) =>
+  root.querySelector<HTMLElement>('[data-slot="empty-value"]');
+
+/**
+ * The defect's signature: an element that exists, occupies the cell and has
+ * nothing inside it. Asserted structurally rather than by text, because its
+ * whole problem is that it has no text to look for.
+ */
+function childlessContainers(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>('div')).filter(
+    (el) => el.childElementCount === 0 && (el.textContent ?? '') === '',
+  );
+}
+
+/** Every multi-value type that reaches one of the three fixed renderers. */
+const MULTI_VALUE_TYPES = [
+  'select', 'status', 'multiselect', 'radio', 'checkboxes', 'tags',
+  'lookup', 'master_detail', 'tree',
+  'user',
+] as const;
+
+describe('objectui#8481 — an empty array is not a cell value', () => {
+  describe('THE DEFECT — a multi-value container with no entries says so', () => {
+    for (const type of MULTI_VALUE_TYPES) {
+      it(`THE DEFECT — \`${type}\` holding [] renders the No-value affordance, not a childless container`, () => {
+        const { container } = renderCell(type, [], { options: OPTIONS });
+
+        const empty = affordance(container);
+        expect(empty, `${type}: expected the shared EmptyValue affordance for []`).not.toBeNull();
+        expect(
+          empty?.getAttribute('aria-label'),
+          `${type}: the affordance must carry its accessible name`,
+        ).toBe('No value');
+
+        expect(
+          childlessContainers(container).length,
+          `${type}: [] must not render a childless container (the objectui#8481 defect)`,
+        ).toBe(0);
+      });
+    }
+  });
+
+  describe('NON-REGRESSION — these refuse an EMPTY-for-everything implementation', () => {
+    it('NON-REGRESSION — a POPULATED multiselect still renders one badge per entry', () => {
+      const { container } = renderCell('multiselect', ['alpha', 'beta'], { options: OPTIONS });
+
+      expect(
+        within(container).queryByText('Alpha'),
+        'a populated multiselect must still draw the first option badge',
+      ).not.toBeNull();
+      expect(
+        within(container).queryByText('Beta'),
+        'a populated multiselect must still draw the second option badge',
+      ).not.toBeNull();
+      expect(
+        affordance(container),
+        'a populated multiselect must NOT render the No-value affordance',
+      ).toBeNull();
+    });
+
+    it('NON-REGRESSION — a POPULATED lookup still renders one chip per referenced record', () => {
+      const { container } = renderCell('lookup', ['alpha', 'beta'], { reference_to: 'other' });
+
+      expect(
+        within(container).queryByText('alpha'),
+        'a populated lookup must still draw the first record chip',
+      ).not.toBeNull();
+      expect(
+        within(container).queryByText('beta'),
+        'a populated lookup must still draw the second record chip',
+      ).not.toBeNull();
+      expect(
+        affordance(container),
+        'a populated lookup must NOT render the No-value affordance',
+      ).toBeNull();
+    });
+
+    it('NON-REGRESSION — a POPULATED user field still renders its avatar stack', () => {
+      const { container } = renderCell('user', [{ name: 'Ada Lovelace' }, { name: 'Grace Hopper' }]);
+
+      const stack = container.querySelector('div.flex');
+      expect(stack, 'a populated user field must still render its stack container').not.toBeNull();
+      expect(
+        stack!.childElementCount,
+        'a populated user field must still render one avatar per user',
+      ).toBe(2);
+      expect(
+        affordance(container),
+        'a populated user field must NOT render the No-value affordance',
+      ).toBeNull();
+    });
+
+    it('NON-REGRESSION — a SCALAR select value still renders its badge', () => {
+      const { container } = renderCell('select', 'alpha', { options: OPTIONS });
+
+      expect(
+        within(container).queryByText('Alpha'),
+        'a scalar select value must still draw its badge',
+      ).not.toBeNull();
+      expect(
+        affordance(container),
+        'a scalar select value must NOT render the No-value affordance',
+      ).toBeNull();
+    });
+
+    it('NON-REGRESSION — a ONE-entry array is a value, even when the entry itself is falsy', () => {
+      // Refuses a widening spelled as "every entry is falsy" rather than
+      // "there are no entries": `[0]` has something to draw and draws it.
+      const { container } = renderCell('multiselect', [0], { options: OPTIONS });
+
+      expect(
+        affordance(container),
+        'a one-entry array must NOT render the No-value affordance',
+      ).toBeNull();
+      const row = container.querySelector('div.flex.flex-wrap');
+      expect(row, 'a one-entry array must still open its multi-value row').not.toBeNull();
+      expect(row!.childElementCount, 'a one-entry array renders exactly one entry').toBe(1);
+    });
+  });
+
+  describe('THE BOUNDARY — the renderers this change deliberately did not move', () => {
+    it('THE BOUNDARY — `json` still draws the two-character literal for [] and for {}', () => {
+      // objectui#8474 measured this and kept it: a json-family cell holding
+      // `[]` was never blank, it printed two characters of punctuation, and
+      // turning that into a placeholder is a taste change, not a bug fix.
+      const arr = renderCell('json', []);
+      expect(
+        within(arr.container).queryByText('[]'),
+        '`json` holding [] must still print the array literal',
+      ).not.toBeNull();
+      cleanup();
+
+      const obj = renderCell('json', {});
+      expect(
+        within(obj.container).queryByText('{}'),
+        '`json` holding {} must still print the object literal',
+      ).not.toBeNull();
+    });
+
+    it('THE BOUNDARY — `file` still states its count rather than the affordance', () => {
+      const { container } = renderCell('file', []);
+      expect(
+        within(container).queryByText('0 files'),
+        '`file` holding [] states a count; it was never blank, so it did not move',
+      ).not.toBeNull();
+    });
+
+    it('THE BOUNDARY — `{}` is untouched on the three renderers this change DOES move', () => {
+      // The widening that would have swept `{}` in — `Object.keys(v).length
+      // === 0` — is separately unsafe (a Date, a populated Map/Set and a
+      // getter-backed class instance all report zero own keys while
+      // rendering). This change tests `Array.isArray`, so `{}` cannot reach it.
+      const { container } = renderCell('multiselect', {}, { options: OPTIONS });
+      expect(
+        affordance(container),
+        '{} must NOT be swept into the empty-array fix',
+      ).toBeNull();
+    });
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -1424,6 +1424,40 @@ export function getSemanticHex(name?: string, fallback: string = '#3b82f6'): str
 }
 
 /**
+ * An array with zero entries is not a cell value (objectui#8481).
+ *
+ * Three renderers below open a MULTI-VALUE container and map their entries
+ * into it — `SelectCellRenderer` (a flex-wrap row of badges/dots),
+ * `LookupCellRenderer` (a flex-wrap row of record chips) and
+ * `UserCellRenderer` (an overlapping avatar stack). Each one's opening guard
+ * tested only `null`/`undefined`/`''`, so `[]` reached the array branch and
+ * mapped over zero entries: the renderer's whole output was a CHILDLESS
+ * container — no glyph, no `aria-label`, a visually blank cell.
+ *
+ * That blindness lived in the SHARED renderer, so it was the same blank cell
+ * on every surface. `@object-ui/plugin-detail` had already grown two private
+ * upstream pre-checks against it (objectui#8474's `hasCellValue`, and
+ * `RelatedList`'s `isValueEmpty` from objectui#8459); every consumer that does
+ * NOT pre-check — `ObjectGrid`, `ObjectGallery`, `ObjectKanban`,
+ * `ObjectDataTable` — reached the renderer directly and painted the blank.
+ * A renderer with nothing to draw says so itself rather than depending on
+ * every caller remembering to ask first.
+ *
+ * ⛔ Deliberately NOT the package's general emptiness predicate, and
+ * deliberately not exported. The renderers in this file do NOT agree on what
+ * "empty" means, and that disagreement is measured and in several places
+ * intentional: `JsonCellRenderer` draws the two-character literal for `[]`
+ * (objectui#8474 measured and kept that), `FileCellRenderer` states "0 files",
+ * `BooleanCellRenderer` treats `false` as a value while `DateCellRenderer`'s
+ * `!value` treats the epoch as empty. This helper answers ONE question — "is
+ * this a multi-value container with no entries to draw?" — for the three
+ * renderers that ask it. Unifying the rest is a separate, contested change.
+ */
+function isEmptyMultiValue(value: unknown): boolean {
+  return Array.isArray(value) && value.length === 0;
+}
+
+/**
  * Select field cell renderer.
  *
  * Two visual styles, controlled by `field.appearance` (renderer-level option,
@@ -1441,7 +1475,10 @@ export function SelectCellRenderer({ value, field }: CellRendererProps): React.R
   const options: SelectOptionMetadata[] = selectField.options || [];
   const appearance: 'badge' | 'dot' = selectField.appearance === 'dot' ? 'dot' : 'badge';
 
-  if (value == null || value === '') return <EmptyValue />;
+  // `[]` is handled HERE rather than in the array branch below, because this
+  // is the statement the renderer makes about having nothing to draw
+  // (objectui#8481).
+  if (value == null || value === '' || isEmptyMultiValue(value)) return <EmptyValue />;
 
   // Match a stored value to a configured option, falling back to a
   // case-insensitive comparison so seed data with mixed case
@@ -1897,7 +1934,10 @@ export function LookupCellRenderer({ value, field }: CellRendererProps): React.R
   // Always call the hook (rules of hooks). It safely no-ops when inputs are missing.
   const resolvedName = useLookupName(referenceTo, primaryPrimitiveId, displayField);
 
-  if (value == null || value === '') return <EmptyValue />;
+  // Same childless-container defect as `SelectCellRenderer` above: the array
+  // branch further down opens a flex-wrap row of chips and maps zero entries
+  // into it (objectui#8481).
+  if (value == null || value === '' || isEmptyMultiValue(value)) return <EmptyValue />;
 
   // A reference can arrive as a JSON-encoded object string — e.g. an
   // unresolved external-id reference '{"externalId":"Website Relaunch"}'.
@@ -2065,7 +2105,9 @@ export function FormulaCellRenderer({ value }: CellRendererProps): React.ReactEl
  * User/Owner field cell renderer (with avatars)
  */
 export function UserCellRenderer({ value }: CellRendererProps): React.ReactElement {
-  if (!value) return <EmptyValue />;
+  // `!value` never saw `[]` — a truthy empty array reached the avatar-stack
+  // branch below and rendered an empty stack (objectui#8481).
+  if (!value || isEmptyMultiValue(value)) return <EmptyValue />;
 
   // Primitive value: just display the ID/username as text
   if (typeof value !== 'object') {

--- a/packages/plugin-grid/src/__tests__/emptyArrayCell-8481.test.tsx
+++ b/packages/plugin-grid/src/__tests__/emptyArrayCell-8481.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8481, consumer half — the surfaces that do NOT pre-check.
+ *
+ * `@object-ui/plugin-detail` guards the shared renderers with two private
+ * upstream predicates (objectui#8474's `hasCellValue`, objectui#8459's
+ * `RelatedList.isValueEmpty`). `ObjectGrid` has neither: it resolves a
+ * renderer through `getCellRenderer(...)` and calls it with the RAW value at
+ * five sites, and its one `EmptyValue` fallback is the no-renderer default
+ * path, whose guard (`value != null && value !== ''`) carries the very same
+ * hole one branch over. So a `multiselect` column holding `[]` painted a
+ * childless flex-wrap DIV — a visually blank cell — in a real grid.
+ *
+ * ── Why this file renders BOTH widths ─────────────────────────────────────
+ * `ObjectGrid` switches to a card layout below 768px (`window.innerWidth <
+ * 768`), and that layout resolves its own cell renderers. Two independent
+ * read paths, so both are pinned and the width is set explicitly in each —
+ * never left at whatever the DOM environment happens to default to.
+ *
+ * ── Which of these cases discriminates ────────────────────────────────────
+ * ⚠️ Not the blank-cell ones. An emptiness test answering EMPTY for every
+ * value would satisfy every "[] renders the affordance" case here. The case
+ * that refuses it is the POPULATED row rendered in the SAME grid: it is the
+ * only assertion in this file that an over-correction fails.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach, beforeAll, vi } from 'vitest';
+import { render, screen, waitFor, cleanup, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ActionProvider, SchemaRendererProvider } from '@object-ui/react';
+import { registerAllFields } from '@object-ui/fields';
+import { ObjectGrid } from '../ObjectGrid';
+
+registerAllFields();
+
+const OPTIONS = [
+  { value: 'alpha', label: 'Alpha' },
+  { value: 'beta', label: 'Beta' },
+];
+
+/** One row whose multiselect is `[]`, one whose multiselect is populated. */
+const ROWS = [
+  { id: 'r1', name: 'Row one', tags: [] as string[] },
+  { id: 'r2', name: 'Row two', tags: ['alpha', 'beta'] },
+];
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async () => ({ data: ROWS, total: ROWS.length, hasMore: false, pageSize: 50 })),
+    getObjectSchema: vi.fn(async (name: string) => ({
+      name,
+      fields: {
+        id: { type: 'text' },
+        name: { type: 'text', label: 'Name' },
+        tags: { type: 'multiselect', label: 'Tags', options: OPTIONS },
+      },
+    })),
+  } as any;
+}
+
+const ORIGINAL_INNER_WIDTH = window.innerWidth;
+
+function setWidth(px: number) {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: px });
+}
+
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn() as any;
+  }
+});
+
+afterEach(() => {
+  setWidth(ORIGINAL_INNER_WIDTH);
+  cleanup();
+});
+
+function renderGrid() {
+  const ds = makeDataSource();
+  return render(
+    <ActionProvider>
+      <SchemaRendererProvider dataSource={ds}>
+        <ObjectGrid
+          schema={{
+            type: 'object-grid',
+            objectName: 'test_object',
+            columns: [
+              { field: 'name', label: 'Name' },
+              { field: 'tags', label: 'Tags', type: 'multiselect' },
+            ],
+            pagination: { pageSize: 50 },
+          } as any}
+          dataSource={ds}
+        />
+      </SchemaRendererProvider>
+    </ActionProvider>,
+  );
+}
+
+/**
+ * ⚠️ Every lookup below is SCOPED TO ONE ROW, and that is load-bearing.
+ * Measured: the grid's own toolbar renders a `div.flex.flex-wrap` that is
+ * legitimately empty when no filter chips are active, so an unscoped
+ * "no childless flex-wrap anywhere" assertion reads the CHROME and fails
+ * against a correct grid — an instrument pointed at the wrong thing.
+ */
+function rowOf(label: string): HTMLElement {
+  const cell = screen.getByText(label);
+  const row = cell.closest('tr') ?? cell.closest('[role="row"]') ?? cell.parentElement;
+  if (!row) throw new Error(`no row found for ${label}`);
+  return row as HTMLElement;
+}
+
+/** The defect's signature: an element occupying the cell with nothing in it. */
+function childlessFlexWrap(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>('div.flex.flex-wrap')).filter(
+    (el) => el.childElementCount === 0,
+  );
+}
+
+const affordances = (root: HTMLElement) =>
+  Array.from(root.querySelectorAll<HTMLElement>('[data-slot="empty-value"]'));
+
+describe('objectui#8481 — ObjectGrid paints no blank cell for an empty array', () => {
+  it('DESKTOP — a multiselect column holding [] renders the No-value affordance', async () => {
+    setWidth(1280);
+    renderGrid();
+    await waitFor(() => expect(screen.queryByText('Row one')).not.toBeNull());
+    const emptyRow = rowOf('Row one');
+
+    expect(
+      childlessFlexWrap(emptyRow).length,
+      'desktop grid: the [] row must not paint a childless flex-wrap cell (the objectui#8481 defect)',
+    ).toBe(0);
+    expect(
+      affordances(emptyRow).length,
+      'desktop grid: the [] cell must carry exactly one No-value affordance',
+    ).toBe(1);
+    expect(
+      affordances(emptyRow)[0]?.getAttribute('aria-label'),
+      'desktop grid: the affordance must carry its accessible name',
+    ).toBe('No value');
+  });
+
+  it('⚠️ DISCRIMINATING — the POPULATED row in the SAME desktop grid still draws its badges', async () => {
+    // The one case here an EMPTY-for-everything implementation fails.
+    setWidth(1280);
+    renderGrid();
+    await waitFor(() => expect(screen.queryByText('Row two')).not.toBeNull());
+    const filledRow = rowOf('Row two');
+
+    expect(
+      within(filledRow).queryByText('Alpha'),
+      'the populated row must still draw its first badge',
+    ).not.toBeNull();
+    expect(
+      within(filledRow).queryByText('Beta'),
+      'the populated row must still draw its second badge',
+    ).not.toBeNull();
+    expect(
+      affordances(filledRow).length,
+      'the populated row has nothing empty in it, so it carries no affordance',
+    ).toBe(0);
+  });
+
+  it('MOBILE CARD VIEW — the same column below the 768px breakpoint also renders the affordance', async () => {
+    setWidth(390);
+    renderGrid();
+    await waitFor(() => expect(screen.queryByText('Row one')).not.toBeNull());
+    const emptyCard = rowOf('Row one');
+    const filledCard = rowOf('Row two');
+
+    expect(
+      childlessFlexWrap(emptyCard).length,
+      'mobile card view: the [] card must not paint a childless flex-wrap cell',
+    ).toBe(0);
+    expect(
+      affordances(emptyCard).length,
+      'mobile card view: the [] card must carry a No-value affordance',
+    ).toBeGreaterThan(0);
+    expect(
+      within(filledCard).queryByText('Alpha'),
+      'mobile card view: the populated card must still draw its badge',
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #8481

Cut from `main` at `7cf6f38fb`. Final commit `c1337dfbb`.

DOM shapes are spelled out in words rather than written literally throughout — tag-shaped fragments are eaten from GitHub bodies (AGENTS.md, "六种已实测的改写" ①). Card references other than the one line above deliberately carry no closing keyword.

## Verdict: the CHILDLESS-CONTAINER class — three renderers, one private helper, not a package predicate

The card names `SelectCellRenderer`. Censused by rendering, it is one of **three**:

| field types | renderer | output for `[]` on `7cf6f38fb` |
|---|---|---|
| `select`, `status`, `multiselect`, `radio`, `checkboxes`, `tags` | `SelectCellRenderer` | a DIV classed `flex flex-wrap gap-1`, **no children** |
| `lookup`, `master_detail`, `tree` | `LookupCellRenderer` | a DIV classed `flex flex-wrap gap-1`, **no children** |
| `user` | `UserCellRenderer` | a DIV classed `flex -space-x-2`, **no children** |

All three open a **multi-value container and map their entries into it**. That is the fence, and it is measured rather than asserted: those are exactly the renderers in this file whose `Array.isArray` branch returns a container of children. `FileCellRenderer` also has an array branch but returns the text `0 files` — a statement, not a blank — and `ImageCellRenderer`'s array branch already tests `imgs.length === 0`.

One private helper, `isEmptyMultiValue`, answers one question at those three opening guards. ⛔ Not exported, and deliberately not the package's general emptiness predicate — see the census below for why.

## The census: this package holds SEVEN private answers to "is this empty"

Measured by rendering every one of the **53 registered field types** through `getCellRenderer` against `[]`, `{}` and `['alpha','beta']` — 159 rendered outputs, before and after.

| guard idiom | renderers |
|---|---|
| `value == null \|\| value === ''` | Select, Lookup, Json, ColorSwatch, Location, Address |
| `coerceToSafeValue(value) == null \|\| === ''` | Text, Formula |
| `value == null` | Number, Currency, Percent, Boolean |
| `!value` | Date, DateTime, Email, Url, Phone, File, User |
| `!value \|\| imgs.length === 0` | Image |
| `Array.isArray(v) ? v.length : 0` | the `repeater` registry entry |
| `Object.keys(v).length === 0` | `AddressCellRenderer`'s second clause |

The brief asked whether the fix belongs in one renderer or in a shared check the package's renderers "ought to agree on". **Measured answer: they must not all agree, and several disagreements are deliberate.** `JsonCellRenderer` draws the two-character array literal on purpose (objectui#8474 measured that and kept it); `FileCellRenderer` states a count; `BooleanCellRenderer` must keep `false` a value while `DateCellRenderer`'s `!value` deliberately treats the epoch as empty. A single predicate over all of them would flip settled decisions. ⇒ **A shared predicate is reported, not built** — see "What a shared predicate would have to look like" below.

## Blast radius: 10 of 159 rendered outputs moved, and nothing else

Re-running the same census after the change, diffed row by row:

- **10 rows changed**, all in the `[]` block, all from a childless container to the shared `No value` affordance: `select`, `status`, `multiselect`, `radio`, `checkboxes`, `tags`, `lookup`, `master_detail`, `tree`, `user`.
- **0 rows changed** in the populated-array block.
- **0 rows changed** in the `{}` block.

## The consumers, verified by RENDERING

Each row is a real component rendered twice against the same fixture: once at HEAD, once with **ablation A** applied (the permissive guards restored verbatim, proved on disk and restored by state). Neither leg is inferred from the source.

| consumer | its own pre-check | BEFORE (ablation A) | AFTER (HEAD) |
|---|---|---|---|
| `ObjectGrid`, desktop table | none between `getCellRenderer(...)` and the raw value | the `[]` row painted a childless flex-wrap cell | one `No value` affordance in that row, **zero** in the populated row |
| `ObjectGrid`, card layout below 768px | none | same blank | affordance present, populated card still draws its badge |
| `ObjectGallery` | ⚠️ **it has one** — `ObjectGallery.tsx:571`, `if (value == null \|\| value === '') return null;` — with the SAME hole | **2** childless containers (`flex flex-wrap gap-1`, `flex -space-x-2`), **0** affordances | **0** childless, **2** affordances |
| `ObjectKanban` | ⚠️ **it has one** — `ObjectKanban.tsx:604`, `if (raw == null \|\| raw === '') continue;` — same hole | **3** childless containers, **0** affordances | **1** childless, **2** affordances — **2 of 3 fixed**, see below |

In every leg the populated card still drew its `Alpha` badge, so no leg is measuring an all-empty renderer.

⚠️ **ObjectKanban only PARTLY changes, and the part that does not is the common case.** Its card-field loop forks four lines after that guard: any field carrying declared `options` takes the board's **own** picklist-badge branch and never reaches a cell renderer at all. For `[]` that branch resolves an empty label and pushes a badge anyway, so the card renders a fully coloured pill with nothing in it. Measured on a real board: `topics` (multiselect, no options) and `owners` (user) now show the affordance; `tags` (multiselect **with** options) still shows an empty indigo pill — it is the one childless container left in the AFTER column above, and its class string is the badge pill's, not a renderer's. Filed as **objectui#8489** with the rendered evidence — deliberately not addressed here, because it is `plugin-kanban`'s own code and a different decision.

## ⚠️ Which of these cases an EMPTY-for-everything implementation would still pass

Stated explicitly, because the brief's pin says the vivid assertion is rarely the discriminating one — and it is right again here.

**Ablation B makes `isEmptyMultiValue` return `true` for every value** (strictly worse than the bug). Under it:

- ✅ **still green**: all ten `THE DEFECT — TYPE holding [] renders the No-value affordance` cases, **and** the desktop-grid case. The most quotable evidence in this PR — *ten field types across the shared renderer now say "No value"* — cannot tell the fix from its worst caricature.
- ❌ **red**: the four populated axes (`multiselect` badges, `lookup` chips, `user` avatars, a scalar `select` value), the one-entry-array axis, `THE BOUNDARY — {} is untouched`, the grid's `⚠️ DISCRIMINATING` populated row, and the mobile case (which carries a populated assertion of its own).

⇒ The brief predicted "a populated multiselect rendering its badges is the likely axis". Confirmed, and sharpened: it is **four** populated axes plus the `{}` boundary, and the single case red under **all three** ablations is the mobile one, because it is the only case that asserts both halves in one render.

Two cases discriminate against **nothing** and are honest about it: `THE BOUNDARY — json still draws the literal` and `THE BOUNDARY — file still states its count` stay green under A, B and C. They are scope declarations, not instruments — they exist so a later widening has to delete an assertion rather than merely forget a consideration.

## Ablations — mutation on disk proved both ways, restore proved BY STATE

Every mutation is on the **READ SITE**, from the committed implementation, under `trap … EXIT INT TERM` with absolute paths. Each proves it reached disk by hash **and** by removed/injected `grep -c` counts in both directions with the matched line printed; each restore is verified by `git hash-object` equal to `git rev-parse HEAD:PATH` **and** `git diff HEAD` empty — never by an exit code.

⚠️ No rebuild leg is needed and none is claimed: `vitest.config.mts:432` maps `@object-ui/fields` to `./packages/fields/src`, so the pins resolve the **source** these mutations edit. Ablation A reddening 12 rows is itself the proof that the tests read the mutated bytes rather than a stale `dist`.

HEAD blob for `packages/fields/src/index.tsx` = `b37e2c62150f6da348143abce3bd518085d62560`.

| ablation | mutated blob | result |
|---|---|---|
| **A** — restore the permissive guards (the bug, verbatim) | `0201d431761468c70bac6ea6e4a501e4150d8a88` | **12 of 21 red by name** |
| **B** — `isEmptyMultiValue` answers EMPTY for everything | `a8cfa76e38247f951742e7c7f78b8c3fd7ec0023` | **8 of 21 red by name** |
| **C** — `Array.isArray(value)` alone, so every array is EMPTY | `64711bb4f8246f5df6dc1127fc5c6bb41c866d53` | **6 of 21 red by name** |

**A** reddens all ten `THE DEFECT` rows plus the grid's `DESKTOP` and `MOBILE CARD VIEW`.
**B** reddens `NON-REGRESSION — a POPULATED multiselect…`, `…a POPULATED lookup…`, `…a POPULATED user field…`, `…a SCALAR select value…`, `…a ONE-entry array…`, `THE BOUNDARY — {} is untouched…`, `⚠️ DISCRIMINATING — the POPULATED row…` and `MOBILE CARD VIEW…`.
**C** reddens the same set minus `…a SCALAR select value…` (a scalar is not an array) and minus `THE BOUNDARY — {}…` (an object is not an array) — the two cases that separate "every array is empty" from "every value is empty".

## An instrument that had to be calibrated, recorded because it read backwards

The grid pin's first draft asserted "no childless flex-wrap element anywhere in the grid". It **failed against the correct implementation**: `ObjectGrid`'s toolbar renders a `div.flex.flex-wrap` that is legitimately empty when no filter chips are active. An unscoped structural assertion was reading the chrome. Every lookup in that file is now scoped to one ROW, and the reason is written into the file so the next reader does not un-scope it.

## What a shared predicate would have to look like (reported, not built)

⛔ `plugin-detail`'s `hasCellValue` was not imported — `@object-ui/fields` is upstream of it, and objectui#8459 measured that the two surfaces want different answers. Reporting the shape instead:

The five surfaces that have now each independently answered "is this empty" are `hasCellValue` (`plugin-detail`), `RelatedList.isValueEmpty` (`plugin-detail`), `ObjectGallery`'s inline guard, `ObjectKanban`'s inline guard, and this package's seven renderer guards. A predicate they could share would have to live below all of them — `@object-ui/types` or `@object-ui/core` — and it could only ever be the **weakest** common claim (`null`, `''`, `[]`), because every consumer legitimately extends it: the detail page also hides `{}`-shaped nothings, `JsonCellRenderer` deliberately does not. That is a real change with a real design decision in it, and it is bigger than this card.

## Tests

Run from the repo root, paths relative to the root, nothing after `--`.

- `pnpm exec vitest run packages/fields/` → **139 files / 2370 tests passed**, exit 0 (the changed package, in full)
- `pnpm exec vitest run packages/plugin-grid/ packages/plugin-detail/ packages/plugin-list/ packages/plugin-kanban/ packages/plugin-gantt/src/ObjectGantt.persistfilters.test.tsx` → **358 files / 3388 tests passed**, exit 0
- `pnpm exec vitest run packages/fields/src/__tests__/cellRenderers.emptyArray-8481.test.tsx` → **18/18**
- `pnpm exec vitest run packages/plugin-grid/src/__tests__/emptyArrayCell-8481.test.tsx` → **3/3**; 21/21 together, and 21/21 again after each ablation leg restored the tree
- closure build first: `pnpm --workspace-concurrency=2 --filter '@object-ui/fields^...' build` → exit 0, and later `--filter '@object-ui/plugin-grid^...' build` → exit 0
- `pnpm --filter @object-ui/fields run type-check` → exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`, script name echoed)
- `pnpm --filter @object-ui/plugin-grid run type-check` → exit 0
- `pnpm --filter @object-ui/fields run lint` → exit 0, `✖ 933 problems (0 errors, 933 warnings)`; the new test file adds 2, both the `as any` fixture cast every sibling test in that directory already uses
- `pnpm --filter @object-ui/plugin-grid run lint` → exit 0, `✖ 781 problems (0 errors, 781 warnings)`; the new test file adds 3, same cast
- `pnpm run check:control-bytes` → exit 0, `scanned 6716 tracked text file(s)`; plus a direct `grep -naP` scan of the four changed paths → **0 hits**, with a **lit control** that fired: a real U+0001 written into a scratch file matched the same class (a TAB would not have — that character is deliberately outside it)
- `pnpm run check:unreferenced-sources`, `check:self-import`, `check:vi-mock-specifiers`, `check:side-effects-array`, `check:esm-specifiers`, `check:handler-key-reads` → all exit 0
- **The exported surface did not move.** `packages/fields/dist/index.d.ts` after a real build: `isEmptyMultiValue` → **0** hits, control symbol `SelectCellRenderer` → **1** hit. The helper is private by measurement, not by intent alone.

⚠️ **Three gates read NOT MEASURED here, and none of them is a red.** `check:readme-exports`, `check:sdui-registration-pins` and `check:eager-closure` exited non-zero with `PREREQUISITE NOT MET`-shaped output — each prints `run pnpm build first` / `pnpm --filter @object-ui/console build` because it reads built `dist` artifacts, and this worktree has only the two dependency closures above built. Reported as unmeasured rather than as failures; CI builds the workspace and grades them properly. My first `plugin-grid` type-check run failed the same way (six `TS2307 Cannot find module` lines) and went green once its closure was built — recorded because that exact shape is what a real breakage would also look like.

**Declared narrowing.** `turbo ls --affected` against `7cf6f38fb` names **20** packages. I ran the changed package plus the four consumer packages that resolve cell renderers, and the narrowing is measured rather than guessed: grepping every test file in the workspace for an empty-array value on a multi-value field found exactly five candidates outside `packages/fields` — two in `plugin-detail`, two in `plugin-grid`, one in `plugin-gantt` — and all five are inside the runs above (the gantt one by explicit path). The rest of the 20 is left to CI.

## Changeset

`.changeset/8481-empty-array-is-not-a-cell-value.md`, `@object-ui/fields: minor`. This moves a **shared renderer's** rendered output for ten field types on every surface that does not pre-check, so it is user-visible; `minor` follows this repo's single-version-group convention and the landed precedent for a render change (objectui#8457, and objectui#8474 / objectui#8459 for the same defect family). ⛔ `major` is forbidden here (one fixed version group), and `skip-changeset` is a phantom label in this repo — no workflow or script reads it — so it was not applied.

The gate's own verdict line:

> `✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/8481-empty-array-is-not-a-cell-value.md.`

`node scripts/check-changeset-no-major.mjs` → `✅  No changeset declares a "major" bump.`

`node scripts/check-governed-queue-guard.mjs --test THE-FOUR-CHANGED-PATHS` (passed explicitly, never bare) → `✅ NOT GOVERNED — 4 path(s) checked against 5 governed surface(s); none matched.`

## Out-of-scope findings, filed unassigned

The `[]` census produced three defects outside this card's fence. All three were dedup-searched first; REST is 403 from this dev container, so one targeted MCP `search_issues` was used and is declared as a channel switch — it returned objectui#8481, objectui#8474 and objectui#8475 as live control hits.

- **objectui#8489** — `ObjectKanban`'s own picklist branch never reaches a cell renderer, so a picklist field holding `[]` still paints an **empty coloured badge pill**. The common case on a kanban board, and untouched by this PR.
- **objectui#8490** — eight `@object-ui/fields` renderers **fabricate** a value for `[]` rather than draw blank: a **checked checkbox** for `boolean`, the digit `0` for `number`/`currency`/`percent`, live `mailto:` / `tel:` / empty-href anchors with no text, and a colourless swatch. Different defect class from this card (wrong value, not no value) and a contested per-renderer ruling, not a mechanical fix.
- **objectui#8491** — `ObjectGrid` spells the empty placeholder by hand at three sites (lines 2479, 2497, 2697) instead of using `EmptyValue`, so those cells carry no `aria-label` and render one type size smaller and italic. Same class as objectui#8475; a repo-wide grep says those two files are the only carriers, so the class can be retired completely.

## Notes for review — what contradicts the brief

- ⭐ **The brief's stated reason for two consumers is wrong, while its conclusion is right.** It says `ObjectGallery` and `ObjectKanban` have "no emptiness predicate mentioned at all". Measured: each has one, and each carries the identical hole (`ObjectGallery.tsx:571`, `ObjectKanban.tsx:604`). They are not innocent pass-throughs — they are the **fourth and fifth** private re-answers of the same question. That strengthens the card's thesis rather than weakening it, but it changes what "the third consumer" means: there were already five.
- **The card as titled would have repaired one renderer of three.** `LookupCellRenderer` and `UserCellRenderer` carry the byte-identical defect in the same file, both reached by `ObjectGrid`, `ObjectGallery`, `ObjectKanban` and `ObjectDataTable`. Repairing only `SelectCellRenderer` would have left a `lookup` column and a `user` column blank on the very surfaces this card exists to protect.
- **A stale premise, in my favour.** Both the dispatch comment and PR #8482's body say PR #8476 (objectui#8459) is still open. It has **merged** — this branch is cut from `7cf6f38fb`, which *is* that merge commit — so `RelatedList.emptinessAgreement-8459.test.tsx` is on this base and ran green in the `plugin-detail` sweep above rather than being unavailable to lean on.
- `packages/spec` is not involved: this is a renderer-side emptiness decision, not a metadata contract, so contract-first (AGENTS.md #0.1) does not apply. Nothing here adds a lenient fallback for off-spec input — `[]` is a perfectly spec-valid stored value for a multi-value field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S


---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_