### PR TITLE
fix(fields): an empty array is not a cell value, and eight renderers fabricated one

### DIFF
--- a/.changeset/8490-fabricated-value-for-empty-array.md
+++ b/.changeset/8490-fabricated-value-for-empty-array.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/fields': patch
+---
+
+An empty array no longer makes a cell renderer fabricate a value (objectui#8490).
+
+objectui#8481 fixed the shared read renderers whose output for `[]` was *blank*. These
+are the other half of that census: the renderers whose output for `[]` was not blank
+but **wrong** — a value the record does not hold. Measured by rendering on `e411c3e58`:
+
+| field types | renderer | rendered for `[]` before |
+|---|---|---|
+| `boolean`, `toggle` | `BooleanCellRenderer` | a **checked**, disabled checkbox (`aria-checked` true); a completion field drew the green "Completed" indicator |
+| `number`, `slider`, `rating` | `NumberCellRenderer` | the digit `0` |
+| `currency` | `CurrencyCellRenderer` | the digit `0` |
+| `percent`, `progress` | `PercentCellRenderer` | a 0% progress bar with `aria-valuenow` of 0 |
+| `email` | `EmailCellRenderer` | a live anchor whose `href` was `mailto:` with no address, plus a copy button |
+| `url` | `UrlCellRenderer` | a live `_blank` anchor with an empty `href` |
+| `phone` | `PhoneCellRenderer` | a live anchor whose `href` was `tel:` with no number |
+| `color` | `ColorSwatchCellRenderer` | a bordered swatch box with no colour and an empty hex span |
+| `date` | `DateCellRenderer` | a hand-rolled em-dash with no accessible name (not the shared placeholder) |
+
+All of them now render the shared `EmptyValue` affordance — the muted em-dash with a
+`No value` accessible name — exactly as they already did for `null`.
+
+**The ruling is per renderer, not one predicate.** A boolean cell is not a text cell:
+`[]` holds no boolean, so the column holds *no value*, not `false` — a real `false` is
+still an unchecked box, and only `[]` moves (scalar truthiness coercions are untouched).
+The number family's `0` was `Number('')`, a coercion artefact rather than a stored zero,
+so its guard is now on the coerced *text* — which **deliberately also sweeps a stored
+`''`** (the same fabrication one input shape over); a real stored `0` still prints. The
+link family draws no anchor when there is nothing to link to; `color` draws no swatch
+without a colour string; `date` reaches the shared affordance instead of `formatDate`'s
+private dash.
+
+**Deliberately narrow.** `{}` is untouched everywhere, `json` still draws the array
+literal and `file` still states `0 files` (the objectui#8481 fence), and whether a
+non-boolean *scalar* in a boolean column should surface as a coercion error is a separate
+question this change does not answer.

--- a/packages/fields/src/__tests__/cellRenderers.fabricatedValue-8490.test.tsx
+++ b/packages/fields/src/__tests__/cellRenderers.fabricatedValue-8490.test.tsx
@@ -1,0 +1,370 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8490 — an empty array is not a cell value, and eight renderers
+ * FABRICATED one.
+ *
+ * objectui#8481 fixed the renderers whose output for `[]` was BLANK. This is
+ * the other half of that census: the renderers whose output for `[]` was not
+ * blank but WRONG — a value the record does not hold. Every row below was
+ * re-measured by rendering on `e411c3e58` (after `639ca9dc0`, the #8481 fix,
+ * which moved none of them):
+ *
+ * | field types                | renderer                  | rendered for `[]` before             | why                                       |
+ * |----------------------------|---------------------------|--------------------------------------|-------------------------------------------|
+ * | boolean, toggle            | `BooleanCellRenderer`     | a CHECKED, disabled checkbox         | guard was `value == null`; `[]` is truthy |
+ * | number, slider, rating     | `NumberCellRenderer`      | the digit `0`                        | `coerceToSafeValue([])` is `''`; `Number('')` is `0` |
+ * | currency                   | `CurrencyCellRenderer`    | the digit `0`                        | same                                      |
+ * | percent, progress          | `PercentCellRenderer`     | a 0% progress bar, `aria-valuenow=0` | same                                      |
+ * | email                      | `EmailCellRenderer`       | a live anchor, `href="mailto:"`      | guard was `!value`                        |
+ * | url                        | `UrlCellRenderer`         | a live `_blank` anchor, `href=""`    | same                                      |
+ * | phone                      | `PhoneCellRenderer`       | a live anchor, `href="tel:"`         | same                                      |
+ * | color                      | `ColorSwatchCellRenderer` | a bordered swatch with no colour     | guard was `value == null \|\| value === ''` |
+ * | date (the adjacent ninth)  | `DateCellRenderer`        | a hand-rolled em-dash, no aria-label | `formatDate('')` draws its own dash       |
+ *
+ * ── The ruling is per renderer, not one predicate ─────────────────────────
+ * Every row lands on the shared `EmptyValue` affordance, but for DIFFERENT
+ * reasons and with different sweep widths, and the card asked for exactly
+ * that distinction:
+ *
+ *   - `boolean`: `[]` is not a boolean and holds no entries, so the column
+ *     holds NO value — not `false`. Only `[]` moves (`isEmptyMultiValue`);
+ *     `false` stays an unchecked box and scalar coercions are untouched.
+ *   - number / currency / percent: the `0` was `Number('')` — a coercion
+ *     artefact, not a stored zero — so the guard is on the coerced TEXT, and
+ *     a stored `''` (the same fabrication one input-shape over) is swept in
+ *     DELIBERATELY. Pinned in THE BOUNDARY below.
+ *   - email / url / phone: nothing to link to means no anchor in the DOM.
+ *   - color: no colour string means no swatch.
+ *   - date: the coerced-empty branch reaches the shared affordance rather
+ *     than `formatDate`'s private dash (the objectui#8475 class of defect).
+ *
+ * `EmptyValue`'s accessible name is "No value", a STATEMENT — it is true at
+ * every site above because in each case the record holds no value of the
+ * field's type.
+ *
+ * ── Why the POPULATED cases are the load-bearing ones ─────────────────────
+ * The caricature is `EmptyValue` drawn unconditionally, populated cells
+ * included. It satisfies every "[] renders the affordance" case in this file.
+ * What refuses it is the POPULATED block: a real `true` still checks, a real
+ * `false` is still an unchecked box, a real stored `0` still prints, a real
+ * address still links, a real colour still swatches. Each of those was RUN
+ * against the caricature, not predicted — see the PR for the observed
+ * failure modes per leg.
+ *
+ * ── Why the defect leg asserts the ARTEFACT'S ABSENCE FIRST ───────────────
+ * Each `[]` case asserts "no fabricated artefact" before "affordance
+ * present", so its failure on the unfixed tree ("a checked checkbox is a
+ * fabricated value") is textually distinct from a harness that has lost its
+ * navigation target ("the shared affordance must be present"). The two legs
+ * were observed to fail on those two different sentences.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { getCellRenderer, resolveCellRendererType } from '../index';
+
+afterEach(() => cleanup());
+
+/** Resolve + render exactly the way a consumer builds a read-mode cell. */
+function renderCell(type: string, value: unknown, field: Record<string, unknown> = {}) {
+  const Renderer = getCellRenderer(resolveCellRendererType({ type }) || type);
+  return render(
+    <Renderer value={value as any} field={{ type, name: type, ...field } as any} />,
+  );
+}
+
+/** The shared "No value" affordance — a muted glyph carrying an aria-label. */
+const affordance = (root: HTMLElement) =>
+  root.querySelector<HTMLElement>('[data-slot="empty-value"]');
+
+function expectAffordance(root: HTMLElement, label: string) {
+  const empty = affordance(root);
+  expect(empty, `${label}: the shared EmptyValue affordance must be present`).not.toBeNull();
+  expect(
+    empty?.getAttribute('aria-label'),
+    `${label}: the affordance must carry its accessible name`,
+  ).toBe('No value');
+}
+
+/**
+ * Every em-dash in the cell must be the shared affordance. `EmptyValue`
+ * itself renders U+2014, so "no dash at all" is the wrong instrument; the
+ * defect is a dash OUTSIDE it.
+ */
+function handRolledDashes(root: HTMLElement): HTMLElement[] {
+  return within(root)
+    .queryAllByText('—')
+    .filter((el) => el.getAttribute('data-slot') !== 'empty-value');
+}
+
+describe('objectui#8490 — an empty array is not a cell value, and these renderers fabricated one', () => {
+  describe('THE DEFECT — [] renders the No-value affordance, not an invented value', () => {
+    for (const type of ['boolean', 'toggle'] as const) {
+      it(`THE DEFECT — \`${type}\` holding [] draws no checkbox (a checked box was a fabricated \`true\`)`, () => {
+        const { container } = renderCell(type, []);
+        expect(
+          container.querySelector('[role="checkbox"]'),
+          `${type}: a checked checkbox is a fabricated value for []`,
+        ).toBeNull();
+        expectAffordance(container, type);
+      });
+    }
+
+    it('THE DEFECT — a COMPLETION-named boolean holding [] draws no "Completed" indicator', () => {
+      // The sharpest row of the card: the green tick read as an affirmative
+      // answer the record never gave.
+      const { container } = renderCell('boolean', [], { name: 'completed' });
+      expect(
+        container.querySelector('[data-testid="completion-indicator"]'),
+        'completed: the green "Completed" indicator is a fabricated value for []',
+      ).toBeNull();
+      expectAffordance(container, 'completed');
+    });
+
+    it('THE DEFECT — an ACTIVE-named boolean holding [] draws neither a checkbox nor an "Off" badge', () => {
+      const { container } = renderCell('boolean', [], { name: 'active' });
+      expect(
+        container.querySelector('[role="checkbox"]'),
+        'active: a checked checkbox is a fabricated value for []',
+      ).toBeNull();
+      expect(
+        container.querySelector('[data-testid="boolean-warning-badge"]'),
+        'active: an "Off" badge would be a fabricated `false` for []',
+      ).toBeNull();
+      expectAffordance(container, 'active');
+    });
+
+    for (const type of ['number', 'slider', 'rating', 'currency'] as const) {
+      it(`THE DEFECT — \`${type}\` holding [] prints no digit (\`Number('')\` is 0, the record holds no zero)`, () => {
+        const { container } = renderCell(type, []);
+        expect(
+          within(container).queryAllByText('0').length,
+          `${type}: the digit 0 is a fabricated value for []`,
+        ).toBe(0);
+        expectAffordance(container, type);
+      });
+    }
+
+    for (const type of ['percent', 'progress'] as const) {
+      it(`THE DEFECT — \`${type}\` holding [] draws no progress bar`, () => {
+        const { container } = renderCell(type, []);
+        expect(
+          container.querySelector('[role="progressbar"]'),
+          `${type}: a 0% progress bar is a fabricated value for []`,
+        ).toBeNull();
+        expect(
+          within(container).queryAllByText('0%').length,
+          `${type}: the text 0% is a fabricated value for []`,
+        ).toBe(0);
+        expectAffordance(container, type);
+      });
+    }
+
+    for (const type of ['email', 'url', 'phone'] as const) {
+      it(`THE DEFECT — \`${type}\` holding [] renders no anchor (a link with nothing to link to)`, () => {
+        const { container } = renderCell(type, []);
+        expect(
+          container.querySelector('a'),
+          `${type}: a live anchor with an empty target is a fabricated affordance for []`,
+        ).toBeNull();
+        expect(
+          container.querySelector('button'),
+          `${type}: a copy button for nothing is a fabricated affordance for []`,
+        ).toBeNull();
+        expectAffordance(container, type);
+      });
+    }
+
+    it('THE DEFECT — `color` holding [] draws no swatch', () => {
+      const { container } = renderCell('color', []);
+      expect(
+        container.querySelector('[aria-hidden="true"]'),
+        'color: a bordered swatch box with no colour is a fabricated value for []',
+      ).toBeNull();
+      expect(
+        container.querySelector('.font-mono'),
+        'color: an empty hex span is a fabricated value for []',
+      ).toBeNull();
+      expectAffordance(container, 'color');
+    });
+
+    it('THE DEFECT (adjacent ninth) — `date` holding [] renders the shared affordance, not a hand-rolled em-dash', () => {
+      const { container } = renderCell('date', []);
+      // Value-span absence FIRST: on the unfixed tree this is the sentence
+      // that fails; a harness that has lost the affordance's `data-slot`
+      // passes it and fails on the dash-ownership sentence below instead.
+      expect(
+        container.querySelector('span.tabular-nums'),
+        'date: the value span must not be drawn around nothing',
+      ).toBeNull();
+      expect(
+        handRolledDashes(container).length,
+        'date: the em-dash must be the shared affordance, not a bare span a screen reader cannot name',
+      ).toBe(0);
+      expectAffordance(container, 'date');
+    });
+  });
+
+  describe('POPULATED — these refuse an EMPTY-for-everything implementation', () => {
+    it('POPULATED — a real `true` is still a CHECKED checkbox', () => {
+      const { container } = renderCell('boolean', true);
+      const box = container.querySelector('[role="checkbox"]');
+      expect(box, 'boolean: a real true must still draw its checkbox').not.toBeNull();
+      expect(box?.getAttribute('aria-checked'), 'boolean: a real true must still be checked').toBe('true');
+      expect(affordance(container), 'boolean: a real true must NOT render the affordance').toBeNull();
+    });
+
+    it('POPULATED — a real `false` is still an UNCHECKED checkbox (false is a value, not an absence)', () => {
+      const { container } = renderCell('boolean', false);
+      const box = container.querySelector('[role="checkbox"]');
+      expect(box, 'boolean: a real false must still draw its checkbox').not.toBeNull();
+      expect(box?.getAttribute('aria-checked'), 'boolean: a real false must still be unchecked').toBe('false');
+      expect(affordance(container), 'boolean: a real false must NOT render the affordance').toBeNull();
+    });
+
+    it('POPULATED — a completion field holding a real `true` still draws "Completed"', () => {
+      const { container } = renderCell('boolean', true, { name: 'completed' });
+      const indicator = container.querySelector('[data-testid="completion-indicator"]');
+      expect(indicator, 'completed: a real true must still draw the indicator').not.toBeNull();
+      expect(indicator?.getAttribute('aria-label'), 'completed: a real true reads "Completed"').toBe('Completed');
+    });
+
+    it('POPULATED — an active field holding a real `false` still draws its "Off" badge', () => {
+      const { container } = renderCell('boolean', false, { name: 'active' });
+      expect(
+        container.querySelector('[data-testid="boolean-warning-badge"]'),
+        'active: a real false must still draw the Off badge',
+      ).not.toBeNull();
+    });
+
+    it('POPULATED — a real stored `0` still prints as 0 in number, currency and percent', () => {
+      const num = renderCell('number', 0);
+      expect(within(num.container).queryAllByText('0').length, 'number: a real 0 must still print').toBe(1);
+      expect(affordance(num.container), 'number: a real 0 must NOT render the affordance').toBeNull();
+      cleanup();
+
+      const cur = renderCell('currency', 0);
+      expect(within(cur.container).queryAllByText('0').length, 'currency: a real 0 must still print').toBe(1);
+      expect(affordance(cur.container), 'currency: a real 0 must NOT render the affordance').toBeNull();
+      cleanup();
+
+      const pct = renderCell('percent', 0);
+      const bar = pct.container.querySelector('[role="progressbar"]');
+      expect(bar, 'percent: a real 0 must still draw its bar').not.toBeNull();
+      expect(bar?.getAttribute('aria-valuenow'), 'percent: a real 0 is a 0% bar').toBe('0');
+      expect(within(pct.container).queryAllByText('0%').length, 'percent: a real 0 must still print 0%').toBe(1);
+      expect(affordance(pct.container), 'percent: a real 0 must NOT render the affordance').toBeNull();
+    });
+
+    it('POPULATED — a non-zero number still prints', () => {
+      const { container } = renderCell('number', 42);
+      expect(within(container).queryAllByText('42').length, 'number: 42 must still print').toBe(1);
+      expect(affordance(container), 'number: 42 must NOT render the affordance').toBeNull();
+    });
+
+    it('POPULATED — a real address still links (mailto:, plain href, tel:)', () => {
+      const email = renderCell('email', 'ada@example.com');
+      const mail = email.container.querySelector('a');
+      expect(mail, 'email: a real address must still draw its anchor').not.toBeNull();
+      expect(mail?.getAttribute('href'), 'email: a real address still links').toBe('mailto:ada@example.com');
+      expect(affordance(email.container), 'email: a real address must NOT render the affordance').toBeNull();
+      cleanup();
+
+      const url = renderCell('url', 'https://example.com/');
+      const link = url.container.querySelector('a');
+      expect(link, 'url: a real URL must still draw its anchor').not.toBeNull();
+      expect(link?.getAttribute('href'), 'url: a real URL still links').toBe('https://example.com/');
+      expect(affordance(url.container), 'url: a real URL must NOT render the affordance').toBeNull();
+      cleanup();
+
+      const phone = renderCell('phone', '+1 555 0100');
+      const tel = phone.container.querySelector('a');
+      expect(tel, 'phone: a real number must still draw its anchor').not.toBeNull();
+      expect(tel?.getAttribute('href'), 'phone: a real number still links').toBe('tel:+1 555 0100');
+      expect(affordance(phone.container), 'phone: a real number must NOT render the affordance').toBeNull();
+    });
+
+    it('POPULATED — a ONE-entry array of addresses is a value: it still links', () => {
+      // Refuses an over-correction spelled `Array.isArray` rather than "is
+      // there anything to link to": `['ada@example.com']` coerces to the
+      // address and links exactly as the scalar does.
+      const { container } = renderCell('email', ['ada@example.com']);
+      expect(
+        container.querySelector('a')?.getAttribute('href'),
+        'email: a one-entry array still links to its one address',
+      ).toBe('mailto:ada@example.com');
+      expect(affordance(container), 'email: a one-entry array must NOT render the affordance').toBeNull();
+    });
+
+    it('POPULATED — a real colour still draws its swatch and its hex', () => {
+      const { container } = renderCell('color', '#ff0000');
+      expect(
+        container.querySelector('[aria-hidden="true"]'),
+        'color: a real colour must still draw its swatch',
+      ).not.toBeNull();
+      expect(within(container).queryAllByText('#ff0000').length, 'color: a real colour prints its hex').toBe(1);
+      expect(affordance(container), 'color: a real colour must NOT render the affordance').toBeNull();
+    });
+
+    it('POPULATED — a real date still renders in its value span', () => {
+      const { container } = renderCell('date', '2024-01-15T00:00:00.000Z', { format: 'short' });
+      const span = container.querySelector('span.tabular-nums');
+      expect(span, 'date: a real date must still draw its value span').not.toBeNull();
+      expect(span?.textContent, 'date: a real date must render a formatted value').toMatch(/24/);
+      expect(handRolledDashes(container).length, 'date: a real date draws no dash').toBe(0);
+      expect(affordance(container), 'date: a real date must NOT render the affordance').toBeNull();
+    });
+  });
+
+  describe('THE BOUNDARY — what this change deliberately does and does not sweep', () => {
+    it("THE BOUNDARY — a stored '' in the number family is swept in: it is the SAME `Number('')` fabrication", () => {
+      // Declared, not incidental. `''` reaches the identical coercion `[]`
+      // does, so a guard that let it through would keep printing a zero the
+      // record never held one input-shape over.
+      for (const type of ['number', 'currency', 'percent'] as const) {
+        const { container } = renderCell(type, '');
+        expect(
+          within(container).queryAllByText(/^0%?$/).length,
+          `${type}: a stored '' must not print a fabricated zero either`,
+        ).toBe(0);
+        expectAffordance(container, `${type} holding ''`);
+        cleanup();
+      }
+    });
+
+    it("THE BOUNDARY — a one-entry array holding '' has no address either: the test is on the coerced text", () => {
+      const { container } = renderCell('email', ['']);
+      expect(container.querySelector('a'), "email: [''] has nothing to link to").toBeNull();
+      expectAffordance(container, "email holding ['']");
+    });
+
+    it('THE BOUNDARY — `boolean` still reads a scalar by truthiness: `0` is an unchecked box, not the affordance', () => {
+      // The boolean ruling moves `[]` ONLY. Whether other non-boolean scalars
+      // should surface as a coercion error is a separate question the card
+      // names and this change does not answer.
+      const { container } = renderCell('boolean', 0);
+      expect(
+        container.querySelector('[role="checkbox"]')?.getAttribute('aria-checked'),
+        'boolean: a scalar 0 still draws an unchecked checkbox',
+      ).toBe('false');
+      expect(affordance(container), 'boolean: a scalar 0 is not swept into the empty-array fix').toBeNull();
+    });
+
+    it('THE BOUNDARY — `json` still draws the literal and `file` still states its count (objectui#8481 fence, unchanged)', () => {
+      const json = renderCell('json', []);
+      expect(within(json.container).queryAllByText('[]').length, '`json` holding [] still prints the literal').toBe(1);
+      cleanup();
+      const file = renderCell('file', []);
+      expect(within(file.container).queryAllByText('0 files').length, '`file` holding [] still states a count').toBe(1);
+    });
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -373,6 +373,30 @@ export function coerceToSafeValue(value: unknown): string | number | boolean | n
 }
 
 /**
+ * A coerced cell text with nothing in it is NOT a cell value (objectui#8490).
+ *
+ * `coerceToSafeValue([])` joins zero entries into `''`, and every renderer
+ * below that fed that string on to a coercion drew something the record never
+ * held: `Number('')` is `0`, so the number / currency / percent family printed
+ * a digit (and a 0% progress bar); the email / url / phone family wrapped it
+ * in a live anchor whose `href` was `mailto:` / `tel:` / nothing; and
+ * `DateCellRenderer` handed it to `formatDate`, whose own hand-rolled em-dash
+ * is a bare punctuation mark to a screen reader. A stored `''` reaches the
+ * same `Number('')` fabrication one input-shape over, so the test is on the
+ * coerced TEXT, not on the array: there is no number, address or date in a
+ * blank string, whatever produced it. Whitespace counts as blank for the same
+ * reason — `Number('  ')` is `0` too.
+ *
+ * ⛔ Not the package's general emptiness predicate — see `isEmptyMultiValue`
+ * below for why there is none. This answers ONE question for the renderers
+ * that coerce to text before they draw: "did the coercion leave anything to
+ * draw?". `BooleanCellRenderer` does not coerce to text and does not ask it.
+ */
+function isBlankCellText(safe: ReturnType<typeof coerceToSafeValue>): boolean {
+  return safe == null || (typeof safe === 'string' && safe.trim() === '');
+}
+
+/**
  * Format currency value. When `currency` is undefined, falls back to a
  * plain number with thousands separators (no symbol). Silently assuming
  * USD for unconfigured currency fields was the #1 source of "why is my
@@ -638,9 +662,12 @@ export function NumberCellRenderer({ value, field }: CellRendererProps): React.R
   // and set must not change the hook count between renders (same rule as
   // CurrencyCellRenderer below).
   const locale = useDisplayLocale();
-  if (value == null) return <EmptyValue />;
-
   const safe = coerceToSafeValue(value);
+  // Tested on the coerced text, not on `value == null` (objectui#8490): `[]`
+  // and `''` both coerce to `''`, and `Number('')` is `0` — a digit the record
+  // never held, indistinguishable from a real stored zero.
+  if (isBlankCellText(safe)) return <EmptyValue />;
+
   const numField = field as any;
   // Decimal places come from `scale` (the `s` in a `decimal(p, s)` column),
   // NOT `precision` — `precision` is the TOTAL digit count (`p`), and reading
@@ -679,9 +706,11 @@ export function CurrencyCellRenderer({ value, field }: CellRendererProps): React
   // null and set must not change the hook count between renders.
   const { currency: tenantCurrency } = useLocalization();
   const locale = useDisplayLocale();
-  if (value == null) return <EmptyValue />;
-
   const safe = coerceToSafeValue(value);
+  // Same fabrication as `NumberCellRenderer` (objectui#8490), one step worse:
+  // a currency column sums and aligns a fabricated `0` like money.
+  if (isBlankCellText(safe)) return <EmptyValue />;
+
   // Resolve the display currency via the shared precedence: field `currency` →
   // `currencyConfig.defaultCurrency` → the tenant default (ADR-0053). When none
   // is known, render a plain number — never a guessed symbol (silently assuming
@@ -706,9 +735,11 @@ export function PercentCellRenderer({ value, field }: CellRendererProps): React.
   // and set must not change the hook count between renders (same rule as
   // NumberCellRenderer / CurrencyCellRenderer above).
   const locale = useDisplayLocale();
-  if (value == null) return <EmptyValue />;
-
   const safe = coerceToSafeValue(value);
+  // Same fabrication as `NumberCellRenderer` (objectui#8490): `[]` drew a 0%
+  // progress bar with a `progressbar` role and `aria-valuenow` of 0.
+  if (isBlankCellText(safe)) return <EmptyValue />;
+
   const percentField = field as any;
   const precision = percentField.precision ?? 0;
   const numValue = Number(safe);
@@ -776,7 +807,14 @@ const STATUS_FIELD_NAMES = new Set([
  * and warning badge for active/enabled fields when false.
  */
 export function BooleanCellRenderer({ value, field }: CellRendererProps): React.ReactElement {
-  if (value == null) {
+  // `[]` is not a boolean and holds no entries, so a boolean column holding it
+  // holds NO value — not `false` (objectui#8490). `[]` is truthy, so before
+  // this guard every branch below read it as `true`: a plain field drew a
+  // CHECKED checkbox, a completion field drew the green "Completed" indicator,
+  // and an `active`-style field skipped its "Off" badge — an affirmative
+  // answer the record never gave. `false` stays a value (an unchecked box);
+  // scalar coercions (`0`, `''`, `'false'`, `{}`) are untouched by this guard.
+  if (value == null || isEmptyMultiValue(value)) {
     return <span className="flex items-center justify-center"><EmptyValue /></span>;
   }
 
@@ -831,6 +869,10 @@ export function DateCellRenderer({ value, field }: CellRendererProps): React.Rea
   const t = useFieldTranslate();
   if (!value) return <EmptyValue />;
   const safe = coerceToSafeValue(value);
+  // `[]` is truthy, so it passed the guard above and reached `formatDate` as
+  // `''`, whose own em-dash is a bare punctuation mark with no accessible
+  // name (objectui#8490). The shared affordance says "No value" instead.
+  if (isBlankCellText(safe)) return <EmptyValue />;
   const dateField = field as any;
   const style = dateField.format || 'relative';
 
@@ -1450,8 +1492,12 @@ export function getSemanticHex(name?: string, fallback: string = '#3b82f6'): str
  * (objectui#8474 measured and kept that), `FileCellRenderer` states "0 files",
  * `BooleanCellRenderer` treats `false` as a value while `DateCellRenderer`'s
  * `!value` treats the epoch as empty. This helper answers ONE question — "is
- * this a multi-value container with no entries to draw?" — for the three
- * renderers that ask it. Unifying the rest is a separate, contested change.
+ * this a multi-value container with no entries to draw?" — for the renderers
+ * that ask it: the three below and, since objectui#8490, `BooleanCellRenderer`
+ * (a boolean column holding `[]` holds no boolean). The renderers that coerce
+ * to text before they draw ask `isBlankCellText` instead — the same ruling,
+ * taken on the coerced string. Unifying the rest is a separate, contested
+ * change.
  */
 function isEmptyMultiValue(value: unknown): boolean {
   return Array.isArray(value) && value.length === 0;
@@ -1562,7 +1608,12 @@ export function EmailCellRenderer({ value }: CellRendererProps): React.ReactElem
   const [copied, setCopied] = React.useState(false);
   if (!value) return <EmptyValue />;
 
-  const safe = String(coerceToSafeValue(value) ?? '');
+  const coerced = coerceToSafeValue(value);
+  // `[]` is truthy and coerces to `''`, which used to become a live anchor
+  // with `href="mailto:"` and no text — an affordance with nothing to link to
+  // (objectui#8490). No address, no link.
+  if (isBlankCellText(coerced)) return <EmptyValue />;
+  const safe = String(coerced);
 
   const handleCopy = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -1608,8 +1659,13 @@ export function EmailCellRenderer({ value }: CellRendererProps): React.ReactElem
  */
 export function UrlCellRenderer({ value }: CellRendererProps): React.ReactElement {
   if (!value) return <EmptyValue />;
-  
-  const safe = String(coerceToSafeValue(value) ?? '');
+
+  const coerced = coerceToSafeValue(value);
+  // `[]` used to become a `target="_blank"` anchor with an EMPTY `href`
+  // (objectui#8490) — same ruling as `EmailCellRenderer`: nothing to link to,
+  // no link.
+  if (isBlankCellText(coerced)) return <EmptyValue />;
+  const safe = String(coerced);
   return (
     <Button
       variant="link"
@@ -1637,7 +1693,11 @@ export function PhoneCellRenderer({ value }: CellRendererProps): React.ReactElem
   const [copied, setCopied] = React.useState(false);
   if (!value) return <EmptyValue />;
 
-  const safe = String(coerceToSafeValue(value) ?? '');
+  const coerced = coerceToSafeValue(value);
+  // `[]` used to become a live `href="tel:"` anchor with no number
+  // (objectui#8490) — same ruling as `EmailCellRenderer`.
+  if (isBlankCellText(coerced)) return <EmptyValue />;
+  const safe = String(coerced);
 
   const handleCopy = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -2252,8 +2312,12 @@ export function JsonCellRenderer({ value }: CellRendererProps): React.ReactEleme
  * Renders a `color` value as a swatch alongside its hex/string value.
  */
 export function ColorSwatchCellRenderer({ value }: CellRendererProps): React.ReactElement {
-  if (value == null || value === '') return <EmptyValue />;
+  if (value == null) return <EmptyValue />;
   const color = String(value);
+  // `String([])` is `''`, which used to draw a bordered swatch box with no
+  // background colour beside an empty text span (objectui#8490): a swatch
+  // with no colour is not a colour.
+  if (isBlankCellText(color)) return <EmptyValue />;
   return (
     <span className="inline-flex items-center gap-1.5 text-sm">
       <span

--- a/packages/plugin-grid/src/__tests__/fabricatedValueCell-8490.test.tsx
+++ b/packages/plugin-grid/src/__tests__/fabricatedValueCell-8490.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8490, consumer half — the fabricated value reached a real grid.
+ *
+ * `ObjectGrid` resolves its cell renderers through `getCellRenderer(...)` and
+ * calls them with the RAW value, so a `boolean` column holding `[]` painted a
+ * CHECKED, disabled checkbox in a real row, and a `number` column holding `[]`
+ * printed the digit `0` — each an assertion about the record that the record
+ * never made. The renderer half of the evidence lives in `@object-ui/fields`'
+ * `cellRenderers.fabricatedValue-8490.test.tsx`; this file pins the surface.
+ *
+ * Both widths are rendered for the same reason objectui#8481's consumer pin
+ * does: the sub-768px card layout resolves its own renderers, so it is a
+ * second read path.
+ *
+ * ⚠️ The DISCRIMINATING case is the populated row in the SAME grid — a real
+ * `true` still checked, a real stored `0` still printed. An EMPTY-for-
+ * everything implementation passes every `[]` case here and fails only that.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach, beforeAll, vi } from 'vitest';
+import { render, screen, waitFor, cleanup, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ActionProvider, SchemaRendererProvider } from '@object-ui/react';
+import { registerAllFields } from '@object-ui/fields';
+import { ObjectGrid } from '../ObjectGrid';
+
+registerAllFields();
+
+/** One row whose boolean and number are `[]`, one whose are real values. */
+const ROWS = [
+  { id: 'r1', name: 'Row one', is_active: [] as unknown[], amount: [] as unknown[] },
+  { id: 'r2', name: 'Row two', is_active: true, amount: 0 },
+];
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async () => ({ data: ROWS, total: ROWS.length, hasMore: false, pageSize: 50 })),
+    getObjectSchema: vi.fn(async (name: string) => ({
+      name,
+      fields: {
+        id: { type: 'text' },
+        name: { type: 'text', label: 'Name' },
+        is_active: { type: 'boolean', label: 'Active' },
+        amount: { type: 'number', label: 'Amount' },
+      },
+    })),
+  } as any;
+}
+
+const ORIGINAL_INNER_WIDTH = window.innerWidth;
+
+function setWidth(px: number) {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: px });
+}
+
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn() as any;
+  }
+});
+
+afterEach(() => {
+  setWidth(ORIGINAL_INNER_WIDTH);
+  cleanup();
+});
+
+function renderGrid() {
+  const ds = makeDataSource();
+  return render(
+    <ActionProvider>
+      <SchemaRendererProvider dataSource={ds}>
+        <ObjectGrid
+          schema={{
+            type: 'object-grid',
+            objectName: 'test_object',
+            columns: [
+              { field: 'name', label: 'Name' },
+              { field: 'is_active', label: 'Active', type: 'boolean' },
+              { field: 'amount', label: 'Amount', type: 'number' },
+            ],
+            pagination: { pageSize: 50 },
+          } as any}
+          dataSource={ds}
+        />
+      </SchemaRendererProvider>
+    </ActionProvider>,
+  );
+}
+
+/** Every lookup below is SCOPED TO ONE ROW (objectui#8481's measured lesson). */
+function rowOf(label: string): HTMLElement {
+  const cell = screen.getByText(label);
+  const row = cell.closest('tr') ?? cell.closest('[role="row"]') ?? cell.parentElement;
+  if (!row) throw new Error(`no row found for ${label}`);
+  return row as HTMLElement;
+}
+
+const affordances = (root: HTMLElement) =>
+  Array.from(root.querySelectorAll<HTMLElement>('[data-slot="empty-value"]'));
+
+describe('objectui#8490 — ObjectGrid fabricates no value for an empty array', () => {
+  it('DESKTOP — a boolean column holding [] draws no checkbox and a number column holding [] prints no 0', async () => {
+    setWidth(1280);
+    renderGrid();
+    await waitFor(() => expect(screen.queryByText('Row one')).not.toBeNull());
+    const emptyRow = rowOf('Row one');
+
+    expect(
+      emptyRow.querySelector('[role="checkbox"]'),
+      'desktop grid: the [] boolean cell must not draw a checkbox (a checked one was the objectui#8490 defect)',
+    ).toBeNull();
+    expect(
+      within(emptyRow).queryAllByText('0').length,
+      'desktop grid: the [] number cell must not print a fabricated 0',
+    ).toBe(0);
+    expect(
+      affordances(emptyRow).length,
+      'desktop grid: the two [] cells must each carry the No-value affordance',
+    ).toBe(2);
+    expect(
+      affordances(emptyRow)[0]?.getAttribute('aria-label'),
+      'desktop grid: the affordance must carry its accessible name',
+    ).toBe('No value');
+  });
+
+  it('⚠️ DISCRIMINATING — the POPULATED row in the SAME desktop grid still checks its box and prints its 0', async () => {
+    setWidth(1280);
+    renderGrid();
+    await waitFor(() => expect(screen.queryByText('Row two')).not.toBeNull());
+    const filledRow = rowOf('Row two');
+
+    const box = filledRow.querySelector('[role="checkbox"]');
+    expect(box, 'the populated row must still draw its checkbox').not.toBeNull();
+    expect(box?.getAttribute('aria-checked'), 'a real true is still checked').toBe('true');
+    expect(
+      within(filledRow).queryAllByText('0').length,
+      'a real stored 0 must still print',
+    ).toBe(1);
+    expect(
+      affordances(filledRow).length,
+      'the populated row has nothing empty in it, so it carries no affordance',
+    ).toBe(0);
+  });
+
+  it('MOBILE CARD VIEW — the same columns below the 768px breakpoint draw no checkbox for [] and keep the real one', async () => {
+    setWidth(390);
+    renderGrid();
+    await waitFor(() => expect(screen.queryByText('Row one')).not.toBeNull());
+    const emptyCard = rowOf('Row one');
+    const filledCard = rowOf('Row two');
+
+    expect(
+      emptyCard.querySelector('[role="checkbox"]'),
+      'mobile card view: the [] boolean must not draw a checkbox',
+    ).toBeNull();
+    expect(
+      affordances(emptyCard).length,
+      'mobile card view: the [] card must carry a No-value affordance',
+    ).toBeGreaterThan(0);
+    expect(
+      filledCard.querySelector('[role="checkbox"]')?.getAttribute('aria-checked'),
+      'mobile card view: the populated card still draws its checked box',
+    ).toBe('true');
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectui#8490

## What this changes

Eight cell renderers in `@object-ui/fields` (twelve field types) drew a value the record does not hold when the stored value was `[]`, and a ninth drew a placeholder that was not the shared one. They now render the shared `EmptyValue` affordance — the muted em-dash carrying a `No value` accessible name — exactly as they already did for `null`. One consumer pin in `plugin-grid` covers both grid widths. Tag-shaped fragments are spelled in words throughout this body (the GitHub sanitizer eats them, even inside backticks).

## The census was re-derived first — the card's eight are still eight

Measured by rendering **every registered field type** (53 keys, extracted from `getCellRenderer`'s map at test time so a new key cannot be missed) against `[]`, `{}`, `''` and `null` on `e411c3e58`, the merge base. The three shas in the brief were each verified as ancestors of that base (`merge-base --is-ancestor` exit 0, which is the self-proving direction; not shallow). `639ca9dc0` (the objectui#8481 landing) moved **none** of the eight: all twelve types in the card's table still fabricated, and the ninth `date` row still drew `formatDate`'s private dash. So the PR keeps the card's shape.

| field types | renderer | rendered for `[]` on `e411c3e58` | now |
|---|---|---|---|
| `boolean`, `toggle` | `BooleanCellRenderer` | a CHECKED disabled checkbox, `aria-checked` true; a completion-named field drew the green "Completed" indicator | `EmptyValue` |
| `number`, `slider`, `rating` | `NumberCellRenderer` | the digit `0` | `EmptyValue` |
| `currency` | `CurrencyCellRenderer` | the digit `0` | `EmptyValue` |
| `percent`, `progress` | `PercentCellRenderer` | a 0% bar with a `progressbar` role, `aria-valuenow` 0, and the text `0%` | `EmptyValue` |
| `email` | `EmailCellRenderer` | a live anchor with `href` of `mailto:` and no text, plus a "Copy email" button | `EmptyValue` |
| `url` | `UrlCellRenderer` | a live `_blank` anchor with an empty `href` | `EmptyValue` |
| `phone` | `PhoneCellRenderer` | a live anchor with `href` of `tel:` and a phone icon, plus a copy button | `EmptyValue` |
| `color` | `ColorSwatchCellRenderer` | a bordered swatch box with no background colour beside an empty hex span | `EmptyValue` |
| `date` (adjacent ninth) | `DateCellRenderer` | a SPAN classed `tabular-nums` with an empty `title` holding a bare em-dash | `EmptyValue` |

Re-running the same census on the fixed tree and diffing cell by cell: **19 of 212 cells moved, 193 unchanged.** The 19 are the 13 types above on `[]`, plus the six number-family types on `''` (the declared sweep below). `{}` moved nowhere.

One correction to the record while measuring: objectui#8481's narrative said `plugin-detail` was already protected by `hasCellValue`. It is not — `hasCellValue` returns `true` for every non-null object, arrays included (it delegates object values to the cell renderers by design), so `DetailSection` reached these renderers with `[]` too and the checked checkbox was on the record page as well as the grid. Only `RelatedList`'s `isValueEmpty` pre-checks arrays. The fix being in the shared renderer covers both.

## The ruling is per renderer, not one predicate

The card asked for this distinction explicitly. Every row lands on `EmptyValue`, but for different reasons and with different sweep widths — and `No value` is a **true** statement at each site, because in each case the record holds no value of the field's type:

- **`boolean` / `toggle`** — `[]` is not a boolean and holds no entries, so the column holds *no value*, not `false`. Only `[]` moves (`isEmptyMultiValue`, the objectui#8481 helper, now with a fourth caller). A real `false` is still an unchecked box; an `active`-named field holding a real `false` still draws its "Off" badge. Scalar truthiness coercions (`0`, `''`, `'false'`, `{}`) are untouched by this guard — that is a separate decision, recorded as objectui#8582.
- **`number` / `slider` / `rating` / `currency` / `percent` / `progress`** — the `0` was `Number('')`, a JavaScript coercion artefact, not a stored zero. The guard is therefore on the coerced *text* (`isBlankCellText`: null, or a string that trims to nothing), which **deliberately also sweeps a stored `''` and whitespace** — the identical fabrication one input shape over. Declared and pinned. A real stored `0` still prints `0` / `0%` with its bar.
- **`email` / `url` / `phone`** — nothing to link to means no anchor and no copy button in the DOM. `['']` has no address either; `['ada@example.com']` still links (the test is on the coerced text, not on `Array.isArray`).
- **`color`** — no colour string means no swatch.
- **`date`** — the coerced-empty branch reaches the shared affordance instead of `formatDate`'s private dash. An *unparsable* string still takes that dash today; that is a decision (`DateTimeCellRenderer` already answers it with the affordance) and is filed as objectui#8581.

## Evidence — every leg was run, none predicted

`packages/fields/src/__tests__/cellRenderers.fabricatedValue-8490.test.tsx` — 29 cases in three blocks: THE DEFECT (15 `[]` cases, each asserting the fabricated artefact's **absence first**, then the affordance), POPULATED (10 load-bearing cases), THE BOUNDARY (4). Each `[]` case is ordered so that its failure on the unfixed tree and its failure under a dead harness land on different sentences.

Three ablation legs, each run against the committed implementation (`index.tsx` blob `b4d6dfe48`), each mutation proven on disk in both directions before the run and restored **by state** afterwards (`git diff HEAD` empty; `git hash-object` of the path equal to the HEAD blob; trap on `EXIT INT TERM` with absolute paths). No dist preflight was needed and that is declared: the root vitest config aliases every `@object-ui/*` specifier to `src`, so both the mutation and the restore are live without a build.

| leg | mutation (on-disk proof) | result | failure sentences (distinct per leg) |
|---|---|---|---|
| **A — red before** | base `index.tsx` swapped in (`isBlankCellText` count 0, base-only guard line count 3, 3338 lines) | **17 fail / 12 pass** | `boolean: a checked checkbox is a fabricated value for []`, `number: the digit 0 is a fabricated value for []`, `percent: a 0% progress bar is a fabricated value for []`, `email: a live anchor with an empty target is a fabricated affordance for []`, `color: a bordered swatch box with no colour is a fabricated value for []`, `date: the value span must not be drawn around nothing`, plus the two `''` / `['']` boundary sentences. All 10 POPULATED cases pass on the base — they measure what the base already did right. |
| **B — the caricature** | nine renderers return `EmptyValue` unconditionally (`ABLATION-8490` marker count 9) | **11 fail / 18 pass** | exactly the 10 POPULATED cases plus the `boolean` scalar-`0` boundary, each on its own sentence: `boolean: a real true must still draw its checkbox`, `boolean: a real false must still draw its checkbox`, `completed: a real true must still draw the indicator`, `active: a real false must still draw the Off badge`, `number: a real 0 must still print`, `email: a real address must still draw its anchor`, `email: a one-entry array still links to its one address`, `color: a real colour must still draw its swatch`, `date: a real date must still draw its value span`. **Survivors, declared as scope:** the 15 `[]` cases and three boundary cases pass under the caricature *by design* — they cannot discriminate it, which is why the POPULATED block exists. |
| **C — harness kill** | `data-slot="empty-value"` renamed in `components/src/custom/empty.tsx` (KILLED count 1, original 0) | **17 fail / 12 pass** | every `[]` case on `…: the shared EmptyValue affordance must be present` (the `date` row on `the em-dash must be the shared affordance, not a bare span…`) — a different sentence from leg A on every row, proving the defect assertions do not navigate by the thing the caricature erases. |

Harness-death signatures (`Cannot read properties of null`, `Unable to find`, `TypeError`, `is not a function`) counted in every leg's log: **0** in A, B and C — every failure is the discriminating assertion's own message.

Recorded for honesty: the first attempt at leg A was a **null operation**. The BASE file I wrote carried a `BASE=` prefix, `git show` failed on the malformed ref and wrote an *empty* `index.tsx`; all 29 cases failed with `TypeError: resolveCellRendererType is not a function`, and my on-disk gate only checked the deleted-text count (0) — the injected-text count was also 0. Discarded; redone with a gate on both counts and the line total. The restore-by-state check held on the null run too.

Consumer pin: `packages/plugin-grid/src/__tests__/fabricatedValueCell-8490.test.tsx` — desktop row with `is_active: []` / `amount: []` draws no checkbox and no `0` and carries two affordances; the populated row in the same grid still checks its box and prints its real `0`; the sub-768px card view repeats both.

## Verification

- `pnpm exec vitest run packages/fields/` — **140 files / 2399 tests passed** (command-exit 0 under the shared verify lock).
- `pnpm exec vitest run packages/plugin-grid/ packages/plugin-kanban/` — **149 files / 1250 tests passed**.
- `pnpm exec vitest run packages/plugin-detail/` — **143 files / 1281 tests passed**.
- `pnpm exec vitest run packages/plugin-dashboard/ packages/plugin-list/` plus, in the same run, the 30 test files elsewhere that name a fields cell renderer or `EmptyValue` (app-shell 24, plugin-gantt 3, plugin-view 1, plugin-report 1, console 1) — **201 files / 2020 tests passed**. Local total: 633 files / 6950 tests, every run with command-exit 0 under the shared verify lock.
- `pnpm --filter @object-ui/fields run type-check` — echoed `tsc --noEmit && tsc -p tsconfig.test.json`, exit 0, after building the dependency closure (`pnpm --filter '@object-ui/fields^...' build`). `tsc -p tsconfig.test.json --showConfig` lists the new test file (and the objectui#8481 control), so the test program covers it.
- `pnpm --filter @object-ui/fields lint` and `pnpm --filter @object-ui/plugin-grid lint` — 0 errors. eslint's own `--format json` counts 221 files linted in `fields` and 152 in `plugin-grid`; the population is each package's `eslint .`, and the config is not type-aware, so this diff cannot move a verdict in any file it did not touch — the untouched packages' lint is invariant and left to CI's `pnpm lint`. Warnings are the repo's pre-existing 935 / 784 at warn level: 0 of `index.tsx`'s 124 warning lines fall on the 78 lines this PR added (intersected against the `-U0` diff), and the two new test files carry five `no-explicit-any` warnings on the same `as any` harness shapes the objectui#8481 tests use.
- `check:control-bytes` OK (6770 files); `check-changeset-presence` OK; `check-changeset-fixed` OK; `check-governed-queue-guard --test` on the four paths: NOT GOVERNED; `check:unreferenced-sources` OK; `check-type-check-coverage` OK (45/46 via `type-check`, 42/42 test programs). `pnpm check` and the rest of `lint.yml`'s repo-wide scans go to CI.
- A Python zero-width / control-character scanner (with a lit control that must fire) over the three committed files read from git objects: 0 hits.

**Declared narrowing.** `turbo ls --affected` lists 20 packages. Run locally in full: `fields` and the read-mode cell surfaces (`plugin-grid`, `plugin-kanban`, `plugin-detail`, `plugin-dashboard`, `plugin-list`), plus the grep-selected files elsewhere. Sent to CI: `app-shell` (653 files), `console` (90), `plugin-form` (84 — it consumes field *widgets*, not the cell renderers this PR touches), and the rest of the affected list. Checkable reason: the diff changes only the bodies of nine cell renderers reached through `getCellRenderer` or direct import, and only for inputs whose coerced text is blank; the packages sent to CI reach those renderers only through the plugins run here.

## Boundary and out of scope

- `{}` is untouched everywhere (the objectui#8481 fence); `json` still draws the array literal and `file` still states `0 files` (pinned again here as THE BOUNDARY).
- Filed while measuring, none swept in: objectui#8580 (`markdown` / `html` / `richtext` paint a childless container for `[]` — the blank class, not this card's), objectui#8581 (`DateCellRenderer`'s dash for an unparsable string), objectui#8582 (`BooleanCellRenderer` reads `'false'` and `{}` as checked).
- Changeset: `patch` — a correction of false output, not a capability. No README or guide documents the empty-value behaviour of these renderers, so no docs moved.

Session: `session_01YBWFb5YgMU5dw8p2VKj16S` (written in prose so it survives a later edit of this body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_