### PR TITLE
fix(plugin-kanban): the swimlane layout takes its column width from the container, not the viewport

### DIFF
--- a/.changeset/8508-swimlane-container-aware-column-width.md
+++ b/.changeset/8508-swimlane-container-aware-column-width.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/plugin-kanban': patch
+---
+
+Container-aware Kanban column sizing now reaches the swimlane layout, not just the
+flat one (objectui#8508).
+
+`KanbanBoardInner` derives a column width from the board's own slot
+(`useResizeObserver` on the wrapper that encloses both layouts) so an embedded board —
+in a panel, a drawer, a pop-out window — sizes to its slot instead of the viewport. The
+docblock over that computation said it "replaces hard-coded `w-[85vw] sm:w-80`", and it
+had exactly one consumer: `KanbanColumnView`, on the flat path. The swimlane layout
+paints plain column cells itself and has no column components to inherit from, so both
+its header cells and its lane cells kept the viewport-relative classes. The sentence was
+true of one of the two layouts, and a swimlane board embedded in a narrow slot — exactly
+the case the feature exists for — was still sized to the viewport.
+
+Both layouts now take their width from one shared `columnWidthClasses(columnStyle)`
+helper plus the same `columnInlineStyle` object, so a container width steps the viewport
+classes aside on either path and its absence (SSR, or before the first observation)
+falls back to them on either path. Nothing about the flat layout's rendered width
+changes; the swimlane header row and its lane rows move together, which is what keeps
+the titles over their columns.
+
+Pinned by `swimlaneContainerAwareColumnWidth-8508.test.tsx`, which reads the inline
+style rather than a rendered dimension — happy-dom performs no layout — and asserts a
+real positive width at each width tier on both layouts, so deleting the viewport classes
+without wiring a width cannot pass.

--- a/packages/plugin-kanban/src/KanbanImpl.tsx
+++ b/packages/plugin-kanban/src/KanbanImpl.tsx
@@ -246,6 +246,30 @@ function QuickAddForm({ columnId, onAdd }: { columnId: string; onAdd: (columnId:
   )
 }
 
+/**
+ * The column-width contract, in ONE place, for BOTH board layouts.
+ *
+ * `KanbanBoardInner` derives `columnInlineStyle` from the board's own slot
+ * (`useResizeObserver`) and hands the SAME object to both layouts: the flat
+ * one through `KanbanColumnView`'s `columnStyle` prop, the swimlane one
+ * straight onto the plain cells it paints itself. Where a container-derived
+ * width is present the viewport-relative classes must step aside rather than
+ * fight the inline value; where it is absent (SSR, or before the first
+ * observation) they are the fallback.
+ *
+ * This is a shared function rather than a ternary copied per call site because
+ * the swimlane layout has no column components to inherit the behaviour from.
+ * The rule previously existed only on the flat path, so a swimlane board stayed
+ * viewport-sized — `w-[85vw]` on every cell — while the docblock over
+ * `columnInlineStyle` claimed those hard-coded classes had been replaced
+ * (objectui#8508). Adding a layout means calling this, not re-deriving it.
+ */
+function columnWidthClasses(columnStyle?: React.CSSProperties): string {
+  return columnStyle && columnStyle.width != null
+    ? "shrink-0"
+    : "w-[85vw] sm:w-80 shrink-0";
+}
+
 function KanbanColumnView({
   column,
   cards,
@@ -287,10 +311,9 @@ function KanbanColumnView({
   const isLimitExceeded = column.limit && safeCards.length >= column.limit
 
   // When the parent passes inline width, drop the viewport-relative classes
-  // so they don't fight with the container-derived value.
-  const widthClasses = columnStyle && columnStyle.width != null
-    ? "shrink-0"
-    : "w-[85vw] sm:w-80 shrink-0";
+  // so they don't fight with the container-derived value. Shared with the
+  // swimlane layout's own cells — see `columnWidthClasses`.
+  const widthClasses = columnWidthClasses(columnStyle);
 
   // Stage progress indicator: the colored top stripe was distracting on
   // boards with many columns ("rainbow stripe" effect). The lane border
@@ -402,6 +425,15 @@ function KanbanBoardInner({ columns, onCardMove, onCardClick, className, dnd, qu
    * (viewport-relative) with a width derived from the board's own slot.
    * That way an embedded Kanban (in a panel, drawer, or pop-out window)
    * scales correctly without overflowing or wasting space.
+   *
+   * `boardRef` is on the wrapper that encloses BOTH layouts, and both read this
+   * value: the flat layout passes it to `KanbanColumnView` as `columnStyle`,
+   * the swimlane layout puts it on the header cells and lane cells it paints
+   * itself. Until objectui#8508 only the flat path consumed it, so the sentence
+   * above was true of one of the two layouts and an embedded swimlane board —
+   * the panel/drawer/pop-out case this exists for — stayed viewport-sized.
+   * Whichever layout a cell belongs to, its class list comes from
+   * `columnWidthClasses(columnInlineStyle)` so the two cannot drift apart.
    */
   const boardRef = React.useRef<HTMLDivElement>(null);
   const { width: boardWidth } = useResizeObserver(boardRef);
@@ -663,6 +695,13 @@ function KanbanBoardInner({ columns, onCardMove, onCardClick, className, dnd, qu
               column cells — so the titles have to be drawn once, above every
               lane, instead of once per column.
 
+              Having no column components is also why the width has to be
+              applied by hand here: these cells and the lane cells below take it
+              from `columnWidthClasses(columnInlineStyle)`, the same source
+              `KanbanColumnView` reads on the flat path (objectui#8508). The two
+              rows must stay on the same width for the titles to sit over their
+              columns, exactly as with the `pl-*` indent noted below.
+
               `shrink-0` is load-bearing, not cosmetic (objectui#7303). This row
               is a flex ITEM of the swimlane region, which is a `flex-col` inside
               a height-bounded board (`h-full`). `overflow-x-auto` makes the row
@@ -684,7 +723,11 @@ function KanbanBoardInner({ columns, onCardMove, onCardClick, className, dnd, qu
               move on both rows or neither. */}
           <div className="flex shrink-0 gap-3 sm:gap-4 pl-36 sm:pl-44 overflow-x-auto">
             {boardColumns.map(col => (
-              <div key={col.id} className="w-[85vw] sm:w-80 shrink-0 text-center">
+              <div
+                key={col.id}
+                style={columnInlineStyle}
+                className={cn(columnWidthClasses(columnInlineStyle), "text-center")}
+              >
                 <span className=" text-xs sm:text-sm font-semibold tracking-wider text-primary/90 uppercase">{col.title}</span>
                 <span className="ml-2 text-xs text-muted-foreground">({col.cards.length})</span>
               </div>
@@ -718,7 +761,11 @@ function KanbanBoardInner({ columns, onCardMove, onCardClick, className, dnd, qu
                         (c[swimlaneField!] != null ? String(c[swimlaneField!]) : UNCATEGORIZED_LANE) === lane
                       )
                       return (
-                        <div key={col.id} className="w-[85vw] sm:w-80 shrink-0 min-h-[60px] rounded-md bg-card/20 p-2">
+                        <div
+                          key={col.id}
+                          style={columnInlineStyle}
+                          className={cn(columnWidthClasses(columnInlineStyle), "min-h-[60px] rounded-md bg-card/20 p-2")}
+                        >
                           <SortableContext items={laneCards.map(c => c.id)} strategy={verticalListSortingStrategy}>
                             <div className="space-y-2" role="list" aria-label={`${col.title} - ${lane} cards`}>
                               {laneCards.map(card => (

--- a/packages/plugin-kanban/src/__tests__/swimlaneContainerAwareColumnWidth-8508.test.tsx
+++ b/packages/plugin-kanban/src/__tests__/swimlaneContainerAwareColumnWidth-8508.test.tsx
@@ -1,0 +1,341 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8508 — container-aware column sizing must reach BOTH board layouts.
+ *
+ * ## What was wrong
+ *
+ * `KanbanBoardInner` derives `columnInlineStyle` from the board's own slot
+ * (`useResizeObserver` on a wrapper that encloses both layouts) so an embedded
+ * board — a panel, a drawer, a pop-out window — sizes to its slot instead of
+ * the viewport. The docblock over it said this "replaces hard-coded
+ * `w-[85vw] sm:w-80`". It had exactly one consumer: the flat layout's
+ * `KanbanColumnView`. The swimlane layout, which paints plain column cells
+ * itself and has no column components to inherit from, still hard-coded the
+ * viewport classes on both its header cells and its lane cells — so the
+ * sentence was true of one of the two layouts, and the embedded case the
+ * feature exists for was still viewport-sized whenever swimlanes were on.
+ *
+ * ## What this file pins, and why it is a PROP and not a measurement
+ *
+ * The width here is an inline style computed in JS, not a layout result, so it
+ * is readable without a browser. That matters: the sibling pin
+ * `swimlaneColumnHeaderRow-7303.test.tsx` documents at length that the #7303
+ * defect was a real *rendered height* and could only be caught in Chromium at
+ * 1600x1000 — happy-dom performs no layout, so every height here is 0 for
+ * healthy and broken markup alike. Nothing below reads a rendered dimension.
+ *
+ * The pin is stated as a SOURCE identity rather than a list of blessed numbers:
+ * at a given board width, a swimlane header cell and a swimlane lane cell must
+ * carry the same width a flat column carries. The tier values are asserted too,
+ * on both sides, so the identity cannot be satisfied by both layouts breaking
+ * together.
+ *
+ * ## How the fixture supplies a board width — deliberate, and it has 3 states
+ *
+ * happy-dom does no layout: `getBoundingClientRect()` is 0x0 for every element,
+ * and a `ResizeObserver` (happy-dom's own, or the no-op polyfill in
+ * `vitest.setup.base.ts`) never fires without one. The single channel into
+ * `boardWidth` is therefore the ONE synchronous `getBoundingClientRect()` read
+ * `useResizeObserver` performs inside its effect — so the fixture stubs
+ * `Element.prototype.getBoundingClientRect` for the duration of a render and
+ * restores it after.
+ *
+ * A fixture that simply omits that stub is NOT "the small board" — it is the
+ * `if (!boardWidth) return {}` early-out, a THIRD state in which
+ * `columnInlineStyle` is `{}` and the viewport classes are the correct
+ * behaviour. That state is pinned separately, on both layouts, and never used
+ * as a stand-in for a sized one. `assertHarnessIsLive` guards the direction
+ * that would otherwise pass silently: if the stub stopped reaching the hook,
+ * every sized case would quietly become the third state.
+ *
+ * ## Non-regression axis (the caricature)
+ *
+ * The caricature is deleting the viewport classes outright, leaving swimlane
+ * cells with no width from any source. It passes any "the cell no longer
+ * carries `w-[85vw]`" assertion, so no assertion here is of that shape: every
+ * sized case demands a real positive width from the container-derived source,
+ * and the unsized case demands the viewport classes be present. The flat layout
+ * is asserted in the same cases, so a change that sized swimlane cells by
+ * breaking flat ones cannot pass either.
+ *
+ * Nothing below navigates by the width class being changed. Cells are reached
+ * through structure and accessible names — the swimlane region's aria-label,
+ * the header row's position, a lane list's aria-label, a flat column's
+ * `role="group"` — none of which any width mutation can erase.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, within } from '@testing-library/react';
+// The board under test. Imported directly rather than through the registry:
+// the defect is entirely inside this module's two layout branches, and the
+// lazy/schema route adds an async boundary this pin has no use for.
+import KanbanBoard from '../KanbanImpl';
+import type { KanbanColumn } from '../types';
+
+afterEach(cleanup);
+
+const LANE_FIELD = 'owner';
+
+const COLUMNS: KanbanColumn[] = [
+  {
+    id: 'open',
+    title: 'Open',
+    cards: [{ id: 'a', title: 'Alpha deal', [LANE_FIELD]: 'ann' }],
+  },
+  {
+    id: 'won',
+    title: 'Won',
+    cards: [{ id: 'b', title: 'Beta deal', [LANE_FIELD]: 'bob' }],
+  },
+];
+
+/**
+ * Give every element a rect of this width for the duration of `fn`.
+ *
+ * Blunt on purpose: `useResizeObserver` reads the rect of exactly one node here
+ * (the board wrapper), and nothing else in this render path reads a rect at all
+ * — dnd-kit measures only while dragging. A narrower stub would have to name
+ * the node, which means finding it, which means navigating by something the
+ * component could legitimately change.
+ */
+function withBoardWidth<T>(width: number, fn: () => T): T {
+  const original = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = function () {
+    return {
+      width,
+      height: 600,
+      top: 0,
+      left: 0,
+      right: width,
+      bottom: 600,
+      x: 0,
+      y: 0,
+      toJSON() {
+        return {};
+      },
+    } as DOMRect;
+  };
+  try {
+    return fn();
+  } finally {
+    Element.prototype.getBoundingClientRect = original;
+  }
+}
+
+function renderBoard(opts: { width?: number; swimlanes: boolean }) {
+  const run = () =>
+    render(
+      <KanbanBoard
+        columns={COLUMNS}
+        swimlaneField={opts.swimlanes ? LANE_FIELD : undefined}
+      />,
+    );
+  return opts.width == null ? run() : withBoardWidth(opts.width, run);
+}
+
+/** The swimlane region, by its accessible name. */
+function swimlaneRegion(container: HTMLElement): HTMLElement {
+  const region = container.querySelector<HTMLElement>(
+    '[role="region"][aria-label="Kanban board with swimlanes"]',
+  );
+  expect(region, 'the fixture must render the SWIMLANE layout, not the flat one').not.toBeNull();
+  return region as HTMLElement;
+}
+
+/**
+ * The header cell for a column title.
+ *
+ * The header row is the swimlane region's first child (the titles are drawn
+ * once, above every lane — see the sibling #7303 pin); the cell is the child of
+ * that row whose text is the column's title.
+ */
+function headerCell(region: HTMLElement, title: string): HTMLElement {
+  const headerRow = region.firstElementChild as HTMLElement;
+  expect(headerRow, 'the swimlane region must have a header row as its first child').not.toBeNull();
+  const cell = [...headerRow.children].find((c) => c.textContent?.startsWith(title));
+  expect(
+    cell,
+    `no swimlane header cell for ${title}; row text was ${JSON.stringify(headerRow.textContent)}`,
+  ).toBeDefined();
+  return cell as HTMLElement;
+}
+
+/** The lane cell holding one column's cards for one lane, by the list's name. */
+function laneCell(region: HTMLElement, column: string, lane: string): HTMLElement {
+  const list = region.querySelector<HTMLElement>(
+    `[role="list"][aria-label="${column} - ${lane} cards"]`,
+  );
+  expect(list, `no lane list for ${column} / ${lane}`).not.toBeNull();
+  return list!.parentElement as HTMLElement;
+}
+
+/** The flat layout's column root — the element `columnStyle` lands on. */
+function flatColumn(container: HTMLElement, title: string): HTMLElement {
+  const col = container.querySelector<HTMLElement>(`[role="group"][aria-label="${title}"]`);
+  expect(col, `no flat column for ${title}`).not.toBeNull();
+  return col as HTMLElement;
+}
+
+/** Class tokens, so "carries the viewport classes" is a set question. */
+const tokens = (el: Element): string[] => el.className.split(/\s+/).filter(Boolean);
+const VIEWPORT_WIDTH_TOKEN = /^(?:[a-z]+:)?w-(?:\[85vw\]|80)$/;
+const carriesViewportWidth = (el: Element): boolean => tokens(el).some((t) => VIEWPORT_WIDTH_TOKEN.test(t));
+
+/**
+ * Controls that make every reading below non-vacuous: a real swimlane board,
+ * with real lanes, holding a real card inside the very cell being measured.
+ * "The cell has no `w-[85vw]`" is trivially true of a board that rendered
+ * nothing.
+ */
+function assertSwimlaneBoardIsReal(container: HTMLElement) {
+  const region = swimlaneRegion(container);
+  const laneButtons = [...region.querySelectorAll('button[aria-expanded]')];
+  expect(
+    laneButtons.map((b) => b.textContent),
+    'both lanes should render with their collapse buttons',
+  ).toEqual(['▶ann(1)', '▶bob(1)']);
+  const cell = laneCell(region, 'Open', 'ann');
+  expect(
+    within(cell).queryAllByText('Alpha deal').length,
+    'the measured lane cell should hold its card',
+  ).toBe(1);
+}
+
+/**
+ * The harness control for the SIZED cases.
+ *
+ * Every sized assertion below is downstream of one synchronous rect read
+ * reaching `useResizeObserver`. If that channel ever closes — a hook rewrite, a
+ * happy-dom change, a `ResizeObserver` that stops existing — `boardWidth` falls
+ * to 0, `columnInlineStyle` becomes `{}`, and the suite would be silently
+ * re-measuring the third state instead of the tiers. This asserts the channel
+ * is open, on the layout that already worked.
+ */
+function assertHarnessIsLive(width: number, expected: number) {
+  expect(
+    typeof ResizeObserver,
+    'useResizeObserver bails out entirely when ResizeObserver is undefined',
+  ).not.toBe('undefined');
+  const { container } = renderBoard({ width, swimlanes: false });
+  expect(
+    flatColumn(container, 'Open').style.width,
+    `the fixture failed to give the board a width of ${width}px: the flat column, ` +
+      `which consumed columnInlineStyle before objectui#8508 and after it, shows no inline width`,
+  ).toBe(`${expected}px`);
+  cleanup();
+}
+
+/**
+ * The three tiers of `columnInlineStyle`, on both sides of each breakpoint so a
+ * re-curved table cannot pass, plus the `Math.max(…, 220)` floor of the first.
+ */
+const TIERS: Array<{ board: number; expected: number; note: string }> = [
+  { board: 240, expected: 220, note: 'tier 1, below the floor' },
+  { board: 360, expected: 328, note: 'tier 1, board minus gutter' },
+  { board: 479, expected: 447, note: 'tier 1, last width before the break' },
+  { board: 480, expected: 280, note: 'tier 2, first width of the break' },
+  { board: 719, expected: 280, note: 'tier 2, last width before the break' },
+  { board: 720, expected: 320, note: 'tier 3, first width of the break' },
+  { board: 1400, expected: 320, note: 'tier 3, a wide board' },
+];
+
+describe('objectui#8508 — container-aware column width reaches the swimlane layout', () => {
+  it.each(TIERS)(
+    'swimlane header cell and lane cell take the flat column width at $board px ($note)',
+    ({ board, expected }) => {
+      // The reference reading, from the layout that always consumed the value.
+      assertHarnessIsLive(board, expected);
+
+      const { container } = renderBoard({ width: board, swimlanes: true });
+      assertSwimlaneBoardIsReal(container);
+      const region = swimlaneRegion(container);
+
+      for (const [what, cell] of [
+        ['header cell', headerCell(region, 'Open')],
+        ['lane cell', laneCell(region, 'Open', 'ann')],
+      ] as const) {
+        // POSITIVE — a real width, from the container-derived source. Deleting
+        // the viewport classes without wiring the width leaves this empty, so
+        // this reading is what makes the caricature fail rather than pass.
+        // Deliberately NOT paired with a `parseFloat(...) > 0` companion: that
+        // companion is implied by this equality and can never fail while this
+        // one passes, which would ship a line that reads as a second axis and
+        // is not one.
+        expect(
+          cell.style.width,
+          `the swimlane ${what} should take its width from columnInlineStyle, the same source ` +
+            `a flat column reads at this board width — a real positive width, not merely the ` +
+            `absence of the viewport classes (objectui#8508)`,
+        ).toBe(`${expected}px`);
+
+        // And the viewport classes must step aside rather than fight it —
+        // the same two-way switch KanbanColumnView has always applied.
+        expect(
+          carriesViewportWidth(cell),
+          `the swimlane ${what} still carries a viewport-relative width class alongside the ` +
+            `container-derived inline width; class was ${JSON.stringify(cell.className)}`,
+        ).toBe(false);
+      }
+    },
+  );
+
+  it('NON-REGRESSION — the flat layout still sizes its columns from the same value', () => {
+    for (const { board, expected } of TIERS) {
+      const { container } = renderBoard({ width: board, swimlanes: false });
+      expect(
+        container.querySelector('[role="region"]')?.getAttribute('aria-label'),
+        'this case must exercise the FLAT layout',
+      ).toBe('Kanban board');
+      for (const title of ['Open', 'Won']) {
+        const col = flatColumn(container, title);
+        expect(col.style.width, `flat column ${title} at ${board}px`).toBe(`${expected}px`);
+        expect(carriesViewportWidth(col), `flat column ${title} at ${board}px`).toBe(false);
+        expect(
+          within(col).queryAllByText(title).length,
+          'the measured column should still render its own heading',
+        ).toBe(1);
+      }
+      cleanup();
+    }
+  });
+
+  it('THIRD STATE — with no measured board width, both layouts keep the viewport classes', () => {
+    // `if (!boardWidth) return {}`. This is not "a small board": it is the
+    // pre-observation / SSR state, where the viewport classes are correct and
+    // their absence would leave a cell with no width at all — the caricature.
+    const swim = renderBoard({ swimlanes: true });
+    assertSwimlaneBoardIsReal(swim.container);
+    const region = swimlaneRegion(swim.container);
+    for (const [what, cell] of [
+      ['header cell', headerCell(region, 'Open')],
+      ['lane cell', laneCell(region, 'Open', 'ann')],
+    ] as const) {
+      expect(
+        cell.style.width,
+        `unmeasured board: the swimlane ${what} must not invent an inline width`,
+      ).toBe('');
+      expect(
+        carriesViewportWidth(cell),
+        `unmeasured board: the swimlane ${what} must fall back to the viewport width classes, ` +
+          `or it renders with no width from any source; class was ${JSON.stringify(cell.className)}`,
+      ).toBe(true);
+    }
+    cleanup();
+
+    const flat = renderBoard({ swimlanes: false });
+    const col = flatColumn(flat.container, 'Open');
+    expect(col.style.width, 'unmeasured board: the flat column must not invent an inline width').toBe('');
+    expect(
+      carriesViewportWidth(col),
+      'unmeasured board: the flat column must fall back to the viewport width classes',
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectui#8508

## The defect, as measured

`KanbanBoardInner` derives `columnInlineStyle` from the board's own slot (`useResizeObserver`
on a wrapper that encloses **both** layouts), and the docblock over it says this "replaces
hard-coded `w-[85vw] sm:w-80`" so an embedded board sizes to its slot. That value had exactly
one consumer: `columnStyle={columnInlineStyle}`, inside the **non-swimlane** branch. The
swimlane branch never read it — its header cells and its lane cells both carried the literal
the docblock says was replaced. So the sentence was true of one of the two layouts, and a
swimlane board embedded in a panel, a drawer or a pop-out — the case the feature exists for —
was still sized to the viewport.

Every line address on the card checks out on `origin/main` at `d65b2baa4`, including the
ternary boundary the card asked to confirm first: the swimlane branch opens at `:655`, its
header cells are `:687`, its lane cells `:721`, the alternative opens at `:738`, and the only
`columnInlineStyle` consumer is `:751`, inside it. **The card's correction to the earlier
reading is right**: the swimlane header cells and lane cells carry byte-identical width
classes, so there is no intra-swimlane misalignment to fix.

## The change

One shared `columnWidthClasses(columnStyle)` helper now holds the two-way switch that
`KanbanColumnView` used to spell inline, and both layouts call it with the same
`columnInlineStyle` object:

- `KanbanColumnView` reads it through its `columnStyle` prop, exactly as before.
- The swimlane header cells and lane cells apply the same style and the same class list
  directly, because that layout has no column components to inherit it from.

After the change the `w-[85vw] sm:w-80` literal exists at **one** place in the repository —
inside the shared helper's fallback arm — down from three code carriers.

Fallback behaviour is unchanged on both paths: with no measured width `columnInlineStyle` is
the empty object and the viewport classes are what sizes a cell.

## Pin — a prop, not a measured dimension

`swimlaneContainerAwareColumnWidth-8508.test.tsx` reads the inline style. It never reads a
rendered dimension: the sibling pin for objectui#7303 documents that the height defect there
was only catchable in a real Chromium, because happy-dom performs no layout, and this suite
deliberately does not re-attempt that.

The fixture supplies a board width through the one channel `useResizeObserver` actually uses
in this environment — the single synchronous `getBoundingClientRect()` read inside its effect
— by stubbing `Element.prototype.getBoundingClientRect` for the duration of a render. A
fixture with **no** width is treated as the third state (`if (!boardWidth) return {}`), pinned
separately on both layouts, never as a stand-in for a sized one.

Nine cases: seven width tiers (both sides of each breakpoint, plus the `Math.max(..., 220)`
floor), a flat-layout non-regression case, and the third state. Nothing navigates by the width
class being changed — cells are reached through the region's accessible name, the header row's
position, a lane list's accessible name, and a flat column's `role="group"`.

## Ablations — run, not predicted; restored by state

Four legs, each mutated from the committed implementation, each proven on disk in both
directions (injected text present **and** removed text absent, plus a blob-hash inequality
against the HEAD blob), each restored and the restore proven by `git diff HEAD` empty **and**
`git hash-object` equal to the HEAD blob. Every script carried `trap ... EXIT INT TERM` with
absolute paths.

| leg | mutation | result | first assertion that fires |
|---|---|---|---|
| defect | swimlane cells back to the pre-fix markup | 7 failed / 2 passed | swimlane cell inline width empty, expected the tier value |
| caricature | delete the viewport classes, wire nothing | **8** failed / 1 passed | same, **plus the third-state case** |
| half-fix | wire the style but keep the hard-coded classes | 7 failed / 2 passed | a **different** assertion: the cell still carries a viewport width class |
| harness-kill | fixture stops supplying a board width | 8 failed / 1 passed | the harness control, by name: "the fixture failed to give the board a width of 240px" |

Read as failure **modes** rather than counts, the interesting reading is that the axis the card
predicted would discriminate the caricature — "a real width at each of the three tiers" — does
**not** discriminate it. In the sized states the caricature fails on exactly the assertion the
plain defect fails on. What separates them is the **third-state** case, which the defect leg
passes and the caricature leg fails, because deleting the classes leaves an unmeasured board's
cells with no width from any source. That case is therefore load-bearing, not scenery.

The half-fix leg exists because without it the "viewport classes must step aside" assertion
would never have fired independently, and would have shipped as a line that reads like a second
axis without being one. It fires, with its own message. The one assertion that could not fail
independently — a `parseFloat(...) > 0` companion to the tier equality — was **removed** rather
than kept and labelled.

The harness-kill leg answers the hazard the dispatch raised: when the fixture's width channel
dies, the suite reports **the fixture**, by name, and does not read as a component failure.

## Verification

- `pnpm exec vitest run packages/plugin-kanban/` — 34 files, 223 tests, all passing. The 34
  reconciles against 34 test files on disk under that package, so the new file is inside the
  run; it also passes standalone (9 tests).
- `pnpm --filter @object-ui/plugin-kanban run type-check` — clean, after building the
  dependency closure first (`pnpm --filter '@object-ui/plugin-kanban^...' build`). Before that
  build it reported 27 errors that were all downstream of unresolved `@object-ui/*` types.
  The package's `tsconfig.test.json` leg covers the new file: `--listFiles` names it.
- ESLint on all three changed files: 0 errors. `--no-inline-config` was **not** used.
- `check-control-bytes`, `check-changeset-presence`, `check-changeset-no-major`,
  `check-changeset-fixed`: all green. A separate scan of the three changed files for control
  bytes, zero-width characters and other irregular whitespace found 0 hits, with the same
  instrument firing on planted samples.
- **Declared narrowing.** The repo-wide `pnpm lint` / full test farm is left to CI rather than
  run locally, since sibling agents share this container. That narrowing is safe to state
  because `eslint.config.js` configures no type-aware linting (no `projectService`, no
  `parserOptions.project`), so this diff cannot move the verdict on any file it does not touch.

## Out-of-scope observation, not filed

`packages/plugin-kanban/src/useColumnWidths.ts` is exported from the package barrel with its
`ColumnWidthConfig` type and its own `objectui:kanban-column-widths` storage key, and **no
board reads it** — the rendered column width comes entirely from `columnInlineStyle`. It also
appears in no docs under `content/`. Two column-width policies, one of them unwired. Left
untouched and handed to the PM to file, because the dedup search it needs is a call the
dispatch asked to conserve.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_