### PR TITLE
feat(types)!: retire sections[].collapsed from RecordDetailsComponentProps (objectui#8583)

### DIFF
--- a/.changeset/retire-record-details-section-collapsed.md
+++ b/.changeset/retire-record-details-section-collapsed.md
@@ -1,0 +1,31 @@
+---
+'@object-ui/types': minor
+---
+
+**BREAKING** — `RecordDetailsComponentProps.sections[]` no longer declares `collapsed`.
+
+**FROM** `collapsed` **TO** `defaultCollapsed`.
+
+```ts
+// before
+sections: [{ label: 'Address', fields: ['street', 'city'], collapsed: true }]
+// after
+sections: [{ label: 'Address', fields: ['street', 'city'], defaultCollapsed: true }]
+```
+
+`@objectstack/spec` `RecordDetailsProps.sections[]` refuses `collapsed` by name
+(`unrecognized_keys`), and `defaultCollapsed` is the spelling it declares for that
+state — the spelling `DetailSection` has always read. So the retired key never
+reached the renderer through a spec parse, and nothing in this repository read it:
+this is a type-face narrowing, not a data or runtime change. There is nothing to
+migrate — rename the key at the authoring site.
+
+`collapsible` is unaffected; it stays.
+
+⚠️ The census behind this removal covers this repository only. A TypeScript
+consumer of `@object-ui/types` outside it that wrote `collapsed` is not
+observable from here, and gets a compile error (TS2353) naming the key — which
+is why the FROM/TO is spelled out above.
+
+Retires the last member of the divergence objectui#8583 measured; the six keys
+this type used to omit landed in the previous release.

--- a/.changeset/retire-record-details-section-collapsed.md
+++ b/.changeset/retire-record-details-section-collapsed.md
@@ -27,5 +27,6 @@ consumer of `@object-ui/types` outside it that wrote `collapsed` is not
 observable from here, and gets a compile error (TS2353) naming the key — which
 is why the FROM/TO is spelled out above.
 
-Retires the last member of the divergence objectui#8583 measured; the six keys
-this type used to omit landed in the previous release.
+Retires the last member of the divergence objectui#8583 measured. The six keys
+this type used to omit are item 1 of the same card; its changeset is still
+pending, so both halves ship in this release.

--- a/packages/types/src/__tests__/p1-spec-alignment.test.ts
+++ b/packages/types/src/__tests__/p1-spec-alignment.test.ts
@@ -498,7 +498,7 @@ describe('P1.5 Record Components', () => {
       layout: 'stacked',
       sections: [
         { label: 'Basic Info', fields: ['name', 'email', 'phone'], collapsible: true },
-        { label: 'Address', fields: ['street', 'city', 'state'], collapsed: true },
+        { label: 'Address', fields: ['street', 'city', 'state'], defaultCollapsed: true },
       ],
       fields: ['name', 'email'],
       aria: { ariaLabel: 'Account Details' },

--- a/packages/types/src/__tests__/record-details-section-members-8583.test.ts
+++ b/packages/types/src/__tests__/record-details-section-members-8583.test.ts
@@ -7,10 +7,18 @@
  */
 
 /**
- * objectui#8583 (item 1) — `RecordDetailsComponentProps.sections[]` declares
- * the six member keys `@objectstack/spec` `RecordDetailsProps.sections[]`
- * declares and this type used to omit: `columns`, `icon`, `description`,
- * `showBorder`, `defaultCollapsed`, `headerColor`.
+ * objectui#8583 — `RecordDetailsComponentProps.sections[]` and the
+ * `@objectstack/spec` `RecordDetailsProps.sections[]` member set, both
+ * directions of the divergence the card measured.
+ *
+ * - **item 1** — this type declares the six keys the spec declares and it used
+ *   to omit: `columns`, `icon`, `description`, `showBorder`,
+ *   `defaultCollapsed`, `headerColor`.
+ * - **item 2** — this type no longer declares `collapsed`, the one key it
+ *   declared that the spec REFUSES by name. Retired outright, no transition
+ *   window (director seat, decision batch #101, applying batch #87 — this repo
+ *   does not declare a key the spec refuses by name — and the 2026-08-27
+ *   retirement-pacing ruling). `defaultCollapsed` is the surviving spelling.
  *
  * ## Why this pin is compile-time, and why a runtime pin alone measures nothing
  *
@@ -143,6 +151,53 @@ const refusedByTsc: RecordDetailsComponentProps = {
   ],
 };
 
+/* ── item 2: `collapsed` is RETIRED, `defaultCollapsed` is the spelling ───── */
+
+/**
+ * The retired key must NOT be a member. The directive is the assertion: re-add
+ * `collapsed?: boolean` to the section entry and `Expect<true>` compiles, the
+ * directive goes UNUSED, and TypeScript reports TS2578 here. That is the
+ * ablation this pin is built to fail on.
+ */
+// @ts-expect-error objectui#8583 (item 2) — `collapsed` is retired; it is not a member of the section entry.
+type _CollapsedIsRetired = Expect<IsSectionMember<'collapsed'>>;
+
+/**
+ * The surviving spelling, asserted with NO directive so it carries the other
+ * half: were `defaultCollapsed` ever dropped too, this line goes red on its own
+ * terms rather than leaving the pin above to pass over an entry that declares
+ * neither collapse key.
+ */
+type _DefaultCollapsedSurvives = Expect<IsSectionMember<'defaultCollapsed'>>;
+
+/**
+ * FROM `collapsed` TO `defaultCollapsed`, at the authoring site an external
+ * consumer actually writes. Excess-property checking on the section literal is
+ * what turns the retirement into a compile error (TS2353 naming the key) rather
+ * than a value that is silently carried and never read.
+ */
+const retiredSpellingRefusedByTsc: RecordDetailsComponentProps = {
+  sections: [
+    {
+      fields: ['phone'],
+      collapsible: true,
+      // @ts-expect-error objectui#8583 (item 2) — the retired spelling does not compile; write `defaultCollapsed`.
+      collapsed: true,
+    },
+  ],
+};
+
+/** The same literal in the surviving spelling — no directive, so it MUST compile. */
+const survivingSpellingAccepted: RecordDetailsComponentProps = {
+  sections: [
+    {
+      fields: ['phone'],
+      collapsible: true,
+      defaultCollapsed: true,
+    },
+  ],
+};
+
 /** Member keys of one `sections[]` entry, read off the INSTALLED spec. */
 const specSectionKeys = (): string[] =>
   listedShapeKeys(arrayElementSchema(resolvePropsShape(RecordDetailsProps)?.sections));
@@ -155,7 +210,7 @@ const specSectionKeys = (): string[] =>
 const refusedKeys = (issues: ReadonlyArray<unknown> | undefined): string[] =>
   (issues ?? []).flatMap((i) => (i as { keys?: string[] }).keys ?? []);
 
-describe('record:details `sections[]` declares the six spec members (objectui#8583, item 1)', () => {
+describe('record:details `sections[]` mirrors the spec member set, both directions (objectui#8583)', () => {
   it('the installed spec still declares all six on the section object', () => {
     // The premise the compile-time pins rest on: were the spec to drop one, the
     // `Equal` above would go red for the right reason, and this names it first.
@@ -215,10 +270,32 @@ describe('record:details `sections[]` declares the six spec members (objectui#85
     ]);
   });
 
+  it('item 2 — the installed spec does not declare `collapsed`, and refuses it BY NAME', () => {
+    // The premise batch #87 rests on, measured rather than recalled, and with
+    // its own control in the same read: a zero here is a reading only because
+    // the surviving spelling is present in the same key list.
+    const keys = specSectionKeys();
+    expect(keys).toContain('defaultCollapsed');
+    expect(keys).not.toContain('collapsed');
+
+    // And the refusal is attributable to the NAME, not to a parser that refuses
+    // everything: the same canonical section parsed clean in control A above.
+    const parsed = RecordDetailsProps.safeParse({
+      sections: [{ ...canonicalSection, collapsed: true }],
+    });
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues.map((i) => i.code)).toContain('unrecognized_keys');
+    expect(refusedKeys(parsed.error?.issues)).toEqual(['collapsed']);
+  });
+
   it('keeps the compile-time literals alive at runtime', () => {
     // Runtime shape is unaffected by the type-level assertions above; these
     // exist so the file also fails visibly if a literal is ever emptied.
     expect(canonicalSection.headerColor).toBe('muted');
     expect(refusedByTsc.sections).toHaveLength(1);
+    // item 2's pair. `collapsed` is read through `Object.keys` because the type
+    // no longer declares it — which is the whole point of the pin above.
+    expect(Object.keys(retiredSpellingRefusedByTsc.sections?.[0] ?? {})).toContain('collapsed');
+    expect(survivingSpellingAccepted.sections?.[0]?.defaultCollapsed).toBe(true);
   });
 });

--- a/packages/types/src/record-components.ts
+++ b/packages/types/src/record-components.ts
@@ -117,7 +117,6 @@ export interface RecordDetailsComponentProps {
       | 'secondary/10'
       | 'destructive/10';
     collapsible?: boolean;
-    collapsed?: boolean;
   }>;
   /** Specific fields to display (overrides auto-detection from object) */
   fields?: string[];


### PR DESCRIPTION
Fixes #8583

Item 2 of the card, executed on the director seat's ruling `5588930745` (decision batch #101, option A), which applies standing ruling batch #87 (this repo does not declare a key `@objectstack/spec` refuses by name) and the 2026-08-27 retirement-pacing ruling 「项目在创业阶段,用户也很少,短期不考虑渐进。」. Item 1 — the six keys this type used to omit — landed in #8601.

## What changed

`RecordDetailsComponentProps.sections[]` no longer declares `collapsed`. `defaultCollapsed` is the surviving spelling: it is what `@objectstack/spec` `RecordDetailsProps.sections[]` declares, and what `DetailSection` has always read (`DetailSection.tsx:142`). Retired outright, no transition window and no "refused upstream" annotation (option B, refused by the ruling).

| file | change |
|---|---|
| `packages/types/src/record-components.ts` | `-1` line: the `collapsed?: boolean;` declaration |
| `packages/types/src/__tests__/record-details-section-members-8583.test.ts` | the item-2 type-level pin, four assertions plus one runtime probe |
| `packages/types/src/__tests__/p1-spec-alignment.test.ts` | `collapsed: true` renamed to `defaultCollapsed: true` on its `RecordDetailsComponentProps` fixture |
| `.changeset/retire-record-details-section-collapsed.md` | `@object-ui/types` `minor`, BREAKING banner, FROM/TO |

⚠️ **One correction to the brief, reported rather than smoothed over.** The ruling asked for "the declaration and its docblock (`:120` and `:100`)". Re-located on this head, and cross-read against the census SHA `9f5de79d` and against `154fe2a` (the merge base of #8601): line `:120` is right, but **`collapsed` has never had a docblock at any of those three points** — line `:100` is `defaultCollapsed`'s docblock, added by item 1, which this ruling explicitly keeps. Deleting it would have hit the one thing the ruling forbids ("no other member touched"), so it was not deleted. The deletion is one line.

## The pin is reached by the leg that TYPE-CHECKS

The card's own lesson: `vitest` strips types, and this package's build project excludes tests, so a pin that runs only under vitest measures nothing. The instrument is `tsc -p packages/types/tsconfig.test.json` — the third leg of `@object-ui/types`'s `type-check` script. Proven, not assumed: `tsc --listFiles` on that project emits 614 files and the pin file is one of them (`packages/types/src/__tests__/record-details-section-members-8583.test.ts`, and `p1-spec-alignment.test.ts` alongside it).

Four legs, run from the committed implementation, each with on-disk mutation proof (anchor grep counts plus a `git hash-object` blob comparison against the HEAD blob) and restored with `git checkout HEAD -- path` verified by an empty `git diff HEAD`:

| leg | mutation | `tsc` exit | what the compiler said |
|---|---|---|---|
| 0 | none (committed state) | `0` | clean |
| 1 — the pin FIRES | strip the `@ts-expect-error` above `collapsed: true` | `2` | `error TS2353: Object literal may only specify known properties, and 'collapsed' does not exist in type '{ name?: …; showBorder?: …; defaultCollapsed?: …; headerColor?: … }'` — the error names the key, and the member set it prints carries `defaultCollapsed` and not `collapsed` |
| 2 — ABLATION | re-add `collapsed?: boolean;` to the interface, directive still stripped | `2` | **TS2353 is gone** (`grep -c TS2353` = 0). The only error left is `TS2578: Unused '@ts-expect-error' directive` on the type-level pin at `:162` |
| 3 — ABLATION on the committed pin | re-add the member, directives intact | `2` | `TS2578` twice, at `:162` and `:184` — both item-2 directives go unused, i.e. re-declaring the member makes this file red rather than quietly passing |

Leg 1 vs leg 2 is the direction proof the ruling asked for: with the member deleted the `collapsed` literal produces a real `tsc` error naming the key, and re-adding the member makes exactly that error disappear. Legs 3 shows the committed pin's own failure mode.

The runtime half is a two-control read on the INSTALLED spec, not a restatement: `defaultCollapsed` is in the section object's key list and `collapsed` is not (the control that makes the zero a reading), and the canonical section plus `collapsed` draws `unrecognized_keys` naming exactly `collapsed` — while the same canonical section parses clean in control A above, so the refusal is attributable to the name.

## The census, re-run on this head with controls — and one item of it FALSIFIED

⚠️ **This section was rewritten after the contract review (defect 1).** Its first version printed a pathspec that matches nothing: on git 2.43 `git ls-files -- 'packages/*/src'` returns **0 files** (`'packages/*/src/*'` returns 3954; `-- packages apps examples` returns 5110), because a git pathspec has to match a FILE path and `*` already spans `/`. In that form the control could not have fired, so "exit 1, zero lines" was not a reading. ⛔ The evidence is not deleted and the conclusion is not restated without a measurement under it — the commands below are the ones actually run on this head, with their real output. The finding is unchanged: no reader or writer of this member survives in this repository.

**1. The decisive reading — nobody who knows the type reads the key.**

```
$ git grep -ln 'RecordDetailsComponentProps' -- packages apps examples
packages/plugin-detail/src/renderers/record-details.tsx
packages/types/src/__tests__/p1-spec-alignment.test.ts
packages/types/src/__tests__/record-details-section-members-8583.test.ts
packages/types/src/index.ts
packages/types/src/record-components.ts

$ git grep -nE '\.collapsed\b' -- $(git grep -ln 'RecordDetailsComponentProps' -- packages apps examples)
$ echo $?          # no output, no match
1
```

Five files know the type at all; not one of them reads `.collapsed`. `record-details.tsx` is the only non-test importer — it declares its schema as the props type intersected with an open string-keyed record, so an undeclared key would still reach it at runtime, and it never mentions the key.

**2. `.collapsed` property reads tree-wide — 39 hits, every one on a different type.**

```
$ git grep -nE '\.collapsed\b' -- packages apps examples | wc -l
39
$ git grep -nE '\.defaultCollapsed\b' -- packages apps examples | wc -l   # control
11
```

| declaring type | sites |
|---|---|
| chats-list hook state | `app-shell/src/console/ai/__tests__/useCollapsibleChatsList.test.tsx` (12) |
| kanban column / lane | `plugin-kanban/src/KanbanEnhanced.tsx` (6) |
| grouping field / group row | `plugin-list/src/ObjectGallery.tsx` (3), `plugin-grid/src/useGroupedData.ts` (2), `plugin-grid/src/ObjectGrid.tsx`, `plugin-grid/src/__tests__/groupingNullEntry-7217.test.tsx`, `components/src/custom/grouping-editor.tsx` |
| object-form section | `plugin-form/src/ObjectForm.tsx` (3), `plugin-form/src/DrawerForm.tsx` (3), `components/src/renderers/form/form.tsx`, `app-shell/src/views/metadata-admin/SchemaForm.tsx`, `plugin-designer/src/__tests__/__mocks__/plugin-form.tsx`, `apps/console/src/components/FormPage.tsx` |
| field GROUP (studio designer) | `app-shell/src/views/studio-design/ObjectGroupInspector.tsx` |
| accordion item | `components/src/renderers/layout/containers.tsx` |
| sidebar UI-state doc prose | `data-objectstack/README.md` |

⭐ The load-bearing row is the one that is empty: `packages/plugin-detail/**`, the only renderer of `record:details`, contributes **zero** of the 39 (`grep -c plugin-detail` over that output = 0, exit 1). Its collapse state is read as `defaultCollapsed` — `DetailSection.tsx:142`, `SectionGroup.tsx:50`, both inside the control's 11.

**3. JSON writers — a true zero, with a live control on the same pathspec.**

```
$ git grep -n '"collapsed"' -- '*.json'; echo $?
1
$ git grep -n '"collapsible"' -- '*.json' | wc -l   # control
4
```

The control's four hits are `content/docs/components/disclosure/meta.json`, two `examples/schema-catalog` schemas and `packages/components/shadcn-components.json` — so the zero above is a reading, not a broken search.

**4. Literal `collapsed:` KEY writes tree-wide — 90 sites, all accounted for.**

```
$ git grep -nE '(^|[^.A-Za-z0-9_])collapsed[[:space:]]*:' -- packages apps examples content e2e scripts | wc -l
90
$ git grep -nE '(^|[^.A-Za-z0-9_])defaultCollapsed[[:space:]]*:' -- packages apps examples content e2e scripts | wc -l   # control
21
```

Only three of the 90 sit anywhere near `record:details`, and each was opened: `packages/types/src/__tests__/p1-spec-alignment.test.ts:293` is an `ObjectFormSection`; `packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts:973` is a `fieldGroups` INPUT entry, whose converter emits `defaultCollapsed` on the way out (`buildDefaultPageSchema.ts:722`); `content/docs/plugins/plugin-detail.mdx:156` is English prose ("collapsible and default-collapsed:"), not a key — that doc's `record:details` schema block writes `defaultCollapsed`. Two more are this PR's own pin literals. The remaining 85 are grouping fields, kanban lanes and columns, form sections, wizard steps, accordion items, sidebar state, the chats-list hook, and gate scripts' own fixtures.

⛔ **And the one census line of the ruling that is FALSE.** The ruling reported "zero `collapsed:` in any record-details test". `packages/types/src/__tests__/p1-spec-alignment.test.ts:501` wrote `{ label: 'Address', fields: [...], collapsed: true }` inside `const props: RecordDetailsComponentProps = {` at `:496`, and `tsconfig.test.json` compiles that file. Left alone, the deletion turns the package's `type-check` red on the first push. Renamed to `defaultCollapsed` — fixture triage of the "it used the retired spelling" kind, not a fixture the pin replaced: the test's own assertions are `columns`, `sections.length` and `layout`, none of which reads the key.

⚠️ **The limit the ruling declared, carried into the changeset:** this census covers this repository only. An external TypeScript consumer of `@object-ui/types` that wrote `collapsed` is not observable from here — it gets TS2353 naming the key, which is why the changeset spells out the FROM/TO.

## Gates run locally, exit code captured before any pipe

| command | exit |
|---|---|
| `pnpm --filter @object-ui/types type-check` (baseline, before any edit) | `0` |
| `pnpm --filter @object-ui/types type-check` (after) | `0` |
| `pnpm --filter @object-ui/types build` (`tsc` + `check-dist-completeness`) | `0` |
| `pnpm --filter '@object-ui/plugin-detail^...' build` (consumer closure) | `0` |
| `pnpm --filter @object-ui/plugin-detail type-check` (the one non-test consumer) | `0` |
| `pnpm exec vitest run` on the two changed test files (repo root, no `--`) | `0` — 2 files, 45 tests |
| `node scripts/check-changeset-presence.mjs` | `0` |
| `node scripts/check-changeset-no-major.mjs` | `0` |
| `node scripts/check-changeset-fixed.mjs` | `0` |
| `node scripts/check-control-bytes.mjs` | `0` |
| `node scripts/check-type-check-coverage.mjs` | `0` |
| `node scripts/check-governed-queue-guard.mjs --test` on the four paths | `0` — NOT GOVERNED |
| `pnpm exec eslint` on the three changed sources | `0` (2 pre-existing `no-explicit-any` warnings, neither on a changed line) |

`plugin-detail type-check` read `2` on its first run — `Cannot find module '@object-ui/core'`, an unbuilt dependency closure, i.e. NOT MEASURED rather than red. It reads `0` after the closure build; that row is the second run.

**Not measured locally, left to CI:** the repo-wide `pnpm test` and `pnpm lint`, `pnpm check`, the docs-snippet and doc-type gates, and every other `check:*` in `lint.yml`.

## Correction round after the ceiling-tier contract review (verdict: PASS)

The review at `5590429735` passed all five axes, reproduced the four ablation legs with matching results, and confirmed both refusals this PR made against the ruling. Two of its three defects are fixed here; the third was declined by the seat.

- **Defect 2 — a false sentence in a published artifact. FIXED, one line.** The changeset used to close "the six keys this type used to omit landed in the previous release." That is false, and re-measured here rather than taken on report: `git show c4326fe:.changeset/8583-record-details-section-members.md` exits 0 — item 1's changeset is **still pending on this PR's own base** — and the `17.6.0` section of `packages/types/CHANGELOG.md` contains zero occurrences of `8583` (control: 17 occurrences of `objectui#` in the same section, so the zero is a reading). Both items ship in the same release. A changeset is this repository's input to release notes, so a wrong sentence there is wrong in the release notes. ⛔ Nothing else in that file moved: the `**BREAKING**` banner and the FROM/TO are byte-identical.
- **Defect 1 — the census evidence was not reproducible as written. FIXED in the body above**, by re-running the census in a form that reproduces rather than by deleting the evidence or restating the conclusion bare.
- **Defect 3 — the changeset filename is not issue-prefixed. NOT changed**, per the seat: 440 precedents of the same form on base, no collision, `check-changeset-overwrite` green.

## 验收备注

- `hideEmpty` stays out, per the objectui#7129 ruling — not touched here.
- `collapsible` stays; only the initial-state key moved.
- No other member of the entry is touched: the diff on `record-components.ts` is a single deleted line.
- Nothing under `packages/types/src/zod/**` or `packages/types/package.json` was touched (`RecordDetailsComponentProps` has no zod mirror; `git grep collapsed packages/types/src/zod/` hits only navigation, complex and views, none of them this member), and `zod-mirror-parity.test.ts` is untouched — the hot-file fence held.
- Out of scope, noted and not filed: `collapsible?: boolean` is now the only member of this entry with no docblock, while its six siblings each carry one. Cosmetic, inside the file this PR edits; the seat that next documents this entry is the carrier. Filing it would be a documentation nit, which is not one of the three fileable classes.

`Clause-②: yes` — the accept set of a published type face narrows. `needs:contract-review` is hung on this PR as well as on the card (双载体); ⛔ only the PM clears it, on a transcript-verified `CONTRACT_REVIEW_TIER` PASS.

Drafted by the `domain:spec` @ objectui dev seat in session `session_01Jmxdo7bmeqCQHLSfmLVX9w`; the branch is `claude/issue-8583-retire-sections-collapsed`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_


---
_Generated by [Claude Code](https://claude.ai/code)_