### PR TITLE
test(components,plugin-grid): pin which body cells the schema-level cellClassName reaches, correct the census root (#6921)

### DIFF
--- a/.changeset/6921-cellclassname-cell-population-pins.md
+++ b/.changeset/6921-cellclassname-cell-population-pins.md
@@ -1,0 +1,16 @@
+---
+---
+
+Test-only and comment-only change (objectui#6921); no published behaviour changes.
+
+Pins, in the rendered DOM, which body cells the SCHEMA-level `cellClassName` on
+`DataTableSchema` reaches: exactly the three utility cells (selection, row-number,
+row-actions) and never a data cell, which folds the per-column `TableColumn.cellClassName`.
+The pin is also the fence the card draws — a renderer that made the old "every body cell"
+sentence true by folding the schema-level key into data cells goes red — and the
+non-regression for the three cells that legitimately fold it.
+
+Pins the corrected census prose in `packages/plugin-grid/src/ObjectGrid.tsx` (present,
+names the measured cells, records the hold as over) and adds a pointer from that prose to
+the measurement. Corrects the one surviving in-repo copy of the false sentence, a test
+docblock in `packages/types`.

--- a/packages/components/src/renderers/complex/__tests__/data-table-cellClassName-population-6921.test.tsx
+++ b/packages/components/src/renderers/complex/__tests__/data-table-cellClassName-population-6921.test.tsx
@@ -14,8 +14,8 @@
  *
  * For three days a census sentence said the schema-level key was "folded into
  * every body cell's `className`". It was false the day it was written and was
- * copied forward into eight texts before a reviewer measured it (objectui#6882
- * review, PR #6918). Re-derived here against `data-table.tsx` on this tree,
+ * copied forward, text to text, for three days before a reviewer measured it
+ * (objectui#6882 review, PR #6918). Re-derived here against `data-table.tsx`,
  * the schema-level key is folded at exactly THREE sites, every one a UTILITY
  * cell:
  *

--- a/packages/components/src/renderers/complex/__tests__/data-table-cellClassName-population-6921.test.tsx
+++ b/packages/components/src/renderers/complex/__tests__/data-table-cellClassName-population-6921.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6921 — WHICH body cells the SCHEMA-level `cellClassName` reaches,
+ * measured in the DOM rather than stated in prose.
+ *
+ * ## The sentence this file replaces with a measurement
+ *
+ * For three days a census sentence said the schema-level key was "folded into
+ * every body cell's `className`". It was false the day it was written and was
+ * copied forward into eight texts before a reviewer measured it (objectui#6882
+ * review, PR #6918). Re-derived here against `data-table.tsx` on this tree,
+ * the schema-level key is folded at exactly THREE sites, every one a UTILITY
+ * cell:
+ *
+ *   - the selection (checkbox) cell,
+ *   - the row-number cell,
+ *   - the row-actions cell.
+ *
+ * The MAIN DATA cell folds `col.cellClassName` — the per-column twin declared
+ * on `TableColumn` — and never the schema-level key. The two slots style
+ * DISJOINT cells and never combine on one.
+ *
+ * ## Why every assertion is about rendered `td` elements
+ *
+ * A prose pin ("the comment does not say every body cell") passes on a comment
+ * that has been deleted, and a source-text pin on `data-table.tsx` breaks on
+ * any reformat. What the card actually asks is a question about the DOM: given
+ * a schema class and a column class, which cells carry which? So this suite
+ * renders the table with every utility column switched ON, takes the one body
+ * row, classifies its cells by CONTENT (checkbox / row number / value / actions
+ * container), and reads the class list off each. The classification is total —
+ * four cells, four roles, each matched exactly once — so a cell that changed
+ * role or count is reported as such rather than silently skipped.
+ *
+ * ## ⛔ The fence, as a pin
+ *
+ * Whether the schema-level key SHOULD reach data cells is a different question
+ * the card neither asks nor answers (its ruling would be a renderer change with
+ * its own card). The plausible WRONG fix for the false sentence is to make it
+ * true — teach the data cell to fold the schema-level key. The first test below
+ * refuses exactly that: it goes red when the data cell folds `cellClassName`
+ * (measured: the fold added, this file red on the data-cell assertion; the fold
+ * swapped for the schema-level key, red on both data-cell assertions).
+ *
+ * ## Non-regression, the other direction
+ *
+ * The corrected prose says three utility cells DO fold the key. A later
+ * "cleanup" that drops one fold would make the corrected sentence false the
+ * other way with nothing going red — so each of the three is asserted by name,
+ * and the count is asserted too (measured: the row-actions fold removed, red
+ * naming that cell; the selection fold removed, red naming that cell).
+ *
+ * ## The control: zero cells
+ *
+ * With no selection, row-number or row-actions column the schema-level key
+ * reaches ZERO body cells while the column key still reaches the data cell.
+ * That is the reading that broke the original mdx example (objectui#6921's
+ * comment record: with `data: []` and no utility column its `cellClassName`
+ * reached nothing and the empty state rendered). Here it is the control for
+ * the instrument: the schema class is not being sprayed onto every cell by
+ * `cn()`, so the three positive hits above mean what they say.
+ *
+ * The prose these cell names are asserted against lives in
+ * `packages/plugin-grid/src/ObjectGrid.tsx` (the schema-slot census) and is
+ * pinned by `packages/plugin-grid/src/__tests__/cellClassNameCensusProse-6921.test.ts`.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import '../data-table';
+
+/** Probe classes — unique tokens no utility or renderer class could collide with. */
+const SCHEMA_SLOT = 'probe-schema-slot-6921';
+const COLUMN_SLOT = 'probe-column-slot-6921';
+
+/** The one cell value in the one data row; how the DATA cell is found. */
+const VALUE = 'Ada Lovelace 6921';
+
+type UtilityColumns = { selectable: boolean; showRowNumbers: boolean; rowActions: boolean };
+
+function renderTable(utility: UtilityColumns) {
+  const DataTable = ComponentRegistry.get('data-table') as any;
+  if (!DataTable) throw new Error('data-table not registered');
+  return render(
+    <DataTable
+      schema={{
+        data: [{ id: '1', name: VALUE }],
+        pagination: false,
+        searchable: false,
+        columns: [{ header: 'Name', accessorKey: 'name', cellClassName: COLUMN_SLOT }],
+        cellClassName: SCHEMA_SLOT,
+        ...utility,
+      }}
+    />,
+  );
+}
+
+/** The body row: the `tr` that holds the data value. */
+function bodyRowCells(): HTMLTableCellElement[] {
+  const row = screen.getByText(VALUE).closest('tr');
+  if (!row) throw new Error('data value rendered outside a table row');
+  return Array.from(row.querySelectorAll('td'));
+}
+
+type Role = 'selection' | 'row-number' | 'data' | 'row-actions';
+
+/**
+ * Classify a body cell by what it CONTAINS, never by position: the selection
+ * cell holds the checkbox, the row-number cell reads `1` (first row), the data
+ * cell holds the value, the row-actions cell holds the actions container
+ * (`flex … justify-end`), which `data-table.tsx` renders unconditionally
+ * whenever `rowActions` is on — even when no menu item survives the row's
+ * predicates.
+ */
+function classify(td: HTMLTableCellElement): Role | 'UNCLASSIFIED' {
+  const hits: Role[] = [];
+  if (td.querySelector('[role="checkbox"]')) hits.push('selection');
+  if (td.textContent?.trim() === '1') hits.push('row-number');
+  if (td.textContent?.includes(VALUE)) hits.push('data');
+  if (td.querySelector('div.justify-end')) hits.push('row-actions');
+  if (hits.length !== 1) return 'UNCLASSIFIED';
+  return hits[0];
+}
+
+function cellsByRole(): Record<Role, HTMLTableCellElement> {
+  const cells = bodyRowCells();
+  const byRole = {} as Record<Role, HTMLTableCellElement>;
+  for (const td of cells) {
+    const role = classify(td);
+    if (role === 'UNCLASSIFIED') {
+      throw new Error(`a body cell matched no role or several: "${td.outerHTML.slice(0, 200)}"`);
+    }
+    if (byRole[role]) throw new Error(`two body cells classified as ${role}`);
+    byRole[role] = td;
+  }
+  return byRole;
+}
+
+describe('data-table: which body cells the SCHEMA-level cellClassName reaches (objectui#6921)', () => {
+  beforeAll(() => {
+    expect(ComponentRegistry.has('data-table')).toBe(true);
+  });
+
+  /**
+   * ⛔ THE FENCE. The data cell folds the per-column key and NOT the
+   * schema-level one. Making the false census sentence true in the renderer
+   * would turn this red — which is the point: the card corrects the sentence,
+   * not the behaviour.
+   */
+  it('the MAIN DATA cell folds col.cellClassName and NOT the schema-level cellClassName', () => {
+    renderTable({ selectable: true, showRowNumbers: true, rowActions: true });
+    const { data } = cellsByRole();
+    expect(data).toHaveClass(COLUMN_SLOT);
+    expect(data).not.toHaveClass(SCHEMA_SLOT);
+  });
+
+  /**
+   * NON-REGRESSION. Each of the three utility cells folds the schema-level
+   * key, named one by one so a dropped fold reports WHICH cell lost it.
+   */
+  it('the selection, row-number and row-actions cells each fold the schema-level cellClassName', () => {
+    renderTable({ selectable: true, showRowNumbers: true, rowActions: true });
+    const cells = cellsByRole();
+    for (const role of ['selection', 'row-number', 'row-actions'] as const) {
+      expect(cells[role], `${role} cell should carry the schema-level class`).toHaveClass(SCHEMA_SLOT);
+    }
+  });
+
+  /**
+   * THE CENSUS AS A NUMBER: exactly four body cells, exactly three carry the
+   * schema-level class, exactly one carries the column class, and no cell
+   * carries both — the two slots style disjoint cells.
+   */
+  it('the schema-level class reaches exactly three cells, the column class exactly one, and they are disjoint', () => {
+    renderTable({ selectable: true, showRowNumbers: true, rowActions: true });
+    const cells = bodyRowCells();
+    expect(cells).toHaveLength(4);
+    const withSchema = cells.filter((td) => td.classList.contains(SCHEMA_SLOT));
+    const withColumn = cells.filter((td) => td.classList.contains(COLUMN_SLOT));
+    expect(withSchema.map(classify).sort()).toEqual(['row-actions', 'row-number', 'selection']);
+    expect(withColumn.map(classify)).toEqual(['data']);
+    expect(cells.filter((td) => td.classList.contains(SCHEMA_SLOT) && td.classList.contains(COLUMN_SLOT))).toHaveLength(0);
+  });
+
+  /**
+   * THE CONTROL. With every utility column off the schema-level key reaches
+   * ZERO body cells — the reading behind the broken mdx example — while the
+   * column key still reaches the data cell. Without this, a renderer that
+   * folded the schema class into EVERY cell would still satisfy the three
+   * positive assertions above.
+   */
+  it('with no utility column the schema-level class reaches ZERO body cells while the column class still lands', () => {
+    renderTable({ selectable: false, showRowNumbers: false, rowActions: false });
+    const cells = bodyRowCells();
+    expect(cells).toHaveLength(1);
+    expect(cells[0]).toHaveClass(COLUMN_SLOT);
+    expect(cells.filter((td) => td.classList.contains(SCHEMA_SLOT))).toHaveLength(0);
+  });
+});

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -852,8 +852,8 @@ export type ObjectGridColumn =
  *     cell does NOT fold this key) and the non-regression (the three utility
  *     cells DO) — and this entry's wording is pinned against that measurement
  *     by `cellClassNameCensusProse-6921.test.ts` beside the slot suite. The
- *     false sentence was copied into eight texts before anyone measured it;
- *     a re-wording here that drops a cell name or revives the hold goes red.
+ *     false sentence was copied forward for three days before anyone measured
+ *     it; a re-wording here that drops a cell name or revives the hold goes red.
  *
  * ⛔ The old closing note ("do not fix either hold by declaring the key on
  * `DataTableSchema` as a rider — that package is published surface with its own

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -846,6 +846,14 @@ export type ObjectGridColumn =
  *     falling out of height alignment with the data beside them, which is why
  *     this grid sets BOTH slots. #6882's declaration is where the authoritative
  *     version of this now lives; this is the local copy agreeing with it.
+ *     ⭐ GUARDED SINCE objectui#6921: the cell set is MEASURED in the rendered
+ *     DOM by `packages/components/src/renderers/complex/__tests__/`
+ *     `data-table-cellClassName-population-6921.test.tsx` — the fence (a data
+ *     cell does NOT fold this key) and the non-regression (the three utility
+ *     cells DO) — and this entry's wording is pinned against that measurement
+ *     by `cellClassNameCensusProse-6921.test.ts` beside the slot suite. The
+ *     false sentence was copied into eight texts before anyone measured it;
+ *     a re-wording here that drops a cell name or revives the hold goes red.
  *
  * ⛔ The old closing note ("do not fix either hold by declaring the key on
  * `DataTableSchema` as a rider — that package is published surface with its own

--- a/packages/plugin-grid/src/__tests__/cellClassNameCensusProse-6921.test.ts
+++ b/packages/plugin-grid/src/__tests__/cellClassNameCensusProse-6921.test.ts
@@ -1,0 +1,202 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6921 — the schema-slot census in `ObjectGrid.tsx` names the cell
+ * population the SCHEMA-level `cellClassName` actually reaches, and no longer
+ * records the key as HELD.
+ *
+ * ## Why a prose pin at all
+ *
+ * The census entry for `cellClassName` was wrong on two axes for three days:
+ * it said the key was "folded into every body cell's `className`" (false the
+ * day it was written — the key reaches three UTILITY cells and never a data
+ * cell), and it recorded the key as HELD pending a `packages/types` ruling
+ * that landed on 2026-08-30 (objectui#6882). The second is the sharper
+ * failure: a stale prohibition stops the next reader from checking at all.
+ * objectui#7196 re-derived and corrected both halves; nothing pinned the
+ * corrected wording, so the next drift would again be caught by a reader or
+ * not at all.
+ *
+ * ## The discriminating question this suite is built around
+ *
+ * Would a comment STRICTLY WORSE than today's pass? A pin that only says "the
+ * entry does not contain 'every body cell'" is satisfied by deleting the entry
+ * — and a missing seam-census note is worse than a wrong one, because the next
+ * reader then has nothing to check against. So the assertions below are
+ * positive first: the entry is PRESENT, it names the measured cell set, it
+ * names the per-column twin the data cell folds instead, and it says the hold
+ * is over. Only then is the stale form refused.
+ *
+ * ## What "the measured cell set" means here
+ *
+ * The three names asserted below are not this file's opinion; they are what
+ * `packages/components/src/renderers/complex/__tests__/data-table-cellClassName-population-6921.test.tsx`
+ * measures in the rendered DOM — which cells carry a schema-level probe class
+ * and which carry a column-level one. That suite is the fence (the data cell
+ * must NOT fold the schema-level key) and the non-regression (the three utility
+ * cells must); this one keeps the prose agreeing with it.
+ *
+ * ## Extraction, and its own controls
+ *
+ * The entry is located structurally — the list item that begins with the
+ * key's name inside the census docblock, up to the next item or blank comment
+ * line — and normalised (comment prefixes stripped, whitespace collapsed) so
+ * a re-wrap does not move the verdict. The extractor is shown able to FIND
+ * (the sibling `renderCellEditor` entry) and able to say ABSENT (a key the
+ * census never listed), so a "present" verdict is not an extractor that
+ * matches anything.
+ *
+ * Measured red before green, on the committed tree: the entry deleted → red
+ * on presence; the pre-#7196 wording re-inserted ("HELD. Live: … folds it into
+ * every body cell's `className` … same pending ruling") → red on the stale-form
+ * refusals and on the missing cell names.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const GRID_SOURCE = path.resolve(HERE, '../ObjectGrid.tsx');
+const gridSource = readFileSync(GRID_SOURCE, 'utf8');
+
+/**
+ * The cell set the DOM suite in `@object-ui/components` measures — spelled the
+ * way the census prose spells it. Kept as one list so the two files cannot
+ * drift apart silently: change the measurement, and this list (and the prose)
+ * must move with it.
+ */
+const MEASURED_UTILITY_CELLS = ['selection', 'row-number', 'row-actions'] as const;
+
+/** A line of block-comment prose with its ` * ` prefix removed. */
+const stripPrefix = (line: string) => line.replace(/^\s*\*\s?/, '');
+
+/** Prose normalised for matching: prefixes off, whitespace collapsed. */
+const normalise = (lines: string[]) => lines.map(stripPrefix).join(' ').replace(/\s+/g, ' ').trim();
+
+/**
+ * The census list entry for `key` under the heading
+ * "### What the two entries used to say, and what is true instead".
+ *
+ * Returns `null` when the heading or the entry is absent — the "absent" answer
+ * the presence pin needs in order to mean anything.
+ */
+function censusEntry(key: string): string | null {
+  const lines = gridSource.split('\n');
+  const heading = lines.findIndex((l) => /^\s*\*\s+### What the two entries used to say/.test(l));
+  if (heading < 0) return null;
+  const itemRe = new RegExp(`^\\s*\\*\\s+- \`${key}\` —`);
+  let start = -1;
+  for (let i = heading + 1; i < lines.length; i++) {
+    if (/^\s*\*\/\s*$/.test(lines[i])) break; // end of the docblock
+    if (itemRe.test(lines[i])) { start = i; break; }
+  }
+  if (start < 0) return null;
+  const collected = [lines[start]];
+  for (let i = start + 1; i < lines.length; i++) {
+    const l = lines[i];
+    if (/^\s*\*\s*$/.test(l)) break; // blank comment line ends the item
+    if (/^\s*\*\s+- `/.test(l)) break; // next list item
+    if (/^\s*\*\/\s*$/.test(l)) break; // end of the docblock
+    collected.push(l);
+  }
+  return normalise(collected);
+}
+
+/**
+ * The docblock immediately above the `key?: …;` member inside
+ * `export type ObjectGridDataTableSchemaHolds = { … }`, or `null`.
+ */
+function holdsMemberDoc(key: string): string | null {
+  const lines = gridSource.split('\n');
+  const open = lines.findIndex((l) => /^export type ObjectGridDataTableSchemaHolds = \{/.test(l));
+  if (open < 0) return null;
+  const memberRe = new RegExp(`^\\s+${key}\\?:`);
+  for (let i = open + 1; i < lines.length; i++) {
+    if (/^\};/.test(lines[i])) return null; // type closed without the member
+    if (!memberRe.test(lines[i])) continue;
+    // Walk back over the docblock that ends on the line above the member.
+    let end = i - 1;
+    while (end > open && /^\s*$/.test(lines[end])) end--;
+    if (!/\*\/\s*$/.test(lines[end])) return null; // no docblock
+    let begin = end;
+    while (begin > open && !/^\s*\/\*\*/.test(lines[begin])) begin--;
+    const body = lines.slice(begin, end + 1).map((l) => l.replace(/^\s*\/\*\*\s?/, '').replace(/\*\/\s*$/, ''));
+    return normalise(body);
+  }
+  return null;
+}
+
+describe('objectui#6921 — the ObjectGrid schema-slot census names the cells cellClassName reaches, and the hold is over', () => {
+  /**
+   * Extractor controls first: it can FIND a sibling entry and it can say
+   * ABSENT for a key the census never carried. Without these, every "present"
+   * below could be an extractor that returns a match for anything.
+   */
+  it('the extractor finds the sibling renderCellEditor entry and reports a never-listed key absent', () => {
+    expect(censusEntry('renderCellEditor')).not.toBeNull();
+    expect(censusEntry('zzNeverACensusEntry6921')).toBeNull();
+    expect(holdsMemberDoc('renderCellEditor')).not.toBeNull();
+    expect(holdsMemberDoc('zzNeverAHoldsMember6921')).toBeNull();
+  });
+
+  /**
+   * PRESENCE — the half a delete-the-comment "fix" would fail. A census entry
+   * for `cellClassName` exists under the correction heading.
+   */
+  it('the cellClassName census entry is PRESENT under the correction heading', () => {
+    expect(censusEntry('cellClassName')).not.toBeNull();
+  });
+
+  /**
+   * THE CORRECTED MECHANISM. The entry names each utility cell the DOM suite
+   * measured, and names the per-column twin the data cell folds instead.
+   */
+  it('the entry names the three measured utility cells and the per-column twin the data cell folds', () => {
+    const entry = censusEntry('cellClassName')!;
+    for (const cell of MEASURED_UTILITY_CELLS) {
+      expect(entry, `census entry should name the ${cell} cell`).toMatch(new RegExp(cell, 'i'));
+    }
+    expect(entry).toMatch(/never reaches a data cell/i);
+    expect(entry).toMatch(/col\.cellClassName/);
+  });
+
+  /**
+   * THE HOLD IS OVER. The entry says so in words, and the stale form —
+   * "HELD. Live: … same pending ruling" — is gone. The one place the false
+   * sentence may still appear is as a QUOTATION inside its own correction
+   * ("described the key as folded …"); the live form ("folds it into every
+   * body cell") is refused.
+   */
+  it('the entry records the hold as OVER and no longer carries the stale HELD-pending wording', () => {
+    const entry = censusEntry('cellClassName')!;
+    expect(entry).toMatch(/hold is over/i);
+    expect(entry).toMatch(/objectui#6882|#6882/);
+    expect(entry).not.toMatch(/HELD\. Live/);
+    expect(entry).not.toMatch(/pending ruling/i);
+    expect(entry).not.toMatch(/folds (it|them|the key) into every body cell/i);
+  });
+
+  /**
+   * THE SAME TWO AXES ON THE HOLDS TYPE. The member docblock above
+   * `cellClassName?: string;` records the hold as REDUNDANT (declared upstream),
+   * names the utility cells, and no longer says "every body cell".
+   */
+  it('the ObjectGridDataTableSchemaHolds member docblock agrees: redundant since #6882, three utility cells, never a data cell', () => {
+    const doc = holdsMemberDoc('cellClassName')!;
+    expect(doc).not.toBeNull();
+    expect(doc).toMatch(/REDUNDANT since objectui#6882/);
+    for (const cell of MEASURED_UTILITY_CELLS) {
+      expect(doc, `member docblock should name the ${cell} cell`).toMatch(new RegExp(cell, 'i'));
+    }
+    expect(doc).toMatch(/never into a data cell/i);
+    expect(doc).not.toMatch(/^HELD \(objectui#6459\)/);
+    expect(doc).not.toMatch(/every body cell/i);
+  });
+});

--- a/packages/types/src/__tests__/data-table-declared-keys-6882.test.ts
+++ b/packages/types/src/__tests__/data-table-declared-keys-6882.test.ts
@@ -16,10 +16,14 @@
  * The enforcement being added is a TYPE declaration. `data-table` behaves
  * IDENTICALLY before and after it: both keys were already read on the
  * production path — `renderCellEditor` through an `(schema as any)` cast,
- * `cellClassName` by destructuring into every body cell's class — so no render
- * changes, no runtime value changes, and a rendering test is blind to the whole
- * change. What can fail is a COMPILE. Same reading as
- * `plugin-grid/src/__tests__/dataTableSchemaSlot-6459.test.ts` next door.
+ * `cellClassName` by destructuring into the class of the three UTILITY body
+ * cells (selection, row-number, row-actions; a data cell folds the per-column
+ * `TableColumn.cellClassName` instead, never this key — measured in the DOM by
+ * `components/src/renderers/complex/__tests__/data-table-cellClassName-population-6921.test.tsx`,
+ * objectui#6921) — so no render changes, no runtime value changes, and a
+ * rendering test is blind to the whole change. What can fail is a COMPILE.
+ * Same reading as `plugin-grid/src/__tests__/dataTableSchemaSlot-6459.test.ts`
+ * next door.
  *
  * ## ⚠️ The index signature is what makes the naive pin vacuous
  *


### PR DESCRIPTION
Fixes #6921

## What this does

The schema-level `cellClassName` on `DataTableSchema` was described — in a census that originated on the #6459 work (PR #6637) and was copied forward through #6882 and PR #6918 — as folded "into every body cell's `className`". That is false, and was false the day it was written. This PR (a) re-derives the population and pins it in the rendered DOM, (b) pins the corrected census prose in `ObjectGrid.tsx`, (c) corrects the one live in-repo copy of the sentence that the card's eight-place table missed, and (d) records the GitHub-side correction of the census root, done in the same landing. No renderer behaviour changes — that is the card's fence — and the fence is now a test.

## Re-derivation, on this tree (`3e0a306e0`)

Every fold site of the key in `packages/components/src/renderers/complex/data-table.tsx`, by grep on this tree (line numbers as of this commit; they move):

- `:725` — `cellClassName,` destructured off the schema (the schema-level key)
- `:2226` — selection cell: `cn(cellClassName, "px-3", …)` — folds the schema-level key
- `:2243` — row-number cell: `cn("text-center w-10 relative", cellClassName, …)` — folds it
- `:2571` — row-actions cell: `cn("text-right", cellClassName)` — folds it
- `:2329` — MAIN DATA cell: `cn(col.cellClassName, …)` — folds the PER-COLUMN key only; the schema-level key is not in that `cn()`

So: three utility cells, never a data cell. Then measured in the DOM rather than read: rendering with `selectable`, `showRowNumbers` and `rowActions` all on and one data row gives four `td` elements; exactly three carry the schema-level probe class (selection, row-number, row-actions), exactly one carries the column probe class (the data cell), none carries both; with the three utility columns off, the schema-level class reaches ZERO cells while the column class still reaches the data cell. That last reading is the one that broke the original mdx example (its `data: []` and no utility column meant its `cellClassName` reached nothing) and here it is the control that the schema class is not being sprayed onto every cell.

## Premise check against origin/main — one half of the card was already discharged

The card and its dispatch describe the `ObjectGrid.tsx` seam-census comment as (1) misstating the mechanism and (2) recording both keys as HELD pending a ruling. On `origin/main` at `3619792bf` neither is true any more: objectui#7196 / PR #7202 (`f08cbd996`, 2026-09-01) rewrote the entry — "the hold is over (declared by the same #6882) … folds the SCHEMA-level key at exactly three sites and every one is a UTILITY cell — the selection checkbox, the row-number cell, the row-actions cell. It never reaches a data cell" — and objectui#7201 / PR #7556 (`834c41e25`, 2026-09-03) added the compile-time declaredness gate. Evidence: `git log -S "into every body cell" -- packages/plugin-grid/src/ObjectGrid.tsx` lists `f241a4df4` (added, PR #6637) and `f08cbd996` (removed, PR #7202) only; the phrase survives in that file solely as a quotation inside its own correction. The card was triaged on 2026-09-04 with a fresh cell re-derivation but without re-reading that comment.

What was NOT there, and is added here: nothing pinned the corrected wording, so the next drift would again have been caught by a reader or not at all. The entry gains a short GUARDED SINCE paragraph pointing at the two pins.

## The census root (the other half), corrected on GitHub in this landing

The sentence's earliest text is PR #6637's body census table (2026-08-28T07:45Z), relayed by two comments on #6459 — the dev report at 07:47Z (option A of its open question) and the decision-facets comment at 08:13Z (in Chinese: "折进每个 body cell 的 className") — and from the facets into #6882's body. Done alongside this PR:

- PR #6637's census row corrected in place, dated, original wording kept struck through (the PR #6918 precedent);
- the two #6459 comments are left as closed records (the same treatment the card gives #6882's body), and a dated correction comment is posted on #6459 naming both and pointing here.

## The ninth copy — a bounded in-place fix, declared

`packages/types/src/__tests__/data-table-declared-keys-6882.test.ts:19` carried the live sentence ("`cellClassName` by destructuring into every body cell's class"). It is not in the card's eight-place table: PR #6918 introduced it in the same commit whose four other new copies were corrected under review. Corrected here under the bounded in-place exemption, all four conditions checked: same defect class (the identical sentence); mechanical with a pinned shape (the wording #7196 established, now pinned); no other claim holds the file (all 148 `claude/*` remote heads fetched into a private ref namespace and diffed against their merge-base for that path — zero touch it); same gate family (vitest and the same changeset gate; no new verification surface). Comment-only.

## Sweep for surviving copies

Query `every(?:\s|\*)+body(?:\s|\*)+cell` — comment-continuation tolerant, because the ObjectGrid quotation wraps across a `*`-prefixed line and a plain `\s+` misses it — over the 6928 `git ls-files` paths, hidden dirs included (a bare `rg` skips `.changeset/` and misses a hit). Hits on this tree before the fix: 4 lines in 3 files — `.changeset/7196-plugin-grid-held-key-census.md:29` (quotation inside a correction record; left), `ObjectGrid.tsx:834-835` (quotation inside its own correction; left), `data-table-declared-keys-6882.test.ts:19` (live; corrected here). Controls on the same command shape: `folds(?:\s|\*)+the(?:\s|\*)+SCHEMA-level` (a real cross-line comment span) fired; `Re-derives the held-key censuses` (a `.changeset/` file) fired. Chinese forms (`每个 body cell`, `所有 body cell`): zero in-repo hits.

## Pins added

1. `packages/components/src/renderers/complex/__tests__/data-table-cellClassName-population-6921.test.tsx` — DOM: the fence (the data cell folds `col.cellClassName` and NOT the schema-level key), non-regression (selection, row-number, row-actions each fold it, named one by one), the count and disjointness census, and the zero-cells control.
2. `packages/plugin-grid/src/__tests__/cellClassNameCensusProse-6921.test.ts` — the `ObjectGrid.tsx` entry is PRESENT, names the three measured cells and `col.cellClassName`, says the hold is over, and no longer carries the HELD-pending wording; the holds-type member docblock agrees; extractor controls (finds the sibling entry, reports a never-listed key absent).

## Red before green — every pin observed to fail

Committed tree; each mutation proven on disk by anchored occurrence counts and a changed blob hash; each restore proven by blob hash equal to HEAD and an empty `git diff HEAD`.

| leg | mutation (anchored counts before → after) | predicted | observed |
|---|---|---|---|
| fence-add | data cell folds BOTH keys (`\n +col\.cellClassName,` 1→0; `cellClassName, col.cellClassName,` 0→1) | RED on the fence | RED: `expect(element).not.toHaveClass("probe-schema-slot-6921")` on the data cell; 3 failed, 1 passed |
| caricature-same | data cell folds the schema-level key instead — every cell the same list | RED on both data-cell assertions | RED: `toHaveClass("probe-column-slot-6921")` on the data cell; 3 failed, 1 passed |
| nonreg-actions | row-actions fold removed | RED naming row-actions | RED: "row-actions cell should carry the schema-level class"; 2 failed, 2 passed |
| nonreg-selection | selection fold removed | RED naming selection | RED: "selection cell should carry the schema-level class"; 2 failed, 2 passed |
| prose-delete | census entry deleted — the strictly-worse comment | RED on presence | RED: "expected null not to be null"; 3 failed, 2 passed |
| prose-stale | pre-#7196 wording re-inserted ("HELD. Live: … folds it into every body cell's … same pending ruling") | RED on cell names and hold-over | RED: "should name the selection cell"; "to match /hold is over/i"; 2 failed, 3 passed |
| holds-stale | member docblock reverted to "HELD (objectui#6459) — folds it into every body cell's class" | RED on the member docblock | RED: "to match /REDUNDANT since objectui#6882/"; 1 failed, 4 passed |

One VOID attempt, declared: the first `fence-add` run was refused by my own anchor rule — the replacement text still contains `col.cellClassName,`, so "the pre-anchor must drop to 0" could never hold — and no test ran on it (the blob had changed; the rule, not the mutation, was wrong). Re-run with a line-start regex anchor; the row above is that re-run. No dist leg applies: the DOM pin imports the renderer by relative source path (`../data-table`), not through a package `exports` entry.

Leg D (vitest JSON reporter, clean tree, both pins): 9 tests, 9 passed, 0 failed, 0 pending; both files `passed`; zero death strings (`Element type is invalid`, `Failed Suites`, `No test suite found in file`, `Tests  no tests`, `Transform failed`) in the log.

## Verification — union at the final commit `3e0a306e0`

- `pnpm exec vitest run packages/plugin-grid/` — `Test Files  118 passed (118)`, `Tests  1045 passed (1045)`; lock line `VERDICT command-exit 0`. JSON: 0 failed suites; the prose pin `passed` on all five tests.
- `pnpm exec vitest run packages/types/ packages/components/src/renderers/complex/__tests__/` plus the three components suites that enumerate test directories — `Test Files  171 passed (171)`, `Tests  3032 passed (3032)`; `VERDICT command-exit 0`. JSON: the DOM pin `passed` on all four; the edited 6882 suite `passed`.
- Declared narrowing: `turbo ls --affected` from the base lists nearly every package (a `packages/types` change reaches all dependents); the full farm is CI's run. Locally the risk surface of this diff is the two new suites, the suites that read `ObjectGrid.tsx` source text (all in `packages/plugin-grid`, run in full above — the added comment lines mention `cellClassName`, so a line census there could have reacted), and the suites that enumerate test directories (run above). `data-table.tsx` is unchanged, so no other components suite can observe this diff.
- Type-check, closures built first so this is a measurement and not an unbuilt tree: `pnpm --filter @object-ui/components exec tsc -p tsconfig.test.json --noEmit --listFiles` — 0 errors, the new `.tsx` pin listed in the program; `pnpm --filter @object-ui/plugin-grid exec tsc -p tsconfig.test.json --noEmit --listFiles` — 0 errors, the prose pin listed.
- `pnpm exec eslint` on all four touched files — 0 errors (224 pre-existing warnings; the one in the new components test is the same `no-explicit-any` on the registry-resolved component that the sibling wrap test carries).
- `node scripts/check-changeset-presence.mjs` — verdict line: `✅  4 source file(s) of 3 released package(s) changed, and this change declares 1 changeset(s): .changeset/6921-cellclassname-cell-population-pins.md.` (empty frontmatter; nothing publishes). `check-changeset-no-major.mjs`: `✅  No changeset declares a major bump.`
- `node scripts/check-control-bytes.mjs` — `✅  check-control-bytes: OK`.
- `node scripts/check-governed-queue-guard.mjs --test …` — `✅ NOT GOVERNED — 4 path(s) checked against 5 governed surface(s); none matched.`

## Out of scope, recorded

- #6882's body table carries the same sentence in its Chinese form; left as a closed decision record, per the card.
- Whether the schema-level key SHOULD reach data cells is not asked here; the fence pin makes that a deliberate, separate change if anyone wants it.

Worktree cleaned after PR creation. No service was started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_