### PR TITLE
test(i18n-gate): pin the factory half's abstention counters on main, as the hand-rolled half already is

### DIFF
--- a/.changeset/8423-i18n-factory-abstention-pins.md
+++ b/.changeset/8423-i18n-factory-abstention-pins.md
@@ -1,0 +1,12 @@
+---
+---
+
+Pin the i18n call-site gate's factory abstention counters on `main`
+(objectui#8423). The factory half of `scripts/check-i18n-call-site-keys.mjs`
+prints `factoryRowsNoEnKey`, `factoryUnjudgedRows` and its matching/compared
+pair on every run and held none of them to anything, so `factoryRowsNoEnKey`
+moved 5 to 0 when objectui#7887 retired the `timeline.relative.*` rows and
+nothing failed. The main-line case now mirrors the three lines the hand-rolled
+half already pins, keeping the existing `factoryTables > 25` and
+`factoryComparedRows > 500` lower bounds so the zeros stay readings rather than
+"the scan found nothing". Test only; no package is released by this change.

--- a/scripts/__tests__/check-i18n-call-site-keys.test.ts
+++ b/scripts/__tests__/check-i18n-call-site-keys.test.ts
@@ -1502,6 +1502,23 @@ export const useBTranslation = createSafeTranslation({ ...ELSEWHERE }, 'common.s
     // should never grow unnoticed.
     expect(counters.factoryUnreadableTables).toBe(0);
     expect(counters.factoryUnreadableRows).toBe(0);
+    // objectui#8423 — the abstention lines the hand-rolled half already pins in
+    // 'and main is measured, not merely green', mirrored onto the half that
+    // actually moves. This half takes its population from the SOURCE, so it
+    // absorbs a new table without anybody choosing to: when objectui#7887
+    // retired the `timeline.relative.*` rows, `factoryRowsNoEnKey` went 5 to 0
+    // and nothing in this repository failed, because the only carriers of that
+    // number were comments. Zero is a READING here only because the two lower
+    // bounds above say the scan had something to judge — measured on this tree,
+    // 32 tables and 846 rows compared, 846 of them matching. ⛔ Do not read the
+    // `.toBe(1)` assertions on these two counters further up this file as this
+    // pin: those are synthetic fixtures ('leaves a key en does not define to
+    // class 1' and 'counts rather than judges a plural family'), they prove the
+    // counters CAN move, and a grep that only asks whether the symbol is ever
+    // expected somewhere confuses them with a reading taken on main.
+    expect(counters.factoryRowsNoEnKey).toBe(0);
+    expect(counters.factoryUnjudgedRows).toBe(0);
+    expect(counters.factoryMatchingRows).toBe(counters.factoryComparedRows);
   });
 
   it('the factory-name set is the one the objectui#3512 test uses, not a second opinion', () => {


### PR DESCRIPTION
Fixes #8423

## The asymmetry

`scripts/check-i18n-call-site-keys.mjs` keeps two parallel halves of one class — the
factory walk (objectui#7567) and the declared hand-rolled registry (objectui#7877) — with
parallel counters. Their MAIN-LINE pin cases were not parallel.

| main-line case | pins |
|:--|:--|
| `and main is measured, not merely green` (hand-rolled) | `handRolledRowsNoEnKey` 0 · `handRolledUnjudgedRows` 0 · `handRolledUnreadableRows` 0 · `handRolledMatchingRows === handRolledComparedRows` |
| `main carries no factory drift, over a surface big enough for that to mean something` (factory) | `factoryUnreadableTables` 0 · `factoryUnreadableRows` 0 — and **nothing else** |

`factoryRowsNoEnKey`, `factoryUnjudgedRows` and the matching/compared equality were
asserted by nothing on main. That is the wrong half to leave unpinned: the factory half
takes its population from the SOURCE, so it absorbs a new table without anybody choosing
to. `factoryRowsNoEnKey` went 5 to 0 when objectui#7887 retired the `timeline.relative.*`
rows and nothing in this repository failed — the only carriers of that number were
comments.

This adds the three missing lines to the factory case. The existing
`factoryTables > 25` and `factoryComparedRows > 500` lower bounds are kept unchanged:
without them a zero degrades from a reading into "the scan found nothing". No threshold
lowered, no ratchet raised, no assertion removed, no test skipped.

## What was measured before pinning

Triage's fence was that the values must be READ on this tree, never copied from the
hand-rolled half. Two independent instruments, both on `ce45a0306`:

`analyze(repoRoot)` — the same call the pin case reads:

```
factorySites = 32          factoryComparedRows  = 846
factoryTables = 32         factoryMatchingRows  = 846
factoryRows = 846          factoryRowsNoEnKey   = 0
factoryUnreadableTables=0  factoryUnjudgedRows  = 0
factoryUnreadableRows = 0  findings.length      = 0
factoryMatchingRows === factoryComparedRows -> true
```

`node scripts/check-i18n-call-site-keys.mjs` (exit 0), its own summary line:

```
Factory defaults tables: 32 createSafeTranslation site(s) over 32 distinct table(s)
(0 unreadable) — 846 row(s) compared against their en value, 846 matching, 0 on a key
en does not define, 0 with no single comparable en value, 0 unreadable.
```

All three read clean, so nothing observed-non-zero was pinned to make a test green. The
zeros are readings and not "nothing was scanned", because the same run reports 32 tables
and 846 compared rows.

## Reverse verification — the new pins can fail, and the old file could not

Each leg mutates the GATE (not the test), proves the mutation reached disk by blob hash,
runs the full test file, then restores with `git checkout HEAD --` and proves
`git diff HEAD` empty.

| leg | mutation | result |
|:--|:--|:--|
| M1 | one factory row forced down the `RowsNoEnKey` branch | **1 failed / 136 passed** — factory case red, `expected 1 to be +0`; hand-rolled case green |
| M2 | one factory row forced down the `UnjudgedRows` branch | **1 failed / 136 passed** — `expected 1 to be +0` |
| M3 | one compared factory row never counted as matching, and no finding pushed | **1 failed / 136 passed** — `expected 845 to be 846` |
| M1 on the PRE-CHANGE test file | same mutation as M1 | **137 passed, exit 0** — the whole file green |

The last row is objectui#8423 itself, reproduced: the identical corruption that now fails
loudly was invisible before this change. M3 is the case the equality earns its place on —
`factoryDriftOf(repoRoot)).toEqual([])` passed in that run; a row counted as compared and
silently never counted as matching produces no finding at all.

## Reviewer trap — please do not "correct" this back

`factoryRowsNoEnKey` and `factoryUnjudgedRows` DO already appear under `expect(...)`
elsewhere in this file, at `.toBe(1)`. Those two hits live in SYNTHETIC fixture cases —
`leaves a key en does not define to class 1, and class 1 cannot see it either` and
`counts rather than judges a plural family — there is no one form to compare`. They prove
the counters can move; they are not a reading on main. A grep that only asks "is this
symbol ever expected?" conflates them with the main-line case and concludes the card was
already fixed. The assertions added here are located by their enclosing `it(...)`, not by
symbol presence; a comment in the file says so, so the next reader does not have to
rediscover it.

## Checks run

| check | outcome |
|:--|:--|
| `pnpm exec vitest run scripts/__tests__/check-i18n-call-site-keys.test.ts` | 137 passed / 137, exit 0 |
| `pnpm lint:root` | exit 0, 0 errors (32 pre-existing warnings, none in the touched file) |
| `pnpm type-check:scripts` | exit 0; the touched file is in that program, confirmed with `tsc --listFiles` |
| `node scripts/check-i18n-call-site-keys.mjs` | exit 0 |
| `node scripts/check-changeset-presence.mjs` | exit 0 |
| `node scripts/check-changeset-no-major.mjs` | exit 0 |
| `node scripts/check-governed-queue-guard.mjs --test` on the touched paths | NOT GOVERNED |

The changeset declares an empty frontmatter: this is test-only tooling, no package is
released by it. Held in **draft** for the PM.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_