### PR TITLE
fix(fields): a readonly BooleanField says Yes / No only for a real boolean

### DIFF
--- a/.changeset/8593-booleanfield-readonly-non-boolean.md
+++ b/.changeset/8593-booleanfield-readonly-non-boolean.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/fields': patch
+---
+
+`BooleanField`'s readonly branch no longer reads the value by truthiness (objectui#8593).
+
+objectui#8582 ruled, on `@objectstack/spec`'s value contract, that only a real boolean is a
+value of a boolean column and moved `BooleanCellRenderer` off truthiness. This takes the same
+reading one surface over: the read-only branch of the edit widget that `FieldEditWidget`
+registers for `boolean` / `toggle` and every generated form renders for a readonly boolean.
+Measured by rendering on `21529629c`:
+
+| stored value | readonly widget said before | says now |
+|---|---|---|
+| the string `'false'`, the string `'0'`, `{}`, `[]` | **Yes** | the shared `EmptyValue` affordance |
+| the string `'true'`, the string `'1'`, `1` | Yes | the affordance |
+| `0`, `''` | **No** | the affordance |
+| `null`, `undefined` | No | the affordance |
+| a real `true` / `false` | Yes / No | **unchanged** |
+
+**The ruling is the spec's.** `@objectstack/spec` declares the runtime value of `boolean` /
+`toggle` as a bare `z.boolean()` — "a JS boolean on the wire (driver read-coercion repairs SQL
+0/1)", stored "never text on any backend". The truth table that turns `'true'` / `1` / `'0'`
+into a boolean already lives at the producer boundaries (objectql's `coerceBooleanFields` and
+its `invalid_boolean` write refusal, `rest`'s CSV `parseBooleanCell`), so a non-boolean that
+reaches the widget is a producer that skipped its repair, and a second copy of that table in
+the widget would be the lenient dialect the contract forbids.
+
+**Both directions.** The truthy non-booleans said "Yes" — an affirmative the record never
+made — and the falsy ones, plus a missing value, said "No", a negative it never made either.
+The widget has no status-name badge, so unlike the cell renderer the fabricated "No" weighed
+no more than the fabricated "Yes"; both now land on the affordance.
+
+**Why `EmptyValue`.** It is this directory's own convention: every sibling widget with a
+readonly branch and a nullable value (`NumberField`, `CurrencyField`, `PercentField`,
+`DateTimeField`, `EmailField`, `PhoneField`, `RadioField`, `ObjectField`, …) draws it for the
+absent case, and the cell renderer happens to draw the same component — the two surfaces agree
+by convention, not by import. A consumer that fed the widget `1` / `0` or `'true'` / `'false'`
+from a backend of its own now sees the affordance instead of a word: coerce at the data source,
+where the platform does.

--- a/content/docs/fields/boolean.mdx
+++ b/content/docs/fields/boolean.mdx
@@ -39,6 +39,19 @@ const isActive: BooleanFieldMetadata = {
 The value being edited, and the `className` / `disabled` a host supplies, are **not**
 metadata keys — they are runtime widget props. See [Field Widget Props](/docs/fields/widget-props).
 
+## Read-only Display
+
+In a read-only row (a `readonly` field in a generated form, or a detail body), the widget draws
+a real `true` as "Yes" and a real `false` as "No". **Only a real boolean is a value of a boolean
+field.** `@objectstack/spec` declares the runtime value of `boolean` / `toggle` as a bare JS
+boolean on the wire; the SQL `0`/`1` repair and the `'true'` / `'false'` spellings belong to
+the producer boundaries (driver read-coercion, CSV import), never to the widget. So `null`,
+`undefined`, `[]`, `{}`, `0`, `1`, `''`, `'true'` and `'false'` all render the shared
+`EmptyValue` affordance — an em-dash with the accessible name "No value", the same affordance
+every other field widget draws for an absent value — because the record holds no boolean
+there. The widget keeps no second truth table: a `'false'` string that reaches it is a producer
+that skipped its coercion, and the place to fix that is the data source.
+
 ## Use Cases
 
 - **Feature Toggles**: Enable/disable features

--- a/packages/fields/src/__tests__/booleanField.readonlyNonBoolean-8593.test.tsx
+++ b/packages/fields/src/__tests__/booleanField.readonlyNonBoolean-8593.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8593 — `BooleanField`'s readonly branch read the value by
+ * TRUTHINESS (`value ? 'Yes' : 'No'`), so the string `'false'`, the string
+ * `'0'`, `{}` and `[]` all said "Yes".
+ *
+ * This is objectui#8582's defect one surface over. That card moved
+ * `BooleanCellRenderer` off truthiness on `@objectstack/spec`'s value
+ * contract; this file takes the read-only branch of the EDIT widget, which
+ * `FieldEditWidget` registers for `boolean` and `toggle` and every generated
+ * form renders for a readonly boolean. Measured on `21529629c` by rendering —
+ * the "before" column is what THE DEFECT / THE OTHER DIRECTION legs of this
+ * file were observed to fail on against that tree (failure modes per leg are
+ * in the PR):
+ *
+ * | stored value                         | readonly widget said | why                      |
+ * |--------------------------------------|----------------------|--------------------------|
+ * | `'false'`, `'0'`, `'no'`, `{}`, `[]` | "Yes"                | truthy non-booleans      |
+ * | `'true'`, `'1'`, `1`                 | "Yes"                | ingest spellings, truthy |
+ * | `0`, `''`                            | "No"                 | falsy non-booleans       |
+ * | `null`, `undefined`                  | "No"                 | absence read as false    |
+ *
+ * ── The ruling is the spec's, not this file's ─────────────────────────────
+ * `@objectstack/spec`'s runtime value contract for `boolean` / `toggle` is a
+ * bare `z.boolean()` (`data/field-value.zod.ts`, `valueSchemaFor`). The same
+ * module declares the class "a JS boolean on the wire (driver read-coercion
+ * repairs SQL 0/1)" and lists it under `NON_TEXT_STORED_VALUE_TYPES`: the
+ * stored value "is never text on any backend". The truth table that turns
+ * `'true'` / `1` / `'0'` into a boolean already lives at the producer
+ * boundaries — objectql's `coerceBooleanFields` on the read path and its
+ * `invalid_boolean` write-path refusal, `rest`'s `parseBooleanCell` on CSV
+ * import — so a non-boolean that reaches this widget is a producer that
+ * skipped its repair, and a second copy of that table here would be the
+ * widget-side dialect AGENTS.md #0.1 forbids. Hence ONLY a real boolean is a
+ * value of a boolean field; everything else is NO value.
+ *
+ * ── What a readonly WIDGET draws for no value ─────────────────────────────
+ * `EmptyValue` — because that is this directory's own convention, not because
+ * the cell renderer uses it. Every sibling widget with a readonly branch and
+ * a nullable value renders `EmptyValue` for the absent case (`NumberField`,
+ * `CurrencyField`, `PercentField`, `DateTimeField`, `EmailField`,
+ * `PhoneField`, `RadioField`, `ObjectField`, `ObjectRefField`, `CodeField`,
+ * `LocationField`, `QRCodeField`, `MultiSelectField`, `CheckboxesField`, …),
+ * and `validation-feedback.test.tsx` already pins that dash for six of them.
+ * `BooleanCellRenderer`'s answer happens to be the same component, so the two
+ * surfaces agree by convention rather than by import.
+ *
+ * ── The second direction ──────────────────────────────────────────────────
+ * objectui#8582 found fabricated FALSEHOOD as well as fabricated truth, and
+ * on a status-named field it was a destructive badge, louder than the
+ * positive. The widget has the fabricated falsehood (`0`, `''`, `null` and
+ * `undefined` said "No") but no louder shape: its readonly branch is one text
+ * span with no field-name conventions, so a "No" weighs exactly what a "Yes"
+ * weighs. Both directions are swept here; there is no badge case because
+ * there is no badge.
+ *
+ * ── Why the POPULATED cases are the load-bearing ones ─────────────────────
+ * The caricature is a widget that says "Yes" for a literal `true` and draws
+ * the affordance for everything else (`value !== true` in place of
+ * `typeof value !== 'boolean'`). It satisfies every THE DEFECT, THE OTHER
+ * DIRECTION and THE RULING case in this file. What refuses it is the
+ * POPULATED block: a real `false` still says "No". Each was RUN against the
+ * caricature, not predicted.
+ *
+ * ── Why each defect case asserts the fabrication's ABSENCE first ──────────
+ * "a Yes here is a fabricated true" / "a No here is a fabricated false" are
+ * the sentences that fail on the unfixed tree; "the shared EmptyValue
+ * affordance must be present" is the one that fails on a widget that draws
+ * nothing at all. They are textually distinct so the legs can be told apart
+ * by failure MODE rather than by count.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BooleanField } from '../widgets/BooleanField';
+import { FieldEditWidget } from '../FieldEditWidget';
+
+afterEach(() => cleanup());
+
+const noop = () => {};
+
+type BooleanType = 'boolean' | 'toggle';
+
+/** Render the widget exactly the way a readonly form row does: `readonly`, a stored value. */
+function renderReadonly(type: BooleanType, value: unknown, field: Record<string, unknown> = {}) {
+  return render(
+    <BooleanField
+      value={value as never}
+      onChange={noop}
+      field={{ type, name: type, ...field } as never}
+      readonly={true}
+    />,
+  );
+}
+
+/** The same, through the `boolean` / `toggle` registration a host resolves. */
+function renderThroughHost(type: BooleanType, value: unknown) {
+  return render(
+    <FieldEditWidget
+      value={value}
+      onChange={noop}
+      field={{ type, name: type } as never}
+      readonly={true}
+    />,
+  );
+}
+
+const affordance = (root: HTMLElement) =>
+  root.querySelector<HTMLElement>('[data-slot="empty-value"]');
+/**
+ * Text-node locators, scoped to the render's own container. `queryAllByText`
+ * rather than `queryByText`: the latter THROWS on a second match, which would
+ * read as a harness death instead of a fabricated value.
+ */
+const yesCount = (root: HTMLElement) => within(root).queryAllByText('Yes').length;
+const noCount = (root: HTMLElement) => within(root).queryAllByText('No').length;
+
+function expectAffordance(root: HTMLElement, label: string) {
+  const empty = affordance(root);
+  expect(empty, `${label}: the shared EmptyValue affordance must be present`).not.toBeNull();
+  expect(
+    empty?.getAttribute('aria-label'),
+    `${label}: the affordance must carry its accessible name`,
+  ).toBe('No value');
+}
+
+/** Non-booleans that are TRUTHY — the values the old branch said "Yes" for. */
+const FABRICATED_TRUE: ReadonlyArray<readonly [label: string, value: unknown]> = [
+  ["the string 'false'", 'false'],
+  ["the string '0'", '0'],
+  ["the string 'no'", 'no'],
+  ['an empty object {}', {}],
+  ['an empty array []', []],
+];
+
+/** Non-booleans that are FALSY — the values the old branch said "No" for. */
+const FABRICATED_FALSE: ReadonlyArray<readonly [label: string, value: unknown]> = [
+  ['the number 0', 0],
+  ["the empty string ''", ''],
+];
+
+/** No value at all — which the old branch ALSO said "No" for. */
+const ABSENT: ReadonlyArray<readonly [label: string, value: unknown]> = [
+  ['null', null],
+  ['undefined', undefined],
+];
+
+/**
+ * Spellings the platform's INGEST boundaries accept and repair (objectql's
+ * `coerceBooleanFields`, `rest`'s `parseBooleanCell`). On the wire they are
+ * still not booleans, and this widget owns no copy of that table.
+ */
+const INGEST_SPELLINGS: ReadonlyArray<readonly [label: string, value: unknown]> = [
+  ["the string 'true'", 'true'],
+  ["the string '1'", '1'],
+  ['the number 1', 1],
+];
+
+const TYPES: ReadonlyArray<BooleanType> = ['boolean', 'toggle'];
+
+describe('objectui#8593 — a readonly BooleanField says Yes / No only for a real boolean', () => {
+  describe('THE DEFECT — a truthy non-boolean said "Yes", an affirmative the record never made', () => {
+    for (const type of TYPES) {
+      for (const [label, value] of FABRICATED_TRUE) {
+        it(`THE DEFECT — readonly \`${type}\` holding ${label} says no "Yes" and draws the No-value affordance`, () => {
+          const { container } = renderReadonly(type, value);
+          expect(
+            yesCount(container),
+            `${type} holding ${label}: a "Yes" here is a fabricated true`,
+          ).toBe(0);
+          expectAffordance(container, `${type} holding ${label}`);
+        });
+      }
+    }
+  });
+
+  describe('THE OTHER DIRECTION — a falsy non-boolean, or no value at all, said "No", a false the record never stored', () => {
+    for (const type of TYPES) {
+      for (const [label, value] of [...FABRICATED_FALSE, ...ABSENT]) {
+        it(`THE OTHER DIRECTION — readonly \`${type}\` holding ${label} says no "No" and draws the No-value affordance`, () => {
+          const { container } = renderReadonly(type, value);
+          expect(
+            noCount(container),
+            `${type} holding ${label}: a "No" here is a fabricated false`,
+          ).toBe(0);
+          expectAffordance(container, `${type} holding ${label}`);
+        });
+      }
+    }
+  });
+
+  describe('THE RULING — the widget owns no truth table: an ingest spelling is still not a boolean on the wire', () => {
+    for (const [label, value] of INGEST_SPELLINGS) {
+      it(`THE RULING — readonly \`boolean\` holding ${label} says no "Yes" and draws the No-value affordance`, () => {
+        const { container } = renderReadonly('boolean', value);
+        expect(
+          yesCount(container),
+          `boolean holding ${label}: the widget owns no truth table, so a "Yes" here is a coercion the spec assigns to the producer`,
+        ).toBe(0);
+        expectAffordance(container, `boolean holding ${label}`);
+      });
+    }
+  });
+
+  describe('POPULATED — a real boolean still says exactly what it said before (the load-bearing block)', () => {
+    // The readonly branch precedes the `widget` split, so the checkbox and
+    // switch variants must read the same; both are pinned so a future
+    // per-variant readonly face cannot drift on one side only.
+    const VARIANTS: ReadonlyArray<readonly [label: string, field: Record<string, unknown>]> = [
+      ['the default (switch) variant', {}],
+      ['the checkbox variant', { widget: 'checkbox' }],
+    ];
+    for (const type of TYPES) {
+      for (const [variant, field] of VARIANTS) {
+        it(`POPULATED — readonly \`${type}\` (${variant}) holding a real \`true\` still says "Yes"`, () => {
+          const { container } = renderReadonly(type, true, field);
+          expect(yesCount(container), `${type}: a real true must still say Yes`).toBe(1);
+          expect(noCount(container), `${type}: a real true must not say No`).toBe(0);
+          expect(affordance(container), `${type}: a real true must NOT render the affordance`).toBeNull();
+          expect(container.textContent, `${type}: the readonly face of a real true is the bare word`).toBe('Yes');
+        });
+
+        it(`POPULATED — readonly \`${type}\` (${variant}) holding a real \`false\` still says "No" (false is a value, not an absence)`, () => {
+          const { container } = renderReadonly(type, false, field);
+          expect(noCount(container), `${type}: a real false must still say No`).toBe(1);
+          expect(yesCount(container), `${type}: a real false must not say Yes`).toBe(0);
+          expect(affordance(container), `${type}: a real false must NOT render the affordance`).toBeNull();
+          expect(container.textContent, `${type}: the readonly face of a real false is the bare word`).toBe('No');
+        });
+      }
+    }
+  });
+
+  describe('THE HOST PATH — the `boolean` / `toggle` registration reaches the same branch', () => {
+    for (const type of TYPES) {
+      it(`THE HOST PATH — \`FieldEditWidget\` readonly \`${type}\` holding the string 'false' draws the affordance, not "Yes"`, () => {
+        const { container } = renderThroughHost(type, 'false');
+        expect(
+          yesCount(container),
+          `${type} via FieldEditWidget holding 'false': a "Yes" here is a fabricated true`,
+        ).toBe(0);
+        expectAffordance(container, `${type} via FieldEditWidget holding 'false'`);
+      });
+
+      it(`THE HOST PATH — \`FieldEditWidget\` readonly \`${type}\` holding a real \`false\` still says "No"`, () => {
+        const { container } = renderThroughHost(type, false);
+        expect(noCount(container), `${type} via FieldEditWidget: a real false must still say No`).toBe(1);
+        expect(affordance(container), `${type} via FieldEditWidget: a real false must NOT render the affordance`).toBeNull();
+      });
+    }
+  });
+});

--- a/packages/fields/src/widgets/BooleanField.tsx
+++ b/packages/fields/src/widgets/BooleanField.tsx
@@ -1,5 +1,5 @@
 import React, { useId } from 'react';
-import { Switch, Checkbox, Label } from '@object-ui/components';
+import { Switch, Checkbox, Label, EmptyValue } from '@object-ui/components';
 import { FieldWidgetComponentProps } from './types.js';
 import { toDomProps } from './toDomProps.js';
 
@@ -51,6 +51,34 @@ export function BooleanField({ value, onChange, field, readonly, error, ...props
   const emitOwnLabel = !hostId;
 
   if (readonly) {
+    // Only a real boolean is a value of a boolean field (objectui#8593 — the
+    // widget-side half of objectui#8582's ruling on `BooleanCellRenderer`).
+    //
+    // `@objectstack/spec`'s runtime value contract for `boolean` / `toggle` is
+    // a bare `z.boolean()` (`data/field-value.zod.ts`, `valueSchemaFor`): the
+    // class is "a JS boolean on the wire (driver read-coercion repairs SQL
+    // 0/1)" and sits under `NON_TEXT_STORED_VALUE_TYPES` — stored "never text
+    // on any backend". The truth table that turns `'true'` / `1` / `'0'` into
+    // a boolean lives at the PRODUCER boundaries (objectql's
+    // `coerceBooleanFields` and its `invalid_boolean` write refusal, `rest`'s
+    // `parseBooleanCell` on CSV import), so a non-boolean reaching this branch
+    // is a producer that skipped its repair, and a second copy of that table
+    // here would be the widget-side dialect AGENTS.md #0.1 forbids.
+    //
+    // This branch used to read the value by TRUTHINESS. The string `'false'`,
+    // the string `'0'`, `{}` and `[]` said "Yes" — an affirmative the record
+    // never made — and `0`, `''`, `null` and `undefined` said "No", a negative
+    // it never made either. Both directions are the same fabrication and both
+    // now land on `EmptyValue`: the affordance every sibling widget in this
+    // directory draws for an absent value in its readonly branch
+    // (`NumberField`, `CurrencyField`, `PercentField`, `DateTimeField`,
+    // `EmailField`, `PhoneField`, `RadioField`, `ObjectField`, …), which is
+    // also what `BooleanCellRenderer` draws for the same input — the two
+    // surfaces agree by this directory's convention, not by import. Its
+    // accessible name ("No value") is a statement about the field's TYPE: the
+    // record holds no boolean here. A real `false` is a value and still says
+    // "No".
+    if (typeof value !== 'boolean') return <EmptyValue />;
     return <span className="text-sm">{value ? 'Yes' : 'No'}</span>;
   }
 


### PR DESCRIPTION
Fixes objectstack-ai/objectui#8593

## What

`BooleanField`'s readonly branch read the value by truthiness (`value ? 'Yes' : 'No'`), so the string `'false'`, the string `'0'`, `{}` and `[]` all said **Yes**, and `0`, `''`, `null` and `undefined` all said **No**. It now says "Yes" / "No" only for a real boolean and draws the shared `EmptyValue` affordance (an em-dash with the accessible name "No value") for anything else.

This is objectui#8582's defect one surface over. The direction was ruled there, on `@objectstack/spec`'s bare `z.boolean()` for `boolean` / `toggle`, `BOOLEAN_VALUE_TYPES`, `NON_TEXT_STORED_VALUE_TYPES`, and the producer-side truth tables (objectql's `coerceBooleanFields` / `invalid_boolean`, `rest`'s `parseBooleanCell`), and it is not re-derived here: a non-boolean is no value, and a widget-side truth table would be the AGENTS.md #0.1 second dialect. The guard is the one `09fab31d1` put in `BooleanCellRenderer`: `typeof value !== 'boolean'`.

Measured on `21529629c` by rendering (LEG A below):

| stored value | readonly widget said | says now |
|---|---|---|
| `'false'`, `'0'`, `'no'`, `{}`, `[]` | Yes | the `EmptyValue` affordance |
| `'true'`, `'1'`, `1` | Yes | the affordance |
| `0`, `''` | No | the affordance |
| `null`, `undefined` | No | the affordance |
| a real `true` / `false` | Yes / No | unchanged |

## The one open question: what a readonly widget draws for no value

`EmptyValue` — because it is this directory's own convention, not because the cell renderer uses it. Every sibling in `packages/fields/src/widgets/` with a readonly branch and a nullable value renders `EmptyValue` for the absent case: `NumberField` (`value == null ? EmptyValue : the value`), `CurrencyField`, `PercentField`, `DateTimeField`, `EmailField`, `PhoneField`, `RadioField`, `ObjectField`, `ObjectRefField`, `CodeField`, `LocationField`, `QRCodeField`, `MultiSelectField`, `CheckboxesField`, `CapabilityMultiSelectField`, `RecipientPickerField`, `ImageField`, `AddressField`, `GeolocationField`. `validation-feedback.test.tsx` already pins that dash in readonly mode for six of them. The widgets that draw something else are the ones with a domain-specific shape (`MasterDetailField`'s "No related records", `FilterConditionField`'s refusal text, `PasswordField`'s mask, `AvatarField`'s initials). `BooleanCellRenderer` happens to use the same component, so the two surfaces agree by convention rather than by import. The bare-element form (`NumberField`'s) is used rather than a `text-sm` span around it, matching the majority.

## The second direction

Checked. The widget has the fabricated falsehood: `0`, `''`, `null` and `undefined` said "No" (LEG A: 8 "fabricated false" failures). It does not have the louder shape objectui#8582 found in the cell renderer: the readonly branch is one text span with no field-name conventions and no destructive badge, so a fabricated "No" weighed exactly what a fabricated "Yes" weighed. Both directions land on the same affordance.

## Evidence: ablation legs

Subject `packages/fields/src/widgets/BooleanField.tsx`, 136 lines at HEAD (blob `035cdf27c`). The test file imports it by relative source path, and `vitest.config.mts` aliases `@object-ui/components` to `packages/components/src` (line 505), so no `dist/` is on the resolution path and no rebuild sits between legs. Every leg: mutate, prove on disk (removed-text count, injected-text count, line total, blob hash), run `packages/fields/src/__tests__/booleanField.readonlyNonBoolean-8593.test.tsx` (33 tests), restore with `git checkout HEAD -- ABSOLUTE_PATH` under a trap on `EXIT INT TERM`, prove the restore by state (`git diff HEAD` empty AND `git hash-object` equal to the HEAD blob). All five restores verified. Instrument: per-test classification from vitest's JSON reporter (each failed test's first failure line: `AssertionError` sentence, or a harness death).

| leg | mutation | on-disk proof | result |
|---|---|---|---|
| 0 | HEAD | hash == `035cdf27c` | 33 passed |
| A, the defect | the `21529629c` blob (`c8325fff6`, 108 lines) | typeof-guard 0, `EmptyValue` 0, truthiness ternary 1, lines 108, hash == BASE blob | 23 failed / 10 passed: 12 "fabricated true" (10 THE DEFECT + 2 THE HOST PATH), 8 "fabricated false", 3 "coercion the spec assigns"; 0 harness deaths; all 8 POPULATED and the 2 HOST PATH `false` cases green |
| B, the caricature | `value !== true` in place of `typeof value !== 'boolean'` | guard 0, marker 1, lines 136, hash differs | 6 failed / 27 passed: all six "a real false must still say No" (4 POPULATED + 2 THE HOST PATH); every THE DEFECT / THE OTHER DIRECTION / THE RULING case green — the caricature satisfies them, and only the populated `false` cases refuse it |
| C, empty element | the readonly branch returns a bare span | guard 0, marker 1, lines 136 | 33 failed: 23 "affordance must be present", 6 "must still say No", 4 "must still say Yes", and **0 "fabricated" sentences** — the locators see only the widget's own output |
| D, empty file | 0 bytes, hash == `e69de29bb` | lines 0, bytes 0 | 33 failed: **29 harness deaths** (`Element type is invalid`) against 4 assertions (the THE HOST PATH cases, where `FieldEditWidget` renders its own fallback for an undefined widget) |

Instrument correction, stated rather than smoothed: the first run counted `grep -c` hits over the text reporter for the death signatures the brief listed (`Cannot read properties of null`, `Unable to find`, `TypeError`, `is not a function`) and read LEG D as **0 deaths / 4 AssertionErrors**. React's death for an empty module is `Element type is invalid`, and vitest prints one block per distinct message, so 29 identical deaths appeared once. The per-test JSON classification above is what told 29 from 4; the first run's counts are not relied on.

## Verification on `c303b681d`

- `pnpm exec vitest run` on the new file plus `standard-widgets.test.tsx`, `validation-feedback.test.tsx`, `readonly-host-plumbing-e2e.test.tsx`: 4 files, 201 passed
- `pnpm exec vitest run packages/fields/`: 141 files, 2432 passed
- `pnpm exec vitest run packages/plugin-form/ packages/plugin-detail/`: 228 files, 2129 passed, 1 skipped
- `pnpm --filter @object-ui/fields type-check`: both programs (`tsc --noEmit && tsc -p tsconfig.test.json`) green after `pnpm --filter '@object-ui/fields^...' build`; `tsc -p tsconfig.test.json --listFiles` lists the new test (1 hit)
- eslint, a measured narrowing: `pnpm exec eslint` on the two `.tsx` files with `--format json`: 2 files, 0 errors; 0 warnings on the test, 1 pre-existing `no-explicit-any` warning at `BooleanField.tsx:11` (`config = field as any`, untouched). Population: `eslint.config.js` `files: ['**/*.{ts,tsx}']` minus its `ignores` (dist, .next, node_modules, public, .source) over 4397 tracked ts/tsx. Invariance: the config sets no `parserOptions.project` / `projectService` (0 hits; control `files:` 7 hits) and its ratchet rules are per-file `error` promotions, not repo-wide counters, so this diff cannot move any untouched file's verdict.
- Gates: `check-control-bytes` OK (6783 files); `check-changeset-no-major`, `check-changeset-presence` (2 source files, 1 changeset), `check-changeset-overwrite`, `check-changeset-fixed` OK; `check-doc-fence-languages`, `check-doc-component-types`, `check-doc-links` OK; a Python zero-width / control-character scan of the four changed files, with a lit control, 0 hits; `check-governed-queue-guard --test` on the four paths: NOT GOVERNED.
- NOT MEASURED, declared: `check-doc-snippet-types` exits 2 ("could not run": eight packages' `dist/` absent), and the docs diff adds prose only (0 new fences; control: 4 fences in the file). `pnpm lint` repo-wide, `pnpm check`, and the other 19 CI-affected packages from `turbo ls --affected` against `21529629c` (app-shell, console, plugin-grid, plugin-kanban, the examples, ...) are CI's; `git grep` finds no test outside `packages/fields` that pins the readonly boolean's Yes / No text.

## Scope notes

- The edit branch's `checked={!!value}` is untouched: the card scopes to the readonly branch and records the edit branch as the lesser. An editable Switch has no "no value" state, so what it should show for a non-boolean is a decision, not a sweep. Left for the PM.
- `origin/main` moved one commit (`d02942b0e`, `packages/types` tests) after this branch was cut, with no file overlap, so `main` was not merged in; PR #8594's edit to `content/docs/fields/boolean.mdx` is in the Cell Renderer section, this one adds a separate Read-only Display section above Use Cases, and the two hunks do not touch.

Written under `session_01YBWFb5YgMU5dw8p2VKj16S`; generic placeholders in this body are spelled as capitalised words because GitHub strips tag-shaped fragments from bodies, backticks included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_