### PR TITLE
fix(types): declare the six spec members on record:details sections (objectui#8583, item 1)

### DIFF
--- a/.changeset/8583-record-details-section-members.md
+++ b/.changeset/8583-record-details-section-members.md
@@ -1,0 +1,20 @@
+---
+'@object-ui/types': patch
+---
+
+`RecordDetailsComponentProps.sections[]` declares the six member keys
+`@objectstack/spec` 17.3.0 `RecordDetailsProps.sections[]` declares and this
+type omitted: `columns`, `icon`, `description`, `showBorder`, `defaultCollapsed`
+and `headerColor` (objectui#8583, item 1).
+
+Every one of the six was already honoured at runtime — `RecordDetailsRenderer`
+spreads each authored section through to `DetailSection`, which reads all six —
+and accepted by the contract, so the published TypeScript face was the only
+layer that said no: a spec-valid section such as `{ group: 'terms', columns: 2 }`
+was refused by `tsc` (`TS2353`) while rendering correctly. The six now carry the
+spec's own authoring types (`columns` a number, `headerColor` the closed
+six-token vocabulary), all optional, exactly as the spec declares them.
+
+Additive only: no existing member moves, no value that type-checked before
+stops type-checking. The remaining item on that card — the member this type
+declares that the spec refuses — is a separate decision and is untouched here.

--- a/.changeset/8583-record-details-section-members.md
+++ b/.changeset/8583-record-details-section-members.md
@@ -1,5 +1,5 @@
 ---
-'@object-ui/types': patch
+'@object-ui/types': minor
 ---
 
 `RecordDetailsComponentProps.sections[]` declares the six member keys

--- a/packages/types/src/__tests__/record-details-section-members-8583.test.ts
+++ b/packages/types/src/__tests__/record-details-section-members-8583.test.ts
@@ -1,0 +1,224 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8583 (item 1) — `RecordDetailsComponentProps.sections[]` declares
+ * the six member keys `@objectstack/spec` `RecordDetailsProps.sections[]`
+ * declares and this type used to omit: `columns`, `icon`, `description`,
+ * `showBorder`, `defaultCollapsed`, `headerColor`.
+ *
+ * ## Why this pin is compile-time, and why a runtime pin alone measures nothing
+ *
+ * The change is a TYPE declaration. Every one of the six was already honoured
+ * by the renderer — `RecordDetailsRenderer` spreads each authored section
+ * through to `DetailSection`, which reads all six — and accepted by the spec's
+ * parser, so nothing at runtime moves; the only layer that said no was `tsc`.
+ * `vitest` strips types: the card recorded that
+ * `{ sections: [{ group: 'terms', columns: 2 }] }` was GREEN under vitest on
+ * the unfixed type and refused only by `type-check`. So the load-bearing half
+ * of this file is what the compiler sees, and this package compiles its tests
+ * through `tsconfig.test.json` — the THIRD leg of its `type-check` script
+ * (`tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`),
+ * the only leg that reads this file.
+ *
+ * ## How the direction is proved rather than asserted
+ *
+ * TypeScript reports an UNUSED `@ts-expect-error` as an error (TS2578), so
+ * each directive below is a claim that the instrument REFUSES something:
+ * `Expect` refuses `false`, `Equal` is invariant (neither `never` nor `any`
+ * reads as `true`), a key nothing declares is not a member, and an excess key
+ * on a section literal does not compile. Break any of those and this file goes
+ * red on the now-unused directive rather than quietly passing. Same shape as
+ * `data-table-declared-keys-6882.test.ts` next door.
+ *
+ * ## The runtime half: the two-control probe on the INSTALLED spec
+ *
+ * The type is a mirror, and what it mirrors is read out of the installed
+ * `@objectstack/spec` at test time, never restated: the six names must be in
+ * the section object's shape; a canonical section carrying all six must parse
+ * with NO issues (the parser accepts the six); and the same section plus one
+ * key nobody declares must draw `unrecognized_keys` naming exactly that key
+ * (the parser CAN refuse, so a refusal is about the name). Either leg alone is
+ * not a reading.
+ */
+import { describe, it, expect } from 'vitest';
+import type { z } from 'zod';
+import { RecordDetailsProps } from '@objectstack/spec/ui';
+import { arrayElementSchema, listedShapeKeys, resolvePropsShape } from '@object-ui/test-support';
+import type { RecordDetailsComponentProps } from '../record-components';
+
+/** One authored `sections[]` entry, as this package declares it. */
+type Section = NonNullable<RecordDetailsComponentProps['sections']>[number];
+
+/**
+ * The same entry on the spec's AUTHORING surface. `z.input`, not `z.output`:
+ * this type describes what an author writes, and an output type would carry
+ * every `.default()` as required.
+ */
+type SpecSection = NonNullable<z.input<typeof RecordDetailsProps>['sections']>[number];
+
+/** Invariant type equality. `A extends B` is NOT this: `never` and `any` pass that. */
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+/** The only assertion form used here — its constraint is what refuses `false`. */
+type Expect<T extends true> = T;
+
+/** Is `K` a DECLARED member of a section entry? */
+type IsSectionMember<K extends PropertyKey> = K extends keyof Section ? true : false;
+
+/* ── Direction proofs: a broken instrument makes THIS file red ─────────────── */
+
+// @ts-expect-error objectui#8583 — `Expect` must refuse `false`. Widen its constraint and this directive goes unused (TS2578).
+type _ExpectRefusesFalse = Expect<false>;
+
+// @ts-expect-error objectui#8583 — `never` must NOT read as equal to `true`. An `extends`-shaped comparison would let it through.
+type _EqualRefusesNever = Expect<Equal<never, true>>;
+
+// @ts-expect-error objectui#8583 — `any` must NOT read as equal to `true`, for the same reason.
+type _EqualRefusesAny = Expect<Equal<any, true>>;
+
+// @ts-expect-error objectui#8583 — a key nothing declares must answer `false`. If the section entry ever grew an index signature this would answer `true` and the directive would go unused.
+type _UndeclaredKeyIsRefused = Expect<IsSectionMember<'bogusKeyNobodyDeclares8583'>>;
+
+/* ── The six: declared, and each with the spec's own authoring type ────────── */
+
+/** RED before objectui#8583 (`Property 'columns' does not exist on type …`), green after. */
+type _Columns = Expect<Equal<Section['columns'], SpecSection['columns']>>;
+/** RED before objectui#8583, green after. */
+type _Icon = Expect<Equal<Section['icon'], SpecSection['icon']>>;
+/** RED before objectui#8583, green after. */
+type _Description = Expect<Equal<Section['description'], SpecSection['description']>>;
+/** RED before objectui#8583, green after. */
+type _ShowBorder = Expect<Equal<Section['showBorder'], SpecSection['showBorder']>>;
+/** RED before objectui#8583, green after. */
+type _DefaultCollapsed = Expect<Equal<Section['defaultCollapsed'], SpecSection['defaultCollapsed']>>;
+/** RED before objectui#8583, green after — the closed six-token vocabulary, not `string`. */
+type _HeaderColor = Expect<Equal<Section['headerColor'], SpecSection['headerColor']>>;
+
+/* ── Literals: what an author can now write, and what they still cannot ────── */
+
+const SIX = ['columns', 'icon', 'description', 'showBorder', 'defaultCollapsed', 'headerColor'] as const;
+
+/**
+ * The card's own repro — a shape the spec accepts and `tsc` refused before
+ * objectui#8583 with TS2353 on `columns`. The annotation is the assertion.
+ */
+const groupReferenceWithLayout: RecordDetailsComponentProps = {
+  sections: [{ group: 'terms', columns: 2 }],
+};
+
+/** A canonical enumerated section carrying all six, typed against THIS package. */
+const canonicalSection: Section = {
+  name: 'contact',
+  label: 'Contact',
+  fields: ['phone', 'email'],
+  columns: 2,
+  icon: 'user',
+  description: 'How to reach them',
+  showBorder: true,
+  collapsible: true,
+  defaultCollapsed: false,
+  headerColor: 'muted',
+};
+
+/**
+ * The compile-time control: excess-property checking on this literal is what
+ * makes the declared member set reach a TypeScript author at all. A key nothing
+ * declares must not compile — otherwise the six being accepted above would say
+ * nothing.
+ */
+const refusedByTsc: RecordDetailsComponentProps = {
+  sections: [
+    {
+      fields: ['phone'],
+      // @ts-expect-error objectui#8583 — a key nothing declares is refused on the section literal.
+      __objectui_8583_probe__: true,
+    },
+  ],
+};
+
+/** Member keys of one `sections[]` entry, read off the INSTALLED spec. */
+const specSectionKeys = (): string[] =>
+  listedShapeKeys(arrayElementSchema(resolvePropsShape(RecordDetailsProps)?.sections));
+
+/**
+ * The keys an `unrecognized_keys` issue names. Zod's issue union carries `keys`
+ * on that one member only, so the read goes through the same widening cast the
+ * sibling `recordDetailsInputs.spec-parity.test.ts` uses.
+ */
+const refusedKeys = (issues: ReadonlyArray<unknown> | undefined): string[] =>
+  (issues ?? []).flatMap((i) => (i as { keys?: string[] }).keys ?? []);
+
+describe('record:details `sections[]` declares the six spec members (objectui#8583, item 1)', () => {
+  it('the installed spec still declares all six on the section object', () => {
+    // The premise the compile-time pins rest on: were the spec to drop one, the
+    // `Equal` above would go red for the right reason, and this names it first.
+    expect(specSectionKeys()).toEqual(expect.arrayContaining([...SIX]));
+  });
+
+  it('control A — a canonical section carrying all six parses with no issues', () => {
+    const parsed = RecordDetailsProps.safeParse({ sections: [canonicalSection] });
+    expect(parsed.error?.issues ?? []).toEqual([]);
+    expect(parsed.success).toBe(true);
+    // The six SURVIVE the parse — the key-reachability criterion, not a bare
+    // success receipt (a stripping schema would hand out that too).
+    expect(parsed.data?.sections?.[0]).toMatchObject({
+      columns: 2,
+      icon: 'user',
+      description: 'How to reach them',
+      showBorder: true,
+      defaultCollapsed: false,
+      headerColor: 'muted',
+    });
+  });
+
+  it('control B — the same section plus a key nobody declares draws `unrecognized_keys` naming exactly that key', () => {
+    const parsed = RecordDetailsProps.safeParse({
+      sections: [{ ...canonicalSection, __objectui_8583_probe__: true }],
+    });
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues.map((i) => i.code)).toContain('unrecognized_keys');
+    // Envelope, not a bare failure: the refusal names the probe and NONE of the
+    // six — which is what makes control A's acceptance attributable to the
+    // names rather than to a parser that never refuses anything.
+    expect(refusedKeys(parsed.error?.issues)).toEqual(['__objectui_8583_probe__']);
+  });
+
+  it("the card's repro — `{ group, columns }` — is accepted by the spec and, now, by this type", () => {
+    // `columns` is one of the three keys the spec permits BESIDE `group` (it
+    // describes how this page lays the section out), so this literal is
+    // spec-valid, renderer-honoured, and until objectui#8583 refused by `tsc`
+    // alone. The compile is the assertion; the parse pins the premise.
+    const parsed = RecordDetailsProps.safeParse(groupReferenceWithLayout);
+    expect(parsed.error?.issues ?? []).toEqual([]);
+    expect(parsed.success).toBe(true);
+    expect(groupReferenceWithLayout.sections?.[0]).toEqual({ group: 'terms', columns: 2 });
+  });
+
+  it('`headerColor` mirrors a CLOSED vocabulary — an off-vocabulary value is refused on its value', () => {
+    // A VALUE verdict on the contract side, so the union declared here is
+    // provably no wider than what the spec accepts: `bg-muted` is a string,
+    // and the spec refuses it by name of the option set, not by type.
+    const parsed = RecordDetailsProps.safeParse({
+      sections: [{ ...canonicalSection, headerColor: 'bg-muted' }],
+    });
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues.map((i) => [i.code, i.path.join('.')])).toContainEqual([
+      'invalid_value',
+      'sections.0.headerColor',
+    ]);
+  });
+
+  it('keeps the compile-time literals alive at runtime', () => {
+    // Runtime shape is unaffected by the type-level assertions above; these
+    // exist so the file also fails visibly if a literal is ever emptied.
+    expect(canonicalSection.headerColor).toBe('muted');
+    expect(refusedByTsc.sections).toHaveLength(1);
+  });
+});

--- a/packages/types/src/record-components.ts
+++ b/packages/types/src/record-components.ts
@@ -69,6 +69,53 @@ export interface RecordDetailsComponentProps {
      * section out.
      */
     group?: string;
+    /**
+     * Field-grid columns for THIS section, an integer 1-4
+     * (`@objectstack/spec` `RecordDetailsProps.sections[].columns`). Omit it
+     * and `DetailSection` derives the width from the field count. Permitted
+     * beside `group`: it describes how this page lays the section out, not
+     * anything the group itself declares.
+     */
+    columns?: number;
+    /**
+     * Heading icon, a lucide name (`sections[].icon`). `DetailSection` draws it
+     * wherever the heading renders: a titled section, or any collapsible one.
+     * Refused beside `group` — the group's own `icon` applies there.
+     */
+    icon?: string;
+    /**
+     * Sub-heading text under the section heading (`sections[].description`).
+     * `DetailSection` renders it as-is, with no translation lookup, unlike
+     * `label`; a collapsible section hides it while collapsed. Refused beside
+     * `group`.
+     */
+    description?: string;
+    /**
+     * Draw the section's Card chrome (`sections[].showBorder`). Unauthored,
+     * `RecordDetailsRenderer` derives it — on for a titled section, off for an
+     * untitled one; an authored value wins. Permitted beside `group`.
+     */
+    showBorder?: boolean;
+    /**
+     * Start a `collapsible: true` section collapsed
+     * (`sections[].defaultCollapsed`). `DetailSection` reads it once, as the
+     * initial open state; a non-collapsible section never reads it. Refused
+     * beside `group`.
+     */
+    defaultCollapsed?: boolean;
+    /**
+     * Section-header background tint (`sections[].headerColor`): the closed
+     * six-token vocabulary `DetailSection` resolves through `headerColorClass`.
+     * The contract refuses any other value at authoring time rather than
+     * silently not painting. Permitted beside `group`.
+     */
+    headerColor?:
+      | 'muted'
+      | 'muted/50'
+      | 'accent'
+      | 'primary/10'
+      | 'secondary/10'
+      | 'destructive/10';
     collapsible?: boolean;
     collapsed?: boolean;
   }>;


### PR DESCRIPTION
Refs #8583 (item 1: the six omitted members)

`RecordDetailsComponentProps.sections[]` in `@object-ui/types` now declares the six member keys the installed `@objectstack/spec` 17.3.0 `RecordDetailsProps.sections[]` declares and this type omitted: `columns`, `icon`, `description`, `showBorder`, `defaultCollapsed`, `headerColor`. Contract-first: the code moves to the contract. Additive only — no existing member moves; the `collapsed` member that item 2 of the card is about is untouched and its disposition stays on the card, so `#8583` remains open after this merges.

## What changed

- `packages/types/src/record-components.ts` — the six members, each optional and typed as the spec's authoring surface types them (`columns` a number, `icon`/`description` strings, `showBorder`/`defaultCollapsed` booleans, `headerColor` the closed six-token vocabulary `muted` | `muted/50` | `accent` | `primary/10` | `secondary/10` | `destructive/10`), each with a short docblock naming the spec key it tracks and whether the spec permits it beside `group`.
- `packages/types/src/__tests__/record-details-section-members-8583.test.ts` — ONE new pin. Compile-time half: invariant `Equal` between each local member type and the spec's z.input type for a `sections[]` entry, four `@ts-expect-error` direction proofs (the instrument refuses `false`, `never`, `any`, and an undeclared key), the card's own repro literal `{ group: 'terms', columns: 2 }`, and an excess-key literal that must not compile. Runtime half: the two-control probe on the installed spec (below).
- `.changeset/8583-record-details-section-members.md` — **`@object-ui/types: minor`**. ⚠️ This was originally graded `patch`, citing objectui#8497 as precedent; a contract review at `CONTRACT_REVIEW_TIER` **failed** that grade and it was corrected in `f299618`. Adding six members to an exported interface of a published package is backwards-compatible new public-API surface — semver §7 MINOR — not an internal fix. The `#8497` precedent is the weak one: its types move rode **inside** a `plugin-detail` runtime crash fix and was graded as that fix, never reviewed as a standalone widening. Four counter-precedents grade a standalone TypeScript-face widening `minor`: `7767-collapsible-trigger-union.md` (which explicitly rejects the same "declaration catching up with what ships" argument), `7952-dashboard-widgets-component-arm.md`, `7697`, `7083`. Verdicts: objectui#8583 comments `5587871554` (FAIL) and `5588057698` (PASS on the corrected head).

## Zone 2 — the PM's mechanism assumptions, measured

**(a) Live reader for each of the six — HOLDS.** `RecordDetailsRenderer` (`packages/plugin-detail/src/renderers/record-details.tsx`) maps every authored entry as `{ ...s, title, showBorder: s.showBorder ?? derived, fields }` — the spread carries every authored key — and `DetailView` passes each entry verbatim as the `section` prop of `DetailSection` (`DetailView.tsx` lines 1559 and 1748). `DetailSection.tsx` reads: `section.defaultCollapsed` (the initial open state), `section.columns` (through `applyDetailAutoLayout`, which honours an explicit value), `section.showBorder` (the flat render and the `border-none` variant), `section.headerColor` (through `headerColorClass`), `section.icon` (the `SectionIcon` in both header variants) and `section.description` (the sub-heading paragraph in both header variants). Six of six have a reader; none is declared without one.

**(b) Spec member list and types re-derived from the INSTALLED spec — HOLDS, with one extra row.** `@objectstack/spec` is installed at 17.3.0 as seen from `packages/types` (`node_modules/.pnpm/@objectstack+spec@17.3.0_ai@7.0.65_zod@4.4.3_`). The `sections[]` element is a strict object (catchall `never`) with 12 keys: `name`, `label`, `columns`, `group`, `fields`, `hideEmpty`, `collapsible`, `showBorder`, `defaultCollapsed`, `icon`, `description`, `headerColor`. Two-control probe on that call shape: a canonical section carrying all six parsed with zero issues (control A); the same section plus `__objectui_8583_probe__` failed with `unrecognized_keys` naming exactly that key (control B). Value probes: `columns` is an integer 1..4 (`too_big` at 5, `too_small` at 0, `invalid_type` at 2.5 and at the string `"2"`); `headerColor` refuses `bg-muted` with `invalid_value` and accepts `accent`; the other four refuse the wrong primitive with `invalid_type`. Beside `group`: `columns`/`showBorder`/`headerColor` accepted, `icon` refused by the spec's group-reference refinement — the docblocks say which. The extra row: the spec-only set is seven, not six — `hideEmpty` is declared upstream at 17.3.0 (it parsed green), but it has NO reader by maintainer ruling (objectui#7129, 2026-09-01: `DetailSection` deliberately reads it nowhere) and is already recorded as the one deliberately-unread key in the `record:details` registry description; it fails Zone 2(a) and is not declared here.

**(c) No parity-ledger row moves — HOLDS, measured.** `packages/types/src/__tests__/zod-mirror-parity.test.ts` contains no `RecordDetails` / `record-components` reference (grep: 0 hits; there is no `.zod.ts` mirror for this file), and the real instrument agrees: the third type-check leg compiles that ledger (it is in the `--listFiles` output) and passed. `check:spec-symbols` stayed at 19 unbacked claims / 14 untriaged collisions — `RecordDetailsComponentProps` keeps its existing `CLAIM_DEBT` row, unchanged.

## Validation (code measurements on `88ee0c7`; `f299618` differs by the one changeset line only)

- `pnpm --filter @object-ui/types build` — exit 0; `dist completeness: 1 package(s) complete (124 emitted files verified)`.
- `pnpm --filter @object-ui/types type-check` (all three legs) — exit 0. Leg-3 evidence: `tsc -p tsconfig.test.json --listFiles` lists 149 test files, the new pin among them.
- `pnpm exec vitest run packages/types/ --maxWorkers=2` — `Test Files 149 passed (149)`, `Tests 2849 passed (2849)`. The pin alone: 6 passed.
- Consumer: `packages/plugin-detail` `tsc --noEmit` (the only importer of `RecordDetailsComponentProps`, by grep) — exit 0.
- **Reverse verification (ablation)**: with the fix committed, `packages/types/src/record-components.ts` was reverted on disk to the branch base `3e71b26` (blob `6f29bb7`, proven by `git hash-object`; the `headerColor?:` declaration anchor went 1 to 0) and leg 3 re-run: exit 2, **9 errors, all in the new pin, 0 elsewhere** — TS2339 on each of the six member reads, TS2353 on both literals. Restored with `git checkout HEAD -- path`; disk blob `6a26170` equals the HEAD blob, `git diff HEAD` empty. The contract reviewer reproduced this ablation independently. ⚠️ A first attempt was a no-op by its own anchor (it counted every `headerColor` occurrence, and the base file already mentions the word once in the `group` docblock, so the script refused to run); the anchor was corrected to the declaration line and the run above is the one that counts.
- ESLint on the two edited TS files — 0 errors (2 pre-existing-class `no-explicit-any` warnings, one on an untouched line).
- Gates derived from `package.json` `check:*` and every `.github/workflows/*.yml` `run:` line, exit code captured before any pipe — all exit 0: `control-bytes`, `changeset-presence`, `changeset-no-major`, `changeset-overwrite`, `changeset-fixed`, `shell-escape-residue`, `phantom-deps`, `self-import`, `published-tsconfig-exclude`, `vi-mock-specifiers`, `vi-mock-inherit`, `readme-exports` (after the tree was built; the first run was a prerequisite-not-met, not a measurement), `unreferenced-sources`, `handler-key-reads`, `designer-field-key-parity`, `icon-record-names`, `side-effects-array`, `element-data-source-declaration`, `action-forward-parity`, `doc-example-readers`, `comment-mask-corpus`, `action-ref-convention`, `spec-symbols`, `esm-specifiers`, `governed-queue-guard --test` (NOT GOVERNED).
- NOT MEASURED locally, declared to CI: `check:published-dist` (a release-time/nightly gate by ruling objectui#4846; the reviewer measured its criterion on the types tarball — 128 files, 0 tooling paths, no `dist/__tests__`), `check:dist-completeness --all`, repo-wide `pnpm lint`, `pnpm check`, the `doc-*` gates and `type-check` for packages other than `types` and `plugin-detail`. ⚠️ Correction of record: `pnpm check` **is** run by CI — `.github/workflows/lint.yml:481`, step "Verify the CLI's own check command passes on this repository"; the `Lint` job log on `f299618` shows it executing and passing (`Analyzing 627 files... ✓ All checks passed`). A contrary claim in the first review verdict was falsified and is corrected at objectui#8583 comment `5587960301`.

## 验收备注

- noted, not filed: `packages/types/src/__tests__/p1-spec-alignment.test.ts` lines 525-532 describe the pre-fix state (`{ group: 'terms', columns: 2 }` does NOT compile) and name this card as the follow-up; the sentence is now dated by this PR. Outside the dispatched file surface (`record-components.ts` plus one new pin), so left as is. 承接者: the seat that lands item 2 of this card, which touches the same interface.
- FILED by the seat from the reviewer's findings: **objectui#8603** — the objectui#7129 `hideEmpty` retirement was ruled on the premise that the spec refuses the key, and the pin moved to 17.3.0 six days later, where it is **declared** with a `describe()` promising the behaviour this repo removed. **objectui#8604** — the *top-level* `RecordDetailsComponentProps.columns` is `number` while the spec declares `z.enum(['1','2','3','4'])`, so `{ columns: 2 }` type-checks here and is refused at publish. ⚠️ Note the asymmetry: `sections[].columns` really is `number` and this PR is correct on it.
- observation for the `collapsed` remainder (not acted on, not annotated): on the `record:details` render path (`RecordDetailsRenderer` → `DetailView` → `DetailSection`) nothing reads a section's `collapsed`; `DetailSection` seeds its open state from `defaultCollapsed` only, and the installed spec answers `unrecognized_keys` naming `collapsed`. A repo-wide census of other readers was not run, and that gap belongs in the decision block for item 2.

Dispatch and identity: the PM claim comment on the card, session `session_01Jmxdo7bmeqCQHLSfmLVX9w`, branch `claude/issue-8583-record-details-sections-member-parity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w