### PR TITLE
ci(budget): raise the `framework` per-chunk ceiling to 100,000 by maintainer ruling

### DIFF
--- a/scripts/__tests__/check-eager-closure-budget.test.ts
+++ b/scripts/__tests__/check-eager-closure-budget.test.ts
@@ -415,8 +415,8 @@ describe('per-chunk ceilings', () => {
  * catalogue and one whose test does not.
  *
  * The byte-level backstop is the re-baselined ceiling itself: `framework` is
- * now pinned at 71,000 over a 61,465 payload, so a regression that puts the
- * 446 KB catalogue back would red the gate six times over. That verdict is
+ * now pinned at 100,000 over a 72,245 payload, so a regression that puts the
+ * 446 KB catalogue back would red the gate four times over. That verdict is
  * loud but mute about the cause. This one names it.
  *
  * ⛔ Every case here fails CLOSED. The parse yielding nothing, or a probe id

--- a/scripts/check-eager-closure-budget.mjs
+++ b/scripts/check-eager-closure-budget.mjs
@@ -561,6 +561,46 @@ export const REGRESSION_THIS_GATE_MUST_CATCH_BYTES = 89 * 1024;
  * constraint to live is the argument for taking the catalogues out of the eager
  * closure rather than for raising anything.
  *
+ * ## Why `framework` moved UP — the maintainer ruling of 2026-09-08
+ *
+ * From 71,000 over a 61,465 payload to 100,000 over 72,245, the latter measured
+ * on `3f775eeb8`. ⛔ The number is the MAINTAINER'S, taken after the trade-off
+ * was put to them; it is not derived here, and nothing in this section should be
+ * read as a derivation of it. What is recorded here is what the raise COSTS,
+ * because that is the half a later reader cannot recover from the constant.
+ *
+ * ⛔ What the bytes buy: NOTHING IDENTIFIABLE, and that is the finding, not an
+ * omission. The failure message this raise silences asks the author to "say in
+ * the PR what the bytes buy". Nobody can: `Bundle Analysis` went red on `main`
+ * at `f76f43628` with `40a7c538a` the last green, and the commits in that window
+ * have never been bisected — this checker is a two-build predicate over them and
+ * no one has run it. ⚠️ So this raise does not answer the attribution question,
+ * it makes it HARDER TO ASK: the line that was holding the unexplained bytes in
+ * view now passes over them. objectui#8542 owns that attribution and stays open;
+ * objectui#8541 recorded the same red first and is closed as its duplicate.
+ *
+ * ⚠️ This also makes `framework` the LOOSEST ceiling in this object, measured
+ * rather than asserted. All four were read from the one `3f775eeb8` console
+ * build, against {@link REGRESSION_THIS_GATE_MUST_CATCH_BYTES}:
+ *
+ *   | ceiling              | headroom | multiple |
+ *   | `framework`          |   27,755 |    0.30x |
+ *   | `vendor-objectstack` |   18,848 |    0.21x |
+ *   | `ui-components`      |    5,729 |    0.06x |
+ *   | `i18n-locales`       |    2,900 |    0.03x |
+ *
+ * ⇒ it carries more slack than the next loosest and an order of magnitude more
+ * than the tightest, and it abandons the 0.10x convention objectui#7399 re-pinned
+ * this key and `i18n-locales` to. It is still inside one regression — 1.00x is
+ * where {@link evaluateHeadroomSensitivity} calls a line blind — but "not blind"
+ * is the floor this file refuses to fall through, not a standard it aims at.
+ *
+ * ⛔ {@link REGRESSION_THIS_GATE_MUST_CATCH_BYTES} did NOT move, and this is the
+ * exact case the rule under {@link MAX_EAGER_CLOSURE_GZIP_BYTES} was written for:
+ * a ceiling that rises while the sensitivity relaxes is a gate quietly retiring
+ * itself. Nothing else moved either — not the other three ceilings, not the
+ * aggregate, not {@link BASELINE}. One ceiling and its baseline, in one commit.
+ *
  * ## Raising one
  *
  * Same discipline as {@link MAX_EAGER_CLOSURE_GZIP_BYTES}, and the same two
@@ -581,7 +621,12 @@ export const PER_CHUNK_GZIP_CEILINGS = Object.freeze({
   // proportion the retiring pair carried (18,539 = 0.20x).
   'vendor-objectstack': 1_254_000,
   'i18n-locales': 455_000,
-  framework: 71_000,
+  // Raised by the maintainer ruling of 2026-09-08, ⛔ not by a measurement here:
+  // `main` had been red on this line since `f76f43628` and the bytes that put it
+  // there are UNATTRIBUTED. Headroom 27,755 bytes = 0.30x
+  // REGRESSION_THIS_GATE_MUST_CATCH_BYTES on `3f775eeb8` — the loosest of the
+  // four. See "Why `framework` moved UP" above for what that costs.
+  framework: 100_000,
   'ui-components': 399_000,
 });
 
@@ -596,22 +641,33 @@ export const PER_CHUNK_GZIP_CEILINGS = Object.freeze({
  *     was raised with the aggregate. Same build as {@link BASELINE}, so the
  *     two are directly comparable; it superseded `2c8474c04` (objectui#5490).
  *   - `ui-components` — `2c8474c04` (objectui#5490).
- *   - `framework`, `i18n-locales` — `e307c9896` plus objectui#7399's own
- *     re-attribution diff; see "Why `framework` moved DOWN" above. Both were
- *     read from ONE console build, so they are directly comparable to each
- *     other and to the 523,959 the same tree measured with the groups still
- *     tied. This `framework` reading supersedes objectui#7173's, whose
- *     three-build attribution the paragraph above that one still explains, and
- *     objectui#6759's `a64e96ca8` before it.
+ *   - `framework` — `3f775eeb8`, the `main` tip this raise's branch was cut
+ *     from, read out of the `apps/console/dist/eager-closure.json` written by
+ *     `pnpm turbo run build --filter='./packages/*'` followed by
+ *     `pnpm --filter @object-ui/console build`, run on that tree with NO diff of
+ *     its own applied. See "Why `framework` moved UP" above for the ruling it
+ *     was measured for and what that raise costs. It supersedes objectui#7399's
+ *     `e307c9896` reading, objectui#7173's before that, and objectui#6759's
+ *     `a64e96ca8` before that. ⚠️ Unlike the entry below it, this one IS a
+ *     reading of an unmodified tree — the change it pins lives entirely in this
+ *     file, and `scripts/check-*.mjs` is not a console build input — so the
+ *     {@link BASELINE} argument DOES cover it, and it is ⛔ NOT comparable to
+ *     the `i18n-locales` figure below, which is an older build on another commit.
+ *   - `i18n-locales` — `e307c9896` plus objectui#7399's own re-attribution
+ *     diff; see "Why `framework` moved DOWN" above. It was read from ONE console
+ *     build together with the `framework` figure objectui#7399 recorded, so it
+ *     is directly comparable to the 523,959 that same tree measured with the
+ *     groups still tied — ⚠️ and, since objectui#8541's raise, ⛔ no longer to
+ *     the `framework` entry above it.
  *
- *     ⚠️ Unlike every other entry here, these two are NOT a reading of an
- *     unmodified tree: the chunks they name do not exist without the diff that
- *     recorded them, because that diff is what creates the second one. The
+ *     ⚠️ Unlike every other entry here, this one is NOT a reading of an
+ *     unmodified tree: the chunk it names does not exist without the diff that
+ *     recorded it, because that diff is what creates it. The
  *     `scripts/vite-*.ts`-versus-`scripts/check-*.mjs` argument {@link BASELINE}
- *     makes about its own commit does NOT cover them — `apps/console/vite.config.ts`
+ *     makes about its own commit does NOT cover it — `apps/console/vite.config.ts`
  *     IS a build input, deliberately, and moving it is the change. What keeps
- *     them honest instead is that the gate re-reads them on every CI build of
- *     the branch that carries the diff.
+ *     it honest instead is that the gate re-reads it on every CI build of the
+ *     branch that carries the diff.
  *
  * Exported so the ceilings are CHECKED against it instead of merely asserted
  * in this comment.
@@ -682,7 +738,10 @@ export const PER_CHUNK_BASELINE = Object.freeze({
   // `34a1578ef`, the same build as BASELINE above (objectui#7122).
   'vendor-objectstack': 1_235_029,
   'i18n-locales': 446_076,
-  framework: 61_465,
+  // `3f775eeb8`, its OWN console build — ⛔ not the one above it and not
+  // BASELINE's. Moved with the ceiling in the same commit, per the maintainer
+  // ruling of 2026-09-08 and the rule stated under "Raising one".
+  framework: 72_245,
   'ui-components': 391_095,
 });
 


### PR DESCRIPTION
Part of #8541. Related: #8542, which owns the attribution and stays open.

⛔ **This is a MAINTAINER RULING, and nothing else.** The number `100_000` is the
maintainer's, taken after the trade-off was put to them. It is ⛔ not derived in this
PR, ⛔ not rounded, and ⛔ not a figure any measurement here recommends. Everything
below is what the ruling COSTS, measured — that is the half a later reader cannot
recover from the constant.

## What moved

| constant | before | after |
| :-- | --: | --: |
| `PER_CHUNK_GZIP_CEILINGS.framework` | `71_000` | `100_000` |
| `PER_CHUNK_BASELINE.framework` | `61_465` | `72_245` |

Both in one commit, as the gate's own failure text and the "Raising one" section
require. ⛔ Nothing else in that file's constants was touched: not the other three
ceilings, not `MAX_EAGER_CLOSURE_GZIP_BYTES`, not `BASELINE`, and above all **not
`REGRESSION_THIS_GATE_MUST_CATCH_BYTES`**, which stays at `89 * 1024` — the file says
at `:203-205` that re-baselining must never become an excuse to widen the sensitivity,
and this raise is the exact case that rule was written for.

## The baseline was re-derived, not copied

`72_245` is read out of `apps/console/dist/eager-closure.json` from a real build on
`3f775eeb8` (this branch's base, the `main` tip it was cut from), with **no diff of its
own applied** — `pnpm turbo run build --filter='./packages/*'` then
`pnpm --filter @object-ui/console build`, wrapper exit 0. ⛔ Not copied from #8541,
#8542, or PR #8544.

It coincides exactly with the `72,245` a dev on PR #8544 measured on merge base
`3bc187b7f`. Two independent builds on two different commits agreeing to the byte is
worth more than either alone, and it is a coincidence of readings, not a citation.

The per-KEY provenance block is updated with it: `framework` is split out of the bullet
it shared with `i18n-locales`, because the two are no longer one build. That split also
corrects a claim in the inherited text — the shared bullet warned that neither entry was
a reading of an unmodified tree, which is true of `i18n-locales` (its chunk does not
exist without the `vite.config.ts` diff that created it) and is **not** true of the new
`framework` reading, whose change lives entirely in `scripts/`, not a build input.

## What the bytes buy: NOTHING IDENTIFIABLE

The gate's failure text demands the author "say in the PR what the bytes buy". The
honest answer is that nobody knows, and stating that is the point rather than a gap to
be filled with a plausible story.

**The ~1.6 KB regression between `40a7c538a` (last green) and `f76f43628` (first red) is
still UNATTRIBUTED.** Nobody has run the bisect. Two seats looked at the same
four-commit window and named two different "obvious" suspects — `f76f43628` (#8512's
per-operator refusal strings into `packages/core`) and `270f2825b` (#8518, five shipped
packages plus console) — and neither built anything to check. The endpoints of that
~1.6 KB are themselves arithmetic over figures quoted in other PRs' commit messages
(`70,651`, then `70,999`), ⛔ neither of them re-measured on the commit it is attributed
to.

⚠️ **And this change makes that question harder to ask, not easier.** The per-chunk line
was the only thing holding the unexplained bytes in view; after this it passes over
them. The checker is a two-build predicate over four commits — the cheapest bisect this
repository has — and raising the ceiling removes the daily reminder that nobody has run
it. #8542 owns that attribution and is deliberately left open.

## This makes `framework` the loosest per-chunk ceiling in the file

Measured, not asserted. All four read from the one `3f775eeb8` build, against
`REGRESSION_THIS_GATE_MUST_CATCH_BYTES` = `91,136`:

| ceiling | measured | ceiling | headroom | multiple |
| :-- | --: | --: | --: | --: |
| **`framework`** | 72,245 | 100,000 | **27,755** | **0.30x** |
| `vendor-objectstack` | 1,235,152 | 1,254,000 | 18,848 | 0.21x |
| `ui-components` | 393,271 | 399,000 | 5,729 | 0.06x |
| `i18n-locales` | 452,100 | 455,000 | 2,900 | 0.03x |

⇒ `framework` now carries more slack than the next loosest and an order of magnitude
more than the tightest, and it abandons the 0.10x convention objectui#7399 re-pinned
this key and `i18n-locales` to. It is still inside one regression — 1.00x is where
`evaluateHeadroomSensitivity` calls a line blind — but "not blind" is the floor this
file refuses to fall through, not a standard it aims at.

## Verification

All exit codes captured by redirect before any pipe.

| check | exit | reading |
| :-- | --: | :-- |
| `node scripts/check-eager-closure-budget.mjs` (before) | 1 | `framework 70.6 KB / 69.3 KB ceiling (OVER by 1.2 KB)` |
| `node scripts/check-eager-closure-budget.mjs` (after) | **0** | all four legs pass |
| `pnpm exec vitest run` — 5 gate test files | 0 | `Test Files 5 passed (5)` · `Tests 219 passed (219)` |
| `node scripts/check-control-bytes.mjs` | 0 | |
| `node scripts/check-changeset-presence.mjs` | 0 | `no changeset is owed` |
| `pnpm run type-check:scripts` | 0 | |
| `pnpm exec eslint` (2 changed files) | 0 | 0 errors, 0 warnings |

Four-leg verdict after the change, from the gate's own printed lines:

```
✅ Console eager closure is 3475.0 KB gzipped across 50 of 518 chunks (budget: 3512.7 KB, headroom: 37.7 KB).
✅ Per-chunk eager budgets (4 chunks weighed):
  ✅ vendor-objectstack      1206.2 KB / 1224.6 KB ceiling (headroom 18.4 KB)
  ✅ i18n-locales             441.5 KB / 444.3 KB ceiling (headroom 2.8 KB)
  ✅ ui-components            384.1 KB / 389.6 KB ceiling (headroom 5.6 KB)
  ✅ framework                 70.6 KB / 97.7 KB ceiling (headroom 27.1 KB)
✅ Ceiling sensitivity (5 ceilings, each weighed against the report just read):
  ✅ chunk `framework`                 70.6 KB measured / 97.7 KB ceiling (headroom 27.1 KB = 0.30x the 89.0 KB regression)
ℹ️  Ceiling freshness: not applicable to a local run.
```

The payload is byte-identical before and after: the diff is two files under `scripts/`,
and the console build's turbo `inputs` cover `scripts/vite-*.ts`, not
`scripts/check-*.mjs` or `scripts/__tests__/` — the same argument `BASELINE`'s own block
makes about its commit. Only the line the payload is weighed against moved.

### `PER_CHUNK_BASELINE` feeds no verdict — ablated, with a positive control

The file states at `:1227` that `BASELINE` and `PER_CHUNK_BASELINE` are deliberately
absent from `VERDICT_CEILING_CONSTANTS`. Checked rather than taken on trust, both legs
restored by comparing `git hash-object` against the `HEAD` blob:

| leg | mutation | gate exit | output vs clean |
| :-- | :-- | --: | :-- |
| A | `PER_CHUNK_BASELINE.framework` 72,245 to 9,999 | 0 | **IDENTICAL** |
| B (control) | `PER_CHUNK_GZIP_CEILINGS.framework` 100,000 to 9,999 | 1 | **DIFFERS** — `framework ... OVER by 60.8 KB` |

⇒ leg A's identity is a real reading and not a harness that sees nothing. Moving the
baseline changes no verdict; it changes what the unit test weighs the ceiling against,
which is the constraint `ceiling - measured` stays under one regression (27,755 against
91,136 — asserted in `scripts/__tests__/check-eager-closure-budget.test.ts`).

## One correction outside the two named constants

`scripts/__tests__/check-eager-closure-budget.test.ts` carried the sentence "`framework`
is now pinned at 71,000 over a 61,465 payload". This commit is what makes that false, so
it is updated in the same commit — two numerals and the magnitude word that follows from
them. ⛔ No constant, assertion or test behaviour changed; `git diff` on that file is
four lines of prose.

## ⚠️ A premise of the brief this PR was written from, falsified

The dispatch stated that #8541 and #8542 are both **unlabelled**, and that no card could
therefore be claimed. Read over REST at the time of writing, both carry labels:

- **#8541** — `bug`, `ci/cd`, `tooling`, `domain:devx` — and is **closed**, as a
  duplicate of #8542.
- **#8542** — `bug`, `ci/cd`, `pm:queue`, `tooling`, `domain:devx`, `priority:p1`, and
  is open.

This does not change what was done: the authorisation for this PR is the maintainer
ruling, not a card claim, and no claim was posted. It does mean the stated reason for
not claiming was not the true one, and that `Part of #8541` points at a card that is
already closed — #8542 is the live one. ⛔ Neither card is closed by this PR; that is
triage's call, and the attribution question stays open regardless.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZY49skxUBYyJcdnTcYPrE

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZY49skxUBYyJcdnTcYPrE)_