### PR TITLE
docs(types): record the #6150 ledger's blind spot — complete only for the un-cast spelling

### DIFF
--- a/.changeset/8327-cast-read-census-ledger-header.md
+++ b/.changeset/8327-cast-read-census-ledger-header.md
@@ -1,0 +1,8 @@
+---
+---
+
+Record the `#6150` ledger's own blind spot in its header: the census it pins is
+complete only for the un-cast `schema.KEY` spelling, and the cast-aware re-run
+(objectui#8327) finds 112 `(schema as any).KEY` reads across 23 files that it
+could never have seen. Comment only, in a test file; no package is released by
+this change.

--- a/packages/types/src/__tests__/undeclared-but-consumed-keys-6150.test.ts
+++ b/packages/types/src/__tests__/undeclared-but-consumed-keys-6150.test.ts
@@ -18,6 +18,39 @@
  * cross-checked against `src/index.ts` — the two agreed on all 8 types): all 13
  * were still undeclared, and all 13 reads were still present.
  *
+ * ## ⚠️ "Complete" above holds ONLY for the un-cast spelling
+ *
+ * ⛔ Nothing above clears this class. Every read that census matched is spelled
+ * `schema.KEY`, a plain member access; it never looked for the cast spelling
+ * `(schema as any).KEY`. A reader who takes "13 genuinely READ" as the whole
+ * population concludes the class has been swept and stops looking — which is
+ * how objectui#7105 stayed open as long as it did.
+ *
+ * Measured, not asserted (objectui#8327). Re-running the CAST spelling alone
+ * over every tracked production `.ts`/`.tsx` under `packages/`, `apps/` and
+ * `examples/` on `origin/main` `154fe2a` — with the cast-aware `schemaReads`
+ * instrument this package already carries in
+ * `widget-schema-anchors-6576.test.ts` (objectui#6576), enumeration and reading
+ * both taken from that one ref — finds 112 (file, key) reads: 88 distinct keys
+ * across 23 files. Asked of the TypeScript checker rather than of a grep, 29 of
+ * the 112 are undeclared on the type the renderer is handed, 8 more are
+ * declared on only one arm of a union `schema` type, and 5 cannot be answered
+ * at all because the renderer is handed `any`. None of those 23 files is a
+ * reader listed below: the two populations were found by two instruments, and
+ * only the un-cast one has ever run for this file.
+ *
+ * ⚠️ Those 29 are NOT pending rows for this ledger. objectui#8327 classifies
+ * all 112, and 31 of them are ALREADY RULED non-author surface — the
+ * objectui#5091 grid ruling and the objectui#5097 host-composition ruling —
+ * so they must never be declared. Every row here is a published-type widening
+ * per key; adding one without its own ruling is not bookkeeping.
+ *
+ * ⭐ This file's completeness claim has now been falsified twice, from two
+ * different directions: by the cast spelling above, and by objectui#6938, which
+ * found four more keys the same 76-page census could not see. ⛔ Do not repair
+ * that by widening the claim — state the blind spot, which is what this section
+ * is for.
+ *
  * ## ⚠️ This is NOT a key-membership widening — measured, not assumed
  *
  * Every one of the 8 mirrors extends `BaseSchema`, which is `.passthrough()`,


### PR DESCRIPTION
Part of #8327

⛔ That wording is deliberate: it is not one of the keywords that shuts a card on merge. This PR carries only the SECOND half of that card. The first half — the three-way classification of every cast read — is delivered as comment `5587605667` on the card itself, and the card also holds the follow-ups that measurement raised, each of which is a ruling to route rather than work to do. Whoever routes those decides when the card is done.

## What changed

One docblock section in `packages/types/src/__tests__/undeclared-but-consumed-keys-6150.test.ts`, plus an empty-frontmatter changeset. No code, no assertions, no ledger rows.

That ledger opens by describing a census over the component docs pages and calling its result the 13 genuinely-read undeclared keys. Every read that census matched is spelled `schema.KEY`; it never looked for `(schema as any).KEY`. A reader who takes the paragraph at face value concludes the class has been swept — which is how #7105 stayed open as long as it did. The header now says so in its own words.

## Why the numbers in it are what they are

Re-measured for #8327 with the cast-aware `schemaReads` instrument the package already carries (`widget-schema-anchors-6576.test.ts:199`, from #6576 — ⛔ no second scanner), enumeration and reading both taken from one pinned ref:

| | at `c842594`, the census card's own ref | that card states | at `154fe2a`, `main` today |
| --- | --- | --- | --- |
| production files in the population | 1596 | 1596 | 1598 |
| raw text | 92 keys / 27 files | 92 keys / 27 files | 92 keys / 27 files |
| comments and string literals stripped | **89 keys / 24 files** | **58 keys / 21 files** | **88 keys / 23 files / 112 reads** |

⭐ The raw row reproduces exactly; the stripped row does not. `58/21` describes that card's own per-file table, and the table is a strict SUBSET of the real read set — `plugin-view/src/ObjectView.tsx` alone has **31 cast reads** and is absent from it. The header therefore quotes the re-measured figures, not the card's.

Asked of the TypeScript checker rather than of a grep — because "genuinely undeclared" is an ABSENCE claim and #8410 is the standing card that grep-shaped absence claims are unsound — the 112 split: 29 undeclared on the type the renderer is handed, 8 declared on one arm of a union only, 38 declared (stale or forced casts), **31 already RULED non-author surface** (#5091, #5097) that must never be declared, 1 the same key as one of those rulings but unpinned at its site, and 5 unanswerable because the renderer is handed `any`. Full per-key table with evidence: comment `5587605667`.

⚠️ The header states plainly that those 29 are **not** pending rows for this ledger: every row it carries is a published-type widening owing its own adjudication.

## Non-vacuity control worth naming

The classifier was told nothing about `plugin-view`'s in-source `OBJECT_VIEW_HOST_COMPOSITION_KEYS`, and independently returned exactly those 27 keys as undeclared and exactly the 4 the file's docblock calls declared. Set difference in both directions: empty.

## Verification

- `pnpm --filter @object-ui/types type-check` — exit 0, all three legs (`tsc --noEmit`, `tsconfig.examples.json`, `tsconfig.test.json`). ⚠️ `vitest run` cannot judge a type-map ledger, so the third leg is the instrument; `tsc -p tsconfig.test.json --listFiles` confirms it compiles this very file (1 hit among 148 test files), so the green is not vacuous.
- `pnpm --filter @object-ui/types lint` — exit 0 (265 pre-existing warnings, 0 errors). `eslint` on the changeset file — exit 0.
- `node scripts/check-control-bytes.mjs` · `check-changeset-presence.mjs` · `check-changeset-no-major.mjs` · `check-changeset-fixed.mjs` · `check-changeset-overwrite.mjs` · `check-type-check-coverage.mjs` · `check-comment-mask-corpus.mjs` — all exit 0, each captured before any pipe.
- `vitest run` on the edited file — 77 passed. Reported as a smoke check only, ⛔ not as evidence about the type map.
- Dependency-closure build: none owed. `@object-ui/types` has no workspace dependencies, so its `^...` closure is empty.

⛔ Draft, targets `main`, ⛔ not enqueued, ⛔ no auto-merge, ⛔ no self-approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_