### PR TITLE
fix(components): make Empty's base classes override-friendly and drop its inert border-dashed

### DIFF
--- a/.changeset/8525-empty-container-override-friendly.md
+++ b/.changeset/8525-empty-container-override-friendly.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/components': patch
+---
+
+fix(components): `Empty`'s base classes stop beating a caller's padding on desktop, and drop an inert `border-dashed`
+
+The shared `Empty` container carried `p-6 … md:p-12` in its base classes. A caller's unprefixed padding override (`px-3 py-8`, `py-10`, even a full `p-4`) lives in a different `tailwind-merge` variant from `md:p-12`, so `cn()` kept both and the `md:` rule won the cascade from 768px up — "tighten this panel" silently did nothing on any desktop viewport. The responsive default now travels in a custom property (`--empty-padding`: 24px, and 48px from `md`) read by ONE unprefixed `padding` utility, so a caller's plain padding wins at every viewport, while a site with no override renders exactly as before: 24px below `md`, 48px at and above it. Callers that are responsive themselves (`p-2 md:p-4`) keep working.
+
+Visible consequence: the three console sites that already wrote a tighter panel now get it on desktop — the AI chat conversations sidebar's empty state (`px-3 py-8`) and the metadata-admin audit panel's error and empty states (`py-10`).
+
+`border-dashed` is removed from the same string. It set only `border-style`; with preflight's zero `border-width` and no width supplied by any call site or ancestor, it drew nothing at any of the 44 `Empty` sites (measured on the console build), so removing it changes no pixel. No border width is added — a dashed frame around every empty state would be a product-wide visual decision that needs its own card.

--- a/packages/components/src/__tests__/empty-base-classes-override-friendly-8525.test.tsx
+++ b/packages/components/src/__tests__/empty-base-classes-override-friendly-8525.test.tsx
@@ -1,0 +1,348 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `Empty`'s base classes are override-friendly, and carry no inert border
+ * (objectui#8525).
+ *
+ * ## What was wrong
+ *
+ * The container's base string read `… rounded-lg border-dashed p-6 … md:p-12`.
+ *
+ *   * `md:p-12` is a different tailwind-merge VARIANT from any unprefixed
+ *     padding a caller passes, so `cn()` kept it next to `px-3 py-8`, and from
+ *     768px up the `md:` rule won the cascade. Three app-shell sites that wrote
+ *     "less padding" (`ConversationsSidebar` `px-3 py-8`, `AuditPanel` `py-10`
+ *     twice) got the full 48px back on every desktop viewport — the card
+ *     measured 118.8px with and without the override, identical. Even a full
+ *     `p-4` lost: tailwind-merge dropped `p-6` for it and `md:p-12` survived.
+ *   * `border-dashed` sets `border-style` only. Preflight zeroes `border-width`
+ *     on every element and nothing at any of the 44 call sites supplied a
+ *     width, so the class drew nothing. Ruled: REMOVE it; ⛔ never add a width
+ *     here — a frame around every empty state is a product-wide visual decision
+ *     nobody has made, and it gets its own card if anyone wants it.
+ *
+ * ## The instrument, and why this is not a class-string pin
+ *
+ * The class attribute is read off the REAL component (RTL render). The CSS the
+ * workspace Tailwind emits for exactly those classes is built through the public
+ * compiler with explicit candidates and `base` pinned to the repo root, on the
+ * shipped `@theme` (`packages/components/src/index.css`, the block every
+ * consuming app loads). No source is scanned, so the reading does not depend on
+ * the cwd Tailwind is launched from — this repo's scanning compiles do.
+ *
+ * A small cascade evaluator then walks that stylesheet in source order and
+ * answers, per padding side and per viewport width, WHICH declaration wins.
+ * Every selector here is one class inside one `@layer`, so source order is the
+ * whole cascade: the evaluator implements no specificity and refuses any
+ * selector it cannot map back to one class. The control below shows it
+ * reproduces the defect on the OLD base shape, so a green reading on the new
+ * shape is a measurement and not an inert instrument.
+ *
+ * Values are spacing units (`p-6` → 6). `12` on every side at 768px for a site
+ * with NO override is the non-regression axis — the caricature that drops
+ * `md:p-12` outright makes every override "win" and fails exactly there. `8` on
+ * the block axis at 768px for `px-3 py-8` is the fix.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { render } from '@testing-library/react';
+import { compile } from 'tailwindcss';
+import { Empty } from '../custom/empty';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '../../../..');
+
+/** The shipped `@theme` block, as `headerColor.test.ts` reads it. */
+function themeBlock(): string {
+  const css = fs.readFileSync(path.join(repoRoot, 'packages/components/src/index.css'), 'utf8');
+  const start = css.indexOf('@theme {');
+  expect(start, 'components/src/index.css should declare a @theme block').toBeGreaterThan(-1);
+  let depth = 0;
+  for (let i = css.indexOf('{', start); i < css.length; i++) {
+    if (css[i] === '{') depth++;
+    else if (css[i] === '}' && --depth === 0) return css.slice(start, i + 1);
+  }
+  throw new Error('unterminated @theme block');
+}
+
+/**
+ * One compiler per file. `build()` is cumulative on a compiler instance, so the
+ * stylesheet grows across calls — harmless, because the evaluator applies only
+ * the rules whose class is on the element it evaluates, as a browser would.
+ */
+let compilerPromise: ReturnType<typeof compile> | undefined;
+async function buildCss(candidates: string[]): Promise<string> {
+  compilerPromise ??= (async () => {
+    const twEntry = path.join(repoRoot, 'node_modules/tailwindcss/index.css');
+    const twDir = path.dirname(fs.realpathSync(twEntry));
+    return compile(`@import "tailwindcss";\n${themeBlock()}\n`, {
+      base: repoRoot,
+      loadStylesheet: async (id: string, base: string) => {
+        const file = id === 'tailwindcss'
+          ? path.join(twDir, 'index.css')
+          : id.startsWith('tailwindcss/')
+            ? path.join(twDir, id.slice('tailwindcss/'.length))
+            : path.resolve(base, id);
+        return { base: path.dirname(file), path: file, content: fs.readFileSync(file, 'utf8') };
+      },
+    });
+  })();
+  return (await compilerPromise).build(candidates);
+}
+
+/** The class list the real component puts in the DOM for a given override. */
+function classesOf(className?: string): string[] {
+  const { container, unmount } = render(<Empty className={className} />);
+  const el = container.querySelector('[data-slot="empty"]');
+  expect(el, 'Empty renders its data-slot="empty" container').not.toBeNull();
+  const classes = (el!.getAttribute('class') ?? '').split(/\s+/).filter(Boolean);
+  unmount();
+  return classes;
+}
+
+// ---------------------------------------------------------------------------
+// A cascade evaluator for single-class utilities in one layer.
+// ---------------------------------------------------------------------------
+
+interface Rule { className: string; media: string[]; decls: Array<[string, string]> }
+
+/** Walk `css` and return every single-class rule inside `@layer utilities`, in source order. */
+function utilityRules(css: string): Rule[] {
+  const rules: Rule[] = [];
+  const walk = (src: string, media: string[], inUtilities: boolean) => {
+    let i = 0;
+    while (i < src.length) {
+      const open = src.indexOf('{', i);
+      if (open === -1) break;
+      let head = src.slice(i, open).replace(/\/\*[\s\S]*?\*\//g, '').trim();
+      const segs = head.split(/[;}]/);
+      head = segs[segs.length - 1].trim();
+      let depth = 1;
+      let j = open + 1;
+      while (j < src.length && depth > 0) {
+        if (src[j] === '{') depth++;
+        else if (src[j] === '}') depth--;
+        j++;
+      }
+      const body = src.slice(open + 1, j - 1);
+      if (head.startsWith('@layer')) {
+        walk(body, media, inUtilities || /^@layer\s+utilities\b/.test(head));
+      } else if (head.startsWith('@media')) {
+        walk(body, [...media, head.slice('@media'.length).trim()], inUtilities);
+      } else if (head.startsWith('@')) {
+        // @property / @keyframes / @supports … — nothing here reads them.
+      } else if (inUtilities && head) {
+        if (!head.startsWith('.') || /[\s>+~,]|(?<!\\):/.test(head.slice(1).replace(/\\./g, 'x'))) {
+          throw new Error(`evaluator cannot map selector to one class: ${head}`);
+        }
+        const className = head.slice(1).replace(/\\(.)/g, '$1');
+        const decls = body
+          .replace(/\/\*[\s\S]*?\*\//g, '')
+          .split(';')
+          .map((d) => d.trim())
+          .filter(Boolean)
+          .map((d): [string, string] => {
+            const k = d.indexOf(':');
+            return [d.slice(0, k).trim(), d.slice(k + 1).trim()];
+          });
+        rules.push({ className, media, decls });
+      }
+      i = j;
+    }
+  };
+  walk(css, [], false);
+  return rules;
+}
+
+/** Does every media condition hold at `widthPx`? Refuses shapes it does not know. */
+function mediaHolds(media: string[], widthPx: number): boolean {
+  return media.every((m) => {
+    const ge = m.match(/\(\s*width\s*>=\s*([\d.]+)(rem|px)\s*\)/);
+    if (ge) return widthPx >= Number(ge[1]) * (ge[2] === 'rem' ? 16 : 1);
+    const lt = m.match(/\(\s*width\s*<\s*([\d.]+)(rem|px)\s*\)/);
+    if (lt) return widthPx < Number(lt[1]) * (lt[2] === 'rem' ? 16 : 1);
+    const min = m.match(/min-width:\s*([\d.]+)(rem|px)/);
+    if (min) return widthPx >= Number(min[1]) * (min[2] === 'rem' ? 16 : 1);
+    throw new Error(`evaluator cannot read media query: ${m}`);
+  });
+}
+
+type Side = 'top' | 'right' | 'bottom' | 'left';
+type Sides = Record<Side, number>;
+const SIDES_OF: Record<string, Side[]> = {
+  'padding': ['top', 'right', 'bottom', 'left'],
+  'padding-inline': ['left', 'right'],
+  'padding-block': ['top', 'bottom'],
+  'padding-top': ['top'],
+  'padding-right': ['right'],
+  'padding-bottom': ['bottom'],
+  'padding-left': ['left'],
+  'padding-inline-start': ['left'],
+  'padding-inline-end': ['right'],
+};
+
+/**
+ * The padding a browser would compute for an element carrying `classes`, at
+ * `widthPx`, in spacing units — from the winning declaration per side after a
+ * source-order walk of the rules that match the element.
+ */
+function computedPadding(css: string, classes: string[], widthPx: number): Sides {
+  const onElement = new Set(classes);
+  const env = new Map<string, string>();
+  const raw: Partial<Record<Side, string>> = {};
+  for (const rule of utilityRules(css)) {
+    if (!onElement.has(rule.className) || !mediaHolds(rule.media, widthPx)) continue;
+    for (const [prop, value] of rule.decls) {
+      if (prop.startsWith('--')) env.set(prop, value);
+      else if (prop in SIDES_OF) for (const side of SIDES_OF[prop]) raw[side] = value;
+    }
+  }
+  const resolve = (side: Side): number => {
+    let value = raw[side];
+    if (value === undefined) throw new Error(`no padding declaration reached side "${side}" at ${widthPx}px`);
+    value = value.replace(/var\((--[\w-]+)\)/g, (token, name: string) => {
+      // `--spacing` is the theme token the unit regex below reads verbatim; every
+      // other custom property must have been set on this element.
+      if (name === '--spacing') return token;
+      const v = env.get(name);
+      if (v === undefined) throw new Error(`"${name}" is consumed but never set on this element at ${widthPx}px`);
+      return v;
+    });
+    const units = value.match(/^calc\(var\(--spacing\) \* ([\d.]+)\)$/);
+    if (units) return Number(units[1]);
+    if (/^0(px)?$/.test(value)) return 0;
+    throw new Error(`evaluator cannot read a padding value: ${value}`);
+  };
+  return { top: resolve('top'), right: resolve('right'), bottom: resolve('bottom'), left: resolve('left') };
+}
+
+const all = (n: number): Sides => ({ top: n, right: n, bottom: n, left: n });
+
+/** Every default breakpoint, one pixel either side, plus a phone and a desktop. */
+const LADDER = [320, 639, 640, 767, 768, 1023, 1024, 1279, 1280, 1535, 1536, 1920];
+
+/** The `md` breakpoint in px, read from the theme through the same compiler. */
+async function mdPx(): Promise<number> {
+  const rule = utilityRules(await buildCss(['md:hidden'])).find((r) => r.className === 'md:hidden');
+  expect(rule?.media, 'md:hidden is emitted under one media query').toHaveLength(1);
+  const m = rule!.media[0].match(/\(\s*width\s*>=\s*([\d.]+)(rem|px)\s*\)/);
+  expect(m, `md media query has a readable threshold: ${rule!.media[0]}`).not.toBeNull();
+  return Number(m![1]) * (m![2] === 'rem' ? 16 : 1);
+}
+
+async function paddingAcrossLadder(override?: string): Promise<Array<{ width: number; sides: Sides }>> {
+  const classes = classesOf(override);
+  const css = await buildCss(classes);
+  return LADDER.map((width) => ({ width, sides: computedPadding(css, classes, width) }));
+}
+
+describe('Empty — the padding default and every override, cascade-evaluated on the emitted CSS', () => {
+  it('the evaluator itself reproduces the defect on the OLD base shape (control)', async () => {
+    // `p-6 … md:p-12` with a caller's `px-3 py-8`, as tailwind-merge left it:
+    // at md the base wins on every side. A green run on the new shape below
+    // therefore means the shape changed, not that the instrument is inert.
+    const old = ['p-6', 'md:p-12', 'px-3', 'py-8'];
+    const css = await buildCss(old);
+    const md = await mdPx();
+    expect(computedPadding(css, old, md - 1)).toEqual({ top: 8, right: 3, bottom: 8, left: 3 });
+    expect(computedPadding(css, old, md)).toEqual(all(12));
+  });
+
+  it('a site with NO override still gets 6 below md and 12 at and above it (the non-regression axis)', async () => {
+    const md = await mdPx();
+    for (const { width, sides } of await paddingAcrossLadder(undefined)) {
+      expect(sides, `no override at ${width}px`).toEqual(all(width >= md ? 12 : 6));
+    }
+  });
+
+  it('`px-3 py-8` (ConversationsSidebar) wins on every side at every width', async () => {
+    for (const { width, sides } of await paddingAcrossLadder('px-3 py-8')) {
+      expect(sides, `px-3 py-8 at ${width}px`).toEqual({ top: 8, right: 3, bottom: 8, left: 3 });
+    }
+  });
+
+  it('`py-10` (AuditPanel) wins on the block axis at every width, and the inline axis keeps the responsive default', async () => {
+    const md = await mdPx();
+    for (const { width, sides } of await paddingAcrossLadder('py-10')) {
+      const inline = width >= md ? 12 : 6;
+      expect(sides, `py-10 at ${width}px`).toEqual({ top: 10, right: inline, bottom: 10, left: inline });
+    }
+  });
+
+  it('a full `p-4` wins on every side at every width', async () => {
+    for (const { width, sides } of await paddingAcrossLadder('p-4')) {
+      expect(sides, `p-4 at ${width}px`).toEqual(all(4));
+    }
+  });
+
+  it('a caller can still be responsive itself: `p-2 md:p-4` reads 2 below md and 4 at and above it', async () => {
+    const md = await mdPx();
+    for (const { width, sides } of await paddingAcrossLadder('p-2 md:p-4')) {
+      expect(sides, `p-2 md:p-4 at ${width}px`).toEqual(all(width >= md ? 4 : 2));
+    }
+  });
+
+  it('a prefixed-only override keeps the default below its breakpoint: `md:p-3` reads 6 then 3', async () => {
+    const md = await mdPx();
+    for (const { width, sides } of await paddingAcrossLadder('md:p-3')) {
+      expect(sides, `md:p-3 at ${width}px`).toEqual(all(width >= md ? 3 : 6));
+    }
+  });
+});
+
+describe('Empty — the mechanism, as rendered', () => {
+  it('no padding utility in the base classes carries a variant prefix', () => {
+    // A `VARIANT:p*-` token in the base is exactly what an unprefixed override
+    // cannot beat through `cn()`; the responsive default has to travel some
+    // other way (today: a custom property).
+    const prefixedPadding = classesOf(undefined).filter((token) => {
+      const bare = token.replace(/^(?:[^\s:[\]]+:)+/, '');
+      return bare !== token && /^-?p[xytrblse]?-/.test(bare);
+    });
+    expect(prefixedPadding).toEqual([]);
+  });
+
+  it('a caller\'s override tokens reach the DOM untouched', () => {
+    for (const override of ['px-3 py-8', 'py-10', 'p-4']) {
+      const classes = classesOf(override);
+      for (const token of override.split(' ')) expect(classes, override).toContain(token);
+    }
+  });
+});
+
+describe('Empty — the border half', () => {
+  it('control: on this workspace build `border-dashed` alone is style-only, `border` carries the width, and preflight zeroes every border', async () => {
+    const css = await buildCss(['border-dashed', 'border']);
+    const rules = utilityRules(css);
+    const dashed = rules.find((r) => r.className === 'border-dashed')!;
+    const border = rules.find((r) => r.className === 'border')!;
+    expect(dashed.decls.map(([k]) => k)).toContain('border-style');
+    expect(dashed.decls.some(([k]) => /width$/.test(k) || k === 'border')).toBe(false);
+    expect(border.decls.some(([k, v]) => k === 'border-width' && v === '1px')).toBe(true);
+    // preflight: `*, ::after, ::before, … { … border: 0 solid; }`
+    expect(css).toMatch(/\*,\s*::after,\s*::before[^{]*\{[^}]*\bborder:\s*0 solid\b/);
+  });
+
+  it('the base classes never declare a border-style without a border-width (the inert-frame class of defect)', async () => {
+    const classes = classesOf(undefined);
+    const rules = utilityRules(await buildCss(classes)).filter((r) => classes.includes(r.className));
+    const styleSetters = rules.filter((r) => r.decls.some(([k]) => /^border(-\w+)?-style$/.test(k))).map((r) => r.className);
+    const widthSetters = rules.filter((r) => r.decls.some(([k]) => /^border(-[\w-]+)?-width$/.test(k) || k === 'border')).map((r) => r.className);
+    expect(styleSetters.length === 0 || widthSetters.length > 0, `style ${styleSetters} without width`).toBe(true);
+  });
+
+  it('carries no border utility today — the former `border-dashed` was inert, and a frame is a design change with its own card', () => {
+    // The ADR-0049 remove branch. A future deliberate frame updates this pin
+    // together with the card that decides it; it does not arrive by accident.
+    expect(classesOf(undefined).filter((token) => /^border(-|$)/.test(token))).toEqual([]);
+  });
+});

--- a/packages/components/src/custom/empty.tsx
+++ b/packages/components/src/custom/empty.tsx
@@ -25,7 +25,22 @@ function Empty({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="empty"
       className={cn(
-        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12",
+        // Padding is 24px, and 48px from `md` up, carried by a custom property
+        // so that the ONE utility writing `padding` is unprefixed. A caller's
+        // plain `px-3 py-8` / `py-10` / `p-4` then wins at every viewport,
+        // which is what a `className` override reads as. The literal `md:p-12`
+        // that stood here was a different tailwind-merge variant from any
+        // unprefixed override, so `cn()` kept it and it won the cascade from
+        // 768px up: three app-shell sites that wrote "less padding" got the
+        // full 48px back on every desktop viewport (objectui#8525).
+        //
+        // No border utility. The `border-dashed` that stood here set only
+        // `border-style`; preflight keeps `border-width` at 0 and no call site
+        // or ancestor supplies one, so it drew nothing at any of the 44 sites
+        // (measured on the console build). A dashed frame, if ever wanted, is
+        // a deliberate `border border-dashed` pair with its own card — never a
+        // width slipped into a cleanup.
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg p-(--empty-padding) [--empty-padding:--spacing(6)] md:[--empty-padding:--spacing(12)] text-center text-balance",
         className
       )}
       {...props}


### PR DESCRIPTION
Fixes objectstack-ai/objectui#8525

## What changed

`packages/components/src/custom/empty.tsx` — the `Empty` container's base classes, one string, two halves per the ruling on the card:

1. **`md:p-12` — repaired.** The responsive default (24px, 48px from `md`) now travels in a custom property, `--empty-padding`, set by `[--empty-padding:--spacing(6)]` and `md:[--empty-padding:--spacing(12)]`, and read by ONE unprefixed utility, `p-(--empty-padding)`. A caller's plain `px-3 py-8`, `py-10` or `p-4` therefore wins at every viewport: the `padding` shorthand sorts before `padding-inline` / `padding-block` in Tailwind's output, and `tailwind-merge` 3.6.0 puts `p-(--var)` in the `p` group, so a caller's `p-4` replaces it outright. A site with no override renders exactly as before.
2. **`border-dashed` — removed, no width added.** Inertness verified below, not taken from the card.

Plus a pin test, `packages/components/src/__tests__/empty-base-classes-override-friendly-8525.test.tsx`, and a `patch` changeset for `@object-ui/components` (a shared component with 44 call sites: the default is unchanged at every one of them, the override contract callers already wrote against now holds, no API moved — a fix, graded `patch`).

Visible consequence: the three console sites that already wrote a tighter panel get it on desktop now — `ConversationsSidebar` (`px-3 py-8`) and the two `AuditPanel` states (`py-10`). No source change at those sites; they now get what they wrote.

## Measurements — all from ONE place

Every CSS compile below ran with cwd = repo root and `base` pinned to `apps/console`, through this workspace's `@tailwindcss/postcss` on `apps/console/src/index.css` (445,063 bytes / 3,239 rules parsed before; 445,387 bytes after — the delta is exactly the three new rules, which also settles that the real scanner extracts the new spellings). The pin test compiles no sources at all: explicit candidates on the shipped `@theme`, `base` = repo root, so it is not exposed to the cwd sensitivity the card warns about.

### Chromium (Playwright, `/opt/pw-browsers/chromium`), the real component rendered through `react-dom/server`, computed padding T/R/B/L, 215px column

| case | 767px before → after | 768px before → after | 1440px before → after |
|---|---|---|---|
| no override | 24/24/24/24 → same | 48/48/48/48 → same | 48/48/48/48 → same |
| `px-3 py-8` (ConversationsSidebar) | 32/12/32/12 → same | **48/48/48/48 → 32/12/32/12** | **48/48/48/48 → 32/12/32/12** |
| `py-10` (AuditPanel, twice) | 40/24/40/24 → same | **48/48/48/48 → 40/48/40/48** | **48/48/48/48 → 40/48/40/48** |
| `p-4` | 16/16/16/16 → same | **48/48/48/48 → 16/16/16/16** | **48/48/48/48 → 16/16/16/16** |

Border on every case at every width: `0px dashed` before → `0px solid` after. Zero pixels of border drawn either way. Note the `p-4` row: before this change even a full unprefixed `p-4` lost on desktop (tailwind-merge dropped `p-6` for it, and `md:p-12` survived), which is wider than the two sites the card names.

### Inertness of `border-dashed` — the ruling's premise, measured

- Preflight in the compiled console CSS: `*, ::after, ::before, ::backdrop, ::file-selector-button { border: 0 solid }`. `.border-dashed` emits `--tw-border-style: dashed; border-style: dashed` and no width; `.border` is what carries `border-width: 1px`.
- Census of every rule in that stylesheet that sets a border width or the `border` shorthand: 51 rules — 29 single-class selectors (apply only to an element carrying the class), 22 other shapes. Of the 22, all but one family require the element itself to be `hr` / `tr` / `input` / `pre` / `table` / `th` / `td` / `img`, to carry `data-topbar-group`, or to carry the class under an ancestor condition (`group-data-*`, `prose-*`). The one family that can reach a plain div from an ancestor is `divide-x` / `divide-y` (`:where(.divide-y > :not(:last-child))`).
- `divide-*`: 30 users under `packages/*/src` and `apps/*/src`; every one maps array rows into `tr` / `li` / `div` / `NavRow` / `DiffRow` children, or slots two divs (`SourcePageEditor`). The five inside files that also render `Empty` are all `tbody.divide-y` blocks with `tr` children. Three components return `Empty` as their root element (`RelatedPanel`, `ReferencesPanel` twice); both are rendered inside a plain `div.flex-1.min-h-0.overflow-auto.p-4`. So no `Empty` is a `divide-*` child.
- Call sites: 44 `Empty` openers in 32 files (a DOTALL regex over whole files, so a multi-line opener would count — there are none; control: 84 `EmptyValue` openers, which the same regex excludes). Only 3 carry a `className`, the three on the card; none carries a `border*` token. No rule in the compiled CSS names `data-slot=empty`. The SDUI `empty` renderer goes through `DataEmptyState`, not `Empty`, so metadata `className` cannot reach this string.
- Border width is not inherited, so that is the complete set of ways a width could arrive. It renders nothing anywhere: removal is zero-delta, the ADR-0049 remove branch. If a dashed frame around every empty state is wanted, that is a product-wide visual decision for its own card; this PR does not make it.

## The pin, and the legs that were run — not predicted

The test reads the class attribute off the REAL component, builds the CSS the workspace Tailwind emits for exactly those classes, and walks it with a small cascade evaluator (single-class selectors in one layer: source order is the whole cascade) at 12 widths — every default breakpoint, one pixel either side, plus 320 and 1920. A control shows the evaluator reproduces the defect on the old shape, so a green reading is a measurement and not an inert instrument. The test imports the component SOURCE, so no `dist/` is involved in any reading here.

Every leg: mutate → prove on disk (injected text count ≥ 1, removed text count 0, then `git diff --stat`) → run → restore by state (`git checkout HEAD -- PATH`, then `git diff HEAD` empty AND `git hash-object` equal to the HEAD blob for all three paths), trap on `EXIT INT TERM`, absolute paths, implementation committed first. All four restores read `RESTORE OK`.

| leg | mutation | pin test | first failing assertion(s) | Chromium at 768px |
|---|---|---|---|---|
| L1 caricature | base padding becomes plain `p-6` | **2 failed** / 10 passed | `no override at 768px` — the labelled non-regression axis — and `py-10 at 768px` (inline axis expected 12, got 6) | no override 24px: the default silently changed |
| L2 plausible wrong fix | component back to `p-6 md:p-12`; the three call sites patched with `md:px-3 md:py-8` / `md:py-10` | **4 failed** / 8 passed | `px-3 py-8 at 768px`, `py-10 at 768px`, `p-4 at 768px`, and the mechanism pin `expected [ 'md:p-12' ] to deeply equal []` | every override 48px |
| L3 axis split | `px-6 py-6 md:px-12 md:py-12` | **4 failed** / 8 passed | the same three at 768px, and the mechanism pin with `[ 'md:px-12', 'md:py-12' ]` | every override 48px |
| L4 arbitrary-property spelling | `[padding:var(--empty-padding)]` instead of `p-(--empty-padding)` | 12 passed | — | identical to the fix |

L4 did not discriminate, and that is reported rather than reshaped: Tailwind sorts the arbitrary property before `p-4`, so the cascade is the same under both instruments. The only difference is that `tailwind-merge` does not classify it as padding, so a caller's `p-4` would leave the dead utility in the DOM; the `p-(--var)` spelling is preferred for that hygiene, not for any measured behaviour. Each discriminating assertion ran in the leg it was written for: the ladder loops report their first failing width (768px, after 320–767 passed), and the mechanism pin is its own `it`.

## Verification, at `102e9fb5c`

- `pnpm exec vitest run packages/components/src/__tests__/empty-base-classes-override-friendly-8525.test.tsx` → `Tests 12 passed (12)`, VERDICT command-exit 0
- `pnpm exec vitest run packages/components/` → `Test Files 243 passed (243)`, `Tests 2248 passed (2248)`, VERDICT command-exit 0
- the four call-site test files (`ConversationsSidebar.test.tsx`, `AuditPanel.emptyPlaceholderAffordance-8504`, `AuditPanel.loadFailure`, `AuditPanel.lockState`) → `Test Files 4 passed (4)`, `Tests 21 passed (21)`
- `pnpm --filter @object-ui/components type-check`, after building the dependency closure → exit 0
- `pnpm exec eslint` on the two changed source files, from the repo root, no `--no-inline-config` → exit 0
- `node scripts/check-changeset-presence.mjs` → declares 1 changeset; `check-changeset-no-major` → OK; `check:control-bytes` → OK over 6756 files; `check:phantom-deps` → OK; `check:comment-mask-corpus` → report-only, within the residue it holds open; `check:unreferenced-sources` → OK

**Declared narrowing.** `turbo ls --affected` lists 31 packages — everything downstream of `@object-ui/components`. Locally this ran the components package in full plus the four test files that exercise the three call sites; the rest is CI's. The checkable reason: no test file or snapshot outside the new test queries `data-slot="empty"` or asserts `p-6` / `md:p-12` / `border-dashed` on it (`git grep` over `*.test.*` and `*.snap`, zero hits; control: 18 test files mention `data-slot="empty-value"`), so no downstream test reads the string this PR changes.

The measurement harness (console compile, border census, SSR render, Playwright reader, the ablation driver) lives in the session scratchpad and is not committed; the committed instrument is the pin test.

## Not in this PR

- No border width, anywhere. A dashed frame is a design decision for its own card.
- The three call sites are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_