### PR TITLE
fix(app-shell): draw the shared EmptyDescription for the previews' empty-collection sentences

### DIFF
--- a/.changeset/previews-shared-empty-description-8526.md
+++ b/.changeset/previews-shared-empty-description-8526.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Metadata-admin previews: the empty-collection sentences under `metadata-admin/previews/` render the shared `EmptyDescription`
+
+Sixteen sites across twelve preview files (`ActionPreview`, `AgentPreview`, `DatasourcePreview`, `EmailTemplatePreview`, `FlowPreview`, `FlowRunsPanel`, `FlowSimulatorPanel`, `JobPreview`, `ScreenPreview`, `SkillPreview`, `ToolPreview`, `TranslationPreview`) each hand-rolled the same empty-collection state — a muted italic sentence in a plain `div` — and two of them (`AgentPreview`, `ToolPreview`) declared a file-local component literally named `Empty`, which shadowed the shared family in the one place a maintainer would reach for it. They now render `EmptyDescription` from `@object-ui/components`, used alone outside any `Empty` container, so every one of these states carries the family's `data-slot="empty-description"` and is one kind of thing.
+
+Each site keeps its measured size (`text-xs` for the rails, `text-[10px]` for the run-row step log, `text-[11px]` for the translation category card, `text-sm` for the screen body), so the layout delta at every site is zero. The two local `Empty` components are removed.

--- a/packages/app-shell/src/views/metadata-admin/previews/ActionPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ActionPreview.tsx
@@ -41,7 +41,7 @@ import {
   Square,
   Workflow,
 } from 'lucide-react';
-import { resolveIcon } from '@object-ui/components';
+import { EmptyDescription, resolveIcon } from '@object-ui/components';
 import type { ActionParam } from '@object-ui/types';
 import { paramDegradesWithoutTarget, resolveParamWidgetType } from '../../../utils/paramToField.js';
 import type { MetadataPreviewProps } from '../preview-registry.js';
@@ -578,7 +578,7 @@ function ResultDialogMock({ dialog }: { dialog: ResultDialog }) {
       <div className="p-3 space-y-2 text-xs">
         {description && <div className="text-muted-foreground">{description}</div>}
         {fields.length === 0 ? (
-          <div className="text-muted-foreground italic">Renders full JSON response.</div>
+          <EmptyDescription className="text-xs italic">Renders full JSON response.</EmptyDescription>
         ) : (
           <ul className="space-y-1.5">
             {fields.map((f, i) => (

--- a/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/AgentPreview.tsx
@@ -133,7 +133,7 @@ export function AgentPreview({ name, draft }: MetadataPreviewProps) {
                   {instructions}
                 </pre>
               ) : (
-                <Empty>No system prompt set yet.</Empty>
+                <EmptyDescription className="text-xs italic">No system prompt set yet.</EmptyDescription>
               )}
             </Section>
 
@@ -189,7 +189,7 @@ export function AgentPreview({ name, draft }: MetadataPreviewProps) {
               </RailBlock>
             )}
             {!planning && !memory && !guardrails && permissions.length === 0 && (
-              <div className="text-muted-foreground italic">Defaults in use.</div>
+              <EmptyDescription className="text-xs italic">Defaults in use.</EmptyDescription>
             )}
           </div>
         </div>
@@ -216,10 +216,6 @@ function Section({
       {children}
     </div>
   );
-}
-
-function Empty({ children }: { children: React.ReactNode }) {
-  return <div className="text-xs text-muted-foreground italic">{children}</div>;
 }
 
 /**
@@ -253,7 +249,7 @@ function ChipList({
     <div>
       <div className="text-[10px] uppercase text-muted-foreground tracking-wider mb-1">{label}</div>
       {items.length === 0 ? (
-        <div className="text-xs text-muted-foreground italic">{emptyHint}</div>
+        <EmptyDescription className="text-xs italic">{emptyHint}</EmptyDescription>
       ) : (
         <div className="flex flex-wrap gap-1">
           {items.map((it) => (

--- a/packages/app-shell/src/views/metadata-admin/previews/DatasourcePreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/DatasourcePreview.tsx
@@ -59,6 +59,7 @@
 
 import * as React from 'react';
 import { Activity, Database, HardDrive, Lock, Power, ShieldCheck } from 'lucide-react';
+import { EmptyDescription } from '@object-ui/components';
 import type { MetadataPreviewProps } from '../preview-registry.js';
 import { PreviewShell, PreviewMessage, PreviewErrorBoundary } from './PreviewShell.js';
 import { ExternalDatasourcePanel } from '../external/ExternalDatasourcePanel.js';
@@ -156,7 +157,7 @@ export function DatasourcePreview({ name, draft }: MetadataPreviewProps) {
           {/* Connection config */}
           <Section title="Connection" icon={Lock}>
             {configEntries.length === 0 ? (
-              <div className="text-xs text-muted-foreground italic">No config keys set.</div>
+              <EmptyDescription className="text-xs italic">No config keys set.</EmptyDescription>
             ) : (
               <div className="rounded border bg-background overflow-hidden">
                 <table className="w-full text-xs">

--- a/packages/app-shell/src/views/metadata-admin/previews/EmailTemplatePreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/EmailTemplatePreview.tsx
@@ -15,6 +15,7 @@
 
 import * as React from 'react';
 import { Mail } from 'lucide-react';
+import { EmptyDescription } from '@object-ui/components';
 import type { MetadataPreviewProps } from '../preview-registry.js';
 import { PreviewShell, PreviewMessage, PreviewErrorBoundary } from './PreviewShell.js';
 
@@ -95,7 +96,7 @@ export function EmailTemplatePreview({ draft }: MetadataPreviewProps) {
               <Mail className="h-3 w-3" /> Variables
             </div>
             {variables.length === 0 ? (
-              <div className="text-muted-foreground italic">No <code>{'{{var}}'}</code> placeholders found.</div>
+              <EmptyDescription className="text-xs italic">No <code>{'{{var}}'}</code> placeholders found.</EmptyDescription>
             ) : (
               <div className="space-y-2">
                 {variables.map((v) => (

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowPreview.tsx
@@ -31,6 +31,7 @@ import {
   Variable,
   Zap,
 } from 'lucide-react';
+import { EmptyDescription } from '@object-ui/components';
 import type { MetadataPreviewProps } from '../preview-registry.js';
 import { PreviewShell, PreviewMessage, PreviewErrorBoundary } from './PreviewShell.js';
 import { uniqueId, appendArray } from '../inspectors/_shared.js';
@@ -343,7 +344,7 @@ export function FlowPreview({ draft, editing, selection, onSelectionChange, onPa
               <Variable className="h-3 w-3" /> {tr('engine.flowPreview.variables', locale)}
             </div>
             {variables.length === 0 ? (
-              <div className="text-muted-foreground italic">{tr('engine.flowPreview.noVars', locale)}</div>
+              <EmptyDescription className="text-xs italic">{tr('engine.flowPreview.noVars', locale)}</EmptyDescription>
             ) : (
               <ul className="space-y-1.5">
                 {variables.map((v, i) => (

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowRunsPanel.tsx
@@ -20,7 +20,7 @@
 
 import * as React from 'react';
 import { AlertCircle, AlertTriangle, CheckCircle2, ChevronDown, ChevronRight, Clock, Loader2, PauseCircle, RefreshCw, SkipForward } from 'lucide-react';
-import { cn } from '@object-ui/components';
+import { EmptyDescription, cn } from '@object-ui/components';
 import { apiBase } from './useFlowNodePalette.js';
 import { t as tr, tFormat } from '../i18n.js';
 
@@ -346,7 +346,7 @@ function RunRow({ run, locale }: { run: FlowRun; locale?: string }) {
             <div className="pb-1 text-[10px] text-rose-600">{runErr}</div>
           )}
           {steps.length === 0 ? (
-            <div className="text-[10px] italic text-muted-foreground">{tr('engine.flowRuns.noSteps', locale)}</div>
+            <EmptyDescription className="text-[10px] italic">{tr('engine.flowRuns.noSteps', locale)}</EmptyDescription>
           ) : (
             <ul>
               {buildStepTree(steps).map((node, i) => (
@@ -403,7 +403,7 @@ export function FlowRunsPanel({ flowName, locale }: { flowName: string; locale?:
           {tr('engine.flowRuns.unavailable', locale)}
         </div>
       ) : state === 'ready' && runs.length === 0 ? (
-        <div className="italic text-muted-foreground">{tr('engine.flowRuns.empty', locale)}</div>
+        <EmptyDescription className="text-xs italic">{tr('engine.flowRuns.empty', locale)}</EmptyDescription>
       ) : (
         <ul className="min-h-0 flex-1 space-y-1.5 overflow-y-auto">
           {runs.map((r) => (

--- a/packages/app-shell/src/views/metadata-admin/previews/FlowSimulatorPanel.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FlowSimulatorPanel.tsx
@@ -9,7 +9,7 @@
 
 import * as React from 'react';
 import { Play, StepForward, RotateCcw, ChevronRight, AlertTriangle, CircleAlert, Plus, Trash2 } from 'lucide-react';
-import { Button, Input, Label, cn } from '@object-ui/components';
+import { Button, EmptyDescription, Input, Label, cn } from '@object-ui/components';
 import { t as tr, tFormat } from '../i18n.js';
 import { FlowSimulator } from './simulator/flow-simulator.js';
 import { ScreenPreview } from './ScreenPreview.js';
@@ -321,7 +321,7 @@ export function FlowSimulatorPanel({ nodes, edges, variables, locale, onRunState
             </button>
           </div>
           {scratch.length === 0 ? (
-            <div className="italic text-muted-foreground">{tr('engine.flowSim.setVariablesHint', locale)}</div>
+            <EmptyDescription className="text-xs italic">{tr('engine.flowSim.setVariablesHint', locale)}</EmptyDescription>
           ) : (
             scratch.map((row, i) => (
               <div key={i} className="flex items-center gap-1.5">
@@ -380,7 +380,7 @@ export function FlowSimulatorPanel({ nodes, edges, variables, locale, onRunState
           <section className="space-y-1.5">
             <div className="font-medium text-muted-foreground">{tr('engine.flowSim.variables', locale)}</div>
             {Object.keys(snapshot.variables).length === 0 ? (
-              <div className="italic text-muted-foreground">{tr('engine.flowSim.noVars', locale)}</div>
+              <EmptyDescription className="text-xs italic">{tr('engine.flowSim.noVars', locale)}</EmptyDescription>
             ) : (
               <ul className="space-y-1">
                 {Object.entries(snapshot.variables).map(([k, val]) => (

--- a/packages/app-shell/src/views/metadata-admin/previews/JobPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/JobPreview.tsx
@@ -38,6 +38,7 @@ import {
   RotateCcw,
   Timer,
 } from 'lucide-react';
+import { EmptyDescription } from '@object-ui/components';
 import type { MetadataPreviewProps } from '../preview-registry.js';
 import { PreviewShell, PreviewMessage, PreviewErrorBoundary } from './PreviewShell.js';
 
@@ -345,7 +346,7 @@ export function JobPreview({ name, draft }: MetadataPreviewProps) {
                 </ScheduleLine>
               )}
               {!cron && !every && !at && (
-                <div className="text-muted-foreground italic">No schedule set — runs only when triggered manually.</div>
+                <EmptyDescription className="text-xs italic">No schedule set — runs only when triggered manually.</EmptyDescription>
               )}
             </div>
           </Section>

--- a/packages/app-shell/src/views/metadata-admin/previews/ScreenPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ScreenPreview.tsx
@@ -22,7 +22,7 @@
  */
 
 import * as React from 'react';
-import { Button, cn } from '@object-ui/components';
+import { Button, EmptyDescription, cn } from '@object-ui/components';
 import { useAdapter } from '../../../providers/AdapterProvider.js';
 import { useMetadata } from '../../../providers/MetadataProvider.js';
 import { ScreenView, isObjectFormScreen, initialScreenValues, screenFields, type ScreenSpec } from '../../ScreenView.js';
@@ -74,9 +74,9 @@ export function ScreenPreview({ node, variables, className }: ScreenPreviewProps
       </div>
       <div className="max-h-[60vh] overflow-auto p-4">
         {empty ? (
-          <p className="text-sm italic text-muted-foreground">
+          <EmptyDescription className="text-sm italic">
             Add a title, description, fields, or an object form to preview this screen.
-          </p>
+          </EmptyDescription>
         ) : (
           <>
             {title && <h3 className="text-base font-semibold leading-tight">{title}</h3>}

--- a/packages/app-shell/src/views/metadata-admin/previews/SkillPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/SkillPreview.tsx
@@ -42,6 +42,7 @@ import {
   Sparkles,
   Wrench,
 } from 'lucide-react';
+import { EmptyDescription } from '@object-ui/components';
 import type { MetadataPreviewProps } from '../preview-registry.js';
 import { PreviewShell, PreviewMessage, PreviewErrorBoundary } from './PreviewShell.js';
 
@@ -104,7 +105,7 @@ export function SkillPreview({ name, draft }: MetadataPreviewProps) {
           {/* Tools */}
           <Section title={`Tools (${tools.length})`} icon={Wrench}>
             {tools.length === 0 ? (
-              <div className="text-xs text-muted-foreground italic">No tools whitelisted.</div>
+              <EmptyDescription className="text-xs italic">No tools whitelisted.</EmptyDescription>
             ) : (
               <div className="flex flex-wrap gap-1">
                 {tools.map((t) => {

--- a/packages/app-shell/src/views/metadata-admin/previews/ToolPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ToolPreview.tsx
@@ -46,6 +46,7 @@ import {
   FileJson,
   Wrench,
 } from 'lucide-react';
+import { EmptyDescription } from '@object-ui/components';
 import type { MetadataPreviewProps } from '../preview-registry.js';
 import { PreviewShell, PreviewMessage, PreviewErrorBoundary } from './PreviewShell.js';
 
@@ -182,7 +183,7 @@ export function ToolPreview({ name, draft }: MetadataPreviewProps) {
           {/* Parameters */}
           <Section title="Input Parameters" count={Object.keys(props).length}>
             {Object.keys(props).length === 0 ? (
-              <Empty>This tool takes no input parameters.</Empty>
+              <EmptyDescription className="text-xs italic">This tool takes no input parameters.</EmptyDescription>
             ) : (
               <ParamTable props={props} required={required} />
             )}
@@ -291,10 +292,6 @@ function Section({
       {children}
     </div>
   );
-}
-
-function Empty({ children }: { children: React.ReactNode }) {
-  return <div className="text-xs text-muted-foreground italic">{children}</div>;
 }
 
 // `tone` ('green' for Active, 'amber' for Requires confirmation) went away with

--- a/packages/app-shell/src/views/metadata-admin/previews/TranslationPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/TranslationPreview.tsx
@@ -37,6 +37,7 @@ import {
   Settings2,
   ShieldAlert,
 } from 'lucide-react';
+import { EmptyDescription } from '@object-ui/components';
 import type { MetadataPreviewProps } from '../preview-registry.js';
 import { PreviewShell, PreviewMessage, PreviewErrorBoundary } from './PreviewShell.js';
 
@@ -150,7 +151,7 @@ function CategoryCard({
       </div>
       <div className="px-2.5 py-1.5 min-h-[3.5rem]">
         {cat.count === 0 ? (
-          <div className="text-[11px] text-muted-foreground italic">empty</div>
+          <EmptyDescription className="text-[11px] italic">empty</EmptyDescription>
         ) : (
           <ul className="space-y-0.5 text-[11px]">
             {cat.sample.map(([k, v]) => (

--- a/packages/app-shell/src/views/metadata-admin/previews/emptyCollection-8526.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/emptyCollection-8526.test.tsx
@@ -17,13 +17,19 @@
  *      all — the assertion that refuses the caricature "EmptyDescription
  *      rendered unconditionally, populated collections included".
  *
- * ⚠️ Navigation vs. assertion. Every harness reaches a site's body slot
- * through a title its container owns (a `Section` heading, a rail label, a
- * panel header), never through anything the empty state renders. A pin that
- * navigated by `data-slot="empty-description"` would die on any caricature
- * that erases the description, and read as a strong refusal while measuring
- * nothing (objectui#8504, objectui#8520). The harness-kill leg — rename a
- * title the harness navigates by — fails with "Unable to find an element",
+ * ⚠️ Navigation vs. assertion. Every harness reaches the CONTAINER that owns
+ * a site — by a title that container renders (a `Section` heading, a rail
+ * label, a panel header) — never anything the empty state renders, and never
+ * a child position. A pin that navigated by `data-slot="empty-description"`
+ * would die on any caricature that erases the description and read as a
+ * strong refusal while measuring nothing (objectui#8504, objectui#8520); a
+ * pin that navigated by `children[1]` died the same way when the caricature
+ * was first run against this file — the inserted sibling shifted the rows one
+ * slot over, and eight populated cases failed on their marker lookup before
+ * the refusing assertion ran. Assertions are descendant queries on the
+ * container: the empty state can never BE the container, because the
+ * container is what holds the title. The harness-kill leg — rename a title
+ * the harness navigates by — fails with "Unable to find an element",
  * textually distinct from the assertion failures the other legs produce.
  */
 
@@ -66,43 +72,33 @@ const ED = '[data-slot="empty-description"]';
 const EV = '[data-slot="empty-value"]';
 
 /**
- * Self-inclusive query: several sites return the empty state AS the body
- * element itself, and `Element.querySelector` never matches the element it is
- * called on — the naive descendant query sat green through a measured
- * caricature on objectui#8520.
- */
-function self(el: Element, selector: string): Element | null {
-  return el.matches(selector) ? el : el.querySelector(selector);
-}
-
-/**
- * The body slot of a `Section` / `RailBlock` / rail-header block, reached by
+ * The `Section` / `RailBlock` / rail-header block that owns a site, reached by
  * the block's TITLE. Every such block in this directory renders
  * `<div><div.header>…{title}…</div>{children}</div>`: the title is either the
- * header's own text (a `div`) or a `span` inside it.
+ * header's own text (a `div`) or a `span` inside it. The block is returned,
+ * not a child slot — see the docblock above for why.
  */
-function bodyByTitle(title: string | RegExp, root: HTMLElement = document.body): HTMLElement {
+function blockByTitle(title: string | RegExp, root: HTMLElement = document.body): HTMLElement {
   const titleEl = within(root).getByText(title);
   const header = titleEl.tagName === 'SPAN' ? titleEl.parentElement! : titleEl;
-  const block = header.parentElement!;
-  const body = block.children[1] as HTMLElement | undefined;
-  expect(body, `body slot under "${String(title)}"`).toBeTruthy();
-  return body!;
+  const block = header.parentElement as HTMLElement | null;
+  expect(block, `the block titled "${String(title)}"`).toBeTruthy();
+  return block!;
 }
 
 /** The empty branch: the family's text slot, with this site's sentence, and no EmptyValue. */
-function expectEmptyState(body: HTMLElement, sentence: string) {
-  const slot = self(body, ED);
+function expectEmptyState(block: HTMLElement, sentence: string) {
+  const slot = block.querySelector(ED);
   expect(slot, 'the shared EmptyDescription slot').toBeTruthy();
   expect((slot!.textContent ?? '').trim()).toBe(sentence);
-  expect(self(body, EV)).toBeNull();
+  expect(block.querySelector(EV)).toBeNull();
 }
 
-/** The populated branch: no empty-description anywhere under this body — the caricature refuser. */
-function expectPopulated(body: HTMLElement, sentence: string) {
-  expect(self(body, ED)).toBeNull();
+/** The populated branch: no empty-description anywhere under this block — the caricature refuser. */
+function expectPopulated(block: HTMLElement, sentence: string) {
+  expect(block.querySelector(ED)).toBeNull();
   // queryAllByText, not queryByText: the latter throws on MULTIPLE matches.
-  expect(within(body).queryAllByText(sentence)).toHaveLength(0);
+  expect(within(block).queryAllByText(sentence)).toHaveLength(0);
 }
 
 // ───────────────────────────── AgentPreview ─────────────────────────────
@@ -127,7 +123,7 @@ describe('AgentPreview — the three hand-rolled empties and the local `Empty` t
 
   /** The side rail has no heading of its own: reached as the grid column next to the one holding "Instructions". */
   function rail(): HTMLElement {
-    const instructions = bodyByTitle('Instructions');
+    const instructions = blockByTitle('Instructions');
     const grid = instructions.closest('.grid') as HTMLElement | null;
     expect(grid, 'the preview grid').toBeTruthy();
     return grid!.children[1] as HTMLElement;
@@ -135,24 +131,24 @@ describe('AgentPreview — the three hand-rolled empties and the local `Empty` t
 
   it('Instructions: an empty prompt is the shared empty-description slot', () => {
     renderAgent({ ...AGENT, instructions: '' });
-    expectEmptyState(bodyByTitle('Instructions'), NO_PROMPT);
+    expectEmptyState(blockByTitle('Instructions'), NO_PROMPT);
   });
 
   it('Instructions: a set prompt renders the pre and no empty-description', () => {
     renderAgent(AGENT);
-    const body = bodyByTitle('Instructions');
+    const body = blockByTitle('Instructions');
     expect(within(body).getByText('Be kind.')).toBeTruthy();
     expectPopulated(body, NO_PROMPT);
   });
 
   it('Skills: an empty chip list is the shared empty-description slot', () => {
     renderAgent({ ...AGENT, skills: [] });
-    expectEmptyState(bodyByTitle('Skills'), NO_SKILLS);
+    expectEmptyState(blockByTitle('Skills'), NO_SKILLS);
   });
 
   it('Skills: an attached skill renders its chip and no empty-description', () => {
     renderAgent(AGENT);
-    const body = bodyByTitle('Skills');
+    const body = blockByTitle('Skills');
     expect(within(body).getByText('summarize_account')).toBeTruthy();
     expectPopulated(body, NO_SKILLS);
   });
@@ -184,7 +180,7 @@ describe('ToolPreview — the empty parameter set and the local `Empty` it went 
 
   it('no parameters is the shared empty-description slot', () => {
     render(<ToolPreview type="tool" name="ping" draft={TOOL} />);
-    expectEmptyState(bodyByTitle('Input Parameters'), SENTENCE);
+    expectEmptyState(blockByTitle('Input Parameters'), SENTENCE);
   });
 
   it('a declared parameter renders the table and no empty-description', () => {
@@ -195,7 +191,7 @@ describe('ToolPreview — the empty parameter set and the local `Empty` it went 
         draft={{ ...TOOL, parameters: { type: 'object', properties: { host: { type: 'string' } }, required: ['host'] } }}
       />,
     );
-    const body = bodyByTitle('Input Parameters');
+    const body = blockByTitle('Input Parameters');
     expect(within(body).getByText('host')).toBeTruthy();
     expectPopulated(body, SENTENCE);
   });
@@ -209,12 +205,12 @@ describe('SkillPreview — the empty tool whitelist', () => {
 
   it('no tools is the shared empty-description slot', () => {
     render(<SkillPreview type="skill" name="draft_email" draft={SKILL} />);
-    expectEmptyState(bodyByTitle('Tools (0)'), SENTENCE);
+    expectEmptyState(blockByTitle('Tools (0)'), SENTENCE);
   });
 
   it('a whitelisted tool renders its chip and no empty-description', () => {
     render(<SkillPreview type="skill" name="draft_email" draft={{ ...SKILL, tools: ['send_email'] }} />);
-    const body = bodyByTitle('Tools (1)');
+    const body = blockByTitle('Tools (1)');
     expect(within(body).getByText('send_email')).toBeTruthy();
     expectPopulated(body, SENTENCE);
   });
@@ -228,12 +224,12 @@ describe('DatasourcePreview — the empty connection config', () => {
 
   it('no config keys is the shared empty-description slot', () => {
     render(<DatasourcePreview type="datasource" name="warehouse" draft={DS} />);
-    expectEmptyState(bodyByTitle('Connection'), SENTENCE);
+    expectEmptyState(blockByTitle('Connection'), SENTENCE);
   });
 
   it('a config key renders the table and no empty-description', () => {
     render(<DatasourcePreview type="datasource" name="warehouse" draft={{ ...DS, config: { host: 'db.local' } }} />);
-    const body = bodyByTitle('Connection');
+    const body = blockByTitle('Connection');
     expect(within(body).getByText('host')).toBeTruthy();
     expectPopulated(body, SENTENCE);
   });
@@ -247,7 +243,7 @@ describe('ActionPreview — a result dialog with no fields', () => {
 
   it('no result fields is the shared empty-description slot', () => {
     render(<ActionPreview type="action" name="rotate_secret" draft={ACTION} />);
-    expectEmptyState(bodyByTitle('Result Dialog'), SENTENCE);
+    expectEmptyState(blockByTitle('Result Dialog'), SENTENCE);
   });
 
   it('a result field renders its row and no empty-description', () => {
@@ -258,7 +254,7 @@ describe('ActionPreview — a result dialog with no fields', () => {
         draft={{ ...ACTION, resultDialog: { title: 'Rotated', fields: [{ path: 'secret', label: 'New secret' }] } }}
       />,
     );
-    const body = bodyByTitle('Result Dialog');
+    const body = blockByTitle('Result Dialog');
     expect(within(body).getByText('New secret')).toBeTruthy();
     expectPopulated(body, SENTENCE);
   });
@@ -272,12 +268,12 @@ describe('EmailTemplatePreview — a template with no placeholders', () => {
 
   it('no placeholders is the shared empty-description slot', () => {
     render(<EmailTemplatePreview type="email_template" name="welcome" draft={{ subject: 'Welcome', bodyText: 'Hello there.' }} />);
-    expectEmptyState(bodyByTitle('Variables'), SENTENCE);
+    expectEmptyState(blockByTitle('Variables'), SENTENCE);
   });
 
   it('a detected placeholder renders its input and no empty-description', () => {
     render(<EmailTemplatePreview type="email_template" name="welcome" draft={{ subject: 'Welcome {{name}}', bodyText: 'Hello there.' }} />);
-    const body = bodyByTitle('Variables');
+    const body = blockByTitle('Variables');
     expect(within(body).getByText('name')).toBeTruthy();
     expectPopulated(body, SENTENCE);
   });
@@ -302,26 +298,24 @@ describe('FlowPreview — the variables rail with no declared variables', () => 
     vi.stubGlobal('fetch', vi.fn(async () => new Response('not found', { status: 404 })));
   }
 
-  /** The rail header is a `div` reading "Variables"; the toggle button reads the same word. */
-  function railBody(): HTMLElement {
+  /** The rail block whose header is a `div` reading "Variables"; the toggle button reads the same word. */
+  function railBlock(): HTMLElement {
     fireEvent.click(screen.getByTitle('Show variables panel'));
     const header = screen.getAllByText('Variables').find((el) => el.tagName === 'DIV');
     expect(header, 'the variables rail header').toBeTruthy();
-    const body = header!.parentElement!.children[1] as HTMLElement;
-    expect(body).toBeTruthy();
-    return body;
+    return header!.parentElement as HTMLElement;
   }
 
   it('no variables is the shared empty-description slot', () => {
     stubCatalogue();
     render(<FlowPreview type="flow" name="ping_flow" draft={FLOW} />);
-    expectEmptyState(railBody(), SENTENCE);
+    expectEmptyState(railBlock(), SENTENCE);
   });
 
   it('a declared variable renders its row and no empty-description', () => {
     stubCatalogue();
     render(<FlowPreview type="flow" name="ping_flow" draft={{ ...FLOW, variables: [{ name: 'amount', type: 'number' }] }} />);
-    const body = railBody();
+    const body = railBlock();
     expect(within(body).getByText('amount')).toBeTruthy();
     expectPopulated(body, SENTENCE);
   });
@@ -352,14 +346,14 @@ describe('FlowRunsPanel — no runs, and a run with no step log', () => {
     stubRuns([]);
     render(<FlowRunsPanel flowName="ping_flow" />);
     await screen.findByText(NO_RUNS);
-    expectEmptyState(bodyByTitle('Runs'), NO_RUNS);
+    expectEmptyState(blockByTitle('Runs'), NO_RUNS);
   });
 
   it('a listed run renders its row and no empty-description at the list level', async () => {
     stubRuns([RUN]);
     render(<FlowRunsPanel flowName="ping_flow" />);
     await screen.findByRole('button', { expanded: false });
-    expectPopulated(bodyByTitle('Runs'), NO_RUNS);
+    expectPopulated(blockByTitle('Runs'), NO_RUNS);
   });
 
   /** The expanded run body, reached by the run-id line it opens with. */
@@ -398,22 +392,22 @@ describe('FlowSimulatorPanel — no scratch variables, and a run that set none',
     edges: [{ source: 's', target: 'e' }],
   };
 
-  /** The variable-watch header is a `div` reading "Variables". */
-  function watchBody(): HTMLElement {
+  /** The variable-watch section, whose header is a `div` reading "Variables". */
+  function watchBlock(): HTMLElement {
     const header = screen.getAllByText('Variables').find((el) => el.tagName === 'DIV');
     expect(header, 'the variable-watch header').toBeTruthy();
-    return header!.parentElement!.children[1] as HTMLElement;
+    return header!.parentElement as HTMLElement;
   }
 
   it('no scratch rows is the shared empty-description slot', () => {
     render(<FlowSimulatorPanel nodes={FLOW.nodes} edges={FLOW.edges} variables={[]} />);
-    expectEmptyState(bodyByTitle('Set variables'), SCRATCH_HINT);
+    expectEmptyState(blockByTitle('Set variables'), SCRATCH_HINT);
   });
 
   it('an added scratch row renders its inputs and no empty-description', () => {
     render(<FlowSimulatorPanel nodes={FLOW.nodes} edges={FLOW.edges} variables={[]} />);
     fireEvent.click(screen.getByRole('button', { name: /^add$/i }));
-    const body = bodyByTitle('Set variables');
+    const body = blockByTitle('Set variables');
     expect(within(body).getAllByRole('textbox').length).toBeGreaterThan(0);
     expectPopulated(body, SCRATCH_HINT);
   });
@@ -421,7 +415,7 @@ describe('FlowSimulatorPanel — no scratch variables, and a run that set none',
   it('a run that set no variables is the shared empty-description slot', () => {
     render(<FlowSimulatorPanel nodes={FLOW.nodes} edges={FLOW.edges} variables={[]} />);
     fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
-    expectEmptyState(watchBody(), NO_VARS);
+    expectEmptyState(watchBlock(), NO_VARS);
   });
 
   it('a run seeded from a declared input renders the variable and no empty-description', () => {
@@ -433,7 +427,7 @@ describe('FlowSimulatorPanel — no scratch variables, and a run that set none',
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
-    const body = watchBody();
+    const body = watchBlock();
     expect(within(body).getByText('amount')).toBeTruthy();
     expectPopulated(body, NO_VARS);
   });
@@ -447,12 +441,12 @@ describe('JobPreview — a job with no schedule keys', () => {
 
   it('no schedule is the shared empty-description slot', () => {
     render(<JobPreview type="job" name="nightly_cleanup" draft={JOB} />);
-    expectEmptyState(bodyByTitle('Schedule'), SENTENCE);
+    expectEmptyState(blockByTitle('Schedule'), SENTENCE);
   });
 
   it('a cron schedule renders its line and no empty-description', () => {
     render(<JobPreview type="job" name="nightly_cleanup" draft={{ ...JOB, schedule: { type: 'cron', expression: '0 0 * * *' } }} />);
-    const body = bodyByTitle('Schedule');
+    const body = blockByTitle('Schedule');
     expect(within(body).getByText('0 0 * * *')).toBeTruthy();
     expectPopulated(body, SENTENCE);
   });
@@ -464,12 +458,11 @@ describe('TranslationPreview — a category with no keys', () => {
   const SENTENCE = 'empty';
   const BUNDLE = { locale: 'en', data: { messages: { hello: 'Hello' }, objects: {} } };
 
-  /** The category card, reached by its label; its body is the card's second child. */
+  /** The category card, reached by its label. */
   function objectsCard(): HTMLElement {
     const label = screen.getAllByText('Objects').find((el) => el.closest('.rounded.border'));
     expect(label, 'the Objects category card label').toBeTruthy();
-    const card = label!.closest('.rounded.border') as HTMLElement;
-    return card.children[1] as HTMLElement;
+    return label!.closest('.rounded.border') as HTMLElement;
   }
 
   it('an empty category is the shared empty-description slot', () => {
@@ -498,16 +491,16 @@ describe('ScreenPreview — a screen with nothing configured', () => {
 
   it('an unconfigured screen is the shared empty-description slot, at the body scale', () => {
     render(<ScreenPreview node={{ id: 's1', config: {} }} />);
-    const body = bodyByTitle('Preview');
+    const body = blockByTitle('Preview');
     expectEmptyState(body, SENTENCE);
     // The deliberate outlier: this sentence stands in for the screen body,
     // whose description renders at text-sm — not for a text-xs rail row.
-    expect(self(body, ED)!.className).toContain('text-sm');
+    expect(body.querySelector(ED)!.className).toContain('text-sm');
   });
 
   it('a titled screen renders its heading and no empty-description', () => {
     render(<ScreenPreview node={{ id: 's1', config: { title: 'Step one' } }} />);
-    const body = bodyByTitle('Preview');
+    const body = blockByTitle('Preview');
     expect(within(body).getByText('Step one')).toBeTruthy();
     expectPopulated(body, SENTENCE);
   });

--- a/packages/app-shell/src/views/metadata-admin/previews/emptyCollection-8526.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/emptyCollection-8526.test.tsx
@@ -1,0 +1,514 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The empty-COLLECTION sentences under `metadata-admin/previews/` render the
+ * shared `EmptyDescription` — used alone, outside any `Empty` container — in
+ * place of a hand-rolled muted `div` (objectui#8526). Two of those files used
+ * to declare a file-local component literally named `Empty`, which shadowed
+ * the shared family in the one place a maintainer would reach for it.
+ *
+ * What each pin proves, per site:
+ *
+ *   1. the empty branch renders the family's block-level text slot
+ *      (`data-slot="empty-description"`) carrying the site's own sentence, and
+ *      not `EmptyValue` (a field-VALUE placeholder whose `aria-label` says
+ *      "No value" — false about a collection);
+ *   2. the populated branch renders its rows and NO `empty-description` at
+ *      all — the assertion that refuses the caricature "EmptyDescription
+ *      rendered unconditionally, populated collections included".
+ *
+ * ⚠️ Navigation vs. assertion. Every harness reaches a site's body slot
+ * through a title its container owns (a `Section` heading, a rail label, a
+ * panel header), never through anything the empty state renders. A pin that
+ * navigated by `data-slot="empty-description"` would die on any caricature
+ * that erases the description, and read as a strong refusal while measuring
+ * nothing (objectui#8504, objectui#8520). The harness-kill leg — rename a
+ * title the harness navigates by — fails with "Unable to find an element",
+ * textually distinct from the assertion failures the other legs produce.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, within, cleanup, fireEvent } from '@testing-library/react';
+
+// `ScreenPreview` reads both providers at its top level (`useAdapter()` /
+// `useMetadata()`), exactly as `ScreenPreview.test.tsx` mocks them.
+vi.mock('../../../providers/AdapterProvider', () => ({
+  useAdapter: () => ({ fake: 'adapter' }),
+}));
+vi.mock('../../../providers/MetadataProvider', () => ({
+  useMetadata: () => ({ objects: [] }),
+}));
+// `DatasourcePreview` mounts the live external panel next to the rail; stubbed
+// the same way `DatasourcePreview.test.tsx` stubs it.
+vi.mock('../external/ExternalDatasourcePanel', () => ({
+  ExternalDatasourcePanel: () => <div data-testid="mock-external-panel" />,
+}));
+
+import { AgentPreview } from './AgentPreview';
+import { ToolPreview } from './ToolPreview';
+import { SkillPreview } from './SkillPreview';
+import { DatasourcePreview } from './DatasourcePreview';
+import { ActionPreview } from './ActionPreview';
+import { EmailTemplatePreview } from './EmailTemplatePreview';
+import { FlowPreview } from './FlowPreview';
+import { FlowRunsPanel } from './FlowRunsPanel';
+import { FlowSimulatorPanel } from './FlowSimulatorPanel';
+import { JobPreview } from './JobPreview';
+import { TranslationPreview } from './TranslationPreview';
+import { ScreenPreview } from './ScreenPreview';
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const ED = '[data-slot="empty-description"]';
+const EV = '[data-slot="empty-value"]';
+
+/**
+ * Self-inclusive query: several sites return the empty state AS the body
+ * element itself, and `Element.querySelector` never matches the element it is
+ * called on — the naive descendant query sat green through a measured
+ * caricature on objectui#8520.
+ */
+function self(el: Element, selector: string): Element | null {
+  return el.matches(selector) ? el : el.querySelector(selector);
+}
+
+/**
+ * The body slot of a `Section` / `RailBlock` / rail-header block, reached by
+ * the block's TITLE. Every such block in this directory renders
+ * `<div><div.header>…{title}…</div>{children}</div>`: the title is either the
+ * header's own text (a `div`) or a `span` inside it.
+ */
+function bodyByTitle(title: string | RegExp, root: HTMLElement = document.body): HTMLElement {
+  const titleEl = within(root).getByText(title);
+  const header = titleEl.tagName === 'SPAN' ? titleEl.parentElement! : titleEl;
+  const block = header.parentElement!;
+  const body = block.children[1] as HTMLElement | undefined;
+  expect(body, `body slot under "${String(title)}"`).toBeTruthy();
+  return body!;
+}
+
+/** The empty branch: the family's text slot, with this site's sentence, and no EmptyValue. */
+function expectEmptyState(body: HTMLElement, sentence: string) {
+  const slot = self(body, ED);
+  expect(slot, 'the shared EmptyDescription slot').toBeTruthy();
+  expect((slot!.textContent ?? '').trim()).toBe(sentence);
+  expect(self(body, EV)).toBeNull();
+}
+
+/** The populated branch: no empty-description anywhere under this body — the caricature refuser. */
+function expectPopulated(body: HTMLElement, sentence: string) {
+  expect(self(body, ED)).toBeNull();
+  // queryAllByText, not queryByText: the latter throws on MULTIPLE matches.
+  expect(within(body).queryAllByText(sentence)).toHaveLength(0);
+}
+
+// ───────────────────────────── AgentPreview ─────────────────────────────
+
+const AGENT = {
+  name: 'sales_copilot',
+  label: 'Sales Copilot',
+  model: { provider: 'openai', model: 'gpt-4o' },
+  instructions: 'Be kind.',
+  skills: ['summarize_account'],
+  planning: { maxIterations: 8 },
+};
+
+function renderAgent(draft: Record<string, unknown>) {
+  return render(<AgentPreview type="agent" name="sales_copilot" draft={draft} />);
+}
+
+describe('AgentPreview — the three hand-rolled empties and the local `Empty` they went through', () => {
+  const NO_PROMPT = 'No system prompt set yet.';
+  const NO_SKILLS = 'No skills attached — this agent can reach no tools.';
+  const DEFAULTS = 'Defaults in use.';
+
+  /** The side rail has no heading of its own: reached as the grid column next to the one holding "Instructions". */
+  function rail(): HTMLElement {
+    const instructions = bodyByTitle('Instructions');
+    const grid = instructions.closest('.grid') as HTMLElement | null;
+    expect(grid, 'the preview grid').toBeTruthy();
+    return grid!.children[1] as HTMLElement;
+  }
+
+  it('Instructions: an empty prompt is the shared empty-description slot', () => {
+    renderAgent({ ...AGENT, instructions: '' });
+    expectEmptyState(bodyByTitle('Instructions'), NO_PROMPT);
+  });
+
+  it('Instructions: a set prompt renders the pre and no empty-description', () => {
+    renderAgent(AGENT);
+    const body = bodyByTitle('Instructions');
+    expect(within(body).getByText('Be kind.')).toBeTruthy();
+    expectPopulated(body, NO_PROMPT);
+  });
+
+  it('Skills: an empty chip list is the shared empty-description slot', () => {
+    renderAgent({ ...AGENT, skills: [] });
+    expectEmptyState(bodyByTitle('Skills'), NO_SKILLS);
+  });
+
+  it('Skills: an attached skill renders its chip and no empty-description', () => {
+    renderAgent(AGENT);
+    const body = bodyByTitle('Skills');
+    expect(within(body).getByText('summarize_account')).toBeTruthy();
+    expectPopulated(body, NO_SKILLS);
+  });
+
+  it('side rail: no planning / memory / guardrails / permissions is the shared empty-description slot', () => {
+    renderAgent({ ...AGENT, planning: undefined });
+    expectEmptyState(rail(), DEFAULTS);
+  });
+
+  it('side rail: a planning block renders its rows and no empty-description', () => {
+    renderAgent(AGENT);
+    const body = rail();
+    expect(within(body).getByText('Planning')).toBeTruthy();
+    expect(within(body).getByText('maxIterations')).toBeTruthy();
+    expectPopulated(body, DEFAULTS);
+  });
+
+  it('a fully populated agent renders no empty-description anywhere', () => {
+    const { container } = renderAgent(AGENT);
+    expect(container.querySelectorAll(ED)).toHaveLength(0);
+  });
+});
+
+// ───────────────────────────── ToolPreview ─────────────────────────────
+
+describe('ToolPreview — the empty parameter set and the local `Empty` it went through', () => {
+  const SENTENCE = 'This tool takes no input parameters.';
+  const TOOL = { name: 'ping', description: 'Pings.', parameters: { type: 'object', properties: {} } };
+
+  it('no parameters is the shared empty-description slot', () => {
+    render(<ToolPreview type="tool" name="ping" draft={TOOL} />);
+    expectEmptyState(bodyByTitle('Input Parameters'), SENTENCE);
+  });
+
+  it('a declared parameter renders the table and no empty-description', () => {
+    render(
+      <ToolPreview
+        type="tool"
+        name="ping"
+        draft={{ ...TOOL, parameters: { type: 'object', properties: { host: { type: 'string' } }, required: ['host'] } }}
+      />,
+    );
+    const body = bodyByTitle('Input Parameters');
+    expect(within(body).getByText('host')).toBeTruthy();
+    expectPopulated(body, SENTENCE);
+  });
+});
+
+// ───────────────────────────── SkillPreview ─────────────────────────────
+
+describe('SkillPreview — the empty tool whitelist', () => {
+  const SENTENCE = 'No tools whitelisted.';
+  const SKILL = { name: 'draft_email', instructions: 'Draft it.', tools: [] as string[] };
+
+  it('no tools is the shared empty-description slot', () => {
+    render(<SkillPreview type="skill" name="draft_email" draft={SKILL} />);
+    expectEmptyState(bodyByTitle('Tools (0)'), SENTENCE);
+  });
+
+  it('a whitelisted tool renders its chip and no empty-description', () => {
+    render(<SkillPreview type="skill" name="draft_email" draft={{ ...SKILL, tools: ['send_email'] }} />);
+    const body = bodyByTitle('Tools (1)');
+    expect(within(body).getByText('send_email')).toBeTruthy();
+    expectPopulated(body, SENTENCE);
+  });
+});
+
+// ───────────────────────────── DatasourcePreview ─────────────────────────────
+
+describe('DatasourcePreview — the empty connection config', () => {
+  const SENTENCE = 'No config keys set.';
+  const DS = { name: 'warehouse', driver: 'postgres', config: {} };
+
+  it('no config keys is the shared empty-description slot', () => {
+    render(<DatasourcePreview type="datasource" name="warehouse" draft={DS} />);
+    expectEmptyState(bodyByTitle('Connection'), SENTENCE);
+  });
+
+  it('a config key renders the table and no empty-description', () => {
+    render(<DatasourcePreview type="datasource" name="warehouse" draft={{ ...DS, config: { host: 'db.local' } }} />);
+    const body = bodyByTitle('Connection');
+    expect(within(body).getByText('host')).toBeTruthy();
+    expectPopulated(body, SENTENCE);
+  });
+});
+
+// ───────────────────────────── ActionPreview ─────────────────────────────
+
+describe('ActionPreview — a result dialog with no fields', () => {
+  const SENTENCE = 'Renders full JSON response.';
+  const ACTION = { name: 'rotate_secret', label: 'Rotate secret', resultDialog: { title: 'Rotated', fields: [] } };
+
+  it('no result fields is the shared empty-description slot', () => {
+    render(<ActionPreview type="action" name="rotate_secret" draft={ACTION} />);
+    expectEmptyState(bodyByTitle('Result Dialog'), SENTENCE);
+  });
+
+  it('a result field renders its row and no empty-description', () => {
+    render(
+      <ActionPreview
+        type="action"
+        name="rotate_secret"
+        draft={{ ...ACTION, resultDialog: { title: 'Rotated', fields: [{ path: 'secret', label: 'New secret' }] } }}
+      />,
+    );
+    const body = bodyByTitle('Result Dialog');
+    expect(within(body).getByText('New secret')).toBeTruthy();
+    expectPopulated(body, SENTENCE);
+  });
+});
+
+// ───────────────────────────── EmailTemplatePreview ─────────────────────────────
+
+describe('EmailTemplatePreview — a template with no placeholders', () => {
+  // The sentence carries a <code> child, so it is matched on the slot's text.
+  const SENTENCE = 'No {{var}} placeholders found.';
+
+  it('no placeholders is the shared empty-description slot', () => {
+    render(<EmailTemplatePreview type="email_template" name="welcome" draft={{ subject: 'Welcome', bodyText: 'Hello there.' }} />);
+    expectEmptyState(bodyByTitle('Variables'), SENTENCE);
+  });
+
+  it('a detected placeholder renders its input and no empty-description', () => {
+    render(<EmailTemplatePreview type="email_template" name="welcome" draft={{ subject: 'Welcome {{name}}', bodyText: 'Hello there.' }} />);
+    const body = bodyByTitle('Variables');
+    expect(within(body).getByText('name')).toBeTruthy();
+    expectPopulated(body, SENTENCE);
+  });
+});
+
+// ───────────────────────────── FlowPreview ─────────────────────────────
+
+describe('FlowPreview — the variables rail with no declared variables', () => {
+  const SENTENCE = 'No variables declared.';
+  const FLOW = {
+    name: 'ping_flow',
+    nodes: [
+      { id: 's', type: 'start' },
+      { id: 'e', type: 'end' },
+    ],
+    edges: [{ source: 's', target: 'e' }],
+    variables: [] as Array<Record<string, unknown>>,
+  };
+
+  /** The canvas palette fetches the action catalogue; a 404 is its normal offline answer. */
+  function stubCatalogue() {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('not found', { status: 404 })));
+  }
+
+  /** The rail header is a `div` reading "Variables"; the toggle button reads the same word. */
+  function railBody(): HTMLElement {
+    fireEvent.click(screen.getByTitle('Show variables panel'));
+    const header = screen.getAllByText('Variables').find((el) => el.tagName === 'DIV');
+    expect(header, 'the variables rail header').toBeTruthy();
+    const body = header!.parentElement!.children[1] as HTMLElement;
+    expect(body).toBeTruthy();
+    return body;
+  }
+
+  it('no variables is the shared empty-description slot', () => {
+    stubCatalogue();
+    render(<FlowPreview type="flow" name="ping_flow" draft={FLOW} />);
+    expectEmptyState(railBody(), SENTENCE);
+  });
+
+  it('a declared variable renders its row and no empty-description', () => {
+    stubCatalogue();
+    render(<FlowPreview type="flow" name="ping_flow" draft={{ ...FLOW, variables: [{ name: 'amount', type: 'number' }] }} />);
+    const body = railBody();
+    expect(within(body).getByText('amount')).toBeTruthy();
+    expectPopulated(body, SENTENCE);
+  });
+});
+
+// ───────────────────────────── FlowRunsPanel ─────────────────────────────
+
+describe('FlowRunsPanel — no runs, and a run with no step log', () => {
+  const NO_RUNS = 'No runs yet.';
+  const NO_STEPS = 'No step log recorded.';
+  const RUN = {
+    id: 'run_8526',
+    status: 'completed',
+    startedAt: '2026-09-08T10:00:00.000Z',
+    durationMs: 12,
+    trigger: { type: 'manual' },
+    steps: [] as Array<Record<string, unknown>>,
+  };
+
+  function stubRuns(runs: unknown[]) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ success: true, data: { runs } }), { status: 200 })),
+    );
+  }
+
+  it('an empty run list is the shared empty-description slot', async () => {
+    stubRuns([]);
+    render(<FlowRunsPanel flowName="ping_flow" />);
+    await screen.findByText(NO_RUNS);
+    expectEmptyState(bodyByTitle('Runs'), NO_RUNS);
+  });
+
+  it('a listed run renders its row and no empty-description at the list level', async () => {
+    stubRuns([RUN]);
+    render(<FlowRunsPanel flowName="ping_flow" />);
+    await screen.findByRole('button', { expanded: false });
+    expectPopulated(bodyByTitle('Runs'), NO_RUNS);
+  });
+
+  /** The expanded run body, reached by the run-id line it opens with. */
+  async function expandedRunBody(): Promise<HTMLElement> {
+    fireEvent.click(await screen.findByRole('button', { expanded: false }));
+    const idLine = await screen.findByText(/^run run_8526/);
+    return idLine.parentElement as HTMLElement;
+  }
+
+  it('a run with no step log is the shared empty-description slot', async () => {
+    stubRuns([RUN]);
+    render(<FlowRunsPanel flowName="ping_flow" />);
+    expectEmptyState(await expandedRunBody(), NO_STEPS);
+  });
+
+  it('a run with steps renders them and no empty-description', async () => {
+    // A node id distinct from its type label: `start`/`start` renders the same word twice.
+    stubRuns([{ ...RUN, steps: [{ nodeId: 'fetch_orders', nodeType: 'http', status: 'success' }] }]);
+    render(<FlowRunsPanel flowName="ping_flow" />);
+    const body = await expandedRunBody();
+    expect(within(body).getByText('fetch_orders')).toBeTruthy();
+    expectPopulated(body, NO_STEPS);
+  });
+});
+
+// ───────────────────────────── FlowSimulatorPanel ─────────────────────────────
+
+describe('FlowSimulatorPanel — no scratch variables, and a run that set none', () => {
+  const SCRATCH_HINT = 'Override or inject any variable (wins over inputs and mocks at start).';
+  const NO_VARS = 'No variables set.';
+  const FLOW = {
+    nodes: [
+      { id: 's', type: 'start' },
+      { id: 'e', type: 'end' },
+    ],
+    edges: [{ source: 's', target: 'e' }],
+  };
+
+  /** The variable-watch header is a `div` reading "Variables". */
+  function watchBody(): HTMLElement {
+    const header = screen.getAllByText('Variables').find((el) => el.tagName === 'DIV');
+    expect(header, 'the variable-watch header').toBeTruthy();
+    return header!.parentElement!.children[1] as HTMLElement;
+  }
+
+  it('no scratch rows is the shared empty-description slot', () => {
+    render(<FlowSimulatorPanel nodes={FLOW.nodes} edges={FLOW.edges} variables={[]} />);
+    expectEmptyState(bodyByTitle('Set variables'), SCRATCH_HINT);
+  });
+
+  it('an added scratch row renders its inputs and no empty-description', () => {
+    render(<FlowSimulatorPanel nodes={FLOW.nodes} edges={FLOW.edges} variables={[]} />);
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }));
+    const body = bodyByTitle('Set variables');
+    expect(within(body).getAllByRole('textbox').length).toBeGreaterThan(0);
+    expectPopulated(body, SCRATCH_HINT);
+  });
+
+  it('a run that set no variables is the shared empty-description slot', () => {
+    render(<FlowSimulatorPanel nodes={FLOW.nodes} edges={FLOW.edges} variables={[]} />);
+    fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
+    expectEmptyState(watchBody(), NO_VARS);
+  });
+
+  it('a run seeded from a declared input renders the variable and no empty-description', () => {
+    render(
+      <FlowSimulatorPanel
+        nodes={FLOW.nodes}
+        edges={FLOW.edges}
+        variables={[{ name: 'amount', type: 'number', isInput: true, defaultValue: 5 }]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /^run$/i }));
+    const body = watchBody();
+    expect(within(body).getByText('amount')).toBeTruthy();
+    expectPopulated(body, NO_VARS);
+  });
+});
+
+// ───────────────────────────── JobPreview ─────────────────────────────
+
+describe('JobPreview — a job with no schedule keys', () => {
+  const SENTENCE = 'No schedule set — runs only when triggered manually.';
+  const JOB = { name: 'nightly_cleanup', handler: 'jobs.cleanup' };
+
+  it('no schedule is the shared empty-description slot', () => {
+    render(<JobPreview type="job" name="nightly_cleanup" draft={JOB} />);
+    expectEmptyState(bodyByTitle('Schedule'), SENTENCE);
+  });
+
+  it('a cron schedule renders its line and no empty-description', () => {
+    render(<JobPreview type="job" name="nightly_cleanup" draft={{ ...JOB, schedule: { type: 'cron', expression: '0 0 * * *' } }} />);
+    const body = bodyByTitle('Schedule');
+    expect(within(body).getByText('0 0 * * *')).toBeTruthy();
+    expectPopulated(body, SENTENCE);
+  });
+});
+
+// ───────────────────────────── TranslationPreview ─────────────────────────────
+
+describe('TranslationPreview — a category with no keys', () => {
+  const SENTENCE = 'empty';
+  const BUNDLE = { locale: 'en', data: { messages: { hello: 'Hello' }, objects: {} } };
+
+  /** The category card, reached by its label; its body is the card's second child. */
+  function objectsCard(): HTMLElement {
+    const label = screen.getAllByText('Objects').find((el) => el.closest('.rounded.border'));
+    expect(label, 'the Objects category card label').toBeTruthy();
+    const card = label!.closest('.rounded.border') as HTMLElement;
+    return card.children[1] as HTMLElement;
+  }
+
+  it('an empty category is the shared empty-description slot', () => {
+    render(<TranslationPreview type="translation" name="en" draft={BUNDLE} />);
+    expectEmptyState(objectsCard(), SENTENCE);
+  });
+
+  it('a populated category renders its sample and no empty-description', () => {
+    render(
+      <TranslationPreview
+        type="translation"
+        name="en"
+        draft={{ ...BUNDLE, data: { ...BUNDLE.data, objects: { account: { label: 'Account' } } } }}
+      />,
+    );
+    const body = objectsCard();
+    expect(within(body).getByText('account')).toBeTruthy();
+    expectPopulated(body, SENTENCE);
+  });
+});
+
+// ───────────────────────────── ScreenPreview ─────────────────────────────
+
+describe('ScreenPreview — a screen with nothing configured', () => {
+  const SENTENCE = 'Add a title, description, fields, or an object form to preview this screen.';
+
+  it('an unconfigured screen is the shared empty-description slot, at the body scale', () => {
+    render(<ScreenPreview node={{ id: 's1', config: {} }} />);
+    const body = bodyByTitle('Preview');
+    expectEmptyState(body, SENTENCE);
+    // The deliberate outlier: this sentence stands in for the screen body,
+    // whose description renders at text-sm — not for a text-xs rail row.
+    expect(self(body, ED)!.className).toContain('text-sm');
+  });
+
+  it('a titled screen renders its heading and no empty-description', () => {
+    render(<ScreenPreview node={{ id: 's1', config: { title: 'Step one' } }} />);
+    const body = bodyByTitle('Preview');
+    expect(within(body).getByText('Step one')).toBeTruthy();
+    expectPopulated(body, SENTENCE);
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectui#8526

Sixteen empty-collection sentences across twelve files under `packages/app-shell/src/views/metadata-admin/previews/` each hand-rolled the same state — a muted italic sentence in a plain `div` — and two of those files (`AgentPreview`, `ToolPreview`) declared a file-local component literally named `Empty`, which shadowed the shared family in the one place a maintainer would reach for it. All sixteen now render `EmptyDescription` from `@object-ui/components`, **used alone, outside any `Empty` container** — the shape PR #8527 (objectui#8520) landed and measured at 16px / 12px / start-aligned / italic against the row it replaced. The two local `Empty` components are deleted. Nothing lands in `@object-ui/components`; `@object-ui/components` is already `workspace:*` in app-shell, so no manifest edge was added.

Per the ruling on the card: the `Empty` container is not used anywhere (118.8px at the rail's 215px width), and `EmptyValue` is not used anywhere (its `aria-label` says "No value", which is false about a collection).

## Census, re-derived

Pathspec `'packages/app-shell/src/views/metadata-admin/previews/*'`, run from the repo root. Lit control on the same pathspec: `git grep -c PreviewShell` fires on 24 files, so a zero from any probe below is an absence rather than a dead glob. Probes: (A) `\bitalic\b`, (B) `border-dashed`, (C) `text-amber`, (D) `PreviewEmptyState`, (E) `function Empty\b`, (F) the `Empty*` family names, (G) length-conditional rendering (`.length === 0`, `!x.length`, `Object.keys(x).length`), (H) JSX text opening with No / none / empty, (I) `tr('engine.*.(no…|empty)')` keys. Every probe's matched lines were read in context, not counted.

Reconciled by their **differences**, not their union: probe G (length shape) returned a false zero on `TranslationPreview:152`, whose condition is `cat.count === 0` — probes A and H found it. Probe A (italic) returned a false zero on the two sites that went through the local `Empty` (`AgentPreview:136`, `ToolPreview:185`) — probes E and H found them. Probe G is the one that surfaces the families probe A cannot see at all: the dashed drop zones, the amber warnings, the palette search empties.

Effective type scale, read from each site's ancestors rather than from its own class list: **text-xs at 13 of the 16 migrated sites** (explicit at six; inherited from a `text-xs` container at seven — `ActionPreview:578`, `EmailTemplatePreview:93`, `FlowPreview:341`, `FlowRunsPanel:388`, `FlowSimulatorPanel:228`, `JobPreview:330`, `AgentPreview:161`), 10px at one, 11px at one, text-sm at one. The card's "six different type scales" does not reproduce; the ruling's "uniform with a few genuine outliers" does. Instrument for the class merge: `tailwind-merge@3.6.0` (the version `cn()` resolves), which evicts the family's `text-sm/relaxed` for any explicit size class — and keeps it for bare `italic`. So every site spells its size out; bare `italic` would have been a 14px / 22.75px delta at the seven inheriting sites.

## Per-site delta

| Site (line on `main`) | Before | `className` now | Delta |
|---|---|---|---|
| `AgentPreview:136` | local `Empty` → `div.text-xs.text-muted-foreground.italic` | `text-xs italic` | zero |
| `AgentPreview:192` "Defaults in use." | `div.text-muted-foreground.italic`, inherits xs | `text-xs italic` | zero |
| `AgentPreview:256` chip-list `emptyHint` | `div.text-xs.text-muted-foreground.italic` | `text-xs italic` | zero |
| `AgentPreview:221` local `Empty` | declaration | deleted | — |
| `ToolPreview:185` | local `Empty` | `text-xs italic` | zero |
| `ToolPreview:296` local `Empty` | declaration | deleted | — |
| `DatasourcePreview:159` | `div.text-xs.text-muted-foreground.italic` | `text-xs italic` | zero |
| `SkillPreview:107` | same | `text-xs italic` | zero |
| `ActionPreview:581` | `div.text-muted-foreground.italic`, inherits xs | `text-xs italic` | zero |
| `EmailTemplatePreview:98` | same shape, inherits xs; keeps its `code` child (the family's child rules target `a` only) | `text-xs italic` | zero |
| `FlowPreview:346` | same, inherits xs | `text-xs italic` | zero |
| `FlowRunsPanel:349` step log | `div.text-[10px].italic.text-muted-foreground` | `text-[10px] italic` | zero — 10px kept: the run row's own metadata (status, time, duration at lines 331–336) is 10px |
| `FlowRunsPanel:406` runs list | `div.italic.text-muted-foreground`, inherits xs | `text-xs italic` | zero |
| `FlowSimulatorPanel:324` scratch rows | same, inherits xs | `text-xs italic` | zero |
| `FlowSimulatorPanel:383` variable watch | same, inherits xs | `text-xs italic` | zero |
| `JobPreview:348` | same, inherits xs | `text-xs italic` | zero |
| `TranslationPreview:153` | `div.text-[11px].text-muted-foreground.italic` | `text-[11px] italic` | zero — 11px kept: the category card's sample list it stands in for is 11px (line 155) |
| `ScreenPreview:77` | `p.text-sm.italic.text-muted-foreground` | `text-sm italic` | zero metrically (14px / 20px both ways; preflight zeroes `p` margins); element `p` → `div` |

## The outliers, one sentence each

- **`text-sm` (`ScreenPreview:77`)** — kept at text-sm, deliberately: this sentence stands in for the screen **body**, whose description renders at text-sm one line below (line 84), not for a text-xs rail row; averaging it down to xs would have been a visible delta with no sibling to justify it. The pin asserts the class stays.
- **Inline `span` "none" (`ValidationPreview:353`)** — left as is; the ruling does not cover inline markers. A **second inline carrier the ruling did not enumerate** turned up: `DatasourcePreview:225` `span.text-muted-foreground.italic` "not configured" (a rail card whose object has no keys). Left for the same reason and reported.
- **Chrome site (`ValidationPreview:387`, `rounded border bg-background p-2.5`)** — establishing what the chrome does: it is the `CelBlock` box (`ValidationPreview:439`, `rounded border bg-background p-2.5 text-xs font-mono`), so the sentence occupies the slot the rule body would have. It is also **not an empty-collection state**: it is the `default:` arm for an unknown rule `type` ("Unknown rule type … Showing common fields only."). Left untouched, chrome and all.

## Not migrated, by class

- **Amber warning-toned sentences** — `JobPreview:357`, `JobPreview:387`, `SkillPreview:100`, `ValidationPreview:282` / `335` / `378` / `408` / `436`, `BookPreview:254`. Two of these are in the card's fifteen. They deliberately are not muted; migrating them means either dropping the amber (a visible delta the ruling did not authorize) or overriding the family's colour so the membership is nominal. A design call above this card.
- **Dashed drop-zone placeholders** — `AppNavCanvas:330`, `FieldsListEditor:170`, `PageBlockCanvas:554` / `828`, `ObjectFormCanvas:516`; bordered, centred editor targets, a different visual class (and two dashed conventions: `border border-dashed` vs `border-2 border-dashed` in `FieldStub`).
- **Palette / search empties** — `PageBlockCanvas:915`, `ObjectFormCanvas:1323`, `AddWidgetPicker:86`, `ViewColumnPanes:320` (via its own `Hint`); centred, padded, not italic.
- **The directory's own full-canvas answers** — `PreviewEmptyState` (`BookPreview:191`, `DatasetPreview`, `ReportPreview`) and `PreviewMessage` sites; `ProblemsPanel:53` (a success state with an icon).
- **Inline value placeholders** — `DashboardPreview:266` "untitled", `ValidationPreview:167` "no message set", `FieldStub:205` (a stub input's placeholder; in the card's fifteen). `EmptyValue`'s question, not this card's.
- **Adjacent non-empty branches with the same styling** — `FlowRunsPanel:402` (service `unavailable`; its sibling branch at 406 is migrated), `FlowSimulatorPanel:442` (idle hint), `BookPreview:250` (explains that members are derived; not an absence).

## Tests

`packages/app-shell/src/views/metadata-admin/previews/emptyCollection-8526.test.tsx` — 33 cases: for each of the sixteen sites an empty leg (the family's `data-slot="empty-description"` is present under the titled container, carries the site's sentence, and no `empty-value` is present) and a populated leg (the rows render and **no** `empty-description` exists under that container — the caricature refuser), plus one whole-surface case on a fully populated agent. Every navigator reaches the **container** that owns a title (`Section` heading, rail label, panel header, category-card label), never the empty state and never a child position.

Measured, not predicted — three legs, each restored by state (`git diff HEAD` empty over the 12 paths and all 12 blob hashes equal to `HEAD:path`), mutation proven on disk in both directions, trap on `EXIT INT TERM`:

- **Fix reverted** (12 source files at the base sha; on disk: 1 `EmptyDescription` tag left — the objectui#8520 precedent — and 2 local `Empty` declarations back): 16 failed / 17 passed; all 16 on "the shared EmptyDescription slot" expected truthy; 0 harness deaths.
- **Caricature** (an unconditional `EmptyDescription` inserted before every migrated conditional; on disk: 16 markers, 0 after restore): 33 failed / 0 passed, **0 harness deaths** — 16 populated cases on `toBeNull`, the whole-surface case on `toHaveLength(0)`, 16 empty cases on the sentence mismatch. The first run of this leg against the first version of the pin was the instrument that mattered: **8 of the 17 populated cases died on their marker lookup** ("Unable to find an element") before the refusing assertion ran, because the harness took `children[1]` as the body and the inserted sibling shifted the rows one slot over. The pin was rewritten to container-level navigation with descendant queries (second commit) and the leg re-run; the numbers above are from the re-run.
- **Harness-kill** (`ToolPreview`'s section title renamed): 2 failed / 31 passed, both `Unable to find an element with the text: Input Parameters` — textually distinct from both modes above.

## Verification

- Closure built first: `turbo run build --filter='@object-ui/app-shell^...'` — 28/28 tasks. `pnpm --filter @object-ui/app-shell type-check` (source leg and the `tsconfig.test.json` leg): exit 0 before and after.
- Tests, from the repo root with paths: the pin 33/33; the 14 test files that import a touched module (enumerated by grep with a firing control) 14 files / 143 tests; the extended set — the seven `FlowNodeInspector` tests (the one consumer of `ScreenPreview` outside the directory) and the two console tests naming the previews — 9 files / 297 tests. `turbo ls --affected` names app-shell, console and two example packages; the two examples carry no test that reaches these modules.
- Lint, declared narrowing: CI's `pnpm lint` is `turbo run lint`, one `eslint .` per package, and only app-shell changed. The CI-exact invocation for app-shell (`eslint .` inside the package, `--format json`) at `61b113204`: **1110 files, 0 errors, 2925 warnings** (the known-debt stream; 24 of them in the twelve touched files, all pre-existing, none on a changed line; 0 in the pin). Invariance: `eslint --print-config` on a preview file shows no `parserOptions.project` / `projectService`, so this diff cannot move any untouched package's verdict.
- Gates green: `check:control-bytes`, `check-changeset-presence` (12 source files of 1 released package, 1 changeset), `check-changeset-no-major`, `check:vi-mock-specifiers`, `check:i18n-keys`, `check:phantom-deps`. `check-governed-queue-guard --test` on the diff paths: NOT GOVERNED.
- Changeset: `.changeset/previews-shared-empty-description-8526.md`, `@object-ui/app-shell: patch` (`skip-changeset` is a phantom label in this repo and is not applied).

## Where the card and the ruling read differently from `main`

- The `EmptyDescription`-alone precedent at `AgentPreview:315` landed in **PR #8527** (commit `5eff8b161`, objectui#8520). **PR #8552** (`1570eac37`, objectui#8525) is the `Empty` container's override change. The ruling attributes the precedent to PR #8552; git says otherwise. The target is the same either way.
- The chrome site (`ValidationPreview:387`) is not an empty-collection state — see above.
- The card's fifteen mixes four visual classes (muted sentences, dashed drop zones, amber warnings, one `PreviewEmptyState`, one stub-input placeholder); nine of its fifteen are in the migrated set, and seven migrated sites were not in the card's list at all (`AgentPreview:136`, `AgentPreview:192`, `FlowRunsPanel:406`, `FlowSimulatorPanel:383`, `JobPreview:348`, `TranslationPreview:153`, `ScreenPreview:77`, `ToolPreview:185` via the local `Empty`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_