### PR TITLE
test(gates): both document-count pins strip the `#` marker before the pattern runs, as the third copy does

### DIFF
--- a/.changeset/7967-twin-count-pin-marker-strip.md
+++ b/.changeset/7967-twin-count-pin-marker-strip.md
@@ -1,0 +1,10 @@
+---
+---
+
+Both objectui#7448 document-count pins now read their workflow header through
+the same extraction the third copy uses: the leading `#` marker is stripped
+before the pattern runs, so a count that wraps across two comment lines is no
+longer invisible to them (objectui#7967). The pattern itself is unchanged,
+byte-identical across all three copies. A positive control demonstrating the
+wrapped-count catch is committed in each pin. Test only; no package is released
+by this change.

--- a/scripts/__tests__/check-doc-component-types.test.ts
+++ b/scripts/__tests__/check-doc-component-types.test.ts
@@ -74,13 +74,30 @@ function documentCounts(text: string): string[] {
  * Lifted to module scope by objectui#7901 for the same reason objectui#7914
  * lifted the pattern: the pin below and the emptiness control beside it must
  * read ONE extraction, or the control demonstrates a surface the pin does not
- * have. The extraction itself is unchanged, character for character, from what
- * the pin carried inline.
+ * have.
+ *
+ * Stripped, not kept: a sentence that wraps across two comment lines has a `#`
+ * sitting in the middle of it, and a scan that reads the raw lines cannot see a
+ * numeral and the noun it qualifies as adjacent when the line break falls
+ * between them. Removing the marker is what makes the count pin below read the
+ * header the way a person does.
+ *
+ * That paragraph is the third copy's (`check-links-workflow.test.ts`), carried
+ * here verbatim by objectui#7967 together with the `.map` line it argues for.
+ * This extraction and its twin in the other objectui#7448 pin KEPT the marker
+ * while the third copy stripped it — one rule, three copies, and the two that
+ * never wrote down WHY were the two that drifted. The divergence is not
+ * theoretical: the census objectui#7967 ran over all 35 workflow headers reads
+ * two document counts under the stripped extraction that the kept extraction
+ * cannot see at all (`pre-install-import-graph.yml`, `shell-escape-residue.yml`
+ * — neither of them read by any pin today, which is why nothing was failing).
+ * The extraction control below fixtures the shape so this cannot drift back.
  */
 function headerComments(yaml: string): string {
   return yaml
     .split('\n')
     .filter((line) => /^\s*#/.test(line))
+    .map((line) => line.replace(/^\s*#\s?/, ''))
     .join('\n');
 }
 
@@ -986,8 +1003,10 @@ describe('wiring — the gate is reachable and a docs-only PR starts it', () => 
     // objectui#7901 — the floor first, or the assertion below is vacuous. The
     // count half cannot distinguish a header that carries no counts from a
     // header this pin has stopped reading; both score `[]`. Measured when this
-    // was added, so it is latent rather than live: the extraction returned 4514
-    // characters from this header, 11.3 times the floor.
+    // was added, so it is latent rather than live: the extraction returned 4312
+    // characters from this header, 10.8 times the floor. It read 4514 at 11.3
+    // before objectui#7967 made this extraction strip the `#` markers: 202 of
+    // those characters were markers, and none of them were prose.
     expect(
       header.length,
       'doc-component-types.yml: the header prose this pin reads came back empty or near-empty, so it asserted over nothing',
@@ -1064,6 +1083,50 @@ describe('wiring — the gate is reachable and a docs-only PR starts it', () => 
     for (const line of legitimate) {
       expect(documentCounts(line), `doc-component-types.yml's count pin must NOT fire on: ${line}`).toEqual([]);
     }
+  });
+
+  /**
+   * The positive control for the EXTRACTION — objectui#7967.
+   *
+   * The control above exercises the PATTERN half of the pin and the one below
+   * exercises the emptiness floor. Neither can fail if the extraction hands the
+   * pattern a string the pattern is unable to read, and that is a third way for
+   * this pin to go vacuous — the one that was live here. Where an empty surface
+   * scores clean because there was nothing to read, this one scores clean with
+   * the surface arriving whole and still unreadable.
+   *
+   * Measured, not inferred. This extraction used to KEEP the `#` markers, so a
+   * count wrapping across two comment lines reached the pattern as
+   * `184\n# pages`: the marker is not one of the two intervening words the
+   * pattern allows, and it also trips the negative lookbehind that exists to
+   * rule out issue references. Run over that fixture the kept-marker extraction
+   * returns `[]`; the stripped one returns `["184 pages"]`.
+   *
+   * ⭐ A count landing at end-of-line is not a corner case in a block this
+   * shape. `doc-component-types.yml`'s header is hard-wrapped at a comment column, so a
+   * numeral parting from its noun is the ordinary outcome of editing a
+   * paragraph, not an unlucky one.
+   *
+   * Both halves are asserted because only the pair means anything. The
+   * unwrapped sentence proves the fixture is a count this pattern accepts, so
+   * the wrapped assertion is a claim about the EXTRACTION rather than about the
+   * regex; without it, a fixture the pattern simply never matched would look
+   * like the same green.
+   */
+  it('the extraction strips the markers, so a count that wraps across comment lines is still caught', () => {
+    const wrapped = ['  # the published site is built from 184', '  # pages today, so the sweep covers', '  name: x'].join(
+      '\n',
+    );
+    expect(
+      documentCounts(headerComments(wrapped)),
+      'a count wrapping across two comment lines must survive the extraction',
+    ).toEqual(['184 pages']);
+
+    const unwrapped = '  # the published site is built from 184 pages today, so the sweep covers\n  name: x';
+    expect(
+      documentCounts(headerComments(unwrapped)),
+      'the same sentence on one line — so the assertion above is about the extraction, not the pattern',
+    ).toEqual(['184 pages']);
   });
   /**
    * The positive control for the emptiness floor — objectui#7901.

--- a/scripts/__tests__/check-doc-fence-languages.test.ts
+++ b/scripts/__tests__/check-doc-fence-languages.test.ts
@@ -64,13 +64,30 @@ function documentCounts(text: string): string[] {
  * Lifted to module scope by objectui#7901 for the same reason objectui#7914
  * lifted the pattern: the pin below and the emptiness control beside it must
  * read ONE extraction, or the control demonstrates a surface the pin does not
- * have. The extraction itself is unchanged, character for character, from what
- * the pin carried inline.
+ * have.
+ *
+ * Stripped, not kept: a sentence that wraps across two comment lines has a `#`
+ * sitting in the middle of it, and a scan that reads the raw lines cannot see a
+ * numeral and the noun it qualifies as adjacent when the line break falls
+ * between them. Removing the marker is what makes the count pin below read the
+ * header the way a person does.
+ *
+ * That paragraph is the third copy's (`check-links-workflow.test.ts`), carried
+ * here verbatim by objectui#7967 together with the `.map` line it argues for.
+ * This extraction and its twin in the other objectui#7448 pin KEPT the marker
+ * while the third copy stripped it — one rule, three copies, and the two that
+ * never wrote down WHY were the two that drifted. The divergence is not
+ * theoretical: the census objectui#7967 ran over all 35 workflow headers reads
+ * two document counts under the stripped extraction that the kept extraction
+ * cannot see at all (`pre-install-import-graph.yml`, `shell-escape-residue.yml`
+ * — neither of them read by any pin today, which is why nothing was failing).
+ * The extraction control below fixtures the shape so this cannot drift back.
  */
 function headerComments(yaml: string): string {
   return yaml
     .split('\n')
     .filter((line) => /^\s*#/.test(line))
+    .map((line) => line.replace(/^\s*#\s?/, ''))
     .join('\n');
 }
 
@@ -434,8 +451,10 @@ describe('check-doc-fence-languages is wired, not merely present', () => {
     // objectui#7901 — the floor first, or the assertion below is vacuous. The
     // count half cannot distinguish a header that carries no counts from a
     // header this pin has stopped reading; both score `[]`. Measured when this
-    // was added, so it is latent rather than live: the extraction returned 4696
-    // characters from this header, 11.7 times the floor.
+    // was added, so it is latent rather than live: the extraction returned 4435
+    // characters from this header, 11.1 times the floor. It read 4696 at 11.7
+    // before objectui#7967 made this extraction strip the `#` markers: 261 of
+    // those characters were markers, and none of them were prose.
     expect(
       header.length,
       `${WORKFLOW}: the header prose this pin reads came back empty or near-empty, so it asserted over nothing`,
@@ -512,6 +531,50 @@ describe('check-doc-fence-languages is wired, not merely present', () => {
     for (const line of legitimate) {
       expect(documentCounts(line), `${WORKFLOW}'s count pin must NOT fire on: ${line}`).toEqual([]);
     }
+  });
+
+  /**
+   * The positive control for the EXTRACTION — objectui#7967.
+   *
+   * The control above exercises the PATTERN half of the pin and the one below
+   * exercises the emptiness floor. Neither can fail if the extraction hands the
+   * pattern a string the pattern is unable to read, and that is a third way for
+   * this pin to go vacuous — the one that was live here. Where an empty surface
+   * scores clean because there was nothing to read, this one scores clean with
+   * the surface arriving whole and still unreadable.
+   *
+   * Measured, not inferred. This extraction used to KEEP the `#` markers, so a
+   * count wrapping across two comment lines reached the pattern as
+   * `184\n# pages`: the marker is not one of the two intervening words the
+   * pattern allows, and it also trips the negative lookbehind that exists to
+   * rule out issue references. Run over that fixture the kept-marker extraction
+   * returns `[]`; the stripped one returns `["184 pages"]`.
+   *
+   * ⭐ A count landing at end-of-line is not a corner case in a block this
+   * shape. `doc-fence-languages.yml`'s header is hard-wrapped at a comment column, so a
+   * numeral parting from its noun is the ordinary outcome of editing a
+   * paragraph, not an unlucky one.
+   *
+   * Both halves are asserted because only the pair means anything. The
+   * unwrapped sentence proves the fixture is a count this pattern accepts, so
+   * the wrapped assertion is a claim about the EXTRACTION rather than about the
+   * regex; without it, a fixture the pattern simply never matched would look
+   * like the same green.
+   */
+  it('the extraction strips the markers, so a count that wraps across comment lines is still caught', () => {
+    const wrapped = ['  # the published site is built from 184', '  # pages today, so the sweep covers', '  name: x'].join(
+      '\n',
+    );
+    expect(
+      documentCounts(headerComments(wrapped)),
+      'a count wrapping across two comment lines must survive the extraction',
+    ).toEqual(['184 pages']);
+
+    const unwrapped = '  # the published site is built from 184 pages today, so the sweep covers\n  name: x';
+    expect(
+      documentCounts(headerComments(unwrapped)),
+      'the same sentence on one line — so the assertion above is about the extraction, not the pattern',
+    ).toEqual(['184 pages']);
   });
   /**
    * The positive control for the emptiness floor — objectui#7901.


### PR DESCRIPTION
Fixes #7967

All three copies of the objectui#7448 document-count pin extract a workflow's comment block before applying one shared pattern. Two kept the leading `#` marker; the third stripped it, and its own docstring said why:

> Stripped, not kept: a sentence that wraps across two comment lines has a `#` sitting in the middle of it, and a scan that reads the raw lines cannot see a numeral and the noun it qualifies as adjacent when the line break falls between them.

That reasoning applied verbatim to the two twins and neither did it. Both twins now carry the third copy's `.map` step **and its paragraph verbatim** — the copy that never wrote down *why* is the copy that drifted.

## What changed

| file | change |
|:--|:--|
| `scripts/__tests__/check-doc-fence-languages.test.ts` | `headerComments` gains the marker-strip step; the third copy's rationale paragraph carried over; a committed positive control; the floor reading re-measured |
| `scripts/__tests__/check-doc-component-types.test.ts` | identical |
| `scripts/__tests__/check-links-workflow.test.ts` | **untouched** — the reference copy, read not moved |
| `.changeset/7967-twin-count-pin-marker-strip.md` | empty frontmatter, explicitly declaring no release |

## objectui#7943's proof — before and after

Instrument `git grep` (exit 0 = matched, 1 = no match, 128 = outside a work tree), run inside the worktree, exit **0** captured before any pipe.

```text
$ git grep -h -A1 -e '^const POPULATION_COUNT =$' -- 'scripts/__tests__/*.test.ts' | grep -E '^\s+/' | sort | uniq -c
BEFORE (origin/main ce45a0306):  3   [the one pattern line]
AFTER  (this branch  3710b40e6):  3   [the one pattern line]
```

**1 distinct line, count 3 — before and after.** Pinned by hash rather than by paste, because the pattern carries a lookbehind whose bytes a comment sanitizer may not survive: `sha256` of that single line, 110 bytes including the trailing newline, is

```text
3f89a4be6c1fa37f17006b67f1b5abe6dca4c5f4ab391b46468939a5917feb0e
```

**identical before and after.** The pattern is byte-identical across all three copies. ⛔ No "after" is reported here that was not run.

A second reading, new with this change — the extraction *bodies* now agree too:

```text
$ git grep -h -A5 -E '^function (headerComments|commentProse)\(yaml: string\): string \{' -- 'scripts/__tests__/*.test.ts' \
    | grep -E '^\s+\.(split|filter|map|join)' | sort | uniq -c
      3     .filter((line) => /^\s*#/.test(line))
      3     .join('\n');
      3     .map((line) => line.replace(/^\s*#\s?/, ''))
      3     .split('\n')
```

Each of the four steps appears exactly three times. Before this change `.map` appeared **once**.

## The census — 35 workflow headers, both extractions

Ordered as fence 1 requires: census first, widening second. Enumeration is `.github/workflows/*.yml` plus `*.yaml` — **35** files, all `.yml`, all carrying at least one comment line, **5284** comment lines in total. ⚠️ The card and triage both say **34**; that was accurate when written and went stale when `action-ref-convention.yml` landed at 2026-09-08T09:43:47Z. Instrument `git ls-tree --name-only`, which **exits 0 even when it finds nothing**, so it is controlled by differencing revisions rather than by its exit code: at the adding commit `3f775eeb8` the parent reads 34 and the commit reads 35; HEAD reads 35. The 35th header contributes no hit under either extraction.

Both extraction functions were taken byte-for-byte from `origin/main`; the pattern is the single distinct `POPULATION_COUNT` line above. Only rows non-empty under either extraction are listed; the other 30 read `[]` / `[]`.

| workflow | comment lines | markers kept | markers stripped | NEW |
|:--|--:|:--|:--|:--|
| changeset-release.yml | 925 | `0 pending changeset file`, `161 files`, `73 files`, `121 files`, `81 test files` | *(identical)* | — |
| cross-repo-issue-closer.yml | 196 | `37 pages` | *(identical)* | — |
| lint.yml | 376 | `0 tracked files`, `206 file`, `12 shell files` | *(identical)* | — |
| **pre-install-import-graph.yml** | 40 | `[]` | **`24 workflow files`** | ⚠️ **YES** |
| **shell-escape-residue.yml** | 48 | `[]` | **`200 markdown documents`** | ⚠️ **YES** |
| doc-fence-languages.yml | 71 | `[]` | `[]` | — |
| doc-component-types.yml | 68 | `[]` | `[]` | — |
| check-links.yml | 135 | `[]` | `[]` | — |

**Difference set: 2 workflows.** Both are this card's mechanism caught in the wild — a numeral at end-of-comment-line with its noun opening the next line behind a marker:

- `pre-install-import-graph.yml` L24-25 — `# … one \`node\` call over 24` / `# workflow files and a dozen scripts, …`
- `shell-escape-residue.yml` L23-24 — `# … one \`node\` call over ~200` / `# markdown documents and ~1300 fenced blocks. …`

**Blind-spot reading** — numerals present in the extracted prose that the pattern declined to judge as document counts:

| extraction | numerals present | judged a document count | declined |
|:--|--:|--:|--:|
| markers kept | 2270 | 9 | **2261** |
| markers stripped | 2270 | 11 | **2259** |

Stripping moves **2** numerals out of the blind spot across the whole population. The remainder is dominated by numerals legitimately not document counts — versions, timeouts, issue references, cron fields — so it is reported as a total, not as a defect count.

**In-class control**, same run, same instrument — a control for "no marker-defeated counts" that is itself a marker-defeated count:

```text
input:  "  # the published site is built from 184\n  # pages today, so the sweep covers\n  name: x\n"
markers kept    : []              (marker-defeated, as the card measured)
markers stripped: ["184 pages"]   (caught)
CONTROL PASSES — every [] in the census above is a reading, not a silence
```

## ⛔ The two new hits are reported, not ridden

They stopped this card once, on purpose, and the PM ruled on the stop (issue comment 5588004325). Recorded here so the PR carries the reason it proceeded:

- **No pin reads either header.** `POPULATION_COUNT` lives in exactly 3 files — the three copies — and neither `check-pre-install-import-graph.test.ts` nor `check-shell-escape-residue.test.ts` carries one. ⇒ this change moves **no pinned reading anywhere in the tree**. The ablation below shows that directly: deleting the strip fails the two new controls and **nothing else**.
- **They are evidence for the repair.** The card argued its mechanism from a synthetic fixture; the corpus supplies two live instances.
- ⛔ Neither workflow is touched by this PR. `pre-install-import-graph.yml`'s stale `24` is filed separately as objectui#8606 and is **not** ridden here. `shell-escape-residue.yml`'s `~200` is approximate by construction and is **not** claimed stale.
- ⚠️ The card body's "Latent, not live" section is true of the three pinned headers and over-broad about the corpus. Corrected on the card by the PM seat; the body is not edited.

## The committed positive control — objectui#7914's ruling

In the file, not only here. One `it(...)` per twin:

```ts
it('the extraction strips the markers, so a count that wraps across comment lines is still caught', () => {
  const wrapped = ['  # the published site is built from 184', '  # pages today, so the sweep covers', '  name: x'].join('\n');
  expect(documentCounts(headerComments(wrapped)), '…').toEqual(['184 pages']);

  const unwrapped = '  # the published site is built from 184 pages today, so the sweep covers\n  name: x';
  expect(documentCounts(headerComments(unwrapped)), '…').toEqual(['184 pages']);
});
```

**What it catches that the old extraction did not:** the wrapped fixture. Under the kept-marker extraction it reached the pattern as `184\n# pages` — the marker is not one of the two intervening `[A-Za-z]`-initial words the pattern allows, and it also trips the negative lookbehind that rules out issue references — so it scored `[]` and the pin reported a header it had read whole and could not read. The unwrapped half is asserted beside it deliberately: it proves the fixture is a count this pattern accepts, so the wrapped assertion is a claim about the **extraction** and not about the regex. Without it, a fixture the pattern simply never matched would look like the same green.

⛔ The superseded kept-marker extraction is **not** inlined into the test as a negative control, though it would demonstrate more: a second copy of an extraction inside one file is objectui#7914's own disease, and it would pollute the `uniq -c` equality reading above. It is measured here instead.

**Ablation — the control has power, run from the committed state.** Delete the `.map` line from both twins:

```text
anchored observation BEFORE: fence=1 comp=1     (grep -cF on '.map((line) => line.replace(')
anchored observation AFTER : fence=0 comp=0     mutation landed on disk
vitest                     : exit 1 — Test Files 2 failed (2), Tests 2 failed | 86 passed (88)
  × the extraction strips the markers, so a count that wraps across comment lines is still caught
    AssertionError: expected [] to deeply equal [ '184 pages' ]        ← the card's own measurement
restore                    : git checkout HEAD -- <both files>
  git diff HEAD            : empty
  blob hashes              : 68ec775246bf6af50c1913cd4d9dd94007da6387 / 35f9f22e269e0b079df83560323198414870ff8d, both == HEAD
```

Exactly the two new controls fail and **86 other assertions keep passing** — which is the same fact as "no pinned reading moves", measured rather than asserted. The mutated file *is* the artifact under test (vitest transforms the TS source; no `dist` sits between), so no rebuild step separates the mutation from the reading.

## Floor readings, re-measured

The pins record what the extraction returned. Stripping shortens it, so both numbers are re-measured rather than left stale:

| pin | before | after | × the 400-char floor | removed |
|:--|--:|--:|--:|--:|
| `doc-fence-languages.yml` | 4696 | 4435 | 11.7 → 11.1 | 261 chars, all markers |
| `doc-component-types.yml` | 4514 | 4312 | 11.3 → 10.8 | 202 chars, all markers |

None of the removed characters were prose, so objectui#7901's emptiness floor keeps the same meaning.

## ⛔ The shared-module question is NOT decided here

Nothing shared was built. It belongs to the PM jointly with objectui#7966, and answering it in one card is how the two get contradictory answers. The one observation this run adds, recorded as **input, not as a decision**:

> The extraction drifted into two shapes across three copies while the pattern stayed at one, and the pattern stayed at one because objectui#7943 gave it a mechanical equality proof the extraction never had. **The distinguishing variable in this family is whether a mechanical equality proof exists, not whether the code is shared.**

## Checks run

| check | outcome |
|:--|:--|
| `vitest run` the three affected files | ✅ exit 0 — **3 files, 97 tests passed** |
| ablation (`.map` deleted, both twins) | ✅ exit 1 — 2 failed / 86 passed, restored to byte-identical blobs |
| `eslint` the two changed files | ✅ exit 0 — `--format json`: 2 files, 0 errors, 0 warnings |
| `tsc -p tsconfig.scripts.json` | ✅ exit 0, and `--listFiles` shows **2 of 2** changed files in the program, so this is a measurement rather than a skip |
| `node scripts/check-control-bytes.mjs` | ✅ exit 0 — 6796 tracked text files scanned |
| `grep -naP` for control bytes over the touched files | ✅ exit 1 — none |
| `node scripts/check-changeset-presence.mjs` | ✅ exit 0 — 1 changeset added; 0 files are published source |
| `node scripts/check-changeset-no-major.mjs` | ✅ exit 0 |
| `node scripts/check-governed-queue-guard.mjs --test` | ✅ NOT GOVERNED — 3 paths against 5 governed surfaces, none matched |

⚠️ **One declared deviation.** The dispatch brief asked for a `patch`-level changeset; `AGENTS.md` says a pure-internal / test-only change writes an **empty frontmatter** changeset explicitly declaring "no release", and names that a first-class passing form. `scripts/__tests__/**` is not published source of any released package — `check-changeset-presence.mjs` agrees: *"0 of them published source of a package the release covers"*. A `patch` would version-bump the 39-package fixed group for a test-only change. AGENTS.md was followed and the divergence is declared rather than chosen silently.

Repo-wide `pnpm lint` is CI's run, not this PR's; the narrowing to the two changed files is declared here, not assumed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_