### PR TITLE
Make the Live E2E artefact promise true instead of unreachable

### DIFF
--- a/.changeset/8238-live-e2e-report-promise.md
+++ b/.changeset/8238-live-e2e-report-promise.md
@@ -1,0 +1,9 @@
+---
+---
+
+Correct the Live E2E lane's claim about what a failing run leaves behind, and pin it to the
+config that decides it (objectui#8238). `playwright.live.config.ts` declares
+`reporter: [['list']]`, which writes to stdout only, so no run of this lane could ever produce
+the `playwright-report/` the workflow header, the job summary, the upload glob and
+`content/docs/guide/ci-cd-pipeline.md` all promised. CI, docs and tests only; no package is
+released by this change.

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -16,8 +16,13 @@
 # art for why a new lane must prove itself outside the merge gate first).
 # Do NOT add this job to required checks, and do not remove
 # `continue-on-error`, until the lane has run clean for long enough to trust
-# (watch the nightly schedule). Failures still surface: red step + uploaded
-# report + job summary.
+# (watch the nightly schedule). Failures still surface: red step + job summary
+# + the `live-e2e-artifacts` upload. That upload carries `test-results/` (the
+# failure screenshots and videos `use.screenshot` / `use.video` write) and the
+# two server logs — it does NOT carry a Playwright HTML report, because
+# `playwright.live.config.ts` declares `reporter: [['list']]` and the `list`
+# reporter writes to stdout only (objectui#8238). The durable record of what
+# the specs actually did is the `Run live E2E allowlist` step's own log.
 #
 # Growing the allowlist: add specs to `test:e2e:live:ci` in package.json a
 # few at a time, only after they prove flake-free here — do not switch all
@@ -227,17 +232,32 @@ jobs:
             echo "## Live E2E failed (informational lane — does not block merge)"
             echo ""
             echo "Backend: published \`@objectstack/*\` per \`e2e/live/ci/backend.env\`."
-            echo "See the \`live-e2e-artifacts\` upload for the Playwright report and server logs."
+            echo "What the specs did is in this job's \`Run live E2E allowlist\` step log (the \`list\` reporter writes to stdout; there is no HTML report to open)."
+            echo "See the \`live-e2e-artifacts\` upload for the failure screenshots and videos (\`test-results/\`) and the two server logs."
             echo "If this failure reproduces on re-run it is a real console x backend integration bug — treat it as such even though the lane cannot block your merge."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload report and server logs
+      # ⛔ Do not add `playwright-report/` back to this glob without changing
+      # `playwright.live.config.ts` in the same PR. That config declares
+      # `reporter: [['list']]`; the `list` reporter writes to stdout and no
+      # reporter in it writes `playwright-report/`, so the path matched nothing
+      # in EVERY outcome — measured on a passing and on a failing run, absent
+      # both times — while this workflow's header and
+      # `content/docs/guide/ci-cd-pipeline.md` promised readers a report they
+      # could open (objectui#8238). The reporter list is the one line that
+      # decides it, and the claim is pinned in
+      # `scripts/__tests__/ci-cd-pipeline-doc.test.ts`.
+      #
+      # ⚠️ This step is gated on `failure()`, so on a GREEN lane it does not run
+      # and there is NO artifact at all. Any acceptance criterion phrased over
+      # this artifact's contents is therefore readable only on a run that
+      # failed; a green run leaves nothing to count (objectui#8238).
+      - name: Upload failure artefacts and server logs
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() && failure() }}
         with:
           name: live-e2e-artifacts
           path: |
-            playwright-report/
             test-results/
             ${{ runner.temp }}/live-backend/backend.log
             ${{ runner.temp }}/console-preview.log

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -508,7 +508,25 @@ header comment in the workflow file (#2835).
 What it does: runs an allowlist of the live specs (`pnpm test:e2e:live:ci`) against a real
 `objectstack dev` backend booted from **published** `@objectstack/*` packages serving the
 showcase app, catching the class of bug only a real browser against a real backend can see.
-Failures still surface as a red step plus an uploaded Playwright report and job summary.
+Failures still surface as a red step, a job summary, and a `live-e2e-artifacts` upload.
+
+**What that upload actually contains — and what it does not.** It carries `test-results/` (the
+failure screenshots and videos the config's `use.screenshot` / `use.video` settings write) plus
+`backend.log` and `console-preview.log`. It carries **no Playwright HTML report**:
+`playwright.live.config.ts` declares `reporter: [['list']]`, and the `list` reporter writes to
+stdout, so nothing in that config ever produces a `playwright-report/` directory. The durable
+record of what the specs did is the `Run live E2E allowlist` step's own log. This page and the
+workflow header both promised an "uploaded Playwright report" for as long as the lane has
+existed, and no run could ever have produced one (objectui#8238) — so if you want a report to
+open, the reporter list in `playwright.live.config.ts` is the one line that decides it, and it
+must move together with this paragraph and the workflow's upload glob.
+
+⚠️ **The upload step is gated `if: ${{ !cancelled() && failure() }}`.** On a **green** lane it
+does not run at all, so there is no artifact and nothing to count. Any acceptance criterion
+phrased over this artifact's contents — "the uploaded artifact has more than N files", "a
+directory X appears in it" — is therefore readable **only on a run that failed**. Phrase checks
+about this lane against the `Run live E2E allowlist` step's log instead, which exists in both
+outcomes.
 
 **Which specs are in the allowlist:** whatever the `test:e2e:live:ci` script in `package.json`
 names — that script is the single source of truth, and this page deliberately does not repeat

--- a/scripts/__tests__/ci-cd-pipeline-doc.test.ts
+++ b/scripts/__tests__/ci-cd-pipeline-doc.test.ts
@@ -1823,3 +1823,169 @@ describe('ci-cd-pipeline.md — Half-State Patrol sweeper wiring (#8043)', () =>
     ).toContain(floor!);
   });
 });
+
+/**
+ * objectui#8238 — the lane promised an artefact its configuration cannot produce.
+ *
+ * `live-e2e.yml`'s header, its job-summary step, its upload glob and this page's Live E2E
+ * section were FOUR spellings of one claim — "failures surface as an uploaded Playwright
+ * report" — and all four were decided by a single line somewhere else entirely:
+ * `playwright.live.config.ts`'s `reporter`. That line reads `[['list']]`; the `list` reporter
+ * writes to stdout and nothing in that config writes `playwright-report/`, so the promised
+ * report was unreachable in EVERY outcome. Measured on a passing run and on a failing run:
+ * absent both times, with an `html` reporter as the control that proves the directory is
+ * observable when a reporter actually writes it.
+ *
+ * Nothing read those four sites against the config, which is exactly how they drifted, and
+ * the cost was not cosmetic: objectui#8084's acceptance criterion was written as "a
+ * `playwright-report/` appears in the uploaded artifact", so a correct fix could never have
+ * satisfied its stated test. An acceptance criterion nobody can pass is the same hazard as a
+ * check nobody can fail, pointed the other way.
+ *
+ * So this block pins the claim to the mechanism rather than to a sentence. It does not care
+ * which way the repository decides the question — it requires only that the reporter list and
+ * everything that describes it move together. Turn the HTML reporter on and this test goes red
+ * naming every site that must be updated with it; leave it off and the sites must keep quoting
+ * the reporter value that makes the absence true.
+ */
+const LIVE_CONFIG_FILE = 'playwright.live.config.ts';
+const liveConfig = fs.readFileSync(path.join(repoRoot, LIVE_CONFIG_FILE), 'utf8');
+
+/**
+ * Source with `//` and block comments removed. The YAML-oriented `withoutComments` above
+ * cannot be reused: this is TypeScript, and `playwright.live.config.ts` opens with a 20-line
+ * block comment that names the config's behaviour in prose. A whole-file regex would read that
+ * prose as configuration — the same class of mistake as counting a commented-out `env:` key.
+ */
+function withoutTsComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+/** The `reporter:` value exactly as written in a Playwright config, e.g. `[['list']]`. */
+function reporterValueOf(source: string): string | undefined {
+  return withoutTsComments(source).match(/^\s*reporter:\s*(.+?),?\s*$/m)?.[1];
+}
+
+describe('ci-cd-pipeline.md + live-e2e.yml — the Playwright report claim (#8238)', () => {
+  const section = sectionForWorkflow('live-e2e.yml');
+  const liveWorkflow = readWorkflow('live-e2e.yml');
+  const header = liveWorkflow.slice(0, liveWorkflow.indexOf('\nname:'));
+  const reporter = reporterValueOf(liveConfig);
+  const declaresHtmlReporter = /['"]html['"]/.test(reporter ?? '');
+
+  it('has all four sides to compare — none may be empty', () => {
+    // The vacuity legs. Each failure below is silent: a renamed heading empties the section, a
+    // restructured config empties the reporter read, and a header that no longer leads the file
+    // empties the header slice. Any one of them would make the assertions pass while comparing
+    // nothing — which is the failure mode this whole block exists to prevent elsewhere.
+    expect(
+      section,
+      'No heading on this page names `live-e2e.yml`, so this block has no section to read and ' +
+        'its assertions below would pass vacuously. The `workflow inventory` block requires ' +
+        'that heading to exist; if it moved, teach `sectionForWorkflow` where it went.',
+    ).not.toBe('');
+
+    expect(
+      reporter,
+      `${LIVE_CONFIG_FILE} no longer declares a \`reporter:\` on a line of its own. That line is ` +
+        'what decides whether `playwright-report/` can exist, and every sentence pinned below ' +
+        'describes it. If the reporter moved to a variable or a spread, this assertion has to ' +
+        'read it from wherever the value now lives — do not delete the comparison, or the four ' +
+        'claim sites go back to being unchecked prose (objectui#8238).',
+    ).toBeDefined();
+
+    expect(header, 'live-e2e.yml must still open with its header comment block').not.toBe('');
+  });
+
+  it('reads the config, not the file as text', () => {
+    // The control for the paragraph above. `playwright.live.config.ts`'s header describes the
+    // config in prose; a whole-file grep cannot tell that prose from a setting. This is the
+    // exact shape of that file, and it is why the parser strips comments first.
+    const specimen = [
+      '/**',
+      " * Run with reporter: [['html']] when you want a browsable report.",
+      ' */',
+      'export default defineConfig({',
+      "  // reporter: [['html']],  — history, not a setting",
+      "  reporter: [['list']],",
+      '});',
+    ].join('\n');
+
+    expect(reporterValueOf(specimen)).toBe("[['list']]");
+  });
+
+  it('uploads no path the reporter cannot produce', () => {
+    // Mechanical and exact: the glob may name `playwright-report/` only when a reporter that
+    // writes it is declared. This is the half of #8238 that is not a matter of wording — the
+    // upload step listed a directory that could not exist in any outcome, and `upload-artifact`
+    // reports that as a warning, not a failure, so nothing ever went red over it.
+    const globsReport = /^\s*playwright-report\/\s*$/m.test(withoutComments(liveWorkflow));
+
+    expect(
+      globsReport,
+      declaresHtmlReporter
+        ? `${LIVE_CONFIG_FILE} declares an HTML reporter (\`${reporter}\`) but live-e2e.yml no ` +
+          'longer uploads `playwright-report/`, so the lane now produces a report and throws it ' +
+          'away. Add the path back to the upload glob.'
+        : `live-e2e.yml's upload glob names \`playwright-report/\`, but ${LIVE_CONFIG_FILE} ` +
+          `declares \`reporter: ${reporter}\` — no reporter in it writes that directory, so the ` +
+          'path matches nothing on a pass, a fail or a crash. Either declare an HTML reporter in ' +
+          'that config, or drop the path. ⛔ Do not do neither: the glob is read by humans as a ' +
+          'promise that the artefact contains a report, and objectui#8084 wrote an acceptance ' +
+          'criterion on exactly that reading which no fix could ever have satisfied.',
+    ).toBe(declaresHtmlReporter);
+  });
+
+  it('quotes the reporter value both prose sites are describing', () => {
+    // The fence, adopted verbatim from #8238: the header, this page's section and the upload
+    // glob are spellings of ONE claim and must move together. Requiring both prose sites to
+    // quote the reporter value as written turns "they must move together" into something a test
+    // can hold: flip the config and both sentences go red until someone rewrites them.
+    for (const [name, text] of [
+      ['live-e2e.yml’s header comment', header],
+      ['the Live E2E section of content/docs/guide/ci-cd-pipeline.md', section],
+    ] as const) {
+      expect(
+        text,
+        `${name} does not quote \`${reporter}\`, the reporter list ${LIVE_CONFIG_FILE} actually ` +
+          'declares. Both sites tell the reader what a failing run leaves behind, and that ' +
+          'answer is decided entirely by this value — a site that describes the artefacts ' +
+          'without naming the line that produces them is how this lane spent its whole ' +
+          'existence promising a Playwright report it could not write (objectui#8238).',
+      ).toContain(reporter!);
+    }
+  });
+
+  it('says that a green run uploads nothing at all', () => {
+    // #8238's second and sharper edge, and the one that outlives whichever way the reporter
+    // question is decided. The upload step is gated on `failure()`, so on a green lane it never
+    // runs: there is no artifact, so there is no file count, so any acceptance criterion
+    // phrased over the artifact's contents is readable ONLY on a run that failed. That trap is
+    // what produced objectui#8084's unpassable criterion, and it is invisible from the prose
+    // unless the prose says it.
+    const uploadStep = withoutComments(liveWorkflow).slice(
+      withoutComments(liveWorkflow).indexOf('name: Upload'),
+    );
+
+    expect(
+      uploadStep,
+      'live-e2e.yml has no `Upload` step, so the sentence pinned below is describing a step ' +
+        'that is gone. Re-point this assertion or drop the sentence with it.',
+    ).not.toBe('');
+
+    expect(
+      /if:.*failure\(\)/.test(uploadStep.split('\n').slice(0, 6).join('\n')),
+      'live-e2e.yml’s upload step is no longer gated on `failure()`. If it now runs on green ' +
+        'runs too, the warning on the page — that a green lane leaves no artifact to inspect — ' +
+        'has become false and must be removed in the same PR.',
+    ).toBe(true);
+
+    expect(
+      section,
+      'The Live E2E section does not mention `failure()`. The upload step is gated on it, so a ' +
+        'green run of this lane produces NO artifact — not an empty one, none — and a reader ' +
+        'who does not know that will write a check against artefact contents that can only ever ' +
+        'be read on a red run. objectui#8084 did exactly that. Say it on the page.',
+    ).toContain('failure()');
+  });
+});


### PR DESCRIPTION
Fixes #8238

## The measurement, re-derived on `3f775eeb8`

All three anchors the card and the triage comment named still hold, byte for byte:

| anchor | reading |
|---|---|
| `playwright.live.config.ts:31` | `reporter: [['list']],` — and nothing else |
| `.github/workflows/live-e2e.yml:240-241` | upload glob is `playwright-report/` + `test-results/` |
| `content/docs/guide/ci-cd-pipeline.md` | "Failures still surface as a red step plus an uploaded Playwright report and job summary." |

⚠️ The card's line number for the docs page (453) was stale, as the brief predicted — it is **511** on `3f775eeb8`, moved by #8465.

### What I actually ran, rather than reading the config

The card's readings are a prediction, and "no reporter writes `playwright-report/`" is a claim about a reporter, so I ran the reporters. Three legs, same harness, this repo's pinned Playwright:

| leg | reporter | outcome | exit | `playwright-report/` | `test-results/` |
|---|---|---|---|---|---|
| A | `[['list']]` — the live config's actual value | 1 passed | 0 | **ABSENT** | 1 file |
| B | `[['list']]` | 1 failed | 1 | **ABSENT** | 2 files |
| control | `[['html', { open: 'never' }]]` | 1 passed | 0 | **PRESENT** (1 file) | — |

⭐ The control leg is what makes legs A and B mean anything: without a run that *does* produce the directory, two absences are indistinguishable from a probe that cannot see directories at all. The card's two-run measurement against a real backend reproduces exactly.

## ⭐ There are FOUR claim sites, not three

The card and the triage comment both fence "the header, the docs sentence and the glob are **three spellings of one claim** and must move together — a fix that repairs two of three reproduces the defect in a smaller place."

That fence is right and it undercounted. There is a **fourth** site, and it is the one a reader of a red run hits first — the job-summary step, `live-e2e.yml:229`:

```yaml
echo "See the \`live-e2e-artifacts\` upload for the Playwright report and server logs."
```

That text is what GitHub renders on the run summary page of a failed lane. Repairing the header, the page and the glob while leaving it would have left the single most-read spelling of the false promise in place. All four move here.

## Which direction, and why that one

The card offers two honest options. ⛔ I did not pick by size. Analysed on the four axes:

**实际业务需求.** What does a reader of a red Live E2E run actually need? Not a report — the failure's evidence. The live config sets `screenshot: 'only-on-failure'` and `video: 'retain-on-failure'`, which write into `test-results/`; the HTML report is a *viewer* over that same data, not a second source of it. (Note `trace: 'on-first-retry'` with `retries: 0` means traces are never written on this lane at all, so the report would have had less to show than on a retrying lane.) Nobody has ever consumed a report here because none has ever existed — this is a capability with zero measured pull, not an unmet need.

**项目长远合理性.** ⭐ This exact question was already answered in this repository, for the sibling lane, and the answer is written into `ci.yml:1370-1383`: `playwright.config.ts` selects the `github` reporter on CI, that reporter produces no `playwright-report/`, the upload step said `No files were found with the provided path` — objectui#4086. The repository's resolution was **not** to add an HTML reporter; it was to keep the stdout-family reporter and make the surrounding text true. Making `live-e2e` diverge would leave two lanes answering one question two ways, for no reason a reader could reconstruct.

**防 AI 写代码犯错.** This is the axis that decides it. The defect class here is *a document declaring a capability the runtime does not deliver*. Growing the runtime to match drifted prose rewards the drift; it is the moral equivalent of a tolerant `??` fallback on the consumer side, and it leaves the next drift equally undetectable. The structural answer is to make the declaration **checkable** — so this PR does not just correct four sentences, it pins them to the mechanism (below). 声明即强制:the reporter list is the declaration, and now nothing can describe it wrongly in silence.

**创业阶段不扩散需求.** An HTML reporter is a capability expansion with no puller, costing a directory per run in artefact storage on an informational lane that already cannot block a merge. Under implementation-first with no named consumer, the default is tight: don't add it.

⇒ **Make the text true.** All four axes agree, and the third one is why the PR is bigger than a wording tidy-up.

### One place I departed from the card's option 2

The card's option 2 says "drop `playwright-report/` from the upload path". `ci.yml` argues the opposite for its own lane — keep the absent path, because `upload-artifact` only warns when *no* path matches, so it costs nothing and keeps working if the HTML reporter is ever enabled.

I dropped it here anyway. That rationale is sound where it is *written down next to the glob*, and on `ci.yml` it is. On `live-e2e.yml` it was not written down, and an undocumented path in a glob is read by humans as a promise the artefact contains it — which is this card. A glob every line of which the config can actually produce is the honest shape; the "if it is ever enabled" property is speculative capability, which axis 4 declines. ⛔ I did not touch `ci.yml`; its comment is truthful and its lane is not mine.

## The card's second, sharper edge

⭐ The load-bearing half, and the one that outlives whichever direction is chosen: the upload step is gated `if: ${{ !cancelled() && failure() }}`, so **on a green lane it does not run at all** — no artifact, no file count, nothing to read. Any acceptance criterion phrased over the artefact's contents is therefore readable **only on a run that failed**.

Its concrete casualty is on the record: objectui#8084's dispatch defined "the fix is real" as *the uploaded artifact's file count goes above 1 **and** a `playwright-report/` appears*. The first half is sound; the second is unreachable, so a correct fix could never have satisfied the stated test. ⭐ *An acceptance criterion nobody can pass is the same hazard as a check nobody can fail, pointed the other way.*

This PR records that trap in both places a reader would form such a criterion — a ⚠️ block in the docs page's Live E2E section, and a comment on the upload step itself — and **pins it**, so the sentence cannot outlive the gate it describes.

⛔ This PR does not touch #8084's defect ② (the run reporting `success` while the job reports `failure`); different mechanism, stays on that card.

## The pin — why this is not just four edited sentences

New block in `scripts/__tests__/ci-cd-pipeline-doc.test.ts`, written in that file's existing idiom (vacuity legs, a parser control, long diagnostic messages). It pins the **claim to the mechanism**, and is deliberately agnostic about which way the repository decides the reporter question:

- **`uploads no path the reporter cannot produce`** — mechanical and exact: the glob may name `playwright-report/` if and only if the config declares a reporter that writes it. Both directions are diagnosed.
- **`quotes the reporter value both prose sites are describing`** — the header and the docs section must each quote the reporter list *as written* (`[['list']]`). This is what turns the card's fence into something a test can hold: flip the config and every prose site goes red until someone rewrites it.
- **`says that a green run uploads nothing at all`** — the docs section must mention `failure()`, and the upload step must actually carry that gate. If the gate ever changes, the warning must change with it.
- **`has all four sides to compare`** — the vacuity legs. A renamed heading, a restructured config or a moved header would each make the comparisons pass while checking nothing, silently.
- **`reads the config, not the file as text`** — control for `reporterValueOf`. `playwright.live.config.ts` opens with a 20-line block comment describing the config in prose, and a whole-file regex cannot tell that prose from a setting. Same class of mistake as counting a commented-out `env:` key, which is why the neighbouring `envKeysOf` block carries the same control.

### Ablation — proof the pin can fail

Both legs: mutate → prove the mutation reached disk (before/after `grep -c` on the exact anchor, plus a `git hash-object` comparison against the `HEAD` blob) → run → restore via `git checkout HEAD -- <abs path>` from an `EXIT INT TERM` trap → prove restoration by an empty `git diff HEAD`.

| leg | mutation | proof it landed | result | restored |
|---|---|---|---|---|
| 1 | reporter → `[['list'], ['html', {open:'never'}]]` | blob `764e69dc` → `fbe41e11`; `'html'` 0→1 | exit 1 — **2 failed**, 52 passed: `uploads no path the reporter cannot produce`, `quotes the reporter value both prose sites are describing` | `git diff HEAD` empty; blob back to `764e69dc` |
| 2 | delete `failure()` from the docs warning | blob changed; `failure()` 1→0 | exit 1 — **1 failed**, 53 passed: `says that a green run uploads nothing at all` | `git diff HEAD` empty |

Direction observed: **turns red**, naming exactly the sites that must move. Leg 1 failing on *both* the glob and the prose is the fence working — one config edit, three sites flagged.

## Verification

All commands' exit codes captured by redirect before any pipe.

| command | exit |
|---|---|
| `vitest run --project unit scripts/__tests__/ci-cd-pipeline-doc.test.ts` | 0 — 54 passed |
| the 3 neighbouring suites that read `live-e2e.yml` (`ensure-chromium-ready`, `workflow-cache-save-bound`, `vitest-invocation-guard`) + the above | 0 — **111 passed** across 4 files |
| `check:action-ref-convention` | 0 |
| `check:control-bytes` | 0 |
| `check:shell-escape-residue` | 0 |
| `type-check:scripts` | 0 |
| `check-doc-links.mjs` | 0 — links valid across 17 scan roots |
| `check-doc-fence-languages.mjs` | 0 |
| `check-doc-expression-carriage.mjs` | 0 (report-only gate) |
| `check-changeset-presence.mjs` | 0 — "no changeset is owed" |
| `check-changeset-no-major.mjs` / `check-changeset-overwrite.mjs` | 0 / 0 |
| `check-governed-queue-guard.mjs --test` | 0 — **NOT GOVERNED**, 4 paths, none matched |

⚠️ Four `check:*` names in my first pass returned **exit 254 / `Command not found`** — my misspellings, not red gates. Re-run under their real spellings, above; a `Command not found` is NOT MEASURED and is not reported here as a pass.

**Control-byte self-scan.** `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over all 4 changed files together with a file containing a deliberate `\v`: exit 0 with the control file as the **only** hit ⇒ the changed files are clean *and* the pattern was live in that run. (My first control used a tab, which is not in that class and returned a false clean; recorded because it is exactly the trap the brief names.)

**Lint, narrowed — a measured narrowing, not a skipped run.** Three pieces:
1. *Population from eslint's own config, not a guess*: `eslint.config.js:53` scopes linting to `files: ['**/*.{ts,tsx}']`; eslint itself reported the `.md` and `.yml` files as ignored.
2. *Count from `--format json`*: 4 paths passed, **1 actually linted** (`ci-cd-pipeline-doc.test.ts`), 3 warn-ignored. `errorCount: 0`, exit 0.
3. *Invariance*: no `projectService`, `parserOptions` or `project:` anywhere in `eslint.config.js` (grep exit 1, with `rules` present 11× as the control) ⇒ type-aware linting is **not** enabled, so nothing in this diff can move the verdict of any untouched file.

The repo-wide `pnpm lint` is CI's run, not one I owe.

### Changeset

`.changeset/8238-live-e2e-report-promise.md`, **empty frontmatter** — this repo's declared mechanism for "this PR publishes nothing" (there is no label-based bypass here, and `ci-cd-pipeline-doc.test.ts` actively fails any script under `.github/` or `scripts/` that introduces one). CI, docs and tests only.

## Out of scope, filed separately

- **#8561** (`finding` only, no assignee) — `ci.yml`'s E2E artifact is *named* `playwright-report` while containing only `test-results/`. ⭐ This is **not** a second instance of #8238: the 12-line comment above that step is accurate and complete, and it is the prior art that decided this whole question. What remains is only that the artifact **name** is the one surface that comment cannot reach — it is what a reader sees in the Actions UI. Filed so the rename-or-keep choice is deliberate; ⛔ untouched here.
- ⚠️ `Bundle Analysis` is red on `main` and on every PR that triggers it — objectui#8542, ⛔ not from this change and not a required check.
- ⚠️ objectui#7990 (`Live E2E (informational)` red on `main`) is a different, already-filed card. ⛔ Not folded in.

## Predictions in the dispatch brief that turned out false

1. **"three spellings of one claim"** (card, triage comment and brief all) — there are **four**; the job-summary step was uncounted, and it is the most-read one.
2. **`ci-cd-pipeline.md` line 453** — stale as predicted; the sentence is at **511**.
3. **"`scripts/__tests__/ci-cd-pipeline-doc.test.ts` pins that page"** — true, but *not* for this claim. It requires a heading per workflow and pins `.github/WORKFLOWS.md` as deleted; **no assertion read the report sentence**, which is precisely how it drifted. I did not have to work around a pin; I had to add one.
4. **The card's option 2, "drop `playwright-report/` from the glob"** — adopted, but only after finding that the sibling lane deliberately does the opposite with a written rationale. Reported above rather than followed silently.
5. **Gate list** — `check:action-ref-convention` had no opinion here: ⛔ I changed no action reference (`actions/upload-artifact@v7` is untouched). The step's `name:` changed, which that gate does not read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_