### PR TITLE
fix(components): name `box` in the div deprecation guidance, on all four surfaces

### DIFF
--- a/.changeset/6877-div-guidance-names-box.md
+++ b/.changeset/6877-div-guidance-names-box.md
@@ -1,0 +1,17 @@
+---
+'@object-ui/components': patch
+---
+
+Rewrite the `div` deprecation guidance so it names `box`, the one replacement measured drop-in.
+
+The notice and the machine-readable `deprecated.replacement` recommended `card` / `flex` /
+`container` / `stack` / `grid` for the plain-wrapper case. Measured through the real renderer,
+each of those injects classes of its own, `card` also moves the children into an extra element,
+and four of the five read `children` only — so a node authoring `body` loses its content
+silently, at an unchanged element count. `box` (objectui#3965) is the class-transparent swap and
+was never mentioned. Deprecation guidance is followed literally, so the old text manufactured
+exactly the conversions objectui#3965 measured and rejected.
+
+Both statements now name `box` first for the mechanical swap, keep the layout components for the
+cases where their layout is actually wanted, and state the `body` → `children` move that every
+option except `card` requires. `span`'s guidance is deliberately unchanged.

--- a/content/docs/components/basic/div.mdx
+++ b/content/docs/components/basic/div.mdx
@@ -9,9 +9,14 @@ description: "Generic container element - use Shadcn components instead"
     The Div component is deprecated. Please use Shadcn components instead:
   </p>
   <ul className="mt-2 list-inside list-disc text-sm text-yellow-700 dark:text-yellow-300">
-    <li>For containers: use <code>card</code>, <code>flex</code>, or semantic layout components</li>
-    <li>For simple wrappers: use layout components like <code>container</code>, <code>stack</code>, or <code>grid</code></li>
+    <li>For a plain wrapper: use <code>box</code> — the one drop-in swap (same element, your className verbatim, no layout of its own)</li>
+    <li>When you want their layout: use <code>card</code>, <code>flex</code>, <code>container</code>, <code>stack</code>, or <code>grid</code> — each injects classes of its own, and <code>card</code> also moves children into an extra element</li>
   </ul>
+  <p className="mt-2 text-sm text-yellow-700 dark:text-yellow-300">
+    Move any content authored under the legacy <code>body</code> key into <code>children</code> first: every
+    replacement listed above except <code>card</code> reads <code>children</code> only, so a blind retype drops
+    that content silently, at an unchanged element count.
+  </p>
 </div>
 
 The Div component is a generic container element. **It is now deprecated in favor of semantic Shadcn-based components** that provide better accessibility, consistency, and design system integration.
@@ -30,7 +35,25 @@ produce no CSS at all when authored in page `source`. `os validate` reports that
 
 ## Migration Guide
 
-Instead of using `div`, use these Shadcn alternatives:
+Which replacement is right depends on whether you want layout or only a wrapper.
+Measured through the real renderer, on a node carrying an authored `className`:
+`box` reproduces `div` exactly, while `card`, `flex`, `container`, `stack` and
+`grid` each add classes of their own — and `card` additionally moves the children
+inside an extra element. So a mechanical `div` → `card`/`flex`/`grid` swap changes
+the page; a `div` → `box` swap does not.
+
+One caveat that applies to every option except `card`: they read `children` and
+never `body`. A node that authored `body` must move that content into `children`
+as part of the swap, or it disappears from the page without changing the element
+count — silently.
+
+### For a Plain Wrapper → Use `box`
+
+The mechanical swap. `box` renders `children` inside a plain block element with
+your `className` passed through verbatim and nothing injected, so retyping a
+`div` node to `box` is the one conversion that leaves the rendered result alone.
+
+<SchemaExample id="components-basic-div/use-box-instead" />
 
 ### For Card-like Containers → Use `card`
 

--- a/examples/schema-catalog/src/index.ts
+++ b/examples/schema-catalog/src/index.ts
@@ -37,6 +37,7 @@ import components_basic_div_custom_card from './schemas/components-basic-div/cus
 import components_basic_div_flex_layout from './schemas/components-basic-div/flex-layout.json' with { type: 'json' };
 import components_basic_div_grid_layout from './schemas/components-basic-div/grid-layout.json' with { type: 'json' };
 import components_basic_div_nested_divs from './schemas/components-basic-div/nested-divs.json' with { type: 'json' };
+import components_basic_div_use_box_instead from './schemas/components-basic-div/use-box-instead.json' with { type: 'json' };
 import components_basic_div_use_card_instead from './schemas/components-basic-div/use-card-instead.json' with { type: 'json' };
 import components_basic_html_basic_html from './schemas/components-basic-html/basic-html.json' with { type: 'json' };
 import components_basic_icon_basic_icon from './schemas/components-basic-icon/basic-icon.json' with { type: 'json' };
@@ -683,6 +684,15 @@ const REGISTRY: Record<string, Example> = {
       category: 'components-basic-div',
     },
     schema: components_basic_div_nested_divs,
+  },
+  'components-basic-div/use-box-instead': {
+    id: 'components-basic-div/use-box-instead',
+    meta: {
+      title: "Use Box Instead",
+      description: "",
+      category: 'components-basic-div',
+    },
+    schema: components_basic_div_use_box_instead,
   },
   'components-basic-div/use-card-instead': {
     id: 'components-basic-div/use-card-instead',

--- a/examples/schema-catalog/src/schemas/components-basic-div/use-box-instead.json
+++ b/examples/schema-catalog/src/schemas/components-basic-div/use-box-instead.json
@@ -1,0 +1,22 @@
+{
+  "type": "box",
+  "className": "max-w-sm rounded-lg border bg-card text-card-foreground shadow-sm",
+  "children": [
+    {
+      "type": "box",
+      "className": "p-6 space-y-2",
+      "children": [
+        {
+          "type": "text",
+          "content": "Card Title",
+          "className": "text-2xl font-semibold"
+        },
+        {
+          "type": "text",
+          "content": "The same markup as the div example, retyped to box: className verbatim, no layout injected, no extra element.",
+          "className": "text-sm text-muted-foreground"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/schema-catalog/test/layout-dom-leak-5574.test.tsx
+++ b/examples/schema-catalog/test/layout-dom-leak-5574.test.tsx
@@ -125,13 +125,20 @@ const NODE_CENSUS: Readonly<Record<string, { rendered: number; noElement: number
   // `body`, not `children`), and as bare text nodes carrying no className,
   // `variant` or `align` they sat in the no-element class — so both counts
   // move by exactly five. Catalog authoring, not a renderer change.
-  text: { rendered: 696, noElement: 154 },
+  // 696 -> 698 with objectui#6877: `components-basic-div/use-box-instead` is
+  // the `div` -> `box` before/after the migration guide was missing, and its
+  // two `text` nodes both carry a className, so both need an element — the
+  // no-element count is unmoved. Catalog authoring, not a renderer change.
+  text: { rendered: 698, noElement: 154 },
   // The objectui#3965 migration population (80 nodes retyped from `div`) plus
   // the 4 nodes of the components-layout-box exemplars. `box` is born on
   // `toDomProps` and class-transparency, so it joins the measured set as a
   // converged renderer from day one — 84 real authored nodes, every one
   // expected to render its element and leak nothing.
-  box: { rendered: 84, noElement: 0 },
+  // 84 -> 86 with objectui#6877: the same new fixture is two `box` nodes (an
+  // outer wrapper and an inner padding box), mirroring the `div` exemplar it
+  // teaches the conversion away from.
+  box: { rendered: 86, noElement: 0 },
 };
 
 /**

--- a/packages/components/src/__tests__/div-deprecation-provenance.test.tsx
+++ b/packages/components/src/__tests__/div-deprecation-provenance.test.tsx
@@ -100,10 +100,12 @@ describe('div deprecation notice — scoped by provenance (#4000)', () => {
     const calls = deprecationCalls(warn);
     expect(calls).toHaveLength(1);
     const notice = String(calls[0][0]);
-    // The migration guidance is untouched — this issue narrows WHO is told, it
-    // does not water down WHAT they are told.
-    expect(notice).toContain('"card", "flex", or semantic layout components');
-    expect(notice).toContain('"container", "stack", or "grid"');
+    // The migration guidance was RE-RULED in objectui#6877 (this file's #4000
+    // ruling narrowed WHO is told; #6877 changed WHAT they are told, because
+    // the old text named only replacements measured non-drop-in and never
+    // named `box`). What #4000 owns — the scope sentence below — is untouched.
+    expect(notice).toContain('the drop-in swap is "box"');
+    expect(notice).toContain('"card", "flex", "container", "stack", or "grid"');
     // …and the notice now names the surface it applies to. A notice that says
     // the type is deprecated FULL STOP is false the moment another tier keeps
     // it as permanent vocabulary; whoever reads the console has to be able to
@@ -154,7 +156,7 @@ describe('div deprecation notice — scoped by provenance (#4000)', () => {
     expect(ComponentRegistry.deprecationFor('div', 'json')).toEqual({
       surfaces: ['json'],
       replacement:
-        'use "card", "flex", or layout components like "container", "stack", or "grid"',
+        'author "box" for a plain wrapper — the one drop-in swap; reach for "card", "flex", "container", "stack" or "grid" only when you want their layout, and move `body` content into `children` first',
     });
 
     // …and NOT where the first case above proves the renderer stays silent. A

--- a/packages/components/src/__tests__/div-deprecation-warn-once.test.tsx
+++ b/packages/components/src/__tests__/div-deprecation-warn-once.test.tsx
@@ -90,10 +90,12 @@ describe('div deprecation notice — once per module load (#3965)', () => {
 
     const calls = deprecationCalls(warn);
     expect(calls).toHaveLength(1);
-    // The notice itself is unchanged — the deprecation is still being reported,
-    // with its migration guidance intact.
-    expect(String(calls[0][0])).toContain('"card", "flex", or semantic layout components');
-    expect(String(calls[0][0])).toContain('"container", "stack", or "grid"');
+    // The deprecation is still being reported, with its migration guidance
+    // intact. The guidance text itself was re-ruled in objectui#6877 (it now
+    // names `box`, the one drop-in swap, and states the `body`→`children`
+    // hazard); the ONCE-semantics this file pins are unaffected by that.
+    expect(String(calls[0][0])).toContain('the drop-in swap is "box"');
+    expect(String(calls[0][0])).toContain('"card", "flex", "container", "stack", or "grid"');
   });
 
   it('does not warn again on a later render', () => {

--- a/packages/components/src/__tests__/div-guidance-names-box.test.tsx
+++ b/packages/components/src/__tests__/div-guidance-names-box.test.tsx
@@ -1,0 +1,336 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6877 — the `div` migration guidance is TRUE, and all four surfaces
+ * that state it agree.
+ *
+ * The guidance is stated four times: the console notice
+ * (`renderers/basic/div.tsx`), the machine-readable `deprecated.replacement` on
+ * the same registration (objectui#6674), `content/docs/components/basic/div.mdx`,
+ * and the `components-basic-div` catalog category. Until this file, only the
+ * first two were held together at all — by
+ * `deprecation-guidance-agreement.test.tsx` (objectui#6823) — and NOTHING held
+ * any of them to the truth.
+ *
+ * ## Why "they agree" is not enough on its own
+ *
+ * Agreement is satisfied by four surfaces that are identically wrong, which is
+ * exactly the state objectui#6877 found. Every replacement the old guidance
+ * named was measured NON-drop-in (each injects classes of its own; `card` also
+ * moves the children into an extra element; four of the five read `children`
+ * only, so a `body`-authoring node loses its content silently at an unchanged
+ * element count), and the one class-transparent swap — `box`, minted by
+ * objectui#3965 — was the one it never named.
+ *
+ * A pin asserting merely "the notice mentions `box`" would pass on a notice
+ * that mentions `box` AND still recommends every non-drop-in replacement
+ * unchanged — an implementation strictly worse than the text it replaced. So
+ * the drop-in claim below is a MEASUREMENT taken through the real renderer,
+ * not a list of names kept here, and the guidance is asserted against what the
+ * measurement says. Re-rank the renderers and this file re-ranks with them.
+ *
+ * ## The plausible WRONG FIX this exists to catch
+ *
+ * Edit one statement of the guidance and leave the others behind, so the four
+ * surfaces disagree. objectui#6823 catches exactly one shape of that — the
+ * notice and the declaration disagreeing with each other — and it is blind to
+ * the other two surfaces by construction: it never reads them. MEASURED on this
+ * branch, with the mdx reverted to its pre-#6877 bullets and, separately, with
+ * the new fixture deleted: all 18 cases of the five pre-existing deprecation
+ * suites stay GREEN in both states. The stale copy is also the one an automated
+ * gate repeats to authors, at a scale no console notice reaches. Case 3 is that
+ * pin, and it reddens in both states.
+ *
+ * ## Quoting convention, shared with objectui#6823
+ *
+ * Both statements name a component type in DOUBLE QUOTES and a property name in
+ * backticks, so the offered alternatives can be read out of either without a
+ * list kept here — a hard-coded list would be a fifth copy of the thing this
+ * file exists to keep from drifting. The mdx follows the same discipline with
+ * `<code>` inside the callout list.
+ *
+ * ⛔ `span` is deliberately out of scope (`box` is block-level; the inline
+ * replacement story did not change), and case 5 asserts this edit did not sweep
+ * it in. What that adds, measured rather than assumed: with `"box"` added to
+ * BOTH of span's statements at once, objectui#6823 stays green (it compares the
+ * two to each other, and they still agree) and so does every `toContain` pin on
+ * span's NOTICE — `span-deprecation-provenance` and `span-deprecation-warn-once`
+ * assert containment, which a longer bullet still satisfies. The one
+ * pre-existing case that does redden is the `toEqual` on span's DECLARATION, so
+ * the notice half of that sweep is covered here and nowhere else.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '@object-ui/react';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../renderers';
+
+/**
+ * Resolved off this module, so nothing here depends on the process cwd.
+ *
+ * String paths, not `new URL(rel, base)`: under the `dom` project happy-dom
+ * installs its own global `URL`, and a URL it builds is not the shape
+ * `fileURLToPath` accepts — it fails with `The URL must be of scheme file` at
+ * module load, i.e. as a suite that reports ZERO tests rather than a red one.
+ */
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '../../../..');
+const DIV_MDX_PATH = path.join(REPO_ROOT, 'content/docs/components/basic/div.mdx');
+const SPAN_MDX_PATH = path.join(REPO_ROOT, 'content/docs/components/basic/span.mdx');
+const CATALOG_DIR = path.join(
+  REPO_ROOT,
+  'examples/schema-catalog/src/schemas/components-basic-div',
+);
+
+/** The component type names a piece of guidance offers: its double-quoted runs. */
+function offeredTypeNames(guidance: string): Set<string> {
+  return new Set([...guidance.matchAll(/"([^"]+)"/g)].map((m) => m[1]));
+}
+
+/** The notice's migration guidance: its bullet lines, and only those. */
+function bulletLines(notice: string): string[] {
+  return notice.split('\n').filter((line) => line.trimStart().startsWith('- '));
+}
+
+/**
+ * The `div` notice, read the way every reader reads it — off the console.
+ *
+ * Memoized because the warn-once guard (objectui#3965) is a module-level Set:
+ * the type may be rendered for its notice exactly once per module instance, so
+ * the FIRST render in this file has to be the one that captures it, whichever
+ * case happens to ask first. A wrong count throws rather than returning
+ * something — a renderer that stopped warning must not reach an assertion as an
+ * empty string, where several of the checks below would read as vacuously true.
+ */
+let cachedNotice: Record<string, string> = {};
+function noticeFor(type: string): string {
+  const cached = cachedNotice[type];
+  if (cached !== undefined) return cached;
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const Component = ComponentRegistry.get(type);
+  if (!Component) throw new Error(`Component "${type}" is not registered`);
+  render(<Component schema={{ type }} />);
+  const deprecation = new RegExp(`The "${type}" component is deprecated`);
+  const hits = warn.mock.calls
+    .map((args: unknown[]) => String(args[0]))
+    .filter((message) => deprecation.test(message));
+  warn.mockRestore();
+  if (hits.length !== 1) {
+    throw new Error(
+      `expected exactly one "${type}" deprecation notice, observed ${hits.length}. ` +
+        'A type that stopped warning, or stopped resolving, must fail here rather ' +
+        'than hand an empty string to the assertions below.',
+    );
+  }
+  cachedNotice = { ...cachedNotice, [type]: hits[0] };
+  return hits[0];
+}
+
+/** The declared, machine-readable guidance for a type on the json surface. */
+function declaredReplacement(type: string): string {
+  const declared = ComponentRegistry.deprecationFor(type, 'json')?.replacement;
+  if (!declared) throw new Error(`"${type}" declares no json-surface replacement guidance`);
+  return declared;
+}
+
+/**
+ * What a node of `type` actually renders, for one authored `className` and one
+ * piece of content — the measurement the guidance has to be true about.
+ */
+const PROBE_CLASS = 'os6877-probe-class';
+const PROBE_TEXT = 'os6877-probe-content';
+
+function measure(type: string, contentKey: 'children' | 'body') {
+  const node: Record<string, unknown> = { type, className: PROBE_CLASS };
+  node[contentKey] = [{ type: 'text', content: PROBE_TEXT }];
+  const { container } = render(<SchemaRenderer schema={node as never} />);
+  const root = container.firstElementChild as HTMLElement | null;
+  return {
+    elements: container.querySelectorAll('*').length,
+    classVerbatim: (root?.className ?? '') === PROBE_CLASS,
+    keepsContent: (container.textContent ?? '').includes(PROBE_TEXT),
+  };
+}
+
+/**
+ * The offered replacements that really ARE drop-in for a `children`-authoring
+ * `div`: same element count, the authored `className` through verbatim, content
+ * preserved. Measured against `div` itself rather than against a constant, so
+ * the baseline cannot go stale either.
+ */
+function measuredDropInReplacements(offered: Iterable<string>): string[] {
+  const baseline = measure('div', 'children');
+  return [...offered]
+    .filter((type) => {
+      const m = measure(type, 'children');
+      return (
+        m.elements === baseline.elements && m.classVerbatim && m.keepsContent
+      );
+    })
+    .sort();
+}
+
+/** Root `type` of every fixture in the `components-basic-div` category. */
+function catalogRootTypes(): string[] {
+  const files = readdirSync(CATALOG_DIR).filter((n) => n.endsWith('.json'));
+  if (files.length === 0) throw new Error(`no fixtures under ${CATALOG_DIR}`);
+  return files.map((name) => {
+    const parsed = JSON.parse(readFileSync(`${CATALOG_DIR}/${name}`, 'utf8')) as { type?: string };
+    if (!parsed.type) throw new Error(`fixture ${name} has no root type`);
+    return parsed.type;
+  });
+}
+
+/** The replacement types the mdx callout offers: its `<code>` runs, in the list. */
+function mdxOfferedTypeNames(mdx: string): Set<string> {
+  const list = mdx.match(/<ul[^>]*>([\s\S]*?)<\/ul>/);
+  if (!list) throw new Error('div.mdx no longer opens with the deprecation callout list');
+  return new Set([...list[1].matchAll(/<code>([^<]+)<\/code>/g)].map((m) => m[1]));
+}
+
+describe('div deprecation guidance — true, and agreed across four surfaces (#6877)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('names exactly the replacements that are MEASURED drop-in — one of them', () => {
+    const offered = offeredTypeNames(bulletLines(noticeFor('div')).join('\n'));
+
+    // Control: the comparison is not vacuous, and the classification below had
+    // something to reject. A notice offering nothing, or offering one name, is
+    // not a test of "exactly the drop-in ones".
+    expect(offered.size).toBeGreaterThan(1);
+
+    const dropIn = measuredDropInReplacements(offered);
+
+    // The measurement, stated: exactly one offered replacement reproduces what
+    // `div` renders. This is the fact objectui#3965 established and the reason
+    // this card exists; if a renderer changes so that a second one qualifies,
+    // this fails and the guidance gets rewritten rather than quietly drifting
+    // out of date.
+    expect(dropIn).toEqual(['box']);
+
+    // Control on the other side: the classifier really discriminates. A
+    // predicate that answered `true` for everything would satisfy nothing here.
+    expect(offered.size - dropIn.length).toBeGreaterThan(0);
+  });
+
+  it('offers the drop-in replacement, and ONLY it, for the plain-wrapper case', () => {
+    const bullets = bulletLines(noticeFor('div'));
+    // Control: the notice really carries bullet guidance. A reflow that
+    // dissolves the bullets has to come back through here.
+    expect(bullets.length).toBeGreaterThan(1);
+
+    const dropIn = measuredDropInReplacements(
+      offeredTypeNames(bullets.join('\n')),
+    );
+    const plainWrapperBullets = bullets.filter((line) =>
+      dropIn.some((type) => line.includes(`"${type}"`)),
+    );
+
+    // Exactly one bullet is about the mechanical swap…
+    expect(plainWrapperBullets).toHaveLength(1);
+    // …and it offers the drop-in replacement ALONE. This is the assertion a
+    // "mentions box" pin cannot make: guidance that adds `box` to the old
+    // "for simple wrappers use container/stack/grid" bullet still points
+    // authors at replacements that silently change the page, and fails here.
+    expect([...offeredTypeNames(plainWrapperBullets[0])].sort()).toEqual(dropIn);
+  });
+
+  it('states the same alternatives on all four surfaces', () => {
+    const notice = offeredTypeNames(bulletLines(noticeFor('div')).join('\n'));
+    const declared = offeredTypeNames(declaredReplacement('div'));
+    const mdx = mdxOfferedTypeNames(readFileSync(DIV_MDX_PATH, 'utf8'));
+
+    // Controls: nothing below compares two empty sets.
+    expect(notice.size).toBeGreaterThan(0);
+    expect(declared.size).toBeGreaterThan(0);
+    expect(mdx.size).toBeGreaterThan(0);
+
+    // Set equality both ways, not containment: drift has no preferred
+    // direction. This is the pin that reddens when the plausible wrong fix
+    // updates one surface and leaves the others behind.
+    expect([...declared].sort()).toEqual([...notice].sort());
+    expect([...mdx].sort()).toEqual([...notice].sort());
+
+    // The catalog category is the fourth surface. It DOCUMENTS the deprecated
+    // type, so `div` itself is expected among its root types — that exemption
+    // is the one `examples/schema-catalog/test/deprecated-component-types.test.ts`
+    // grants and checks for non-vacuity. Everything else it demonstrates must
+    // be a replacement the other three surfaces actually offer…
+    const fixtures = catalogRootTypes();
+    const demonstrated = [...new Set(fixtures.filter((type) => type !== 'div'))].sort();
+    expect(demonstrated.length).toBeGreaterThan(0);
+    expect(demonstrated.filter((type) => !notice.has(type))).toEqual([]);
+
+    // …and the one mechanical swap has to be among them, reachable from the
+    // migration guide. A guide that teaches `box` while the corpus only
+    // exemplifies the non-drop-in conversions is the same defect one surface
+    // over.
+    expect(demonstrated).toContain('box');
+    expect(readFileSync(DIV_MDX_PATH, 'utf8')).toContain(
+      'components-basic-div/use-box-instead',
+    );
+    expect(fixtures.length).toBe(readdirSync(CATALOG_DIR).filter((n) => n.endsWith('.json')).length);
+  });
+
+  it('no surface still carries the falsified recommendations', () => {
+    const notice = noticeFor('div');
+    const declared = declaredReplacement('div');
+    const mdx = readFileSync(DIV_MDX_PATH, 'utf8');
+
+    // The two sentences objectui#6877 retired. Both offered a NON-drop-in
+    // replacement for the plain-wrapper case, which is the falsehood; keeping
+    // either while adding `box` elsewhere would leave the guidance wrong for
+    // the reader who follows it literally.
+    for (const [surface, text] of [
+      ['notice', notice],
+      ['declaration', declared],
+      ['div.mdx', mdx],
+    ] as const) {
+      expect(text, `${surface} still recommends "semantic layout components"`).not.toContain(
+        'semantic layout components',
+      );
+      expect(text, `${surface} still carries the old simple-wrapper bullet`).not.toContain(
+        'For simple wrappers',
+      );
+    }
+
+    // Controls, same shape and same surfaces: each `not.toContain` above is
+    // read over text that really was loaded. Without these, an empty string
+    // would satisfy every one of them.
+    expect(notice).toContain('deprecated');
+    expect(declared).toContain('"box"');
+    expect(mdx).toContain('Migration Guide');
+  });
+
+  it('leaves `span` alone — a separate judgement, not swept in', () => {
+    // `box` is a block-level container; nothing about the inline replacement
+    // story changed, so span's guidance must be untouched by this edit.
+    const notice = noticeFor('span');
+    const declared = declaredReplacement('span');
+    const mdx = readFileSync(SPAN_MDX_PATH, 'utf8');
+
+    const offered = offeredTypeNames(bulletLines(notice).join('\n'));
+    // Control first: span's guidance was really read, and really offers
+    // something — otherwise the absence checks below are vacuous.
+    expect([...offered].sort()).toEqual(['badge', 'text']);
+
+    expect(offered.has('box')).toBe(false);
+    expect(declared).not.toContain('box');
+    expect(mdx).not.toContain('<code>box</code>');
+  });
+});

--- a/packages/components/src/renderers/basic/div.tsx
+++ b/packages/components/src/renderers/basic/div.tsx
@@ -50,13 +50,63 @@ function warnDeprecatedOnce(type: string, message: string): void {
  * false for one of its two readers, and it was the reader who could do nothing
  * about it who kept receiving it (objectui#4000).
  *
- * The migration guidance below is byte-for-byte what it was: this issue narrows
- * WHO is told, it does not water down WHAT they are told.
+ * ## The guidance was RE-RULED in objectui#6877 — it is no longer #4000's bytes
+ *
+ * objectui#4000 recorded the migration guidance as "byte-for-byte what it was",
+ * and that pin was right for as long as the guidance was merely INCOMPLETE. It
+ * became FALSE when the neutral `box` container landed (objectui#3965 /
+ * PR #6878). Measured through the real `SchemaRenderer`, on a node carrying an
+ * authored `className` and one text child — every replacement the old bullets
+ * named changes the rendered result:
+ *
+ *   card       + `rounded-lg border bg-card text-card-foreground shadow-sm`,
+ *              and the children move inside an extra `CardContent` element
+ *              (1 element becomes 2)
+ *   flex       + `flex flex-row justify-start items-start gap-1.5 sm:gap-2`
+ *   container  + `w-full max-w-xl mx-auto p-2 sm:p-3 md:p-4`
+ *   stack      + `flex flex-col justify-start items-stretch gap-1.5 sm:gap-2`
+ *   grid       + `grid grid-cols-2 gap-4`
+ *
+ * and four of those five — `flex`, `container`, `stack`, `grid` — read
+ * `children` ONLY, so a node that authored `body` loses its content SILENTLY,
+ * at an unchanged element count. `box` is the one class-transparent swap, and
+ * the old text never named it.
+ *
+ * That is why this is worth a re-ruling rather than a nice-to-have. Deprecation
+ * guidance is followed LITERALLY, by humans and by generating models reading
+ * the console alike, so a notice naming only non-drop-in replacements
+ * manufactures exactly the conversions objectui#3965 measured and rejected.
+ *
+ * ⚠️ `box` is not unconditionally drop-in either, and the text below says so
+ * instead of selling it as one: it too reads `children` only, so `body` content
+ * has to move first. A recommendation that is true WITH a caveat beats a
+ * cleaner one that is false — trading one false recommendation for another
+ * would be worse than leaving the old text alone.
+ *
+ * The four surfaces that state this guidance move in ONE stroke: this notice,
+ * the declaration below, `content/docs/components/basic/div.mdx`, and the
+ * `components-basic-div` catalog category. They are held together by
+ * `__tests__/div-guidance-names-box.test.tsx` (objectui#6877) and, for the
+ * first two, by `__tests__/deprecation-guidance-agreement.test.tsx`
+ * (objectui#6823).
+ *
+ * ⛔ `span`'s notice is a SEPARATE judgement and is deliberately untouched:
+ * `box` is a block-level container, and nothing about the inline replacement
+ * story changed. The same pin file asserts that this edit did not sweep it in.
+ *
+ * ## Quoting convention — load-bearing, not style
+ *
+ * Inside the bullets, DOUBLE QUOTES mean "component type name" and nothing
+ * else; property names take backticks. The objectui#6823 agreement test reads
+ * the offered alternatives out of both statements as their double-quoted runs,
+ * so a `"body"` written with the wrong quotes would arrive as a component type
+ * this notice claims to offer.
  */
 const DIV_DEPRECATION_NOTICE =
   '[ObjectUI] The "div" component is deprecated for JSON-authored pages. Please use Shadcn components instead:\n' +
-  '  - For containers: use "card", "flex", or semantic layout components\n' +
-  '  - For simple wrappers: use layout components like "container", "stack", or "grid"\n' +
+  '  - For a plain wrapper the drop-in swap is "box": same element, your `className` verbatim, no layout of its own.\n' +
+  '  - Reach for "card", "flex", "container", "stack", or "grid" only when you want their layout — each injects classes of its own, and "card" also moves children into an extra element.\n' +
+  '  - Move any `body` content into `children` first: every replacement above except "card" reads `children` only, so a blind retype drops it silently at an unchanged element count.\n' +
   '  This applies to JSON-authored nodes. In a kind:\'html\' page the tag is part of that tier\'s own\n' +
   '  vocabulary, is compiled straight through, and is not reported here.\n' +
   'See documentation at https://www.objectui.org/docs/components for alternatives.';
@@ -131,8 +181,14 @@ ComponentRegistry.register('div',
      */
     deprecated: {
       surfaces: ['json'],
+      /**
+       * Re-ruled with the notice above in objectui#6877 — the two are asserted
+       * to offer the SAME set of alternatives (objectui#6823), so they cannot
+       * be moved one at a time. Same quoting convention: double quotes are
+       * component type names, backticks are property names.
+       */
       replacement:
-        'use "card", "flex", or layout components like "container", "stack", or "grid"',
+        'author "box" for a plain wrapper — the one drop-in swap; reach for "card", "flex", "container", "stack" or "grid" only when you want their layout, and move `body` content into `children` first',
     },
     inputs: [
       { name: 'className', type: 'string' }


### PR DESCRIPTION
Fixes #6877

## The judged call, stated first

objectui#4000 recorded the `div` migration guidance as "byte-for-byte what it was". **This PR re-rules that wording deliberately.** The pin was right while the guidance was merely *incomplete*; it became *false* when `box` landed (objectui#3965 / PR #6878), because every replacement the old text named is measured non-drop-in and the one that is drop-in was never mentioned. The two pins that held those bytes (`div-deprecation-provenance`, `div-deprecation-warn-once`) move with the text, and their comments now record why.

## Re-verified the not-drop-in measurement before rewriting around it

Measured on this branch through the real `SchemaRenderer`, one node carrying an authored `className` plus one text child. `div` is the baseline:

| type | className verbatim | elements | content kept when authored under `body` |
|---|---|---|---|
| `div` (baseline) | yes | 1 | yes (it reads children-or-body) |
| `box` | **yes** | **1** | **no** |
| `card` | no — adds `rounded-lg border bg-card text-card-foreground shadow-sm` | **2** (children move into an extra element) | yes |
| `flex` | no — adds `flex flex-row justify-start items-start gap-1.5 sm:gap-2` | 1 | **no** |
| `container` | no — adds `w-full max-w-xl mx-auto p-2 sm:p-3 md:p-4` | 1 | **no** |
| `stack` | no — adds `flex flex-col justify-start items-stretch gap-1.5 sm:gap-2` | 1 | **no** |
| `grid` | no — adds `grid grid-cols-2 gap-4` | 1 | **no** |

So the card's premise holds in full: all five named replacements change the rendered result, and four of the five drop `body` content **silently, at an unchanged element count**. `box` is the one class-transparent swap.

⚠️ And the honest half the card did not ask for: **`box` is not unconditionally drop-in either** — it also reads `children` only. The new guidance says so instead of selling it as one. Trading one false recommendation for another would have been worse than leaving the old text alone.

## The four surfaces, moved in one stroke

1. the console notice in `packages/components/src/renderers/basic/div.tsx`;
2. the machine-readable `deprecated.replacement` on the same registration;
3. `content/docs/components/basic/div.mdx` — callout, a new plain-wrapper migration section, and the `body`-to-`children` caveat;
4. the `components-basic-div` catalog category — a new `use-box-instead` fixture, the div-to-box before/after the guide was missing (index regenerated with the repo's own generator; `NODE_CENSUS` in `layout-dom-leak-5574` updated for the 2 box + 2 text nodes it adds).

All three prose surfaces now name `box` first for the mechanical swap, keep `card` / `flex` / `container` / `stack` / `grid` for the cases where their layout is actually wanted, and state the `body` move.

## The new pin answers the discriminating question

A pin asserting only "the notice mentions `box`" passes on a notice that mentions `box` **and** still recommends every non-drop-in replacement unchanged. So `div-guidance-names-box.test.tsx` pins the **measurement** and the **agreement**, never the presence of a word:

- the drop-in set is *measured* through the renderers, and must be exactly `box`;
- the bullet about the plain-wrapper case must offer **exactly that set** — this is the case that refuses the strictly-worse implementation;
- the notice, the declaration and the mdx must offer the **same set** of alternatives, and the catalog fixtures must demonstrate a subset of it including `box`;
- the two retired sentences must be **absent** from every surface;
- span's guidance must not have been swept in.

### Red-leg evidence (every mutation proved on disk by blob hash, every restore proved by an empty `git diff HEAD`)

| leg | mutation | result |
|---|---|---|
| R1 | revert **only** the mdx callout | new pin RED — "states the same alternatives on all four surfaces" and "no surface still carries the falsified recommendations" |
| R1b | same state, run the **five pre-existing** deprecation suites | **all 18 cases GREEN** — this is the non-regression axis, measured |
| R2 | delete **only** the new fixture | new pin RED (`expected [ 'card', 'flex', 'grid' ] to include 'box'`) |
| R2b | same state, five pre-existing suites | **all 18 cases GREEN** |
| R3 | **strictly worse**: mention `box` but keep `container`/`stack`/`grid` in the wrapper bullet | new pin RED (`expected [ 'box', 'container', 'grid', 'stack' ] to deeply equal [ 'box' ]`); the four-surface case stays green, which is exactly why this case exists |
| R4 | revert **only** the declaration | new pin RED, and objectui#6823's div arm RED |
| R5 | add `box` to **both** of span's statements | new pin RED (`expected [ 'badge', 'box', 'text' ] to deeply equal [ 'badge', 'text' ]`); objectui#6823 GREEN and every `toContain` pin on span's notice GREEN — only the `toEqual` on span's declaration reddens, so the notice half of that sweep is covered here and nowhere else |
| R6 | **the caricature** — one constant notice string for every component | objectui#6823 catches it (`expected [] to have a length of 1`, via its per-type header filter), and so does the new pin. Reporting this because the dispatch asked: **#6823 does catch the constant-notice mutation.** |

## Verification

- `pnpm exec vitest run packages/components/` — **245 files / 2260 tests passed**
- `pnpm exec vitest run examples/schema-catalog/` — 30 files / 2146 passed after the `NODE_CENSUS` update (it was the one red, and it is catalog authoring, not a renderer change)
- `pnpm exec vitest run scripts/__tests__/catalog-index-regenerable-4633.test.ts` — 6 passed (the generated index really is regenerable from the schemas dir)
- `pnpm --filter @object-ui/components type-check`, `pnpm --filter @object-ui/example-schema-catalog type-check` — both exit 0 after building each dependency closure. Confirmed the new test is really in the program: `tsc -p tsconfig.test.json --listFiles` names it.
- `eslint` on every changed file — 0 errors (2 pre-existing warnings in `div.tsx`, untouched lines)
- `node scripts/check-control-bytes.mjs` — OK, plus a manual control-byte scan of the changed files: no hits
- `node scripts/check-changeset-presence.mjs`, verdict line quoted verbatim:
  `✅  3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/6877-div-guidance-names-box.md.`
  A real `patch` on `@object-ui/components`, not an empty frontmatter — a published package's source moved. `check-changeset-no-major.mjs`: `✅  No changeset declares a major bump.`
- `check:doc-types` OK (188 files, every documented type registered), `check:doc-fences` OK, `check:doc-example-readers` OK
- `check:doc-examples` exits 2 on an unbuilt tree with "run the build first" — recorded as **NOT MEASURED**, not as a red

### ⚠️ What CI does and does not verify about the mdx edit

The mdx change is **not** inside a `plaintext` fence, so objectui#5250 does not apply to it — but neither does any existing gate *verify* it: `check-doc-component-types` reads type string literals in code blocks and my edit adds none, and `check-doc-snippet-types` compiles `ts`/`tsx` only. What does verify it is the new pin, which reads `div.mdx` off disk and holds its callout to the same alternative set as the notice and the declaration, and asserts the migration guide really references the new fixture id.

## Scope

- ⛔ `span` untouched — separate judgement, `box` is block-level. Asserted, not assumed (case 5 + leg R5).
- ⛔ `packages/core/src/registry/__tests__/component-deprecation-declaration.test.ts` also contains the old sentence and is deliberately **not** touched: it is a `DIV_LIKE` fixture registered on a private `Registry` instance to test the *reader*, not a surface of `div`'s deprecation. A find-and-replace would have swept it in.
- No governed surface in the diff. Left as **draft**, auto-merge not armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_