### PR TITLE
docs(types): let package.json own the spec floor, and fold the duplicate Links section

### DIFF
--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -29,7 +29,9 @@ pnpm add @object-ui/types
 Object UI follows a strict **"Protocol First"** approach with a clear inheritance hierarchy:
 
 ```
-@objectstack/spec (v15.x)           ← The "Highest Law" - Universal protocol
+@objectstack/spec                   ← The "Highest Law" - Universal protocol. The
+                                      required range is declared in package.json,
+                                      the authority; a copy here goes stale unnoticed.
     ↓
 BaseSchema (@object-ui/types)       ← A component node: the base interface every
                                       UI component schema extends, carrying `type`
@@ -326,6 +328,7 @@ We follow these constraints for this package:
 - 📚 [Documentation](https://www.objectui.org/docs/api/schema-reference)
 - 📦 [npm package](https://www.npmjs.com/package/@object-ui/types)
 - 📝 [Changelog](./CHANGELOG.md)
+- 💻 [GitHub repository](https://github.com/objectstack-ai/objectui)
 - 🐛 [Report an issue](https://github.com/objectstack-ai/objectui/issues)
 - 🤝 [Contributing Guide](https://github.com/objectstack-ai/objectui/blob/main/CONTRIBUTING.md)
 - 🗺️ [Roadmap](https://github.com/objectstack-ai/objectui/blob/main/ROADMAP.md)
@@ -333,9 +336,3 @@ We follow these constraints for this package:
 ## License
 
 MIT
-
-## Links
-
-- [Documentation](https://objectui.org/docs/api/schema-reference)
-- [GitHub](https://github.com/objectstack-ai/objectui)
-- [NPM](https://www.npmjs.com/package/@object-ui/types)


### PR DESCRIPTION
Fixes #8037

Two repairs in one file, `packages/types/README.md`. Triage (comment 5583380673) declined to split them; the whole diff is `4 insertions(+), 7 deletions(-)`.

## 1. The protocol floor now names its authority instead of a number

The "Architecture: The Inheritance Chain" diagram named `@objectstack/spec (v15.x)` as the "Highest Law" while `packages/types/package.json` declares `"@objectstack/spec": "^17.3.0"` — so the page told a reader to pin a version this package refuses to install against.

**The repair deliberately does not write `v17.x`.** That recreates the identical defect one major later, and the manifest is a moving target *by design*: `scripts/check-spec-range-floors.mjs` tightens these floors as symbols land, which is exactly why this range moved from `^17.0.0` (at filing) to `^17.3.0` (at triage) while the card sat open. The diagram now names `package.json` as the authority and states no version of its own, so the next bump cannot silently falsify it:

```
@objectstack/spec                   left-arrow The "Highest Law" - Universal protocol. The
                                      required range is declared in package.json,
                                      the authority; a copy here goes stale unnoticed.
```

(The literal arrow glyph is spelled out above only in this PR description; the file itself carries the same arrow character every other row of the diagram uses, and column alignment at char 36 is preserved.)

### Re-derived, not taken on trust

- Manifest on current `main` (`ce45a03`): `packages/types/package.json` `dependencies` -> `^17.3.0`. It has **not** moved a third time since triage measured it — the PM brief's assumption (a) is falsified, and the range is unchanged from comment 5583380673.
- Installed copy in this workspace: `@objectstack/spec@17.3.0` (the card recorded 17.2.0 at filing).
- Sites located by content (`git grep 'Highest Law'`, `grep '^## '`), per standing ruling objectui#7853, not by the line numbers in the card. They happen to land on the same `:32` / `:324` / `:337` triage recorded, so assumption (b) is falsified too — but the location method is the content search either way.
- `git grep 'v15.x'` finds this spelling in exactly one tracked file, so it was one line and not a population. Widening the sweep to any `@objectstack/spec vNN` claim in markdown returns only CHANGELOG / ROADMAP / changeset entries, which are dated historical records rather than current claims. **Triage's p2 re-grade trigger therefore does not fire; the grade stays p3.**

## 2. One `## Links` section, on the host this package itself declares

The page carried two `## Links` sections with `## License` between them, disagreeing on host. They are folded into one, in the first position.

**Which host is canonical was re-derived rather than assumed.** The repo states no canonical-host *rule* anywhere — there is no lychee or site setting for it — so the evidence is:

| evidence | reading |
|:--|:--|
| `packages/types/package.json` `"homepage"` | `https://www.objectui.org/docs/api/schema-reference` — this package's own manifest names the `www.` form of *exactly* the Documentation URL the two sections disagreed about |
| root `package.json` `"homepage"` | `https://www.objectui.org` |
| repo-wide count | 141 occurrences of `https://www.objectui.org` against 21 without `www.` |

So the first section (already `www.`) stays and the second is deleted. Its one entry the first section did not already carry — the repository root link — is kept as a new bullet, so the merge loses nothing. Nothing in the tree references either heading anchor (`git grep 'types/README.md#'` is empty), so deleting the second heading breaks no link.

`check-doc-links.mjs` was green over both spellings because it judges reachability, not canonicity; that is unchanged and not something this PR alters.

## Verification

Gates derived from the repo's own `package.json` `check:*` scripts **and** every `.github/workflows/*.yml` trigger block, against the actual changed path. Exit codes captured before any pipe (`cmd redirected-to file; EXIT=$?`).

**Which workflows this diff actually reaches.** `lint.yml` and `ci.yml` both gate their expensive steps on a `Decide whether this change needs a full run` step whose diff excludes `**/*.md`; `ci.yml`'s `docs` job gates on `apps/site/` and `content/` only. A README-only PR therefore reports those contexts green having run nothing in them, and the gates that really judge it are the unconditional per-gate workflows.

Ran on the final commit `76a9175`, all exit 0:

`check-doc-links`, `check-doc-fence-languages` (+ `--self-test`), `check-control-bytes`, `check-shell-escape-residue`, `check-changeset-presence`, `check-action-ref-convention`, `check-doc-component-types`, `check-docs-route-eager-closure`, `check-pre-install-import-graph` (+ `--self-test`), `check-skill-eval-tokens` (+ `--self-test`), `check-skills-paths`, `check-vi-mock-specifiers`, `check-vi-mock-inherit`, `check-changeset-fixed`, `check-doc-expression-carriage`, and `check-governed-queue-guard --test packages/types/README.md` (which answers `NOT GOVERNED`).

**Declared narrowing — two gates that read package READMEs were not run to a verdict locally**, because both need a whole-tree `dist/` this container has not built (`check-readme-exports` wants all 40 `./packages/*` built; `check-doc-snippet-types` wants the 34-package closure its `--build-filter` names). Both are unconditional on this PR, so CI runs them. In their place, three measurements show their input is unchanged rather than assuming it:

1. **Population read from the gate's own code, not guessed.** `analyze()` from `check-doc-snippet-types.mjs` reports 244 documents, 240 covered, and `packages/types/README.md` **is** in the covered set — it has left `UNGATED_DOCS`. Its own `scanFences()` returns **7** blocks for this file before the edit and **7** after, every one `typescript`, at fence lines `[58,85,108,219,236,250,271]` -> `[60,87,110,221,238,252,273]`. The edited diagram fence is **not among them**: it carries no language, so the scanner never returns it. That is fence 2 of the triage comment, measured — leaving the ledger did not make line 32 watched.
2. **The compilable corpus is byte-identical.** `sha256` over every language-tagged fenced block of the file: `f9f0949bda14ba2e3dbb9067d571d5601da7a3b007d0b69adbf76cc9e02c8128` before and after. Block counts 9 total / 8 tagged / 1 untagged, unchanged; the single untagged block contains no `import` line.
3. **The shipped gate says so itself.** `check-readme-exports.mjs` run twice in the same unbuilt state, once with `--readme` pointing this path at the PRE-EDIT copy (spelled without angle brackets on purpose: GitHub's body sanitizer eats tag-shaped fragments, backticks included), prints a **byte-identical census** both times — `408 fenced block(s) (308 parsed as code, 6 untagged); 751 import binding(s)` — and the only difference in the entire run output is the `+2` line-number shift on the same 19 findings for this file, in the same order, with the same symbols. Both legs share the same pre-existing `36 unbuilt` prerequisite, which CI's build step satisfies.

Also self-scanned for control bytes beyond the gate: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]' packages/types/README.md` returns nothing (exit 1).

## Changeset decision: none, deliberately

`README.md` **is** published — it is listed in `packages/types/package.json` `files[]`, so it ships in the tarball. It still owes no changeset, and that is the repo's own rule rather than a judgement call. `scripts/check-changeset-presence.mjs` is the authority AGENTS.md names, its header subtracts "documentation and licences (`*.md`, `LICENSE*`), which do ship in the tarball but are not behaviour", and run against this working tree it prints:

> Compared the working tree with ce45a0306 (merge-base with origin/main): 1 file(s) changed, 0 of them published source of a package the release covers, 0 of them a manifest whose published contract moved, 0 under a package changesets ignores, 0 changeset(s) added.
> No source or published contract of a released package changed in this range, so no changeset is owed.

Stated plainly so nobody has to re-derive it: **this repo does not cut a release for a README-only change**, so the corrected page reaches npm with the next release of `@object-ui/types` for some other reason. Adding an empty-frontmatter changeset would also have breached this dispatch's one-file surface, and empty frontmatter is for declining a release the gate *demands* — which it does not here.

## Acceptance notes (out of scope, noted and not filed)

- **Gate-scope question, left where triage put it.** Whether `doc-version-claims`' scan should reach *unlabelled* fenced blocks is that gate owner's decision with its own false-positive budget (triage fence 1). Not filed and not ridden in here. Taker: the `scripts/__tests__/doc-version-claims.test.ts` owner, whenever they next widen that scan.
- **The bare-host spelling is a small population, not just this page.** `https://objectui.org/...` without `www.` also appears in `packages/app-shell/README.md` (1), `packages/components/README.md` (2), `packages/core/README.md` (1), `packages/react/README.md` (2) and `apps/console/src/sdui-tiers-preview.tsx` (1). Hits in `scripts/__tests__/check-doc-links.test.ts` and `packages/sdui-parser/src/__tests__/inline-whitespace.test.tsx` are deliberate fixtures. This is presentation with every URL resolving, so it is none of the three filing classes; noted rather than filed, and out of this card's one-file surface. Taker: none today.

---

Draft on purpose: not enqueued, no auto-merge, no self-approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_