### PR TITLE
feat(types): declare `dependsOn` on BaseFieldMetadata in the spec's field-level shape; widgets read it through the declared type (objectui#6153)

### DIFF
--- a/.changeset/fields-depends-on-declared-read-6153.md
+++ b/.changeset/fields-depends-on-declared-read-6153.md
@@ -1,0 +1,14 @@
+---
+'@object-ui/fields': patch
+---
+
+The option widgets and the lookup read `dependsOn` through the declared type.
+
+`SelectField`, `MultiSelectField`, `RadioField` and `CheckboxesField` now read the
+cascade key as `field.dependsOn` — `BaseFieldMetadata.dependsOn` — instead of
+through an `as any`; `LookupField` reads both of its spellings (`depends_on`, then
+`dependsOn`) through `LookupFieldMetadata`. Behaviour is unchanged: a select whose
+metadata carries `dependsOn` still gates and prunes its options, a lookup still
+scopes its candidate queries, and the metadata key still wins over the `dependsOn`
+widget prop. What changed is that a wrong spelling or shape at the read site is now
+a compile error rather than a silent no-op. objectui#6153.

--- a/.changeset/types-field-depends-on-declared-6153.md
+++ b/.changeset/types-field-depends-on-declared-6153.md
@@ -1,0 +1,20 @@
+---
+'@object-ui/types': minor
+---
+
+`dependsOn` is now a declared member of the field-metadata face.
+
+`BaseFieldMetadata` gains `dependsOn?: FieldDependsOn`, the spec's field-level
+cascade key in the spec's own shape — derived from `@objectstack/spec/data`'s
+`Field` by reference: an array of controlling field names, or `{ field, param }`
+entries. Every field type inherits it, so an annotated `SelectFieldMetadata` or
+`LookupFieldMetadata` literal can now carry the key the running widgets have
+honoured all along; before, the excess-property check refused it and the widgets
+reached it through an `as any`. A bare parent name is refused at the type, as the
+spec refuses it at publish (`invalid_type`) — that shape belongs to the form-level
+`FormField.dependsOn` and to the `dependsOn` widget prop. `FieldDependsOn` is
+exported.
+
+The snake_case `depends_on` stays declared for now: it is objectui's legacy twin,
+never a spec key, and retires on its own card (objectui#7357). Maintainer ruling A
+on objectui#6153.

--- a/content/docs/fields/lookup.mdx
+++ b/content/docs/fields/lookup.mdx
@@ -77,6 +77,33 @@ and must never reach authored object metadata
 `dataSource` a host injects and the `onCreateNew` callback it passes are widget props,
 not metadata.
 
+A **dependent lookup** scopes its candidates by a sibling field's value, declared
+with `dependsOn` — the same `BaseFieldMetadata` member the select widgets gate on
+([objectui#6153](https://github.com/objectstack-ai/objectui/issues/6153)), in the
+spec's field-level shape: an array of controlling field names, or `{ field, param }`
+entries when the remote filter parameter differs from the local field name. While
+any controlling value is empty the trigger is gated ("Select account first"); once
+set, every candidate query — the typeahead popover, the Record Picker and the
+people picker — carries the chain as a hard `$filter` no user input can override.
+
+```ts
+import type { LookupFieldMetadata } from '@object-ui/types';
+
+const contact: LookupFieldMetadata = {
+  type: 'lookup',
+  name: 'contact',
+  label: 'Contact',
+  reference_to: 'contacts',
+  // Filter `contacts` by `account_id` equal to the form's current `account`.
+  dependsOn: [{ field: 'account', param: 'account_id' }],
+};
+```
+
+The snake_case `depends_on` is objectui's legacy twin of the same key: still read
+by this widget, never a spec key, and retiring under
+[objectui#7357](https://github.com/objectstack-ai/objectui/issues/7357) — author
+`dependsOn`.
+
 The value being edited, and the `className` / `disabled` a host supplies, are **not**
 metadata keys — they are runtime widget props. See [Field Widget Props](/docs/fields/widget-props).
 

--- a/content/docs/fields/select.mdx
+++ b/content/docs/fields/select.mdx
@@ -84,7 +84,7 @@ cascade-clear propagate down the chain.
 `visibleWhen` options are for **small, static dictionaries** (category →
 subcategory, a handful of provinces). When the data is large, changes over time,
 or is shared across forms (real country/province/city tables, org units, product
-catalogs), model each level as a **`lookup`** with `depends_on` instead — the
+catalogs), model each level as a **`lookup`** with `dependsOn` instead — the
 candidate query is filtered server-side and paginated. See
 [Lookup Field](/docs/fields/lookup).
 
@@ -116,11 +116,38 @@ const status: SelectFieldMetadata = {
 };
 ```
 
-Cascading option lists are driven by a sibling field's value. The widget reads a
-camelCase `dependsOn` off the metadata, but no exported metadata type declares it —
-`BaseFieldMetadata` declares the snake_case `depends_on` instead — so the two
-spellings disagree and the gap is tracked as
-[objectui#6153](https://github.com/objectstack-ai/objectui/issues/6153).
+Cascading option lists are driven by a sibling field's value, declared with
+`dependsOn` — a `BaseFieldMetadata` member every field type inherits
+([objectui#6153](https://github.com/objectstack-ai/objectui/issues/6153)), in the
+shape `@objectstack/spec` declares at field level: an **array** of controlling
+field names, or `{ field, param }` entries when the remote parameter name differs
+from the local field name. While any controlling value is empty the widget is
+gated; once it is set, each option's `visibleWhen` decides whether it is offered,
+and a selection the parent no longer offers is cleared.
+
+```ts
+import type { SelectFieldMetadata } from '@object-ui/types';
+
+const province: SelectFieldMetadata = {
+  type: 'select',
+  name: 'province',
+  label: 'Province',
+  dependsOn: ['country'],
+  options: [
+    { label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" },
+    { label: 'California', value: 'ca', visibleWhen: "record.country == 'us'" },
+  ],
+};
+```
+
+A bare parent name (`dependsOn: "country"`, as in the form schema above) is the
+**form-level** shape, `FormField.dependsOn`; on field metadata the spec accepts
+only the array, and `SelectFieldMetadata` refuses the string for the same reason.
+The metadata key wins over the `dependsOn` widget prop a host may pass. The
+snake_case `depends_on` is objectui's legacy twin of the same key — read only by
+the lookup widget and retiring under
+[objectui#7357](https://github.com/objectstack-ai/objectui/issues/7357); author
+`dependsOn`.
 
 The value being edited, and the `className` / `disabled` a host supplies, are **not**
 metadata keys — they are runtime widget props. See [Field Widget Props](/docs/fields/widget-props).

--- a/packages/fields/src/widgets/CheckboxesField.tsx
+++ b/packages/fields/src/widgets/CheckboxesField.tsx
@@ -40,7 +40,8 @@ export function CheckboxesField({
   const groupId = useId();
   const fieldName = props.name || config?.name || props.id || '';
 
-  const dependsOn = config?.dependsOn ?? dependsOnProp;
+  // Read through the declared type, not the untyped carrier (objectui#6153) — see SelectField.
+  const dependsOn = field?.dependsOn ?? dependsOnProp;
   const { options, gated, dependsOnFields } = useCascadingOptions<Option>(
     rawOptions,
     dependsOn,

--- a/packages/fields/src/widgets/LookupField.dependsOnDeclared-6153.test.tsx
+++ b/packages/fields/src/widgets/LookupField.dependsOnDeclared-6153.test.tsx
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * A lookup whose METADATA carries `dependsOn` scopes its candidates — read
+ * through the DECLARED type (objectui#6153, instance 1; maintainer ruling A,
+ * 2026-09-02).
+ *
+ * `LookupField.dependsOn.test.tsx` (#2215) proves the gate and the hard
+ * `$filter` through the legacy `depends_on` spelling on an `as any` literal.
+ * This file proves the same two facts through the spec's field-level spelling
+ * on ANNOTATED `LookupFieldMetadata` literals with NO cast — the
+ * excess-property check refused `dependsOn` on this exact document before the
+ * declaration landed (compile half), and the widget still gates and scopes on
+ * it (runtime half). Both spellings stay readable until objectui#7357 retires
+ * the snake_case twin; that card, not this one, drops the arm.
+ */
+
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { LookupFieldMetadata } from '@object-ui/types';
+import { LookupField } from './LookupField';
+
+const contacts = [
+  { id: 'c1', name: 'Nora Field', account: 'a1' },
+  { id: 'c2', name: 'Oscar Grant', account: 'a2' },
+];
+
+function makeDataSource() {
+  const find = vi.fn(async (_obj: string, params: { $filter?: Record<string, unknown> } | undefined) => {
+    const account = params?.$filter?.account ?? params?.$filter?.account_id;
+    const data = account ? contacts.filter((c) => c.account === account) : contacts;
+    return { data, total: data.length };
+  });
+  return { find } as never;
+}
+
+beforeEach(() => {
+  // jsdom has no matchMedia; the people-picker branch's useIsMobile needs it.
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  })) as never;
+});
+
+// The literal `content/docs/fields/lookup.mdx` teaches — annotated, uncast.
+const contactField: LookupFieldMetadata = {
+  type: 'lookup',
+  name: 'contact',
+  label: 'Contact',
+  reference_to: 'contacts',
+  reference_field: 'name',
+  dependsOn: [{ field: 'account', param: 'account_id' }],
+};
+
+const shorthandField: LookupFieldMetadata = {
+  ...contactField,
+  dependsOn: ['account'],
+};
+
+// `dependentValues` is a HOST prop (the form renderer's channel), not metadata.
+const host = (dependentValues: Record<string, unknown>) => ({ dependentValues }) as Record<string, unknown>;
+
+describe('LookupField — `dependsOn` off the DECLARED metadata type (objectui#6153)', () => {
+  it('gates the trigger while the controlling field is empty', () => {
+    render(
+      <LookupField
+        field={contactField}
+        value={undefined}
+        onChange={vi.fn()}
+        readonly={false}
+        dataSource={makeDataSource()}
+        {...host({ account: null })}
+      />,
+    );
+    const trigger = screen.getByTestId('lookup-trigger-gated');
+    expect(trigger).toBeDisabled();
+    expect(trigger).toHaveTextContent(/select account first/i);
+  });
+
+  it('scopes the candidate query by the `{ field, param }` entry once the parent is set', async () => {
+    const ds = makeDataSource();
+    render(
+      <LookupField
+        field={contactField}
+        value={undefined}
+        onChange={vi.fn()}
+        readonly={false}
+        dataSource={ds}
+        {...host({ account: 'a1' })}
+      />,
+    );
+
+    const trigger = screen.getByRole('button', { name: /select/i });
+    expect(trigger).not.toBeDisabled();
+    await act(async () => {
+      fireEvent.click(trigger);
+    });
+
+    await waitFor(() => {
+      expect((ds as { find: ReturnType<typeof vi.fn> }).find).toHaveBeenCalledWith(
+        'contacts',
+        expect.objectContaining({ $filter: expect.objectContaining({ account_id: 'a1' }) }),
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Nora Field')).toBeInTheDocument();
+      expect(screen.queryByText('Oscar Grant')).not.toBeInTheDocument();
+    });
+  });
+
+  it('the shorthand `[name]` entry filters by the sibling name itself', async () => {
+    const ds = makeDataSource();
+    render(
+      <LookupField
+        field={shorthandField}
+        value={undefined}
+        onChange={vi.fn()}
+        readonly={false}
+        dataSource={ds}
+        {...host({ account: 'a1' })}
+      />,
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /select/i }));
+    });
+    await waitFor(() => {
+      expect((ds as { find: ReturnType<typeof vi.fn> }).find).toHaveBeenCalledWith(
+        'contacts',
+        expect.objectContaining({ $filter: expect.objectContaining({ account: 'a1' }) }),
+      );
+    });
+  });
+});

--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -12,7 +12,7 @@ import { cn,
 import { Search, X, Loader2, AlertCircle, Plus, TableProperties } from 'lucide-react';
 import { FieldWidgetComponentProps } from './types.js';
 import { toDomProps } from './toDomProps.js';
-import type { DataSource, QueryParams, LookupColumnDef } from '@object-ui/types';
+import type { DataSource, QueryParams, LookupColumnDef, LookupFieldMetadata } from '@object-ui/types';
 import { RecordPickerDialog, lookupFiltersToRecord } from './RecordPickerDialog.js';
 import type { RecordPickerFilterColumn } from './RecordPickerDialog.js';
 import { PeoplePicker } from './PeoplePicker.js';
@@ -288,24 +288,33 @@ export function LookupField({ value, onChange, field, readonly, error: fieldErro
    * Dependent lookups — restrict candidates based on values of *other* fields
    * in the same form. Two shapes are accepted:
    *
-   * 1. `depends_on: ['country']` → shorthand. The dependent field value is sent
+   * 1. `dependsOn: ['country']` → shorthand. The dependent field value is sent
    *    as both the filter field and the source field (i.e. `country = ${country}`).
-   * 2. `depends_on: [{ field: 'country', param: 'country_id' }]` → explicit.
+   * 2. `dependsOn: [{ field: 'country', param: 'country_id' }]` → explicit.
    *    The remote field name (`param`) can differ from the local field name.
+   *
+   * The key is read THROUGH THE DECLARED TYPE (objectui#6153): `dependsOn` is
+   * `BaseFieldMetadata.dependsOn`, the spec's field-level spelling; `depends_on`
+   * is objectui's legacy twin, still declared and still honoured until
+   * objectui#7357 retires it — that card drops the snake_case arm below. Only
+   * this cascade read goes through `LookupFieldMetadata`; the rest of
+   * `fieldMeta` stays untyped because its camelCase-fallback family
+   * (`displayField`, `descriptionField`, …) is objectui#4631's population.
    *
    * When any dependency is empty, the lookup is gated and the user sees a
    * helpful "Select {field} first" hint instead of unfiltered records.
    */
+  const cascadeMeta: LookupFieldMetadata | undefined = fieldMeta;
   const dependsOn = useMemo<Array<{ field: string; param: string }>>(() => {
-    const raw = fieldMeta?.depends_on ?? fieldMeta?.dependsOn;
-    if (!raw) return [];
-    if (Array.isArray(raw)) {
-      return raw.map((d: any) =>
-        typeof d === 'string' ? { field: d, param: d } : { field: d.field, param: d.param ?? d.field },
-      );
-    }
-    return [];
-  }, [fieldMeta?.depends_on, fieldMeta?.dependsOn]);
+    const raw = cascadeMeta?.depends_on ?? cascadeMeta?.dependsOn;
+    // A bare parent name is the FORM-level shape (`FormField.dependsOn`), not the
+    // field-level one the spec declares (array only) — an untyped host handing
+    // one through still gets no cascade here, exactly as before.
+    if (!raw || !Array.isArray(raw)) return [];
+    return raw.map((d) =>
+      typeof d === 'string' ? { field: d, param: d } : { field: d.field, param: d.param ?? d.field },
+    );
+  }, [cascadeMeta?.depends_on, cascadeMeta?.dependsOn]);
 
   /**
    * The gate sentence's `{{fields}}` — the controlling fields named the way the

--- a/packages/fields/src/widgets/MultiSelectField.tsx
+++ b/packages/fields/src/widgets/MultiSelectField.tsx
@@ -41,7 +41,8 @@ export function MultiSelectField({
   const selected: string[] = Array.isArray(value) ? value : value == null ? [] : [value as unknown as string];
   const fieldName = props.name || config?.name || props.id || '';
 
-  const dependsOn = config?.dependsOn ?? dependsOnProp;
+  // Read through the declared type, not the untyped carrier (objectui#6153) — see SelectField.
+  const dependsOn = field?.dependsOn ?? dependsOnProp;
   const { options, gated, dependsOnFields } = useCascadingOptions<Option>(
     rawOptions,
     dependsOn,

--- a/packages/fields/src/widgets/RadioField.tsx
+++ b/packages/fields/src/widgets/RadioField.tsx
@@ -39,7 +39,8 @@ export function RadioField({
   const groupId = useId();
   const fieldName = props.name || config?.name || props.id || '';
 
-  const dependsOn = config?.dependsOn ?? dependsOnProp;
+  // Read through the declared type, not the untyped carrier (objectui#6153) — see SelectField.
+  const dependsOn = field?.dependsOn ?? dependsOnProp;
   const { options, gated, dependsOnFields } = useCascadingOptions<Option>(
     rawOptions,
     dependsOn,

--- a/packages/fields/src/widgets/SelectField.dependsOnDeclared-6153.test.tsx
+++ b/packages/fields/src/widgets/SelectField.dependsOnDeclared-6153.test.tsx
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * A select whose METADATA carries `dependsOn` gates and prunes its options —
+ * read through the DECLARED type (objectui#6153, instance 1; maintainer ruling
+ * A, 2026-09-02).
+ *
+ * The behaviour predates the card: `SelectField` has gated on the metadata's
+ * `dependsOn` since ADR-0058 / #2284, reached through `(config as any)`. What
+ * the card changed is the CONTRACT — `BaseFieldMetadata` now declares
+ * `dependsOn` in the spec's field-level shape, and the widget reads it as
+ * `field.dependsOn`. So the fixtures below are ANNOTATED `SelectFieldMetadata`
+ * literals with NO cast: the excess-property check that refused this exact
+ * document before the declaration is the compile half of the pin, and the gate
+ * + cascade-clear are the runtime half. The sibling `*.cascade.test.tsx` files
+ * keep proving the same behaviour through `as any` literals; this file proves
+ * it through the declared type, which is the fact the card records.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { SelectFieldMetadata } from '@object-ui/types';
+import { SelectField } from './SelectField';
+
+// The literal `content/docs/fields/select.mdx` teaches — annotated, uncast.
+const provinceField: SelectFieldMetadata = {
+  type: 'select',
+  name: 'province',
+  label: 'Province',
+  dependsOn: ['country'],
+  options: [
+    { label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" },
+    { label: 'California', value: 'ca', visibleWhen: "record.country == 'us'" },
+  ],
+};
+
+const provincesField: SelectFieldMetadata = {
+  ...provinceField,
+  name: 'provinces',
+  multiple: true,
+};
+
+// `name` / `dependentValues` are HOST props (the form renderer's channel), not
+// metadata — spread the way every other option-widget test does.
+const host = (name: string, dependentValues: Record<string, unknown>) =>
+  ({ name, dependentValues }) as Record<string, unknown>;
+
+describe('SelectField — `dependsOn` off the DECLARED metadata type (objectui#6153)', () => {
+  it('gates with a "select the parent first" hint while the controlling field is empty', () => {
+    render(
+      <SelectField value={undefined} onChange={vi.fn()} field={provinceField} {...host('province', {})} />,
+    );
+    expect(screen.getByTestId('select-empty-province')).toHaveTextContent(/select country first/i);
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('unlocks once the controlling value is set', () => {
+    render(
+      <SelectField
+        value={undefined}
+        onChange={vi.fn()}
+        field={provinceField}
+        {...host('province', { country: 'cn' })}
+      />,
+    );
+    expect(screen.queryByTestId('select-empty-province')).not.toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('prunes a value the controlling field no longer offers, and keeps one it does', () => {
+    const dropped = vi.fn();
+    render(
+      <SelectField value="ca" onChange={dropped} field={provinceField} {...host('province', { country: 'cn' })} />,
+    );
+    // 'ca' is offered only under country=us — under cn it is not, so it is cleared.
+    expect(dropped).toHaveBeenCalledWith(undefined);
+
+    const kept = vi.fn();
+    render(
+      <SelectField value="zj" onChange={kept} field={provinceField} {...host('province', { country: 'cn' })} />,
+    );
+    expect(kept).not.toHaveBeenCalled();
+  });
+
+  it('the `multiple` arm (MultiSelectField) reads the same declared key', () => {
+    render(
+      <SelectField value={[]} onChange={vi.fn()} field={provincesField} {...host('provinces', {})} />,
+    );
+    expect(screen.getByTestId('multiselect-empty-provinces')).toHaveTextContent(/select country first/i);
+  });
+});

--- a/packages/fields/src/widgets/SelectField.tsx
+++ b/packages/fields/src/widgets/SelectField.tsx
@@ -95,7 +95,10 @@ function SingleSelectField({
   // react-hook-form field name spread in by the form renderer (FormField).
   const fieldName = props.name || (config as any)?.name || props.id || '';
 
-  const dependsOn = (config as any)?.dependsOn ?? dependsOnProp;
+  // The cascade key is read THROUGH THE DECLARED TYPE — `BaseFieldMetadata.dependsOn`,
+  // the spec's field-level spelling, which every `FieldMetadata` member inherits
+  // (objectui#6153; formerly reached through an `as any`). Metadata wins over the prop.
+  const dependsOn = field?.dependsOn ?? dependsOnProp;
   const { options, gated, dependsOnFields } = useCascadingOptions(
     rawOptions,
     dependsOn,

--- a/packages/fields/src/widgets/toHostProps.ts
+++ b/packages/fields/src/widgets/toHostProps.ts
@@ -75,7 +75,7 @@ import type { FieldWidgetComponentProps } from './types.js';
  *    because there has never been one to displace.
  *  - `dependsOn`: the FIELD METADATA wins over the prop — the one documented
  *    inversion, stated on the key's own doc comment and implemented as
- *    `config?.dependsOn ?? dependsOnProp` in all four option widgets.
+ *    `field?.dependsOn ?? dependsOnProp` in all four option widgets.
  *  - `emptyHint`: the host's value wins when supplied (objectui#3231).
  *  - `onCreateNew`: the prop wins over `field.onCreateNew`; `onSelectRecord`
  *    has no metadata carrier at all, so the prop is its ONLY one.

--- a/packages/plugin-grid/src/__tests__/relationalMetaCopySet.derivation.test.ts
+++ b/packages/plugin-grid/src/__tests__/relationalMetaCopySet.derivation.test.ts
@@ -79,13 +79,21 @@
  *
  * ## ⛔ The extractor is bounded, and says so
  *
- * It reads member accesses off named receivers. A key that reaches a consumer
- * some other way — destructuring, a computed `meta[expr]`, a helper that takes
- * the whole bag — is outside its reach. That is the honest limit; the five
- * spellings objectui#6875 measured were all plain member reads, and so is every
- * key the three chains use today. `assertExtractorFoundKnownChains` is the
- * positive control that keeps a silently-empty extraction from reading as a
- * clean bill of health.
+ * It reads member accesses off named receivers — the receiver itself and every
+ * ANNOTATED ALIAS of it, `const NAME: TYPE = receiver;`, which is the same
+ * object read through a declared type (objectui#6153 introduced the first one:
+ * `LookupField`'s `cascadeMeta`, the `LookupFieldMetadata` view of `fieldMeta`
+ * through which `dependsOn` / `depends_on` are now read; a consumer that
+ * de-casts a read this way has not stopped reading, and a scanner that could
+ * not see it would have reported two real reads as orphans). Aliases are
+ * derived from the consumer's own source on every run, never listed here. A key
+ * that reaches a consumer some other way — destructuring, a computed
+ * `meta[expr]`, a helper that takes the whole bag — is outside its reach. That
+ * is the honest limit; the five spellings objectui#6875 measured were all plain
+ * member reads, and so is every key the three chains use today.
+ * `assertExtractorFoundKnownChains` is the positive control that keeps a
+ * silently-empty extraction from reading as a clean bill of health, and the
+ * alias CONTROL below keeps the alias rule from reaching further than it says.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -154,12 +162,31 @@ function renderCellEditorProperty(): string {
   return lines.slice(start, end).join('\n');
 }
 
-/** `recv?.key` / `recv.key` member reads off one named receiver. */
+/**
+ * The receiver plus every annotated alias of it declared in `src` —
+ * `const NAME: TYPE = receiver;` (the annotation is optional to the regex, so a
+ * bare `const NAME = receiver;` counts too). An alias is the SAME object read
+ * through a declared type (objectui#6153: `cascadeMeta` is `fieldMeta` typed as
+ * `LookupFieldMetadata`), so its member reads are the receiver's member reads.
+ * Only whole-object aliases qualify: `const x = receiver.key;` is a read of
+ * `key`, not a new receiver, and the trailing `;` anchor is what excludes it.
+ */
+function receiverAliases(src: string, receiver: string): string[] {
+  const names = [receiver];
+  const re = new RegExp(`\\bconst\\s+([A-Za-z_$][\\w$]*)\\s*(?::[^=;]+)?=\\s*${receiver}\\s*;`, 'g');
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(src))) names.push(m[1]);
+  return names;
+}
+
+/** `recv?.key` / `recv.key` member reads off one named receiver and its annotated aliases. */
 function memberReads(src: string, receiver: string): Set<string> {
   const out = new Set<string>();
-  const re = new RegExp(`\\b${receiver}\\s*\\??\\.\\s*([A-Za-z_$][\\w$]*)`, 'g');
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(src))) out.add(m[1]);
+  for (const recv of receiverAliases(src, receiver)) {
+    const re = new RegExp(`\\b${recv}\\s*\\??\\.\\s*([A-Za-z_$][\\w$]*)`, 'g');
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(src))) out.add(m[1]);
+  }
   return out;
 }
 
@@ -210,12 +237,42 @@ function assertExtractorFoundKnownChains(x: Extraction): void {
   expect(x.cell).toContain('reference_to');
   expect(x['lookup-editor']).toContain('lookup_columns');
   expect(x['lookup-editor']).toContain('lookupColumns');
+  // objectui#6153: these two are read through the ANNOTATED ALIAS `cascadeMeta`
+  // (`const cascadeMeta: LookupFieldMetadata | undefined = fieldMeta;`), not off
+  // `fieldMeta` directly. An extractor that stopped following aliases would drop
+  // both, and the orphan assertion below would then call two real reads stale.
+  expect(x['lookup-editor']).toContain('dependsOn');
+  expect(x['lookup-editor']).toContain('depends_on');
   expect(x['user-editor']).toContain('reference_field');
 }
 
 const specProps = new Set(Object.keys((FieldSchema as any).shape));
 
 describe('objectui#6875 — the copy set is derived from the consumers, not restated', () => {
+  it('the extractor follows an annotated alias of the receiver, and nothing else (CONTROL)', () => {
+    const fixture = [
+      'const view: SomeType | undefined = fieldMeta;',
+      'const bare = fieldMeta;',
+      'const notAnAlias = fieldMeta.picked;',
+      'const other: SomeType = someoneElse;',
+      'view?.viaAnnotated; bare.viaBare; other?.notOurs; someoneElse.notOurs2;',
+      'fieldMeta?.direct;',
+    ].join('\n');
+    expect(receiverAliases(fixture, 'fieldMeta')).toEqual(['fieldMeta', 'view', 'bare']);
+    const reads = memberReads(fixture, 'fieldMeta');
+    // Reached: the direct read, the reads through both alias forms, and the
+    // member the non-alias line reads off the receiver itself.
+    expect([...reads].sort()).toEqual(['direct', 'picked', 'viaAnnotated', 'viaBare']);
+    // Not reached: a different receiver, and a name that only LOOKS like an
+    // alias because it was initialised from a member read.
+    expect(reads.has('notOurs')).toBe(false);
+    expect(reads.has('notOurs2')).toBe(false);
+    // The real consumer declares exactly one alias today; a second one is a new
+    // fact about the seam, not a silent widening of this sweep.
+    expect(receiverAliases(read('widgets/LookupField.tsx'), 'fieldMeta')).toEqual(['fieldMeta', 'cascadeMeta']);
+    expect(receiverAliases(read('widgets/UserField.tsx'), 'meta')).toEqual(['meta']);
+  });
+
   it('the extractor reaches all three consumers (CONTROL)', () => {
     const x = extractReadSet();
     assertExtractorFoundKnownChains(x);

--- a/packages/types/src/__tests__/field-metadata-depends-on-declared-6153.test.ts
+++ b/packages/types/src/__tests__/field-metadata-depends-on-declared-6153.test.ts
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#6153, instance 1 — `dependsOn` is a DECLARED member of the
+ * field-metadata face (maintainer ruling A, recorded on the card 2026-09-02,
+ * verbatim 「同意」; it amends the 2026-09-01 ruling whose premise — that the
+ * snake_case spelling was the declared one — was false on the spec side).
+ *
+ *   1. `BaseFieldMetadata.dependsOn?: FieldDependsOn`, where `FieldDependsOn`
+ *      is DERIVED from `@objectstack/spec/data`'s `Field` — the spec's
+ *      field-level cascade key, in the spec's shape: an array of controlling
+ *      field names or `{ field, param }` entries. Every field type inherits it.
+ *   2. The five reader widgets (`SelectField`, `MultiSelectField`, `RadioField`,
+ *      `CheckboxesField`, `LookupField`) read it THROUGH the declared type; the
+ *      `as any` the card measured at the read is gone.
+ *   3. The fence the shape draws: a bare parent name is the FORM-level shape
+ *      (`FormField.dependsOn` / the widget prop, both `DependsOnInput`), and the
+ *      installed spec refuses it on a field document — so the metadata type
+ *      refuses it too, rather than letting an author write metadata the publish
+ *      door rejects.
+ *   4. The ordering the ruling set up: `LookupField` keeps BOTH arms of its
+ *      two-spelling read until objectui#7357 retires `depends_on`; both are
+ *      declared today. That card, not this one, drops the snake_case arm.
+ *
+ * ## Why membership pins are type-level here
+ *
+ * Plain interfaces, no index signature, no zod mirror (`src/zod/` has no
+ * field-types mirror, so no parity-ledger row moves) — an undeclared member read
+ * is a compile error and `Equal` cannot be satisfied by an index-signature
+ * fallback. The pins bite under `tsc -p tsconfig.test.json` (the package's
+ * `type-check` chain), not under the vitest RUNTIME, which is why the runtime
+ * half below pins the READ SITES (house form of
+ * `undeclared-but-consumed-keys-6150.test.ts`) and the installed spec's answer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { FieldSchema } from '@objectstack/spec/data';
+
+import type {
+  BaseFieldMetadata,
+  FieldDependsOn,
+  LookupFieldMetadata,
+  SelectFieldMetadata,
+} from '../field-types';
+import type { DependsOnInput } from '../form';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..', '..', '..');
+
+/* ── Type-level helpers (invariant equality, house form) ─────────────────── */
+
+type Equal< A, B > =
+  (< T >() => T extends A ? 1 : 2) extends (< T >() => T extends B ? 1 : 2) ? true : false;
+type Expect< T extends true > = T;
+
+/* ── 1. The declared member, in the spec's shape ─────────────────────────── */
+
+export type _DependsOnIsDeclaredInSpecShape = Expect< Equal< NonNullable< BaseFieldMetadata['dependsOn'] >, FieldDependsOn > >;
+// The derived shape is exactly what the installed spec declares at field level
+// (`z.array(z.union([z.string(), z.strictObject({ field, param? })]))`) — if a
+// spec release widens or narrows it, this line moves with it and says so.
+export type _SpecShapeIsArrayOfNameOrEntry = Expect< Equal< FieldDependsOn, Array< string | { field: string; param?: string | undefined } > > >;
+// Inherited, not restated: the select and lookup faces carry the SAME member.
+export type _SelectInherits = Expect< Equal< SelectFieldMetadata['dependsOn'], BaseFieldMetadata['dependsOn'] > >;
+export type _LookupInherits = Expect< Equal< LookupFieldMetadata['dependsOn'], BaseFieldMetadata['dependsOn'] > >;
+
+// Every runtime reader (`useCascadingOptions`, `resolveCascadingOptions`,
+// `isOptionGroupGated`) takes `DependsOnInput`; the declared shape flows into
+// it without a cast. Compiling at all is the assertion.
+export const _readerAccepts: DependsOnInput = [] as FieldDependsOn;
+
+/* ── 3. The fence: a bare parent name is not the field-level shape ───────── */
+
+export const _bareStringRefusedAtTheType: SelectFieldMetadata = {
+  type: 'select',
+  name: 'province',
+  // @ts-expect-error — `dependsOn: 'country'` is `FormField.dependsOn`'s shape; the spec's `FieldSchema` answers invalid_type to it on a field document (pinned at runtime below)
+  dependsOn: 'country',
+};
+
+/* ── The authoring proof: annotated literals carry the key ───────────────── */
+// These assignments are the excess-property check that FAILED before the
+// declaration landed — an author (human or AI) could not legally write what the
+// running widgets honoured. Compiling at all is the assertion. The literals are
+// the ones `content/docs/fields/select.mdx` and `lookup.mdx` teach.
+
+export const _selectWithDependsOn: SelectFieldMetadata = {
+  type: 'select',
+  name: 'province',
+  label: 'Province',
+  dependsOn: ['country'],
+  options: [
+    { label: 'Zhejiang', value: 'zj', visibleWhen: "record.country == 'cn'" },
+    { label: 'California', value: 'ca', visibleWhen: "record.country == 'us'" },
+  ],
+};
+
+export const _multiSelectWithDependsOn: SelectFieldMetadata = {
+  ..._selectWithDependsOn,
+  name: 'provinces',
+  multiple: true,
+};
+
+export const _lookupWithDependsOnEntry: LookupFieldMetadata = {
+  type: 'lookup',
+  name: 'contact',
+  label: 'Contact',
+  reference_to: 'contacts',
+  dependsOn: [{ field: 'account', param: 'account_id' }],
+};
+
+export const _lookupWithDependsOnShorthand: LookupFieldMetadata = {
+  ..._lookupWithDependsOnEntry,
+  dependsOn: ['account'],
+};
+
+/* ── 4. The ordering: the legacy twin is still declared until #7357 ──────── */
+// objectui#7357 retires `depends_on` and deletes this literal in the same
+// stroke — until then both spellings are declared, and `LookupField` reads both.
+
+export const _legacyTwinStillDeclaredUntil7357: LookupFieldMetadata = {
+  type: 'lookup',
+  name: 'contact',
+  reference_to: 'contacts',
+  depends_on: ['account'],
+};
+
+/* ── The installed spec's answer (the two-control probe) ─────────────────── */
+
+/** Pull the `unrecognized_keys` issue naming `key`, or undefined. */
+function refusedByName(res: ReturnType<typeof FieldSchema.safeParse>, key: string) {
+  if (res.success) return undefined;
+  return res.error.issues.find(
+    (i) => i.code === 'unrecognized_keys' && ((i as { keys?: string[] }).keys ?? []).includes(key),
+  );
+}
+
+const provinceDocument = {
+  name: 'province',
+  type: 'select',
+  label: 'Province',
+  options: [{ label: 'Zhejiang', value: 'zj' }],
+  dependsOn: ['country', { field: 'region', param: 'region_id' }],
+};
+
+describe('installed @objectstack/spec — the field-level `dependsOn` that FieldDependsOn derives', () => {
+  it('control: a canonical select carrying both entry shapes draws NO issue', () => {
+    expect(FieldSchema.safeParse(provinceDocument).success).toBe(true);
+  });
+
+  it('control: a bogus key on the same document is refused BY NAME — the door is strict', () => {
+    const res = FieldSchema.safeParse({ ...provinceDocument, dependsOnBogusKey6153: true });
+    expect(refusedByName(res, 'dependsOnBogusKey6153')).toBeDefined();
+  });
+
+  it('a bare parent name is refused as invalid_type at `dependsOn` — why the declared shape is array-only', () => {
+    const res = FieldSchema.safeParse({ ...provinceDocument, dependsOn: 'country' });
+    expect(res.success).toBe(false);
+    if (res.success) return;
+    expect(res.error.issues.some((i) => i.code === 'invalid_type' && i.path.join('.') === 'dependsOn')).toBe(true);
+  });
+
+  it('the legacy snake_case twin is refused BY NAME — it was never a spec key (objectui#7357 retires it)', () => {
+    const { dependsOn, ...rest } = provinceDocument;
+    void dependsOn;
+    const res = FieldSchema.safeParse({ ...rest, depends_on: ['country'] });
+    expect(refusedByName(res, 'depends_on')).toBeDefined();
+  });
+});
+
+/* ── Read-site pins ──────────────────────────────────────────────────────── */
+
+const OPTION_WIDGETS = [
+  'packages/fields/src/widgets/SelectField.tsx',
+  'packages/fields/src/widgets/MultiSelectField.tsx',
+  'packages/fields/src/widgets/RadioField.tsx',
+  'packages/fields/src/widgets/CheckboxesField.tsx',
+] as const;
+
+const readSites: Array<{ file: string; text: string; why: string }> = [
+  ...OPTION_WIDGETS.map((file) => ({
+    file,
+    text: 'const dependsOn = field?.dependsOn ?? dependsOnProp;',
+    why: 'the cascade key is read off the TYPED `field` prop (`BaseFieldMetadata.dependsOn`); metadata wins over the prop',
+  })),
+  {
+    file: 'packages/fields/src/widgets/LookupField.tsx',
+    text: 'const cascadeMeta: LookupFieldMetadata | undefined = fieldMeta;',
+    why: 'the DECLARED carrier the lookup reads its cascade key through',
+  },
+  {
+    file: 'packages/fields/src/widgets/LookupField.tsx',
+    text: 'const raw = cascadeMeta?.depends_on ?? cascadeMeta?.dependsOn;',
+    why: 'BOTH arms, through the declared type — objectui#7357 drops the snake_case one, not this card',
+  },
+];
+
+describe('objectui#6153 — `dependsOn` read through the declared type at every reader', () => {
+  describe.each(readSites.map((s) => [`${s.file} — ${s.why}`, s] as const))('%s', (_title, s) => {
+    it('the read site still exists — the fact the declaration records', () => {
+      const src = readFileSync(join(REPO_ROOT, s.file), 'utf8');
+      expect(src, `${s.file} no longer contains \`${s.text}\``).toContain(s.text);
+    });
+  });
+
+  it('no reader reaches `dependsOn` through an `as any` any more', () => {
+    for (const file of [...OPTION_WIDGETS, 'packages/fields/src/widgets/LookupField.tsx']) {
+      const src = readFileSync(join(REPO_ROOT, file), 'utf8');
+      expect(src, `${file} launders the cascade key through a cast again`).not.toMatch(
+        /as any\)\??\.dependsOn\b/,
+      );
+      expect(src, `${file} reads the cascade key off the untyped carrier again`).not.toMatch(
+        /\bconfig\??\.dependsOn\b/,
+      );
+    }
+  });
+});

--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -16,6 +16,29 @@
  * @packageDocumentation
  */
 
+import type { Field as SpecField } from '@objectstack/spec/data';
+
+/**
+ * A field's `dependsOn` in the shape `@objectstack/spec` declares at FIELD
+ * level — derived from `@objectstack/spec/data`'s `Field` by reference rather
+ * than restated (objectui#6153), so the two cannot drift: a list of controlling
+ * sibling field names, or `{ field, param }` entries mapping a sibling onto the
+ * remote query parameter a dependent lookup filters by.
+ *
+ * Measured on the installed `@objectstack/spec` 17.3.0, `FieldSchema` declares
+ * `dependsOn` as an OPTIONAL ARRAY of `string | { field, param? }` — never a
+ * bare string. That is deliberately narrower than `DependsOnInput` (`form.ts`),
+ * the shape the widget prop `FieldWidgetComponentProps.dependsOn` and
+ * `FormField.dependsOn` take, which also admits a bare parent name and `null`:
+ * `FieldSchema.safeParse` answers `invalid_type` at `dependsOn` to a bare
+ * string on a field document, with the same field carrying `['country']`
+ * accepted as the control — so declaring the wider shape here would let an
+ * author write metadata the publish door refuses. Every runtime reader takes
+ * `DependsOnInput`, and this type is assignable to it (pinned in
+ * `__tests__/field-metadata-depends-on-declared-6153.test.ts`).
+ */
+export type FieldDependsOn = NonNullable<SpecField['dependsOn']>;
+
 /**
  * Base field metadata interface
  * Common properties shared by all field types
@@ -124,8 +147,37 @@ export interface BaseFieldMetadata {
   /**
    * Field dependencies (Phase 3.2.3)
    * List of fields that this field depends on
+   *
+   * objectui's LEGACY spelling of {@link BaseFieldMetadata.dependsOn} — never a
+   * `@objectstack/spec` key (`FieldSchema` refuses `depends_on` BY NAME,
+   * measured on 17.3.0). Only `LookupField` still reads it; it retires under
+   * enforce-or-remove on objectui#7357. Author `dependsOn`.
    */
   depends_on?: string[];
+
+  /**
+   * Controlling sibling field(s) — the spec's field-level cascade key, declared
+   * here so every field-metadata member carries it THROUGH THE DECLARED TYPE
+   * (objectui#6153, maintainer ruling A, 2026-09-02). The option widgets
+   * (`SelectField`, `MultiSelectField`, `RadioField`, `CheckboxesField`) gate
+   * their authored option list behind it — a "select the parent first" hint
+   * while any controlling value is empty — and prune a selection the parent no
+   * longer offers; `LookupField` scopes its candidate queries by it.
+   *
+   * Two shapes, both {@link FieldDependsOn}:
+   *  - `['country']` — the sibling's value is sent as both the filter field and
+   *    the value (`country = ${country}`).
+   *  - `[{ field: 'account', param: 'account_id' }]` — the remote parameter
+   *    name differs from the local field name (dependent lookups).
+   *
+   * Precedence: this metadata key wins over the `dependsOn` WIDGET PROP
+   * (`FieldWidgetComponentProps.dependsOn`) — the one documented inversion, see
+   * `toHostProps.ts` in `@object-ui/fields`. Before this member existed the
+   * widgets reached the key through an `as any`, so it worked at runtime while
+   * no annotated literal could carry it — the declared/enforced gap the card
+   * measured.
+   */
+  dependsOn?: FieldDependsOn;
   
   /*
    * There is deliberately no `indexed` here (objectui#4679). The ObjectStack

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -467,6 +467,7 @@ export type {
 // ============================================================================
 export type {
   BaseFieldMetadata,
+  FieldDependsOn,
   VisibilityCondition,
   FieldValidationFunction,
   TextFieldMetadata,


### PR DESCRIPTION
Fixes #6153

## What

Instance 1 of the card, per the maintainer ruling recorded at comment 5510108593 (director seat, summon #8, 2026-09-02, verbatim 「同意」): **A** — objectui's metadata face mirrors the spec's field-level `dependsOn`.

- `BaseFieldMetadata` (`packages/types/src/field-types.ts`) declares `dependsOn?: FieldDependsOn`. `FieldDependsOn` is DERIVED by reference from `@objectstack/spec/data`'s `Field` (`NonNullable` of its `dependsOn` member) rather than restated: an array of controlling field names or `{ field, param }` entries. It is exported from `@object-ui/types`.
- The reader set, re-derived from the tree: FIVE sites, matching the ruling. `SelectField`, `MultiSelectField`, `RadioField`, `CheckboxesField` read `field?.dependsOn ?? dependsOnProp` (the typed `field` prop) instead of `(config as any)?.dependsOn` / the untyped `config` carrier; `LookupField` reads both of its spellings through an annotated `LookupFieldMetadata` alias (`cascadeMeta?.depends_on ?? cascadeMeta?.dependsOn`) — BOTH arms kept, precedence unchanged, because dropping the snake_case arm is objectui#7357's job (`pm:blocked` on this card).
- `content/docs/fields/select.mdx` and `lookup.mdx` document `dependsOn` as a metadata key again, each with an annotated `ts` snippet (the same literals the pins compile); `select.mdx`'s "model each level as a lookup with `depends_on`" now names `dependsOn`.
- Two changesets: `@object-ui/types` minor (a new declared member plus its export), `@object-ui/fields` patch (read path only; behaviour unchanged).

Not touched, by ruling: instance 2 (`options[].description`, landed with #6140 / PR #7061); the #4631 camelCase-fallback family in `LookupField` (`displayField`, `descriptionField`, `allowCreate`, `lookupColumns`, `lookupPageSize`, `lookupFilters`, `avatarField`); `packages/types/src/__tests__/zod-mirror-parity.test.ts` (held by PR #8501 and PR #8553 — no ledger row moves, measured below).

## Zone 2 — the PM's mechanism assumptions, measured

- (a) Line numbers drifted, as assumed: everything located by symbol. `SelectField.tsx` read at 98 in the ruling → 101 now; `LookupField.tsx` "around :300" → 300 to 308 at BASE, 307 to 317 now; `CheckboxesField.tsx:43` → 43 at BASE. Every site the ruling names was found.
- (b) "Five widgets" is exactly right: the non-test `dependsOn` / `depends_on` reads under `packages/fields/src/widgets` are the four option widgets plus `LookupField`; `FieldEditWidget.tsx`, `toHostProps.ts`, `OptionsEmptyState.tsx` and `useCascadingOptions.ts` carry the key only as a PROP. Not four, not six.
- (c) PARTIALLY FALSIFIED — the one place this PR follows the ruling's sentence over its parenthesis. `DependsOnInput` is reachable (`form.ts`, exported) and every reader takes it, but it is NOT the spec's field-level shape. Measured on the installed `@objectstack/spec` 17.3.0 with the two-control probe (`FieldSchema.safeParse`): a canonical select carrying `dependsOn: ['country', { field: 'region', param: 'region_id' }]` draws NO issue; the same document plus a bogus key draws `unrecognized_keys` naming it; `dependsOn: 'country'` (a bare string, which `DependsOnInput` admits) draws `invalid_type` at `dependsOn`; `depends_on: ['country']` draws `unrecognized_keys` naming `depends_on`. The ruling's primary clause is "declares `dependsOn` in the spec's shape"; declaring the wider `DependsOnInput` would let an author write field metadata the publish door refuses and that `LookupField` silently ignores. So the member is typed with the spec-derived `FieldDependsOn`, which is assignable to `DependsOnInput` at every reader (pinned). If the seat prefers the literal `DependsOnInput`, it is a one-line change on `field-types.ts` plus the fence pins.
- (d) No parity-ledger row moves: `src/zod/` has no field-types mirror (the ledger's only mention of `field-types.ts` is a disclaimer in its header), and the instrument — `pnpm --filter @object-ui/types type-check`, third leg `tsc -p tsconfig.test.json` — is green; `--listFiles` counts the new pin (1) and the #6140 pin (1) among 612 files.

## Pins

- `packages/types/src/__tests__/field-metadata-depends-on-declared-6153.test.ts` — type-level: `BaseFieldMetadata['dependsOn']` is exactly `FieldDependsOn`, which is exactly an array of `string | { field, param? }`; select and lookup inherit it; it flows into `DependsOnInput`; a bare string is refused (`@ts-expect-error`); annotated `SelectFieldMetadata` (single and `multiple`) and `LookupFieldMetadata` (entry and shorthand) literals compile; the legacy `depends_on` literal still compiles until #7357 deletes that line. Runtime: the four-way spec probe above, read-site text pins for all five readers, and a "no reader reaches `dependsOn` through a cast" assertion.
- `packages/fields/src/widgets/SelectField.dependsOnDeclared-6153.test.tsx` — an annotated, uncast `SelectFieldMetadata` gates (`select-empty-province`), unlocks, prunes `ca` under `country: cn` and keeps `zj`; the `multiple` arm gates (`multiselect-empty-provinces`).
- `packages/fields/src/widgets/LookupField.dependsOnDeclared-6153.test.tsx` — an annotated, uncast `LookupFieldMetadata` gates the trigger, scopes `$filter` by `account_id` for the entry shape and by `account` for the shorthand.
- Showcase paths: the objectui-side proxies for `examples/app-showcase`'s cascading-select and invoice-to-contact are `form-cascading-select.test.tsx`, `form-dependent-values.test.tsx`, `SelectField.cascade.test.tsx` and `LookupField.dependsOn.test.tsx`; all pass unchanged. The live e2e `e2e/live/cascading-options.spec.ts` needs a running stack and stays with CI's live lane.

## Reverse verification (from commit `cbbca66`; restore = `git checkout HEAD -- PATH`, byte-proved)

- Leg 1 — delete `dependsOn?: FieldDependsOn;` from `BaseFieldMetadata` (src count 1 → 0; `pnpm exec tsc` in `packages/types`; `dist/field-types.d.ts` count 1 → 0): `tsc -p tsconfig.test.json` exit 2, 8 errors, all in the new pin (`TS2339 Property 'dependsOn' does not exist on type 'BaseFieldMetadata'` and siblings); `packages/fields` `tsc --noEmit` exit 2, 6 errors `TS2551` at exactly the six read sites (SelectField 101, MultiSelectField 45, RadioField 43, CheckboxesField 44, LookupField 309 and 317). Restore: `git diff HEAD` empty, blob hash equals HEAD's, dist count back to 1, both checks exit 0.
- Leg 2 — put `(config as any)?.dependsOn` back into `SelectField`: the read-site pin fails 2 of 11 ("the read site still exists", "no reader reaches dependsOn through an as any"); restore: blob equals HEAD's, 11 of 11 pass.
- Direction observed: red on both legs, as expected.

## Gates (local, targeted; exit codes captured before any pipe)

- `pnpm --filter @object-ui/types type-check` (3 legs) — VERDICT command-exit 0 (28 s, shared-box seconds).
- `pnpm --filter @object-ui/fields type-check` (2 legs) — first run exit 2 with 113 × TS2307 "Cannot find module '@object-ui/…'" = NOT MEASURED (fresh worktree, no sibling `dist/`); after `turbo run build --filter='@object-ui/fields^...' --concurrency=2` (9 tasks, 51 s) — VERDICT command-exit 0.
- vitest, 20 files (3 new pins, the `dependsOn` / cascade family, the #6140 / #7014 / #6150 pins, the parity ledger's runtime): `Test Files 20 passed (20)`, `Tests 252 passed (252)`.
- eslint on the 11 changed source and test files, package spelling (`eslint` without `--no-inline-config` — that flag is objectstack's, and here it un-silences a pre-existing block-disabled import at `index.ts:1298` outside this diff): exit 0, 0 errors, 73 pre-existing warnings, 0 in the new files or on the changed lines.
- `check-control-bytes` ✅ 6796 files · `check-changeset-presence` ✅ "8 source file(s) of 2 released package(s) changed, and this change declares 2 changeset(s)" · `check-changeset-no-major` ✅ · `check-changeset-fixed` ✅ · `check-changeset-overwrite` ✅ · `check-doc-fence-languages` ✅ · `check-spec-symbol-derivation` ✅ "nothing cites a key its spec symbol does not declare" · `check-unreferenced-sources` ✅ · `check-type-check-coverage` ✅ 42/42 · `check-doc-links` ✅ "Links are valid across 17 scan roots" · `check-doc-expression-carriage` exit 0 (report-only) · `check-doc-component-types` ✅ · `check-doc-example-shared-reader` ✅ · `check-governed-queue-guard --test` ✅ NOT GOVERNED (15 paths).
- `check-doc-snippet-types` — declared to CI (its `--build-filter` is the whole workspace). Local proxy, measured: the two new `ts` snippets extracted from the pages compile `--strict` against the BUILT `@object-ui/types` `dist/*.d.ts` (exit 0), and the same harness turns red (`TS2322`) when `dependsOn: ['country']` is replaced by a bare string.
- Not run locally, CI-owned: the full `pnpm lint` farm, `check-designer-field-key-parity`, `check-handler-key-reads`, `check-i18n-*`, and the remaining `check:*` scripts these paths do not reach.

## 验收备注

noted, not filed:
- `RadioField` / `CheckboxesField` keep `const config = field as any` for `options` / `name` — the `FieldMetadata` union declares no `radio` / `checkboxes` member (their `type` literal is absent), so no declared type exists to read those keys through. Incompleteness, not a defect: the runtime honours the keys. Bearer: #4631's three-face reconciliation would meet it; otherwise 承接者:无.
- `SelectField.tsx` still carries `(config as any)?.name` although `config` is typed `SelectFieldMetadata` — a dead cast, outside this card's key. 承接者:无.
- `LookupField` ignores a bare-string `dependsOn` that the option widgets honour (core's `resolveDependsOnFields` wraps a string). Unreachable through the declared type (array-only) and consistent with the spec; reachable only from untyped hosts. Bearer: #7357 edits exactly that block when it drops the snake_case arm.
- `LookupField`'s two-arm precedence is unchanged (`depends_on` first). Moot once #7357 lands.

## Serial / overlap

None of this PR's files is touched by PR #8501, #8553, #8601 or #8602 (measured from their changed-file lists at claim time). #7357 remains `pm:blocked` on this card and is the one that removes the snake_case arm and the `depends_on` member; the pin that keeps `depends_on` compiling is labelled for deletion in that stroke. Related, not addressed here: #4631, #6140, #7061 (instance 2, already merged).

Clause-②: yes — adds a declared member to a published type; `needs:contract-review` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_