### PR TITLE
fix(core): a non-string stored value satisfies `not_contains` instead of failing the operator and its negation both

### DIFF
--- a/.changeset/8452-not-contains-non-string-value.md
+++ b/.changeset/8452-not-contains-non-string-value.md
@@ -1,0 +1,20 @@
+---
+"@object-ui/core": patch
+---
+
+`ValueDataSource`: a stored value that is not a string now satisfies `not_contains`
+/ `$notContains` instead of failing the operator and its negation both.
+
+Both arms were written as `typeof value === 'string' && !value.includes(target)` — a
+type test standing in for the predicate. A row whose column held the number `5`
+failed `contains '5'` (correct: a number cannot contain a substring) and also failed
+`not_contains '5'` (wrong: for that same reason it does not contain it), so the row
+appeared in **no** filter answer, and the opposite filter — the one thing a user has
+to debug a missing row with — was silent too. Measured on a mixed fixture,
+`not_contains '5'` returned 1 of 8 rows where it now returns 7.
+
+The arms are now the exact complement of `contains` / `$contains`. The positive text
+operators are unchanged and keep their type gate: that is the other half of
+objectstack#14079 (maintainer ruling 2026-09-05, option A) — a non-string never
+satisfies a positive text operator and always satisfies `$notContains`, so
+complementarity holds on every face.

--- a/packages/core/src/adapters/README.md
+++ b/packages/core/src/adapters/README.md
@@ -99,6 +99,16 @@ That is **all sixteen** — nothing the spec declares is refused by name.
 is IS NOT NULL. `$exists` is its exact inverse — `$exists: true` is IS NOT NULL — which
 is the lowering `convertFiltersToAST` already performs, not a reading invented here.
 
+A stored value that is **not a string** never satisfies `$contains`, `$icontains`,
+`$startsWith` or `$endsWith`, and always satisfies `$notContains` — the number `5`
+does not contain the substring `"5"`, so it is on the negation side. That is
+objectstack#14079 (maintainer ruling 2026-09-05, option A), and it is what makes the
+operator and its negation a **partition**: before objectui#8452 both arms carried the
+type test, so a numeric column answered NO to `$notContains` as well and those rows
+appeared in no filter answer at all. The stored value is never coerced to text —
+searching `String(50)` would answer a query nobody wrote, in a spelling the storage
+class chose. A `null` and an absent key take the same side of the same predicate.
+
 Anything else is **refused**: the row is excluded and the reason is logged once per
 distinct refusal per `find()` — never passed through as "no constraint", which is
 what an unrecognised operator used to mean here. Refused on purpose, each with a

--- a/packages/core/src/adapters/ValueDataSource.ts
+++ b/packages/core/src/adapters/ValueDataSource.ts
@@ -416,8 +416,32 @@ function matchesComparisonNode(
     // folds ASCII only, so a Unicode promise here is one the wire cannot keep.
     case 'icontains':
       return typeof value === 'string' && asciiCaseInsensitiveContains(value, String(target));
+    // objectui#8452 — this arm answers the PREDICATE, not a TYPE TEST. It used
+    // to read `typeof value === 'string' && !value.includes(...)`, so a row
+    // whose value is the number 5 failed `contains '5'` (right: a number cannot
+    // contain a substring) AND failed `not_contains '5'` (wrong: for the very
+    // same reason it cannot contain it, it does not contain it). Measured on
+    // this fixture before the fix, `not_contains '5'` answered `['sx']` where
+    // it now answers seven of eight rows: six rows sat outside BOTH halves of
+    // the partition, so no filter answer included them and the opposite filter
+    // — the one thing a user has to debug with — was silent too.
+    //
+    // The direction is objectstack#14079 (maintainer ruling 2026-09-05,
+    // option A), quoted from `filter-text-conformance.ts`, the contract that
+    // carries it: "a stored value that is not a string never satisfies a
+    // positive text operator (`$contains` / `$startsWith` / `$endsWith` /
+    // `$icontains` / `$like` / `$ilike`) and satisfies `$notContains` —
+    // complementarity holds, on every face." `FILTER_TEXT_CASES`' `score` rows
+    // pin it, and `driver-memory`'s reference matcher — the face the defect was
+    // measured on — carries the same expression negated the same way.
+    //
+    // So this is the exact complement of the `contains` arm above, and it has
+    // to STAY spelled that way: the type gate on the positive operators is the
+    // other half of the same ruling, not a leftover to clean up. A `null` or an
+    // absent key is admitted by the same predicate (they are not strings),
+    // which is also what objectstack#13166 ruled for this operator.
     case 'not_contains':
-      return typeof value === 'string' && !value.includes(String(target));
+      return !(typeof value === 'string' && value.includes(String(target)));
     case 'starts_with':
       return typeof value === 'string' && value.startsWith(String(target));
     case 'ends_with':
@@ -603,8 +627,14 @@ function matchesDollarOperator(
       return typeof value === 'string' && value.includes(String(target));
     case '$icontains':
       return typeof value === 'string' && asciiCaseInsensitiveContains(value, String(target));
+    // objectui#8452 — the `$` spelling of the same cell, and the same fix: the
+    // complement of the `$contains` arm above rather than a `typeof` test
+    // standing in for the predicate. objectstack#14079 option A: a stored value
+    // that is not a string never satisfies a positive text operator and
+    // satisfies `$notContains`, so complementarity holds on every face. The two
+    // dialects are pinned against each other so this one cannot drift back.
     case '$notContains':
-      return typeof value === 'string' && !value.includes(String(target));
+      return !(typeof value === 'string' && value.includes(String(target)));
     case '$startsWith':
       return typeof value === 'string' && value.startsWith(String(target));
     case '$endsWith':

--- a/packages/core/src/adapters/__tests__/ValueDataSource.nonStringStoredValue.test.ts
+++ b/packages/core/src/adapters/__tests__/ValueDataSource.nonStringStoredValue.test.ts
@@ -1,0 +1,265 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8452 — a text operator aimed at a stored value that is NOT a string.
+ *
+ * ## What was wrong
+ *
+ * `not_contains` / `$notContains` were written as
+ * `typeof value === 'string' && !value.includes(target)`. The leading `typeof`
+ * is a TYPE test standing in for the predicate, so a row whose `score` is the
+ * number `5` failed `contains '5'` (correct — a number cannot contain a
+ * substring) AND failed `not_contains '5'` (wrong — for the very same reason it
+ * cannot contain it, it does not contain it). One row, excluded from both
+ * halves of a partition: no filter answer includes it, and a user who tries the
+ * opposite filter to debug it gets the same silence twice.
+ *
+ * ## Why "the non-string satisfies the negation" is the answer, not this file's opinion
+ *
+ * objectstack#14079, maintainer ruling 2026-09-05, option A — quoted from the
+ * contract that carries it (`filter-text-conformance.ts`, section "A stored
+ * value that is not a string"):
+ *
+ * > The ruling took the type-gate (option A): a stored value that is not a
+ * > string never satisfies a positive text operator (`$contains` /
+ * > `$startsWith` / `$endsWith` / `$icontains` / `$like` / `$ilike`) and
+ * > satisfies `$notContains` — complementarity holds, on every face.
+ *
+ * `FILTER_TEXT_CASES` (`@objectstack/spec/data`) pins it as five rows over a
+ * numeric `score` column, and `driver-memory`'s reference matcher — the face
+ * the card was measured on — now answers the PREDICATE:
+ * `if (typeof value === 'string' && value.includes(target)) return false;`.
+ * This adapter's two arms are the same expression, negated the same way.
+ *
+ * ⚠️ The POSITIVE operators were already right and are deliberately re-pinned
+ * here rather than left alone: option A is a rule about the whole family, and
+ * the cheapest way to break the family is to "fix" the negation by making the
+ * type test disappear from its siblings too. Their rows below are the class
+ * guard, not decoration.
+ *
+ * ## How these cases are written, and why
+ *
+ * Every assertion is a row-SET equality over a fixture that holds BOTH a
+ * numeric and a string `score`, because each half alone is satisfiable by an
+ * implementation strictly worse than the bug:
+ *
+ *   - the EXCLUSION half alone (`contains` returns few rows) is satisfied by a
+ *     matcher answering `[]` to everything;
+ *   - the INCLUSION half alone (`not_contains` returns the numeric rows) is
+ *     satisfied by `case 'not_contains': return true` — the caricature that
+ *     restores the partition by making the operator mean nothing.
+ *
+ * So the load-bearing cases are the STRING ones: `s5` must be the only row
+ * `contains '5'` returns, and the only row `not_contains '5'` withholds.
+ *
+ * The fixture mirrors `FILTER_TEXT_ROWS`' `score` column rather than importing
+ * `FILTER_TEXT_CASES`: enrolling this adapter in that table means answering ALL
+ * of it, and the table's own rule 2 is that a face's rows join it in the PR
+ * that closes the gap, not before. That enrolment is filed separately.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ValueDataSource } from '../ValueDataSource';
+
+/**
+ * One column, eight stored values, chosen so that every wrong answer is a
+ * VISIBLY different id set rather than a different count:
+ *
+ * | row     | stored     | what it catches |
+ * |---|---|---|
+ * | `n5`    | `5`        | the card's cell: fails `contains '5'` and `not_contains '5'` both |
+ * | `n50`   | `50`       | a COERCING backend: `String(50)` contains `'5'` and ends with `'0'` |
+ * | `n0`    | `0`        | a guard written as a TRUTHINESS test rather than a `typeof` one |
+ * | `s5`    | `'5'`      | the load-bearing string: the ONLY row a positive operator may return |
+ * | `sx`    | `'x'`      | a string the positive operator misses, so the negation is not vacuous |
+ * | `bool`  | `false`    | a non-string that is not a number either — the rule is about strings |
+ * | `nul`   | `null`     | present, no value |
+ * | `gone`  | key absent | absent, no value |
+ */
+const ROWS = [
+  { id: 'n5', score: 5 },
+  { id: 'n50', score: 50 },
+  { id: 'n0', score: 0 },
+  { id: 's5', score: '5' },
+  { id: 'sx', score: 'x' },
+  { id: 'bool', score: false },
+  { id: 'nul', score: null },
+  { id: 'gone' },
+];
+
+const ALL_IDS = ['n5', 'n50', 'n0', 's5', 'sx', 'bool', 'nul', 'gone'];
+
+/** Every row except the one string that does contain the comparand. */
+const ALL_BUT_S5 = ['n5', 'n50', 'n0', 'sx', 'bool', 'nul', 'gone'];
+
+async function selectedIds(filter: unknown): Promise<string[]> {
+  const ds = new ValueDataSource({ items: ROWS });
+  const result = await ds.find('rows', { $filter: filter as any });
+  return result.data.map((r) => r.id as string);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// 0. The harness discriminates — in BOTH directions
+// ---------------------------------------------------------------------------
+
+describe('objectui#8452 — the fixture discriminates in both directions', () => {
+  it('an empty filter returns every row, so an exclusion is a real narrowing', async () => {
+    expect(await selectedIds([]), 'no filter must select all eight rows').toEqual(ALL_IDS);
+  });
+
+  it('an operator that never read the value TYPE still selects — the live control', async () => {
+    // `=` carries no `typeof` guard, so it is green on the broken tree and on
+    // the fixed one. Its job is to prove the rows, the adapter and the id
+    // projection all work, so a red below is about the text operators rather
+    // than about the harness.
+    expect(await selectedIds(['score', '=', 5])).toEqual(['n5']);
+    expect(await selectedIds(['score', '=', '5'])).toEqual(['s5']);
+  });
+
+  it('the inclusion half is non-empty and the exclusion half is not everything', async () => {
+    // Stated as its own case so neither `[]` for everything nor `ALL_IDS` for
+    // everything can pass this file.
+    const positive = await selectedIds(['score', 'contains', '5']);
+    const negative = await selectedIds(['score', 'not_contains', '5']);
+    expect(positive.length, 'a matcher answering [] to everything fails here').toBeGreaterThan(0);
+    expect(negative, 'a matcher answering every row to everything fails here').not.toEqual(ALL_IDS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 1. The card's cell: the operator and its negation partition the fixture
+// ---------------------------------------------------------------------------
+
+describe('objectui#8452 — `not_contains` over a non-string stored value', () => {
+  it('a number satisfies `not_contains`, exactly as it fails `contains`', async () => {
+    expect(
+      await selectedIds(['score', 'contains', '5']),
+      'a number cannot contain a substring — only the STRING "5" may come back',
+    ).toEqual(['s5']);
+    expect(
+      await selectedIds(['score', 'not_contains', '5']),
+      'the numeric rows were dropped from the negation too — the defect',
+    ).toEqual(ALL_BUT_S5);
+  });
+
+  it('every row satisfies exactly one of the two — no row fails both', async () => {
+    const positive = await selectedIds(['score', 'contains', '5']);
+    const negative = await selectedIds(['score', 'not_contains', '5']);
+    expect(
+      [...positive, ...negative].sort(),
+      'a row missing from both halves is the defect objectstack#14079 ruled on',
+    ).toEqual([...ALL_IDS].sort());
+    expect(
+      positive.filter((id) => negative.includes(id)),
+      'and no row may satisfy both halves either',
+    ).toEqual([]);
+  });
+
+  it('the partition holds for a comparand only a STRING row matches', async () => {
+    // `x` appears in no coerced number, so this comparand separates "the
+    // negation admits non-strings" from "the negation admits everything".
+    expect(await selectedIds(['score', 'contains', 'x'])).toEqual(['sx']);
+    expect(await selectedIds(['score', 'not_contains', 'x'])).toEqual(
+      ['n5', 'n50', 'n0', 's5', 'bool', 'nul', 'gone'],
+    );
+  });
+
+  it('`not_contains` still EXCLUDES a real string that contains the comparand', async () => {
+    // The caricature guard, spelled as its own case: `return true` for every
+    // value restores the partition and makes the operator mean nothing.
+    const negative = await selectedIds(['score', 'not_contains', '5']);
+    expect(negative, 'the string "5" DOES contain "5" and must be withheld').not.toContain('s5');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The positive family keeps the type gate — the class guard
+// ---------------------------------------------------------------------------
+
+describe('objectui#8452 — a positive text operator never matches a non-string', () => {
+  it('`contains` does not coerce the stored number to text', async () => {
+    // A coercing backend answers ['n5','n50','s5'] here.
+    expect(await selectedIds(['score', 'contains', '5'])).toEqual(['s5']);
+  });
+
+  it('`starts_with` does not coerce', async () => {
+    expect(await selectedIds(['score', 'starts_with', '5'])).toEqual(['s5']);
+  });
+
+  it('`ends_with` does not coerce — the storage-class tell', async () => {
+    // `0` is the comparand the coercion shows up on: `String(50)` and
+    // `String(0)` both end with it, and a SQLite REAL column renders every
+    // value with a trailing `0`. No STORED STRING in this fixture ends with
+    // `0`, so the declared answer is empty.
+    expect(await selectedIds(['score', 'ends_with', '0'])).toEqual([]);
+    expect(await selectedIds(['score', 'ends_with', '5'])).toEqual(['s5']);
+  });
+
+  it('`icontains` applies the guard before the fold, not instead of it', async () => {
+    expect(await selectedIds(['score', 'icontains', '5'])).toEqual(['s5']);
+    expect(await selectedIds(['score', 'icontains', 'X'])).toEqual(['sx']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. The `$` dialect of the same adapter answers the same way
+// ---------------------------------------------------------------------------
+
+describe('objectui#8452 — the `$` dialect agrees with the AST dialect', () => {
+  it('`$notContains` is satisfied by every non-string stored value', async () => {
+    expect(await selectedIds({ score: { $contains: '5' } })).toEqual(['s5']);
+    expect(await selectedIds({ score: { $notContains: '5' } })).toEqual(ALL_BUT_S5);
+  });
+
+  it('`$notContains` still withholds the string that contains the comparand', async () => {
+    expect(await selectedIds({ score: { $notContains: '5' } })).not.toContain('s5');
+  });
+
+  it('the `$` positive family keeps its type gate too', async () => {
+    expect(await selectedIds({ score: { $startsWith: '5' } })).toEqual(['s5']);
+    expect(await selectedIds({ score: { $endsWith: '0' } })).toEqual([]);
+    expect(await selectedIds({ score: { $icontains: '5' } })).toEqual(['s5']);
+  });
+
+  it('both dialects answer the same rows for the same question', async () => {
+    expect(await selectedIds({ score: { $notContains: '5' } })).toEqual(
+      await selectedIds(['score', 'not_contains', '5']),
+    );
+    expect(await selectedIds({ score: { $contains: '5' } })).toEqual(
+      await selectedIds(['score', 'contains', '5']),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. A no-value row satisfies the negation — the same expression, stated
+// ---------------------------------------------------------------------------
+
+describe('objectui#8452 — a row with no value is on the negation side', () => {
+  it('a null and an absent key both satisfy `not_contains`', async () => {
+    // Not a separate rule and not a separate code path: `null` and `undefined`
+    // are non-strings, so the one predicate covers them. It is pinned because
+    // the platform ruled the same cell separately (objectstack#13166 —
+    // `$ne` / `$nin` / `$notContains` admit a no-value row) and the two answers
+    // must not drift apart here.
+    const negative = await selectedIds(['score', 'not_contains', '5']);
+    expect(negative).toContain('nul');
+    expect(negative).toContain('gone');
+  });
+
+  it('and neither of them satisfies the positive operator', async () => {
+    const positive = await selectedIds(['score', 'contains', '5']);
+    expect(positive).not.toContain('nul');
+    expect(positive).not.toContain('gone');
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectui#8452

## What was wrong

`ValueDataSource`'s two negation arms — `not_contains` (AST / infix dialect, `matchesComparisonNode`) and `$notContains` (`$` dialect, `matchesDollarOperator`) — were both written as:

```ts
return typeof value === 'string' && !value.includes(String(target));
```

The leading `typeof` is a **type test standing in for the predicate**. A row whose column holds the number `5` fails `contains '5'` (correct — a number cannot contain a substring) and *also* fails `not_contains '5'` (wrong — for that same reason it does not contain it). The row is excluded from **both halves of a partition**: it appears in no filter answer at all, and the opposite filter, the one thing a user has to debug a missing row with, is silent too.

Measured on `21529629c` over an eight-row fixture mixing numeric, string, boolean, `null` and absent values:

| filter | before | after |
| --- | --- | --- |
| `['score','contains','5']` | `['s5']` | `['s5']` — unchanged |
| `['score','not_contains','5']` | `['sx']` | `['n5','n50','n0','sx','bool','nul','gone']` |

Six of the eight rows were in neither half.

## The direction is ruled upstream, not decided here

objectstack#14079, maintainer ruling 2026-09-05, **option A**. Quoted verbatim from the contract that carries it — `packages/spec/src/data/filter-text-conformance.ts` in `@objectstack/spec`, section *"A stored value that is not a string"*:

> The ruling took the type-gate (option A): a stored value that is not a string never satisfies a positive text operator (`$contains` / `$startsWith` / `$endsWith` / `$icontains` / `$like` / `$ilike`) and satisfies `$notContains` — complementarity holds, on every face.

`FILTER_TEXT_CASES` pins it as five rows over a numeric `score` column, and `driver-memory`'s reference matcher — the face the defect was originally measured on — now answers the **predicate**:

```ts
if (typeof value === 'string' && value.includes(target)) return false;
```

This adapter's two arms are that same expression, negated the same way:

```ts
return !(typeof value === 'string' && value.includes(String(target)));
```

No second dialect was needed and none was invented. The only other statement about this operator in the package is `filter-converter.ts`'s `$not` refusal, which says the negated operators "follow each operator's own answer for a missing value" — this change is what supplies that answer here, so the two files agree.

## The same axis on the other text operators — checked, already conformant

The card asked for the whole class, not one spelling. Both dialects were swept; the vocabulary has exactly one negated text operator.

| operator | non-string stored value | verdict |
| --- | --- | --- |
| `contains` / `$contains` | never matches | already correct, unchanged, now pinned |
| `icontains` / `$icontains` | never matches | already correct, unchanged, now pinned |
| `starts_with` / `$startsWith` | never matches | already correct, unchanged, now pinned |
| `ends_with` / `$endsWith` | never matches | already correct, unchanged, now pinned |
| `not_contains` / `$notContains` | **must match** | the defect — both arms changed |
| `like` / `ilike` | n/a | refused by name with a prescription; this matcher has no pattern engine, unchanged |

`VALID_AST_OPERATORS` and `ALL_OPERATORS` (read from the installed `@objectstack/spec`) carry no other negated text spelling — no `not_starts_with`, no `not_icontains` — so the class is shut by these two arms. The type gate on the positive family is deliberately **kept**: it is the other half of the same ruling, not a leftover to clean up, and the code comment says so.

## Evidence — four legs, each mutation proven on disk in both directions

Harness: `pnpm exec vitest run packages/core/src/adapters/__tests__/ValueDataSource.nonStringStoredValue.test.ts`, from the repo root, paths not behind a bare separator. Every leg restores by **state**: `git hash-object PATH` compared against `git rev-parse HEAD:PATH`, plus `git diff HEAD` empty; the script traps on `EXIT INT TERM` with absolute paths.

| leg | mutation | on-disk proof | vitest exit | `AssertionError` lines | harness-death lines |
| --- | --- | --- | --- | --- | --- |
| **B** control | none, tree as committed | n/a | 0 | **0** | 0 |
| **A** fix removed | both arms back to the `typeof` spelling | injected 2, fixed spelling remaining 0, lines 1103 to 1103 (one-for-one swap) | 1 | **5** | 0 |
| **C** caricature | both arms `return true` unconditionally | injected marker 2, fixed spelling remaining 0, lines 1103 to 1103 | 1 | **7** | 0 |
| **D** empty file | the test file truncated to 0 bytes | lines 265 to 0, bytes 0 | 1 | **0** | 3 |

**LEG C is the caricature the card named** — "`not_contains` returns true for every value" restores the partition and makes the operator mean nothing. It is not predicted here, it was executed. Three cases go red in **C and not in A**, and they are precisely the string-side, load-bearing ones:

- `` `not_contains` still EXCLUDES a real string that contains the comparand ``
- `` `$notContains` still withholds the string that contains the comparand ``
- `the inclusion half is non-empty and the exclusion half is not everything`

One case goes red in **A and not in C** — `a null and an absent key both satisfy not_contains` — because the caricature happens to admit those rows. So every discriminating assertion was **observed to fail** in the leg it was written for; none of them passed by comparing one absent thing to another.

**LEG D is the harness-death control**, and it corrected the instrument rather than confirming it. The alternation borrowed from objectui#8582 (`Cannot read properties of null`, `Unable to find`, `TypeError`, `is not a function`) matched **0** lines on this repo's empty-file mode: vitest here reports `Failed Suites` / `Error: No test suite found in file` / `Tests  no tests`, none of which is a TypeError. Counted with the narrow alternation alone, leg D would have read as *"a clean run with zero assertion failures"* — the exact misreading the leg exists to prevent. The widened alternation (adding `No test suite found`, `Failed Suites`, `Tests  no tests`) reads 3 on D and **0 on B, A and C**, so it separates the two failure modes without firing on a real red.

Nothing in this change refuses anything, so objectui#8530's envelope-only-refusal hazard has no surface here: there is no new error code, status or message to pin.

## Other checks

Run from the repo root, exit codes captured before any pipe.

- `pnpm exec vitest run packages/core/` — **132 files, 2788 tests, all pass** (re-run after merging current `main` in).
- `pnpm exec vitest run` over the eight packages that consume `ValueDataSource` (`react`, `types`, `data-objectstack`, `plugin-designer`, `plugin-map`, `plugin-gantt`, `plugin-list`, `fields`) — **592 files, 8505 tests, all pass**.
- `pnpm --filter '@object-ui/core^...' build` then `pnpm --filter @object-ui/core type-check` — exit 0, **both** programs (`tsc --noEmit` and `tsc -p tsconfig.test.json`). Verified with `tsc -p tsconfig.test.json --listFiles` that the new test file really is in the test program: 1 hit, and the control (the sibling `textOperatorCase` file) also 1.
- `eslint .` over the whole of `packages/core` at `c3fbc7b14` — **231 files** in eslint's own selection, **0 errors**, 532 warnings, all pre-existing `no-explicit-any`. The new test file contributes exactly 1 warning, identical to the sibling `ValueDataSource.textOperatorCase.test.ts` baseline.
- `check:control-bytes` OK (6789 files); `check:doc-fences` OK; `check-changeset-presence` / `check-changeset-fixed` / `check-changeset-no-major` / `check-changeset-overwrite` OK; `check:vi-mock-specifiers` / `check:vi-mock-inherit` / `check:unreferenced-sources` OK.
- Zero-width and control characters: a Python scanner over all four changed files reads 0 hits, with a lit control string that reads 2. `check:control-bytes` does not cover zero-width spaces inside string literals, which is why the separate scan exists.
- `node scripts/check-governed-queue-guard.mjs --test` over the four changed paths: **NOT GOVERNED** — an ordinary pull request.

**Declared narrowing:** the repo-wide `turbo run lint` and the full `pnpm test` farm are left to CI. The diff touches one package, and `eslint.config.js` configures no type-aware linting (0 hits for `projectService` / `parserOptions` / `project:`; lit control `rules` reads 11), so this diff cannot move the verdict on any file it does not edit.

## History cited by sha

Verified with `git log -1` and `git show --stat` in a non-shallow checkout rather than taken on trust:

- `f76f43628` — `$`-operator vocabulary and the `refuseFilterNode` idiom, `ValueDataSource.ts`
- `e76634cc8` — comparand shapes (array by reference, `{ $field }`)
- `f5cfbbd81` — both filter-converter arms gate the comparand
- `617707a48` — `$and` / `$or` lowered to real AST group nodes

`refuseFilterNode` is defined at `ValueDataSource.ts:65`; `FilterOperatorError` at `filter-converter.ts:53`. Different files, different conventions — this change touches neither idiom.

## Base

Branched from `21529629c`; current `main` (`70c452369`) was brought in by **merge**, not rebase, and the branch has never been force-pushed. The merge touched nothing this change depends on, and `packages/core` was re-verified afterwards.

## Not addressed here, deliberately

- Enrolling `ValueDataSource` in `FILTER_TEXT_CASES` itself. That table's own rule 2 is that a face's rows join it in the pull request that shuts the gap, and enrolling means answering **all** of it, including the folding and comparand-literalness rows. Out of scope for this card; recorded for the PM instead.
- objectui#8447 is already landed — the `$` dialect refuses what it does not recognise, so no unimplemented arm returns every row underneath this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_