### PR TITLE
docs(scripts): put the fixture-discipline paragraph back under its heading

### DIFF
--- a/.changeset/8012-fixture-discipline-heading.md
+++ b/.changeset/8012-fixture-discipline-heading.md
@@ -1,0 +1,8 @@
+---
+---
+
+Move the `scripts/` is not in `SCAN_ROOTS` paragraph back under the
+`## Fixture discipline` heading it belongs to in
+`scripts/__tests__/check-shell-escape-residue.test.ts`'s docblock
+(objectui#8012). Prose only, inside a comment; no package is released by this
+change.

--- a/scripts/__tests__/check-shell-escape-residue.test.ts
+++ b/scripts/__tests__/check-shell-escape-residue.test.ts
@@ -50,6 +50,12 @@ import { REQUIRED_CONTEXTS } from '../dependabot-merge-gate.mjs';
  *
  * ## Fixture discipline
  *
+ * `scripts/` is not in `SCAN_ROOTS`, so this file could carry the literal
+ * plainly. It builds it from code points anyway — belt and braces against a
+ * future widening of the scan surface turning this suite into the gate's own
+ * first finding — and then PINS the constructed value against the shipped
+ * `RESIDUE_PATTERNS` entry, so a typo in the source literal reddens here.
+ *
  * ## The second skills root (objectui#7403)
  *
  * `SCAN_ROOTS` carries TWO skills trees: the published `skills/` and the
@@ -59,12 +65,6 @@ import { REQUIRED_CONTEXTS } from '../dependabot-merge-gate.mjs';
  * residue planted under `.claude/skills`, and — the case the miss itself asks
  * for — a root that walks to ZERO documents while every other root is healthy,
  * which must be NAMED AND RED rather than absorbed by a healthy total.
- *
- * `scripts/` is not in `SCAN_ROOTS`, so this file could carry the literal
- * plainly. It builds it from code points anyway — belt and braces against a
- * future widening of the scan surface turning this suite into the gate's own
- * first finding — and then PINS the constructed value against the shipped
- * `RESIDUE_PATTERNS` entry, so a typo in the source literal reddens here.
  *
  * ## Coverage, which is a different question from residue (objectui#7413)
  *


### PR DESCRIPTION
Fixes #8012

## What

`scripts/__tests__/check-shell-escape-residue.test.ts`'s header docblock carried an empty `## Fixture discipline` heading. The `## The second skills root (objectui#7403)` section had been inserted **between that heading and its own body**, leaving the body — the paragraph beginning ```scripts/` is not in `SCAN_ROOTS``` — two sections lower, with no heading of its own.

This moves that paragraph back under `## Fixture discipline`, above the #7403 section. Nothing else.

- Paragraph text unchanged, headings unchanged, neighbouring prose unchanged.
- No section reordered. `## Coverage, which is a different question from residue (objectui#7413)` stays at the **end** of the docblock — the arrangement PR #8010 chose rather than deepening the split.
- Diff shape: 6 insertions / 6 deletions in one file — the paragraph's five lines plus its trailing `*` separator, relocated.

## ⛔ There is no gate over this, and the diff is the evidence

Triage said so in advance, and this PR does not buy an assertion:

> ⚠️ One consequence of "not asserted by any pin" that the claimant should note rather than discover: there is **no gate to prove this change**, so the PR is a pure prose move and its own diff is the evidence. ⛔ Do not add a pin over the docblock's section structure.

So no pin, lint rule, snapshot or test was added over the docblock's section structure. That absence was measured rather than assumed, on the branch worktree with `git grep -nIF` (exit 0 = matches, 1 = none, ≥2 = error; exit captured before any pipe) and with firing controls in the same run:

| probe | exit | reading |
|---|---|---|
| control — `RESIDUE_PATTERNS` | 0 | 12 matches, instrument fires |
| control — `## Fixture discipline` | 0 | 3 matches, instrument fires on the heading class |
| `The second skills root` | 0 | 1 match — the file itself, line 53 |
| `check-shell-escape-residue.test.ts` | 0 | 4 matches — a workflow comment, a docs-guide sentence and two prose references in `check-shell-escape-residue.mjs`; all about the suite's *behaviour*, none about its docblock's sections |
| `eslint-plugin-jsdoc` | 1 | no jsdoc lint plugin |
| `jsdoc/` | 1 | no jsdoc rules configured |
| `__snapshots__` | 1 | no snapshots in this tree |

The suite reads `scripts/check-shell-escape-residue.mjs` and the workflow files; it never reads its own source.

## Checks

Run on the branch before pushing:

- `pnpm exec vitest run scripts/__tests__/check-shell-escape-residue.test.ts` — exit 0, **43 passed (43)**. Run because a nested `*/` inside a docblock closes the comment early; the file still parses.
- `pnpm type-check:scripts` (`tsc -p tsconfig.scripts.json`) — exit 0. `--listFiles` confirms the edited file is in that program (1 hit), so the green covers it.
- `pnpm lint:root` (`eslint .` over the root surface, which is where `scripts/` lives) — exit 0; 32 pre-existing warnings, 0 errors, none in the edited file.
- `node scripts/check-changeset-presence.mjs` — exit 0: *"0 of them published source of a package the release covers … no changeset is owed."* The `.changeset/*.md` here is therefore an **empty-frontmatter declaration** (AGENTS.md §9's first-class "not released" form), not a bump.
- Control-character self-scan over both touched files — clean, with an in-class control (`\x0b`) proving the pattern fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_