### PR TITLE
test(plugin-tree): split the contractEnvelope-6839 waits by expected outcome

### DIFF
--- a/.changeset/tree-contract-envelope-waits-6839.md
+++ b/.changeset/tree-contract-envelope-waits-6839.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only change in `@object-ui/plugin-tree`: the `contractEnvelope-6839` pin now
+splits its waits by expected outcome instead of reading the row count the instant
+the tree-grid wrapper mounts. No published behaviour changes.

--- a/packages/plugin-tree/src/ObjectTree.contractEnvelope-6839.test.tsx
+++ b/packages/plugin-tree/src/ObjectTree.contractEnvelope-6839.test.tsx
@@ -28,10 +28,64 @@
  * ⚠️ The refusal case is ALSO satisfied by an `extractRecords` that returns
  * `[]` for everything — an implementation strictly worse than the bug. The
  * `data` and bare-array cases refuse it: same rows, same mount.
+ *
+ * ## ⭐ Why the two outcomes wait DIFFERENTLY
+ *
+ * This file used to hand all three cases ONE wait, and it went red on `main`
+ * on PRs that cannot reach `plugin-tree` at all — `expected 1 to be 2`.
+ *
+ * That wait was `container.querySelector('[data-testid="object-tree"]') ??
+ * queryByText('No records')`, and the row count was read the instant it passed.
+ * The testid is on the TABLE WRAPPER, so it is a MOUNT signal, not a rows
+ * signal — and the rows this file counts arrive at a LATER commit than the
+ * table does.
+ *
+ * MEASURED, the mechanism is one race, in `ObjectTree` itself: expansion is a
+ * `useState<Set<string>>(new Set())` MIRROR that a `useEffect` keyed on
+ * `[roots, defaultExpandedDepth]` re-seeds from the forest. Rows are then
+ * `flattenVisible(roots, expanded)`. So when `find()`'s rows land, the commit
+ * that first paints the table still carries the PREVIOUS (empty) mirror: the
+ * root draws, its child does not, and `tbody tr` is 1. The mirror is seeded in
+ * the passive effect that follows, and a second commit takes it to 2. Probed
+ * on this file's own fixture, the DOM sequence is exactly
+ * `loading → table:1rows → table:2rows`, and the OLD wait's first passing state
+ * was `table:1rows`, where it yielded 1 — the CI failure, by construction and
+ * not by luck. Which of the two commits the read lands on is decided by machine
+ * load, which is why it was green locally and red on a saturated shard.
+ *
+ * ⚠️ NOT the same shape as the `plugin-kanban` twin (objectui#8532 / PR #8533),
+ * although it is the same family. That board had TWO independent races —
+ * `React.lazy(() => import('./KanbanImpl'))` chunk reveal AND a prop-mirrored
+ * `boardColumns` — and its symptom was `expected +0 to be 2`, nothing drawn at
+ * all. `plugin-tree` has NO lazy boundary anywhere in its source (`index.tsx`
+ * imports `./ObjectTree` eagerly), so only the mirrored-state half transfers,
+ * and the symptom is a PARTIAL draw: the root without its child.
+ *
+ * The two outcomes therefore no longer share a wait:
+ *
+ *   - the POSITIVE arms wait FOR the DESCENDANT row — the row that only exists
+ *     once the mirror has been seeded. That is the condition the race is
+ *     about, so waiting on it is what makes these arms immune to which commit
+ *     the read lands on. It is NOT a wider window on the same race, which is
+ *     all a raised timeout would have bought. They then assert the drawn SHAPE
+ *     (label + depth per row) plus the root's toggle reading `Collapse`, so the
+ *     pin is the seeded-open hierarchy and not merely "eventually 2 rows" — a
+ *     count alone is also satisfied by a tree that flattens everything.
+ *   - the REFUSAL arm cannot wait for an absence, so it takes a SETTLED read
+ *     anchored on something that DOES appear in that scenario: the tree's own
+ *     "No records" panel, which `ObjectTree` renders only once `loading` has
+ *     flipped false. Probed on the `records` fixture the sequence is
+ *     `loading → empty-state` with no table at any point, and the panel is
+ *     absent while loading — so this arm cannot pass by timing out on an
+ *     absence, which is the failure mode every absence-shaped pin has.
+ *
+ * ⛔ Do not fold these back into one wait, and ⛔ do not "fix" a future red here
+ * with a longer timeout: the failure was never slowness, it was reading a
+ * signal that does not carry the answer.
  */
 
 import React from 'react';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { render, waitFor, cleanup, within, act } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { ObjectTree } from './ObjectTree';
 
@@ -66,21 +120,87 @@ const asData: Envelope = (rows) => ({ data: rows, total: rows.length });
 const asBareArray: Envelope = (rows) => rows;
 const asRecords: Envelope = (rows) => ({ records: rows, total: rows.length });
 
+/** One row the forest actually painted, as the tree-grid describes it. */
+interface DrawnRow {
+  readonly label: string;
+  readonly depth: number;
+}
+
+/**
+ * Everything this file reads off a settled tree.
+ *
+ * `tableDrawn` and `emptyPanelDrawn` are carried SEPARATELY rather than
+ * collapsed into a row count: `ObjectTree` returns early on an empty forest and
+ * never mounts the table, so a refused envelope and a mount that never rendered
+ * are DIFFERENT DOM, not both "zero rows". Reporting which one happened is what
+ * keeps them distinguishable.
+ */
+interface Settled {
+  readonly rows: readonly DrawnRow[];
+  readonly tableDrawn: boolean;
+  readonly emptyPanelDrawn: boolean;
+  /** The root row's toggle, by accessible name — the mirror's state, named. */
+  readonly rootToggle: string | null;
+}
+
+/** The rows the tree-grid has painted, in document order. */
+function drawnRows(container: HTMLElement): DrawnRow[] {
+  return Array.from(
+    container.querySelectorAll('tbody tr[data-testid="object-tree-row"]'),
+  ).map((tr) => ({
+    label: (tr.querySelector('td')?.textContent ?? '').trim(),
+    depth: Number(tr.getAttribute('data-depth')),
+  }));
+}
+
+/**
+ * Has the tree drawn its own "No records" panel?
+ *
+ * ⚠️ `queryAllByText`, not `queryByText`: the singular form THROWS on multiple
+ * matches as well as answering `null` on none, so it cannot express "how many"
+ * without the throw becoming the result.
+ */
+function emptyPanelDrawn(container: HTMLElement): boolean {
+  return within(container).queryAllByText('No records').length > 0;
+}
+
+function readSettled(container: HTMLElement): Settled {
+  const root = container.querySelector('tbody tr[data-depth="0"]');
+  return {
+    rows: drawnRows(container),
+    tableDrawn: container.querySelector('[data-testid="object-tree"]') !== null,
+    emptyPanelDrawn: emptyPanelDrawn(container),
+    rootToggle: root?.querySelector('button')?.getAttribute('aria-label') ?? null,
+  };
+}
+
+/**
+ * What a case expects the tree to settle on — which is also what decides HOW it
+ * waits. See this file's header.
+ */
+type Outcome =
+  /** Wait FOR that shape. `because` is carried into the timeout message. */
+  | { readonly draws: readonly DrawnRow[]; readonly because: string }
+  /** No absence to wait for: anchor on the empty panel, settle, then read. */
+  | { readonly refuses: true };
+
+const REFUSES: Outcome = { refuses: true };
+
 /**
  * Mount the tree over a `find()` answering `envelope`, and hand back what it
- * settled on: the number of rows it drew, or `'empty-state'` when it drew its
- * own "No records" panel instead.
- *
- * The two outcomes are DIFFERENT DOM, not a count of 0 — `ObjectTree` returns
- * early on an empty forest and never mounts the table. Reporting which one
- * happened is what keeps a refused envelope distinguishable from a mount that
- * never rendered.
+ * settled on once `outcome` says it has settled.
  *
  * ⛔ Call ONCE per case, never inside a `waitFor` predicate (objectui#7802):
  * it renders, and `waitFor` re-runs its callback on DOM mutations, so a
  * predicate that renders feeds itself and leaks a container div per run.
+ *
+ * ⚠️ The predicates BELOW are inside `waitFor` on purpose and stay sound under
+ * that same rule: `drawnRows` and `emptyPanelDrawn` are pure reads of a
+ * container that is already mounted. They mount nothing, so re-running them on
+ * a DOM mutation is free — which is exactly the property this helper itself
+ * does not have.
  */
-async function settledOn(envelope: Envelope): Promise<number | 'empty-state'> {
+async function settledOn(envelope: Envelope, outcome: Outcome): Promise<Settled> {
   const find = vi.fn(async () => envelope(ROWS));
   const ds: any = {
     find,
@@ -103,16 +223,37 @@ async function settledOn(envelope: Envelope): Promise<number | 'empty-state'> {
   // touches no DOM. Without it "no rows" is satisfied by the mount's initial
   // empty state, which every arm renders identically.
   await find.mock.results[0].value;
+
+  if ('refuses' in outcome) {
+    // A refusal has no arrival to wait for, so this is a SETTLED read built
+    // from the two things that CAN be observed: `find` has answered (above),
+    // and the tree has drawn the "No records" panel — a node it renders only
+    // after `loading` flips false, so it is a COMPLETION ANCHOR and not the
+    // mere passage of time. `act` then flushes what React still had queued; it
+    // is the opposite of widening a timeout.
+    await waitFor(() =>
+      expect(
+        emptyPanelDrawn(container),
+        'the tree must have drawn its own "No records" panel before it is read — without that anchor an absence assertion passes by timing out',
+      ).toBe(true),
+    );
+    await act(async () => {});
+    return readSettled(container);
+  }
+
+  // Wait on the SHAPE, whose deepest row is the one the expansion mirror gates.
+  // The table wrapper appears a commit earlier, carrying the root alone.
   await waitFor(() =>
-    expect(
-      container.querySelector('[data-testid="object-tree"]') ??
-        screen.queryByText('No records'),
-    ).not.toBeNull(),
+    expect(drawnRows(container), outcome.because).toEqual(outcome.draws),
   );
-  return container.querySelector('[data-testid="object-tree"]')
-    ? container.querySelectorAll('tbody tr').length
-    : 'empty-state';
+  return readSettled(container);
 }
+
+/** Both positive arms draw the same seeded-open hierarchy. */
+const OPEN_FOREST: readonly DrawnRow[] = [
+  { label: 'Root', depth: 0 },
+  { label: 'Child', depth: 1 },
+];
 
 afterEach(() => {
   cleanup();
@@ -121,11 +262,24 @@ afterEach(() => {
 
 describe('ObjectTree — the find() envelope it reads (objectui#6839)', () => {
   it("still reads the contract's `data` member", async () => {
-    expect(await settledOn(asData), 'the declared rows member must still draw').toBe(2);
+    const because = 'the declared rows member must still draw the whole forest';
+    const settled = await settledOn(asData, { draws: OPEN_FOREST, because });
+    expect(settled.rows, because).toEqual(OPEN_FOREST);
+    // The CONDITION the wait above is keyed to, asserted rather than assumed:
+    // the child is on screen because the root was seeded OPEN, not because the
+    // tree flattens its forest regardless of expansion.
+    expect(settled.rootToggle, 'the root must have settled open').toBe('Collapse');
+    expect(settled.tableDrawn, 'the tree-grid must be the node that drew').toBe(true);
+    expect(settled.emptyPanelDrawn, 'and not the empty panel').toBe(false);
   });
 
   it('still reads a bare array — the live non-envelope shape fakes answer with', async () => {
-    expect(await settledOn(asBareArray), 'the bare-array arm must still draw').toBe(2);
+    const because = 'the bare-array arm must still draw the whole forest';
+    const settled = await settledOn(asBareArray, { draws: OPEN_FOREST, because });
+    expect(settled.rows, because).toEqual(OPEN_FOREST);
+    expect(settled.rootToggle, 'the root must have settled open').toBe('Collapse');
+    expect(settled.tableDrawn, 'the tree-grid must be the node that drew').toBe(true);
+    expect(settled.emptyPanelDrawn, 'and not the empty panel').toBe(false);
   });
 
   it('does NOT read `records` — not a QueryResult member', async () => {
@@ -133,9 +287,18 @@ describe('ObjectTree — the find() envelope it reads (objectui#6839)', () => {
     // declare, and did so AHEAD of `data`. The tree now settles on its own
     // "No records" panel — a DIFFERENT node from the table, which is what makes
     // this a reading of the refusal rather than of a mount that never happened.
+    const settled = await settledOn(asRecords, REFUSES);
     expect(
-      await settledOn(asRecords),
+      settled.emptyPanelDrawn,
+      'the refusal must be OBSERVED: the tree drew its "No records" panel',
+    ).toBe(true);
+    expect(
+      settled.rows,
       'a `records` envelope must reach the forest as no rows at all, not as the rows it names',
-    ).toBe('empty-state');
+    ).toEqual([]);
+    expect(
+      settled.tableDrawn,
+      'a refused envelope must not mount the tree-grid at all',
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Part of objectui#6839. CI repair — this unblocks PR #8553, whose `packages/types` diff cannot reach `plugin-tree` at all.

No card is claimed here and no assignee is set.

## The failure

```
packages/plugin-tree/src/ObjectTree.contractEnvelope-6839.test.tsx:124
AssertionError: the declared rows member must still draw: expected 1 to be 2
```

## The race, diagnosed here rather than ported

The file handed all three cases **one** wait:

```js
await waitFor(() =>
  expect(
    container.querySelector('[data-testid="object-tree"]') ?? screen.queryByText('No records'),
  ).not.toBeNull(),
);
return container.querySelector('[data-testid="object-tree"]')
  ? container.querySelectorAll('tbody tr').length
  : 'empty-state';
```

That testid is on the **table wrapper**, so it is a MOUNT signal — but the rows this file counts arrive a commit **later**. In `ObjectTree`, expansion is a state MIRROR:

```js
const [expanded, setExpanded] = useState<Set<string>>(new Set());
useEffect(() => {
  setExpanded(initialExpanded(roots, config.defaultExpandedDepth));
}, [roots, config.defaultExpandedDepth]);
const visibleRows = useMemo(() => flattenVisible(roots, expanded), [roots, expanded]);
```

So when `find()`'s rows land, the commit that first paints the table still carries the **previous (empty)** mirror: the root draws, its child does not, `tbody tr` is 1. The passive effect then seeds the mirror and a second commit takes it to 2.

**Measured, not assumed.** A probe recorded every DOM state this fixture passes through, and evaluated both waits at each:

| DOM state | old wait passes? | old wait yields | new wait passes? |
|---|---|---|---|
| `loading` | no | – | no |
| `table:1rows` | **yes** | **1** | no |
| `table:2rows` | yes | 2 | yes |

The old wait's *first passing state* is `table:1rows`, where it yields 1 — the CI red, by construction rather than by luck. Which commit the read lands on is decided by machine load, which is why it was green locally and red on a saturated shard.

## ⚠️ It is NOT the kanban twin's shape, although it is the same family

PR #8533 fixed `plugin-kanban` against **two** races — `React.lazy(() => import('./KanbanImpl'))` chunk reveal **and** a prop-mirrored `boardColumns` — with the symptom `expected +0 to be 2`, nothing drawn.

`plugin-tree` has **no lazy boundary anywhere in its source** (measured: `index.tsx` imports `./ObjectTree` eagerly; zero `React.lazy` / dynamic `import()` in the package's non-test sources). Only the mirrored-state half transfers, and the symptom is a **partial** draw — the root without its child, `expected 1 to be 2`. #8533's diff shape was read first and then re-derived against this file's actual mechanism rather than applied to it.

## What changed

Test file only. No timeout was raised, no assertion loosened, nothing skipped.

- **Positive arms** wait for the **descendant row** — the row the mirror gates — then assert the drawn **shape** (label + depth per row) plus the root toggle reading `Collapse`. The pin is the seeded-open hierarchy, not an eventual count: a count alone is also satisfied by a tree that flattens everything, and by a fix that merely waits longer.
- **Refusal arm** cannot wait for an absence, so it takes a settled read anchored on something that *does* appear in that scenario: the tree's own **"No records" panel**, which `ObjectTree` renders only after `loading` flips false. Probed on the `records` fixture the sequence is `loading → empty-state`, with no table at any point and the panel absent while loading — so this arm cannot pass by timing out, which is the failure mode every absence-shaped pin has.

## Evidence

**Deterministic reproduction.** Pushing the mirror's seed past the table's own commit (`setTimeout(…, 50)` on `setExpanded`, mutation proven on disk by anchor/marker counts and by `git hash-object` differing from the HEAD blob, restored to an empty `git diff HEAD`):

| file | result |
|---|---|
| pre-fix | `AssertionError: the declared rows member must still draw: expected 1 to be 2` ×2 arms |
| this PR | 3 passed |

An earlier leg with `setTimeout(…, 0)` landed on disk but did **not** redden — RTL's `asyncWrapper` drains one macrotask before returning, so the gap was hidden. Reported as fired-but-negative, not as void.

**Unmutated flake caught in-container.** Under a 6-way CPU load on a 4-core box, the pre-fix file (materialised from the parent commit) failed **1 of 12** runs with the exact CI text — same sentence, same `expected 1 to be 2`, same line 124. The fixed file: **20 of 20** green under the same load, and **20 of 20** idle.

**Ablations** (per-test classification from vitest's JSON reporter; every mutation proven on disk, every restore proven by an empty `git diff HEAD`):

| leg | mutation | result |
|---|---|---|
| B — caricature | `extractRecords` returns a **constant** row set for every input | refusal arm RED, positives green |
| C — caricature | `extractRecords` returns `[]` for every input | both positives RED, refusal green |
| D — non-regression | `extractRecords` reads `records` too, so the **wrong envelope draws** | refusal arm RED |
| E — wait non-vacuity | the mirror is **never** seeded | both positives RED (`[{Root,0}]` vs `[{Root,0},{Child,1}]`) |

Legs B and C are the caricature in both directions; D is the card's own subject — the pin still distinguishes the declared `data` member from the undeclared one.

## Family sweep

`git ls-files | grep contractEnvelope-6839` → **11** files. Control fired: both files known in advance (kanban, fixed; tree, broken) are in the result, so the reading is not an empty instrument.

Two are pure unit tests with no DOM (`packages/core/.../extract-records`, `packages/react/.../nonGridRowCeiling`) — not exposed. Of the nine DOM mounts, kanban is fixed and tree is this PR. The remaining **seven are structurally exposed** — a single shared wait on a mount/settle signal, then a count — and several say so in their own comments:

| file | shared wait | note |
|---|---|---|
| `plugin-calendar/ObjectCalendar` | `queryByTestId('calendar-view')` | comment already calls it "a mount signal rather than a rows signal" |
| `plugin-charts/ObjectChart` | `lastSchema ?? queryByTestId('chart-empty-state')` | this package **does** have a lazy boundary — closest kin to kanban |
| `plugin-dashboard/ObjectDataTable` | `queryByTestId('rows') ?? queryByTestId('table-empty-state')` | same two-branch shape this PR replaces |
| `plugin-dashboard/ObjectPivotTable` | `queryByTestId('pivot')` | sharpest: the refusal arm expects `0` on the **same node**, so "drawn empty" and "drawn before the data" are one reading |
| `plugin-map/ObjectMap` | `queryByText('Loading map...')` is null | comment already calls it "a settle signal rather than a rows signal" |
| `plugin-timeline/ObjectTimeline` | `getByTestId('timeline-renderer').getAttribute('data-item-count')` not null | satisfied the instant the renderer mounts, `"0"` included |
| `plugin-gantt/ObjectGantt` | positives already wait **for** the bars | inverse gap: the refusal arm reads `bars === 0` right after a wait on `find` having been *called*, with no completion anchor |

**Measured, and the zero is reported with its sensitivity:** all nine family files, five iterations under the same 6-way load — **zero failures**. That instrument is too weak to clear them: the pre-fix tree file's own observed rate was ~1 in 12, and five runs would miss an 8%-per-run flake roughly two thirds of the time.

⇒ **Listed, not fixed here.** Each needs its own component-level diagnosis the way this one got it; applying this diff shape to a race nobody has measured is the thing #8533's own write-up warns against.

## Gates

- `node scripts/check-changeset-presence.mjs` → `✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/tree-contract-envelope-waits-6839.md.` / `Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.`
- `node scripts/check-changeset-no-major.mjs` → `✅  No changeset declares a `major` bump.`
- `pnpm exec eslint packages/plugin-tree/src/ObjectTree.contractEnvelope-6839.test.tsx` → exit 0, 0 errors, 3 pre-existing `no-explicit-any` warnings (same three `any`s the file already carried).
- `pnpm --filter @object-ui/plugin-tree type-check` → exit 0, **MEASURED**: the closure was built first (`pnpm --filter '@object-ui/plugin-tree^...' build`), and `tsc -p tsconfig.test.json --listFiles` shows the changed file in the program.
- `pnpm exec vitest run packages/plugin-tree/` → `Test Files 12 passed (12)` / `Tests 54 passed (54)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_