### PR TITLE
docs(data-objectstack): re-derive the filter-operator table from convertFiltersToAST and pin it

### DIFF
--- a/.changeset/8558-data-objectstack-operator-table.md
+++ b/.changeset/8558-data-objectstack-operator-table.md
@@ -1,0 +1,13 @@
+---
+---
+
+Re-derive `packages/data-objectstack/README.md`'s filter-operator table against
+`@object-ui/core`'s `convertFiltersToAST` and pin it there (objectui#8558).
+`$nin` / `$notin` lower to `nin`, not `notin`, and the worked example now shows
+the node the server accepts; `$regex` is refused, not lowered to `contains`;
+`$startsWith` is the spec spelling and is listed beside its lowercase alias;
+`$notContains`, `$endsWith`, `$null` and `$exists` — the four operators the
+code's own "Supported operators" message enumerates that had no row — gain rows,
+as do the `$and` / `$or` combinators and the `$not` refusal. A test reconciles
+every row against the code on every run. Documentation and a test only; no
+package is released by this change.

--- a/packages/data-objectstack/README.md
+++ b/packages/data-objectstack/README.md
@@ -122,19 +122,65 @@ AST format**. This is what keeps it compatible with the ObjectStack Protocol
 
 #### Supported Filter Operators
 
+Every row below is decided by `@object-ui/core`'s `convertFiltersToAST`, and
+this package's `src/readme-filter-operator-table.test.ts` runs each worked
+example through it on every test run, so a row cannot drift from the code
+unnoticed again (objectui#8558). Where a row lists two spellings, the camelCase
+one is the spec's (`FILTER_OPERATORS` in `@objectstack/spec`'s
+`data/filter.zod.ts`) and the lowercase one is an alias the converter also
+accepts; both lower to the same node.
+
 | MongoDB Operator | ObjectStack Operator | Example |
 |------------------|---------------------|---------|
-| `$eq` or simple value | `=` | `{ status: 'active' }` → `['status', '=', 'active']` |
+| plain value (no operator) | `=` | `{ status: 'active' }` → `['status', '=', 'active']` |
+| `$eq` | `=` | `{ status: { $eq: 'active' } }` → `['status', '=', 'active']` |
 | `$ne` | `!=` | `{ status: { $ne: 'archived' } }` → `['status', '!=', 'archived']` |
 | `$gt` | `>` | `{ age: { $gt: 18 } }` → `['age', '>', 18]` |
 | `$gte` | `>=` | `{ age: { $gte: 18 } }` → `['age', '>=', 18]` |
 | `$lt` | `<` | `{ age: { $lt: 65 } }` → `['age', '<', 65]` |
 | `$lte` | `<=` | `{ age: { $lte: 65 } }` → `['age', '<=', 65]` |
 | `$in` | `in` | `{ status: { $in: ['active', 'pending'] } }` → `['status', 'in', ['active', 'pending']]` |
-| `$nin` / `$notin` | `notin` | `{ status: { $nin: ['archived'] } }` → `['status', 'notin', ['archived']]` |
-| `$contains` / `$regex` | `contains` | `{ name: { $contains: 'John' } }` → `['name', 'contains', 'John']` |
-| `$startswith` | `startswith` | `{ email: { $startswith: 'admin' } }` → `['email', 'startswith', 'admin']` |
+| `$nin` / `$notin` | `nin` | `{ status: { $nin: ['archived'] } }` → `['status', 'nin', ['archived']]` |
 | `$between` | `between` | `{ age: { $between: [18, 65] } }` → `['age', 'between', [18, 65]]` |
+| `$contains` | `contains` | `{ name: { $contains: 'John' } }` → `['name', 'contains', 'John']` |
+| `$notContains` / `$notcontains` | `notcontains` | `{ name: { $notContains: 'test' } }` → `['name', 'notcontains', 'test']` |
+| `$startsWith` / `$startswith` | `startswith` | `{ email: { $startsWith: 'admin' } }` → `['email', 'startswith', 'admin']` |
+| `$endsWith` / `$endswith` | `endswith` | `{ email: { $endsWith: '@example.com' } }` → `['email', 'endswith', '@example.com']` |
+| `$null` | `is_null` / `is_not_null` | `{ email: { $null: true } }` → `['email', 'is_null', true]` |
+| `$exists` | `is_not_null` / `is_null` | `{ email: { $exists: true } }` → `['email', 'is_not_null', true]` |
+
+`$null` and `$exists` read their boolean: `$null: false` lowers to
+`is_not_null` and `$exists: false` to `is_null`. The lowered node's value slot
+is always `true` — the direction comes from the operator name, which is how the
+spec's `data/filter.zod.ts` reads it.
+
+#### Logical combinators
+
+`$and` and `$or` take an array of filter conditions and lower to an AST group
+node whose members are lowered with the table above. Sibling keys of one
+object are still combined with `and` (see "Complex Filter Examples" below). An
+empty `$and` is TRUE and is dropped rather than emitted as an empty group —
+`['and']` is not a filter, so emitting it would widen the result set — and an
+empty `$or` is FALSE and matches no row.
+
+| MongoDB Key | AST Keyword | Example |
+|-------------|-------------|---------|
+| `$and` | `and` | `{ $and: [{ status: 'open' }, { priority: { $gte: 2 } }] }` → `['and', ['status', '=', 'open'], ['priority', '>=', 2]]` |
+| `$or` | `or` | `{ $or: [{ status: 'open' }, { status: 'blocked' }] }` → `['or', ['status', '=', 'open'], ['status', '=', 'blocked']]` |
+
+#### Refused at lowering time
+
+These shapes throw a `FilterOperatorError` (`code: 'INVALID_FILTER'`,
+`httpStatus: 400`) from `convertFiltersToAST` instead of reaching the wire. The
+refusal names the field and the value, so a filter that carries one fails at
+the call site rather than as a `400` from the server or as an empty list.
+
+| Shape | Why | Example |
+|-------|-----|---------|
+| `$regex` | The spec has no `$regex`, and it is not downgraded to `contains`: a pattern match and a substring match are different questions, not stronger and weaker forms of one. Use `$contains`, `$startsWith` or `$endsWith`. | `{ name: { $regex: '^J' } }` → throws `INVALID_FILTER` |
+| `$not` | The AST has no negation keyword, and rewriting the negation inward would be silently partial. Use a negated operator instead: `$ne`, `$nin`, `$notContains`. | `{ $not: { status: 'open' } }` → throws `INVALID_FILTER` |
+| a bare array as a field's value | The AST has no array-equality node, and the array is deliberately not read as `$in` (see below). | `{ tags: ['a', 'b'] }` → throws `INVALID_FILTER` |
+| any other `$` key in operator position | Unknown operator; the error message lists the supported ones. | `{ age: { $foo: 1 } }` → throws `INVALID_FILTER` |
 
 A bare array as a field's value — `{ tags: ['a', 'b'] }` — is **refused** at
 lowering time with a `FilterOperatorError` (`INVALID_FILTER` / 400) naming the

--- a/packages/data-objectstack/src/readme-filter-operator-table.test.ts
+++ b/packages/data-objectstack/src/readme-filter-operator-table.test.ts
@@ -1,0 +1,483 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `packages/data-objectstack/README.md`'s filter-operator tables are held to
+ * `@object-ui/core`'s `convertFiltersToAST` — the code that decides every row
+ * (objectui#8558).
+ *
+ * ## Why this file exists
+ *
+ * The "Supported Filter Operators" table was a hand-written mirror of the
+ * `operatorMap` inside `convertOperatorToAST`, and by objectui#8558 it had
+ * drifted from the code in three independent ways at once:
+ *
+ *   - `$nin` / `$notin` were documented as lowering to `notin`, with a worked
+ *     example whose OUTPUT read `['status', 'notin', ['archived']]`. The map
+ *     says `nin`. A reader who copied the example got a node the server
+ *     refuses;
+ *   - `$regex` was documented as lowering to `contains`. That downgrade was
+ *     retired (objectui#8447 / PR #8512): `$regex` is REFUSED with a
+ *     `FilterOperatorError`, because a substring match is a different
+ *     question, not a weaker version of the same one;
+ *   - only `$startswith` was listed, while the map carries both spellings and
+ *     `$startsWith` is the spec's (`FILTER_OPERATORS`, `data/filter.zod.ts`).
+ *
+ * Re-deriving the whole table for that card found the rest of the drift: four
+ * operators the code's own "Supported operators:" message enumerates —
+ * `$notContains`, `$endsWith`, `$null`, `$exists` — had no row at all, and
+ * neither did the `$and` / `$or` combinators nor the `$not` refusal.
+ *
+ * Three drifts in one table is the signal that hand-maintenance does not
+ * survive here — the same shape as the ledger figures in
+ * `packages/types/src/__tests__/zod-mirror-parity.test.ts` rotting while every
+ * pin stayed green (objectui#8252). This file is the smaller version of
+ * "generate the table": the table stays authored, and every claim it makes is
+ * EXECUTED against the code on every run.
+ *
+ * ## What is asserted — every claim, by execution, never by a restated list
+ *
+ *   - every row's worked example is run through `convertFiltersToAST`, and its
+ *     documented output must be exactly what the function returns — or, for a
+ *     row in the refused table, the function must throw the `INVALID_FILTER`
+ *     / 400 envelope the table promises. This is the check that would have
+ *     caught the `notin` example: it is a claim about OUTPUT, so it is checked
+ *     as one;
+ *   - every `$`-spelling in the supported table's first column must lower, and
+ *     to exactly the operator(s) its row's second column names. `$null` and
+ *     `$exists` are probed with both booleans, so their rows must name both
+ *     directions;
+ *   - the supported table must carry a row for EVERY key of
+ *     `convertOperatorToAST`'s `operatorMap` (alias spellings included — the
+ *     omitted `$startsWith` was an alias row) and for every operator the
+ *     unknown-operator error message calls supported (`$null` / `$exists`
+ *     live outside the map);
+ *   - every `$`-spelling in the refused table must be refused, and every
+ *     combinator row's keyword must be the one its lowered group carries.
+ *
+ * ## The expected values are READ OUT OF the code, never listed here
+ *
+ * Hardcoding `nin` below would rebuild the defect one level up: a second
+ * hand-maintained copy, in a test, that would then have to be edited whenever
+ * the map changed — the edit everybody makes without reading. So the map is
+ * read from `filter-converter.ts`'s source (the only way to see its lowercase
+ * aliases without exporting it; a control below proves the read agrees with
+ * the runtime), the supported list is read from the error the function throws
+ * for an unknown operator, and every lowering comes from calling the function.
+ * A red here is always "fix the README (or the code)", never "update the test".
+ *
+ * ## Exhaustiveness IS asserted, deliberately
+ *
+ * `plugin-calendar`'s `readme-calendar-view-schema.test.ts` declines to assert
+ * exhaustiveness because its fence is a declared partial summary. This table
+ * is headed "Supported Filter Operators" and is the only place the
+ * `$`-dialect lowering is documented for consumers, so a missing row is
+ * exactly the omission objectui#8558 counted as a defect. It is held complete
+ * in the direction that misleads a reader: every operator the code accepts
+ * has a row.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { convertFiltersToAST, convertOperatorToAST } from '@object-ui/core';
+
+/** Walk up to the workspace root, so both files are found by repo layout. */
+function repoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 10; i += 1) {
+    if (existsSync(join(dir, 'pnpm-workspace.yaml'))) return dir;
+    dir = resolve(dir, '..');
+  }
+  throw new Error('repo root (pnpm-workspace.yaml) not found from this test file');
+}
+
+const ROOT = repoRoot();
+const README_PATH = 'packages/data-objectstack/README.md';
+const CONVERTER_PATH = 'packages/core/src/utils/filter-converter.ts';
+const README = readFileSync(join(ROOT, README_PATH), 'utf8');
+const CONVERTER_SOURCE = readFileSync(join(ROOT, CONVERTER_PATH), 'utf8');
+
+const SUPPORTED_HEADING = '#### Supported Filter Operators';
+const COMBINATORS_HEADING = '#### Logical combinators';
+const REFUSED_HEADING = '#### Refused at lowering time';
+
+/** The arrow every worked example puts between its input and its output. */
+const ARROW = '→';
+
+interface Row {
+  /** 1-based line in the README, for the failure message. */
+  readonly line: number;
+  readonly cells: readonly string[];
+}
+
+/**
+ * Body rows (header and separator dropped) of the first markdown table under
+ * `heading`. A missing heading or a heading with no table fails LOUDLY: a pin
+ * that silently iterated zero rows would be green over a deleted table.
+ */
+function tableUnder(heading: string): Row[] {
+  const lines = README.split('\n');
+  const start = lines.findIndex((line) => line.trim() === heading);
+  if (start === -1) {
+    throw new Error(
+      `${README_PATH} no longer has a "${heading}" heading, so this pin has nothing to `
+        + 'compare (objectui#8558). If the page was restructured, re-point this reader at '
+        + 'the new heading — do not delete the pin, or the table goes back to being prose '
+        + 'that nothing holds to convertFiltersToAST.',
+    );
+  }
+  let i = start + 1;
+  while (i < lines.length && !lines[i].startsWith('|')) {
+    if (/^#{1,6} /.test(lines[i])) {
+      throw new Error(`${README_PATH}: no table between "${heading}" and the next heading`);
+    }
+    i += 1;
+  }
+  const rows: Row[] = [];
+  for (; i < lines.length && lines[i].startsWith('|'); i += 1) {
+    const cells = lines[i]
+      .replace(/^\|/, '')
+      .replace(/\|\s*$/, '')
+      .split('|')
+      .map((cell) => cell.trim());
+    rows.push({ line: i + 1, cells });
+  }
+  if (rows.length < 3) {
+    throw new Error(`${README_PATH}: the table under "${heading}" has no body rows`);
+  }
+  return rows.slice(2);
+}
+
+/** `$`-spellings written as inline code in a cell, in order of appearance. */
+function operatorSpellings(cell: string): string[] {
+  return [...cell.matchAll(/`(\$[A-Za-z]+)`/g)].map((match) => match[1]);
+}
+
+/** Every inline-code span in a cell, in order of appearance. */
+function codeSpans(cell: string): string[] {
+  return [...cell.matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+}
+
+/**
+ * The README's examples are JS literals — bare keys, single quotes. They are
+ * rewritten to JSON and parsed, deliberately narrowly: `JSON.parse` throws on
+ * anything the rewrite does not understand, which is the right answer for an
+ * example this file cannot execute. No `eval`.
+ */
+function parseLiteral(source: string, where: string): unknown {
+  const json = source
+    .replace(/'((?:[^'\\]|\\.)*)'/g, (_match, text: string) => JSON.stringify(text))
+    .replace(/([{,]\s*)([A-Za-z_$][\w$]*)\s*:/g, '$1"$2":');
+  try {
+    return JSON.parse(json);
+  } catch (error) {
+    // `Object.assign` rather than the `{ cause }` constructor option: this
+    // tree compiles against `lib: ES2020`, which has no `ErrorOptions`. Same
+    // idiom `src/index.ts` uses.
+    throw Object.assign(
+      new Error(
+        `${where}: cannot parse the example literal ${source} (rewritten as ${json}): `
+          + `${(error as Error).message}`,
+      ),
+      { cause: error },
+    );
+  }
+}
+
+interface Example {
+  readonly input: Record<string, unknown>;
+  /** The documented output; `undefined` when the row documents a throw. */
+  readonly output: unknown;
+  readonly throws: boolean;
+  /** Everything after the arrow, verbatim — the refused table's promise lives here. */
+  readonly rhs: string;
+}
+
+/** The third cell of a row, split at its arrow into an executable input and a documented result. */
+function exampleOf(row: Row, where: string): Example {
+  const cell = row.cells[2] ?? '';
+  const at = cell.indexOf(ARROW);
+  if (at === -1) throw new Error(`${where}: the example cell has no "${ARROW}": ${cell}`);
+  const lhs = codeSpans(cell.slice(0, at));
+  if (lhs.length !== 1) {
+    throw new Error(`${where}: expected exactly one code span before the arrow, found ${lhs.length}`);
+  }
+  const input = parseLiteral(lhs[0], where);
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error(`${where}: the example input must be an object literal: ${lhs[0]}`);
+  }
+  const rhs = cell.slice(at + ARROW.length).trim();
+  const throws = /\bthrows\b/.test(rhs);
+  const rhsSpans = codeSpans(rhs);
+  if (!throws && rhsSpans.length !== 1) {
+    throw new Error(`${where}: expected exactly one code span after the arrow, found ${rhsSpans.length}`);
+  }
+  return {
+    input: input as Record<string, unknown>,
+    output: throws ? undefined : parseLiteral(rhsSpans[0], where),
+    throws,
+    rhs,
+  };
+}
+
+type Lowering =
+  | { readonly refused: true }
+  | { readonly refused: false; readonly operators: ReadonlySet<string> };
+
+/**
+ * What `convertFiltersToAST` does with `spelling` in operator position — the
+ * AST operator(s) it emits, or a refusal. Probed with both booleans because
+ * `$null` / `$exists` read their value to pick a direction; for every other
+ * operator the value is irrelevant and both probes agree.
+ */
+function lowerings(spelling: string): Lowering {
+  const operators = new Set<string>();
+  for (const value of [true, false]) {
+    let node: unknown;
+    try {
+      node = convertFiltersToAST({ probe: { [spelling]: value } });
+    } catch (error) {
+      expect(
+        error,
+        `${spelling} threw something other than the INVALID_FILTER / 400 envelope`,
+      ).toMatchObject({ code: 'INVALID_FILTER', httpStatus: 400 });
+      return { refused: true };
+    }
+    if (!Array.isArray(node) || node[0] !== 'probe' || typeof node[1] !== 'string') {
+      throw new Error(
+        `probing ${spelling} lowered to ${JSON.stringify(node)}, not a comparison node on the probed field`,
+      );
+    }
+    operators.add(node[1]);
+  }
+  return { refused: false, operators };
+}
+
+/**
+ * `convertOperatorToAST`'s `operatorMap`, read out of the source so the
+ * lowercase aliases are visible without exporting the map. The slice is
+ * anchored on the declaration, and a control below holds every entry to the
+ * runtime, so a moved or reshaped map fails loudly rather than reading empty.
+ */
+function operatorMapFromSource(): Map<string, string> {
+  const start = CONVERTER_SOURCE.indexOf('const operatorMap');
+  const end = start === -1 ? -1 : CONVERTER_SOURCE.indexOf('};', start);
+  if (start === -1 || end === -1) {
+    throw new Error(
+      `${CONVERTER_PATH} no longer declares \`const operatorMap\` (objectui#8558): re-point `
+        + 'this reader at wherever the $-operator vocabulary now lives',
+    );
+  }
+  const map = new Map<string, string>();
+  for (const match of CONVERTER_SOURCE.slice(start, end).matchAll(/'(\$[A-Za-z]+)':\s*'([^']+)'/g)) {
+    map.set(match[1], match[2]);
+  }
+  return map;
+}
+
+/**
+ * The operators the unknown-operator error calls supported — the code's own
+ * enumeration, which is where `$null` / `$exists` (handled outside the map)
+ * are listed.
+ */
+function supportedOperatorsFromError(): string[] {
+  let message = '';
+  try {
+    convertFiltersToAST({ probe: { $definitelyNotAnOperator: 1 } });
+  } catch (error) {
+    message = (error as Error).message;
+  }
+  const match = /Supported operators:\s*([^.]+)\./.exec(message);
+  if (!match) {
+    throw new Error(
+      'convertFiltersToAST no longer enumerates its supported operators in the '
+        + `unknown-operator error (objectui#8558); the message was: ${JSON.stringify(message)}`,
+    );
+  }
+  return [...match[1].matchAll(/\$[A-Za-z]+/g)].map((m) => m[0]);
+}
+
+const sorted = (values: Iterable<string>) => [...values].sort();
+
+describe('README filter-operator tables are decided by convertFiltersToAST (objectui#8558)', () => {
+  const operatorMap = operatorMapFromSource();
+  const supportedByError = supportedOperatorsFromError();
+  const supported = tableUnder(SUPPORTED_HEADING);
+  const combinators = tableUnder(COMBINATORS_HEADING);
+  const refused = tableUnder(REFUSED_HEADING);
+
+  describe('controls — the code-side populations were really read', () => {
+    it('reads the operator map out of filter-converter.ts, and it agrees with the runtime', () => {
+      expect(operatorMap.size).toBeGreaterThanOrEqual(12);
+      expect(operatorMap.get('$eq')).toBe('=');
+      const disagreeing = [...operatorMap]
+        .filter(([spelling, target]) => convertOperatorToAST(spelling) !== target)
+        .map(([spelling, target]) => `${spelling}: source says ${target}, runtime says ${convertOperatorToAST(spelling)}`);
+      expect(disagreeing, 'the source read of operatorMap does not match convertOperatorToAST').toEqual([]);
+    });
+
+    it('reads the supported list out of the unknown-operator error', () => {
+      expect(supportedByError.length).toBeGreaterThanOrEqual(10);
+      expect(supportedByError).toContain('$eq');
+      expect(supportedByError).toContain('$exists');
+    });
+
+    it('found all three tables, each with rows', () => {
+      expect(supported.length).toBeGreaterThanOrEqual(12);
+      expect(combinators.length).toBeGreaterThanOrEqual(2);
+      expect(refused.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  describe('every worked example does what its row says', () => {
+    it('supported and combinator rows lower to exactly the documented output', () => {
+      const bad: string[] = [];
+      for (const row of [...supported, ...combinators]) {
+        const where = `${README_PATH}:${row.line}`;
+        const example = exampleOf(row, where);
+        if (example.throws) {
+          bad.push(`${where}: a row outside the refused table documents a throw`);
+          continue;
+        }
+        let actual: unknown;
+        try {
+          actual = convertFiltersToAST(example.input);
+        } catch (error) {
+          bad.push(`${where}: ${JSON.stringify(example.input)} threw: ${(error as Error).message}`);
+          continue;
+        }
+        if (JSON.stringify(actual) !== JSON.stringify(example.output)) {
+          bad.push(
+            `${where}: ${JSON.stringify(example.input)} lowers to ${JSON.stringify(actual)}, `
+              + `the row says ${JSON.stringify(example.output)}`,
+          );
+        }
+      }
+      expect(
+        bad,
+        'a worked example a reader can copy must be the exact node convertFiltersToAST '
+          + 'emits (the objectui#8558 `notin` example was not)',
+      ).toEqual([]);
+    });
+
+    it('refused rows throw the INVALID_FILTER / 400 envelope they promise', () => {
+      const bad: string[] = [];
+      for (const row of refused) {
+        const where = `${README_PATH}:${row.line}`;
+        const example = exampleOf(row, where);
+        if (!example.throws || !example.rhs.includes('INVALID_FILTER')) {
+          bad.push(`${where}: a refused row must document "throws \`INVALID_FILTER\`", found: ${example.rhs}`);
+          continue;
+        }
+        let thrown: unknown;
+        try {
+          const node = convertFiltersToAST(example.input);
+          bad.push(`${where}: ${JSON.stringify(example.input)} lowered to ${JSON.stringify(node)} instead of throwing`);
+          continue;
+        } catch (error) {
+          thrown = error;
+        }
+        const envelope = thrown as { code?: unknown; httpStatus?: unknown; name?: unknown };
+        if (envelope.code !== 'INVALID_FILTER' || envelope.httpStatus !== 400) {
+          bad.push(
+            `${where}: ${JSON.stringify(example.input)} threw ${String(envelope.name)} with code `
+              + `${String(envelope.code)} / status ${String(envelope.httpStatus)}, not INVALID_FILTER / 400`,
+          );
+        }
+      }
+      expect(bad, 'the refused table promises a specific envelope; the code must honour it').toEqual([]);
+    });
+  });
+
+  describe('the Supported Filter Operators table', () => {
+    it('every spelling in the first column lowers to exactly the operator(s) the second column names', () => {
+      const bad: string[] = [];
+      for (const row of supported) {
+        const where = `${README_PATH}:${row.line}`;
+        const documented = sorted(codeSpans(row.cells[1] ?? ''));
+        for (const spelling of operatorSpellings(row.cells[0] ?? '')) {
+          const lowering = lowerings(spelling);
+          if (lowering.refused) {
+            bad.push(`${where}: ${spelling} is refused by convertFiltersToAST, so it is not a supported operator`);
+            continue;
+          }
+          const emitted = sorted(lowering.operators);
+          if (JSON.stringify(emitted) !== JSON.stringify(documented)) {
+            bad.push(`${where}: ${spelling} lowers to ${emitted.join(' / ')}, the row says ${documented.join(' / ')}`);
+          }
+        }
+      }
+      expect(
+        bad,
+        'the ObjectStack Operator column is the operator the lowered node carries — '
+          + 'a wrong one (objectui#8558: `notin` for `nin`) is a node the server refuses',
+      ).toEqual([]);
+    });
+
+    it('carries a row for every key of the operator map, alias spellings included', () => {
+      const listed = new Set(supported.flatMap((row) => operatorSpellings(row.cells[0] ?? '')));
+      const missing = [...operatorMap.keys()].filter((spelling) => !listed.has(spelling));
+      expect(
+        missing,
+        'convertOperatorToAST accepts these spellings and the table does not list them '
+          + '(objectui#8558: `$startsWith`, the spec spelling, was the missing one)',
+      ).toEqual([]);
+    });
+
+    it('carries a row for every operator the unknown-operator error calls supported', () => {
+      const listed = new Set(supported.flatMap((row) => operatorSpellings(row.cells[0] ?? '')));
+      const missing = supportedByError.filter((spelling) => !listed.has(spelling));
+      expect(
+        missing,
+        'the code tells an author these operators are supported and the table has no row for them '
+          + '(objectui#8558 found `$notContains`, `$endsWith`, `$null`, `$exists` missing)',
+      ).toEqual([]);
+    });
+  });
+
+  describe('the Logical combinators table', () => {
+    it('the second column is the keyword the lowered group carries', () => {
+      const bad: string[] = [];
+      for (const row of combinators) {
+        const where = `${README_PATH}:${row.line}`;
+        const spellings = operatorSpellings(row.cells[0] ?? '');
+        const documented = codeSpans(row.cells[1] ?? '');
+        const { input, output } = exampleOf(row, where);
+        const head = Array.isArray(output) ? output[0] : undefined;
+        if (spellings.length !== 1 || documented.length !== 1) {
+          bad.push(`${where}: a combinator row names one key and one keyword`);
+          continue;
+        }
+        if (!(spellings[0] in input)) {
+          bad.push(`${where}: the example does not use ${spellings[0]}`);
+        }
+        if (head !== documented[0]) {
+          bad.push(`${where}: the documented output opens with ${String(head)}, the row says ${documented[0]}`);
+        }
+      }
+      expect(bad).toEqual([]);
+    });
+  });
+
+  describe('the Refused at lowering time table', () => {
+    it('every $-spelling in the first column is refused when probed in operator position', () => {
+      const bad: string[] = [];
+      for (const row of refused) {
+        const where = `${README_PATH}:${row.line}`;
+        for (const spelling of operatorSpellings(row.cells[0] ?? '')) {
+          if (!lowerings(spelling).refused) {
+            bad.push(`${where}: ${spelling} is listed as refused but convertFiltersToAST lowers it`);
+          }
+        }
+      }
+      expect(bad, 'a spelling the code accepts must not be documented as refused').toEqual([]);
+    });
+  });
+});

--- a/packages/data-objectstack/tsconfig.json
+++ b/packages/data-objectstack/tsconfig.json
@@ -4,7 +4,17 @@
     "outDir": "dist",
     "composite": true,
     "declaration": true,
-    "noEmit": false
+    "noEmit": false,
+    // This program type-checks the package's tests too (see
+    // `src/adapterFactoryReturn.types.test.ts`), and
+    // `src/readme-filter-operator-table.test.ts` reads the README and
+    // `@object-ui/core`'s source off disk through `node:fs` / `node:url`.
+    // Measured with TypeScript 6.0.3: without naming `node`, the root
+    // `node_modules/@types/node` is not seen from here (TS2591 on `node:fs`).
+    // Naming `types` switches off automatic `@types/*` inclusion; nothing else
+    // in this program needs an ambient type package (`tsc --types node` on the
+    // otherwise unchanged program reports nothing).
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "references": [


### PR DESCRIPTION
Fixes objectstack-ai/objectui#8558

## What changed

`packages/data-objectstack/README.md`'s "Supported Filter Operators" table was a hand-written mirror of `convertOperatorToAST`'s `operatorMap` and had drifted from the code. Every row is re-derived against `packages/core/src/utils/filter-converter.ts` as it stands on `origin/main` (`1570eac37`, i.e. after PRs #8512, #8529 and #8551 — the card's quotes were not trusted), the missing rows are added, two small tables document the combinators and the refusals, and a new pin reconciles all three tables against the code on every test run.

`filter-converter.ts` itself is untouched (the sibling worktree for objectui#8555 works on that file; there is no shared file between the two branches).

## Row by row — the code that decides each row

Line numbers are `packages/core/src/utils/filter-converter.ts` at `1570eac37`.

| README row (before) | what the code does | verdict |
|---|---|---|
| `$eq` or simple value → `=` | `'$eq': '='` (L61); the simple-equality arm pushes `[field, '=', value]` (L350) | correct — split into a `plain value` row and a `$eq` row so each has its own executable example |
| `$ne` → `!=` · `$gt` → `>` · `$gte` → `>=` · `$lt` → `<` · `$lte` → `<=` · `$in` → `in` · `$between` → `between` | L62–L67, L70 | correct, unchanged |
| `$nin` / `$notin` → **`notin`**, example output `['status', 'notin', ['archived']]` | `'$nin': 'nin'`, `'$notin': 'nin'` (L68–L69) | **wrong output** → `nin`; the example now reads `['status', 'nin', ['archived']]` |
| `$contains` / **`$regex`** → `contains` | `'$contains': 'contains'` (L71); `if (operator === '$regex') throw new FilterOperatorError(...)` (L312–L320) | `$contains` correct; `$regex` is refused, so it moves to the refused table with the code's own reason (pattern vs substring) and prescription |
| only `$startswith` | `'$startsWith': 'startswith'`, `'$startswith': 'startswith'` (L74–L75); the map's header says the camelCase keys are the spec's and the lowercase ones are aliases (L57–L59) | omission → both spellings listed, spec spelling first |
| *(no row)* | `'$notContains' / '$notcontains': 'notcontains'` (L72–L73) | **missing** → added |
| *(no row)* | `'$endsWith' / '$endswith': 'endswith'` (L76–L77) | **missing** → added |
| *(no row)* | `$null` → `is_null` / `is_not_null` with value slot `true` (L325–L328) | **missing** → added, both directions named |
| *(no row)* | `$exists` → `is_not_null` / `is_null` with value slot `true` (L329–L332) | **missing** → added |
| *(no row)* | `$and` / `$or` → `['and', ...]` / `['or', ...]` group nodes (`AST_LOGIC_KEYWORD` L92–L95, arm L236–L241, `lowerLogicalGroup`) | **missing** → new "Logical combinators" table; the README had never mentioned `$or` (its three `$or` hits were all `$orderby`) |
| *(no row)* | `$not` refused (L243–L256) | **missing** → refused table |
| *(prose only, added by PR #8551)* | bare array comparand refused (L282–L296) | row added in the refused table, pointing at the existing paragraph |
| *(no row)* | unknown `$` key refused, with the "Supported operators:" enumeration (L338–L346) | row added |

So the answer to "check the whole table": the eight rows the card did not name were all **correct**, but the table was **incomplete** by four supported operators — exactly the four the code's own `Supported operators:` message (L342–L343) lists that the table did not: `$notContains`, `$endsWith`, `$null`, `$exists` — plus the two combinators and the `$not` refusal. That is the "fourth wrong row": not a wrong output, an omission of the same kind as `$startsWith`, four times over.

## The judgement asked for: generate, or pin?

**Pin, and it is in this PR.** Not generation. Reasons, in order of weight:

1. **The defect that actually happened was in the example column, and a generator does not reach it.** `:134` was a wrong *output* in a worked example. A generator that emits the two operator columns from the map leaves the example column hand-written — the exact cell that was wrong — or must synthesise examples by running the converter, at which point it is a build-time script needing `@object-ui/core` built, a marker region in a file that ships in the npm tarball, and a drift gate. The drift gate is the pin. Generation is the pin plus a writer, and for a sixteen-row table the writer buys nothing.
2. **The pin checks claims a generator cannot express.** Every worked example is *executed* through `convertFiltersToAST` and must equal its documented output; every refused row must throw the `INVALID_FILTER` / 400 envelope the table promises (asserted on `code` + `httpStatus`, not on "it threw"); every spelling must lower to the operator its row names (`$null` / `$exists` probed with both booleans, so their rows must name both directions).
3. **Completeness is reconciled against two code-side populations, both read out of the code, never restated in the test:** the `operatorMap` (read from `filter-converter.ts`'s source, so the lowercase aliases are visible without exporting the map; a control holds every entry to `convertOperatorToAST` at runtime) and the `Supported operators:` list parsed from the error the function throws for an unknown operator (where `$null` / `$exists`, which live outside the map, are enumerated). A missing alias row (`$startsWith`) and a missing operator row (`$endsWith`) both redden.
4. **Cost.** One test file, no source change, no new gate, no workflow. It sits in `packages/data-objectstack/src/` beside the document it guards, so a red says "fix the README" in the README's own package; `@object-ui/core` resolves to `packages/core/src` under the root vitest alias, so the pin exercises the converter's source directly.

`packages/data-objectstack/src/readme-filter-operator-table.test.ts` — 10 tests: 3 controls (the map was really read and agrees with the runtime; the error list was really read; all three tables were found with rows), 2 example-execution tests, 3 supported-table tests (spelling parity, map completeness, error-list completeness), 1 combinator test, 1 refused-table test.

## Ablation — the pin reddens on each defect shape, restored by state

Run against the committed README (`d7c2e99bd`), each leg: mutate with `perl -i`, prove the mutation landed with `grep -c` of the injected and the removed text, run the pin, restore with `git checkout HEAD -- ABSOLUTE_PATH`, prove restoration with `git hash-object` equal to the HEAD blob (`116e313fdc168ca7f2dd17e34df4015c556c1be0`; an empty hash is a failure) and an empty `git diff HEAD`. `trap ... EXIT INT TERM` with absolute paths.

| leg | mutation | markers before → after | pin |
|---|---|---|---|
| the objectui#8558 defect | example output `'nin'` → `'notin'` | injected 0→1, removed 1→0 | exit 1, `1 failed / 9 passed`: `README.md:143: {"status":{"$nin":["archived"]}} lowers to ["status","nin",["archived"]], the row says ["status","notin",["archived"]]` |
| spelling column | `\| nin \|` → `\| notin \|` on the `$nin` row | injected 0→1, removed 1→0 | exit 1, `1 failed / 9 passed`: `$nin lowers to nin, the row says notin` and the same for `$notin` |
| omission | the `$endsWith` / `$endswith` row deleted | removed 1→0, lines 780→779 | exit 1, `2 failed / 8 passed`: both completeness checks (map keys; error list) |

All three legs: `restored by state: hash-object == HEAD blob; git diff HEAD -- README empty`. Final tree state verified the same way.

## The one non-doc change: `packages/data-objectstack/tsconfig.json` names `types: ["node"]`

This package deliberately type-checks its tests in its main program (`src/adapterFactoryReturn.types.test.ts` documents why), and none of its tests had imported a node builtin before. Measured with TypeScript 6.0.3: the package `type-check` failed on the new pin with TS2591 on `node:fs` / `node:path` / `node:url` (plus two cascading TS7006) because the root `node_modules/@types/node` is not seen from here without naming it. `tsc --types node` on the otherwise unchanged program reported nothing, which is the evidence that restricting `types` to `node` drops nothing else this program needs. Nineteen packages already carry `"types": ["node"]` in the project that compiles their tests; this package's is its main tsconfig. `check:published-tsconfig-exclude`, `check-type-check-coverage` and `check:phantom-deps` are green after the change.

## Changeset

Empty frontmatter (`.changeset/8558-data-objectstack-operator-table.md`) — documentation and a test; no package is released. `scripts/check-changeset-presence.mjs`: `1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s) ... EMPTY frontmatter ... the explicit exemption`. No `skip-changeset` label is applied — in this repository it is a phantom.

## Verification (all from the repo root; exit codes captured by redirect before any pipe; lock verdict lines quoted)

- `pnpm exec vitest run --maxWorkers=2 packages/data-objectstack/src/readme-filter-operator-table.test.ts` → `Test Files 1 passed (1) · Tests 10 passed (10)`, `VERDICT command-exit 0`
- `pnpm exec vitest run --maxWorkers=2 packages/data-objectstack/` (the affected package's whole suite) → `Test Files 58 passed (58) · Tests 785 passed (785)`, `VERDICT command-exit 0`
- `pnpm --filter @object-ui/data-objectstack type-check` → `VERDICT command-exit 0` (after `pnpm --filter '@object-ui/data-objectstack^...' build` built `types` and `core`)
- `pnpm exec eslint packages/data-objectstack/src/readme-filter-operator-table.test.ts` → exit 0 (one `preserve-caught-error` finding fixed with the `Object.assign(new Error(...), { cause })` idiom `src/index.ts` uses, because `lib: ES2020` has no `ErrorOptions`)
- `pnpm check:doc-fences` → exit 0, `every TypeScript block in 227 document(s) is fenced ts/tsx/typescript`
- `pnpm check:doc-types` → exit 0 — but note its scan roots are `content/docs` and the root `README.md` only; it does not read `packages/*/README.md`, so it is not a gate on this file
- `pnpm check:control-bytes` → exit 0, `scanned 6760 tracked text file(s)`; plus a `grep -naP` control-byte scan of the three changed files: clean
- `node scripts/check-changeset-presence.mjs` → exit 0 (quoted above); `node scripts/check-changeset-fixed.mjs` → exit 0
- `pnpm check:published-tsconfig-exclude` → exit 0; `node scripts/check-type-check-coverage.mjs` → exit 0 (`42/42 packages compile their tests`); `pnpm check:phantom-deps` → exit 0
- Declared narrowing: `turbo ls --affected` (base `1570eac37`) lists this package's dependents (`plugin-*`, `react`, `runner`, `sdui-parser`, `site`, ...). Their tests are not run here: the diff changes no runtime module — it touches a README, a new `*.test.ts`, a tsconfig and a changeset — so no import edge into any dependent moved. CI runs the whole suite.
- NOT MEASURED: `check:readme-exports` and `check:doc-snippets` need every package built (`465 self-import(s) could not be judged ... run pnpm build first` / exit 2 on an unbuilt tree); they are CI's. No `ts` fence was added or changed in the README, so `check:doc-snippets`'s population is unchanged.

Session: `session_01YBWFb5YgMU5dw8p2VKj16S`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_