### PR TITLE
fix(permissions): key MePermissionsProvider's fetch effect on values, not a memo identity

### DIFF
--- a/.changeset/lucky-pandas-shake.md
+++ b/.changeset/lucky-pandas-shake.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/permissions': patch
+---
+
+`MePermissionsProvider` no longer keys its permissions-fetch effect on a memoised
+driver's identity. The driver was a `useCallback` over
+`[endpoint, fetcher, maxRetries, retryBaseDelayMs]` and the effect named that
+callback as its dependency; React is permitted to discard a `useCallback` cache
+and rebuild even when the dependency list compares equal, and the rebuilt
+function is a new identity, so a discard tore the effect down and re-ran it —
+costing a redundant `/api/v1/auth/me/permissions` round trip with none of the
+four inputs changed. The driver is now a module-level function and the effect
+keys on the four values directly. The trigger set is unchanged, so every
+legitimate refetch (a new endpoint, a swapped fetcher, either retry knob) still
+happens exactly once.

--- a/packages/permissions/src/MePermissionsProvider.tsx
+++ b/packages/permissions/src/MePermissionsProvider.tsx
@@ -143,6 +143,93 @@ const NOT_LOADED: object = { isLoaded: false };
 const NO_ROW_FILTER: PermissionContextValue['getRowFilter'] = () => undefined;
 
 /**
+ * [objectui#6862] The four inputs a fetch is derived from, named once so the
+ * effect below and `retry` cannot drift apart on what "the fetch changed" means.
+ */
+interface FetchConfig {
+  endpoint: string;
+  fetcher: typeof fetch | undefined;
+  maxRetries: number;
+  retryBaseDelayMs: number;
+}
+
+/**
+ * Where a completed attempt reports. Every member is a `useState` setter, whose
+ * identity React DOES guarantee — unlike `useMemo`/`useCallback`, which is the
+ * whole point of moving this function out of the component in the first place.
+ */
+interface FetchSink {
+  setData: (data: MePermissionsResponse) => void;
+  setError: (error: Error | null) => void;
+  setLoading: (loading: boolean) => void;
+}
+
+/**
+ * Run the fetch, re-attempting a transient failure.
+ *
+ * `token` cancels an in-flight attempt. Retries put real time (a backoff, or
+ * a server-stated `Retry-After`) between the request and the `setState`, and
+ * during that window the effect may be torn down — by an unmount, or by
+ * `endpoint`/`fetcher` changing. Without the token a superseded attempt would
+ * still land, so a slow answer for the OLD endpoint could overwrite a fast
+ * answer for the new one.
+ *
+ * [objectui#6862] This is a module-level function rather than the `useCallback`
+ * it used to be. A `useCallback` carries no semantic guarantee: React may
+ * discard the cache and rebuild even when the dependency list compares equal,
+ * and the rebuilt function is a NEW identity. The fetch effect named that
+ * identity as its dependency, so a discard tore the effect down and re-ran it
+ * with none of the four inputs changed — a redundant
+ * `/api/v1/auth/me/permissions` round trip on the provider that gates the whole
+ * console. Nothing here closes over render scope, so there is no identity left
+ * for React to move: the effect keys on the four VALUES instead.
+ */
+async function loadPermissions(
+  { endpoint, fetcher, maxRetries, retryBaseDelayMs }: FetchConfig,
+  { setData, setError, setLoading }: FetchSink,
+  token?: { cancelled: boolean },
+): Promise<void> {
+  const live = () => !token?.cancelled;
+  setLoading(true);
+  setError(null);
+  const doFetch = fetcher ?? fetch;
+  const attempts = Math.max(0, maxRetries) + 1;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      const res = await doFetch(endpoint, {
+        credentials: 'include',
+        headers: { Accept: 'application/json' },
+      });
+      if (!res.ok) {
+        throw new HttpFetchError(
+          res.status,
+          retryAfterFrom(res),
+          `Permissions endpoint returned ${res.status}`,
+        );
+      }
+      const json = (await res.json()) as MePermissionsResponse;
+      if (!live()) return;
+      setData(json);
+      setLoading(false);
+      return;
+    } catch (e) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      if (!isTransientFailure(err) || attempt === attempts - 1) {
+        if (!live()) return;
+        setError(err);
+        setLoading(false);
+        return;
+      }
+      // `loading` stays true across the wait, so the fail-closed loading
+      // state holds and the recovery is invisible to consumers.
+      const stated = err instanceof HttpFetchError ? err.retryAfterMs : undefined;
+      await sleep(backoffMs(attempt, retryBaseDelayMs, stated));
+      if (!live()) return;
+    }
+  }
+}
+
+/**
  * MePermissionsProvider
  *
  * Fetches the current user's effective permissions from the framework's
@@ -168,68 +255,47 @@ export function MePermissionsProvider({
   const [loading, setLoading] = useState(!initialPermissions);
 
   /**
-   * Run the fetch, re-attempting a transient failure.
+   * [objectui#6862] Keyed on the four VALUES the fetch is derived from, never
+   * on a memoised driver's identity. React may discard a `useMemo`/`useCallback`
+   * cache even when its dependency list compares equal, and this effect used to
+   * name such a callback — so a discard cost a redundant round trip with nothing
+   * an author or a caller controls having changed.
    *
-   * `token` cancels an in-flight attempt. Retries put real time (a backoff, or
-   * a server-stated `Retry-After`) between the request and the `setState`, and
-   * during that window the effect may be torn down — by an unmount, or by
-   * `endpoint`/`fetcher` changing. Without the token a superseded attempt would
-   * still land, so a slow answer for the OLD endpoint could overwrite a fast
-   * answer for the new one.
+   * The trigger set is unchanged: these are exactly the four the old callback
+   * listed, so every legitimate refetch still happens (pinned in
+   * `providerCtxIdentity.discarded.test.tsx`). What is gone is React's licence
+   * to re-run this effect on its own. Merely DROPPING the dependency would also
+   * have stopped the redundant trip — and would have stopped the legitimate ones
+   * with it.
    */
-  const fetchPermissions = useCallback(
-    async (token?: { cancelled: boolean }) => {
-      const live = () => !token?.cancelled;
-      setLoading(true);
-      setError(null);
-      const doFetch = fetcher ?? fetch;
-      const attempts = Math.max(0, maxRetries) + 1;
-      for (let attempt = 0; attempt < attempts; attempt++) {
-        try {
-          const res = await doFetch(endpoint, {
-            credentials: 'include',
-            headers: { Accept: 'application/json' },
-          });
-          if (!res.ok) {
-            throw new HttpFetchError(
-              res.status,
-              retryAfterFrom(res),
-              `Permissions endpoint returned ${res.status}`,
-            );
-          }
-          const json = (await res.json()) as MePermissionsResponse;
-          if (!live()) return;
-          setData(json);
-          setLoading(false);
-          return;
-        } catch (e) {
-          const err = e instanceof Error ? e : new Error(String(e));
-          if (!isTransientFailure(err) || attempt === attempts - 1) {
-            if (!live()) return;
-            setError(err);
-            setLoading(false);
-            return;
-          }
-          // `loading` stays true across the wait, so the fail-closed loading
-          // state holds and the recovery is invisible to consumers.
-          const stated = err instanceof HttpFetchError ? err.retryAfterMs : undefined;
-          await sleep(backoffMs(attempt, retryBaseDelayMs, stated));
-          if (!live()) return;
-        }
-      }
-    },
-    [endpoint, fetcher, maxRetries, retryBaseDelayMs],
-  );
-
-  /** The `retry` handed to `errorFallback` — uncancelled, it is user-initiated. */
-  const retry = useCallback(() => { void fetchPermissions(); }, [fetchPermissions]);
-
   useEffect(() => {
     if (initialPermissions) return;
     const token = { cancelled: false };
-    void fetchPermissions(token);
+    void loadPermissions(
+      { endpoint, fetcher, maxRetries, retryBaseDelayMs },
+      { setData, setError, setLoading },
+      token,
+    );
     return () => { token.cancelled = true; };
-  }, [fetchPermissions, initialPermissions]);
+  }, [endpoint, fetcher, maxRetries, retryBaseDelayMs, initialPermissions]);
+
+  /**
+   * The `retry` handed to `errorFallback` — uncancelled, it is user-initiated.
+   *
+   * This one may stay a `useCallback`: nothing keys on its identity. It is
+   * passed to a render prop, so a discard rebuilds a function and costs a
+   * re-render of the error fallback — never a round trip, which is what the
+   * effect above was paying.
+   */
+  const retry = useCallback(
+    () => {
+      void loadPermissions(
+        { endpoint, fetcher, maxRetries, retryBaseDelayMs },
+        { setData, setError, setLoading },
+      );
+    },
+    [endpoint, fetcher, maxRetries, retryBaseDelayMs],
+  );
 
   const dataKey: object = data ?? NO_DATA;
 

--- a/packages/permissions/src/__tests__/providerCtxIdentity.discarded.test.tsx
+++ b/packages/permissions/src/__tests__/providerCtxIdentity.discarded.test.tsx
@@ -47,7 +47,7 @@
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { cleanup, render, waitFor } from '@testing-library/react';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
 import * as ReactNS from 'react';
 import type { ObjectPermissionConfig, RoleDefinition } from '@object-ui/types';
 import { PermCtx, type PermissionContextValue } from '../PermissionContext';
@@ -472,5 +472,188 @@ describe('MePermissionsProvider — ctx identity survives a discarded cache (obj
     expect(last.checkField('accounts', 'secret', 'write')).toBe(true);
     expect(last.getObjectApiOperations('accounts')).toBeUndefined();
     expect(last.check('accounts', 'update').allowed).toBe(true);
+  });
+});
+
+/**
+ * objectui#6862 — the EFFECT end of the same provider, and a different shape
+ * from the value end above.
+ *
+ * `MePermissionsProvider` built its fetch driver in a `useCallback` over
+ * `[endpoint, fetcher, maxRetries, retryBaseDelayMs]` and named THAT CALLBACK
+ * as its fetch effect's dependency. A discard rebuilds the callback with a new
+ * identity, so the effect tears down and re-runs with none of the four inputs
+ * changed — one redundant `/api/v1/auth/me/permissions` round trip on the
+ * provider that gates the whole console.
+ *
+ * ⚠️ WHY THESE PINS FORCE A DISCARD. Exactly the reason recorded at the top of
+ * this file: React does not discard spontaneously here (51 / 51 / 42 re-renders
+ * each returned ONE identity on the pinned React 19.2.8, and this repo still
+ * has no `Activity`/Offscreen subtree — re-verified for this card: zero imports
+ * of `Activity` from `react`, against 179 files importing `useMemo` from it on
+ * the same command shape). ⇒ An ordinary render-count or effect-count pin here
+ * would be GREEN on the defect AND on the fix, and would therefore assert
+ * nothing. The discriminating input is a FORCED discard, so the proxy above is
+ * armed and fired for the first pin. The three that follow are deliberately
+ * NOT armed: they are the non-regression axis, and what they must survive is a
+ * fix that over-reaches rather than a discard.
+ *
+ * ⚠️ AND WHY THE FIRST PIN COUNTS REQUESTS. An identity comparison alone can
+ * hold while the effect re-runs for some other reason, so the observable the
+ * card actually names — the number of `/me/permissions` requests — is asserted
+ * directly. Requests are served from a double passed as the `fetcher` prop, so
+ * nothing here can reach happy-dom's `http://localhost:3000` and be attributed
+ * to this file by the network-escape guard (objectui#8537).
+ */
+describe('MePermissionsProvider — the fetch effect survives a discarded cache (objectui#6862)', () => {
+  /**
+   * A fetch double that records who was called with what, and answers with a
+   * payload naming itself. The tag rides on `userId`, which the context value
+   * publishes — so a pin can tell a REAL refetch from a driver that has been
+   * mutated into answering one constant for every input.
+   */
+  function makeFetcher(tag: string, log: string[]): typeof fetch {
+    return vi.fn(async (input: RequestInfo | URL) => {
+      log.push(`${tag} ${String(input)}`);
+      return new Response(JSON.stringify({ ...ME, userId: tag }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+  }
+
+  /**
+   * Give a re-run effect a real turn to issue its request. Asserting the
+   * ABSENCE of a round trip needs a settle window; `waitFor` cannot express it.
+   */
+  const settle = () => act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+
+  it('costs no redundant round trip when a discard rebuilds the driver, inputs unchanged', async () => {
+    const log: string[] = [];
+    const fetcher = makeFetcher('A', log);
+    const { ctxSeen, effectRuns, Probe } = makeProbe();
+    const tree = () => (
+      <MePermissionsProvider endpoint="/api/v1/auth/me/permissions" fetcher={fetcher}>
+        <Probe />
+      </MePermissionsProvider>
+    );
+
+    let loaded: PermissionContextValue | undefined;
+    const restore = armDiscardProxy();
+    try {
+      const { rerender } = render(tree());
+      await waitFor(() => expect(log).toHaveLength(1));
+      loaded = ctxSeen[ctxSeen.length - 1]!;
+
+      // Armed but NOT fired: an ordinary re-render must not refetch either, so
+      // a green below cannot come from the proxy having broken caching outright.
+      rerender(tree());
+      await settle();
+      expect(log).toHaveLength(1);
+
+      // Two discards, each followed by a re-render with the SAME four inputs.
+      discardNow();
+      rerender(tree());
+      discardNow();
+      rerender(tree());
+      await settle();
+    } finally {
+      restore();
+    }
+
+    // THE observable this card names: a request count, not an identity compare.
+    expect(log).toEqual(['A /api/v1/auth/me/permissions']);
+    // …and the consequence that OUTLIVES the round trip. `setData` installs a
+    // fresh payload object even for a byte-identical answer, and that object is
+    // the key objectui#6813's caches are built on — so a discard that refetches
+    // walks straight through the guard #6813 landed: the ctx identity moves
+    // permanently (not just the transient `isLoaded` flip the card describes)
+    // and every consumer effect downstream re-runs.
+    expect(ctxSeen[ctxSeen.length - 1]).toBe(loaded);
+    expect(effectRuns).toHaveLength(1);
+  });
+
+  /**
+   * The non-regression axis, from the plausible WRONG fix rather than from the
+   * bug's shape: dropping the dependency altogether would also stop the
+   * redundant round trip — and would stop every LEGITIMATE refetch with it. The
+   * three pins below fail on such a fix. Together they cover all four inputs the
+   * discarded `useCallback` named, which is the parity claim: the fix removes
+   * React's licence to discard and narrows nothing else.
+   */
+  it('still refetches exactly once when the endpoint genuinely changes', async () => {
+    const log: string[] = [];
+    const fetcher = makeFetcher('A', log);
+    const { Probe } = makeProbe();
+    const tree = (endpoint: string) => (
+      <MePermissionsProvider endpoint={endpoint} fetcher={fetcher}>
+        <Probe />
+      </MePermissionsProvider>
+    );
+
+    const { rerender } = render(tree('/v1/me/permissions'));
+    await waitFor(() => expect(log).toHaveLength(1));
+
+    rerender(tree('/v2/me/permissions'));
+    await waitFor(() => expect(log).toHaveLength(2));
+    await settle();
+    expect(log).toEqual(['A /v1/me/permissions', 'A /v2/me/permissions']);
+  });
+
+  it('still refetches exactly once when the fetcher itself is swapped', async () => {
+    // ⚠️ Two CONCRETE, distinguishable fetchers. `fetcher` is optional, and a
+    // pin that swapped one `undefined` for another would prove nothing: it is
+    // green on a fix that never refetches at all, because the two compare equal.
+    const log: string[] = [];
+    const fetcherA = makeFetcher('A', log);
+    const fetcherB = makeFetcher('B', log);
+    const { ctxSeen, Probe } = makeProbe();
+    const tree = (f: typeof fetch) => (
+      <MePermissionsProvider endpoint="/me/permissions" fetcher={f}>
+        <Probe />
+      </MePermissionsProvider>
+    );
+
+    const { rerender } = render(tree(fetcherA));
+    await waitFor(() => expect(log).toHaveLength(1));
+    expect(ctxSeen[ctxSeen.length - 1]!.userId).toBe('A');
+
+    rerender(tree(fetcherB));
+    // Not merely "a request happened": the NEW fetcher's answer must reach the
+    // context. This is what a driver mutated to answer one constant fails.
+    await waitFor(() => expect(ctxSeen[ctxSeen.length - 1]!.userId).toBe('B'));
+    await settle();
+    expect(log).toEqual(['A /me/permissions', 'B /me/permissions']);
+  });
+
+  it('still refetches exactly once when either retry primitive changes', async () => {
+    // These two are the remaining members of the four the `useCallback` named.
+    // Pinning them is a PARITY claim — the fix must not narrow the trigger set —
+    // not an assertion that a retry-tuning knob ought to refetch on its own.
+    const log: string[] = [];
+    const fetcher = makeFetcher('A', log);
+    const { Probe } = makeProbe();
+    const tree = (maxRetries: number, retryBaseDelayMs: number) => (
+      <MePermissionsProvider
+        endpoint="/me/permissions"
+        fetcher={fetcher}
+        maxRetries={maxRetries}
+        retryBaseDelayMs={retryBaseDelayMs}
+      >
+        <Probe />
+      </MePermissionsProvider>
+    );
+
+    const { rerender } = render(tree(3, 500));
+    await waitFor(() => expect(log).toHaveLength(1));
+
+    rerender(tree(1, 500));
+    await waitFor(() => expect(log).toHaveLength(2));
+
+    rerender(tree(1, 20));
+    await waitFor(() => expect(log).toHaveLength(3));
+
+    await settle();
+    expect(log).toHaveLength(3);
   });
 });


### PR DESCRIPTION
Fixes #6862

## The defect

`MePermissionsProvider` built its fetch driver in a `useCallback` over
`[endpoint, fetcher, maxRetries, retryBaseDelayMs]` and named **that callback** as its
fetch effect's dependency:

```
const fetchPermissions = useCallback(async (token) => { … },
  [endpoint, fetcher, maxRetries, retryBaseDelayMs]);

useEffect(() => { … void fetchPermissions(token); … },
  [fetchPermissions, initialPermissions]);
```

`useCallback` carries no semantic guarantee — React may discard the cache and rebuild
even when the dependency list compares equal. The rebuilt function is a new identity, so
the effect tore down and re-ran with **none of the four inputs changed**: one redundant
`/api/v1/auth/me/permissions` round trip on the provider that gates the whole console.

This is the **effect** end of the provider whose **value** end objectui#6813 hardened.
`#6813`'s `WeakMap` input-keying does not transfer: a `WeakMap` cannot key the three
primitives, and the possibly-`undefined` `fetcher` has no object to key on either.

## The fix

`loadPermissions(config, sink, token)` is now a module-level function that closes over
nothing, so there is no identity left for React to move. The effect keys on the four
**values** directly:

```
}, [endpoint, fetcher, maxRetries, retryBaseDelayMs, initialPermissions]);
```

The trigger set is **unchanged** — those are exactly the four the old callback listed —
so every legitimate refetch still happens. `retry` may stay a `useCallback`: nothing keys
on its identity, it is handed to a render prop, and a discard there costs a re-render
rather than a round trip.

Public surface is untouched: `FetchConfig`, `FetchSink` and `loadPermissions` are
module-private and do not appear in the emitted `dist/MePermissionsProvider.d.ts`
(verified after `pnpm --filter @object-ui/permissions build`).

## Why the pins force a discard

⭐ **A pin that does not force a discard proves nothing, because React will not discard on
its own.** Re-verified on this branch, not recalled: React is pinned and resolves to
**19.2.8**, and the repo still has **no `Activity`/Offscreen subtree** — zero imports of
`Activity` from `react`, against **179** files importing `useMemo` from it on the same
command shape (a zero-hit sweep with a lit control). ⇒ An ordinary render-count or
effect-count test would be green on the defect **and** on the fix.

So the pins reuse the forced-discard proxy already in
`packages/permissions/src/__tests__/providerCtxIdentity.discarded.test.tsx` (added by
objectui#6813) — it already patches `useCallback` as well as `useMemo`. No second harness
was built; the new pins live in that file and arm the same proxy.

The pins also assert the **observable** — the number of `/me/permissions` requests, served
from a `fetcher`-prop double so nothing can reach happy-dom's `http://localhost:3000` and
be attributed to this file by the network-escape guard (objectui#8537).

## Measured on the defect, before the fix

Two forced discards, all four inputs unchanged:

| | measured | correct |
|---|---|---|
| `/me/permissions` requests | **3** | 1 |
| distinct context identities | **3** | 1 |
| consumer effect runs | **3** | 1 |

⚠️ **The card's "one redundant round trip" is not the whole cost.** The card says the
`isLoaded` flip goes "false and then back". It does not come back to the same *identity*:
`setData(json)` installs a **fresh payload object** even for a byte-identical answer, and
that object is exactly the key objectui#6813's caches are built on (`dataKey`). So a
discard that refetches walks **straight through the guard #6813 landed** — the context
identity moves permanently and every consumer effect downstream re-runs. This does not
change the fix, and it does not change the p3 grading (still latent, still no wrong data),
but it means the family's own remedy is defeated by this card's defect.

## Ablation — every pin observed to fail on purpose

Each mutation was proven on disk (before/after marker counts), run, then restored with
`git checkout HEAD -- …` and `git diff HEAD` proven empty. No void legs.

| leg | mutation | pin 1 (forced discard) | pins 2–4 (legitimate refetch) |
|---|---|---|---|
| A | effect never runs | **FAILED** | **FAILED** |
| B | **the plausible wrong fix** — deps dropped to `[initialPermissions]` | PASSED | **FAILED ×3** |
| C | dependency array removed entirely (refetch every render) | **FAILED** | **FAILED** |
| D | driver ignores `endpoint`, fetches a constant URL | **FAILED** | **FAILED ×2**, 1 passed |

⭐ **Leg B is the one that matters.** A fix that simply removes the dependency also stops
the redundant fetch — and stops every legitimate refetch with it. It passes the
forced-discard pin and is rejected by all three non-regression pins, which is exactly what
those pins exist for. Leg D's one green is honest: the retry-primitive pin counts requests
and does not assert the URL, which pin 2 does.

⚠️ Both fetchers in the swap pin are **concrete and distinguishable**, and the pin asserts
the new fetcher's answer reaches the context (`userId` `'A'` → `'B'`). Swapping one
`undefined` fetcher for another would have proved nothing.

## Verification

Run from the repo root with root-relative paths, on a built dependency closure.

- `pnpm --filter '@object-ui/permissions^...' build` → exit 0 (so `type-check` below is a
  result, not a precondition)
- `pnpm exec vitest run packages/permissions/` → **`Test Files 8 passed (8)` · `Tests 89
  passed (89)`**; JSON reporter: `{"passed":89}`, 0 failed suites, no death strings
- `pnpm --filter @object-ui/permissions type-check` → exit 0. `tsc -p tsconfig.test.json
  --listFiles` confirms the new pins are actually in the checked file set (the config does
  **not** exclude `*.test.tsx`)
- `pnpm --filter @object-ui/permissions lint` → **0 errors**, 27 warnings, all pre-existing
  `no-explicit-any`
- Consumer sweep — all 12 test files outside `packages/permissions` that render
  `MePermissionsProvider` (`apps/console`, `app-shell`, `plugin-form`, `plugin-grid`):
  **`Test Files 12 passed (12)` · `Tests 90 passed (90)`**
- `node scripts/check-changeset-presence.mjs` → `✅  2 source file(s) of 1 released
  package(s) changed, and this change declares 1 changeset(s):
  .changeset/lucky-pandas-shake.md.`
- `node scripts/check-changeset-no-major.mjs` → `✅  No changeset declares a 'major' bump.`
- Control-character sweep over the changed files: zero hits, with a lit control firing on
  the same command shape.

## Out of scope

⛔ The **family house rule** (when may `useMemo`/`useCallback` identity be depended upon)
is not written here. It would land on `AGENTS.md`, a governed surface, and it is a
maintainer ruling rather than a finding — recorded on the card as the eighth named
instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_