### PR TITLE
fix(plugin-detail): record:alert's config-bag reader asks isConfigBag; a degenerate properties contributes no keys

### DIFF
--- a/.changeset/6790-record-alert-degenerate-config-bag.md
+++ b/.changeset/6790-record-alert-degenerate-config-bag.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+`record:alert` stops re-reading a degenerate `properties` bag as its own character indices — the sixth and last member of the `readProps()` family joins the five objectui#6783 converged (objectui#6790).
+
+The renderer's config-bag reader spelled its fallback `(schema?.properties ?? {})`. `??` only replaces `null`/`undefined`, so a non-object `properties` (a string, an array) went into the object spread and came back out as indexed keys: for `properties: 'not-a-bag'` the bag held `{ '0': 'n', … '8': 'g' }` beside the node's own keys — nine keys nobody authored. The reader — now its own module, `renderers/record-alert.readProps.ts`, the way `@object-ui/components` keeps its reader — asks `isConfigBag`, exported from `@object-ui/react`'s package entry since objectui#6783, and a degenerate bag contributes no keys. The expression itself is unchanged: the node's own keys stay underneath (the legacy flat spelling still resolves) and a nested key still wins the contested one; there is no `props` alias leg here and none is added.
+
+**What this does not change, measured rather than predicted.** No rendered output moves. `record:alert` reads named keys off the bag (`title`, `body`, `severity`, `icon`, `action`, `dismissible`, `dismissKey`, `visible`) and never spreads it onto a DOM element, so the indices were computed and then dropped; a degenerate bag renders exactly as no bag at all, before and after. The census behind objectui#6708 found zero authored nodes carrying a degenerate config bag. What the guard buys is what objectui#6752 measured its own guard buys: the authored value's shape is not reinterpreted.

--- a/packages/plugin-detail/src/renderers/__tests__/record-alert.degenerateProperties.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-alert.degenerateProperties.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6790 — `record:alert`'s config-bag reader and a DEGENERATE `properties`.
+ *
+ * The sixth member of the `readProps()` family
+ * (`packages/components/src/__tests__/alias-precedence-cross-channel.test.tsx`
+ * names it), spelled `{ ...schema, ...schema.properties }` — the node's own
+ * keys underneath, no `props` alias leg. objectui#6783 converged the other five
+ * on `isConfigBag`; this one kept `?? {}`, which replaces only
+ * `null`/`undefined`, so a string or an array went into the object spread and
+ * came back out as its own indices.
+ *
+ * ## BASE_READING — measured on `c4326fe0a`, this branch's base
+ *
+ * Captured by reverting the guard to `(schema?.properties ?? {})` (leg L1 of
+ * the PR's ablation); the failing assertions' received values, verbatim:
+ *
+ *   readProps({ type: 'record:alert', properties: 'not-a-bag' })
+ *     -> indexed keys ["0","1","2","3","4","5","6","7","8"]
+ *   readProps({ type: 'record:alert', properties: ['a', 'b'] })
+ *     -> indexed keys ["0","1"]
+ *
+ * beside the node's own `type` and `properties`, which the indices sort AHEAD
+ * of whatever the spread order (integer-like keys come first in JS property
+ * order). So what the first pins below assert is the ABSENCE of the indices,
+ * not the position of `type` and `properties`.
+ *
+ * ## The discriminating input is the degenerate one
+ *
+ * A well-formed bag passes on the guarded AND the unguarded reader — it cannot
+ * see the defect. So the pins that see it feed a string and an array and assert
+ * the indices are NOT among the keys. The well-formed pins are the other axis:
+ * the plausible WRONG fix guards too broadly and drops a legitimate bag, so
+ * they pin that authored config still reaches every named read (`title`,
+ * `body`, `severity`, `action.label`, `dismissible`) — through the real
+ * renderer, not the reader alone.
+ *
+ * ## What the guard does not buy, measured
+ *
+ * Nothing rendered moves: this renderer reads NAMED keys off the bag and never
+ * spreads it onto a DOM element, so a degenerate bag renders exactly as no bag
+ * at all — GREEN on the pre-fix tree too, and recorded as such rather than
+ * dressed up as a regression pin.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const stub = {
+  recordCtx: undefined as any,
+  metadataItem: undefined as any,
+};
+
+// The same DATA-layer doubles `record-alert.test.tsx` uses — record context,
+// the metadata fetch behind the CTA, the action dispatch. Everything else,
+// `isConfigBag` included, is the shipped module: the factory inherits `actual`.
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/react')>();
+  return {
+    ...actual,
+    useRecordContext: () => stub.recordCtx,
+    useMetadataItem: (_type: string, _name: string | null) => ({ item: stub.metadataItem }),
+    useActionEngine: (_opts: unknown) => ({
+      executeAction: vi.fn(async () => ({ success: true })),
+      getActionsForLocation: () => [],
+      getBulkActions: () => [],
+      handleShortcut: async () => null,
+      engine: {} as any,
+    }),
+  };
+});
+
+vi.mock('@object-ui/components', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  Alert: ({ children, className, role, ...rest }: any) => (
+    <div data-testid="alert" role={role} className={className} {...rest}>
+      {children}
+    </div>
+  ),
+  AlertTitle: ({ children }: any) => <h5 data-testid="alert-title">{children}</h5>,
+  AlertDescription: ({ children }: any) => <div data-testid="alert-body">{children}</div>,
+  Button: ({ children, onClick, variant, ...rest }: any) => (
+    <button data-testid="alert-cta" data-variant={variant} onClick={onClick} {...rest}>
+      {children}
+    </button>
+  ),
+  cn: (...args: any[]) => args.filter(Boolean).join(' '),
+  LazyIcon: ({ name, className }: any) => (
+    <svg data-testid="alert-icon" data-name={name} className={className} />
+  ),
+}));
+
+import { RecordAlertRenderer } from '../record-alert';
+import { readProps } from '../record-alert.readProps';
+
+const keysOf = (schema: unknown) => Object.keys(readProps(schema));
+const indexKeys = (keys: string[]) => keys.filter((k) => /^\d+$/.test(k));
+
+/** Every named key the renderer reads, authored once, read back three ways below. */
+const WELL_FORMED = {
+  severity: 'warning' as const,
+  title: 'Heads up',
+  body: 'Pay attention.',
+  action: { actionName: 'resend_verification_email', label: 'Send again' },
+  dismissible: true,
+};
+
+describe('objectui#6790 — a degenerate `properties` contributes no keys', () => {
+  it('a string is not enumerated into its character indices', () => {
+    // BASE_READING: indexed keys ["0" … "8"], beside `type` and `properties`.
+    const keys = keysOf({ type: 'record:alert', properties: 'not-a-bag' });
+    expect(indexKeys(keys)).toEqual([]);
+    // The node's own keys are still underneath, and the authored string stays
+    // where it was authored — unreinterpreted, not sanitized away.
+    expect(keys).toEqual(['type', 'properties']);
+  });
+
+  it('an ARRAY is degenerate too — `typeof [] === "object"` is why the predicate has two halves', () => {
+    // BASE_READING: indexed keys ["0","1"].
+    expect(indexKeys(keysOf({ type: 'record:alert', properties: ['a', 'b'] }))).toEqual([]);
+  });
+
+  it('the empty-ish values behave exactly as they did — `??` and the predicate agree here', () => {
+    expect(keysOf({})).toEqual([]);
+    expect(keysOf({ properties: null })).toEqual(['properties']);
+    expect(keysOf({ properties: undefined })).toEqual(['properties']);
+    expect(keysOf(undefined)).toEqual([]);
+    // A number spreads to nothing even pre-fix; pinned so the fix is not read
+    // as having introduced this.
+    expect(keysOf({ properties: 42 })).toEqual(['properties']);
+  });
+});
+
+describe('objectui#6790 — a well-formed `properties` bag still contributes every key (the over-broad-guard axis)', () => {
+  it('every authored key reaches the bag, and a nested key still wins the flat legacy spelling', () => {
+    const bag = readProps({ type: 'record:alert', title: 'FLAT', properties: WELL_FORMED });
+    expect(bag).toMatchObject(WELL_FORMED);
+    expect(bag.title).toBe('Heads up');
+  });
+
+  it("the flat legacy spelling still resolves on its own — the node's keys underneath are untouched", () => {
+    expect(readProps({ type: 'record:alert', title: 'FLAT' }).title).toBe('FLAT');
+  });
+});
+
+describe('objectui#6790 — the named reads still resolve through the real renderer', () => {
+  beforeEach(() => {
+    stub.recordCtx = {
+      data: { id: 'rec_1', name: 'Acme' },
+      objectName: 'sys_user',
+      recordId: 'rec_1',
+    };
+    stub.metadataItem = {
+      actions: [
+        {
+          name: 'resend_verification_email',
+          label: 'Resend Verification Email',
+          type: 'api',
+          target: '/api/v1/auth/send-verification-email',
+        },
+      ],
+    };
+  });
+  afterEach(cleanup);
+
+  it('title, body, severity, action.label and dismissible all come from the bag', () => {
+    render(<RecordAlertRenderer schema={{ properties: WELL_FORMED }} />);
+    expect(screen.getByTestId('alert-title').textContent).toBe('Heads up');
+    expect(screen.getByTestId('alert-body').textContent).toContain('Pay attention.');
+    expect(screen.getByTestId('alert').className).toMatch(/amber/);
+    expect(screen.getByTestId('alert-cta').textContent).toBe('Send again');
+    expect(screen.getByLabelText('Dismiss')).toBeTruthy();
+  });
+
+  it('what the guard does not buy: a degenerate bag renders exactly as no bag at all (GREEN pre-fix too)', () => {
+    // Deliberately off-type: the input under test is the one the declaration
+    // refuses, which is the whole point — `tsc -p tsconfig.test.json` would
+    // otherwise (rightly) reject it as TS2559.
+    const degenerate = render(
+      <RecordAlertRenderer schema={{ properties: 'not-a-bag' } as any} />
+    );
+    const degenerateHtml = degenerate.container.innerHTML;
+    cleanup();
+
+    const absent = render(<RecordAlertRenderer schema={{}} />);
+    expect(degenerateHtml).toBe(absent.container.innerHTML);
+  });
+});
+
+/**
+ * The ratchet objectui#6761 and objectui#6783 each added for their own site:
+ * every spelling of this read is an expression that produces no error when it
+ * drifts, so the cheap path — copying `?? {}` back, or retelling the predicate
+ * inline — has to fail on its own.
+ */
+describe('objectui#6790 — the reader asks the shared predicate, and the pin that keeps it so', () => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const reader = readFileSync(path.resolve(here, '../record-alert.readProps.ts'), 'utf8');
+  const renderer = readFileSync(path.resolve(here, '../record-alert.tsx'), 'utf8');
+  /** Comments out first: the reader's own docblock quotes the spelling it replaced. */
+  const stripComments = (s: string) =>
+    s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:'"`])\/\/[^\n]*/g, '$1');
+  /** `schema.properties ?? {}` / `schema?.properties || {}` — the local read objectui#6783 removed. */
+  const LOCAL_BAG_READ = /\??\.\s*properties\s*(?:\?\?|\|\|)\s*\{\s*\}/;
+
+  it("the reader imports `isConfigBag` from `@object-ui/react`'s package entry — the one definition, not a retelling", () => {
+    expect(reader).toMatch(/import \{ isConfigBag \} from '@object-ui\/react';/);
+    // The conjunction objectui#6761's pin scans for, spelled here, would be a
+    // copy one package over where that pin cannot see it.
+    expect(reader).not.toMatch(/Array\.isArray/);
+    expect(stripComments(reader)).not.toMatch(LOCAL_BAG_READ);
+  });
+
+  it('the renderer reads its bag through that module and has no `?? {}` read of its own', () => {
+    expect(renderer).toMatch(/import \{ readProps \} from '\.\/record-alert\.readProps';/);
+    expect(stripComments(renderer)).not.toMatch(LOCAL_BAG_READ);
+  });
+});

--- a/packages/plugin-detail/src/renderers/record-alert.readProps.ts
+++ b/packages/plugin-detail/src/renderers/record-alert.readProps.ts
@@ -1,0 +1,48 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { isConfigBag } from '@object-ui/react';
+
+/**
+ * The config bag `record:alert` reads: the node's own keys UNDERNEATH (the
+ * legacy flat spelling `RecordAlertProps` tolerates) and `properties` on top.
+ * It is the sixth member of the `readProps()` family that
+ * `packages/components/src/__tests__/alias-precedence-cross-channel.test.tsx`
+ * names, spelled differently — `{ ...schema, ...schema.properties }`, no
+ * `props` alias leg — and since objectui#6790 it asks the same question the
+ * other five have asked since objectui#6783: is `properties` a real config
+ * bag? `??` only replaces `null`/`undefined`, so the previous spelling
+ * `(schema?.properties ?? {})` let a DEGENERATE `properties` (a string, an
+ * array) into the object spread, where it came back out as its own indexed
+ * keys — `{ '0': 'n', … '8': 'g' }` for `'not-a-bag'`, nine keys nobody
+ * authored, sitting beside the named ones the renderer reads.
+ *
+ * What the guard buys is what objectui#6752 measured its own guard buys: the
+ * authored value's shape is not reinterpreted. Not a rendered pixel, today —
+ * every read in `record-alert.tsx` is a NAMED key (`title`, `body`,
+ * `severity`, `action`, `dismissible`, …) and the bag is never spread onto a
+ * DOM element, so the indices were computed and then dropped. It asks the
+ * predicate `@object-ui/react` exports rather than retelling it
+ * (objectui#6761's pin cannot see a spelling one package over), and it does
+ * not reuse `@object-ui/components`' `readProps`: that reader is not exported,
+ * and its expression is a different one (`props` alias underneath, not the
+ * node).
+ *
+ * Its own module for the same reason `@object-ui/components` gave its reader
+ * one: `record-alert.tsx` keeps exporting components only, and the pin
+ * (`__tests__/record-alert.degenerateProperties.test.tsx`) imports the reader
+ * directly. `index.tsx` imports `RecordAlertRenderer` by name, so this does
+ * not reach the package entry.
+ */
+export function readProps(schema: any) {
+  // A degenerate bag contributes NO keys. The node's own keys underneath are
+  // untouched, so the legacy flat spelling still resolves and a nested key
+  // still wins the contested one.
+  const fromNested = isConfigBag(schema?.properties) ? schema.properties : {};
+  return { ...schema, ...fromNested };
+}

--- a/packages/plugin-detail/src/renderers/record-alert.tsx
+++ b/packages/plugin-detail/src/renderers/record-alert.tsx
@@ -83,6 +83,10 @@ import {
   useActionEngine,
 } from '@object-ui/react';
 import { Alert, AlertTitle, AlertDescription, Button, cn, LazyIcon } from '@object-ui/components';
+// The config bag this renderer reads — its own module so this file keeps
+// exporting components only; the reader's contract and its pin live there
+// (objectui#6790).
+import { readProps } from './record-alert.readProps';
 import { useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import type { ActionDef } from '@object-ui/core';
 // The spec's INLINE locale-map form (`string | Record< string, string >`), bound
@@ -164,11 +168,6 @@ const SEVERITY_STYLES: Record<Severity, { wrap: string; icon: string }> = {
     icon: 'circle-check',
   },
 };
-
-function readProps(schema: any) {
-  const fromNested = (schema?.properties ?? {}) as any;
-  return { ...schema, ...fromNested };
-}
 
 export const RecordAlertRenderer: React.FC<RecordAlertProps> = ({ schema = {}, className }) => {
   const props = readProps(schema);


### PR DESCRIPTION
Fixes #6790

## Arm chosen: the guard (arm 1), predicate alone — and why not the ruling sentence

Triage comment 5544675993 offered two legitimate outcomes: add the guard, or rule that this reader may reinterpret whatever it is handed and say so at the reader. I took arm 1, and not because it is the larger diff — the production change is one identifier on an existing import line and one ternary. Three reasons:

1. **The cost the triage flagged is zero.** `@object-ui/plugin-detail` already declares `@object-ui/react` — `peerDependencies` (`workspace:^`) and `devDependencies` (`workspace:*`) — and `record-alert.tsx` already imported four names from it (`useCondition`, `toPredicateInput`, `usePredicateRecordContext`, `useActionEngine`). No edge is added. `check:phantom-deps` verdict: `Every in-scope import is declared by the package that publishes it.`
2. **The class ruling already exists; arm 2 would be a per-site exception to it.** objectui#6752 measured what the guard buys, objectui#6761 converged the predicate behind one exported definition, objectui#6783 converged the five `@object-ui/components` readers. The only ground for ruling this site differently is an accident of current usage — it reads named keys and never spreads the bag onto a DOM element — and that property is one onward spread away from false. A ruling sentence would then need its own pin to stay true; the triage anticipated exactly that ("state plainly what, if anything, should be pinned to keep the ruling true"). A guard makes the question moot instead of keeping it open.
3. **Arm 2 is not the smaller deliverable in files touched.** `alias-precedence-cross-channel.test.tsx`'s docblock names this site as the sixth member of the family with "the same `properties`-wins order"; a ruling that it may reinterpret would have to amend that docblock as well as write the sentence.

## Predicate, not reader — and where the reader lives

Taken: the **predicate** `isConfigBag` from `@object-ui/react`'s package entry. Not taken: `@object-ui/components`' `readProps` — it is not exported (the barrel is side-effect imports only), and its expression is a different one (`props` alias underneath, not the node's own keys). The record-alert reader keeps its own expression, `{ ...schema, ...schema.properties }`, unchanged.

The reader moves into its own module, `renderers/record-alert.readProps.ts`, for the same reason #6783 gave its reader one: exporting a function from `record-alert.tsx` (needed so the pin can read the bag directly — see below for why rendering cannot see the defect) tripped a new `react-refresh/only-export-components` warning (baseline 0 on that file). `index.tsx` imports `RecordAlertRenderer` by name, so nothing new reaches the package entry.

## What changed

- `packages/plugin-detail/src/renderers/record-alert.readProps.ts` (new): `readProps` asks `isConfigBag(schema?.properties)`; a degenerate bag contributes no keys; the node's own keys underneath are untouched.
- `packages/plugin-detail/src/renderers/record-alert.tsx`: imports the reader from that module; the local `(schema?.properties ?? {}) as any` read is gone.
- `packages/plugin-detail/src/renderers/__tests__/record-alert.degenerateProperties.test.tsx` (new): 9 pins, each observed to fail (table below).
- `.changeset/6790-record-alert-degenerate-config-bag.md`: `@object-ui/plugin-detail: patch` (the same bump #6783 took for `components`).

## What does not change — measured, not predicted

No rendered output moves. `record:alert` reads named keys off the bag (`title`, `body`, `severity`, `icon`, `action`, `dismissible`, `dismissKey`, `visible`) and never spreads it onto a DOM element, so the indices were computed and then dropped. The pin file carries an explicit "what the guard does not buy" case — a degenerate bag renders byte-identically to no bag at all — and it stayed GREEN on every ablation leg, including the revert-to-bug leg. Recorded as such rather than dressed up as a regression pin. objectui#5123's precedence is untouched: a nested key still wins the flat legacy spelling (pinned).

## Why the discriminating pin reads the bag, not the DOM

A well-formed bag passes on the guarded and the unguarded reader alike — it cannot see the defect. And because the renderer drops the indices, a render-level pin fed a degenerate bag ALSO passes on both. The only observable difference is the set of keys the reader produces, so the discriminating pins call `readProps` directly and assert the character indices are absent. BASE_READING, captured from the revert leg's received values, verbatim: string `'not-a-bag'` yields indexed keys `["0","1","2","3","4","5","6","7","8"]`; array `['a','b']` yields `["0","1"]`.

## Pins, and how each was observed to fail

Four mutation legs against the committed reader, each mutation proved on disk (`grep -cF` of the original and the injected text before/after: 1/0 then 0/1), each restore proved by blob-hash equality with `HEAD` plus empty `git diff HEAD` (never by exit code), all under an EXIT/INT/TERM trap. Verdicts read per-test from vitest's JSON reporter; no death strings (`Element type is invalid`, `Failed Suites`, `No test suite found in file`, `Tests  no tests`, `Transform failed`) in any log.

| Leg | Mutation | RED | GREEN | Reading |
|---|---|---|---|---|
| L1 | guard reverted to `(schema?.properties ?? {}) as any` | 3 — string pin, array pin, the structural pin (its `?? {}` clause) | 6 — both well-formed pins, both render pins | the pins see the bug; nothing rendered moves (honest) |
| L2 | predicate constant `false` (`fromNested = {}` — the over-broad wrong fix) | 2 — well-formed reader pin, render named-reads pin | 7 | the non-regression axis reddens as required |
| L3 | reader returns a constant object (`return {}`) | 5 | 4 | the caricature |
| L4 | `isConfigBag` retold inline (`typeof === 'object' && !Array.isArray`) | 1 — the structural pin | 8 | the drift objectui#6761 is about is invisible to behaviour; only the ratchet sees it |

Zero void legs. Run twice — once against the reader while it still lived in `record-alert.tsx`, once against `record-alert.readProps.ts` on the final tree — identical verdicts both times.

## Verification (final tree, `e1b0a9c4e`)

- Dependency closure built first (12 packages, `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-detail^...' build`, under the shared verify lock).
- `pnpm --filter @object-ui/plugin-detail type-check` → both projects (`tsc --noEmit && tsc -p tsconfig.test.json`) exit 0; `--listFiles` confirms the new test is in the test project. An earlier draft of the pin file was vitest-green and `tsc`-red (TS2353/TS2559 on off-type render inputs) — exactly the trap the order warned about; fixed before this push.
- `pnpm --filter @object-ui/plugin-detail lint` (`eslint .`) → 0 errors. Warnings attributed to my files are `no-explicit-any` only, mirroring the sibling `record-alert.test.tsx` mocks; production-file `any` count unchanged (the reader's `schema: any` moved modules).
- Affected tests under the lock, JSON reporter (`pnpm exec vitest run packages/plugin-detail/ packages/components/src/__tests__/alias-precedence-cross-channel.test.tsx packages/react/src/utils/configBag.pin.test.ts`): 150 files, 1330 tests passed, 0 failed, on `e1b0a9c4e`, classified per-test from the JSON output.
- Gates, by verdict line: changeset-presence `3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`; changeset-no-major `No changeset declares a major bump`; control-bytes `OK (scanned 6839 tracked text file(s))`; vi-mock-inherit OK; vi-mock-specifiers OK; phantom-deps OK; self-import OK; unreferenced-sources OK; governed-queue-guard `NOT GOVERNED`.
- NOT MEASURED locally, CI-owned: `check:readme-exports` (needs all 40 packages built; verdict on a 12-package build was "the population COLLAPSED — this run proves nothing"), `check:eager-closure` (needs a console build). My diff touches no README and adds nothing to the package entry.

## Scope fence honoured

`record-activity.tsx`, `ResourceEditPage.tsx` and the `metadata-admin` JSON-Schema `properties` readers were not re-swept, per the order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_