### PR TITLE
fix(tooling): drop git-ignored paths from the lint-rule-coverage census

### DIFF
--- a/scripts/__tests__/check-lint-rule-coverage.test.ts
+++ b/scripts/__tests__/check-lint-rule-coverage.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -8,6 +9,7 @@ import { ESLint } from 'eslint';
 
 import {
   CENSUS_FLOORS,
+  GIT_IGNORED_CONTROL,
   PROBE_BASENAME,
   SOURCE_EXTENSIONS,
   UNREACHED_GROUPS,
@@ -16,6 +18,9 @@ import {
   censusCollapse,
   extensionProbeCollapse,
   extensionReach,
+  gitIgnoreCollapse,
+  gitIgnoreReading,
+  isGitWorkTree,
   ruleCountFor,
   walkedFiles,
 } from '../check-lint-rule-coverage.mjs';
@@ -55,6 +60,16 @@ import {
  *  9. **Predicate 2 cannot pass vacuously even once it is fixed.** Its control
  *     is on the probe -- both answers in the same run -- so an empty population
  *     stays a reading rather than becoming a blind spot.
+ * 10. **objectui#8369 -- the census is over the tree GIT tracks.** A build
+ *     output on disk is not a file anybody wrote, so the walk drops what git
+ *     ignores. The load-bearing pin is the card's own control turned into a
+ *     fixture: the same tree analysed with and without a generated file gives
+ *     the IDENTICAL verdict and the identical census. The three git semantics
+ *     it rests on are pinned separately, each against a real `git` process --
+ *     an untracked-and-unignored file is still reported (which is why this is
+ *     not `git ls-files`), a TRACKED file stays counted even when a rule names
+ *     it, and outside a work tree the filter reports itself unavailable rather
+ *     than filtering silently.
  *  6. **The gate is wired** in `package.json`, and its only enforcement path is
  *     the `this repository is green` case above, running inside `pnpm test`.
  *     The absence of a `ci.yml` step is asserted rather than assumed, so the
@@ -411,6 +426,153 @@ describe('the census cannot pass by collapsing', () => {
   });
 });
 
+/**
+ * A fixture tree that IS a git repository. Nothing is committed: `git
+ * check-ignore` reads the ignore files and the index, and neither needs a
+ * commit -- which also keeps these fixtures free of any identity config.
+ */
+function gitTree(label: string, files: Record<string, string>, forceAdd: string[] = []): string {
+  const root = tree(label, files);
+  execFileSync('git', ['init', '-q'], { cwd: root, stdio: 'ignore' });
+  if (forceAdd.length) execFileSync('git', ['add', '-f', ...forceAdd], { cwd: root, stdio: 'ignore' });
+  return root;
+}
+
+describe('objectui#8369 -- the census is over the tree git tracks, not the files on disk', () => {
+  it('gives the identical verdict and census whether or not the tree has been built', async () => {
+    // The card's own control, as a fixture: `built.js` is a generated file --
+    // named in `.gitignore`, absent from any commit -- and before this fix its
+    // mere presence turned the gate red with `unledgered: built.js`.
+    const root = gitTree('git-artifact', {
+      'eslint.config.js': TS_ONLY_CONFIG,
+      ...FILES,
+      '.gitignore': 'built.js\n',
+    });
+
+    const unbuilt = await analyze({ root, groups: LEDGER, unreachedGroups: [] });
+    fs.writeFileSync(path.join(root, 'built.js'), 'export const built = 1;\n');
+    const built = await analyze({ root, groups: LEDGER, unreachedGroups: [] });
+
+    expect(unbuilt.findings).toEqual([]);
+    expect(built.findings).toEqual([]);
+    expect(built.walked).toEqual(unbuilt.walked);
+    expect(built.vacuous).toEqual(unbuilt.vacuous);
+    expect(built.ruleBearing).toEqual(unbuilt.ruleBearing);
+    // The one number that DOES move, and it is reported rather than silent.
+    expect(unbuilt.git.excluded).toEqual([]);
+    expect(built.git.excluded).toEqual(['built.js']);
+    // ...and the census is not trivially empty on either side.
+    expect(built.walked).toContain('src/covered.ts');
+    expect(built.vacuous).toContain('tools/vacuous.mjs');
+  });
+
+  it('still reports a source file git does NOT ignore, before anybody stages it', async () => {
+    // Why this is a git-IGNORE filter and not `git ls-files`: enumerating
+    // tracked files would make the verdict depend on whether the developer had
+    // run `git add`, which is the same defect wearing a different hat.
+    const root = gitTree('git-untracked', {
+      'eslint.config.js': TS_ONLY_CONFIG,
+      ...FILES,
+      '.gitignore': 'built.js\n',
+      'elsewhere/new-tool.mjs': 'export const e = 5;\n',
+    });
+    const result = await analyze({ root, groups: LEDGER, unreachedGroups: [] });
+
+    const unledgered = result.findings.filter((f) => f.kind === 'unledgered');
+    expect(unledgered).toHaveLength(1);
+    expect(unledgered[0].files).toEqual(['elsewhere/new-tool.mjs']);
+    expect(result.git.excluded).toEqual([]);
+  });
+
+  it('keeps a TRACKED file in the census even when an ignore rule names it', async () => {
+    // Measured semantics of `git check-ignore`, pinned because the whole filter
+    // rests on them: it consults the index, so a tracked path is never called
+    // ignored. A file in the repository stays judged whatever `.gitignore` says.
+    const root = gitTree(
+      'git-tracked',
+      { 'eslint.config.js': TS_ONLY_CONFIG, ...FILES, '.gitignore': 'tools/vacuous.mjs\n' },
+      ['tools/vacuous.mjs'],
+    );
+    const result = await analyze({ root, groups: LEDGER, unreachedGroups: [] });
+
+    expect(result.walked).toContain('tools/vacuous.mjs');
+    expect(result.vacuous).toContain('tools/vacuous.mjs');
+    expect(result.git.excluded).toEqual([]);
+    expect(result.findings).toEqual([]);
+  });
+
+  it('narrows the ESLint#lintFiles equivalence by exactly the ignored paths', async () => {
+    // The header's "272 files, 272 matches, zero difference" claim now holds
+    // only up to this filter, so the difference is pinned rather than the
+    // equality -- one file, and it is the generated one.
+    const root = gitTree('git-walk-equiv', {
+      'eslint.config.js': TS_ONLY_CONFIG,
+      ...FILES,
+      '.gitignore': 'built.js\n',
+      'built.js': 'export const built = 1;\n',
+    });
+    const eslint = new ESLint({ cwd: root });
+
+    const mine = await walkedFiles(root, eslint);
+    const theirs = (await eslint.lintFiles(['.']))
+      .map((r) => path.relative(root, r.filePath).split(path.sep).join('/'))
+      .sort();
+
+    expect(theirs).toContain('built.js');
+    expect(mine).not.toContain('built.js');
+    expect(theirs.filter((f) => f !== 'built.js')).toEqual(mine);
+  });
+
+  it('reports itself unavailable outside a git work tree rather than filtering silently', async () => {
+    const root = tree('no-git', { 'eslint.config.js': TS_ONLY_CONFIG, ...FILES });
+    expect(isGitWorkTree(root)).toBe(false);
+
+    const result = await analyze({ root, groups: LEDGER, unreachedGroups: [] });
+    expect(result.git.available).toBe(false);
+    expect(result.git.excluded).toEqual([]);
+    // Nothing is dropped, and the entry point refuses that state for THIS
+    // repository -- an unavailable filter is the broken state, not a lenient one.
+    expect(result.findings).toEqual([]);
+    expect(gitIgnoreCollapse(result.git)).toMatch(/not a git work tree/);
+  });
+
+  it('takes both halves of its control from a real git process, in one run', () => {
+    // The control lives on the INSTRUMENT: an empty ignored set is what an
+    // unbuilt tree legitimately looks like, so "git answered nothing" and "git
+    // did not answer" have to be told apart by something other than the set.
+    const noNodeModulesRule = gitTree('git-control-half', { '.gitignore': 'built.js\n' });
+    const half = gitIgnoreReading(noNodeModulesRule, []);
+    expect(half.available).toBe(true);
+    expect(half.controlVisible).toBe(true);
+    // This fixture ignores nothing under node_modules, so the positive half is
+    // genuinely absent -- and the collapse message says which half.
+    expect(half.controlIgnored).toBe(false);
+    expect(gitIgnoreCollapse(half)).toMatch(new RegExp(GIT_IGNORED_CONTROL.replace(/[/.]/g, '\\$&')));
+
+    const both = gitTree('git-control-both', { '.gitignore': 'node_modules\nbuilt.js\n' });
+    const reading = gitIgnoreReading(both, ['built.js', 'src/covered.ts']);
+    expect(reading.controlIgnored).toBe(true);
+    expect(reading.controlVisible).toBe(true);
+    expect(gitIgnoreCollapse(reading)).toBeNull();
+    // ...and the reading itself discriminates, on paths that need not exist.
+    expect(reading.ignored.has('built.js')).toBe(true);
+    expect(reading.ignored.has('src/covered.ts')).toBe(false);
+  });
+
+  it('names both directions of a collapsed filter', () => {
+    expect(gitIgnoreCollapse({ available: false, controlIgnored: false, controlVisible: false })).toMatch(
+      /not a git work tree/,
+    );
+    expect(gitIgnoreCollapse({ available: true, controlIgnored: false, controlVisible: true })).toMatch(
+      /cannot\s+say "yes"/,
+    );
+    expect(gitIgnoreCollapse({ available: true, controlIgnored: true, controlVisible: false })).toMatch(
+      /cannot\s+say "no"/,
+    );
+    expect(gitIgnoreCollapse({ available: true, controlIgnored: true, controlVisible: true })).toBeNull();
+  });
+});
+
 describe('this repository', () => {
   it('is green, with every ledger row still live and the census standing', async () => {
     const result = await analyze({ root: repoRoot });
@@ -428,6 +590,10 @@ describe('this repository', () => {
     // green here means that file is DECLARED rather than invisible.
     expect(extensionProbeCollapse(result.reach)).toBeNull();
     expect(result.unreached).toEqual(['vitest.config.mts']);
+    // objectui#8369: this run is only a reading of the tree git tracks if the
+    // filter was there and could answer both ways.
+    expect(result.git.available).toBe(true);
+    expect(gitIgnoreCollapse(result.git)).toBeNull();
     for (const row of result.unreachedRows) {
       expect(row.unreachedMatches.length, `unreached row '${row.glob}' declares nothing any more`).toBeGreaterThan(0);
       expect(row.walkedMatches, `unreached row '${row.glob}' over-claims`).toEqual([]);
@@ -495,6 +661,19 @@ describe('this repository', () => {
       expect(row.glob, `row '${row.glob}' must not be a population glob`).not.toMatch(/[*?[\]{]/);
     }
   });
+
+  it('never judges apps/console/plugin.js, built or not (objectui#8369)', async () => {
+    const result = await analyze({ root: repoRoot });
+    // The reading is about PATHS, so it holds whether or not this checkout has
+    // been built -- and its control is a real source file in the same package,
+    // asked in the same run.
+    const reading = gitIgnoreReading(repoRoot, ['apps/console/plugin.js', 'apps/console/src/main.tsx']);
+    expect(reading.ignored.has('apps/console/plugin.js')).toBe(true);
+    expect(reading.ignored.has('apps/console/src/main.tsx')).toBe(false);
+
+    expect(result.walked).not.toContain('apps/console/plugin.js');
+    expect(result.walked).toContain('apps/console/src/main.tsx');
+  }, 60_000);
 
   it('is wired in package.json, and deliberately not in a workflow yet', () => {
     const manifest = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));

--- a/scripts/check-lint-rule-coverage.mjs
+++ b/scripts/check-lint-rule-coverage.mjs
@@ -138,6 +138,12 @@
  * was compared with the `filePath` set of a real
  * `eslint . --ignore-pattern ... --format json` run at the `lint:root` scope on
  * `fedfa3e4a`. 272 files, 272 matches, zero difference in either direction.
+ *
+ * ⚠️ That equivalence is exact only up to the git filter below: since
+ * objectui#8369 the walk drops paths GIT ignores, so on a tree that has been
+ * built this enumeration is deliberately SMALLER than `eslint .`'s. The
+ * difference is always exactly the ignored paths, and the pin asserts that
+ * shape rather than plain equality.
  * `scripts/__tests__/check-lint-rule-coverage.test.ts` re-pins that equivalence
  * against `ESLint#lintFiles` on a fixture tree, where it costs milliseconds.
  *
@@ -250,6 +256,61 @@
  * unreachable (so the probe is able to say "no" at all). If those two hold and
  * the unreachable set is empty, the emptiness is a reading.
  *
+ * ## Why the walk asks git what is in the repository (objectui#8369)
+ *
+ * A file on disk is not the same thing as a file in the repository, and this
+ * gate used to conflate them. `apps/console/plugin.js` is a build OUTPUT --
+ * `apps/console/.gitignore` names it, it is absent from `HEAD`, and it appears
+ * only after `turbo run build` -- so the gate reported it as unledgered vacuity
+ * and exited 1 on any developer who had built. Measured on `1cca4415e`:
+ *
+ *   before any build       pnpm check:lint-rule-coverage   exit 0
+ *   after turbo run build                                  exit 1
+ *                            unledgered: apps/console/plugin.js
+ *   control: rm that one file, re-run                      exit 0
+ *
+ * ⭐ That is the failure a coverage gate can least afford: the verdict was a
+ * property of the WORKING TREE rather than of the tree under test, which makes
+ * its green as unexplainable as its red. It also collides with this
+ * repository's own workflow -- `check-doc-snippet-types.mjs` and
+ * `check-skill-examples.mjs` both exit 2 with "run the build first", so obeying
+ * them reddens this gate, and the red points at a file nobody wrote and nobody
+ * can fix at the site.
+ *
+ * The remedy is NOT a ledger row: {@link VACUOUS_GROUPS} is a list of decisions
+ * about files that are in the repository, and a row for a generated path would
+ * be a permanent waiver nobody can ever check or shrink. Nor is it a second
+ * ignore list here -- that would be a copy of `.gitignore` needing to be kept
+ * in sync with it, which is the defect one level up.
+ *
+ * So the walk asks git, which is the only thing entitled to answer. One batched
+ * `git check-ignore --stdin -z` over the candidates, and the paths it names are
+ * dropped from BOTH populations before anything is judged. Its semantics are
+ * exactly the wanted ones, measured rather than assumed:
+ *
+ *   untracked + matched by an ignore rule  -> reported   DROPPED (build output)
+ *   TRACKED, even when a rule matches it   -> not reported, stays in the census
+ *   untracked + matched by nothing         -> not reported, stays in the census
+ *
+ * ⭐ That last row is why this is a git-IGNORE filter and not `git ls-files`.
+ * Enumerating tracked files would drop a source file that exists but has not
+ * been `git add`ed yet -- and then the verdict would depend on whether the
+ * developer happened to stage, which is the same defect wearing a different
+ * hat. A brand-new unstaged `scripts/check-foo.mjs` is still reported.
+ *
+ * The reading has its own control, on the INSTRUMENT and in the same run --
+ * {@link gitIgnoreReading} appends two synthetic paths to the batch and
+ * {@link gitIgnoreCollapse} requires both answers: `node_modules/<probe>` must
+ * come back IGNORED (the process ran and can say yes) and the same probe at the
+ * repository root must come back VISIBLE (it can say no). An empty ignored set
+ * is then a reading -- which is what an unbuilt tree legitimately looks like --
+ * rather than a `git` that failed and silently answered "nothing".
+ *
+ * Outside a git work tree there is nothing to ask, so the filter reports itself
+ * unavailable and the walk is what it always was. That is the state the fixture
+ * trees in the pin test are in, and {@link main} refuses it: for THIS
+ * repository an unavailable filter is the broken state, not a lenient one.
+ *
  * ## Cost
  *
  * Measured on `fedfa3e4a`, this branch's base: 4438 walked files out of 6699 on disk. Directory
@@ -259,6 +320,16 @@
  * ESLint startup per file, seconds each. The per-file API call is 3.65ms
  * amortised, so there is no need to resolve per file-GROUP instead of per file,
  * and this gate does not.
+ *
+ * The git filter adds two short-lived processes to that, not one per file:
+ * `rev-parse --is-inside-work-tree`, then a single `check-ignore --stdin -z`
+ * fed every candidate path at once. Measured on `1cca4415e` over a built tree,
+ * 4523 candidates, three runs: 6ms for the work-tree probe and 407 / 414 /
+ * 484ms for the batch, against 2.5s for the walk it sits on -- about a sixth
+ * more, for one process. Per-path spawning was never a candidate at this
+ * scale, for the same reason `eslint --print-config` per file was not. The
+ * candidates are also filtered BEFORE `calculateConfigForFile` runs, so the
+ * dropped paths cost no rule resolution at all.
  *
  * ## Wiring, and what actually enforces this
  *
@@ -278,6 +349,7 @@
  * this session's declared file surface, exactly as in objectui#8301.
  */
 
+import { spawnSync } from 'node:child_process';
 import { readdirSync } from 'node:fs';
 import { extname, join, matchesGlob, relative, sep } from 'node:path';
 import { dirname, resolve } from 'node:path';
@@ -306,6 +378,124 @@ export const STRUCTURAL_SKIP_DIRS = new Set(['.git', 'node_modules']);
  * should be.
  */
 export const PROBE_BASENAME = 'eslint-rule-coverage-probe.js';
+
+/**
+ * Basename of the synthetic path pair that controls the git reading. Never
+ * written to disk, like every other probe here: `git check-ignore` answers
+ * about a PATH, and the path need not exist.
+ */
+export const GIT_PROBE_BASENAME = 'eslint-git-ignore-probe.ts';
+
+/**
+ * The positive half of the git probe's control: a path git must call IGNORED.
+ * `node_modules` is the one directory whose ignored-ness this gate can assert
+ * without reading anybody's `.gitignore` -- it is in {@link
+ * STRUCTURAL_SKIP_DIRS} for the same reason, this file cannot even load
+ * without it, and a repository that did NOT ignore it would have its
+ * dependencies in the census, which is a state this gate would already be
+ * shouting about.
+ */
+export const GIT_IGNORED_CONTROL = `node_modules/${GIT_PROBE_BASENAME}`;
+
+/**
+ * The negative half: the same probe at the repository root, which no ignore
+ * rule names, so a filter able to say "no" at all must say it here. Without it
+ * a `check-ignore` that answered "ignored" to everything would empty the census
+ * -- loudly, via {@link censusCollapse}, but for the wrong stated reason.
+ */
+export const GIT_VISIBLE_CONTROL = GIT_PROBE_BASENAME;
+
+/**
+ * Is `root` inside a git work tree at all? Asked separately from the reading
+ * itself because the two failures are different: OUTSIDE a work tree there is
+ * no question to put (the pin test's fixture trees live in `os.tmpdir()`, which
+ * is not a repository -- exit 128, `not a git repository`), while INSIDE one a
+ * failing `check-ignore` is a broken instrument and throws.
+ *
+ * @param {string} root absolute
+ * @returns {boolean}
+ */
+export function isGitWorkTree(root) {
+  const probe = spawnSync('git', ['-C', root, 'rev-parse', '--is-inside-work-tree'], { encoding: 'utf8' });
+  return probe.status === 0 && probe.stdout.trim() === 'true';
+}
+
+/**
+ * Which of `candidates` git ignores, as one batched question with its own
+ * control inside the same run.
+ *
+ * @param {string} root absolute
+ * @param {string[]} candidates paths relative to `root`, forward slashes
+ * @returns {{ available: boolean, ignored: Set<string>, controlIgnored: boolean, controlVisible: boolean }}
+ */
+export function gitIgnoreReading(root, candidates) {
+  if (!isGitWorkTree(root)) {
+    return { available: false, ignored: new Set(), controlIgnored: false, controlVisible: false };
+  }
+
+  const asked = [...candidates, GIT_IGNORED_CONTROL, GIT_VISIBLE_CONTROL];
+  const run = spawnSync('git', ['-C', root, 'check-ignore', '--stdin', '-z'], {
+    input: asked.map((path) => `${path}\0`).join(''),
+    encoding: 'utf8',
+    maxBuffer: 256 * 1024 * 1024,
+  });
+
+  if (run.error) {
+    throw new Error(
+      `git check-ignore could not be run in ${root}: ${run.error.message}. This tree IS a git work ` +
+        'tree, so the question is a real one and answering it with "nothing is ignored" would put build ' +
+        'output back in the census.',
+    );
+  }
+  // 0 = at least one path is ignored, 1 = none of them are. Both are answers;
+  // anything else is git failing, and a failure must never read as "nothing".
+  if (run.status !== 0 && run.status !== 1) {
+    throw new Error(
+      `git check-ignore exited ${run.status} in ${root}: ${(run.stderr || '').trim()}. Only 0 and 1 are ` +
+        'answers here.',
+    );
+  }
+
+  const ignored = new Set(run.stdout.split('\0').filter(Boolean));
+  return {
+    available: true,
+    ignored,
+    controlIgnored: ignored.has(GIT_IGNORED_CONTROL),
+    controlVisible: !ignored.has(GIT_VISIBLE_CONTROL),
+  };
+}
+
+/**
+ * The control on the git filter, the same shape as {@link
+ * extensionProbeCollapse}: both answers in one run, so an empty ignored set is
+ * a reading rather than a silence. Applied by {@link main} only -- {@link
+ * analyze} runs on fixture trees that are deliberately not repositories.
+ *
+ * @param {{ available: boolean, controlIgnored: boolean, controlVisible: boolean }} reading
+ * @returns {string | null} the collapse message, or null when the filter discriminates
+ */
+export function gitIgnoreCollapse(reading) {
+  if (!reading.available) {
+    return (
+      'The git filter is unavailable: this tree is not a git work tree, so the walk cannot tell a ' +
+      'build output from a source file. Every generated file on disk would be judged as if somebody ' +
+      'had written it -- which is objectui#8369, and it made this gate red for anyone who had built.'
+    );
+  }
+  if (!reading.controlIgnored) {
+    return (
+      `The git filter collapsed: '${GIT_IGNORED_CONTROL}' came back NOT ignored. The filter cannot ` +
+      'say "yes", so an empty ignored set would mean nothing rather than meaning this tree is unbuilt.'
+    );
+  }
+  if (!reading.controlVisible) {
+    return (
+      `The git filter collapsed: '${GIT_VISIBLE_CONTROL}' at the repository root came back IGNORED. ` +
+      'The filter cannot say "no", so it would drop the very files this gate exists to judge.'
+    );
+  }
+  return null;
+}
 
 /**
  * The JS/TS module extensions ESLint could lint here, as the CLOSED set Node
@@ -516,9 +706,20 @@ export async function isIgnoredDirectory(eslint, dir) {
  * is why `packages/core/dist/x.mts` never reaches predicate 2: a build output
  * is not an extension gap.
  *
+ * Paths GIT ignores are dropped from both populations for the same reason one
+ * level out (objectui#8369): they are not in the repository, so no ledger row
+ * could ever own them and no author could act on a finding about them. The
+ * question is put to git once, after the walk, because that is one process
+ * instead of one per directory -- see the header. Outside a git work tree
+ * nothing is dropped and `git.available` says so.
+ *
  * @param {string} root absolute
  * @param {ESLint} eslint an instance whose `cwd` is `root`
- * @returns {Promise<{ walked: string[], unwalkedSource: string[] }>}
+ * @returns {Promise<{
+ *   walked: string[],
+ *   unwalkedSource: string[],
+ *   git: { available: boolean, controlIgnored: boolean, controlVisible: boolean, excluded: string[] },
+ * }>}
  */
 export async function walkTree(root, eslint) {
   /** @type {string[]} */
@@ -556,7 +757,19 @@ export async function walkTree(root, eslint) {
   await descend(root);
   walked.sort();
   unwalkedSource.sort();
-  return { walked, unwalkedSource };
+
+  const reading = gitIgnoreReading(root, [...walked, ...unwalkedSource]);
+  const excluded = [...walked, ...unwalkedSource].filter((file) => reading.ignored.has(file)).sort();
+  return {
+    walked: walked.filter((file) => !reading.ignored.has(file)),
+    unwalkedSource: unwalkedSource.filter((file) => !reading.ignored.has(file)),
+    git: {
+      available: reading.available,
+      controlIgnored: reading.controlIgnored,
+      controlVisible: reading.controlVisible,
+      excluded,
+    },
+  };
 }
 
 /**
@@ -649,6 +862,7 @@ export async function ruleCountFor(eslint, file) {
  *   vacuous: string[],
  *   ruleBearing: string[],
  *   unwalkedSource: string[],
+ *   git: { available: boolean, controlIgnored: boolean, controlVisible: boolean, excluded: string[] },
  *   reach: { reachable: string[], unreachable: string[], controlUnreachable: boolean },
  *   unreached: string[],
  *   rows: { glob: string, reason: string, card: string, vacuousMatches: string[], ruleBearingMatches: string[] }[],
@@ -671,7 +885,7 @@ export async function analyze({ root, groups = VACUOUS_GROUPS, unreachedGroups =
   }
 
   const eslint = new ESLint({ cwd: root });
-  const { walked, unwalkedSource } = await walkTree(root, eslint);
+  const { walked, unwalkedSource, git } = await walkTree(root, eslint);
   const reach = await extensionReach(eslint, root);
   const unreached = await unreachedByExtension(eslint, root, unwalkedSource, reach.reachable);
 
@@ -734,7 +948,18 @@ export async function analyze({ root, groups = VACUOUS_GROUPS, unreachedGroups =
     }
   }
 
-  return { walked, vacuous, ruleBearing, unwalkedSource, reach, unreached, rows, unreachedRows, findings };
+  return {
+    walked,
+    vacuous,
+    ruleBearing,
+    unwalkedSource,
+    git,
+    reach,
+    unreached,
+    rows,
+    unreachedRows,
+    findings,
+  };
 }
 
 /**
@@ -756,7 +981,7 @@ async function main() {
   const root = resolve(scriptDir, '..');
   const result = await analyze({ root });
 
-  const collapse = censusCollapse(result) ?? extensionProbeCollapse(result.reach);
+  const collapse = censusCollapse(result) ?? extensionProbeCollapse(result.reach) ?? gitIgnoreCollapse(result.git);
   if (collapse) {
     console.error(collapse);
     process.exit(1);
@@ -780,6 +1005,12 @@ async function main() {
     for (const row of result.unreachedRows) {
       console.log(`      ${String(row.unreachedMatches.length).padStart(3)}  ${row.glob}  (${row.card})`);
     }
+    console.log(
+      `\n    ${result.git.excluded.length} path(s) on disk are git-ignored and therefore outside the census ` +
+        'entirely --\n    build output and local scratch, which nobody wrote and no ledger row could own ' +
+        '(objectui#8369).\n    The verdict is a property of the tree git tracks, not of whether you have ' +
+        'built.',
+    );
     console.log(
       '\n    A zero-rule file is one ESLint parses and has nothing to say about. It is not clean; it is\n' +
         '    unjudged, and every exit code downstream reads it as clean. An unreached file is one step\n' +
@@ -856,7 +1087,8 @@ async function main() {
     `    census: ${result.walked.length} walked, ${result.ruleBearing.length} rule-bearing, ` +
       `${result.vacuous.length} zero-rule; ${result.unwalkedSource.length} source file(s) not walked, ` +
       `${result.unreached.length} of them only because of their extension ` +
-      `(unreached: ${result.reach.unreachable.map((e) => `.${e}`).join(' ') || 'none'}).\n` +
+      `(unreached: ${result.reach.unreachable.map((e) => `.${e}`).join(' ') || 'none'}); ` +
+      `${result.git.excluded.length} git-ignored path(s) excluded before judging.\n` +
       '    See https://github.com/objectstack-ai/objectui/issues/7908 (predicate 1) and\n' +
       '    https://github.com/objectstack-ai/objectui/issues/8337 (predicate 2) for why this gate exists.',
   );


### PR DESCRIPTION
Fixes #8369

`check:lint-rule-coverage` walked the FILESYSTEM, so a build output counted as a source file. `apps/console/plugin.js` is generated by `build:plugin`, named in `apps/console/.gitignore:16`, and absent from `HEAD` — so after any local `turbo run build` the gate reported it as unledgered vacuity and exited 1, while several doc gates (`check-doc-snippet-types.mjs`, `check-skill-examples.mjs`) exit 2 telling you to build first. The verdict was a property of the working tree rather than of the tree under test, which makes a green as unexplainable as a red.

## Reproduction, measured on this branch's base `1cca4415e`

The card's control, re-run here before anything was changed:

```
before any build        pnpm check:lint-rule-coverage   exit 0   census 4519 / 4392 / 127
after turbo run build                                   exit 1   unledgered: apps/console/plugin.js
                                                                 census 4522 / 4394 / 128
control: rm apps/console/plugin.js, re-run              exit 0
```

The artefact was restored byte-identically after the control (`git hash-object` = `dab03a3e` both sides), so the tree the fix was measured on is the built one.

The build added **three** files to the census, not one — measured by asking git about every walked path:

```
apps/console/plugin.js       zero-rule   <- the red
apps/console/plugin.d.ts     rule-bearing  \  silently counted as COVERED:
apps/site/next-env.d.ts      rule-bearing  /  the quiet half of the same defect
```

## What changed

The walk now asks git, once. One batched `git check-ignore --stdin -z` over every candidate path, and what it names is dropped from both populations before anything is judged. Two short-lived processes, no per-file spawning: measured 6ms for `rev-parse --is-inside-work-tree` and 407 / 414 / 484ms over three runs for the batch of 4523 candidates, against the 2.5s the walk already costs — and the dropped paths never reach `calculateConfigForFile` at all.

Both repairs the card excluded stay excluded. A `VACUOUS_GROUPS` row would be a permanent waiver against a path that is not in the repository and that nobody could ever shrink; a second ignore list inside this script would be a copy of `.gitignore` needing to be kept in sync with it, which is the same defect one level up.

**Ignore, not `git ls-files`.** The semantics were measured rather than assumed, and they are the ones this gate needs:

| path | `git check-ignore` | census |
|---|---|---|
| untracked, matched by an ignore rule | reported | dropped (build output) |
| TRACKED, even when a rule matches it | not reported | stays |
| untracked, matched by nothing | not reported | stays |

That last row is the point: enumerating tracked files would make the verdict depend on whether the developer had run `git add`, which is the same defect wearing a different hat. A brand-new unstaged `scripts/check-foo.mjs` still reds this gate.

**The reading has its own control, in the same run.** `gitIgnoreReading` appends two synthetic paths to the batch and `gitIgnoreCollapse` requires both answers — `node_modules/eslint-git-ignore-probe.ts` must come back IGNORED (the process ran and can say yes) and the same probe at the repository root must come back VISIBLE (it can say no). An empty ignored set is then a reading — which is what an unbuilt tree legitimately looks like — instead of a `git` that failed and silently answered "nothing". Outside a git work tree the filter reports itself unavailable and `main()` refuses that state loudly.

## Acceptance criterion from triage: both states green, same census

```
built tree, artefact PRESENT     pnpm check:lint-rule-coverage   exit 0   4519 / 4392 / 127   3 excluded
same tree, artefacts removed                                     exit 0   4519 / 4392 / 127   0 excluded
```

Identical to the pre-build census taken before the fix. The only number that moves is the excluded count, and it is printed rather than silent.

## Tests

`scripts/__tests__/check-lint-rule-coverage.test.ts` — 35 passed (was 27). The load-bearing new case is the card's control as a fixture: one git fixture tree analysed with and without a generated file, asserting the identical `findings`, `walked`, `vacuous` and `ruleBearing`. The three git semantics above are pinned separately against a real `git` process, and both halves of the filter's control are taken from a real process rather than a constructed object.

### Ablation — the pins fail without the fix

Implementation committed first, then `reading.ignored.has(file)` mutated to `false` at all 3 sites (marker count 3 to 0, 3 injected, blob `b11814bd` to `663bf8e3`), restored under an `EXIT INT TERM` trap and proved restored by `git diff HEAD` empty and the blob back to `b11814bd`:

```
leg A  node scripts/check-lint-rule-coverage.mjs   exit 1
       unledgered: apps/console/plugin.js          census 4522 / 4394 / 128
leg B  the pin file                                4 failed | 31 passed
       x gives the identical verdict and census whether or not the tree has been built
       x narrows the ESLint#lintFiles equivalence by exactly the ignored paths
       x never judges apps/console/plugin.js, built or not (objectui#8369)
       x is green, with every ledger row still live and the census standing
```

Leg A reproduces the card's exact red through the ablation. One honest nuance on leg B: the fourth failure, the repository-green case, is red under ablation only because this container's checkout has been built — in a clean CI checkout it would stay green either way, which is precisely why the fixture pins exist.

### Other verification

`scripts-type-check`, `check-vi-mock-specifiers`, `check-vi-mock-inherit`, `check-doc-expression-carriage` — 178 passed. `check:control-bytes`, `check:entry-guard`, `check:shell-escape-residue`, `check:unreferenced-sources`, `check:changeset-presence` — all exit 0. Targeted `eslint --no-inline-config` over both changed files: 2 files linted, 0 errors, 0 warnings (the `.mjs` half of that is the vacuity objectui#7908 declared — this gate's own subject — so the judged file there is the `.ts` one).

No changeset: `check-changeset-presence.mjs` reports 2 files changed, 0 of them published source of a released package, so none is owed. `check-governed-queue-guard.mjs --test` on both paths: NOT GOVERNED.

`Bundle Analysis` is red on `main` and on every PR that triggers it (objectui#8542) — not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_