### PR TITLE
refactor(types)!: retire `BaseFieldMetadata.depends_on`, objectui's snake_case twin of the spec's `dependsOn`

### DIFF
--- a/.changeset/7357-retire-field-metadata-depends-on.md
+++ b/.changeset/7357-retire-field-metadata-depends-on.md
@@ -1,0 +1,54 @@
+---
+"@object-ui/types": minor
+"@object-ui/fields": minor
+"@object-ui/app-shell": minor
+"@object-ui/plugin-grid": patch
+"@object-ui/components": patch
+---
+
+**Removed `depends_on` from field metadata. Rename it to `dependsOn`.**
+
+FROM `depends_on` → TO `dependsOn`, on field-metadata documents. Nothing is
+renamed for you and there is no transition period: metadata that still spells the
+key the old way no longer gates a dependent lookup and no longer scopes its
+candidate query. It is silently inert, not an error.
+
+`depends_on` was objectui's own snake_case twin of `@objectstack/spec`'s
+field-level `dependsOn`. It was never a spec key — the object contract's
+`FieldSchema` refuses it BY NAME, so a producer that authored it produced a
+document the publish door rejects — and it is retired here under ADR-0049
+enforce-or-remove (maintainer ruling A on objectui#6153, 2026-09-02;
+objectui#7357). `dependsOn`, declared on `BaseFieldMetadata` since objectui#6153,
+is now the only spelling, and it is the one every reader widget already used.
+
+What changed, concretely:
+
+- `@object-ui/types` — `BaseFieldMetadata.depends_on?: string[]` is gone. Every
+  field-metadata face that inherited it (`LookupFieldMetadata`,
+  `SelectFieldMetadata`, …) loses it too. An annotated metadata literal carrying
+  `depends_on` is now an excess-property error, which is the intended signal.
+- `@object-ui/fields` — `LookupField` read
+  `cascadeMeta?.depends_on ?? cascadeMeta?.dependsOn`; it now reads `dependsOn`
+  only. This is the behaviour half: hosts that hand the widget an UNTYPED bag
+  (`as any`, a JSON metadata document off the wire) were unaffected by the type
+  removal alone and are affected by this. The option widgets (`SelectField`,
+  `MultiSelectField`, `RadioField`, `CheckboxesField`) never had a snake arm, so
+  nothing changes for them.
+- `@object-ui/app-shell` — `paramToField()` emitted `depends_on` onto the field
+  bag it hands the action-param dialog's widgets. It now emits `dependsOn`. This
+  was the one in-repo framework producer of the retired spelling; without this
+  half, dependent lookups in action-param dialogs would have gone dead silently.
+- `@object-ui/plugin-grid` — the relational-metadata ledger drops its
+  `depends_on` row, because the reader it recorded no longer exists.
+- `@object-ui/components` — comment only, no behaviour.
+
+⚠️ Hand-written objectui host applications outside this repository cannot be
+measured from here. If yours authors `depends_on` on field metadata, rename it to
+`dependsOn`; the shapes are identical (`['country']`, or
+`[{ field: 'account', param: 'account_id' }]`).
+
+Unrelated and untouched: `AdvancedValidationRule.depends_on` (cross-field
+validation dependencies, a different concept), the object-schema documents the
+metadata designer and `resolveActionParams` read (their snake legs read STORED
+pre-strict documents — objectui#7642's census verdict), and plugin-gantt's
+`dependenciesField: 'depends_on'`, which names a record data field, not this key.

--- a/.changeset/7357-retire-field-metadata-depends-on.md
+++ b/.changeset/7357-retire-field-metadata-depends-on.md
@@ -36,8 +36,14 @@ What changed, concretely:
   nothing changes for them.
 - `@object-ui/app-shell` — `paramToField()` emitted `depends_on` onto the field
   bag it hands the action-param dialog's widgets. It now emits `dependsOn`. This
-  was the one in-repo framework producer of the retired spelling; without this
-  half, dependent lookups in action-param dialogs would have gone dead silently.
+  was the one in-repo framework producer of the retired spelling, and the emit
+  has to move with the reader: a lookup param declaring the cascade key renders a
+  gated picker there, and without this half that gate would have silently
+  disappeared, leaving an unfiltered picker. (Precisely, and no larger: that
+  dialog supplies dependent values only to the option widgets, so the lookup's
+  gate in it never lifts on its own — a pre-existing limitation this change
+  neither introduces nor fixes. What moved is a permanent gate, not a working
+  cascade.)
 - `@object-ui/plugin-grid` — the relational-metadata ledger drops its
   `depends_on` row, because the reader it recorded no longer exists.
 - `@object-ui/components` — comment only, no behaviour.

--- a/content/docs/fields/lookup.mdx
+++ b/content/docs/fields/lookup.mdx
@@ -99,10 +99,12 @@ const contact: LookupFieldMetadata = {
 };
 ```
 
-The snake_case `depends_on` is objectui's legacy twin of the same key: still read
-by this widget, never a spec key, and retiring under
-[objectui#7357](https://github.com/objectstack-ai/objectui/issues/7357) — author
-`dependsOn`.
+`dependsOn` is the only spelling this widget reads.
+[objectui#7357](https://github.com/objectstack-ai/objectui/issues/7357) retired
+objectui's snake_case twin `depends_on`: it was never a `@objectstack/spec` key
+(the object contract refuses it by name, so a document carrying it is rejected
+at publish), and the widget no longer reads it. Metadata that still spells it
+that way does not gate and does not scope the picker — rename it to `dependsOn`.
 
 The value being edited, and the `className` / `disabled` a host supplies, are **not**
 metadata keys — they are runtime widget props. See [Field Widget Props](/docs/fields/widget-props).

--- a/content/docs/fields/select.mdx
+++ b/content/docs/fields/select.mdx
@@ -143,11 +143,11 @@ const province: SelectFieldMetadata = {
 A bare parent name (`dependsOn: "country"`, as in the form schema above) is the
 **form-level** shape, `FormField.dependsOn`; on field metadata the spec accepts
 only the array, and `SelectFieldMetadata` refuses the string for the same reason.
-The metadata key wins over the `dependsOn` widget prop a host may pass. The
-snake_case `depends_on` is objectui's legacy twin of the same key — read only by
-the lookup widget and retiring under
-[objectui#7357](https://github.com/objectstack-ai/objectui/issues/7357); author
-`dependsOn`.
+The metadata key wins over the `dependsOn` widget prop a host may pass.
+[objectui#7357](https://github.com/objectstack-ai/objectui/issues/7357) retired
+objectui's snake_case twin `depends_on`, which was never a `@objectstack/spec`
+key; `dependsOn` is the only spelling any widget reads. Metadata that still
+spells it the old way has no effect — rename it.
 
 The value being edited, and the `className` / `disabled` a host supplies, are **not**
 metadata keys — they are runtime widget props. See [Field Widget Props](/docs/fields/widget-props).

--- a/packages/app-shell/src/utils/paramToField.test.ts
+++ b/packages/app-shell/src/utils/paramToField.test.ts
@@ -104,11 +104,15 @@ describe('paramToField', () => {
   });
 
   // ⭐ objectui#7155 converged the lookup dialect: `displayField` / `idField` /
-  // `descriptionField` / `lookupFilters` are emitted in the SPEC spelling now.
+  // `descriptionField` / `lookupFilters` are emitted in the SPEC spelling now,
+  // and objectui#7357 added `dependsOn` to that half when it retired the
+  // snake_case `depends_on` this adapter used to emit — this face was the one
+  // in-repo framework producer of that spelling, so the emit had to move with
+  // the reader or the dialog's dependent lookups would have gone dead silently.
   // The remaining snake members below (`reference_to`, `title_format`,
-  // `lookup_columns`, `lookup_page_size`, `depends_on`) were outside that
-  // ruling's four keys and are unchanged — this mixed shape is deliberate, and
-  // asserting it keeps the two halves visibly separate.
+  // `lookup_columns`, `lookup_page_size`) were outside both rulings and are
+  // unchanged — this mixed shape is deliberate, and asserting it keeps the two
+  // halves visibly separate.
   it('maps the full lookup picker config to the field metadata the widgets read', () => {
     const field = paramToField(p({
       type: 'lookup',
@@ -134,8 +138,13 @@ describe('paramToField', () => {
       lookup_columns: [{ field: 'name' }],
       lookupFilters: [{ field: 'active', operator: '=', value: true }],
       lookup_page_size: 25,
-      depends_on: ['org'],
+      dependsOn: ['org'],
     });
+    // objectui#7357 — the emit moved, so pin that it MOVED rather than that it
+    // gained a second spelling. `LookupField` reads `dependsOn` only now; an
+    // emit that also carried `depends_on` would look green above while
+    // re-seeding the retired dialect onto every action-param field bag.
+    expect(field).not.toHaveProperty('depends_on');
   });
 
   it('lookup param without a referenceTo target falls back to a text input (param-only fallback)', () => {

--- a/packages/app-shell/src/utils/paramToField.ts
+++ b/packages/app-shell/src/utils/paramToField.ts
@@ -182,7 +182,15 @@ export function paramToField(param: ActionParamDef): Record<string, any> {
       lookup_columns: param.lookupColumns,
       lookupFilters: param.lookupFilters,
       lookup_page_size: param.lookupPageSize,
-      depends_on: param.dependsOn,
+      // ⭐ objectui#7357 retired `depends_on`, objectui's snake_case twin of
+      // the spec's field-level cascade key. This emit was the ONE in-repo
+      // framework producer of that spelling on a widget field-metadata bag —
+      // the card's own census said there was none, and it was wrong here — so
+      // leaving it would have handed `LookupField` a key it no longer reads and
+      // silently killed the ActionParamDialog's dependent lookups. The
+      // remaining snake members above are a different question (objectui#7155's
+      // ruling covered four keys and this was not one of them).
+      dependsOn: param.dependsOn,
     });
   }
 

--- a/packages/app-shell/src/utils/paramToField.ts
+++ b/packages/app-shell/src/utils/paramToField.ts
@@ -186,10 +186,24 @@ export function paramToField(param: ActionParamDef): Record<string, any> {
       // the spec's field-level cascade key. This emit was the ONE in-repo
       // framework producer of that spelling on a widget field-metadata bag —
       // the card's own census said there was none, and it was wrong here — so
-      // leaving it would have handed `LookupField` a key it no longer reads and
-      // silently killed the ActionParamDialog's dependent lookups. The
-      // remaining snake members above are a different question (objectui#7155's
-      // ruling covered four keys and this was not one of them).
+      // leaving it would have handed `LookupField` a key it no longer reads.
+      //
+      // ⚠️ What that would have changed, stated as MEASURED and not larger:
+      // this dialog supplies `dependentValues` only to
+      // `CASCADE_OPTION_WIDGET_TYPES` (`select` / `multiselect` / `radio` /
+      // `checkboxes`, the supply site being `ActionParamDialog.tsx`'s
+      // `cascadeProps`), and `LookupField`'s context fallback resolves to `{}`
+      // here, so a lookup param's cascade gate in this dialog is PERMANENT:
+      // it never lifts, whatever the user types into the parent. Dropping the
+      // read arm without moving this emit would therefore have flipped that
+      // permanent gate into an UNGATED, UNFILTERED picker — a silent behaviour
+      // change, and the reason the emit moves with the reader; ⛔ not a
+      // working cascade that would have died. That the gate never lifts here
+      // is a PRE-EXISTING residue of its own, not something this card
+      // introduced or fixes.
+      //
+      // The remaining snake members above are a different question
+      // (objectui#7155's ruling covered four keys and this was not one of them).
       dependsOn: param.dependsOn,
     });
   }

--- a/packages/components/src/renderers/form/__tests__/form-data-source-wiring.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-data-source-wiring.test.tsx
@@ -90,7 +90,7 @@ function renderWith(fieldTypes: string[]) {
               name: `f_${t}`,
               label: `F ${t}`,
               type: `field:${t}`,
-              field: { name: `f_${t}`, depends_on: ['parent'] },
+              field: { name: `f_${t}`, dependsOn: ['parent'] },
             })),
           ],
         }}

--- a/packages/components/src/renderers/form/__tests__/form-dependent-values.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-dependent-values.test.tsx
@@ -9,7 +9,7 @@
 /**
  * Live `dependentValues` injection for data-source fields (#2215).
  *
- * Dependent (cascading) lookups resolve their `depends_on` gate and filters
+ * Dependent (cascading) lookups resolve their `dependsOn` gate and filters
  * from the `dependentValues` prop. The form renderer must inject the LIVE
  * form values there — pre-fix nothing injected the prop and the widget's
  * context fallback read `ctx.formValues`, a member `SchemaRendererContext`

--- a/packages/components/src/renderers/form/__tests__/form-depends-on-labels.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-depends-on-labels.test.tsx
@@ -11,7 +11,7 @@
  * whose VALUES it already hands them — objectstack#5407.
  *
  * A dependency-gated lookup has to name its controlling field in user-visible
- * copy ("Select Account first"), but the widget only ever sees `depends_on`,
+ * copy ("Select Account first"), but the widget only ever sees `dependsOn`,
  * which holds API names. Only the form knows the label. It already resolves
  * exactly this map for the fixed-option widgets (`emptyHint`); the lookup side
  * had no equivalent, so the gate sentence interpolated `crm_account` into every
@@ -62,7 +62,7 @@ const fields = [
     name: 'contact',
     label: 'Contact',
     type: 'lookup',
-    field: { name: 'contact', reference_to: 'crm_contact', depends_on: ['crm_account'] },
+    field: { name: 'contact', reference_to: 'crm_contact', dependsOn: ['crm_account'] },
   },
   // A widget outside the data-source family, to pin the strip half.
   { name: 'topics', label: 'Topics', type: 'tags' },
@@ -84,7 +84,7 @@ describe('form renderer — dependsOnLabels plumbing (objectstack#5407)', () => 
     );
   });
 
-  it('keys the map by API name, so the widget can resolve its own depends_on', () => {
+  it('keys the map by API name, so the widget can resolve its own dependsOn', () => {
     renderForm();
 
     // The exact lookup the widget performs. Written as the resolution rather
@@ -107,7 +107,7 @@ describe('form renderer — dependsOnLabels plumbing (objectstack#5407)', () => 
             {
               name: 'contact',
               type: 'lookup',
-              field: { name: 'contact', depends_on: ['crm_account'] },
+              field: { name: 'contact', dependsOn: ['crm_account'] },
             },
           ],
         }}

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -2830,7 +2830,7 @@ ComponentRegistry.register('form',
                   // can say "Select Account first" instead of naming the raw
                   // API name (objectstack#5407). The whole form's map is passed
                   // (not a per-field slice) because the widget reads only the
-                  // entries its own `depends_on` names, and one stable
+                  // entries its own `dependsOn` names, and one stable
                   // reference keeps the widget's memo deps from thrashing.
                   dependsOnLabels: fieldLabelByName,
                   // The validation slot the widget props contract has declared

--- a/packages/fields/src/__tests__/selectFirst-gate-joiner-locale-parity.test.tsx
+++ b/packages/fields/src/__tests__/selectFirst-gate-joiner-locale-parity.test.tsx
@@ -120,7 +120,7 @@ function lookupGateHint(language: string): string {
             label: 'Contact',
             reference_to: 'crm_contact',
             reference_field: 'name',
-            depends_on: [PARENT_A.name, PARENT_B.name],
+            dependsOn: [PARENT_A.name, PARENT_B.name],
           } as any
         }
         value={undefined}

--- a/packages/fields/src/widgets/LookupField.dependsOn.test.tsx
+++ b/packages/fields/src/widgets/LookupField.dependsOn.test.tsx
@@ -9,7 +9,7 @@
 /**
  * Dependent (cascading) lookups — #2215.
  *
- * A lookup with `depends_on` must:
+ * A lookup with `dependsOn` must:
  *  1. gate every candidate surface while a dependency is empty,
  *  2. unlock as soon as the dependent values arrive (the form renderer
  *     injects live form values via the `dependentValues` prop), and
@@ -63,13 +63,13 @@ beforeEach(() => {
   }
 });
 
-describe('LookupField — depends_on gating and cascade filter (#2215)', () => {
+describe('LookupField — dependsOn gating and cascade filter (#2215)', () => {
   const dependentField = {
     name: 'contact',
     label: 'Contact',
     reference_to: 'contacts',
     reference_field: 'name',
-    depends_on: ['account'],
+    dependsOn: ['account'],
   } as any;
 
   it('gates the trigger while the dependency is empty', () => {
@@ -126,7 +126,7 @@ describe('LookupField — depends_on gating and cascade filter (#2215)', () => {
     const ds = makeDataSource();
     const explicitField = {
       ...dependentField,
-      depends_on: [{ field: 'account', param: 'account_id' }],
+      dependsOn: [{ field: 'account', param: 'account_id' }],
     };
     render(
       <LookupField

--- a/packages/fields/src/widgets/LookupField.dependsOnDeclared-6153.test.tsx
+++ b/packages/fields/src/widgets/LookupField.dependsOnDeclared-6153.test.tsx
@@ -6,13 +6,13 @@
  * 2026-09-02).
  *
  * `LookupField.dependsOn.test.tsx` (#2215) proves the gate and the hard
- * `$filter` through the legacy `depends_on` spelling on an `as any` literal.
+ * `$filter` on an `as any` literal — an untyped host bag.
  * This file proves the same two facts through the spec's field-level spelling
  * on ANNOTATED `LookupFieldMetadata` literals with NO cast — the
  * excess-property check refused `dependsOn` on this exact document before the
  * declaration landed (compile half), and the widget still gates and scopes on
- * it (runtime half). Both spellings stay readable until objectui#7357 retires
- * the snake_case twin; that card, not this one, drops the arm.
+ * it (runtime half). objectui#7357 has since retired the snake_case twin
+ * `depends_on`, so this spelling is now the only one the widget reads.
  */
 
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';

--- a/packages/fields/src/widgets/LookupField.dependsOnRetired-7357.test.tsx
+++ b/packages/fields/src/widgets/LookupField.dependsOnRetired-7357.test.tsx
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#7357 — the snake_case twin `depends_on` is RETIRED, and the
+ * retirement is observable, not merely declared.
+ *
+ * `BaseFieldMetadata.depends_on` was objectui's own consumer-side twin of
+ * `@objectstack/spec`'s field-level `dependsOn`. It was any a spec key —
+ * `FieldSchema` refuses it BY NAME, pinned in
+ * `@object-ui/types`' `field-metadata-depends-on-declared-6153.test.ts` — so a
+ * producer that authored it produced a document the publish door rejects.
+ * ADR-0049 enforce-or-remove, maintainer ruling A on objectui#6153
+ * (2026-09-02), no grace window (2026-08-27 ruling): one spelling, one concept.
+ *
+ * ## Why this file exists, when the type member is already gone
+ *
+ * Deleting the member is a COMPILE-time fact and is pinned type-level. The
+ * runtime read arm is a separate fact: `LookupField` reached its cascade key
+ * through `cascadeMeta?.depends_on ?? cascadeMeta?.dependsOn`, and every host
+ * that hands the widget an untyped bag (`as any`, `Record<string, any>`, a
+ * JSON metadata document off the wire) bypasses the type entirely. For those
+ * hosts the type deletion changes NOTHING; only dropping the arm does. This
+ * file measures the arm.
+ *
+ * ## The shape of each assertion: a live control on every zero
+ *
+ * Every "snake does nothing" assertion is paired with the SAME document spelled
+ * `dependsOn`, asserted to still do the thing. Without that pair a zero here
+ * would be satisfied by a broken harness — a widget that gates nothing, a data
+ * source that is never called — rather than by the retirement.
+ */
+
+import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { LookupField } from './LookupField';
+import { SelectField } from './SelectField';
+
+const contacts = [
+  { id: 'c1', name: 'Nora Field', account: 'a1' },
+  { id: 'c2', name: 'Oscar Grant', account: 'a2' },
+];
+
+function makeDataSource() {
+  const find = vi.fn(async (_obj: string, params: { $filter?: Record<string, unknown> } | undefined) => {
+    const account = params?.$filter?.account;
+    const data = account ? contacts.filter((c) => c.account === account) : contacts;
+    return { data, total: data.length };
+  });
+  return { find } as unknown as { find: ReturnType<typeof vi.fn> };
+}
+
+/** The reported document, minus its cascade key — each test adds one spelling. */
+const baseLookup = {
+  name: 'contact',
+  label: 'Contact',
+  reference_to: 'contacts',
+  reference_field: 'name',
+};
+
+function renderLookup(field: Record<string, unknown>, dependentValues: Record<string, unknown>) {
+  const ds = makeDataSource();
+  render(
+    <LookupField
+      field={field as any}
+      value={undefined}
+      onChange={vi.fn()}
+      readonly={false}
+      dataSource={ds as any}
+      {...({ dependentValues } as any)}
+    />,
+  );
+  return ds;
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1280 });
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as any;
+  try {
+    localStorage.clear();
+  } catch {
+    /* jsdom */
+  }
+});
+
+afterEach(cleanup);
+
+describe('objectui#7357 — a lookup carrying ONLY `depends_on` no longer cascades', () => {
+  it('CONTROL: the same document spelled `dependsOn` still GATES while the parent is empty', () => {
+    renderLookup({ ...baseLookup, dependsOn: ['account'] }, { account: null });
+    const gated = screen.getByTestId('lookup-trigger-gated');
+    expect(gated).toBeDisabled();
+    expect(gated).toHaveTextContent(/select account first/i);
+  });
+
+  it('the snake_case document does NOT gate — the arm that read it is gone', () => {
+    renderLookup({ ...baseLookup, depends_on: ['account'] }, { account: null });
+    // The zero: no gated trigger at all. Its control is the assertion above,
+    // which found one on the identical document spelled the spec's way.
+    expect(screen.queryByTestId('lookup-trigger-gated')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /select/i })).not.toBeDisabled();
+  });
+
+  it('CONTROL: the same document spelled `dependsOn` still SCOPES the candidate query', async () => {
+    const ds = renderLookup({ ...baseLookup, dependsOn: ['account'] }, { account: 'a1' });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /select/i }));
+    });
+    await waitFor(() => {
+      expect(ds.find).toHaveBeenCalledWith(
+        'contacts',
+        expect.objectContaining({ $filter: expect.objectContaining({ account: 'a1' }) }),
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Nora Field')).toBeInTheDocument();
+      expect(screen.queryByText('Oscar Grant')).not.toBeInTheDocument();
+    });
+  });
+
+  it('the snake_case document does NOT filter the lookup — every candidate is offered', async () => {
+    const ds = renderLookup({ ...baseLookup, depends_on: ['account'] }, { account: 'a1' });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /select/i }));
+    });
+    // Positive control for the zero below: the query really went out, so
+    // "no `account` in `$filter`" is a reading of a real call and not of silence.
+    await waitFor(() => {
+      expect(ds.find).toHaveBeenCalled();
+    });
+    for (const call of ds.find.mock.calls) {
+      expect(call[1]?.$filter ?? {}).not.toHaveProperty('account');
+    }
+    // The visible half of the same fact: the unscoped set reaches the popover.
+    await waitFor(() => {
+      expect(screen.getByText('Nora Field')).toBeInTheDocument();
+      expect(screen.getByText('Oscar Grant')).toBeInTheDocument();
+    });
+  });
+});
+
+/**
+ * The select half of the card's pin.
+ *
+ * ⚠️ Measured, and worth stating rather than implying: on the option widgets
+ * this was ALREADY true before this card. `SelectField` reads
+ * `field?.dependsOn ?? dependsOnProp` and has any had a snake arm
+ * (objectui#6153 landed that read through the declared type). So these two
+ * assertions pin a fact this change did not alter — they close the card's pin
+ * honestly instead of implying a behaviour change the lookup alone carried.
+ */
+describe('objectui#7357 — a select carrying ONLY `depends_on` does not gate either', () => {
+  const options = [
+    { label: 'Zhejiang', value: 'zj' },
+    { label: 'California', value: 'ca' },
+  ];
+
+  it('CONTROL: `dependsOn` gates the authored list while the parent is empty', () => {
+    render(
+      <SelectField
+        value={undefined}
+        onChange={vi.fn()}
+        field={{ name: 'province', type: 'select', dependsOn: ['country'], options } as any}
+        {...({ name: 'province', dependentValues: {} } as any)}
+      />,
+    );
+    expect(screen.getByTestId('select-empty-province')).toHaveTextContent(/select country first/i);
+    expect(screen.queryByTestId('select-trigger-province')).not.toBeInTheDocument();
+  });
+
+  it('`depends_on` does not gate — the authored list is offered', () => {
+    render(
+      <SelectField
+        value={undefined}
+        onChange={vi.fn()}
+        field={{ name: 'province', type: 'select', depends_on: ['country'], options } as any}
+        {...({ name: 'province', dependentValues: {} } as any)}
+      />,
+    );
+    expect(screen.queryByTestId('select-empty-province')).not.toBeInTheDocument();
+    expect(screen.getByTestId('select-trigger-province')).toBeInTheDocument();
+  });
+});

--- a/packages/fields/src/widgets/LookupField.dependsOnRetired-7357.test.tsx
+++ b/packages/fields/src/widgets/LookupField.dependsOnRetired-7357.test.tsx
@@ -5,7 +5,7 @@
  * retirement is observable, not merely declared.
  *
  * `BaseFieldMetadata.depends_on` was objectui's own consumer-side twin of
- * `@objectstack/spec`'s field-level `dependsOn`. It was any a spec key —
+ * `@objectstack/spec`'s field-level `dependsOn`. It was never a spec key —
  * `FieldSchema` refuses it BY NAME, pinned in
  * `@object-ui/types`' `field-metadata-depends-on-declared-6153.test.ts` — so a
  * producer that authored it produced a document the publish door rejects.
@@ -152,7 +152,7 @@ describe('objectui#7357 — a lookup carrying ONLY `depends_on` no longer cascad
  *
  * ⚠️ Measured, and worth stating rather than implying: on the option widgets
  * this was ALREADY true before this card. `SelectField` reads
- * `field?.dependsOn ?? dependsOnProp` and has any had a snake arm
+ * `field?.dependsOn ?? dependsOnProp` and has never had a snake arm
  * (objectui#6153 landed that read through the declared type). So these two
  * assertions pin a fact this change did not alter — they close the card's pin
  * honestly instead of implying a behaviour change the lookup alone carried.

--- a/packages/fields/src/widgets/LookupField.gateHintLabel.test.tsx
+++ b/packages/fields/src/widgets/LookupField.gateHintLabel.test.tsx
@@ -10,7 +10,7 @@
  * A gated lookup names its controlling field by LABEL — objectstack#5407.
  *
  * The gate sentence (`lookup.selectFirst`) is translated in all ten packs, but
- * its `{{fields}}` interpolation came straight off `depends_on`, which holds
+ * its `{{fields}}` interpolation came straight off `dependsOn`, which holds
  * API names. So the rendered hint was localized around a raw identifier in
  * every locale, English included:
  *
@@ -39,7 +39,7 @@ const gatedField = {
   label: 'Contact',
   reference_to: 'crm_contact',
   reference_field: 'name',
-  depends_on: ['crm_account'],
+  dependsOn: ['crm_account'],
 } as any;
 
 const dataSource = { find: vi.fn(async () => ({ data: [], total: 0 })) } as any;
@@ -96,7 +96,7 @@ describe('LookupField gate hint names the controlling field (objectstack#5407)',
   it('joins several controlling fields by their labels', () => {
     render(
       <LookupField
-        field={{ ...gatedField, depends_on: ['crm_account', 'lead_source'] }}
+        field={{ ...gatedField, dependsOn: ['crm_account', 'lead_source'] }}
         value={undefined}
         onChange={vi.fn()}
         readonly={false}

--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -294,9 +294,11 @@ export function LookupField({ value, onChange, field, readonly, error: fieldErro
    *    The remote field name (`param`) can differ from the local field name.
    *
    * The key is read THROUGH THE DECLARED TYPE (objectui#6153): `dependsOn` is
-   * `BaseFieldMetadata.dependsOn`, the spec's field-level spelling; `depends_on`
-   * is objectui's legacy twin, still declared and still honoured until
-   * objectui#7357 retires it — that card drops the snake_case arm below. Only
+   * `BaseFieldMetadata.dependsOn`, the spec's field-level spelling — and since
+   * objectui#7357 the ONLY one. That card retired objectui's snake_case twin
+   * `depends_on` under ADR-0049 enforce-or-remove: it was never a spec key
+   * (`FieldSchema` refuses it by name), so a second arm here would keep a
+   * renderer-side dialect alive against a contract that rejects it. Only
    * this cascade read goes through `LookupFieldMetadata`; the rest of
    * `fieldMeta` stays untyped because its camelCase-fallback family
    * (`displayField`, `descriptionField`, …) is objectui#4631's population.
@@ -306,7 +308,7 @@ export function LookupField({ value, onChange, field, readonly, error: fieldErro
    */
   const cascadeMeta: LookupFieldMetadata | undefined = fieldMeta;
   const dependsOn = useMemo<Array<{ field: string; param: string }>>(() => {
-    const raw = cascadeMeta?.depends_on ?? cascadeMeta?.dependsOn;
+    const raw = cascadeMeta?.dependsOn;
     // A bare parent name is the FORM-level shape (`FormField.dependsOn`), not the
     // field-level one the spec declares (array only) — an untyped host handing
     // one through still gets no cascade here, exactly as before.
@@ -314,13 +316,13 @@ export function LookupField({ value, onChange, field, readonly, error: fieldErro
     return raw.map((d) =>
       typeof d === 'string' ? { field: d, param: d } : { field: d.field, param: d.param ?? d.field },
     );
-  }, [cascadeMeta?.depends_on, cascadeMeta?.dependsOn]);
+  }, [cascadeMeta?.dependsOn]);
 
   /**
    * The gate sentence's `{{fields}}` — the controlling fields named the way the
    * user sees them on the form, not the way the metadata spells them.
    *
-   * `depends_on` holds API names, and this used to interpolate them straight
+   * `dependsOn` holds API names, and this used to interpolate them straight
    * into the sentence, so every locale — `en` included — read "Select
    * crm_account first" (objectstack#5407): an internal identifier in the UI,
    * not merely an untranslated word. The host form supplies the name→label map
@@ -860,14 +862,14 @@ export function LookupField({ value, onChange, field, readonly, error: fieldErro
   // take right now?" (#5195). It used to answer a different one — it re-read
   // each remembered id with `dataSource.findOne(referenceTo, id)`, which
   // carries no filter at all, so a record the author's `lookupFilters`
-  // exclude, or one belonging to the PREVIOUS value of a `depends_on` parent,
+  // exclude, or one belonging to the PREVIOUS value of a `dependsOn` parent,
   // stayed visible and selectable. Reported from a deployed project: pick a
   // product under project A, switch to project B, and the rail still offered
   // project A's product — the declared filter was enforced on every surface
   // except this one, leaving a server-side hook as the app's only defence.
   //
   // The fix is one filtered query, not a client-side prune: `popoverFilter`
-  // (base `lookupFilters` + the `depends_on` chain) is merged with the id
+  // (base `lookupFilters` + the `dependsOn` chain) is merged with the id
   // restriction through `mergeFilterNodes`, the repo's single filter sink, so
   // the SERVER decides admissibility exactly as it does for the main query.
   // Merging as a conjunction rather than spreading matters — a spread would

--- a/packages/fields/src/widgets/PeoplePicker.tsx
+++ b/packages/fields/src/widgets/PeoplePicker.tsx
@@ -179,7 +179,7 @@ export function PeoplePicker({
   // Recents and the current value used to ride ONE unfiltered `$in` query
   // (`seedIds = valueIds + recentIds`), which is the defect in #5195: the main
   // candidate query above merges `baseFilter` (the author's `lookupFilters`
-  // plus the `depends_on` cascade the host passes down) and this one merged
+  // plus the `dependsOn` cascade the host passes down) and this one merged
   // nothing, so the "Recently used" rail kept offering records the declared
   // filters exclude — a product from the previously-selected project, still
   // selectable after switching parents.

--- a/packages/fields/src/widgets/types.ts
+++ b/packages/fields/src/widgets/types.ts
@@ -201,7 +201,7 @@ export type FieldWidgetComponentProps<T = any> = {
    * sibling field in user-visible copy (the dependent-lookup gate hint).
    *
    * Only the form renderer knows a field's label — the widget sees its own
-   * metadata and a `depends_on` list of API names. Without this map the gate
+   * metadata and a `dependsOn` list of API names. Without this map the gate
    * sentence interpolated the raw API name into every locale, `en` included
    * ("Select crm_account first"), which is an internal identifier leaking into
    * the UI, not merely an untranslated word (objectstack#5407). This is the

--- a/packages/plugin-grid/src/__tests__/relationalMetaCopySet.derivation.test.ts
+++ b/packages/plugin-grid/src/__tests__/relationalMetaCopySet.derivation.test.ts
@@ -83,7 +83,7 @@
  * ANNOTATED ALIAS of it, `const NAME: TYPE = receiver;`, which is the same
  * object read through a declared type (objectui#6153 introduced the first one:
  * `LookupField`'s `cascadeMeta`, the `LookupFieldMetadata` view of `fieldMeta`
- * through which `dependsOn` / `depends_on` are now read; a consumer that
+ * through which `dependsOn` is read; a consumer that
  * de-casts a read this way has not stopped reading, and a scanner that could
  * not see it would have reported two real reads as orphans). Aliases are
  * derived from the consumer's own source on every run, never listed here. A key
@@ -237,12 +237,17 @@ function assertExtractorFoundKnownChains(x: Extraction): void {
   expect(x.cell).toContain('reference_to');
   expect(x['lookup-editor']).toContain('lookup_columns');
   expect(x['lookup-editor']).toContain('lookupColumns');
-  // objectui#6153: these two are read through the ANNOTATED ALIAS `cascadeMeta`
+  // objectui#6153: this one is read through the ANNOTATED ALIAS `cascadeMeta`
   // (`const cascadeMeta: LookupFieldMetadata | undefined = fieldMeta;`), not off
   // `fieldMeta` directly. An extractor that stopped following aliases would drop
-  // both, and the orphan assertion below would then call two real reads stale.
+  // it, and the orphan assertion below would then call a real read stale.
+  // ⭐ objectui#7357 removed the `depends_on` line that stood beside it. That
+  // was a DELETION, not a weakening: the snake arm it controlled for is gone
+  // from `LookupField`, so keeping the line would have pinned a read that no
+  // longer happens. The two-spelling SHAPE this control needs is unaffected —
+  // it lives on the `lookup_columns` / `lookupColumns` pair above, which that
+  // card did not touch.
   expect(x['lookup-editor']).toContain('dependsOn');
-  expect(x['lookup-editor']).toContain('depends_on');
   expect(x['user-editor']).toContain('reference_field');
 }
 

--- a/packages/plugin-grid/src/relationalMetaKeys.ts
+++ b/packages/plugin-grid/src/relationalMetaKeys.ts
@@ -369,7 +369,12 @@ export const RELATIONAL_META_READ_SET: Readonly<Record<string, RelationalMetaEnt
   // ── Read on this path, no producer ──────────────────────────────────────
   allow_create: { verdict: 'no-producer', readers: LOOKUP_EDITOR_ONLY, note: 'Runtime twin of `allowCreate`. Not on FieldSchema.' },
   lookup_page_size: { verdict: 'no-producer', readers: LOOKUP_EDITOR_ONLY, note: 'Runtime twin of `lookupPageSize`. Not on FieldSchema.' },
-  depends_on: { verdict: 'no-producer', readers: LOOKUP_EDITOR_ONLY, note: 'Runtime twin of `dependsOn`. Not on FieldSchema.' },
+  // ⭐ objectui#7357 removed the `depends_on` row. It is NOT a verdict change:
+  // the key left this table because `LookupField` stopped reading it — the
+  // snake_case twin was retired under ADR-0049 enforce-or-remove — and a row
+  // here states that a swept consumer reads the key. Keeping it would have made
+  // the derivation test's own orphan check the thing that failed, and widening
+  // the extractor to keep it alive would have asserted a read that is gone.
   picker: { verdict: 'no-producer', readers: BOTH_EDITORS, note: 'PeoplePicker variant opt-in. Not on FieldSchema.' },
   subtitle: { verdict: 'no-producer', readers: BOTH_EDITORS, note: 'PeoplePicker subtitle fields. Not on FieldSchema.' },
   avatarField: { verdict: 'no-producer', readers: BOTH_EDITORS, note: 'PeoplePicker avatar field. Not on FieldSchema.' },

--- a/packages/types/src/__tests__/field-metadata-depends-on-declared-6153.test.ts
+++ b/packages/types/src/__tests__/field-metadata-depends-on-declared-6153.test.ts
@@ -18,9 +18,11 @@
  *      installed spec refuses it on a field document — so the metadata type
  *      refuses it too, rather than letting an author write metadata the publish
  *      door rejects.
- *   4. The ordering the ruling set up: `LookupField` keeps BOTH arms of its
- *      two-spelling read until objectui#7357 retires `depends_on`; both are
- *      declared today. That card, not this one, drops the snake_case arm.
+ *   4. The ordering the ruling set up: `LookupField` kept BOTH arms of its
+ *      two-spelling read until objectui#7357 retired `depends_on`. That card
+ *      has since landed — it deleted the member, dropped the snake_case arm and
+ *      deleted this file's two pins on them (see the two markers below), so
+ *      `dependsOn` is now the only spelling declared and the only one read.
  *
  * ## Why membership pins are type-level here
  *
@@ -117,14 +119,21 @@ export const _lookupWithDependsOnShorthand: LookupFieldMetadata = {
   dependsOn: ['account'],
 };
 
-/* ── 4. The ordering: the legacy twin is still declared until #7357 ──────── */
-// objectui#7357 retires `depends_on` and deletes this literal in the same
-// stroke — until then both spellings are declared, and `LookupField` reads both.
+/* ── 4. RETIRED PIN — the legacy twin's declaration (objectui#7357) ──────── */
+// DELETED: `_legacyTwinStillDeclaredUntil7357`, an annotated `LookupFieldMetadata`
+// literal carrying `depends_on: ['account']`. It pinned ONE fact — that the
+// snake_case twin was still a DECLARED member of the field-metadata face while
+// both spellings were readable. objectui#7357 removed that member under ADR-0049
+// enforce-or-remove, so the fact it pinned no longer exists and the literal no
+// longer compiles. It is replaced, not merely dropped: the retirement's own
+// direction is pinned below, where the excess-property check now REFUSES the
+// spelling this literal used to prove legal.
 
-export const _legacyTwinStillDeclaredUntil7357: LookupFieldMetadata = {
+export const _retiredTwinIsRefusedByTheType: LookupFieldMetadata = {
   type: 'lookup',
   name: 'contact',
   reference_to: 'contacts',
+  // @ts-expect-error — objectui#7357: `depends_on` is no longer a member of `BaseFieldMetadata`; author `dependsOn`
   depends_on: ['account'],
 };
 
@@ -163,7 +172,7 @@ describe('installed @objectstack/spec — the field-level `dependsOn` that Field
     expect(res.error.issues.some((i) => i.code === 'invalid_type' && i.path.join('.') === 'dependsOn')).toBe(true);
   });
 
-  it('the legacy snake_case twin is refused BY NAME — it was never a spec key (objectui#7357 retires it)', () => {
+  it('the legacy snake_case twin is refused BY NAME — it was never a spec key (objectui#7357 retired it)', () => {
     const { dependsOn, ...rest } = provinceDocument;
     void dependsOn;
     const res = FieldSchema.safeParse({ ...rest, depends_on: ['country'] });
@@ -193,8 +202,15 @@ const readSites: Array<{ file: string; text: string; why: string }> = [
   },
   {
     file: 'packages/fields/src/widgets/LookupField.tsx',
-    text: 'const raw = cascadeMeta?.depends_on ?? cascadeMeta?.dependsOn;',
-    why: 'BOTH arms, through the declared type — objectui#7357 drops the snake_case one, not this card',
+    // RETIRED PIN (objectui#7357). This entry used to pin the text
+    // `const raw = cascadeMeta?.depends_on ?? cascadeMeta?.dependsOn;` — the
+    // TWO-ARM read, and its `why` read "BOTH arms … objectui#7357 drops the
+    // snake_case one, not this card". That card has landed, so the two-arm read
+    // is gone and a pin on its text would assert a line that no longer exists.
+    // The pin MOVES with the code rather than being deleted: read-site coverage
+    // is unchanged, and what it now records is the retirement itself.
+    text: 'const raw = cascadeMeta?.dependsOn;',
+    why: 'the ONE surviving arm, through the declared type — objectui#7357 retired the snake_case twin',
   },
 ];
 

--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -144,16 +144,15 @@ export interface BaseFieldMetadata {
    */
   validate?: FieldValidationFunction | FieldConstraints;
   
-  /**
-   * Field dependencies (Phase 3.2.3)
-   * List of fields that this field depends on
-   *
-   * objectui's LEGACY spelling of {@link BaseFieldMetadata.dependsOn} — never a
-   * `@objectstack/spec` key (`FieldSchema` refuses `depends_on` BY NAME,
-   * measured on 17.3.0). Only `LookupField` still reads it; it retires under
-   * enforce-or-remove on objectui#7357. Author `dependsOn`.
+  /*
+   * There is deliberately no `depends_on` here (objectui#7357). It was
+   * objectui's own snake_case twin of {@link BaseFieldMetadata.dependsOn} and
+   * never a `@objectstack/spec` key — `FieldSchema` refuses it BY NAME, so any
+   * producer that authored it produced a document the publish door rejects.
+   * Retired under ADR-0049 enforce-or-remove (maintainer ruling, 2026-09-02,
+   * recommendation A on objectui#6153, and no grace window per the 2026-08-27
+   * ruling). One spelling, one concept: author `dependsOn`.
    */
-  depends_on?: string[];
 
   /**
    * Controlling sibling field(s) — the spec's field-level cascade key, declared

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -1134,7 +1134,7 @@ export interface FormField {
    * The resolved object-field metadata **object** (typically a
    * {@link FieldMetadata} / server-served field definition), stashed by the
    * object-bound form paths so widgets can read `precision`, `currency`,
-   * `reference_to`, `depends_on`, … It feeds the field-widget `field` prop.
+   * `reference_to`, `dependsOn`, … It feeds the field-widget `field` prop.
    *
    * ⚠️ Same key, different layer: in the SPEC form-view vocabulary `field` is
    * a **string** (the referenced object-field name). That authored shape ends


### PR DESCRIPTION
Fixes #7357

Retires `BaseFieldMetadata.depends_on` — objectui's own snake_case twin of `@objectstack/spec`'s field-level `dependsOn` — under ADR-0049 enforce-or-remove. Maintainer ruling, 2026-09-02, decision batch #8 item 4 on objectui#6153, recommendation A, verbatim 「同意」. No grace window, per the 2026-08-27 ruling 「项目在创业阶段,用户也很少,短期不考虑渐进。」 — no shim, no re-export alias, no transition period.

One spelling, one concept. `dependsOn` stays on `BaseFieldMetadata`, `FormField.dependsOn` stays, and the widget prop `dependsOn` on `FieldWidgetComponentProps` stays.

## What changed, and why each half was needed

| half | file | why it is not optional |
|---|---|---|
| the type | `packages/types/src/field-types.ts` | the member is deleted, with a tombstone comment in the file's own `indexed` style |
| the read | `packages/fields/src/widgets/LookupField.tsx` | `const raw = cascadeMeta?.depends_on ?? cascadeMeta?.dependsOn;` becomes `const raw = cascadeMeta?.dependsOn;`. This is the only half an UNTYPED host feels: `as any` bags and JSON metadata off the wire bypass the type entirely, so the deletion above reaches none of them |
| the producer | `packages/app-shell/src/utils/paramToField.ts` | ⭐ see "the card's census was wrong" below — the one in-repo emitter of the retired spelling onto a widget bag |
| the ledger | `packages/plugin-grid/src/relationalMetaKeys.ts` | its `depends_on` row recorded a reader that no longer exists |
| the docs | `content/docs/fields/lookup.mdx`, `select.mdx` | both told authors the snake spelling was still read |

## ⭐ The card's own measurement was falsified: there IS a framework-level producer

The card states, from objectui `origin/main` `ec0a7b84`: "The snake spelling has no framework-level producer: no bridge, no spec, no generated metadata writes it." Re-measured on this branch, that is **false in one place**, and it is a place that would have broken:

`packages/app-shell/src/utils/paramToField.ts:185` emitted `depends_on: param.dependsOn` onto the `Record` bag that `ActionParamDialog` hands straight to the field widgets, where `LookupField` picks it up as `fieldMeta`. Chain, all in-repo:

`resolveActionParams()` reads a runtime object-schema field def and emits `ActionParamDef.dependsOn` (camel) → `paramToField()` re-spelled it to `depends_on` → `ActionParamDialog` passes the bag as the widget `field` prop → `LookupField` read `fieldMeta.depends_on`.

Dropping the read arm without moving this emit would have changed that dialog's behaviour silently, with no type error anywhere (the bag is an untyped `Record` of string keys to ANY, spelled out in words here because a literal angle-bracket generic does not survive GitHub's body sanitizer). Corrected at the producer, which is also what commandment #0.1 requires — the alternative was keeping a renderer-side dialect alive against a contract that rejects the key.

⚠️ **Stated as measured, and no larger.** An earlier revision of this body said the deletion "would have silently killed dependent lookups". That overstates the base state, and the contract review measured why: `CASCADE_OPTION_WIDGET_TYPES` (`packages/core/src/evaluator/optionRules.ts:214`) is `{select, multiselect, radio, checkboxes}`, `ActionParamDialog.tsx:356` supplies `dependentValues` only to that set, and `LookupField`'s context fallback resolves to an empty record there. Re-verified independently on this branch. ⇒ A lookup param's cascade gate in that dialog is **permanent**: it never lifts, whatever the user types into the parent. So what the counterfactual flips is a **permanent gate becoming an ungated, unfiltered picker** — still a silent behaviour change on a ruled card, still the reason the emit has to move with the reader, ⛔ but not a working cascade that would have died. The gate never lifting is a **pre-existing** residue this card neither introduces nor fixes.

## Deleted pins — each one justified

⛔ A deleted pin needs the same evidence as an added one, so here is what each pinned and why that thing is gone.

**1. `_legacyTwinStillDeclaredUntil7357`** (`packages/types/src/__tests__/field-metadata-depends-on-declared-6153.test.ts`) — an annotated `LookupFieldMetadata` literal carrying `depends_on: ['account']`. It pinned exactly one fact: that the snake twin was still a DECLARED member of the field-metadata face. That member is what this PR removes, so the literal no longer compiles and the fact it recorded no longer exists. Its own comment named this card as the one that would delete it.

It is **replaced, not merely dropped**: `_retiredTwinIsRefusedByTheType` is the same literal with a `ts-expect-error` directive on the key, so the type now pins the retirement's DIRECTION (the spelling is refused) where it used to pin its absence of one. Ablation below proves it fires.

**2. the two-arm read-site entry** in the same file — it pinned the text `const raw = cascadeMeta?.depends_on ?? cascadeMeta?.dependsOn;` with the note "BOTH arms … objectui#7357 drops the snake_case one, not this card". That card is this one; the two-arm line is gone, and a pin on its text would assert a line that does not exist. The entry **moves with the code** rather than being deleted — it now pins `const raw = cascadeMeta?.dependsOn;`. Read-site coverage is unchanged in count and stronger in content, and the sibling entry pinning `const cascadeMeta: LookupFieldMetadata | undefined = fieldMeta;` (the declared carrier) is untouched.

**3. the `depends_on` control line** in `packages/plugin-grid/src/__tests__/relationalMetaCopySet.derivation.test.ts` — this is the cross-package TEXT-SCAN pin. It extracts `LookupField.tsx`'s member reads by identifier, not by import, and `assertExtractorFoundKnownChains` asserted the extraction contained `depends_on`. The read is gone, so the line is deleted rather than the scanner widened — widening it to keep a dead entry alive is what would have asserted a falsehood. ⚠️ The control's SHAPE requirement survives: the "a consumer whose reads include both a camel and a snake spelling" property lives on the `lookup_columns` / `lookupColumns` pair in the same block, which this PR does not touch.

**4. the `depends_on` row in `RELATIONAL_META_READ_SET`** — a row there asserts that a swept consumer reads the key. Ablation below shows keeping it turns the derivation test red on its own orphan check, so this deletion is forced, not cosmetic.

## Pins this card owes, and the ablation for each

New file `packages/fields/src/widgets/LookupField.dependsOnRetired-7357.test.tsx` (6 tests, all green). Every "the snake spelling does nothing" assertion is paired with the SAME document spelled `dependsOn`, asserted still to do the thing — without that pair, a broken harness would satisfy the zero.

**Runtime ablation (the read arm).** Restored the two-arm read on disk, verified the mutation landed (anchor counts 1 to 0 and 0 to 1; blob `e9d573c` to `135b958`), re-ran the file:

```text
Tests  2 failed | 4 passed (6)
 × the snake_case document does NOT gate — the arm that read it is gone
 × the snake_case document does NOT filter the lookup — every candidate is offered
```

Exactly the two zero-assertions fired; the four camel controls stayed green. Restore verified by blob hash back to `e9d573c` and by an empty `git diff HEAD`.

**Type ablation (the declared member).** Re-declared `depends_on?: string[]` on `BaseFieldMetadata`, verified on disk (blob `d693480` to `faa4fe9`), ran `tsc -p tsconfig.test.json`:

```text
ABLATION-TSC-EXIT=2
src/__tests__/field-metadata-depends-on-declared-6153.test.ts(136,3): error TS2578: Unused 'ts-expect-error' directive.
```

Line 136 is the directive on the retired key. (The directive's leading at-sign is dropped throughout this body so it does not read as a GitHub mention; in the source it is spelled normally.) Restore verified by blob hash.

**Non-vacuity of the type instrument.** ⚠️ A type-level assertion is read by `tsc -p tsconfig.test.json` and by nothing else. Measured with `--listFiles`:

- `tsc -p tsconfig.test.json` — 614 files, and the pin file appears **1** time. Live control: `src/field-types.ts` also 1. Negative control: a plugin-grid path, 0.
- plain `tsc --noEmit` (the package's build project) — 277 files, pin file appears **0** times. So the build project genuinely excludes it, exactly as warned; a run of that project says nothing about this pin.

**Ledger ablation (the deleted row).** Re-added a `depends_on` row to `RELATIONAL_META_READ_SET`, verified on disk (blob `950c027` to `35b2aca`):

```text
ABLATION-VITEST-EXIT=1
 × carries no orphan — every declared reader is still a real read
AssertionError: The table says fields/src/widgets/LookupField.tsx reads these and it does not any more … expected [ 'depends_on' ] to deeply equal []
```

## Re-run census on this head, every zero with a live control

⛔ The card's population was not inherited. `git grep` on `9038177`, exit codes captured before any pipe.

- **Zod mirror** — the card says to check `packages/types/src/zod/` for the key. `depends_on` there: **0** (exit 1). Live control on the same tree: `dependsOn` in `zod/form.zod.ts` = **2** (exit 0). `BaseFieldMetadata` appears **0** times in that whole directory, so there is no field-types mirror at all. ⇒ Nothing to edit, and in particular nothing inside the hot-file fence.
- **Hot-file fence** — every fenced path that exists on this base carries **0** `depends_on`, each with a live control proving the grep reached the file: `packages/types/src/zod/**` (control 208), `README.md` (3), `package.json` (3), `src/record-components.ts` (17), `src/__tests__/zod-mirror-parity.test.ts` (23). Two fenced paths do not exist on this base at all (`src/strict-authoring-face.ts`, `vite.config.ts`) — files the held PRs add. **No fenced file was opened or edited.**
- **Instrument sanity** — a deliberately bogus term greps to 0 rows (exit 1) on the same command shape, so the zeros above are readings and not a broken invocation. Surviving-spelling control across `packages/`: `dependsOn` = 508 hits in 113 files.

## Deliberately NOT touched — measured, and each for a stated reason

- `packages/types/src/data-protocol.ts:737` — `AdvancedValidationRule.depends_on`. **A different concept** (cross-field validation dependencies, Phase 3.5.4), not the field-level cascade key. Same spelling, unrelated surface.
- `packages/app-shell/src/utils/resolveActionParams.ts:312,551` and `.../inspectors/ObjectFieldInspector.tsx:1239` — these read the **stored object-schema document**, not widget field metadata, and both emit camel. objectui#7642's census carries an explicit KEEP verdict for this class, spelled out in `readLookupFilters` right above the second one: retiring such a leg shows an admin an empty list for a stored pre-strict document and lets a save strand real data. A separate adjudicated question.
- `packages/types/src/internal/retired-field-keys.ts` — considered and rejected. That registry drives three DESIGNER strip sites and its membership rule ("the server refuses to store these") is satisfied, but its read-door column is precisely the ruling above; adding a row is a new three-column decision on stored documents, not part of retiring a widget-facing member.
- `packages/plugin-detail/src/fieldEnrichment.ts:206` — see the acceptance note below.
- plugin-gantt's `dependenciesField: 'depends_on'` (docs, README, schema-catalog JSON) — names a **record data field**, not this metadata key.

## Verification

Every exit code captured before any pipe.

| what | exit | result |
|---|---|---|
| `vitest run packages/types/ packages/plugin-grid/` | 0 | 268 files, 3917 tests passed |
| `vitest run packages/fields/` | 0 | 147 files, 2497 tests passed |
| `vitest run packages/app-shell/ packages/components/` | 0 | 902 files, 8598 passed, 1 skipped |
| `turbo run type-check` on the 5 affected packages | 0 | 34 tasks successful |
| `turbo run lint` on the same 5 (CI's own leg) | 0 | 0 errors in all five; warnings only, and this repo deliberately sets no `--max-warnings` |
| `node scripts/check-changeset-presence.mjs` | 0 | 19 source files of 5 released packages, 1 changeset declared |
| `pnpm check` (the CLI check CI runs at `lint.yml:481`) | 0 | "All checks passed" |
| `check:designer-field-key-parity` | 0 | OK |
| `check:spec-symbols` | 0 | nothing cites a key its spec symbol does not declare |
| `check:control-bytes` | 0 | 6848 tracked text files scanned |
| `check:doc-fences` | 0 | OK |
| `check:doc-types` | 0 | every documented component type registered |
| `check:doc-snippets` | 0 | 634 of 634 blocks judged, 0 failed (after the gate's own scoped build; its first run was exit **2** = PRECONDITION NOT MET, which is "could not run", not a red) |
| `check:doc-examples` | 0 | every covered example compiles or fails as its ledger declares (same precondition remedy) |
| `check:esm-specifiers` | 0 | no un-ledgered package emits an extensionless relative specifier |
| `check:node-esm-load` (plain) | **1** | ✗ 2 of 37 entries REFUSED, **foreign**: `@object-ui/auth` and `@object-ui/react-runtime`, both replayed from another worktree's turbo cache. ⛔ Neither package is in this diff |
| `check:node-esm-load --force-build` (the gate's own remedy) | 0 | Provenance leg: **37 of 37** gradable entries built by this tree; load leg 34 of 39 evaluated |
| `check-governed-queue-guard --test` on all 22 paths | 0 | NOT GOVERNED — none of the 5 governed surfaces matched |

⚠️ The plain `check:node-esm-load` red is the shared-container turbo cache, not this diff, and it is reported here as both readings rather than as one. ⛔ And it is NOT covered by CI on a PR: `node-esm-load-gate.yml` runs on a nightly cron and on push to `main`; the only per-PR leg is the cheap `check:esm-specifiers`. So this gate is measured **here or nowhere**.

### The repo-wide lint reading, and why the CI-shaped one is the one to read

A repo-wide `eslint . --no-inline-config --format json` linted **4560** files and reported 94 errors / 12507 warnings. That is not CI's shape: this repo's per-package `lint` script is a plain `eslint .`, and `--no-inline-config` disables in-file `eslint-disable` directives, which is where those errors come from. **0 of them are in this diff**: all 19 lintable changed files were seen by that run (19 of 19), with **0 errors** and 211 warnings, every warning a pre-existing `no-explicit-any` / `react-refresh` in files that already carry dozens. The CI-shaped run (`turbo run lint` over the five packages) exits 0.

Invariance of the narrowing: this config extends `tseslint.configs.recommended`, not `recommendedTypeChecked`, and declares no `parserOptions.project` / `projectService` — **type-aware linting is not enabled**, so a change to a type in this diff cannot move any verdict on a file the diff does not touch.

## ⛔ NOT measured

- **`examples/app-showcase` cascading-select and invoice-to-contact.** The card names these as pins. `examples/app-showcase` **does not exist in this repository** — measured, with a live control (`examples/` holds `byo-backend-console`, `console-starter`, `hello-world`, `schema-catalog`, and `schema-catalog` greps to 149 files). It lives in the sibling `objectstack` repo; `AGENTS.md:529` says `cd ../objectstack/examples/app-showcase`. Its objectui-side driver is `e2e/live/cascading-options.spec.ts`, which needs a real backend on :3000 plus the console on :5180 and is excluded from the default Playwright run. What CAN be said from here: that spec's own header records the showcase cascade as authored with per-option `visibleWhen` plus field-level **`dependsOn`**, and `dependsOn` / `depends_on` appear **nowhere** in `e2e/` outside that one sentence — so no in-repo e2e authored the retired spelling. "invoice-to-contact" matches **0** files repo-wide.
- **Out-of-repo hand-written objectui hosts.** The declared limit. The changeset spells the FROM/TO (`depends_on` to `dependsOn`) so an external author gets a rename instruction rather than a mystery.
- **The browser.** No dogfood run; the behaviour change is pinned by the widget tests above.
- **CI.** This report is written at PR-open time.

## Correction round after the ceiling-tier contract review (PASS)

Head `45bb295` adds one commit on top of `9038177`. `git diff --stat 9038177 45bb295`:

```text
 .../7357-retire-field-metadata-depends-on.md       | 10 ++++++++--
 packages/app-shell/src/utils/paramToField.ts       | 22 ++++++++++++++++++----
 .../LookupField.dependsOnRetired-7357.test.tsx     |  4 ++--
 3 files changed, 28 insertions(+), 8 deletions(-)
```

⛔ **No code changed.** Every non-comment line in that increment is changeset markdown prose; a mechanical scan of the increment's added and removed lines, after dropping comment and blank lines, leaves exactly the 10 changeset lines.

1. **The overstatement, in all three places it appeared** — this body (above), the changeset, and the `paramToField.ts` comment. The changeset is this repository's input to release notes, which is why the carrier was held for it. Rewritten to the measured claim: a permanent gate becoming an unfiltered picker, with the pre-existing limitation named as pre-existing.
2. **Two comment typos** in `packages/fields/src/widgets/LookupField.dependsOnRetired-7357.test.tsx` — line 8 read "It was any a spec key" and line 155 "has any had a snake arm"; both now read "never". Root cause, for the record: a blanket `as never` to `as any` substitution during the type-error fixup earlier in this branch also matched the substring inside "w**as never**" and "h**as never**". A scan of all 22 changed files finds no third instance.

Re-verified on `45bb295`, exit codes captured before any pipe: `vitest` on both touched suites **0** (2 files, 26 tests); `turbo type-check` for `fields` + `app-shell` **0** (31 tasks); `turbo lint` for the same two **0**, 0 errors; `check-changeset-presence` **0**; `check:control-bytes` **0**.

Provenance for this body: written by the implementer session `session_01Jmxdo7bmeqCQHLSfmLVX9w` (recorded here in prose because an edit to a pull request body does not preserve the session form of the footer block).

## 验收备注 — noted, not filed

- `packages/plugin-detail/src/fieldEnrichment.ts:206` still lists `'depends_on'` in the detail-view copy set. After this PR nothing reads that key off a widget field-metadata bag, so the entry forwards a key no consumer consults — the exact condition that file's own objectui#7155 comment cites when it excludes a key. It is harmless (no gate fails, no behaviour changes: the copy reached a reader that is now gone), so it is left alone rather than pulled into this card's verification surface. **Taker:** the next card in objectui#7642's object-schema census family, which already owns this file's class of question.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_


---
_Generated by [Claude Code](https://claude.ai/code)_