### PR TITLE
fix(app-shell): declare the spec's `escalation.enabled` default in the flow-node inspector

### DIFF
--- a/.changeset/6620-escalation-enabled-default.md
+++ b/.changeset/6620-escalation-enabled-default.md
@@ -1,0 +1,37 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The flow-node inspector now declares the spec's default for
+`escalation.enabled`, so approval nodes that omit the key render as the
+escalating nodes they are (objectui#6620).
+
+`FLOW_NODE_CONFIG`'s approval group declared `defaultValue: 'false'` for
+`escalation.enabled`, while the installed `@objectstack/spec` (17.3.0) defaults
+the key to `true` — `ApprovalEscalationSchema.safeParse({ timeoutHours: 24 })`
+returns `enabled: true`. An approval node whose escalation block omits the key
+therefore escalates at runtime, while the designer drew the SLA-escalation
+toggle OFF and hid all four sub-fields behind it (`timeoutHours`, `action`,
+`escalateTo`, `notifySubmitter`). The inspector said "no escalation" about a
+node that escalates, and the author had no way to see or edit the timeout that
+was live.
+
+`defaultValue` has two read sites, so the one-line flip repairs both: it is what
+`controllerAdmits` resolves an unset `showWhen` controller against (the gating
+of those four sub-fields) and, since the boolean control learned to seed itself,
+what the rendered toggle shows. The online half of the same form was already
+correct — a backend publishing the approval `configSchema` sends `default: true`,
+which `json-schema-to-fields` turns into `defaultValue: 'true'` — so offline and
+online rendered the same node from two different claims about the spec.
+
+An explicitly stored `escalation.enabled: false` is unchanged: it still beats the
+declared default and still hides every sibling.
+
+The reconciliation assertion in `flow-node-config.spec-reconciliation.test.ts`
+now covers the whole escalation block rather than `notifySubmitter` alone, and
+derives every expected value from the installed `ApprovalEscalationSchema`
+instead of pinning literals. This is the substance of the fix as much as the flip
+is: the previous tripwire for this key read only the hand-written table, so a
+spec bump could never redden it and the divergence went live unnoticed. A
+vacuity guard fails if the spec stops materialising defaults for the block, so
+the ledger cannot quietly become a comparison against nothing.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.tsx
@@ -224,12 +224,20 @@ export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, 
         //    renderer-side alias for off-spec metadata (AGENTS.md #0.1).
         //
         // ⛔ Nothing is rendered NAMING the default — no "(default)" caption,
-        // no help line. Of the two boolean fields the offline table declares a
-        // default for, one (`escalation.enabled`) declares the OPPOSITE of what
-        // the installed spec applies to an omitted key (objectui#6620), so any
-        // caption asserting "this is the declared default" would ship that
-        // wrong claim to authors in words. The seed alone leaves that field
-        // rendering byte-identically to before; a caption would not. Pinned by
+        // no help line. That is triage's arm-A ruling and stands on its own.
+        //
+        // ⚑ Its original SECONDARY argument has been discharged and must not be
+        // cited again: `escalation.enabled` used to declare the OPPOSITE of what
+        // the installed spec applies to an omitted key, so a caption would have
+        // shipped a wrong claim to authors in words. objectui#6620 fixed the
+        // declaration and, from this seed, that field now draws CHECKED — it no
+        // longer renders byte-identically to before, and the argument that the
+        // seed is the safe half of the change no longer applies to it. Both
+        // boolean fields the offline table declares a default for now agree with
+        // the spec, and `flow-node-config.spec-reconciliation.test.ts` keeps the
+        // whole escalation block reconciled against the installed
+        // `ApprovalEscalationSchema`, so a future divergence reddens there rather
+        // than being absorbed by a rendering decision here. Pinned by
         // `FlowNodeInspector.declaredDefault.test.tsx`'s #6620 case.
         const checked = isUnsetFieldValue(value) ? field.defaultValue === 'true' : value === true;
         return (

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.declaredDefault.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.declaredDefault.test.tsx
@@ -77,6 +77,12 @@ vi.mock('../previews/useObjectFields', () => ({
 import { FlowNodeInspector } from './FlowNodeInspector';
 import { fieldsForNodeType, FLOW_NODE_TYPE_OPTIONS } from './flow-node-config';
 import type { MetadataSelection } from '../preview-registry';
+// The runtime's own answer for an omitted `escalation` key. Imported so the
+// #6620 rows below compare the RENDERED control against the installed contract
+// instead of against a literal this file would then own a second copy of.
+// ⛔ The subpath is load bearing: `ApprovalEscalationSchema` is NOT on the
+// package root, where it reads `undefined` and any `.parse` on it throws.
+import { ApprovalEscalationSchema } from '@objectstack/spec/automation';
 
 /* ── The `meta/*` double (objectui#7307) ───────────────────────────────
  * `FlowNodeInspector` renders `FlowReferenceField` for every reference-kind key
@@ -276,25 +282,36 @@ describe('boolean: a declared defaultValue seeds the control (objectui#8451, arm
     ).toBe(false);
   });
 
-  it('boolean: the #6620-wrong declaration ships NO worded claim (objectui#6620)', () => {
-    // `escalation.enabled` is the one field in the offline table whose declared
-    // default contradicts what the installed spec applies to an omitted key.
-    // This card ships the SEED and no caption, which is why: the seed renders
-    // that field exactly as it rendered before (unchecked — the declaration
-    // says 'false'), so no new claim about the declaration reaches the author,
-    // while a "(default)" caption would have asserted the wrong one in words.
+  it('boolean: the gate seeds from the SPEC default, still with no worded claim (objectui#6620)', () => {
+    // Was 'the #6620-wrong declaration ships NO worded claim'. `escalation.enabled`
+    // used to be the one field in the offline table whose declared default
+    // contradicted what the installed spec applies to an omitted key, so this row
+    // pinned that the seed shipped no caption asserting the wrong default in words.
+    // objectui#6620 fixed the declaration; the row now pins the repaired half —
+    // the control the author sees agrees with the runtime — and the no-caption rule
+    // still holds, now over a declaration that is right.
     //
-    // ⚠️ Deliberately does NOT compare the declaration against the spec. That
-    // comparison is objectui#6620's tripwire, held disarmed on purpose in
-    // `flow-node-config.spec-reconciliation.test.ts`; arming it here would
-    // discharge an on-hold card from an unrelated PR.
+    // ⭐ The expectation is DERIVED from the installed spec, never the literal
+    // 'true'. A literal would restate the very claim that drifted: it passes just
+    // as happily on the next upstream flip, which is how #6620 stayed invisible.
+    const specEnabled = ApprovalEscalationSchema.safeParse({ timeoutHours: 24 });
+    expect(specEnabled.success, 'a minimal escalation block must parse').toBe(true);
+    const specDefault = (specEnabled.data as { enabled?: unknown } | undefined)?.enabled;
+    // Vacuity guard: without it, a spec that stopped materialising the key would
+    // turn both sides into `undefined` and the comparison into a tautology.
+    expect(typeof specDefault, 'the spec still materialises `enabled` from an omitted key').toBe('boolean');
+
     const gate = fieldsForNodeType('approval').find((f) => f.id === 'escalation.enabled');
-    expect(gate?.defaultValue, 'the gate declares a default at all').toBe('false');
+    // Defaults are strings in this table — the spelling `controllerAdmits` compares.
+    expect(gate?.defaultValue, 'the table declares the default the spec applies').toBe(String(specDefault));
 
     renderInspector(draftWith('approval', { config: { escalation: { timeoutHours: 24 } } }));
     const box = checkbox('SLA escalation');
     expect(box, 'the gate control is on screen').not.toBeNull();
-    expect(box!.checked, 'and it renders as it always did — unchecked').toBe(false);
+    expect(
+      box!.checked,
+      'and the RENDERED toggle carries the spec default — the defect was that it did not',
+    ).toBe(specDefault);
     expect(
       box!.closest('label')?.textContent,
       'the control carries its label and nothing else — no caption naming a default',
@@ -329,11 +346,14 @@ describe('the online writer of defaultValue hits the same dead end', () => {
 describe('the one read site: a declared default on a showWhen CONTROLLER changes visibility', () => {
   /**
    * `controllerAdmits` resolves an UNSET controller through its `defaultValue`.
-   * The hand-written approval group declares `escalation.enabled: 'false'`, so
-   * the offline table cannot demonstrate the effect (an absent default and a
-   * 'false' default both hide the group). The engine-published schema can: the
-   * spec's own `ApprovalEscalationSchema` defaults `enabled` to TRUE, and
-   * `json-schema-to-fields` carries that onto the gate field.
+   *
+   * The hand-written approval group used to declare `escalation.enabled: 'false'`,
+   * so the offline table could not demonstrate the effect at all — an absent
+   * default and a 'false' default both hide the group, which is precisely why the
+   * divergence survived: the two writers of this property answered the same node
+   * differently and only the engine-published one was pinned. objectui#6620 made
+   * the table declare the spec's `.default(true)`, so BOTH writers are exercised
+   * here now, and the offline row below is the one that changed.
    */
   const escalationSchema = {
     type: 'object',
@@ -374,15 +394,45 @@ describe('the one read site: a declared default on a showWhen CONTROLLER changes
     ).toBeNull();
   });
 
-  it('the offline table hides the same siblings, because it declares the gate false', () => {
-    // Recorded, not endorsed: the hand-written 'false' contradicts the spec's
-    // `.default(true)`. That divergence is objectui#6620's subject, not this
-    // card's; pinned here only so a change to either side is visible.
+  it('the offline table REVEALS the same siblings — it declares the gate true (objectui#6620)', () => {
+    // Was 'the offline table hides the same siblings, because it declares the gate
+    // false' — recorded there, explicitly not endorsed, because the hand-written
+    // 'false' contradicted the spec's `.default(true)`. objectui#6620 removed the
+    // divergence, so the two writers now answer this node identically. The row is
+    // updated to the new truth rather than worked around: it exists to make a
+    // change to either side visible, and this was that change.
     renderInspector(draftWith('approval', { config: { escalation: { timeoutHours: 24 } } }));
+    const sibling = checkbox('Notify submitter');
     expect(
-      checkbox('Notify submitter'),
-      'offline, the same node hides the sibling the online schema reveals',
-    ).toBeNull();
+      sibling,
+      'offline, the same node reveals the sibling the online schema reveals',
+    ).not.toBeNull();
+    expect(
+      sibling!.checked,
+      'and the offline table seeds it from its own declared default too',
+    ).toBe(true);
+  });
+
+  /**
+   * NON-REGRESSION (objectui#6620). Derived from a plausible WRONG FIX rather
+   * than from the bug: revealing the sub-fields unconditionally — dropping the
+   * `showWhen` gates, or making `controllerAdmits` fall through to `true` —
+   * satisfies "a node that omits the key now reveals" completely, while
+   * destroying the author's ability to turn escalation OFF.
+   *
+   * So the stored `false` must still beat the declared default, and must still
+   * hide EVERY sibling, not just the first. Four keys, named individually: an
+   * assertion over one of them passes on a fix that leaks the other three.
+   */
+  it('a node that explicitly stores `enabled: false` still hides every sibling', () => {
+    renderInspector(draftWith('approval', { config: { escalation: { enabled: false } } }));
+    expect(checkbox('SLA escalation')!.checked, 'the stored false beats the declared true').toBe(false);
+    for (const label of ['Timeout (hours)', 'On timeout', 'Escalate to', 'Notify submitter']) {
+      expect(
+        screen.queryByText(label),
+        `'${label}' must stay hidden while the author has switched escalation off`,
+      ).toBeNull();
+    }
   });
 });
 

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.inactiveRetained.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.inactiveRetained.test.ts
@@ -62,20 +62,27 @@ describe('inactiveRetainedKind — the escalation instance the card measured', (
     for (const f of ungated) expect(inactiveRetainedKind(f, node, fields)).toBeNull();
   });
 
-  it('an absent controller value resolves through the spec defaultValue, not to "off"', () => {
-    // `escalation.enabled` declares defaultValue 'false', so an omitted key is
-    // off — and a stored dependent under it is therefore retained-but-inactive.
+  it('an absent controller value resolves through the spec defaultValue — now ON, so the dependent is LIVE', () => {
+    // `escalation.enabled` declares defaultValue 'true', mirroring the installed
+    // spec's `.default(true)`: an omitted key means ENABLED, so a stored dependent
+    // under it is live config, not retained-but-inert.
     //
-    // ⚠️ Coupled to objectui#6620 ON PURPOSE. That card is the mirror defect:
-    // `@objectstack/spec` flipped `ApprovalEscalation.enabled` to `default(true)`
-    // upstream, so once this repo consumes a spec release carrying the flip, this
-    // descriptor's `defaultValue: 'false'` becomes wrong and must follow. When it
-    // does, THIS assertion flips to `toBeNull()` — an omitted key will mean ON,
-    // and a stored dependent under it is live, not retained. Measured here on
-    // 2026-08-29: installed spec is 17.2.0, still `.default(false)`, so the two
-    // agree and #6620 is latent. The failure is the intended signal, not a break.
+    // This assertion flipped from `'controller-off'` to `toBeNull()` when
+    // objectui#6620 made the table follow the spec — exactly the flip the previous
+    // revision of this comment predicted, and the intended signal rather than a
+    // break. (Measured on the spec installed then: 17.2.0 / `.default(false)`.)
+    //
+    // ⚠️ It still reads only the TABLE, so it cannot see a spec bump on its own.
+    // The declaration ↔ installed-spec comparison that CAN detect the next
+    // divergence lives in `flow-node-config.spec-reconciliation.test.ts`; #6620's
+    // root cause was that no such comparison existed for this key.
     const node = { id: 'a', type: 'approval', config: { escalation: { timeoutHours: 24 } } };
-    expect(inactiveRetainedKind(timeout(), node, fields)).toBe('controller-off');
+    expect(inactiveRetainedKind(timeout(), node, fields)).toBeNull();
+    // Lit control on the same node shape — the ONLY difference is the stored gate.
+    // A predicate that had simply stopped flagging anything fails here, so the
+    // `toBeNull()` above is a measurement rather than an absence.
+    const gateOff = { id: 'a', type: 'approval', config: { escalation: { enabled: false, timeoutHours: 24 } } };
+    expect(inactiveRetainedKind(timeout(), gateOff, fields)).toBe('controller-off');
   });
 
   it('flags every dependent in the group, not just the first', () => {

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.spec-reconciliation.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.spec-reconciliation.test.ts
@@ -284,58 +284,121 @@ describe('sibling-block forms ↔ FlowNodeSchema blocks (framework#4278 ratchet)
 });
 
 /**
- * **Declared defaults ↔ spec defaults — `escalation.notifySubmitter`** (#6794).
+ * **Declared defaults ↔ spec defaults — the whole escalation block** (#6794, #6620).
  *
  * Everything above is a KEY-set ledger: it proves the form edits exactly the
  * keys the executor reads. The default a field DECLARES is the other axis, and
- * it had drifted here — the hand-written table declared no `defaultValue` for
- * `escalation.notifySubmitter` while the installed `@objectstack/spec` defaults
- * the key to `true`, so the table stated the opposite of what an omitted key
- * does at runtime. Not cosmetic: `defaultValue` is what `isFieldVisible`
- * resolves an unset controller against, and it is what the ONLINE half of this
- * form already carries (a published `configSchema` sends `default: true`, which
+ * it has drifted here twice — first `escalation.notifySubmitter`, which declared
+ * no `defaultValue` at all while the spec defaults the key to `true` (#6794),
+ * then `escalation.enabled`, which declared `'false'` against a spec that had
+ * flipped to `.default(true)` (#6620). Not cosmetic: `defaultValue` is what
+ * `controllerAdmits` resolves an unset controller against and what a `boolean`
+ * control seeds from, and it is what the ONLINE half of this form already
+ * carries (a published `configSchema` sends `default: true`, which
  * `json-schema-to-fields` turns into `defaultValue: 'true'`) — so offline and
- * online disagreed about the same key.
+ * online rendered the same node from two different claims about the spec.
  *
- * The expected value is READ FROM THE INSTALLED SPEC, never spelled out here:
- * objectui is the consumer, and a literal would make this file a second source
- * of truth for a published contract.
+ * ⭐ **Why this is now block-wide, and why it is the point of #6620.** The
+ * previous revision scoped this to `notifySubmitter` ALONE and said so, to avoid
+ * arming an on-hold card from an unrelated PR. The cost of that scoping was the
+ * card's real defect: `escalation.enabled` had a "tripwire" in
+ * `flow-node-config.inactiveRetained.test.ts` that reads only the TABLE, so a
+ * spec bump could never redden anything — the divergence went live and stayed
+ * invisible until a human happened to re-read the spec. A one-directional check
+ * is not a check. This ledger walks whatever the installed spec materialises, so
+ * the NEXT flip, on any key in the block, reddens here on the bump itself.
  *
- * ⛔ Deliberately scoped to `notifySubmitter` alone. The sibling controller
- * `escalation.enabled` is #6620 — held on hold behind a future
- * `@objectstack/spec` bump that flips ITS default; installed spec and table
- * agree on it today. Generalising this assertion across the block would arm
- * that card's tripwire here, discharging an on-hold card without its restart
- * condition being met.
+ * The expected values are READ FROM THE INSTALLED SPEC, never spelled out here:
+ * objectui is the consumer, and a literal restates exactly the claim that
+ * drifts — it would pass just as happily on the next upstream flip.
  */
-describe('approval escalation: declared default ↔ ApprovalEscalationSchema (#6794)', () => {
+describe('approval escalation: declared defaults ↔ ApprovalEscalationSchema (#6794, #6620)', () => {
+  // ⛔ The subpath is load bearing. `ApprovalEscalationSchema` is NOT on the
+  // package root: `require('@objectstack/spec').ApprovalEscalationSchema` is
+  // `undefined`, so a probe written that way dies with `Cannot read properties
+  // of undefined` — a failure that reads as "the spec does not have it yet" and
+  // sends the reader back to waiting. #6620 sat on hold behind exactly that
+  // misreading. This file's own `import * as Automation` is the working spelling.
   const EscalationSchema = spec.ApprovalEscalationSchema as
     | { safeParse: (value: unknown) => { success: boolean; data?: Record<string, unknown> } }
     | undefined;
 
-  /** What the spec applies when the key is omitted — the runtime's own answer. */
-  function specDefaultFor(key: string): unknown {
+  /** The block's only REQUIRED key. Supplied as input, so never a default. */
+  const SUPPLIED: Record<string, unknown> = { timeoutHours: 24 };
+
+  /**
+   * Every key the spec MATERIALISES from an omitted-key block, with its value —
+   * the runtime's own answer to "what does this node actually do", read fresh.
+   *
+   * Keys we supplied are subtracted: `timeoutHours` comes back only because we
+   * sent it, and counting it would demand the form declare a default for a
+   * required key that has none.
+   */
+  function specDefaults(): Record<string, unknown> {
     expect(
       EscalationSchema,
       '@objectstack/spec/automation must export ApprovalEscalationSchema',
     ).toBeDefined();
-    // `timeoutHours` is the block's only required key.
-    const parsed = EscalationSchema!.safeParse({ timeoutHours: 24 });
+    const parsed = EscalationSchema!.safeParse({ ...SUPPLIED });
     expect(parsed.success, 'a minimal escalation block must parse').toBe(true);
-    return parsed.data?.[key];
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(parsed.data ?? {})) if (!(k in SUPPLIED)) out[k] = v;
+    return out;
   }
 
-  it('the spec still materialises notifySubmitter from an omitted key', () => {
-    // Vacuity guard: were the key to stop being defaulted, the comparison below
-    // would silently be a comparison against `undefined`.
-    expect(typeof specDefaultFor('notifySubmitter')).toBe('boolean');
+  /** The approval form's escalation fields, keyed by the spec key each edits. */
+  function escalationFields(): Map<string, FlowConfigField> {
+    const out = new Map<string, FlowConfigField>();
+    for (const f of fieldsForNodeType('approval')) {
+      if (f.path[0] === 'config' && f.path[1] === 'escalation' && f.path[2]) out.set(f.path[2], f);
+    }
+    return out;
+  }
+
+  it('the gate `enabled` is inside the ledger — and the ledger is not empty', () => {
+    // THE VACUITY GUARD, and the reason it names a key. Both assertions below
+    // iterate `specDefaults()`; a spec that stopped materialising anything would
+    // make each of them pass over an empty collection, which is the shape #6620's
+    // old tripwire failed in. This row fails instead — and it names `enabled`
+    // because that is the key the card was about, so the ledger's coverage of it
+    // is visible in a test name rather than only inferable from a loop.
+    const defaults = specDefaults();
+    expect(Object.keys(defaults).length, 'the spec materialises at least one default here').toBeGreaterThan(0);
+    expect(typeof defaults.enabled, 'the spec materialises `enabled` from an omitted key').toBe('boolean');
   });
 
-  it('the form declares the default the spec applies', () => {
-    const field = fieldsForNodeType('approval').find((f) => f.id === 'escalation.notifySubmitter');
-    expect(field, 'the approval form must offer escalation.notifySubmitter').toBeDefined();
-    // Defaults are strings in this table — booleans spelled 'true' / 'false',
-    // the spelling `isFieldVisible` compares a controller against.
-    expect(field!.defaultValue).toBe(String(specDefaultFor('notifySubmitter')));
+  it('every default the spec applies is declared by the form, with the same value', () => {
+    const fields = escalationFields();
+    const mismatches: string[] = [];
+    for (const [key, value] of Object.entries(specDefaults())) {
+      const field = fields.get(key);
+      if (!field) {
+        mismatches.push(`${key}: the spec defaults it, the form offers no field for it`);
+        continue;
+      }
+      // Defaults are strings in this table — booleans spelled 'true' / 'false',
+      // the spelling `controllerAdmits` compares a controller against.
+      if (field.defaultValue !== String(value)) {
+        mismatches.push(
+          `${key}: the form declares ${JSON.stringify(field.defaultValue)}, the spec applies ${JSON.stringify(String(value))}`,
+        );
+      }
+    }
+    expect(
+      mismatches,
+      'the hand-written table must state what an omitted key actually does at runtime',
+    ).toEqual([]);
+  });
+
+  it('and the form declares no default the spec does not apply', () => {
+    // The other direction, and not symmetric decoration: a `defaultValue` with no
+    // spec counterpart is a claim about the contract with nothing behind it, and
+    // it is ACTED ON — it resolves a `showWhen` controller and seeds a boolean
+    // control off a value the runtime never applies.
+    const defaults = specDefaults();
+    const invented = [...escalationFields()]
+      .filter(([key, f]) => f.defaultValue !== undefined && !(key in defaults))
+      .map(([key, f]) => `${key}: the form declares ${JSON.stringify(f.defaultValue)}, the spec applies none`);
+    expect(invented, 'a declared default with no spec counterpart').toEqual([]);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
@@ -762,7 +762,16 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
     }),
     // Per-node SLA escalation (spec ApprovalEscalationSchema, nested under
     // config.escalation). Sub-fields reveal once escalation is enabled.
-    { id: 'escalation.enabled', path: ['config', 'escalation', 'enabled'], label: 'SLA escalation', kind: 'boolean', defaultValue: 'false', help: 'Escalate when a decision is not recorded within the timeout.' },
+    //
+    // `defaultValue` mirrors the spec's `.default(true)` (objectui#6620). An
+    // approval node whose escalation block OMITS `enabled` parses as ENABLED,
+    // so a table declaring 'false' drew the gate OFF and hid four sub-fields
+    // that are live at runtime — the inspector said "no escalation" about a
+    // node that escalates. The value is NOT a constant of this file:
+    // `flow-node-config.spec-reconciliation.test.ts` derives every default in
+    // this block from the installed `ApprovalEscalationSchema`, so the next
+    // upstream flip reddens there rather than diverging silently again.
+    { id: 'escalation.enabled', path: ['config', 'escalation', 'enabled'], label: 'SLA escalation', kind: 'boolean', defaultValue: 'true', help: 'Escalate when a decision is not recorded within the timeout.' },
     { id: 'escalation.timeoutHours', path: ['config', 'escalation', 'timeoutHours'], label: 'Timeout (hours)', kind: 'number', placeholder: '24', showWhen: { field: 'escalation.enabled', equals: ['true'] } },
     {
       id: 'escalation.action', path: ['config', 'escalation', 'action'], label: 'On timeout', kind: 'select', defaultValue: 'notify',


### PR DESCRIPTION
Fixes #6620

## The probe, run rather than read

The card's restart probe cannot produce the reading it asks for, exactly as the dispatch predicted. Both spellings, run on this worktree against installed `@objectstack/spec` **17.3.0**:

```
# The card's spelling — root export
$ node -e "const { ApprovalEscalationSchema } = require('@objectstack/spec'); \
           console.log(JSON.stringify(ApprovalEscalationSchema.parse({ timeoutHours: 24 })));"
TypeError: Cannot read properties of undefined (reading 'parse')
    at [eval]:1:120

# The working spelling — the `automation` subpath
$ node --input-type=module -e "import { ApprovalEscalationSchema } from '@objectstack/spec/automation'; ..."
typeof schema: function
safeParse.success: true
safeParse.data: {"enabled":true,"timeoutHours":24,"action":"notify","notifySubmitter":true}
effective escalation.enabled default => true
```

The restart criterion is met and the divergence is live: the table declared `'false'`, the runtime applies `true`.

## What changed

**The flip.** `FLOW_NODE_CONFIG`'s approval group declared `defaultValue: 'false'` for `escalation.enabled`. `defaultValue` has exactly **two** consumers — confirmed by reading, as the dispatch asked:

| site | file | what it does with it |
|---|---|---|
| `controllerAdmits` | `flow-node-config.ts` | resolves an unset `showWhen` controller — the gating of `timeoutHours` / `action` / `escalateTo` / `notifySubmitter` |
| the `boolean` control | `FlowNodeConfigField.tsx` | seeds the checkbox's checked state |

So the one-line flip repairs the **rendered toggle** as well as the gating. (`FlowNodeInspector.tsx`'s `v.defaultValue` is a different property — a flow *variable* declaration, not a `FlowConfigField`.)

**The tripwire, armed.** This is the substance of the card. `flow-node-config.inactiveRetained.test.ts` was described as this card's tripwire, but its assertion reads only the **table** and never the spec, so no spec bump could ever redden it. The reconciliation ledger in `flow-node-config.spec-reconciliation.test.ts` now covers the **whole escalation block** instead of `notifySubmitter` alone, in **both directions**, deriving every expected value by `safeParse`-ing a minimal block:

- every default the spec materialises must be declared by the form with the same value;
- and the form must declare no default the spec does not apply;
- plus a vacuity guard, because both assertions iterate the spec's answer and would pass over an empty collection.

⛔ No literal `'true'` anywhere in the assertion. A literal restates the exact claim that drifts, and would pass just as happily on the next upstream flip — which is how this one stayed invisible.

**Pins updated to the new truth, not worked around.** Three rows reddened from the flip, all three predicted, all three correct:

- `flow-node-config.inactiveRetained.test.ts` — the absent-controller row flipped to `toBeNull()`, which is what its own comment instructed the next seat to do. Given a lit control (the same node with a stored `enabled: false` still flags `controller-off`), so the new `toBeNull()` is a measurement rather than an absence.
- `FlowNodeInspector.declaredDefault.test.tsx` — PR #8431's row *"the offline table hides the same siblings, because it declares the gate false"* now reads *"REVEALS"*. Offline and online agree about this node for the first time.
- the same file's `#6620` boolean row, which pinned that the seed shipped no worded claim *because the declaration was wrong*. It now derives its expectation from the installed spec and asserts the rendered toggle carries it.

**Stale text repaired.** The two comments named in the dispatch, plus a third the same grep surfaced: `FlowNodeConfigField.tsx`'s boolean branch cited "one declares the OPPOSITE of the spec" as a live secondary argument for shipping no caption. The arm-A no-caption ruling stands on its own; the discharged argument is marked as discharged so it is not cited again.

## Non-regression axis

Derived from a plausible **wrong fix**, not from the bug's shape: revealing the sub-fields unconditionally satisfies "omitted-key nodes now reveal" completely while destroying the author's ability to switch escalation off. Pinned as a new case naming all four siblings individually — an assertion over one of them passes on a fix that leaks the other three.

## Red-leg evidence — every new pin observed failing

**Leg A — revert the fix** (`'true'` back to `'false'`; on-disk proof: injected 1, removed 0). The derived ledger named the divergence itself:

```
AssertionError: the hand-written table must state what an omitted key actually does at runtime:
  expected [ Array(1) ] to deeply equal []
+   "enabled: the form declares \"false\", the spec applies \"true\"",
AssertionError: the table declares the default the spec applies: expected 'false' to be 'true'
AssertionError: offline, the same node reveals the sibling the online schema reveals: expected null not to be null
```

**Leg B — the wrong fix** (`controllerAdmits` made to admit unconditionally). The non-regression pin reddened while the bug-shaped rows stayed **green**, which is what makes the axis discriminating:

```
× and hides them when the gate is stored off — the lit control for the same predicate
× a node that explicitly stores `enabled: false` still hides every sibling
AssertionError: 'Timeout (hours)' must stay hidden while the author has switched escalation off:
  expected <label …(2)></label> to be null
```

Both legs restored from `HEAD` and proven byte-identical (`git diff HEAD` empty; blob hash `faa4b533` on disk == `faa4b533` at HEAD).

## Caricature — reported honestly

The mutation run was *the table declares every `boolean` field's default as `'true'`*. **My new pins stay green under it**, and structurally must: post-fix, both boolean fields the offline table declares a default for genuinely **are** `'true'`, so no spec-derived assertion can tell "declared true because the spec says true" from "declared true because everything is true". Detecting it needs an assertion **not** derived from the spec — precisely the decorative literal the card rules out.

It is caught anyway, by a complementary pre-existing pin — the declaration-surface census in the same file, which pins **which** fields declare a default rather than their values:

```
× exactly ten fields declare a defaultValue, and these are they
+   "approval.lockRecord",
+   "boundary_event.boundaryConfig.interrupting",
+   "screen.waitForInput",
```

⇒ the two pins are complementary by design: the derived ledger checks **values** against the spec, the census checks **membership**. The broader caricature ("declare *every* field's default `'true'`") is caught by my ledger alone, because `escalation.action` is a `select` whose spec default is `'notify'` and it sits inside the same block-wide walk.

## Verification

Run from the repo root, root-relative paths, nothing after a bare `--`.

| check | result |
|---|---|
| `vitest run packages/app-shell/` | **654 files, 6333 passed**, 1 skipped, 0 failed |
| `vitest run apps/console/` | **90 files, 1072 passed** |
| `vitest run examples/console-starter/` | 1 file, 9 passed |
| `pnpm --filter @object-ui/app-shell run type-check` | exit 0 (`tsc --noEmit` **and** `tsc -p tsconfig.test.json`) |
| `eslint` on the 5 changed files | exit 0, plain form |
| `check:control-bytes` | OK, 6797 tracked text files |
| `check:vi-mock-specifiers`, `check:esm-specifiers` | OK |
| `check-changeset-presence.mjs` / `check-changeset-no-major.mjs` | OK / no `major` |
| `check-governed-queue-guard.mjs --test` | **NOT GOVERNED** — 6 paths, none matched |

Affected packages read from `turbo ls --affected` against the pinned base, not guessed: `app-shell`, `console`, and the two example consoles.

**`type-check` really measured the tests** — `tsc -p tsconfig.test.json --listFiles` lists all four edited test files, so this is not the "excluded from the project, reads green" trap.

**LEG D (harness death), from the JSON reporter, not the text one:** 259 suites, 0 failed, `assertionResults` counted 803 == `numTotalTests` 803, **0 anomalies** — no `Failed Suites`, no zero-test files.

Blast radius was measured before touching any pin: across `packages/app-shell/src/views/metadata-admin/` the flip alone moved **3 tests out of 2535** — the three named above, and nothing else.

## Notes for the reviewer

- Opened as **draft** and auto-merge deliberately **not** armed.
- `.changeset/6620-escalation-enabled-default.md`, `patch` on `@object-ui/app-shell` (never `major` — objectui's major is the cross-repo pin).
- One thing I did **not** touch and am flagging instead: `.changeset/6794-notify-submitter-default.md` still closes with *"installed spec and table agree on it today"* about `escalation.enabled`, which this PR makes false. It is an unreleased changeset owned by the release pipeline, so I left it alone rather than edit a file a release run may be consuming; my own changeset states the corrected fact and lands in the same CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_