### PR TITLE
fix(lint): guard the registry meta seam with an AST rule, not a source-text pin

### DIFF
--- a/.changeset/registry-assertion-ratchet-8316.md
+++ b/.changeset/registry-assertion-ratchet-8316.md
@@ -1,0 +1,13 @@
+---
+---
+
+Internal only — no published behaviour changes, so this declares "no release"
+deliberately rather than carrying a bump.
+
+`eslint.config.js` now scopes `@typescript-eslint/consistent-type-assertions`
+with `assertionStyle: 'never'` to `packages/core/src/registry/Registry.ts`, and
+the two source-text `not.toMatch` assertions that used to stand for the same
+claim in `packages/types/src/__tests__/injected-component-input-6950.test.ts`
+are retired (objectui#8316). The only edits under a published package's `src/`
+are that pin's removal and one docblock sentence in `Registry.ts` naming the
+guard that replaced it; the emitted code is byte-identical.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -322,6 +322,44 @@ export default tseslint.config({
     'object-ui/no-inline-spec-config': 'error',
   },
 }, {
+  // objectui#8316 ratchet — no type assertion in the registry's meta seam.
+  //
+  // The objectui#6950 ruling made removing the `as ComponentMeta` cast from
+  // `withElementDataSourceInput` a deliverable, on the ground that a cast at
+  // the one place `binding` is written is exactly what hides the next drift
+  // between `ELEMENT_DATA_SOURCE_INPUT` and its type. PR objectui#8297 removed
+  // it. Nothing the compiler runs can hold that removal: an assertion is
+  // invisible to `tsc` by construction, and it was measured — re-adding
+  // `as ComponentMeta` to the return leaves `packages/core`'s `tsc --noEmit`
+  // at exit 0, as does the `<ComponentMeta>{…}` spelling. (Control taken in
+  // the same run: a real type error on the line above, `const injected:
+  // InjectedComponentInput = 42`, does fail it — TS2322 at Registry.ts.)
+  //
+  // So the removal was pinned by reading the file's source text, in
+  // `packages/types/src/__tests__/injected-component-input-6950.test.ts`. That
+  // pin worked for the spelling it was written against and for nothing else:
+  // measured on 4dc80d0fc, re-adding `as ComponentMeta` turned it red, and
+  // re-adding `<ComponentMeta>{…}` — the same assertion, other spelling — left
+  // it green at 9 passed. A regex over source is also moved by a reflow and
+  // asserts an ABSENCE, which is what a broken pattern returns too. This rule
+  // replaces those two `not.toMatch` lines; the pin's positive half (the local
+  // is annotated `InjectedComponentInput`) is a different claim and stays.
+  //
+  // AST-level, so both spellings are one report and formatting cannot move it,
+  // and it fails at `Lint`, a gate the repo already runs over this file.
+  //
+  // ⛔ Scoped to the ONE file the ruling is about, deliberately. A repo-wide
+  // `assertionStyle: 'never'` is a much larger decision with its own decision
+  // box and is NOT this ratchet (objectui#8316); so is the pre-existing
+  // sibling `as unknown as RegistryConfigLike[]` in
+  // `packages/sdui-parser/scripts/gen-manifest.ts`, which this scope does not
+  // reach. `Registry.ts` carries zero type assertions today, so this lints
+  // clean with no allowlist.
+  files: ['packages/core/src/registry/Registry.ts'],
+  rules: {
+    '@typescript-eslint/consistent-type-assertions': ['error', { assertionStyle: 'never' }],
+  },
+}, {
   // objectui#5191 ratchet — `getBadgeColorClasses(color, value)` returns a
   // class string and therefore cannot carry an author-declared hex: it
   // quantizes the declared colour onto one of nine palette families. The

--- a/packages/core/src/registry/Registry.ts
+++ b/packages/core/src/registry/Registry.ts
@@ -397,9 +397,15 @@ type LazyEntry = {
  * because `ELEMENT_DATA_SOURCE_INPUT` carried a hand-written inline type and
  * `binding` had no declared home — and a cast at the one place the key is
  * written is exactly what would have hidden any later drift between the
- * constant and the type. `packages/types/src/__tests__/injected-component-input-6950.test.ts`
- * pins the cast's absence. Keep the local typed: if the shape ever stops
- * fitting, this line is where the compiler should say so.
+ * constant and the type. The absence is held by `eslint.config.js`, which
+ * scopes `@typescript-eslint/consistent-type-assertions` with
+ * `assertionStyle: 'never'` to THIS FILE (objectui#8316) — an AST rule,
+ * because `tsc --noEmit` stays at exit 0 with the cast re-added and the
+ * source-text pin that used to stand here was green for `<ComponentMeta>{…}`,
+ * the same assertion in the other spelling.
+ * `packages/types/src/__tests__/injected-component-input-6950.test.ts` still
+ * pins the positive half, that the local below is ANNOTATED. Keep it typed: if
+ * the shape ever stops fitting, that line is where the compiler should say so.
  */
 export function withElementDataSourceInput<T>(
   component: ComponentRenderer<T>,

--- a/packages/types/src/__tests__/injected-component-input-6950.test.ts
+++ b/packages/types/src/__tests__/injected-component-input-6950.test.ts
@@ -40,15 +40,32 @@
  * type-checks its tests through `tsconfig.test.json`, so re-widening a
  * declaration fails the build on the unused directive.
  *
- * ## Why two of the pins read SOURCE TEXT
+ * ## Why two of the pins read SOURCE TEXT, and what no longer does
  *
  * A cast is invisible to every runtime and every type-level assertion — that
  * is what a cast is for. `as ComponentMeta` returning to the splice would
  * compile, pass every runtime limb, and hide the next drift exactly as it hid
- * this one. So the absence is read off the file, the way
+ * this one. So the POSITIVE claims are read off the file, the way
  * `packages/core/src/registry/__tests__/component-meta-derives-from-canonical.test.ts`
  * reads its import line: a source-identity assertion is the only kind that
  * can see a cast.
+ *
+ * The cast's ABSENCE used to be read here too, as two `not.toMatch` regexes
+ * over the spliced function's body. objectui#8316 retired them and moved that
+ * claim to `eslint.config.js`, which scopes
+ * `@typescript-eslint/consistent-type-assertions` with `assertionStyle:
+ * 'never'` to `packages/core/src/registry/Registry.ts`. The two regexes were
+ * measured on 4dc80d0fc before they were removed: re-adding `as ComponentMeta`
+ * to the return did turn them red, so they were LIVE, not already broken — but
+ * re-adding the same assertion as `<ComponentMeta>{…}` left this file green at
+ * 9 passed. An AST rule reports both spellings, survives a reflow, and fails
+ * loudly rather than asserting an absence, which is also what a pattern that
+ * has stopped matching returns.
+ *
+ * What stays here is the pin's other half: the spliced local is ANNOTATED
+ * `InjectedComponentInput`. That is a positive claim about text that must be
+ * present, so it cannot go quiet the way an absence pin can, and it is a
+ * different claim from "no assertion" — ESLint would not notice its deletion.
  */
 
 import { readFileSync } from 'node:fs';
@@ -140,7 +157,7 @@ describe('the write sites are typed by `InjectedComponentInput` and carry no cas
     expect(src).toMatch(/import type \{[^}]*\bInjectedComponentInput\b[^}]*\} from '@object-ui\/types';/);
   });
 
-  it('the splice in `withElementDataSourceInput` names the type and has no `as ComponentMeta`', () => {
+  it('the splice in `withElementDataSourceInput` annotates the local with the injected type', () => {
     const src = read('packages/core/src/registry/Registry.ts');
     const start = src.indexOf('export function withElementDataSourceInput<');
     const end = src.indexOf('export class Registry<', start);
@@ -148,10 +165,9 @@ describe('the write sites are typed by `InjectedComponentInput` and carry no cas
     expect(end).toBeGreaterThan(start);
     const body = src.slice(start, end);
     expect(body).toContain('const injected: InjectedComponentInput = { ...ELEMENT_DATA_SOURCE_INPUT };');
-    // The cast the card measured. Any `as` assertion here would hide drift
-    // between the constant and the type, which is the defect this closed.
-    expect(body).not.toMatch(/\bas\s+ComponentMeta\b/);
-    expect(body).not.toMatch(/\}\s*as\s+[A-Za-z]/);
+    // The cast's ABSENCE is no longer asserted here — objectui#8316 moved it to
+    // the `assertionStyle: 'never'` rule `eslint.config.js` scopes to this file,
+    // which sees `<ComponentMeta>{…}` too and cannot go quiet on a reflow.
   });
 
   it('the declaration extends `ComponentInput` rather than restating its members', () => {

--- a/scripts/__tests__/registry-assertion-ratchet-8316.test.ts
+++ b/scripts/__tests__/registry-assertion-ratchet-8316.test.ts
@@ -1,0 +1,119 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8316 — the ratchet that replaced a source-text pin, and its fence.
+ *
+ * ## What this file is for
+ *
+ * The objectui#6950 ruling made removing the `as ComponentMeta` cast from
+ * `withElementDataSourceInput` a deliverable. Nothing the compiler runs can
+ * hold that removal — an assertion is invisible to `tsc` by construction, and
+ * it was measured on `4dc80d0fc`: with `as ComponentMeta` re-added to the
+ * return, `packages/core`'s `tsc --noEmit` exits 0 (control taken in the same
+ * run: `const injected: InjectedComponentInput = 42` on the line above does
+ * fail it, TS2322 at `Registry.ts`). So the removal was pinned by reading the
+ * file's source text, in
+ * `packages/types/src/__tests__/injected-component-input-6950.test.ts`.
+ *
+ * That pin was LIVE — re-adding `as ComponentMeta` did turn it red — and blind
+ * anyway: `<ComponentMeta>{…}`, the same assertion in the other spelling, left
+ * it green at 9 passed. `eslint.config.js` now scopes
+ * `@typescript-eslint/consistent-type-assertions` with `assertionStyle:
+ * 'never'` to `Registry.ts` instead, and that pin is retired.
+ *
+ * ## Why the ratchet needs a test of its own
+ *
+ * A rule scoped by a path glob has the same failure mode the pin had: if the
+ * glob stops selecting the file, ESLint reports nothing and every downstream
+ * reading — the package's `lint` script, `lint.yml`'s exit code — is green.
+ * A silent scope is a silent guard. So the assertions below are BEHAVIOURAL,
+ * driven through ESLint's own API against the real config, and every zero has
+ * a non-zero control in the same class taken in the same run.
+ *
+ * ## And the fence, which is half of it
+ *
+ * A repo-wide `assertionStyle: 'never'` ban is a much larger decision with its
+ * own decision box and is NOT what objectui#8316 proposed. The scope is one
+ * file. `neighbouring core files are untouched by the rule` is what holds that,
+ * and it is the reason a scope widened by accident fails here rather than
+ * arriving as a thousand-error lint run someone silences.
+ */
+
+import { ESLint } from 'eslint';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const RULE = '@typescript-eslint/consistent-type-assertions';
+
+const GUARDED = path.join(REPO_ROOT, 'packages/core/src/registry/Registry.ts');
+/** Same package, same extension, one directory over — differs only in path. */
+const NEIGHBOUR = path.join(REPO_ROOT, 'packages/core/src/data-scope/element-data-source.ts');
+
+const eslint = new ESLint({ cwd: REPO_ROOT });
+
+/** Rule ids reported for `code` when ESLint is told it lives at `filePath`. */
+async function ruleIdsFor(code: string, filePath: string): Promise<string[]> {
+  const [result] = await eslint.lintText(code, { filePath });
+  return (result?.messages ?? []).map((m) => m.ruleId ?? '<fatal>');
+}
+
+const countRule = (ids: string[]): number => ids.filter((id) => id === RULE).length;
+
+/**
+ * The two spellings of one assertion. `<T>expr` is legal in a `.ts` file (it is
+ * only ambiguous with JSX, and `Registry.ts` is not `.tsx`), which is exactly
+ * why a regex written against `as T` could not see it.
+ */
+const AS_CAST = 'export const meta = { inputs: [] } as ComponentMeta;\n';
+const ANGLE_CAST = 'export const meta = <ComponentMeta>{ inputs: [] };\n';
+const NO_CAST = 'export const meta: ComponentMeta = { inputs: [] };\n';
+
+describe('the registry meta seam refuses type assertions (objectui#8316)', () => {
+  it('reports `as ComponentMeta` in `Registry.ts`', async () => {
+    expect(countRule(await ruleIdsFor(AS_CAST, GUARDED))).toBe(1);
+  });
+
+  it('reports the `<ComponentMeta>{…}` spelling too — the half the source-text pin was blind to', async () => {
+    expect(countRule(await ruleIdsFor(ANGLE_CAST, GUARDED))).toBe(1);
+  });
+
+  it('permits an annotation, which is the shape the ruling asked for', async () => {
+    expect(countRule(await ruleIdsFor(NO_CAST, GUARDED))).toBe(0);
+  });
+
+  it('`Registry.ts` as it stands on disk carries no assertion — the ratchet lints clean today', async () => {
+    const [result] = await eslint.lintFiles([GUARDED]);
+    const reported = (result?.messages ?? []).filter((m) => m.ruleId === RULE);
+    expect(reported).toEqual([]);
+    // The zero above is a reading and not a broken invocation: the same file,
+    // in the same run, resolves rules and reports under them.
+    expect(result?.messages.length ?? 0).toBeGreaterThan(0);
+  });
+});
+
+describe('the scope is one file, not the repo (objectui#8316 fence)', () => {
+  it('leaves a neighbouring `packages/core` file alone', async () => {
+    // Controlled by the identical text scoring 1 at `Registry.ts` above; the
+    // two readings differ in the file path and in nothing else.
+    expect(countRule(await ruleIdsFor(AS_CAST, GUARDED))).toBe(1);
+    expect(countRule(await ruleIdsFor(AS_CAST, NEIGHBOUR))).toBe(0);
+  });
+
+  it('does not reach the `gen-manifest.ts` sibling the card recorded and did not file', async () => {
+    const sibling = path.join(REPO_ROOT, 'packages/sdui-parser/scripts/gen-manifest.ts');
+    const code = 'export const configs = [] as unknown as RegistryConfigLike[];\n';
+    // Two reports at the guarded path, because `as unknown as T` is two
+    // assertions — which is the control that makes the sibling's zero a
+    // reading rather than a pattern that failed to match.
+    expect(countRule(await ruleIdsFor(code, GUARDED))).toBe(2);
+    expect(countRule(await ruleIdsFor(code, sibling))).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #8316

> **Notation.** `ANGLE_CAST` below stands for the angle-bracket assertion form — the type name wrapped in angle brackets, written immediately before the expression. It is spelled out rather than shown because GitHub's body sanitizer eats tag-shaped fragments, including inside backticks.

## The measurement that came first

The card asked for one reading before any work, because **a pin asserting an absence gives the same green either way**. Taken on `4dc80d0fc`, restore proven by blob hash each time (`42216190f5dab75adf2a32c4a59b79d973e7afc1`), never by an exit code:

| mutation to the `withElementDataSourceInput` return | source-text pin | `packages/core` `tsc --noEmit` |
|---|---|---|
| none (`origin/main` as it stands) | green, 9 passed | exit 0 |
| `… } as ComponentMeta;` | **RED**, 1 failed / 9 | exit 0 |
| `return ANGLE_CAST{ … };` | **green, 9 passed** | exit 0 |
| control: `const injected: InjectedComponentInput = 42` | — | **exit 2**, `TS2322` at `Registry.ts(411,9)` |

**The pin is NOT already broken** — no p2 re-grade. It fails for the spelling it was written against. It is blind to the other one, which is half the card's complaint, and the `tsc` blindness the card asserts is confirmed rather than taken on the card's word. The control in the last row is what makes those three `exit 0`s readings rather than a `tsc` invocation that never looked at the file.

## Preconditions, verified against the tree

1. **CONFIRMED** — the cast is gone. Read the line, not the number: it is `Registry.ts:412` today, not `:394` (card) and not `:313` (#6950). The expression is `return { ...(meta ?? {}), inputs: [...inputs, injected] };`, with `const injected: InjectedComponentInput = { ...ELEMENT_DATA_SOURCE_INPUT };` above it.
2. **CONFIRMED** — the pin is `packages/types/src/__tests__/injected-component-input-6950.test.ts`. It slices the function body from the `export function withElementDataSourceInput` line to the `export class Registry` line and asserts `not.toMatch(/\bas\s+ComponentMeta\b/)` and `not.toMatch(/\}\s*as\s+[A-Za-z]/)` over it, plus one positive `toContain` on the annotated local.
3. **CONFIRMED (live)** — see the table.
4. **CONFIRMED (`tsc` is blind)** — see the table.
5. **CONFIRMED, with a correction.** `@typescript-eslint/consistent-type-assertions` is configured nowhere in this repo. ⚠️ **There is no `packages/lint`** — the triage comment names one, and this repo has no such package. Rules live in one flat config, `eslint.config.js`, and path scoping is already the house style: `files: ['packages/types/src/objectql.ts']` is an existing single-file ratchet three objects above the new one. So a scoped rule is expressible with what exists, in the place the repo already puts them.

## The change

`eslint.config.js` gains one config object scoping `@typescript-eslint/consistent-type-assertions` at `['error', { assertionStyle: 'never' }]` to `files: ['packages/core/src/registry/Registry.ts']`, and the two `not.toMatch` absence assertions it replaces are **retired**.

**Scope: that one file, and nothing else.** It is the file the #6950 ruling is about. `Registry.ts` carries zero type assertions today, so this lints clean with no allowlist. A repo-wide `assertionStyle: 'never'` is a separate decision with its own decision box and is not smuggled in here.

**The `gen-manifest.ts` sibling: NOT caught.** `as unknown as RegistryConfigLike[]` lives in `packages/sdui-parser/scripts/gen-manifest.ts`, a different package; the narrowest sound scope does not reach it, so nothing had to be contorted either way. Pinned as a fact rather than left to drift, in the fence test.

**What the rule still permits:** `as const`. Measured — `… } as const;` in `Registry.ts` leaves `eslint .` at exit 0, because typescript-eslint exempts const assertions from `assertionStyle`. It also permits everything outside this one file, by design. An ordinary annotation is permitted, which is the shape the ruling asked for.

## Proof the new guard fails, both spellings

`pnpm exec eslint .` from `packages/core` — the real gate command, not a targeted invocation:

```
control (pristine)     exit 0    0 consistent-type-assertions reports
as ComponentMeta       exit 1    412:10  error  Do not use any type assertions
ANGLE_CAST spelling    exit 1    412:10  error  Do not use any type assertions
as const               exit 0    (still permitted — see above)
```

Every leg restored with `git checkout HEAD -- packages/core/src/registry/Registry.ts` and the restore **proven by blob hash** back to `42216190f5dab75adf2a32c4a59b79d973e7afc1`, with `git diff HEAD` empty. Each mutation was proven to land on disk first (`grep -c` on both the replaced and the injected text, before and after) — a `sed` that matches nothing also exits 0.

And the retirement is real, not nominal: with `as ComponentMeta` re-added, the pin file is now **green at 9 passed** while `eslint` is **red** at the same instant.

## Why the new guard gets a test

A rule scoped by a path glob has the failure mode the pin had: if the glob stops selecting the file, ESLint reports nothing and the package's `lint` script, `lint.yml`'s exit code and everything downstream read green. `scripts/__tests__/registry-assertion-ratchet-8316.test.ts` drives the **real config** through ESLint's API. Ablated: repointing the scope to `RegistryX.ts` turns **4 of its 6 tests red**; restore proven by hash (`165c086ff993c968c5d6e1eb1140c233571d0a94`). Every zero in it has a non-zero control in the same class in the same run.

## Reported, not silently done

⚠️ One docblock sentence in `Registry.ts` said "`…injected-component-input-6950.test.ts` pins the cast's absence", which this PR makes false. It is corrected to name the rule that now holds it. **The cast site itself is byte-identical** — the change is entirely inside the comment above the `export function withElementDataSourceInput` line, which is outside the region the remaining pin slices.

## Checks

| check | outcome |
|---|---|
| `eslint .` in `packages/core` / `packages/types` | exit 0 / exit 0 (0 errors) |
| `pnpm lint:root` | exit 0 (0 errors) |
| `turbo type-check` `@object-ui/core` + `@object-ui/types` | exit 0 |
| `pnpm type-check:scripts` | exit 0 — and `--listFiles` shows the new test IS in that program |
| `vitest run --project unit packages/core/ packages/types/` | 281 files, 5591 passed |
| `vitest run --project unit scripts/__tests__/` | 126 files, 3692 passed, 2 skipped |
| `check:lint-rule-coverage` · `check:control-bytes` · `check:element-data-source-declaration` · `check:unreferenced-sources` · `lint:coverage` · `type-check:coverage` · `changeset:check` · `check-changeset-presence` | all exit 0 |
| `check:sdui-registration-pins` | exit 2 = **PREREQUISITE NOT MET**, not a red: it needs `apps/console/dist`. NOT MEASURED locally; it reads bundle output and this diff changes no registration. |

Changeset: `.changeset/registry-assertion-ratchet-8316.md`, **empty frontmatter** — the explicit "releases nothing" form from AGENTS.md §9. The only edits under a published package's `src/` are the pin's removal and that one docblock sentence; emitted code is unchanged. `check-changeset-presence` confirms it as a complete answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_