### PR TITLE
docs(scripts): record the measured `framework` attribution the ceiling raise could not (objectui#8542)

### DIFF
--- a/.changeset/8542-framework-chunk-attribution.md
+++ b/.changeset/8542-framework-chunk-attribution.md
@@ -1,0 +1,28 @@
+---
+---
+
+Record the measured attribution for the `framework` per-chunk overage in
+`scripts/check-eager-closure-budget.mjs` (objectui#8542). Prose only; no package
+is released by this change and no constant moves.
+
+The ceiling raise that landed as `fa9e76ccd` wrote that the bytes behind the red
+were `NOTHING IDENTIFIABLE` because "the commits in that window have never been
+bisected". They have been now, one `apps/console` build per point from the repo
+root, and the finding corrects the framing every filing card carried:
+
+| build       | landed by | `framework` gzip | moved by                 |
+| ----------- | --------- | ---------------- | ------------------------ |
+| `40a7c538a` | #8503     | 70,999           | last GREEN, 1 byte under |
+| `512c84b16` | #8519     | 70,999           | 0                        |
+| `f76f43628` | #8512     | 71,261           | +262                     |
+| `e76634cc8` | #8529     | 72,245           | +984                     |
+| `e411c3e58` | #8562     | 72,248           | +3                       |
+
+Two commits own the overage, not one, and the larger is **outside** the window
+the cards bisected: `e76634cc8` carries 984 of the 1,246 bytes the pair added.
+`270f2825b`, the suspect objectui#8541 named, is measurably innocent — the
+emitted chunk is byte-identical across it and it touches no file under
+`packages/(core|react|types)`.
+
+Both contributors are silent-wrong-answer fixes on one file's filter path, so
+what the bytes buy is now stated where the gate's failure message asks for it.

--- a/scripts/check-eager-closure-budget.mjs
+++ b/scripts/check-eager-closure-budget.mjs
@@ -569,15 +569,49 @@ export const REGRESSION_THIS_GATE_MUST_CATCH_BYTES = 89 * 1024;
  * read as a derivation of it. What is recorded here is what the raise COSTS,
  * because that is the half a later reader cannot recover from the constant.
  *
- * ⛔ What the bytes buy: NOTHING IDENTIFIABLE, and that is the finding, not an
- * omission. The failure message this raise silences asks the author to "say in
- * the PR what the bytes buy". Nobody can: `Bundle Analysis` went red on `main`
- * at `f76f43628` with `40a7c538a` the last green, and the commits in that window
- * have never been bisected — this checker is a two-build predicate over them and
- * no one has run it. ⚠️ So this raise does not answer the attribution question,
- * it makes it HARDER TO ASK: the line that was holding the unexplained bytes in
- * view now passes over them. objectui#8542 owns that attribution and stays open;
- * objectui#8541 recorded the same red first and is closed as its duplicate.
+ * ⛔ What the bytes buy — MEASURED, but AFTER this constant moved. When the raise
+ * landed nobody could answer the question its own failure message asks — "say in
+ * the PR what the bytes buy" — because the window had not been bisected, and this
+ * section recorded that as the finding. objectui#8542 has since run it: one
+ * `apps/console` build per point, each from the repo ROOT, `framework` read out
+ * of the `apps/console/dist/eager-closure.json` the build itself writes.
+ *
+ *   | build       | landed by | `framework` gzip | moved by                 |
+ *   | `40a7c538a` | #8503     | 70,999           | last GREEN, 1 byte under |
+ *   | `512c84b16` | #8519     | 70,999           |                        0 |
+ *   | `f76f43628` | #8512     | 71,261           |                     +262 |
+ *   | `e76634cc8` | #8529     | 72,245           |                     +984 |
+ *   | `e411c3e58` | #8562     | 72,248           |                       +3 |
+ *
+ * ⚠️ TWO commits own the overage and the LARGER one is OUTSIDE the window this
+ * section bounded. `e76634cc8` landed after the red had already started and
+ * carries 984 of the 1,246 bytes the pair added — 79% — against 262 for the
+ * commit the red first appeared on. ⛔ A repair scoped to the window would have
+ * left `main` red. `512c84b16` emitted a byte-identical chunk to `40a7c538a`
+ * (the same `framework-nDOJv2Ij.js` content hash), so the three commits between
+ * them moved this chunk by ZERO — and objectui#8541's named suspect
+ * `270f2825b` is measurably innocent: it touches no file under
+ * `packages/(core|react|types)` at all.
+ *
+ * ⇒ So the bytes are identifiable, and they are two silent-wrong-answer fixes on
+ * ONE file's filter path, `packages/core`'s `ValueDataSource`. `f76f43628`
+ * (#8512): an unrecognised `$` operator ended the switch on `default: break`,
+ * adding no constraint, so it matched EVERY row. `e76634cc8` (#8529): an array
+ * comparand and a `{ $field }` reference were compared by REFERENCE, selecting
+ * every row under `$ne` and no rows under `$eq`, neither of them saying so. The
+ * bytes ARE the refusals and the prescriptions that replaced that silence.
+ *
+ * ⛔ None of which retires the cost above: the line that was holding these bytes
+ * in view now passes over them, and the attribution arrived after the constant
+ * moved rather than before it. ⚠️ Nor is trimming the alternative it looks like
+ * — deleting every refusal message string these two commits ship was measured at
+ * 610 gzip bytes against the 1,245 the overage needed (recorded on
+ * objectui#8542, ⛔ not re-measured here), so the whole diagnostic surface is
+ * worth under half the payload it gets blamed for. ⭐ Why `main` was one byte from
+ * this line in the first place is objectui#8554: it sat at 70,999 against 71,000
+ * — headroom 0.00x — and printed a GREEN sensitivity row while it did, because
+ * {@link evaluateHeadroomSensitivity} has no floor. objectui#8541 recorded the
+ * same red first and is closed as this card's duplicate.
  *
  * ⚠️ This also makes `framework` the LOOSEST ceiling in this object, measured
  * rather than asserted. All four were read from the one `3f775eeb8` console
@@ -622,8 +656,10 @@ export const PER_CHUNK_GZIP_CEILINGS = Object.freeze({
   'vendor-objectstack': 1_254_000,
   'i18n-locales': 455_000,
   // Raised by the maintainer ruling of 2026-09-08, ⛔ not by a measurement here:
-  // `main` had been red on this line since `f76f43628` and the bytes that put it
-  // there are UNATTRIBUTED. Headroom 27,755 bytes = 0.30x
+  // `main` had been red on this line since `f76f43628`. The bytes that put it
+  // there were UNATTRIBUTED when this moved and have since been measured to
+  // `f76f43628` (+262) and `e76634cc8` (+984) — see the table under "Why
+  // `framework` moved UP" above. Headroom 27,755 bytes = 0.30x
   // REGRESSION_THIS_GATE_MUST_CATCH_BYTES on `3f775eeb8` — the loosest of the
   // four. See "Why `framework` moved UP" above for what that costs.
   framework: 100_000,


### PR DESCRIPTION
Part of objectstack-ai/objectui#8542

⛔ **Deliberately `Part of`, not a closing keyword — see "Why this does not close the card" at the bottom.** This PR was opened with a closing keyword and corrected within the hour, on a card amendment posted after it.

⚠️ **Read the first section before the diff. The premise this card was dispatched on is dead, and the change here is what is left of it.**

## ⭐ `main` is already GREEN — `fa9e76ccd` landed the repair while this card was in flight

The card, its triage, and my dispatch brief all describe a red trunk: *"every PR whose diff adds a byte to `packages/core`, `packages/react` or `packages/types` now fails a required check it cannot fix within its own appetite."* Measured on `e411c3e58` (the `main` tip this branch is cut from), that is **no longer true**:

- `fa9e76ccd` (PR #8550, merged 12:05:35Z) raised `PER_CHUNK_GZIP_CEILINGS.framework` 71,000 → 100,000 with `PER_CHUNK_BASELINE.framework` 61,465 → 72,245.
- `pnpm check:eager-closure` on a full console build of this branch exits **0**, every leg green: `framework 70.6 KB / 97.7 KB ceiling (headroom 27.1 KB)`.
- **Acceptance test, answered:** PR #8540 — one of the two the card names as held — **has already landed**, as `532316884`. PR #8501 measured 71,007 against the old 71,000 ceiling; against 100,000 it clears by 28,993 bytes. Both pass. Neither needed this PR.

⇒ There is no byte to trim, and both actions the dispatch forbade (raise the ceiling, revert `f76f43628`) are moot: one already happened above my floor, the other never will.

## What IS left, and it is the thing the card was filed for

`fa9e76ccd` moved a ratchet 29,000 bytes and recorded, honestly, that it could not say what the bytes bought:

> ⛔ What the bytes buy: NOTHING IDENTIFIABLE, and that is the finding, not an omission. The failure message this raise silences asks the author to "say in the PR what the bytes buy". Nobody can: `Bundle Analysis` went red on `main` at `f76f43628` with `40a7c538a` the last green, and the commits in that window **have never been bisected** — this checker is a two-build predicate over them and no one has run it. ⚠️ So this raise does not answer the attribution question, it makes it HARDER TO ASK: the line that was holding the unexplained bytes in view now passes over them. **objectui#8542 owns that attribution and stays open.**

That paragraph is still in the tree, and it is what this PR replaces. The bisect has been run. **This PR is prose only — ⛔ no constant moves, and that is proved mechanically below, not asserted.**

## ⭐ The attribution — one `apps/console` build per point

| build       | landed by | `framework` gzip | moved by                 | chunk file                  | gate |
| ----------- | --------- | ---------------- | ------------------------ | --------------------------- | ---- |
| `40a7c538a` | #8503     | **70,999**       | last GREEN, 1 byte under | `framework-nDOJv2Ij.js`     | exit 0 |
| `512c84b16` | #8519     | **70,999**       | **0**                    | `framework-nDOJv2Ij.js`     | exit 0 |
| `f76f43628` | #8512     | **71,261**       | **+262** — the crossing  | `framework-DGfxffQ7.js`     | exit 1, OVER by 261 |
| `e76634cc8` | #8529     | **72,245**       | **+984**                 | `framework-Dzpi76rg.js`     | exit 1, OVER by 1,245 |
| `e411c3e58` | #8562     | **72,248**       | +3                       | `framework-Go_72ibC.js`     | exit 0 (new ceiling) |

`70,999 + 262 + 984 = 72,245`, and the `e76634cc8` row reproduces the card's CI reading — `framework 70.6 KB / 69.3 KB ceiling (OVER by 1.2 KB)` — to the byte.

**Method**, stated because bundle readings in this repo are CWD-sensitive: one detached worktree, `pnpm install` once (`pnpm-lock.yaml` is identical across all five points, verified), then at each point `pnpm turbo run build --filter='./packages/*' --concurrency=2` followed by `pnpm --filter @object-ui/console build`, **both from the worktree ROOT**, and `framework` read out of the `apps/console/dist/eager-closure.json` the build itself writes (`reportVersion` 2). Identical command, identical CWD, at every point. Every build went through the shared verify lock; each printed `VERDICT command-exit 0`.

### ⚠️ Finding 1 — TWO commits own the overage, and the larger one is OUTSIDE the window every card bounded

`e76634cc8` (#8529) landed **after** the red had already started and carries **984 of the 1,246 bytes the pair added — 79%** — against 262 for the commit the red first appeared on. ⛔ **A repair scoped to the four-commit window, which is what this card, objectui#8541 and my own dispatch brief all specified, would have left `main` red.** The two-build bisect that triage adopted as its handover instruction answers a question narrower than the defect.

### ⚠️ Finding 2 — objectui#8541's named suspect is measurably innocent

`512c84b16` emits a **byte-identical chunk** to `40a7c538a` — the same `framework-nDOJv2Ij.js` content hash — so `d65b2baa4`, `270f2825b` and `512c84b16` together moved this chunk by **zero**. Corroborated structurally: `git show --name-only 270f2825b` touches **13 files and not one** under `packages/(core|react|types)` (grep exit 1, control: 13 files present), so it has no path into this chunk at all.

### ⭐ What the bytes buy, which is what the gate's failure message asks for

Both contributors are silent-wrong-answer repairs on ONE file's filter path, `packages/core`'s `ValueDataSource`:

- **`f76f43628` (#8512)** — `matchesFilter` ended its operator switch on `default: break`, which adds no constraint, so **an unrecognised `$` operator matched EVERY row**, silently.
- **`e76634cc8` (#8529)** — an array comparand and a `{ $field }` reference were compared **by reference**: `$ne` against an array was always true and **selected every row**, while `$eq` and the `{ $field }` orderings **answered no rows**. Fail-open and fail-closed, neither saying anything.

The bytes ARE the refusals and the prescriptions that replaced that silence.

## ⛔ What this PR deliberately does not do

- ⛔ **No ceiling is raised or lowered.** Not `PER_CHUNK_GZIP_CEILINGS`, not `PER_CHUNK_BASELINE`, not `REGRESSION_THIS_GATE_MUST_CATCH_BYTES`, not the aggregate.
- ⛔ **Nothing is reverted.** `f76f43628` and `e76634cc8` are ruled correctness repairs.
- ⛔ **Nothing is re-chunked.** Moving budgeted bytes into an unbudgeted chunk turns the check green while the browser downloads the same bytes — the exact pattern objectui#5490 built the per-chunk half to catch.
- ⛔ **The trim number is cited, not claimed.** The 610-gzip-bytes-for-the-whole-diagnostic-surface figure is recorded on this card by the earlier run at `issuecomment-5584083163`; I did **not** re-measure it, and the prose says so in as many words.

## Evidence

### The diff cannot move the gate's verdict — proved, not argued

- 47 lines added, 11 removed in the checker; **0 of them non-comment** (classifier control: a real constant line is correctly rejected as code).
- The checker with comments stripped is **byte-identical** to `origin/main`'s: both 25,505 characters, `==` true, with the control that the raw files do differ.

### Per-chunk numbers before and after — all four budgeted chunks, not just `framework`

`before` is a build of `origin/main` at `e411c3e58`; `after` is a build of this branch. Same command, same CWD.

| chunk | before (gzip) | after (gzip) | delta | chunk file |
| ----- | ------------- | ------------ | ----- | ---------- |
| `framework`          | 72,248    | 72,248    | **0** | `framework-Go_72ibC.js` (identical hash) |
| `vendor-objectstack` | 1,235,152 | 1,235,152 | **0** | `vendor-objectstack-TSYB5b1r.js` (identical) |
| `i18n-locales`       | 452,100   | 452,100   | **0** | `i18n-locales-hFYzG_D0.js` (identical) |
| `ui-components`      | 393,295   | 393,295   | **0** | `ui-components-B372jD9I.js` (identical) |
| aggregate eager      | 3,558,850 | 3,558,850 | **0** | 50 of 518 chunks |

⇒ ⭐ Nothing was pushed into a chunk that happened to have headroom. Every content hash is the same one `origin/main` emits.

### Gates, exit codes captured by redirect before any pipe

| command | exit |
| ------- | ---- |
| `pnpm exec vitest run scripts/__tests__/check-eager-closure-budget.test.ts` | **0** — 104 passed (104) |
| `pnpm check:eager-closure` on a full console build of this branch | **0** — all five legs green |
| `node scripts/check-control-bytes.mjs` | **0** — 6,767 tracked text files scanned |
| `node scripts/check-changeset-fixed.mjs` | **0** |
| `node scripts/check-changeset-no-major.mjs` | **0** |
| `node scripts/check-changeset-presence.mjs` | **0** — no changeset owed; one added anyway |
| `pnpm exec eslint .` (repo-wide, ⛔ never `--no-inline-config`) | **0** — 4,516 files, 0 errors, 12,267 pre-existing warnings |
| `pnpm exec tsc -p tsconfig.scripts.json --noEmit` | **0** |
| `node scripts/check-governed-queue-guard.mjs --test` on both changed paths | **0 — NOT GOVERNED** (lit control: `AGENTS.md` returns exit 3, GOVERNED) |

### ⚠️ Ablation, and it came back NEGATIVE — reported rather than fitted to the guess

I injected an unanchored chunk count (`which weighs 50 of 518 chunks`) into the new prose to test whether the objectui#7528 pin reads this region. **It does not fire.** The mutation demonstrably reached disk — anchor line count 1 → 0, injected string 0 → 1, blob hash `1e108dfd…` → `7e07c1cc…` — and the suite still passed 104/104. ⇒ The honest reading is that a backticked commit hash elsewhere in the same JSDoc block anchors the whole block, so **this narrative region carries no mechanical pin**; the review is the guard on it. Restored by state, not by exit code: blob hash back to `1e108dfdbe3d385f1c5fd04e0f6db0ed0a2582b7`, equal to `git rev-parse HEAD:scripts/check-eager-closure-budget.mjs`, and `git diff HEAD --stat` empty. The trap on `EXIT INT TERM` used absolute paths and `git checkout HEAD --`, never a bare restore.

## ⛔ Why this does not close the card

The card amendment at `issuecomment-5585168282` puts objectui#8542 into two live branches, and this PR satisfies neither of them on its own:

- **If the maintainer confirms 100,000**, the card's attribution deliverable is complete and it closes — but on that ruling, not on this PR.
- **If the maintainer does not confirm it**, the card's queued work becomes **re-tightening the ceiling** to the file's own 0.10x convention (about 81,359 over the 72,245 baseline), maintainer-merged. ⛔ This PR does not do that and must not close the card out from under it.

⇒ `Part of`, not a closing keyword. This PR is the tree-side half of the attribution: it removes a sentence that is now false whichever way the maintainer answers.

## Draft, and staying draft

⛔ Not flipped ready, ⛔ no auto-merge armed. `check-governed-queue-guard` says this diff is not on a governed surface, so that posture is my dispatch's instruction rather than the repo's requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S