### PR TITLE
fix(permissions): evaluateCondition reads a condition's field in three cases, not two

### DIFF
--- a/.changeset/permissions-evaluator-prototype-guard-8044.md
+++ b/.changeset/permissions-evaluator-prototype-guard-8044.md
@@ -1,0 +1,19 @@
+---
+'@object-ui/permissions': minor
+---
+
+`evaluateCondition` now **denies** a record when a row-level condition names something that is not the record's own data. It used to **admit** it — silently, on a permission boundary.
+
+The guard it replaces refused three field names by list (`__proto__`, `constructor`, `prototype`) and read every other name with `hasOwnProperty`. `hasOwnProperty` collapses *inherited* into *absent*, and on a negative operator absent ADMITS, so every prototype member outside those three spellings passed every record through the rule that existed to hide it. Measured against the record `{ id: 1, tenant: 'acme' }`: `{ field: 'toString', operator: 'neq' }` returned `true`, as did `valueOf`, `hasOwnProperty` and `isPrototypeOf`, on both `neq` and `not_in`. A longer list does not close this — a list enumerates spellings, and `Object.prototype` has more of them than any list will hold.
+
+**The second reach path needs no crafted condition.** The same read widened for records whose value is *inherited*: on `Object.create({ tenant: 'acme' })`, `{ field: 'tenant', operator: 'neq', value: 'acme' }` returned `true` — the record's tenant *is* `acme`, and the rule that hides `acme` rows admitted it. A class instance with a prototype accessor is enough to reach it.
+
+**The field a condition names is now read in three cases instead of two.** A name in the refused list denies. An own member is read as before, including a record whose own key happens to be spelled `toString`. A name that is not an own member but still resolves on the record's prototype chain denies, because the value exists but is not this record's data. A name that resolves nowhere is a genuinely absent field and still reads as `undefined`, so the ordinary "this record has no `status`" rules keep every verdict they have always had.
+
+That last case is load-bearing rather than a detail: refusing *every* non-own read would deny records this evaluator should admit, which on a permission boundary is a worse defect than the fail-open being closed.
+
+This is the shape `readField` in `@object-ui/core`'s `DataScopeManager` adopted at objectui#7751, ported back to the evaluator that was #7751's reference — and which, it turned out, carried the defect it was being used as the standard for. The two evaluators now give the same answer for a prototype-named field and for an inherited value; operator SPELLING (`neq` / `not_in` here, `ne` / `nin` there) is untouched and remains objectui#7750's question.
+
+**The narrowing, named plainly for anyone upgrading with conditions already stored.** A condition loses records in exactly two shapes: one that names a prototype member (`toString`, `valueOf`, `hasOwnProperty`, `isPrototypeOf`, …), and one that reads a field records inherit from a shared prototype rather than own — for the second, the fix is to give the record the field as its own data. Measured over a 3696-case differential matrix of field names, record shapes, operators and values, replaying every case through both the previous release's read and this one: **234 verdicts narrowed, zero widened**, and zero change across the 924 genuinely-absent-field cases.
+
+Graded `minor` because a release reader can observe the narrowing on stored conditions; no declared type changed and the set of inputs the evaluator accepts has not widened.

--- a/packages/core/src/data-scope/DataScopeManager.ts
+++ b/packages/core/src/data-scope/DataScopeManager.ts
@@ -295,15 +295,16 @@ type FieldRead = { readable: true; value: unknown } | { readable: false };
  *          returned exactly as before, so the ordinary "this row has no
  *          `status`" rules keep the verdicts they have always had.
  *
- * Case 3 is where this goes further than the sibling, deliberately. Reading
- * with `hasOwnProperty` alone collapses "inherited" into "absent", and on a
+ * Case 3 is where this went further than the sibling. Reading with
+ * `hasOwnProperty` alone collapses "inherited" into "absent", and on a
  * negative operator absent ADMITS: `{ field: 'toString', operator: 'ne' }`
- * admits every row through `evaluateCondition` in `@object-ui/permissions`
- * today, measured, because `toString` is not one of the three names it
- * refuses. Distinguishing inherited from absent closes the whole class rather
- * than three spellings of it, and it is what keeps this change a NARROWING:
- * collapsing inherited into absent would have flipped inherited-value rows
- * from denied to admitted on `ne` / `nin`.
+ * admitted every row through `evaluateCondition` in `@object-ui/permissions`
+ * — measured — because `toString` was not one of the three names its list
+ * refused. objectui#8044 ported this same three-case read there, so the two
+ * evaluators now agree. Distinguishing inherited from absent closes the whole
+ * class rather than three spellings of it, and it is what keeps this change a
+ * NARROWING: collapsing inherited into absent would have flipped
+ * inherited-value rows from denied to admitted on `ne` / `nin`.
  *
  * A `null` / `undefined` row still throws from the `hasOwnProperty` call, as
  * the direct `row[field]` access it replaces did.

--- a/packages/core/src/data-scope/__tests__/DataScopeManager.hardening.test.ts
+++ b/packages/core/src/data-scope/__tests__/DataScopeManager.hardening.test.ts
@@ -71,9 +71,10 @@ describe('DataScopeManager hardening — field reads (objectui#7751 gap 1)', () 
 
   // The class, not three spellings of it. A name list enumerates; the prototype
   // chain has more members than any list holds, and each one that is not on the
-  // list reads as an absent field, which ADMITS on a negative operator. This is
-  // the gap the sibling still has (objectui#8044) and the reason this evaluator
-  // distinguishes "inherited" from "absent" instead of copying its read.
+  // list reads as an absent field, which ADMITS on a negative operator. That is
+  // the reason this evaluator distinguishes "inherited" from "absent" instead
+  // of copying the sibling's read — and objectui#8044 has since ported the same
+  // three-case read back to the sibling, so the two now agree.
   it.each([
     '__proto__',
     'constructor',
@@ -247,31 +248,30 @@ describe('cross-evaluator conformance — both evaluators refuse the same rules'
   });
 
   /**
-   * Where the two evaluators are NOT yet equal, asserted rather than left to be
-   * rediscovered. Both rows below are the sibling's open gap objectui#8044:
-   * its guard is a three-name list plus a `hasOwnProperty` read, which
-   * collapses "inherited" into "absent", and absent ADMITS on a negative
-   * operator. `DataScopeManager` distinguishes the two and denies.
+   * CLOSED at objectui#8044 — these two blocks were written as `KNOWN GAP`
+   * assertions expecting the sibling to ADMIT, precisely so that fixing it
+   * would turn this file red and lead the implementer here. It did. The
+   * sibling now reads its field in the same three cases `readField` above
+   * does, so the rows below have flipped to `false` and joined the conformance
+   * table: both evaluators refuse a prototype member name, and both refuse a
+   * value the record inherits rather than owns.
    *
-   * ⚠️ When objectui#8044 lands, these expectations FLIP to `false` and this
-   * block folds into the table above. It is written as an assertion, not a
-   * comment, so that fixing the sibling turns this red and tells the
-   * implementer where the standard is recorded. ⛔ Do not "fix" a red here by
-   * loosening `DataScopeManager` to match.
+   * ⛔ A red here is never fixed by loosening either evaluator to match the
+   * other. The whole file exists because the two diverged twice.
    */
   it.each([
     ['toString'],
     ['valueOf'],
     ['hasOwnProperty'],
-  ])('KNOWN GAP objectui#8044 — the sibling still admits the prototype member name %s', (field) => {
+  ])('a prototype member name outside the refusal list — %s — is refused by both', (field) => {
     expect(admits(field, NEGATIVE_EQ.core, 'x', record)).toBe(false);
-    expect(sibling(field, NEGATIVE_EQ.sibling, 'x', record)).toBe(true);
+    expect(sibling(field, NEGATIVE_EQ.sibling, 'x', record)).toBe(false);
   });
 
-  it('KNOWN GAP objectui#8044 — the sibling admits an inherited value under a negative rule', () => {
+  it('an inherited value under a negative rule is refused by both', () => {
     const inherited = Object.assign(Object.create({ tenant: 'acme' }), { id: 1 }) as Record<string, unknown>;
     expect(admits('tenant', NEGATIVE_EQ.core, 'acme', inherited)).toBe(false);
-    expect(sibling('tenant', NEGATIVE_EQ.sibling, 'acme', inherited)).toBe(true);
+    expect(sibling('tenant', NEGATIVE_EQ.sibling, 'acme', inherited)).toBe(false);
   });
 
   /**

--- a/packages/permissions/src/__tests__/evaluator.prototype-guard-8044.test.ts
+++ b/packages/permissions/src/__tests__/evaluator.prototype-guard-8044.test.ts
@@ -1,0 +1,400 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8044 — `evaluateCondition` reads a condition's field in THREE cases,
+ * not two, so that *inherited* and *genuinely absent* stop being the same
+ * answer.
+ *
+ * The defect this pins closed, in one sentence: `hasOwnProperty` collapses
+ * inherited into absent, and on a negative operator absent ADMITS. Measured on
+ * the pre-fix source against the record `{ id: 1, tenant: 'acme' }`, every
+ * prototype member name outside the three-name refusal list —  `toString`,
+ * `valueOf`, `hasOwnProperty`, `isPrototypeOf` — returned `true` on `neq` and
+ * on `not_in`. `true` on a row-level condition means the record passes the rule
+ * that exists to hide it.
+ *
+ * ⛔ The fix is NOT a longer name list. A list enumerates spellings, and
+ * `Object.prototype` has more of them than any list will hold; the defect is
+ * the shape of the guard. The shape that closes the class is `readField` in
+ * `packages/core/src/data-scope/DataScopeManager.ts` (objectui#7751), and this
+ * change is a port of it back to the evaluator that was #7751's reference.
+ *
+ * ## What this file measures, and why the last describe block is the important one
+ *
+ * A pin asserting only "`toString` no longer admits" would ALSO pass on an
+ * implementation strictly worse than the bug: one that refuses every non-own
+ * read. That implementation denies records it should admit — ordinary rows with
+ * an ordinary missing field — which on a permission boundary is a worse defect
+ * than the fail-open being fixed. So the discriminating pin here is the
+ * GENUINELY-ABSENT case (`describe('a field that resolves nowhere …')`), per
+ * operator, and the differential matrix at the bottom is what carries the rest:
+ * it replays every case through the pre-fix read and the shipped one and counts
+ * the verdicts that moved in each direction.
+ *
+ * ⭐ `widened === 0` is the acceptance criterion, matching the bar objectui#7751
+ * set on `DataScopeManager` over its own 2772-case matrix (352 narrowed, zero
+ * widened, zero change in the genuinely-absent family).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { evaluateCondition } from '../evaluator';
+import type { PermissionCondition } from '@object-ui/types';
+
+/** Every operator `PermissionCondition` declares. The matrix runs all of them. */
+const OPERATORS = [
+  'eq',
+  'neq',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'in',
+  'not_in',
+  'contains',
+  'is_null',
+  'is_not_null',
+] as const;
+
+type Operator = (typeof OPERATORS)[number];
+
+const condition = (field: string, operator: Operator, value: unknown): PermissionCondition =>
+  ({ field, operator, value }) as PermissionCondition;
+
+/** One verdict out of the shipped evaluator. */
+const admits = (field: string, operator: Operator, value: unknown, record: Record<string, unknown>): boolean =>
+  evaluateCondition(condition(field, operator, value), record);
+
+/**
+ * The PRE-FIX read, transcribed from the source this change replaces
+ * (`4eb665bcf`: a three-name list plus `hasOwnProperty`), so the differential
+ * below can replay both reads in one process.
+ *
+ * Only the READ differs — the operator switch is the shipped one, reached
+ * through `evaluateCondition` with the value this legacy read produces. That
+ * keeps the transcription to the four lines that actually changed, and it is
+ * why a later edit to an operator arm cannot silently desynchronise the two
+ * halves of the matrix: both halves evaluate through the same switch.
+ *
+ * Verified against the real pre-fix module: over the full case space below,
+ * `legacyVerdict` and the pre-fix `evaluateCondition` agreed on every case.
+ */
+function legacyVerdict(field: string, operator: Operator, value: unknown, record: Record<string, unknown>): boolean {
+  if (['__proto__', 'constructor', 'prototype'].includes(field)) return false;
+  const read = Object.prototype.hasOwnProperty.call(record, field) ? record[field] : undefined;
+  // Replay the shipped switch over the legacy value by handing it a record that
+  // carries exactly that value under a name with no prototype meaning.
+  return evaluateCondition(condition('__legacy_value__', operator, value), { __legacy_value__: read });
+}
+
+/* ------------------------------------------------------------------ *
+ * The record shapes. All three cases the fix distinguishes are here,
+ * and they are distinguishable from each other by construction — not by
+ * two reads that both come back `undefined`.
+ * ------------------------------------------------------------------ */
+
+/** `tenant` is the record's OWN data. */
+const ownRecord = (): Record<string, unknown> => ({ id: 1, tenant: 'acme', age: 30 });
+
+/** `tenant` resolves — on the prototype. It is NOT this record's data. */
+const inheritedRecord = (): Record<string, unknown> =>
+  Object.assign(Object.create({ tenant: 'acme', age: 30 }), { id: 1 }) as Record<string, unknown>;
+
+/** No prototype at all: `toString` resolves NOWHERE on this record. */
+const nullProtoRecord = (): Record<string, unknown> => {
+  const bare = Object.create(null) as Record<string, unknown>;
+  bare.id = 1;
+  bare.tenant = 'acme';
+  bare.age = 30;
+  return bare;
+};
+
+/** An OWN key spelled like a prototype member — genuinely the record's data. */
+const shadowRecord = (): Record<string, unknown> => ({
+  id: 1,
+  tenant: 'acme',
+  age: 30,
+  toString: 'shadow',
+  valueOf: 'shadow',
+});
+
+const RECORD_SHAPES = [
+  ['own', ownRecord],
+  ['inherited', inheritedRecord],
+  ['null-prototype', nullProtoRecord],
+  ['own-key-shadowing-a-prototype-name', shadowRecord],
+] as const;
+
+/** Refused outright by name, before the record is consulted. */
+const REFUSED_NAMES = ['__proto__', 'constructor', 'prototype'] as const;
+
+/** On `Object.prototype` and NOT on the refusal list — the reach path. */
+const UNLISTED_PROTOTYPE_NAMES = [
+  'toString',
+  'valueOf',
+  'hasOwnProperty',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+  'toLocaleString',
+] as const;
+
+/** Ordinary data fields. */
+const OWN_NAMES = ['id', 'tenant', 'age'] as const;
+
+/** Names that resolve nowhere on any shape above — ordinary missing fields. */
+const ABSENT_NAMES = ['status', 'missing'] as const;
+
+const FIELDS = [...REFUSED_NAMES, ...UNLISTED_PROTOTYPE_NAMES, ...OWN_NAMES, ...ABSENT_NAMES];
+
+const VALUES: readonly unknown[] = ['acme', 'x', 30, 0, ['acme'], null];
+
+/* ------------------------------------------------------------------ *
+ * 1. The attack-shaped reach path
+ * ------------------------------------------------------------------ */
+
+describe('objectui#8044 — a condition naming an unlisted prototype member no longer admits', () => {
+  it.each(UNLISTED_PROTOTYPE_NAMES)(
+    'denies rather than admits for the prototype member name %s',
+    (field) => {
+      const record = ownRecord();
+      // Every one of these returned `true` on the pre-fix source. That is the
+      // card's probe table, and it is the whole defect.
+      expect(admits(field, 'neq', 'x', record)).toBe(false);
+      expect(admits(field, 'not_in', ['x'], record)).toBe(false);
+      // These were already `false`; pinned so the fix is not read as having
+      // moved them.
+      expect(admits(field, 'eq', 'x', record)).toBe(false);
+      expect(admits(field, 'in', ['x'], record)).toBe(false);
+      expect(admits(field, 'contains', 'x', record)).toBe(false);
+      expect(admits(field, 'gte', 0, record)).toBe(false);
+      // `is_null` answered `true` before, off the same collapsed read.
+      expect(admits(field, 'is_null', null, record)).toBe(false);
+      expect(admits(field, 'is_not_null', null, record)).toBe(false);
+    },
+  );
+
+  it.each(REFUSED_NAMES)('keeps refusing the listed name %s', (field) => {
+    const record = ownRecord();
+    for (const operator of OPERATORS) {
+      expect(admits(field, operator, 'x', record)).toBe(false);
+    }
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * 2. The accident-shaped reach path — no attacker required
+ * ------------------------------------------------------------------ */
+
+describe('objectui#8044 — an INHERITED value is not read as the record\'s data', () => {
+  it('denies the negative rule that used to admit an inherited tenant', () => {
+    // The record's tenant IS `acme`, through its prototype. Admitting it under
+    // "tenant is not acme" is the fail-open; both verdicts below are the
+    // refusal, not a comparison.
+    expect(admits('tenant', 'neq', 'acme', inheritedRecord())).toBe(false);
+    expect(admits('tenant', 'not_in', ['acme'], inheritedRecord())).toBe(false);
+  });
+
+  it('refuses the positive rule too, rather than answering from the prototype', () => {
+    expect(admits('tenant', 'eq', 'acme', inheritedRecord())).toBe(false);
+    expect(admits('tenant', 'in', ['acme'], inheritedRecord())).toBe(false);
+    expect(admits('age', 'gte', 18, inheritedRecord())).toBe(false);
+    expect(admits('tenant', 'is_null', null, inheritedRecord())).toBe(false);
+  });
+
+  it('reads OWN members of the same record unchanged', () => {
+    // `id` is own on the inherited-shape record; only `tenant` / `age` are not.
+    expect(admits('id', 'eq', 1, inheritedRecord())).toBe(true);
+    expect(admits('id', 'neq', 1, inheritedRecord())).toBe(false);
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * 3. ⭐ THE DISCRIMINATING PIN
+ *
+ * An implementation that refused every non-own read would pass sections 1
+ * and 2 and would be strictly worse than the bug. This is the section that
+ * fails on it.
+ * ------------------------------------------------------------------ */
+
+describe('objectui#8044 — a field that resolves NOWHERE keeps the verdicts it has always had', () => {
+  const absent = () => ({ id: 1, tenant: 'acme' }) as Record<string, unknown>;
+
+  it.each([
+    ['eq', 'archived', false],
+    ['neq', 'archived', true],
+    ['gt', 0, false],
+    ['gte', 0, false],
+    ['lt', 0, false],
+    ['lte', 0, false],
+    ['in', ['archived'], false],
+    ['not_in', ['archived'], true],
+    ['contains', 'arch', false],
+    ['is_null', null, true],
+    ['is_not_null', null, false],
+  ] as const)(
+    'operator %s on an ordinary missing field still returns %s',
+    (operator, value, expected) => {
+      expect(admits('status', operator as Operator, value, absent())).toBe(expected);
+    },
+  );
+
+  it('distinguishes absent from inherited from own with three concrete records, one rule', () => {
+    // One rule — "tenant is not acme" — three record shapes, three verdicts.
+    // ⚠️ Not a comparison of two `undefined` reads: each record below is a
+    // different shape and the three verdicts are not all the same.
+    const rule = (record: Record<string, unknown>) => admits('tenant', 'neq', 'acme', record);
+    expect(rule({ id: 1, tenant: 'acme' })).toBe(false); // own, and it matches → hidden
+    expect(rule(inheritedRecord())).toBe(false); // inherited → refused → hidden
+    expect(rule({ id: 1 })).toBe(true); // genuinely absent → admitted, as always
+  });
+
+  it('a prototype member name on a NULL-PROTOTYPE record resolves nowhere, so it is absent', () => {
+    // The same name, the same operator, a different record shape — and the
+    // verdict follows the record, not the spelling.
+    expect(admits('toString', 'neq', 'x', nullProtoRecord())).toBe(true);
+    expect(admits('toString', 'neq', 'x', ownRecord())).toBe(false);
+  });
+
+  it('an OWN key spelled like a prototype member is still the record\'s data', () => {
+    expect(admits('toString', 'eq', 'shadow', shadowRecord())).toBe(true);
+    expect(admits('toString', 'neq', 'shadow', shadowRecord())).toBe(false);
+  });
+
+  it('ordinary rules over ordinary records are untouched', () => {
+    expect(admits('tenant', 'eq', 'acme', ownRecord())).toBe(true);
+    expect(admits('tenant', 'neq', 'other', ownRecord())).toBe(true);
+    expect(admits('age', 'gte', 18, ownRecord())).toBe(true);
+    expect(admits('age', 'gte', 31, ownRecord())).toBe(false);
+    expect(admits('id', 'in', [1, 2], ownRecord())).toBe(true);
+  });
+
+  it('a null record still throws from the read, exactly as before', () => {
+    // Unchanged behaviour, pinned so the port is not read as having introduced
+    // a swallow. A refused NAME still answers without touching the record.
+    expect(() => evaluateCondition(condition('status', 'eq', 'x'), null as never)).toThrow(TypeError);
+    expect(evaluateCondition(condition('constructor', 'eq', 'x'), null as never)).toBe(false);
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * 4. The differential matrix — the quantitative bar
+ * ------------------------------------------------------------------ */
+
+interface MatrixCase {
+  shape: string;
+  field: string;
+  operator: Operator;
+  value: unknown;
+  before: boolean;
+  after: boolean;
+  /** The field resolves nowhere on this record and is not a refused name. */
+  genuinelyAbsent: boolean;
+}
+
+function buildMatrix(
+  fields: readonly string[] = FIELDS,
+  shapes: readonly (readonly [string, () => Record<string, unknown>])[] = RECORD_SHAPES,
+  operators: readonly Operator[] = OPERATORS,
+  values: readonly unknown[] = VALUES,
+): MatrixCase[] {
+  const cases: MatrixCase[] = [];
+  for (const [shape, make] of shapes) {
+    for (const field of fields) {
+      for (const operator of operators) {
+        for (const value of values) {
+          const record = make();
+          cases.push({
+            shape,
+            field,
+            operator,
+            value,
+            before: legacyVerdict(field, operator, value, record),
+            after: admits(field, operator, value, record),
+            genuinelyAbsent:
+              !(REFUSED_NAMES as readonly string[]).includes(field) && !(field in Object(record)),
+          });
+        }
+      }
+    }
+  }
+  return cases;
+}
+
+interface MatrixSummary {
+  total: number;
+  narrowed: number;
+  widened: number;
+  absentTotal: number;
+  absentChanged: number;
+}
+
+function summarize(cases: readonly MatrixCase[]): MatrixSummary {
+  return {
+    total: cases.length,
+    narrowed: cases.filter((c) => c.before && !c.after).length,
+    widened: cases.filter((c) => !c.before && c.after).length,
+    absentTotal: cases.filter((c) => c.genuinelyAbsent).length,
+    absentChanged: cases.filter((c) => c.genuinelyAbsent && c.before !== c.after).length,
+  };
+}
+
+describe('objectui#8044 — differential matrix: pre-fix read vs shipped read', () => {
+  const summary = summarize(buildMatrix());
+
+  /**
+   * ⚠️ VACUITY GUARD, and it comes first on purpose.
+   *
+   * Every assertion below iterates a GENERATED case list, and every one of them
+   * passes over an empty list — `widened === 0` most of all. So the size is
+   * asserted exactly, and the next test proves that this exact-size assertion
+   * is the thing that fails when the list is emptied.
+   */
+  it('runs the exact case space it claims to: 14 fields x 4 record shapes x 11 operators x 6 values', () => {
+    expect(FIELDS).toHaveLength(14);
+    expect(RECORD_SHAPES).toHaveLength(4);
+    expect(OPERATORS).toHaveLength(11);
+    expect(VALUES).toHaveLength(6);
+    expect(summary.total).toBe(14 * 4 * 11 * 6);
+    expect(summary.total).toBe(3696);
+  });
+
+  it('the vacuity guard is real: an emptied matrix fails the size assertion and only the size assertion', () => {
+    const empty = summarize(buildMatrix([], [], [], []));
+    expect(empty.total).toBe(0);
+    // Vacuously satisfied — this is exactly why they cannot stand alone.
+    expect(empty.widened).toBe(0);
+    expect(empty.absentChanged).toBe(0);
+    // The assertion that actually notices.
+    expect(() => expect(empty.total).toBe(3696)).toThrow();
+  });
+
+  it('⭐ widened ZERO — not one verdict moved from deny to admit', () => {
+    expect(summary.widened).toBe(0);
+  });
+
+  it('narrowed 234 — the fail-open verdicts this card was filed for', () => {
+    expect(summary.narrowed).toBe(234);
+  });
+
+  it('the genuinely-absent family changed ZERO verdicts, and is not empty', () => {
+    expect(summary.absentTotal).toBe(924);
+    expect(summary.absentChanged).toBe(0);
+  });
+
+  it('every narrowed case is a prototype-name read or an inherited read — nothing else moved', () => {
+    const moved = buildMatrix().filter((c) => c.before !== c.after);
+    expect(moved.length).toBeGreaterThan(0);
+    for (const c of moved) {
+      const record = RECORD_SHAPES.find(([name]) => name === c.shape)![1]();
+      const own = Object.prototype.hasOwnProperty.call(record, c.field);
+      const resolves = c.field in Object(record);
+      expect(own).toBe(false);
+      expect(resolves).toBe(true);
+    }
+  });
+});

--- a/packages/permissions/src/evaluator.ts
+++ b/packages/permissions/src/evaluator.ts
@@ -119,18 +119,92 @@ function resolveRoles(userRoles: string[], roleDefinitions: RoleDefinition[]): s
 }
 
 /**
+ * Field names refused outright, before the record is consulted at all.
+ *
+ * `__proto__` and `constructor` resolve on every ordinary object's chain, so
+ * the own-member rule in `readField` would refuse them anyway. `prototype`
+ * earns its place separately: it is NOT present on a plain object's chain
+ * (`'prototype' in {}` is `false`), so without this list it would classify as
+ * an ordinary absent field. The same three names, for the same reasons, as
+ * `PROTOTYPE_FIELD_NAMES` in `DataScopeManager` (`@object-ui/core`).
+ */
+const PROTOTYPE_FIELD_NAMES: ReadonlySet<string> = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+]);
+
+/**
+ * The outcome of reading a condition's field off a record.
+ *
+ * `readable: false` is not "the value was falsy" — it is "this evaluator
+ * refuses to answer this condition from this record", which
+ * `evaluateCondition` turns into a denial.
+ */
+type FieldRead = { readable: true; value: unknown } | { readable: false };
+
+/**
+ * Read a condition's field as an OWN member of the record.
+ *
+ * Measured on the pre-fix source (objectui#8044): the guard refused three
+ * field names by list and read every other name with `hasOwnProperty`. That
+ * read collapses *inherited* into *absent*, and on a negative operator absent
+ * ADMITS — so every prototype member outside the list admitted every record.
+ * Against `{ id: 1, tenant: 'acme' }`, `{ field: 'toString', operator: 'neq' }`
+ * returned `true`, as did `valueOf`, `hasOwnProperty` and `isPrototypeOf`; a
+ * fail-open on a row-level permission boundary. A longer list does not close
+ * it: a list enumerates spellings, and `Object.prototype` has more of them
+ * than any list will hold.
+ *
+ * Three cases, and the third is why this is not simply `hasOwnProperty`:
+ *
+ *   1. A name in `PROTOTYPE_FIELD_NAMES` — refused outright.
+ *   2. An own member — its value, which is the only value ever read. A record
+ *      whose OWN key happens to be spelled `toString` is answered from its own
+ *      data, unchanged.
+ *   3. Not an own member. Here the record is asked whether the name resolves
+ *      on its prototype chain at all:
+ *        - it does (`toString`, `valueOf`, an `Object.create` parent's field)
+ *          → REFUSED. The value exists but is not this record's data.
+ *        - it does not → the field is genuinely absent, and `undefined` is
+ *          returned exactly as before, so the ordinary "this record has no
+ *          `status`" rules keep the verdicts they have always had.
+ *
+ * The second half of case 3 is load-bearing. Refusing every non-own read would
+ * deny records this evaluator should admit, which on a permission boundary is
+ * a worse defect than the one being fixed, and it is what the differential
+ * matrix in `__tests__/evaluator.prototype-guard-8044.test.ts` measures: the
+ * genuinely-absent family changed zero verdicts.
+ *
+ * This is a port of the shape objectui#7751 landed in `readField` in
+ * `packages/core/src/data-scope/DataScopeManager.ts`, which was written
+ * against this evaluator as its reference — and then went further than it,
+ * because this evaluator had the defect it was being used as the standard for.
+ */
+function readField(record: Record<string, unknown>, field: string): FieldRead {
+  if (PROTOTYPE_FIELD_NAMES.has(field)) return { readable: false };
+  if (Object.prototype.hasOwnProperty.call(record, field)) return { readable: true, value: record[field] };
+  if (field in Object(record)) return { readable: false };
+  return { readable: true, value: undefined };
+}
+
+/**
  * Evaluates a permission condition against a record.
  */
 export function evaluateCondition(
   condition: PermissionCondition,
   record: Record<string, unknown>,
 ): boolean {
-  // Prevent prototype pollution via dangerous property access
-  if (['__proto__', 'constructor', 'prototype'].includes(condition.field)) {
+  // Fail closed: a condition this evaluator cannot answer FROM THE RECORD must
+  // not admit the record it exists to hide. Prototype-named and inherited
+  // reads both land here (objectui#8044); the `default` arm below gives the
+  // same answer for an operator this switch does not implement.
+  const read = readField(record, condition.field);
+  if (!read.readable) {
     return false;
   }
 
-  const value = Object.prototype.hasOwnProperty.call(record, condition.field) ? record[condition.field] : undefined;
+  const value = read.value;
 
   switch (condition.operator) {
     case 'eq':


### PR DESCRIPTION
Fixes #8044

A port of the shape objectui#7751 landed in `readField` (`packages/core/src/data-scope/DataScopeManager.ts`) back to the evaluator that was #7751's reference — and which, it turned out, carried the defect it was being used as the standard for. Not a redesign: the reference shape was read first and followed.

## Root cause, one sentence

`hasOwnProperty` collapses **inherited** into **absent**, and on a negative operator absent **ADMITS**.

The pre-fix guard (verified by content on `4eb665bcf`, the base of this branch — `:129` and `:133`, exactly where triage measured them) refused three field names by list and read every other name with `hasOwnProperty`. ⛔ Not fixed by lengthening the list: a list enumerates spellings, and `Object.prototype` has more of them than any list will hold.

## The fix — three cases, and the third is the whole thing

`readField` in `packages/permissions/src/evaluator.ts` now answers:

1. a name in the refusal list (`__proto__`, `constructor`, `prototype`) → **refused**, the rule denies;
2. an **own** member → its value, unchanged — including a record whose own key is spelled `toString`;
3. **not own** → if the name resolves on the prototype chain at all (`field in Object(record)`) the read is **refused**; if it resolves nowhere the field is **genuinely absent** and `undefined` is returned, so ordinary *"this record has no `status`"* rules keep the verdicts they have always had.

The second half of case 3 is load-bearing. Refusing *every* non-own read would deny records this evaluator should admit — a worse defect on a permission boundary than the fail-open being closed. It is measured below, and it is what the ablation in leg C fails on.

## ⭐ The quantitative bar — both counts

Differential matrix, **3696 cases** (14 field names × 4 record shapes × 11 operators × 6 values), each case replayed through the previous release's read and this one:

| | count |
|---|---|
| total cases | **3696** |
| verdicts **narrowed** (admit → deny) | **234** |
| verdicts **widened** (deny → admit) | **0** |
| genuinely-absent-field cases | 924 |
| genuinely-absent verdicts **changed** | **0** |

Measured twice, and the two agree:

- against the **real pre-fix module** (`git show 4eb665bcf:packages/permissions/src/evaluator.ts`, imported alongside the shipped one in a throwaway test): `total=3696 mismatches=0 narrowed=234 widened=0 absentTotal=924 absentChanged=0`;
- against the transcribed legacy read committed in `evaluator.prototype-guard-8044.test.ts`, which the run above confirms agrees with the real pre-fix module on **every one** of the 3696 cases (`mismatches=0`).

The matrix is committed, so the counts stay asserted rather than recorded in a PR comment.

⚠️ **Matrix vacuity guard.** An assertion iterating a generated list passes over an empty list — `widened === 0` most of all. So the case space is asserted by exact size *first*, and that guard is itself proven: emptying `FIELDS` (leg D) turns 4 tests red, including `expected [] to have a length of 14 but got +0` — while `⭐ widened ZERO` stayed **green** over the empty list, which is precisely the hazard.

## Every narrowed verdict, characterised

A committed assertion walks all cases whose verdict moved and requires each one to be a read that is **not own** and **does resolve** on the chain. Nothing outside the prototype-name / inherited-value families moved.

## Caricature — both directions, neither reads as success

Each leg: mutate → prove it landed on disk (marker count + `git hash-object` ≠ HEAD blob) → run → restore → prove `git diff HEAD` empty and the hash back to the HEAD blob. Classified from vitest's **JSON reporter**, not the text one. No void legs.

| leg | mutation | result |
|---|---|---|
| A | evaluator **denies everything** | 🔴 **10 failed** — caught by the absent-field pins and the ordinary-admit pins |
| B | evaluator **admits everything** | 🔴 **42 failed** — caught by the prototype-name and inherited-value pins |
| C | the plausible **wrong fix**: refuse *all* non-own reads (the two-case version) | 🔴 **8 failed** — caught **only** by the genuinely-absent pins and the matrix |
| D | matrix case space emptied | 🔴 **4 failed**, incl. the exact-size assertion |

Leg C is the discriminating one: it leaves every *"`toString` no longer admits"* pin **green**. A patch strictly worse than the bug would have passed a pin set built only around the attack path.

## Sibling read-site sweep — `packages/permissions`

`evaluateCondition` was the only read site of this shape.

- Query: `grep -rn "hasOwnProperty" packages/permissions/` → 1 hit, `evaluator.ts:133` (the subject).
- Query: `grep -rn "record\[|row\[" packages/permissions/src` → 1 hit, the same line. **Lit control** on the identical command shape against `packages/core/src` fired (`optionRules.ts:86`, `listConditional.ts:447`, `DataScopeManager.ts:313`, …), so the zero-elsewhere reading is a measurement and not a broken command.
- Query: `grep -rn "\[(condition\.field|filter\.field|field|key|name|f)\]" packages/permissions/src` → 2 hits: the subject, and `MePermissionsProvider.tsx:309`, which indexes a **server-supplied permission map** by an object/field key — a different subject (not a record, and its miss path falls through to the authentication-gated object-level default), so it is **not** part of this defect and is not touched here.

⛔ No widening into a third package: the only source change outside `packages/permissions` is a doc comment in `DataScopeManager.ts` that asserted, in the present tense, that the sibling still admits — now false.

## The `KNOWN GAP` pins that this flips

`packages/core/src/data-scope/__tests__/DataScopeManager.hardening.test.ts` recorded this card as **assertions expecting the sibling to admit**, so that fixing it would turn red and lead the implementer to where the standard is written:

> ⚠️ When objectui#8044 lands, these expectations FLIP to `false` and this block folds into the table above.

Done as instructed — the two blocks now assert that **both** evaluators refuse a prototype member name and an inherited value, and they have joined the conformance table. Neither evaluator was loosened to match the other. Operator **spelling** (`neq`/`not_in` here, `ne`/`nin` there) is untouched and remains objectui#7750's question.

## Verification

- `pnpm exec vitest run packages/permissions/ packages/core/` — **141 files, 2911 tests, 0 failed** (JSON reporter).
- `pnpm --filter @object-ui/permissions... --filter @object-ui/core... build` → exit 0, dist completeness verified — run **before** type-check, so the type-check below is a result and not a precondition report.
- `pnpm --filter @object-ui/permissions --filter @object-ui/core type-check` (`tsc --noEmit` **and** `tsc -p tsconfig.test.json`) → `Done`, no diagnostics. `tsc -p packages/permissions/tsconfig.test.json --listFiles` confirms the new pin file is in the checked set — it is not silently excluded.
- `pnpm exec eslint` on the four touched files → **0 errors** (8 pre-existing `no-explicit-any` warnings on `DataScopeManager` lines this PR does not add).
- Changeset gate, quoting its own printed verdict line:
  > `✅  3 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s): .changeset/permissions-evaluator-prototype-guard-8044.md.`
  and `✅  No changeset declares a 'major' bump.` Graded **`minor`** — a release reader can observe the narrowing on stored conditions; no declared type changed and the accepted input set did not widen.

## Note for the release editor

`.changeset/core-datascope-field-and-comparison-guards-7751.md` (still unreleased) says the sibling *"still returns `true` for `{ field: 'toString', operator: 'neq' }`"*. If both changesets ship in one release, that sentence is superseded by this one. Left untouched here rather than rewritten — it is another card's release note, and #7751's reasoning for going further than the sibling is still the correct history.

## Exploitation evidence

None found, and the search is named rather than asserted. A repo-wide sweep for a condition literal whose `field` is a prototype member name — over `packages`, `apps`, `examples`, `content` and `e2e`, in `.ts`/`.tsx`/`.json`/`.md`/`.mdx` — returns only the prose in the two files this PR touches that *describes* the defect; no fixture, example app, metadata file or docs page configures one. The **lit control** on the identical command shape (`field: 'status'`) fired. Nothing was found indicating a deployment relies on a prototype-named condition either. The escalation clause (p1 → p0 on evidence of exploitation or of such a deployment) was therefore not triggered — reported here rather than absorbed silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_