### PR TITLE
test(scripts): hoist the whole-repository scan out of check-unused-dependencies' timed window

### DIFF
--- a/scripts/__tests__/check-unused-dependencies.test.ts
+++ b/scripts/__tests__/check-unused-dependencies.test.ts
@@ -374,9 +374,30 @@ describe('scope', () => {
 
 // ── 7. this repository ───────────────────────────────────────────────────────
 
+/**
+ * One whole-repository scan, shared by the three tests below.
+ *
+ * `analyze(repoRoot)` walks every package in the release group — 47 manifests
+ * and >1000 files — and the three assertions read three different fields of the
+ * SAME verdict, so a call per test paid for the identical walk three times, each
+ * time inside a bounded assertion window. On the push lane, where the suite runs
+ * under v8 coverage instrumentation, a single pass crosses vitest's 15 s
+ * `testTimeout`: all three tests then fail with `Test timed out in 15000ms`
+ * while the gate itself is green, and because the coverage thresholds live only
+ * on the merged 4-shard report, one red shard means the coverage gate does not
+ * run at all (objectui#8479).
+ *
+ * Module scope, not `beforeAll`: the import phase is governed by no timeout,
+ * whereas a hook would trade the 15 s `testTimeout` for the narrower 10 s
+ * `hookTimeout`. Same reasoning, same file family as `check-doc-links.test.ts`'s
+ * `ANCHOR_CORPUS` (objectui#8419). No timeout is raised and no assertion is
+ * weakened — each test asserts exactly what it asserted before.
+ */
+const REPOSITORY_SCAN = analyze(repoRoot);
+
 describe('this repository', () => {
   it('is green: every gated declaration has a consumer', () => {
-    const { findings } = analyze(repoRoot);
+    const { findings } = REPOSITORY_SCAN;
     expect(findings).toEqual([]);
   });
 
@@ -392,14 +413,14 @@ describe('this repository', () => {
   });
 
   it('scans a population big enough for the verdict to mean something', () => {
-    const { counters } = analyze(repoRoot);
+    const { counters } = REPOSITORY_SCAN;
     expect(counters.packages).toBeGreaterThanOrEqual(30);
     expect(counters.gatedDeclared).toBeGreaterThanOrEqual(200);
     expect(counters.files).toBeGreaterThanOrEqual(1000);
   });
 
   it('keeps the non-gated fields VISIBLE rather than absorbed', () => {
-    const { measured } = analyze(repoRoot);
+    const { measured } = REPOSITORY_SCAN;
     // Not an equality: these move with the tree. The pin is that the gate still
     // MEASURES them — a zero here would mean the reporting quietly stopped.
     expect(measured.peerDependencies).toBeGreaterThan(0);


### PR DESCRIPTION
Fixes #8479

## The failing test, named

`main`'s push-lane coverage gate has been unevaluated since 2026-09-07T08:28:39Z. The card and the triage comment both stop at "which test fails inside the coverage shard is not established". It is:

```
FAIL  |unit| scripts/__tests__/check-unused-dependencies.test.ts > this repository > is green: every gated declaration has a consumer
Error: Test timed out in 15000ms.
 ❯ scripts/__tests__/check-unused-dependencies.test.ts:378:3

FAIL  |unit| scripts/__tests__/check-unused-dependencies.test.ts > this repository > scans a population big enough for the verdict to mean something
Error: Test timed out in 15000ms.
 ❯ scripts/__tests__/check-unused-dependencies.test.ts:394:3

FAIL  |unit| scripts/__tests__/check-unused-dependencies.test.ts > this repository > keeps the non-gated fields VISIBLE rather than absorbed
Error: Test timed out in 15000ms.
 ❯ scripts/__tests__/check-unused-dependencies.test.ts:401:3
```

Three timeouts. ⛔ The gate itself is green — `findings` is `[]` on every pass that completes. Nothing is wrong with `check-unused-dependencies.mjs`.

## Why the log never carried that summary

⚠️ Worth recording, because the card, the triage comment and the dispatch note all read this as the Actions log API windowing the failure summary out. It is not.

The shard step runs with `--reporter=blob` as its **only** reporter, so no vitest failure summary is ever written to stdout. The full job log for `101973830157` is 397 lines end to end and contains a 15-minute silence between the `##[group]Run` line and the first test stdout. The summary was never emitted; no download channel would have produced it. Reproducing locally is the only way to get the name — which is what this PR did.

(The `check-vi-mock-specifiers` / `check-vi-mock-inherit` "the population COLLAPSED — sources: found 0, floor is 1000" text in that log's tail is fixture output from those gates' self-tests, exactly as the dispatch note cautioned. It is not the failure.)

## The cause

The three tests each call `analyze(repoRoot)` and then read one field of the result — `findings`, `counters`, `measured`. That is the same whole-repository walk (47 manifests, >1000 files) paid for three times, each pass inside a bounded assertion window.

On PRs the suite runs uninstrumented and each pass fits inside vitest's 15 s `testTimeout`. The push lane runs the same 4-way shard split **under v8 coverage** (`if: github.event_name == 'push'`), and there a single pass crosses it. That is the entire difference between the two lanes.

Because `coverage.thresholds` live only on the merged 4-shard report — the shard legs override them to zero — one red shard skips the merge and the thresholds are not evaluated at all. The sentinel has been reporting exactly that, correctly.

## The fix

Hoist the scan to module scope as `REPOSITORY_SCAN`, where the cost lands in the import phase that no `testTimeout` governs.

Not a `beforeAll`, which would trade the 15 s `testTimeout` for the narrower 10 s `hookTimeout`. This is the same defect class and the same remedy as #8419, which moved `check-doc-links.test.ts`'s corpus walk to `ANCHOR_CORPUS` last night.

⛔ No timeout was raised. ⛔ No threshold was lowered. ⛔ No `continue-on-error`. The three tests read the same three fields of the same verdict they read before; a real finding still reds them.

## Verification — same box, same command, before and after

The workflow's own command, copied from the job's `##[group]Run` line, with `--reporter=default` added so failures are named. Both legs ran under the shared heavy-verify lock.

```
pnpm test:coverage --reporter=blob --reporter=default --shard=1/4 \
  --coverage.thresholds.lines=0 --coverage.thresholds.functions=0 \
  --coverage.thresholds.branches=0 --coverage.thresholds.statements=0
```

| leg | tree | result | that file |
|:--|:--|:--|:--|
| before | `3bc187b7f` (`origin/main`) | **exit 1** — `Tests 3 failed \| 8943 passed` | `(37 tests \| 3 failed) 82977ms` |
| after | `e4af215f1` (this branch) | **exit 0** — `Test Files 682 passed (682)`, `Tests 8946 passed \| 1 skipped` | `(37 tests) 1992ms` |

Single-file run after the fix shows where the cost moved: `Duration 7.89s (import 7.06s, tests 454ms)`.

Control, so "shard 1 is green" is a reading and not an artefact of a query that cannot see red: the same command on the same tree **without** `--coverage` was already green before the fix (`682 passed`, exit 0, 12m04s) — the failure is coverage-lane-specific, and the instrumented leg is the one that changed verdict.

Gates run locally: `check-changeset-presence` (exit 0 — "No source or published contract of a released package changed in this range, so no changeset is owed"), `check-control-bytes` (exit 0, 6746 files), `eslint` on the changed file (exit 0). No changeset is owed and none is added; ⛔ no `skip-changeset` label, which this repository does not use.

## Corrections to the readings this card was dispatched with

⚠️ Each of these was measured here; the numbers in the card, the triage comment and the dispatch note were explicitly flagged as predictions.

- **"66 consecutive failures" → 81.** Re-derived over 400 `branch=main&event=push` runs of `ci.yml`. Control in the same window: 119 successes, so the query returns green when green exists. Last green is unchanged: `3c6394cb2` @ 2026-09-07T08:28:39Z.
- **"It is `coverage shard 1/4` on all six" holds for that six-run window but not for the streak.** The streak's *first* failure, run `34107014367` @ `272ea0302` @ 2026-09-07T09:36:56Z, failed on **`Test (coverage shard 2/4)`** alone; shard 1 first joined four runs later, at `0ea7054f8` @ 09:52:35 — the commit that landed this gate (#8304). Walking the streak, the failing shard is 2, then 1, then both, oscillating. Consistent with a per-test timeout whose file moves between shards as the file list grows.
- **"The vitest failure summary is absent from what the API returned — the same windowing."** No. See above: with `--reporter=blob` alone it is never produced.
- **The raw log download being 403 at this container's proxy is confirmed**, and so is the artifact download: `GET /actions/artifacts/{id}/zip` fails `CONNECT tunnel failed, response 403` on its redirect to blob storage. The REST listing endpoints themselves work fine.

## Not fixed here, and deliberately not widened

`Test (coverage shard 2/4)` failed intermittently earlier in the streak and is **not** named by this PR — the last seven completed runs on `main` show shard 1 as the only red shard, so this change is what the live blocker needs. If shard 2 reds again after this lands, the gate still will not run, and that is a separate name to read. ⛔ Not folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_