### PR TITLE
fix(components): route ui:sidebar-trigger's spread through the form-control DOM declaration

### DIFF
--- a/.changeset/5632-sidebar-trigger-dom-passthrough.md
+++ b/.changeset/5632-sidebar-trigger-dom-passthrough.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/components': patch
+---
+
+`ui:sidebar-trigger` routes its host spread through the form-control DOM
+declaration (objectui#5632, the `ui:sidebar-trigger` slice of objectui#5574).
+
+The renderer forwarded its whole prop bag to `SidebarTrigger`, which spreads its
+own rest onto the `<button>` it renders — so every authored SDUI key on the node
+became an attribute. Fourteen of them, one more than the shape this target
+derives from, because this registration also never destructured `schema`: every
+other registration in `renderers/navigation/sidebar.tsx` names it (they need
+`schema.body`), while this one renders no children and named only `className`,
+so the node `SchemaRenderer` injects on every render rode the spread and landed
+as `schema="[object Object]"`.
+
+The declaration is the form-control one, not the bare `toDomProps`: the host is
+a `<button>`, where HTML defines `name` and `disabled`. That is measurable in
+the ledger row itself — it recorded thirteen attributes plus `schema` and never
+`name`, because the leak judge counts an authored `name` as legitimate on this
+element. A bare `toDomProps` would therefore have un-named this control without
+moving a single number in the gate that grades the change.
+
+Nothing else about the trigger moves. The `<button>` still carries its
+`data-sidebar="trigger"` hook, its "Toggle Sidebar" accessible name, the
+resolved `aria-label` / `aria-describedby`, the `data-obj-*` designer
+attributes, its `id` and its `name`; an authored `className` still merges into
+the primitive's computed classes rather than replacing them; and `style`, `role`
+and `tabIndex` still reach the DOM — `style` forwarded by name, the two others
+on the shared pass-through list. The leak set went from 14 to 0 underneath an
+unchanged 8-attribute legitimate set, and clicking the trigger still toggles the
+sidebar.

--- a/examples/schema-catalog/test/sidebar-trigger-dom-leak-5632.test.tsx
+++ b/examples/schema-catalog/test/sidebar-trigger-dom-leak-5632.test.tsx
@@ -1,0 +1,355 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ui:sidebar-trigger` puts nothing authored on the DOM, and still renders the
+ * button it always rendered (objectui#5632, the `ui:sidebar-trigger` slice of
+ * objectui#5574).
+ *
+ * ## The two mechanisms this one target carried
+ *
+ * Its ledger row was the only one in the family with FOURTEEN attributes where
+ * the shape it derives from leaks thirteen, and the extra one was `schema`
+ * ITSELF — the node `SchemaRenderer` injects on every single render. That is a
+ * second defect sitting on top of the group's, not a variant of it:
+ *
+ *   1. the bare spread the group records. `{...props}` reached `SidebarTrigger`,
+ *      which spreads its own rest onto the `Button` it renders.
+ *   2. `schema` was never destructured off the bag. Every other registration in
+ *      `renderers/navigation/sidebar.tsx` names it (`({ schema, ...props })`)
+ *      because it needs `schema.body`; this one renders no children, named only
+ *      `className`, and so the injected node rode the same spread.
+ *
+ * Both close with one filter, because a whitelist does not have to enumerate
+ * what it drops. Which is also why re-ledgering `schema` would be the wrong
+ * repair, and why the sweep gate now carries an inverted case refusing it.
+ *
+ * ## Why the FORM-CONTROL declaration and not the bare `toDomProps`
+ *
+ * The host is the `<button>` `SidebarTrigger` renders. HTML defines `name`
+ * there, so `@object-ui/test-support`'s judge counts an authored `name` as
+ * LEGITIMATE on it — which is exactly why the row was thirteen-plus-`schema`
+ * and never listed `name` at all. A bare `toDomProps` would therefore have
+ * un-named this control while every number the sweep gate watches stayed
+ * still. Measured, not reasoned: the judge self-check below shows the same bag
+ * reported differently on a `<button>` and on a `<div>`.
+ *
+ * ## What this file measures that the sweep gate cannot
+ *
+ * The same split the three probes next door describe
+ * (`layout-dom-leak-5574.test.tsx`, `form-control-dom-leak-5632.test.tsx`,
+ * `svg-host-dom-leak-5632.test.tsx`). `packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx`
+ * is the gate for this class and the stronger instrument for the OPEN TAIL. It
+ * reports attributes that ARRIVE illegitimately and has no case at all for one
+ * that STOPS arriving — so the whole legitimate half of this host is invisible
+ * to it in BOTH directions, `name` included. Everything below the leak
+ * assertion is that half.
+ *
+ * ## Designing against the failure mode this test could have
+ *
+ * A zero means nothing on its own — a renderer that renders NOTHING spreads
+ * nothing and reads clean, and this card's own documented failure is sixteen
+ * phantom-clean targets, four of them `useSidebar` throws caught by an
+ * attribute-clean error boundary. Four guards:
+ *
+ *   1. The REAL MARKUP is asserted first, every time, and it is asserted as
+ *      markup rather than as "an element exists": a `<button>` carrying the
+ *      primitive's own `data-sidebar="trigger"` hook and the "Toggle Sidebar"
+ *      accessible name. An error boundary satisfies none of that.
+ *   2. The LEGITIMATE attribute set is pinned as a full set, not a spot check.
+ *      A filter that drops everything — the caricature that must not read as
+ *      success — reddens here even though its leak reading is a perfect zero.
+ *   3. The BEHAVIOUR is pinned: the trigger still toggles the sidebar. An
+ *      over-broad filter that strips a handler or the ARIA passes the leak
+ *      assertion and fails this one.
+ *   4. The JUDGE is self-checked in the direction this file depends on — that
+ *      it is ELEMENT-AWARE about `name`. A judge that reported `name` nowhere
+ *      would pass every assertion below while hiding the one behaviour a bare
+ *      `toDomProps` would have destroyed.
+ *
+ * `document.cookie` is cleared before each case: `SidebarProvider` PERSISTS the
+ * open state to `sidebar_state` on every toggle and reads it back on mount
+ * (objectui#4234), so a case that clicks the trigger would otherwise decide the
+ * starting state of the next one.
+ *
+ * Module-scope import of `@object-ui/components`, not `beforeAll` (AGENTS.md
+ * §测试纪律): registering the renderers is an unbounded module load and must not
+ * be billed to a bounded hook timeout.
+ */
+import type { ReactNode } from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import '@object-ui/components';
+import { SidebarProvider, Sidebar } from '@object-ui/components';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+import { findLeaks, leakReport } from '@object-ui/test-support';
+
+/**
+ * The canary families the sweep gate plants, kept identical on purpose so the
+ * two instruments report the same vocabulary: the keys `SchemaRenderer`
+ * injects, the authored SDUI metadata that survives its strip list, the open
+ * tail of keys no component declares, and the authored `props` container.
+ */
+const CANARY_NODE = {
+  type: 'sidebar-trigger',
+  id: 'canary-node',
+  name: 'canary_node',
+  className: 'authored-class',
+  bind: 'data.revenue',
+  events: { onClick: [{ action: 'navigate', params: { url: '/x' } }] },
+  ariaLabel: 'Canary label',
+  ariaDescribedBy: 'canary-desc',
+  zzcanary: 'CANARY-STR',
+  zzcanaryobj: { nested: true },
+  zzcanarynum: 42,
+  zzcanaryCamel: 'CANARY-CAMEL',
+  reference_to: 'contacts',
+  props: { colorVariant: 'success', zzcanaryprop: 'CANARY-PROP' },
+} as const;
+
+/** The injected data-source ADAPTER — one more family, and one the node cannot carry. */
+const FAKE_ADAPTER = {
+  find: async () => [],
+  findOne: async () => null,
+  aggregate: async () => [],
+  count: async () => 0,
+  getObject: async () => null,
+};
+
+/**
+ * Renders one node through the real SDUI path inside the React host this
+ * renderer requires, and returns the trigger element — after proving it is the
+ * trigger's REAL markup and not an error boundary.
+ *
+ * `SidebarProvider` is a REACT host, deliberately not a `ui:sidebar-provider`
+ * SCHEMA node: that node is a swept target of its own and wrapping in it would
+ * attribute its leaks to the target inside.
+ */
+function renderTrigger(node: Record<string, unknown>, extra?: ReactNode) {
+  const view = render(
+    <SidebarProvider>
+      <SchemaRendererProvider dataSource={FAKE_ADAPTER as never}>
+        <div data-probe-root="">
+          <SchemaRenderer schema={node as never} dataSource={FAKE_ADAPTER as never} />
+        </div>
+      </SchemaRendererProvider>
+      {extra}
+    </SidebarProvider>,
+  );
+
+  const host = view.container.querySelector('[data-probe-root]')?.firstElementChild;
+
+  // Guard 1. Asserted BEFORE anything is read off the element, and asserted as
+  // MARKUP: `SchemaErrorBoundary`'s alert is attribute-clean, and so is a
+  // renderer made to bail early.
+  expect(host, 'ui:sidebar-trigger rendered no element at all').toBeTruthy();
+  expect(host!.tagName, 'the trigger must render a real <button>').toBe('BUTTON');
+  expect(
+    host!.getAttribute('data-sidebar'),
+    "the primitive's own behaviour hook is missing — this is not SidebarTrigger's markup",
+  ).toBe('trigger');
+  expect(
+    host!.textContent,
+    'the trigger lost its accessible name; a nameless icon button is not a pass',
+  ).toContain('Toggle Sidebar');
+  expect(view.container.textContent ?? '').not.toContain('failed to render');
+
+  return { view, host: host as Element };
+}
+
+/** Every attribute on the trigger, `name="value"`, sorted. */
+function attributesOf(host: Element): string[] {
+  return Array.from(host.attributes)
+    .map((attribute) => `${attribute.name}="${attribute.value}"`)
+    .sort();
+}
+
+/** Leaked attribute NAMES, deduped and sorted — the ledger's own unit. */
+function leakedNames(host: Element): string[] {
+  return [...new Set(findLeaks(host).map((leak) => leak.attribute))].sort();
+}
+
+beforeEach(() => {
+  document.cookie = 'sidebar_state=; path=/; max-age=0';
+});
+
+describe('schema-catalog — ui:sidebar-trigger leaks nothing and still works (#5632)', () => {
+  it('the judge is element-aware about `name` — a zero below is a reading, not a blind spot', () => {
+    // Rendered directly rather than through the registry: this checks the
+    // JUDGE, and it must keep working even if every renderer in the repo is
+    // fixed. Without it `findLeaks` could return `[]` unconditionally and every
+    // assertion in this file would still pass.
+    //
+    // The bag is spread rather than written as JSX attributes, which is not a
+    // typing dodge but the defect's own shape: `<button schema={…}>` does not
+    // type-check, and a bare spread of an untyped record is exactly how these
+    // attributes reached real elements without anyone hearing about it.
+    const bag: Record<string, unknown> = {
+      schema: { type: 'sidebar-trigger' },
+      name: 'canary_node',
+      id: 'i',
+      className: 'c',
+      'data-sidebar': 'trigger',
+      'aria-label': 'A',
+      bind: 'data.x',
+      zzcanary: 'S',
+    };
+
+    // On a BUTTON host `name` is a real attribute, so only the three undeclared
+    // keys are leaks. This is the half objectui#5632 depends on: it is why the
+    // ledger row listed thirteen-plus-`schema` and never `name`, and therefore
+    // why converging this renderer on the bare `toDomProps` would have been
+    // invisible to the gate that grades it.
+    const button = render(<button {...bag} />);
+    expect(leakedNames(button.container.firstElementChild!)).toEqual([
+      'bind',
+      'schema',
+      'zzcanary',
+    ]);
+    button.unmount();
+
+    // On a `<div>` the SAME bag leaks `name` too — the judge answers per
+    // element rather than from one flat list. A judge that did not would report
+    // the same set for both, and this file would be vacuous exactly where the
+    // target lives.
+    const div = render(<div {...bag} />);
+    expect(leakedNames(div.container.firstElementChild!)).toEqual([
+      'bind',
+      'name',
+      'schema',
+      'zzcanary',
+    ]);
+    div.unmount();
+  });
+
+  it('the full canary set reaches the renderer and none of it reaches the DOM', () => {
+    const { view, host } = renderTrigger({ ...CANARY_NODE });
+    expect(
+      leakReport('ui:sidebar-trigger', findLeaks(host)),
+      'an authored or injected schema key reached the DOM as an attribute. ' +
+        'Route the spread through the form-control DOM declaration ' +
+        '(`packages/components/src/lib/form-control-dom-props.ts`) — never ' +
+        'widen that list to reach one host, and never re-ledger the row in ' +
+        '`widget-dom-leak-sweep.test.tsx`. A key that genuinely belongs on this ' +
+        'element is DECLARED and forwarded BY NAME (objectui#4435), the way ' +
+        '`style` is.',
+    ).toBe('');
+    view.unmount();
+  });
+
+  /**
+   * Guard 2 — the other direction, which no leak gate can assert: the
+   * attributes that SHOULD be on this element still are, as a FULL SET.
+   *
+   * This is the assertion a "drops everything" filter fails. Its leak reading
+   * is a perfect zero; what it cannot produce is `name`, `id`, the resolved
+   * `aria-*` pair, the `data-obj-*` designer attributes, or a `class` carrying
+   * both the primitive's computed utilities and the authored override.
+   *
+   * These are the same eight attributes, byte for byte, that the pre-fix tree
+   * produced — the leak set went 14 → 0 underneath an unchanged legitimate set.
+   */
+  it('the legitimate attributes on this host are exactly these, and none was filtered away', () => {
+    const { view, host } = renderTrigger({ ...CANARY_NODE });
+    const attributes = attributesOf(host);
+
+    expect(attributes.map((attribute) => attribute.slice(0, attribute.indexOf('=')))).toEqual([
+      // The camelCase `ariaDescribedBy` / `ariaLabel` the author wrote are
+      // meaningless to assistive technology; `SchemaRenderer` resolves them to
+      // these hyphenated forms, and the open `aria-` family carries them
+      // through the filter.
+      'aria-describedby',
+      'aria-label',
+      'class',
+      // The designer's own attributes, carried by the open `data-` family.
+      'data-obj-id',
+      'data-obj-type',
+      // `SidebarTrigger`'s own behaviour hook, which the renderer never touches.
+      'data-sidebar',
+      'id',
+      // The one that makes this a form control rather than a container, and the
+      // one a bare `toDomProps` would have taken.
+      'name',
+    ]);
+
+    expect(attributes).toContain('aria-label="Canary label"');
+    expect(attributes).toContain('aria-describedby="canary-desc"');
+    expect(attributes).toContain('data-obj-id="canary-node"');
+    expect(attributes).toContain('data-obj-type="sidebar-trigger"');
+    expect(attributes).toContain('data-sidebar="trigger"');
+    expect(attributes).toContain('id="canary-node"');
+    expect(attributes).toContain('name="canary_node"');
+
+    // `className` is on the pass-through list, so it is the one key that could
+    // be written twice — once by the renderer and once out of the filtered bag.
+    // It is not: the renderer destructures it, and `SidebarTrigger` MERGES it
+    // into its own `cn("h-7 w-7", …)`. Both halves asserted, because the
+    // sibling slice measured what happens when only one arrives: `ui:spinner`
+    // rendered with lucide's classes and none of its own, and did not spin.
+    const className = host.getAttribute('class') ?? '';
+    expect(className.split(/\s+/)).toContain('authored-class');
+    expect(className.split(/\s+/)).toContain('h-7');
+    expect(className.split(/\s+/)).toContain('w-7');
+
+    view.unmount();
+  });
+
+  /**
+   * Guard 3 — the non-regression axis, taken from a plausible WRONG FIX rather
+   * than from the bug's shape. The filter is a whitelist, so the way to get
+   * this wrong is to over-filter: strip the handler channel, the ARIA, or a
+   * `data-*` the sidebar's own machinery reads. None of that moves the leak
+   * reading, and all of it breaks the button.
+   */
+  it('the trigger still toggles the sidebar, from the DOM the sidebar itself reads', () => {
+    const { view, host } = renderTrigger({ ...CANARY_NODE }, <Sidebar />);
+
+    const state = () => view.container.querySelector('[data-state]')?.getAttribute('data-state');
+    expect(state(), 'the sidebar did not mount, so a toggle proves nothing').toBe('expanded');
+
+    fireEvent.click(host);
+    expect(
+      state(),
+      'clicking the trigger no longer collapses the sidebar — the click channel ' +
+        'was filtered away, or the trigger stopped being a button',
+    ).toBe('collapsed');
+
+    fireEvent.click(host);
+    expect(state()).toBe('expanded');
+
+    view.unmount();
+  });
+
+  /**
+   * The declared channels a whitelist must not silently close. `role` and
+   * `tabIndex` are on the SDUI pass-through list; `style` is NOT, and is
+   * forwarded BY NAME for exactly that reason (objectui#4435). All three
+   * reached the DOM before this slice, so all three are non-regressions rather
+   * than new behaviour — and `style` is the one an unthinking `toDomProps`
+   * conversion drops without a word.
+   */
+  it('the declared pass-through channels still arrive, `style` included', () => {
+    const { view, host } = renderTrigger({
+      type: 'sidebar-trigger',
+      id: 'styled-node',
+      className: 'authored-class',
+      style: { marginTop: '4px' },
+      role: 'button',
+      tabIndex: 3,
+    });
+
+    const attributes = attributesOf(host);
+    expect(attributes).toContain('style="margin-top: 4px;"');
+    expect(attributes).toContain('role="button"');
+    expect(attributes).toContain('tabindex="3"');
+    // …and the injected node still does not ride along with them.
+    expect(leakedNames(host)).toEqual([]);
+
+    view.unmount();
+  });
+});

--- a/packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx
+++ b/packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx
@@ -37,9 +37,9 @@
  *   | plugin-calendar  |       3 |               0 |                 0 |
  *   | plugin-chatbot   |       3 |               0 |                 0 |
  *   | plugin-dashboard |       8 |               2 |             7 / 9 |
- *   | components       |     158 |              95 |          12 .. 15 |
+ *   | components       |     159 |              89 |          12 .. 15 |
  *
- * **97 of 181 targets leak.** The `components` row is objectui#5574 and is
+ * **91 of 182 targets leak.** The `components` row is objectui#5574 and is
  * covered in its own section below; the two `plugin-dashboard` rows are the
  * older tail. Both are in {@link LEAK_LEDGER}:
  * `plugin-dashboard:metric` and `plugin-dashboard:metric-card`, the open tail
@@ -121,7 +121,7 @@
  * have failed. These two differ in exactly one thing: which namespace the extra
  * widget went into.
  *
- * ### The reading — 119 of 158 ON ARRIVAL, in seven shapes; 97 today
+ * ### The reading — 119 of 158 ON ARRIVAL, in seven shapes; 89 today
  *
  * The card named four candidates (`flex`, `stack`, `container`, `text`) and was
  * careful to call them candidates. All four leaked. So did 115 others, and the
@@ -136,7 +136,10 @@
  * (objectui#5632) — which took a SHAPE off this list, not just rows, so the
  * grouping is six mechanisms now and not seven. All twenty-two measure clean,
  * so their rows had to go for the gate to pass — the two-way expiry below,
- * working exactly once it had something to expire. 97 rows remain. What the arrival reading measured is preserved here in prose and in
+ * working exactly once it had something to expire. Later slices took more,
+ * and objectui#5632's `ui:sidebar-trigger` took the last shape that named a
+ * single renderer: **89 rows in FOUR shapes** remain, on a target set that has
+ * itself grown to 159. What the arrival reading measured is preserved here in prose and in
  * the burn-down note on {@link COMPONENTS_LEAK_GROUPS}; what the gate asserts
  * is always current truth, which is the whole point of not writing dates into
  * a ledger.
@@ -862,8 +865,8 @@ const TARGETS: Readonly<Record<string, readonly Target[]>> = {
     // `DashboardRenderer`'s widget grid — the element its `{...props}` lands on.
     { type: 'view:dashboard', ready: '.grid.auto-rows-min' },
   ],
-  // objectui#5574 — 158 targets, built above rather than spelled here because
-  // 138 of them need nothing but the shared readiness class.
+  // objectui#5574 — 159 targets, built above rather than spelled here because
+  // 140 of them need nothing but the shared readiness class.
   components: COMPONENTS_TARGETS,
 };
 
@@ -947,8 +950,8 @@ interface LedgerEntry {
 /* ── objectui#5574: the `packages/components` reading, as a LEDGER ─────────── */
 
 /**
- * 95 of the 158 `packages/components` targets leak, and they do it in exactly
- * FIVE shapes (119 targets in seven shapes did on arrival; see the burn-down
+ * 89 of the 159 `packages/components` targets leak, and they do it in exactly
+ * FOUR shapes (119 targets in seven shapes did on arrival; see the burn-down
  * note below — and note the arrival count of shapes read `eight` here until
  * objectui#5632 counted them: the groups were seven, and the card's own table
  * listed seven). Writing that
@@ -1003,7 +1006,8 @@ interface LedgerEntry {
  *     group above could NOT take: `IconSchema` and `SpinnerSchema` declare only
  *     `icon` / `size` / `color`, and both renderers already consume all three by
  *     name, so nothing legitimate was withheld and no third declaration was
- *     warranted. The group is DELETED, so the grouping is five mechanisms now.
+ *     warranted. The group is DELETED, which took the grouping from six
+ *     mechanisms to five.
  *
  *     ⚠️ What this file could not have graded, recorded here because the next
  *     slice needs the warning: on an SVG host the judge counts `stroke`,
@@ -1019,6 +1023,28 @@ interface LedgerEntry {
  *     asserts the LEGITIMATE attribute sets too — the guard this gate
  *     structurally cannot provide.
  *
+ *   - objectui#5632 (the slice after that one) — `ui:sidebar-trigger`, the
+ *     one-member group that leaked FOURTEEN where the rest of its shape leaks
+ *     thirteen. The extra attribute was `schema` ITSELF, and it was there for a
+ *     SECOND reason, not the group's: every other registration in
+ *     `renderers/navigation/sidebar.tsx` destructures `schema` because it needs
+ *     `schema.body`, while this one renders no children and named only
+ *     `className` — so the node `SchemaRenderer` injects on every render simply
+ *     rode the same spread. One filter closed both, and it is the FORM-CONTROL
+ *     declaration rather than the bare `toDomProps`: the host is the `<button>`
+ *     `SidebarTrigger` renders, where HTML defines `name`. The row's own
+ *     thirteen-not-fourteen shape is the evidence — the judge counts the
+ *     authored `name` LEGITIMATE here, so a bare `toDomProps` would have
+ *     un-named this control without moving one number in this file.
+ *
+ *     ⚠️ Same warning as the SVG group above, in the other host's vocabulary:
+ *     on a `<button>` the legitimate half this gate never reports is `name`,
+ *     `id`, `class`, the resolved `aria-*`, `data-obj-*` and the primitive's own
+ *     `data-sidebar="trigger"` — eight attributes, measured IDENTICAL before and
+ *     after. That reading, plus the fact that the trigger still toggles and
+ *     still carries its "Toggle Sidebar" accessible name, is pinned in
+ *     `examples/schema-catalog/test/sidebar-trigger-dom-leak-5632.test.tsx`.
+ *
  * ## This is a ledger, not an allowlist — the difference, stated once
  *
  * An allowlist says "do not look here". Every row below says "we looked, this
@@ -1027,8 +1053,8 @@ interface LedgerEntry {
  * leaking a NINTH attribute the gate fails, because the measured set no longer
  * equals the recorded one; if it stops leaking, the gate ALSO fails until the
  * row goes. An allowlist has neither property. Nothing below is skipped,
- * `it.skip`-ed, quarantined or excluded from the sweep — all 158 targets render
- * and all 158 are scanned on every run, the 61 clean ones included.
+ * `it.skip`-ed, quarantined or excluded from the sweep — all 159 targets render
+ * and all 159 are scanned on every run, the 70 clean ones included.
  */
 
 /**
@@ -1053,10 +1079,11 @@ const BARE_SPREAD: readonly string[] = [
  * NO GROUP CARRIES THIS SHAPE ANY MORE — objectui#5632 burned all eighteen of
  * its members and DELETED the group, which is why what is left is a bare
  * attribute list. It survives as the base three other groups still derive from
- * (`action:menu`, `ui:form`, `ui:sidebar-trigger`), each of which measures this
- * shape plus or minus one attribute. Deleting it would mean hand-copying
- * thirteen strings into three places and losing the statement that those three
- * ARE this shape, varied.
+ * (`action:menu` and `ui:form`), each of which measures this shape plus or
+ * minus one attribute. It derived a THIRD until objectui#5632 burned
+ * `ui:sidebar-trigger`. Deleting it would mean hand-copying thirteen strings
+ * into two places and losing the statement that those two ARE this shape,
+ * varied.
  *
  * The prediction this docblock carried before the burn-down — "converging these
  * renderers on `toDomProps` will not change that attribute, only the thirteen
@@ -1132,15 +1159,6 @@ const COMPONENTS_LEAK_GROUPS: readonly LedgerGroup[] = [
     issue: 'objectui#5574',
     targets: ['ui:form'],
   },
-  {
-    attributes: [...BARE_SPREAD_MINUS_NAME, 'schema'].sort(),
-    reason:
-      'the only target in this family that leaks `schema` ITSELF — the node ' +
-      '`SchemaRenderer` injects on every render — because the renderer ' +
-      'forwards its prop bag, `schema` included, to the underlying button.',
-    issue: 'objectui#5574',
-    targets: ['ui:sidebar-trigger'],
-  },
 ];
 
 const LEAK_LEDGER: Readonly<Record<string, LedgerEntry>> = {
@@ -1179,7 +1197,7 @@ const LEAK_LEDGER: Readonly<Record<string, LedgerEntry>> = {
     issue: 'objectui#4425',
   },
 
-  /* ── packages/components: 95 of 158 targets, in five measured shapes ───── */
+  /* ── packages/components: 89 of 159 targets, in four measured shapes ───── */
   ...Object.fromEntries(
     COMPONENTS_LEAK_GROUPS.flatMap((group) =>
       group.targets.map((type) => [
@@ -1534,6 +1552,31 @@ describe('the sweep covers a real, non-empty target set (objectui#4425)', () => 
         're-ledgered instead of fixed.',
     ).toEqual([]);
     // …and they are still SWEPT, so "no row" cannot mean "no longer looked at".
+    const sweptTypes = new Set(ALL_TARGETS.map((target) => target.type));
+    expect(converged.filter((type) => !sweptTypes.has(type))).toEqual([]);
+  });
+
+  it('`ui:sidebar-trigger` is CLEAN — the `schema` row may not be re-absorbed', () => {
+    // objectui#5632's slice: the one-member group that leaked FOURTEEN — the
+    // thirteen of `BARE_SPREAD_MINUS_NAME` plus `schema` itself. Its group is
+    // DELETED, and this is the inverted case that keeps it deleted, same
+    // treatment and same reason as the two families directly above.
+    //
+    // What this one adds over both is the SECOND mechanism. `schema` did not
+    // leak here because of the shape the group records; it leaked because this
+    // registration alone never destructured it (it renders no children, so it
+    // had no reason to name `schema` at all) and the injected node rode the
+    // spread. Re-ledgering that is the repair to refuse: the filter drops
+    // `schema` without anyone enumerating it, and a row here would say the
+    // opposite.
+    const converged = ['ui:sidebar-trigger'];
+    expect(
+      converged.filter((type) => LEAK_LEDGER[type]),
+      '`ui:sidebar-trigger` is converged on the form-control DOM declaration ' +
+        '(objectui#5632) and measures clean. A row here means a regression was ' +
+        're-ledgered instead of fixed.',
+    ).toEqual([]);
+    // …and it is still SWEPT, so "no row" cannot mean "no longer looked at".
     const sweptTypes = new Set(ALL_TARGETS.map((target) => target.type));
     expect(converged.filter((type) => !sweptTypes.has(type))).toEqual([]);
   });

--- a/packages/components/src/renderers/navigation/sidebar.tsx
+++ b/packages/components/src/renderers/navigation/sidebar.tsx
@@ -210,11 +210,17 @@ ComponentRegistry.register('sidebar-trigger',
     //     family became an attribute on a real `<button>`.
     //  2. `schema` was never taken off the bag. Every other registration in
     //     this family destructures it (`({ schema, ...props })`) because it
-    //     needs `schema.body`; this one renders no children and named only
+    //     renders a child list; this one renders none and named only
     //     `className`, so the node `SchemaRenderer` injects on EVERY render
     //     rode the spread and landed as `schema="[object Object]"`. That is
     //     why this target was its own ledger group: fourteen attributes where
     //     the rest of the shape leaks thirteen.
+    //
+    //     ⚠️ It still takes no `schema` parameter, and must not start:
+    //     `scripts/__tests__/body-dialect-census.test.ts` pins this
+    //     registration as the one `sidebar-*` entry that reads no child list.
+    //     The filter is what drops the key — a whitelist never has to name
+    //     what it refuses.
     //
     // One filter closes both — `schema` is not on the pass-through list, so
     // nothing here has to enumerate it. The declaration is the FORM-CONTROL

--- a/packages/components/src/renderers/navigation/sidebar.tsx
+++ b/packages/components/src/renderers/navigation/sidebar.tsx
@@ -200,9 +200,45 @@ ComponentRegistry.register('sidebar-inset',
 );
 
 ComponentRegistry.register('sidebar-trigger',
-  ({ className, ...props }: { className?: string; [key: string]: any }) => (
-    <SidebarTrigger className={className} {...props} />
-  ),
+  ({ className, ...props }: { className?: string; [key: string]: any }) => {
+    // TWO defects met on this one registration, and only the first is the
+    // family's ordinary bare spread (objectui#5632, the `ui:sidebar-trigger`
+    // slice of objectui#5574).
+    //
+    //  1. the spread itself — `{...props}` reached `SidebarTrigger`, which
+    //     spreads its own rest onto the `Button` it renders, so every canary
+    //     family became an attribute on a real `<button>`.
+    //  2. `schema` was never taken off the bag. Every other registration in
+    //     this family destructures it (`({ schema, ...props })`) because it
+    //     needs `schema.body`; this one renders no children and named only
+    //     `className`, so the node `SchemaRenderer` injects on EVERY render
+    //     rode the spread and landed as `schema="[object Object]"`. That is
+    //     why this target was its own ledger group: fourteen attributes where
+    //     the rest of the shape leaks thirteen.
+    //
+    // One filter closes both — `schema` is not on the pass-through list, so
+    // nothing here has to enumerate it. The declaration is the FORM-CONTROL
+    // one, not the bare `toDomProps`: the host is a `<button>`, where HTML
+    // defines `name` and `disabled`. The sweep gate measures `name` arriving
+    // here and counts it LEGITIMATE, so a bare `toDomProps` would have
+    // un-named this control without moving a single number the gate watches.
+    //
+    // `className` is destructured so the filtered bag can never carry a second
+    // writer for it (`className` IS on the pass-through list): one writer here,
+    // and `SidebarTrigger` merges it into its own `cn("h-7 w-7", …)` rather
+    // than being overwritten by it. `style` is forwarded BY NAME, the
+    // objectui#4435 route every converged sibling in this package takes — it
+    // reaches the DOM today and the whitelist does not carry it.
+    const { style, ...triggerProps } = props;
+
+    return (
+      <SidebarTrigger
+        className={className}
+        {...toFormControlDomProps(triggerProps)}
+        style={style}
+      />
+    );
+  },
   {
     namespace: 'ui',
     label: 'Sidebar Trigger',


### PR DESCRIPTION
Part of #5632 — one slice, the `ui:sidebar-trigger` group. The parent burn-down stays OPEN; #5632 is not addressed in full here and remains open, exactly as PR #7564 left it.

## The defect, and the second one hiding inside it

`ComponentRegistry.register('sidebar-trigger', …)` destructured `className` and spread the rest onto `SidebarTrigger`, which spreads its own rest onto the `Button` it renders. So every canary family became an attribute on a real button element. Fourteen of them — one more than the shape this target derives from — and the extra one is the interesting half:

1. **the bare spread** the group records.
2. **`schema` was never taken off the bag.** Every other registration in `renderers/navigation/sidebar.tsx` names it (`({ schema, ...props })`) because it renders a child list. This one renders none and named only `className`, so the node `SchemaRenderer` injects on every render rode the same spread and landed as `schema="[object Object]"`.

That is a **second mechanism**, not a variant of the group's — which is why this target was ledgered on its own. One filter closes both, because a whitelist never has to enumerate what it drops; re-ledgering `schema` would have been the wrong repair, and the sweep gate now carries an inverted case that refuses it.

## Why the FORM-CONTROL declaration and not the bare `toDomProps`

The host is a button element, where HTML defines `name` and `disabled`. The ledger row is the evidence: it recorded thirteen attributes plus `schema` and **never `name`**, because the shared judge counts an authored `name` as legitimate on this element. A bare `toDomProps` would therefore have un-named this control **without moving a single number in the gate that grades the change** — the exact failure `packages/components/src/lib/form-control-dom-props.ts` exists to prevent, one host over.

`style` is forwarded BY NAME (#4435), as every converged sibling in this package does: it reaches the DOM today and the whitelist does not carry it. Dropping it is the plausible wrong fix, and it is pinned (leg E below).

## Measured, through the real SchemaRenderer path

Renders-real-markup established **before** any reading counted: the trigger renders a button element carrying the primitive's own `data-sidebar="trigger"` hook, a lucide `panel-left` glyph and the sr-only "Toggle Sidebar" label — asserted as markup, so an error boundary or an early bail cannot satisfy it. Dump written to a file, with a lit control asserted first (a deliberately leaky div must report leaks), because vitest swallows console output from a passing test.

| reading | before | after |
|---|---|---|
| leaked attributes | **14** | **0** |
| legitimate attributes | **8** | **8 — identical** |
| `class` | `… h-7 w-7 os-sweep-ready` | unchanged (merged, not clobbered) |
| toggle | fires | fires |

The 14: `ariadescribedby`, `arialabel`, `bind`, `colorvariant`, `datasource`, `events`, `props`, `reference_to`, `schema`, `zzcanary`, `zzcanarycamel`, `zzcanarynum`, `zzcanaryobj`, `zzcanaryprop` — re-derived from `LEAK_LEDGER` (`[...BARE_SPREAD_MINUS_NAME, 'schema'].sort()`), not from the card's summary table, and confirmed by measurement.

The 8 legitimate, unchanged in both runs: `aria-describedby`, `aria-label`, `class`, `data-obj-id`, `data-obj-type`, `data-sidebar`, `id`, `name`. This is the half a leak gate reports in **neither** direction — PR #7564's lesson, asked again on this host rather than inherited from the SVG one. On a button element the answer is `name`, not `stroke`/`fill`.

Lesson 1 checked too: this host does **not** have `ui:spinner`'s clobber shape. The renderer computes no class of its own; `SidebarTrigger` merges via `cn("h-7 w-7", className)`, and `className` is destructured so the filtered bag can never become a second writer for it. Both halves are asserted.

## Ledger

The row is **DELETED**, as the two-way exact-set assertion requires. `ui:grid` stays out. `BARE_SPREAD_MINUS_NAME` survives as the base for the two groups that still derive from it (`action:menu`, `ui:form`). The three meta-cases still hold, and the sweep gains a fourth inverted case (`ui:sidebar-trigger` is CLEAN — the `schema` row may not be re-absorbed).

⚠️ The docblock's hand-written counts had **already drifted** before this slice: it read `95 of 158` / `97 of 181` / `61 clean` while the file's own arrays held 90 rows of 159 targets and 69 clean. Re-derived here by parsing those arrays; the class is filed as #8659 and is not addressed in this PR.

## Pins added — `examples/schema-catalog/test/sidebar-trigger-dom-leak-5632.test.tsx`

Five cases, every one observed RED on purpose:

1. the judge is element-aware about `name` (the same bag reported differently on a button and on a div)
2. the full canary set reaches the renderer and none of it reaches the DOM
3. **the legitimate attributes on this host are exactly these** — the full set, which is what a "drops everything" filter fails
4. **the trigger still toggles the sidebar**, read off the `data-state` the sidebar itself carries
5. the declared pass-through channels still arrive, `style` included

Every case asserts real markup first, and `document.cookie` is cleared per case because `SidebarProvider` persists `sidebar_state` and reads it back on mount (#4234).

## Red legs — mutate, prove on disk, run, restore, prove restored

Each leg re-run against the final commit. Restore is `git checkout HEAD -- path` under an EXIT/INT/TERM trap, proven by an empty `git diff HEAD`; every leg's mutated blob hash differed from the HEAD blob, so no leg is void. Classified from vitest's JSON reporter.

| leg | mutation | this PR's pin | sweep gate |
|---|---|---|---|
| A | forward everything (the bug, restored) | **RED 3/5** | **RED** (`leaked 14 non-DOM`) |
| B | **drop everything** (the caricature that must not read as success) | **RED 2/5** | GREEN 203/203 |
| C | over-broad filter — the open `aria-*` / `data-*` families dropped | **RED 2/5** | GREEN 203/203 |
| D | the control rendered inert (`disabled`) | **RED 2/5**, incl. the toggle case | GREEN 203/203 |
| E | `style` no longer forwarded by name | **RED 1/5** (the `style` case) | GREEN 203/203 |
| F | the deleted ledger row put BACK | GREEN | **RED 2/203** — the inverted case *and* the two-way expiry |
| G | the element-awareness self-check ablated (both arms on a div) | **RED 1/5** | GREEN |

Both caricature directions go red on the pin, which is the point: **B, C, D and E are invisible to the sweep gate.** A filter that strips every attribute, one that strips the ARIA and the designer `data-*`, one that leaves an inert button, and one that swallows `style` all read as a perfect zero there. That is the same blind spot #7564 documented on the SVG host, in this host's vocabulary.

## Verification

- `pnpm exec vitest run packages/components/ packages/app-shell/ examples/schema-catalog/ scripts/__tests__/body-dialect-census.test.ts` — **Test Files 934 passed (934), Tests 10761 passed | 1 skipped (10762)**.
- Final targeted run on the shipped commit — `Test Files 3 passed (3), Tests 222 passed (222)`.
- `pnpm --filter @object-ui/components --filter @object-ui/app-shell --filter @object-ui/example-schema-catalog run type-check` — all three `Done`, on a tree whose dependency closure was built first (an unbuilt tree would have been a precondition, not a result).
- `pnpm exec eslint` on the three changed source files — **0 errors**, 11 pre-existing `no-explicit-any` warnings on the index signatures already in the file.
- `node scripts/check-changeset-presence.mjs` — `2 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s): .changeset/5632-sidebar-trigger-dom-passthrough.md.` `node scripts/check-changeset-no-major.mjs` — `No changeset declares a major bump.`
- `check:control-bytes`, `check:unreferenced-sources`, `check:phantom-deps`, `type-check:coverage`, `lint:coverage` — all exit 0.
- `check:sdui-registration-pins` exits **2 with a stated PRECONDITION** ("No console build to weigh"), which is NOT MEASURED locally rather than a failure — it needs `apps/console` built, and this diff adds, removes and renames no registration (11 `sidebar-*` registrations before and after). Declared to CI.

## One repo pin this nearly broke, recorded because it is not obvious

`scripts/__tests__/body-dialect-census.test.ts` slices this file from `register('sidebar-trigger'` to EOF and asserts the slice contains neither `schema.body` nor `schema.children` — that is how it pins this as the one `sidebar-*` registration reading no child list. The first draft of the new comment quoted `schema.body` while explaining why the *other* registrations destructure `schema`, and reddened the pin on a prose match. Reworded, and the constraint is now written beside the code. It is also why this fix does **not** add a `schema` parameter: the filter drops the key without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_