### PR TITLE
feat(core): curate `box` in PUBLIC_BLOCKS Tier B, pinned by a derived roster census

### DIFF
--- a/.changeset/6879-public-blocks-box.md
+++ b/.changeset/6879-public-blocks-box.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/core': minor
+---
+
+Curate `box` in `PUBLIC_BLOCKS` Tier B, so `getPublicConfigs()` offers the neutral block container the catalog already teaches.
+
+`box` was minted as the JSON authoring surface's class-transparent replacement for the deprecated `div` and landed on every declaration face — the `BoxSchema` interface, its zod mirror, `SchemaRegistry`, the registration in `@object-ui/components`, a docs page and 27 catalog fixtures. The curated contract was the one face it missed, so the published `sdui.manifest.json` and `sdui-intrinsics.d.ts` (both generated from `getPublicConfigs()`) omitted a type the vocabulary teaches. Authoring `box` still validated — `page.tsx` builds the JSX-page compiler's manifest from the registry, not from this roster — but a model reading the curated vocabulary could not learn it.
+
+No spec entry was needed: `@objectstack/spec` describes no Tier B layout primitive, so `box` joins `flex` / `grid` / `stack` / `card` / `container` in a population the `registry-inputs-spec-parity` gate has never judged. Measured before the roster was touched, and pinned in `apps/console` over a population derived from the zod layout union rather than restated as a list, so the next minted layout container fails by absence instead of repeating this.

--- a/apps/console/src/__tests__/public-contract.test.ts
+++ b/apps/console/src/__tests__/public-contract.test.ts
@@ -27,6 +27,8 @@
 
 import { describe, it, expect } from 'vitest';
 import { ComponentRegistry, PUBLIC_BLOCKS, type PublicComponentConfig } from '@object-ui/core';
+import { LayoutSchema } from '@object-ui/types/zod';
+import { ComponentPropsMap } from '@objectstack/spec/ui';
 // The two graphs whose registrations this file reads. At module scope, NOT
 // awaited inside a `beforeAll` — there their cold transform is billed to the
 // hook, against `hookTimeout`, which is why this needed a 60s budget. The import
@@ -95,6 +97,7 @@ const EXPECTED_COVERED = [
   'tabs',
   'accordion',
   'container',
+  'box',
   'page:header',
   'text',
   'image',
@@ -350,5 +353,191 @@ describe('PUBLIC_BLOCKS ↔ console coverage (reverse direction)', () => {
     });
 
     expect(nearMisses.filter((m) => m.alsoTry.length > 0)).toEqual([]);
+  });
+});
+
+/**
+ * ── The DERIVED half: the declared layout containers (objectui#6879) ─────────
+ *
+ * Everything above this line asserts an EXACT LIST, and that is right for what
+ * it guards — a SHRINKING contract, which `toContain` sails past. But an exact
+ * list cannot answer the question objectui#6879 was filed about, and the
+ * distinction is the whole content of that card:
+ *
+ *   an exact list goes red when a CURATED type disappears;
+ *   nothing went red when a newly minted type never arrived.
+ *
+ * `box` was minted by the 2026-08-29 ruling as the JSON surface's neutral block
+ * container and landed on every declaration face there is — the `BoxSchema`
+ * interface, its zod mirror, `SchemaRegistry`, the registration in
+ * `@object-ui/components`, a docs page, and 27 catalog fixtures. `PUBLIC_BLOCKS`
+ * was the one face it missed, and `EXPECTED_COVERED` above agreed with the
+ * roster about the omission, because both are hand-carried. Two hand-carried
+ * lists that agree prove only that the same hand wrote both.
+ *
+ * ⭐ So this half DERIVES its population instead of listing it, and a pin over a
+ * derived population fails by ABSENCE. The naive alternative — asserting
+ * `PUBLIC_BLOCKS` contains `box` — passes on a roster that carries `box` AND
+ * has already missed the type minted after it, which is this same defect one
+ * iteration later.
+ *
+ * THE POPULATION, and why these two readings:
+ *
+ *   1. `LayoutSchema.options` — the runtime-enumerable zod authoring union in
+ *      `@object-ui/types/zod`. It is the JSON layout vocabulary as DECLARED:
+ *      a type that has been minted is an arm of it, and a type that has not is
+ *      not. Read from the union's own arms, so minting the next one moves this
+ *      set with no list here to maintain.
+ *   2. `isContainer === true` — the registry's own declared containment
+ *      (objectui#3900 / #6740 / #6764). It is what makes the population the one
+ *      Tier B's layout primitives live in: `box`'s five curated siblings
+ *      (`flex` / `grid` / `stack` / `card` / `container`) are exactly the
+ *      objectui#6764 control set, which is what makes this a reading rather
+ *      than a broken scan — and it is asserted below rather than assumed.
+ *
+ * Scope, stated plainly: this covers the CONTAINER half of the layout
+ * vocabulary. The non-container arms (`span`, `separator`, `scroll-area`,
+ * `resizable`, `page`, and the deprecated `div`) are outside it because
+ * curating any of them is an unruled question of its own, and a ledger is a
+ * forcing function, not a place to park four of those at once.
+ *
+ * ── THE MEASUREMENT THIS CARD WAS DISPATCHED TO MAKE, RECORDED ──────────────
+ *
+ * Before `box` was added to the roster, triage required an answer to: what does
+ * `registry-inputs-spec-parity` (next door) do with a PUBLIC block that has no
+ * `@objectstack/spec` entry? Adding it first is how a gate discovers a new
+ * population at merge time.
+ *
+ * The answer is a third one, neither "it demands a spec entry" nor "it tolerates
+ * the absence": IT CANNOT SEE THE BLOCK AT ALL. That file's coverage set is
+ * `Object.keys(ComponentPropsMap)` filtered to what this repo registers with
+ * inputs; it never reads `PUBLIC_BLOCKS`, and the spec carries no entry for ANY
+ * Tier B layout primitive. So `box` did not arrive as a new spec-less
+ * population — it joined one five types deep that the gate has never judged.
+ * Pinned below, over the derived population, with a lit control on the same
+ * command shape so the empty result is a measurement and not a broken query.
+ */
+
+/**
+ * The JSON layout vocabulary, read from the zod union's own arms.
+ *
+ * A discriminated union member declares its `type` literal to Zod, so the arm
+ * list IS the vocabulary. Filtering to real strings is deliberate: a zod release
+ * that moved this accessor would otherwise yield a population of `undefined` and
+ * make every assertion below vacuously true, which is why the first case
+ * compares the resolved count against the raw arm count.
+ */
+const LAYOUT_UNION_ARMS = (LayoutSchema as unknown as { options: unknown[] }).options;
+const LAYOUT_VOCABULARY: string[] = LAYOUT_UNION_ARMS.map(
+  (arm) => (arm as { shape?: { type?: { value?: unknown } } }).shape?.type?.value,
+).filter((value): value is string => typeof value === 'string' && value.length > 0);
+
+/** …of those, the ones the registry DECLARES it renders a child list for. */
+const DECLARED_LAYOUT_CONTAINERS = LAYOUT_VOCABULARY.filter(
+  (type) => ComponentRegistry.getMeta(type)?.isContainer === true,
+).sort();
+
+/**
+ * objectui#6764's control set — the five that declared containment before that
+ * card, and the five Tier B curates. Asserted, not assumed: if the derivation
+ * ever stops reaching the real registrations, these vanish from the population
+ * and the ledger pin below would pass over a set that means nothing.
+ */
+const CONTAINER_CONTROL_SET = ['card', 'container', 'flex', 'grid', 'stack'];
+
+/**
+ * Declared layout containers deliberately OUTSIDE the curated vocabulary, each
+ * with its reason and a tracking issue.
+ *
+ * ⚠️ This is a forcing function, not an allowlist. A newly minted layout
+ * container is in neither this ledger nor `PUBLIC_BLOCKS`, so it fails the pin
+ * below by ABSENCE — which is the property `box` needed and did not have. An
+ * entry here is the deliberate, reviewable alternative to curating, never a
+ * silent one, and it must name an issue that resolves it.
+ */
+const UNCURATED_LAYOUT_CONTAINERS: Record<string, string> = {
+  'aspect-ratio':
+    'NOT YET RULED, either way — and that is the entry, stated honestly rather than dressed as merits. ' +
+    'It is the only member of this derived population no card has ever asked about: it declares four real ' +
+    'inputs (ratio/image/alt/className) and a container slot, so it is authorable today, and the tree records ' +
+    'only the CONSEQUENCE of its absence (renderers/layout/aspect-ratio.tsx, at its registration: "Not in ' +
+    '`PUBLIC_BLOCKS`, so the react-page scope builder never saw this tag"), never a reason. objectui#6879 ' +
+    'measured the population and filed the decision as objectui#8628 — curate it, or refuse it on stated ' +
+    'merits and replace this text with them. Until then it stays visible here instead of invisible in a gap.',
+};
+
+describe('PUBLIC_BLOCKS ↔ the declared layout containers (derived, objectui#6879)', () => {
+  it('reads the vocabulary off the union rather than restating it', () => {
+    // The anti-vacuity case, and it comes first. Every arm must resolve a real
+    // `type` literal: a population of `undefined`s would make the ledger pin
+    // below pass while asserting nothing at all.
+    expect(LAYOUT_UNION_ARMS.length).toBeGreaterThan(0);
+    expect(LAYOUT_VOCABULARY).toHaveLength(LAYOUT_UNION_ARMS.length);
+    // And it must be the vocabulary we think it is — the minted type this card
+    // is about, plus two of its long-standing siblings.
+    expect(LAYOUT_VOCABULARY).toEqual(expect.arrayContaining(['box', 'flex', 'container']));
+  });
+
+  it('derives a non-empty container population holding the objectui#6764 control set', () => {
+    // The second anti-vacuity case: a roster/census pin iterating an EMPTY set
+    // passes. Both halves of the derivation are checked — the union read above,
+    // and the registry read here. If `isContainer` stopped resolving, this set
+    // empties and every case below would go quietly green.
+    expect(DECLARED_LAYOUT_CONTAINERS.length).toBeGreaterThan(0);
+    expect(DECLARED_LAYOUT_CONTAINERS).toEqual(expect.arrayContaining(CONTAINER_CONTROL_SET));
+    // `box` must be IN the population, or the pin below would be satisfied by a
+    // roster that had silently dropped it again.
+    expect(DECLARED_LAYOUT_CONTAINERS).toContain('box');
+  });
+
+  it('curates every declared layout container, or records why not', () => {
+    // ⭐ The load-bearing case. Derived on both sides: the population from the
+    // union and the registry, the expectation from the ledger's own keys. A
+    // newly minted layout container is in neither, so it lands here BY ABSENCE
+    // — which is exactly what did not happen when `box` was minted.
+    const curated = new Set<string>(PUBLIC_BLOCKS);
+    const uncurated = DECLARED_LAYOUT_CONTAINERS.filter((type) => !curated.has(type));
+
+    expect(uncurated).toEqual(Object.keys(UNCURATED_LAYOUT_CONTAINERS).sort());
+  });
+
+  it('keeps every ledger entry live — a real member, a reason, a tracking issue', () => {
+    for (const [type, reason] of Object.entries(UNCURATED_LAYOUT_CONTAINERS)) {
+      // A dangling entry would be a standing licence for a type that is not even
+      // in the population any more.
+      expect(DECLARED_LAYOUT_CONTAINERS, `${type} is not a declared layout container`).toContain(
+        type,
+      );
+      expect(reason, `${type} states no tracking issue`).toMatch(/#\d+/);
+      expect(reason.length, `${type} states no reason`).toBeGreaterThan(40);
+    }
+  });
+
+  it('carries no stale ledger entry — a curated type must lose its entry', () => {
+    // The other direction, and the reason the list cannot rot into a permanent
+    // allowlist: once a ledgered type IS curated, the entry must be deleted
+    // rather than left standing next to the thing it claims is excluded.
+    const curated = new Set<string>(PUBLIC_BLOCKS);
+    expect(Object.keys(UNCURATED_LAYOUT_CONTAINERS).filter((type) => curated.has(type))).toEqual(
+      [],
+    );
+  });
+
+  it('adds no block that registry-inputs-spec-parity can judge (the objectui#6879 measurement)', () => {
+    // The measurement, kept as an assertion so nobody has to re-run it: this
+    // whole population is outside `ComponentPropsMap`, so the spec-parity gate
+    // next door — whose coverage set is derived from that map's keys, and which
+    // never reads `PUBLIC_BLOCKS` — cannot see any of it. Curating `box` moved
+    // that gate by nothing, and needed no spec entry and no loosening.
+    const specCarried = (type: string): boolean =>
+      Object.prototype.hasOwnProperty.call(ComponentPropsMap, type);
+
+    expect(DECLARED_LAYOUT_CONTAINERS.filter(specCarried)).toEqual([]);
+
+    // ⭐ The LIT CONTROL, on the same command shape and over the right
+    // population: the curated roster at large DOES carry spec-described blocks,
+    // so the empty result above is a reading and not a broken lookup.
+    expect(Object.keys(ComponentPropsMap).length).toBeGreaterThan(0);
+    expect(PUBLIC_BLOCKS.filter(specCarried).length).toBeGreaterThan(0);
   });
 });

--- a/apps/console/src/__tests__/public-contract.test.ts
+++ b/apps/console/src/__tests__/public-contract.test.ts
@@ -410,12 +410,34 @@ describe('PUBLIC_BLOCKS ↔ console coverage (reverse direction)', () => {
  *
  * The answer is a third one, neither "it demands a spec entry" nor "it tolerates
  * the absence": IT CANNOT SEE THE BLOCK AT ALL. That file's coverage set is
- * `Object.keys(ComponentPropsMap)` filtered to what this repo registers with
- * inputs; it never reads `PUBLIC_BLOCKS`, and the spec carries no entry for ANY
- * Tier B layout primitive. So `box` did not arrive as a new spec-less
- * population — it joined one five types deep that the gate has never judged.
- * Pinned below, over the derived population, with a lit control on the same
- * command shape so the empty result is a measurement and not a broken query.
+ * SPEC-shaped — `Object.keys(ComponentPropsMap)` filtered to what this repo
+ * registers with inputs — and it never reads `PUBLIC_BLOCKS`.
+ *
+ * ⭐ Membership in this roster is therefore neither NECESSARY nor SUFFICIENT for
+ * being judged, and both halves have live specimens, so the measurement is not a
+ * story about one block:
+ *
+ *   - not necessary — `element:record_picker` is absent from `PUBLIC_BLOCKS` and
+ *     judged anyway, because the spec describes it (the parity file says so
+ *     itself, in its own words about why its coverage is not limited to the
+ *     public tier);
+ *   - not sufficient — `flex` / `grid` / `stack` / `card` / `container` are all
+ *     curated and all unjudged, because `@objectstack/spec@17` carries no entry
+ *     for any Tier B layout primitive.
+ *
+ * So `box` did not arrive as a new spec-less population; it joined one five
+ * types deep that the gate has never judged. Both halves are pinned below.
+ *
+ * ⚠️ ONE THING THIS GAP WAS NOT. "Absent from `PUBLIC_BLOCKS`" never meant "not
+ * on an authoring surface", and saying so would overstate the card. `box`'s
+ * `inputs` have been live all along through the OTHER consumer of the same
+ * metadata: `components/src/renderers/layout/page.tsx` builds the JSX-page
+ * compiler's manifest from `getKnownTypes()` — registry-wide, no roster in it —
+ * and `validateTree` judges authored pages against that. What this roster gates
+ * is `getPublicConfigs()`: the curated AI-authoring vocabulary, and through
+ * `sdui-parser/scripts/gen-manifest.ts` the published `sdui.manifest.json` and
+ * `sdui-intrinsics.d.ts`. That is the surface `box` was missing from — narrower,
+ * and true.
  */
 
 /**
@@ -444,6 +466,10 @@ const DECLARED_LAYOUT_CONTAINERS = LAYOUT_VOCABULARY.filter(
  * and the ledger pin below would pass over a set that means nothing.
  */
 const CONTAINER_CONTROL_SET = ['card', 'container', 'flex', 'grid', 'stack'];
+
+/** Does `@objectstack/spec` describe this block's props? The parity gate's own reach. */
+const specCarried = (type: string): boolean =>
+  Object.prototype.hasOwnProperty.call(ComponentPropsMap, type);
 
 /**
  * Declared layout containers deliberately OUTSIDE the curated vocabulary, each
@@ -529,9 +555,6 @@ describe('PUBLIC_BLOCKS ↔ the declared layout containers (derived, objectui#68
     // next door — whose coverage set is derived from that map's keys, and which
     // never reads `PUBLIC_BLOCKS` — cannot see any of it. Curating `box` moved
     // that gate by nothing, and needed no spec entry and no loosening.
-    const specCarried = (type: string): boolean =>
-      Object.prototype.hasOwnProperty.call(ComponentPropsMap, type);
-
     expect(DECLARED_LAYOUT_CONTAINERS.filter(specCarried)).toEqual([]);
 
     // ⭐ The LIT CONTROL, on the same command shape and over the right
@@ -539,5 +562,40 @@ describe('PUBLIC_BLOCKS ↔ the declared layout containers (derived, objectui#68
     // so the empty result above is a reading and not a broken lookup.
     expect(Object.keys(ComponentPropsMap).length).toBeGreaterThan(0);
     expect(PUBLIC_BLOCKS.filter(specCarried).length).toBeGreaterThan(0);
+  });
+
+  it('measures that gate as SPEC-shaped — this roster is neither necessary nor sufficient', () => {
+    // The half that stops the measurement above from reading as "curated blocks
+    // are the unjudged ones". Both directions have live specimens, and a pin
+    // that held only one of them would license exactly the wrong conclusion.
+    //
+    // NOT SUFFICIENT — curated, and still outside that gate's reach:
+    expect(CONTAINER_CONTROL_SET.every((type) => PUBLIC_BLOCKS.includes(type))).toBe(true);
+    expect(CONTAINER_CONTROL_SET.filter(specCarried)).toEqual([]);
+
+    // NOT NECESSARY — outside this roster, judged by that gate anyway, because
+    // the spec describes it. `element:record_picker` is the standing specimen;
+    // the parity file records the same block for the same reason.
+    expect(PUBLIC_BLOCKS).not.toContain('element:record_picker');
+    expect(specCarried('element:record_picker')).toBe(true);
+  });
+
+  it('keeps `box` on the authoring surface it was already on, and adds the one it was not', () => {
+    // ⚠️ The overstatement this case exists to refuse: "absent from
+    // `PUBLIC_BLOCKS`" is not "unvalidated". `page.tsx` builds the JSX-page
+    // compiler's manifest from `getKnownTypes()` + these same `inputs`, so
+    // `box`'s declaration has been live there all along — with no roster in the
+    // path. Asserted with its declared input, because a registration present but
+    // declaring nothing would publish no authoring surface at all.
+    expect(ComponentRegistry.getKnownTypes()).toContain('box');
+    expect((ComponentRegistry.getMeta('box')?.inputs ?? []).map((i) => i.name)).toContain(
+      'className',
+    );
+
+    // What this card actually moved: `getPublicConfigs()` — the curated
+    // vocabulary, and the source `gen-manifest.ts` serialises into the published
+    // `sdui.manifest.json` and `sdui-intrinsics.d.ts`.
+    expect(contract.has('box')).toBe(true);
+    expect(contract.get('box')!.type).toBe('box');
   });
 });

--- a/packages/core/src/registry/public-blocks.ts
+++ b/packages/core/src/registry/public-blocks.ts
@@ -103,6 +103,24 @@ export const PUBLIC_BLOCKS: readonly string[] = [
   'tabs',
   'accordion',
   'container',
+  // The neutral block container, minted by the 2026-08-29 ruling as the JSON
+  // surface's replacement for the deprecated `div` (objectui#3965, PR #6878).
+  // It landed on every other declaration face -- interface, zod mirror,
+  // `SchemaRegistry`, registration, docs page, and 27 catalog fixtures -- and
+  // this list was the one face it missed, so the vocabulary taught a type the
+  // contract did not carry (objectui#6879).
+  //
+  // MEASURED before it was added, because "add it and see" is how a gate
+  // discovers a new population at merge time. `registry-inputs-spec-parity`
+  // (apps/console) does NOT judge it, and not by tolerance: its coverage set is
+  // derived from `Object.keys(ComponentPropsMap)`, it never reads this list,
+  // and `@objectstack/spec@17` carries NO entry for any Tier B layout primitive
+  // -- `flex`, `grid`, `stack`, `card` and `container` are all equally absent.
+  // So `box` joins a spec-less population that gate has never covered; it needs
+  // no spec entry, and no gate needed loosening to accept it. The measurement is
+  // pinned next to the roster census in `apps/console`, over the DERIVED
+  // container population rather than over this list.
+  'box',
   'page:header',
   'text',
   'image',

--- a/packages/core/src/registry/public-blocks.ts
+++ b/packages/core/src/registry/public-blocks.ts
@@ -113,13 +113,27 @@ export const PUBLIC_BLOCKS: readonly string[] = [
   // MEASURED before it was added, because "add it and see" is how a gate
   // discovers a new population at merge time. `registry-inputs-spec-parity`
   // (apps/console) does NOT judge it, and not by tolerance: its coverage set is
-  // derived from `Object.keys(ComponentPropsMap)`, it never reads this list,
-  // and `@objectstack/spec@17` carries NO entry for any Tier B layout primitive
-  // -- `flex`, `grid`, `stack`, `card` and `container` are all equally absent.
-  // So `box` joins a spec-less population that gate has never covered; it needs
-  // no spec entry, and no gate needed loosening to accept it. The measurement is
-  // pinned next to the roster census in `apps/console`, over the DERIVED
-  // container population rather than over this list.
+  // SPEC-shaped -- `Object.keys(ComponentPropsMap)`, filtered to what this repo
+  // registers with inputs. It never reads this list, and membership here is
+  // neither necessary nor sufficient for being judged: `element:record_picker`
+  // is judged while absent from this list, and `flex` / `grid` / `stack` /
+  // `card` / `container` are all listed here and all unjudged, because
+  // `@objectstack/spec@17` carries no entry for ANY Tier B layout primitive. So
+  // `box` joins a spec-less population five types deep rather than opening a
+  // new one; it needs no spec entry, and no gate needed loosening to accept it.
+  //
+  // ⚠️ And "not on this list" never meant "not on an authoring surface". `box`
+  // has been validated all along through the OTHER consumer of the same
+  // `inputs`: `components/src/renderers/layout/page.tsx` builds the JSX-page
+  // compiler's manifest from `getKnownTypes()`, registry-wide. What this list
+  // gates is `getPublicConfigs()` -- the curated AI-authoring vocabulary, and
+  // through `sdui-parser/scripts/gen-manifest.ts` the published
+  // `sdui.manifest.json` and `sdui-intrinsics.d.ts`. THAT is the surface `box`
+  // was missing from, which is a narrower and truer statement of the gap than
+  // "the contract does not know it".
+  //
+  // The measurement is pinned next to the roster census in `apps/console`, over
+  // the DERIVED container population rather than over this list.
   'box',
   'page:header',
   'text',

--- a/packages/core/src/registry/public-blocks.ts
+++ b/packages/core/src/registry/public-blocks.ts
@@ -105,15 +105,15 @@ export const PUBLIC_BLOCKS: readonly string[] = [
   'container',
   // The neutral block container, minted by the 2026-08-29 ruling as the JSON
   // surface's replacement for the deprecated `div` (objectui#3965, PR #6878).
-  // It landed on every other declaration face -- interface, zod mirror,
-  // `SchemaRegistry`, registration, docs page, and 27 catalog fixtures -- and
+  // It landed on every other declaration face — interface, zod mirror,
+  // `SchemaRegistry`, registration, docs page, and 27 catalog fixtures — and
   // this list was the one face it missed, so the vocabulary taught a type the
   // contract did not carry (objectui#6879).
   //
   // MEASURED before it was added, because "add it and see" is how a gate
   // discovers a new population at merge time. `registry-inputs-spec-parity`
   // (apps/console) does NOT judge it, and not by tolerance: its coverage set is
-  // SPEC-shaped -- `Object.keys(ComponentPropsMap)`, filtered to what this repo
+  // SPEC-shaped — `Object.keys(ComponentPropsMap)`, filtered to what this repo
   // registers with inputs. It never reads this list, and membership here is
   // neither necessary nor sufficient for being judged: `element:record_picker`
   // is judged while absent from this list, and `flex` / `grid` / `stack` /
@@ -126,7 +126,7 @@ export const PUBLIC_BLOCKS: readonly string[] = [
   // has been validated all along through the OTHER consumer of the same
   // `inputs`: `components/src/renderers/layout/page.tsx` builds the JSX-page
   // compiler's manifest from `getKnownTypes()`, registry-wide. What this list
-  // gates is `getPublicConfigs()` -- the curated AI-authoring vocabulary, and
+  // gates is `getPublicConfigs()` — the curated AI-authoring vocabulary, and
   // through `sdui-parser/scripts/gen-manifest.ts` the published
   // `sdui.manifest.json` and `sdui-intrinsics.d.ts`. THAT is the surface `box`
   // was missing from, which is a narrower and truer statement of the gap than


### PR DESCRIPTION
Fixes #6879

## STEP 1 FIRST — the measurement, and it is the third answer

Triage forbade touching `PUBLIC_BLOCKS` before measuring what `registry-inputs-spec-parity` does with a public block that has no spec entry. It was measured before the roster was touched, and the answer is neither "it demands a spec entry" nor "it tolerates the absence":

**The gate cannot see the block at all — its population is SPEC-shaped.**

```
covered = Object.keys(ComponentPropsMap)
            .filter(type => (declaredInputs(type) ?? []).length > 0)
```

Measured over that expression on `origin/main@86ef0c764`:

| set | size |
|---|---|
| `ComponentRegistry.getKnownTypes()` | 501 |
| `PUBLIC_BLOCKS` | 58 |
| `ComponentPropsMap` (the spec) | 45 |
| the gate's `covered` | **29** |

`PUBLIC_BLOCKS` appears in that file exactly twice, both times in docblock prose. It is never imported.

**Mutation E1 — `'box'` added to Tier B, parity gate run:**

```
Test Files  1 passed (1)
      Tests  198 passed (198)      command-exit=0
```

Byte-identical to the pre-mutation baseline. Restore verified by blob hash (`92197f3ce`) and an empty `git diff HEAD`.

**Why silent, stated as a property rather than as luck.** Roster membership is neither necessary nor sufficient for being judged, and both halves have live specimens:

- **not necessary** — `element:record_picker`, `element:text_input` and `record:chatter` are all outside `PUBLIC_BLOCKS` and all judged, because the spec describes them;
- **not sufficient** — `flex` / `grid` / `stack` / `card` / `container` are all curated and all unjudged, because `@objectstack/spec@17` carries **no entry for any Tier B layout primitive**.

So `box` did not arrive as a new spec-less population that a gate would discover at merge time. It joined one **five types deep** that the gate has never judged. ⇒ **No spec entry is owed, and nothing needed loosening.** The Tier B addition stands alone.

**LIT CONTROL — the gate is not unconditionally green.** `page:card`'s spec-declared `bordered` input was deleted and the same gate re-run:

```
FAIL  registry-inputs-spec-parity > page:card publishes every top-level key its spec props schema declares
AssertionError: expected [ 'bordered' ] to deeply equal []
      Tests  1 failed | 197 passed (198)      command-exit=1
```

This PR's diff touches that file by **zero lines**; its own `covered === EXPECTED_COVERED` and stale-exemption pins remain the standing guard.

## ⚠️ One thing this gap was NOT

Verified after a reading from the objectui#6955 seat, and it sharpens the card: **"absent from `PUBLIC_BLOCKS`" never meant "not on an authoring surface."** `box`'s `inputs` have been live all along through the other consumer of the same metadata — `packages/components/src/renderers/layout/page.tsx:462` builds the JSX-page compiler's manifest from `getKnownTypes()`, registry-wide, with no roster in the path.

What this roster gates is `getPublicConfigs()`: the curated AI-authoring vocabulary, and through `packages/sdui-parser/scripts/gen-manifest.ts:20` the published `sdui.manifest.json` and `sdui-intrinsics.d.ts`. **That** is the surface `box` was missing from — narrower than "the contract does not know it", and true. Both facts are now pinned rather than left in prose.

## The pin DERIVES, it does not list

An exact list goes red when a curated type **disappears**. Nothing went red when a newly minted type **never arrived** — `EXPECTED_COVERED` agreed with the roster about omitting `box` because both are hand-carried, and two hand-carried lists that agree prove only that the same hand wrote both.

A pin asserting "`PUBLIC_BLOCKS` contains `box`" passes on a roster that carries `box` and has already missed the type minted after it. So the population is derived:

```
LayoutSchema.options                       (the runtime-enumerable zod authoring
  ∩ ComponentMeta.isContainer === true      union ∩ declared containment)
```

= 7 members, and after this PR exactly one is uncurated:

| member | curated |
|---|---|
| `card` `container` `flex` `grid` `stack` | yes — the objectui#6764 control set, asserted not assumed |
| `box` | **yes, as of this PR** |
| `aspect-ratio` | no — ledgered, tracked by #8628 |

A newly minted layout container is in neither the roster nor the ledger, so it fails **by absence**. That is the property `box` needed and did not have.

**Which set the pin derives from, said out loud** (the false-green hazard when two sets exist): the *population* comes from the declaration faces — the zod union plus registry containment. `PUBLIC_BLOCKS` is only the *question* asked of each member. The pin never derives from the same set it interrogates.

**Scope, stated plainly.** This covers the container half of the layout vocabulary. The non-container arms (`span`, `separator`, `scroll-area`, `resizable`, `page`, deprecated `div`) are outside it because curating any of them is an unruled question of its own, and a ledger is a forcing function, not a place to park four at once.

## Every pin was observed to fail — seven red legs

Each mutation was proved on disk (marker counts + blob hash) before the run, and restored with `git checkout HEAD -- path` verified by an empty `git diff HEAD`.

| leg | mutation | assertion that fired |
|---|---|---|
| **R1 — the defect** | `'box'` removed from the roster | `curates every declared layout container` → `expected [ 'aspect-ratio', 'box' ] to deeply equal [ 'aspect-ratio' ]` |
| **R2 — caricature** | roster curates everything (`aspect-ratio` added) | same pin → `expected [] to deeply equal [ 'aspect-ratio' ]`, plus the stale-ledger pin |
| **R3 — caricature** | derivation answers the same for every input (`isContainer` → `false`) | vacuity guard → `expected 0 to be greater than 0` |
| **R4** | union read stops resolving literals | `expected [] to have a length of 17` |
| **R5** | spec lookup always answers no | lit control → `expected 0 to be greater than 0` |
| **R6a** | spec lookup always answers yes | `expected [ 'card', 'container', 'flex', …(2) ] to deeply equal []` |
| **R7 — ablation** | `box` registers with no declared inputs | `expected [] to include 'className'` |

R3 is the one worth reading twice: a roster/census pin that iterates an empty set **passes**, so the vacuity guard is what makes the rest mean anything.

## Non-regression axis

- **Every type already in Tier B is still there** — `EXPECTED_COVERED` is exact (57 → 58), and R1/R2 show it fails in both directions.
- **The gate still reds on a genuinely missing spec entry** — the `page:card` / `bordered` lit control above, with zero lines of this PR's diff touching that file.
- **The gate was not loosened.** No exemption added, no ledger widened, no coverage set changed.

## Verification

Local, all on the final commit `7bb3addc4`:

| run | result |
|---|---|
| `public-contract` + `registry-inputs-spec-parity` | `Tests 217 passed (217)` — parity still **198/198**, census 11 → 19 |
| `apps/console/` + `packages/core/src/registry/` | `98 files / 1199 tests passed` |
| `packages/components/` census + ratchet + `body-dialect-census` | `145 files / 1400 tests passed` |
| app-shell metadata-admin, plugin-dashboard, plugin-tree, sdui-parser | `367 files / 3654 passed, 1 skipped` |
| `examples/schema-catalog/`, `packages/types/`, `packages/core/`, `packages/layout/` | `331 files / 7993 tests passed` |
| `pnpm lint` (full repo, not narrowed) | `47 successful, 47 total` — **0 errors** |
| `@object-ui/core` + `@object-ui/console` `type-check` | both exit 0, on a built closure |
| `check-control-bytes`, `check-phantom-dependencies`, `check-unused-dependencies` | all green |

**LEG D** — classified per test from vitest's JSON reporter, not the text reporter: `numTotalTests 19, passed 19, failed 0, pending 0, failedSuites 0`. All eight new pins individually `passed`; no `Failed Suites`, no `no tests`.

**Typecheck coverage is measured, not assumed**: `tsc -p apps/console/tsconfig.json --noEmit --listFiles` lists `public-contract.test.ts` among its 3551 files, so the type-check really does cover the new pins.

## Changeset

`node scripts/check-changeset-presence.mjs`, verbatim:

> `✅  2 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s): .changeset/6879-public-blocks-box.md.`

`@object-ui/core: minor` — a real bump, not an empty declaration: `getPublicConfigs()` now offers a block it did not, and that is what `gen-manifest.ts` publishes. `scripts/check-changeset-no-major.mjs`: `✅  No changeset declares a major bump.`

## Re-derived figures (⛔ none quoted from the card)

- **Exemplars: 27**, not "27 but stale". Measured as files under `examples/schema-catalog/src/schemas` containing a `"type": "box"` node (84 nodes across them), on **both** my base `86ef0c764` **and** the newest `origin/main` `841dd2b7e`. The dispatch expected 28 because PR #8622 adds `components-basic-div/use-box-instead.json` — that file is absent from `origin/main` at both revisions, so **#8622 has not landed** and 27 is current. It becomes 28 when it does. Homonym hazard avoided: the sweep counts `"type": "box"` JSON nodes only, never the bare word; lit control on the same command shape, `"type": "flex"` → 70 files.
- **Roster re-derived from the tree**, not from the card's `EXPECTED_COVERED`: the census assertion's own received list was read back from a failing run rather than hand-edited.

## Not in this PR

⛔ Nothing from PR #8622 (objectui#6877). `div.tsx`, `div.mdx` and the `components-basic-div` fixtures are untouched — the diff is 2 files plus a changeset. #6877 is not addressed here.

---

## 维护者速读(草稿)

**改了什么** — `box` 进 `PUBLIC_BLOCKS` Tier B(`packages/core`),`apps/console` 的名单普查测试同步更新,并新增一组**推导式**的门禁:待判人口从 zod `LayoutSchema` 的分支 ∩ 注册表 `isContainer` 推出,而不是手抄一份清单。

**为什么改** — `box` 由 2026-08-29 裁决铸造为 `div` 的中性替代,落在了所有声明面上(接口、zod 镜像、`SchemaRegistry`、注册、文档页、27 个目录范例),唯独漏了策展契约。于是 `getPublicConfigs()` 生成的 `sdui.manifest.json` 与 `sdui-intrinsics.d.ts` 少了一个目录正在教的类型 —— AI 作者读得到范例,读不到词汇表。

**风险与代价(含回滚)** — 风险低:契约面**只增不减**,现有 Tier B 一个不动。`registry-inputs-spec-parity` 实测纹丝不动(198/198),因为它的人口是 spec 形状,而 spec 从不描述任何 Tier B 布局原语。⚠️ 唯一的新增维护负担是那条一格账本:`aspect-ratio` 从未被裁决过,已另开 #8628 逼出决定;它若被长期搁置,账本就会退化成许可证。回滚 = revert 本 PR 三个 commit,无迁移、无数据、无生成物。

**席位意见** — (待定稿)

**你要做的** — ① 确认 `box` 确实该进策展词汇表(裁决说它是「新增公开类型」,本 PR 按此执行);② 认领或分诊 #8628,决定 `aspect-ratio` 是策展还是按理由拒绝;③ 确认推导式门禁的**范围划法**可接受:只管布局词汇表的容器那一半,非容器分支(`span` / `separator` / `scroll-area` / `resizable` / `page` / 已弃用的 `div`)留给原来的精确清单,因为逐个策展是四个各自独立的未裁决问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_