### PR TITLE
fix(examples): author catalog badge text under `label`, the key `ui:badge` reads (objectui#6829 arm A)

### DIFF
--- a/.changeset/6829-badge-children-arm-a.md
+++ b/.changeset/6829-badge-children-arm-a.md
@@ -1,0 +1,11 @@
+---
+---
+
+Re-author the seven catalog `badge` nodes that carried their text under
+`children` — a key `ui:badge` never reads — to `label`, the key 31 of the
+other badge nodes already use (objectui#6829, arm A). Restores the three
+`components-basic-span` demos that drew an empty pill and the two badges
+`core-schema-renderer/nested-schema-example` silently dropped, and adds a
+per-renderer pin that reads each pill's rendered text. Fixtures and tests only,
+in the private `@object-ui/example-schema-catalog`; no published package
+changes, so no version bump.

--- a/examples/schema-catalog/src/schemas/components-basic-span/default-badge.json
+++ b/examples/schema-catalog/src/schemas/components-basic-span/default-badge.json
@@ -1,10 +1,5 @@
 {
   "type": "badge",
   "variant": "default",
-  "children": [
-    {
-      "type": "text",
-      "content": "Badge Style"
-    }
-  ]
+  "label": "Badge Style"
 }

--- a/examples/schema-catalog/src/schemas/components-basic-span/secondary-badge.json
+++ b/examples/schema-catalog/src/schemas/components-basic-span/secondary-badge.json
@@ -1,10 +1,5 @@
 {
   "type": "badge",
   "variant": "secondary",
-  "children": [
-    {
-      "type": "text",
-      "content": "Secondary"
-    }
-  ]
+  "label": "Secondary"
 }

--- a/examples/schema-catalog/src/schemas/components-basic-span/status-badges.json
+++ b/examples/schema-catalog/src/schemas/components-basic-span/status-badges.json
@@ -5,32 +5,17 @@
     {
       "type": "badge",
       "variant": "default",
-      "children": [
-        {
-          "type": "text",
-          "content": "● Active"
-        }
-      ]
+      "label": "● Active"
     },
     {
       "type": "badge",
       "variant": "secondary",
-      "children": [
-        {
-          "type": "text",
-          "content": "● Pending"
-        }
-      ]
+      "label": "● Pending"
     },
     {
       "type": "badge",
       "variant": "destructive",
-      "children": [
-        {
-          "type": "text",
-          "content": "● Inactive"
-        }
-      ]
+      "label": "● Inactive"
     }
   ]
 }

--- a/examples/schema-catalog/src/schemas/core-schema-renderer/nested-schema-example.json
+++ b/examples/schema-catalog/src/schemas/core-schema-renderer/nested-schema-example.json
@@ -12,11 +12,11 @@
           "children": [
             {
               "type": "badge",
-              "children": "Nested"
+              "label": "Nested"
             },
             {
               "type": "badge",
-              "children": "Components",
+              "label": "Components",
               "variant": "outline"
             }
           ]

--- a/examples/schema-catalog/test/badge-demo-label-6829.test.tsx
+++ b/examples/schema-catalog/test/badge-demo-label-6829.test.tsx
@@ -1,0 +1,375 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6829 (arm A) — every catalog `badge` node draws its authored text,
+ * measured as the pill's RENDERED text and compared to the `label` it authors.
+ *
+ * ## The reading this file was written against
+ *
+ * `packages/components/src/renderers/data-display/badge.tsx` renders
+ * `schema.label || renderChildren(schema.body)`: it reads `label` and `body`
+ * and never `children`. Seven catalog nodes authored `children` anyway —
+ * `components-basic-span/{default-badge, secondary-badge, status-badges x3}`
+ * and `core-schema-renderer/nested-schema-example x2` — and were carried as
+ * the exact `BADGE_CHILDREN_LEDGER_6829` in
+ * `catalog-authored-key-6805-6806.test.tsx` until the card was ruled. That
+ * file owns the KEY half (the read set, per renderer); this one owns the
+ * RENDER half.
+ *
+ * Re-derived on this branch's base `ce45a0306`, walking all 431 fixtures:
+ *
+ *     badge nodes                 40   in 12 categories
+ *     keys authored on them       type 40 · variant 36 · label 33 ·
+ *                                 className 8 · children 7
+ *
+ * (The card's census read `label 31 · content 2`; the two `content` nodes had
+ * already moved to `label` with objectui#6805/#6806.) Rendered through the
+ * real `SchemaRenderer` the way the docs gallery renders them, BEFORE the
+ * fixture edits:
+ *
+ *     entry                                        elements   text
+ *     components-basic-span/default-badge                 2   ""
+ *     components-basic-span/secondary-badge               2   ""
+ *     components-basic-span/status-badges                 5   ""
+ *     core-schema-renderer/nested-schema-example         13   "Parent ComponentSibling Component
+ *                                                             All rendered from a single schema tree"
+ *
+ * AFTER — the seven nodes re-authored to `label`, the spelling the other 33
+ * badge nodes already use:
+ *
+ *     components-basic-span/default-badge                 2   "Badge Style"
+ *     components-basic-span/secondary-badge               2   "Secondary"
+ *     components-basic-span/status-badges                 5   "● Active● Pending● Inactive"
+ *     core-schema-renderer/nested-schema-example         13   "Parent ComponentNestedComponents
+ *                                                             Sibling ComponentAll rendered
+ *                                                             from a single schema tree"
+ *
+ * (`elements` counts this file's one wrapper `div`; the gallery harness adds
+ * two, which is where its `WRAPPER_ELEMENTS = 2` comes from.)
+ *
+ * ## Why a PER-RENDERER pin, not a stricter global threshold
+ *
+ * `catalog-gallery-render.test.tsx` rendered all four entries before the fix
+ * and PASSED. Its non-vacuity control is `elements > WRAPPER_ELEMENTS || text`,
+ * and the empty pill's OWN host element is the element past the wrappers, so
+ * a demo drawing nothing but an empty pill clears the control on the pill.
+ * That is the third independent hole in that one control (objectui#6805:
+ * Radix's injected stylesheet counts as text; objectui#6806: a large correct
+ * render hides a small omission), which is the argument that the instrument
+ * belongs per renderer. So nothing here is a threshold: the assertion is that
+ * the pill's rendered text EQUALS the label the fixture authors, for every
+ * `badge` node in the corpus, at any depth, in any entry.
+ *
+ * ## The discriminating question this file was written against
+ *
+ * "Would an implementation strictly worse than the bug pass this pin?" A pin
+ * asserting "the demo renders at least one element" passes on an empty pill —
+ * that is the hole above. A pin asserting "non-empty text" passes on a
+ * renderer that emits one constant string for every node. The corpus
+ * assertion below compares the FULL vector of rendered texts to the full
+ * vector of authored labels and pins that the two are equally diverse: the
+ * constant-string caricature fails it on every node, and the empty pill fails
+ * it on every node it used to hide behind.
+ *
+ * ## The non-regression axis — derived from the plausible WRONG fix
+ *
+ * The plausible wrong fix is a blind sweep renaming `children` to `label`
+ * across the corpus. It satisfies "the badges now draw" and breaks every
+ * container that legitimately authors `children` — 652 non-badge nodes on this
+ * base (`flex` 248 · `stack` 153 · `card` 86 · `box` 76 · `grid` 22 · …).
+ * Measured: that sweep applied to `nested-schema-example` renders the EMPTY
+ * string (2 elements — the wrapper and a bare `stack`). The last block pins
+ * that the corpus still authors `children` on hundreds of containers, that the
+ * touched entries' own containers still draw their children, and that the
+ * blind-sweep shape is the empty demo it is.
+ *
+ * ## ⛔ What arm A does NOT do — the class stays open
+ *
+ * This restores four demos; it does not close the class. `children` is
+ * declared on `BaseSchema`, accepted by every other container renderer,
+ * refused by neither zod nor tsc (`BaseSchema` is `.passthrough()` with an
+ * index signature), and consumed by the pipeline before it can leak to the
+ * DOM — so the next author who writes `children` on a badge draws an empty
+ * pill again, and the only instruments that see it are the exact ledger and
+ * this file's corpus sweep. Arm B (teaching `badge.tsx` to read `children`)
+ * widens a published renderer's read set, which AGENTS.md #0.1 governs; it is
+ * objectui#6810's decision and deliberately untouched here.
+ *
+ * Module-scope import of `@object-ui/components`, not `beforeAll` (AGENTS.md
+ * §测试纪律): registering the renderers is an unbounded module load and must
+ * not be billed to a bounded hook timeout.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@object-ui/components';
+import { SchemaRenderer, toRenderableSchema } from '@object-ui/react';
+import { allExamples, getExample } from '../src/index.js';
+
+type Json = Record<string, unknown>;
+
+/**
+ * The four entries the card measured, and the EXACT text each draws after
+ * arm A. Exact, not `toContain`: the nested demo drew its prose and silently
+ * dropped both badges before the fix, so presence of prose proves nothing —
+ * only the whole string, badges beside their card title, does.
+ */
+const MEMBER_ENTRIES: Record<string, string> = {
+  'components-basic-span/default-badge': 'Badge Style',
+  'components-basic-span/secondary-badge': 'Secondary',
+  'components-basic-span/status-badges': '● Active● Pending● Inactive',
+  'core-schema-renderer/nested-schema-example':
+    'Parent ComponentNestedComponentsSibling ComponentAll rendered from a single schema tree',
+};
+
+/** The seven node locations arm A re-authored — the former exact ledger. */
+const REAUTHORED_NODES = [
+  'components-basic-span/default-badge',
+  'components-basic-span/secondary-badge',
+  'components-basic-span/status-badges.children[0]',
+  'components-basic-span/status-badges.children[1]',
+  'components-basic-span/status-badges.children[2]',
+  'core-schema-renderer/nested-schema-example.children[0].children[0].children[0]',
+  'core-schema-renderer/nested-schema-example.children[0].children[0].children[1]',
+];
+
+/**
+ * The container nodes inside the touched entries that legitimately author
+ * `children` and must go on doing so — the nodes a blind sweep would break.
+ */
+const TOUCHED_CONTAINERS = [
+  'components-basic-span/status-badges',
+  'core-schema-renderer/nested-schema-example',
+  'core-schema-renderer/nested-schema-example.children[0]',
+  'core-schema-renderer/nested-schema-example.children[0].children[0]',
+  'core-schema-renderer/nested-schema-example.children[1]',
+];
+
+/** Measured on this base; a floor so catalog growth never reds this file. */
+const CONTAINER_CHILDREN_FLOOR = 600;
+
+type Located = { where: string; node: Json };
+
+/** Every node matching `pick` in a subtree, at any depth, with a readable location. */
+function collect(
+  node: unknown,
+  where: string,
+  pick: (record: Json) => boolean,
+  into: Located[] = [],
+): Located[] {
+  if (Array.isArray(node)) {
+    node.forEach((child, i) => collect(child, `${where}[${i}]`, pick, into));
+    return into;
+  }
+  if (!node || typeof node !== 'object') return into;
+  const record = node as Json;
+  if (pick(record)) into.push({ where, node: record });
+  for (const [key, value] of Object.entries(record)) {
+    collect(value, `${where}.${key}`, pick, into);
+  }
+  return into;
+}
+
+const isBadge = (record: Json) => record.type === 'badge';
+const isContainerAuthoringChildren = (record: Json) =>
+  'children' in record && record.type !== 'badge';
+
+/** Render one schema the way `SchemaThumbnail` does. */
+function draw(schema: unknown) {
+  const { container, unmount } = render(
+    <div className="w-full p-4">
+      <SchemaRenderer schema={toRenderableSchema(schema as never) as never} />
+    </div>,
+  );
+  return {
+    text: container.textContent ?? '',
+    elements: container.querySelectorAll('*').length,
+    /** Elements carrying the authored value as a host attribute (objectui#5574). */
+    leaked: container.querySelectorAll('[content]').length,
+    unmount,
+  };
+}
+
+/** The text one schema draws, with the tree unmounted again. */
+function drawnText(schema: unknown): string {
+  const drawn = draw(schema);
+  try {
+    return drawn.text;
+  } finally {
+    drawn.unmount();
+  }
+}
+
+/** The blind sweep, as a function: rename one key to another at every depth. */
+function renameDeep(node: unknown, from: string, to: string): unknown {
+  if (Array.isArray(node)) return node.map((child) => renameDeep(child, from, to));
+  if (!node || typeof node !== 'object') return node;
+  return Object.fromEntries(
+    Object.entries(node as Json).map(([key, value]) => [
+      key === from ? to : key,
+      renameDeep(value, from, to),
+    ]),
+  );
+}
+
+const entries = allExamples();
+const badges = entries.flatMap((entry) => collect(entry.schema, entry.id, isBadge));
+const containers = entries.flatMap((entry) =>
+  collect(entry.schema, entry.id, isContainerAuthoringChildren),
+);
+
+// ---------------------------------------------------------------------------
+// 1. The corpus sweep — every `badge` node, rendered, against its own label.
+// ---------------------------------------------------------------------------
+
+describe('catalog corpus: every `badge` node draws its authored `label` (objectui#6829 arm A)', () => {
+  it('the walk is not vacuous — a broken collector would pass every case below', () => {
+    // Floors, not equalities: catalog growth must not fail this file, only a
+    // walk that stopped working.
+    expect(entries.length).toBeGreaterThanOrEqual(431);
+    expect(badges.length).toBeGreaterThanOrEqual(40);
+    expect(new Set(badges.map((b) => b.where.split('/')[0])).size).toBeGreaterThanOrEqual(12);
+    // …and it sees the seven nodes this card is about, by location.
+    expect(badges.map((b) => b.where)).toEqual(expect.arrayContaining(REAUTHORED_NODES));
+  });
+
+  it('every `badge` node authors a non-empty string `label` and never `children`', () => {
+    const offenders = badges
+      .filter(
+        ({ node }) =>
+          typeof node.label !== 'string' || node.label.trim() === '' || 'children' in node,
+      )
+      .map(({ where }) => where);
+    expect(offenders).toEqual([]);
+  });
+
+  it.each(badges.map((b) => [b.where, b] as const))(
+    '%s draws exactly its label',
+    (_where, located) => {
+      // The acceptance criterion, per node: not "something rendered", not
+      // "some text rendered" — THIS text, and nothing else in the pill.
+      expect(drawnText(located.node)).toBe(String(located.node.label));
+    },
+  );
+
+  it('⭐ the rendered texts are as diverse as the authored labels — a constant-string renderer cannot pass', () => {
+    const authored = badges.map((b) => String(b.node.label));
+    const rendered = badges.map((b) => drawnText(b.node));
+    // Same vector, same order — one diff names every node that drifted.
+    expect(rendered).toEqual(authored);
+    // And the vector is not degenerate: the caricature that answers one
+    // string for every input has a single distinct value; the corpus does not.
+    expect(new Set(authored).size).toBeGreaterThan(1);
+    expect(new Set(rendered).size).toBe(new Set(authored).size);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The four entries the card measured — one exact render each.
+// ---------------------------------------------------------------------------
+
+describe('the four entries objectui#6829 measured draw their badges', () => {
+  it('every member still names a real entry — a vacuous table would pass every case below', () => {
+    const ids = new Set(entries.map((e) => e.id));
+    for (const id of Object.keys(MEMBER_ENTRIES)) expect(ids.has(id), id).toBe(true);
+    expect(Object.keys(MEMBER_ENTRIES)).toHaveLength(4);
+  });
+
+  it.each(Object.entries(MEMBER_ENTRIES))(
+    '%s draws exactly the text arm A restores',
+    (id, expected) => {
+      expect(drawnText(getExample(id).schema)).toBe(expected);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 3. Counter-probes — every assertion above proven able to fail.
+// ---------------------------------------------------------------------------
+
+describe('counter-probes (objectui#6157 discipline)', () => {
+  it('the pre-arm-A array shape draws an EMPTY pill — and does not even leak', () => {
+    // Verbatim the shape `default-badge.json` carried before this change.
+    const drawn = draw({
+      type: 'badge',
+      variant: 'default',
+      children: [{ type: 'text', content: 'Badge Style' }],
+    });
+    try {
+      expect(drawn.text).toBe('');
+      // `children` is a pipeline key the renderer machinery consumes, so it
+      // never reaches the DOM: the objectui#5574 attribute sweep that finds
+      // the `content` spelling structurally cannot find this one.
+      expect(drawn.leaked).toBe(0);
+    } finally {
+      drawn.unmount();
+    }
+  });
+
+  it('the pre-arm-A string shape draws an EMPTY pill', () => {
+    // Verbatim the shape the two `nested-schema-example` badges carried.
+    expect(drawnText({ type: 'badge', children: 'Nested' })).toBe('');
+  });
+
+  it('⭐ the gallery control cannot see this: the pre-fix `status-badges` demo is five elements of empty DOM', () => {
+    // Verbatim `status-badges.json` before this change. Five elements — this
+    // file's wrapper, the `flex`, three empty pills — with no text at all:
+    // `elements > 2 || text` reads it as "drew something", on the pills.
+    const drawn = draw({
+      type: 'flex',
+      gap: 2,
+      children: [
+        { type: 'badge', variant: 'default', children: [{ type: 'text', content: '● Active' }] },
+        { type: 'badge', variant: 'secondary', children: [{ type: 'text', content: '● Pending' }] },
+        { type: 'badge', variant: 'destructive', children: [{ type: 'text', content: '● Inactive' }] },
+      ],
+    });
+    try {
+      expect(drawn.text).toBe('');
+      expect(drawn.elements).toBe(5);
+      expect(drawn.elements).toBeGreaterThan(2);
+    } finally {
+      drawn.unmount();
+    }
+  });
+
+  it('the key that works: `label` draws the string — the live control', () => {
+    expect(drawnText({ type: 'badge', label: '12' })).toBe('12');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. The non-regression axis — containers that legitimately author `children`.
+// ---------------------------------------------------------------------------
+
+describe('non-regression: containers that legitimately author `children` still draw them (the blind-sweep axis)', () => {
+  it('the corpus still authors `children` on hundreds of non-badge nodes, deliberately', () => {
+    // If this ever reads 0, someone ran the blind sweep this file argues
+    // against, and hundreds of working demos went with it.
+    expect(containers.length).toBeGreaterThanOrEqual(CONTAINER_CHILDREN_FLOOR);
+    // …and the touched entries' own containers are among them, by location.
+    expect(containers.map((c) => c.where)).toEqual(expect.arrayContaining(TOUCHED_CONTAINERS));
+  });
+
+  it('a `card` and a `flex` authoring `children` draw them — the live controls', () => {
+    expect(drawnText({ type: 'card', children: 'kept' })).toContain('kept');
+    expect(drawnText({ type: 'flex', children: [{ type: 'text', content: 'kept' }] })).toBe('kept');
+  });
+
+  it('⭐ the blind sweep EMPTIES the demos: `children` renamed to `label` at every depth draws nothing', () => {
+    for (const id of ['core-schema-renderer/nested-schema-example', 'components-basic-span/status-badges']) {
+      const swept = renameDeep(getExample(id).schema, 'children', 'label');
+      // The probe really swept: no container authors `children` any more, and
+      // every badge still authors `label` — so the badge sweep above would be
+      // GREEN on this shape. This is the assertion that catches it.
+      expect(collect(swept, id, isContainerAuthoringChildren)).toEqual([]);
+      expect(collect(swept, id, isBadge).every(({ node }) => 'label' in node)).toBe(true);
+      expect(drawnText(swept)).toBe('');
+    }
+  });
+});

--- a/examples/schema-catalog/test/catalog-authored-key-6805-6806.test.tsx
+++ b/examples/schema-catalog/test/catalog-authored-key-6805-6806.test.tsx
@@ -94,7 +94,9 @@
  *
  * (A third hole was measured while sizing this file and filed as
  * objectui#6829: an empty `badge` host element is itself the third element, so
- * a demo drawing nothing but an empty pill clears the control too.)
+ * a demo drawing nothing but an empty pill clears the control too. Arm A of
+ * that card re-authored those seven nodes to `label`; the per-renderer render
+ * pin lives in `badge-demo-label-6829.test.tsx`.)
  *
  * ⚠️ The fix for all three is the per-renderer sweep below, ⛔ not a stricter
  * global non-vacuity threshold — that is out of scope here and would red on
@@ -164,25 +166,22 @@ const RENDERERS = [
 ] as const;
 
 /**
- * Known `badge` nodes authoring `children` — a key `badge.tsx` does NOT read,
- * unlike `card.tsx` which reads `children || body`. Measured while sizing this
- * file and filed as objectui#6829, where the repair is a genuine decision
- * (re-author the fixtures, or widen the renderer's read set) rather than the
- * mechanical rename these two cards take. OUT OF THIS PR'S FENCE.
+ * `badge` nodes authoring `children` — a key `badge.tsx` does NOT read, unlike
+ * `card.tsx` which reads `children || body`. Measured while sizing this file as
+ * SEVEN nodes (`components-basic-span/{default-badge, secondary-badge,
+ * status-badges x3}` and `core-schema-renderer/nested-schema-example x2`) and
+ * filed as objectui#6829. Its triage split the repair in two: arm A re-authors
+ * the fixtures to `label` and has landed, so the ledger is now EMPTY; arm B
+ * (widening the renderer's read set) is objectui#6810's, not this file's.
  *
- * Asserted as an EXACT set, not a floor: it may shrink when objectui#6829 is
- * ruled, and an eighth node appearing must turn this red rather than join a
- * growing allowance.
+ * Still asserted as an EXACT set, not a floor, and deliberately KEPT rather
+ * than deleted: arm A restored the demos and did NOT close the class. Every
+ * other container renderer accepts `children`, so the next author who writes
+ * it on a badge draws an empty pill again — and that node must turn this red
+ * by name rather than join a growing allowance. The RENDER half (the pill's
+ * text equals its label, corpus-wide) is `badge-demo-label-6829.test.tsx`.
  */
-const BADGE_CHILDREN_LEDGER_6829 = [
-  'components-basic-span/default-badge',
-  'components-basic-span/secondary-badge',
-  'components-basic-span/status-badges.children[0]',
-  'components-basic-span/status-badges.children[1]',
-  'components-basic-span/status-badges.children[2]',
-  'core-schema-renderer/nested-schema-example.children[0].children[0].children[0]',
-  'core-schema-renderer/nested-schema-example.children[0].children[0].children[1]',
-];
+const BADGE_CHILDREN_LEDGER_6829: string[] = [];
 
 /**
  * Keys that carry visible text in the nodes these families author.
@@ -282,13 +281,14 @@ describe('catalog corpus: every node authors keys ITS renderer reads (objectui#6
     expect(offenders).toEqual([]);
   });
 
-  it('every `badge` node authors only keys `badge.tsx` READS, except the objectui#6829 ledger', () => {
+  it('every `badge` node authors only keys `badge.tsx` READS — the objectui#6829 ledger is exact and empty', () => {
     const allowed = [...RENDERERS[1].readKeys, ...PIPELINE_KEYS];
     const offenders = nodesOf('badge')
       .map(({ where, node }) => ({ where, keys: unreadKeys(node, allowed) }))
       .filter((hit) => hit.keys.length > 0);
-    // Every offender left is the `children` shape objectui#6829 owns, and the
-    // ledger is EXACT — an eighth node reds here rather than being absorbed.
+    // Any offender is the `children` shape objectui#6829 owns, and the ledger
+    // is EXACT — empty since arm A, so the FIRST node reds here by name rather
+    // than being absorbed.
     expect(offenders.map((hit) => hit.keys)).toEqual(offenders.map(() => ['children']));
     expect(offenders.map((hit) => hit.where).sort()).toEqual(
       [...BADGE_CHILDREN_LEDGER_6829].sort(),

--- a/examples/schema-catalog/test/layout-dom-leak-5574.test.tsx
+++ b/examples/schema-catalog/test/layout-dom-leak-5574.test.tsx
@@ -119,7 +119,13 @@ const NODE_CENSUS: Readonly<Record<string, { rendered: number; noElement: number
   // `components-basic-text/text-with-colors` nodes authored a phantom `color`
   // nothing declared or read, and now author `className`, which the renderer
   // DOES forward — so each one needs an element to carry its colour class.
-  text: { rendered: 701, noElement: 159 },
+  // 701 -> 696 and 159 -> 154 with objectui#6829 (arm A): the five `text`
+  // nodes that were the `children` of five `badge` nodes are gone, folded into
+  // each badge's `label`. `ui:badge` never rendered them (it reads `label` and
+  // `body`, not `children`), and as bare text nodes carrying no className,
+  // `variant` or `align` they sat in the no-element class — so both counts
+  // move by exactly five. Catalog authoring, not a renderer change.
+  text: { rendered: 696, noElement: 154 },
   // The objectui#3965 migration population (80 nodes retyped from `div`) plus
   // the 4 nodes of the components-layout-box exemplars. `box` is born on
   // `toDomProps` and class-transparency, so it joins the measured set as a


### PR DESCRIPTION
Fixes #6829

**Arm A only**, per the triage split in comment 5544671702 on that card. Arm B (teaching `badge.tsx` to read `children || body`) widens a published renderer's read set, which AGENTS.md #0.1 governs, and belongs to the open decision card objectui#6810 — `badge.tsx` is untouched here. Related, bare references only: objectui#6805 · objectui#6806 · objectui#6832 (the PR that pinned the ledger) · objectui#6771 (retiring `body`) · objectui#5574.

## What changed

- `examples/schema-catalog/src/schemas/components-basic-span/default-badge.json`, `secondary-badge.json`, `status-badges.json` (three nodes), `core-schema-renderer/nested-schema-example.json` (two nodes): exactly the seven `badge` nodes that authored their text under `children` now author it under `label` — the key `packages/components/src/renderers/data-display/badge.tsx` reads (`schema.label || renderChildren(schema.body)`), and the spelling the other 33 badge nodes in the corpus already use. Five of the seven were `children: [ one text node ]`, flattened to the string; two were `children: "..."` strings.
- `examples/schema-catalog/test/catalog-authored-key-6805-6806.test.tsx`: `BADGE_CHILDREN_LEDGER_6829` is now the empty array and stays **exact**, deliberately kept rather than deleted — the first badge that authors `children` again reds there by name instead of joining an allowance. Test title and comments say why.
- `examples/schema-catalog/test/badge-demo-label-6829.test.tsx` (new): the per-renderer render pin described below.
- `examples/schema-catalog/test/layout-dom-leak-5574.test.tsx`: `NODE_CENSUS.text` moves `701 -> 696` and `159 -> 154` — the five `text` nodes that were badge children are gone (folded into `label`); `ui:badge` never rendered them and they sat in the no-element class, so both counts move by exactly five with no renderer touched. That is the "diff only adds/removes examples, update NODE_CENSUS" case the pin's own message names.
- `.changeset/6829-badge-children-arm-a.md`: **empty frontmatter**. `@object-ui/example-schema-catalog` is `"private": true` and in the changeset `ignore` list; no released package changed. `check-changeset-presence` confirms nothing is owed.

## Premises re-derived on today's tree (base `ce45a0306`, 431 fixtures)

    badge nodes                 40   in 12 categories
    keys authored on them       type 40 · variant 36 · label 33 · className 8 · children 7 · content 0

The card's census read `label 31 · content 2`; the two `content` nodes had already moved to `label` with objectui#6805 / objectui#6806, as the triage predicted. All seven ledger members existed at the locations the ledger pinned. Rendered through the real `SchemaRenderer` before the edit: `default-badge` and `secondary-badge` drew the empty string on 2 elements, `status-badges` the empty string on 5, and `nested-schema-example` drew its prose and dropped both badges. After: `Badge Style` · `Secondary` · `● Active● Pending● Inactive` · `Parent ComponentNestedComponentsSibling ComponentAll rendered from a single schema tree`.

No badge node authors `children` anywhere outside the catalog (docs, skills, apps, packages scanned) — nothing to file.

## The pin, and the question it was written against

`badge-demo-label-6829.test.tsx` is per-renderer, not a threshold. It walks every `badge` node in the corpus at any depth and asserts the pill's **rendered text equals the authored `label`** (55 cases: 40 per-node, one aggregate, four whole-demo exact strings, counter-probes, and the non-regression axis).

- **Discriminating question** — would an implementation strictly worse than the bug pass? "At least one element" passes on an empty pill (the gallery control's third hole: the empty pill's own host element is the element past the wrappers — measured, and pinned as a counter-probe: the pre-fix `status-badges` shape is 5 elements of empty DOM). "Non-empty text" passes on a constant-string renderer. So the aggregate case compares the full vector of rendered texts to the full vector of authored labels and pins that they are equally diverse.
- **Caricature run**: `badge.tsx` mutated on disk to emit `'CONSTANT_PILL_6829'` for every node (injected-marker count 1, original-expression count 0, both grepped), pin run: **49 of 55 red**, messages of the shape `expected 'CONSTANT_PILL_6829' to be 'Pending'`. Restored with `git checkout HEAD -- path`; blob hash equals the HEAD blob, marker count 0, `git diff HEAD` empty. vitest aliases `@object-ui/components` to `packages/components/src`, so no `dist` sits on the resolution path — the mutation reached the run directly.
- **Non-regression axis** (derived from the plausible wrong fix — a blind corpus-wide `children -> label` sweep): the corpus still authors `children` on 652 non-badge container nodes (`flex` 248 · `stack` 153 · `card` 86 · `box` 76 · …), pinned as a floor of 600 plus the touched entries' own containers by location; `card` and `flex` live controls draw their children; and the blind sweep applied in memory to `nested-schema-example` and `status-badges` renders the **empty string** — measured, 2 elements, a bare `stack` — while every badge in the swept shape still authors `label`, so the badge sweep alone would have been green on it. That last assertion is the one that catches it.

## ⛔ Arm A restores the demos and leaves the class OPEN — do not read the green gallery otherwise

The next author who writes `children` on a badge draws an empty pill again: every other container renderer accepts `children`; it is declared on `BaseSchema`, refused by neither zod nor tsc (`.passthrough()` plus an index signature), and consumed by the pipeline before it can leak to the DOM, so the objectui#5574 attribute sweep cannot see it and `catalog-gallery-render.test.tsx`'s control clears on the pill itself. The only instruments that see it are the exact (now empty) ledger and this PR's corpus sweep. Whether the renderer's read set widens is objectui#6810's decision, not this PR's.

Observation for the record, not a change: a badge authoring `label` carries `label="..."` on its host element — the objectui#5574 bare-spread class, already ledgered for `ui:badge` (with `label` among the canary attributes) in `packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx`. The seven nodes now share that already-ledgered state with the other 33 label-authoring badges; nothing new to file.

## Verification (final head `42d96eef7`; every verdict read from the tool's own line, exit codes captured before any pipe)

- `pnpm exec vitest run examples/schema-catalog/` (root-relative form, under the shared verify lock): `Test Files 30 passed (30)`, `Tests 2143 passed (2143)`, lock `VERDICT command-exit 0`. Leg D from the JSON reporter: 2143 cases, 0 failed, 0 pending, no file-level death strings (`Element type is invalid` / `Failed Suites` / `No test suite found in file` / `Tests  no tests`) in any file.
- **Red leg**: fixtures reverted to the pinned base commit (`git checkout BASE -- paths`, grep proof: `children` back, `label` 0 in all four files), same two files run: **14 red** — the new pin's authoring case names the 7 offenders by location (`expected [ …(7) ] to deeply equal []`), seven per-node cases read the empty string, the aggregate and the four whole-demo cases red, and the ledger test in `catalog-authored-key-6805-6806.test.tsx` reds on the empty ledger. Restored from HEAD; all four blob hashes equal HEAD, `git diff HEAD` empty.
- **Census red/green**: the whole-directory run before the `NODE_CENSUS` edit was red on exactly one case with the diff `rendered 701 -> 696`, `noElement 159 -> 154`; green after.
- The ten tests outside the catalog that import it by path (components, plugin-charts, plugin-dashboard, plugin-map, types): `10 passed`, `185 passed`, under the lock.
- `pnpm --filter @object-ui/example-schema-catalog type-check` on the built dependency closure (turbo, 28 tasks, `VERDICT command-exit 0`): script echoed `tsc --noEmit && tsc -p tsconfig.test.json`, exit 0, the new file present in `--listFiles`.
- `eslint` (plain form) on the three touched test files: exit 0. `node scripts/check-changeset-presence.mjs`: no changeset owed. `node scripts/check-changeset-no-major.mjs`: OK. `pnpm check:control-bytes`: OK (6798 files). `pnpm check:doc-types`: every documented type registered. `pnpm check:icon-record-names`: OK. `regenerate-catalog-index.py --check`: index up to date (431 entries).
- Declared to CI, not run locally: `@object-ui/site` type-check (`fumadocs-mdx && next typegen && tsc`; it consumes the catalog through `Example.schema: unknown`, so fixture shape cannot reach its types) and the repo-wide `pnpm lint` / four-shard `pnpm test`.

Governed surfaces: none touched. `skip-changeset` not applied (phantom label in this repo). Session: `https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_