### PR TITLE
fix(types): key `GridSchema.columns` by the breakpoint vocabulary, not `string`

### DIFF
--- a/.changeset/8505-grid-columns-breakpoint-narrowing.md
+++ b/.changeset/8505-grid-columns-breakpoint-narrowing.md
@@ -1,0 +1,43 @@
+---
+'@object-ui/types': minor
+---
+
+**Breaking for TypeScript consumers, at compile time only:** `GridSchema.columns`
+in `@object-ui/types` is now `number | Partial<Record<BreakpointName, number>>`
+instead of `number | Record<string, number>` (objectui#8505). A `grid` node whose
+responsive map is keyed by a spelling no renderer reads — `{ xxl: 6 }`,
+`{ XL: 5 }`, `{ '2XL': 6 }` — stops compiling, and `tsc` names the member it
+meant (`'XL' does not exist in type 'Partial<Record<BreakpointName, number>>'.
+Did you mean to write 'xl'?`). Nothing changes at runtime and no emitted byte
+moves: the declaration erases.
+
+**What was measured.** `@object-ui/components`' `grid` renderer reads exactly six
+keys — `xs` `sm` `md` `lg` `xl` `2xl`, the whole of `BreakpointName` — and
+`grid-breakpoint-columns-7097.test.tsx` already pinned that read set exhaustive in
+both directions. So the renderer and its pins agreed on six while the type still
+said "any string": on this branch's base,
+`const node: GridSchema = { type: 'grid', columns: { xxl: 6 } }` compiled, passed
+the zod mirror, emitted no class, and rendered the grid at its `xs` count on every
+screen with no error and no warning. That is the declared-but-not-read shape
+objectui#7097 fixed at the value level, reached through the type surface instead
+of the renderer, and this was its last copy.
+
+**No producer was touched, and that is a measurement rather than an absence.**
+`turbo run type-check` across the whole repo — 81 tasks, every package's source,
+test and example program — is green with the narrowing applied and zero call sites
+edited. The structural reason is pinned in the new test: a string index signature
+supplies every optional member of the target, so code assigning into `columns`
+from a computed `Record<string, number>` still type-checks, and only fresh object
+LITERALS meet excess-property checking. The narrowing is therefore a check on the
+authoring spelling, which is where the defect was authored.
+
+**The zod mirror is deliberately NOT narrowed here.** `zod/layout.zod.ts` still
+validates `columns` as `z.record(z.string(), z.number())`, so the JSON authoring
+face — `os-ui validate` / `check` in `@object-ui/cli`, the real consumer of these
+mirrors — still admits `{ xxl: 6 }`. That is reported for its own card, on a
+measurement: closing it ships runtime bytes into the console's `framework` chunk
+(`packages/(core|react|types)`), which measured 70,999 gzip bytes against its
+71,000 ceiling on this branch's base — one byte of headroom. The current reading is
+held visible by a handoff assertion in the new test, with a lit control next to it,
+so it flips to a refusal when that card lands rather than rotting into an
+assumption that both faces closed together.

--- a/packages/types/src/__tests__/grid-columns-breakpoint-narrowing-8505.test.ts
+++ b/packages/types/src/__tests__/grid-columns-breakpoint-narrowing-8505.test.ts
@@ -1,0 +1,285 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8505 — `GridSchema.columns` is keyed by the BREAKPOINT VOCABULARY,
+ * not by `string`.
+ *
+ * ## What was wrong
+ *
+ * The member was declared `number | Record<string, number>`. The renderer
+ * (`@object-ui/components`, `renderers/layout/grid.tsx`) reads exactly six keys
+ * — `xs` `sm` `md` `lg` `xl` `2xl`, the whole of {@link BreakpointName} — and
+ * `grid-breakpoint-columns-7097.test.tsx` already pins that read set exhaustive
+ * in BOTH directions. So the renderer and its pins agreed on six; only the type
+ * still said "any string". Measured on the base commit:
+ *
+ * ```
+ * const node: GridSchema = { type: 'grid', columns: { xxl: 6 } };  // compiled
+ * ```
+ *
+ * `{ xxl: 6 }`, `{ XL: 5 }` and `{ '2XL': 6 }` type-checked, passed the zod
+ * mirror, emitted no class and rendered the grid at its `xs` count on every
+ * screen — the declared-but-not-read shape objectui#7097 fixed at the value
+ * level, surviving one card longer at the type level.
+ *
+ * ## Why the assertions below are shaped the way they are
+ *
+ * The caricature of this fix is a narrowing that rejects EVERYTHING —
+ * `Record<never, number>`, or quietly dropping the bare-number arm. Either
+ * would satisfy any "a typo is now rejected" assertion while being strictly
+ * worse than the bug. So the negatives are never load-bearing alone, and the
+ * division of labour between the constructs below was MEASURED by mutating the
+ * member four ways and reading `tsc -p tsconfig.test.json` each time — not
+ * reasoned about. What each mutation actually reddened:
+ *
+ * | member mutated to                      | what catches it, in this file |
+ * | :------------------------------------- | :---------------------------- |
+ * | `number \| Record<string, number>` (the bug) | the five `@ts-expect-error`s go TS2578 "unused", + both `Eq`s |
+ * | `number \| Record<never, number>`       | `_keyedByVocabulary` only, + the five TS2578s |
+ * | `Partial<Record<BreakpointName, number>>` (no number arm) | `_columnsShape`, the bare-number row, + 2 reds in the sibling `zod-mirror-parity` pin |
+ * | `number \| Partial<Record<'xs', number>>` | five {@link ONE_KEY_NODES} rows, + both `Eq`s, + 2 positive rows |
+ *
+ * ⚠️ The row that is easy to get wrong, and was: {@link ONE_KEY_NODES} does NOT
+ * catch `Record<never, number>`. That type is `{}`, and TypeScript runs no
+ * excess-property check against the empty object type, so all six rows stay
+ * green under the very caricature they look like they exist to stop. The
+ * `keyof` equality is what actually holds that line. Both are kept: they fail
+ * on different mutations, and neither alone covers the pair.
+ *
+ * ⚠️ The trap next door, recorded by objectui#7097: `const x: '2xl'[] = []`
+ * type-checks happily, so an empty-array assertion proves nothing about an
+ * element type. Every negative here is a `@ts-expect-error`, which `tsc` itself
+ * verifies in the failing direction — an unused one is TS2578 — and all five
+ * were observed to become TS2578 under the first two mutations above.
+ *
+ * ## Which program checks this file
+ *
+ * `packages/types`' `type-check` script runs THREE programs; this file is in
+ * the third, `tsconfig.test.json` (`tsc --noEmit` builds `tsconfig.json`, which
+ * excludes `__tests__/` by directory). Confirmed with `--listFiles`, not
+ * assumed — objectui#8342 measured a case that was red only in a test program.
+ * The subject is imported as a sibling SOURCE module (`../layout`), so that one
+ * program reads the declaration directly and no `dist` staleness sits between
+ * this file and what it pins.
+ *
+ * ## What this card deliberately did NOT change
+ *
+ * The zod mirror. See the last block: it still validates `columns` as an open
+ * record, so the JSON authoring face still admits `{ xxl: 6 }`. That is a
+ * REPORTED gap with its own card, not an oversight — the reasoning is in the
+ * PR body and the block below holds the current reading visible so it cannot
+ * rot into a silent assumption that both faces closed together.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { GridSchema } from '../layout';
+import type { BreakpointName } from '../mobile';
+import { GridSchema as GridZodMirror } from '../zod/layout.zod';
+
+/** Mutual assignability, the standard invariant `Eq` — not `extends`. */
+type Eq<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+  ? true
+  : false;
+
+/**
+ * One authored node per breakpoint, EVERY key positively type-checked inside
+ * `columns`.
+ *
+ * The annotation is the gate. `Record<BreakpointName, …>` is exhaustive both
+ * ways in a single construct: drop a member from the vocabulary and the entry
+ * for it becomes an excess property; add a seventh and this object stops
+ * satisfying its annotation. And because each VALUE is a `GridSchema`, a
+ * narrowing that admits FEWER than the vocabulary reddens once per key it
+ * dropped rather than passing quietly — measured: mutating the member to
+ * `Partial<Record<'xs', number>>` produced exactly five TS2353 here, one per
+ * lost breakpoint. It does NOT catch `Record<never, number>`; `_keyedByVocabulary`
+ * does. See the table in the file header.
+ */
+const ONE_KEY_NODES: Record<BreakpointName, GridSchema> = {
+  xs: { type: 'grid', columns: { xs: 1 } },
+  sm: { type: 'grid', columns: { sm: 2 } },
+  md: { type: 'grid', columns: { md: 3 } },
+  lg: { type: 'grid', columns: { lg: 4 } },
+  xl: { type: 'grid', columns: { xl: 5 } },
+  '2xl': { type: 'grid', columns: { '2xl': 6 } },
+};
+
+const BREAKPOINTS = Object.keys(ONE_KEY_NODES) as BreakpointName[];
+
+/* ── (a) the member's type, pinned whole ──────────────────────────────────── */
+
+describe('objectui#8505 — GridSchema.columns declares the breakpoint vocabulary', () => {
+  it('the member type is exactly the bare number OR a partial breakpoint map', () => {
+    // Mutual assignability, so this fails in BOTH directions: widened back to
+    // `Record<string, number>` it fails, and narrowed to `Record<never, number>`
+    // or stripped of the `number` arm it also fails. A one-way `extends` check
+    // would pass for the caricature.
+    const _columnsShape: Eq<
+      GridSchema['columns'],
+      number | Partial<Record<BreakpointName, number>> | undefined
+    > = true;
+    expect(_columnsShape).toBe(true);
+  });
+
+  it('the map arm is keyed by the vocabulary the renderer reads, not by string', () => {
+    // This is the assertion that catches the `Record<never, number>` caricature,
+    // and the ONLY one in this file that does — see the table in the header.
+    const _keyedByVocabulary: Eq<
+      keyof NonNullable<Exclude<GridSchema['columns'], number>>,
+      BreakpointName
+    > = true;
+    expect(_keyedByVocabulary).toBe(true);
+  });
+});
+
+/* ── (b) non-regression: everything that was valid is still valid ─────────── */
+
+describe('objectui#8505 — every shape the renderer honours still type-checks', () => {
+  it.each(BREAKPOINTS)('a map naming only `%s` is accepted', (bp) => {
+    // The TYPE-level assertion for this row is `ONE_KEY_NODES`' annotation; the
+    // runtime half asserts the same six survive the mirror unchanged, so the
+    // accept set is measured on both faces rather than assumed to move together.
+    const node = ONE_KEY_NODES[bp];
+    const parsed = GridZodMirror.safeParse(node);
+    expect(parsed.success, `zod refused ${JSON.stringify(node)}`).toBe(true);
+    if (parsed.success) expect(parsed.data.columns).toEqual(node.columns);
+  });
+
+  it('the bare-number form is still accepted — the arm a caricature would drop', () => {
+    const bare: GridSchema = { type: 'grid', columns: 4 };
+    expect(bare.columns).toBe(4);
+    expect(GridZodMirror.safeParse(bare).success).toBe(true);
+  });
+
+  it('the node objectui#7097 was reported with is still accepted', () => {
+    const reported: GridSchema = { type: 'grid', columns: { xs: 1, '2xl': 6 }, gap: 4 };
+    expect(reported.columns).toEqual({ xs: 1, '2xl': 6 });
+    expect(GridZodMirror.safeParse(reported).success).toBe(true);
+  });
+
+  it('a fully authored six-breakpoint map is still accepted', () => {
+    const full: GridSchema = {
+      type: 'grid',
+      columns: { xs: 1, sm: 2, md: 3, lg: 4, xl: 5, '2xl': 6 },
+    };
+    expect(Object.keys(full.columns as object)).toHaveLength(BREAKPOINTS.length);
+    expect(GridZodMirror.safeParse(full).success).toBe(true);
+  });
+
+  it('omitting `columns` entirely is still accepted — the member stays optional', () => {
+    const none: GridSchema = { type: 'grid', gap: 4 };
+    expect(none.columns).toBeUndefined();
+  });
+});
+
+/* ── (c) the refusals this card exists for ────────────────────────────────── */
+
+describe('objectui#8505 — a key outside the vocabulary no longer compiles', () => {
+  it('`xxl` — the card\'s own reproduction — is refused', () => {
+    // @ts-expect-error `xxl` is not a breakpoint; the vocabulary is `xs`…`2xl` (objectui#8505)
+    const typo: GridSchema = { type: 'grid', columns: { xxl: 6 } };
+    expect(typo).toBeDefined();
+  });
+
+  it('`XL` is refused, and `tsc` names the member it meant', () => {
+    // @ts-expect-error `XL` is not a breakpoint — the authored spelling is `xl` (objectui#8505)
+    const upper: GridSchema = { type: 'grid', columns: { XL: 5 } };
+    expect(upper).toBeDefined();
+  });
+
+  it('`2XL` is refused — the authored key is and stays lower-case `2xl`', () => {
+    // @ts-expect-error `2XL` is not a breakpoint — the authored spelling is `2xl` (objectui#8505)
+    const upper: GridSchema = { type: 'grid', columns: { '2XL': 6 } };
+    expect(upper).toBeDefined();
+  });
+
+  it('a bad key mixed in with a good one is refused too', () => {
+    // Freshness matters here: this is an object LITERAL, so excess-property
+    // checking fires on `xxl` even though `xs` is present. The non-fresh case is
+    // pinned in the block below, deliberately, as the boundary it is.
+    // @ts-expect-error `xxl` is not a breakpoint, even alongside a valid one (objectui#8505)
+    const mixed: GridSchema = { type: 'grid', columns: { xs: 1, xxl: 6 } };
+    expect(mixed).toBeDefined();
+  });
+});
+
+/* ── (d) the boundary: what this narrowing does NOT catch, measured ───────── */
+
+describe('objectui#8505 — the narrowing broke no producer, and this is why', () => {
+  it('a computed `Record<string, number>` still assigns — index signatures satisfy optional members', () => {
+    // The blast-radius question this card was dispatched with: does something
+    // assign into `columns` from a COMPUTED record rather than a literal, and
+    // would that go red at the call site? Measured two ways and they agree.
+    //
+    // Structurally, here: a string index signature supplies every optional
+    // member of the target, so this compiles and a computed-record producer
+    // cannot be broken by the narrowing. This line is the pin for that fact —
+    // a future tightening that removes the escape (a mapped type with no index
+    // signature, say) turns it red and names its own blast radius instead of
+    // discovering it in a consumer's build.
+    //
+    // Empirically: `turbo run type-check` over the whole repo — 81 tasks, every
+    // package's source, test and example programs — was green with the
+    // narrowing applied and zero call sites edited.
+    const computed: Record<string, number> = { xs: 1, sm: 2 };
+    const fromComputed: GridSchema = { type: 'grid', columns: computed };
+    expect(fromComputed.columns).toEqual({ xs: 1, sm: 2 });
+  });
+
+  it('a NON-fresh object with at least one valid key also still assigns', () => {
+    // Excess-property checking only fires on fresh literals. Through a variable
+    // the extra key survives the type system — so the narrowing is a check on
+    // the authoring spelling, not a proof that no bad key can reach the
+    // renderer. Stated rather than papered over.
+    const viaVariable = { xs: 1, xxl: 6 };
+    const node: GridSchema = { type: 'grid', columns: viaVariable };
+    expect(node.columns).toEqual({ xs: 1, xxl: 6 });
+  });
+
+  it('a NON-fresh object with NO valid key is still refused — weak-type detection', () => {
+    // The one case the freshness gap does not swallow: a target whose members
+    // are all optional requires the source to share at least one of them.
+    const noValidKey = { xxl: 6 };
+    // @ts-expect-error `{ xxl: number }` shares no member with the breakpoint map (objectui#8505)
+    const node: GridSchema = { type: 'grid', columns: noValidKey };
+    expect(node).toBeDefined();
+  });
+});
+
+/* ── (e) the other authoring face, REPORTED and left open by this card ────── */
+
+describe('objectui#8505 — the zod mirror still admits an open record, deliberately', () => {
+  it('the JSON face still accepts `{ xxl: 6 }` — the gap this card did not close', () => {
+    // NOT the desired end state. `GridSchema` in `zod/layout.zod.ts` is
+    // `z.record(z.string(), z.number())`, so `os-ui validate` / `check`
+    // (`@object-ui/cli`, the real consumer of these mirrors) still passes a
+    // grid document whose map is keyed by a spelling no renderer reads.
+    //
+    // Left open on a measurement, not a preference: closing it ships runtime
+    // bytes into the console's `framework` chunk (`packages/(core|react|types)`),
+    // which measured 70,999 gzip bytes against its 71,000 ceiling on this
+    // branch's base — one byte of headroom. A zod narrowing here would turn
+    // `Bundle Analysis` red and make its own fix a byte-hunt through two other
+    // packages, which is a different card. The TypeScript narrowing this card
+    // ships costs zero runtime bytes.
+    //
+    // This assertion is the HANDOFF (the objectui#7070 convention): when that
+    // card lands, this block flips to a refusal rather than quietly agreeing
+    // with whatever the mirror ends up doing.
+    const r = GridZodMirror.safeParse({ type: 'grid', columns: { xxl: 6 } });
+    expect(r.success).toBe(true);
+  });
+
+  it('CONTROL — the mirror is live: it refuses a non-numeric column count', () => {
+    // Without this, the reading above would be equally green against a mirror
+    // that validates nothing at all.
+    const r = GridZodMirror.safeParse({ type: 'grid', columns: { xs: 'two' } });
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/types/src/layout.ts
+++ b/packages/types/src/layout.ts
@@ -18,6 +18,7 @@
 
 import type { PageType as SpecPageType } from '@objectstack/spec/ui';
 import type { BaseSchema, SchemaNode } from './base.js';
+import type { BreakpointName } from './mobile.js';
 
 /**
  * Basic HTML div container
@@ -384,7 +385,7 @@ export interface GridSchema extends BaseSchema {
    * `maxWidth`).
    * @default 2
    */
-  columns?: number | Record<string, number>;
+  columns?: number | Partial<Record<BreakpointName, number>>;
   /**
    * Gap between items (Tailwind scale 0-8)
    * @default 4


### PR DESCRIPTION
Fixes objectstack-ai/objectui#8505

⚠️ **Notation.** Generic type arguments are written with SQUARE brackets throughout — `Partial[Record[BreakpointName, number]]`, never the real spelling. AGENTS.md's "GitHub 会改写你写进 issue/PR 正文的字节" section records that tag-shaped fragments are deleted on save, backticks and fenced blocks included, and this PR is entirely about the shape of one type. Session: `https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S`.

## What changed

`GridSchema.columns` (`packages/types/src/layout.ts`) goes from `number | Record[string, number]` to `number | Partial[Record[BreakpointName, number]]`. `BreakpointName` is declared in this package's own `mobile.ts`, which imports nothing, so the layering carries no cycle. Plus one pin file and a changeset. Three files, no other edit.

The `grid` renderer reads exactly six keys — `xs sm md lg xl 2xl`, the whole of `BreakpointName` — and `grid-breakpoint-columns-7097.test.tsx` already pinned that read set exhaustive in both directions. Only the type still said "any string", so `{ xxl: 6 }` compiled, passed zod, emitted no class and rendered at the `xs` count on every screen. Last surviving copy of the shape objectui#7097 fixed at the value level.

## ⭐ Which surface this closes: the TypeScript one ONLY

The card asked for this to be decided deliberately and stated here, so: **the zod mirror is not narrowed by this PR.** `zod/layout.zod.ts` keeps `z.record(z.string(), z.number())`, so `os-ui validate` still admits `{ xxl: 6 }` from JSON.

That is a byte measurement, not a preference. The console `framework` chunk is `packages/(core|react|types)` and `check-eager-closure-budget.mjs` ceilings it at 71,000 gzip bytes; on this branch's base it measures **70,999** — one byte of headroom, which objectui#8485 had just spent down while explicitly refusing to raise the ceiling. A zod narrowing ships real runtime bytes and would turn `Bundle Analysis` red, making its own remedy a byte-hunt through two other packages. This change emits **nothing** — `packages/types/dist/layout.js` is `export {};` — and the budget gate is green on this head.

Reported as objectstack-ai/objectui#8516, with the byte figure and the shape questions it needs ruled. The last block of the new pin holds the current `success: true` reading visible with a lit control beside it, as a handoff in the objectui#7070 sense, so it flips to a refusal when that card lands instead of quietly agreeing with whatever the mirror ends up doing.

## Producers: zero touched, and that is a measurement

The dispatch asked me to find producers before narrowing and to stop rather than widen this PR to absorb them. Two independent readings agree there are none.

**Empirical.** `turbo run type-check` repo-wide, cache forced off: **81 tasks successful, 0 TS errors**, no call site edited. `pnpm type-check:coverage` reports **42/42 packages compile their tests**, so that number covers every package's source, test and example program rather than sources alone.

**Structural.** A string index signature supplies every optional member of the target, so a computed `Record[string, number]` still assigns; only fresh object LITERALS meet excess-property checking. That is pinned in the new file, so a future tightening that removes the escape reddens there and names its own blast radius instead of surfacing in a consumer's build.

## The instrument, and which program each red came from

`packages/types` runs three programs. `tsc --noEmit` (source) compiles `src/layout.ts` and excludes `__tests__` by directory; `tsc -p tsconfig.test.json` (test) compiles both. Verified with `--listFiles` rather than assumed, per the objectui#8342 note on the card:

| program | `src/layout.ts` | the new pin |
| :--- | :--- | :--- |
| `tsc --noEmit` | present | **absent** |
| `tsc -p tsconfig.test.json` | present | present |

The test program contains **zero** files from `packages/types/dist`, so the pin reads the declaration as source and no stale `.d.ts` can sit between them. **Every red quoted below is from the test program.** A vitest run proves nothing about any of it and none is claimed from one.

## ⭐ The caricature was RUN, not reasoned about

Four mutations of the member, from the committed implementation, each restored by state (`git diff HEAD` empty AND `git hash-object` equal to `git rev-parse HEAD:PATH`), trap on `EXIT INT TERM`, absolute paths, mutation proven on disk by a before/after count on both the removed and the injected text.

| member mutated to | tsc | what caught it |
| :--- | :--- | :--- |
| `number \| Record[string, number]` (the bug restored) | 7 errors | 5 `@ts-expect-error` go TS2578 "unused" + both `Eq` assertions |
| `number \| Record[never, number]` (reject everything) | 6 errors | `_keyedByVocabulary` + the 5 TS2578 |
| `Partial[Record[BreakpointName, number]]` (bare-number arm dropped) | 4 errors | `_columnsShape`, the bare-number row, **and 2 independent reds in the sibling `zod-mirror-parity` pin** |
| `number \| Partial[Record['xs', number]]` (reject 5 of 6) | 9 errors | 5 `ONE_KEY_NODES` rows, one per lost breakpoint, + both `Eq`s + 2 positive rows |

⚠️ **One thing I asserted and the measurement refuted, corrected in the file rather than left standing.** I first wrote that `ONE_KEY_NODES` — the six-row `Record[BreakpointName, GridSchema]` — is what catches the reject-everything caricature. It is not. `Record[never, number]` is `{}`, TypeScript runs no excess-property check against the empty object type, and all six rows stay green under the very caricature they look like they exist to stop. What holds that line is the `keyof` equality. Both are kept because they fail on different mutations and neither alone covers the pair; the docblock now carries the table above and says which is which.

## Non-regression, positively held

All six keys accepted (`ONE_KEY_NODES`, typed `Record[BreakpointName, GridSchema]`, exhaustive both ways in one construct), the bare-number form accepted, the partial map `{ xs: 1, '2xl': 6 }` — the exact node objectui#7097 was reported with — accepted, an omitted `columns` still accepted, and the whole member type pinned by MUTUAL assignability so a one-way `extends` cannot pass the caricature.

The boundary is stated rather than papered over: a non-fresh object carrying a bad key alongside a good one still assigns. This is a check on the authoring spelling, not a proof that no bad key reaches the renderer.

## Changeset

`minor`, graded deliberately: `major` is refused repo-wide (`check-changeset-no-major.mjs` — the family major is pinned to `@objectstack`'s), and narrowing a published type is source-breaking for TypeScript consumers even though nothing moves at runtime. The body leads with that, in the shape objectui#8485 used for the same class of change.

## Verification

- `turbo run type-check` repo-wide — 81/81, **0 cached**, 0 TS errors
- `turbo run build` repo-wide — 43/43
- `vitest run packages/types` + the three grid pins in `components` / `schema-catalog` — **149 files, 2822 tests, all passing**
- gates: `check:control-bytes`, `check:changeset-no-major`, `type-check:coverage`, `check:doc-types`, `check:doc-snippets`, `check:doc-examples`, `check:eager-closure`, `check:spec-symbols`, `check:dist-completeness`, `check:published-tsconfig-exclude`, `check:unreferenced-sources`, `check:self-import`, `check:phantom-deps` — all green; `eslint` on both touched files — 0 errors, 0 warnings
- ⚠️ `check:published-dist` exits 1 locally, on 10 packages this PR does not touch, all findings being gitignored `dist/tsconfig.tsbuildinfo` build records replayed from a turbo cache this container shares with sibling worktrees (the log shows another worktree's path). `@object-ui/types` has zero findings. Read as NOT MEASURED locally; CI builds clean and its reading is the authoritative one.

## Reported, not absorbed

- objectstack-ai/objectui#8516 — the zod mirror half, with the byte constraint that kept it out of here.
- objectstack-ai/objectui#8517 — `finding`: `zod-mirror-parity`'s WiderThanDeclared operator cannot see this widening at all, because an index-signature record and a partial record over a key union are mutually assignable. Measured with the operator's own predicate and a lit control. It is why the new disagreement does not appear in objectui#7759's census.

Draft on purpose, and auto-merge deliberately not armed — the PM flips both after contract review.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_