### PR TITLE
fix(core): execute the declared `$` operators in ValueDataSource, refuse the rest

### DIFF
--- a/.changeset/8447-valuedatasource-dollar-operator-refusal.md
+++ b/.changeset/8447-valuedatasource-dollar-operator-refusal.md
@@ -13,18 +13,26 @@ row and logs it; an object `$filter` went to `matchesFilter`, which admitted it 
 included the row. Same file, opposite defaults, and nothing told an author which dialect
 their filter took.
 
-**Now executed** — one arm per member of the spec's `FILTER_OPERATORS`, each answering
-the same question its AST twin already answered: `$eq`, `$ne`, `$gt`, `$gte`, `$lt`,
-`$lte`, `$in`, `$nin`, `$between`, `$contains`, `$icontains`, `$notContains`,
-`$startsWith`, `$endsWith`, `$null`. Eight of those were already implemented; the other
-seven selected every row. `$eq` is the sharpest of them: `{ age: { $eq: 26 } }` selected
-everything while the plain `{ age: 26 }` beside it was correct all along.
+**Now executed** — one arm per member of the spec's `FILTER_OPERATORS`, **all sixteen**,
+each answering the same question its AST twin already answered: `$eq`, `$ne`, `$gt`,
+`$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$between`, `$contains`, `$icontains`,
+`$notContains`, `$startsWith`, `$endsWith`, `$null`, `$exists`. Eight of those were
+already implemented; the other eight selected every row. `$eq` is the sharpest of them:
+`{ age: { $eq: 26 } }` selected everything while the plain `{ age: 26 }` beside it was
+correct all along. `$exists` is the exact inverse of `$null` — `$exists: true` is
+IS NOT NULL — which is the lowering `convertFiltersToAST` already performs, not a
+reading invented here.
+
+**The closed vocabulary matters more than any one arm.** Because nothing the spec
+declares is refused by name, the parity guard in the companion test can assert that the
+case table equals `FILTER_OPERATORS` *exactly* — so a future spec release that adds a
+`$` operator turns this file red instead of letting the new spelling reach the refusal
+arm unannounced. An operator parked on a refused list would have been a hole that guard
+could not see into.
 
 **Now refused** — excluded and logged once per distinct refusal per `find()`, in
-`matchesASTFilter`'s own idiom:
+`matchesASTFilter`'s own idiom. Everything here is OUTSIDE the declared vocabulary:
 
-- `$exists`, with a refusal that names the exact synonym this matcher does execute
-  (`$exists: true` is `$null: false`; `$exists: false` is `$null: true`).
 - `$like` / `$ilike`, declared by `StringOperatorSchema` but deliberately staged out of
   `FILTER_OPERATORS`; this matcher has no pattern engine.
 - `$regex` / `$options`, retired from the protocol — the refusal prints the spec's own
@@ -44,7 +52,7 @@ everything while the plain `{ age: 26 }` beside it was correct all along.
   this repair; the AST array `$filter`, which the sibling arm of `find()` already
   executes, is the door that works today.
 
-**Migration.** A filter that used any of the seven newly-executed operators was
+**Migration.** A filter that used any of the eight newly-executed operators was
 returning unfiltered data; it now returns the rows it names. A filter using a refused
 spelling now returns nothing and says why on the console — rewrite it in the canonical
 spelling the refusal prints, or express it as an AST array `$filter`.

--- a/.changeset/8447-valuedatasource-dollar-operator-refusal.md
+++ b/.changeset/8447-valuedatasource-dollar-operator-refusal.md
@@ -1,0 +1,50 @@
+---
+'@object-ui/core': minor
+---
+
+`ValueDataSource`'s object-dialect matcher executes the operators the spec declares and
+refuses the rest, instead of waving every unrecognised one through (objectui#8447).
+
+**Breaking, deliberately — this MOVES RESULTS.** `matchesFilter` ended its operator
+switch with `default: break`, which adds no constraint, so an unrecognised operator
+matched **every** row, silently. The asymmetry sat inside one `if` in `find()`: an
+array `$filter` goes to `matchesASTFilter`, which refuses an unknown node, excludes the
+row and logs it; an object `$filter` went to `matchesFilter`, which admitted it and
+included the row. Same file, opposite defaults, and nothing told an author which dialect
+their filter took.
+
+**Now executed** — one arm per member of the spec's `FILTER_OPERATORS`, each answering
+the same question its AST twin already answered: `$eq`, `$ne`, `$gt`, `$gte`, `$lt`,
+`$lte`, `$in`, `$nin`, `$between`, `$contains`, `$icontains`, `$notContains`,
+`$startsWith`, `$endsWith`, `$null`. Eight of those were already implemented; the other
+seven selected every row. `$eq` is the sharpest of them: `{ age: { $eq: 26 } }` selected
+everything while the plain `{ age: 26 }` beside it was correct all along.
+
+**Now refused** — excluded and logged once per distinct refusal per `find()`, in
+`matchesASTFilter`'s own idiom:
+
+- `$exists`, with a refusal that names the exact synonym this matcher does execute
+  (`$exists: true` is `$null: false`; `$exists: false` is `$null: true`).
+- `$like` / `$ilike`, declared by `StringOperatorSchema` but deliberately staged out of
+  `FILTER_OPERATORS`; this matcher has no pattern engine.
+- `$regex` / `$options`, retired from the protocol — the refusal prints the spec's own
+  `RETIRED_FILTER_OPERATORS` prescription verbatim, the way the driver-side refusal
+  sites do.
+- Lowercase aliases (`$startswith`, `$notcontains`, `$notin`) and the off-spec
+  `$ncontains`: the canonical `$` spellings are camelCase, and growing alias arms in the
+  renderer would fossilise a second dialect.
+- A nested relation constraint (`{ profile: { verified: true } }`), refused by the key
+  it could not read; this matcher does not descend into relations.
+- `$and` / `$or` / `$not`, which are combinators rather than field operators. `$and` and
+  `$or` carry an array and were already excluding every row through the equality branch,
+  silently — those rows do not move, only the silence does. `$not` carries an object, so
+  it entered the operator branch, its inner field names were read as operator names and
+  each hit `default: break`: it matched **every** row, and now matches none. Executing a
+  group in this dialect is a feature with its own semantics to settle and is not part of
+  this repair; the AST array `$filter`, which the sibling arm of `find()` already
+  executes, is the door that works today.
+
+**Migration.** A filter that used any of the seven newly-executed operators was
+returning unfiltered data; it now returns the rows it names. A filter using a refused
+spelling now returns nothing and says why on the console — rewrite it in the canonical
+spelling the refusal prints, or express it as an AST array `$filter`.

--- a/packages/core/src/adapters/README.md
+++ b/packages/core/src/adapters/README.md
@@ -78,6 +78,38 @@ It implements `$filter` (both MongoDB-style objects and FilterNode AST arrays),
 `aggregate()` and `onMutation()`. `getAll()` returns a cloned snapshot and
 `count` the current length.
 
+#### What `$filter` executes, and what it refuses
+
+`find()` picks a matcher on the SHAPE of `$filter` — a FilterNode **array** goes
+to the AST matcher, an **object** to the `$`-dialect matcher — and since
+objectui#8447 the two answer the same question and refuse in the same way.
+
+The object dialect executes one arm per member of the spec's `FILTER_OPERATORS`:
+
+```text
+$eq  $ne  $gt  $gte  $lt  $lte  $in  $nin  $between
+$contains  $icontains  $notContains  $startsWith  $endsWith  $null
+```
+
+`$contains`, `$notContains`, `$startsWith` and `$endsWith` are **case-sensitive**;
+`$icontains` is the one case-insensitive member and its fold is **ASCII-only**.
+`$null` takes its direction from the value: `$null: true` is IS NULL, `$null: false`
+is IS NOT NULL.
+
+Anything else is **refused**: the row is excluded and the reason is logged once per
+distinct refusal per `find()` — never passed through as "no constraint", which is
+what an unrecognised operator used to mean here. Refused on purpose, each with a
+prescription in the message:
+
+| spelling | why | write instead |
+| --- | --- | --- |
+| `$exists` | not executed here | `$null` (`$exists: true` is `$null: false`) |
+| `$like` / `$ilike` | declared, but staged out of `FILTER_OPERATORS`; no pattern engine in memory | `$contains` / `$icontains` |
+| `$regex` / `$options` | retired from the protocol | `$icontains` |
+| `$startswith`, `$notcontains`, `$notin`, `$ncontains` | non-canonical spellings | the camelCase spelling |
+| `$and` / `$or` / `$not` | combinators, not field operators | an AST array `$filter` |
+| `{ relation: { field: … } }` | this matcher does not descend into relations | filter on the stored key |
+
 ### `resolveDataSource`
 
 Turns a `ViewData` config into a concrete adapter. This is the function a

--- a/packages/core/src/adapters/README.md
+++ b/packages/core/src/adapters/README.md
@@ -88,13 +88,16 @@ The object dialect executes one arm per member of the spec's `FILTER_OPERATORS`:
 
 ```text
 $eq  $ne  $gt  $gte  $lt  $lte  $in  $nin  $between
-$contains  $icontains  $notContains  $startsWith  $endsWith  $null
+$contains  $icontains  $notContains  $startsWith  $endsWith  $null  $exists
 ```
+
+That is **all sixteen** — nothing the spec declares is refused by name.
 
 `$contains`, `$notContains`, `$startsWith` and `$endsWith` are **case-sensitive**;
 `$icontains` is the one case-insensitive member and its fold is **ASCII-only**.
 `$null` takes its direction from the value: `$null: true` is IS NULL, `$null: false`
-is IS NOT NULL.
+is IS NOT NULL. `$exists` is its exact inverse — `$exists: true` is IS NOT NULL — which
+is the lowering `convertFiltersToAST` already performs, not a reading invented here.
 
 Anything else is **refused**: the row is excluded and the reason is logged once per
 distinct refusal per `find()` — never passed through as "no constraint", which is
@@ -103,7 +106,6 @@ prescription in the message:
 
 | spelling | why | write instead |
 | --- | --- | --- |
-| `$exists` | not executed here | `$null` (`$exists: true` is `$null: false`) |
 | `$like` / `$ilike` | declared, but staged out of `FILTER_OPERATORS`; no pattern engine in memory | `$contains` / `$icontains` |
 | `$regex` / `$options` | retired from the protocol | `$icontains` |
 | `$startswith`, `$notcontains`, `$notin`, `$ncontains` | non-canonical spellings | the camelCase spelling |

--- a/packages/core/src/adapters/ValueDataSource.ts
+++ b/packages/core/src/adapters/ValueDataSource.ts
@@ -18,7 +18,11 @@ import type {
   AggregateParams,
   AggregateResult,
 } from '@object-ui/types';
-import { asciiCaseInsensitiveContains, canonicalAstOperator } from '@objectstack/spec/data';
+import {
+  asciiCaseInsensitiveContains,
+  canonicalAstOperator,
+  RETIRED_FILTER_OPERATORS,
+} from '@objectstack/spec/data';
 import { emulateBatchTransaction } from './batchTransaction.js';
 
 // ---------------------------------------------------------------------------
@@ -236,54 +240,182 @@ function matchesASTFilter(record: any, filterNode: any, refusals: Set<string>): 
 }
 
 /**
- * Simple in-memory filter evaluation.
- * Supports flat key-value equality and basic operators ($gt, $gte, $lt, $lte, $ne, $in).
+ * Evaluate ONE `$`-dialect operator against a record's value for a field.
+ *
+ * The vocabulary is the spec's own `FILTER_OPERATORS` (`@objectstack/spec/data`)
+ * and each arm answers the same question its AST twin answers in
+ * {@link matchesComparisonNode} — `$eq`/`=`, `$nin`/`nin`, `$startsWith`/
+ * `starts_with`, and so on, one-to-one across all sixteen. That pairing IS the
+ * fix for objectui#8447: `find()` picks between the two matchers on nothing
+ * more than whether `$filter` arrived as an array or an object, so any operator
+ * one of them executes and the other waves through is a result that changes
+ * with the SHAPE of the filter rather than with its meaning.
+ *
+ * ## What the `default` arm used to be
+ *
+ * `default: break` — which adds NO constraint. An operator this switch did not
+ * name therefore matched EVERY row, silently, while the array arm of the very
+ * same `if` refused the unknown node, excluded the row and logged it
+ * (objectui#7349). Measured before the fix: `$nin`, `$startsWith`, `$null` and
+ * `$exists` each returned the full set, and so did `$eq` — the most ordinary
+ * operator an author can reach for, whose plain-equality sibling
+ * (`{ age: 26 }`) was correct all along.
+ *
+ * The direction of the change is worth stating plainly, because it MOVES
+ * RESULTS: a filter that silently selected everything now selects the rows it
+ * names, and one this matcher cannot execute selects nothing and says so. Both
+ * are louder than what they replace; neither is "match everything", which was
+ * nobody's intent.
+ *
+ * ## What is refused, and why each one
+ *
+ * - **`$exists`** — refused rather than implemented, and the refusal names the
+ *   exact synonym that works. `$exists: true` is `$null: false` and
+ *   `$exists: false` is `$null: true` (`convertFiltersToAST`,
+ *   `../utils/filter-converter.ts`), so nothing is unreachable through it.
+ * - **`$like` / `$ilike`** — declared by `StringOperatorSchema` but deliberately
+ *   kept OUT of `FILTER_OPERATORS` while the faces that cannot execute them are
+ *   staged in (objectstack#7536). This matcher has no pattern engine, and the
+ *   spec's own note says naming them before an arm exists turns a loud refusal
+ *   into a dropped predicate — i.e. every row, the defect this file just fixed.
+ * - **`$regex` / `$options`** — RETIRED from the protocol (objectstack#4706).
+ *   The refusal prints `RETIRED_FILTER_OPERATORS`' prescription verbatim, the
+ *   way the five driver-side refusal sites do, so six faces say one thing.
+ * - **Anything else**, including a nested relation constraint
+ *   (`{ profile: { verified: true } }`), whose keys are field names rather than
+ *   operators: this matcher does not descend into relations.
  */
-function matchesFilter(record: any, filter: Record<string, any>): boolean {
+function matchesDollarOperator(
+  value: any,
+  operator: string,
+  target: any,
+  field: string,
+  refusals: Set<string>,
+): boolean {
+  switch (operator) {
+    case '$eq':
+      return value === target;
+    case '$ne':
+      return value !== target;
+    case '$gt':
+      return value > target;
+    case '$gte':
+      return value >= target;
+    case '$lt':
+      return value < target;
+    case '$lte':
+      return value <= target;
+    case '$in':
+      return Array.isArray(target) && target.includes(value);
+    case '$nin':
+      return Array.isArray(target) && !target.includes(value);
+    case '$between':
+      return Array.isArray(target) && target.length === 2
+        && value >= target[0] && value <= target[1];
+    // -- Text operators. Same ruling the AST arms carry (objectstack#4706 Q2):
+    // the `$contains` family is case-SENSITIVE and `$icontains` is its one
+    // case-insensitive member, folding ASCII only on both sides.
+    case '$contains':
+      return typeof value === 'string' && value.includes(String(target));
+    case '$icontains':
+      return typeof value === 'string' && asciiCaseInsensitiveContains(value, String(target));
+    case '$notContains':
+      return typeof value === 'string' && !value.includes(String(target));
+    case '$startsWith':
+      return typeof value === 'string' && value.startsWith(String(target));
+    case '$endsWith':
+      return typeof value === 'string' && value.endsWith(String(target));
+    // -- Null-ness. Unlike the AST spelling, direction comes from the VALUE:
+    // `$null: true` is IS NULL and `$null: false` is IS NOT NULL, which is the
+    // lowering `convertFiltersToAST` already performs.
+    case '$null':
+      return target
+        ? value === null || value === undefined
+        : value !== null && value !== undefined;
+
+    case '$exists':
+      return refuseFilterNode(
+        refusals,
+        `filter operator '$exists' on field '${field}' is not executed by the in-memory `
+        + `matcher; write { ${field}: { $null: ${target ? 'false' : 'true'} } }, which this `
+        + `matcher executes and which the platform lowers $exists to`,
+      );
+
+    default: {
+      const retired = RETIRED_FILTER_OPERATORS[operator];
+      if (retired) {
+        return refuseFilterNode(
+          refusals,
+          `filter operator '${operator}' on field '${field}' is retired. ${retired.why}`,
+        );
+      }
+      if (!operator.startsWith('$')) {
+        return refuseFilterNode(
+          refusals,
+          `filter condition on field '${field}' carries the non-operator key `
+          + `'${operator}'; the in-memory matcher does not descend into a nested `
+          + `relation constraint`,
+        );
+      }
+      return refuseFilterNode(
+        refusals,
+        `filter operator '${operator}' on field '${field}' is not implemented by the `
+        + `in-memory matcher`,
+      );
+    }
+  }
+}
+
+/**
+ * In-memory evaluation of an OBJECT-shaped (`$`-dialect) filter.
+ *
+ * Reads a flat key/value equality (`{ age: 26 }`) or a `FieldOperatorsSchema`
+ * condition object (`{ age: { $gte: 25 } }`), one entry per field, ANDed. What
+ * it cannot execute it refuses through {@link refuseFilterNode} — excluded and
+ * logged once per distinct refusal per `find()` — rather than adding no
+ * constraint, which is what its `default: break` used to do (objectui#8447).
+ *
+ * ## Combinators are refused here, not implemented (objectui#8447, its own case)
+ *
+ * `$and` / `$or` / `$not` are `LOGICAL_OPERATORS`, not field names, and this
+ * matcher has no grouping. They were already excluded-and-silent in two of
+ * three cases before this card and fail-OPEN in the third, which is why they
+ * get an arm now rather than being swept into the operator fix:
+ *
+ * - `{ $and: [...] }` / `{ $or: [...] }` carry an ARRAY, so they fell to the
+ *   simple-equality branch below (`record['$and'] !== [...]` is always true) and
+ *   excluded every row with no diagnostic. The rows do not move; the silence does.
+ * - `{ $not: {...} }` carries an OBJECT (`FilterConditionSchema`, not an array),
+ *   so it entered the operator branch, its inner FIELD names were read as
+ *   operator names, and every one of them hit `default: break`. It therefore
+ *   matched EVERY row — the same fail-open direction as the operators, and the
+ *   one behaviour here whose result changes.
+ *
+ * Executing them is a feature with its own semantics to settle (the empty-group
+ * identities and `$not`'s NULL-safe rule, objectstack#5146 / #5322), not part of
+ * this repair. An author who needs a group today writes the AST array `$filter`,
+ * which the sibling arm of `find()` already executes.
+ */
+function matchesFilter(
+  record: any,
+  filter: Record<string, any>,
+  refusals: Set<string>,
+): boolean {
   for (const [key, condition] of Object.entries(filter)) {
+    if (key.startsWith('$')) {
+      return refuseFilterNode(
+        refusals,
+        `filter combinator '${key}' is not implemented by the object-dialect matcher; `
+        + `express the group as an AST array $filter, which this adapter executes`,
+      );
+    }
+
     const value = record[key];
 
     if (condition && typeof condition === 'object' && !Array.isArray(condition)) {
-      // Operator-based filter
+      // Operator-based filter — every operator on the field is ANDed.
       for (const [op, target] of Object.entries(condition)) {
-        switch (op) {
-          case '$gt':
-            if (!(value > (target as any))) return false;
-            break;
-          case '$gte':
-            if (!(value >= (target as any))) return false;
-            break;
-          case '$lt':
-            if (!(value < (target as any))) return false;
-            break;
-          case '$lte':
-            if (!(value <= (target as any))) return false;
-            break;
-          case '$ne':
-            if (value === target) return false;
-            break;
-          case '$in':
-            if (!Array.isArray(target) || !target.includes(value)) return false;
-            break;
-          // The `$` dialect of the same ruling the AST arms carry
-          // (objectui#7379): `$contains` is case-SENSITIVE, `$icontains` is the
-          // case-insensitive one, and the fold is ASCII-only on both sides.
-          // This arm lower-cased both sides, so the two spellings named one
-          // predicate here too — and `$icontains` had no arm at all, which in
-          // this switch means the `default` below and therefore NO constraint:
-          // a case-insensitive filter selected every row. Making `$contains`
-          // exact without adding its twin would have left the dialect with no
-          // working case-insensitive door.
-          case '$contains':
-            if (typeof value !== 'string' || !value.includes(String(target))) return false;
-            break;
-          case '$icontains':
-            if (typeof value !== 'string'
-              || !asciiCaseInsensitiveContains(value, String(target))) return false;
-            break;
-          default:
-            break;
-        }
+        if (!matchesDollarOperator(value, op, target, key, refusals)) return false;
       }
     } else {
       // Simple equality
@@ -399,15 +531,20 @@ export class ValueDataSource<T = any> implements DataSource<T> {
 
     // Filter — support both MongoDB-style objects and AST-format arrays
     if (params?.$filter) {
+      // ONE collector for BOTH arms, drained after the pass: a node either
+      // matcher refuses would otherwise log once PER ROW. Shared on purpose —
+      // the two arms differ only in the SHAPE of `$filter`, and objectui#8447
+      // was exactly the asymmetry of one arm refusing loudly while the other
+      // waved everything through in silence.
+      const refusals = new Set<string>();
       if (Array.isArray(params.$filter) && params.$filter.length > 0) {
-        // One collector per `find()`, drained after the pass: a node the matcher
-        // refuses would otherwise log once PER ROW.
-        const refusals = new Set<string>();
         result = result.filter((r) => matchesASTFilter(r, params.$filter as any[], refusals));
-        for (const message of refusals) console.warn(message);
       } else if (!Array.isArray(params.$filter) && Object.keys(params.$filter).length > 0) {
-        result = result.filter((r) => matchesFilter(r, params.$filter!));
+        result = result.filter(
+          (r) => matchesFilter(r, params.$filter as Record<string, any>, refusals),
+        );
       }
+      for (const message of refusals) console.warn(message);
     }
 
     // Search (simple text search across all string fields)

--- a/packages/core/src/adapters/ValueDataSource.ts
+++ b/packages/core/src/adapters/ValueDataSource.ts
@@ -245,7 +245,8 @@ function matchesASTFilter(record: any, filterNode: any, refusals: Set<string>): 
  * The vocabulary is the spec's own `FILTER_OPERATORS` (`@objectstack/spec/data`)
  * and each arm answers the same question its AST twin answers in
  * {@link matchesComparisonNode} — `$eq`/`=`, `$nin`/`nin`, `$startsWith`/
- * `starts_with`, and so on, one-to-one across all sixteen. That pairing IS the
+ * `starts_with`, and so on, one-to-one across ALL SIXTEEN: every declared
+ * operator is executed here, none is refused by name. That pairing IS the
  * fix for objectui#8447: `find()` picks between the two matchers on nothing
  * more than whether `$filter` arrived as an array or an object, so any operator
  * one of them executes and the other waves through is a result that changes
@@ -269,10 +270,11 @@ function matchesASTFilter(record: any, filterNode: any, refusals: Set<string>): 
  *
  * ## What is refused, and why each one
  *
- * - **`$exists`** — refused rather than implemented, and the refusal names the
- *   exact synonym that works. `$exists: true` is `$null: false` and
- *   `$exists: false` is `$null: true` (`convertFiltersToAST`,
- *   `../utils/filter-converter.ts`), so nothing is unreachable through it.
+ * Nothing the spec DECLARES is on this list — `REFUSED_OPERATORS` in the
+ * companion test is empty, so the `FILTER_OPERATORS` parity guard covers the
+ * whole published vocabulary rather than a subset of it. What follows is
+ * everything OUTSIDE that vocabulary.
+ *
  * - **`$like` / `$ilike`** — declared by `StringOperatorSchema` but deliberately
  *   kept OUT of `FILTER_OPERATORS` while the faces that cannot execute them are
  *   staged in (objectstack#7536). This matcher has no pattern engine, and the
@@ -333,13 +335,22 @@ function matchesDollarOperator(
         ? value === null || value === undefined
         : value !== null && value !== undefined;
 
+    // `$exists` is the exact INVERSE of `$null`, and that is the platform's own
+    // reading rather than one invented here: `convertFiltersToAST`
+    // (`../utils/filter-converter.ts`) lowers `$exists: true` to `is_not_null`
+    // and `$exists: false` to `is_null`, three lines below where it lowers
+    // `$null` the other way round. Both operators are absent from that file's
+    // `convertOperatorToAST` map and both are special-cased BEFORE it, so that
+    // map's silence is not a decision about either of them. Two producers in
+    // this repo emit `$exists` — `FilterConditionField`'s `exists` /
+    // `notExists` (kept reachable on purpose by objectui#4736) and
+    // `datasetFilterCondition`'s `isEmpty` / `isNotEmpty` — so refusing it
+    // would have turned "every row" into "no rows" on a filter that looks like
+    // it works, which is the one outcome worse than the bug.
     case '$exists':
-      return refuseFilterNode(
-        refusals,
-        `filter operator '$exists' on field '${field}' is not executed by the in-memory `
-        + `matcher; write { ${field}: { $null: ${target ? 'false' : 'true'} } }, which this `
-        + `matcher executes and which the platform lowers $exists to`,
-      );
+      return target
+        ? value !== null && value !== undefined
+        : value === null || value === undefined;
 
     default: {
       const retired = RETIRED_FILTER_OPERATORS[operator];

--- a/packages/core/src/adapters/__tests__/ValueDataSource.dollarFilterVocabulary.test.ts
+++ b/packages/core/src/adapters/__tests__/ValueDataSource.dollarFilterVocabulary.test.ts
@@ -1,0 +1,417 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8447 — the OBJECT (`$`-dialect) matcher executes the operators the
+ * spec declares, and refuses the rest instead of waving them through.
+ *
+ * ## The defect these cases have to be able to see
+ *
+ * `find()` picks its matcher on nothing but the SHAPE of `$filter` — two arms
+ * of one `if`. The array arm (`matchesASTFilter`) refuses an unknown node,
+ * excludes the row and logs; the object arm (`matchesFilter`) ended its switch
+ * with `default: break`, which adds NO constraint, so an unrecognised operator
+ * selected EVERY row in silence. Same file, opposite defaults, and nothing
+ * tells an author which dialect their filter took.
+ *
+ * ## Why every case is a non-empty PROPER subset
+ *
+ * Two wrong implementations have to fail here, not one:
+ *
+ * 1. **the bug** — no constraint, so the answer is the full set;
+ * 2. **the caricature** — a matcher that answers `false` for everything, so the
+ *    answer is the empty set. It is strictly WORSE than the bug and it passes
+ *    every assertion whose expected value is `[]`.
+ *
+ * A row-set equality against a non-empty proper subset of `ROW_IDS` is red for
+ * both. The refusal cases below, whose expected row set IS empty, therefore
+ * carry the `console.warn` assertion as the half that discriminates: the
+ * caricature refuses nothing, so it logs nothing.
+ *
+ * Both were RUN, not reasoned about:
+ *
+ * | ablation | red | green |
+ * |---|---|---|
+ * | the bug — `ValueDataSource.ts` restored to its pre-card bytes | 37 | 24 |
+ * | the caricature — `matchesFilter` returns `false` unconditionally | 54 | 7 |
+ *
+ * The seven survivors of the caricature are named rather than counted, because
+ * which ones survive is the finding: the two `{}` cases and the AST-group case
+ * never reach `matchesFilter` at all, the `FILTER_OPERATORS` parity guard reads
+ * no rows, and the remaining three are the card's own `$nin` / `$startsWith` /
+ * `$null` examples — the quotable ones, and they cannot tell this fix from an
+ * empty result set. They are kept in §5 and labelled as a scope declaration.
+ *
+ * Assertions name ROWS (`['a','c']`), never a container shape (objectui#8495).
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { FILTER_OPERATORS } from '@objectstack/spec/data';
+import { ValueDataSource } from '../ValueDataSource';
+
+/**
+ * Three rows: two share a `role`, the ages straddle every bound used below, and
+ * `nickname` is present / null / absent so the null-ness arms discriminate.
+ */
+const ROWS = [
+  { id: 'a', role: 'admin', age: 30, nickname: 'ace' },
+  { id: 'b', role: 'user', age: 25, nickname: null },
+  { id: 'c', role: 'admin', age: 20 },
+];
+
+/** What the BUG answers for every case below. No expectation may equal it. */
+const ROW_IDS = ['a', 'b', 'c'];
+
+async function selectedIds(
+  filter: unknown,
+  rows: Array<Record<string, unknown>> = ROWS,
+): Promise<string[]> {
+  const ds = new ValueDataSource({ items: rows });
+  const result = await ds.find('rows', { $filter: filter as any });
+  return result.data.map((r) => r.id as string);
+}
+
+/** Spy that returns the calls, so a case can assert BOTH the rows and the log. */
+function spyWarn() {
+  return vi.spyOn(console, 'warn').mockImplementation(() => {});
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// 0. Live controls — the harness itself discriminates
+// ---------------------------------------------------------------------------
+
+describe('objectui#8447 — live controls', () => {
+  it('the plain-equality arm, which was correct all along, still selects', async () => {
+    const warn = spyWarn();
+    expect(await selectedIds({ role: 'admin' })).toEqual(['a', 'c']);
+    expect(await selectedIds({ age: 25 })).toEqual(['b']);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('a genuinely matching row still comes back', async () => {
+    expect(await selectedIds({ id: 'b' })).toEqual(['b']);
+  });
+
+  it('the broken answer is the full set, so every case below discriminates', async () => {
+    expect(await selectedIds({})).toEqual(ROW_IDS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 1. Every declared operator this matcher executes
+// ---------------------------------------------------------------------------
+
+/**
+ * One case per EXECUTED member of the spec's `FILTER_OPERATORS`, each paired
+ * with the AST spelling of the same question. Both halves matter:
+ *
+ *   - the row set proves the operator constrains (vs. the bug) and selects
+ *     something (vs. the caricature);
+ *   - the AST twin proves the two arms of `find()`'s `if` now answer the same
+ *     question, which is this card's objective rather than "add the missing
+ *     arms" — adding arms alone leaves the next unrecognised spelling on the
+ *     permissive side.
+ */
+const EXECUTED_CASES: Record<
+  string,
+  { filter: Record<string, unknown>; ast: unknown[]; expected: string[] }
+> = {
+  $eq: { filter: { role: { $eq: 'admin' } }, ast: ['role', '=', 'admin'], expected: ['a', 'c'] },
+  $ne: { filter: { role: { $ne: 'admin' } }, ast: ['role', '!=', 'admin'], expected: ['b'] },
+  $gt: { filter: { age: { $gt: 24 } }, ast: ['age', '>', 24], expected: ['a', 'b'] },
+  $gte: { filter: { age: { $gte: 25 } }, ast: ['age', '>=', 25], expected: ['a', 'b'] },
+  $lt: { filter: { age: { $lt: 25 } }, ast: ['age', '<', 25], expected: ['c'] },
+  $lte: { filter: { age: { $lte: 25 } }, ast: ['age', '<=', 25], expected: ['b', 'c'] },
+  $in: { filter: { role: { $in: ['admin'] } }, ast: ['role', 'in', ['admin']], expected: ['a', 'c'] },
+  $nin: { filter: { role: { $nin: ['admin'] } }, ast: ['role', 'nin', ['admin']], expected: ['b'] },
+  $between: {
+    filter: { age: { $between: [24, 31] } },
+    ast: ['age', 'between', [24, 31]],
+    expected: ['a', 'b'],
+  },
+  $contains: {
+    filter: { role: { $contains: 'dmi' } },
+    ast: ['role', 'contains', 'dmi'],
+    expected: ['a', 'c'],
+  },
+  $icontains: {
+    filter: { role: { $icontains: 'ADMI' } },
+    ast: ['role', 'icontains', 'ADMI'],
+    expected: ['a', 'c'],
+  },
+  $notContains: {
+    filter: { role: { $notContains: 'dmi' } },
+    ast: ['role', 'not_contains', 'dmi'],
+    expected: ['b'],
+  },
+  $startsWith: {
+    filter: { role: { $startsWith: 'adm' } },
+    ast: ['role', 'starts_with', 'adm'],
+    expected: ['a', 'c'],
+  },
+  $endsWith: {
+    filter: { role: { $endsWith: 'min' } },
+    ast: ['role', 'ends_with', 'min'],
+    expected: ['a', 'c'],
+  },
+  // `$null` takes its direction from the VALUE, not from the operator name —
+  // the lowering `convertFiltersToAST` performs. Both directions are cases.
+  $null: {
+    filter: { nickname: { $null: true } },
+    ast: ['nickname', 'is_null'],
+    expected: ['b', 'c'],
+  },
+};
+
+/** Refused on purpose. Every one carries its reason in the refusal cases below. */
+const REFUSED_OPERATORS = ['$exists'];
+
+describe('objectui#8447 — every executed operator constrains', () => {
+  it.each(Object.entries(EXECUTED_CASES))(
+    '`%s` selects the rows it names rather than every row',
+    async (_op, { filter, expected }) => {
+      const warn = spyWarn();
+      const ids = await selectedIds(filter);
+      expect(ids).toEqual(expected);
+      // Executed, not refused. The row-set assertion already fails on a
+      // refusal; this names WHICH failure it is.
+      expect(warn).not.toHaveBeenCalled();
+    },
+  );
+
+  it('`$null: false` is the other direction of the same operator', async () => {
+    const warn = spyWarn();
+    expect(await selectedIds({ nickname: { $null: false } })).toEqual(['a']);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it.each(Object.entries(EXECUTED_CASES))(
+    '`%s` answers the same rows as its AST twin — the two arms of find() agree',
+    async (_op, { filter, ast, expected }) => {
+      expect(await selectedIds(filter)).toEqual(await selectedIds(ast));
+      // Pinned to the literal set as well, so the case cannot pass by both
+      // arms being wrong in the same direction.
+      expect(await selectedIds(ast)).toEqual(expected);
+    },
+  );
+
+  it('the case table covers FILTER_OPERATORS exactly — none drops out unnoticed', () => {
+    // A parity guard against spec drift: when a release adds a `$` operator,
+    // this goes red instead of the new operator reaching the refusal arm
+    // unannounced — or, before this card, selecting every row.
+    expect([...FILTER_OPERATORS].sort()).toEqual(
+      [...Object.keys(EXECUTED_CASES), ...REFUSED_OPERATORS].sort(),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Composition — several operators, several fields
+// ---------------------------------------------------------------------------
+
+describe('objectui#8447 — operators compose without losing a constraint', () => {
+  it('two operators on ONE field are ANDed', async () => {
+    expect(await selectedIds({ age: { $gte: 21, $lte: 29 } })).toEqual(['b']);
+  });
+
+  it('an executed operator beside an unexecutable one refuses the whole row', async () => {
+    // The failure direction that matters: dropping the unreadable half would
+    // WIDEN the answer to `['a','b']`, which is the defect one level down.
+    const warn = spyWarn();
+    expect(await selectedIds({ age: { $gte: 21, $zzz: 1 } })).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('two fields are ANDed, mixing the equality arm and the operator arm', async () => {
+    expect(await selectedIds({ role: 'admin', age: { $gt: 24 } })).toEqual(['a']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Refusal — the arm that used to be `default: break`
+// ---------------------------------------------------------------------------
+
+describe('objectui#8447 — what the matcher cannot execute, it refuses', () => {
+  it('an unknown operator excludes every row and logs ONCE for the whole find()', async () => {
+    const warn = spyWarn();
+    expect(await selectedIds({ role: { $zzz: 'admin' } })).toEqual([]);
+    // One line for three rows: refusals are collected per `find()`, not per row.
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('$zzz');
+  });
+
+  it('`$exists` is refused and the refusal prescribes the synonym that works', async () => {
+    const warn = spyWarn();
+    expect(await selectedIds({ nickname: { $exists: true } })).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = String(warn.mock.calls[0]?.[0]);
+    expect(message).toContain('$exists');
+    expect(message).toContain('$null: false');
+  });
+
+  it('`$exists: false` prescribes the other direction', async () => {
+    const warn = spyWarn();
+    expect(await selectedIds({ nickname: { $exists: false } })).toEqual([]);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('$null: true');
+  });
+
+  it('the prescription `$exists` points at is itself executed', async () => {
+    // The refusal is only honest if the alternative works. `$exists: true` is
+    // `$null: false` and `$exists: false` is `$null: true`.
+    expect(await selectedIds({ nickname: { $null: false } })).toEqual(['a']);
+    expect(await selectedIds({ nickname: { $null: true } })).toEqual(['b', 'c']);
+  });
+
+  it.each(['$like', '$ilike'])(
+    '`%s` — declared by the schema but staged OUT of FILTER_OPERATORS — refuses',
+    async (op) => {
+      const warn = spyWarn();
+      expect(await selectedIds({ role: { [op]: 'adm%' } })).toEqual([]);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0])).toContain(op);
+    },
+  );
+
+  it('`$regex` refuses with the retired-operator prescription, verbatim', async () => {
+    const warn = spyWarn();
+    expect(await selectedIds({ role: { $regex: 'adm.n' } })).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = String(warn.mock.calls[0]?.[0]);
+    expect(message).toContain('$regex');
+    // The spec's own table is what six faces now print, rather than six sentences.
+    expect(message).toContain('$icontains');
+  });
+
+  it('`$options`, the retired regex-flags companion, refuses too', async () => {
+    const warn = spyWarn();
+    expect(await selectedIds({ role: { $options: 'i' } })).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['$startswith', '$notcontains', '$notin'])(
+    'the lowercase alias `%s` is refused, not silently accepted',
+    async (op) => {
+      // Contract-first (AGENTS.md #0.1): the canonical `$` spellings are
+      // camelCase. Growing an alias arm here would fossilise a second dialect
+      // in the renderer; refusing is loud and points the author at the spec.
+      const warn = spyWarn();
+      expect(await selectedIds({ role: { [op]: 'adm' } })).toEqual([]);
+      expect(warn).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('`$ncontains`, the off-spec spelling one widget used to emit, refuses', async () => {
+    const warn = spyWarn();
+    expect(await selectedIds({ role: { $ncontains: 'dmi' } })).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('a nested relation constraint is refused by NAME rather than ignored', async () => {
+    // `{ profile: { verified: true } }` and an operator object are the same
+    // SHAPE — the spec says so, which is why `FilterConditionSchema` cannot
+    // narrow to a closed vocabulary. This matcher does not descend into
+    // relations, so it says which key it could not read.
+    const warn = spyWarn();
+    expect(await selectedIds({ profile: { verified: true } })).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('verified');
+  });
+
+  it('an empty filter still means "no filter"', async () => {
+    const warn = spyWarn();
+    expect(await selectedIds({})).toEqual(ROW_IDS);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Combinators — refused as their own case, NOT implemented
+// ---------------------------------------------------------------------------
+
+describe('objectui#8447 — `$and` / `$or` / `$not` are refused, and say so', () => {
+  it('`$not` moves results: it matched EVERY row before this card', async () => {
+    // The one combinator that was fail-OPEN. Its value is an OBJECT
+    // (`FilterConditionSchema`), so it entered the operator branch, its inner
+    // FIELD names were read as operator names, and each hit `default: break`.
+    const warn = spyWarn();
+    expect(await selectedIds({ $not: { role: 'admin' } })).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('$not');
+  });
+
+  it.each(['$and', '$or'])(
+    '`%s` keeps excluding every row, but no longer in silence',
+    async (op) => {
+      // Their value is an ARRAY, so they fell to the simple-equality branch and
+      // were already fail-CLOSED. The rows do not move here; the silence does.
+      const warn = spyWarn();
+      expect(await selectedIds({ [op]: [{ role: 'admin' }] })).toEqual([]);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0])).toContain(op);
+    },
+  );
+
+  it('the AST array dialect is the door that DOES execute a group', async () => {
+    // The refusal names this as the alternative, so it has to be true.
+    expect(await selectedIds(['or', ['role', '=', 'user'], ['age', '>', 28]])).toEqual(['a', 'b']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. The card's own measured examples
+// ---------------------------------------------------------------------------
+
+/**
+ * ⚠️ SCOPE DECLARATION, NOT PROOF.
+ *
+ * These are the four readings objectui#8447 was filed with, reproduced on the
+ * two rows it used. Three of the four expect an EMPTY result, so a matcher that
+ * answered `false` for everything — strictly worse than the bug — passes them.
+ * MEASURED, not predicted: under that caricature exactly these three stayed
+ * green and the fourth (`$exists`, which asserts the refusal was LOGGED) went
+ * red. They are kept because they are the card's own words and someone will
+ * look for them, not because they measure the fix. The discriminating cases
+ * are §1-§4.
+ */
+describe('objectui#8447 — the card’s measured examples (scope declaration)', () => {
+  const CARD_ROWS = [
+    { id: 'n', score: 5 },
+    { id: 's', score: '5' },
+  ];
+
+  it('`$nin [5, "5"]` selects neither row', async () => {
+    expect(await selectedIds({ score: { $nin: [5, '5'] } }, CARD_ROWS)).toEqual([]);
+  });
+
+  it('`$startsWith "zzz"` selects neither row', async () => {
+    expect(await selectedIds({ score: { $startsWith: 'zzz' } }, CARD_ROWS)).toEqual([]);
+  });
+
+  it('`$null true` selects neither row — both have the key', async () => {
+    expect(await selectedIds({ score: { $null: true } }, CARD_ROWS)).toEqual([]);
+  });
+
+  it('`$exists false` selects neither row, and now logs why', async () => {
+    // The one of the four that DOES discriminate against the caricature: it
+    // refuses, and a matcher that answers `false` for everything refuses
+    // nothing and logs nothing.
+    const warn = spyWarn();
+    expect(await selectedIds({ score: { $exists: false } }, CARD_ROWS)).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('the complements of the first three DO select — the fix is not "exclude everything"', async () => {
+    expect(await selectedIds({ score: { $in: [5, '5'] } }, CARD_ROWS)).toEqual(['n', 's']);
+    expect(await selectedIds({ score: { $startsWith: '5' } }, CARD_ROWS)).toEqual(['s']);
+    expect(await selectedIds({ score: { $null: false } }, CARD_ROWS)).toEqual(['n', 's']);
+  });
+});

--- a/packages/core/src/adapters/__tests__/ValueDataSource.dollarFilterVocabulary.test.ts
+++ b/packages/core/src/adapters/__tests__/ValueDataSource.dollarFilterVocabulary.test.ts
@@ -33,19 +33,31 @@
  * carry the `console.warn` assertion as the half that discriminates: the
  * caricature refuses nothing, so it logs nothing.
  *
- * Both were RUN, not reasoned about:
+ * Both were RUN, not reasoned about, and both were RE-RUN after the contract
+ * review flipped `$exists` from refused to executed — the survivor list is not
+ * carried forward across that edit, because the edit changes the shape of one
+ * of the assertions in it:
  *
- * | ablation | red | green |
- * |---|---|---|
- * | the bug — `ValueDataSource.ts` restored to its pre-card bytes | 37 | 24 |
- * | the caricature — `matchesFilter` returns `false` unconditionally | 54 | 7 |
+ * | ablation | red | green | of |
+ * |---|---|---|---|
+ * | the bug — `ValueDataSource.ts` restored to its pre-card bytes | 38 | 24 | 62 |
+ * | the caricature — `matchesFilter` returns `false` unconditionally | 54 | 8 | 62 |
  *
- * The seven survivors of the caricature are named rather than counted, because
+ * The eight survivors of the caricature are named rather than counted, because
  * which ones survive is the finding: the two `{}` cases and the AST-group case
  * never reach `matchesFilter` at all, the `FILTER_OPERATORS` parity guard reads
- * no rows, and the remaining three are the card's own `$nin` / `$startsWith` /
- * `$null` examples — the quotable ones, and they cannot tell this fix from an
- * empty result set. They are kept in §5 and labelled as a scope declaration.
+ * no rows, and the remaining FOUR are the card's own `$nin` / `$startsWith` /
+ * `$null` / `$exists` examples — the quotable ones, and they cannot tell this
+ * fix from an empty result set. They are kept in §5 and labelled as a scope
+ * declaration.
+ *
+ * ⚠️ **The one mover across the flip**, measured rather than predicted:
+ * `$exists false selects neither row` was RED under the caricature before the
+ * flip and is GREEN after it. Nothing else moved — the red count is 54 in both
+ * runs. It discriminated only because it asserted the refusal was LOGGED, and
+ * executing the operator removed the log. §5 therefore has no case left that
+ * tells the fix from the caricature EXCEPT its last one, which asserts the
+ * complement of all four and is four non-empty answers.
  *
  * Assertions name ROWS (`['a','c']`), never a container shape (objectui#8495).
  */
@@ -170,10 +182,23 @@ const EXECUTED_CASES: Record<
     ast: ['nickname', 'is_null'],
     expected: ['b', 'c'],
   },
+  // The exact INVERSE of `$null`, and the platform's own reading of it:
+  // `convertFiltersToAST` lowers `$exists: true` to `is_not_null` three lines
+  // below where it lowers `$null: true` to `is_null`.
+  $exists: {
+    filter: { nickname: { $exists: true } },
+    ast: ['nickname', 'is_not_null'],
+    expected: ['a'],
+  },
 };
 
-/** Refused on purpose. Every one carries its reason in the refusal cases below. */
-const REFUSED_OPERATORS = ['$exists'];
+/**
+ * EMPTY, and that is the point of the parity guard below rather than an
+ * accident: every operator the spec DECLARES is executed, so the guard covers
+ * the whole published vocabulary instead of a subset of it. An operator parked
+ * here would be a hole the guard could not see into.
+ */
+const REFUSED_OPERATORS: string[] = [];
 
 describe('objectui#8447 — every executed operator constrains', () => {
   it.each(Object.entries(EXECUTED_CASES))(
@@ -192,6 +217,27 @@ describe('objectui#8447 — every executed operator constrains', () => {
     const warn = spyWarn();
     expect(await selectedIds({ nickname: { $null: false } })).toEqual(['a']);
     expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('`$exists: false` is the other direction of ITS operator', async () => {
+    const warn = spyWarn();
+    expect(await selectedIds({ nickname: { $exists: false } })).toEqual(['b', 'c']);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('`$exists` and `$null` are one predicate read from opposite ends', async () => {
+    // Not a restatement of the two cases above: it pins the INVERSION, so an
+    // arm that got the boolean the wrong way round fails here even if each
+    // spelling looks self-consistent. Both directions, and both against a row
+    // set that is a non-empty proper subset either way.
+    expect(await selectedIds({ nickname: { $exists: true } }))
+      .toEqual(await selectedIds({ nickname: { $null: false } }));
+    expect(await selectedIds({ nickname: { $exists: false } }))
+      .toEqual(await selectedIds({ nickname: { $null: true } }));
+    // …and they are NOT the same set as each other, which is what makes the
+    // two assertions above worth anything.
+    expect(await selectedIds({ nickname: { $exists: true } }))
+      .not.toEqual(await selectedIds({ nickname: { $exists: false } }));
   });
 
   it.each(Object.entries(EXECUTED_CASES))(
@@ -247,28 +293,6 @@ describe('objectui#8447 — what the matcher cannot execute, it refuses', () => 
     // One line for three rows: refusals are collected per `find()`, not per row.
     expect(warn).toHaveBeenCalledTimes(1);
     expect(String(warn.mock.calls[0]?.[0])).toContain('$zzz');
-  });
-
-  it('`$exists` is refused and the refusal prescribes the synonym that works', async () => {
-    const warn = spyWarn();
-    expect(await selectedIds({ nickname: { $exists: true } })).toEqual([]);
-    expect(warn).toHaveBeenCalledTimes(1);
-    const message = String(warn.mock.calls[0]?.[0]);
-    expect(message).toContain('$exists');
-    expect(message).toContain('$null: false');
-  });
-
-  it('`$exists: false` prescribes the other direction', async () => {
-    const warn = spyWarn();
-    expect(await selectedIds({ nickname: { $exists: false } })).toEqual([]);
-    expect(String(warn.mock.calls[0]?.[0])).toContain('$null: true');
-  });
-
-  it('the prescription `$exists` points at is itself executed', async () => {
-    // The refusal is only honest if the alternative works. `$exists: true` is
-    // `$null: false` and `$exists: false` is `$null: true`.
-    expect(await selectedIds({ nickname: { $null: false } })).toEqual(['a']);
-    expect(await selectedIds({ nickname: { $null: true } })).toEqual(['b', 'c']);
   });
 
   it.each(['$like', '$ilike'])(
@@ -374,13 +398,19 @@ describe('objectui#8447 — `$and` / `$or` / `$not` are refused, and say so', ()
  * ⚠️ SCOPE DECLARATION, NOT PROOF.
  *
  * These are the four readings objectui#8447 was filed with, reproduced on the
- * two rows it used. Three of the four expect an EMPTY result, so a matcher that
- * answered `false` for everything — strictly worse than the bug — passes them.
- * MEASURED, not predicted: under that caricature exactly these three stayed
- * green and the fourth (`$exists`, which asserts the refusal was LOGGED) went
- * red. They are kept because they are the card's own words and someone will
- * look for them, not because they measure the fix. The discriminating cases
- * are §1-§4.
+ * two rows it used. ALL FOUR expect an EMPTY result, so a matcher that answered
+ * `false` for everything — strictly worse than the bug — passes every one of
+ * them. Before the contract review flipped `$exists` from refused to executed,
+ * that fourth case still discriminated, because it asserted the refusal was
+ * LOGGED; executing it removed the log and with it the only half of §5 that
+ * could tell the fix from the caricature. RE-MEASURED after the flip rather
+ * than carried forward — see the ablation table in this file's header.
+ *
+ * They are kept because they are the card's own words and someone will look for
+ * them, not because they measure the fix. The last case in this block is the
+ * exception and the reason the block is not purely decorative: it asserts the
+ * COMPLEMENT of each of the four, which is four non-empty answers. The
+ * discriminating cases are §1-§4.
  */
 describe('objectui#8447 — the card’s measured examples (scope declaration)', () => {
   const CARD_ROWS = [
@@ -400,18 +430,22 @@ describe('objectui#8447 — the card’s measured examples (scope declaration)',
     expect(await selectedIds({ score: { $null: true } }, CARD_ROWS)).toEqual([]);
   });
 
-  it('`$exists false` selects neither row, and now logs why', async () => {
-    // The one of the four that DOES discriminate against the caricature: it
-    // refuses, and a matcher that answers `false` for everything refuses
-    // nothing and logs nothing.
+  it('`$exists false` selects neither row — both have the key', async () => {
+    // EXECUTED, not refused (the contract review flipped this one), so it no
+    // longer logs — and with the log gone it stopped discriminating against
+    // the caricature. Re-measured after the flip rather than assumed; see the
+    // ablation table in this file's header.
     const warn = spyWarn();
     expect(await selectedIds({ score: { $exists: false } }, CARD_ROWS)).toEqual([]);
-    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
   });
 
-  it('the complements of the first three DO select — the fix is not "exclude everything"', async () => {
+  it('the complements of all four DO select — the fix is not "exclude everything"', async () => {
+    // This is the case that carries §5, and the only one here the caricature
+    // cannot pass: four non-empty answers, each naming rows.
     expect(await selectedIds({ score: { $in: [5, '5'] } }, CARD_ROWS)).toEqual(['n', 's']);
     expect(await selectedIds({ score: { $startsWith: '5' } }, CARD_ROWS)).toEqual(['s']);
     expect(await selectedIds({ score: { $null: false } }, CARD_ROWS)).toEqual(['n', 's']);
+    expect(await selectedIds({ score: { $exists: true } }, CARD_ROWS)).toEqual(['n', 's']);
   });
 });


### PR DESCRIPTION
Fixes objectstack-ai/objectui#8447

## The defect, in its strongest form

`find()` picks a matcher on nothing but the **shape** of `$filter` — two arms of one `if`:

| `$filter` shape | matcher | what it does with input it cannot execute |
|---|---|---|
| **array** | `matchesASTFilter` | **refuses** — excludes the row *and* `console.warn`s once per distinct refusal |
| **object** | `matchesFilter` | **`default: break`** — no constraint, so **every** row passed, silently |

Same file, opposite defaults, and nothing tells an author which dialect their filter took. `$eq` is the sharpest case: `{ age: { $eq: 26 } }` selected every row while the plain `{ age: 26 }` on the sibling equality arm was correct all along.

## The census that decided refuse-vs-implement

Re-derived on `origin/main` with `'packages/*/src/*'` pathspecs and `$gt` as a lit control (the `'packages/*/src'` form is a whole-path glob and returns a silent zero for every operator). Producers of an **object-shaped** `$`-dialect criteria in this repo:

| spelling | emitted by | verdict |
|---|---|---|
| `$eq` | `datasetFilterCondition.ts`, `ObjectFieldInspector.tsx` | implement |
| `$nin` | `FilterConditionField.tsx` (x2), `RecordPickerDialog.tsx`, `datasetFilterCondition.ts`, `ObjectFieldInspector.tsx` | implement |
| `$notContains` | `FilterConditionField.tsx` | implement |
| `$startsWith` / `$endsWith` | `FilterConditionField.tsx` | implement |
| `$null` | `FilterConditionField.tsx` (both directions) | implement |
| `$exists` | `FilterConditionField.tsx` (`exists` / `notExists`, kept reachable on purpose by objectui#4736), `datasetFilterCondition.ts` (`isEmpty` / `isNotEmpty`) | implement — **ruling flipped in contract review**, see below |
| `$between` | no `$`-dialect producer; accepted by `convertOperatorToAST` and executed by the AST twin in this same file | implement — see note |
| `$like` / `$ilike` | nothing | refuse — the spec stages them out of `FILTER_OPERATORS` on purpose |
| `$regex` / `$options` | nothing (`filter-converter.ts` already throws on `$regex`) | refuse with the spec's retirement prescription |

`$between` is the one place the strict census reading ("a spelling nothing emits, refuse-and-warn") was widened, deliberately and declared: `matchesComparisonNode` implements `between` 130 lines above in the same file, so refusing it in the object dialect would re-create this card's own asymmetry one level down.

## What changed

`matchesFilter` now carries one arm per member of the spec's `FILTER_OPERATORS` — **all sixteen**, a one-to-one pairing with the AST arms that already existed:

```text
$eq -> =    $ne -> !=    $gt -> >    $gte -> >=    $lt -> <    $lte -> <=
$in -> in   $nin -> nin  $between -> between
$contains -> contains    $icontains -> icontains  $notContains -> not_contains
$startsWith -> starts_with    $endsWith -> ends_with
$null -> is_null / is_not_null      $exists -> is_not_null / is_null
```

`$exists` is the exact inverse of `$null`, and that is the platform's own reading rather than one invented here: `convertFiltersToAST` lowers `$exists: true` to `is_not_null` three lines below where it lowers `$null: true` to `is_null`.

### The closed vocabulary is worth more than any one arm

Because nothing the spec **declares** is refused by name, `REFUSED_OPERATORS` in the companion test is **empty**, so the parity guard can assert the case table equals `FILTER_OPERATORS` *exactly*. A future spec release that adds a `$` operator now turns this file red instead of letting the new spelling reach the refusal arm unannounced. An operator parked on a refused list would have been a hole that guard could not see into.

### What is still refused — everything outside the declared vocabulary

Through the **same** `refuseFilterNode` the AST arm uses — excluded, and logged once per distinct refusal per `find()` — with a message that names the spelling that does work:

- `$like` / `$ilike`, declared by `StringOperatorSchema` but deliberately staged out of `FILTER_OPERATORS` (objectstack#7536); this matcher has no pattern engine, and the spec's own note says naming them before an arm exists turns a loud refusal into a dropped predicate;
- `$regex` / `$options` print `RETIRED_FILTER_OPERATORS`' prescription verbatim, the way the five driver-side refusal sites do, so six faces say one thing;
- lowercase aliases (`$startswith`, `$notcontains`, `$notin`) and the off-spec `$ncontains` are refused rather than aliased — growing alias arms in the renderer is exactly the second de-facto contract AGENTS.md #0.1 forbids;
- a nested relation constraint (`{ profile: { verified: true } }`) is refused **by the key it could not read**; this matcher does not descend into relations.

Both arms of `find()` now drain **one** refusal collector. That is what makes the two dialects symmetrical, rather than merely both non-empty.

### Combinators — stated as their own case, not swept in

- `$and` / `$or` carry an **array**, so they fell to the simple-equality branch and were **already excluding every row**, silently. The rows do not move here; only the silence does.
- `$not` carries an **object** (`FilterConditionSchema`, not an array), so it entered the operator branch, its inner **field** names were read as operator names, and each hit `default: break`. It matched **every** row and now matches none.

None of the three is implemented: executing a group in this dialect has its own semantics to settle (the empty-group identities, objectstack#5322, and `$not`'s NULL-safe rule, objectstack#5146). The refusal names the AST array `$filter` as the door that works today, and there is a test proving that door is open.

## Pin discipline — both ablations were RUN, and RE-RUN after the flip

Restored by state each time (`git diff HEAD` empty **and** `git hash-object PATH` equal to `git rev-parse HEAD:PATH`), from a committed implementation, with the mutation proven on disk by a marker count before and after plus a blob-hash inequality.

| ablation | red | green | of |
|---|---|---|---|
| **the bug** — `ValueDataSource.ts` restored to its pre-card bytes | 38 | 24 | 62 |
| **the caricature** — `matchesFilter` returns `false` unconditionally (an empty result set, strictly worse than the bug) | 54 | 8 | 62 |

The survivor list was **re-derived**, not carried across the `$exists` flip. **Exactly one case moved**, and it is the one the review predicted: `` `$exists false` selects neither row `` was RED under the caricature before the flip and is GREEN after it — it discriminated only because it asserted the refusal was *logged*, and executing the operator removed the log. Nothing else moved; the red count is 54 in both runs.

The eight survivors are named rather than counted: the two `{}` cases and the AST-group case never reach `matchesFilter` at all; the `FILTER_OPERATORS` parity guard reads no rows; and the remaining **four** are the card's own `$nin` / `$startsWith` / `$null` / `$exists` examples — the quotable ones, and none of them can tell this fix from an empty result set. They are kept in the test file's section 5 and labelled a **scope declaration**, not proof. Section 5's last case is the exception that keeps the block from being decorative: it asserts the **complement** of all four, which is four non-empty answers.

The weight is carried by the non-regression axis: every executed operator asserts a **non-empty proper subset** of the three rows, so the full set (the bug) and the empty set (the caricature) are both red; the plain-equality arm and a genuinely matching row have their own controls; every operator is additionally asserted to answer the same rows as its AST twin; and `$exists` / `$null` are pinned as one predicate read from opposite ends, including a `not.toEqual` so an arm with the boolean inverted cannot pass.

## Verification

Every row below was run on this branch's final commit, `09374d601`.

| run | result |
|---|---|
| `pnpm exec vitest run` on the new file `ValueDataSource.dollarFilterVocabulary.test.ts` | 62 passed |
| `pnpm exec vitest run packages/core/` | 126 files, 2694 passed |
| `pnpm exec vitest run` over data-objectstack + fields + components tests + plugin-list + app-shell metadata-admin inspectors — **every package or directory in the repo that mentions `$exists`** | 473 files, 6142 passed, 1 skipped |
| `pnpm --filter @object-ui/core run type-check` (**both** programs: `tsc --noEmit` and `tsc -p tsconfig.test.json`) | exit 0 |
| `pnpm --filter @object-ui/core run lint` (`eslint .`, the unit `turbo run lint` runs) | exit 0 — 0 errors, 526 pre-existing warnings |
| `node scripts/check-changeset-presence.mjs` | 3 source files of 1 released package, 1 changeset declared |
| `check:control-bytes` · `check:spec-symbols` · `check:doc-fences` · `check:vi-mock-specifiers` · `check:vi-mock-inherit` · `check:unreferenced-sources` | all exit 0 |
| `check:readme-exports` | **not measured** — it needs a full `pnpm build` first ("type entry `./dist/index.d.ts` is not on disk") and reports 532 unjudged self-imports across every package, none of them this diff's. Declared to CI. |

On the first commit of this branch the wider consumer set was also green — core + fields + data-objectstack + types + plugin-designer + plugin-map + plugin-list + plugin-gantt + examples/schema-catalog (669 files, 12322 passed) and react + app-shell + core/adapters (731 files, 7393 passed, 1 skipped). The second commit's only behavioural delta is the `$exists` arm, and no file outside `packages/core` both constructs a value data source and mentions `$exists` (measured: the two matches are a CHANGELOG and a comment in `filter-entry-translation.test.ts`, which constructs none). The whole-repo `pnpm test` (4 shards) and `turbo run lint` are CI's runs.

Lint narrowing is a measurement, not an omission: the population is `packages/core`'s own `eslint .` (the exact unit CI's `turbo run lint` runs for the only package this diff touches), the count is eslint's own (0 errors / 526 warnings), and **type-aware linting is not enabled** — `eslint.config.js` uses `tseslint.configs.recommended` with no `parserOptions.project` or `projectService` — so this diff cannot move the verdict of any file it does not touch.

## Contract review — two corrections against the dispatch brief, both accepted

Recorded because the reasoning is load-bearing for the census, not to relitigate.

1. **`$not` does not fall to the equality arm.** The brief said `$and` / `$or` / `$not` all carry an array and therefore all fail *closed*. `FilterConditionSchema` declares `$not: FilterConditionSchema` — an **object** — so `$not` reached `default: break` and matched **every** row. It was in this card's defect class after all. Fixed here as a refusal, with its own case. Accepted.
2. **`$exists` was refused on a falsified ground, and the ruling is now flipped.** The brief refused `$exists` because `filter-converter.test.ts:31` pins `convertOperatorToAST('$exists')` to `null`. That map contains **neither** `$null` **nor** `$exists`; both are special-cased *before* it is consulted (`:283` and `:287`), so the pin distinguished nothing between the operator to refuse and the operator to implement. The first commit of this branch shipped the ruling as written and flagged the flip; the second commit implements `$exists`, per the review.

## Out of scope — found here, filed by the PM

Both dedupe channels were down for this seat (`search_issues`: `API rate limit already exceeded`; repo-scoped REST: 403), so these were handed over rather than filed blind:

1. **The object dialect cannot express a group.** `filterGroupToMongo` in `FilterConditionField.tsx` **emits** `{ $or: [...] }` / `{ $and: [...] }`, so a value-provider list given that criteria returns zero rows. Pre-existing; this PR makes it explicit instead of silent.
2. **An array comparand under the simple-equality arm can never match.** `{ tags: ['a','b'] }` compares by reference, so it excludes every row even when the stored array is deep-equal. Silent and fail-closed; untouched here because it is the equality branch, not the `default` arm.
3. **Neither dialect resolves a `{ $field: path }` comparand.** Declared by the spec and produced by `@objectstack/formula`; both matchers compare the reference object itself. Symmetric across the two arms, so not this card's asymmetry — but after this PR the `$` side excludes rather than passes, which makes it visible.

Drafted by the `domain:ui` dev seat, session `https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S`. (Written into the prose deliberately: a `PATCH` downgrades a session-URL attribution footer to the bare form, so a PR body that is edited after creation loses the reference unless it is carried as a code span.)