### PR TITLE
fix(plugin-form,types): resolve `form.sections[].group` through the single field-group assembler, and bound the section loop that blanked the form

### DIFF
--- a/.changeset/7051-form-section-group-reference.md
+++ b/.changeset/7051-form-section-group-reference.md
@@ -1,0 +1,48 @@
+---
+'@object-ui/plugin-form': minor
+'@object-ui/types': minor
+---
+
+A form-view section can reference a declared field group instead of copying its
+members (objectstack#13855, objectui#7051 — the view-level half; the
+`record:details` half shipped as objectui#8497).
+
+`@objectstack/spec` 17.3.0 declares two ways for a `form.sections[]` entry to give
+itself members: enumerate `fields`, or point `group` at one of the object's declared
+`fieldGroups` and inherit that group's membership **and** its presentation. Nothing on
+this renderer read `group`, and the omission was not a no-op:
+
+- on the default `simple` layout an authored `{ group: 'contact_info' }` threw
+  `Cannot read properties of undefined (reading 'map')` out of the section loop in
+  `SimpleObjectForm`'s own body — above the JSX it returns, so no per-section error
+  boundary could contain it — and **blanked the entire form**, taking every
+  well-formed sibling section with it;
+- on `tabbed` / `split` / `drawer` / `modal` the section silently rendered nothing;
+- on `wizard` it rendered an empty step.
+
+`ObjectForm` now resolves the reference **once**, above its routing fork, so all six
+layouts inherit it: a `{ group }` section renders the members that group declares, in
+the order and with the label, description and collapse state the object declares them
+with. Resolution goes through `deriveFieldGroupLayout` (ADR-0085 §5) via this
+package's existing single adapter — the same code path the no-sections field-group
+fallback already used, so authoring a group by reference and letting the fallback
+derive it produce the same section by construction. No assembly rule is
+re-implemented here.
+
+The object definition is fetched only when a section actually authors `group`, so a
+form that does not use the reference form issues no additional request and takes no
+new path.
+
+Diagnostics rather than silence, for the shapes the spec door cannot see (programmatic
+SDUI callers): a `group` naming no declared group renders nothing and is reported once
+on the console (`@objectstack/lint` owns it as `form-section-group-unknown`); a
+group-owned presentation key restated beside `group` is ignored — the spec grants no
+override semantics — and reported; `group` on a wizard step is refused and reported,
+because a step has no slot for the `collapse` / `visibleWhen` a group carries.
+
+Also in this change: `@object-ui/types`' `ObjectFormSection` declares `group` and makes
+`fields` optional, so the spec-legal shape finally compiles for a TypeScript author;
+and the shared field-group adapter now carries the group's `description` and
+`visibleWhen` onto the section it derives — both are keys the assembler emits and
+`ObjectFormSection` declares, and a key-by-key rebuild that drops one is how a declared
+group's presentation goes missing.

--- a/apps/console/src/__tests__/public-block-binding-reach.test.tsx
+++ b/apps/console/src/__tests__/public-block-binding-reach.test.tsx
@@ -292,16 +292,26 @@ const SUPERSEDES_BINDING = new Set(['data', 'staticData', 'customFields']);
  * generic `array` sample is `['name']`, and a bare string is not a section:
  * `@objectstack/spec`'s `FormViewSchema.sections` rejects it at parse —
  * `safeParse(['name'])` returns *"Invalid input: expected object, received
- * string"* — and requires `fields` on every entry (`[{}]` returns *"0.fields:
- * Invalid input: expected array, received undefined"*). This repo's own type
- * says the same: `ObjectFormSection.fields` is REQUIRED
- * (`packages/types/src/objectql.ts`). So `['name']` is not metadata any author
- * could publish, while `ObjectForm.tsx:1166` reads `section.fields.map(...)` off
- * each entry unguarded and takes the whole block down with *"Cannot read
+ * string"* — and requires every entry to declare its members (`[{}]` returns
+ * *"0.fields: A section must declare its members exactly one way, and this form
+ * section declares neither"*). So `['name']` is not metadata any author could
+ * publish, while `ObjectForm.tsx`'s section loop read `section.fields.map(...)`
+ * off each entry unguarded and took the whole block down with *"Cannot read
  * properties of undefined (reading 'map')"*. That makes the error card a
  * FIXTURE defect, not the product bug the shape suggested — the discriminator
  * being the spec shape, not the fact that a different sample stops the crash
  * (which is true either way).
+ *
+ * ⚠️ Two halves of that reasoning moved with objectui#7051 and are restated
+ * here rather than left to read as still-true. (1) `ObjectFormSection.fields`
+ * is no longer REQUIRED on this repo's type: `group` — the field-group
+ * REFERENCE form, `@objectstack/spec` 17.3.0 / objectstack#13855 — is the other
+ * way a section declares the same fact, so the spec refuses an entry carrying
+ * NEITHER rather than one missing `fields`. The fixture reasoning is unchanged
+ * (a bare string is still not a section, and `{}` is still refused), only its
+ * quoted grounds. (2) That unguarded `.map` is now spelled `?? []`, so this
+ * sample's shape no longer decides whether the block survives — which is
+ * exactly why the sample is justified on the SPEC shape and not on the crash.
  *
  * `formType` is the SEVENTH, and it is why `object-master-detail-form` read GREEN
  * while carrying the identical latent crash. That block declares `formType` as a

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -42,6 +42,7 @@ import {
   inferColumns,
 } from './autoLayout';
 import { deriveFieldGroupSections } from './fieldGroups';
+import { hasSectionGroupReference, resolveSectionGroupReferences } from './sectionGroups';
 import { sanitizeFormData } from './sanitize';
 import { noSubmitTargetError } from './submitTarget';
 import {
@@ -137,6 +138,43 @@ export const ObjectForm: React.FC<ObjectFormComponentProps> = ({
   dataSource,
 }) => {
   const perms = usePermissions();
+
+  // ── `sections[].group` — the ADR-0085 §5 REFERENCE form (objectui#7051) ───
+  //
+  // A section may point `group` at one of the object's declared `fieldGroups`
+  // instead of enumerating members (`@objectstack/spec` 17.3.0,
+  // objectstack#13855). Resolving it needs the OBJECT definition, and this
+  // dispatcher — unlike the six bodies below it — has never loaded one.
+  //
+  // It is resolved HERE, above the routing, on purpose: every variant's
+  // `sections` prop is rebuilt key by key in the maps below, so a `group` left
+  // in place would be dropped before any container could see it, and each
+  // container would need its own copy of the resolution. One site above the
+  // fork is what makes "one assembler" true for all six layouts at once —
+  // including `simple`, whose section loop read `section.fields.map(...)`
+  // unguarded and threw `Cannot read properties of undefined (reading 'map')`
+  // on a spec-legal `{ group }` section, blanking the WHOLE form (measured on
+  // this file at `origin/main`; the other five silently dropped the section
+  // instead, because `buildSectionFields` spells the same read `?? []`).
+  //
+  // The load is gated on an authored `group` being present, so a form that
+  // does not use the reference form issues no request and takes no new path.
+  const needsGroupLayout = hasSectionGroupReference((rawSchema as any)?.sections);
+  const canResolveGroups = typeof (dataSource as any)?.getObjectSchema === 'function';
+  const [groupObjectDef, setGroupObjectDef] = useState<any>(null);
+  useEffect(() => {
+    if (!needsGroupLayout || !canResolveGroups) return;
+    let alive = true;
+    Promise.resolve((dataSource as any).getObjectSchema(rawSchema.objectName))
+      .then((def: any) => { if (alive) setGroupObjectDef(def ?? null); })
+      // A failed load leaves the references unresolved (their sections render
+      // empty). It is deliberately NOT reported as a dangling reference: the
+      // body below owns the load error for the object, and claiming the group
+      // does not exist would be a second, wrong diagnosis of one failure.
+      .catch(() => { if (alive) setGroupObjectDef(null); });
+    return () => { alive = false; };
+  }, [needsGroupLayout, canResolveGroups, dataSource, rawSchema.objectName]);
+
   // Apply field-level permissions to the entire schema (sections + flat
   // fields) BEFORE dispatching to any variant. This way all variants
   // (Tabbed/Wizard/Split/Drawer/Modal/Simple) transparently honour FLS.
@@ -168,7 +206,22 @@ export const ObjectForm: React.FC<ObjectFormComponentProps> = ({
             })),
           }
         : folded;
-    if (!perms?.isLoaded) return base;
+    /**
+     * Resolve every `{ group }` section into the section that group declares.
+     *
+     * Returns its input UNCHANGED — same array reference — when no section
+     * uses the reference form, so this memo cannot perturb any existing form.
+     */
+    const withGroups = (s: ObjectFormComponentProps['schema']) => {
+      const resolved = resolveSectionGroupReferences(s.sections as any, {
+        objectName: s.objectName,
+        formType: s.formType,
+        objectDef: groupObjectDef,
+        resolvable: canResolveGroups,
+      });
+      return resolved === (s.sections as any) ? s : { ...s, sections: resolved as any };
+    };
+    if (!perms?.isLoaded) return withGroups(base);
     const gateField = (f: any) => {
       if (!f?.name) return f;
       const canRead = perms.checkField(base.objectName, f.name, 'read');
@@ -181,15 +234,15 @@ export const ObjectForm: React.FC<ObjectFormComponentProps> = ({
     };
     const filterArr = (arr?: any[]) =>
       Array.isArray(arr) ? arr.map(gateField).filter(Boolean) : arr;
-    return {
+    return withGroups({
       ...base,
       fields: filterArr(base.fields as any[]),
       sections: base.sections?.map((s: any) => ({
         ...s,
         fields: filterArr(s.fields),
       })),
-    } as ObjectFormComponentProps['schema'];
-  }, [rawSchema, perms]);
+    } as ObjectFormComponentProps['schema']);
+  }, [rawSchema, perms, groupObjectDef, canResolveGroups]);
   const { sectionLabel } = useSafeFieldLabel();
   const tSec = (s: any) =>
     s?.name ? sectionLabel(schema.objectName, s.name, s.label || s.name) : s?.label;
@@ -277,7 +330,16 @@ export const ObjectForm: React.FC<ObjectFormComponentProps> = ({
             label: tSec(s),
             description: s.description,
             columns: s.columns,
-            fields: s.fields,
+            // `?? []` because `ObjectFormSection.fields` is OPTIONAL since objectui#7051
+            // — `group` is the other way a section declares its members. A `{ group }`
+            // section has already been resolved into one carrying `fields` before this
+            // map runs (and an unresolvable one into `fields: []`), so this default is
+            // reached only by a programmatic caller sending a section with neither,
+            // which the spec door refuses. These per-layout config types stay
+            // `fields`-required on purpose: they are the programmatic React-mount
+            // shapes, not the authorable surface, and the reference form is resolved
+            // above them.
+            fields: s.fields ?? [],
             // ADR-0089 section predicate (objectui#6237) — key-by-key rebuild,
             // so an uncopied key is silently dropped before TabbedForm ever
             // sees it, exactly as it was on this route until this card. The
@@ -348,7 +410,8 @@ export const ObjectForm: React.FC<ObjectFormComponentProps> = ({
             label: tSec(s),
             description: s.description,
             columns: s.columns,
-            fields: s.fields,
+            // `?? []` — see the tabbed arm above (objectui#7051).
+            fields: s.fields ?? [],
             // `className` / `gridClassName`: deliberately not copied — see the
             // tabbed arm above (objectstack#13626, ruled 2026-09-01).
           })),
@@ -375,7 +438,8 @@ export const ObjectForm: React.FC<ObjectFormComponentProps> = ({
             label: tSec(s),
             description: s.description,
             columns: s.columns,
-            fields: s.fields,
+            // `?? []` — see the tabbed arm above (objectui#7051).
+            fields: s.fields ?? [],
             // Explicit pane placement (spec FormSection.pane). This mapping
             // rebuilds each section key by key, so a key it doesn't copy is
             // silently dropped — exactly how `visibleOn` once vanished here.
@@ -410,7 +474,8 @@ export const ObjectForm: React.FC<ObjectFormComponentProps> = ({
             label: tSec(s),
             description: s.description,
             columns: s.columns,
-            fields: s.fields,
+            // `?? []` — see the tabbed arm above (objectui#7051).
+            fields: s.fields ?? [],
             collapsible: (s as any).collapsible,
             collapsed: (s as any).collapsed,
             // ADR-0089 section predicate (#6111) — key-by-key rebuild, so an
@@ -445,7 +510,8 @@ export const ObjectForm: React.FC<ObjectFormComponentProps> = ({
             label: tSec(s),
             description: s.description,
             columns: s.columns,
-            fields: s.fields,
+            // `?? []` — see the tabbed arm above (objectui#7051).
+            fields: s.fields ?? [],
             // ADR-0089 section predicate (#6111) — key-by-key rebuild, so an
             // uncopied key is silently dropped before ModalForm ever sees it.
             visibleWhen: (s as any).visibleWhen,
@@ -1269,7 +1335,18 @@ const SimpleObjectForm: React.FC<ObjectFormComponentProps> = ({
         // legitimately be the spec identity STRING (the cast is the boundary,
         // not a leak; on runtime FormFields the declared `field` slot is
         // always the metadata object, #3090).
-        section.fields.map(f => [typeof f === 'string' ? f : ((f as any).field ?? f.name), f]),
+        // ⚠️ `?? []`, not a bare `.map` — the second containment layer for
+        // objectui#7051. The group-reference resolution above this component
+        // means a `{ group }` section never arrives here carrying no `fields`,
+        // but this loop runs in `SimpleObjectForm`'s own body, ABOVE the JSX it
+        // returns: a throw here is outside every per-section subtree, so no
+        // error boundary that a section could own would contain it. That is
+        // exactly how a spec-legal section blanked the entire form — the
+        // well-formed siblings with it — before this card. The five container
+        // variants have always spelled this read `section.fields ?? []` in
+        // `buildSectionFields`; this is the sixth joining them, so no section
+        // shape can take the form down again through this line.
+        (section.fields ?? []).map(f => [typeof f === 'string' ? f : ((f as any).field ?? f.name), f]),
       );
       const sectionFieldNames = Array.from(sectionDefByName.keys());
       const sectionFields = applyFieldPerms(sourceFields.filter(f => sectionFieldNames.includes(f.name)))

--- a/packages/plugin-form/src/__tests__/formSectionGroupReference-7051.test.tsx
+++ b/packages/plugin-form/src/__tests__/formSectionGroupReference-7051.test.tsx
@@ -1,0 +1,475 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `form.sections[].group` — the view-level half of objectstack#13855
+ * (objectui#7051), the sibling of objectui#8497's `record:details` half.
+ *
+ * ⭐ WHICH LEG DISCRIMINATES, said out loud so nobody re-reads the weak one as
+ * the strong one. `SIBLING_SECTION_SURVIVES` and `FORM_IS_NOT_BLANKED` are
+ * NON-REGRESSION legs: both PASS under the caricature (a resolver that answers
+ * the same thing for every input), because sibling sections are exactly what a
+ * caricature preserves — this is the correction objectui#8497 recorded after
+ * its own stated axis failed to discriminate. The leg that separates the fix
+ * from the plausible wrong one is `SECTION_GROUP_RENDERS_ITS_OWN_MEMBERS`: two
+ * sections referencing two DIFFERENT groups, each asserted to render exactly
+ * the members ITS group declares, by concrete field identifier and in order.
+ * "The section is non-empty" would be decorative; "the form renders" passes on
+ * a form that silently drops every group-referenced section, which is what
+ * five of the six layouts did before this card.
+ *
+ * ⚠️ The two surfaces are NOT symmetric, measured rather than inferred:
+ *   - `simple` THREW `Cannot read properties of undefined (reading 'map')` out
+ *     of `SimpleObjectForm`'s own body (`ObjectForm.tsx`, the section loop
+ *     above the returned JSX) and blanked the whole form — the same
+ *     above-the-loop shape `record:details` had, so a per-section boundary
+ *     could not have contained it either.
+ *   - `tabbed` / `split` / `drawer` / `modal` did NOT throw: `buildSectionFields`
+ *     spells the same read `section.fields ?? []`, so the section silently
+ *     rendered nothing, with no diagnostic.
+ *   - `wizard` rendered an empty step ("No fields configured for this step").
+ * Both failure modes are pinned below.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import { registerAllFields } from '@object-ui/fields';
+import { FormSectionSchema, FormViewSchema } from '@objectstack/spec/ui';
+import { ObjectForm } from '../ObjectForm';
+import {
+  resolveSectionGroupReferences,
+  resetSectionGroupReports,
+  hasSectionGroupReference,
+} from '../sectionGroups';
+
+registerAllFields();
+
+// ─── Fixture ──────────────────────────────────────────────────────────────
+
+/**
+ * Two declared groups with DISTINCT members, plus an ungrouped field and the
+ * harness anchor. Distinct membership is what makes the discriminating leg
+ * discriminate: a resolver that returns one constant member list cannot
+ * satisfy both group sections at once.
+ */
+const TICKET = {
+  name: 'ticket',
+  fieldGroups: [
+    { key: 'contact_info', label: 'Contact Info' },
+    { key: 'billing', label: 'Billing Details' },
+    { key: 'archive', label: 'Archive', description: 'Retired references', collapse: 'collapsed' },
+  ],
+  fields: {
+    email: { type: 'text', label: 'Email Address', group: 'contact_info' },
+    phone: { type: 'text', label: 'Phone Number', group: 'contact_info' },
+    invoice_no: { type: 'text', label: 'Invoice No', group: 'billing' },
+    po_number: { type: 'text', label: 'PO Number', group: 'billing' },
+    old_ref: { type: 'text', label: 'Old Ref', group: 'archive' },
+    channel: { type: 'text', label: 'Channel' },
+    anchor_note: { type: 'text', label: 'Anchor Note' },
+  },
+};
+
+const makeDS = (objectSchema: any = TICKET) =>
+  ({
+    getObjectSchema: vi.fn().mockResolvedValue(objectSchema),
+    create: vi.fn().mockResolvedValue({ id: 't1' }),
+    update: vi.fn().mockResolvedValue({ id: 't1' }),
+    findOne: vi.fn().mockResolvedValue({ id: 't1' }),
+  }) as any;
+
+/** The anchor every rendered form carries — no leg asserts anything about it. */
+const ANCHOR = { label: 'Harness Anchor', fields: ['anchor_note'] };
+
+// ─── Harness ──────────────────────────────────────────────────────────────
+
+/**
+ * Harness-kill leg. Fires in BOTH directions — zero anchors and duplicated
+ * anchors — so a caricature cannot satisfy the harness by adding a section,
+ * and its text is unlike every content assertion in this file, so a harness
+ * death can never be read as a content failure.
+ */
+function requireLiveForm(): HTMLFormElement {
+  const forms = document.body.querySelectorAll('form');
+  if (forms.length !== 1) {
+    throw new Error(`HARNESS DEAD: expected exactly 1 <form>, found ${forms.length}`);
+  }
+  const anchors = Array.from(forms[0].querySelectorAll('input[name="anchor_note"]'));
+  if (anchors.length !== 1) {
+    throw new Error(
+      `HARNESS DEAD: expected exactly 1 anchor input, found ${anchors.length}`,
+    );
+  }
+  return forms[0] as HTMLFormElement;
+}
+
+/**
+ * The rendered form's structure, in document order: `H:<label>` for a section
+ * heading, `F:<name>` for a field input. Structural on purpose — presence
+ * alone would not catch a resolver that gave every section the same members.
+ */
+function formOutline(form: HTMLElement): string[] {
+  const out: string[] = [];
+  form.querySelectorAll('input[name], .col-span-full').forEach((el) => {
+    if (el.tagName === 'INPUT') {
+      out.push(`F:${el.getAttribute('name')}`);
+    } else if (el.classList.contains('border-b')) {
+      out.push(`H:${(el.textContent ?? '').trim()}`);
+    }
+  });
+  return out;
+}
+
+let uiErrors: string[] = [];
+let uiWarns: string[] = [];
+let errSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetSectionGroupReports();
+  uiErrors = [];
+  uiWarns = [];
+  // Only this repo's own diagnostics are collected: React's act() advice also
+  // arrives on console.error, and counting it would make "reported once"
+  // depend on React's internals rather than on the reporter under test.
+  errSpy = vi.spyOn(console, 'error').mockImplementation((...args: any[]) => {
+    const s = args.map(String).join(' ');
+    if (s.includes('[object-ui]')) uiErrors.push(s);
+  });
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation((...args: any[]) => {
+    const s = args.map(String).join(' ');
+    if (s.includes('[object-ui]')) uiWarns.push(s);
+  });
+});
+
+afterEach(() => {
+  errSpy.mockRestore();
+  warnSpy.mockRestore();
+  cleanup();
+});
+
+const renderForm = async (formType: string, sections: any[], ds = makeDS()) => {
+  render(
+    <ObjectForm
+      schema={{
+        type: 'object-form',
+        formType,
+        objectName: 'ticket',
+        mode: 'create',
+        open: true,
+        sections,
+      } as any}
+      dataSource={ds}
+    />,
+  );
+  await waitFor(
+    () => {
+      expect(document.body.querySelectorAll('form').length).toBe(1);
+      expect(
+        document.body.querySelectorAll('input[name="anchor_note"]').length,
+      ).toBe(1);
+    },
+    { timeout: 4000 },
+  );
+};
+
+// ─── The renderer legs ────────────────────────────────────────────────────
+
+describe('objectui#7051 — `form.sections[].group` resolves through the single assembler', () => {
+  it('⭐ SECTION_GROUP_RENDERS_ITS_OWN_MEMBERS — each group section renders exactly the members ITS group declares', async () => {
+    await renderForm('simple', [
+      { group: 'contact_info' },
+      { group: 'billing' },
+      { label: 'Extra', fields: ['channel'] },
+      ANCHOR,
+    ]);
+
+    const form = requireLiveForm();
+    // The whole structure, in order. Not "the section is non-empty": a
+    // constant member list, or every section resolving to the same group,
+    // changes this array. So does dropping a group section, which is what
+    // this renderer did before the card.
+    expect(formOutline(form)).toEqual([
+      'H:Contact Info',
+      'F:email',
+      'F:phone',
+      'H:Billing Details',
+      'F:invoice_no',
+      'F:po_number',
+      'H:Extra',
+      'F:channel',
+      'H:Harness Anchor',
+      'F:anchor_note',
+    ]);
+    // Membership is exclusive in both directions — `billing`'s members are not
+    // in `contact_info`'s section and vice versa. Stated separately from the
+    // outline so the failure message says WHICH half broke.
+    expect(form.querySelectorAll('input[name="invoice_no"]').length).toBe(1);
+    expect(form.querySelectorAll('input[name="old_ref"]').length).toBe(0);
+    expect(uiErrors).toEqual([]);
+  });
+
+  it('SECTION_GROUP_LABEL_IS_THE_GROUPS_OWN — presentation comes from the object, not from the section', async () => {
+    await renderForm('simple', [{ group: 'contact_info' }, ANCHOR]);
+    const form = requireLiveForm();
+    // The referencing section cannot declare a label (the spec refuses it), so
+    // a heading reading "Contact Info" can only have come from the object's
+    // `fieldGroups` entry through `deriveFieldGroupLayout`.
+    expect(formOutline(form)).toEqual([
+      'H:Contact Info',
+      'F:email',
+      'F:phone',
+      'H:Harness Anchor',
+      'F:anchor_note',
+    ]);
+  });
+
+  it('SIBLING_SECTION_SURVIVES (non-regression — passes under the caricature, kept for the contrast)', async () => {
+    await renderForm('simple', [
+      { group: 'contact_info' },
+      { label: 'Extra', fields: ['channel'] },
+      ANCHOR,
+    ]);
+    const form = requireLiveForm();
+    expect(form.querySelectorAll('input[name="channel"]').length).toBe(1);
+    expect(form.textContent).toContain('Extra');
+  });
+
+  it('FORM_IS_NOT_BLANKED — a `{ group }` section no longer takes the whole simple form down (non-regression)', async () => {
+    // Before this card this exact render produced an EMPTY document: the
+    // section loop in `SimpleObjectForm`'s body threw
+    // `Cannot read properties of undefined (reading 'map')` above the JSX it
+    // returns, so React unmounted the tree and the well-formed siblings went
+    // with it. `requireLiveForm` finding one live <form> IS the assertion.
+    await renderForm('simple', [{ group: 'contact_info' }, ANCHOR]);
+    expect(requireLiveForm().querySelectorAll('input').length).toBeGreaterThan(0);
+  });
+
+  it('UNKNOWN_GROUP_RENDERS_NOTHING_AND_REPORTS_ONCE', async () => {
+    await renderForm('simple', [
+      { group: 'no_such_group' },
+      { label: 'Extra', fields: ['channel'] },
+      ANCHOR,
+    ]);
+    const form = requireLiveForm();
+    // Renders nothing — no phantom heading, no borrowed members — and the
+    // sibling is untouched.
+    expect(formOutline(form)).toEqual([
+      'H:Extra',
+      'F:channel',
+      'H:Harness Anchor',
+      'F:anchor_note',
+    ]);
+    // Dropped, but never silently: `@objectstack/spec` assigns EXISTENCE to
+    // `@objectstack/lint`'s `form-section-group-unknown`, not to parse, so the
+    // renderer is the only place an author gets told at runtime.
+    expect(uiErrors).toHaveLength(1);
+    expect(uiErrors[0]).toContain('no_such_group');
+    expect(uiErrors[0]).toContain('form-section-group-unknown');
+  });
+
+  it('GROUP_OWNED_KEY_BESIDE_GROUP_IS_IGNORED_AND_REPORTED — no override semantics, and not silent either', async () => {
+    // `@objectstack/spec` refuses this shape at parse (pinned below), so it
+    // only reaches the renderer from a programmatic SDUI caller. The group's
+    // own label still wins — the spec grants no override — and the ignored key
+    // is reported rather than quietly honoured or quietly dropped.
+    await renderForm('simple', [
+      { group: 'contact_info', label: 'My Own Label', collapsible: true },
+      ANCHOR,
+    ]);
+    const form = requireLiveForm();
+    expect(formOutline(form)[0]).toBe('H:Contact Info');
+    expect(form.textContent).not.toContain('My Own Label');
+    expect(uiWarns).toHaveLength(1);
+    expect(uiWarns[0]).toContain('`label`');
+    expect(uiWarns[0]).toContain('`collapsible`');
+  });
+
+  it('WIZARD_STEP_GROUP_IS_REFUSED_AND_REPORTED — the renderer agrees with the spec instead of inventing semantics', async () => {
+    render(
+      <ObjectForm
+        schema={{
+          type: 'object-form',
+          formType: 'wizard',
+          objectName: 'ticket',
+          mode: 'create',
+          sections: [{ group: 'contact_info' }, { label: 'Step Two', fields: ['channel'] }],
+        } as any}
+        dataSource={makeDS()}
+      />,
+    );
+    await waitFor(() => {
+      expect(document.body.textContent).toContain('Step');
+    }, { timeout: 4000 });
+    // Not resolved: a wizard step has no slot for the `collapse` /
+    // `visibleWhen` a group carries, which is exactly why the spec refuses the
+    // combination. Rendering it would mean the wizard's own key-by-key step map
+    // silently dropped both keys.
+    expect(document.body.querySelectorAll('input[name="email"]').length).toBe(0);
+    expect(document.body.querySelectorAll('input[name="phone"]').length).toBe(0);
+    expect(uiWarns).toHaveLength(1);
+    expect(uiWarns[0]).toContain('wizard');
+  });
+});
+
+// ─── The five container layouts ───────────────────────────────────────────
+
+/**
+ * Resolution happens ONCE, above `ObjectForm`'s routing fork, so every layout
+ * inherits it. These rows are what makes that claim checkable: a future
+ * re-fork shows up as one layout's row going red while the others stay green.
+ *
+ * `tabbed` renders only the ACTIVE tab, so the group section is first there.
+ */
+const CONTAINERS: Array<[string, any[]]> = [
+  ['tabbed', [{ group: 'contact_info' }, ANCHOR]],
+  ['split', [{ group: 'contact_info' }, ANCHOR]],
+  ['drawer', [{ group: 'contact_info' }, ANCHOR]],
+  ['modal', [{ group: 'contact_info' }, ANCHOR]],
+];
+
+describe.each(CONTAINERS)(
+  'objectui#7051 — %s inherits the resolution from the one site above the fork',
+  (formType, sections) => {
+    it('renders the referenced group\'s OWN members', async () => {
+      await renderForm(formType, sections);
+      const form = requireLiveForm();
+      expect(form.querySelectorAll('input[name="email"]').length).toBe(1);
+      expect(form.querySelectorAll('input[name="phone"]').length).toBe(1);
+      // Exclusive: not somebody else's members.
+      expect(form.querySelectorAll('input[name="invoice_no"]').length).toBe(0);
+      expect(form.textContent).toContain('Contact Info');
+      expect(uiErrors).toEqual([]);
+    });
+  },
+);
+
+// ─── The resolver, as a unit ──────────────────────────────────────────────
+
+describe('objectui#7051 — resolveSectionGroupReferences', () => {
+  const opts = { objectName: 'ticket', objectDef: TICKET } as const;
+
+  it('returns its input UNCHANGED (same reference) when no section uses the reference form', () => {
+    const sections = [{ label: 'Extra', fields: ['channel'] }] as any;
+    expect(resolveSectionGroupReferences(sections, opts)).toBe(sections);
+    expect(hasSectionGroupReference(sections)).toBe(false);
+    expect(resolveSectionGroupReferences(undefined, opts)).toBeUndefined();
+  });
+
+  it('carries the group\'s presentation — label, description and the collapse pair', () => {
+    // `collapse: 'collapsed'` on the object's group becomes the renderer's
+    // boolean pair, and `description` rides along: both are GROUP-owned per the
+    // spec, so a key-by-key rebuild that dropped either would leave the
+    // reference form unable to inherit it from anywhere.
+    const [resolved] = resolveSectionGroupReferences([{ group: 'archive' }] as any, opts)!;
+    expect(resolved).toEqual({
+      name: 'archive',
+      label: 'Archive',
+      description: 'Retired references',
+      fields: ['old_ref'],
+      collapsible: true,
+      collapsed: true,
+    });
+  });
+
+  it('keeps the two layout keys the spec PERMITS beside `group`, and only those', () => {
+    const [resolved] = resolveSectionGroupReferences(
+      [{ group: 'billing', columns: 3, pane: 'secondary', label: 'ignored' }] as any,
+      opts,
+    )!;
+    expect(resolved.columns).toBe(3);
+    expect(resolved.pane).toBe('secondary');
+    // The group's own label wins; the authored one is not merged in.
+    expect(resolved.label).toBe('Billing Details');
+    expect((resolved as any).group).toBeUndefined();
+  });
+
+  it('leaves a reference EMPTY rather than dropping it while the object definition is still loading', () => {
+    // Emptying and dropping both render nothing. Dropping is what this surface
+    // cannot afford: an emptied `sections` array stops being a sectioned form
+    // and falls back to the flat every-field layout, so one mistyped key would
+    // render MORE than the author asked for.
+    const out = resolveSectionGroupReferences(
+      [{ group: 'contact_info' }, { label: 'Extra', fields: ['channel'] }] as any,
+      { objectName: 'ticket', objectDef: null },
+    )!;
+    expect(out).toHaveLength(2);
+    expect(out[0]).toEqual({ fields: [] });
+    // Nothing reported: a pending load is not a dangling reference.
+    expect(uiErrors).toEqual([]);
+  });
+
+  it('does not resolve a group nothing points at — the assembler already dropped it', () => {
+    const [resolved] = resolveSectionGroupReferences([{ group: 'contact_info' }] as any, {
+      objectName: 'ticket',
+      objectDef: { ...TICKET, fields: { channel: { type: 'text' } } },
+    })!;
+    expect(resolved).toEqual({ fields: [] });
+    expect(uiErrors).toHaveLength(1);
+  });
+});
+
+// ─── The spec's own refusals, pinned where they are actually enforced ─────
+
+/**
+ * ⭐ The second axis. The card asks that group-owned presentation keys beside
+ * `group`, and `group` on a wizard step, not be SILENTLY accepted. Measured
+ * against the installed `@objectstack/spec` 17.3.0: both are refused at PARSE
+ * — a stronger door than the lint that objectui#8497 concluded owns EXISTENCE
+ * checking, and a different one. So authored metadata carrying either never
+ * reaches this renderer at all; the renderer's own reports above exist for the
+ * programmatic SDUI callers that do not pass this door.
+ *
+ * Pinned here because "enforcement lives upstream" is a claim about upstream,
+ * and a claim nothing checks is how a door quietly stops closing.
+ */
+describe('objectui#7051 — @objectstack/spec is the enforcing door for the two refusals', () => {
+  const refusal = (input: unknown, schema: any = FormSectionSchema) => {
+    const r = schema.safeParse(input);
+    expect(r.success).toBe(false);
+    return (r as any).error.issues.map((i: any) => `${i.code}:${i.path.join('.')}`);
+  };
+
+  it('refuses `group` beside `fields` — a section declares its members exactly one way', () => {
+    expect(refusal({ group: 'contact_info', fields: ['email'] })).toContain('custom:group');
+    expect(refusal({ label: 'x' })).toContain('custom:fields');
+  });
+
+  it('refuses every group-owned presentation key beside `group`, and PERMITS the layout pair', () => {
+    for (const key of ['name', 'label', 'description', 'collapsible', 'collapsed', 'visibleWhen']) {
+      const value = key === 'collapsible' || key === 'collapsed' ? true : 'v';
+      expect(refusal({ group: 'contact_info', [key]: value })).toContain(`custom:${key}`);
+    }
+    expect(FormSectionSchema.safeParse({ group: 'contact_info', columns: 2 }).success).toBe(true);
+    expect(FormSectionSchema.safeParse({ group: 'contact_info', pane: 'primary' }).success).toBe(true);
+  });
+
+  it('refuses `group` on a wizard step, and accepts it on every other form type', () => {
+    const view = (type: string) => ({ type, sections: [{ group: 'contact_info' }, { fields: ['channel'] }] });
+    expect(refusal(view('wizard'), FormViewSchema)).toContain('custom:sections.0.group');
+    for (const type of ['simple', 'tabbed', 'split', 'drawer', 'modal']) {
+      expect(FormViewSchema.safeParse(view(type)).success).toBe(true);
+    }
+  });
+
+  it('refuses the `fieldGroup` / `groupKey` alias spellings rather than folding them', () => {
+    // ⚠️ Recorded because the dispatch order carried the opposite premise. On
+    // `FormSectionSchema` these are NOT folded to `group`: they are
+    // unrecognized keys, refused with a "did you mean" hint. A renderer-side
+    // fold would therefore be a second, more permissive contract.
+    for (const alias of ['fieldGroup', 'groupKey']) {
+      expect(refusal({ [alias]: 'contact_info' })).toContain('unrecognized_keys:');
+    }
+  });
+
+  it('refuses a key that breaks the shared grammar (FIELD_GROUP_KEY_PATTERN)', () => {
+    expect(refusal({ group: 'Not A Key' })).toContain('invalid_format:group');
+  });
+});

--- a/packages/plugin-form/src/__tests__/formSectionGroupReference-7051.test.tsx
+++ b/packages/plugin-form/src/__tests__/formSectionGroupReference-7051.test.tsx
@@ -217,15 +217,20 @@ describe('objectui#7051 — `form.sections[].group` resolves through the single 
   });
 
   it('SECTION_GROUP_LABEL_IS_THE_GROUPS_OWN — presentation comes from the object, not from the section', async () => {
-    await renderForm('simple', [{ group: 'contact_info' }, ANCHOR]);
+    // ⚠️ `billing`, the SECOND declared group, deliberately — measured: with
+    // `contact_info` (the first) this leg stayed GREEN under the "every section
+    // resolves to the same group" caricature, because the first group is what
+    // that caricature happens to return. A leg that a caricature satisfies by
+    // accident is not testing the thing it names.
+    await renderForm('simple', [{ group: 'billing' }, ANCHOR]);
     const form = requireLiveForm();
     // The referencing section cannot declare a label (the spec refuses it), so
-    // a heading reading "Contact Info" can only have come from the object's
+    // a heading reading "Billing Details" can only have come from the object's
     // `fieldGroups` entry through `deriveFieldGroupLayout`.
     expect(formOutline(form)).toEqual([
-      'H:Contact Info',
-      'F:email',
-      'F:phone',
+      'H:Billing Details',
+      'F:invoice_no',
+      'F:po_number',
       'H:Harness Anchor',
       'F:anchor_note',
     ]);
@@ -348,23 +353,26 @@ describe('objectui#7051 — `form.sections[].group` resolves through the single 
  * `tabbed` renders only the ACTIVE tab, so the group section is first there.
  */
 const CONTAINERS: Array<[string, any[]]> = [
-  ['tabbed', [{ group: 'contact_info' }, ANCHOR]],
-  ['split', [{ group: 'contact_info' }, ANCHOR]],
-  ['drawer', [{ group: 'contact_info' }, ANCHOR]],
-  ['modal', [{ group: 'contact_info' }, ANCHOR]],
+  ['tabbed', [{ group: 'billing' }, ANCHOR]],
+  ['split', [{ group: 'billing' }, ANCHOR]],
+  ['drawer', [{ group: 'billing' }, ANCHOR]],
+  ['modal', [{ group: 'billing' }, ANCHOR]],
 ];
 
 describe.each(CONTAINERS)(
   'objectui#7051 — %s inherits the resolution from the one site above the fork',
   (formType, sections) => {
     it('renders the referenced group\'s OWN members', async () => {
+      // `billing` — the SECOND declared group, for the reason spelled out on
+      // SECTION_GROUP_LABEL_IS_THE_GROUPS_OWN: referencing the first one let a
+      // constant-resolution caricature satisfy these rows by accident.
       await renderForm(formType, sections);
       const form = requireLiveForm();
-      expect(form.querySelectorAll('input[name="email"]').length).toBe(1);
-      expect(form.querySelectorAll('input[name="phone"]').length).toBe(1);
+      expect(form.querySelectorAll('input[name="invoice_no"]').length).toBe(1);
+      expect(form.querySelectorAll('input[name="po_number"]').length).toBe(1);
       // Exclusive: not somebody else's members.
-      expect(form.querySelectorAll('input[name="invoice_no"]').length).toBe(0);
-      expect(form.textContent).toContain('Contact Info');
+      expect(form.querySelectorAll('input[name="email"]').length).toBe(0);
+      expect(form.textContent).toContain('Billing Details');
       expect(uiErrors).toEqual([]);
     });
   },

--- a/packages/plugin-form/src/__tests__/formSectionGroupReference-7051.test.tsx
+++ b/packages/plugin-form/src/__tests__/formSectionGroupReference-7051.test.tsx
@@ -252,6 +252,25 @@ describe('objectui#7051 — `form.sections[].group` resolves through the single 
     expect(requireLiveForm().querySelectorAll('input').length).toBeGreaterThan(0);
   });
 
+  it('SECTION_WITHOUT_MEMBERS_IS_BOUNDED — the second containment layer, pinned separately from the resolution', async () => {
+    // ⚠️ Added because the ablation said the guard was otherwise UNPINNED —
+    // the same discovery objectui#8497 recorded. With `group` resolved, a
+    // `{ group }` section becomes one carrying `fields` BEFORE the section loop
+    // sees it, so every group leg above stays green with the tolerant read
+    // reverted. This leg is the only one that fails then: a section carrying
+    // NEITHER `fields` nor `group` — off-spec, so reachable only from a
+    // programmatic SDUI caller — must render nothing instead of throwing
+    // `Cannot read properties of undefined (reading 'map')` out of a body above
+    // the JSX and taking the whole form with it.
+    await renderForm('simple', [
+      { label: 'Memberless' } as any,
+      { label: 'Extra', fields: ['channel'] },
+      ANCHOR,
+    ]);
+    const form = requireLiveForm();
+    expect(form.querySelectorAll('input[name="channel"]').length).toBe(1);
+  });
+
   it('UNKNOWN_GROUP_RENDERS_NOTHING_AND_REPORTS_ONCE', async () => {
     await renderForm('simple', [
       { group: 'no_such_group' },

--- a/packages/plugin-form/src/fieldGroups.ts
+++ b/packages/plugin-form/src/fieldGroups.ts
@@ -60,6 +60,18 @@ export function deriveFieldGroupSections(
   const sections: ObjectFormSection[] = derived.map((s) => ({
     ...(s.key !== undefined ? { name: s.key } : {}),
     ...(s.key !== undefined ? { label: s.label ?? s.key } : {}),
+    // The other two presentation keys the shared derivation emits and
+    // `ObjectFormSection` declares (objectui#7051). This map is a key-by-key
+    // rebuild, so a key it does not copy is dropped before any renderer can
+    // see it — the failure mode that lost `visibleOn` at the container maps and
+    // that objectui#6111 / #6237 fixed there. Both are GROUP-owned presentation
+    // per `@objectstack/spec` (its refusal message beside `group` names
+    // "the label, icon, description, collapse state and `visibleWhen` a group
+    // renders with"), so the reference form cannot inherit them from anywhere
+    // else. `icon` is not copied because `ObjectFormSection` declares no such
+    // key — nothing on this surface would read it.
+    ...(s.description !== undefined ? { description: s.description } : {}),
+    ...(s.visibleWhen !== undefined ? { visibleWhen: s.visibleWhen as ObjectFormSection['visibleWhen'] } : {}),
     fields: [...s.fields],
     // Map the shared `collapse` enum onto the renderer's boolean pair.
     ...(s.collapse !== 'none' ? { collapsible: true } : {}),

--- a/packages/plugin-form/src/sectionGroups.ts
+++ b/packages/plugin-form/src/sectionGroups.ts
@@ -1,0 +1,245 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `form.sections[].group` — the ADR-0085 §5 REFERENCE form on the view-level
+ * form surface (`@objectstack/spec` 17.3.0, objectstack#13855; objectui#7051).
+ *
+ * A form section declares its members exactly one way: it enumerates `fields`,
+ * or it points `group` at one of the object's declared `fieldGroups` and
+ * inherits that group's members AND its presentation. This module resolves the
+ * second form into the first, so every downstream reader — the simple grouped
+ * body and all five container variants — keeps seeing the one section shape it
+ * already knows.
+ *
+ * ⛔ No assembly rule is re-implemented here. Declared order, the empty-group
+ * drop, the ungrouped trailing bucket and the collapse / `visibleWhen`
+ * passthrough all come from `deriveFieldGroupLayout` (ADR-0085 §5), reached
+ * through this package's ONE adapter onto the form-section shape,
+ * `deriveFieldGroupSections`. That is the same adapter the no-sections
+ * field-group fallback uses, deliberately: authoring a group by reference and
+ * letting the fallback derive it must produce the same section, and they do
+ * because one of them IS the other's code path.
+ *
+ * What this module owns is only the three things the reference form adds on
+ * top of that derivation:
+ *
+ *   1. matching an authored key to a derived section (and reporting a miss);
+ *   2. keeping the two page-layout keys the spec permits beside `group`;
+ *   3. refusing the shapes the spec refuses, out loud rather than silently.
+ */
+
+import type { ObjectFormSection } from '@object-ui/types';
+import { deriveFieldGroupSections } from './fieldGroups';
+
+/**
+ * The keys `@objectstack/spec` REFUSES beside `group`, measured against
+ * `FormSectionSchema` in `@objectstack/spec` 17.3.0 and pinned in
+ * `__tests__/formSectionGroupReference-7051.test.tsx`.
+ *
+ * There are no override semantics: each of these is something the object's
+ * `fieldGroups` entry declares, so restating one on the referencing section
+ * would be a second writable spelling of one fact. Authored metadata carrying
+ * one never reaches this renderer (the spec door rejects it); a programmatic
+ * SDUI caller, which does not pass that door, is reported instead of quietly
+ * having its key honoured or quietly having it dropped.
+ */
+export const GROUP_OWNED_SECTION_KEYS = [
+  'name',
+  'label',
+  'description',
+  'collapsible',
+  'collapsed',
+  'visibleWhen',
+] as const;
+
+/**
+ * The keys the spec PERMITS beside `group`. They describe how THIS form lays
+ * the section out, which is the form's business and not the group's, so the
+ * authored value wins over the derived section.
+ */
+export const SECTION_LAYOUT_KEYS = ['columns', 'pane'] as const;
+
+/** Diagnostics already emitted, keyed so one typo is loud once, not per render. */
+const reported = new Set<string>();
+
+function reportOnce(key: string, emit: () => void): void {
+  if (reported.has(key)) return;
+  reported.add(key);
+  emit();
+}
+
+/** Test seam — forget which section-group diagnostics have been reported. */
+export function resetSectionGroupReports(): void {
+  reported.clear();
+}
+
+/** Does any section in this list use the reference form? */
+export function hasSectionGroupReference(sections: unknown): boolean {
+  return (
+    Array.isArray(sections) &&
+    sections.some((s) => s != null && typeof s === 'object' && typeof (s as any).group === 'string')
+  );
+}
+
+/** The object's declared field groups, as the shape `deriveFieldGroupSections` reads. */
+function declaredGroupSections(objectDef: any): ObjectFormSection[] | null {
+  const fields = objectDef?.fields;
+  if (!fields || typeof fields !== 'object') return null;
+  return deriveFieldGroupSections(
+    Object.entries(fields as Record<string, any>).map(
+      ([name, def]) => ({ name, group: def?.group }) as any,
+    ),
+    objectDef?.fieldGroups,
+  );
+}
+
+export interface ResolveSectionGroupsOptions {
+  /** Object name — diagnostics say WHICH object is missing the group. */
+  objectName: string;
+  /** The form's layout. `wizard` is the one the spec bans `group` on. */
+  formType?: string;
+  /**
+   * The object definition (`{ fields, fieldGroups }`), or `null`/`undefined`
+   * while it is still loading. A `group` section is rendered EMPTY until it
+   * arrives — never dropped, see the note on the return value.
+   */
+  objectDef: any;
+  /**
+   * `false` when this form can never load an object definition (no
+   * DataSource), so an unresolvable reference is reported as such instead of
+   * being left to look like a load that never finished.
+   */
+  resolvable?: boolean;
+}
+
+/**
+ * Replace every `{ group }` section with the section that group declares.
+ *
+ * Returns the SAME array reference when nothing uses the reference form, so a
+ * caller can keep this in a `useMemo` without perturbing any existing form.
+ *
+ * ⚠️ A reference that cannot be resolved yields `{ fields: [] }` — an empty
+ * section — and NOT a dropped one. Both render nothing, which is what the spec
+ * assigns to an unresolvable reference (`deriveFieldGroupLayout` already drops
+ * a declared group nothing references, and `@objectstack/lint`'s
+ * `form-section-group-unknown` is the declared reporter of a dangling key).
+ * The choice between them is forced by THIS surface and was measured: a form
+ * whose `sections` array empties out stops being a sectioned form at all and
+ * falls back to the flat every-field layout, so dropping would make a single
+ * mistyped key render MORE than the author asked for. Emptying renders
+ * exactly nothing, and leaves the array length — which is the wizard's step
+ * count and the container routing's condition — untouched.
+ */
+export function resolveSectionGroupReferences(
+  sections: ObjectFormSection[] | undefined,
+  opts: ResolveSectionGroupsOptions,
+): ObjectFormSection[] | undefined {
+  if (!hasSectionGroupReference(sections)) return sections;
+  const authored = sections as ObjectFormSection[];
+  const { objectName, formType, objectDef, resolvable = true } = opts;
+
+  // The spec REFUSES `group` on a wizard step: a field group carries
+  // `visibleWhen` and `collapse`, and `deriveFieldGroupLayout` passes both
+  // through to the section it derives, while a wizard step has a slot for
+  // neither (steps are entered in array order behind the step gate). Honouring
+  // the reference here would mean inventing the semantics the spec declined to
+  // give it, and the wizard's own key-by-key step map would then silently drop
+  // the two keys — the same silent drop objectui#6237 reported rather than
+  // accepted. So the step renders empty and says why, exactly as an inert step
+  // predicate already does.
+  if (formType === 'wizard') {
+    for (const s of authored) {
+      const g = (s as any)?.group;
+      if (typeof g !== 'string') continue;
+      reportOnce(`wizard:${objectName}.${g}`, () =>
+        console.warn(
+          `[object-ui] form section { group: '${g}' } is not supported on a wizard step and renders nothing. ` +
+            "`@objectstack/spec` refuses `group` on a `formType: 'wizard'` section at parse: a field group " +
+            'carries `visibleWhen` and `collapse`, and a wizard step has no slot for either. Enumerate ' +
+            '`fields` on the step instead.',
+        ),
+      );
+    }
+    return authored.map((s) =>
+      typeof (s as any)?.group === 'string' ? withoutGroup(s, []) : s,
+    );
+  }
+
+  const derived = objectDef ? declaredGroupSections(objectDef) : null;
+  const byKey = new Map<string, ObjectFormSection>();
+  for (const d of derived ?? []) {
+    // The trailing ungrouped bucket carries no `name`, so no reference can
+    // resolve to it — which is correct: it is not a declared group.
+    if (typeof d.name === 'string') byKey.set(d.name, d);
+  }
+
+  return authored.map((section) => {
+    const group = (section as any)?.group;
+    if (typeof group !== 'string') return section;
+
+    const layout = pickLayout(section);
+    reportGroupOwnedKeys(section, group, objectName);
+
+    const match = byKey.get(group);
+    if (!match) {
+      // Only a LOADED object definition proves the key resolves to nothing. An
+      // absent one is a load still in flight (or a form with no DataSource at
+      // all), and reporting it would fire a dangling-reference diagnostic at
+      // every author whose form simply had not finished loading.
+      if (objectDef || !resolvable) {
+        reportOnce(`unknown:${objectName}.${group}`, () =>
+          console.error(
+            `[object-ui] form section group "${group}" is not declared in fieldGroups on object ` +
+              `"${objectName}" — the section renders nothing. Declare the group on the object, or ` +
+              'enumerate `fields` on the section. (`@objectstack/lint` reports this as ' +
+              '`form-section-group-unknown`.)',
+          ),
+        );
+      }
+      return withoutGroup(section, []);
+    }
+
+    // The spread order IS the spec's precedence. The authored half can only
+    // ever carry layout (everything else beside `group` is refused at parse
+    // and reported above when a programmatic caller sends it anyway), so
+    // letting it win gives the group its presentation and the form its layout,
+    // with no key able to have two sources.
+    return { ...match, ...layout };
+  });
+}
+
+/** Strip `group` from an authored section, keeping only what the spec permits beside it. */
+function withoutGroup(section: ObjectFormSection, fields: ObjectFormSection['fields']): ObjectFormSection {
+  return { ...pickLayout(section), fields };
+}
+
+/** The authored keys the spec permits beside `group`. */
+function pickLayout(section: ObjectFormSection): Partial<ObjectFormSection> {
+  const out: Record<string, unknown> = {};
+  for (const k of SECTION_LAYOUT_KEYS) {
+    const v = (section as any)[k];
+    if (v !== undefined) out[k] = v;
+  }
+  return out as Partial<ObjectFormSection>;
+}
+
+/** Report — once — an off-spec key restated beside `group`. */
+function reportGroupOwnedKeys(section: ObjectFormSection, group: string, objectName: string): void {
+  const restated = GROUP_OWNED_SECTION_KEYS.filter((k) => (section as any)[k] !== undefined);
+  if (restated.length === 0) return;
+  reportOnce(`owned:${objectName}.${group}:${restated.join(',')}`, () =>
+    console.warn(
+      `[object-ui] form section { group: '${group}' } also declares ${restated
+        .map((k) => `\`${k}\``)
+        .join(', ')} — the group owns ${restated.length > 1 ? 'those keys' : 'that key'} and the ` +
+        'authored value is ignored. `@objectstack/spec` refuses this combination at parse (there are no ' +
+        `override semantics); set it on the object's \`fieldGroups\` entry for "${group}" instead.`,
+    ),
+  );
+}

--- a/packages/types/src/__tests__/object-form-section-style-keys-undeclared.test.ts
+++ b/packages/types/src/__tests__/object-form-section-style-keys-undeclared.test.ts
@@ -86,6 +86,7 @@ const DECLARED_KEYS = [
   'columns',
   'pane',
   'fields',
+  'group',
   'visibleWhen',
 ] as const;
 
@@ -143,6 +144,10 @@ describe('objectui#7200 — `ObjectFormSection` does not declare the retired sec
       columns: true,
       pane: true,
       fields: true,
+      // objectui#7051 — the group-reference form (`@objectstack/spec` 17.3.0,
+      // objectstack#13855). Added to the census, not to the retired list: the
+      // spec DECLARES it on `FormSectionSchema`, and `ObjectForm` resolves it.
+      group: true,
       visibleWhen: true,
     };
     expect(Object.keys(census).sort()).toEqual([...DECLARED_KEYS].sort());

--- a/packages/types/src/__tests__/p1-spec-alignment.test.ts
+++ b/packages/types/src/__tests__/p1-spec-alignment.test.ts
@@ -296,6 +296,39 @@ describe('P1.2 FormView Spec Alignment', () => {
     });
   });
 
+  it('accepts the `sections[].group` REFERENCE form on a FORM section, and `fields` without it (objectui#7051)', () => {
+    // The view-level half of objectstack#13855, the sibling of the
+    // `record:details` pin further down this file (objectui#8497).
+    // `@objectstack/spec` 17.3.0's `FormSectionSchema` declares two ways to
+    // give a section its members — enumerate `fields`, or point `group` at one
+    // of the object's declared `fieldGroups` — and refuses a section carrying
+    // neither or both. `ObjectFormSection` required `fields` and declared no
+    // `group`, so the spec-legal shape did not COMPILE for a TypeScript author
+    // while `ObjectForm` read the key nowhere: declared on one side, absent on
+    // the other, in both directions at once.
+    //
+    // ⚠️ This is a COMPILE-time assertion first — the annotation does the work,
+    // which is why `type-check` and not `test` is the instrument that can fail
+    // it. Measured on this very literal while writing it: with `group`
+    // undeclared, `pnpm --filter @object-ui/types type-check` reported
+    // `TS2353`/`TS2739` here while `vitest` stayed GREEN, because vitest strips
+    // types. The runtime expectations below exist only so the leg also fails
+    // visibly if the shape is ever silently emptied.
+    const sections: ObjectFormSection[] = [
+      { group: 'contact_info' },
+      // `columns` and `pane` are the two keys the spec PERMITS beside `group`:
+      // they describe how this form lays the section out, not anything the
+      // group declares.
+      { group: 'billing', columns: 2, pane: 'secondary' },
+      { name: 'audit', label: 'Audit', fields: ['created_at'] },
+    ];
+    expect(sections).toHaveLength(3);
+    expect(sections[0]).toEqual({ group: 'contact_info' });
+    // The enumerated arm still carries its members — a `fields` that became
+    // optional must not have become absent.
+    expect(sections[2].fields).toEqual(['created_at']);
+  });
+
   it('should accept FormField properties: widget, dependsOn, visibleOn, colSpan', () => {
     const schema: ObjectFormSchema = {
       type: 'object-form',

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -1089,9 +1089,41 @@ export interface ObjectFormSection {
   pane?: 'primary' | 'secondary';
 
   /**
-   * Field names or inline field configurations for this section
+   * Field names or inline field configurations for this section.
+   *
+   * OPTIONAL since objectui#7051, and optional ONLY in the sense that
+   * {@link group} is the other way to declare the same fact —
+   * `@objectstack/spec`'s `FormSectionSchema` refuses a section carrying
+   * neither ("A section must declare its members exactly one way") and refuses
+   * one carrying both. It was required here while no form-section renderer
+   * read `group`, so this type refused the exact shape the spec declares and a
+   * TypeScript author could not write the group-reference form at all.
    */
-  fields: (string | FormField)[];
+  fields?: (string | FormField)[];
+
+  /**
+   * Reference a declared field GROUP instead of enumerating members
+   * (`@objectstack/spec` 17.3.0, objectstack#13855, ADR-0085 §5).
+   *
+   * `{ group: 'contact_info' }` inherits the object's `fieldGroups` entry with
+   * that key: its members (every field pointing at it, in declaration order)
+   * and its own presentation (label, description, collapse) both, assembled by
+   * `deriveFieldGroupLayout` — the single assembler this repo never
+   * re-implements.
+   *
+   * Mutually exclusive with {@link fields}, and refused beside every key the
+   * group itself declares (`name`, `label`, `description`, `collapsible`,
+   * `collapsed`, `visibleWhen`) — the spec grants no override semantics, so a
+   * restated key would be a second writable spelling of one fact. What a
+   * section keeps beside `group` is how THIS form lays it out: `columns` and
+   * `pane`. Refused outright on a wizard step (`formType: 'wizard'`), which
+   * has no slot for a group's `collapse` or `visibleWhen`.
+   *
+   * The aliases `fieldGroup` / `groupKey` are NOT accepted spellings: the spec
+   * refuses them as unrecognized keys with a "did you mean `group`" hint, so
+   * they are deliberately absent here too.
+   */
+  group?: string;
 
   /**
    * Conditional visibility for the SECTION HEADER, as an authored predicate.

--- a/scripts/check-doc-example-types.mjs
+++ b/scripts/check-doc-example-types.mjs
@@ -732,7 +732,7 @@ export const UNGATED_EXAMPLES = {
     reason:
       'usage fragment: references `FormField`, which the example never declares',
   },
-  'packages/plugin-form/src/ObjectForm.tsx:122 ObjectForm': {
+  'packages/plugin-form/src/ObjectForm.tsx:123 ObjectForm': {
     card: null,
     codes: [2304],
     reason:
@@ -978,7 +978,7 @@ export const UNGATED_EXAMPLES = {
     reason:
       'usage fragment: references `save`, `storedPage`, which the example never declares',
   },
-  'packages/types/src/objectql.ts:1572 ObjectFormSchema': {
+  'packages/types/src/objectql.ts:1604 ObjectFormSchema': {
     card: null,
     codes: [1005, 1109],
     reason:


### PR DESCRIPTION
Fixes objectstack-ai/objectui#7051

Deliverable 2 of that card — the view-level `form.sections` half of objectstack#13855. Deliverable 1 (`record:details`) landed as #8584 and is not touched here. Base pinned at `c4326fe0a`; every reading below is against that commit, not against the moving `origin/main`.

---

## The premise held, and the two surfaces are NOT symmetric

**Re-measured, with a lit control.** Sweeping `packages/*/src/*` + `apps/*/src/*` for a section-level `group` read returns 4 hits, all of them PR #8584's `record-details.tsx`. The same command shape over the same population for `field.group` returns 9 hits across 6 files, so the instrument fires and the zero is a real zero: **no form-section renderer read `section.group`.** Premise valid.

The card's warning not to assume symmetry was the right one, and the answer is that the six form layouts are not even symmetric with **each other**. Measured by rendering an authored `{ group: 'basic' }` section on each, on the base commit:

| layout | what an on-spec `{ group }` section did | containment needed |
|---|---|---|
| `simple` | **threw** `Cannot read properties of undefined (reading 'map')` and blanked the ENTIRE form — sibling sections gone, body empty | yes |
| `tabbed` / `split` / `drawer` / `modal` | silently rendered nothing, no diagnostic; siblings fine | no |
| `wizard` | rendered an empty step ("No fields configured for this step") | no |

The throw was captured with an error boundary rather than inferred: `SimpleObjectForm (ObjectForm.tsx:1262) -> ObjectForm.tsx:1272`, i.e. the section loop **in the component's own body, above the JSX it returns**. That is the same above-the-loop shape `record:details` had, so a per-section error boundary could not have caught it either — the card's central warning, confirmed on the one layout where it applies. The other five differ because `buildSectionFields` (`sectionFields.ts`) already spells the same read `section.fields ?? []`.

## What changed

**One resolution site, above the routing fork.** `ObjectForm`'s dispatcher rebuilds each variant's `sections` prop key by key, so a `group` left in place is dropped before any container can see it, and each container would otherwise need its own copy of the resolution. Resolving in the dispatcher's own `schema` memo is what makes "one assembler" true for all six layouts at once — and the four container rows in the pin file are what makes that claim checkable rather than asserted.

**Resolution goes through the one adapter.** `deriveFieldGroupSections` (`fieldGroups.ts`) is this package's single adapter onto `deriveFieldGroupLayout` (ADR-0085 §5), and it is the same one the no-sections field-group fallback already used. Authoring a group by reference and letting the fallback derive it now produce the same section *because one of them is the other's code path* — the same construction argument #8584 made for `deriveFieldGroupDetailSections`. No assembly rule is re-implemented here.

**The load is gated.** The dispatcher fetches the object definition only when a section actually authors `group`, so a form that does not use the reference form issues no request and takes no new path. `resolveSectionGroupReferences` returns its input array **by reference** when nothing uses the form, so the memo cannot perturb an existing form either.

**Two containment layers, and only one of them is about `group`.** Layer 1 is the resolution itself. Layer 2 is `section.fields ?? []` at `ObjectForm.tsx`'s section loop, which bounds *every other* way a memberless section can reach that line — the sixth reader joining the five that already spelled it that way.

### One divergence from #8584, deliberate and measured

#8584 **drops** an unresolvable group section. Here it is **emptied** (`fields: []`) instead. Both render nothing; the difference is forced by this surface. A form whose `sections` array empties out stops being a sectioned form at all and falls back to the flat every-field layout, so dropping would make one mistyped key render **more** than the author asked for — and it would also move the wizard's step count and the container routing's condition. Reasoning is in the module docstring so the next reader does not "fix" it back.

## Where the spec's refusals are actually enforced — measured, not assumed

The card asked that group-owned presentation keys beside `group`, and `group` on a wizard step, not be silently accepted. #8584 concluded that **existence** checking belongs to `@objectstack/lint`. These two are stronger than that: they are refused at **parse**, by `@objectstack/spec` 17.3.0 itself.

| authored shape | `FormSectionSchema` / `FormViewSchema` verdict |
|---|---|
| `{ group, fields }` | REFUSED — "mutually exclusive on this form section" |
| `{}` / neither key | REFUSED — "must declare its members exactly one way" |
| `group` + `name` / `label` / `description` / `collapsible` / `collapsed` / `visibleWhen` | REFUSED, one issue per key |
| `group` + `columns` / `pane` | ACCEPTED (the two page-layout keys) |
| `group` on a `type: 'wizard'` section | REFUSED; accepted on `simple` / `tabbed` / `split` / `drawer` / `modal` |
| `group: 'Not A Key'` | REFUSED — `FIELD_GROUP_KEY_PATTERN` |

So authored metadata carrying any of them never reaches this renderer. What does reach it is a **programmatic SDUI caller**, which does not pass the spec door — and for those the renderer reports rather than accepts: a restated group-owned key is ignored (no override semantics) and warned about; a wizard `group` is refused and warned about; an unresolvable key renders nothing and is reported once, naming `form-section-group-unknown`. The parse door itself is pinned in the test file, because "enforcement lives upstream" is a claim about upstream, and a claim nothing checks is how a door quietly stops closing.

⚠️ **One premise in the dispatch order was falsified here.** It carried "aliases `fieldGroup` / `groupKey` fold to `group`". On `FormSectionSchema` they do **not** fold: they are unrecognized keys, refused with a did-you-mean hint. A renderer-side fold would therefore have been a second, more permissive contract. Pinned so the correction survives.

## The types half — and which instrument can see it

`ObjectFormSection` had the analogous omission `record:details` had (objectui#8583), but a narrower one: **exactly one missing key** (`group`) plus a `fields` that was REQUIRED, and **nothing declared that the spec refuses**. Enumerated against the installed schema, `FormSectionSchema` accepts `name, label, description, collapsible, collapsed, columns, pane, visibleWhen, visibleOn, fields, group`; the type declared all of those but `group` and `visibleOn`. (`visibleOn` is the deprecated ADR-0089 alias and its absence from the *authoring* type looks deliberate; it is left alone and reported, not widened.)

⭐ **The instrument was established with a lit control before either reading was trusted.** With `group?: string` removed from the interface — mutation proven on disk, `1 -> 0` occurrences, blob hash moved:

| instrument | verdict on the offending literal |
|---|---|
| `vitest` (2 files, 43 tests) | **GREEN, exit 0** — it strips types |
| `pnpm --filter @object-ui/types type-check` | **RED, exit 2** — `TS2353` x3, naming `group` on `ObjectFormSection` and on the `keyof ObjectFormSection` key census |

So the type-level legs are `type-check` legs, and a green `vitest` says nothing about them. Restored and proven restored (blob hash equal to HEAD's, `git diff HEAD` empty).

The same instrument caught a consequence I would otherwise have shipped: making `fields` optional broke **five** call sites in `ObjectForm.tsx` (`TS2322`, the per-layout config types are `fields`-required), and `vitest` was green on all 3736 tests at that moment.

## Ablation — run, not predicted, and it changed the tests twice

Every leg: mutation proven on disk in both directions (before/after occurrence counts plus a moved blob hash, with a void-leg abort if the blob did not move), classified per-test from vitest's **JSON reporter**, restored by `git checkout HEAD -- path` and proven restored by blob hash **and** an empty `git diff HEAD`.

| leg | reddens | stays green |
|---|---|---|
| **caricature** — resolver answers a constant group for every input | `SECTION_GROUP_RENDERS_ITS_OWN_MEMBERS`, `SECTION_GROUP_LABEL_IS_THE_GROUPS_OWN`, `UNKNOWN_GROUP_...`, all four container rows, 2 resolver units (9 red / 22) | `SIBLING_SECTION_SURVIVES`, `FORM_IS_NOT_BLANKED`, `SECTION_WITHOUT_MEMBERS_IS_BOUNDED`, every spec-door row |
| resolution removed entirely | 13 / 22, every group leg | the three containment / non-regression legs |
| layer 2 (`?? []`) reverted, resolution kept | `SECTION_WITHOUT_MEMBERS_IS_BOUNDED` **only** (1 / 22) | everything else |
| wizard refusal removed | `WIZARD_STEP_GROUP_IS_REFUSED_AND_REPORTED` only | everything else |
| `description` / `visibleWhen` carry removed | the presentation resolver unit only | everything else |

⚠️ **The stated non-regression axis does not discriminate — again.** `SIBLING_SECTION_SURVIVES` and `FORM_IS_NOT_BLANKED` both pass under the caricature, exactly as the card's correction from objectui#8497 predicted. The file says out loud which legs are which so nobody re-reads the weak one as the strong one. The discriminating leg is `SECTION_GROUP_RENDERS_ITS_OWN_MEMBERS`: **two** sections referencing **different** groups, asserted as an ordered structural outline of headings and concrete field names, so a resolver that answers the same thing for every input cannot satisfy both.

**The ablation changed the tests twice.**

1. The four container rows and the label leg originally referenced `contact_info`, the **first** declared group — and stayed **GREEN under the caricature**, because the first group is exactly what a constant resolver returns. They now reference the second group (`billing`) and go red. A leg a caricature satisfies by accident tests nothing.
2. Layer 2 was **unpinned by anything else**: with `group` resolved first, a `{ group }` section is never memberless by the time the loop sees it, so every group leg stayed green with the tolerant read reverted. `SECTION_WITHOUT_MEMBERS_IS_BOUNDED` was added specifically for it, and the third row above is the proof that it is the only leg that catches it. This is the same discovery #8584 recorded about its own two guards.

**Harness-kill leg.** Every rendered leg navigates through `requireLiveForm`, whose anchor is a section no leg asserts anything about, and whose failure text (`HARNESS DEAD: expected exactly 1 ...`) is textually unlike every content assertion. It fires in both directions — zero anchors and duplicated anchors — so a caricature cannot satisfy the harness by adding a section. No positional navigation anywhere.

## Verification

| check | result |
|---|---|
| `packages/plugin-form` + `packages/types` (final HEAD `3c57b9c2f`) | **236 files / 3737 pass, 1 skipped**, exit 0 |
| `@object-ui/types` `type-check` (3 programs) | pass, exit 0 |
| `@object-ui/plugin-form` `type-check` (2 programs) | pass, exit 0 |
| `apps/console` touched test file | 16 pass, exit 0 |
| `node scripts/check-changeset-presence.mjs` | verdict line: *"8 source file(s) of 3 released package(s) changed, and this change declares 1 changeset(s): .changeset/7051-form-section-group-reference.md."* |
| `node scripts/check-changeset-fixed.mjs` | *"All workspace packages are in the changeset fixed group."* |
| `node scripts/check-control-bytes.mjs` | *"OK (scanned 6839 tracked text file(s); skipped 85 binary)."* |
| `eslint` over the 8 changed files, `--format json` | **0 errors**, 114 warnings, all pre-existing `no-explicit-any` / `react-hooks` rules on untouched lines |

**On the eslint narrowing, so it reads as a measurement and not as a skipped run.** Population is the 8 files this PR changes, counted from the JSON reporter's own array length. The repo's `eslint.config.js` sets no `parserOptions.project` and no `projectService`, so type-aware linting is not enabled and this diff cannot move the verdict on any file it does not touch. The repo-wide run is CI's.

Everything else in the affected set is CI's: `@object-ui/types` is a root dependency, so `turbo ls --affected` names essentially the whole monorepo, and running that locally would be re-running CI.

## Fixture triage

One pre-existing file needed a prose correction rather than an assertion change: `apps/console/src/__tests__/public-block-binding-reach.test.tsx` documented its `sections` sample by asserting *"this repo's own type says the same: `ObjectFormSection.fields` is REQUIRED"* and *"`ObjectForm.tsx:1166` reads `section.fields.map(...)` off each entry unguarded"*. Both halves moved with this PR. The docblock is rewritten, not deleted: the fixture's reasoning is unchanged (a bare string is still not a section, and `{}` is still refused — the quoted spec message is re-measured against 17.3.0), only its grounds, and the two moved halves are called out explicitly so the paragraph cannot be read as still-true. That file's 16 tests pass unchanged.

## Out of scope, filed

**objectui#8641** — `apps/console`'s own `FormPage.buildSections` is a **third** form-section consumer with the same gap: `sec.fields ?? []` on a `{ group }` section yields a section with no label and no fields, silently. It does not go through `ObjectForm`'s dispatcher and the resolver here is package-internal, so fixing it is a real design choice (export the resolver / call the assembler directly / record the divergence), not a copy-paste. Filed with the discriminating axis attached, and with the honest note that it was established by reading the source rather than by a DOM measurement.

## Risk and rollback

The one behaviour change reaching a path that does **not** author `group`: `deriveFieldGroupSections` now carries the group's `description` and `visibleWhen` onto the section it derives, which the no-sections field-group fallback also uses. `description` is additive. `visibleWhen` is not purely additive — an object that declares a `fieldGroups[].visibleWhen` and relies on the fallback would now have that predicate honoured, and a predicate resolving false hides the section. That is the ADR-0089 contract and the key the spec names as group-owned, so carrying it is the correct direction; it is called out because it is the only line in this PR that can change an existing form. Rollback is the two added lines in `fieldGroups.ts`, and the resolver unit leg pins them.

Everything else is gated on an authored `group`: no such section, no fetch, same array reference out of the resolver, no new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_