### PR TITLE
fix(plugin-detail): declare detail-section's headerColor as the closed six-token enum

### DIFF
--- a/.changeset/6955-headercolor-authoring-enum.md
+++ b/.changeset/6955-headercolor-authoring-enum.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/plugin-detail': minor
+---
+
+`detail-section`'s `headerColor` input is now the closed six-token vocabulary it
+has been contractually since objectui#6594, instead of a free-form `string`.
+
+**Breaking for authors, deliberately** (objectui's own breaking changes ship as
+`minor` — AGENTS.md 版本号策略). The registration declared
+`{ name: 'headerColor', type: 'string' }`, unchanged since before the vocabulary
+was ruled, while `DetailViewSection.headerColor` and its `@object-ui/types/zod`
+mirror are a six-member `z.enum` — `muted`, `muted/50`, `accent`, `primary/10`,
+`secondary/10`, `destructive/10` — matching `@objectstack/spec`'s strict
+`record:details` section schema (maintainer ruling A, 2026-08-26,
+objectstack#12126). The two ends disagreed about what an author may write: the
+registration said "any string", the validator said "one of six".
+
+`inputs` is not documentation. `detail-section` is outside `PUBLIC_BLOCKS`, so
+it never reaches `sdui.manifest.json` — but `PageRenderer` builds the JSX-page
+compiler's manifest from `getKnownTypes()` plus these same `inputs`, and
+`sdui-parser`'s `validateTree` judges an authored page against it. Before this
+change a value outside the six drew no diagnostic there at all; it now draws an
+`invalid-enum` **error** naming the prop and listing the legal tokens, so the
+refusal arrives while the page is being written rather than at parse time — or,
+for a value that happened to render under some host app's Tailwind build, never.
+
+Two things that did NOT change, and are pinned as such:
+
+- **The renderer's verbatim `bg-*` pass-through is untouched.** `headerColorClass`
+  still hands a complete `bg-*` class through unmodified. It stays an
+  **undeclared** affordance: ruling A refused to declare it, because whether such
+  a class renders depends on the host app's Tailwind build. That is why the input
+  declares exactly ONE arm — a `'string'` arm beside the enum would clear every
+  value again and declare the pass-through by accident.
+- **`@object-ui/types` is unchanged.** It was already correct; the published enum
+  is derived from `headerColorVocabulary` rather than hand-copied, so the
+  one-to-one pin objectui#6594 established carries this surface too.
+
+Authors writing one of the six are unaffected. An author writing anything else
+was already being refused by the validator and is now told so at authoring time.

--- a/packages/plugin-detail/package.json
+++ b/packages/plugin-detail/package.json
@@ -53,6 +53,7 @@
     "@object-ui/permissions": "workspace:*",
     "@object-ui/test-support": "workspace:*",
     "@object-ui/react": "workspace:*",
+    "@object-ui/sdui-parser": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",

--- a/packages/plugin-detail/src/__tests__/detailSectionHeaderColorEnum-6955.test.ts
+++ b/packages/plugin-detail/src/__tests__/detailSectionHeaderColorEnum-6955.test.ts
@@ -1,0 +1,214 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6955 — `detail-section.headerColor` is a CLOSED SIX-TOKEN authoring
+ * surface, and it REFUSES everything else.
+ *
+ * ## The defect this pins closed
+ *
+ * The registration in `../index.tsx` declared `{ name: 'headerColor', type:
+ * 'string' }`, unchanged since before the vocabulary was ruled. objectui#6594
+ * had already narrowed the other end — `DetailViewSection.headerColor` and its
+ * `@object-ui/types/zod` mirror are a six-member `z.enum`, matching
+ * @objectstack/spec's strict `record:details` section schema (maintainer
+ * ruling A, 2026-08-26, objectstack#12126). So the two ends disagreed about
+ * what an author may write: the registration said "any string", the validator
+ * said "one of six", and an author got no completion and no refusal at
+ * authoring time — discovery was at parse time, or, for a value that happened
+ * to render under some host app's Tailwind build, never.
+ *
+ * ## The surface this reads, and why it is the live one
+ *
+ * ⚠️ NOT `sdui.manifest.json`. `detail-section` is absent from
+ * `PUBLIC_BLOCKS` (`packages/core/src/registry/public-blocks.ts`) and its
+ * registration declares no `tier: 'public'`, so `gen-manifest.ts` — which
+ * serialises `getPublicConfigs()` — never writes it into `sdui.manifest.json`
+ * or `sdui-intrinsics.d.ts`. Its `inputs` are a live authoring surface all the
+ * same, through the other consumer:
+ * `packages/components/src/renderers/layout/page.tsx` builds the JSX-page
+ * compiler's manifest from `getKnownTypes()` plus these same `inputs`, and
+ * `sdui-parser`'s `validateTree` judges an authored page against it. That is
+ * exactly the reach `registry-inputs-spec-parity.test.ts` records for
+ * `element:record_picker`, which is likewise outside `PUBLIC_BLOCKS`.
+ *
+ * So `liveManifest()` below is built the way BOTH generators build theirs —
+ * from the live registry, never from a hand-written fixture that could agree
+ * with itself and prove nothing.
+ *
+ * ## What makes each row a reading rather than a restatement
+ *
+ * 1. THE REFUSAL. A seventh value draws an `invalid-enum` ERROR naming the
+ *    prop. This is the row the card turns on: a pin asserting merely that the
+ *    declaration MENTIONS the six would pass on a declaration that lists them
+ *    and still accepts anything else.
+ * 2. THE SIX ARE ACCEPTED. Narrowing must not cost a legal write.
+ * 3. NO FREE-TEXT ESCAPE HATCH — the trap this card is built around. A
+ *    six-option control that ALSO keeps a `'string'` arm would declare the
+ *    renderer's verbatim `bg-*` pass-through by accident, which ruling A
+ *    refused to declare. Pinned twice over: the declared arms are exactly
+ *    `['enum']`, and a `bg-*` value is REFUSED by this surface.
+ * 4. THE PASS-THROUGH IS UNCHANGED. The renderer still hands `bg-*` through
+ *    verbatim. Asserted beside row 3 so the asymmetry — refused as authoring
+ *    surface, honoured as a renderer affordance — cannot drift apart.
+ * 5. THE CONTROLS. A genuinely unknown prop is still reported, and a legal
+ *    value on a neighbouring key still passes, so rows 1-2's readings are
+ *    verdicts and not a validator that reports nothing (or everything).
+ * 6. THE VOCABULARY IS THE CONTRACT'S. The published `enum` is compared
+ *    against `DetailViewSectionSchema.shape.headerColor`'s own options, read
+ *    at runtime. The declaration derives its list from the renderer's resolver
+ *    map and this row derives its oracle from the Zod mirror, so the two sides
+ *    of this comparison have DIFFERENT sources — a self-confirming read would
+ *    be worth nothing here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ComponentRegistry } from '@object-ui/core';
+import { DetailViewSectionSchema } from '@object-ui/types/zod';
+import { inputTypeArms, manifestFromConfigs, validateTree } from '@object-ui/sdui-parser';
+import { headerColorClass } from '../headerColor';
+// Module scope, not a hook: this import IS the registration (AGENTS.md's
+// test-discipline section — an unbounded module load must not be billed to a
+// bounded window).
+import '../index';
+
+/** The tag an author writes, and the namespaced key the registry stores it under. */
+const TAG = 'detail-section';
+const NAMESPACE = 'plugin-detail';
+
+/** A value outside the vocabulary that is not `bg-*` shaped. */
+const SEVENTH_VALUE = 'blue-100';
+
+/** The shape of value the resolver hands through verbatim, and ruling A refused to declare. */
+const PASS_THROUGH_VALUE = 'bg-accent';
+
+/**
+ * The mirror's declared options, read from its own shape — never restated.
+ * Same accessor as `headerColor.contractPin-6594.test.ts`, which is the file
+ * that pins this mirror against the renderer's resolver in both directions.
+ */
+function contractVocabulary(): string[] {
+  const member = DetailViewSectionSchema.shape.headerColor;
+  const unwrapped = (member as { unwrap?: () => unknown }).unwrap?.() ?? member;
+  const options = (unwrapped as { options?: unknown }).options;
+  expect(
+    Array.isArray(options),
+    'DetailViewSectionSchema.headerColor should be an enum with declared options — a widening back to z.string() lands here',
+  ).toBe(true);
+  return [...(options as string[])];
+}
+
+/** The `headerColor` entry of the registration, read straight off the registry. */
+function declaredInput(): { type: unknown; enum?: unknown } {
+  const inputs = ((ComponentRegistry.getConfig(TAG, NAMESPACE) as unknown as {
+    inputs?: Array<{ name: string; type: unknown; enum?: unknown }>;
+  })?.inputs ?? []);
+  // Non-vacuity: an empty read (wrong tag/namespace) must fail here rather
+  // than silently pass every assertion built on it.
+  expect(inputs.map((i) => i.name), `${TAG} inputs`).toContain('fields');
+  const input = inputs.find((i) => i.name === 'headerColor');
+  expect(input, `${TAG} declares no headerColor input`).toBeDefined();
+  return input!;
+}
+
+/** The published option values, in either declaration form. */
+const declaredEnumValues = (): unknown[] =>
+  ((declaredInput().enum ?? []) as Array<string | { value: unknown }>).map((e) =>
+    typeof e === 'object' && e !== null ? e.value : e,
+  );
+
+/**
+ * A manifest built the way `gen-manifest.ts` and the JSX-page compiler build
+ * theirs — from the live registry — so these verdicts are the ones a real
+ * author gets.
+ */
+const liveManifest = () =>
+  manifestFromConfigs(
+    ComponentRegistry.getKnownTypes().map((type) => {
+      const meta = ComponentRegistry.getMeta(type);
+      return { type, namespace: meta?.namespace, isContainer: meta?.isContainer, inputs: meta?.inputs };
+    }) as unknown as Parameters<typeof manifestFromConfigs>[0],
+  );
+
+/**
+ * Diagnostics a one-node `<detail-section>` document draws. `fields` is always
+ * supplied because it is `required: true`, so only `headerColor` decides the
+ * verdict.
+ */
+const diagnose = (props: Record<string, unknown>) =>
+  validateTree({ type: TAG, fields: [{ name: 'amount' }], ...props } as never, liveManifest())
+    .diagnostics;
+
+const codesFor = (props: Record<string, unknown>, code: string): string[] =>
+  diagnose(props).filter((d) => d.code === code).map((d) => d.message);
+
+describe('objectui#6955 — the detail-section headerColor authoring surface refuses', () => {
+  it('REFUSES a seventh value, as an error naming the prop and the legal list', () => {
+    const refusals = diagnose({ headerColor: SEVENTH_VALUE }).filter(
+      (d) => d.code === 'invalid-enum',
+    );
+    expect(
+      refusals.length,
+      `<${TAG}> accepted headerColor="${SEVENTH_VALUE}" — the authoring surface is still free text`,
+    ).toBe(1);
+    expect(refusals[0].severity).toBe('error');
+    expect(refusals[0].message).toContain('headerColor');
+    expect(refusals[0].message).toContain(SEVENTH_VALUE);
+    // The message carries the legal list, so an author is told what to write.
+    for (const token of contractVocabulary()) {
+      expect(refusals[0].message).toContain(token);
+    }
+  });
+
+  it('ACCEPTS every token the contract declares, so narrowing costs no legal write', () => {
+    for (const token of contractVocabulary()) {
+      expect(
+        diagnose({ headerColor: token }).filter((d) => d.message.includes('headerColor')),
+        `<${TAG} headerColor="${token}"> should be clean`,
+      ).toEqual([]);
+    }
+  });
+
+  it('offers exactly ONE arm — no `string` beside the enum, so there is no free-text escape hatch', () => {
+    expect(
+      inputTypeArms(declaredInput().type as never),
+      'a `string` arm would clear every value again and declare the `bg-*` pass-through by accident',
+    ).toEqual(['enum']);
+  });
+
+  it('REFUSES the verbatim `bg-*` pass-through, which ruling A declined to declare', () => {
+    expect(declaredEnumValues()).not.toContain(PASS_THROUGH_VALUE);
+    expect(
+      codesFor({ headerColor: PASS_THROUGH_VALUE }, 'invalid-enum').length,
+      "declaring the pass-through would promise a class only the host app's Tailwind build can emit",
+    ).toBe(1);
+  });
+
+  it("leaves the renderer's pass-through behaviour UNCHANGED — the asymmetry is the ruling", () => {
+    expect(headerColorClass(PASS_THROUGH_VALUE)).toBe(PASS_THROUGH_VALUE);
+    for (const token of contractVocabulary()) {
+      expect(headerColorClass(token)).toBeDefined();
+    }
+  });
+
+  it('control — a genuinely unknown prop is still reported', () => {
+    expect(codesFor({ bogusProp: 'x' }, 'unknown-prop')).toEqual([
+      `<${TAG}> has no prop "bogusProp"`,
+    ]);
+  });
+
+  it('control — a neighbouring key still takes free text, so the refusal is about this key', () => {
+    expect(diagnose({ title: SEVENTH_VALUE })).toEqual([]);
+  });
+
+  it('publishes exactly the contract vocabulary, in order, from a DIFFERENT source', () => {
+    const contract = contractVocabulary();
+    expect(contract.length, 'the six-member enum should still be six').toBe(6);
+    expect(declaredEnumValues()).toEqual(contract);
+  });
+});

--- a/packages/plugin-detail/src/index.tsx
+++ b/packages/plugin-detail/src/index.tsx
@@ -16,6 +16,7 @@ import {
 import { withFieldCarrier } from '@object-ui/fields';
 import { DetailView } from './DetailView';
 import { DetailSection } from './DetailSection';
+import { headerColorVocabulary } from './headerColor';
 import { DetailTabs } from './DetailTabs';
 import { RelatedList } from './RelatedList';
 import { RecordDetailsRenderer } from './renderers/record-details';
@@ -333,7 +334,34 @@ ComponentRegistry.register('detail-section', DetailSection, {
     { name: 'defaultCollapsed', type: 'boolean' },
     { name: 'columns', type: 'number' },
     { name: 'showBorder', type: 'boolean' },
-    { name: 'headerColor', type: 'string' },
+    {
+      name: 'headerColor',
+      /**
+       * A CLOSED six-token vocabulary, not free text (objectui#6955).
+       *
+       * The values are `Object.keys(headerColorVocabulary)` rather than a
+       * fourth hand-written copy of the six. `./headerColor` is the renderer's
+       * resolver map, and `headerColor.contractPin-6594.test.ts` already pins
+       * it one-to-one against `DetailViewSection.headerColor` and its
+       * `@object-ui/types/zod` mirror in BOTH directions — so this surface
+       * inherits that pin instead of adding a copy that can drift out of it.
+       *
+       * ONE arm, and deliberately no `'string'` beside it. `['enum','string']`
+       * would clear every value again (any arm accepting a value clears the
+       * prop) and hand the authoring surface its free-text box back — and in
+       * doing so it would DECLARE the resolver's verbatim `bg-*` pass-through,
+       * which maintainer ruling A (2026-08-26, objectstack#12126) refused to
+       * declare because whether such a class renders depends on the host app's
+       * Tailwind build. The pass-through stays an UNDECLARED affordance:
+       * `headerColorClass` still hands a `bg-*` value through untouched, and
+       * this input still refuses it. Pinned as that asymmetry in
+       * `detailSectionHeaderColorEnum-6955.test.ts`.
+       */
+      type: 'enum',
+      enum: Object.keys(headerColorVocabulary),
+      description:
+        'Header tint, from the design system\'s closed palette: one of `muted`, `muted/50`, `accent`, `primary/10`, `secondary/10`, `destructive/10`. Any other value is refused — `@object-ui/types` parses this key as that same six-member enum (objectui#6594), matching @objectstack/spec\'s strict `record:details` section schema. Omit the key for no tint.',
+    },
   ],
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1876,6 +1876,9 @@ importers:
       '@object-ui/react':
         specifier: workspace:*
         version: link:../react
+      '@object-ui/sdui-parser':
+        specifier: workspace:*
+        version: link:../sdui-parser
       '@object-ui/test-support':
         specifier: workspace:*
         version: link:../test-support


### PR DESCRIPTION
Fixes #6955

## The deciding question, answered before anything was written

**Can `ComponentInput` carry an options list, and does the designer render it?** Read fresh off `packages/types/src/base.ts` on `origin/main` at `b1a14f28e`, not off the card:

- **YES, it can.** `ComponentInput` declares `enum?: string[] | { label: string; value: any }[]`, documented "for type='enum'". It is not one of the ADR-0049 tombstones — `label`, `defaultValue`, `advanced`, `inputType`, `min`, `max`, `step`, `placeholder` are `?: never`; `enum` is live.
- **And it is READ, by three consumers.** The manifest serializer forwards it in its fixed key list (`name`, `type`, `of`, `required`, `enum`, `binding`, `description`); `sdui-parser`'s `checkType` raises `invalid-enum` at **error** severity on a value outside the list; the codegen emits it as a TypeScript literal union.
- **The designer renders nothing of it — and never did.** No designer or app-shell inspector consults registry `inputs` at all. Re-measured here rather than inherited from the objectui#7493 census: the only non-test readers of `ComponentMeta.inputs` in the tree are `page.tsx:464`, the `sdui-parser` serializer and codegen, `Registry.ts:409`'s data-source injection seam, and one WRITE in `WidgetRegistry.ts:182`. So the designer half of the question is orthogonal to this card in both directions.
- objectui#6950, the card about `ComponentInput`'s declaration surface, was read alongside. It is **closed** (merged as PR #8297) and typed the framework-injected `binding` instead of casting it. It neither blocks nor constrains this.

⇒ **Branch taken: narrow to the six values** — triage's preferred outcome. The honest-label fallback was not needed.

## What changed

`packages/plugin-detail/src/index.tsx`, one input in the `detail-section` registration:

```ts
- { name: 'headerColor', type: 'string' },
+ { name: 'headerColor', type: 'enum', enum: Object.keys(headerColorVocabulary), description: '…' },
```

The six values are **derived, not hand-copied**: `headerColorVocabulary` is this package's own resolver map, and `headerColor.contractPin-6594.test.ts` already pins it one-to-one against `DetailViewSection.headerColor` and its `@object-ui/types/zod` mirror **in both directions**. A fourth hand-written copy would need a fourth pin; this one inherits the pin that exists. Read off the source, they are `muted`, `muted/50`, `accent`, `primary/10`, `secondary/10`, `destructive/10`.

**Exactly ONE arm, deliberately.** `['enum', 'string']` would clear every value again (any arm accepting a value clears the prop) and would thereby DECLARE the renderer's verbatim `bg-*` pass-through, which maintainer ruling A (2026-08-26, objectstack#12126) refused to declare because whether such a class renders depends on the host app's Tailwind build. That is the trap triage named, and it is pinned as a test rather than left to a comment.

## ⚠️ One premise of the dispatch is corrected here

The card and the triage comment both say the consequence runs through `gen-manifest.ts` into `sdui.manifest.json` and `sdui-intrinsics.d.ts`. **For this block it does not.** `gen-manifest.ts` serialises `getPublicConfigs()`, and `detail-section` is absent from `PUBLIC_BLOCKS` and declares no `tier: 'public'` — so it reaches neither artifact.

The defect and the fix are unchanged, because the surface is live through the *other* consumer: `packages/components/src/renderers/layout/page.tsx` builds the JSX-page compiler's manifest from `getKnownTypes()` plus these same `inputs`, and `validateTree` judges an authored page against it. That is exactly the reach `registry-inputs-spec-parity.test.ts` records for `element:record_picker`, likewise outside `PUBLIC_BLOCKS`. So the p2 grading survives intact — only the named artifact was wrong.

## The pins, and the red legs that make them readings

New file `packages/plugin-detail/src/__tests__/detailSectionHeaderColorEnum-6955.test.ts`, 8 tests. It builds its manifest from the **live registry**, the way both generators build theirs, never from a fixture that could agree with itself.

Every leg below was run from a COMMITTED tree, mutated on disk with a before/after occurrence count in both directions, and restored by asserting the file's blob hash equals its `HEAD` blob and that `git diff HEAD` is empty. Classification is per-test from vitest's **JSON reporter**.

| leg | mutation | result |
|---|---|---|
| **A — green** | none (as committed) | 8 passed / 0 failed, 0 failed suites |
| **B — the bug's own shape** | `type: 'enum'` + the list, back to `type: 'string'` | **4 failed / 4 passed** |
| **C — the caricature** | keep the six AND add a free-text arm: `type: ['enum', 'string']` | **3 failed / 5 passed** |

Leg B's four failures, read from the reporter, with their messages:

- *REFUSES a seventh value* — `accepted headerColor="blue-100" — the authoring surface is still free text: expected +0 to be 1`
- *offers exactly ONE arm* — `expected [ 'string' ] to deeply equal [ 'enum' ]`
- *REFUSES the verbatim `bg-*` pass-through* — `expected +0 to be 1`
- *publishes exactly the contract vocabulary* — `expected [] to deeply equal [ 'muted', 'muted/50', 'accent', …(3) ]`

The four that stayed green under leg B are the four that SHOULD: the six still parse (a `string` arm takes them), the renderer pass-through is untouched, and both controls still fire.

**Leg C is the one that matters for the trap.** The caricature — a six-option control that also keeps free text — leaves *"publishes exactly the contract vocabulary"* **GREEN**. A pin asserting only that the declaration lists the six would therefore have passed an implementation strictly worse than the bug. The three rows that go red are the refusal rows, on the arm count and on two refused values.

A mutation that did not land was reported as such rather than retried into silence: leg C's first anchor matched two sites in the file, the guard refused, printed `LEG C MUTATION DID NOT LAND — reading VOID`, and the leg was re-run with a unique two-line anchor.

## Non-regression axis — the plausible WRONG fix

The wrong fix narrows the validator or the renderer, breaking authors whose `bg-*` value renders today under their own Tailwind build. Both halves are covered:

- **`packages/types` is byte-for-byte untouched.** `views.zod.ts` blob `5c8a30dd…` and `views.ts` blob `7e6de89b…` are identical at `b1a14f28e` and at HEAD; `git diff --name-only BASE..HEAD -- packages/types` is empty.
- **The renderer's pass-through is unchanged and verified.** `headerColorClass('bg-accent')` still returns `'bg-accent'`, asserted in the same file as the refusal so the asymmetry — refused as authoring surface, honoured as a renderer affordance — cannot drift apart. `headerColor.ts` is not touched by this diff.

## Verification

Run from the repo root, paths relative to it, nothing after a bare `--`.

- `pnpm exec vitest run packages/plugin-detail/` — **146 files / 1309 tests passed**.
- `pnpm exec vitest run apps/console/src/__tests__/registry-inputs-spec-parity.test.ts apps/console/src/__tests__/component-input-union-specimens.test.ts packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts scripts/__tests__/unit-registry-absence-collision.test.ts` — **4 files / 273 tests passed**.
- `pnpm --filter @object-ui/plugin-detail type-check` — exit 0, on a tree built first with `pnpm --filter '@object-ui/plugin-detail^...' build`. On an UNBUILT tree it exits 2 with `TS2307 Cannot find module '@object-ui/core'`, which is a precondition, not a red gate. The new pin file is inside that check: `tsc -p tsconfig.test.json --listFiles` lists it (1 hit of 197 package files).
- `pnpm exec eslint packages/plugin-detail/src/index.tsx packages/plugin-detail/src/__tests__/detailSectionHeaderColorEnum-6955.test.ts` — exit 0, **0 errors**; the 31 warnings are pre-existing `react-refresh/only-export-components` and `no-explicit-any` at lines 93-244, above this diff's hunk.
- `node scripts/check-changeset-presence.mjs` — verdict line, quoted: `✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/6955-headercolor-authoring-enum.md.` Before the changeset was added the same script exited 1 naming `@object-ui/plugin-detail` / `packages/plugin-detail/src/index.tsx`. `node scripts/check-changeset-no-major.mjs` — `✅  No changeset declares a 'major' bump.` The bump is `minor`; `skip-changeset` was not used, and per the dispatch it is a phantom label here anyway.
- `pnpm check:control-bytes` ✅, `pnpm check:phantom-deps` ✅, `pnpm check:unused-deps` ✅, `node scripts/check-side-effects-array.mjs` ✅, `node scripts/check-governed-queue-guard.mjs --test …` — `NOT GOVERNED`.
- **NOT MEASURED, not red:** `pnpm check:eager-closure` exits 2 with `No eager-closure report … This is a broken gauge, not a passing budget` — it needs a built `apps/console/dist`. Same precondition class as `check:doc-snippets` / `check:doc-examples` / `check:readme-exports` and `check:sdui-registration-pins`. Left to CI, which builds first.

`@object-ui/sdui-parser` was added to `@object-ui/plugin-detail`'s **devDependencies** so the pin can drive the real validator — the same declaration `plugin-calendar`, `plugin-kanban` and `plugin-grid` already carry for the same kind of test. `check:phantom-deps` and `check:unused-deps` both pass with it. `devDependencies` is not one of the eight published-contract fields the changeset gate guards.

## Generated outputs

None to regenerate. `sdui.manifest.json`, `sdui-intrinsics.d.ts` and `sdui-blocks.md` are build-time artifacts written by `packages/sdui-parser/scripts/gen-manifest.ts` into an output dir; no copy of any of them is tracked in this repository, and `detail-section` is outside the public tier they cover regardless.

## Out of scope, filed rather than repaired here

objectui#8626 — every `detail-section` input is a FLAT prop name, while `DetailSection` reads `section.*` only, so the intersection of the two name sets is empty. Filed unassigned and ungraded. It is the shape question about the same eight lines; narrowing one input's value vocabulary neither creates nor worsens it, and repairing it is a product decision (adapt at the seam / declare `section` / retire the tag). Nothing in this pull request addresses objectui#8626.

## Merge posture

Draft, per the dispatch. Auto-merge is NOT armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S


---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_