### PR TITLE
test(vscode-extension): bind both documented mirrors to the emitted Export-to-React preamble

### DIFF
--- a/.changeset/7976-bind-documented-export-preamble.md
+++ b/.changeset/7976-bind-documented-export-preamble.md
@@ -1,0 +1,8 @@
+---
+---
+
+Bind both hand-kept documentation mirrors of the `Export to React` preamble to
+the text `generateReactComponent()` actually emits (objectui#7976) —
+`packages/vscode-extension/DESIGN.md` section 4 and the Output Example in
+`content/docs/utilities/vscode-extension.mdx`, held by one assertion so the two
+cannot drift apart again. Test only; no package is released by this change.

--- a/packages/vscode-extension/src/__tests__/export-to-react-compiles.test.ts
+++ b/packages/vscode-extension/src/__tests__/export-to-react-compiles.test.ts
@@ -249,3 +249,166 @@ describe('Export to React — the file the command hands the user (objectui#7862
     expect(diagnostics[0]).toContain("'React'");
   });
 });
+
+/**
+ * objectui#7976 — BINDS the two hand-kept documentation mirrors of the preamble
+ * to the preamble `generateReactComponent()` actually emits.
+ *
+ * WHY. Two documents transcribe that preamble by hand, and nothing held either
+ * to the original: the template lives inside a TEMPLATE LITERAL, so this
+ * package's `tsc --noEmit` sees one string, and `DESIGN.md` is markdown in a
+ * package whose README is the only file the doc gates' surfaces name. Both
+ * copies could drift indefinitely with every gate green. Hand-correction had
+ * been spent three times before this pin existed — objectui#7837, objectui#7978
+ * and objectui#8112 — and the third re-created the defect while fixing it: it
+ * hand-copied the product byte for byte and asserted the equality in its PULL
+ * REQUEST DESCRIPTION, which ran once, in one session, and is not in the tree.
+ * objectui#7914's ruling is that the control demonstrating the catch belongs in
+ * the FILE. This is that file.
+ *
+ * ⛔ WHAT THIS PIN DOES NOT SEE — read this before trusting it.
+ *
+ * It binds the PREAMBLE ONLY: the lines above `const schema =`. Everything
+ * BELOW that line is unbound and can still drift out of both documents
+ * silently — the component name `GeneratedComponent`, the returned JSX, and the
+ * `export default` line. It also says nothing about prose OUTSIDE the fence:
+ * the sentence claiming the output went to the clipboard (objectui#7977) was
+ * false for as long as it stood, and no fence assertion would have caught it,
+ * because it was a paragraph and not code.
+ *
+ * WHY NOT THE WHOLE BLOCK, WHICH WOULD SEE ALL OF THAT. Whole-block verbatim
+ * equality is RED on BOTH copies today, and neither red is a defect:
+ * `DESIGN.md` assigns `const schema` a braces-with-a-comment placeholder naming
+ * the user's schema, where the
+ * generator interpolates the real thing, and the `.mdx` was evaluated against
+ * the example schema that page teaches rather than this file's `SAMPLE_SCHEMA`.
+ * Widening to the whole block would mean editing both documents to fit the
+ * test. ⛔ Sanding a document to fit its pin is not available: the readable
+ * placeholder is the document doing its job. So the pin is drawn at the widest
+ * line that is green on both copies UNCHANGED, and its blind half is named here
+ * rather than left for a reader to discover.
+ *
+ * NOTE the four-line `// No React import:` comment is NOT a readability
+ * addition someone made to the docs — it is inside the returned template
+ * literal, so it is emitted into every user's file. It is product, and this pin
+ * holds the documents to it rather than exempting it.
+ */
+
+/** Repo root, from `packages/vscode-extension/src/__tests__`. */
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+/**
+ * Every document that hand-keeps a copy of the preamble, located STRUCTURALLY —
+ * by the heading it lives under, not by the text being compared, which would
+ * make the locator agree with whatever it found.
+ */
+const DOCUMENTED_MIRRORS = [
+  {
+    file: 'packages/vscode-extension/DESIGN.md',
+    heading: '### 4. Export to React',
+  },
+  {
+    file: 'content/docs/utilities/vscode-extension.mdx',
+    heading: '### `Object UI: Export to React Component`',
+  },
+] as const;
+
+/** The part shape B binds: everything above the schema assignment. */
+function preambleOf(source: string, what: string): string {
+  const lines = source.split('\n');
+  const end = lines.findIndex((line) => line.startsWith('const schema ='));
+  if (end < 0) {
+    throw new Error(
+      `no \`const schema =\` line in ${what} — this pin needs rewriting, not deleting.`
+    );
+  }
+  return lines.slice(0, end).join('\n').trimEnd();
+}
+
+/**
+ * The preamble as one document prints it. Kept pure on TEXT so the controls
+ * below can drive the same extractor over a synthetic document — a control that
+ * skipped the extractor would not be controlling the part that can break.
+ */
+function documentedPreambleFrom(
+  text: string,
+  mirror: { file: string; heading: string }
+): string {
+  const heading = text.indexOf(mirror.heading);
+  if (heading < 0) {
+    throw new Error(
+      `${mirror.file} no longer has the heading ${mirror.heading} — this pin needs rewriting, not deleting.`
+    );
+  }
+  const fence = '```typescript\n';
+  const open = text.indexOf(fence, heading);
+  if (open < 0) {
+    throw new Error(
+      `no typescript fence under ${mirror.heading} in ${mirror.file} — this pin needs rewriting, not deleting.`
+    );
+  }
+  const start = open + fence.length;
+  const close = text.indexOf('```', start);
+  if (close < 0) {
+    throw new Error(
+      `unterminated fence under ${mirror.heading} in ${mirror.file} — this pin needs rewriting, not deleting.`
+    );
+  }
+  return preambleOf(text.slice(start, close), `${mirror.file}'s fence`);
+}
+
+function documentedPreamble(mirror: { file: string; heading: string }): string {
+  const path = join(REPO_ROOT, mirror.file);
+  if (!existsSync(path)) {
+    throw new Error(
+      `${mirror.file} is gone — this pin needs rewriting, not deleting.`
+    );
+  }
+  return documentedPreambleFrom(readFileSync(path, 'utf8'), mirror);
+}
+
+describe('Export to React — the documented mirrors of the preamble (objectui#7976)', () => {
+  // ONE assertion, both consumers. The two documents are not pinned separately:
+  // a second copy of this comparison is how the two would drift apart again.
+  it.each(DOCUMENTED_MIRRORS)(
+    '$file reproduces the emitted preamble verbatim',
+    (mirror) => {
+      expect(documentedPreamble(mirror)).toBe(
+        preambleOf(generatedFile(), 'the generated file')
+      );
+    }
+  );
+
+  it('binds every known mirror — an emptied list would assert nothing', () => {
+    // The floor. A refactor that quietly emptied the list above would satisfy
+    // `it.each` by running zero cases and report green having compared nothing.
+    expect(DOCUMENTED_MIRRORS).toHaveLength(2);
+    for (const mirror of DOCUMENTED_MIRRORS) {
+      expect(existsSync(join(REPO_ROOT, mirror.file))).toBe(true);
+    }
+  });
+
+  it('is a harness that can fail — a document that drops the side-effect import is rejected', () => {
+    // The positive control objectui#7914 requires IN THE FILE, executed on every
+    // run rather than once by hand in a PR description. It drives the real
+    // extractor over a synthetic document, so if the extractor ever stops
+    // finding the fence, THIS goes red instead of the pin above going quietly,
+    // permanently green over an empty string.
+    const product = preambleOf(generatedFile(), 'the generated file');
+    const mirror = DOCUMENTED_MIRRORS[0];
+    const asDocument = (preamble: string): string =>
+      `${mirror.heading}\n\n\`\`\`typescript\n${preamble}\n\nconst schema = {};\n\`\`\`\n`;
+
+    // Negative: a drifted document is caught.
+    const drifted = product
+      .split('\n')
+      .filter((line) => line !== "import '@object-ui/components';")
+      .join('\n');
+    expect(drifted).not.toBe(product); // the mutation really removed a line
+    expect(documentedPreambleFrom(asDocument(drifted), mirror)).not.toBe(product);
+
+    // Positive: an accurate document is accepted, so the check above is not
+    // simply rejecting everything the extractor hands it.
+    expect(documentedPreambleFrom(asDocument(product), mirror)).toBe(product);
+  });
+});


### PR DESCRIPTION
Fixes #7976

`generateReactComponent()`'s preamble is transcribed **by hand in two places**, and nothing held either to the original. This binds both to the text the generator actually emits, with **one** assertion.

## The mechanism, and why hand-correction kept failing

The template lives inside a template literal, so this package's `tsc --noEmit` sees one string; `DESIGN.md` is markdown in a package whose README is the only file the doc gates' surfaces name. Both copies could drift indefinitely with every gate green.

Hand-correction has been spent **three** times: objectui#7837, objectui#7978, objectui#8112. ⚠️ The third re-created the defect while fixing it — PR objectui#8112 (which closed objectui#7977) hand-copied the product byte for byte and asserted the equality **in its pull request description** (`FENCE_EQUALS_PRODUCT: True`). That assertion ran once, in one session, and `FENCE_EQUALS_PRODUCT` appears nowhere in the tree. objectui#7914's ruling is that the control demonstrating the catch belongs in the **file**. This is that file.

## The census — why this PR covers two documents and not one

Ordered by the triage fence on objectui#7976 (comment 5583774909, fence 1) before any binding could land.

**Class counted**: a copy, kept by hand in a prose file, of text some code in this repo emits programmatically, with nothing binding the copy to the emitter.

**Instrument**: `emittedCensus()`, exported from `scripts/check-doc-snippet-types.mjs` (objectui#7864, report-only), driven directly — the gate's CLI, `--emit-census` included, is behind a `PRECONDITION NOT MET (exit 2)` wanting 34 built packages, while the exported walk needs no build. It recognises a code-emitting template by the heuristic *"the template text contains an import-from statement"*. ⛔ Not re-run for this PR.

**Emitting side**: **20** recognised templates in **4** files — `packages/cli/src/commands/init.ts` (3), `packages/cli/src/utils/app-generator.ts` (8), `packages/create-plugin/src/index.ts` (1), `packages/create-plugin/src/templates.ts` (7), `packages/vscode-extension/src/extension.ts` (1).

**Copy side**: every tracked `.md`/`.mdx` — **338** files, `.changeset/` excluded.

### Confirmed members: 2 — both this same generator

| copy | mirrors | was bound by |
|---|---|---|
| `packages/vscode-extension/DESIGN.md` section 4 | `generateReactComponent()` | nothing |
| `content/docs/utilities/vscode-extension.mdx` Output Example (`:90-114`) | the same generator | nothing |

Each reproduces **10** provenance-bearing lines including the four-line `// No React import:` block — prose that exists nowhere but that template, so the provenance is not shared idiom.

### Rejected after adjudication, not silently dropped

- `content/docs/guide/building-crud-app.md` — 4 shared lines with `app-generator.ts`, but independently authored: it teaches `src/setup.ts` plus `initializeComponents()`, which that generator never emits.
- `content/docs/guide/objectos-integration.mdx` — 4 shared lines, but builds an `ObjectStackAdapter` and exports `App` as a named function where the generator emits a default export.
- Everything else scored 1-2 lines on generic imports or MIT licence headers.

### In-class control

A bare zero is not a reading, so the instrument was made to prove it can see the class member it was built for, **in the same run**: `packages/vscode-extension/DESIGN.md` is in the doc surface (`true`), carries the control line (`true`), and **appears as a hit** (`true`).

### ⚠️ Blind-spot reading, in full

- **3,869** template literals walked; only **20** recognised. The recogniser is an import-from heuristic, so a generator emitting JSON, `package.json`, markdown, CSS, HTML or shell is **invisible**. Residue: ~3,849 templates, unjudged.
- **5** declared `moduleShapedMisses` — open a top-level `export` yet were not recognised: `packages/cli/src/commands/generate.ts:92`, `packages/cli/src/commands/init.ts:495`, `packages/cli/src/utils/app-generator.ts:260`, `packages/sdui-parser/src/codegen.ts:38`, `packages/sdui-parser/src/codegen.ts:80`.
- The opt-in escape hatch is unused: `markerSeen = 0`.
- **Scope**: the walk covers `packages/NAME/src` only — `scripts/` (**213** files), `apps/*/src` (**187**) and `e2e/` were **never scanned**.
- **2,501** templates excluded as tooling.
- Copy side is prose only: a product hand-copied into a test fixture, snapshot or source comment is outside the surface.

⇒ The honest reading is **"at least 2"**. Both confirmed members copy the *same* generator; the other 19 recognised templates and the 5 declared misses are **not** cleared.

### On fence 1

Fence 1 permits the binding to land only if the census reads **zero**. It reads 2, so the binding did not ride along with the census — it was returned as `blocked`, and the `domain:devx` PM seat re-planned it in comment 5588085443, on the record: the census can never read zero, so a literal reading makes the passing condition unreachable and leaves **both** copies unbound, which is the outcome fence 1 exists to prevent. Its purpose is *do not bind one copy while its siblings drift*; the census delivered what that purpose needs — population 2, same generator, one assertion measured green on both. ⛔ The fence is **not** claimed to be satisfied as written.

## The shape, and what it deliberately does not see

**Shape B**: assert the 9-line preamble above `const schema =`.

Shape A — whole-fence verbatim equality — is **RED on both copies today**, and neither red is a defect: `DESIGN.md` uses a readable placeholder where the generator interpolates the schema, and the `.mdx` was evaluated against the example schema that page teaches rather than this file's `SAMPLE_SCHEMA`. Widening would mean editing both documents to fit the test. ⛔ No document is sanded to fit a pin, so the binding is drawn at the widest line green on both copies **unchanged**.

⚠️ **Drift shape B still permits** — everything below `const schema =`: the component name `GeneratedComponent`, the returned JSX, and the `export default` line. Plus **all prose outside the fence**: the sentence claiming the output went to the clipboard (objectui#7977) was false for as long as it stood, and no fence assertion would have caught it, because it was a paragraph and not code.

⭐ That statement is also **in the file**, not only here — naming what a pin does not see is this family's whole subject, and objectui#8112 landed on `main` in breach of exactly that.

⭐ Note the four-line `// No React import:` comment is **not** a readability addition someone made to the docs. `packages/vscode-extension/src/extension.ts:228` is `return` followed by the backtick and that comment, so it is **generator-owned text emitted into every user's file**. The triage comment predicted verbatim equality would be red *because* the doc carried a readability comment; that reason is falsified, and the conclusion survives on a different fact — the `const schema` placeholder line. A binding written to the stated reason would have excluded the wrong lines.

## What landed

One assertion, both consumers, via `it.each` over a structurally-located list — a second copy of the comparison is how the two documents would drift apart again. Each document is located by **the heading it lives under**, never by the text being compared, so the locator cannot agree with whatever it happens to find. Every failure mode throws `this pin needs rewriting, not deleting`, in the house style of the two sibling pins.

Two controls run beside it on every run:

- **a floor** — the mirror list is asserted non-empty and each file asserted to exist, because a refactor that quietly emptied the list would satisfy `it.each` by running zero cases and report green having compared nothing;
- **a positive control** — it drives the real extractor over a synthetic document, showing a drifted document rejected *and* an accurate one accepted, so the check is not merely rejecting everything handed to it.

## Verification

`pnpm exec vitest run packages/vscode-extension/src/__tests__` — **10 passed** (baseline before this change: 6).

**Drift mutation, per consumer**, mutating the *document* rather than the generator, each restored and verified against its `HEAD` blob hash:

| mutation (drop the side-effect import) | result |
|---|---|
| `packages/vscode-extension/DESIGN.md` | vitest exit **1** — `1 failed / 9 passed`, and the failing case is that document's |
| `content/docs/utilities/vscode-extension.mdx` | vitest exit **1** — `1 failed / 9 passed`, and the failing case is that document's |
| tree restored, suite re-run | exit **0**, `10 passed` |

Each mutation was proved to have reached disk before the run (matching import lines `before=1 after=0`) and each restore proved by `git diff HEAD` reporting 0 changed files with the blob hash back to its `HEAD` value — so neither leg is a no-op reading a void.

Also green: `pnpm --filter object-ui run type-check` (both programs; `tsc -p tsconfig.test.json --listFiles` confirms this test file is **in** the type program, so the type-check genuinely covers it), `eslint` on the changed file, and `node scripts/check-changeset-presence.mjs`.

The changeset declares an **empty frontmatter** — this is test-only, no published source changes, and per AGENTS.md section 9 an empty frontmatter is the explicit first-class way to declare "releases nothing". The gate confirms it: *"Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate."*

## Not in scope

⛔ Neither census member's content is touched — this binds them as they stand. ⛔ No workflow header counts were adjusted, and ⛔ `scripts/check-doc-snippet-types.mjs` is not modified.


---
_Generated by [Claude Code](https://claude.ai/code)_