### PR TITLE
fix(core): refuse a bare array comparand in convertFiltersToAST

### DIFF
--- a/.changeset/8530-filter-converter-array-comparand.md
+++ b/.changeset/8530-filter-converter-array-comparand.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/core': patch
+---
+
+`convertFiltersToAST` now refuses a bare ARRAY in comparand position —
+`{ tags: ['a', 'b'] }` — with a `FilterOperatorError` (`INVALID_FILTER` / 400)
+that names the field, prints the comparand and prescribes the spelling that
+works, instead of lowering it to `['tags', '=', ['a', 'b']]` (objectui#8530).
+
+That node was never answerable: the ObjectQL filter AST has no array-equality,
+so `@objectstack/driver-sql` refused it with `400 INVALID_FILTER` from the wire
+and every in-memory matcher (`@objectstack/formula`, `ValueDataSource` since
+objectui#8514) excluded every row. The author found out two layers away, as a
+failed list or an empty one. The refusal now lands at lowering time, where the
+field and the offending value are still in hand — the same treatment this file
+already gives `$regex` and `$not`, the two other shapes it cannot lower.
+
+It is deliberately NOT read as membership. `{ tags: [...] }` and
+`{ tags: { $in: [...] } }` are different statements and the second is already
+spellable; rewriting one into the other would guess at intent and silently
+change which rows a stored view returns — the lenient second contract
+objectui#8514 was resolved against on this same data shape one layer down. The
+error message says so, and names `$in` / `$nin` / `$between` as the spellings to
+use. `$in` / `$nin` / `$between` members, `$and` / `$or` groups and stored
+`ViewFilterRule` values (`in` / `between`) are legitimately arrays and keep
+lowering exactly as before.
+
+Every producer in this repository already spells a multi-value comparand
+`{ $in: [...] }` (measured across the `$filter` literals and record builders
+under `packages/*/src` and `apps/*/src`), so no shipped surface changes
+behaviour; only a hand-authored `{ field: [...] }` — which no backend honoured —
+now fails at the producer instead of the consumer.

--- a/.changeset/8530-filter-converter-array-comparand.md
+++ b/.changeset/8530-filter-converter-array-comparand.md
@@ -28,5 +28,8 @@ lowering exactly as before.
 Every producer in this repository already spells a multi-value comparand
 `{ $in: [...] }` (measured across the `$filter` literals and record builders
 under `packages/*/src` and `apps/*/src`), so no shipped surface changes
-behaviour; only a hand-authored `{ field: [...] }` — which no backend honoured —
-now fails at the producer instead of the consumer.
+behaviour; only a hand-authored `{ field: [...] }` now fails at the producer
+instead of the consumer. No ruled contract ever answered that shape — the spec
+leaves an array outside `$in` / `$nin` / `$between` unruled, `driver-sql` and the
+in-memory matchers refuse it, and only a document store's native array-equality
+happened to read it — so nothing a backend was promised is taken away.

--- a/packages/core/src/utils/__tests__/filter-array-comparand-8530.test.ts
+++ b/packages/core/src/utils/__tests__/filter-array-comparand-8530.test.ts
@@ -1,0 +1,256 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A bare ARRAY in comparand position through the repo's ONE lowering —
+ * objectui#8530.
+ *
+ * ## The defect
+ *
+ * `convertFiltersToAST` ended its per-field loop with a simple-equality `else`
+ * that was reached for every non-object value — arrays included. So
+ * `{ tags: ['a', 'b'] }` became `['tags', '=', ['a', 'b']]`: an array sitting
+ * in a scalar-equality slot. Nothing answers that node with a row.
+ *
+ * MEASURED (this file, section 1) — the spec's own doors do not catch it:
+ * `isFilterAST` is `true` and `parseFilterAST` hands back `{ tags: [...] }`
+ * unjudged, because `assertListComparandShapes` rules only on `$in` / `$nin` /
+ * `$between`. The refusal therefore arrived two layers away — `driver-sql`'s
+ * `400 INVALID_FILTER` from the wire, or an empty list from every in-memory
+ * matcher — and the author learned nothing at lowering time.
+ *
+ * ## The ruling (objectui#8530, PM comment 5583351371)
+ *
+ * Throw `FilterOperatorError`, matching the file's two existing refusals of
+ * shapes it cannot lower (`$regex`, `$not`). ⛔ NOT lowered to `in`:
+ * `{ tags: [...] }` and `{ tags: { $in: [...] } }` are different statements,
+ * the second is already spellable, and rewriting one into the other is the
+ * lenient second contract objectui#8514 was resolved against on this same data
+ * shape one layer down.
+ *
+ * ## What carries the weight here — the NON-regression axis
+ *
+ * The caricature of this fix throws on everything array-shaped. It passes every
+ * "the bare array is now refused" assertion in section 1 and breaks `$in` /
+ * `$nin` / `$between` members, `$and` / `$or` groups and stored `ViewFilterRule`
+ * values with `in` / `between` — all legitimately arrays. Section 2 is what
+ * discriminates the fix from the caricature, and it asserts PRODUCED values put
+ * through the spec's own doors, not the absence of a throw: a lowering that
+ * emits nothing would pass "does not throw" and still be the caricature's
+ * silent twin.
+ *
+ * Section 1's refusals assert the envelope (`code` + `httpStatus`, ADR-0112 /
+ * objectui#3066) on a CAPTURED error, so the message-quality assertions run
+ * unconditionally in the leg they were written for rather than sitting inside
+ * a `catch` that a non-throwing lowering never enters.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isFilterAST, parseFilterAST } from '@objectstack/spec/data';
+import {
+  convertFiltersToAST,
+  toFilterNode,
+  mergeFilterNodes,
+  FilterOperatorError,
+} from '../filter-converter';
+
+/**
+ * Run the lowering and hand back the refusal it raised. Fails the test — on
+ * the FIRST line, with the produced value in the message — when it did not
+ * refuse, so no later assertion is silently skipped.
+ */
+function captureRefusal(run: () => unknown): FilterOperatorError {
+  let caught: unknown;
+  let produced: unknown;
+  try {
+    produced = run();
+  } catch (e) {
+    caught = e;
+  }
+  expect(
+    caught,
+    `expected the lowering to refuse, it produced ${JSON.stringify(produced)}`,
+  ).toBeInstanceOf(FilterOperatorError);
+  return caught as FilterOperatorError;
+}
+
+// ---------------------------------------------------------------------------
+// 1. The bare array is refused — with the envelope and an actionable message
+// ---------------------------------------------------------------------------
+
+describe('objectui#8530 — a bare array in comparand position is refused', () => {
+  it('records why the producer must refuse: the spec doors pass the old node unjudged', () => {
+    // The pre-fix emission. Both spec doors accept it, so nothing between this
+    // file and the driver would have said a word. If the spec ever starts
+    // refusing it, this pin reddens and the reader learns the refusal now has
+    // a sibling — not that the producer arm can go.
+    const preFixNode = ['tags', '=', ['a', 'b']];
+    expect(isFilterAST(preFixNode)).toBe(true);
+    expect(parseFilterAST(preFixNode)).toEqual({ tags: ['a', 'b'] });
+  });
+
+  it('refuses { tags: [...] } with the INVALID_FILTER / 400 envelope', () => {
+    const err = captureRefusal(() => convertFiltersToAST({ tags: ['a', 'b'] }));
+    // A bare `Error` classifies as a network fault in the list error panel
+    // (objectui#3066); the data API's own code and status are what make it
+    // render as "the filter is malformed".
+    expect(err.code).toBe('INVALID_FILTER');
+    expect(err.httpStatus).toBe(400);
+    expect(err.name).toBe('FilterOperatorError');
+  });
+
+  it('names the field, prints the comparand, and prescribes $in / $nin', () => {
+    const err = captureRefusal(() => convertFiltersToAST({ tags: ['a', 'b'] }));
+    // The first sentence is the contract a reader acts on without opening the
+    // source: which field, what value.
+    expect(err.message).toMatch(
+      /^\[ObjectUI\] The filter on field 'tags' carries a bare ARRAY as its equality comparand: \["a","b"\]\./,
+    );
+    // The door that works, spelled for THIS field — and its negation.
+    expect(err.message).toContain('{ tags: { $in: [...] } }');
+    expect(err.message).toContain('{ tags: { $nin: [...] } }');
+    // Says out loud that it was not rewritten to membership, and why, so a
+    // reader who wants `in` knows that door exists and is a separate decision.
+    expect(err.message).toMatch(/NOT read as membership/);
+    expect(err.message).toContain('objectui#8530');
+    // Not the sibling diagnostics: this is neither an unknown operator nor a
+    // combinator problem, and it must not be reported as one.
+    expect(err.message).not.toMatch(/Unknown filter operator/);
+    expect(err.message).not.toMatch(/combinator/);
+  });
+
+  it('prints the comparand it was given, not a placeholder', () => {
+    const err = captureRefusal(() => convertFiltersToAST({ owner_id: [42, null, 'x'] }));
+    expect(err.message).toContain("field 'owner_id'");
+    expect(err.message).toContain('[42,null,"x"]');
+  });
+
+  it('refuses the empty array too — it is not "no constraint"', () => {
+    // `['tags', '=', []]` is exactly as unanswerable as the two-member one, and
+    // reading `[]` as TRUE would silently widen the result set — the one
+    // failure direction this file exists to avoid.
+    const err = captureRefusal(() => convertFiltersToAST({ tags: [] }));
+    expect(err.code).toBe('INVALID_FILTER');
+    expect(err.message).toContain('comparand: []');
+  });
+
+  it('refuses the array wherever it sits: beside other fields and inside $and / $or', () => {
+    // Beside a scalar condition — the array must not hide behind a sibling
+    // that lowers fine.
+    expect(captureRefusal(() => convertFiltersToAST({ status: 'active', tags: ['a'] })).message)
+      .toContain("field 'tags'");
+    // As a member condition of a combinator — children lower recursively, so
+    // the refusal propagates from the child.
+    expect(captureRefusal(
+      () => convertFiltersToAST({ $or: [{ status: 'open' }, { tags: ['a'] }] }),
+    ).message).toContain("field 'tags'");
+    expect(captureRefusal(
+      () => convertFiltersToAST({ $and: [{ status: 'open' }, { tags: ['a', 'b'] }] }),
+    ).message).toContain("field 'tags'");
+  });
+
+  it('is refused by the sink the same way — toFilterNode and mergeFilterNodes delegate', () => {
+    // `toFilterNode` is the last hop before the wire for an OBJECT source, and
+    // `mergeFilterNodes` is what every renderer calls; both route the object
+    // through `convertFiltersToAST`, so the refusal reaches them unchanged.
+    const viaSink = captureRefusal(() => toFilterNode({ tags: ['a', 'b'] }));
+    expect(viaSink.code).toBe('INVALID_FILTER');
+    const viaMerge = captureRefusal(() => mergeFilterNodes({ status: 'x' }, { tags: ['a'] }));
+    expect(viaMerge.code).toBe('INVALID_FILTER');
+    expect(viaMerge.message).toContain("field 'tags'");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. NON-regression — arrays that are LEGITIMATELY arrays keep lowering.
+//    This is the axis that separates the fix from "throw on anything array-
+//    shaped". Every case asserts the PRODUCED node and puts it through the
+//    spec's own doors; none of them is "does not throw".
+// ---------------------------------------------------------------------------
+
+describe('objectui#8530 — legitimate array positions are untouched', () => {
+  it('$in still lowers to `in` with its member array intact', () => {
+    const node = convertFiltersToAST({ status: { $in: ['active', 'pending'] } });
+    expect(node).toEqual(['status', 'in', ['active', 'pending']]);
+    expect(isFilterAST(node)).toBe(true);
+    // Round trip through the spec's shape door: `$in` with an array member is
+    // exactly what `assertListComparandShapes` accepts.
+    expect(parseFilterAST(node)).toEqual({ status: { $in: ['active', 'pending'] } });
+  });
+
+  it('$nin (and its $notin alias) still lower to `nin`', () => {
+    expect(convertFiltersToAST({ status: { $nin: ['archived'] } }))
+      .toEqual(['status', 'nin', ['archived']]);
+    expect(convertFiltersToAST({ status: { $notin: ['archived', 'deleted'] } }))
+      .toEqual(['status', 'nin', ['archived', 'deleted']]);
+    expect(parseFilterAST(['status', 'nin', ['archived']])).toEqual({ status: { $nin: ['archived'] } });
+  });
+
+  it('$between still lowers with its [min, max] pair', () => {
+    const node = convertFiltersToAST({ age: { $between: [18, 65] } });
+    expect(node).toEqual(['age', 'between', [18, 65]]);
+    expect(isFilterAST(node)).toBe(true);
+    expect(parseFilterAST(node)).toEqual({ age: { $between: [18, 65] } });
+  });
+
+  it('$in / $nin members inside $and / $or still lower', () => {
+    const node = convertFiltersToAST({
+      $or: [{ status: { $in: ['open', 'blocked'] } }, { tags: { $nin: ['x'] } }],
+    });
+    expect(node).toEqual([
+      'or',
+      ['status', 'in', ['open', 'blocked']],
+      ['tags', 'nin', ['x']],
+    ]);
+    expect(isFilterAST(node)).toBe(true);
+  });
+
+  it('$and / $or themselves — arrays OF conditions — still lower to groups', () => {
+    // The combinator's VALUE is an array. The caricature ("throw on any array")
+    // placed ahead of the combinator arm would refuse it as a field called
+    // `$or` carrying an array comparand.
+    const node = convertFiltersToAST({ $or: [{ status: 'open' }, { status: 'blocked' }] });
+    expect(node).toEqual(['or', ['status', '=', 'open'], ['status', '=', 'blocked']]);
+    expect(parseFilterAST(node)).toEqual({ $or: [{ status: 'open' }, { status: 'blocked' }] });
+    const conj = convertFiltersToAST({ $and: [{ a: 1 }, { b: 2 }] });
+    expect(conj).toEqual(['and', ['a', '=', 1], ['b', '=', 2]]);
+  });
+
+  it('a stored ViewFilterRule whose operator is `in` / `between` keeps its array value', () => {
+    // The card asked for this path to be checked before choosing: a saved view
+    // rule legitimately carries an array on these operators and lowers through
+    // `viewFilterRuleToNode`, not through the object arm. It must keep working.
+    const inRule = toFilterNode([{ field: 'status', operator: 'in', value: ['a', 'b'] }]);
+    expect(inRule).toEqual([['status', 'in', ['a', 'b']]]);
+    expect(isFilterAST(inRule)).toBe(true);
+    const betweenRule = toFilterNode([{ field: 'amount', operator: 'between', value: [1, 10] }]);
+    expect(betweenRule).toEqual([['amount', 'between', [1, 10]]]);
+    expect(isFilterAST(betweenRule)).toBe(true);
+  });
+
+  it('an object source with $in merges beside a rule array under one `and`', () => {
+    const merged = mergeFilterNodes(
+      { status: { $in: ['open', 'blocked'] } },
+      [{ field: 'amount', operator: 'between', value: [1, 10] }],
+    );
+    expect(merged).toEqual([
+      'and',
+      ['status', 'in', ['open', 'blocked']],
+      [['amount', 'between', [1, 10]]],
+    ]);
+  });
+
+  it('scalar equality is exactly what it was', () => {
+    expect(convertFiltersToAST({ status: 'active' })).toEqual(['status', '=', 'active']);
+    expect(convertFiltersToAST({ count: 0, ok: false })).toEqual([
+      'and',
+      ['count', '=', 0],
+      ['ok', '=', false],
+    ]);
+  });
+});

--- a/packages/core/src/utils/filter-converter.ts
+++ b/packages/core/src/utils/filter-converter.ts
@@ -216,8 +216,10 @@ function falseIdentityLeaf(field: string, value: unknown[]): FilterNode {
  * convertFiltersToAST({ $or: [{ status: 'open' }, { status: 'blocked' }] })
  * // => ['or', ['status', '=', 'open'], ['status', '=', 'blocked']]
  *
- * @throws {FilterOperatorError} If an unknown operator is encountered, or if
- * `$not` is used — see the `$not` arm for why the AST cannot carry it.
+ * @throws {FilterOperatorError} If an unknown operator is encountered, if
+ * `$not` is used — see the `$not` arm for why the AST cannot carry it — or if a
+ * field's value is a bare ARRAY (`{ tags: ['a', 'b'] }`) — see the array arm for
+ * why that is refused rather than read as `$in`.
  */
 export function convertFiltersToAST(filter: Record<string, any>): FilterNode | Record<string, any> {
   const conditions: FilterNode[] = [];
@@ -250,6 +252,46 @@ export function convertFiltersToAST(filter: Record<string, any>): FilterNode | R
         `$notContains); note those follow each operator's own answer for a missing ` +
         `value rather than $not's NULL-safe rule (objectstack#5146). ` +
         `Value: ${JSON.stringify(value)}.`
+      );
+    }
+
+    // A bare ARRAY in comparand position is the third shape this file cannot
+    // lower, after `$regex` and `$not` (objectui#8530). The equality `else`
+    // below used to catch it and emit `[field, '=', [...]]` — an array in a
+    // scalar-equality slot. The spec's own doors pass that node through
+    // unjudged (`isFilterAST` is true and `parseFilterAST` hands back
+    // `{ field: [...] }`; measured against @objectstack/spec 17.3.0, whose
+    // `assertListComparandShapes` rules only on `$in` / `$nin` / `$between`),
+    // so the refusal arrived two layers later: `@objectstack/driver-sql`
+    // answers 400 INVALID_FILTER, and the in-memory matchers
+    // (`@objectstack/formula`, `ValueDataSource` since objectui#8514) refuse
+    // the node and exclude every row. Either way the author learned nothing at
+    // lowering time. Refused HERE instead, where the field name and the
+    // offending value are both still in hand.
+    //
+    // NOT lowered to `in`. `{ tags: ['a', 'b'] }` and `{ tags: { $in: ['a', 'b'] } }`
+    // are different statements and the second is already spellable; rewriting
+    // one into the other guesses at intent and silently changes which rows a
+    // stored view returns — the lenient second contract objectui#8514 was
+    // resolved against on this same data shape one layer down. A lowering to
+    // `in` would be a deliberate, separately-argued change, not a fallback.
+    //
+    // `$in` / `$nin` / `$between` MEMBERS are legitimately arrays and are read
+    // by the operator loop below, never here; `$and` / `$or` carry arrays of
+    // conditions and were consumed by the combinator arm above.
+    if (Array.isArray(value)) {
+      throw new FilterOperatorError(
+        `[ObjectUI] The filter on field '${field}' carries a bare ARRAY as its ` +
+        `equality comparand: ${JSON.stringify(value)}. It cannot be lowered: the ` +
+        `ObjectQL filter AST has no array-equality node, so the lowered node ` +
+        `[${field}, '=', [...]] is refused by @objectstack/driver-sql (400 INVALID_FILTER) ` +
+        `and matches no row in the in-memory matchers — it can never select anything. ` +
+        `It is deliberately NOT read as membership here: { ${field}: [...] } and ` +
+        `{ ${field}: { $in: [...] } } are different statements, and guessing the ` +
+        `second from the first would silently change which rows a stored view ` +
+        `returns (objectui#8530; the same ruling objectui#8514 applied one layer ` +
+        `down). Spell membership as { ${field}: { $in: [...] } }, its negation as ` +
+        `{ ${field}: { $nin: [...] } }, or a range as { ${field}: { $between: [min, max] } }.`
       );
     }
 

--- a/packages/data-objectstack/README.md
+++ b/packages/data-objectstack/README.md
@@ -136,6 +136,13 @@ AST format**. This is what keeps it compatible with the ObjectStack Protocol
 | `$startswith` | `startswith` | `{ email: { $startswith: 'admin' } }` → `['email', 'startswith', 'admin']` |
 | `$between` | `between` | `{ age: { $between: [18, 65] } }` → `['age', 'between', [18, 65]]` |
 
+A bare array as a field's value — `{ tags: ['a', 'b'] }` — is **refused** at
+lowering time with a `FilterOperatorError` (`INVALID_FILTER` / 400) naming the
+field and the comparand, not read as `$in` (objectui#8530): the ObjectQL AST
+has no array-equality node, so `['tags', '=', ['a', 'b']]` was answered by a
+`400` from the wire or an empty list from every in-memory matcher. Spell
+membership as `{ tags: { $in: ['a', 'b'] } }` (or `$nin` for its negation).
+
 #### Complex Filter Examples
 
 **Multiple conditions** are combined with `'and'`:


### PR DESCRIPTION
Fixes objectstack-ai/objectui#8530

## What changed

`convertFiltersToAST` (`packages/core/src/utils/filter-converter.ts`) now refuses a bare ARRAY in comparand position — `{ tags: ['a', 'b'] }` — with a `FilterOperatorError` (`INVALID_FILTER` / 400) instead of lowering it to `['tags', '=', ['a', 'b']]`. The message names the field, prints the comparand, says the value is deliberately NOT read as membership (and why), and prescribes `{ $in: [...] }` / `{ $nin: [...] }` / `{ $between: [min, max] }`. It is the third member of the family this file already refuses (`$regex`, `$not`), per the ruling on the card (comment 5583351371): not lowered to `in`.

`$in` / `$nin` / `$between` members, `$and` / `$or` groups and stored `ViewFilterRule` values (`in` / `between`) lower exactly as before — the non-regression section of the pin file is what carries the weight (see the caricature leg below).

## Why the producer, measured

Against `@objectstack/spec` 17.3.0 (pinned in the test): the spec's own doors pass the old node through unjudged — `isFilterAST(['tags', '=', ['a', 'b']])` is `true` and `parseFilterAST` hands back `{ tags: ['a', 'b'] }` — because `assertListComparandShapes` rules only on `$in` / `$nin` / `$between`. So the refusal arrived two layers later (driver-sql's 400 from the wire, or an empty list from the in-memory matchers) and the author learned nothing at lowering time. Contract-first (AGENTS.md #0.1): the producer says it.

No shipped producer emits the shape: every multi-value comparand under `packages/*/src` and `apps/*/src` is spelled `{ $in: [...] }` (`FilterConditionField.condToMongo`, `dashboard-filters.buildFilterCondition`, the `LookupField` / `PeoplePicker` / `RecordPickerDialog` id restrictions), and no test fixture feeds a bare-array object literal to `convertFiltersToAST` / `toFilterNode` / `mergeFilterNodes` — ripgrep over `packages/**/src`, `apps/**/src`, `examples/**/src`: 0 hits; lit control (same regex without the array constraint): 32 hits.

## Files

- `packages/core/src/utils/filter-converter.ts` — the arm and its `@throws` line. The `typeof value === 'object' && !Array.isArray(value)` condition is kept as-is on purpose: with the arm ahead of it, an arm deleted later degrades to the honest pre-fix shape rather than to a nonsense "Unknown filter operator '0'" diagnostic (see the first ablation attempt below).
- `packages/core/src/utils/__tests__/filter-array-comparand-8530.test.ts` — 15 pins: 7 refusal pins (envelope on a CAPTURED error, message quality, comparand print, empty array, placement beside siblings and inside `$and` / `$or`, sink delegation) and 8 non-regression pins on PRODUCED nodes put through `isFilterAST` / `parseFilterAST`, none of them "does not throw".
- `packages/data-objectstack/README.md` — one paragraph under the operator table that documents this lowering. Two rows of that table are stale independently of this card (`$nin` documented as `notin`, `$regex` documented as `contains`); not touched here, reported to the PM.
- `.changeset/8530-filter-converter-array-comparand.md` — `@object-ui/core: patch`.

## Verification

Code head `3fff2fd7e`; the only later commit (`e8d5804f7`) rewords the changeset, and the ratchet gates were re-run on it.

- `pnpm exec vitest run --maxWorkers=2 packages/core/ packages/data-objectstack/` → `Test Files 186 passed (186)`, `Tests 3514 passed (3514)`; lock verdict `VERDICT command-exit 0`.
- Targeted run of every test file that calls the sink (`git grep`, lit control 12 hits in the sink's own test), including `fields/.../FilterConditionField.operators.test.ts`, `data-objectstack/src/filter-dialect-wire-7221.test.ts` and `filter-entry-translation.test.ts` → `Test Files 9 passed (9)`, `Tests 250 passed (250)`.
- `pnpm --filter @object-ui/core type-check` (build and test programs) exit 0; `pnpm --filter @object-ui/core lint` 0 errors (531 pre-existing `no-explicit-any` warnings, none in the touched files).
- Gates on `e8d5804f7`: `check-changeset-presence` ✅ (2 source files of 1 released package, 1 changeset declared), `check-changeset-fixed` ✅, `check-changeset-no-major` ✅, `check:control-bytes` ✅ (6758 files), `check:doc-fences` ✅. On `3fff2fd7e`: `check:shell-escape-residue` ✅, `check:unreferenced-sources` OK, `check:vi-mock-specifiers` ✅, `check:doc-example-readers` OK.
- `check:readme-exports`: NOT MEASURED locally. It exits 1 with "465 self-import(s) could not be judged … `./dist/index.d.ts` is not on disk -- run `pnpm build` first" — the whole-repo unbuilt-tree precondition (`packages/data-objectstack/README.md` is not among its complaints, and the added paragraph carries no import or export name). CI owns the built run.
- Narrowing declared: `turbo ls --affected` lists every package (core is a root dependency), and the full `pnpm test` is CI's four-shard run. Local scope: core and data-objectstack in full plus every sink-calling test file, with the two ripgrep controls above as the checkable reason nothing outside that scope can change verdict.

## Ablation and caricature — run from the committed head, not predicted

Both legs mutate the committed file, prove the mutation on disk in both directions, run the pin file, and restore by STATE (`git checkout HEAD -- path`, then `git diff HEAD` empty and `git hash-object` equal to the `HEAD:` blob `92cd70dc3`), with a trap on `EXIT INT TERM` using absolute paths. The pin file imports `../filter-converter` relatively, so no `dist/` sits in the resolution path and no rebuild is needed between mutation and observation.

- **Leg A — ablation** (arm deleted → exact pre-fix shape; marker count 1 → 0, `git diff --stat` 40 deletions): `Tests 6 failed | 9 passed (15)`. Red: all six refusal pins. Green: the spec-door pin (it pins the spec, not the fix) and all eight non-regression pins.
- **Leg B — caricature** (the arm moved ahead of the combinator arm plus a copy on operator members, i.e. "throw on everything array-shaped"; marker 1 → 2, `Array.isArray(operatorValue)` 0 → 1, arm at line 254 before the combinator arm at 277): `Tests 7 failed | 8 passed (15)`. Red: the six non-regression pins that pass through the object arm (`$in`, `$nin`, `$between`, members inside `$or`, `$and` / `$or` groups, merge with `$in`) plus "refuses the array wherever it sits" — the caricature refuses `{ $or: [...] }` on field `$or` before reaching `tags`. Green under the caricature, i.e. NOT discriminating it: envelope, message quality, comparand print, empty array, sink delegation, spec-door pin, scalar equality — and the stored-`ViewFilterRule` `in` / `between` pin, which lowers through `viewFilterRuleToNode` rather than the object arm and therefore discriminates a different caricature (one placed in that function), not this one.
- A first ablation attempt is reported as the null-ish reading it was: it deleted the arm but kept an interim `typeof value === 'object'` condition, so arrays fell into the operator loop and were refused as "Unknown filter operator '0'" — `Tests 3 failed | 12 passed`, with the envelope pin passing on a tree refusing for the wrong reason. The condition was restored and both legs re-run from the amended commit.

## Related, left open

- objectui#8514 / PR #8529 — the consumer half (`ValueDataSource`); this PR is the producer half the card asked for. Refs only.
- objectui#6948 — the `$and` / `$or` / `$not` arms this one sits beside. Refs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_