### PR TITLE
fix(console): the `object` preview sample's status options are option objects

### DIFF
--- a/.changeset/objectui-6844-preview-sample-status-options.md
+++ b/.changeset/objectui-6844-preview-sample-status-options.md
@@ -1,0 +1,12 @@
+---
+---
+
+Dev-only. The metadata-designer preview gallery's `object` sample spelled its
+`status.options` as three bare strings, a shape `FieldSchema` refuses; they are
+now `{ label, value }` option objects, with the ledger reason in
+`preview-samples-spec-valid.test.ts` updated to match and new pins closing the
+two masks that hid the defect.
+
+Nothing published changes: `preview-samples.ts` is reachable only from
+`preview-gallery.html`, which is not an input of the console's production build,
+and every other file in this change is a test.

--- a/apps/console/src/__tests__/preview-samples-designer-options.test.tsx
+++ b/apps/console/src/__tests__/preview-samples-designer-options.test.tsx
@@ -30,7 +30,6 @@
  * designer as WIRED, not a component picked out by hand.
  */
 
-import * as React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 import { getMetadataInspector } from '@object-ui/app-shell';

--- a/apps/console/src/__tests__/preview-samples-designer-options.test.tsx
+++ b/apps/console/src/__tests__/preview-samples-designer-options.test.tsx
@@ -1,0 +1,120 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The `object` preview sample, read by the DESIGNER that renders it
+ * (objectui#6844).
+ *
+ * This sample's `status.options` were three bare strings, a shape `FieldSchema`
+ * refuses. `preview-samples-spec-valid.test.ts` now pins the contract half. This
+ * file pins the half a person actually sees, because the defect was masked
+ * TWICE and closing only one mask leaves the next one invisible:
+ *
+ *  1. Zod short-circuits at `objects.0.fields` on the sample's deliberate array
+ *     shape, so the options were never validated — the GATES could not see it.
+ *     (Pinned in the sibling file, by lifting the array to a record.)
+ *  2. `ObjectFieldInspector`'s `readOptions()` maps every entry through
+ *     `String(o?.value ?? '')`, which turns a bare string into an option with an
+ *     EMPTY value and no label. Three malformed options therefore rendered as
+ *     three BLANK rows in the picklist editor — a person opening the sample in
+ *     the designer saw an empty option list rather than an error. That is this
+ *     file.
+ *
+ * ⚠️ `undefined === undefined` is the trap this file exists to avoid. A pin
+ * asserting "the option editor renders three rows" passes on three blank ones,
+ * and a pin comparing two empty strings proves nothing at all. Every assertion
+ * below therefore names CONCRETE text — the codes and faces the sample teaches.
+ *
+ * The inspector is taken from the registry rather than imported, which is the
+ * route the console itself uses (`getMetadataInspector('object')`, registered by
+ * app-shell's `register-builtins` on package entry). So this renders the
+ * designer as WIRED, not a component picked out by hand.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { getMetadataInspector } from '@object-ui/app-shell';
+import { SAMPLES } from '../preview-samples';
+
+/**
+ * ONE fetch double, installed at module scope and never torn down
+ * (objectui#6640 / #7439). The inspector's `useObjectFields` issues a
+ * fire-and-forget `/meta/object` read that no barrier awaits, so a per-test
+ * teardown would restore the real fetch while the tree is still mounted and
+ * the read would escape to a live socket — happy-dom's document URL is
+ * `http://localhost:3000`, so a relative fetch is a real TCP connection.
+ * Nothing here depends on what the probe returns: the sample is passed in as
+ * `draft`, and the catalog this serves only feeds the LOOKUP target picker.
+ */
+vi.stubGlobal(
+  'fetch',
+  vi.fn(async () =>
+    new Response('[]', { status: 200, headers: { 'content-type': 'application/json' } }),
+  ),
+);
+
+afterEach(cleanup);
+
+/** The English placeholders of the two inputs each option row carries. */
+const VALUE_BOX = 'value';
+const LABEL_BOX = 'Label';
+
+function renderStatusInspector() {
+  const Inspector = getMetadataInspector('object');
+  // Not a formality: a missing registration would otherwise surface as
+  // React's "Element type is invalid", which reads like a broken test rather
+  // than a broken wiring.
+  expect(Inspector).toBeTruthy();
+  const Component = Inspector as NonNullable<typeof Inspector>;
+  render(
+    <Component
+      type="object"
+      name={String(SAMPLES.object.name)}
+      // The REAL sample, verbatim — including its deliberate array `fields`,
+      // so the inspector reaches `status` through `readFields()`'s array branch
+      // exactly as the preview gallery does.
+      draft={SAMPLES.object}
+      selection={{ kind: 'field', id: 'status' }}
+      onPatch={vi.fn()}
+      onClearSelection={vi.fn()}
+      onSelectionChange={vi.fn()}
+      readOnly={false}
+      locale="en-US"
+    />,
+  );
+}
+
+/** The text currently sitting in each box of the picklist editor. */
+const boxValues = (placeholder: string): string[] =>
+  screen.getAllByPlaceholderText(placeholder).map((el) => (el as HTMLInputElement).value);
+
+describe('object preview sample · the designer can read its picklist (objectui#6844)', () => {
+  it('reaches `status` through the array `fields` branch and renders it', () => {
+    renderStatusInspector();
+    // The field the selection names resolved out of an ARRAY `fields` draft —
+    // the branch this sample exists to cover. Its own Label box carries the
+    // authored face, so this is not satisfied by an empty inspector shell.
+    expect(screen.getAllByDisplayValue('Status').length).toBeGreaterThan(0);
+  });
+
+  it('shows all three options — not three blank rows', () => {
+    renderStatusInspector();
+
+    // Count first. Deleting the options would leave the editor's single blank
+    // starter row, so `3` is itself load-bearing.
+    expect(boxValues(VALUE_BOX)).toHaveLength(3);
+    expect(boxValues(LABEL_BOX)).toHaveLength(3);
+
+    // Then the content, literally. Before the fix every one of these six boxes
+    // was '' — `readOptions` produced `value: String(o?.value ?? '')` = '' and
+    // no label at all, and the editor rendered `value={o.label ?? ''}`.
+    expect(boxValues(VALUE_BOX)).toEqual(['draft', 'open', 'closed']);
+    expect(boxValues(LABEL_BOX)).toEqual(['Draft', 'Open', 'Closed']);
+
+    // Said once more as the property that actually failed, so a future reader
+    // sees the claim and not only the fixtures: no box is blank.
+    for (const text of [...boxValues(VALUE_BOX), ...boxValues(LABEL_BOX)]) {
+      expect(text).not.toBe('');
+    }
+  });
+});

--- a/apps/console/src/__tests__/preview-samples-spec-valid.test.ts
+++ b/apps/console/src/__tests__/preview-samples-spec-valid.test.ts
@@ -61,6 +61,12 @@
 
 import { describe, it, expect } from 'vitest';
 import { ObjectStackSchema } from '@objectstack/spec';
+// `SelectOptionSchema` is NOT on the spec's root export — it is reachable only
+// at the `/data` subpath (measured on 17.3.0: importing it from the root is a
+// hard `SyntaxError`, "does not provide an export named"). Worth spelling out,
+// because the near-miss fails toward "nothing to assert here".
+import { SelectOptionSchema } from '@objectstack/spec/data';
+import { readFields } from '@object-ui/app-shell/views/metadata-admin/previews/object-fields-io';
 import { SAMPLES } from '../preview-samples';
 
 /**
@@ -134,38 +140,38 @@ const SPEC_CLEAN = [
  * delete the only thing keeping the gallery's examples honest.
  */
 const KNOWN_STALE: Record<string, string> = {
-  // TWO defects, and the reason says both on purpose (objectui#6647). A row
-  // here records what a reader would be rejected for, and a reason naming only
-  // the first blocker sends whoever fixes it back to a sample that is STILL
-  // red with no note — which is exactly how this row read until #6647.
+  // ONE defect, and it is the DELIBERATE one (objectui#6844). This row named
+  // TWO until #6844 fixed the second; a row here records what a reader would be
+  // rejected for, and a reason naming a blocker that is no longer there
+  // over-states what remains — the mirror of the defect objectui#6647 was
+  // itself filed about, so the reason is maintained in the same PR as the fix.
   //
-  // 1. The array `fields` — NOT a typo:
-  //    `packages/app-shell/.../object-fields-io.ts` `readFields()` branches on
-  //    `shape: 'array' | 'record'` and round-trips whichever the draft used, so
-  //    this sample is what covers the array branch in the gallery. Rewriting it
-  //    to a record would drop that coverage while leaving the designer still
-  //    able to author a shape ObjectSchema rejects, which is the actual
-  //    question (AGENTS.md #0.1) — an app-shell question, not a
-  //    preview-samples one.
+  // What remains — the array `fields`, NOT a typo:
+  //   `packages/app-shell/.../object-fields-io.ts` `readFields()` branches on
+  //   `shape: 'array' | 'record'` and round-trips whichever the draft used, so
+  //   this sample is what covers the array branch in the gallery. Rewriting it
+  //   to a record would drop that coverage while leaving the designer still
+  //   able to author a shape ObjectSchema rejects, which is the actual question
+  //   (AGENTS.md #0.1) — an app-shell question, not a preview-samples one.
   //
-  // 2. `status.options` as bare strings, where `FieldSchema` wants option
-  //    OBJECTS (`{ label, value }`; an empty `{}` reports both as missing).
-  //    Unlike (1) this one is not deliberate — the designer cannot read it
-  //    either (`ObjectFieldInspector`'s `readOptions()` does
-  //    `String(o?.value ?? '')`, so three string options render as three BLANK
-  //    rows) — but re-authoring it means inventing the `value` codes the sample
-  //    should demonstrate, which is a sample-content decision, not a mechanical
-  //    re-spelling. Filed separately rather than smuggled in here.
+  // What is GONE — `status.options` as bare strings, where `FieldSchema` wants
+  // option OBJECTS. Fixed in objectui#6844 as `{ label, value }` pairs; the
+  // `value` codes are the spec's own system-identifier spelling, since
+  // `SelectOptionSchema.value` refuses `'Draft'` by format.
   //
-  // Both are measured against spec 17.2.0; only (1) is REPORTED today, because
-  // the parse short-circuits at `objects.0.fields` before it ever descends into
-  // a field. That masking is the whole hazard this ledger row now records: the
-  // third defect, `reference_to` on the lookup field, hid behind it for four
-  // spec releases and was fixed in #6647 — see its RETIRED_KEYS pin below,
-  // which is what stops it (or its twin) drifting back in while this row's
-  // quarantine keeps the reverse assertion satisfied on the array shape alone.
+  // ⚠️ Neither the gates nor the product could SEE that second defect, which is
+  // why it lived here in prose for as long as it did:
+  //   • the parse short-circuits at `objects.0.fields` on the array shape, and
+  //     the reverse assertion below only asks for `length > 0` — which the
+  //     array shape satisfies forever;
+  //   • `ObjectFieldInspector`'s `readOptions()` does `String(o?.value ?? '')`,
+  //     so the three strings rendered as three BLANK rows rather than an error.
+  // Prose is not a gate, so both masks are now pinned instead of narrated —
+  // see the objectui#6844 block at the bottom of this file for the first
+  // (everything but the array shape must parse clean), and
+  // `preview-samples-designer-options.test.tsx` for the second.
   object:
-    '`fields` is an array; ObjectSchema wants a record keyed by field name (deliberate — it covers the array branch of `readFields()`). Fixing that alone is NOT enough: `status.options` are bare strings where the spec wants `{ label, value }` objects, reported only once the array shape stops short-circuiting the parse.',
+    '`fields` is an array; ObjectSchema wants a record keyed by field name (deliberate — it covers the array branch of `readFields()`). It is the ONLY remaining defect: with the array shape lifted to a record this sample parses clean, pinned below.',
   dashboard: 'widgets miss `dataset`/`values` and use retired `value`/`format`; `chart` is not a widget type',
   translation:
     'the `translations` collection is Array< Record< locale, TranslationData > >, but this sample is the metadata-RECORD form (name/label/locale/data) the console edits — so this row is a mapping mismatch, not necessarily a stale sample. Settle which contract the sample targets before guarding it.',
@@ -355,4 +361,112 @@ describe('preview-samples conform to @objectstack/spec', () => {
       expect([...keyNamesIn(SAMPLES[type])]).not.toContain(key);
     },
   );
+});
+/**
+ * objectui#6844 — the `object` row's reason, ASSERTED instead of narrated.
+ *
+ * The reverse assertion above asks the `object` row for `length > 0`, and the
+ * deliberate array `fields` shape supplies exactly that, forever. Zod
+ * short-circuits at `objects.0.fields` before descending into a single field,
+ * so every defect BELOW that point on this sample is invisible to the gate —
+ * which is how `status.options` sat here as bare strings, recorded only in
+ * prose, and how `reference_to` rode along for four spec releases before it.
+ *
+ * The fix for one malformed option is not the same as the fix for the mask.
+ * Repairing the sample alone would leave the NEXT one exactly as invisible, so
+ * the mask is closed here: with the array shape lifted to the record the spec
+ * wants, the sample must parse CLEAN. That makes "the array shape is the only
+ * thing wrong with this sample" a measured claim rather than a comment, and it
+ * is the assertion that goes red the day a new defect lands under it.
+ *
+ * ⚠️ Cleanliness alone is not enough, which is the second `it` below. A sample
+ * with `status.options` DELETED parses just as clean, and it would be strictly
+ * worse than the bug — the field that exists to demonstrate a picklist would
+ * stop demonstrating one. So presence and concrete content are pinned too.
+ */
+describe('object sample: the deliberate array `fields` shape is its ONLY defect (objectui#6844)', () => {
+  /**
+   * The `object` sample with its array `fields` lifted to the record shape
+   * `ObjectSchema` wants — i.e. the sample minus its one deliberate defect.
+   * Nothing else is touched, so every issue this reports belongs to a field.
+   */
+  function objectSampleAsRecord(): Record<string, unknown> {
+    const sample = SAMPLES.object as { fields: Array<Record<string, unknown>> };
+    return {
+      ...sample,
+      fields: Object.fromEntries(sample.fields.map((f) => [String(f.name), f])),
+    };
+  }
+
+  /** The sample's `status` field definition, read off the authored array. */
+  function statusField(): Record<string, unknown> {
+    const sample = SAMPLES.object as { fields: Array<Record<string, unknown>> };
+    const field = sample.fields.find((f) => f.name === 'status');
+    if (!field) throw new Error('the `object` sample no longer has a `status` field');
+    return field;
+  }
+
+  it('parses clean once the array shape stops short-circuiting the parse', () => {
+    const result = ObjectStackSchema.safeParse({ objects: [objectSampleAsRecord()] });
+    const issues = result.success
+      ? []
+      : result.error.issues.map((i) => `${i.code}@[${i.path.join('.')}] ${i.message}`);
+    // Listed, not counted: a failure here has to name the new defect, because
+    // naming it is the whole point of taking the quarantine's word away.
+    expect(issues).toEqual([]);
+  });
+
+  it('still TEACHES a picklist — the options are present, and concrete', () => {
+    const options = statusField().options;
+    // Presence first. `toEqual([])` above passes on a sample with `options`
+    // deleted outright, and that would be strictly worse than the defect.
+    expect(Array.isArray(options)).toBe(true);
+    expect(options as unknown[]).toHaveLength(3);
+
+    // Shape: option OBJECTS, each one a document `SelectOptionSchema` accepts
+    // on its own. A bare string fails this by itself, without needing the
+    // whole-stack parse above.
+    for (const option of options as unknown[]) {
+      expect(typeof option).toBe('object');
+      expect(SelectOptionSchema.safeParse(option).success).toBe(true);
+    }
+
+    // Content, spelled out. Asserting "label is a non-empty string" would pass
+    // on any three placeholders; these are the codes and faces the sample
+    // exists to teach, so they are pinned literally.
+    expect((options as Array<Record<string, unknown>>).map((o) => o.value)).toEqual([
+      'draft',
+      'open',
+      'closed',
+    ]);
+    expect((options as Array<Record<string, unknown>>).map((o) => o.label)).toEqual([
+      'Draft',
+      'Open',
+      'Closed',
+    ]);
+  });
+
+  it('refuses the Title-Case `value` a reader might reach for first', () => {
+    // Why the codes are lowercase is not a house style: `SelectOptionSchema`'s
+    // `value` is a SYSTEM IDENTIFIER. Pinned as a pair so the reason survives
+    // — the accepted arm alone would also pass if the format rule vanished.
+    expect(SelectOptionSchema.safeParse({ label: 'Draft', value: 'draft' }).success).toBe(true);
+    expect(SelectOptionSchema.safeParse({ label: 'Draft', value: 'Draft' }).success).toBe(false);
+  });
+
+  /**
+   * The non-regression axis, aimed at the plausible WRONG fix rather than at
+   * the bug: "tidy the sample up" — repair the options AND the array `fields`
+   * in one pass. That deletes the gallery's only coverage of `readFields()`'s
+   * array branch, silently, while every other assertion in this file goes
+   * greener. Both halves are asserted: the shape as authored, and the shape
+   * the real reader classifies it as.
+   */
+  it('keeps the array `fields` shape, and `readFields()` still takes its array branch', () => {
+    expect(Array.isArray(SAMPLES.object.fields)).toBe(true);
+    expect(readFields(SAMPLES.object.fields).shape).toBe('array');
+    // And the branch actually carries the field this card is about, so the
+    // coverage is over the sample as it stands rather than over an empty list.
+    expect(readFields(SAMPLES.object.fields).entries.map((e) => e.name)).toContain('status');
+  });
 });

--- a/apps/console/src/__tests__/preview-samples-spec-valid.test.ts
+++ b/apps/console/src/__tests__/preview-samples-spec-valid.test.ts
@@ -66,7 +66,6 @@ import { ObjectStackSchema } from '@objectstack/spec';
 // hard `SyntaxError`, "does not provide an export named"). Worth spelling out,
 // because the near-miss fails toward "nothing to assert here".
 import { SelectOptionSchema } from '@objectstack/spec/data';
-import { readFields } from '@object-ui/app-shell/views/metadata-admin/previews/object-fields-io';
 import { SAMPLES } from '../preview-samples';
 
 /**
@@ -477,11 +476,22 @@ describe('object sample: the deliberate array `fields` shape is its ONLY defect 
    * greener. Both halves are asserted: the shape as authored, and the shape
    * the real reader classifies it as.
    */
-  it('keeps the array `fields` shape, and `readFields()` still takes its array branch', () => {
+  it('keeps the array `fields` shape that selects `readFields()`\'s array branch', () => {
+    // `readFields(fieldsInput)` in app-shell's
+    // `views/metadata-admin/previews/object-fields-io.ts` opens with
+    // `if (Array.isArray(fieldsInput)) return { shape: 'array', … }`. That
+    // predicate is asserted here rather than the function imported: app-shell's
+    // `exports` map publishes `.` and `./styles.css` only, and `readFields` is
+    // on neither, so a deep import would type-check solely by accident of the
+    // console's Vite alias — green under vitest, red under `tsc`.
     expect(Array.isArray(SAMPLES.object.fields)).toBe(true);
-    expect(readFields(SAMPLES.object.fields).shape).toBe('array');
-    // And the branch actually carries the field this card is about, so the
-    // coverage is over the sample as it stands rather than over an empty list.
-    expect(readFields(SAMPLES.object.fields).entries.map((e) => e.name)).toContain('status');
+    // And the branch carries the field this card is about, so the coverage is
+    // over the sample as it stands rather than over an empty list.
+    expect(
+      (SAMPLES.object.fields as Array<Record<string, unknown>>).map((f) => f.name),
+    ).toContain('status');
+    // The branch is also RUN, not merely selected: the sibling
+    // `preview-samples-designer-options.test.tsx` renders the real inspector
+    // over this same draft, and it reaches `status` only through `readFields`.
   });
 });

--- a/apps/console/src/__tests__/preview-samples-spec-valid.test.ts
+++ b/apps/console/src/__tests__/preview-samples-spec-valid.test.ts
@@ -386,24 +386,39 @@ describe('preview-samples conform to @objectstack/spec', () => {
  */
 describe('object sample: the deliberate array `fields` shape is its ONLY defect (objectui#6844)', () => {
   /**
-   * The `object` sample with its array `fields` lifted to the record shape
-   * `ObjectSchema` wants — i.e. the sample minus its one deliberate defect.
-   * Nothing else is touched, so every issue this reports belongs to a field.
+   * The sample's `fields` keyed by field name, whichever shape they are
+   * authored in.
+   *
+   * Shape-agnostic ON PURPOSE, even though the array is what this sample
+   * carries: the wrong fix these pins guard against is "tidy it up to a
+   * record", and if these helpers only spoke array then that fix would make
+   * every assertion below explode with a `TypeError` instead of letting the
+   * ONE pin that is about the shape say so. The lift is otherwise verbatim —
+   * no key is stripped, so a retired key re-added to a field still reaches the
+   * parse below.
    */
-  function objectSampleAsRecord(): Record<string, unknown> {
-    const sample = SAMPLES.object as { fields: Array<Record<string, unknown>> };
-    return {
-      ...sample,
-      fields: Object.fromEntries(sample.fields.map((f) => [String(f.name), f])),
-    };
+  function objectFieldsAsRecord(): Record<string, unknown> {
+    const fields = (SAMPLES.object as { fields: unknown }).fields;
+    if (!Array.isArray(fields)) return fields as Record<string, unknown>;
+    return Object.fromEntries(
+      (fields as Array<Record<string, unknown>>).map((f) => [String(f.name), f]),
+    );
   }
 
-  /** The sample's `status` field definition, read off the authored array. */
+  /**
+   * The `object` sample minus its one deliberate defect — i.e. with `fields`
+   * in the record shape `ObjectSchema` wants. Nothing else is touched, so
+   * every issue this reports belongs to a field.
+   */
+  function objectSampleAsRecord(): Record<string, unknown> {
+    return { ...(SAMPLES.object as Record<string, unknown>), fields: objectFieldsAsRecord() };
+  }
+
+  /** The sample's `status` field definition. */
   function statusField(): Record<string, unknown> {
-    const sample = SAMPLES.object as { fields: Array<Record<string, unknown>> };
-    const field = sample.fields.find((f) => f.name === 'status');
+    const field = objectFieldsAsRecord().status;
     if (!field) throw new Error('the `object` sample no longer has a `status` field');
-    return field;
+    return field as Record<string, unknown>;
   }
 
   it('parses clean once the array shape stops short-circuiting the parse', () => {

--- a/apps/console/src/preview-samples.ts
+++ b/apps/console/src/preview-samples.ts
@@ -11,7 +11,33 @@ export const SAMPLES: Record<string, Record<string, unknown>> = {
     fields: [
       { name: 'name', label: 'Order Name', type: 'text', required: true },
       { name: 'amount', label: 'Amount', type: 'currency' },
-      { name: 'status', label: 'Status', type: 'select', options: ['Draft', 'Open', 'Closed'] },
+      // Option OBJECTS, not bare strings (objectui#6844). `FieldSchema` refuses
+      // a string here — `invalid_type`, "expected object, received string", one
+      // per entry — and the designer could not read them either
+      // (`ObjectFieldInspector`'s `readOptions()` does `String(o?.value ?? '')`,
+      // so the three strings rendered as three BLANK rows in the option editor).
+      //
+      // The `value` codes are NOT a matter of taste: `SelectOptionSchema.value`
+      // is a SYSTEM IDENTIFIER, so `'Draft'` is rejected outright
+      // (`invalid_format`, "must be lowercase, starting with a letter, and may
+      // contain letters, numbers, underscores, or dots"; minimum two
+      // characters). The authored strings therefore become the human `label`
+      // and the machine code is its lowercase spelling — the pairing the whole
+      // ecosystem already writes, from `os init`'s generated object down to the
+      // showcase objects. `label` + `value` are exactly the two members an
+      // empty `{}` here reports as missing, and nothing beyond them is invented:
+      // `color`, `default` and `visibleWhen` are all accepted, but a sample
+      // teaches what it shows, and this field exists to demonstrate a picklist.
+      {
+        name: 'status',
+        label: 'Status',
+        type: 'select',
+        options: [
+          { label: 'Draft', value: 'draft' },
+          { label: 'Open', value: 'open' },
+          { label: 'Closed', value: 'closed' },
+        ],
+      },
       { name: 'close_date', label: 'Close Date', type: 'date' },
       // The lookup target is `reference` (objectui#6647). `reference_to` is
       // refused BY NAME by `FieldSchema` — `unrecognized_keys` with its own


### PR DESCRIPTION
Fixes #6844

`preview-samples.ts`'s `object` sample declared `options: ['Draft', 'Open', 'Closed']` on its `status` field — three bare strings, where `FieldSchema` wants option OBJECTS.

## The parse ladder, re-measured

The card's ladder was measured against installed `@objectstack/spec` **17.2.0**; this repo now installs **17.3.0** (`node_modules/@objectstack/spec/package.json`). Re-run today against what is installed, over `ObjectStackSchema.safeParse`:

| document | issues |
|---|---|
| the sample as authored | **1** — `objects.0.fields`, `invalid_type`, "expected record, received array" (the deliberate array shape, short-circuiting) |
| array `fields` lifted to a record | **3** — `objects.0.fields.status.options.0..2`, `invalid_type`, "expected object, received string" |
| the same, with an empty `{}` as one option (positive control) | **2** — `label` and `value` both reported missing |

So the reading is unchanged across 17.2.0 → 17.3.0. **The card's premise holds.**

⚠️ The import trap the dispatch warned about is real and worth recording: `FieldSchema` / `SelectOptionSchema` are **not on the spec's root export** in 17.3.0 — importing them from `@objectstack/spec` is a hard `SyntaxError` ("does not provide an export named"). They live at `@objectstack/spec/data`. The near-miss fails toward "nothing to fix".

## The decision this card was about: the `value` codes

⭐ **They are not a matter of taste, and that is the finding.** `SelectOptionSchema.value` is a **system identifier**, so the authored strings could not have become the codes even if someone wanted them to:

```
{ label: 'Draft', value: 'draft' }   -> ACCEPT
{ label: 'Draft', value: 'Draft' }   -> invalid_format: "System identifier must be lowercase,
                                        starting with a letter, and may contain letters, numbers,
                                        underscores, or dots"
{ label: 'X',     value: 'd' }       -> too_small: "System identifier must be at least 2 characters"
```

⇒ the authored `Draft` / `Open` / `Closed` become the human **`label`**, and the machine code is its lowercase spelling.

**Convention followed, with the evidence:** `{ label: TITLE_CASE, value: lowercase_identifier }` is what the ecosystem already writes, and `draft`/`Draft` specifically is the most attested pair there is —

* `objectstack` `packages/cli/src/commands/init.ts` — the **scaffolder**, i.e. the peer of this file on the platform side, emits `{ label: 'Draft', value: 'draft' }`;
* `objectstack` `packages/cli/src/lint/corpus.ts`, and the showcase objects (`invoice`, `expense-report`, `client-brief`, `contact`, `inquiry`);
* in this repo, `packages/app-shell/src/views/metadata-admin/anchors.page-seed.test.ts` carries the *identical* field: `status: { type: 'select', options: [{ value: 'draft', label: 'Draft' }, …] }`.

**Nothing beyond `label` + `value` is invented.** Those are exactly the two members the positive control reports as missing on `{}`. `color`, `default` and `visibleWhen` are all accepted by the schema and all appear in showcase objects, but a sample teaches what it shows, and this field exists to demonstrate a picklist — adding a colour or a default would be a second content decision riding along unasked.

## ⭐ The durability half — decided, and decided against a coercion

The defect was masked twice, and repairing the sample alone leaves the NEXT malformed option exactly as invisible. The two masks got different answers.

**Mask 1 — the gates — is CLOSED here.** The ledger's reverse assertion asks the `object` row for `length > 0`, and the deliberate array shape satisfies that forever, so nothing below `objects.0.fields` was ever validated. The new pin lifts the array to a record and demands the sample parse **clean**, which turns "the array shape is the only thing wrong with this sample" from a comment into a measurement — and it is what goes red the day a new defect lands underneath.

**Mask 2 — `ObjectFieldInspector`'s `readOptions` — is filed, not repaired: objectui#8632.** Reasoning, stated as the order requires:

* The only *mechanical* repair is to coerce a bare string into `{ value: STRING, label: STRING }` so it renders. That is precisely the tolerant renderer fallback **AGENTS.md #0.1 bans** — the spec refuses that shape at the producer, and a designer that silently makes it work fossilises a second de-facto contract and hides the producer's bug. Doing it *in the file that teaches authors the right shape* would be the sharpest possible version of that mistake.
* The non-coercing repair is a decision about what the surface should **say** (mark the row? route it through `clientValidation`? accept it?), which is a product change in a published package plus its strings in ten locales. objectui#8632 lays out those three options and takes no recommendation.
* ⚠️ That card also carries a consequence this PR's investigation turned up and the original card did not: `OptionsEditor.commit` persists only `next.filter((o) => o.value.trim() !== '')`, so the malformed rows are not merely invisible — they are **deleted** from the draft on the next unrelated edit to that field.

What this PR does instead is pin the rendered face of *this* sample against concrete text, through the registry-resolved inspector, so a regression here is loud even though the general reader is unchanged.

## The pins, and the mutation each one answers

`apps/console/src/__tests__/preview-samples-spec-valid.test.ts`

1. **parses clean once the array shape stops short-circuiting** — mask 1.
2. **still TEACHES a picklist — the options are present, and concrete** — presence, per-option `SelectOptionSchema` acceptance, and the literal codes/labels.
3. **refuses the Title-Case `value` a reader might reach for first** — the accept/reject pair that carries the *reason* the codes are lowercase.
4. **keeps the array `fields` shape that selects `readFields()`'s array branch** — the non-regression axis.

`apps/console/src/__tests__/preview-samples-designer-options.test.tsx` (new) — resolves the inspector the way the console does (`getMetadataInspector('object')`) and renders it over the **real** sample draft.

5. **reaches `status` through the array `fields` branch and renders it**
6. **shows all three options — not three blank rows**

### Reverse verification — every leg mutated on disk (before/after counts), run, restored, and classified from vitest's JSON reporter

| leg | mutation | result |
|---|---|---|
| **A** — the bug | options back to bare strings | **3 RED.** `expected [ '', '', '' ] to deeply equal [ 'draft', 'open', 'closed' ]` — the three BLANK rows, observed directly; plus the parse-clean pin and the shape pin |
| **B** — the plausible WRONG FIX | array `fields` converted to a record | **2 RED**, and the right two: pin 4 (`expected false to be true`) and the pre-existing reverse assertion demanding promotion. Pins 1–3 keep asserting their own claim, which is why the helpers are shape-agnostic |
| **C1** — the caricature the discriminating question names | `status.options` **deleted entirely** | **2 RED** (`expected [ '' ] to have a length of 3 but got 1`; presence pin) — while pin 1 **PASSES**, which is the control: "the sample parses cleanly" alone would have accepted a strictly-worse sample |
| **C2** — the caricature | `readOptions` returns a constant for every input | **1 RED**: `expected [ 'constant', 'constant', 'constant' ] to deeply equal [ 'draft', 'open', 'closed' ]` |

⚠️ **One void leg is reported as void, not retried into a pass.** The first attempt at leg B converted the fields with a regex that missed the multi-line `status` entry, so the file did not parse: vitest reported `numTotalTests: 0` with a `Transform failed … [PARSE_ERROR]` per suite. That is a suite-load failure, **not** a red assertion — it was discarded and the mutation rewritten to land as valid TypeScript, which is the run in the table.

## The `KNOWN_STALE` reason — updated in this PR, as ordered

PR #6845 recorded this defect inside that reason to keep the ledger honest; leaving it would put the ledger back to over-stating what remains, which is the mirror of the defect objectui#6647 was itself filed about.

**Verified before rewriting** (the dispatch asked): after this change, rung 2 of the ladder is **empty** — the deliberate array shape really is the only thing left, so nothing else had accumulated in that row. The reason now says exactly that, and points at the pin that keeps it true.

⛔ The array `fields` shape is untouched. objectui#6153 and objectui#4356 are adjacent cards at a different layer and are not addressed here.

## Verification

* `pnpm exec vitest run apps/console/` — **91 files, 1078 tests, all passed** (the whole `@object-ui/console` project, root-relative form).
* `pnpm --filter @object-ui/console type-check` — **exit 0, 0 errors**, echoing `tsc --noEmit && tsc -b tsconfig.node.json --force`. ⚠️ On an **unbuilt** tree the same command reports 395 errors, all `TS2307`/`TS2882` "Cannot find module '@object-ui/…'"; that is the precondition, not a result. Read after `pnpm --filter '@object-ui/console^...' build`.
  * That precondition caught a real defect in the first draft of these tests: `import { readFields } from '@object-ui/app-shell/views/…/object-fields-io'` resolves under vitest **only** through the console's Vite alias — app-shell's `exports` map publishes `.` and `./styles.css` and nothing else — so it was green under vitest and `TS2307` under `tsc`. The pin now asserts `Array.isArray(fields)`, which *is* the predicate `readFields` branches on, and names the DOM pin as the place the branch is actually run.
* `pnpm exec eslint <the three changed files>` — exit 0, no output. (Plain form; `--no-inline-config` is an objectstack convention, not this repo's.)
* Control-byte sweep over the changed files: no hits.

## Changeset

`node scripts/check-changeset-presence.mjs`, verbatim verdict:

> ✅  2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/objectui-6844-preview-sample-status-options.md.
> Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.

Empty frontmatter is the honest declaration, and it was checked rather than assumed: `preview-samples.ts` is reachable only from `preview-gallery.tsx`, whose entry `preview-gallery.html` is **not** an input of the console's production build (`apps/console/vite.config.ts` declares no `rollupOptions.input`, so Vite builds `index.html` alone). Everything else in this change is a test. `node scripts/check-changeset-no-major.mjs` — exit 0.

Session: `session_01YBWFb5YgMU5dw8p2VKj16S`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_