### PR TITLE
test(app-shell): route the two HomePage runtime-config doubles instead of sinking every url (objectui#8033)

### DIFF
--- a/.changeset/8033-homepage-fetch-router.md
+++ b/.changeset/8033-homepage-fetch-router.md
@@ -1,0 +1,13 @@
+---
+---
+
+Test-only change: the two `app-shell` `console/home` HomePage suites that boot the real
+runtime-config module (`HomePage.marketplaceDisabled.test.tsx`,
+`HomePage.aiStudioDisabled.test.tsx`) now serve `GET /api/v1/runtime/config` and
+`GET /api/v1/meta/_drafts` from one recording router that fails on any other url, instead
+of a blanket `fetch` sink that answered every url with the runtime-config body
+(objectui#8033). Their teardown also calls RTL `cleanup()` before `vi.unstubAllGlobals()`,
+so the real `fetch` is never back in place while the tree is still mounted
+(objectui#7439). All four stub sites across the two files are converted. `_drafts` answers
+an empty ledger, which is what `PendingDraftsBanner` already rendered from the failed read,
+so no assertion moves. No published behaviour changes — no product source is touched.

--- a/packages/app-shell/src/console/home/__tests__/HomePage.aiStudioDisabled.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/HomePage.aiStudioDisabled.test.tsx
@@ -56,7 +56,7 @@
 import '@testing-library/jest-dom/vitest';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import { MePermissionsProvider, type MePermissionsResponse } from '@object-ui/permissions';
 
 const navigateMock = vi.fn();
@@ -132,9 +132,97 @@ const serverConfig = (features: Record<string, unknown>) => ({
   branding: { productName: 'ObjectOS', productShortName: 'ObjectOS' },
 });
 
+/* ── The HomePage fetch router (objectui#8033) ────────────────────────────────
+ * These cases boot the REAL `initRuntimeConfig()`, so the global `fetch` has to
+ * answer `GET /api/v1/runtime/config`. It used to answer with a blanket SINK:
+ * one `vi.fn` handing the runtime-config body back for EVERY url. Two things
+ * were wrong with that.
+ *
+ * `HomePage` reaches more than one endpoint. Besides the config read, every
+ * render mounts `PendingDraftsBanner`, whose `usePendingDrafts({})` fetches
+ * `GET /api/v1/meta/_drafts` with the GLOBAL `fetch` — `usePendingDrafts.ts:48`,
+ * no `apiFetch` seam anywhere on the path — from its mount effect
+ * (`usePendingDrafts.ts:116` via `refresh` at `:90`). The sink handed THAT reader
+ * the runtime-config body; it found no `drafts` key and yielded `[]`, so nothing
+ * failed. And nothing could: a sink keeps no record of what it was handed and
+ * asserts nothing about what it served, so a future new escape from `HomePage`
+ * would be answered silently instead of going red.
+ *
+ * So the double is a RECORDING ROUTER — the shape objectui#5225 settled on,
+ * carried by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx`
+ * and installed by objectui#7307's batches in the four sibling files in this
+ * directory; copied from `HomePage.approvalsTarget.test.tsx` (batch 4, #8032).
+ * It serves exactly the two routes these renders reach, records every url it is
+ * handed, and `afterEach` fails on any url outside that set. This file is NOT on
+ * the network-escape burn-down list — that list reached zero and was retired, and
+ * no gate covers these two routes here — so that assertion is the file's own
+ * evidence rather than a duplicate of one.
+ *
+ * `_drafts` answers a known-EMPTY ledger in the `{ drafts: [...] }` envelope
+ * `fetchPendingDrafts` reads. Empty rather than seeded is load-bearing:
+ * `PendingDraftsBanner` renders `null` for both `count === null` (what the sink's
+ * unparseable answer produced) and `count === 0`, so no assertion in this file
+ * moves. Routes are matched on the PATHNAME because the hook appends a
+ * `?packageId=` scope for package-bound callers; the full url is what is recorded.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+const CONFIG_ROUTE = '/api/v1/runtime/config';
+const DRAFTS_ROUTE = '/api/v1/meta/_drafts';
+const SERVED_ROUTES = [CONFIG_ROUTE, DRAFTS_ROUTE];
+
+/** Every url this file's renders handed the global `fetch`, in request order. */
+let fetchCalls: string[] = [];
+
+/** The route key of a recorded url: its pathname, without the scope query. */
+const routeOf = (url: string) => url.split('?')[0];
+
+/**
+ * What `GET /api/v1/runtime/config` answers for the case now running — set by
+ * `bootOn` / `bootOnNoConfig` before `initRuntimeConfig()`. The per-case default
+ * is the 404 a runtime predating the endpoint gives, so a case that never boots
+ * cannot silently inherit the previous case's payload.
+ */
+let configAnswer: { ok: boolean; status: number; body: unknown } = { ok: false, status: 404, body: {} };
+
+/** Serve the two routes these renders reach; record every url regardless. */
+function installHomeRouter() {
+  fetchCalls = [];
+  configAnswer = { ok: false, status: 404, body: {} };
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      fetchCalls.push(url);
+      if (routeOf(url) === CONFIG_ROUTE) {
+        return {
+          ok: configAnswer.ok,
+          status: configAnswer.status,
+          json: async () => configAnswer.body,
+        };
+      }
+      if (routeOf(url) === DRAFTS_ROUTE) {
+        return { ok: true, status: 200, json: async () => ({ drafts: [] }) };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    }),
+  );
+}
+
+beforeEach(installHomeRouter);
+
+/** Boot the REAL runtime-config module over a served `/runtime/config` payload. */
 async function bootOn(body: Record<string, unknown>) {
   resetRuntimeConfigForTesting();
-  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200, json: async () => body })));
+  configAnswer = { ok: true, status: 200, body };
+  await initRuntimeConfig();
+}
+
+/** Boot against a runtime whose `/api/v1/runtime/config` answers 404. */
+async function bootOnNoConfig() {
+  resetRuntimeConfigForTesting();
+  configAnswer = { ok: false, status: 404, body: {} };
   await initRuntimeConfig();
 }
 
@@ -168,6 +256,17 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of being answered with the runtime-config body. No gate covers
+  // this file, so this line is the evidence that the double only served what it
+  // meant to serve.
+  expect(fetchCalls.filter((url) => !SERVED_ROUTES.includes(routeOf(url)))).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a read that cleanup()'s act-flush triggers
+  // would reach a live socket (objectui#7439).
+  cleanup();
   vi.unstubAllGlobals();
   resetRuntimeConfigForTesting();
 });
@@ -259,9 +358,7 @@ describe('Home on a runtime that DOES offer AI Studio', () => {
   });
 
   it('fails OPEN when the runtime answers no config at all', async () => {
-    resetRuntimeConfigForTesting();
-    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 404, json: async () => ({}) })));
-    await initRuntimeConfig();
+    await bootOnNoConfig();
 
     renderHome();
 

--- a/packages/app-shell/src/console/home/__tests__/HomePage.marketplaceDisabled.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/HomePage.marketplaceDisabled.test.tsx
@@ -34,7 +34,7 @@
 import '@testing-library/jest-dom/vitest';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MePermissionsProvider, type MePermissionsResponse } from '@object-ui/permissions';
 
@@ -104,9 +104,97 @@ const serverConfig = (cloudUrl: string, marketplace: boolean) => ({
   branding: { productName: 'ObjectOS', productShortName: 'ObjectOS' },
 });
 
+/* ── The HomePage fetch router (objectui#8033) ────────────────────────────────
+ * These cases boot the REAL `initRuntimeConfig()`, so the global `fetch` has to
+ * answer `GET /api/v1/runtime/config`. It used to answer with a blanket SINK:
+ * one `vi.fn` handing the runtime-config body back for EVERY url. Two things
+ * were wrong with that.
+ *
+ * `HomePage` reaches more than one endpoint. Besides the config read, every
+ * render mounts `PendingDraftsBanner`, whose `usePendingDrafts({})` fetches
+ * `GET /api/v1/meta/_drafts` with the GLOBAL `fetch` — `usePendingDrafts.ts:48`,
+ * no `apiFetch` seam anywhere on the path — from its mount effect
+ * (`usePendingDrafts.ts:116` via `refresh` at `:90`). The sink handed THAT reader
+ * the runtime-config body; it found no `drafts` key and yielded `[]`, so nothing
+ * failed. And nothing could: a sink keeps no record of what it was handed and
+ * asserts nothing about what it served, so a future new escape from `HomePage`
+ * would be answered silently instead of going red.
+ *
+ * So the double is a RECORDING ROUTER — the shape objectui#5225 settled on,
+ * carried by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx`
+ * and installed by objectui#7307's batches in the four sibling files in this
+ * directory; copied from `HomePage.approvalsTarget.test.tsx` (batch 4, #8032).
+ * It serves exactly the two routes these renders reach, records every url it is
+ * handed, and `afterEach` fails on any url outside that set. This file is NOT on
+ * the network-escape burn-down list — that list reached zero and was retired, and
+ * no gate covers these two routes here — so that assertion is the file's own
+ * evidence rather than a duplicate of one.
+ *
+ * `_drafts` answers a known-EMPTY ledger in the `{ drafts: [...] }` envelope
+ * `fetchPendingDrafts` reads. Empty rather than seeded is load-bearing:
+ * `PendingDraftsBanner` renders `null` for both `count === null` (what the sink's
+ * unparseable answer produced) and `count === 0`, so no assertion in this file
+ * moves. Routes are matched on the PATHNAME because the hook appends a
+ * `?packageId=` scope for package-bound callers; the full url is what is recorded.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+const CONFIG_ROUTE = '/api/v1/runtime/config';
+const DRAFTS_ROUTE = '/api/v1/meta/_drafts';
+const SERVED_ROUTES = [CONFIG_ROUTE, DRAFTS_ROUTE];
+
+/** Every url this file's renders handed the global `fetch`, in request order. */
+let fetchCalls: string[] = [];
+
+/** The route key of a recorded url: its pathname, without the scope query. */
+const routeOf = (url: string) => url.split('?')[0];
+
+/**
+ * What `GET /api/v1/runtime/config` answers for the case now running — set by
+ * `bootOn` / `bootOnNoConfig` before `initRuntimeConfig()`. The per-case default
+ * is the 404 a runtime predating the endpoint gives, so a case that never boots
+ * cannot silently inherit the previous case's payload.
+ */
+let configAnswer: { ok: boolean; status: number; body: unknown } = { ok: false, status: 404, body: {} };
+
+/** Serve the two routes these renders reach; record every url regardless. */
+function installHomeRouter() {
+  fetchCalls = [];
+  configAnswer = { ok: false, status: 404, body: {} };
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      fetchCalls.push(url);
+      if (routeOf(url) === CONFIG_ROUTE) {
+        return {
+          ok: configAnswer.ok,
+          status: configAnswer.status,
+          json: async () => configAnswer.body,
+        };
+      }
+      if (routeOf(url) === DRAFTS_ROUTE) {
+        return { ok: true, status: 200, json: async () => ({ drafts: [] }) };
+      }
+      return { ok: false, status: 404, json: async () => ({}) };
+    }),
+  );
+}
+
+beforeEach(installHomeRouter);
+
+/** Boot the REAL runtime-config module over a served `/runtime/config` payload. */
 async function bootOn(body: Record<string, unknown>) {
   resetRuntimeConfigForTesting();
-  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200, json: async () => body })));
+  configAnswer = { ok: true, status: 200, body };
+  await initRuntimeConfig();
+}
+
+/** Boot against a runtime whose `/api/v1/runtime/config` answers 404. */
+async function bootOnNoConfig() {
+  resetRuntimeConfigForTesting();
+  configAnswer = { ok: false, status: 404, body: {} };
   await initRuntimeConfig();
 }
 
@@ -136,6 +224,17 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of being answered with the runtime-config body. No gate covers
+  // this file, so this line is the evidence that the double only served what it
+  // meant to serve.
+  expect(fetchCalls.filter((url) => !SERVED_ROUTES.includes(routeOf(url)))).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a read that cleanup()'s act-flush triggers
+  // would reach a live socket (objectui#7439).
+  cleanup();
   vi.unstubAllGlobals();
   resetRuntimeConfigForTesting();
 });
@@ -195,9 +294,7 @@ describe('Home on a runtime that HAS a marketplace', () => {
   });
 
   it('fails OPEN when the runtime answers no config at all', async () => {
-    resetRuntimeConfigForTesting();
-    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 404, json: async () => ({}) })));
-    await initRuntimeConfig();
+    await bootOnNoConfig();
 
     renderHome();
 


### PR DESCRIPTION
Fixes #8033

The two `console/home` HomePage suites that boot the REAL runtime-config module each
installed a blanket `fetch` **sink** and tore it down in a locally registered
`afterEach` with **no `cleanup()` in front of it**. Both defects land here, together —
ordering without routing leaves the sink, routing without ordering leaves the socket
window.

## Preconditions, re-measured on `4dc80d0fc` before a line was written

| # | claim | reading |
|:--|:--|:--|
| 1 | both files unstub in a local `afterEach`, neither imports or calls `cleanup` | **CONFIRMED.** `grep -n cleanup` exits **1** in both files. The zero has its control in the same run: the same query finds `vi.unstubAllGlobals` at `marketplaceDisabled:139` / `aiStudioDisabled:171` and `vi.stubGlobal` at `:109`+`:199` / `:137`+`:263`. |
| 2 | there are **four** `vi.stubGlobal('fetch', …)` sites, not two | **CONFIRMED**, at exactly the four lines above — triage's re-measured numbers, unchanged. |
| 3 | the second route is real | **CONFIRMED.** `HomePage.tsx:209` calls `usePendingDrafts({})` inside `PendingDraftsBanner`, mounted at `HomePage.tsx:401` and `:487`; the hook fetches `/api/v1/meta/_drafts` at `usePendingDrafts.ts:48` from its mount effect (`:116` via `refresh` at `:90`), with the GLOBAL `fetch` and no `apiFetch` seam. |
| 4 | neither file is on the network-escape ledger | **CONFIRMED, and stronger: there is no ledger.** `KNOWN_ESCAPES` was retired on `4b9fe9819` when the burn-down reached zero, and `scripts/__tests__/network-escape-ledger.test.ts` now pins its ABSENCE. Neither filename appears anywhere outside its own directory (`grep` exit 1); the control for that query — `HomePage.approvalsTarget` — does return a hit, so the zero is a reading. |
| 5 | the reference router shape exists in batch 4 | **CONFIRMED.** Copied from `packages/app-shell/src/console/home/__tests__/HomePage.approvalsTarget.test.tsx` (objectui#7307 batch 4, PR #8032). No third shape was invented. |

## The four stub sites and what each became

| site (on `4dc80d0fc`) | was | is |
|:--|:--|:--|
| `HomePage.marketplaceDisabled.test.tsx:109` (`bootOn`) | blanket sink: `{ ok: true, status: 200 }` + the runtime-config body for **every** url | the shared recording router; `bootOn` now only sets `configAnswer` and awaits `initRuntimeConfig()` |
| `HomePage.marketplaceDisabled.test.tsx:199` (fail-open case) | second blanket sink: `{ ok: false, status: 404 }` for **every** url | `await bootOnNoConfig()` — drives the SAME router, whose `/runtime/config` leg answers 404 |
| `HomePage.aiStudioDisabled.test.tsx:137` (`bootOn`) | blanket sink | the shared recording router |
| `HomePage.aiStudioDisabled.test.tsx:263` (fail-open case) | second blanket sink | `await bootOnNoConfig()` |

After the change each file contains exactly **one** `vi.stubGlobal` — inside
`installHomeRouter()`, registered by a module-scope `beforeEach` so it covers every
`describe` block in the file.

## The router

Two routes, matched on the PATHNAME (`usePendingDrafts` appends a `?packageId=` scope
for package-bound callers; the full url is what gets recorded):

- `GET /api/v1/runtime/config` → the per-case `configAnswer`, set by `bootOn(body)` or
  `bootOnNoConfig()` **before** `initRuntimeConfig()`. `installHomeRouter` resets it to
  the 404 a runtime predating the endpoint gives, so a case that never boots cannot
  silently inherit the previous case's payload.
- `GET /api/v1/meta/_drafts` → a known-EMPTY ledger in the `{ drafts: [...] }` envelope
  `fetchPendingDrafts` reads. Empty rather than seeded is load-bearing:
  `PendingDraftsBanner` renders `null` for both `count === null` (what the sink's
  unparseable answer produced) and `count === 0`, so no assertion moves.
- anything else → `{ ok: false, status: 404 }`, **and recorded**.

`afterEach` then, in this order: assert nothing outside the served set was requested;
`cleanup()`; `vi.unstubAllGlobals()`; `resetRuntimeConfigForTesting()`. The
`cleanup()`-before-unstub pairing is the remedy the network-escape guard's own error
text spells out, and the ordering objectui#7439 landed — installed in 16 files by
objectui#7307's batches. **No gate covers these two files**, so that assertion is this
PR's own evidence.

## The assertion can fail — demonstrated, restore proven by blob hash

Both legs ran from one script whose `trap ... EXIT INT TERM` restores both paths from
HEAD, with absolute paths throughout, on the COMMITTED tree (`2aeecf4f8`), with the
mutation proven on disk by anchor counts and blob hashes rather than by an exit code.

**Leg A — non-vacuity: the router really is handed both routes.** The `afterEach` line
was mutated to demand the recorded set be EMPTY. Mutation on disk: injected anchor
count 1, removed anchor (`SERVED_ROUTES.includes`) count 0, blobs
`1e547fa8 → 0d97c54b` and `ec59bf4f → ed63ecfc`. **Red as predicted** — exit 1,
`Test Files 2 failed (2)`, `Tests 14 failed (14)`, every case enumerating exactly:

```
AssertionError: expected [ '/api/v1/runtime/config', …(1) ] to deeply equal []
+ [
+   "/api/v1/runtime/config",
+   "/api/v1/meta/_drafts",
```

So the served set is exactly the set requested, in all 14 cases, and neither route is
decoration.

**Leg B — the escape probe: an unexpected endpoint reds.** `void
fetch('/api/v1/ABLATION/unexpected-endpoint')` was injected into each file's
`renderHome()`. Mutation on disk: injected anchor count 1 in each, blobs
`1e547fa8 → 62ccca59` and `ec59bf4f → 39de5a39`. Predicted direction before running:
red, naming the unexpected url. **OBSERVED red** — exit 1, `Test Files 2 failed (2)`,
`Tests 14 failed (14)`, every case:

```
AssertionError: expected [ Array(1) ] to deeply equal []
+   "/api/v1/ABLATION/unexpected-endpoint",
```

Under the old sink that same probe is answered `{ ok: true }` with the runtime-config
body and the suites stay green. That is the whole difference between a sink and a
router, and it is what the card is about.

**Restore proven by observation, not by an exit code.** After each leg, both paths'
`git hash-object` are byte-equal to their `HEAD` blobs — `1e547fa8…` and `ec59bf4f…` —
and `git diff HEAD --name-only` is empty. No dist/preflight leg is owed: these are the
vitest projects' own test files, transformed from source.

## Checks — exit codes captured by redirect-then-capture, never through a pipe

All on the final head `d8a971b72`, working tree clean.

- `pnpm exec vitest run packages/app-shell/src/console/home/ scripts/__tests__/network-escape-ledger.test.ts` — exit **0**, `Test Files 13 passed (13)`, `Tests 75 passed (75)`, and **zero** lines matching `Network escape` or `ECONNREFUSED` in the whole run. The two files under change are `14 passed`, the same 14 as before the change: the router adds no case and removes none.
- `pnpm --filter @object-ui/app-shell run type-check` — exit **0** (`tsc --noEmit && tsc -p tsconfig.test.json`). Proven non-vacuous rather than assumed: `tsc -p tsconfig.test.json --listFiles` names each edited file exactly once. Its first reading on the freshly installed tree was TS2307 on `@object-ui/*` — a missing prerequisite, not a red gate; `pnpm --filter '@object-ui/app-shell^...' run build` (exit 0) is what it was owed, and it is green on the built tree.
- `eslint` over both edited files — exit **0**, `--format json` reports **2 files linted, 0 errors**, 2 warnings. Neither warning is mine: both are the pre-existing `no-explicit-any` on the `useObjectLabel` mock, at `marketplaceDisabled:53` and `aiStudioDisabled:74`, unmoved lines strictly before every insertion point in this diff.
- `node scripts/check-changeset-presence.mjs` — exit **1** before, exit **0** after: "2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)". The declaration is `.changeset/8033-homepage-fetch-router.md` with an **EMPTY frontmatter** — the explicit first-class pass for a test-only change under a released package's `src/`, per AGENTS.md §9. Not a label: objectui declares, it does not exempt.
- `node scripts/check-control-bytes.mjs` — exit **0** (6851 tracked text files), plus a `grep -naP` self-scan of the control range over all three changed paths, no hits.
- `node scripts/check-governed-queue-guard.mjs --test` over all changed paths — exit **0**, "NOT GOVERNED — 3 path(s) checked against 5 governed surface(s)". This PR nonetheless **stays in draft**: the dispatch fences it, no auto-merge, no merge.

The repo-wide `turbo run lint` / `turbo run type-check` runs belong to CI and CI is not
awaited here — the report is delivered at draft-PR time per the dispatch contract.

## Scope

Test files only; no product source is touched, and no assertion in either file changed.
Nothing was skipped, quarantined or silenced. Neither file is on any ledger, so no
ledger arithmetic is owed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_