### PR TITLE
fix(test-env): register the network-escape guard's afterEach per test file, not per worker (objectui#8537)

### DIFF
--- a/.changeset/8537-network-escape-guard-worker-coverage.md
+++ b/.changeset/8537-network-escape-guard-worker-coverage.md
@@ -1,0 +1,7 @@
+---
+---
+
+The network-escape guard's `afterEach` is now registered per test file in the
+`unit` project (`isolate: false`) instead of once per worker, so an escape in
+any file is red, not only one in the worker's first file (objectui#8537).
+Test harness only; no package is released by this change.

--- a/scripts/__tests__/network-escape-ledger.test.ts
+++ b/scripts/__tests__/network-escape-ledger.test.ts
@@ -33,6 +33,12 @@
  * wrapper and the `afterEach` that fails ANY escape in ANY file. Re-adding a
  * list is red here; deleting the guard while deleting the list is red here too.
  *
+ * "ANY file" has a registration-time condition of its own (objectui#8537): in
+ * the `unit` project the hook must be registered per test file through the
+ * guard's exported installer, called from `vitest.setup.base.ts`. That wiring is
+ * pinned below; the export list this file used to pin as EMPTY now holds exactly
+ * that installer.
+ *
  * ## How it reads the guard, and why not with a regex
  *
  * The absence assertions run over the guard's source with COMMENTS BLANKED, via
@@ -76,11 +82,19 @@ describe('the network-escape burn-down list stays retired (objectui#7307)', () =
     expect(guardCode, 'comment masking is not blanking comments').not.toContain(PROSE_ONLY);
   });
 
-  it('exports nothing — the ledger was its only export', () => {
+  it('exports exactly the installer, and no ledger', () => {
     // Runtime, not source: this is the SAME module instance the run is guarded
     // by (`vitest.setup.base.ts` imports it for every project), so a re-exported
     // list shows up here whatever the source looks like.
-    expect(Object.keys(guard as Record<string, unknown>).sort()).toEqual([]);
+    //
+    // This used to pin an EMPTY export list — the ledger was the only export
+    // the guard ever had. objectui#8537 added one on purpose: the `afterEach`
+    // has to be registered per test file, and under the `unit` project's
+    // `isolate: false` only a function CALLED from the setup file can do that
+    // (an imported module's body runs once per worker). Exactly that name, so a
+    // list coming back as a second export is still red here.
+    expect(Object.keys(guard as Record<string, unknown>).sort()).toEqual(['installNetworkEscapeGuard']);
+    expect(typeof guard.installNetworkEscapeGuard).toBe('function');
   });
 
   it('declares no allowlist of tolerated escapes in its code', () => {
@@ -131,5 +145,31 @@ describe('the STANDING guard survived the retirement (objectui#6640)', () => {
     expect(guardCode, 'the remedy the red points at').toContain(
       'Fix: serve the probe from a double rather than the network',
     );
+  });
+
+  it('registers that afterEach from the installer, and the setup file calls it (objectui#8537)', () => {
+    // "ANY file" is only true if the hook is registered per test file. In the
+    // `unit` project (`isolate: false`) this module's body runs once per worker,
+    // so a module-scope `afterEach(` here would cover the first file of each
+    // worker and no other — which is what it did until objectui#8537. So: the
+    // one `afterEach(` in the guard's CODE sits inside the exported installer,
+    // and `vitest.setup.base.ts` — a setup file Vitest re-executes per test
+    // file — calls it. The behavioural half (two escaping files in one worker,
+    // both red) is `network-escape-worker-coverage-8537.test.ts`.
+    const hooks = guardCode.match(/\bafterEach\(/g) ?? [];
+    expect(hooks, 'exactly one afterEach registration in the guard').toHaveLength(1);
+    const installerAt = guardCode.indexOf('export function installNetworkEscapeGuard(');
+    expect(installerAt, 'the installer is exported').toBeGreaterThan(-1);
+    expect(
+      guardCode.indexOf('afterEach('),
+      'the afterEach must be registered inside installNetworkEscapeGuard(), not at module scope',
+    ).toBeGreaterThan(installerAt);
+
+    const baseCode = maskComments(fs.readFileSync(path.join(repoRoot, 'vitest.setup.base.ts'), 'utf8'));
+    expect(baseCode, 'vitest.setup.base.ts must call the installer').toContain('installNetworkEscapeGuard();');
+    expect(
+      baseCode.includes("import './vitest.setup.network-escape-guard'"),
+      'a bare side-effect import of the guard registers no hook any more — call the installer',
+    ).toBe(false);
   });
 });

--- a/scripts/__tests__/network-escape-worker-coverage-8537.escape-a.test.ts
+++ b/scripts/__tests__/network-escape-worker-coverage-8537.escape-a.test.ts
@@ -1,0 +1,29 @@
+/**
+ * objectui#8537 — deliberate network-escape fixture (a of two).
+ *
+ * This file is one half of the LIVE CONTROL for
+ * `network-escape-worker-coverage-8537.test.ts`: that pin spawns a real vitest
+ * on the `unit` project with both fixtures in ONE worker, and every file must go
+ * red under the guard, naming itself. In the ordinary suite the escape below is
+ * skipped — the fixture is inert unless the pin's child marker is set, so it
+ * cannot red a normal run.
+ *
+ * The two fixtures are byte-identical apart from their tag, so a difference in
+ * their outcome can only come from their POSITION in the worker.
+ */
+import { it } from 'vitest';
+
+const IS_CHILD = process.env.OBJECTUI_ESCAPE_PIN_CHILD === '1';
+const MARK = '__objectui_escape_pin_8537__';
+const scope = globalThis as unknown as Record<string, unknown>;
+
+it.skipIf(!IS_CHILD)('fixture a reaches a real socket, on purpose', async () => {
+  // Leave a mark on the shared global object and report the other fixture's,
+  // so the pin can see that both files ran in ONE worker and which came second.
+  const seenOther = scope[MARK] === 'b' ? 'yes' : 'no';
+  scope[MARK] = 'a';
+  console.log(`ESCAPE_PIN_8537 file=a saw_other=${seenOther}`);
+  // The `unit` project is a node environment: no `location`, so only an
+  // ABSOLUTE URL at the escape origin can be an escape. Outcome irrelevant.
+  await fetch('http://localhost:3000/__objectui_escape_pin_8537__/a').catch(() => undefined);
+});

--- a/scripts/__tests__/network-escape-worker-coverage-8537.escape-a.test.ts
+++ b/scripts/__tests__/network-escape-worker-coverage-8537.escape-a.test.ts
@@ -10,10 +10,19 @@
  *
  * The two fixtures are byte-identical apart from their tag, so a difference in
  * their outcome can only come from their POSITION in the worker.
+ *
+ * Evidence that the escape RAN goes to a ledger file the pin names, not to the
+ * console: vitest's default reporter prints a passing test's console output
+ * nowhere, so a console line would be visible exactly when the test failed —
+ * a liveness control that can only fire on the outcome it is meant to be
+ * independent of (measured while writing the pin: under the defect the pin
+ * went red on "fixture b never ran" when b had run and passed silently).
  */
+import { appendFileSync } from 'node:fs';
 import { it } from 'vitest';
 
 const IS_CHILD = process.env.OBJECTUI_ESCAPE_PIN_CHILD === '1';
+const LEDGER = process.env.OBJECTUI_ESCAPE_PIN_LEDGER;
 const MARK = '__objectui_escape_pin_8537__';
 const scope = globalThis as unknown as Record<string, unknown>;
 
@@ -22,7 +31,7 @@ it.skipIf(!IS_CHILD)('fixture a reaches a real socket, on purpose', async () => 
   // so the pin can see that both files ran in ONE worker and which came second.
   const seenOther = scope[MARK] === 'b' ? 'yes' : 'no';
   scope[MARK] = 'a';
-  console.log(`ESCAPE_PIN_8537 file=a saw_other=${seenOther}`);
+  if (LEDGER) appendFileSync(LEDGER, `file=a saw_other=${seenOther}\n`);
   // The `unit` project is a node environment: no `location`, so only an
   // ABSOLUTE URL at the escape origin can be an escape. Outcome irrelevant.
   await fetch('http://localhost:3000/__objectui_escape_pin_8537__/a').catch(() => undefined);

--- a/scripts/__tests__/network-escape-worker-coverage-8537.escape-b.test.ts
+++ b/scripts/__tests__/network-escape-worker-coverage-8537.escape-b.test.ts
@@ -1,0 +1,29 @@
+/**
+ * objectui#8537 — deliberate network-escape fixture (b of two).
+ *
+ * This file is one half of the LIVE CONTROL for
+ * `network-escape-worker-coverage-8537.test.ts`: that pin spawns a real vitest
+ * on the `unit` project with both fixtures in ONE worker, and every file must go
+ * red under the guard, naming itself. In the ordinary suite the escape below is
+ * skipped — the fixture is inert unless the pin's child marker is set, so it
+ * cannot red a normal run.
+ *
+ * The two fixtures are byte-identical apart from their tag, so a difference in
+ * their outcome can only come from their POSITION in the worker.
+ */
+import { it } from 'vitest';
+
+const IS_CHILD = process.env.OBJECTUI_ESCAPE_PIN_CHILD === '1';
+const MARK = '__objectui_escape_pin_8537__';
+const scope = globalThis as unknown as Record<string, unknown>;
+
+it.skipIf(!IS_CHILD)('fixture b reaches a real socket, on purpose', async () => {
+  // Leave a mark on the shared global object and report the other fixture's,
+  // so the pin can see that both files ran in ONE worker and which came second.
+  const seenOther = scope[MARK] === 'a' ? 'yes' : 'no';
+  scope[MARK] = 'b';
+  console.log(`ESCAPE_PIN_8537 file=b saw_other=${seenOther}`);
+  // The `unit` project is a node environment: no `location`, so only an
+  // ABSOLUTE URL at the escape origin can be an escape. Outcome irrelevant.
+  await fetch('http://localhost:3000/__objectui_escape_pin_8537__/b').catch(() => undefined);
+});

--- a/scripts/__tests__/network-escape-worker-coverage-8537.escape-b.test.ts
+++ b/scripts/__tests__/network-escape-worker-coverage-8537.escape-b.test.ts
@@ -10,10 +10,19 @@
  *
  * The two fixtures are byte-identical apart from their tag, so a difference in
  * their outcome can only come from their POSITION in the worker.
+ *
+ * Evidence that the escape RAN goes to a ledger file the pin names, not to the
+ * console: vitest's default reporter prints a passing test's console output
+ * nowhere, so a console line would be visible exactly when the test failed —
+ * a liveness control that can only fire on the outcome it is meant to be
+ * independent of (measured while writing the pin: under the defect the pin
+ * went red on "fixture b never ran" when b had run and passed silently).
  */
+import { appendFileSync } from 'node:fs';
 import { it } from 'vitest';
 
 const IS_CHILD = process.env.OBJECTUI_ESCAPE_PIN_CHILD === '1';
+const LEDGER = process.env.OBJECTUI_ESCAPE_PIN_LEDGER;
 const MARK = '__objectui_escape_pin_8537__';
 const scope = globalThis as unknown as Record<string, unknown>;
 
@@ -22,7 +31,7 @@ it.skipIf(!IS_CHILD)('fixture b reaches a real socket, on purpose', async () => 
   // so the pin can see that both files ran in ONE worker and which came second.
   const seenOther = scope[MARK] === 'a' ? 'yes' : 'no';
   scope[MARK] = 'b';
-  console.log(`ESCAPE_PIN_8537 file=b saw_other=${seenOther}`);
+  if (LEDGER) appendFileSync(LEDGER, `file=b saw_other=${seenOther}\n`);
   // The `unit` project is a node environment: no `location`, so only an
   // ABSOLUTE URL at the escape origin can be an escape. Outcome irrelevant.
   await fetch('http://localhost:3000/__objectui_escape_pin_8537__/b').catch(() => undefined);

--- a/scripts/__tests__/network-escape-worker-coverage-8537.test.ts
+++ b/scripts/__tests__/network-escape-worker-coverage-8537.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
@@ -44,10 +45,18 @@ import { fileURLToPath } from 'node:url';
  * A spawn-based pin fails silently in two ways: the fixtures might not have
  * escaped at all (skipped, or the marker never reached the child), or they
  * might have landed in two workers, where the defect is invisible. So each
- * fixture prints a line when its escape RUNS, and reports whether it found the
- * other fixture's mark on the shared global object — which is only possible in
- * one worker, for the file that ran second. Exactly one `saw_other=yes` is the
- * reading that says "one worker, and one of these was not first in it".
+ * fixture writes a line to a LEDGER FILE when its escape RUNS, and reports
+ * whether it found the other fixture's mark on the shared global object — which
+ * is only possible in one worker, for the file that ran second. Exactly one
+ * `saw_other=yes` is the reading that says "one worker, and one of these was
+ * not first in it".
+ *
+ * A file, not the child's console, and that is measured: vitest's default
+ * reporter shows a passing test's console output nowhere, so a console-based
+ * liveness line is present exactly when the test FAILED. Under the defect the
+ * first draft of this pin went red on "fixture b never ran its escape" while b
+ * had run and passed silently — a red for the wrong reason, which is the shape
+ * the pin exists to refuse. The ledger is independent of the outcome.
  *
  * ## Recursion
  *
@@ -82,8 +91,12 @@ describe('objectui#8537 — the network-escape guard covers every file in a work
     expect(a.length).toBeGreaterThan(500);
     expect(a).not.toBe(b);
     expect(normalise(a)).toBe(normalise(b));
-    // And they are inert outside the child: the escape is behind the marker.
-    for (const src of [a, b]) expect(src).toContain("it.skipIf(!IS_CHILD)");
+    // And they are inert outside the child: the escape is behind the marker,
+    // and the liveness evidence goes to the ledger, not the console.
+    for (const src of [a, b]) {
+      expect(src).toContain('it.skipIf(!IS_CHILD)');
+      expect(src).toContain('appendFileSync(LEDGER');
+    }
   });
 
   it.skipIf(IS_CHILD)(
@@ -93,21 +106,35 @@ describe('objectui#8537 — the network-escape guard covers every file in a work
       // A fresh CLI, not a nested worker of this run.
       for (const key of Object.keys(env)) if (key.startsWith('VITEST')) delete env[key];
       env.OBJECTUI_ESCAPE_PIN_CHILD = '1';
+      const ledgerDir = fs.mkdtempSync(path.join(os.tmpdir(), 'objectui-escape-pin-8537-'));
+      const ledgerPath = path.join(ledgerDir, 'ledger.txt');
+      env.OBJECTUI_ESCAPE_PIN_LEDGER = ledgerPath;
 
-      const child = spawnSync(
-        process.execPath,
-        [vitestCli, 'run', '--project', 'unit', '--maxWorkers=1', '--fileParallelism=false', ...FIXTURES],
-        { cwd: repoRoot, encoding: 'utf8', env, timeout: 300_000 },
-      );
-      const output = `${child.stdout ?? ''}${child.stderr ?? ''}`;
+      const { output, status, ledger } = (() => {
+        try {
+          const child = spawnSync(
+            process.execPath,
+            [vitestCli, 'run', '--project', 'unit', '--maxWorkers=1', '--fileParallelism=false', ...FIXTURES],
+            { cwd: repoRoot, encoding: 'utf8', env, timeout: 300_000 },
+          );
+          return {
+            output: `${child.stdout ?? ''}${child.stderr ?? ''}`,
+            status: child.status,
+            ledger: fs.existsSync(ledgerPath) ? fs.readFileSync(ledgerPath, 'utf8') : '',
+          };
+        } finally {
+          fs.rmSync(ledgerDir, { recursive: true, force: true });
+        }
+      })();
 
-      // Live control 1: both escapes RAN (not skipped, not filtered out).
-      expect(output, 'fixture a never ran its escape').toContain('ESCAPE_PIN_8537 file=a');
-      expect(output, 'fixture b never ran its escape').toContain('ESCAPE_PIN_8537 file=b');
+      // Live control 1: both escapes RAN (not skipped, not filtered out) —
+      // read off the ledger, which does not depend on how the child ended.
+      expect(ledger, 'fixture a never ran its escape').toContain('file=a ');
+      expect(ledger, 'fixture b never ran its escape').toContain('file=b ');
       // Live control 2: ONE worker, and one of the two was not first in it.
       // Under `isolate: false` the second file sees the first file's mark on
       // the shared global; in two workers neither would.
-      const sawOther = output.match(/saw_other=yes/g) ?? [];
+      const sawOther = ledger.match(/saw_other=yes/g) ?? [];
       expect(sawOther, 'the fixtures did not share a worker, so the defect could not show').toHaveLength(1);
 
       // The claim: every file in the worker is covered — BOTH red, each
@@ -119,7 +146,7 @@ describe('objectui#8537 — the network-escape guard covers every file in a work
       for (const fixture of FIXTURES) {
         expect(output, `${fixture} was not named by the guard`).toContain(`  file: ${fixture}`);
       }
-      expect(child.status, 'an escape must fail the child run').toBe(1);
+      expect(status, 'an escape must fail the child run').toBe(1);
     },
     360_000,
   );

--- a/scripts/__tests__/network-escape-worker-coverage-8537.test.ts
+++ b/scripts/__tests__/network-escape-worker-coverage-8537.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * objectui#8537 — the network-escape guard covers EVERY test file in a worker
+ * of the `unit` project, not only the first.
+ *
+ * ## What this guards
+ *
+ * The `unit` project runs `isolate: false`. Vitest re-executes each
+ * `setupFiles` entry per test file, but a module a setup file IMPORTS is
+ * evaluated once per worker — so an `afterEach` registered in that module's
+ * body attaches to the first test file of the worker and to no other.
+ * `vitest.setup.network-escape-guard.ts` is such a module, and that is exactly
+ * where its `afterEach` used to be registered. Measured on `1cca4415e` with
+ * three byte-identical escaping files: one worker, `1 failed | 2 passed`; three
+ * workers, `3 failed`; each alone, red. Coverage was one file per worker, and
+ * a green suite read as "no escapes".
+ *
+ * The repair registers the hook from `vitest.setup.base.ts` through the guard's
+ * exported `installNetworkEscapeGuard()`, so it is per file.
+ *
+ * ## Why a spawn, and why two files
+ *
+ * An in-process assertion cannot see this defect: whichever file holds the
+ * assertion, its own hook state says nothing about the NEXT file's. The fact
+ * has to be measured across a file boundary, inside one worker, on the real
+ * `unit` project — so a real vitest is spawned with the two fixtures beside
+ * this file, forced into one worker, and BOTH must go red naming themselves.
+ *
+ * ## The caricature this also rejects
+ *
+ * A repair that re-registers the hook per file but loses the detection — every
+ * file "covered", nothing caught — passes any "the hook ran in file 2"
+ * assertion. Here it reads `0 failed`, which is as red as the defect's
+ * `1 failed | 1 passed`. Both were run against this pin before it landed.
+ *
+ * ## The live controls
+ *
+ * A spawn-based pin fails silently in two ways: the fixtures might not have
+ * escaped at all (skipped, or the marker never reached the child), or they
+ * might have landed in two workers, where the defect is invisible. So each
+ * fixture prints a line when its escape RUNS, and reports whether it found the
+ * other fixture's mark on the shared global object — which is only possible in
+ * one worker, for the file that ran second. Exactly one `saw_other=yes` is the
+ * reading that says "one worker, and one of these was not first in it".
+ *
+ * ## Recursion
+ *
+ * The child runs only the two fixtures, never this file, so it cannot spawn a
+ * grandchild; `OBJECTUI_ESCAPE_PIN_CHILD` is what un-skips the fixtures' escape
+ * there and is never set in the ordinary suite.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+const FIXTURES = ['a', 'b'].map((tag) =>
+  path.relative(repoRoot, path.join(here, `network-escape-worker-coverage-8537.escape-${tag}.test.ts`)),
+);
+
+const IS_CHILD = process.env.OBJECTUI_ESCAPE_PIN_CHILD === '1';
+
+/** The vitest CLI entry, resolved rather than assumed at a `node_modules` path. */
+const vitestCli = (() => {
+  const require = createRequire(path.join(repoRoot, 'noop.js'));
+  const pkgPath = require.resolve('vitest/package.json');
+  const bin = (JSON.parse(fs.readFileSync(pkgPath, 'utf8')).bin as { vitest: string }).vitest;
+  return path.resolve(path.dirname(pkgPath), bin);
+})();
+
+describe('objectui#8537 — the network-escape guard covers every file in a worker', () => {
+  it('the two fixtures are byte-identical apart from their tag', () => {
+    // The floor under the spawn below: if the fixtures differed in anything
+    // but position, a difference in their outcome would not be about coverage.
+    const [a, b] = FIXTURES.map((f) => fs.readFileSync(path.join(repoRoot, f), 'utf8'));
+    const normalise = (s: string) => s.replace(/\bfixture [ab]\b/g, 'fixture X').replace(/\b[ab]\b/g, 'X');
+    expect(a.length).toBeGreaterThan(500);
+    expect(a).not.toBe(b);
+    expect(normalise(a)).toBe(normalise(b));
+    // And they are inert outside the child: the escape is behind the marker.
+    for (const src of [a, b]) expect(src).toContain("it.skipIf(!IS_CHILD)");
+  });
+
+  it.skipIf(IS_CHILD)(
+    'a deliberate escape reds in a file that is NOT first in its worker',
+    () => {
+      const env: NodeJS.ProcessEnv = { ...process.env };
+      // A fresh CLI, not a nested worker of this run.
+      for (const key of Object.keys(env)) if (key.startsWith('VITEST')) delete env[key];
+      env.OBJECTUI_ESCAPE_PIN_CHILD = '1';
+
+      const child = spawnSync(
+        process.execPath,
+        [vitestCli, 'run', '--project', 'unit', '--maxWorkers=1', '--fileParallelism=false', ...FIXTURES],
+        { cwd: repoRoot, encoding: 'utf8', env, timeout: 300_000 },
+      );
+      const output = `${child.stdout ?? ''}${child.stderr ?? ''}`;
+
+      // Live control 1: both escapes RAN (not skipped, not filtered out).
+      expect(output, 'fixture a never ran its escape').toContain('ESCAPE_PIN_8537 file=a');
+      expect(output, 'fixture b never ran its escape').toContain('ESCAPE_PIN_8537 file=b');
+      // Live control 2: ONE worker, and one of the two was not first in it.
+      // Under `isolate: false` the second file sees the first file's mark on
+      // the shared global; in two workers neither would.
+      const sawOther = output.match(/saw_other=yes/g) ?? [];
+      expect(sawOther, 'the fixtures did not share a worker, so the defect could not show').toHaveLength(1);
+
+      // The claim: every file in the worker is covered — BOTH red, each
+      // attributed to itself. The defect reads `1 failed | 1 passed`; the
+      // caricature (hook per file, detection lost) reads `2 passed`.
+      expect(output).toMatch(/Test Files\s+2 failed \(2\)/);
+      const escapes = output.match(/Network escape: this test reached a REAL socket/g) ?? [];
+      expect(escapes.length, 'fewer Network escape verdicts than files').toBeGreaterThanOrEqual(2);
+      for (const fixture of FIXTURES) {
+        expect(output, `${fixture} was not named by the guard`).toContain(`  file: ${fixture}`);
+      }
+      expect(child.status, 'an escape must fail the child run').toBe(1);
+    },
+    360_000,
+  );
+});

--- a/scripts/__tests__/network-escape-worker-coverage-8537.test.ts
+++ b/scripts/__tests__/network-escape-worker-coverage-8537.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
+import { stripAnsi } from './helpers/child-verdict';
 
 /**
  * objectui#8537 — the network-escape guard covers EVERY test file in a worker
@@ -57,6 +58,28 @@ import { fileURLToPath } from 'node:url';
  * first draft of this pin went red on "fixture b never ran its escape" while b
  * had run and passed silently — a red for the wrong reason, which is the shape
  * the pin exists to refuse. The ledger is independent of the outcome.
+ *
+ * ## Why the child's output is read ANSI-stripped
+ *
+ * The child colours its own output, so every assertion below is made against
+ * `stripAnsi(...)` and never against the raw bytes. `Test Files  2 failed (2)`
+ * arrives as `SGR Test Files SGR SGR 2 failed SGR SGR (2) SGR`: `\s+` cannot
+ * match an SGR sequence and the count is split across two coloured spans, so a
+ * pattern written against the rendered text cannot match. That is objectui#7897
+ * — the reason `helpers/child-verdict.ts` exists — and it landed here anyway,
+ * because it is invisible locally:
+ *
+ *   - vitest calls `disableDefaultColors()` when `std-env`'s `isAgent` is true,
+ *     and an agent container sets `CLAUDECODE` / `AI_AGENT`. The child inherits
+ *     those (only `VITEST*` keys are dropped below), so an agent's local run is
+ *     UNCOLOURED and green while CI is coloured and red. Measured: same tree,
+ *     `env -u CLAUDECODE -u AI_AGENT` flips the child from 0 to 264 escape
+ *     bytes and this file's `Test Files` assertion from pass to fail.
+ *
+ * Stripping at the READER, rather than putting `NO_COLOR` on the child's env,
+ * is deliberate: the child's reporting environment stays byte-for-byte what CI
+ * gives it — including the GitHub-Actions annotation reporter it adds itself —
+ * so what is asserted on is what CI actually produces.
  *
  * ## Recursion
  *
@@ -118,7 +141,9 @@ describe('objectui#8537 — the network-escape guard covers every file in a work
             { cwd: repoRoot, encoding: 'utf8', env, timeout: 300_000 },
           );
           return {
-            output: `${child.stdout ?? ''}${child.stderr ?? ''}`,
+            // ANSI-STRIPPED AT THE READER (objectui#7897, the failure the
+            // helper was extracted for). Everything below reads plain text.
+            output: stripAnsi(`${child.stdout ?? ''}${child.stderr ?? ''}`),
             status: child.status,
             ledger: fs.existsSync(ledgerPath) ? fs.readFileSync(ledgerPath, 'utf8') : '',
           };

--- a/vitest.setup.base.ts
+++ b/vitest.setup.base.ts
@@ -9,7 +9,27 @@
 
 import { vi } from 'vitest';
 import { installI18nGlobalReset } from './vitest.setup.i18n-global';
-import './vitest.setup.network-escape-guard';
+import { installNetworkEscapeGuard } from './vitest.setup.network-escape-guard';
+
+// objectui#8537 — the network-escape guard's `afterEach` is registered HERE,
+// per execution of this setup file, and not by importing the guard.
+//
+// The `unit` project runs `isolate: false`. Vitest re-executes this setup file
+// for every test file, but a module it imports is evaluated once per worker —
+// so a hook registered in that module's body attached to the first test file
+// of each worker and to no other (measured: three byte-identical escaping
+// files in one worker, `1 failed | 2 passed`). The guard's `fetch` wrapper is a
+// module-scope assignment on a shared global and is unaffected; only the
+// asserting half needs to be per file, so only that half is a function. Same
+// split as `installI18nGlobalReset()` below, whose header carries the same
+// reason.
+//
+// First, deliberately: hooks run in REVERSE registration order, and this one
+// registered first (as the side-effect import it replaced) so that it runs
+// LAST — after the i18n reset below and after the DOM setups' RTL `cleanup()`,
+// whose act-flush can itself issue the read this hook exists to catch. The
+// guard's own `Fix:` text describes that ordering to test authors.
+installNetworkEscapeGuard();
 
 // objectui#4514 — put react-i18next's GLOBAL default-instance pointer back
 // after every test, so a provider-less render resolves the same way whether it

--- a/vitest.setup.network-escape-guard.ts
+++ b/vitest.setup.network-escape-guard.ts
@@ -68,6 +68,39 @@
  * `afterEach` that fails ANY escape in ANY file. Every escape is now unknown,
  * every escape is red on its first run, and the remedy is the `Fix:` text at the
  * bottom of this file — serve the probe from a double.
+ *
+ * ## Two halves, registered at two different times (objectui#8537)
+ *
+ * "ANY file" was not true in the `unit` project until objectui#8537, and the way
+ * it was false is worth keeping in view because it is silent by construction.
+ *
+ * That project runs `isolate: false`: one module graph per worker. Vitest still
+ * re-executes each `setupFiles` entry for every test file — it invalidates the
+ * setup file's own module node before importing it again — but a module the
+ * setup file IMPORTS is not invalidated, so it is evaluated once per worker.
+ * This file is imported by `vitest.setup.base.ts`; it is not a `setupFiles`
+ * entry. So an `afterEach` registered in its module scope attached to the
+ * FIRST test file of each worker and to no other. Measured on `1cca4415e` with
+ * three byte-identical escaping files: in one worker, `1 failed | 2 passed`;
+ * the same three files across three workers, `3 failed`; each alone, red. The
+ * guard covered one file per worker — on a 4-shard CI run, a handful of the
+ * ~1000 `unit` files — and read as covering all of them.
+ *
+ * The two halves of the guard therefore live at two different times:
+ *
+ *   - the RECORDING half — the `fetch` wrapper — is a module-scope assignment
+ *     on a shared global, and once per worker is exactly right for it. Under
+ *     `isolate: false` re-wrapping per file would stack a wrapper per file;
+ *   - the ASSERTING half — the `afterEach` — must be registered per test file,
+ *     so it is exported as `installNetworkEscapeGuard()` and CALLED from
+ *     `vitest.setup.base.ts`, which Vitest does re-execute per file. Same
+ *     split, same reason, as `installI18nGlobalReset()` next to it.
+ *
+ * `scripts/__tests__/network-escape-worker-coverage-8537.test.ts` pins the
+ * repair behaviourally: a real vitest runs two escaping files in ONE worker of
+ * the `unit` project and both must red, each naming itself. That is also the
+ * pin against the caricature of this repair — a hook that re-registers per
+ * file and no longer detects anything would cover every file and catch none.
  */
 import { afterEach, expect } from 'vitest';
 
@@ -148,42 +181,54 @@ globalThis.fetch = function guardedFetch(input: any, init?: any) {
   return realFetch.call(globalThis, input, init);
 } as typeof globalThis.fetch;
 
-afterEach(() => {
-  const seen = pending;
-  pending = [];
-  // No known/unknown split: the burn-down list reached zero on objectui#7307,
-  // so every escape is a defect on its first run.
-  if (seen.length === 0) return;
+/**
+ * Register the asserting half for the CURRENT test file.
+ *
+ * Called from `vitest.setup.base.ts` on every execution of that setup file —
+ * which under `isolate: false` is every test file, while this module's body
+ * above runs once per worker (objectui#8537, header). Nothing else in this file
+ * registers a hook, so importing it registers nothing: that is what lets
+ * `scripts/__tests__/unit-registry-absence-collision.test.ts` re-execute it in a
+ * private module graph without arming a stray hook there.
+ */
+export function installNetworkEscapeGuard(): void {
+  afterEach(() => {
+    const seen = pending;
+    pending = [];
+    // No known/unknown split: the burn-down list reached zero on objectui#7307,
+    // so every escape is a defect on its first run.
+    if (seen.length === 0) return;
 
-  const byUrl = [...new Set(seen.map((e) => e.url))];
-  const file = seen[0].file;
-  throw new Error(
-    `Network escape: this test reached a REAL socket at ${byUrl.join(', ')}.\n` +
-      `  file: ${file}\n` +
-      `  test: ${seen[0].test}\n` +
-      `\n` +
-      `happy-dom's default document URL is http://localhost:3000, so a relative\n` +
-      `fetch from a component under test resolves to a live TCP connection. The\n` +
-      `product call site catches the failure by design, so the test stayed green\n` +
-      `while printing an unattributable ECONNREFUSED stack — that is objectui#6640.\n` +
-      `\n` +
-      `Fix: serve the probe from a double rather than the network. See\n` +
-      `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx for the\n` +
-      `shape (vi.stubGlobal('fetch', router) + vi.unstubAllGlobals()).\n` +
-      `\n` +
-      `WHERE that pair is torn down is part of the shape, not a detail\n` +
-      `(objectui#7439). Vitest runs afterEach hooks in REVERSE registration order,\n` +
-      `so a teardown written in THIS file runs FIRST — before the root setup's\n` +
-      `RTL cleanup() and before this assertion. Unstubbing there restores the real\n` +
-      `fetch while the tree is still mounted, so even a read that cleanup()'s\n` +
-      `act-flush triggers escapes. So:\n` +
-      `  - call cleanup() BEFORE vi.unstubAllGlobals(), as that\n` +
-      `    DatasetReportRenderer afterEach already does; and\n` +
-      `  - if the component can issue a read AFTER the test body returns — any\n` +
-      `    refreshAfter, any notifyDataChanged consumer, any fire-and-forget\n` +
-      `    refresh no barrier awaits — do not tear the double down at all.\n` +
-      `    Install ONE at module scope and leave it up for the whole file, so no\n` +
-      `    test can ever end with the real fetch back in place. Worked example:\n` +
-      `    packages/app-shell/src/views/RecordDetailView.approvalDeclaredActions.test.tsx`,
-  );
-});
+    const byUrl = [...new Set(seen.map((e) => e.url))];
+    const file = seen[0].file;
+    throw new Error(
+      `Network escape: this test reached a REAL socket at ${byUrl.join(', ')}.\n` +
+        `  file: ${file}\n` +
+        `  test: ${seen[0].test}\n` +
+        `\n` +
+        `happy-dom's default document URL is http://localhost:3000, so a relative\n` +
+        `fetch from a component under test resolves to a live TCP connection. The\n` +
+        `product call site catches the failure by design, so the test stayed green\n` +
+        `while printing an unattributable ECONNREFUSED stack — that is objectui#6640.\n` +
+        `\n` +
+        `Fix: serve the probe from a double rather than the network. See\n` +
+        `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx for the\n` +
+        `shape (vi.stubGlobal('fetch', router) + vi.unstubAllGlobals()).\n` +
+        `\n` +
+        `WHERE that pair is torn down is part of the shape, not a detail\n` +
+        `(objectui#7439). Vitest runs afterEach hooks in REVERSE registration order,\n` +
+        `so a teardown written in THIS file runs FIRST — before the root setup's\n` +
+        `RTL cleanup() and before this assertion. Unstubbing there restores the real\n` +
+        `fetch while the tree is still mounted, so even a read that cleanup()'s\n` +
+        `act-flush triggers escapes. So:\n` +
+        `  - call cleanup() BEFORE vi.unstubAllGlobals(), as that\n` +
+        `    DatasetReportRenderer afterEach already does; and\n` +
+        `  - if the component can issue a read AFTER the test body returns — any\n` +
+        `    refreshAfter, any notifyDataChanged consumer, any fire-and-forget\n` +
+        `    refresh no barrier awaits — do not tear the double down at all.\n` +
+        `    Install ONE at module scope and leave it up for the whole file, so no\n` +
+        `    test can ever end with the real fetch back in place. Worked example:\n` +
+        `    packages/app-shell/src/views/RecordDetailView.approvalDeclaredActions.test.tsx`,
+    );
+  });
+}


### PR DESCRIPTION
Fixes objectstack-ai/objectui#8537

## What was wrong

`vitest.setup.network-escape-guard.ts` promises "the `afterEach` that fails ANY escape in ANY file". In the `unit` project (`isolate: false`) it registered that hook in its module scope, and the module is IMPORTED by `vitest.setup.base.ts` rather than being a `setupFiles` entry. Vitest 4.1.10 re-executes a setup file per test file by invalidating that file's own module node (`importFile(filepath, "setup")` in `vitest/dist/chunks/test.DNmyFkvJ.js`, around line 4287) and nothing else — so the guard's body, and its `afterEach`, ran once per worker and attached to the worker's first test file only.

## Measurement first, on `1cca4415e` (unfixed), with a lit control

Three byte-identical test files (label only differs), each fetching an absolute `http://localhost:3000/...` URL, run on the real `unit` project:

| run | result |
|---|---|
| one worker, three files (`--maxWorkers=1 --fileParallelism=false`) | `Test Files 1 failed, 2 passed (3)` — only the first in execution order (ZZORDER 1) was reported |
| three workers, same three files (`--maxWorkers=3`) | `Test Files 3 failed (3)` — each file is first in its own worker |
| each file alone | red, every time |

So coverage today is exactly one file per worker, and the three-worker leg shows it is per worker rather than per run. Vitest's default worker count is `max(availableParallelism - 1, 1)` (`getDefaultThreadsCount`), so on a 4-thread box that is 3 of the project's 991 files; on a 4-shard CI run it is roughly a dozen of 991. The card's reading holds: `premise_still_valid: true`.

With the hook armed for every file (this branch), the same three files in one worker read `Test Files 3 failed (3)`.

## Blast radius, measured

The whole `unit` project on this branch, hook armed per file, four shards run sequentially on a shared box: 247 + 247 + 248 + 247 = 989 passed, 2 skipped (the two fixtures, inert outside the pin's child), 0 `Network escape` verdicts. The burn-down the card deferred is empty — every real escape had already been served from a double by objectui#7307's batches — so this lands as one PR, and the change adds no red to `main`.

## The repair

The two halves of the guard are registered at two different times, deliberately:

- the recording half — the `globalThis.fetch` wrapper — stays a module-scope assignment on a shared global, once per worker (re-wrapping per file would stack a wrapper per file under `isolate: false`);
- the asserting half — the `afterEach` — moves into an exported `installNetworkEscapeGuard()` which `vitest.setup.base.ts` calls on every execution, which under `isolate: false` is every test file. Same split, same reason, as `installI18nGlobalReset()` beside it. The call sits where the side-effect import stood, so hook order is unchanged: registered first, runs last, after the i18n reset and after the DOM setups' RTL `cleanup()` — the order the guard's own `Fix:` text describes to test authors.

`isolate: true` was not reached for and was not priced: the repair does not touch isolation, and the per-file installer is the pattern the same file already uses one line below. Declared as a narrowing rather than measured.

## The deliberate pin edit (objectui#6640's ledger pin)

`scripts/__tests__/network-escape-ledger.test.ts` pinned that the guard "exports nothing". That assertion is edited on purpose, not incidentally: it now pins that the guard exports exactly `installNetworkEscapeGuard` (a ledger coming back as a second export is still red), that the guard's ONE `afterEach(` in code sits inside that installer rather than at module scope, and that `vitest.setup.base.ts` calls it and no longer carries the bare side-effect import.

## The behavioural pin, and the caricature it rejects

`scripts/__tests__/network-escape-worker-coverage-8537.test.ts` spawns a real vitest on the `unit` project with two byte-identical escaping fixtures forced into ONE worker and requires `Test Files 2 failed (2)` with each file named by the guard's own `file:` line. Live controls, read off a ledger file the fixtures write: both escapes ran, and exactly one fixture saw the other's mark on the shared global (one worker, and one of the two was not first in it). In the ordinary suite the fixtures are skipped.

Run, not predicted — each leg restored by state (empty `git diff HEAD`, blob hash equal to `HEAD`'s) with an `EXIT INT TERM` trap on absolute paths:

| leg | on-disk proof | child summary | pin |
|---|---|---|---|
| defect: guard + base restored to `1cca4415e` | `installNetworkEscapeGuard` count in base.ts 0, export in guard 0 | `1 failed, 1 passed (2)` | red on the discriminating assertion; ledger pin red on the export list |
| caricature: hook per file, detection lost (`if (seen.length >= 0) return;`) | marker count 1, original line 0, installer still exported | `2 passed (2)` | red on the same discriminating assertion |
| control: fixed tree, same fixtures in TWO workers | — | `2 failed (2)`, `saw_other=yes` count 0 | the one-worker control discriminates |
| fixed tree | — | `2 failed (2)` | green |

One wrong-reason failure was found and fixed in the pin's own first draft (second commit, `c30521fe5`): with the liveness evidence on the child's console, the defect leg went red on "fixture b never ran its escape" — b had run and passed, and vitest's default reporter prints a passing test's console output nowhere, so the control fired exactly on the outcome it was meant to be independent of. The evidence now goes to a ledger file; re-run, both mutated legs fail on `Test Files 2 failed (2)` itself with the controls green.

## Load dependence

The defect reproduces deterministically here because the pin forces one worker; it does not depend on scheduling. The only load-sensitive part is the child spawn's wall time (1.4 s locally; 300 s timeout, 360 s test timeout, same budget as `vitest-timezone-pin-8366.test.ts`).

## Verification (tree `c30521fe5`)

- `pnpm exec vitest run --project unit` on the pin, both fixtures, the ledger pin and the shared-global-leak-guard pin: `3 passed, 2 skipped (5)`, exit 0.
- `--project unit --shard=k/4` for k = 1..4: 989 passed, 2 skipped, 0 escapes (shard walls 57 s / 75 s / 35 s / 30 s on a shared box).
- `pnpm type-check:scripts`: 0 errors. `pnpm type-check:vitest-setup`: the same 4 errors before and after, all in `vitest.setup.dom.tsx` and all the documented missing-`dist` shape (the four packages it maps to are not built in this worktree) — no error in the two edited files; declared as a narrowing.
- `pnpm lint:root`: 0 errors (32 pre-existing warnings; the six in the touched root files are `no-explicit-any` on lines that pre-exist at `1cca4415e`, 3 in the guard and 2 in base.ts, same count before and after).
- `node scripts/check-changeset-presence.mjs` green (empty-frontmatter changeset added — test harness only, nothing released); `pnpm changeset:check`, `check:control-bytes`, `check:esm-specifiers`, `check:shell-escape-residue`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:comment-mask-corpus`, `check:entry-guard`, `check:bash32-floor`: all exit 0. Python zero-width/control scan over every touched file with a lit U+200B control: 0 hits.
- `node scripts/check-governed-queue-guard.mjs --test` over all seven paths: NOT GOVERNED.

Draft; not flipped to ready, no auto-merge armed. Session: `https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_