### PR TITLE
fix(data-objectstack): one spelling for the publish route's wire envelope

### DIFF
--- a/.changeset/publish-envelope-one-spelling-6962.md
+++ b/.changeset/publish-envelope-one-spelling-6962.md
@@ -1,0 +1,50 @@
+---
+'@object-ui/data-objectstack': patch
+---
+
+**Fix:** `MetadataClient.publishDraft` no longer unwraps a `{ success, data }`
+envelope, so it and `MetadataClient.publish` hold ONE belief about the route
+they share (objectui#6962).
+
+The two methods sit ~250 lines apart in `metadata-client.ts` and both POST
+`/api/v1/meta/:type/:name/publish`. `publishDraft` tolerated a dispatcher-shaped
+envelope and returned the inner object; `publish` returned the body as parsed.
+Nothing said which was right, and the card explicitly refused to settle it from
+`PublishMetaItemResponseSchema` alone — an inference from a declaration is not a
+measurement of the server.
+
+So the producer was read instead, in the framework checkout:
+
+- `POST /api/v1/meta/:type/:name/publish` has exactly ONE mount,
+  `packages/rest/src/rest-server.ts`, whose handler ends
+  `res.json(await p.publishMetaItem(publishRequest))` — the protocol object
+  verbatim, no envelope branch on any arm. The ADR-0006 project-scoped base
+  re-mounts that same handler.
+- The `{ success, data }` envelope has ONE producer, `HttpDispatcher.success()`,
+  and it does not serve this route: no publish branch in `runtime`'s `/meta`
+  domain (its three-segment arm is `/published`, GET only), no row in the
+  dispatcher's route ledger, and a three-segment `/meta` path that is not
+  `/published` terminates in a located `routeNotFound`. That holds for the
+  dispatcher-only Hono adapter as much as for a full `rest` +
+  `plugin-hono-server` boot, where the REST mount shadows the catch-all.
+- `packages/spec` declares the split in so many words:
+  `PublishMetaItemResponseSchema` documents "the FULL body" of this route and
+  records that the REST route hands the producer's object to `res.json()`
+  verbatim, while the batch sibling `PublishPackageDraftsResponseSchema`
+  documents a body answered "inside the dispatcher's `{ success, data }`
+  envelope".
+
+The route never envelopes, so the tolerance was a dialect with no producer —
+Commandment #0.1's lenient fallback, and the kind that fails in the direction
+that hides the problem: a body arriving enveloped is one this door did not
+serve, and unwrapping it presents that as a successful promotion.
+
+**Behaviour delta, stated plainly.** Handed an enveloped body, `publishDraft`
+used to return the inner object and now returns the body as-is. Graded `patch`
+because that input is not one any measured configuration emits: on a conformant
+response — which has no `data` member at all — the removed branch was already a
+no-op, so `seedApplied`, `version` and `seq` read off both methods exactly as
+before. Sibling tolerances in the same file are untouched and still correct:
+`listDrafts` reads `data?.data?.drafts` because `GET /meta/_drafts` really is a
+dispatcher route, and `publishHealthFromResponse` unwraps because the batch
+publish door really is enveloped. The rule is per-route, not per-file.

--- a/packages/data-objectstack/src/metadata-client.publishAdvisories.test.ts
+++ b/packages/data-objectstack/src/metadata-client.publishAdvisories.test.ts
@@ -267,10 +267,23 @@ describe('MetadataClient.publishDraft — the same door, so the same report', ()
     expect(events[0]!.advisories).toEqual([PURGE_ADVISORY]);
   });
 
-  it('reads them through the dispatcher `{ success, data }` envelope it already unwraps', async () => {
-    // This method tolerates an enveloped body and returns the inner object, so
-    // it must read the advisories from the same place — otherwise the report
-    // would depend on which of two equivalent server shapes answered.
+  /**
+   * REPLACED, not merely re-spelled (objectui#6962). This case used to pin the
+   * `{ success, data }` unwrapping this method carried and `publish()` did
+   * not, and it kept passing for the wrong reason: what it proved was that a
+   * dialect stayed consistent with itself, on a body no server on this route
+   * emits. The route was measured at the producer — one REST mount answering
+   * `res.json(protocol.publishMetaItem(...))` verbatim, and no dispatcher
+   * branch, ledger row or spec declaration putting an envelope on it — so the
+   * unwrapping is gone and both doors read the top level.
+   *
+   * What replaces it asserts the same thing the old case was reaching for —
+   * "the report does not depend on which shape answered" — in the direction
+   * that is now true: an enveloped body reports NOTHING, identically at both
+   * doors. The full shape-agreement pins live in
+   * `metadata-client.publishEnvelope.test.ts`.
+   */
+  it('reports nothing for an enveloped body, and returns it verbatim', async () => {
     const events: MetadataSaveAdvisoryEvent[] = [];
     const client = clientWith(
       { success: true, data: { ...CLEAN_BODY, advisories: [PURGE_ADVISORY] } },
@@ -279,10 +292,13 @@ describe('MetadataClient.publishDraft — the same door, so the same report', ()
 
     const result = await client.publishDraft('flow', 'nightly_purge');
 
-    expect(events).toHaveLength(1);
-    expect(events[0]!.advisories).toEqual([PURGE_ADVISORY]);
-    // and the unwrapping itself is unchanged
-    expect((result as { seq?: number }).seq).toBe(7);
+    // `advisories` is declared at the TOP LEVEL of `PublishMetaItemResponse`;
+    // an enveloped body has none there, and nothing digs for one.
+    expect(events).toEqual([]);
+    // The body comes back untouched — no hoisting, so a caller can still see
+    // it is not the shape this door declares.
+    expect(result).toEqual({ success: true, data: { ...CLEAN_BODY, advisories: [PURGE_ADVISORY] } });
+    expect((result as { seq?: number }).seq).toBeUndefined();
   });
 
   it('says nothing on a clean by-reference publish', async () => {

--- a/packages/data-objectstack/src/metadata-client.publishEnvelope.test.ts
+++ b/packages/data-objectstack/src/metadata-client.publishEnvelope.test.ts
@@ -1,0 +1,241 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `publish` and `publishDraft` hit ONE route and must hold ONE belief about
+ * its wire shape (objectui#6962).
+ *
+ * ## What was measured, because this card forbids inferring it
+ *
+ * The card's own triage refused to act on `PublishMetaItemResponseSchema`
+ * alone — "an inference from the declaration, not a measurement of the
+ * server". So the producer was read instead, in the framework checkout:
+ *
+ *  - `POST /api/v1/meta/:type/:name/publish` is mounted in exactly one place,
+ *    `packages/rest/src/rest-server.ts`, and that handler ends
+ *    `res.json(await p.publishMetaItem(publishRequest))` — the protocol's own
+ *    object, verbatim, with no envelope branch on any arm. The ADR-0006
+ *    project-scoped base re-mounts the same handler.
+ *  - The `{ success, data }` envelope has ONE producer, `HttpDispatcher`
+ *    (`runtime/src/http-dispatcher.ts`, `success()` → `{ success, data, meta }`),
+ *    and it does not serve this route. `runtime/src/domains/meta.ts` has no
+ *    publish branch — its three-segment arm matches `/published` on GET only —
+ *    and `runtime/src/route-ledger.ts` carries no row for a publish POST, so a
+ *    dispatcher-fronted host answers this path with `routeNotFound`, never with
+ *    a payload. That holds for the dispatcher-only Hono adapter
+ *    (`adapters/hono`, whose `${prefix}/*` catch-all IS `dispatch()`) as much
+ *    as for a full `rest` + `plugin-hono-server` boot, where the REST mount
+ *    shadows that catch-all.
+ *  - `packages/spec` declares the split explicitly rather than by omission:
+ *    `PublishMetaItemResponseSchema` documents "the FULL body" of this route,
+ *    while its batch sibling `PublishPackageDraftsResponseSchema` documents a
+ *    body answered "inside the dispatcher's `{ success, data }` envelope".
+ *
+ * ⇒ The route never envelopes, so the tolerance `publishDraft` carried was a
+ * dialect with no producer, and Commandment #0.1 says it goes.
+ *
+ * ## Why these pins use an envelope-shaped INPUT, and why that is the point
+ *
+ * A pin asserting only "publish returns the body" is worthless here: it passes
+ * on a method that returns the body AND on one that would have unwrapped an
+ * envelope it never receives. Those two spellings differ on exactly one input,
+ * so that input is what gets driven. `expect(result).toEqual(ENVELOPED)` goes
+ * RED the moment either method starts unwrapping again — which is the whole
+ * caricature this card has to exclude (both unwrap, or the two disagree).
+ *
+ * ⚠️ Read the assertions as pinning ONE ANSWER FOR TWO METHODS, not as a
+ * blessing of the enveloped body. Nothing serves it. If a server ever does,
+ * that is a producer defect to file upstream — the answer is not a second
+ * unwrapping site here, and the `version` assertion below says why: unwrapping
+ * would let a body this door never served read as a successful promotion.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { PublishMetaItemResponseSchema } from '@objectstack/spec/api';
+import { MetadataClient, type MetadataSaveAdvisoryEvent } from './metadata-client';
+
+/** The three keys `PublishMetaItemResponseSchema` states as REQUIRED, plus its receipt. */
+const BARE_BODY = {
+  success: true,
+  version: 'sha256:0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a69788796a5b4c3d2e1f0',
+  seq: 7,
+  message: 'Published draft — type=view, name=cases [seq=7]',
+};
+
+/**
+ * The discriminating input: the dispatcher-shaped envelope nobody serves on
+ * this route. Deliberately carries the SAME payload as {@link BARE_BODY} one
+ * level down, so an unwrapping method and a verbatim one return values that
+ * differ only in the nesting — which is precisely what the pins read.
+ */
+const ENVELOPED_BODY = { success: true, data: { ...BARE_BODY } };
+
+function response(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function clientWith(body: unknown, onSaveAdvisory?: (ev: MetadataSaveAdvisoryEvent) => void) {
+  return new MetadataClient({
+    baseUrl: 'http://test.local',
+    fetch: vi.fn(async () => response(body)) as unknown as typeof fetch,
+    ...(onSaveAdvisory ? { onSaveAdvisory } : {}),
+  });
+}
+
+/**
+ * The premise, asserted against the INSTALLED spec rather than quoted from the
+ * card: the declared body carries its keys at the TOP LEVEL and declares no
+ * envelope, so `data` is not a member a conformant publish response can have.
+ *
+ * The reverse probe is what makes it a reading rather than a restatement: the
+ * enveloped shape must be REJECTED by the same schema, or "the bare shape
+ * parses" would prove only that the schema accepts anything.
+ */
+describe('the declared publish body (objectstack#7294), read off the installed spec', () => {
+  it('declares `success` / `version` / `seq` at the top level, with no envelope', () => {
+    const bare = PublishMetaItemResponseSchema.safeParse(BARE_BODY);
+    expect(bare.success).toBe(true);
+    expect(bare.success && bare.data.version).toBe(BARE_BODY.version);
+    // `data` is not a declared member, so an object schema STRIPS it — the
+    // discriminating reading is that it does not survive the parse.
+    const withData = PublishMetaItemResponseSchema.safeParse({ ...BARE_BODY, data: { seq: 99 } });
+    expect(withData.success && Object.prototype.hasOwnProperty.call(withData.data, 'data')).toBe(
+      false,
+    );
+  });
+
+  it('refuses the enveloped shape outright — `version` and `seq` are missing from it', () => {
+    const enveloped = PublishMetaItemResponseSchema.safeParse(ENVELOPED_BODY);
+    expect(enveloped.success).toBe(false);
+  });
+});
+
+/**
+ * THE CARD. One route, one spelling — driven on the only input that can tell
+ * the two spellings apart.
+ */
+describe('publish and publishDraft answer the same route the same way (#6962)', () => {
+  it('publishDraft returns an envelope-shaped body VERBATIM — it no longer unwraps', async () => {
+    const result = await clientWith(ENVELOPED_BODY).publishDraft('view', 'cases');
+
+    // The whole assertion: the envelope is still an envelope on the way out.
+    expect(result).toEqual(ENVELOPED_BODY);
+    // Spelled out, because `toEqual` on a two-key object is easy to misread:
+    // the payload stays NESTED and is not hoisted to the top level.
+    expect((result as { data?: unknown }).data).toEqual(BARE_BODY);
+    expect((result as { version?: unknown }).version).toBeUndefined();
+    expect((result as { seq?: unknown }).seq).toBeUndefined();
+  });
+
+  it('publish returns the same envelope-shaped body verbatim, as it always did', async () => {
+    const result = await clientWith(ENVELOPED_BODY).publish<Record<string, unknown>>('view', 'cases');
+
+    expect(result).toEqual(ENVELOPED_BODY);
+    expect(result.version).toBeUndefined();
+  });
+
+  it('the two methods return DEEP-EQUAL values for one response — the disagreement is gone', async () => {
+    // The card itself: same route, same bytes, two methods. Compared as
+    // values rather than asserted twice, so a future edit that changes one
+    // method's shape cannot leave the other silently behind.
+    const viaPublish = await clientWith(ENVELOPED_BODY).publish('view', 'cases');
+    const viaDraft = await clientWith(ENVELOPED_BODY).publishDraft('view', 'cases');
+    expect(viaDraft).toEqual(viaPublish);
+
+    const bareViaPublish = await clientWith(BARE_BODY).publish('view', 'cases');
+    const bareViaDraft = await clientWith(BARE_BODY).publishDraft('view', 'cases');
+    expect(bareViaDraft).toEqual(bareViaPublish);
+  });
+
+  /**
+   * ⚠️ The `undefined === undefined` trap this card is actually about.
+   *
+   * `version` reading `undefined` IS the failure mode under investigation, so
+   * a pin that merely compared it to `undefined` would prove nothing. Both
+   * legs below therefore assert a CONCRETE token, and the enveloped leg above
+   * asserts the absence separately — the two together are what separate "the
+   * OCC token is readable" from "both sides are blank".
+   */
+  it('keeps the ADR-0008 `version` / `seq` readable off BOTH methods on a normal response', async () => {
+    const viaPublish = await clientWith(BARE_BODY).publish<typeof BARE_BODY>('view', 'cases');
+    const viaDraft = await clientWith(BARE_BODY).publishDraft('view', 'cases');
+
+    expect(viaPublish.version).toBe(BARE_BODY.version);
+    expect((viaDraft as { version?: string }).version).toBe(BARE_BODY.version);
+    expect(viaPublish.seq).toBe(7);
+    expect((viaDraft as { seq?: number }).seq).toBe(7);
+  });
+
+  it('leaves the unenveloped path — the one every server actually serves — untouched', async () => {
+    // The non-regression axis: the plausible WRONG fix over-tightens and
+    // breaks the shape existing callers read. `usePublishAllDrafts` reads
+    // `seedApplied` off `publishDraft`'s return, so the whole body must
+    // survive, not just the three required keys.
+    const withSeed = { ...BARE_BODY, seedApplied: { success: false, inserted: 0, updated: 0, error: 'no rows' } };
+    const result = await clientWith(withSeed).publishDraft('seed', 'demo_rows');
+
+    expect(result).toEqual(withSeed);
+    expect(result.seedApplied).toEqual({ success: false, inserted: 0, updated: 0, error: 'no rows' });
+  });
+});
+
+/**
+ * The advisory channel follows the same object, on both doors — PR #6961's
+ * presentation reads whatever each method treats as the response, so it stays
+ * correct without a second decision (the scope fence this card adopted).
+ */
+describe('advisory reporting reads the same object both methods return (#6962)', () => {
+  /**
+   * FULLY shaped, and that is load-bearing rather than tidy: `readSaveAdvisories`
+   * requires all six string keys and silently DROPS a finding missing any of
+   * them. A half-shaped fixture would make the "reports NOTHING" case below
+   * pass for the wrong reason — an empty sink proving only that the fixture was
+   * malformed. Measured: with three keys, the positive control below went red
+   * (`expected [] to have a length of 1`) while the absence case stayed green.
+   */
+  const ADVISORY = {
+    severity: 'warning' as const,
+    rule: 'flow/delete-without-filter',
+    where: 'flow "nightly_purge" · node "purge old rows"',
+    path: 'flows[0].nodes[2].config.filters',
+    message: 'this delete_record node sets multi: true with no filter',
+    hint: 'add a filter, or set multi: false to delete a single record',
+  };
+
+  it('reports top-level advisories through both doors', async () => {
+    const body = { ...BARE_BODY, advisories: [ADVISORY] };
+
+    const viaPublish: MetadataSaveAdvisoryEvent[] = [];
+    await clientWith(body, (e) => viaPublish.push(e)).publish('flow', 'nightly_purge');
+    const viaDraft: MetadataSaveAdvisoryEvent[] = [];
+    await clientWith(body, (e) => viaDraft.push(e)).publishDraft('flow', 'nightly_purge');
+
+    expect(viaPublish).toHaveLength(1);
+    expect(viaDraft).toEqual(viaPublish);
+    expect(viaDraft[0]!.advisories).toEqual([ADVISORY]);
+  });
+
+  it('reports NOTHING for an enveloped body — through both doors, identically', async () => {
+    // The honest consequence of the ruling, pinned rather than left implicit:
+    // advisories are declared at the top level, an enveloped body has none
+    // there, and neither door goes hunting one level down for them. Pinned as
+    // an absence so a "helpful" traversal cannot be re-added silently.
+    const enveloped = { success: true, data: { ...BARE_BODY, advisories: [ADVISORY] } };
+
+    const viaPublish: MetadataSaveAdvisoryEvent[] = [];
+    await clientWith(enveloped, (e) => viaPublish.push(e)).publish('flow', 'nightly_purge');
+    const viaDraft: MetadataSaveAdvisoryEvent[] = [];
+    await clientWith(enveloped, (e) => viaDraft.push(e)).publishDraft('flow', 'nightly_purge');
+
+    expect(viaPublish).toEqual([]);
+    expect(viaDraft).toEqual([]);
+  });
+});

--- a/packages/data-objectstack/src/metadata-client.test.ts
+++ b/packages/data-objectstack/src/metadata-client.test.ts
@@ -218,8 +218,12 @@ describe('MetadataClient', () => {
     await expect(c.publishDraft('view', 'x')).rejects.toBeTruthy();
   });
 
-  it('publishDraft returns the result (incl. seedApplied) and unwraps the {data} envelope', async () => {
-    // Flat shape (rest-server passes protocol result through).
+  it('publishDraft returns the result (incl. seedApplied) verbatim — no {data} unwrapping', async () => {
+    // The shape the route actually serves, and the ONLY one it serves: the
+    // single REST mount answers `res.json(protocol.publishMetaItem(...))`
+    // straight through, and the `{ success, data }` envelope's one producer
+    // (the runtime dispatcher) does not serve this path at all — no publish
+    // branch in its `/meta` domain, no row in its route ledger (objectui#6962).
     const flat = new MetadataClient({
       baseUrl: '',
       fetch: mockFetch(async () =>
@@ -228,14 +232,18 @@ describe('MetadataClient', () => {
     const r1 = await flat.publishDraft('seed', 'job_sample');
     expect(r1.seedApplied).toEqual({ success: false, error: 'no readable seed bodies' });
 
-    // Dispatcher `{ success, data: {...} }` envelope.
+    // The unwrapping this method used to carry is GONE, so the enveloped body
+    // comes back as it arrived. This half used to assert the opposite; it was
+    // pinning a dialect with no producer, against `publish()` — the same route,
+    // a couple of hundred lines down — which never unwrapped at all.
     const enveloped = new MetadataClient({
       baseUrl: '',
       fetch: mockFetch(async () =>
         jsonResponse({ success: true, data: { success: true, seedApplied: { success: true, inserted: 6, updated: 0 } } })),
     });
     const r2 = await enveloped.publishDraft('seed', 'candidate_sample');
-    expect(r2.seedApplied).toEqual({ success: true, inserted: 6, updated: 0 });
+    expect(r2.seedApplied).toBeUndefined();
+    expect(r2).toEqual({ success: true, data: { success: true, seedApplied: { success: true, inserted: 6, updated: 0 } } });
   });
 });
 

--- a/packages/data-objectstack/src/metadata-client.ts
+++ b/packages/data-objectstack/src/metadata-client.ts
@@ -989,6 +989,44 @@ export class MetadataClient {
    * (`POST /packages/:id/publish-drafts`) is a different route that discards
    * per-draft advisories server-side; that is objectstack#9343 and nothing here
    * compensates for it.
+   *
+   * ## Why there is no `{ success, data }` unwrapping here (objectui#6962)
+   *
+   * This method used to unwrap a dispatcher-shaped envelope before returning,
+   * while {@link publish} — the same route, a couple of hundred lines down —
+   * did not. Two spellings of one wire contract, and nothing said which was
+   * right. The tolerance is gone because the route was MEASURED, at the
+   * producer rather than inferred from the response schema:
+   *
+   *  - The only mount of `POST /api/v1/meta/:type/:name/publish` is the REST
+   *    server's own route-manager registration, which answers
+   *    `res.json(await protocol.publishMetaItem(...))` — the protocol's object
+   *    verbatim, with no envelope branch. The project-scoped mirror
+   *    (`/api/v1/environments/:environmentId/...`) re-mounts that same handler.
+   *  - The `{ success, data }` envelope has exactly one producer, the runtime
+   *    `HttpDispatcher`, and it does not serve this route: its `/meta` domain
+   *    has no publish branch, the dispatcher's own route ledger has no row for
+   *    it, and a three-segment `/meta` path that is not `/published` terminates
+   *    in a located `routeNotFound`. So no composition — REST server, the
+   *    dispatcher-only Hono adapter, or both — puts an envelope on this body.
+   *  - `packages/spec` states the same split in the two docstrings side by
+   *    side: `PublishMetaItemResponseSchema` describes "the FULL body" this
+   *    route returns and records that the REST route hands the producer's
+   *    object to `res.json()` verbatim, while its batch sibling
+   *    `PublishPackageDraftsResponseSchema` describes a body answered
+   *    explicitly "inside the dispatcher's `{ success, data }` envelope".
+   *
+   * ⛔ So an enveloped body on THIS route is not a shape the platform emits,
+   * and unwrapping one is not a kindness: it is Commandment #0.1's lenient
+   * fallback, a second de-facto contract for a route that declares one. It
+   * also fails in the direction that hides the problem — a body that arrived
+   * enveloped is one this door did not actually serve, and unwrapping it
+   * would present that as a successful promotion.
+   *
+   * ⚠️ Sibling tolerances in this file are NOT this defect and must stay:
+   * {@link listDrafts} reads `data?.data?.drafts` because `GET /meta/_drafts`
+   * IS a dispatcher route, and `publishHealthFromResponse` unwraps because the
+   * batch door really is enveloped. The rule is per-route, not per-file.
    */
   async publishDraft(
     type: string,
@@ -1005,14 +1043,12 @@ export class MetadataClient {
     });
     if (!res.ok) throw await parseError(res);
     const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
-    // Tolerate the dispatcher's `{ success, data: {...} }` envelope.
-    const inner = (body as any)?.data && typeof (body as any).data === 'object' ? (body as any).data : body;
     // #5026 — this is the SAME single-item publish door `publish()` uses, so it
-    // reports the same way. Read off `inner`, the object this method returns:
-    // `advisories` is declared at the top level of `PublishMetaItemResponse`,
-    // which is what `inner` is once the dispatcher envelope (if any) is off.
-    this.emitAdvisories(inner, { type, name, door: 'publish', mode: 'publish' });
-    return inner as any;
+    // reports the same way, and now off the SAME object: the response body
+    // itself. `advisories` is declared at the TOP LEVEL of
+    // `PublishMetaItemResponse`, which is what this route answers (#6962).
+    this.emitAdvisories(body, { type, name, door: 'publish', mode: 'publish' });
+    return body as any;
   }
 
   /**


### PR DESCRIPTION
Fixes #6962

## The measurement, which was the first deliverable

Triage forbade settling this from `PublishMetaItemResponseSchema` alone — "an inference from the declaration, not a measurement of the server". So the **producer was read**, in the framework checkout (`objectstack` @ `6c546ab9`, packages at `17.3.0`; objectui depends on `^17.x`, so this is the line it talks to).

**Verdict: A — the route never envelopes.**

| Configuration | What serves `POST /api/v1/meta/:type/:name/publish` | Body |
|---|---|---|
| `@objectstack/rest` route-manager mount (default `/api/v1`) | `rest-server.ts`, the route's **only** mount | `res.json(await p.publishMetaItem(publishRequest))` — **bare** |
| ADR-0006 project-scoped base `/api/v1/environments/:environmentId/...` | the same handler, re-mounted | **bare** |
| Full boot: `plugin-hono-server` + `createRestApiPlugin` (`objectstack serve`, `bootStack`) | REST mount shadows the dispatcher catch-all | **bare** |
| Dispatcher-only host (`adapters/hono` `createHonoApp`, whose `${prefix}/*` catch-all *is* `dispatch()`) | nothing — `routeNotFound` | **not served** |
| Direct-mount registrars (`package-routes.ts`, `external-datasource-routes.ts`) — these *do* use the enveloping `sendOk` | mount only `/packages/*` and `/datasources/*` | **not this route** |

Three independent readings agree:

1. **The handler.** `packages/rest/src/rest-server.ts` registers `${metaPath}/:type/:name/publish` and ends `const result = await p.publishMetaItem(publishRequest); res.json(result);` — the protocol object verbatim, with no envelope branch on any arm.
2. **The envelope's only producer does not serve it.** `{ success, data }` is minted in exactly one place, `HttpDispatcher.success()` (`runtime/src/http-dispatcher.ts` → `{ success: true, data, meta }`). `runtime/src/domains/meta.ts` has **no publish branch** — its three-segment arm matches `/published`, GET only — and `runtime/src/route-ledger.ts` carries **no row** for a publish POST, so a three-segment `/meta` path that is not `/published` terminates in a located `routeNotFound`. Corroborated structurally by `scripts/check-route-envelope.mjs`, which classifies `rest-server.ts` as `dialectOnly`: the file is deliberately **not** converted onto the enveloping `sendOk`/`sendError` pair.
3. **`packages/spec` declares the split in so many words.** `PublishMetaItemResponseSchema` documents "the FULL body" this route returns and records that "the REST route hands it to `res.json()` verbatim"; its batch sibling `PublishPackageDraftsResponseSchema` documents a body answered "**inside the dispatcher's `{ success, data }` envelope**". The contrast is declared, not inferred from silence.

The `re: response-envelope.ts` lead was read, not assumed from its name: it is the **CLI-side reader** of the declared envelope and is not on this route's path at all.

⇒ The tolerance was a dialect with **no producer** — Commandment #0.1's lenient fallback — and it fails in the direction that hides the problem: a body arriving enveloped is one this door did *not* serve, so unwrapping it presents that as a successful promotion.

## What changed

- `publishDraft` no longer unwraps `{ success, data }`; it returns the parsed body and reads advisories off the same object, exactly as `publish` always did. `publish` is untouched.
- The measurement is recorded on the method, including the boundary: sibling tolerances in the same file stay, because they are correct — `listDrafts` reads `data?.data?.drafts` because `GET /meta/_drafts` really *is* a dispatcher route, and `publishHealthFromResponse` unwraps because the batch publish door really is enveloped. The rule is per-route, not per-file.

## Pins — driven on the only input that separates the two spellings

A pin asserting *"publish returns the body"* is worthless here: it passes on a method that returns the body **and** on one that would have unwrapped an envelope it never receives. So the pins drive an **envelope-shaped body** and assert both methods return it **verbatim** (payload still nested, `version` *not* hoisted), that the two methods are **deep-equal** for one response, and — the non-regression axis — that on a normal unenveloped body `version` / `seq` / `seedApplied` stay readable off **both**.

**Red-leg evidence** (per-test classification from vitest's **JSON reporter**, not the text one; each mutation proved on disk by grep counts before running, restored by `git checkout HEAD --` and verified byte-identical via `git hash-object` == the HEAD blob):

| Mutation | Result |
|---|---|
| **M1 — the bug's shape**: restore `publishDraft`'s tolerance (the two disagree again) | **5 RED**, across all three files |
| **M2 — the caricature**: *both* methods unwrap unconditionally, so the code answers the same thing for every input | **17 RED**, including both non-regression pins |

⭐ Worth reading: the *deep-equal* pin **passes** under M2 — both methods do the same wrong thing, so they still agree. That is exactly why the verbatim pins exist beside it, and it demonstrates the pin set is not redundant.

One pin was also **red-first by accident and fixed**: the advisory fixture started three-key, and `readSaveAdvisories` requires all six, so the positive control went red (`expected [] to have a length of 1`) while the "reports NOTHING" case stayed green — i.e. the absence pin would have passed for the wrong reason. The fixture is now fully shaped and the reason is recorded in the file.

## Two fixtures replaced, not re-spelled

Both pinned exactly the branch this deletes, and both kept passing for the wrong reason — proving a dialect stayed consistent with itself on a body no server emits:

- `metadata-client.publishAdvisories.test.ts` — "reads them through the dispatcher `{ success, data }` envelope it already unwraps"
- `metadata-client.test.ts` — "publishDraft returns the result … and unwraps the {data} envelope"

Each now asserts what the old case was reaching for ("the report does not depend on which shape answered") in the direction that is now true.

## Verification

- `pnpm exec vitest run packages/data-objectstack/ packages/app-shell/src/views/metadata-admin/useMetadataClient.advisorySink.test.tsx packages/app-shell/src/preview/` → **73 files, 895 tests passed**, at `f585b834`.
- `pnpm --filter @object-ui/data-objectstack run type-check` → clean. First run was `TS6305` (unbuilt dependency closure — a **precondition**, recorded as NOT MEASURED, not red); re-run after `pnpm --filter '@object-ui/data-objectstack^...' build`. `tsc --listFiles` confirms the new test file **is** in the type-check program.
- `pnpm exec eslint .` (plain form — `--no-inline-config` is an objectstack convention, not this repo's) → **0 errors across 4533 files**, eslint's own file selection. Whole population, so no narrowing argument is owed.
- `node scripts/check-changeset-presence.mjs` → ✅ "3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)". `node scripts/check-changeset-no-major.mjs` → ✅.

Changeset: `.changeset/publish-envelope-one-spelling-6962.md`, `patch` — the behaviour delta is confined to an input no measured configuration emits, and on a conformant response (which has no `data` member at all) the removed branch was already a no-op.

## Scope

⛔ PR #6961's advisory presentation is **not** touched and **not** coupled to this card — it reads from what each method already treats as the response object, so it is correct under either ruling. `priority:p2` not re-graded.

## Two premises reported back to triage

1. ⚠️ **The `version`-reads-`undefined` consequence is not wired today.** Both callers of `publish()` — `publishRuntimeMetadata` and `ResourceEditPage.doPublish` — `await` the call and **discard the return value**; neither reads `version` for a subsequent `If-Match`. The silent-concurrency-control framing is what arm B *would* have cost, not a live defect. (`publishDraft`'s return *is* read, for `seedApplied`, in `usePublishAllDrafts`.)
2. ✅ **The third-caller check came back clean.** No third site in objectui holds a belief about *this* route's envelope. Adjacent tolerances exist and are correctly scoped to routes the dispatcher genuinely serves. Outside objectui there is one more belief-holder: `@objectstack/client`'s private `unwrapResponse` tolerates the envelope on `meta.publishItem` — but it applies that unwrapping uniformly to nearly every SDK method regardless of route, so it is not evidence about this one.

<sub>One configuration was out of reach and is declared rather than assumed: the sibling `objectstack-ai/cloud` repo is not checked out here, so whether a cloud deployment fronts `/api/v1/meta/**` with a re-enveloping gateway is not answerable from these two repos. Everything above is a source reading of the current released line, not a drive against a live server.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_