### PR TITLE
build(types)!: ship the `./zod` subpath as ONE bundled module (#8598)

### DIFF
--- a/.changeset/8598-zod-subpath-single-bundled-module.md
+++ b/.changeset/8598-zod-subpath-single-bundled-module.md
@@ -1,0 +1,44 @@
+---
+'@object-ui/types': minor
+---
+
+Ship the `./zod` subpath as ONE bundled module, so the objectui#8344 node
+recursion-point fill survives a bundler that honours `"sideEffects": false`
+(objectui#8598).
+
+**The defect.** This package declares `"sideEffects": false`, and
+`src/zod/index.zod.ts` fills the node recursion point as the initializer of its
+`AnyComponentSchema` const. `tsc` emitted that barrel as a module whose only other
+content is re-exports — so a bundler resolving
+`import { CardSchema } from '@object-ui/types/zod'` followed the re-export to
+`dist/zod/layout.zod.js`, needed nothing from the barrel's own body, and the flag
+let it drop that body whole. The fill went with it, and every child slot then
+validated against the pre-#8344 `BaseSchemaCore` arm — the ~21 base keys and
+nothing type-specific — with no error, no warning and no way for the guard inside
+the dropped code to notice. objectui#8344 shipped that window DECLARED and pointed
+here to close it.
+
+**The change is to the build, not to any schema.** `dist/zod/index.zod.js` is now
+a single self-contained module built with Vite in lib mode, overwriting the one
+`tsc` output in place. Nothing in `src/` moved: no schema, no accept set at the
+source level, and none of `exports`, `files`, `main`, `module`, `types`,
+`sideEffects`, `peerDependencies` or `engines`. `zod` and `@objectstack/spec` stay
+external, so a consumer keeps one copy of zod and the `instanceof` identities that
+come with it.
+
+**What changes for a consumer.** A single-schema or otherwise partial entry into
+`@object-ui/types/zod` now gets the same accept set as one that imports the whole
+barrel: a nested off-spec node is REFUSED where it was previously ACCEPTED. That is
+the objectui#8344 behaviour arriving where it was already meant to be, so metadata
+that a full-barrel consumer already validated is unaffected — but metadata that
+only ever passed through a tree-shaken entry may now be refused at a child slot,
+and refusals there are pre-existing debt this SURFACES rather than creates.
+
+**Cost.** The subpath is now indivisible: a consumer that imports one schema pulls
+the whole `./zod` module. Measured with Vite 8.2.1 / rolldown 1.2.3, `zod` and
+`@objectstack/spec` external, consumer bundle esbuild-minified: a `CardSchema`-only
+entry went from 18,755 B raw / 4,835 B gzipped (fill absent, nested off-spec node
+ACCEPTED) to 165,382 B / 37,117 B (fill present, REFUSED). The full-barrel entry is
+165,432 B / 37,139 B either way — i.e. a partial entry now costs what the barrel
+always cost, which is the whole point: there is no longer a cheaper entry with a
+weaker accept set.

--- a/.changeset/8598-zod-subpath-single-bundled-module.md
+++ b/.changeset/8598-zod-subpath-single-bundled-module.md
@@ -34,6 +34,18 @@ that a full-barrel consumer already validated is unaffected — but metadata tha
 only ever passed through a tree-shaken entry may now be refused at a child slot,
 and refusals there are pre-existing debt this SURFACES rather than creates.
 
+**One thing this does NOT change, and it matters if you reach past the package
+name.** Only the `./zod` entry is bundled. The per-category sibling files under
+`dist/zod/` are still `tsc`'s output and still carry the pre-#8344 accept set, so
+a nested off-spec node is ACCEPTED through them. They are not a published entry —
+`import '@object-ui/types/dist/zod/layout.zod.js'` is refused with
+`ERR_PACKAGE_PATH_NOT_EXPORTED`, because the `exports` map has no wildcard — and
+the only way to reach one is a raw filesystem path that bypasses `exports`
+entirely. ⚠️ Doing that alongside the normal entry also gives you TWO schema
+instances rather than one (measured: the two `CardSchema` values are not
+identical), so `instanceof`-style identity and any shared mutation break. Import
+from `@object-ui/types/zod` and nothing else.
+
 **Cost.** The subpath is now indivisible: a consumer that imports one schema pulls
 the whole `./zod` module. Measured with Vite 8.2.1 / rolldown 1.2.3, `zod` and
 `@objectstack/spec` external, consumer bundle esbuild-minified: a `CardSchema`-only

--- a/packages/cli/src/__tests__/cli-bin.test.ts
+++ b/packages/cli/src/__tests__/cli-bin.test.ts
@@ -39,6 +39,40 @@ const SUBCOMMANDS = [
   'analyze',
 ] as const;
 
+/**
+ * The environment a build SPAWNED BY THIS TEST runs in (objectui#8598).
+ *
+ * ⛔ `VITEST` must not reach it, and that is a correctness requirement rather
+ * than hygiene.
+ *
+ * Vitest sets `VITEST=true` in the worker, and a child process inherits it. But
+ * the variable means "vitest is loading this config" — and in a build this test
+ * starts, that is FALSE. Every one of the 24 `packages/*` vite configs opens
+ * with `if (process.env.VITEST) { assertCanonicalVitestInvocation(...) }`, and
+ * that guard derives its "vitest root" from `cwd` when argv carries no `--root`.
+ * `pnpm --filter PKG run build` sets cwd to the package directory, so an
+ * inherited `VITEST` makes the guard compare `packages/PKG` against the repo
+ * root, decide it is a vitest run launched from the wrong place, and
+ * `process.exit(1)` before the bundler starts.
+ *
+ * ⭐ The ratchet that keeps the 24 configs identical states this property as its
+ * own name — `scripts/__tests__/vitest-invocation-guard.test.ts`, "gates that
+ * call on VITEST, **so `vite build` is never refused**". A leaked `VITEST` is
+ * exactly what falsifies it, from the outside, where no config can see it. ⇒ the
+ * repair belongs at the spawn, which is the only place that knows the child is a
+ * BUILD and not a test run.
+ *
+ * Measured on objectui#8598: with `VITEST` inherited, `@object-ui/types`
+ * (the first vite-built package a test ever builds) failed `Test (shard 2/4)`
+ * in CI; with it scrubbed, the same build exits 0. `scripts/__tests__/
+ * spawned-build-vitest-env-8598.test.ts` keeps every future build spawn here.
+ */
+const BUILD_ENV: NodeJS.ProcessEnv = (() => {
+  const env = { ...process.env };
+  delete env.VITEST;
+  return env;
+})();
+
 function run(args: string[], opts: { cwd?: string } = {}) {
   const res = spawnSync('node', [CLI_BIN, ...args], {
     cwd: opts.cwd ?? process.cwd(),
@@ -69,7 +103,7 @@ describe('@object-ui/cli bin', () => {
       const result = spawnSync(
         'pnpm',
         ['--filter', '@object-ui/types', 'run', 'build'],
-        { cwd: repoRoot, encoding: 'utf-8', stdio: 'pipe' },
+        { cwd: repoRoot, encoding: 'utf-8', stdio: 'pipe', env: BUILD_ENV },
       );
       if (result.status !== 0 || !existsSync(TYPES_ZOD)) {
         throw new Error(
@@ -86,6 +120,7 @@ describe('@object-ui/cli bin', () => {
         cwd: pkgRoot,
         encoding: 'utf-8',
         stdio: 'pipe',
+        env: BUILD_ENV,
       });
       if (result.status !== 0 || !existsSync(CLI_BIN)) {
         throw new Error(

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -64,7 +64,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc && node ../../scripts/check-dist-completeness.mjs",
+    "build": "tsc && vite build && node ../../scripts/check-dist-completeness.mjs",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "type-check": "tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json",
     "lint": "eslint ."
@@ -97,7 +97,8 @@
   },
   "devDependencies": {
     "@object-ui/test-support": "workspace:*",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vite": "^8.2.1"
   },
   "bugs": {
     "url": "https://github.com/objectstack-ai/objectui/issues"

--- a/packages/types/src/__tests__/package-exports-manifest.test.ts
+++ b/packages/types/src/__tests__/package-exports-manifest.test.ts
@@ -65,10 +65,19 @@ describe('@object-ui/types package.json exports map (objectui#4896)', () => {
     expect(pkg.type).toBe('module');
   });
 
-  it('builds with bare tsc — no bundler that could emit a second (CJS) format', () => {
+  it('emits with bare tsc — no build step emits a second (CJS) format', () => {
     // If this ever changes to a bundler/dual-emit build, the `require`-less
     // exports map below should be revisited rather than assumed to still be
     // correct.
+    //
+    // ⭐ THAT REVISION HAS BEEN DONE, for the `vite build` step objectui#8598
+    // added below. It is a lib-mode build with `formats: ['es']` — ONE format,
+    // asserted by name in `zod-subpath-bundle-config-8598.test.ts` rather than
+    // trusted here — writing a single file, `dist/zod/index.zod.js`, over the
+    // one `tsc` already emitted at that path. It adds no output, no `exports`
+    // entry and no `require` condition, so the map below is still correct for
+    // the reason it always was. ⛔ A SECOND format arriving in that config is
+    // what would reopen this question, and it reds that file, not this one.
     //
     // What that sentence pins is that NOTHING IN THE BUILD EMITS A SECOND
     // FORMAT. `toBe('tsc')` conflated it with the literal string, so appending
@@ -91,7 +100,15 @@ describe('@object-ui/types package.json exports map (objectui#4896)', () => {
     // other.
     const steps = (pkg.scripts?.build ?? '').split('&&').map((step) => step.trim());
     expect(steps[0]).toBe('tsc');
-    expect(steps.slice(1)).toEqual(['node ../../scripts/check-dist-completeness.mjs']);
+    expect(steps.slice(1)).toEqual([
+      // objectui#8598. ⛔ The ORDER is the contract, not a preference: `tsc`
+      // writes all of `dist/` first, this step replaces exactly one of its
+      // outputs in place, and the count then verifies `tsc`'s expected set is
+      // still whole. Reversed, the count runs before the overwrite and stops
+      // covering it.
+      'vite build',
+      'node ../../scripts/check-dist-completeness.mjs',
+    ]);
   });
 
   it('the root "." export carries exactly {types, import} — no "require" condition', () => {

--- a/packages/types/src/__tests__/zod-subpath-bundle-config-8598.test.ts
+++ b/packages/types/src/__tests__/zod-subpath-bundle-config-8598.test.ts
@@ -83,6 +83,24 @@ interface ZodBundleBuild {
  * TypeScript cannot resolve a non-literal specifier, so the config stays out of
  * the type program while the RUNTIME import — and every assertion below — is
  * exactly as strong as before.
+ *
+ * ⚠️ ⭐ IMPORTING THE CONFIG RUNS ITS GUARD, and that is worth stating because the
+ * same gate went on to break CI. `vite.config.ts` opens with
+ * `if (process.env.VITEST) { assertCanonicalVitestInvocation(...) }`, and vitest
+ * sets `VITEST`, so the import below EXECUTES that guard. It passes here for one
+ * reason only: this file is reached through the canonical root invocation, which
+ * is exactly what the guard checks for. ⛔ Run this suite from
+ * `packages/types/` and the guard refuses — correctly, and loudly.
+ *
+ * That is the benign face of the class. Its harmful face is objectui#8598's
+ * `Test (shard 2/4)` failure: `VITEST` is inherited by CHILD processes too, so a
+ * test that spawns `pnpm --filter PKG run build` handed the same guard a cwd of
+ * `packages/PKG` and it killed the build before the bundler started. The repair
+ * landed at the spawn (`BUILD_ENV` in `packages/cli/src/__tests__/cli-bin.test.ts`)
+ * and is kept there by `scripts/__tests__/spawned-build-vitest-env-8598.test.ts`.
+ * ⛔ Not repaired by loosening the gate in this config: that would diverge 1 of 24
+ * identical guard blocks, and `scripts/__tests__/vitest-invocation-guard.test.ts`
+ * refuses the divergence mechanically.
  */
 const CONFIG_SPECIFIER = '../../vite.config.ts';
 const viteConfig = ((await import(CONFIG_SPECIFIER)) as { default?: { build?: Partial<ZodBundleBuild> } })

--- a/packages/types/src/__tests__/zod-subpath-bundle-config-8598.test.ts
+++ b/packages/types/src/__tests__/zod-subpath-bundle-config-8598.test.ts
@@ -48,14 +48,12 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-import viteConfig from '../../vite.config.js';
-
 const PACKAGE_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
 /**
- * `defineConfig` passes an object literal straight through, so the import above
- * is the config itself. Vite's own `BuildOptions` types every field as optional,
- * which would make each assertion below read through a `?.` and pass on
+ * `defineConfig` passes an object literal straight through, so what is imported
+ * below is the config itself. Vite's own `BuildOptions` types every field as
+ * optional, which would make each assertion read through a `?.` and pass on
  * `undefined` — so the shape is spelled here as what this config MUST declare.
  */
 interface ZodBundleBuild {
@@ -65,8 +63,32 @@ interface ZodBundleBuild {
   rollupOptions: { external: (id: string) => boolean };
 }
 
-const build = ((viteConfig as { build?: Partial<ZodBundleBuild> }).build ??
-  {}) as ZodBundleBuild;
+/**
+ * ⚠️ The specifier is held in a variable, and that is load-bearing rather than
+ * stylistic — the same mechanism `page-header-action-ids.dist.spec.tsx` uses,
+ * for a second reason on top of its one.
+ *
+ * A LITERAL specifier puts `vite.config.ts` into this package's type program:
+ * `tsconfig.test.json` compiles every `src/**` test (deliberately — see its
+ * header), and an import pulls its target in with it. That config imports
+ * `scripts/vitest-invocation-guard.mjs`, which ships no typings anywhere in this
+ * repo, so `pnpm --filter @object-ui/types type-check` fails with TS7016 —
+ * measured, not predicted. No other package hits it because no other package's
+ * checked program has ever imported a `vite.config.ts`.
+ *
+ * ⛔ The alternatives were weighed and rejected: reading the config as TEXT is
+ * the `toContain` weakness this file's header exists to refuse; a
+ * `@ts-expect-error` suppresses a real diagnostic; and a repo-wide `.d.mts` for
+ * the guard is a change to a file 24 vite configs share, for one test's benefit.
+ * TypeScript cannot resolve a non-literal specifier, so the config stays out of
+ * the type program while the RUNTIME import — and every assertion below — is
+ * exactly as strong as before.
+ */
+const CONFIG_SPECIFIER = '../../vite.config.ts';
+const viteConfig = ((await import(CONFIG_SPECIFIER)) as { default?: { build?: Partial<ZodBundleBuild> } })
+  .default;
+
+const build = (viteConfig?.build ?? {}) as ZodBundleBuild;
 
 describe('objectui#8598 — the `./zod` subpath build config', () => {
   it('reads a real config — an empty object would satisfy every negative below', () => {

--- a/packages/types/src/__tests__/zod-subpath-bundle-config-8598.test.ts
+++ b/packages/types/src/__tests__/zod-subpath-bundle-config-8598.test.ts
@@ -1,0 +1,111 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The `./zod` subpath is built as ONE module, and these are the properties of
+ * `packages/types/vite.config.ts` that make that true (objectui#8598).
+ *
+ * ## Why the config and not the artifact
+ *
+ * The artifact assertion — "the shipped `dist/zod/index.zod.js` imports no
+ * sibling category module" — lives in `zod-subpath-single-module-8598.dist.spec.tsx`,
+ * in the `dist` project, because it needs the package BUILT. This file needs
+ * nothing built, so it runs in `unit` on every pull request and catches the
+ * edits that would break the build face before anyone runs it.
+ *
+ * ## What each assertion is protecting, in the order the damage gets worse
+ *
+ *  1. ⛔ `emptyOutDir: false`. `outDir` is inside the project root, so Vite's
+ *     DEFAULT is to empty it — and by the time this config runs, `dist/` holds
+ *     the 124 files `tsc` just emitted for the whole package. Flipping this
+ *     deletes the published package and leaves one bundle behind; the build
+ *     still exits 0. This is the assertion this file exists for.
+ *  2. The entry is `src/zod/index.zod.ts` and the output lands on
+ *     `dist/zod/index.zod.js`. Those two together are what makes this an
+ *     IN-PLACE overwrite of one `tsc` output rather than a new published file:
+ *     `exports['./zod'].import` already names that path, and
+ *     `check:dist-completeness` counts it as one of `tsc`'s expected outputs.
+ *     Move either and the package publishes a bundle nobody resolves while the
+ *     barrel it was meant to replace ships unchanged — green, and inert.
+ *  3. Exactly one format, `es`. A second format would write a second file into
+ *     `dist/zod/`, which is not in `tsc`'s expected set and not in `exports`.
+ *  4. Bare specifiers stay external. `zod` and `@objectstack/spec` are declared
+ *     `dependencies`; inlining either would ship a second copy of zod inside a
+ *     types package and break the identity `instanceof` checks a shared zod
+ *     gives consumers.
+ *
+ * ⚠️ The config is IMPORTED, not read as text. A `toContain('emptyOutDir: false')`
+ * is satisfied by the string appearing in a comment — which is the exact shape of
+ * a setting somebody disabled and explained.
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import viteConfig from '../../vite.config.js';
+
+const PACKAGE_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+/**
+ * `defineConfig` passes an object literal straight through, so the import above
+ * is the config itself. Vite's own `BuildOptions` types every field as optional,
+ * which would make each assertion below read through a `?.` and pass on
+ * `undefined` — so the shape is spelled here as what this config MUST declare.
+ */
+interface ZodBundleBuild {
+  outDir: string;
+  emptyOutDir: boolean;
+  lib: { entry: string; formats: string[]; fileName: (format: string) => string };
+  rollupOptions: { external: (id: string) => boolean };
+}
+
+const build = ((viteConfig as { build?: Partial<ZodBundleBuild> }).build ??
+  {}) as ZodBundleBuild;
+
+describe('objectui#8598 — the `./zod` subpath build config', () => {
+  it('reads a real config — an empty object would satisfy every negative below', () => {
+    // Non-vacuity. Every assertion in this file is about `build`, so a config
+    // that failed to load and left `{}` behind would pass the `toBe(false)` and
+    // `toEqual([...])` cases by having nothing to judge.
+    expect(Object.keys(build).length).toBeGreaterThan(0);
+    expect(build.lib).toBeTruthy();
+  });
+
+  it('⛔ never empties the out dir — `dist/` holds the whole published package by then', () => {
+    expect(
+      build.emptyOutDir,
+      '`outDir` is inside the project root, so Vite empties it by DEFAULT. `tsc` has ' +
+        'already written all of `dist/` when this build runs, so the default deletes the ' +
+        'published package and exits 0.',
+    ).toBe(false);
+  });
+
+  it('overwrites `dist/zod/index.zod.js` in place, from `src/zod/index.zod.ts`', () => {
+    expect(path.resolve(build.lib.entry)).toBe(
+      path.join(PACKAGE_DIR, 'src', 'zod', 'index.zod.ts'),
+    );
+    expect(path.resolve(build.outDir)).toBe(path.join(PACKAGE_DIR, 'dist', 'zod'));
+    expect(build.lib.fileName('es')).toBe('index.zod.js');
+  });
+
+  it('emits exactly one format, `es`', () => {
+    expect(build.lib.formats).toEqual(['es']);
+  });
+
+  it('keeps every bare specifier external', () => {
+    const { external } = build.rollupOptions;
+    // Declared `dependencies` — resolved by the consumer, never inlined.
+    expect(external('zod')).toBe(true);
+    expect(external('@objectstack/spec')).toBe(true);
+    // ...and the package's own sources are the thing being bundled. Both
+    // spellings a module graph produces reach this predicate.
+    expect(external('./layout.zod.js')).toBe(false);
+    expect(external(path.join(PACKAGE_DIR, 'src/zod/layout.zod.ts'))).toBe(false);
+  });
+});

--- a/packages/types/src/__tests__/zod-subpath-single-module-8598.dist.spec.tsx
+++ b/packages/types/src/__tests__/zod-subpath-single-module-8598.dist.spec.tsx
@@ -1,0 +1,121 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * BUILT-ARTIFACT PIN — the shipped `./zod` subpath is ONE module (objectui#8598).
+ *
+ * ## The defect this closes, and why only the BUILT face can answer it
+ *
+ * This package declares `"sideEffects": false`. `src/zod/index.zod.ts` fills the
+ * node recursion point (objectui#8344) as the initializer of its
+ * `AnyComponentSchema` const, and `tsc` emits that barrel as a module whose only
+ * other content is re-exports. So a bundler resolving
+ * `import { CardSchema } from '@object-ui/types/zod'` follows the re-export to
+ * `dist/zod/layout.zod.js`, needs NOTHING from the barrel's own body, and the
+ * flag lets it drop that body whole — fill included. Every child slot then
+ * validates with the pre-#8344 `BaseSchemaCore` arm, silently.
+ *
+ * Every other test here reads `src` (the root alias map points
+ * `@object-ui/types/zod` at `src/zod/index.zod.ts`), and a MODULE GRAPH always
+ * evaluates the barrel. So no source test can fail on this defect: it is a
+ * property of what `dist/` looks like, and nothing else.
+ *
+ * The `.dist.spec.tsx` suffix keeps this file out of `unit` (`*.test.ts`), `dom`
+ * (`*.test.tsx`) and each package's `tsconfig.test.json` — see the header of
+ * `packages/components/src/__tests__/page-header-action-ids.dist.spec.tsx`, the
+ * first resident of this project, for why each of those matters.
+ *
+ * ⚠️ REQUIRES THE PACKAGE BUILT with `vite build` wired into its `build` script.
+ * Case 1 below asserts that wiring by name, so "the manifest half never landed"
+ * fails HERE, as a named assertion, instead of silently reducing this file to a
+ * pin over `tsc`'s barrel.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const PACKAGE_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const MANIFEST = JSON.parse(fs.readFileSync(path.join(PACKAGE_DIR, 'package.json'), 'utf8')) as {
+  exports: Record<string, { import: string }>;
+  scripts: Record<string, string>;
+};
+
+/** The path a consumer resolves for `@object-ui/types/zod`, read from `exports`. */
+const BUILT_ZOD_ENTRY = path.resolve(PACKAGE_DIR, MANIFEST.exports['./zod'].import);
+
+/** A sibling `tsc` output, used as the live control for the reader below. */
+const TSC_SIBLING = path.join(PACKAGE_DIR, 'dist', 'zod', 'layout.zod.js');
+
+/** Every relative module specifier in an emitted ES module. */
+function relativeSpecifiers(file: string): string[] {
+  const source = fs.readFileSync(file, 'utf8');
+  return [...source.matchAll(/\bfrom\s*(['"])(\.[^'"]*)\1/g)].map((m) => m[2]);
+}
+
+/**
+ * The nested off-spec node from objectui#7869. `IconSchema.size` is declared
+ * `z.number()`, so `size: 'large'` one slot down is REFUSED under the filled arm
+ * and ACCEPTED under the pre-#8344 one. Paired with a well-formed control, so a
+ * schema that refuses EVERYTHING cannot pass for a fix.
+ */
+const NESTED_OFF_SPEC = { type: 'card', children: { type: 'icon', icon: 'check', size: 'large' } };
+const NESTED_WELL_FORMED = { type: 'card', children: { type: 'icon', icon: 'check', size: 16 } };
+
+/**
+ * ⚠️ THE LINE THAT MAKES THIS A BUILT-ARTIFACT MEASUREMENT — relative on
+ * purpose, because the specifier `@object-ui/types/zod` is redirected to `src`
+ * by the root alias map. Held in a variable so Vite cannot resolve it at
+ * transform time: with a literal specifier a missing `dist/` fails the file's
+ * TRANSFORM and the named preconditions below never get to run.
+ */
+const BUILT_ZOD_SPECIFIER = '../../dist/zod/index.zod.js';
+const BUILT = fs.existsSync(BUILT_ZOD_ENTRY)
+  ? ((await import(BUILT_ZOD_SPECIFIER)) as { CardSchema: { safeParse(v: unknown): { success: boolean } } })
+  : null;
+
+describe('objectui#8598 — the shipped `./zod` face is one bundled module', () => {
+  it('is wired: `build` runs `vite build` after `tsc` and before the completeness count', () => {
+    // The order is the contract, not a preference. `tsc` writes all of `dist/`,
+    // this build replaces exactly one of its outputs, and the completeness
+    // count then verifies `tsc`'s expected set is still whole.
+    expect(MANIFEST.scripts.build).toMatch(
+      /^tsc\s*&&\s*vite build\s*&&\s*node \.\.\/\.\.\/scripts\/check-dist-completeness\.mjs$/,
+    );
+  });
+
+  it('has been built — every assertion below is about a file that must exist', () => {
+    expect(fs.existsSync(BUILT_ZOD_ENTRY), `${BUILT_ZOD_ENTRY} is missing — run \`pnpm --filter @object-ui/types build\``).toBe(true);
+    expect(BUILT).not.toBeNull();
+  });
+
+  it('reads relative specifiers at all — the live control', () => {
+    // Without this, "the barrel imports no sibling" is satisfied by a regex that
+    // matches nothing, on any file, forever. `tsc`'s own `layout.zod.js` imports
+    // its siblings by construction, so a working reader must find some there.
+    expect(fs.existsSync(TSC_SIBLING)).toBe(true);
+    expect(relativeSpecifiers(TSC_SIBLING).length).toBeGreaterThan(0);
+  });
+
+  it('imports NO sibling category module — that boundary is what the flag drops', () => {
+    expect(
+      relativeSpecifiers(BUILT_ZOD_ENTRY),
+      'The published `./zod` entry still re-exports across a module boundary, so a bundler ' +
+        'honouring `"sideEffects": false` can take the barrel body — and the #8344 fill — ' +
+        'without taking the schema the consumer asked for.',
+    ).toEqual([]);
+  });
+
+  it('REFUSES a nested off-spec node through a single-schema entry', () => {
+    expect(BUILT!.CardSchema.safeParse(NESTED_OFF_SPEC).success).toBe(false);
+    // The control: the same slot, on-spec, still parses. A schema that refused
+    // everything would satisfy the case above and be a much worse regression.
+    expect(BUILT!.CardSchema.safeParse(NESTED_WELL_FORMED).success).toBe(true);
+  });
+});

--- a/packages/types/vite.config.ts
+++ b/packages/types/vite.config.ts
@@ -1,0 +1,81 @@
+import path from 'path';
+import { defineConfig } from 'vite';
+
+// objectui#3240 — with the per-package `vitest.config.*` files gone, Vitest
+// launched from THIS directory falls back to this file and uses it as its test
+// config. Guard that entry point (route 4 in
+// scripts/vitest-invocation-guard.mjs, which carries the mechanism and the
+// measurement). Gated on `VITEST` because the same file is the BUILD config:
+// Vitest sets that variable when it loads a config, `vite build` does not, so
+// a test run is refused and a build never is.
+import {
+  assertCanonicalVitestInvocation,
+  repoRootFrom,
+} from '../../scripts/vitest-invocation-guard.mjs';
+
+if (process.env.VITEST) {
+  assertCanonicalVitestInvocation({ repoRoot: repoRootFrom(import.meta.url) });
+}
+
+/**
+ * The `./zod` subpath, built as ONE module (objectui#8598).
+ *
+ * ## What this exists to close
+ *
+ * `packages/types` declares `"sideEffects": false`, and `src/zod/index.zod.ts`
+ * fills the node recursion point (objectui#8344) as the initializer of its
+ * `AnyComponentSchema` const. `tsc` emits that barrel as a module whose only
+ * other content is re-exports — so a bundler resolving
+ * `import { CardSchema } from '@object-ui/types/zod'` follows the re-export to
+ * `dist/zod/layout.zod.js`, needs NOTHING from the barrel's own body, and the
+ * flag lets it drop that body whole. The fill goes with it and every child slot
+ * silently reverts to the pre-#8344 `BaseSchemaCore` arm. Measured on
+ * `c4326fe0a1fe1de666cc81c793aed4e4722649b1` (Vite 8.2.1 / rolldown 1.2.3, `zod`
+ * and `@objectstack/spec` external, es, unminified consumer entry): a barrel
+ * entry importing only `CardSchema` ACCEPTED a nested off-spec `icon` node.
+ *
+ * Bundling the subpath removes the module boundary the drop needs. `CardSchema`
+ * is then DEFINED in the module the consumer imports, so that module is included
+ * rather than skipped, and the fill survives with it: `z.union` keeps its option
+ * array by reference (the assumption `defineNodeComponentUnion` asserts at load),
+ * the array is handed to an external `z.union` call, and the write into slot 0 is
+ * therefore an effect the tree-shaker must keep.
+ *
+ * ## Why it overwrites `dist/zod/index.zod.js` in place
+ *
+ * `tsc` runs FIRST (`"build": "tsc && vite build && …"`) and emits every file in
+ * `dist/`, typings included; this build then replaces exactly one of them. That
+ * keeps the shape every gate already reads: `check:dist-completeness` derives its
+ * expected set from tsconfig and only counts PRESENCE, the `./zod` typings stay
+ * `tsc`'s own, and no `exports` / `files` / `sideEffects` field moves.
+ *
+ * ⛔ `emptyOutDir` MUST stay false. `dist/` holds `tsc`'s 124 files by the time
+ * this runs, and the default for an `outDir` inside the project root is to empty
+ * it — which would delete the whole published package and leave one bundle.
+ */
+export default defineConfig({
+  build: {
+    outDir: path.resolve(import.meta.dirname, 'dist/zod'),
+    // ⛔ See above: this is not a formality.
+    emptyOutDir: false,
+    // `tsc` emits at the root tsconfig's `target` (ES2020). The bundle is a
+    // replacement for one of its outputs, so it is emitted at the same level.
+    target: 'es2020',
+    sourcemap: false,
+    // The rest of `dist/` is unminified `tsc` output. A minified barrel beside
+    // it would be a published file no reviewer can read or diff, for bytes the
+    // consumer's own bundler removes anyway.
+    minify: false,
+    lib: {
+      entry: path.resolve(import.meta.dirname, 'src/zod/index.zod.ts'),
+      formats: ['es'],
+      fileName: () => 'index.zod.js',
+    },
+    rollupOptions: {
+      // Everything this package declares as a dependency stays external, so the
+      // bundle is this package's own bytes: `zod` and `@objectstack/spec` are
+      // resolved by the consumer, exactly as they are in the `tsc` output.
+      external: (id: string) => !/^[./]/.test(id) && !id.startsWith(import.meta.dirname),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2822,6 +2822,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vite:
+        specifier: ^8.2.1
+        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/vscode-extension:
     dependencies:

--- a/scripts/__tests__/spawned-build-vitest-env-8598.test.ts
+++ b/scripts/__tests__/spawned-build-vitest-env-8598.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
+
+/**
+ * A build a TEST spawns must not inherit `VITEST` (objectui#8598).
+ *
+ * ## The defect this closes, and why it needs a gate rather than a comment
+ *
+ * Vitest sets `VITEST=true` in its worker, and a child process inherits the
+ * worker's environment. All 24 `packages/*` vite configs open with
+ * `if (process.env.VITEST) { assertCanonicalVitestInvocation(...) }`, and that
+ * guard derives its "vitest root" from `cwd` when argv carries no `--root`. So
+ * a build spawned as `pnpm --filter PKG run build` — cwd = the package
+ * directory — is read as a vitest run launched from the wrong place, and the
+ * guard calls `process.exit(1)` before the bundler starts.
+ *
+ * ⚠️ It is invisible until two independent things line up: a test that spawns a
+ * build, and a target package whose build loads a vite config. objectui#8598
+ * created the second half by giving `@object-ui/types` a `vite build` step, and
+ * `Test (shard 2/4)` went red in CI on a diff that touched no test at all. The
+ * build script is correct in isolation, the spawning test is correct in
+ * isolation, and the guard is correct in isolation — nothing but their
+ * intersection is wrong, which is exactly the shape no reviewer of one file
+ * catches.
+ *
+ * ## Why HERE, and not in the configs
+ *
+ * ⛔ The alternative repair — teach one config to gate on vite's `command`
+ * instead of the variable — was rejected twice over. It diverges 1 of 24
+ * otherwise byte-identical guard blocks, and
+ * `scripts/__tests__/vitest-invocation-guard.test.ts` mechanically REFUSES that
+ * divergence: its "gates that call on VITEST" case requires the literal
+ * `if (process.env.VITEST) {` + `assertCanonicalVitestInvocation(` shape in
+ * every `packages/*` vite config. ⭐ And that ratchet's own name states the
+ * property being violated — "gates that call on VITEST, so `vite build` is never
+ * refused". The leak falsifies it from OUTSIDE, where no config can see it, so
+ * the repair belongs at the spawn: the only place that knows its child is a
+ * build and not a test run.
+ *
+ * ## What is asserted
+ *
+ *  1. The population is derived from the tree, never listed — a hand-copied
+ *     enumeration drifts toward checking fewer call sites.
+ *  2. It has a FLOOR and a named member, so a walk that resolves nothing goes
+ *     red instead of green. That is the one failure a ratchet cannot notice
+ *     about itself.
+ *  3. Spawns are found by AST, not by substring: `toContain('VITEST')` is
+ *     satisfied by the word appearing in a comment, which is precisely the shape
+ *     of a call site somebody explained instead of fixing.
+ */
+
+/** Node child-process entry points that start a program. */
+const SPAWNERS = new Set(['spawnSync', 'spawn', 'execFileSync', 'execFile', 'execSync', 'exec']);
+
+/** Test files anywhere in the workspace — the only files this gate judges. */
+function testFiles(): string[] {
+  const found: string[] = [];
+  const skip = new Set(['node_modules', 'dist', 'build', 'coverage', '.turbo', '.next', '.git']);
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (skip.has(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (/\.(test|spec)\.tsx?$/.test(entry.name)) found.push(path.relative(ROOT, full));
+    }
+  };
+  for (const top of ['packages', 'apps', 'scripts', 'examples']) walk(path.join(ROOT, top));
+  return found.sort();
+}
+
+interface BuildSpawn {
+  readonly file: string;
+  readonly line: number;
+  /**
+   * Text of the `env:` value passed in the options object, if any — with an
+   * IDENTIFIER resolved to its declaration in the same file.
+   *
+   * ⚠️ Resolving is the difference between this gate working and this gate
+   * looking like it works. The fix it exists to enforce is naturally written as
+   * a named constant (`env: BUILD_ENV`), and the text of that property contains
+   * no `VITEST` at all — so a gate reading the property alone reports the FIXED
+   * tree as leaking. Measured: it did, on both call sites, before this resolved.
+   * ⛔ The resolution is also deliberately narrow — the declaration of that one
+   * name, never the whole file — because a file-wide substring search passes on
+   * any mention of `VITEST` anywhere, including a comment about it.
+   */
+  readonly env: string | null;
+}
+
+/** The initializer text of a `const`/`let` named `name` in this file, if there is one. */
+function declarationText(source: ts.SourceFile, name: string): string | null {
+  let text: string | null = null;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name &&
+      node.initializer !== undefined
+    ) {
+      text = node.initializer.getText(source);
+    }
+    node.forEachChild(visit);
+  };
+  visit(source);
+  return text;
+}
+
+/** Every call in `file` that starts a child process running a `build` script. */
+function buildSpawns(file: string): BuildSpawn[] {
+  const abs = path.join(ROOT, file);
+  const text = fs.readFileSync(abs, 'utf8');
+  // Cheap pre-filter, then AST. Every judgement below is made on the AST.
+  if (!text.includes('build')) return [];
+
+  const source = ts.createSourceFile(abs, text, ts.ScriptTarget.Latest, true);
+  const found: BuildSpawn[] = [];
+
+  const namesABuild = (node: ts.CallExpression): boolean =>
+    node.arguments.some((arg) => {
+      if (ts.isStringLiteralLike(arg)) return /(^|\s)build(\s|$)/.test(arg.text);
+      if (ts.isArrayLiteralExpression(arg)) {
+        return arg.elements.some((el) => ts.isStringLiteralLike(el) && el.text === 'build');
+      }
+      return false;
+    });
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const callee = ts.isPropertyAccessExpression(node.expression)
+        ? node.expression.name.text
+        : ts.isIdentifier(node.expression)
+          ? node.expression.text
+          : '';
+      if (SPAWNERS.has(callee) && namesABuild(node)) {
+        const options = node.arguments.find(ts.isObjectLiteralExpression.bind(ts));
+        let env: string | null = null;
+        if (options !== undefined) {
+          for (const property of options.properties) {
+            const key =
+              property.name !== undefined && ts.isIdentifier(property.name) ? property.name.text : '';
+            if (key !== 'env' || !ts.isPropertyAssignment(property)) continue;
+            const value = property.initializer;
+            env = ts.isIdentifier(value)
+              ? (declarationText(source, value.text) ?? value.getText(source))
+              : value.getText(source);
+          }
+        }
+        found.push({
+          file,
+          line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
+          env,
+        });
+      }
+    }
+    node.forEachChild(visit);
+  };
+  visit(source);
+  return found;
+}
+
+const SPAWNS = testFiles().flatMap(buildSpawns);
+
+/**
+ * The floor, plus a named member.
+ *
+ * Two build spawns exist today, both in `cli-bin.test.ts`. The floor is set at
+ * 1 rather than 2 on purpose: it is a vacuity guard, not a second copy of the
+ * count, so retiring one spawn stays an ordinary green change while a walk that
+ * resolves nothing does not.
+ */
+const POPULATION_FLOOR = 1;
+const NAMED_MEMBER = 'packages/cli/src/__tests__/cli-bin.test.ts';
+
+describe(`objectui#8598 — ${SPAWNS.length} build spawn(s) in the test tree`, () => {
+  it(`finds a real population: floor ${POPULATION_FLOOR}, and ${NAMED_MEMBER}`, () => {
+    expect(SPAWNS.length).toBeGreaterThanOrEqual(POPULATION_FLOOR);
+    expect(SPAWNS.map((s) => s.file)).toContain(NAMED_MEMBER);
+  });
+
+  it('every one of them scrubs VITEST from the child environment', () => {
+    const leaking = SPAWNS.filter((s) => s.env === null || !s.env.includes('VITEST')).map(
+      (s) => `${s.file}:${s.line}`,
+    );
+
+    expect(
+      leaking,
+      'These start a BUILD from inside a vitest worker without removing `VITEST` from the ' +
+        "child's environment. Every packages/* vite config refuses to load when it sees that " +
+        'variable with a cwd that is not the repo root, so the build exits 1 before the bundler ' +
+        'runs and the test reports a build failure it did not cause (objectui#8598, ' +
+        '`Test (shard 2/4)`). Pass an env with `VITEST` deleted — see `BUILD_ENV` in ' +
+        `${NAMED_MEMBER}:\n  ` + leaking.join('\n  '),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #8598.

Manifest half landed under decision batch #103 (option A). The contract review then returned **FAIL** on `8b8cbfd` for one real defect this PR introduced, plus two owed items; all three are addressed on `d7a81dbbe6ca5bc33a4c92251928cbbdc452220f`.

## ⚠️ The defect the review caught, and where it is fixed

`Test (shard 2/4)` was red on `8b8cbfd` on a diff that touched **no test at all**.

`packages/cli/src/__tests__/cli-bin.test.ts` self-builds `@object-ui/types` when the zod bundle is absent — CI's test job has no build step, by design — and it spawned `pnpm --filter @object-ui/types run build` with the vitest worker's entire environment. Vitest sets `VITEST=true`, children inherit it, all **24** `packages/*` vite configs open with `if (process.env.VITEST) { assertCanonicalVitestInvocation(...) }`, and that guard derives its vitest root from `cwd` — which `pnpm --filter` sets to the package directory. So the guard read a *build* as a vitest run launched from the wrong place and called `process.exit(1)` before the bundler started.

⭐ The build script, the spawning test and the guard are each correct in isolation. This PR created the intersection: it made `@object-ui/types` **the first vite-built package that a test builds from inside vitest**. The cli's own self-build survives only because it builds with `tsup`. On `8e028c2` the build script never loaded the config, so nothing could have surfaced it earlier.

### Fix home chosen: **the spawn**, not the config

| | |
| --- | --- |
| **Chosen** | scrub `VITEST` from the spawned build's env (`BUILD_ENV` in `cli-bin.test.ts`, applied to **both** build spawns in that file — the only two in the repo) |
| **Rejected** | gate the config on vite's `command: 'build'` instead of the variable |

Three reasons, in order of force:

1. **The variable is what is false.** `VITEST` means "vitest is loading this config". In a build the test *starts*, that is untrue. The spawn is the only place that knows its child is a build rather than a test run.
2. ⛔ **The rejected fix is mechanically refused.** `scripts/__tests__/vitest-invocation-guard.test.ts` requires the literal `if (process.env.VITEST) {` + `assertCanonicalVitestInvocation(` shape in **every** `packages/*` vite config. Gating on `command` would red that ratchet and diverge 1 of 24 byte-identical blocks.
3. ⭐ **That ratchet's own case name states the property being violated** — *"gates that call on VITEST, so `vite build` is never refused"*. The leak falsifies it from OUTSIDE, where no config can see it.

**What the rejected fix would still leave open:** it immunises one config and leaves the other 23 exactly as exposed — the next test that spawns a build of `@object-ui/fields`, `plugin-grid` or any of the rest breaks the same way. The chosen fix is caller-side, so it holds no matter which package a future spawn targets.

### Item 4 — the class, not just the symptom

The review recorded this class LOW last round and it became the HIGH defect this round. Closed two ways:

- `scripts/__tests__/spawned-build-vitest-env-8598.test.ts` (new) derives **every** build spawn in the test tree by AST, resolves an `env:` identifier to its declaration in the same file, and requires `VITEST` to be scrubbed. Population floor plus a named member, so an empty walk goes red rather than green.
- `zod-subpath-bundle-config-8598.test.ts`'s header now says that importing the config **executes** that same guard, why it passes there (canonical root invocation) and where the harmful face of the class was repaired.

⚠️ Worth recording: the ratchet **first went red on the fixed tree** — it read the `env:` property text, and the fix is naturally written as a named constant (`env: BUILD_ENV`), which contains no `VITEST` token. Resolving the identifier to its declaration is what makes it a measurement. A gate that reports a fixed tree as broken is one edit away from a gate that reports a broken tree as fixed.

### Both legs of the re-measurement

Leg (c) is the review's prescribed shape: from the **repo root**, with `packages/types/dist/zod/index.zod.js` **absent**, `pnpm exec vitest run packages/cli/src/__tests__/cli-bin.test.ts`.

| leg | command | before the fix (`8b8cbfd`) | after (`d7a81db`) |
| --- | --- | --- | --- |
| **(c) CI shape** | repo root, bundle absent, the real test | **exit 1** — `Failed to build @object-ui/types for tests`, 1 file failed | **exit 0** — 1 file passed, **38 tests passed** |
| (d) control | bundle present, same test | exit 0, 38 passed | exit 0, 38 passed |
| (a) minimal | `VITEST=true pnpm --filter @object-ui/types run build` | exit 1, guard refusal (`vitest root: …/packages/types` vs 仓库根 `…/objectui-issue-8598`) | exit 1 — **unchanged by design** |
| (b) control | same with `env -u VITEST` | exit 0, `✓ built in 157ms`, 124 files verified | exit 0 |

⭐ Leg (a) staying red is the point: the guard is untouched and still refuses a `VITEST`-marked build. What changed is that no test lies to it any more. And on leg (c) after the fix, the test's own `beforeAll` rebuilt the artifact and it is the **bundle** — 0 relative specifiers — so the CLI suite now exercises the new published face.

Ratchet reverse-verification, hash-proven and trap-restored: fixed file `sha256 9f633e13…` with 2 scrubs → mutated to `70e38e39…` with 1 → the ratchet goes **red naming `cli-bin.test.ts:103`** → restored to `9f633e13…`, 2 scrubs.

### Item 5 — the changeset now carries the deep-link sentence

It was byte-unchanged in the previous increment; the statement lived only here. Added to `.changeset/8598-zod-subpath-single-bundled-module.md`, and re-measured rather than inherited: a raw-path sibling keeps the pre-#8344 accept set (nested off-spec **ACCEPTED**), the path is not reachable through the package name (`ERR_PACKAGE_PATH_NOT_EXPORTED`), and mixing a raw-path import with the bundled entry yields **two distinct schema instances** (`Bundled === RawPath` → `false`).

### ⭐ Item 6 — `check:published-dist` is measured locally or nowhere

The ruling said CI would run it on the moved head. **It cannot.** `published-dist-gate.yml` fires only on `workflow_dispatch`, cron `41 3 * * *`, and `push: main`, and its own header says why: *"the gate has to build all 39 published packages. This repository deliberately has no per-PR full-repo build."*

⇒ The reading below is the only one this change will ever get. ⛔ It is **not** deferred to CI:

> **`pnpm check:published-dist` — measured locally, exit 0.** 39 published packages inspected, 5932 tarball files, 5776 of them build output, **0 tooling artifacts**. Its build leg was `FULL TURBO` off cache entries this tree had just force-built.

⚠️ That makes it the **third** gate on this repo implying per-PR coverage it does not provide, after `Build Docs` (#8647) and `check:node-esm-load`.

## What ships

| file | what it is |
| --- | --- |
| `packages/types/package.json` | `"build": "tsc && vite build && node ../../scripts/check-dist-completeness.mjs"` + `"vite": "^8.2.1"` |
| `pnpm-lock.yaml` | three added lines, the `vite` entry for this importer, nothing else |
| `packages/types/vite.config.ts` | the lib-mode build of `./zod` as ONE module, overwriting `dist/zod/index.zod.js` in place |
| `packages/types/src/__tests__/zod-subpath-bundle-config-8598.test.ts` | `unit` pin on the config, chiefly `emptyOutDir: false` |
| `packages/types/src/__tests__/zod-subpath-single-module-8598.dist.spec.tsx` | the built-artifact pin |
| `packages/types/src/__tests__/package-exports-manifest.test.ts` | build-script expectation, edited with its demanded justification |
| `packages/cli/src/__tests__/cli-bin.test.ts` | **the shard-2 fix** |
| `scripts/__tests__/spawned-build-vitest-env-8598.test.ts` | **the class ratchet** |
| `.changeset/8598-zod-subpath-single-bundled-module.md` | the published behaviour change, declared |

## The defect this card closes, in one paragraph

`@object-ui/types` declares `"sideEffects": false`. `src/zod/index.zod.ts` fills the #8344 node recursion point as the initializer of its `AnyComponentSchema` const, and `tsc` emitted that barrel as a module whose only other content is re-exports — so a bundler resolving `import { CardSchema } from '@object-ui/types/zod'` followed the re-export to `dist/zod/layout.zod.js`, needed nothing from the barrel's body, and the flag let it drop that body whole, fill included. Bundling removes the boundary the drop needs.

## The H-check — three bundlers, each with a control

Taken on `8b8cbfd`; the increment since touches no `packages/types` source or build input, so the artifact is unchanged (`sha256 e06b8a5b…`). Entry in every row: **only `CardSchema`**; `zod` and `@objectstack/spec` external. Left column is the ablation.

| bundler | `tsc` barrel (ablated) | bundled `./zod` |
| --- | --- | --- |
| Vite 8.2.1 / rolldown 1.2.3 | **ACCEPTED**, 18,755 / 4,835 B, fill absent | **REFUSED**, 165,382 / 37,117 B, fill present |
| rollup 4.62.2 | **ACCEPTED**, 60,002 / 18,420 B, fill absent | **REFUSED**, 325,953 / 90,720 B, fill present |
| Next 16.3.1 (Turbopack) | **ACCEPTED** | **REFUSED** |

Rollup is measured beside Vite because Vite 8 bundles with rolldown, not rollup. Well-formed control (`size: 16`) ACCEPTED in all six cells. Ablation hash-proven (`e06b8a5b…` / 0 relative specifiers / 331,934 B → `4b46cbda…` / 29 / 15,943 B) and restored byte-identical under an `EXIT INT TERM` trap.

⚠️ `Build Docs` is a **no-regression** reading, not an accept-set one — it is green on the ablated artifact too, and per #8647 the CI check skips the build entirely on a `packages/**`-only diff. The Turbopack accept-set reading is the third row, from a standalone Next 16.3.1 app whose only import is `CardSchema`.

## Lockfile — the ruling's two conditions, both MET

Mechanism: the importer block was written to the resolution **already locked** for 28 of the 29 existing `vite` importers, then verified with `pnpm install --frozen-lockfile` (exit 0, lockfile not rewritten, same store path as the other 28). A naive install lands `8.2.2` and drags `picomatch`; `resolution-mode=lowest-direct` gets the version right but rewrites 17/176 lines. Both measured, both rejected.

- **One version:** `origin/main` 29 importers, this head 30, base set `{8.2.1}` on both. `packages/types` is the only addition; no existing resolution moved.
- **No unrelated line:** the whole lockfile diff is **3 added, 0 removed**.

The pre-existing peer-suffix split (`esbuild@0.28.2` ×29, `esbuild@0.27.7` ×1) and the 17 transitive `vite@8.2.2` peer keys are byte-equal on both trees.

## Gates on `d7a81db`, exit captured before any pipe

| command | exit | verdict |
| --- | --- | --- |
| `pnpm --filter @object-ui/types type-check` | 0 | all three `tsc` projects |
| `pnpm --filter @object-ui/cli type-check` | 0 | — |
| `vitest run --project unit packages/types/ scripts/__tests__/` | 0 | `Test Files 278 passed \| 2 skipped (280) · Tests 6568 passed` |
| `pnpm test:dist` | 0 | `Test Files 2 passed (2) · Tests 8 passed (8)` |
| `pnpm exec eslint` on the three edited/new files | 0 | no errors, no warnings |
| the four changeset gates | 0 | presence, no-major, fixed, overwrite |
| `pnpm check:control-bytes` | 0 | `scanned 6840 tracked text file(s)` |

Carried from `8b8cbfd`, unaffected by an increment that touches only tests and the changeset: `pnpm check` (`All checks passed`, CI runs it at `lint.yml:481`), `check:published-dist` (see item 6), `check:node-esm-load --force-build` (0, provenance 37/37 — its plain run exits 1 on a foreign shared-turbo-cache entry naming a package outside this diff, and the gate prints that remedy itself), `check:dist-completeness`, `check:phantom-deps`, `check:unused-deps`, `check:side-effects-array`, `check:readme-exports`, `check:self-import`, `check:published-tsconfig-exclude`, `check:unreferenced-sources`, `check:esm-specifiers`, `check-governed-queue-guard --test` (`NOT GOVERNED`).

## Recorded, not fixed here

- This repo's console and vitest alias `@object-ui/types/zod` to `src`, so they always evaluate the barrel and are unaffected. The console is a class-(ii) consumer (`plugin-map/ObjectMap.tsx` only).
- No `sideEffects` change, no `ci.yml` change, nothing under `packages/types/src/zod/**`. #8578 and #8572 untouched.
- `scripts/vitest-invocation-guard.mjs` ships no typings; that is why the config import here is behind a variable specifier rather than a literal one.

Generated by Claude Code — session `session_01Jmxdo7bmeqCQHLSfmLVX9w` (https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w). Kept in prose because a PR-body edit strips the markdown attribution footer.