### PR TITLE
fix(console): tombstone a deleted record reference in the approvals inbox, never the raw record id

### DIFF
--- a/.changeset/7108-approvals-inbox-dead-record-tombstone.md
+++ b/.changeset/7108-approvals-inbox-dead-record-tombstone.md
@@ -1,0 +1,28 @@
+---
+"@object-ui/console": patch
+---
+
+Approvals inbox: a record that was deleted now renders a "record deleted"
+tombstone instead of degrading to the bare record id (objectui#7108).
+
+When an approval's underlying record is deleted, the platform voids the
+still-pending requests and stamps the cause on the row (`status: 'cancelled'`
+plus `cancel_reason: 'record_deleted'`, objectstack#13568). The console did not
+read that cause: the row fell back to `formatIdentity(record_id)` and showed an
+opaque id where the business identifier used to be, still offering a link into a
+page that no longer exists. The desktop row, the mobile card and the request
+drawer now all render the tombstone, drop the link, and keep the snapshot's
+business identifier on the meta line so the audit row still says which record
+the approval was about. The `cancelled` status badge gained a label too — it was
+rendering the raw wire token.
+
+The copy is the platform's own: the localized `cancel_reason` option label when
+the server's translation bundle has loaded, falling back to the authored English
+in `@objectstack/spec`. No second string is authored here.
+
+Terminal (`approved` / `rejected`) rows are deliberately unchanged. They were
+never cancelled, so they carry no cause, and the read path fuses "deleted" with
+"hidden from this viewer" on purpose (existence non-disclosure) — so nothing on
+the wire tells them apart. Rendering a tombstone from a failed lookup would
+report a deletion to someone whose only problem is permissions
+(objectstack#7345), which is a worse claim than the id it replaces.

--- a/apps/console/src/pages/system/ApprovalsInboxPage.tombstone.test.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.tombstone.test.tsx
@@ -1,0 +1,355 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Approvals Inbox — a DEAD record reference renders as a tombstone, never as
+ * the bare record id (objectui#7108).
+ *
+ * ## The ruling
+ *
+ * Maintainer ruling 2026-08-31 (总监席第 5 场决裁批 #5) point 2, kept in the
+ * language it was ruled in: 历史终态审批单保留 + 墓碑呈现：审计行不动；呈现层把
+ * 死引用渲染为「关联记录已删除」墓碑，不再退化为裸记录 id。
+ *
+ * ## What each case measures, and why a weaker pin would pass on worse code
+ *
+ * A pin asserting only "the row does not show a raw record id" passes on a row
+ * that renders NOTHING — and an empty row is worse than the bare id, because
+ * the approver loses the fact that an approval exists. So the cases below pin
+ * the tombstone's PRESENCE, its TEXT, and that the rest of the row (flow,
+ * submitter, status, submitted-at) still renders.
+ *
+ * A second discriminator, against the caricature that makes every reference
+ * answer the same thing: a LIVE reference must still render its business
+ * identifier and its link.
+ *
+ * And the non-regression axis, aimed at the plausible WRONG fix rather than at
+ * the bug's shape: treating any failed lookup as a deletion would report a
+ * deletion to a viewer whose only problem is permissions (objectstack#7345's
+ * case). The fixture makes that failure mode visible — `rec_hidden` and
+ * `rec_deleted` are BOTH absent from the readability probe's answer, exactly as
+ * the platform's read path fuses them (existence non-disclosure) — and pins
+ * that only the row the SERVER marked `record_deleted` gets a tombstone.
+ *
+ * ## Fixture notes
+ *
+ * The stubbed `listRequests` answers every tab with the same rows, as this
+ * file's siblings do; the "All" tab is selected because that is where a
+ * `cancelled` row actually lives (objectstack#13568 clears the approver index,
+ * so a cancelled request leaves "My Pending" by construction).
+ *
+ * `queryAllByText` / `within(row)` throughout, never a bare `queryByText`: an
+ * inbox renders each request twice (desktop table + mobile card), so the
+ * tombstone string is present more than once and a bare query THROWS on the
+ * multiple match rather than reporting a miss.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import {
+  APPROVAL_CANCEL_REASON_LABELS,
+  APPROVAL_STATUS_LABELS,
+} from '@objectstack/spec/contracts';
+
+const APP = 'com.objectstack.account';
+
+/** The copy under test, taken from the CONTRACT — never re-typed here. */
+const TOMBSTONE = APPROVAL_CANCEL_REASON_LABELS.record_deleted;
+
+/**
+ * Opaque record ids, each with a distinct 6-char prefix. `formatIdentity`
+ * truncates anything over 14 characters to `<first 6>…<last 4>`, so asserting
+ * on the PREFIX catches both the full id and the truncated form the row would
+ * actually have rendered.
+ */
+const ID_LIVE = 'LiveRec0rdAAAAA';
+const ID_DELETED = '9SEmly8kQx2vJ7Z';
+const ID_DELETED_BARE = 'K3pQr7WzLm4Nb8T';
+const ID_HIDDEN = 'H1dd3nRec0rdXYZ';
+
+const { adapterFind, approvalsApiStub, ADAPTER, AUTH, I18N } = vi.hoisted(() => {
+  const base = {
+    process_name: 'leave_approval',
+    process_label: 'Leave Approval',
+    object_name: 'showcase_leave_request',
+    object_label: 'Leave Request',
+    submitted_at: '2026-09-01T00:00:00.000Z',
+    created_at: '2026-09-01T00:00:00.000Z',
+  };
+  const rows = [
+    {
+      ...base,
+      id: 'req_live',
+      record_id: 'LiveRec0rdAAAAA',
+      record_title: 'LR-00006',
+      status: 'approved',
+      submitter_id: 'u_live',
+      submitter_name: 'Liv Live',
+    },
+    {
+      ...base,
+      id: 'req_dead',
+      record_id: '9SEmly8kQx2vJ7Z',
+      // The snapshot kept a business identifier; the RECORD is gone.
+      record_title: 'LR-00007',
+      status: 'cancelled',
+      cancel_reason: 'record_deleted',
+      submitter_id: 'u_dead',
+      submitter_name: 'Dana Deleter',
+      completed_at: '2026-09-02T00:00:00.000Z',
+    },
+    {
+      ...base,
+      id: 'req_dead_bare',
+      record_id: 'K3pQr7WzLm4Nb8T',
+      // No snapshot title at all — THE case the card reports: the row used to
+      // degrade to the bare record id right here.
+      status: 'cancelled',
+      cancel_reason: 'record_deleted',
+      submitter_id: 'u_bare',
+      submitter_name: 'Barry Bare',
+    },
+    {
+      ...base,
+      id: 'req_hidden',
+      record_id: 'H1dd3nRec0rdXYZ',
+      record_title: 'LR-00009',
+      // Terminal, never cancelled ⇒ no `cancel_reason` exists for it. Its
+      // record is unreadable to this viewer for a reason the API does not
+      // disclose. NOT a deletion this console may assert.
+      status: 'approved',
+      submitter_id: 'u_hidden',
+      submitter_name: 'Hana Hidden',
+    },
+  ];
+
+  /**
+   * The platform's read path, reduced to the property that matters here: a
+   * deleted record and a record this principal may not see are BOTH simply
+   * absent from an `id in (…)` list read. The probe cannot tell them apart —
+   * by design, not by omission.
+   */
+  const adapterFind = vi.fn(async (_object: string, params?: Record<string, unknown>) => {
+    const ids = (params?.$filter as { id?: { $in?: string[] } } | undefined)?.id?.$in ?? [];
+    const gone = new Set(['9SEmly8kQx2vJ7Z', 'K3pQr7WzLm4Nb8T', 'H1dd3nRec0rdXYZ']);
+    return { data: ids.filter((id) => !gone.has(id)).map((id) => ({ id })) };
+  });
+
+  const approvalsApiStub = {
+    listRequests: vi.fn(async () => ({ data: rows, total: rows.length })),
+    getRequest: vi.fn(async (id: string) => ({ data: rows.find((r) => r.id === id) })),
+    listActions: vi.fn(async () => ({ data: [] })),
+    approve: vi.fn(async () => ({ data: rows[0], finalized: true })),
+    reject: vi.fn(async () => ({ data: rows[0], finalized: true })),
+  };
+
+  // STABLE singletons — a fresh object per render re-runs the page's load
+  // effect forever and the table never leaves its skeleton.
+  const ADAPTER = { find: adapterFind };
+  const AUTH = { user: { id: 'u_1', email: 'approver@example.com' } };
+  const I18N = {
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+    language: 'en',
+  };
+
+  return { adapterFind, approvalsApiStub, ADAPTER, AUTH, I18N };
+});
+
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => I18N,
+}));
+
+vi.mock('@object-ui/auth', async (importOriginal) => {
+  const authFetch = vi.fn(async () => new Response('{}', { status: 200 }));
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    useAuth: () => AUTH,
+    createAuthenticatedFetch: () => authFetch,
+    TokenStorage: { get: () => null },
+  };
+});
+
+vi.mock('@object-ui/app-shell', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAdapter: () => ADAPTER,
+  DeclaredActionsBar: () => null,
+  isViaOverrideRow: () => false,
+}));
+
+vi.mock('../../services/approvalsApi', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  approvalsApi: approvalsApiStub,
+}));
+
+// Imported after the mocks so the page picks them up.
+import { ApprovalsInboxPage } from './ApprovalsInboxPage';
+import { isDeletedRecordReference } from './deadRecordReference';
+
+function renderInbox() {
+  return render(
+    <MemoryRouter initialEntries={[`/apps/${APP}/system/approvals`]}>
+      <Routes>
+        <Route path="/apps/:appName/system/approvals" element={<ApprovalsInboxPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/** Land on "All" — the tab a `cancelled` request actually appears in. */
+async function renderAllTab(): Promise<void> {
+  renderInbox();
+  fireEvent.click(await screen.findByRole('tab', { name: 'All' }));
+  // `findAllByText`: each request renders twice (desktop table + mobile card),
+  // and the singular query THROWS on the second match instead of waiting.
+  await screen.findAllByText('Liv Live');
+}
+
+/** The desktop table row holding `text` (the mobile card renders no table rows). */
+function rowFor(text: string): HTMLElement {
+  const found = screen.getAllByRole('row').find((r) => within(r).queryAllByText(text).length > 0);
+  if (!found) throw new Error(`no row for ${text}`);
+  return found;
+}
+
+beforeEach(() => {
+  adapterFind.mockClear();
+  for (const fn of Object.values(approvalsApiStub)) fn.mockClear();
+});
+afterEach(cleanup);
+
+describe('isDeletedRecordReference (objectui#7108)', () => {
+  it('answers true only for the status AND cause the platform writes together', () => {
+    expect(isDeletedRecordReference({ status: 'cancelled', cancel_reason: 'record_deleted' })).toBe(true);
+  });
+
+  it('refuses every near miss — a status alone, a cause alone, and nothing at all', () => {
+    // `cancelled` is a reason CLASS: a future platform cause extends the
+    // vocabulary rather than minting a status, so the status alone must not
+    // start rendering "deleted".
+    expect(isDeletedRecordReference({ status: 'cancelled' })).toBe(false);
+    expect(isDeletedRecordReference({ status: 'cancelled', cancel_reason: null })).toBe(false);
+    // The contract declares the cause present ONLY on `cancelled` rows, so a
+    // value anywhere else is a row this console does not understand.
+    expect(isDeletedRecordReference({ status: 'approved', cancel_reason: 'record_deleted' })).toBe(false);
+    expect(isDeletedRecordReference({ status: 'rejected' })).toBe(false);
+    expect(isDeletedRecordReference(null)).toBe(false);
+    expect(isDeletedRecordReference(undefined)).toBe(false);
+  });
+});
+
+describe('Approvals Inbox — dead record reference tombstone (objectui#7108)', () => {
+  it('renders the tombstone, in the platform’s own words, for a record the server says was deleted', async () => {
+    await renderAllTab();
+
+    const row = rowFor('Dana Deleter');
+    // PRESENCE and TEXT, not merely "no id": the text is asserted to BE the
+    // contract's label, so a hand-written English string in this repo reds it.
+    expect(within(row).getAllByText(TOMBSTONE).length).toBeGreaterThan(0);
+    expect(TOMBSTONE).toBe('Related record deleted');
+  });
+
+  it('never shows the bare record id — not as text, not as a tooltip, not with a snapshot title and not without one', async () => {
+    await renderAllTab();
+
+    // With a snapshot title…
+    const withTitle = rowFor('Dana Deleter');
+    expect(withTitle.innerHTML).not.toContain('9SEmly');
+    // …and without one, which is the degradation the card reports.
+    const bare = rowFor('Barry Bare');
+    expect(bare.innerHTML).not.toContain('K3pQr7');
+    expect(within(bare).getAllByText(TOMBSTONE).length).toBeGreaterThan(0);
+
+    // The whole page, both viewports: the id is nowhere.
+    expect(document.body.innerHTML).not.toContain('9SEmly');
+    expect(document.body.innerHTML).not.toContain('K3pQr7');
+  });
+
+  /**
+   * ⭐ The discriminating case. A suite that only asserted "no raw record id"
+   * would pass on a row rendering NOTHING — strictly worse than the bug, since
+   * the approver would lose the fact that an approval exists. Ablating
+   * `DeadRecordReference` to render `null` reds the tombstone-presence cases
+   * above; this one holds the other half, that the surrounding row survives.
+   */
+  it('keeps the rest of the row — an empty row would be worse than the id it replaced', async () => {
+    await renderAllTab();
+
+    const row = rowFor('Dana Deleter');
+    // The flow, the requester, the decision state and the age all survive: the
+    // approver can still see THAT an approval happened and what became of it.
+    expect(within(row).getAllByText('Leave Approval').length).toBeGreaterThan(0);
+    expect(within(row).getAllByText('Dana Deleter').length).toBeGreaterThan(0);
+    expect(within(row).getAllByText(APPROVAL_STATUS_LABELS.cancelled).length).toBeGreaterThan(0);
+    expect(within(row).getAllByText('Leave Request').length).toBeGreaterThan(0);
+    // The snapshot's business identifier is not swallowed — it moves to the
+    // meta line, where it reads as history rather than as an address.
+    expect(within(row).getAllByText(/LR-00007/).length).toBeGreaterThan(0);
+    // And the status chip names the state instead of echoing the wire token.
+    expect(within(row).queryByText('cancelled')).toBeNull();
+  });
+
+  /**
+   * A CHARACTERIZATION pin, stated as one on purpose: it passes on the tree
+   * BEFORE this change too, because objectui#5211's probe already withholds the
+   * link once it answers (a deleted record is absent from its read like any
+   * other unreadable one). What this change adds is that the link never appears
+   * at all, rather than disappearing a tick later — measured by the ablation,
+   * not asserted here, because pinning the pre-probe paint would be pinning a
+   * render tick. Kept because "the tombstone must not re-introduce a link" is
+   * the thing that must keep being true.
+   */
+  it('offers no link into a record that is gone', async () => {
+    await renderAllTab();
+
+    expect(within(rowFor('Dana Deleter')).queryByRole('link')).toBeNull();
+    expect(within(rowFor('Barry Bare')).queryByRole('link')).toBeNull();
+  });
+
+  it('leaves a LIVE reference alone — business identifier and link both intact', async () => {
+    await renderAllTab();
+
+    const link = await screen.findByRole('link', { name: /LR-00006/ });
+    expect(link).toHaveAttribute(
+      'href',
+      `/apps/${APP}/showcase_leave_request/record/${ID_LIVE}`,
+    );
+    // The tombstone did not leak onto a healthy row.
+    expect(within(rowFor('Liv Live')).queryAllByText(TOMBSTONE)).toHaveLength(0);
+  });
+
+  it('does NOT claim a deletion for a reference that fails to resolve for some other reason', async () => {
+    await renderAllTab();
+    await waitFor(() => expect(adapterFind).toHaveBeenCalled());
+
+    // The probe was asked about the hidden record and the deleted ones in the
+    // SAME read, and answered the same way for all of them…
+    const asked = adapterFind.mock.calls[0]?.[1] as { $filter?: { id?: { $in?: string[] } } };
+    expect(asked?.$filter?.id?.$in).toEqual(
+      expect.arrayContaining([ID_DELETED, ID_DELETED_BARE, ID_HIDDEN]),
+    );
+
+    // …yet only the rows the SERVER marked `record_deleted` are tombstoned.
+    const hidden = rowFor('Hana Hidden');
+    expect(within(hidden).queryAllByText(TOMBSTONE)).toHaveLength(0);
+    // Today's behaviour for that row is untouched (objectui#5211): the payload
+    // snapshot's title still shows, the link is suppressed, and nothing tells
+    // the viewer their permissions problem is a deletion.
+    expect(within(hidden).getAllByText('LR-00009').length).toBeGreaterThan(0);
+    await waitFor(() =>
+      expect(within(rowFor('Hana Hidden')).queryByRole('link')).toBeNull(),
+    );
+  });
+
+  it('tombstones the same reference in the drawer — not one click deeper', async () => {
+    await renderAllTab();
+
+    fireEvent.click(rowFor('Dana Deleter'));
+    const drawer = await screen.findByRole('dialog');
+
+    expect(within(drawer).getAllByText(TOMBSTONE).length).toBeGreaterThan(0);
+    expect(drawer.innerHTML).not.toContain('9SEmly');
+    expect(within(drawer).queryByRole('link', { name: /LR-00007/ })).toBeNull();
+  });
+});

--- a/apps/console/src/pages/system/ApprovalsInboxPage.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.tsx
@@ -75,6 +75,7 @@ import { toast } from 'sonner';
 import { useAuth } from '@object-ui/auth';
 import { usePermissions } from '@object-ui/permissions';
 import { useObjectTranslation } from '@object-ui/i18n';
+import { APPROVAL_STATUS_LABELS } from '@objectstack/spec/contracts';
 import {
   CheckCircle2,
   XCircle,
@@ -96,6 +97,7 @@ import {
   Circle,
   Paperclip,
   ShieldAlert,
+  Trash2,
 } from 'lucide-react';
 import {
   approvalsApi,
@@ -105,6 +107,7 @@ import {
   type ApprovalActionAttachment,
 } from '../../services/approvalsApi';
 import { useRecordReadability } from './recordReadability';
+import { isDeletedRecordReference, useDeadRecordReferenceLabel } from './deadRecordReference';
 import { useHiddenFieldsByObject } from './hiddenFields';
 import { holdsStudioAccess } from '../../components/studioEntry';
 
@@ -124,6 +127,9 @@ const STATUS_CLASSES: Record<string, string> = {
   rejected: 'border-red-200 bg-red-50 text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-400',
   recalled: 'border-border bg-muted text-muted-foreground',
   returned: 'border-violet-200 bg-violet-50 text-violet-700 dark:border-violet-500/30 dark:bg-violet-500/10 dark:text-violet-400',
+  // objectstack#13568's terminal state: the platform voided the request, nobody
+  // decided it. Muted like `recalled` — the other exit that records no decision.
+  cancelled: 'border-border bg-muted text-muted-foreground',
 };
 
 /**
@@ -138,6 +144,27 @@ function StatusBadge({ status, label }: { status: string; label: string }) {
     <Badge variant="outline" className={cn('font-medium', STATUS_CLASSES[status] ?? '')}>
       {label}
     </Badge>
+  );
+}
+
+/**
+ * The tombstone that replaces a dead record reference (objectui#7108).
+ *
+ * Module scope for the same reason `StatusBadge` is, and the label is a prop
+ * for the same reason its label is: the copy is resolved once by the page from
+ * the platform's own `cancel_reason` option label (see `deadRecordReference`),
+ * never authored here.
+ *
+ * It renders the tombstone TEXT, not merely the absence of a link: a row that
+ * silently drops its record reference is worse than the bare id it replaces,
+ * because the approver loses the fact that an approval exists at all.
+ */
+function DeadRecordReference({ label, className }: { label: string; className?: string }) {
+  return (
+    <div className={cn('flex items-center gap-1.5 text-muted-foreground min-w-0', className)} title={label}>
+      <Trash2 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      <span className="truncate italic">{label}</span>
+    </div>
   );
 }
 
@@ -455,10 +482,11 @@ function RequestCell({ r, tr }: { r: ApprovalRequestRow; tr: Translate }) {
  * many objects, so it is a per-row prop and not something this cell could
  * resolve for itself — see the page body, which drives it off one lookup.
  */
-function RecordCell({ r, href, hiddenKeys }: {
+function RecordCell({ r, href, hiddenKeys, deadLabel }: {
   r: ApprovalRequestRow;
   href: string | null;
   hiddenKeys: ReadonlySet<string>;
+  deadLabel: string | null;
 }) {
   // Surface the decision-relevant amount inline so a reviewer can triage the
   // queue without opening each request (#2762 P1-3) — minus anything the
@@ -470,7 +498,14 @@ function RecordCell({ r, href, hiddenKeys }: {
   const title = r.record_title || formatIdentity(r.record_id);
   return (
     <div className="min-w-0">
-      {href === null ? (
+      {/* objectui#7108: the record is GONE (the platform said so), so the
+          reference slot becomes the tombstone rather than degrading to the
+          bare record id. The snapshot's business identifier is not lost —
+          it moves to the meta line below, where it stays readable as history
+          without pretending to address anything. */}
+      {deadLabel !== null ? (
+        <DeadRecordReference label={deadLabel} className="text-sm max-w-full" />
+      ) : href === null ? (
         <div className="text-sm truncate max-w-full" title={r.record_id}>{title}</div>
       ) : (
       <Link
@@ -485,6 +520,9 @@ function RecordCell({ r, href, hiddenKeys }: {
       )}
       <div className="text-xs text-muted-foreground truncate">
         {objectDisplay(r)}
+        {deadLabel !== null && r.record_title && (
+          <span className="ml-1.5">· {r.record_title}</span>
+        )}
         {amount && (
           <span className="ml-1.5 font-medium text-foreground" title={`${amount.label}: ${amount.display}`}>
             · {amount.display}
@@ -661,6 +699,11 @@ export function ApprovalsInboxPage() {
       case 'rejected': return tr('statusRejected', 'Rejected');
       case 'recalled': return tr('statusRecalled', 'Recalled');
       case 'returned': return tr('statusReturned', 'Returned for revision');
+      // objectstack#13568 added this terminal state; without a case the badge
+      // rendered the raw wire token `cancelled`. The default is the CONTRACT's
+      // own authored label rather than a fresh English string here — same
+      // discipline as the tombstone's copy (see `deadRecordReference`).
+      case 'cancelled': return tr('statusCancelled', APPROVAL_STATUS_LABELS.cancelled);
       default: return status;
     }
   }, [tr]);
@@ -694,6 +737,27 @@ export function ApprovalsInboxPage() {
     const app = appName || 'setup';
     return `/apps/${app}/${encodeURIComponent(r.object_name)}/record/${encodeURIComponent(r.record_id)}`;
   }, [appName]);
+
+  /**
+   * [objectui#7108] The tombstone copy, resolved once for the whole page from
+   * the platform's own `cancel_reason` option label.
+   *
+   * `deadLabelFor` answers non-null ONLY for a row the platform itself marked
+   * `cancelled` + `record_deleted`. ⛔ It must never be widened to a failed
+   * lookup: `readability.isUnreadable` (objectui#5211) reports that this viewer
+   * cannot read the target and deliberately says nothing about why — the read
+   * path fuses "deleted" and "hidden by permissions" on purpose (existence
+   * non-disclosure). Rendering a deletion off that answer would tell a viewer
+   * their permissions problem is a deletion (objectstack#7345's case), which is
+   * a worse claim than the bare id it replaces. The two causes stay separate
+   * here exactly as the ruling requires.
+   */
+  const deadReferenceLabel = useDeadRecordReferenceLabel();
+  const deadLabelFor = useCallback(
+    (r: ApprovalRequestRow | null | undefined): string | null =>
+      (isDeletedRecordReference(r) ? deadReferenceLabel : null),
+    [deadReferenceLabel],
+  );
 
   const [tab, setTab] = useState<TabKey>('pending');
   const [rows, setRows] = useState<ApprovalRequestRow[]>([]);
@@ -1625,8 +1689,13 @@ export function ApprovalsInboxPage() {
                           <TableCell>
                             <RecordCell
                               r={r}
-                              href={readability.isUnreadable(r) ? null : recordHref(r)}
+                              // A known-dead reference needs no probe: there is
+                              // nothing to link to, and the probe is async and
+                              // fails open, so leaving it to answer would render
+                              // a live-looking link for the first paint.
+                              href={deadLabelFor(r) !== null || readability.isUnreadable(r) ? null : recordHref(r)}
                               hiddenKeys={hiddenFields.forObject(r.object_name)}
+                              deadLabel={deadLabelFor(r)}
                             />
                           </TableCell>
                           <TableCell>
@@ -1690,17 +1759,33 @@ export function ApprovalsInboxPage() {
                         <div className="font-medium text-sm truncate">{processLabel(r)}</div>
                         <StatusBadge status={r.status} label={statusLabel(r.status)} />
                       </div>
-                      <div className="text-sm truncate">
-                        {r.record_title || formatIdentity(r.record_id)}
-                        <span className="text-muted-foreground text-xs ml-1.5">{objectDisplay(r)}</span>
-                        {(() => {
-                          // objectui#6020: this row's OWN object decides.
-                          const amount = decisionAmountEntry(r, hiddenFields.forObject(r.object_name));
-                          return amount ? (
-                            <span className="text-xs ml-1.5 font-medium" title={amount.label}>· {amount.display}</span>
-                          ) : null;
-                        })()}
-                      </div>
+                      {/* objectui#7108: same tombstone as the desktop row —
+                          the mobile card renders the SAME reference for the
+                          same request, so fixing only the table would leave
+                          the bare id on every phone. */}
+                      {(() => {
+                        const deadLabel = deadLabelFor(r);
+                        return (
+                          <div className="text-sm truncate">
+                            {deadLabel !== null ? (
+                              <span className="italic text-muted-foreground">{deadLabel}</span>
+                            ) : (
+                              r.record_title || formatIdentity(r.record_id)
+                            )}
+                            <span className="text-muted-foreground text-xs ml-1.5">{objectDisplay(r)}</span>
+                            {deadLabel !== null && r.record_title && (
+                              <span className="text-muted-foreground text-xs ml-1.5">· {r.record_title}</span>
+                            )}
+                            {(() => {
+                              // objectui#6020: this row's OWN object decides.
+                              const amount = decisionAmountEntry(r, hiddenFields.forObject(r.object_name));
+                              return amount ? (
+                                <span className="text-xs ml-1.5 font-medium" title={amount.label}>· {amount.display}</span>
+                              ) : null;
+                            })()}
+                          </div>
+                        );
+                      })()}
                       <div className="flex items-center justify-between text-xs text-muted-foreground">
                         {isSystemSubmitter(r) ? (
                           <span className="inline-flex items-center gap-1 truncate italic">
@@ -1902,7 +1987,16 @@ export function ApprovalsInboxPage() {
                           offers the same link to the same record for the same
                           viewer, so fixing only the row would move the dead end
                           one click deeper instead of removing it. */}
-                      {readability.isUnreadable(selected) ? (
+                      {/* objectui#7108: and the same tombstone again — the
+                          drawer addresses the same record, so leaving the bare
+                          id here would move it one click deeper instead of
+                          removing it. */}
+                      {deadLabelFor(selected) !== null ? (
+                        <DeadRecordReference
+                          label={deadLabelFor(selected) as string}
+                          className="text-base font-semibold"
+                        />
+                      ) : readability.isUnreadable(selected) ? (
                         <div className="text-base font-semibold truncate">
                           {selected.record_title || formatIdentity(selected.record_id)}
                         </div>
@@ -1915,7 +2009,12 @@ export function ApprovalsInboxPage() {
                         <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                       </Link>
                       )}
-                      <div className="text-xs text-muted-foreground">{objectDisplay(selected)}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {objectDisplay(selected)}
+                        {deadLabelFor(selected) !== null && selected.record_title && (
+                          <span className="ml-1.5">· {selected.record_title}</span>
+                        )}
+                      </div>
                     </div>
                     <div className="text-right text-xs text-muted-foreground shrink-0">
                       <div className="inline-flex items-center gap-1">

--- a/apps/console/src/pages/system/deadRecordReference.ts
+++ b/apps/console/src/pages/system/deadRecordReference.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * "The record this approval was about has been deleted" — the one signal the
+ * platform actually publishes, and the copy that goes with it (objectui#7108).
+ *
+ * ## The ruling this serves
+ *
+ * Maintainer ruling 2026-08-31 (总监席第 5 场决裁批 #5), point 2, kept in the
+ * language it was ruled in:
+ *
+ *   历史终态审批单保留 + 墓碑呈现：审计行不动；呈现层把死引用渲染为
+ *   「关联记录已删除」墓碑，不再退化为裸记录 id。
+ *
+ * The audit rows stay; the PRESENTATION layer stops degrading a dead reference
+ * to a bare record id.
+ *
+ * ## The signal — published upstream, consumed here, never re-derived
+ *
+ * `@objectstack/plugin-approvals` voids a record's still-`pending` approvals
+ * when that record is deleted (objectstack#13568), and stamps the cause on the
+ * row: `status: 'cancelled'` + `cancel_reason: 'record_deleted'`. The pair is
+ * declared on `ApprovalRequestRow` in `@objectstack/spec` and comes back on
+ * every read. That pair is the ONLY thing this module treats as "the record is
+ * gone" — a deletion the server asserted, never one this console inferred.
+ *
+ * ## ⛔ What a failed lookup is NOT
+ *
+ * A record that fails to resolve is NOT evidence of a deletion, and this module
+ * must never be widened to say it is. The platform fuses the two causes on
+ * purpose: an RLS-invisible row and an id that names nothing both answer
+ * `RECORD_NOT_FOUND` / 404, described in the framework's own words as
+ * "existence non-disclosure" — 403 is deliberately not used, because answering
+ * differently would confirm to a viewer that a record they may not see exists.
+ * So `recordReadability`'s probe (objectui#5211) reports "this viewer cannot
+ * read it" and says nothing whatsoever about why; treating its answer as a
+ * deletion would report "deleted" to someone whose only problem is permissions
+ * (objectstack#7345's case), asserting a deletion that may not have happened.
+ * That is strictly worse than the bare id it would replace.
+ *
+ * ## The consequence, recorded rather than papered over
+ *
+ * TERMINAL rows — `approved` / `rejected` — were never cancelled (the upstream
+ * cancel path names `status: 'pending'` in its `where`), so they carry no
+ * `cancel_reason`, and by the paragraph above nothing else on the wire
+ * separates "deleted" from "not visible" for them. They therefore get NO
+ * tombstone here, on purpose. See the PR for the measurement.
+ */
+
+import { useMemo } from 'react';
+import { useSafeFieldLabel } from '@object-ui/i18n';
+import { APPROVAL_CANCEL_REASON_LABELS } from '@objectstack/spec/contracts';
+import type { ApprovalRequestRow } from '../../services/approvalsApi';
+
+/**
+ * Where the platform records the cause. The tombstone's copy is the label of
+ * this field's `record_deleted` option, so the string the console renders and
+ * the string the platform's own admin UI renders are one authored text.
+ */
+export const CANCEL_REASON_OBJECT = 'sys_approval_request';
+export const CANCEL_REASON_FIELD = 'cancel_reason';
+export const RECORD_DELETED_REASON = 'record_deleted';
+
+/**
+ * Did the platform tell us this request's target record was deleted?
+ *
+ * Both halves are required. `status` alone is not enough — `cancelled` is a
+ * reason CLASS on the contract, and the next platform-initiated cause extends
+ * that vocabulary rather than minting its own status, so a future
+ * `cancel_reason` must not silently start rendering "deleted". `cancel_reason`
+ * alone is not enough either: the contract declares it "present only on rows
+ * whose status is `cancelled`", so a value on any other status is a row this
+ * console does not understand, not a deletion.
+ */
+export function isDeletedRecordReference(
+  r: Pick<ApprovalRequestRow, 'status' | 'cancel_reason'> | null | undefined,
+): boolean {
+  return r?.status === 'cancelled' && r?.cancel_reason === RECORD_DELETED_REASON;
+}
+
+/**
+ * The tombstone's text — upstream's, in both of its two forms.
+ *
+ * 1. The platform's own localized option label, which
+ *    `@objectstack/plugin-approvals` ships and `/api/v1/i18n/translations/:locale`
+ *    serves (en / ja-JP / es-ES / zh-CN today). `transformSpecTranslations`
+ *    lands it at `fieldOptions.sys_approval_request.cancel_reason.record_deleted`,
+ *    which is exactly what `fieldOptionLabel` resolves.
+ * 2. When that bundle has not loaded (an older backend, an offline console),
+ *    the contract's own authored English from `@objectstack/spec` — the very
+ *    text the `en` bundle is generated from.
+ *
+ * ⛔ Deliberately no objectui-authored string on either path: a second copy of
+ * this sentence in this repo would be a second de-facto contract, localized on
+ * its own schedule, drifting from the platform's.
+ */
+export function useDeadRecordReferenceLabel(): string {
+  const { fieldOptionLabel } = useSafeFieldLabel();
+  return useMemo(
+    () => fieldOptionLabel(
+      CANCEL_REASON_OBJECT,
+      CANCEL_REASON_FIELD,
+      RECORD_DELETED_REASON,
+      APPROVAL_CANCEL_REASON_LABELS.record_deleted,
+    ),
+    [fieldOptionLabel],
+  );
+}

--- a/apps/console/src/services/approvalsApi.ts
+++ b/apps/console/src/services/approvalsApi.ts
@@ -12,6 +12,7 @@
  * `packages/rest/src/rest-server.ts`.
  */
 import { TokenStorage } from '@object-ui/auth';
+import type { ApprovalCancelReason } from '@objectstack/spec/contracts';
 
 const SERVER_URL = (import.meta.env.VITE_SERVER_URL || '').replace(/\/$/, '');
 const API_BASE = `${SERVER_URL}/api/v1`;
@@ -32,7 +33,21 @@ export interface ApprovalRequestRow {
   process_name: string;
   object_name: string;
   record_id: string;
-  status: 'pending' | 'approved' | 'rejected' | 'recalled' | 'returned' | string;
+  status: 'pending' | 'approved' | 'rejected' | 'recalled' | 'returned' | 'cancelled' | string;
+  /**
+   * Why the platform voided this request (objectstack#13568). Present only on
+   * rows whose `status` is `cancelled`, absent everywhere else — so a value on
+   * any other status is a row this console does not understand, never a cause
+   * to act on.
+   *
+   * The union is IMPORTED from `@objectstack/spec` rather than re-spelled here:
+   * the contract calls it a reason CLASS whose next platform-initiated cause
+   * extends the same list, and a hand-copied union would go stale the day it
+   * does. Optional-nullable exactly as the contract declares it — a row written
+   * before the column existed reads as "not recorded", never as "cancelled for
+   * no reason".
+   */
+  cancel_reason?: ApprovalCancelReason | null;
   current_step?: string | null;
   current_step_index?: number | null;
   pending_approvers?: string[] | null;


### PR DESCRIPTION
Fixes #7108

Implements the presentation half of the maintainer ruling of 2026-08-31 (总监席第 5 场决裁批 #5), point 2, quoted in the language it was ruled in:

> **历史终态审批单保留 + 墓碑呈现**：审计行不动;呈现层把死引用渲染为「关联记录已删除」墓碑,⛔ 不再退化为裸记录 id。

## What was broken

When an approval's underlying record is deleted, `@objectstack/plugin-approvals` voids the still-`pending` requests and stamps the cause on the row — `status: 'cancelled'` plus `cancel_reason: 'record_deleted'` (objectstack-ai/objectstack#13568, already shipped). The console read neither field. The row fell through to `formatIdentity(record_id)` and showed an opaque id where the business identifier used to be, and still offered a link into a page that no longer exists.

## What this changes

- **The reference slot becomes a tombstone** on the desktop row, the mobile card and the request drawer — all three, because all three address the same record and leaving any one alone just moves the dead end.
- **The link is dropped** without waiting for the readability probe. A known-dead reference needs no probe, and the probe is async and fails open, so leaving it to answer would paint a live-looking link first.
- **The snapshot's business identifier is not swallowed** — it moves to the meta line, where it reads as history rather than as an address. An audit row still says which record the approval was about.
- **The `cancelled` status badge gained a label.** objectstack-ai/objectstack#13568 added the state; with no case for it the badge rendered the raw wire token `cancelled`. Included deliberately as a bounded in-place change: it is the same defect class (a raw machine value where business copy belongs), on the very row this card creates, and its shape is pinned upstream.

## The copy is upstream's, on both paths

⛔ No English string is authored in this repo. `useDeadRecordReferenceLabel` resolves the platform's own localized `cancel_reason` option label (shipped in en / ja-JP / es-ES / zh-CN by `plugin-approvals`, served at the i18n translations endpoint, landed by `transformSpecTranslations` under `fieldOptions.sys_approval_request.cancel_reason.record_deleted`), and falls back to `APPROVAL_CANCEL_REASON_LABELS.record_deleted` from `@objectstack/spec` — the very text the `en` bundle is generated from. The reason union is imported rather than re-spelled, for the same reason.

An ablation leg pins that: replacing the contract label with a hand-written objectui string reds three cases.

## ⚠️ Terminal rows are UNCHANGED, and that is the deliberate outcome

The card's own stop condition was: *if "deleted" and "not visible" cannot be told apart from what the API returns, report that as a finding rather than guessing a rendering.* They cannot. Measured against `objectstack` at `6c546ab9` and `@objectstack/spec@17.3.0` as installed here:

1. `cancelForDeletedRecord`'s `where` names `status: 'pending'`; its own docstring says *"Terminal rows are untouched … history is kept."* So an `approved` / `rejected` row about a deleted record carries no `cancel_reason` at all — the spec declares that field *"present only on rows whose status is `cancelled`"*.
2. `record_title` is no proxy: `enrichRows` resolves it under the SYSTEM context and falls back to the payload snapshot, so the client receives one string either way and cannot see which branch produced it.
3. The readability probe cannot separate them: it is an `id in (…)` list read as the viewer, and a deleted record and an RLS-filtered one are both simply absent.
4. That fusion is deliberate. From the framework's own source (`packages/runtime/src/action-execution.ts`): *"the read path collapses 'filtered out by RLS' and 'this id names nothing' on purpose (existence non-disclosure) … inventing a 403 for the pair would answer a question the platform declines to answer everywhere else."*

⇒ A terminal row about a deleted record still shows the opaque id. Rendering a tombstone from a failed lookup would report a deletion to a viewer whose only problem is permissions — objectstack-ai/objectstack#7345's case, where the record **exists** and a visibility gate hides it — asserting something that may not have happened. That is a worse claim than the id it would replace, so it is not made. The two causes stay distinct in both the code and the copy, as the ruling requires; objectstack-ai/objectstack#7345 is a different cause and is not addressed here.

The measurement, the three options and a recommendation are recorded in objectui#8631 for the maintainer to decide.

## Pins, and every one of them observed RED

`apps/console/src/pages/system/ApprovalsInboxPage.tombstone.test.tsx` — 9 cases. Four ablation legs, each proved to reach disk before the run and each restored by blob-hash comparison against HEAD afterwards:

| leg | mutation | result |
|---|---|---|
| 1 | the predicate always answers `false` (fix removed) | 4 red — the tombstone, the no-bare-id case and the drawer |
| 2 | the predicate always answers `true` (the caricature: every reference tombstoned) | 3 red — the **live-reference** pin and the **non-deletion-failure** pin, exactly the two discriminators |
| 3 | the contract label swapped for a local English string | 3 red — copy provenance holds |
| 4 | the tombstone component renders nothing (an empty row — strictly worse than the bug) | 3 red — the suite does not accept a blank row |

The non-deletion-failure fixture is the one worth reading: `rec_hidden` and both deleted ids are **all** absent from the probe's answer, exactly as the platform fuses them, and only the rows the server marked `record_deleted` are tombstoned.

## Verification

- `pnpm exec vitest run --project @object-ui/console` — **91 files / 1081 tests passed**, at `4835a7c3d` (the final commit).
- `pnpm --filter @object-ui/console run type-check` — exit 0, on a built dependency closure. `tsc --listFiles` confirms both new files are in the 3538-file program, so the check is not vacuous.
- LEG D, from the JSON reporter: 5 suites passed / 0 failed, 14 tests passed / 0 failed / 0 pending across this file and `ApprovalsInboxPage.recordLink.test.tsx`.
- `node scripts/check-changeset-presence.mjs` — `✅  4 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`. `check-changeset-no-major.mjs`: `✅  No changeset declares a major bump.`
- `node scripts/check-control-bytes.mjs` — OK, 6826 files. `eslint` on the four touched files — exit 0, no new warnings.
- `node scripts/check-governed-queue-guard.mjs --test` — `✅ NOT GOVERNED`.

Draft, and no auto-merge armed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_