### PR TITLE
fix(setup): let turbo own the build order, and make a wrong script name loud

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -22,6 +22,33 @@ if ! command -v node &> /dev/null; then
 fi
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Assert the root manifest actually DECLARES a script before this file invokes
+# it, so a name this file gets wrong is LOUD.
+#
+# The alternative failed silently for as long as it was wrong: this script used
+# to call `pnpm test:root`, a script the root manifest has never declared. pnpm
+# exits 254 on an unknown script -- but that call sat inside an `if`, and an
+# `if` condition suppresses `set -e`, so the miss took the else branch and
+# printed "Some tests failed, but setup is complete". The "run tests" step was
+# a no-op that reported it had run (objectui#7987). A step that cannot run
+# while reporting that it did is worse than one that fails: the contributor who
+# reads the warning believes the suite exists and is partly broken, the one who
+# does not believes it passed, and nothing distinguishes the two.
+#
+# Reading the name back out of the manifest is the same discipline the Node
+# floor above follows (objectui#5306): the script and the manifest cannot drift
+# apart, because the script asks the manifest.
+require_root_script() {
+    if ! node -e 'process.exit(require(process.argv[1]).scripts[process.argv[2]] ? 0 : 1)' \
+        "$REPO_ROOT/package.json" "$1"; then
+        echo -e "${RED}❌ setup.sh bug: root package.json declares no \"$1\" script${NC}"
+        echo -e "${YELLOW}That is a defect in this script, not in your environment.${NC}"
+        echo -e "${YELLOW}Please report it: https://github.com/objectstack-ai/objectui/issues${NC}"
+        exit 1
+    fi
+}
+
 # `>=22.11` -> `22.11`. A failed read exits the script under `set -e`, so an
 # unreadable manifest can never be mistaken for a satisfied floor.
 NODE_FLOOR=$(node -p "require('$REPO_ROOT/package.json').engines.node.replace(/^[^0-9]*/, '')")
@@ -48,31 +75,41 @@ echo -e "${GREEN}✓ pnpm $(pnpm -v) detected${NC}"
 echo -e "\n${YELLOW}📦 Installing dependencies...${NC}"
 pnpm install
 
-# Build core packages
-echo -e "\n${YELLOW}🔨 Building core packages...${NC}"
+# Build the packages
+#
+# One `pnpm build` -- which is `turbo run build`, and derives the order from the
+# manifests. Do NOT hand-list packages here again. This block used to build six
+# of them one at a time in a hand-written order (types, core, react, components,
+# fields, layout): a hand-maintained copy of a dependency graph turbo already
+# owns, and it had drifted from it. `@object-ui/react` depends on
+# `@object-ui/i18n` and `@object-ui/data-objectstack`, neither of which was on
+# the list, so on a CLEAN checkout the third step died with
+#
+#   src/index.ts(99,8): error TS2307: Cannot find module '@object-ui/i18n' ...
+#
+# and `set -e` took the whole script down before it reached anything else --
+# reproduced at exit status 2 on `3f775eeb8` (objectui#7987; the same defect
+# class objectui#7292 measured on `packages/components/package.json`'s
+# `prebuild`). A hand-written order cannot be kept correct by review, because
+# nothing tells the person adding a dependency that this file exists.
+echo -e "\n${YELLOW}🔨 Building packages...${NC}"
 echo -e "${BLUE}This may take a few minutes on first run...${NC}"
 
-pnpm --filter @object-ui/types build
-echo -e "${GREEN}✓ @object-ui/types built${NC}"
-
-pnpm --filter @object-ui/core build
-echo -e "${GREEN}✓ @object-ui/core built${NC}"
-
-pnpm --filter @object-ui/react build
-echo -e "${GREEN}✓ @object-ui/react built${NC}"
-
-pnpm --filter @object-ui/components build
-echo -e "${GREEN}✓ @object-ui/components built${NC}"
-
-pnpm --filter @object-ui/fields build
-echo -e "${GREEN}✓ @object-ui/fields built${NC}"
-
-pnpm --filter @object-ui/layout build
-echo -e "${GREEN}✓ @object-ui/layout built${NC}"
+require_root_script build
+pnpm build
+echo -e "${GREEN}✓ Packages built${NC}"
 
 # Run tests
+#
+# `pnpm test` -- the script README.md's manual-setup path tells a contributor to
+# run, and the one this file's own "Available commands" block advertises below.
+# A red suite is still tolerated (setup is complete either way), but that
+# tolerance now covers ONLY a genuine test failure: `require_root_script` has
+# already refused an undeclared name, so the else branch below can no longer be
+# reached by a step that never ran.
 echo -e "\n${YELLOW}🧪 Running tests...${NC}"
-if pnpm test:root; then
+require_root_script test
+if pnpm test; then
     echo -e "${GREEN}✓ All tests passed${NC}"
 else
     echo -e "${YELLOW}⚠ Some tests failed, but setup is complete${NC}"


### PR DESCRIPTION
Fixes #7987

One file, `scripts/setup.sh`. Both of the card's halves are the same shape — a name the script asserts that the repository does not back — and they are fixed together because separating them would double the review on a file nothing gates.

## What I measured, before changing anything

Everything below was re-taken on a fresh `origin/main` = `3f775eeb8`, in a dedicated worktree with a clean checkout (no `dist/` anywhere). The card measured `9de3141a0` and the triage `83d4fda16`.

**Half 1 — the hand-listed chain. The prediction is TRUE, verbatim.** The card and the triage both flagged the `TS2307` reading as quoted from the #7292 dev and re-measured by neither. It reproduces exactly. Steps 1 and 2 of the hand list pass; step 3 dies:

```
=== STEP: pnpm --filter @object-ui/types build ===   STEP_EXIT[types]=0
=== STEP: pnpm --filter @object-ui/core build ===    STEP_EXIT[core]=0
=== STEP: pnpm --filter @object-ui/react build ===   STEP_EXIT[react]=2

src/context/AppShellContext.tsx(2,41): error TS2307: Cannot find module '@object-ui/data-objectstack' or its corresponding type declarations.
src/hooks/useActionTextLocalizer.ts(58,69): error TS2307: Cannot find module '@object-ui/i18n' or its corresponding type declarations.
src/hooks/useDatasetDimensionLabels.ts(69,35): error TS2307: Cannot find module '@object-ui/i18n' or its corresponding type declarations.
src/index.ts(99,8): error TS2307: Cannot find module '@object-ui/i18n' or its corresponding type declarations.
src/utils/error-message.ts(24,40): error TS2307: Cannot find module '@object-ui/data-objectstack' or its corresponding type declarations.
src/utils/nonGridRowCeiling.tsx(11,42): error TS2307: Cannot find module '@object-ui/i18n' or its corresponding type declarations.
```

The mechanism, confirmed at the manifest: `packages/react/package.json` declares `@object-ui/i18n` and `@object-ui/data-objectstack` as `workspace:*` dependencies, both of whose `exports` point at `./dist/*`; neither was on the hand list, so at step 3 neither had a `dist`. Under `set -e` the script exits there and never reaches install-verification, tests, or the "Next steps" block.

**Half 2 — `test:root`. Confirmed, and measured as a running program rather than as a grep.**

```
$ pnpm test:root ; echo $?
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "test:root" not found
 Did you mean "pnpm test:unit"?
254
```

pnpm is loud. The `if` is what silences it: an `if` condition suppresses `set -e`, so exit 254 took the `else` branch and printed `⚠ Some tests failed, but setup is complete`. Repo-wide, `test:root` occurs on exactly one line — `scripts/setup.sh:75`, its only use site, with no declaration anywhere (`grep -rn 'test:root'`, exit 0, 1 hit; the quoted-declaration form `grep -rn '"test:root"'` exits 1 with 0 hits, against the control `"lint:root"` which exits 0 — so the zero is the tree's, not the grep's).

## What changed

**Half 1 — delete the hand list.** Six `pnpm --filter ... build` lines become one `pnpm build`, which is `turbo run build --filter=!@object-ui/site`. The order now comes from the manifests turbo already reads, so it cannot drift from them again. A comment at the site records the failure it replaces, so the next person tempted to hand-list is told why not.

**Half 2 — the decision, stated because the triage asked for it: point the step at `pnpm test`, and make a wrong name refuse.**

A step that silently degrades is not repaired by swapping in a script name that happens to exist. That fixes today's symptom and leaves the mechanism: the next rename puts the step straight back into the branch that reports tests ran when they did not. So the step now asks the manifest before it invokes it:

```bash
require_root_script() {
    if ! node -e 'process.exit(require(process.argv[1]).scripts[process.argv[2]] ? 0 : 1)' \
        "$REPO_ROOT/package.json" "$1"; then
        echo -e "${RED}❌ setup.sh bug: root package.json declares no \"$1\" script${NC}"
        ...
        exit 1
    fi
}
```

This is the discipline the Node-floor check directly above already follows (#5306): the script asks the manifest instead of repeating it, so the two cannot drift apart. Both the build step and the test step go through it.

The tolerant `else` branch survives, and that is deliberate: setup completing over a red suite is a real and intended promise. What changed is that the tolerance is now bounded to what it was meant to cover. A genuine test failure still warns; a name this file gets wrong exits 1 with a message that says it is a bug in the script, not in the reader's environment. The two are no longer indistinguishable.

**Why `pnpm test` and not `pnpm test:unit`, and not deleting the step.** Against the four axes:

- *Real need.* The reader is measured, not hypothetical: `README.md`'s "Quick Setup (Recommended)" block is the only invocation of this script in the tree, and its "Manual Setup" block next to it prescribes exactly `pnpm install` / `pnpm build` / `pnpm test`. The automated path should do what the manual path says, or the two documents disagree — which the triage explicitly warned against. This script's own "Available commands" block also advertises `pnpm test` as "Run all tests".
- *Long-term soundness.* Deleting the step leaves a setup script that verifies nothing after building, and it would have to be re-added the first time someone wants a smoke check. Keeping it, with the name enforced, is the no-workaround shape.
- *Making it hard to get wrong.* Contract-first, on the side that matters here: the invocation asserts its precondition and refuses loudly, rather than tolerating a miss on the consumer side. `pnpm test:unit` would have been a third promise, declared in no document, which is the tolerant-alias shape this repo rejects.
- *Startup-stage focus.* No new script, no new gate, no new surface — one helper of nine lines inside the file that already had the defect. The class-level fix (a repo-wide gate asserting every `pnpm SCRIPT` call in a tracked shell script against the manifest) is deliberately not built: I measured the population and `scripts/setup.sh:75` was the class's only live instance across all 12 tracked shell files, so a gate for it would be a verification surface for a set of size zero.

Cost, stated plainly: `pnpm build` builds 43 packages rather than 6, so first-run setup is slower than the hand list *when the hand list worked*. It does not currently work, so the comparison is against a script that exits at step 3.

## Verification

| what | command | reading |
| --- | --- | --- |
| the defect, half 1 | the hand list's steps 1-3, clean checkout | exits 0, 0, **2** — `TS2307`, as quoted above |
| the defect, half 2 | `pnpm test:root` | **254**, `Command "test:root" not found` |
| the fix, half 1 | `turbo run build --filter='!@object-ui/site' --concurrency=2` | **43 successful, 43 total**, exit 0, 1m37s |
| the fix, half 2, leg A | `require_root_script test` | exit **0**, silent |
| the fix, half 2, leg B | `require_root_script test:root` | exit **1** + `setup.sh bug: root package.json declares no "test:root" script` |
| the fix, half 2, leg C | `require_root_script build` | exit **0** |
| grammar | `bash -n scripts/setup.sh` | exit 0 |
| `pnpm check:bash32-floor` | — | `✓ 12 tracked shell file(s) ... name no bash 4+ construct`, exit 0 |
| `pnpm check:control-bytes` | — | `✅ OK (scanned 6756 tracked text file(s))`, exit 0 |
| `pnpm check:shell-escape-residue` | — | `✅ OK (206 file(s), 1310 fenced block(s))`, exit 0 |
| the test that names this file | `vitest run --project unit scripts/__tests__/bash32-floor-wiring.test.ts` | **9 passed**, exit 0 |
| changeset | `node scripts/check-changeset-presence.mjs` | exit 0 — `No source or published contract of a released package changed in this range, so no changeset is owed` |

Legs A/B/C exercise the **shipped bytes**: the function body was extracted out of the committed `scripts/setup.sh` with `sed` and sourced, not re-typed, so leg B is a real demonstration that the guard can fail and leg A that it does not fire on a declared name.

Every exit code above was captured by redirect before any pipe (`cmd  /tmp/out 2 and 1; EXIT=$?`), never read across a `| tail`. Heavy runs went through the shared verify lock; the two locked runs reported `VERDICT command-exit 0`, held 18s and 99s, waited 0s each — shared-box seconds, not idle-box figures.

**Affected packages: none.** `turbo ls --affected` against the merge base reports `0 no packages` — `scripts/setup.sh` belongs to no workspace package, so no package `test` or `type-check` is owed.

**Lint, narrowed and the narrowing proved.** The diff is one `.sh` file. eslint's own configuration resolution puts it outside the linted population — `eslint --no-inline-config --format json scripts/setup.sh` returns exactly 1 result, `errorCount: 0`, message `File ignored because no matching configuration was supplied`. So the linted file count contributed by this diff is 0, and since the diff contains no eslint config or rule file, no untouched file's verdict can move either.

## Two corrections to the card, both about its readers count

1. **The card and the triage both state that `git grep -l 'setup\.sh'` returns only the root `README.md`. Run as written on `origin/main`, it returns 7 files** (exit 0, against a control returning 4447):

   ```
   README.md
   scripts/__tests__/bash32-floor-wiring.test.ts
   scripts/__tests__/shared-global-leak-guard.test.ts
   scripts/__tests__/unit-registry-absence-collision.test.ts
   vitest.config.mts
   vitest.setup.shared-global-leak-guard.ts
   vitest.setup.shared-global-leak.ts
   ```

   Five of those are substring artifacts — the pattern `setup\.sh` matches inside `vitest.setup.shared-...`. The sixth, `scripts/__tests__/bash32-floor-wiring.test.ts`, is a genuine reference: it names `scripts/setup.sh` as the motivating example for the bash-3.2 floor.

2. **Consequently "CI cannot see either defect" is right about these two defects but wrong as a statement about the file.** `scripts/setup.sh` is inside `pnpm check:bash32-floor`'s population — the gate's own verdict counts it among "12 tracked shell file(s)" — and that gate runs on pull requests via `lint.yml`. What no workflow does is *execute* the script, which is why these two defects specifically are invisible to CI. The p3 grade's reasoning survives; its supporting grep does not, as written.

Neither correction changes the fix.

## Out of scope, filed not fixed

- **#8559** — the same file's "Next steps" block sends every contributor to `ARCHITECTURE_EVALUATION.md`, which is not a tracked file (`git ls-files --error-unmatch` exit 1, against a control exit 0 in the same run). Not repaired here: there are three defensible replacements and choosing between them is a documentation decision, so it does not meet the bar for an in-place fix. Filed unlabelled and unassigned.

## Known-red, not mine

`Bundle Analysis` is red on `main` and on every PR that triggers it — #8542. Not caused by this change and not a required check.

Session: `https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr`


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_