### PR TITLE
fix(app-shell): AgentPreview's empty rail collection announces itself in words

### DIFF
--- a/.changeset/olive-crabs-visit.md
+++ b/.changeset/olive-crabs-visit.md
@@ -1,0 +1,21 @@
+---
+'@object-ui/app-shell': patch
+---
+
+AgentPreview: an empty rail collection now says so instead of drawing a bare em dash
+
+`KeyVals`'s zero-rows branch — every requested key resolved to `undefined`/`null`,
+so a Planning / Memory / Guardrails rail block has no key/values at all — rendered
+`<div className="text-muted-foreground italic">—</div>`: no role, no label, no text
+alternative, so a screen-reader user reached it as a naked punctuation mark. It now
+renders `EmptyDescription` from `@object-ui/components` with the text "No values
+set.".
+
+This is an empty **collection**, not an empty field value, so `EmptyValue` is the
+wrong member of that family: its docblock scopes it to a missing cell/field value
+and its `aria-label` resolves `detail.noValue` ("No value"), which would be a false
+statement about a collection that simply has no members. The container `Empty` is
+not used either — measured in the browser at this rail's real 215px content width
+it is 118.8px tall against the 16px row it replaces. `EmptyDescription` at
+`text-xs italic` is metrically identical to the row it replaces, so the layout is
+unchanged and only the announcement differs.

--- a/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.emptyCollection-8520.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.emptyCollection-8520.test.tsx
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `KeyVals`'s zero-rows branch is a block-level empty-COLLECTION state
+ * (objectui#8520). It used to render a bare em dash in a plain `<div>`:
+ *
+ *     if (rows.length === 0) return <div className="…italic">—</div>;
+ *
+ * with no role, no label and no text alternative, so a screen-reader user
+ * reaching a rail block whose keys all resolved to `undefined` heard a naked
+ * punctuation mark. It survived three censuses across objectui#8491 /
+ * PR #8503 / objectui#8504 because every instrument in that thread was
+ * anchored on `<span`, and this carrier is a `<div>`.
+ *
+ * The two carriers this pin has to keep out are BOTH plausible fixes, not
+ * only the obviously-worse one:
+ *
+ *   1. the original bare `—` (nothing announced), and
+ *   2. `<EmptyValue />` — the sibling component the other nine carriers in
+ *      this class converted to. It looks like the fix, renders a placeholder,
+ *      and is wrong here: its docblock scopes it to a missing cell/field
+ *      VALUE, it renders a `<span>`, and its `aria-label` resolves
+ *      `detail.noValue` — "No value" — which is a false statement about a
+ *      collection that simply has no members.
+ *
+ * ⚠️ Navigation vs. assertion. The harness reaches the state through the rail
+ * block's own title ("Planning", owned by `RailBlock`), never through anything
+ * the empty state renders. If it navigated by `data-slot="empty-description"`
+ * — the thing under change — then any caricature that removes the description
+ * would kill the harness instead of failing the assertion, and the pin would
+ * read as a strong refusal while measuring nothing.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, within, cleanup } from '@testing-library/react';
+import { AgentPreview } from './AgentPreview';
+
+afterEach(cleanup);
+
+const BASE = {
+  name: 'sales_copilot',
+  label: 'Sales Copilot',
+  active: true,
+  model: { provider: 'openai', model: 'gpt-4o' },
+  instructions: 'You are a helpful sales assistant.',
+  skills: ['summarize_account'],
+} satisfies Record<string, unknown>;
+
+/**
+ * `planning` is present (so the rail block renders at all) but carries none of
+ * the keys `KeyVals` is asked for, so every row filters out — the zero-rows
+ * branch, reached exactly the way an author reaches it.
+ */
+const EMPTY_COLLECTION_DRAFT = { ...BASE, planning: { retries: 3 } };
+
+/** Same block, one resolvable key: the populated branch. */
+const POPULATED_DRAFT = { ...BASE, planning: { maxIterations: 8 } };
+
+function renderPreview(draft: Record<string, unknown>) {
+  return render(<AgentPreview type="agent" name="sales_copilot" draft={draft} />);
+}
+
+/**
+ * The rail block's body slot, reached by the block's TITLE. `RailBlock` renders
+ * `<div><div>{icon}{title}</div>{children}</div>`, so the title's parent is the
+ * block root and its second child is whatever `KeyVals` returned.
+ */
+/**
+ * Self-inclusive `querySelector` over the rail block's body. `KeyVals` returns
+ * the empty state AS that body element, and `Element.querySelectorAll` never
+ * matches the element it is called on — so a plain descendant query silently
+ * misses the very node under test.
+ */
+function self(selector: string): Element | null {
+  const body = planningBody();
+  return body.matches(selector) ? body : body.querySelector(selector);
+}
+
+function planningBody(): HTMLElement {
+  const title = screen.getByText('Planning');
+  const block = title.parentElement;
+  expect(block).toBeTruthy();
+  const body = block!.children[1] as HTMLElement | undefined;
+  expect(body).toBeTruthy();
+  return body!;
+}
+
+describe('AgentPreview: an empty rail collection announces itself in words', () => {
+  it('states the condition instead of drawing a bare em dash', () => {
+    renderPreview(EMPTY_COLLECTION_DRAFT);
+    const body = planningBody();
+    expect(within(body).getByText('No values set.')).toBeTruthy();
+  });
+
+  it('announces letters, not punctuation — the axis both wrong fixes fail', () => {
+    renderPreview(EMPTY_COLLECTION_DRAFT);
+    const text = (planningBody().textContent ?? '').trim();
+    expect(text.length).toBeGreaterThan(0);
+    // A bare `—` and an `<EmptyValue />` glyph both leave this false.
+    expect(/\p{Letter}/u.test(text)).toBe(true);
+  });
+
+  it('leaves no em dash behind for a screen reader to read as the whole state', () => {
+    renderPreview(EMPTY_COLLECTION_DRAFT);
+    // queryAllByText, not queryByText: the latter throws on MULTIPLE matches,
+    // which would report a second carrier as a harness crash rather than a miss.
+    expect(within(planningBody()).queryAllByText('—')).toHaveLength(0);
+  });
+
+  it('is not labelled "No value" — that is a claim about a field, not a collection', () => {
+    renderPreview(EMPTY_COLLECTION_DRAFT);
+    // `self` and not `querySelectorAll`: `KeyVals` returns the empty state as
+    // the rail block's body ELEMENT, and `querySelectorAll` never matches the
+    // element it is called on. Written the naive way this assertion sat green
+    // through a measured `<EmptyValue />` caricature — the labelled
+    // discriminator was the one axis of six that did NOT fire (objectui#8520).
+    expect(self('[data-slot="empty-value"]')).toBeNull();
+    expect(self('[aria-label="No value"]')).toBeNull();
+  });
+
+  it('is a block-level member of the shared Empty family, not a hand-rolled div', () => {
+    renderPreview(EMPTY_COLLECTION_DRAFT);
+    expect(self('[data-slot="empty-description"]')).toBeTruthy();
+  });
+
+  it('still renders the rows when the collection has any', () => {
+    renderPreview(POPULATED_DRAFT);
+    const body = planningBody();
+    expect(within(body).getByText('maxIterations')).toBeTruthy();
+    expect(within(body).getByText('8')).toBeTruthy();
+    expect(within(body).queryByText('No values set.')).toBeNull();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.tsx
@@ -46,7 +46,7 @@ import {
   Shield,
   Sparkles,
 } from 'lucide-react';
-import { cn } from '@object-ui/components';
+import { cn, EmptyDescription } from '@object-ui/components';
 import type { MetadataPreviewProps } from '../preview-registry.js';
 import { PreviewShell, PreviewMessage, PreviewErrorBoundary } from './PreviewShell.js';
 
@@ -299,7 +299,20 @@ function KeyVals({ data, keys }: { data: Record<string, unknown>; keys: string[]
   const rows = keys
     .map((k) => [k, getPath(data, k)] as const)
     .filter(([, v]) => v !== undefined && v !== null);
-  if (rows.length === 0) return <div className="text-muted-foreground italic">—</div>;
+  // Empty COLLECTION, not an empty field value: every requested key resolved
+  // to undefined/null, i.e. this rail block has no key/values at all. It used
+  // to render a bare `—` in a plain <div>, which a screen reader reaches as an
+  // unnamed punctuation mark (objectui#8520). `EmptyValue` is the wrong member
+  // of the family here — its docblock scopes it to a missing cell/field VALUE
+  // and its aria-label resolves `detail.noValue` ("No value"), a false
+  // statement about a collection. `EmptyDescription` is the family's
+  // block-level text slot and states the condition in words; the container
+  // `Empty` is deliberately NOT used — measured at this rail's real 215px
+  // width it is 118.8px tall against the 16px row it replaces (objectui#8520
+  // PR body has the numbers). `text-xs italic` matches the sibling empty
+  // states in this file and this directory.
+  if (rows.length === 0)
+    return <EmptyDescription className="text-xs italic">No values set.</EmptyDescription>;
   return (
     <dl className="space-y-0.5">
       {rows.map(([k, v]) => (


### PR DESCRIPTION
Fixes objectstack-ai/objectui#8520

`KeyVals`'s zero-rows branch in `AgentPreview.tsx` rendered a bare em dash in a plain `div` — no role, no label, no text alternative. It now renders `EmptyDescription` from `@object-ui/components` with the text "No values set.".

## Which members, and why

**Used:** `EmptyDescription`, alone, with `className="text-xs italic"`.
**Not used:** `EmptyValue` (ruled out by the card). **Also not used:** the `Empty` container.

Dropping the container is the one judgement objectui#8520 left open, and it is a departure from the ruling's stated guess, so here is the measurement it was asked to rest on rather than an assertion.

### The measurement

Chromium at `/opt/pw-browsers/chromium`, the dev preview gallery (`apps/console` at `?only=agent`), viewport 1440x900. Every candidate rendered **in the same page load**, inside the real `AgentPreview` side rail — rail box 240px, content column **215px** — reading `getBoundingClientRect` and `getComputedStyle` off each:

| candidate | height | font | align | border |
|---|---|---|---|---|
| **A** before: `div.text-muted-foreground.italic` holding the em dash | **16px** | 12px | start | none |
| **B** shipped: `EmptyDescription` + `text-xs italic` | **16px** | 12px | start | none |
| C `EmptyDescription`, family defaults | 22.8px | 14px | start | none |
| D `Empty` wrapping `EmptyDescription` — the ruling's prediction | **118.8px** | 12px | center | `dashed` at 0px width |
| E the same, `className="px-3 py-8"` — this repo's own sidebar precedent | 118.8px, identical to D | 12px | center | `dashed` at 0px |
| F the file's own local `Empty` (see below) | 16px | 12px | start | none |

**D is 7.4x the row it replaces**, centred, inside a 215px rail whose other blocks are 16px-per-row definition lists. It is a full-canvas panel and the rail is not a canvas. E shows the obvious escape hatch does not work: an unprefixed `px-3 py-8` replaces the base `p-6` but never touches `md:p-12`, so above 768px the padding comes straight back — filed as objectui#8525 along with the dashed border that renders at 0px width at every call site in the repo.

**B is metrically identical to A on all four axes.** The layout delta of this PR is zero; only the announcement changes. That is worth stating plainly because the ruling predicted the opposite ("the visual delta here is deliberate and larger than the six sites in objectui#8504") — measured, there is no visual delta at all, which is a better outcome than the one that was being braced for.

### Why not the container at a smaller size

`Empty` can be beaten into 16px with `gap-0 p-0 md:p-0 items-start text-left` — measured, it works. It also neutralises six of the container's ten utilities and leaves `rounded-lg border-dashed text-balance` doing nothing. Fighting a component that hard is the component telling you it is the wrong member.

### Why `EmptyDescription` standing alone

All 28 existing `EmptyDescription` call sites in this repo nest it inside `Empty`, so this is a new composition and reviewers should look at it. The case for it: it is a block-level text slot (`data-slot="empty-description"`), it carries the design-system hook so a future restyle reaches this site, and it states the condition in words — which is the whole of the defect. The case against is precedent, and it loses to a 7.4x height difference.

## What the sibling census found

The ruling asked for it before choosing. Probing `packages/app-shell/src/views/metadata-admin/previews/*` with an element-agnostic grep for the family: **zero** of the 15 empty-collection states in that directory use it. All 15 hand-roll a muted sentence, across six type scales. Two of them — `AgentPreview.tsx:221` and `ToolPreview.tsx:296` — declare a **local component named `Empty`**, which is why this PR imports `EmptyDescription` and not `Empty`: the names collide in this file, with no compiler error waiting for whoever tries. Filed as objectui#8526.

The local `Empty` sits 166 lines above the defect and is used at line 136 for the same kind of state. The zero-rows branch was the file's own outlier, not a site that had no block-level empty state available.

## Test

`AgentPreview.emptyCollection-8520.test.tsx`, six cases. It navigates by the rail block's **title** ("Planning", owned by `RailBlock`) and never by anything the empty state renders — so a caricature that erases the description fails an assertion instead of killing the harness.

Four ablation legs, each mutated on disk, proven by hash in both directions, restored by state:

| leg | result | failure mode |
|---|---|---|
| revert to the bare em dash | RED 4/6 | assertion failures, harness alive |
| **`EmptyValue` with `className="italic"`** — the plausible wrong fix | RED 5/6 | assertion failures, harness alive |
| strip the "Planning" title from `RailBlock` — harness-kill | RED 6/6 | *every* case dies on "Unable to find an element with the text: Planning", textually distinct from the two above |
| `Empty` wrapping `EmptyDescription` — the ruling's guess | **GREEN 6/6** | survivor, see below |

**The labelled discriminator was inert on first run and had to be repaired.** The assertion written specifically to catch `EmptyValue` — "is not labelled No value" — sat green through a measured `EmptyValue` caricature, because `KeyVals` returns the empty state *as* the rail block's body element and `Element.querySelectorAll` never matches the element it is called on. The axis that actually caught it was the generic one: *the state announces letters, not punctuation*. Repaired with a self-inclusive selector, re-run, and it now fires; the miss is recorded in the test's own comments so it does not get re-introduced.

**Declared scope:** the surviving leg is not a bug in the pin. This test measures the accessibility contract — a readable, correctly-scoped, block-level announcement — and **not** visual weight. The container variant is a legitimate fix by that contract and is rejected on the browser measurement above, which is argument, not assertion. A future change that swaps in the container will pass this test; that is intended.

## Checks run locally

- `pnpm exec vitest run packages/app-shell/src/views/metadata-admin/` — 239 files, 2487 passed, 1 skipped
- `pnpm --filter @object-ui/app-shell type-check` — green, after `pnpm --filter '@object-ui/app-shell^...' build`. That project chains `tsc -p tsconfig.test.json`, whose `include` is `src/**/*.test.tsx`, so the new pin is compiled and not merely run.
- `pnpm exec eslint .` — the full repo population, **4494 files, 0 errors**. No narrowing, and no `--no-inline-config` (an objectstack convention that manufactures errors CI does not have here). `no-irregular-whitespace` is on at error level via the preset; note its `skipStrings: true`, so a separate scan of the diff for control bytes, zero-width and irregular whitespace was run and is clean.
- `pnpm check:control-bytes` — green. `node scripts/check-changeset-presence.mjs` — green, 1 changeset for 1 changed published source file.

## Reachability

No manifest edge. `@object-ui/components` is already `"workspace:*"` under `dependencies` in `packages/app-shell/package.json`, and this file already imported `cn` from it.

## i18n

The string is a literal, matching this file — `AgentPreview.tsx` has no `t()` call anywhere and states all of its copy in English ("No system prompt set yet.", "Defaults in use."). Introducing one key here would be the inconsistency, not the fix.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_