### PR TITLE
fix(layout): describe AppShellBranding.title as the whole document title, not a suffix

### DIFF
--- a/.changeset/6872-app-shell-branding-title-jsdoc.md
+++ b/.changeset/6872-app-shell-branding-title-jsdoc.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/layout': patch
+---
+
+Correct the `AppShellBranding.title` doc comment (objectui#6872). It read "Page title
+suffix (sets document.title)" while `useAppShellBranding` assigns `document.title = title`
+wholesale — nothing is appended; the caller composes the whole string (the console passes
+`"App label — Product name"`). That comment ships in `dist/index.d.ts` and is the only
+description a consumer sees on editor hover, so a reader who followed it passed a
+suffix-only fragment and got a truncated title with no error. The comment now carries the
+same wording as `content/docs/layout/app-shell.mdx`, and agrees with the `AppShellProps`
+tables in the package README and `content/docs/guide/layout.md`. No runtime behaviour
+changes; the wholesale assignment and the four-surface agreement are now pinned by tests.

--- a/packages/layout/src/AppShell.tsx
+++ b/packages/layout/src/AppShell.tsx
@@ -16,7 +16,11 @@ export interface AppShellBranding {
   accentColor?: string;
   /** Favicon URL — replaces the <link rel="icon"> href */
   favicon?: string;
-  /** Page title suffix (sets document.title) */
+  /**
+   * Assigned to `document.title` as given. It is the whole title, not a suffix:
+   * the caller composes the string it wants (the console passes
+   * `"App label — Product name"`).
+   */
   title?: string;
 }
 

--- a/packages/layout/src/__tests__/app-shell-branding-title-assignment.test.tsx
+++ b/packages/layout/src/__tests__/app-shell-branding-title-assignment.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `AppShellBranding.title` is assigned to `document.title` as given — the whole
+ * title, not a suffix (objectui#6872).
+ *
+ * objectui#6872 is a documentation defect: the JSDoc said "suffix" while the
+ * code assigns wholesale. The plausible WRONG fix is the other direction — edit
+ * the code to match the comment and have `useAppShellBranding` append a product
+ * name. That would double-concatenate for every caller that already composes the
+ * whole string (`ConsoleLayout.tsx` passes `"App label — Product name"`), and it
+ * would break two teaching surfaces that were already right to satisfy the one
+ * that was wrong. This file pins the behaviour the corrected wording describes,
+ * so the wording and the code cannot be reconciled in the wrong direction.
+ *
+ * Shape: set `document.title` to a sentinel, render `AppShell` with a known
+ * `branding.title`, and assert `document.title` EQUALS that string — `toBe`, not
+ * `toContain`, so an appended product name is a failure, not a superset that
+ * still matches. The first test is an environment control: happy-dom must let
+ * the assignment be observed at all, otherwise every later assertion would be
+ * asserting about a property this environment never lets anyone write.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { AppShell, useAppShellBranding, type AppShellBranding } from '../AppShell';
+
+const SENTINEL = 'sentinel — document.title before AppShell mounted';
+
+/** Mounts only the hook — the actual `document.title` writer — with no shell chrome. */
+function HookOnly({ branding, title }: { branding?: AppShellBranding; title?: string }) {
+  useAppShellBranding(branding, title);
+  return null;
+}
+
+beforeEach(() => {
+  document.title = SENTINEL;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('environment control', () => {
+  it('happy-dom lets `document.title` be written and read back', () => {
+    // Without this the assertions below could all be vacuous in a DOM whose
+    // `title` setter is a no-op. Measured, not assumed.
+    document.title = 'probe';
+    expect(document.title).toBe('probe');
+    document.title = SENTINEL;
+    expect(document.title).toBe(SENTINEL);
+  });
+});
+
+describe('`AppShell` writes `branding.title` to `document.title` as given (objectui#6872)', () => {
+  it('a bare app label stays a bare app label — nothing is appended', () => {
+    render(
+      <AppShell branding={{ title: 'Sales CRM' }}>
+        <div>content</div>
+      </AppShell>,
+    );
+    expect(
+      document.title,
+      [
+        '`document.title` is not the `title` the caller passed. `AppShellBranding.title` is the',
+        'WHOLE title: the caller composes the string it wants (ConsoleLayout.tsx passes',
+        '"App label — Product name"). Appending here double-concatenates for every such caller.',
+      ].join('\n'),
+    ).toBe('Sales CRM');
+  });
+
+  it('a caller-composed "App label — Product name" passes through with exactly one separator', () => {
+    render(
+      <AppShell branding={{ title: 'Sales CRM — ObjectStack' }}>
+        <div>content</div>
+      </AppShell>,
+    );
+    expect(document.title).toBe('Sales CRM — ObjectStack');
+    expect(document.title.split(' — ')).toHaveLength(2);
+  });
+
+  it('no `title` leaves `document.title` untouched', () => {
+    render(
+      <AppShell branding={{ primaryColor: '#3B82F6' }}>
+        <div>content</div>
+      </AppShell>,
+    );
+    expect(document.title).toBe(SENTINEL);
+  });
+});
+
+describe('`useAppShellBranding` is the writer, and it writes the second argument as given', () => {
+  it('assigns the `title` argument wholesale', () => {
+    render(<HookOnly title="Hook Title" />);
+    expect(document.title).toBe('Hook Title');
+  });
+
+  it('does not read `branding.title` on its own — `AppShell` is what forwards it', () => {
+    // `AppShell` calls `useAppShellBranding(branding, branding?.title)`; the hook
+    // itself only writes its explicit second argument. Pinned so the two halves
+    // of the contract (who composes, who forwards, who writes) stay legible.
+    render(<HookOnly branding={{ title: 'Not Forwarded' }} />);
+    expect(document.title).toBe(SENTINEL);
+  });
+});

--- a/packages/layout/src/__tests__/app-shell-branding-title-surfaces.test.ts
+++ b/packages/layout/src/__tests__/app-shell-branding-title-surfaces.test.ts
@@ -1,0 +1,329 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `AppShellBranding.title` is described the same way on every surface that
+ * describes it, and that description is the one the code implements
+ * (objectui#6872).
+ *
+ * ## The defect
+ *
+ * `AppShell.tsx` declared `title` with the JSDoc `Page title suffix (sets
+ * document.title)`, while `useAppShellBranding` assigns `document.title = title`
+ * wholesale — no concatenation anywhere. The suffix is composed by the CALLER
+ * (`ConsoleLayout.tsx` builds `"App label — Product name"` and passes the
+ * finished string in). So the word "suffix" was backwards, and three sibling
+ * teaching surfaces already had it right:
+ *
+ *   - `content/docs/layout/app-shell.mdx` — "assigned to `document.title` as
+ *     given. It is the whole title, not a suffix: …"
+ *   - `packages/layout/README.md`, `#### AppShellProps` table — "`title` sets
+ *     `document.title`"
+ *   - `content/docs/guide/layout.md`, `### Props` table — same clause
+ *
+ * The JSDoc matters more than a README line: it ships in `dist/index.d.ts` and is
+ * the ONLY description a consumer reads on editor hover. Following it produces a
+ * truncated title with no error of any kind.
+ *
+ * ## What is pinned, and why each pin is shaped the way it is
+ *
+ * 1. **Present.** A pin that only says "the JSDoc does not say suffix" passes on
+ *    a JSDoc that has been DELETED — and an absent description on a published
+ *    `.d.ts` is worse than a wrong one (the hover shows nothing). So the first
+ *    assertion is that `title` carries a non-empty doc comment at all.
+ *
+ * 2. **States the whole-assignment behaviour.** The comment must name
+ *    `document.title` and say the value is used as given / is the whole title.
+ *    The old wording is run through the same reader as a built-in RED control,
+ *    so the reader is known to reject it rather than merely known to accept the
+ *    new text.
+ *
+ * 3. **Never a suffix, on any surface.** Every occurrence of the word "suffix"
+ *    in a `title` description must be the negated one ("not a suffix"). This is
+ *    checked on all four surfaces, so the reversed wording cannot reappear on
+ *    any of them.
+ *
+ * 4. **The surfaces agree.** The disease on this card was one behaviour with
+ *    several descriptions and one of them reversed; a FOURTH wording would be
+ *    the same defect again. So the JSDoc must be, after whitespace
+ *    normalization, the SAME text as the `content/docs/layout/app-shell.mdx`
+ *    bullet it was copied from, and the two props-table cells (README, guide)
+ *    must carry the same `title` clause as each other. The wording is read off
+ *    the sibling files on every run — nothing is hand-copied into this test, so
+ *    it cannot rot into "update the test".
+ *
+ * 5. **Distinct per field.** The caricature of "one behaviour, one description"
+ *    is a source where EVERY field's JSDoc was replaced by the same constant
+ *    string — every single-field pin above stays green under that if the
+ *    constant happens to be the right sentence. So the four fields the
+ *    interface declares (read off the source, not hand-listed) must each carry
+ *    a doc comment and those comments must be pairwise distinct.
+ *
+ * 6. **The code half, by source.** `document.title` is written exactly once in
+ *    `AppShell.tsx`, and the right-hand side is the bare `title` — no template,
+ *    no `+`, no `+=`. The behavioural version of this pin (render, then read
+ *    `document.title`) lives in `app-shell-branding-title-assignment.test.tsx`;
+ *    this half exists so a source diff that adds a SECOND writer is caught by
+ *    the same file that pins the wording, since a second writer would change
+ *    what the correct wording is.
+ *
+ * ## Scan surface
+ *
+ * `packages/layout/src/AppShell.tsx`, `packages/layout/README.md`,
+ * `content/docs/guide/layout.md`, `content/docs/layout/app-shell.mdx` — and
+ * within each, only the description of `AppShellBranding.title` (plus, for #5,
+ * the doc comments of the interface's other fields). The `<AppShell …>`
+ * examples and the props-table KEYS on those pages belong to
+ * `readme-app-shell-example.test.ts`, `guide-layout-app-shell-doc.test.ts` and
+ * `app-shell-docs-nav-example.test.ts` and are not judged here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+/** `packages/layout` — two levels up from `src/__tests__`. */
+const PKG_DIR = resolve(__dirname, '../..');
+/** Repository root — two more. */
+const REPO_ROOT = resolve(PKG_DIR, '../..');
+
+const APP_SHELL_SRC = readFileSync(join(PKG_DIR, 'src', 'AppShell.tsx'), 'utf8');
+const README = readFileSync(join(PKG_DIR, 'README.md'), 'utf8');
+const GUIDE = readFileSync(join(REPO_ROOT, 'content', 'docs', 'guide', 'layout.md'), 'utf8');
+const MDX = readFileSync(join(REPO_ROOT, 'content', 'docs', 'layout', 'app-shell.mdx'), 'utf8');
+
+// ---------------------------------------------------------------------------
+// Readers
+// ---------------------------------------------------------------------------
+
+/** Collapse all whitespace runs to one space and trim, so line wrapping is not a difference. */
+function normalize(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * `normalize`, then lower-case the first character. The JSDoc is a sentence and
+ * opens with a capital; the mdx bullet continues after its `- \`title\` — ` lead
+ * and opens lower-case. That one letter is the only difference the copy is
+ * allowed to have.
+ */
+function normalizeSentenceStart(text: string): string {
+  const n = normalize(text);
+  return n.charAt(0).toLowerCase() + n.slice(1);
+}
+
+/** The body of `export interface NAME { … }` in `AppShell.tsx`. */
+function interfaceBody(name: string): string {
+  const body = new RegExp(`export interface ${name} \\{\\n([\\s\\S]*?)\\n\\}`).exec(APP_SHELL_SRC);
+  if (!body) throw new Error(`\`export interface ${name}\` is gone from AppShell.tsx`);
+  return body[1];
+}
+
+/**
+ * Keys declared by an interface, read off the source. Anchored at line start,
+ * so JSDoc lines (which start with `*` or `/`) are never collected as keys.
+ */
+function interfaceKeys(name: string): string[] {
+  return [...interfaceBody(name).matchAll(/^\s*(\w+)\??\s*:/gm)].map((match) => match[1]);
+}
+
+/**
+ * The doc comment immediately preceding `KEY?:` / `KEY:` inside an interface
+ * body, with the comment delimiters and each line's leading `*` stripped, then
+ * whitespace-normalized. `null` when the key has no doc comment at all — which
+ * is the "strictly worse than the bug" shape pin #1 exists to reject.
+ */
+function fieldDoc(interfaceName: string, key: string): string | null {
+  const body = interfaceBody(interfaceName);
+  // Tempered: the capture may not contain `*/`, so this matches the comment
+  // DIRECTLY above the key, not a lazy span from the interface's first `/**`.
+  const re = new RegExp(`/\\*\\*((?:(?!\\*/)[\\s\\S])*?)\\*/\\s*\\n\\s*${key}\\??\\s*:`);
+  const match = re.exec(body);
+  if (!match) return null;
+  const text = match[1]
+    .split('\n')
+    .map((line) => line.replace(/^\s*\*\s?/, ''))
+    .join(' ');
+  return normalize(text);
+}
+
+/**
+ * The `title` bullet of the `AppShellBranding` prose on
+ * `content/docs/layout/app-shell.mdx`, with its `- \`title\` — ` lead removed
+ * and whitespace normalized. The bullet runs until the next list item or a
+ * blank line.
+ */
+function mdxTitleBullet(): string {
+  const match = /^- `title` — ([\s\S]*?)(?=\n- |\n\n)/m.exec(MDX);
+  if (!match) throw new Error('the `- `title` — …` bullet is gone from content/docs/layout/app-shell.mdx');
+  return normalize(match[1]);
+}
+
+/** The `| \`branding\` | … |` props-table row of a markdown page, trimmed. */
+function brandingRow(page: string, where: string): string {
+  const row = page.split('\n').map((line) => line.trim()).find((line) => line.startsWith('| `branding` |'));
+  if (!row) throw new Error(`no \`| \`branding\` |\` props-table row in ${where}`);
+  return row;
+}
+
+/** The `\`title\` … \`document.title\`` clause inside a props-table cell. */
+function titleClause(row: string, where: string): string {
+  const match = /`title`[^,.;|]*`document\.title`/.exec(row);
+  if (!match) {
+    throw new Error(
+      `${where}'s \`branding\` row no longer has a \`title\` … \`document.title\` clause: ${row}`,
+    );
+  }
+  return normalize(match[0]);
+}
+
+/**
+ * Does a `title` description state the whole-assignment behaviour? It must
+ * name `document.title` and say the value is used as given / is the whole
+ * title. Deliberately a predicate, so the OLD wording can be run through it
+ * below as a red control.
+ */
+function describesWholeAssignment(text: string): boolean {
+  return /`document\.title` as given/.test(text) && /whole title, not a suffix/.test(text);
+}
+
+/** Every `suffix` in `text` is the negated one. */
+function onlyNegatedSuffix(text: string): boolean {
+  return [...text.matchAll(/suffix/g)].every((match) => text.slice(0, match.index).endsWith('not a '));
+}
+
+const OLD_JSDOC = 'Page title suffix (sets document.title)';
+
+// ---------------------------------------------------------------------------
+// The JSDoc — the surface that ships in `dist/index.d.ts`
+// ---------------------------------------------------------------------------
+
+describe('`AppShellBranding.title` JSDoc (objectui#6872)', () => {
+  const doc = fieldDoc('AppShellBranding', 'title');
+
+  it('is present — a deleted description is worse than a wrong one on a published .d.ts', () => {
+    expect(
+      doc,
+      [
+        '`AppShellBranding.title` in packages/layout/src/AppShell.tsx carries no doc comment.',
+        'That comment ships in dist/index.d.ts and is the only description a consumer reads on',
+        'editor hover; deleting it is not a fix for objectui#6872, it is a worse defect.',
+      ].join('\n'),
+    ).not.toBeNull();
+    expect(doc!.length).toBeGreaterThan(0);
+  });
+
+  it('states the whole-assignment behaviour: `document.title` as given, the whole title, not a suffix', () => {
+    expect(
+      describesWholeAssignment(doc ?? ''),
+      [
+        '`AppShellBranding.title` JSDoc does not describe what useAppShellBranding does.',
+        `The code assigns \`document.title = title\` wholesale; the comment reads: ${JSON.stringify(doc)}`,
+        'Copy the wording from content/docs/layout/app-shell.mdx — do not invent another phrasing.',
+      ].join('\n'),
+    ).toBe(true);
+  });
+
+  it('never calls the value a suffix except to deny it', () => {
+    expect(onlyNegatedSuffix(doc ?? '')).toBe(true);
+  });
+
+  it('the reader rejects the wording this issue removed (red control for the pin above)', () => {
+    // Without this the two tests above could be green because the predicate
+    // accepts everything. The reversed wording must FAIL both predicates.
+    expect(describesWholeAssignment(OLD_JSDOC)).toBe(false);
+    expect(onlyNegatedSuffix(OLD_JSDOC)).toBe(false);
+    // And the source no longer carries it anywhere.
+    expect(APP_SHELL_SRC).not.toContain(OLD_JSDOC);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The surfaces agree
+// ---------------------------------------------------------------------------
+
+describe('every surface describes `AppShellBranding.title` the same way (objectui#6872)', () => {
+  it('the JSDoc is the `content/docs/layout/app-shell.mdx` bullet, verbatim modulo whitespace and sentence case', () => {
+    const doc = fieldDoc('AppShellBranding', 'title');
+    const bullet = mdxTitleBullet();
+    expect(
+      doc === null ? null : normalizeSentenceStart(doc),
+      [
+        'The `AppShellBranding.title` JSDoc and the `title` bullet under `branding` on',
+        'content/docs/layout/app-shell.mdx have drifted apart. objectui#6872 exists because one',
+        'behaviour had several descriptions and one of them was reversed; keep ONE wording and',
+        'change both together.',
+      ].join('\n'),
+    ).toBe(normalizeSentenceStart(bullet));
+  });
+
+  it('the mdx bullet itself states whole assignment and never calls it a suffix', () => {
+    const bullet = mdxTitleBullet();
+    expect(describesWholeAssignment(bullet)).toBe(true);
+    expect(onlyNegatedSuffix(bullet)).toBe(true);
+  });
+
+  it('the README and guide props tables carry the same `title` clause, and it names `document.title`', () => {
+    const readmeRow = brandingRow(README, 'packages/layout/README.md');
+    const guideRow = brandingRow(GUIDE, 'content/docs/guide/layout.md');
+    const readmeClause = titleClause(readmeRow, 'packages/layout/README.md');
+    const guideClause = titleClause(guideRow, 'content/docs/guide/layout.md');
+    expect(readmeClause).toBe(guideClause);
+    expect(readmeClause).toMatch(/^`title` sets `document\.title`$/);
+    expect(onlyNegatedSuffix(readmeRow)).toBe(true);
+    expect(onlyNegatedSuffix(guideRow)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Distinct per field — the caricature of "one constant string for every prop"
+// ---------------------------------------------------------------------------
+
+describe('`AppShellBranding` fields are each described, and each differently (objectui#6872)', () => {
+  it('every declared field carries its own doc comment', () => {
+    const keys = interfaceKeys('AppShellBranding');
+    expect(keys, 'the interface declares no keys at all').toContain('title');
+    expect(keys.length).toBeGreaterThan(1);
+    const docs = keys.map((key) => [key, fieldDoc('AppShellBranding', key)] as const);
+    const undocumented = docs.filter(([, doc]) => doc === null || doc.length === 0).map(([key]) => key);
+    expect(undocumented, 'fields with no doc comment').toEqual([]);
+    const distinct = new Set(docs.map(([, doc]) => doc));
+    expect(
+      distinct.size,
+      [
+        'Two or more `AppShellBranding` fields share one doc comment. A description that is the',
+        'same for every field describes none of them; each field says what IT does.',
+        JSON.stringify(Object.fromEntries(docs), null, 2),
+      ].join('\n'),
+    ).toBe(docs.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The code half, by source
+// ---------------------------------------------------------------------------
+
+describe('`AppShell.tsx` writes `document.title` once, wholesale (objectui#6872)', () => {
+  it('exactly one writer, and its right-hand side is the bare `title`', () => {
+    const writers = [...APP_SHELL_SRC.matchAll(/document\.title\s*(\+?=)\s*([^;\n]+);/g)];
+    expect(
+      writers.map((match) => match[0]),
+      'a second `document.title` writer appeared — the wording every surface carries would need to change with it',
+    ).toHaveLength(1);
+    const [, operator, rhs] = writers[0];
+    expect(operator).toBe('=');
+    expect(
+      rhs.trim(),
+      [
+        '`document.title` is no longer assigned the `title` prop as given. The suffix is composed',
+        'by the CALLER (ConsoleLayout.tsx passes "App label — Product name"); appending here would',
+        'double-concatenate for every caller that already builds the whole string.',
+      ].join('\n'),
+    ).toBe('title');
+  });
+});


### PR DESCRIPTION
Fixes #6872

## What changed

`AppShellBranding.title` in `packages/layout/src/AppShell.tsx` was documented as `Page title suffix (sets document.title)` while `useAppShellBranding` assigns `document.title = title` wholesale — the suffix is composed by the caller (`ConsoleLayout.tsx` passes the finished `LABEL — PRODUCT` string). That comment is emitted into `packages/layout/dist/AppShell.d.ts` and is the only description a consumer reads on editor hover; a reader who followed it passed a suffix-only fragment and got a truncated title with no error.

The doc comment now carries the wording of `content/docs/layout/app-shell.mdx` verbatim (one sentence-initial capital aside): "Assigned to `document.title` as given. It is the whole title, not a suffix: the caller composes the string it wants (the console passes `"App label — Product name"`)." No runtime code changed. Changeset: `.changeset/6872-app-shell-branding-title-jsdoc.md`, `@object-ui/layout: patch`.

### Wording source — the sibling count was three, not two

The dispatch named two already-correct siblings (`packages/layout/README.md` and `content/docs/guide/layout.md`, both "`title` sets `document.title`"). A repository sweep found a third, more explicit one already on `main`: `content/docs/layout/app-shell.mdx`, the `title` bullet under `branding` (landed with objectui#4830, the card this issue was written from — the issue's proposed wording is that bullet). Copying the bullet satisfies "copy, do not invent" and also states the whole-assignment behaviour in words, which the two table cells do not. All four surfaces now say the same thing and are pinned to keep saying it.

## Premise checks

- Three surfaces re-located by content at the triage line numbers: `AppShell.tsx:19` (comment), `AppShell.tsx:211` (`document.title = title;`), `README.md:82`, `guide/layout.md:83`. Fourth surface: `app-shell.mdx:94`.
- `ConsoleLayout.tsx:174-176` is the caller that composes `LABEL — PRODUCT`. Other `AppShell` `branding` callers: `packages/layout/src/AppSchemaRenderer.tsx:578` passes `title: schema.title` — the app's own title as the whole title, consistent with wholesale assignment; no caller passes a fragment expecting the component to append a product name. `AppCreationWizard.tsx:956` is a `branding=` prop on `BrandingStep`, not on `AppShell` (false hit).
- `document.title` writers: `git grep -nE 'document\.title\s*='` over every tracked file — `packages/layout/src/AppShell.tsx:211` is the only writer in any published package (`packages/*/src/*`: 3954 files, 1 writer file); lit control `document\.documentElement` on the same command shape and population: 17 files. `apps/console` has 5 writer files of its own (`index.html`, `main.tsx`, `App.tsx` `BrandingSync`, `AuthLayout.tsx`); their interplay with the composed title is filed separately as objectui#8637 and deliberately not touched here.

## Pins

`packages/layout/src/__tests__/app-shell-branding-title-surfaces.test.ts` (unit project; reads the four files on every run, nothing hand-copied):
- the `title` doc comment is **present** — a deleted comment is worse than a wrong one on a published `.d.ts`;
- it **states whole assignment** (`document.title` as given / whole title, not a suffix), and the reader is shown to **reject the removed wording** as a built-in red control;
- every `suffix` on all four surfaces is the negated one;
- **agreement**: the doc comment equals the mdx bullet after whitespace and sentence-case normalization; the README and guide `title` clauses equal each other and read `title` sets `document.title`;
- **distinct per field**: every key `AppShellBranding` declares (read off the source) carries its own doc comment and the comments are pairwise distinct — the pin that answers the "one constant string for every prop" caricature;
- the source has exactly one `document.title` writer and its right-hand side is the bare `title`.

`packages/layout/src/__tests__/app-shell-branding-title-assignment.test.tsx` (dom project, happy-dom): an environment control that `document.title` is writable and readable; render `AppShell` with `branding.title` = `Sales CRM` and assert `document.title` **equals** `Sales CRM` (`toBe`, so an appended product name fails rather than matching a superset); a caller-composed `Sales CRM — ObjectStack` passes through with exactly one separator; no `title` leaves a sentinel untouched; the hook writes its second argument as given and does not read `branding.title` on its own.

## Red legs

Each mutation proven on disk, each restore proven by blob hash against HEAD; the script self-restores on EXIT/INT/TERM.

| leg | mutation | on-disk proof | result |
|---|---|---|---|
| A | doc comment reverted to the bug wording | new 1 → 0, old 0 → 1 | 4 red (states-whole-assignment, negated-suffix, red-control, agreement) |
| B | doc comment deleted entirely | new 1 → 0, key still present 1 | 4 red, led by **present** |
| C | all four field comments replaced by one constant `Branding field.` | constant 0 → 4, `Primary brand color` 1 → 0 | 3 red (states-whole-assignment, agreement, distinct-per-field) |
| C2 | all four replaced by the **correct** sentence | new 1 → 4 | 1 red: distinct-per-field only — every single-prop pin stays green here by construction, which is why the distinctness pin exists |
| D | the plausible wrong fix: the writer becomes a template literal appending ` — ObjectStack` | bare 1 → 0; source pin received the injected template; behavioural pins received `Sales CRM — ObjectStack` and `Sales CRM — ObjectStack — ObjectStack` | 4 red |
| E | sibling drift: mdx bullet reworded to "appended as a suffix", README clause to "suffixes" | mdx 1 → 0 (mutant 0 → 1), README mutant 0 → 1 | 3 red (all three agreement pins) |

Two of the script's grep counters were shell-escaping casualties (leg D's `appended` counter and leg E's README `before` counter read 0 regardless); those directions are proven instead by the pins' own received values quoted above and by properly quoted counts on the restored tree (README clause 1, both mutants 0). Final tree after all legs: `git status` clean, `git diff HEAD` empty.

## Verification (on `532f0a492`)

- `pnpm exec vitest run packages/layout/` — `Test Files 21 passed (21)`, `Tests 217 passed (217)`; JSON reporter: 15/15 new tests passed, no suite-death strings.
- `pnpm --filter @object-ui/layout type-check` — exit 0 with the script name echoed (`tsc --noEmit && tsc -p tsconfig.test.json`, so both new test files compiled), after building the dependency closure (`pnpm --filter '@object-ui/layout^...' build`, 8 packages).
- `pnpm --filter @object-ui/layout build` — `packages/layout/dist/AppShell.d.ts` carries the new wording (1 line) and not the old (0).
- `pnpm --filter @object-ui/layout lint` — 0 errors, 40 pre-existing warnings, none in the two new files.
- `node scripts/check-changeset-presence.mjs` — "✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/6872-app-shell-branding-title-jsdoc.md."
- `node scripts/check-changeset-no-major.mjs` — "✅  No changeset declares a `major` bump."
- `check:control-bytes`, `check:comment-mask-corpus`, `check:shell-escape-residue`, `check:unreferenced-sources`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check-changeset-fixed` — all OK by their printed verdict lines.
- Repository-wide `pnpm lint` and `pnpm test` are CI's runs and were not run locally.

Session: `https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_