### PR TITLE
fix(core): ValueDataSource reads its array and `{ $field }` comparands instead of comparing them by reference

### DIFF
--- a/.changeset/valuedatasource-comparand-shapes-8514.md
+++ b/.changeset/valuedatasource-comparand-shapes-8514.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/core': minor
+---
+
+`ValueDataSource` reads the two comparand shapes it used to compare by reference.
+
+**An ARRAY comparand is refused rather than compared by reference**
+(objectui#8514). `{ tags: ['a', 'b'] }` took the simple-equality branch and
+`!==` compares references, so it excluded every row including the deep-equal
+one — silently. It is now excluded with a logged reason naming `$in`, in both
+dialects and on the `$`-operator positions too. The equality positions move no
+rows (a reference comparison already excluded everything); the negations do:
+`$ne` / `!=` against an array was always true, so it had been selecting EVERY
+row in silence.
+
+The repair is a refusal rather than a deep-equality reading because the spec
+declines to rule on an array outside `$in` / `$nin` / `$between`, and the two
+in-memory matchers nearest this one both refuse it — inventing a reading here
+would be a second de-facto contract the wire does not honour. Every producer in
+this repo already spells a multi-value comparand `{ $in: [...] }`.
+
+**A `{ $field }` comparand is now resolved** (objectui#8515). The spec declares
+it, `@objectstack/formula` emits it, and both platform evaluation paths execute
+it; this adapter compared the reference object, so such a filter answered with
+no rows and no diagnostic. It is now dereferenced against the record on the six
+scalar comparisons it is declared for, in both dialects. A reference in a list
+position, one carrying an `addDays` offset, a dotted path, and a non-string
+`$field` are refused with the reason — an `addDays` silently dropped would
+return wrong rows rather than none.

--- a/packages/core/src/adapters/README.md
+++ b/packages/core/src/adapters/README.md
@@ -111,6 +111,21 @@ prescription in the message:
 | `$startswith`, `$notcontains`, `$notin`, `$ncontains` | non-canonical spellings | the camelCase spelling |
 | `$and` / `$or` / `$not` | combinators, not field operators | an AST array `$filter` |
 | `{ relation: { field: … } }` | this matcher does not descend into relations | filter on the stored key |
+| an **array** comparand outside `$in` / `$nin` / `$between` | the spec leaves it unruled and the sibling in-memory matcher refuses it; a reference comparison excluded every row, and on `$ne` selected every row (objectui#8514) | `{ field: { $in: [ … ] } }` |
+| `{ $field }` in an `$in` / `$nin` member or a `$between` endpoint | removed from those positions because no backend resolved one (objectstack#7596) | a scalar comparison |
+| `{ $field, addDays }` | the offset is defined against the column's temporal class, which this schema-less matcher cannot read (objectstack#14104) | shift the value at the producer |
+| `{ $field: 'a.b' }` (dotted) | this matcher addresses a flat record, so a dotted reference would not mean what a dotted field name means | a same-record column |
+| `{ field: { $field: … } }` (implicit) | reads as an operator named `$field`, not a comparand (objectstack#7597) | `{ field: { $eq: { $field: … } } }` |
+
+#### Cross-field comparands
+
+A `{ $field: 'other_column' }` comparand is **executed**, in both dialects, as the
+whole comparand of the six scalar comparisons (`$eq` `$ne` `$gt` `$gte` `$lt`
+`$lte` and their AST spellings) — the positions `FieldReferenceSchema` declares
+it for. It resolves against the record being matched, so
+`{ amount: { $lte: { $field: 'budget' } } }` selects the rows whose `amount` is
+within their own `budget` (objectui#8515). Every other position is refused, in
+the rows above.
 
 ### `resolveDataSource`
 

--- a/packages/core/src/adapters/ValueDataSource.ts
+++ b/packages/core/src/adapters/ValueDataSource.ts
@@ -147,6 +147,158 @@ function refuseArrayComparand(
 }
 
 /**
+ * The operators a `{ $field }` reference is a legal comparand ON, in both
+ * dialects — the SIX scalar comparisons and nothing else.
+ *
+ * Not this file's choice: `FieldReferenceSchema` (`@objectstack/spec/data`)
+ * declares the reference on `$eq`/`$ne`/`$gt`/`$gte`/`$lt`/`$lte`, and
+ * objectstack#7596 REMOVED it from `$in` / `$nin` members and `$between`
+ * endpoints at the schema door, on the finding that no backend ever resolved
+ * one there.
+ */
+const DOLLAR_FIELD_REFERENCE_OPERATORS = new Set(['$eq', '$ne', '$gt', '$gte', '$lt', '$lte']);
+const AST_FIELD_REFERENCE_OPERATORS = new Set(['=', '!=', '>', '>=', '<', '<=']);
+
+/** A comparand this matcher refused; distinguishable from a resolved `undefined`. */
+const REFUSED_COMPARAND: unique symbol = Symbol('ValueDataSource:refused-comparand');
+
+/**
+ * Is this comparand shaped like a Filter Protocol FIELD REFERENCE?
+ *
+ * The test is `'$field' in value`, which is what `@objectstack/formula`'s
+ * `resolveValue` uses, so the three faces agree on what a reference IS before
+ * they differ on what to do with one. Validity of the `$field` VALUE is judged
+ * by {@link resolveFieldReference}, which refuses loudly — reporting a
+ * malformed reference beats letting it fall through to a comparison against
+ * the object, which is the silence this card is about.
+ */
+function isFieldReferenceComparand(value: any): boolean {
+  return !!value && typeof value === 'object' && !Array.isArray(value) && '$field' in value;
+}
+
+/**
+ * Resolve `{ $field: 'other_column' }` against the record being matched
+ * (objectui#8515), or refuse it with the reason.
+ *
+ * ## Why this is implemented rather than refused
+ *
+ * `@objectstack/spec/data` declares the shape, `@objectstack/formula`'s
+ * `compileCelToFilter` emits it for a field-to-field comparison in a CEL
+ * permission rule, and BOTH platform evaluation paths execute it — the
+ * in-memory `matchesFilter` resolves it in `resolveValue`, and `driver-sql`
+ * compiles it to a same-table column-to-column comparison (objectstack#5222),
+ * held to the same rows by a shared conformance corpus. Refusing it here would
+ * make this adapter the one face that answers a declared, executed shape with
+ * "no rows" — the outcome the sibling card ruled worse than the bug.
+ *
+ * Both of this file's matchers compared the reference OBJECT against the stored
+ * value: `value === target` for `$eq` (never equal — no rows) and `value > target`
+ * for the orderings (an object bound — no rows). Neither said anything.
+ *
+ * ## The three positions this refuses instead, each for a recorded reason
+ *
+ * - **A `$field` that is not a STRING.** `FieldReferenceSchema` declares
+ *   `z.string()`, and the spec's own lowering predicate (matching `driver-sql`'s
+ *   `fieldReferenceOf`) treats a non-string `$field` as "not a field reference
+ *   on any path". Downstream that means "refused as the uncompilable object it
+ *   is", which is what this does — loudly, rather than by object comparison.
+ * - **A DOTTED path.** This matcher addresses the left-hand side as
+ *   `record[field]`, flat, so resolving a dotted path only on the right would
+ *   make `['a.b', '=', x]` and `['x', '=', { $field: 'a.b' }]` disagree about
+ *   what a dot means. SQL push-down refuses a dotted path too, under the
+ *   maintainer's 2026-08-06 same-table ruling (no JOIN planning, no alias
+ *   contract). `@objectstack/formula` DOES walk dots — that divergence is named
+ *   here rather than papered over, because this adapter has no path accessor to
+ *   be consistent with.
+ * - **`addDays`.** The whole-day offset (objectstack#14104) is defined against
+ *   the referenced column's TEMPORAL CLASS — a `date` stays a calendar day, a
+ *   `datetime` keeps its time of day — and SQL push-down compiles it only
+ *   between two temporal columns of the same class, refusing everything else
+ *   loudly. This matcher has no field types to read a class from, so it refuses
+ *   for the same reason rather than guessing. Silently IGNORING the offset is
+ *   the one answer that must not happen: it would compare against an unshifted
+ *   column and return WRONG rows, where today's defect returns none.
+ */
+function resolveFieldReference(
+  record: any,
+  reference: Record<string, any>,
+  operator: string,
+  rawOperator: string,
+  field: string,
+  legalOperators: ReadonlySet<string>,
+  refusals: Set<string>,
+): any {
+  const path = reference.$field;
+
+  if (typeof path !== 'string') {
+    refuseFilterNode(
+      refusals,
+      `filter comparand for field '${field}' carries a non-string $field `
+      + `(${JSON.stringify(path) ?? String(path)}); a field reference declares `
+      + `$field as a string, so this is not one on any path`,
+    );
+    return REFUSED_COMPARAND;
+  }
+
+  if (!legalOperators.has(operator)) {
+    refuseFilterNode(
+      refusals,
+      `a { $field } reference is not a comparand for operator '${rawOperator}' on field `
+      + `'${field}'. It is declared only on the six scalar comparisons `
+      + `($eq/$ne/$gt/$gte/$lt/$lte and their AST spellings); the spec removed it from `
+      + `$in / $nin members and $between endpoints because no backend resolves one there`,
+    );
+    return REFUSED_COMPARAND;
+  }
+
+  if ('addDays' in reference && reference.addDays !== undefined) {
+    refuseFilterNode(
+      refusals,
+      `the { $field } reference on field '${field}' carries an addDays offset, which is `
+      + `defined against the referenced column's temporal class; this matcher has no field `
+      + `types to read one from, and answering without the offset would compare against an `
+      + `unshifted column and return the wrong rows`,
+    );
+    return REFUSED_COMPARAND;
+  }
+
+  if (path.includes('.')) {
+    refuseFilterNode(
+      refusals,
+      `the { $field } reference on field '${field}' names the dotted path '${path}'; this `
+      + `matcher addresses a flat record, so a dotted reference would not mean the same `
+      + `thing as the dotted field name on the other side of the comparison`,
+    );
+    return REFUSED_COMPARAND;
+  }
+
+  return record[path];
+}
+
+/**
+ * A `{ $field }` reference sitting INSIDE a list comparand — an `$in` / `$nin`
+ * member or a `$between` endpoint (objectstack#7596, ruled 2026-08-11).
+ *
+ * The positions were declared once and honoured by nobody; the ruling was
+ * REMOVE rather than implement. The `$nin` direction is why this is loud rather
+ * than left alone: an unresolved member drops an EXCLUSION the author wrote,
+ * so the row passes — a filter that widens its result set in silence.
+ */
+function refuseListMemberFieldReference(
+  refusals: Set<string>,
+  field: string,
+  operator: string,
+): false {
+  return refuseFilterNode(
+    refusals,
+    `a { $field } reference appears inside the list comparand of '${operator}' on field `
+    + `'${field}'. A reference may be the WHOLE comparand of a scalar comparison, never a `
+    + `member of $in / $nin nor an endpoint of $between — the spec removed those positions `
+    + `because no evaluation path resolved them`,
+  );
+}
+
+/**
  * Evaluate ONE comparison node — `[field, operator]` or `[field, operator, value]`.
  *
  * The operator is canonicalized through the spec's own
@@ -175,19 +327,37 @@ function matchesComparisonNode(
   const operator =
     rawOperator === 'not in' ? 'nin' : canonicalAstOperator(rawOperator);
   const value = record[field];
-  const target = node[2];
+  const rawTarget = node[2];
 
   // objectui#8514 — an array where a single-value comparand belongs. Checked
   // before the switch so `=` / `!=` cannot answer it by reference (never equal
   // / always unequal), and skipped for the operators that DECLARE an array
   // comparand and for the two that never read the slot.
   if (
-    Array.isArray(target)
+    Array.isArray(rawTarget)
     && !AST_LIST_COMPARAND_OPERATORS.has(operator)
     && !AST_NO_COMPARAND_OPERATORS.has(operator)
   ) {
     return refuseArrayComparand(refusals, field, String(rawOperator));
   }
+
+  // objectui#8515 — a `{ $field }` reference inside a list comparand. The
+  // members are walked only for the three operators that HAVE a list comparand;
+  // everywhere else an array was already refused above.
+  if (Array.isArray(rawTarget) && rawTarget.some(isFieldReferenceComparand)) {
+    return refuseListMemberFieldReference(refusals, field, String(rawOperator));
+  }
+
+  // objectui#8515 — a `{ $field }` reference as the WHOLE comparand. Resolved
+  // against this record so the switch below compares two of its own values,
+  // exactly as `matchesFilter` (`@objectstack/formula`) and `driver-sql` do.
+  const target = isFieldReferenceComparand(rawTarget)
+    ? resolveFieldReference(
+      record, rawTarget, operator, String(rawOperator), field,
+      AST_FIELD_REFERENCE_OPERATORS, refusals,
+    )
+    : rawTarget;
+  if (target === REFUSED_COMPARAND) return false;
 
   switch (operator) {
     // -- Null-ness. Direction comes from the operator NAME; the value slot is
@@ -379,17 +549,32 @@ function matchesASTFilter(record: any, filterNode: any, refusals: Set<string>): 
  *   operators: this matcher does not descend into relations.
  */
 function matchesDollarOperator(
+  record: any,
   value: any,
   operator: string,
-  target: any,
+  rawTarget: any,
   field: string,
   refusals: Set<string>,
 ): boolean {
   // objectui#8514 — the `$` twin of the AST guard above, and the position that
   // carries the fail-OPEN case: `$ne` against an array is always true.
-  if (Array.isArray(target) && !DOLLAR_LIST_COMPARAND_OPERATORS.has(operator)) {
+  if (Array.isArray(rawTarget) && !DOLLAR_LIST_COMPARAND_OPERATORS.has(operator)) {
     return refuseArrayComparand(refusals, field, operator);
   }
+
+  // objectui#8515 — a `{ $field }` reference inside a list comparand.
+  if (Array.isArray(rawTarget) && rawTarget.some(isFieldReferenceComparand)) {
+    return refuseListMemberFieldReference(refusals, field, operator);
+  }
+
+  // objectui#8515 — a `{ $field }` reference as the WHOLE comparand.
+  const target = isFieldReferenceComparand(rawTarget)
+    ? resolveFieldReference(
+      record, rawTarget, operator, operator, field,
+      DOLLAR_FIELD_REFERENCE_OPERATORS, refusals,
+    )
+    : rawTarget;
+  if (target === REFUSED_COMPARAND) return false;
 
   switch (operator) {
     case '$eq':
@@ -448,6 +633,22 @@ function matchesDollarOperator(
       return target
         ? value !== null && value !== undefined
         : value === null || value === undefined;
+
+    // objectui#8515 — the hand-authored IMPLICIT form `{ amount: { $field: 'x' } }`.
+    // It is not a reference comparand: an object whose only key starts with `$`
+    // reads as an OPERATOR SPEC named `$field`, which is why this arrives here
+    // as an operator at all. objectstack#7597 ruled that form keeps its
+    // fail-closed fate rather than being promoted, and named the spelling that
+    // works — the same one `driver-sql`'s refusal names. The default arm below
+    // already excluded the row; this arm only replaces "not implemented" with
+    // the prescription, so an author reading the console can act on it.
+    case '$field':
+      return refuseFilterNode(
+        refusals,
+        `field '${field}' carries a bare { $field } object, which reads as an operator `
+        + `named '$field' rather than as a comparand. Write the explicit comparison `
+        + `{ ${field}: { $eq: { $field: ${JSON.stringify(String(rawTarget))} } } }`,
+      );
 
     default: {
       const retired = RETIRED_FILTER_OPERATORS[operator];
@@ -523,7 +724,7 @@ function matchesFilter(
     if (condition && typeof condition === 'object' && !Array.isArray(condition)) {
       // Operator-based filter — every operator on the field is ANDed.
       for (const [op, target] of Object.entries(condition)) {
-        if (!matchesDollarOperator(value, op, target, key, refusals)) return false;
+        if (!matchesDollarOperator(record, value, op, target, key, refusals)) return false;
       }
     } else if (Array.isArray(condition)) {
       // objectui#8514 — the implicit-equality position this card was filed

--- a/packages/core/src/adapters/ValueDataSource.ts
+++ b/packages/core/src/adapters/ValueDataSource.ts
@@ -68,6 +68,85 @@ function refuseFilterNode(refusals: Set<string>, reason: string): false {
 }
 
 /**
+ * The operators whose comparand IS an array by declaration, in both dialects.
+ *
+ * `$in` / `$nin` take a member list and `$between` a two-element range; every
+ * other operator reads its comparand as a single value. That split is what
+ * {@link refuseArrayComparand} is checked against — an array anywhere else is
+ * not a comparand this protocol has a meaning for.
+ */
+const DOLLAR_LIST_COMPARAND_OPERATORS = new Set(['$in', '$nin', '$between']);
+const AST_LIST_COMPARAND_OPERATORS = new Set(['in', 'nin', 'between']);
+
+/**
+ * The AST operators that never read the value slot at all, so nothing sitting
+ * there is a comparand. `matchesComparisonNode`'s null arms take their
+ * direction from the operator NAME and the ObjectUI client sends a truthy
+ * placeholder in the third position, so the array guard must not judge it.
+ */
+const AST_NO_COMPARAND_OPERATORS = new Set(['is_null', 'is_not_null']);
+
+/**
+ * An ARRAY where a single-value comparand belongs — `{ tags: ['a', 'b'] }`,
+ * `{ tags: { $eq: ['a', 'b'] } }`, `['tags', '=', ['a', 'b']]` (objectui#8514).
+ *
+ * ## Why this is refused rather than given a deep-equality reading
+ *
+ * The card was filed as "reference comparison excludes even the deep-equal
+ * row", which is true, and the obvious repair is to make `['a','b']` equal
+ * `['a','b']`. The census says otherwise, and the spec says who owns the
+ * question. `assertListComparandShapes` (`@objectstack/spec/data`) lists
+ * "arrays outside `$in`/`$nin`/`$between`" among the positions its comparand
+ * door deliberately does NOT judge, on the stated ground that the ruling does
+ * not name it and the matrix did not measure it — it is left "to the layers
+ * that already answer it". Those layers do not agree, and the two nearest to
+ * this one both REFUSE:
+ *
+ * - `@objectstack/formula`'s `matchesFilter` — the record-at-a-time evaluator
+ *   this adapter is the closest sibling of — answers `false` structurally, on
+ *   the comment "a bare array value is not a valid field spec (must be
+ *   `{ $in: [...] }`)".
+ * - `@objectstack/driver-sql` refuses an array comparand with its own message.
+ * - Only the document stores give it array-equality, as a native behaviour of
+ *   the store rather than a ruled contract.
+ *
+ * So there is no protocol answer to implement, and inventing one HERE is the
+ * lenient-consumer fallback the repo forbids (AGENTS.md #0.1): a second
+ * de-facto contract, agreed with by no backend, that a `provider: 'value'` list
+ * would honour and the same filter on the wire would not. Every producer in
+ * this repo already spells a multi-value comparand `{ $in: [...] }` — measured
+ * across every `$filter` literal under the packages' and apps' source trees,
+ * where the only array-valued comparands are `$in` / `$nin` members — so
+ * refusing costs no caller a working filter, and the message names the
+ * spelling that works. (The glob is spelled in words because a literal one
+ * would close this comment.)
+ *
+ * ## The rows do not move; the silence does — except on the negations
+ *
+ * For `{ tags: [...] }` and `{ tags: { $eq: [...] } }` this changes no result
+ * set: `!==` / `===` against a fresh array already excluded every row, so the
+ * repair is the diagnostic. `$ne` / `!=` are the exception and the reason this
+ * guard covers the operator positions too — `value !== target` against an
+ * array is always TRUE, so an array comparand there selected EVERY row, in
+ * silence. That is objectui#8447's fail-open direction surviving inside the
+ * arm objectui#8514 was filed about, and the same repair closes both.
+ */
+function refuseArrayComparand(
+  refusals: Set<string>,
+  field: string,
+  operator: string,
+): false {
+  return refuseFilterNode(
+    refusals,
+    `filter comparand for field '${field}' on operator '${operator}' is an ARRAY, `
+    + `which is a declared comparand only for $in / $nin / $between. The spec leaves `
+    + `an array in any other position unruled and the sibling in-memory matcher `
+    + `(@objectstack/formula) refuses it; express membership as `
+    + `{ ${field}: { $in: [...] } } or its negation { ${field}: { $nin: [...] } }`,
+  );
+}
+
+/**
  * Evaluate ONE comparison node — `[field, operator]` or `[field, operator, value]`.
  *
  * The operator is canonicalized through the spec's own
@@ -97,6 +176,18 @@ function matchesComparisonNode(
     rawOperator === 'not in' ? 'nin' : canonicalAstOperator(rawOperator);
   const value = record[field];
   const target = node[2];
+
+  // objectui#8514 — an array where a single-value comparand belongs. Checked
+  // before the switch so `=` / `!=` cannot answer it by reference (never equal
+  // / always unequal), and skipped for the operators that DECLARE an array
+  // comparand and for the two that never read the slot.
+  if (
+    Array.isArray(target)
+    && !AST_LIST_COMPARAND_OPERATORS.has(operator)
+    && !AST_NO_COMPARAND_OPERATORS.has(operator)
+  ) {
+    return refuseArrayComparand(refusals, field, String(rawOperator));
+  }
 
   switch (operator) {
     // -- Null-ness. Direction comes from the operator NAME; the value slot is
@@ -294,6 +385,12 @@ function matchesDollarOperator(
   field: string,
   refusals: Set<string>,
 ): boolean {
+  // objectui#8514 — the `$` twin of the AST guard above, and the position that
+  // carries the fail-OPEN case: `$ne` against an array is always true.
+  if (Array.isArray(target) && !DOLLAR_LIST_COMPARAND_OPERATORS.has(operator)) {
+    return refuseArrayComparand(refusals, field, operator);
+  }
+
   switch (operator) {
     case '$eq':
       return value === target;
@@ -428,6 +525,13 @@ function matchesFilter(
       for (const [op, target] of Object.entries(condition)) {
         if (!matchesDollarOperator(value, op, target, key, refusals)) return false;
       }
+    } else if (Array.isArray(condition)) {
+      // objectui#8514 — the implicit-equality position this card was filed
+      // about. It reaches here because the operator branch above is guarded by
+      // `!Array.isArray(condition)`, and that guard STAYS: routing an array
+      // into the operator loop would read its INDICES as operator names, the
+      // exact shape `$not` had before objectui#8447 fixed it.
+      return refuseArrayComparand(refusals, key, 'implicit equality');
     } else {
       // Simple equality
       if (value !== condition) return false;

--- a/packages/core/src/adapters/__tests__/ValueDataSource.arrayComparand.test.ts
+++ b/packages/core/src/adapters/__tests__/ValueDataSource.arrayComparand.test.ts
@@ -1,0 +1,185 @@
+/**
+ * ObjectUI — ValueDataSource, ARRAY comparand (objectui#8514)
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `{ tags: ['a', 'b'] }` took the simple-equality branch — the operator loop is
+ * guarded by `!Array.isArray(condition)` — and `!==` compares REFERENCES, so it
+ * excluded every row including the deep-equal one. Silent, fail-closed.
+ *
+ * ## What these cases are checked against
+ *
+ * The repair is a REFUSAL, not a deep-equality reading, and the file's own
+ * docblock carries the census that decided it. So the discriminating axis here
+ * is not "the deep-equal row comes back" — it is that the matcher SAYS it
+ * cannot read the shape, and that the negations stop selecting everything.
+ *
+ * Two wrong fixes this file is built to redden, stated before the assertions
+ * that catch them:
+ *
+ *   1. **Deep-equality** (`JSON.stringify(a) === JSON.stringify(b)`, the
+ *      caricature the card names). It returns the deep-equal row, logs nothing,
+ *      and answers `$ne` with the non-equal rows — so every "is refused"
+ *      assertion below fails on it, and so does the `$ne` row set.
+ *   2. **Routing an array into the operator loop** by dropping the
+ *      `!Array.isArray(condition)` guard, which reads the array's INDICES as
+ *      operator names — the shape `$not` had. It produces refusals naming
+ *      `'0'` / `'1'`, so the message assertions name the offender.
+ *
+ * Assertion ORDER is deliberate (objectui#8506): each block states its
+ * discriminating expectation first and its control afterwards, so a failure
+ * summary names the defect rather than the scaffolding.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ValueDataSource } from '../ValueDataSource';
+
+interface Row { id: string; tags: unknown; role: string }
+
+const ROWS: Row[] = [
+  { id: 'equal', tags: ['a', 'b'], role: 'admin' },
+  { id: 'reordered', tags: ['b', 'a'], role: 'user' },
+  { id: 'superset', tags: ['a', 'b', 'c'], role: 'admin' },
+  { id: 'shorter', tags: ['a'], role: 'user' },
+  { id: 'scalar', tags: 'a', role: 'admin' },
+];
+
+const ALL_IDS = ROWS.map((r) => r.id);
+
+function spyWarn() {
+  return vi.spyOn(console, 'warn').mockImplementation(() => {});
+}
+
+async function selectedIds(filter: unknown, rows: Row[] = ROWS): Promise<string[]> {
+  const ds = new ValueDataSource<Row>({ items: rows });
+  const res = await ds.find('t', { $filter: filter as never });
+  return (res.data as Row[]).map((r) => r.id);
+}
+
+/** Every distinct refusal `find()` drained for this filter. */
+async function refusalsFor(filter: unknown, rows: Row[] = ROWS): Promise<string[]> {
+  const warn = spyWarn();
+  await selectedIds(filter, rows);
+  const messages = warn.mock.calls.map((c) => String(c[0]));
+  warn.mockRestore();
+  return messages;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// 1. The headline — an array comparand is REFUSED, and says so
+// ---------------------------------------------------------------------------
+
+describe('objectui#8514 — an array comparand is refused, in both dialects', () => {
+  it('the implicit-equality position names the field and prescribes $in', async () => {
+    const [message, ...rest] = await refusalsFor({ tags: ['a', 'b'] });
+
+    // Discriminating: a deep-equality fix logs nothing at all.
+    expect(message).toBeDefined();
+    expect(message).toContain("comparand for field 'tags'");
+    expect(message).toContain('is an ARRAY');
+    expect(message).toContain('$in');
+    // One distinct refusal per `find()`, not one per row.
+    expect(rest).toEqual([]);
+  });
+
+  it('the array never reaches the operator loop, so no INDEX is read as a key', async () => {
+    // The hazard the card names: dropping `matchesFilter`'s
+    // `!Array.isArray(condition)` guard routes `['a','b']` into the operator
+    // loop, where `Object.entries` yields `['0','a']` and the refusal names the
+    // INDEX. This assertion is first in its own case on purpose — measured, the
+    // block above catches that same leg one assertion earlier, so this one had
+    // never run where it was originally written (objectui#8506's lesson).
+    const message = (await refusalsFor({ tags: ['a', 'b'] }))[0] ?? '';
+    expect(message).not.toMatch(/'\d+'/);
+    expect(message).toContain("comparand for field 'tags'");
+  });
+
+  it('the $-operator positions are refused too, including the fail-OPEN negation', async () => {
+    // $ne against an array was `value !== target` — always true — so it
+    // selected EVERY row in silence. This is the assertion that moves rows.
+    expect(await selectedIds({ tags: { $ne: ['a', 'b'] } })).toEqual([]);
+    expect(await selectedIds({ tags: { $eq: ['a', 'b'] } })).toEqual([]);
+
+    const message = (await refusalsFor({ tags: { $ne: ['a', 'b'] } }))[0];
+    expect(message).toContain("operator '$ne'");
+    expect(message).toContain('is an ARRAY');
+  });
+
+  it('the AST dialect answers the same question the same way', async () => {
+    expect(await selectedIds(['tags', '!=', ['a', 'b']])).toEqual([]);
+    expect(await selectedIds(['tags', '=', ['a', 'b']])).toEqual([]);
+
+    const message = (await refusalsFor(['tags', '=', ['a', 'b']]))[0];
+    expect(message).toContain("operator '='");
+    expect(message).toContain('is an ARRAY');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The rows that must NOT be selected — the deep-equality caricature's axis
+// ---------------------------------------------------------------------------
+
+describe('objectui#8514 — no array comparand selects anything, however similar', () => {
+  // A deep-equality fix returns `['equal']` here; a JSON.stringify one returns
+  // `['equal']` too. Both fail. A set-equality reading would add `reordered`,
+  // a contains-all reading `superset` — each named so the failure says which
+  // invented semantics was implemented.
+  it.each([
+    ['deep-equal row', ['a', 'b'], 'equal'],
+    ['same set, different order', ['b', 'a'], 'reordered'],
+    ['a subset of a stored superset', ['a', 'b', 'c'], 'superset'],
+    ['a single-element list', ['a'], 'shorter'],
+  ])('%s selects nothing', async (_label, comparand) => {
+    expect(await selectedIds({ tags: comparand })).toEqual([]);
+    expect(await selectedIds(['tags', '=', comparand])).toEqual([]);
+  });
+
+  it('an empty array comparand is refused rather than read as "no constraint"', async () => {
+    expect(await selectedIds({ tags: [] })).toEqual([]);
+    expect((await refusalsFor({ tags: [] }))[0]).toContain('is an ARRAY');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Controls — the harness discriminates, and nothing else moved
+// ---------------------------------------------------------------------------
+
+describe('objectui#8514 — controls', () => {
+  it('CONTROL: the broken answer is the full set, so the cases above discriminate', async () => {
+    expect(await selectedIds({})).toEqual(ALL_IDS);
+  });
+
+  it('CONTROL: scalar equality is untouched, and stays silent', async () => {
+    const warn = spyWarn();
+    expect(await selectedIds({ role: 'admin' })).toEqual(['equal', 'superset', 'scalar']);
+    expect(await selectedIds({ tags: 'a' })).toEqual(['scalar']);
+    expect(await selectedIds(['role', '=', 'admin'])).toEqual(['equal', 'superset', 'scalar']);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL: the three operators that DECLARE an array comparand still execute', async () => {
+    const warn = spyWarn();
+    expect(await selectedIds({ role: { $in: ['admin'] } })).toEqual(['equal', 'superset', 'scalar']);
+    expect(await selectedIds({ role: { $nin: ['admin'] } })).toEqual(['reordered', 'shorter']);
+    expect(await selectedIds(['role', 'in', ['admin']])).toEqual(['equal', 'superset', 'scalar']);
+    expect(
+      await selectedIds({ n: { $between: [2, 3] } }, [
+        { id: 'lo', tags: [], role: 'x' },
+        { id: 'hi', tags: [], role: 'x' },
+      ].map((r, i) => ({ ...r, n: i + 2 })) as never),
+    ).toEqual(['lo', 'hi']);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL: the null operators never read the value slot, so no array reaches the guard', async () => {
+    const warn = spyWarn();
+    expect(await selectedIds(['tags', 'is_not_null'])).toEqual(ALL_IDS);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/adapters/__tests__/ValueDataSource.fieldReferenceComparand.test.ts
+++ b/packages/core/src/adapters/__tests__/ValueDataSource.fieldReferenceComparand.test.ts
@@ -1,0 +1,190 @@
+/**
+ * ObjectUI — ValueDataSource, `{ $field }` comparand (objectui#8515)
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `@objectstack/spec/data` declares a field-reference comparand — "compare this
+ * field against that field" — and both platform evaluation paths execute it.
+ * Neither of this adapter's matchers dereferenced it: both compared the
+ * reference OBJECT against the stored value, so every such filter answered with
+ * no rows and no diagnostic.
+ *
+ * ## What these cases are checked against
+ *
+ * The implemented half and the refused half are BOTH load-bearing, and the
+ * wrong fixes this file is built to redden differ in which half they break:
+ *
+ *   1. **No resolution at all** (the state before this card): every "resolves"
+ *      row set below empties out.
+ *   2. **The naive resolve** — `record[ref.$field]` wherever a `$field` appears,
+ *      with no position check, no `addDays` check and no dotted-path check. It
+ *      passes every "resolves" case and fails every refusal case. That is the
+ *      plausible wrong fix, and it is the dangerous one: ignoring an `addDays`
+ *      offset returns WRONG rows where the defect returned none.
+ *
+ * Assertion ORDER is deliberate (objectui#8506): the discriminating expectation
+ * leads each case and the controls follow, so a failure summary names the
+ * defect rather than the scaffolding.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ValueDataSource } from '../ValueDataSource';
+
+interface Row { id: string; amount: number; budget: number | null; label: string }
+
+const ROWS: Row[] = [
+  { id: 'eq', amount: 7, budget: 7, label: 'x' },
+  { id: 'under', amount: 3, budget: 9, label: 'y' },
+  { id: 'over', amount: 10, budget: 5, label: 'z' },
+];
+
+function spyWarn() {
+  return vi.spyOn(console, 'warn').mockImplementation(() => {});
+}
+
+async function selectedIds(filter: unknown, rows: Row[] = ROWS): Promise<string[]> {
+  const ds = new ValueDataSource<Row>({ items: rows });
+  const res = await ds.find('t', { $filter: filter as never });
+  return (res.data as Row[]).map((r) => r.id);
+}
+
+async function refusalsFor(filter: unknown, rows: Row[] = ROWS): Promise<string[]> {
+  const warn = spyWarn();
+  await selectedIds(filter, rows);
+  const messages = warn.mock.calls.map((c) => String(c[0]));
+  warn.mockRestore();
+  return messages;
+}
+
+const REF = { $field: 'budget' };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// 1. The headline — the reference is DEREFERENCED on the six scalar operators
+// ---------------------------------------------------------------------------
+
+describe('objectui#8515 — a { $field } comparand resolves against the record', () => {
+  // Each row set is a different subset of ROWS, so "no resolution" (every set
+  // empties) and "resolution" are distinguishable case by case rather than in
+  // aggregate.
+  it.each([
+    ['$eq', '=', ['eq']],
+    ['$ne', '!=', ['under', 'over']],
+    ['$gt', '>', ['over']],
+    ['$gte', '>=', ['eq', 'over']],
+    ['$lt', '<', ['under']],
+    ['$lte', '<=', ['eq', 'under']],
+  ])('%s / %s compares amount against the referenced budget column', async (dollarOp, astOp, expected) => {
+    // Discriminating: unresolved, every one of these is [].
+    expect(await selectedIds({ amount: { [dollarOp]: REF } })).toEqual(expected);
+    // Both dialects agree — the property objectui#8447 established for this pair
+    // of matchers, applied to the comparand rather than to the operator.
+    expect(await selectedIds(['amount', astOp, REF])).toEqual(expected);
+  });
+
+  it('resolving is SILENT — a working filter logs nothing', async () => {
+    const warn = spyWarn();
+    expect(await selectedIds({ amount: { $lte: REF } })).toEqual(['eq', 'under']);
+    expect(await selectedIds(['amount', '<=', REF])).toEqual(['eq', 'under']);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The positions the spec removed, and the two malformed references
+// ---------------------------------------------------------------------------
+
+describe('objectui#8515 — the positions a reference is NOT a comparand for', () => {
+  it('a reference inside a list comparand is refused, not resolved (objectstack#7596)', async () => {
+    // $nin is the direction that matters: an unresolved member drops an
+    // EXCLUSION the author wrote, so the row passes and the result set WIDENS.
+    // The naive resolve returns rows here; no resolution returns all three.
+    expect(await selectedIds({ label: { $nin: [REF] } })).toEqual([]);
+    expect(await selectedIds({ label: { $in: [REF] } })).toEqual([]);
+    expect(await selectedIds({ amount: { $between: [REF, 9] } })).toEqual([]);
+
+    const message = (await refusalsFor({ label: { $nin: [REF] } }))[0];
+    expect(message).toContain('inside the list comparand');
+    expect(message).toContain("'$nin'");
+  });
+
+  it('a reference on a non-scalar operator is refused by name', async () => {
+    expect(await selectedIds({ label: { $contains: REF } })).toEqual([]);
+
+    const message = (await refusalsFor({ label: { $contains: REF } }))[0];
+    expect(message).toContain('not a comparand for operator');
+    expect(message).toContain("'$contains'");
+  });
+
+  it('an addDays offset is refused rather than silently dropped', async () => {
+    // The failure this guards is the WORST direction available here: resolving
+    // the bare column and ignoring the offset answers with wrong rows, where
+    // the original defect answered with none.
+    expect(await selectedIds({ amount: { $lte: { $field: 'budget', addDays: 3 } } })).toEqual([]);
+
+    const message = (await refusalsFor({ amount: { $lte: { $field: 'budget', addDays: 3 } } }))[0];
+    expect(message).toContain('addDays');
+    expect(message).toContain('temporal class');
+  });
+
+  it('a dotted path is refused, because this matcher addresses a flat record', async () => {
+    expect(await selectedIds({ amount: { $eq: { $field: 'nested.budget' } } })).toEqual([]);
+
+    const message = (await refusalsFor({ amount: { $eq: { $field: 'nested.budget' } } }))[0];
+    expect(message).toContain("dotted path 'nested.budget'");
+  });
+
+  it('a non-string $field is refused rather than compared as an object', async () => {
+    expect(await selectedIds({ amount: { $eq: { $field: 42 } } })).toEqual([]);
+    expect((await refusalsFor({ amount: { $eq: { $field: 42 } } }))[0])
+      .toContain('non-string $field');
+  });
+
+  it('the hand-authored implicit form keeps its ruled fate, with the working spelling named', async () => {
+    // objectstack#7597: `{ amount: { $field: 'budget' } }` is an operator spec
+    // named `$field`, not a comparand. It stays fail-closed; only the message
+    // improves, so an author can act on it.
+    expect(await selectedIds({ amount: REF })).toEqual([]);
+
+    const message = (await refusalsFor({ amount: REF }))[0];
+    expect(message).toContain("reads as an operator named '$field'");
+    expect(message).toContain('$eq');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Controls — the harness discriminates, and nothing else moved
+// ---------------------------------------------------------------------------
+
+describe('objectui#8515 — controls', () => {
+  it('CONTROL: the unfiltered answer is the full set, so the cases above discriminate', async () => {
+    expect(await selectedIds({})).toEqual(['eq', 'under', 'over']);
+  });
+
+  it('CONTROL: a LITERAL comparand on the same operators is untouched, and silent', async () => {
+    const warn = spyWarn();
+    expect(await selectedIds({ amount: { $eq: 7 } })).toEqual(['eq']);
+    expect(await selectedIds({ amount: { $lte: 7 } })).toEqual(['eq', 'under']);
+    expect(await selectedIds(['amount', '>', 7])).toEqual(['over']);
+    expect(await selectedIds({ label: { $contains: 'x' } })).toEqual(['eq']);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL: list operators with ordinary members still execute', async () => {
+    const warn = spyWarn();
+    expect(await selectedIds({ label: { $in: ['x', 'z'] } })).toEqual(['eq', 'over']);
+    expect(await selectedIds({ label: { $nin: ['x'] } })).toEqual(['under', 'over']);
+    expect(await selectedIds({ amount: { $between: [3, 7] } })).toEqual(['eq', 'under']);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL: a plain object comparand that is NOT a reference keeps its own refusal', async () => {
+    const message = (await refusalsFor({ profile: { verified: true } }))[0];
+    expect(message).toContain('non-operator key');
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectui#8514
Fixes objectstack-ai/objectui#8515

Two comparand-side defects in `ValueDataSource`'s matchers, dispatched together because both edit the same function. One commit each, plus a docs/changeset commit.

## objectui#8514 — an ARRAY comparand, refused

`{ tags: ['a', 'b'] }` took `matchesFilter`'s simple-equality branch and `!==` compares **references**, so it excluded every row including the deep-equal one, silently.

**The repair is a refusal, not a deep-equality reading, and the census is why.** The card and the brief both framed this as "which deep-equality semantics is right". Reading `@objectstack/spec/data` says the question is not the spec's to answer: `assertListComparandShapes` lists *arrays outside `$in`/`$nin`/`$between`* among the positions its comparand door deliberately does **not** judge — "the matrix did not measure it and the ruling does not name it", left "to the layers that already answer it". Those layers disagree, and the two nearest this adapter both refuse:

| layer | answer for `{ tags: [ ... ] }` |
| --- | --- |
| `@objectstack/formula` `matchesFilter` (record-at-a-time, the closest sibling) | **refuses** — `if (Array.isArray(spec)) return false;`, on the comment *"a bare array value is not a valid field spec (must be `{ $in: [...] }`)"* |
| `@objectstack/driver-sql` | **refuses**, with its own message |
| document stores | array-equality, as a native store behaviour rather than a ruled contract |

So there is no protocol answer to implement, and inventing one here is the lenient-consumer fallback AGENTS.md commandment 0.1 forbids — a second de-facto contract a `provider: 'value'` list would honour and the same filter on the wire would not. Every producer in this repo already spells a multi-value comparand `{ $in: [...] }`: measured over every `$filter` literal in the packages' and apps' source trees, the only array-valued comparands are `$in` / `$nin` members (2 hits, both `$in`; lit control on the same regex and path set fires on 12 files).

**Result-set impact, stated plainly.** For the equality positions this moves **no rows** — a reference comparison already excluded everything, so the repair is the diagnostic. The negations are the exception and the reason the guard covers the operator positions too: **`$ne` / `!=` against an array is always true, so it had been selecting EVERY row in silence.** That is objectui#8447's fail-open direction surviving inside the arm this card was filed about; the card describes the defect as failing "in the opposite direction" from #8447, and half of it does not.

The `!Array.isArray(condition)` guard **stays** — routing an array into the operator loop would read its indices as operator names, the shape `$not` had. A dedicated case pins that.

## objectui#8515 — dereferencing a `{ $field }` comparand

The spec declares it, `@objectstack/formula`'s `compileCelToFilter` emits it, and **both** platform evaluation paths execute it. This adapter compared the reference object: no rows, no diagnostic. Refusing would have made it the one face answering a declared, executed shape with "no rows" — the outcome ruled worse than the bug. So it is dereferenced against the record, on exactly the six scalar comparisons `FieldReferenceSchema` declares it for, in **both** dialects.

Four positions are refused instead, each on a recorded ruling rather than this adapter's convenience:

- **a reference in an `$in` / `$nin` member or `$between` endpoint** — objectstack#7596 removed those positions after finding that no backend ever dereferenced one. `$nin` is why the refusal is loud: an unresolved member drops an exclusion the author wrote, so the row passes and the set **widens**.
- **`addDays`** (objectstack#14104) — defined against the referenced column's temporal class; SQL push-down compiles it only between two temporal columns of the same class. This matcher has no field types. Silently dropping the offset would return **wrong** rows where the defect returned none.
- **a dotted path** — this matcher addresses the left side as `record[field]`, flat. SQL push-down refuses one too under the same-table ruling. `@objectstack/formula` does walk dots; the divergence is named in the code rather than papered over.
- **a non-string `$field`** — the spec's own lowering predicate treats it as "not a field reference on any path".

The hand-authored implicit form `{ amount: { $field: 'budget' } }` keeps the row-excluding fate objectstack#7597 ruled for it. **Merged `main` already excluded it loudly** — only the message changes, to name the explicit `$eq` spelling, as driver-sql's refusal does.

## Bounded in-place widening, declared

Both cards name the *implicit-equality* position. Both repairs also cover the **`$`-operator and AST scalar positions**, because the mechanism is identical there and leaving them would knowingly keep two fail-**open** holes (`$ne` with an array; `$nin` with a reference member) in the function this PR is about. Same defect class, same file, same gate family, no new verification surface.

## Verification

Every ablation restored **by state** (`git diff HEAD` empty **and** `git hash-object` equal to `git rev-parse HEAD:PATH`), each mutation proved on disk by injected-marker count in both directions, `trap ... EXIT INT TERM` with absolute paths.

| leg | what it mutates | result |
| --- | --- | --- |
| **plausible wrong fix — `JSON.stringify` deep-equality** | the array-comparand guards answer equality instead of refusing | **8 of 12 red**, and every failure is a headline case: `['equal']`, `['reordered']`, `['superset']`, `['shorter']` each vs `[]` — naming which invented semantics was implemented. The 4 that pass are exactly the 4 CONTROLs. |
| **plausible wrong fix — naive `record[ref.$field]` everywhere** | no position / `addDays` / dotted check | **5 of 17 red**, exactly the refusal cases. The `addDays` case reads `expected [ 'eq', 'under' ] to deeply equal []` — the wrong-rows direction, demonstrated. |
| **ablation of the field-reference dereferencing** | resolution removed | **11 of 17 red**, all six operator row sets plus the refusals. |
| **the operator-loop hazard the card names** | `!Array.isArray(condition)` dropped | **3 of 13 red**, including the dedicated "no INDEX is read as a key" case. |
| **harness-kill — `$filter` ignored entirely** | unrelated to either mechanism | **27 of 30 red** across both pin files, signature `expected [ 'equal', 'reordered', ...(3) ]` — textually distinct from every other leg. The 3 survivors are the unfiltered-population CONTROLs. |

**Reported against the brief:** the brief asked for a leg for the plausible wrong fix and said to say so if it turned out byte-identical to what shipped. It did not — both wrong-fix legs are strongly discriminating. But one assertion of mine was **not**: `expect(message).not.toMatch(/operator '.d.'/)` was written inside a block whose *earlier* assertion already caught that leg, so it had never run. Measured, moved into its own case with a regex that matches what the hazard actually emits, and re-measured red. That is objectui#8506's lesson landing on this PR.

**Gates** (final commit `0b4fe1133`): `@object-ui/core` suite **128 files / 2724 tests pass**; `type-check` **both programs** (`tsc --noEmit` and `tsc -p tsconfig.test.json`) after building the dependency closure; `check:control-bytes`, `check:doc-fences`, `check:doc-types`, `check:doc-examples`, `check:doc-snippets`, `check:readme-exports`, `check:unreferenced-sources`, `check:comment-mask-corpus`, `check:doc-example-readers` all exit 0; changeset presence and no-major both green.

The first run of `check:doc-snippets` / `check:doc-examples` / `check:readme-exports` exited non-zero reading **PRECONDITION NOT MET** and *"the population COLLAPSED — this run proves nothing"*. Those are **not measurements**; the scoped 36-package build they name was run and all three then exit 0.

**Declared narrowing on lint.** Ran the whole `@object-ui/core` eslint project — the exact unit `turbo run lint` runs for the only package this diff touches — not the repo-wide farm. Population **227 files**, read from `--format json`, **0 errors**, 531 warnings (all pre-existing `no-explicit-any` style in this deliberately `any`-typed adapter; `lint.yml` sets no `--max-warnings`). Invariance for the untouched packages: `eslint --print-config` reports `languageOptions.parserOptions` with **no `project` and no `projectService`**, so type-aware linting is off and this diff cannot move the verdict on any file it does not itself contain.

Manual unicode sweep of the diff (the cover `check:control-bytes` does not give, since `no-irregular-whitespace` carries `skipStrings: true`): **0 suspect code points** across all five changed files, with a synthetic ZWSP+NBSP lit control confirming the sweep fires.

Draft on purpose, and auto-merge is **not** armed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_