### PR TITLE
fix(plugin-designer): preserve a stored field type MetadataFieldsPage cannot author (#8060)

### DIFF
--- a/.changeset/hungry-poems-shave.md
+++ b/.changeset/hungry-poems-shave.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/plugin-designer': minor
+---
+
+**`MetadataFieldsPage` no longer rewrites a stored field type it cannot author.**
+
+`toDesignerType` mapped every type outside `DESIGNER_FIELD_TYPES` to `'text'` on the
+READ path, and `fromDesignerField` emitted the designer's type on the write path — so
+relabelling one field rewrote every other field whose type this designer does not
+author, on the same PUT. `text` is a legal spec type, so the save succeeded, the
+designer redrew the fields as text, and nothing reported it; restoring a field required
+knowing what its type used to be.
+
+The census: `DESIGNER_FIELD_TYPES` has 27 members, `FieldType` in `@objectstack/spec`
+17.3.0 declares 49, and all 27 are a subset of the 49. The 22 in the difference were
+each a distinct data-loss case — `secret`, `richtext`, `toggle`, `multiselect`, `radio`,
+`checkboxes`, `master_detail`, `tree`, `user`, `avatar`, `video`, `audio`, `summary`,
+`composite`, `repeater`, `record`, `json`, `signature`, `qrcode`, `progress`, `tags`,
+`vector`.
+
+A field whose stored type is outside the designer's set is now carried through the
+save verbatim — the mechanism this page already used one level down, where unknown
+per-field KEYS survive via `carryOver` — and is listed on the page read-only, showing
+its real stored type, instead of being drawn as an editable `text` field. Types inside
+the set are unchanged: still editable, and a type change the author makes is still
+honoured. A stored type in NEITHER vocabulary is carried through too, so an unknown
+type produces a loud 422 naming the field rather than a silent rewrite.
+
+Two behaviour changes worth naming:
+
+- Fields with a carried-through type are no longer editable or deletable from this
+  page — including deleting them, which was previously possible only because they had
+  already been misrepresented as text. Use metadata-admin to change them.
+- An object holding a target-less stored `master_detail` used to save from this page by
+  flattening the field to `text` and losing the relationship. That field now reaches
+  the existing relationship-target guard with its real type and is refused by name
+  before the PUT. `@objectstack/spec` 17.3.0 requires `reference` on `master_detail`,
+  so such a document's PUT answers 422 regardless; refusing here names the field and
+  leaves the stored relationship intact.

--- a/packages/plugin-designer/src/MetadataFieldsPage.specKeyReference.test.tsx
+++ b/packages/plugin-designer/src/MetadataFieldsPage.specKeyReference.test.tsx
@@ -68,7 +68,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import { FieldSchema } from '@objectstack/spec/data';
 import { MetadataClient } from '@object-ui/data-objectstack';
 import type { DesignerFieldDefinition } from '@object-ui/types';
@@ -373,27 +373,113 @@ describe('objectui#6041 · WRITE — the save carries `reference`, never `refere
     }
   });
 
-  it('does NOT pin a `master_detail` refusal — this page cannot reach one (measured)', () => {
-    // objectui#7714. The guard's list carries `master_detail` for parity with
-    // the sibling writer, where it IS reachable (`FieldMetadataPayload['type']`
-    // is an unconstrained `string`, and `MetadataService.saveObject` refuses a
-    // target-less master-detail today — pinned in
-    // `MetadataService.specKeyReference.test.ts`).
-    //
-    // Through THIS page it is unreachable, and the reason is worth stating
-    // rather than leaving as an empty spot: `toDesignerType` maps every type
-    // outside `DESIGNER_FIELD_TYPES` to `'text'`, so a stored `master_detail`
-    // arrives at the guard already flattened. Measured on this page:
-    //
-    //   stored { type: 'master_detail', reference: 'invoice' }
-    //     => designer field type "text"
-    //     => WIRE { "type": "text", "label": "Parent", "reference": "invoice" }
-    //
-    // So a refusal assertion here would be a PHANTOM — green because the guard
-    // never sees a `master_detail`, not because it handled one. The flattening
-    // is a separate defect (objectui#8060) and this case is a marker, so
-    // that when it is fixed the missing coverage is visible rather than assumed.
-    expect(true).toBe(true);
+  /**
+   * ⭐ This WAS the marker case, and it is now a real pin — objectui#8060.
+   *
+   * ## What it used to assert, and why that was not coverage
+   *
+   * It asserted `expect(true).toBe(true)`. The guard's list carries
+   * `master_detail` for parity with the sibling writer, where it IS reachable
+   * (`FieldMetadataPayload['type']` is an unconstrained `string`, and
+   * `MetadataService.saveObject` refuses a target-less master-detail — pinned
+   * in `MetadataService.specKeyReference.test.ts`). Through THIS page it was
+   * unreachable: `toDesignerType` mapped every type outside
+   * `DESIGNER_FIELD_TYPES` to `'text'` on the READ path, so a stored
+   * `master_detail` arrived at the guard already flattened —
+   *
+   *   stored { type: 'master_detail', reference: 'invoice' }
+   *     => designer field type "text"
+   *     => WIRE { "type": "text", "label": "Parent", "reference": "invoice" }
+   *
+   * — and a refusal assertion here would have been a PHANTOM: green because the
+   * guard never saw a `master_detail`, not because it handled one. The case
+   * existed so that when the flattening was fixed the missing coverage would be
+   * visible rather than assumed. ⭐ *A check that cannot fire is
+   * indistinguishable from one that passed.*
+   *
+   * ## What it asserts now
+   *
+   * objectui#8060 removed the flattening: a stored type this designer cannot
+   * author is carried through verbatim and `toFieldsMap` runs the guard over
+   * the carried-through entries too. So the branch FIRES on the real type, and
+   * both of its outcomes are pinned below — the passing one first, because a
+   * refusal pin alone cannot tell "the guard rejected it" from "the guard
+   * rejects every master-detail".
+   *
+   * ⚠️ The refusal half is a BEHAVIOUR CHANGE, not merely restored coverage: an
+   * object holding a target-less stored `master_detail` used to save from this
+   * page by flattening the field to `text`, losing the relationship. It is now
+   * refused by name before the PUT. `@objectstack/spec` 17.3.0 requires
+   * `reference` on `master_detail`, so that document's PUT answers 422 anyway;
+   * refusing here names the field and leaves the stored relationship intact.
+   */
+  it('DOES pin a `master_detail` now — the guard is reachable, and both outcomes are real', async () => {
+    const body = {
+      name: 'md_probe',
+      label: 'MD Probe',
+      fields: {
+        name: { type: 'text', label: 'Name' },
+        parent_id: { type: 'master_detail', label: 'Parent', reference: 'invoice' },
+      },
+    };
+    const localPuts: Array<Record<string, unknown>> = [];
+    const client = new MetadataClient({
+      baseUrl: 'http://localhost:3000',
+      fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if ((init?.method ?? 'GET').toUpperCase() === 'PUT') {
+          localPuts.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>);
+          return json({ success: true, name: 'md_probe' });
+        }
+        if (/\/meta\/object\/md_probe(\?|$)/.test(url)) {
+          return json({ type: 'object', name: 'md_probe', item: body });
+        }
+        return json({ items: [] });
+      }) as unknown as typeof fetch,
+    });
+
+    render(<MetadataFieldsPage objectName="md_probe" client={client} />);
+    await waitFor(() => expect(designerProps).not.toBeNull());
+
+    // (a) The guard SEES a real `master_detail` — the type is no longer
+    //     flattened before it gets there — and passes it, because the target is
+    //     present. Concrete strings on both sides: `'text'` is what the defect
+    //     wrote, so asserting `not.toBe('text')` is what tells them apart.
+    const next = designerProps!.fields.map((f) =>
+      f.name === 'name' ? { ...f, label: 'Renamed' } : f,
+    );
+    await act(async () => {
+      designerProps!.onFieldsChange!(next);
+    });
+    await waitFor(() => expect(localPuts).toHaveLength(1));
+    const wire = localPuts[0].fields as Record<string, Record<string, unknown>>;
+    expect(wire.parent_id.type).toBe('master_detail');
+    expect(wire.parent_id.type).not.toBe('text');
+    expect(wire.parent_id.reference).toBe('invoice');
+
+    // (b) And the refusal branch is live: strip the target from the STORED
+    //     document and the same edit is refused by name, with no PUT. Under the
+    //     old flattening this saved happily as a `text` field.
+    delete (body.fields.parent_id as Record<string, unknown>).reference;
+    // Unmount the first page before mounting the second: two live pages would
+    // both answer `getByTestId`, and `designerProps` would name whichever
+    // rendered last rather than the one being driven.
+    cleanup();
+    designerProps = null;
+    localPuts.length = 0;
+    render(<MetadataFieldsPage objectName="md_probe" client={client} />);
+    await waitFor(() => expect(designerProps).not.toBeNull());
+    await act(async () => {
+      designerProps!.onFieldsChange!(
+        designerProps!.fields.map((f) => (f.name === 'name' ? { ...f, label: 'Renamed again' } : f)),
+      );
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('metadata-fields-page-error').textContent,
+      ).toMatch(/a `master_detail` field needs a `reference` naming the object it links to/),
+    );
+    expect(localPuts).toEqual([]);
   });
 
 });

--- a/packages/plugin-designer/src/MetadataFieldsPage.storedTypePreserved.test.tsx
+++ b/packages/plugin-designer/src/MetadataFieldsPage.storedTypePreserved.test.tsx
@@ -1,0 +1,465 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8060 — a stored field type this designer cannot author SURVIVES an
+ * edit to a different field.
+ *
+ * ## The defect these pins close
+ *
+ * `toDesignerType` answered `DesignerFieldType` for every input by returning
+ * `'text'` for anything outside `DESIGNER_FIELD_TYPES`, and `toDesignerField`
+ * called it on the READ path — so the collapse happened before the author saw
+ * anything — while `fromDesignerField` emitted `type: designed.type`, so the
+ * collapsed value was written back. Relabelling ONE field rewrote every other
+ * field whose type the designer does not author, on the same PUT:
+ *
+ *     stored  parent_id { type: 'master_detail', reference: 'invoice' }
+ *     stored  vec       { type: 'vector' }
+ *     relabel the unrelated `name` field
+ *       => WIRE parent_id { "type": "text", "reference": "invoice" }
+ *       => WIRE vec       { "type": "text" }
+ *
+ * `text` is a LEGAL spec type, so the PUT succeeded and nothing reported it.
+ * That is what separates this from the tombstone family (objectui#6041 /
+ * objectui#6043 / objectui#4644), which 422s loudly and leaves the object
+ * recoverable: here the save SUCCEEDS and the evidence of what the field was is
+ * gone.
+ *
+ * ## ⭐ Why these pins are driven from a CENSUS and not from a list of two
+ *
+ * The card confirmed `master_detail` and `vector`. A pin asserting only those
+ * two passes on a fix that SPECIAL-CASES those two and leaves every other
+ * member flattening — an implementation strictly worse than a general one, and
+ * indistinguishable from it at this level. So `CENSUS` below is DERIVED from
+ * the two vocabularies at test time and the class pin iterates it. Adding a
+ * type to `@objectstack/spec` without teaching this page about it fails here,
+ * rather than becoming the next silent data-loss report.
+ *
+ * ⚠️ A census-driven pin is the classic VACUOUS pin: `for (const t of set)`
+ * passes over an empty set, so a mistake that empties the census turns the
+ * class pin green while measuring nothing. `C0` asserts the size AND the exact
+ * membership, and every iterating pin counts its own iterations and asserts the
+ * count — so an emptied census fails in three places instead of passing in one.
+ *
+ * ## The evidence bar, inherited from the filing
+ *
+ * The card drove the REAL page with a REAL `MetadataClient` over a fetch double
+ * and asserted the CAPTURED PUT BYTES, with an untouched control field in the
+ * same document. These pins are held to that: a helper-level unit test of the
+ * type predicate would not discharge this card. `FieldDesigner` — the
+ * presentational leaf — is the only double, and it is a prop recorder, so the
+ * page's read/partition/merge/save chain runs for real.
+ *
+ * ## The read path is pinned SEPARATELY from the wire, on purpose
+ *
+ * The collapse happened on the READ path, so a fix applied only at the write
+ * path would show the author a text field and then write back the preserved
+ * type — a different lie, and one a wire-only pin cannot see. `P2` asserts what
+ * the author is SHOWN; `P1` asserts what is WRITTEN.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { MetadataClient } from '@object-ui/data-objectstack';
+import { DESIGNER_FIELD_TYPES } from '@object-ui/types';
+import type { DesignerFieldDefinition } from '@object-ui/types';
+// The same subpath `MetadataFieldsPage.specKeyReference.test.tsx` already reads
+// the spec through. ⚠️ The root export is thin — `FieldType` lives on `/data`,
+// and a root import answering `undefined` would be a SPECIFIER problem, not
+// evidence the type is absent.
+import { FieldType } from '@objectstack/spec/data';
+
+// ---------------------------------------------------------------------------
+// The census — derived, never restated
+// ---------------------------------------------------------------------------
+
+/** Every field type `@objectstack/spec` declares. */
+const SPEC_FIELD_TYPES: readonly string[] = FieldType.options;
+
+/** Every field type the Field Designer can author. */
+const DESIGNER_TYPES: readonly string[] = DESIGNER_FIELD_TYPES;
+
+/**
+ * The difference set: spec types the designer cannot author, i.e. exactly the
+ * types that used to collapse to `'text'`. Each member is a distinct data-loss
+ * case.
+ */
+const CENSUS: readonly string[] = SPEC_FIELD_TYPES.filter((t) => !DESIGNER_TYPES.includes(t));
+
+/**
+ * Measured on `@objectstack/spec` 17.3.0 with `DESIGNER_FIELD_TYPES` at 27
+ * members. Restated here as a LITERAL so the derivation above cannot quietly
+ * answer something else: if either vocabulary moves, this fails and a human
+ * reads the new difference rather than inheriting a stale one.
+ */
+const CENSUS_AT_FILING = [
+  'audio', 'avatar', 'checkboxes', 'composite', 'json', 'master_detail',
+  'multiselect', 'progress', 'qrcode', 'radio', 'record', 'repeater',
+  'richtext', 'secret', 'signature', 'summary', 'tags', 'toggle', 'tree',
+  'user', 'vector', 'video',
+] as const;
+
+// ---------------------------------------------------------------------------
+// The one double: the presentational leaf, recording its props
+// ---------------------------------------------------------------------------
+
+interface RecordedDesignerProps {
+  objectName: string;
+  fields: DesignerFieldDefinition[];
+  onFieldsChange?: (fields: DesignerFieldDefinition[]) => void;
+  readOnly?: boolean;
+}
+
+let designerProps: RecordedDesignerProps | null = null;
+
+vi.mock('./FieldDesigner', () => ({
+  FieldDesigner: (props: RecordedDesignerProps) => {
+    designerProps = props;
+    return null;
+  },
+}));
+
+import { MetadataFieldsPage } from './MetadataFieldsPage';
+
+// ---------------------------------------------------------------------------
+// A real MetadataClient over a fetch double
+// ---------------------------------------------------------------------------
+
+interface CapturedPut {
+  url: string;
+  body: { fields: Record<string, Record<string, unknown>> } & Record<string, unknown>;
+}
+
+let puts: CapturedPut[] = [];
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/**
+ * The object document, built per test. `name` is the CONTROL — a designer-owned
+ * `text` field, the only one the edit ever touches.
+ */
+function objectBody(fields: Record<string, Record<string, unknown>>) {
+  return {
+    name: 'showcase_project',
+    label: 'Project',
+    fields: { name: { type: 'text', label: 'Name' }, ...fields },
+  };
+}
+
+/**
+ * ⚠️ The client is served from a double and never reaches a relative URL, so
+ * nothing in this file can escape to happy-dom's `http://localhost:3000`. No
+ * global is stubbed, so there is no `vi.unstubAllGlobals()` ordering to get
+ * wrong; `cleanup()` still runs first in `afterEach` out of the same discipline.
+ */
+function realClient(body: ReturnType<typeof objectBody>): MetadataClient {
+  return new MetadataClient({
+    baseUrl: 'http://localhost:3000',
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (method === 'PUT') {
+        puts.push({ url, body: JSON.parse(String(init?.body ?? '{}')) });
+        return json({ success: true, name: 'showcase_project' });
+      }
+      if (/\/meta\/object\/showcase_project(\?|$)/.test(url)) {
+        // The single-item read answers the ENVELOPE (objectstack#5563).
+        return json({ type: 'object', name: 'showcase_project', item: body });
+      }
+      return json({ items: [] });
+    }) as unknown as typeof fetch,
+  });
+}
+
+async function renderPage(fields: Record<string, Record<string, unknown>>) {
+  render(<MetadataFieldsPage objectName="showcase_project" client={realClient(objectBody(fields))} />);
+  await waitFor(() => expect(designerProps).not.toBeNull());
+}
+
+/**
+ * The unrelated edit: relabel the CONTROL field `name` and nothing else. This
+ * is the whole point — the author has no reason to inspect the other fields.
+ */
+async function relabelControlOnly() {
+  const next = designerProps!.fields.map((f) =>
+    f.name === 'name' ? { ...f, label: 'Renamed by the author' } : f,
+  );
+  await act(async () => {
+    designerProps!.onFieldsChange!(next);
+  });
+  await waitFor(() => expect(puts).toHaveLength(1));
+  return puts[0].body.fields;
+}
+
+beforeEach(() => {
+  puts = [];
+  designerProps = null;
+});
+
+afterEach(() => {
+  cleanup();
+  designerProps = null;
+});
+
+// ---------------------------------------------------------------------------
+// C0 — the census itself, and the vacuity guard
+// ---------------------------------------------------------------------------
+
+describe('objectui#8060 · C0 the census', () => {
+  it('is non-empty, is exactly the 22 measured members, and is the SPEC minus the DESIGNER set', () => {
+    expect(SPEC_FIELD_TYPES).toHaveLength(49);
+    expect(DESIGNER_TYPES).toHaveLength(27);
+
+    // ⚠️ The vacuity guard. Every iterating pin below is green over an empty
+    // set; these three lines are what makes an emptied census fail loudly.
+    expect(CENSUS.length).toBeGreaterThan(0);
+    expect(CENSUS).toHaveLength(22);
+    expect([...CENSUS].sort()).toEqual([...CENSUS_AT_FILING]);
+
+    // Why direction 1 (preserve + read-only) is viable at all: the designer's
+    // vocabulary is a strict SUBSET of the spec's, so nothing it can author is
+    // unknown to the spec, and 27 + 22 = 49 accounts for every declared type.
+    expect(DESIGNER_TYPES.filter((t) => !SPEC_FIELD_TYPES.includes(t))).toEqual([]);
+    expect(DESIGNER_TYPES.length + CENSUS.length).toBe(SPEC_FIELD_TYPES.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P1 — the CLASS pin, on the wire
+// ---------------------------------------------------------------------------
+
+describe('objectui#8060 · P1 every census member survives an edit to a different field', () => {
+  it('round-trips its stored type through the PUT bytes, with the control field untouched', async () => {
+    let checked = 0;
+
+    for (const storedType of CENSUS) {
+      puts = [];
+      designerProps = null;
+      // `master_detail` is one of the two relationship types the spec requires
+      // a `reference` on, so the fixture gives it one — otherwise this pin
+      // would be measuring the target guard instead of the type.
+      const probe: Record<string, unknown> = { type: storedType, label: 'Probe' };
+      if (storedType === 'master_detail') probe.reference = 'invoice';
+
+      await renderPage({ probe });
+      const wire = await relabelControlOnly();
+
+      // ⚠️ Concrete, distinguishable strings on both sides. `undefined ===
+      // undefined` would prove nothing, and `'text'` is what the defect wrote.
+      expect(wire.probe, `${storedType}: the field must reach the wire at all`).toBeDefined();
+      expect(wire.probe.type, `${storedType} must not be rewritten`).toBe(storedType);
+      expect(wire.probe.type, `${storedType} must not collapse to text`).not.toBe('text');
+      expect(wire.probe.label, `${storedType}: the untouched field keeps its label`).toBe('Probe');
+      if (storedType === 'master_detail') {
+        expect(wire.probe.reference, 'the relationship target survives too').toBe('invoice');
+      }
+
+      // The control: the edit really happened, so a green above is not a green
+      // produced by a save that never fired.
+      expect(wire.name.label, `${storedType}: the control field was edited`).toBe('Renamed by the author');
+      expect(wire.name.type, `${storedType}: the control field is still text`).toBe('text');
+
+      checked += 1;
+      cleanup();
+    }
+
+    // The vacuity guard, restated where the iteration happens.
+    expect(checked).toBe(22);
+    expect(checked).toBe(CENSUS.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P2 — the READ path: what the author is SHOWN
+// ---------------------------------------------------------------------------
+
+describe('objectui#8060 · P2 the author is shown the real stored type', () => {
+  it('lists the carried-through fields with their stored type, and never as editable text fields', async () => {
+    await renderPage({
+      parent_id: { type: 'master_detail', label: 'Parent', reference: 'invoice' },
+      vec: { type: 'vector', label: 'Vec' },
+    });
+
+    // Shown: the real types, by name, as concrete distinguishable strings.
+    expect(screen.getByTestId('metadata-fields-page-preserved-type-parent_id').textContent)
+      .toBe('master_detail');
+    expect(screen.getByTestId('metadata-fields-page-preserved-type-vec').textContent)
+      .toBe('vector');
+
+    // NOT shown as editable text fields — the half of the lie a wire-only pin
+    // cannot see. The designer's own list holds the control field alone.
+    const designed = designerProps!.fields;
+    expect(designed.map((f) => f.name)).toEqual(['name']);
+    expect(designed.find((f) => f.name === 'parent_id')).toBeUndefined();
+    expect(designed.find((f) => f.name === 'vec')).toBeUndefined();
+  });
+
+  it('renders no carried-through section at all when every stored type is authorable', async () => {
+    await renderPage({ stage: { type: 'select', label: 'Stage' } });
+
+    expect(screen.queryByTestId('metadata-fields-page-preserved')).toBeNull();
+    expect(designerProps!.fields.map((f) => f.name)).toEqual(['name', 'stage']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P3 / P4 — the NON-REGRESSION axis, from the plausible WRONG FIX
+// ---------------------------------------------------------------------------
+
+describe('objectui#8060 · P3 the designer still owns every type inside its own set', () => {
+  it('offers all 27 as editable, carries none of them through, and round-trips each', async () => {
+    const stored: Record<string, Record<string, unknown>> = {};
+    for (const t of DESIGNER_TYPES) {
+      stored[`f_${t}`] = t === 'lookup'
+        ? { type: t, label: t, reference: 'invoice' }
+        : { type: t, label: t };
+    }
+
+    await renderPage(stored);
+
+    // ⚠️ The plausible WRONG FIX preserves so broadly that a field the designer
+    // legitimately owns becomes read-only. Nothing here may be carried through.
+    expect(screen.queryByTestId('metadata-fields-page-preserved')).toBeNull();
+
+    let offered = 0;
+    for (const t of DESIGNER_TYPES) {
+      const field = designerProps!.fields.find((f) => f.name === `f_${t}`);
+      expect(field, `${t} must be offered to the designer`).toBeDefined();
+      expect(field!.type, `${t} must be read back as itself`).toBe(t);
+      offered += 1;
+    }
+    expect(offered).toBe(27);
+    expect(offered).toBe(DESIGNER_TYPES.length);
+
+    const wire = await relabelControlOnly();
+    let written = 0;
+    for (const t of DESIGNER_TYPES) {
+      expect(wire[`f_${t}`].type, `${t} must round-trip on the wire`).toBe(t);
+      written += 1;
+    }
+    expect(written).toBe(27);
+  });
+});
+
+describe('objectui#8060 · P4 a designer-owned type CHANGE is still honored', () => {
+  it('writes the new type the author chose, not the stored one', async () => {
+    await renderPage({ stage: { type: 'select', label: 'Stage' } });
+
+    const next = designerProps!.fields.map((f) =>
+      f.name === 'stage' ? { ...f, type: 'number' as const } : f,
+    );
+    await act(async () => {
+      designerProps!.onFieldsChange!(next);
+    });
+    await waitFor(() => expect(puts).toHaveLength(1));
+
+    // A "preserve everything" fix writes `select` here and this goes RED — the
+    // caricature in the OTHER direction from the bug.
+    expect(puts[0].body.fields.stage.type).toBe('number');
+    expect(puts[0].body.fields.stage.type).not.toBe('select');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P5 — a stored type in NEITHER vocabulary
+// ---------------------------------------------------------------------------
+
+describe('objectui#8060 · P5 a stored type in neither set', () => {
+  it('is carried through verbatim, so the server refuses it LOUDLY instead of it being erased', async () => {
+    // Not a spec `FieldType` and not a designer type. Preserving it means the
+    // PUT comes back 422 naming this field — the author is told and the stored
+    // document is untouched. Rewriting it to `text` would make the save SUCCEED
+    // and destroy the evidence, which is this card's whole shape.
+    expect(SPEC_FIELD_TYPES).not.toContain('quantum_flux');
+    expect(DESIGNER_TYPES).not.toContain('quantum_flux');
+
+    await renderPage({ odd: { type: 'quantum_flux', label: 'Odd' } });
+
+    expect(screen.getByTestId('metadata-fields-page-preserved-type-odd').textContent)
+      .toBe('quantum_flux');
+
+    const wire = await relabelControlOnly();
+    expect(wire.odd.type).toBe('quantum_flux');
+    expect(wire.odd.type).not.toBe('text');
+  });
+
+  it('leaves a field with NO stored type to the designer — there is nothing stored to destroy', async () => {
+    await renderPage({ typeless: { label: 'Typeless' } });
+
+    // Deliberately the OTHER side of the rule: the defect was rewriting a type
+    // the document HELD. An absent type is not one, so `'text'` here invents a
+    // value rather than replacing one, and the field stays editable.
+    expect(screen.queryByTestId('metadata-fields-page-preserved')).toBeNull();
+    expect(designerProps!.fields.find((f) => f.name === 'typeless')!.type).toBe('text');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P6 — ordering, and the collision the read-only half makes reachable
+// ---------------------------------------------------------------------------
+
+describe('objectui#8060 · P6 the carried-through half keeps its place in the document', () => {
+  it('writes the fields back in stored declaration order, preserved ones in situ', async () => {
+    await renderPage({
+      vec: { type: 'vector', label: 'Vec' },
+      stage: { type: 'select', label: 'Stage' },
+    });
+
+    const wire = await relabelControlOnly();
+    // The spec has no field-level ordering key, so DECLARATION ORDER in the
+    // `fields` record IS the object's field order — a preserved field that
+    // jumped to the end would silently reorder the author's object.
+    expect(Object.keys(wire)).toEqual(['name', 'vec', 'stage']);
+  });
+
+  it('keeps stored fields ahead of a newly added one, carried-through ones included', async () => {
+    await renderPage({
+      vec: { type: 'vector', label: 'Vec' },
+      stage: { type: 'select', label: 'Stage' },
+    });
+
+    const next: DesignerFieldDefinition[] = [
+      ...designerProps!.fields,
+      { id: 'fld_new', name: 'brand_new', label: 'Brand new', type: 'text' },
+    ];
+    await act(async () => {
+      designerProps!.onFieldsChange!(next);
+    });
+    await waitFor(() => expect(puts).toHaveLength(1));
+
+    // `vec` is not in the designer's list at all, so it has no anchor of its
+    // own to sort against the new field — it must still land in its stored slot
+    // rather than being pushed behind a field the author only just created.
+    expect(Object.keys(puts[0].body.fields)).toEqual(['name', 'vec', 'stage', 'brand_new']);
+    expect(puts[0].body.fields.vec.type).toBe('vector');
+  });
+
+  it('refuses a new field whose name collides with a carried-through one, and issues no PUT', async () => {
+    await renderPage({ vec: { type: 'vector', label: 'Vec' } });
+
+    const next: DesignerFieldDefinition[] = [
+      ...designerProps!.fields,
+      { id: 'fld_new', name: 'vec', label: 'My new field', type: 'text' },
+    ];
+    await act(async () => {
+      designerProps!.onFieldsChange!(next);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('metadata-fields-page-error').textContent)
+        .toMatch(/collides with a stored field of type `vector`/),
+    );
+    expect(puts).toEqual([]);
+  });
+});

--- a/packages/plugin-designer/src/MetadataFieldsPage.tsx
+++ b/packages/plugin-designer/src/MetadataFieldsPage.tsx
@@ -28,6 +28,14 @@
  * know about (indexes, hooks, permissions, lifecycle, …) by deep
  * cloning the loaded raw payload and only swapping in the new
  * `fields` map on save.
+ *
+ * The same principle runs one and two levels down. Per-field KEYS
+ * the designer does not render survive via `carryOver`; and a whole
+ * FIELD whose stored `type` the designer cannot author is carried
+ * through verbatim rather than rebuilt from a model that has no way
+ * to hold it (objectui#8060 — see `partitionStoredFields`). Those
+ * fields are listed on the page read-only, showing their real stored
+ * type, instead of being drawn as editable `text` fields.
  */
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -101,11 +109,51 @@ interface ServerObjectSchema {
 // Derived from the canonical vocabulary rather than restated (objectui#3017).
 const KNOWN_FIELD_TYPES: ReadonlySet<DesignerFieldType> = new Set(DESIGNER_FIELD_TYPES);
 
-function toDesignerType(raw: string | undefined): DesignerFieldType {
-  if (raw && KNOWN_FIELD_TYPES.has(raw as DesignerFieldType)) {
-    return raw as DesignerFieldType;
-  }
-  return 'text';
+/**
+ * Does the designer own this stored `type` — i.e. can it round-trip it?
+ *
+ * ## What this replaced, and why the replacement is a PARTITION and not a default
+ *
+ * This predicate is what is left of `toDesignerType`, which answered
+ * `DesignerFieldType` for every input by falling back to `'text'`
+ * (objectui#8060). That fallback was not a display default: `toDesignerField`
+ * called it on the READ path, so the collapse happened before the author saw
+ * anything, and `fromDesignerField` emits `type: designed.type`, so the
+ * collapsed value was written back. Relabelling ONE field rewrote every other
+ * field whose type this designer does not author:
+ *
+ *   stored { parent_id: { type: 'master_detail', reference: 'invoice' } }
+ *   relabel an unrelated `name` field
+ *     => WIRE { parent_id: { "type": "text", "reference": "invoice" } }
+ *
+ * `text` is a LEGAL spec type, so the PUT succeeded, the designer redrew the
+ * field as text, and nothing reported it. Restoring the relationship required
+ * knowing what the type used to be, which the stored document no longer said.
+ *
+ * ## The census — measured, not estimated (objectui#8060 step 1)
+ *
+ * `DESIGNER_FIELD_TYPES` has 27 members and every one of them is a declared
+ * `FieldType`, so the designer's vocabulary is a strict SUBSET of the spec's.
+ * `FieldType` in `@objectstack/spec` 17.3.0 declares 49. The difference is 22
+ * members, and each one was a distinct data-loss case:
+ *
+ *   secret, richtext, toggle, multiselect, radio, checkboxes, master_detail,
+ *   tree, user, avatar, video, audio, summary, composite, repeater, record,
+ *   json, signature, qrcode, progress, tags, vector
+ *
+ * The card confirmed two of them (`master_detail`, `vector`); the other 20 are
+ * enumerated here. The set is pinned by size AND by membership in
+ * `MetadataFieldsPage.storedTypePreserved.test.tsx`, which drives its class pin
+ * from the difference rather than from a hand-written list — a fix scoped to
+ * the two known members would leave 20 fields failing in the way that is
+ * hardest to notice next.
+ *
+ * ⚠️ The 22 are the census, NOT the predicate. This function deliberately does
+ * not consult `@objectstack/spec`: see {@link partitionStoredFields} for why a
+ * type in NEITHER set is preserved too.
+ */
+function isDesignerAuthorableType(raw: unknown): raw is DesignerFieldType {
+  return typeof raw === 'string' && KNOWN_FIELD_TYPES.has(raw as DesignerFieldType);
 }
 
 function toDesignerField(name: string, raw: ServerFieldSchema): DesignerFieldDefinition {
@@ -113,7 +161,11 @@ function toDesignerField(name: string, raw: ServerFieldSchema): DesignerFieldDef
     id: name,
     name,
     label: raw.label ?? name,
-    type: toDesignerType(raw.type),
+    // Safe by construction rather than by fallback: only fields whose stored
+    // type this designer authors reach here — `partitionStoredFields` routes
+    // the rest to the preserved half, and a field with NO stored type has
+    // nothing to destroy, so it lands here and takes the designer's `'text'`.
+    type: isDesignerAuthorableType(raw.type) ? raw.type : 'text',
     group: raw.group,
     description: raw.description,
     required: raw.required,
@@ -179,6 +231,73 @@ function carryOver(prev?: ServerFieldSchema): ServerFieldSchema {
   return next;
 }
 
+/** One stored field the designer cannot author, kept whole. */
+interface PreservedField {
+  name: string;
+  raw: ServerFieldSchema;
+  /** The verbatim stored `type`, rendered so the author sees the truth. */
+  storedType: string;
+}
+
+/**
+ * Split the stored `fields` map into the half this designer authors and the
+ * half it only carries (objectui#8060).
+ *
+ * ## The rule, in three cases — it turns on the STORED type, nothing else
+ *
+ * | stored `type`             | where it goes | why                                    |
+ * |---------------------------|---------------|----------------------------------------|
+ * | in `DESIGNER_FIELD_TYPES` | designable    | the designer authors it; unchanged     |
+ * | present, outside that set | preserved     | there is a stored type to destroy      |
+ * | absent                    | designable    | nothing stored, so nothing to destroy  |
+ *
+ * The absent case is deliberate and is NOT the old fallback returning under a
+ * new name. The defect was rewriting a type the author's document HELD; a field
+ * with no `type` holds none, so `'text'` there invents a value rather than
+ * replacing one. Routing it to the preserved half instead would emit a
+ * type-less field the spec refuses and give the author no control to repair it.
+ *
+ * ## ⭐ A type in NEITHER set is preserved as well, and that is the decision
+ *
+ * The predicate asks only "does `DESIGNER_FIELD_TYPES` contain it". It does NOT
+ * ask `@objectstack/spec` whether the value is a legal `FieldType`, and the
+ * omission is chosen rather than skipped:
+ *
+ * 1. **A stale local vocabulary must not get a vote on destruction.** The spec
+ *    is a versioned dependency and the stored document was written by a server
+ *    that may be AHEAD of the copy bundled here. Flattening everything this
+ *    build's `FieldType` does not recognise would re-create this very defect
+ *    the day the spec declares its 50th type — silently, and only for the
+ *    people running a newer backend.
+ * 2. **Re-sending a genuinely garbage type is the LOUD failure, not the silent
+ *    one.** `FieldSchema` refuses an unknown type by value, so the PUT comes
+ *    back `422 INVALID_METADATA` naming `fields.<name>.type`: the author is
+ *    told, and the stored document is untouched and still repairable. Rewriting
+ *    it to `text` is the opposite trade — the save SUCCEEDS and the evidence of
+ *    what the field was is gone. This card exists because that trade was made.
+ * 3. It keeps `@objectstack/spec` out of this plugin's runtime graph. The
+ *    census above is derived in the TEST, where being one spec version behind
+ *    makes a pin stale rather than makes a document lossy.
+ *
+ * A non-string `type` (an untrusted payload can carry `42`) is "present and
+ * outside the set", so it preserves too, on exactly reason 2.
+ */
+function partitionStoredFields(rawFields: Record<string, ServerFieldSchema> | undefined): {
+  designable: DesignerFieldDefinition[];
+  preserved: PreservedField[];
+} {
+  const designable: DesignerFieldDefinition[] = [];
+  const preserved: PreservedField[] = [];
+  for (const [name, raw] of Object.entries(rawFields ?? {})) {
+    if (raw?.type !== undefined && !isDesignerAuthorableType(raw.type)) {
+      preserved.push({ name, raw, storedType: String(raw.type) });
+    } else {
+      designable.push(toDesignerField(name, raw));
+    }
+  }
+  return { designable, preserved };
+}
+
 function fromDesignerField(
   designed: DesignerFieldDefinition,
   prev?: ServerFieldSchema,
@@ -213,16 +332,27 @@ function fromDesignerField(
  * exactly these two are refused at path `reference`, both with code `custom`,
  * and the other 47 are not refused at all on that minimal document.
  *
- * ⚠️ `master_detail` is RECORDED-DEFENSIVE on this page rather than reachable,
- * and says so instead of reading as coverage: `toDesignerType` maps every type
- * outside `DESIGNER_FIELD_TYPES` to `'text'`, and `master_detail` is not in
- * that set — so a stored master-detail field arrives here already flattened and
- * this branch never fires. Measured for objectui#7714: a stored
- * `{ type: 'master_detail', reference: 'invoice' }` reaches the wire as
- * `{ type: 'text', reference: 'invoice' }`. That flattening is its own defect,
- * filed from this card as objectui#8060; the entry stays so the two writers state ONE invariant
- * and so this page is already correct when the flattening is fixed. The sibling
- * in `MetadataService.ts` has it reachable today, through `saveObject`.
+ * ⭐ `master_detail` is now REACHABLE on this page. It was RECORDED-DEFENSIVE
+ * — the entry existed for parity with the sibling writer while nothing here
+ * could ever hand the guard one, because `toDesignerType` mapped every type
+ * outside `DESIGNER_FIELD_TYPES` to `'text'` on the READ path, so a stored
+ * master-detail arrived already flattened. objectui#8060 removed that
+ * flattening: a stored type this designer cannot author is now carried through
+ * verbatim (see {@link partitionStoredFields}) and `toFieldsMap` runs this
+ * guard over the carried-through entries as well, so the branch fires on the
+ * real type.
+ *
+ * ⚠️ That makes this a BEHAVIOUR CHANGE, not just restored coverage, and it is
+ * stated rather than left to be discovered: an object holding a target-less
+ * stored `master_detail` used to SAVE from this page — by flattening the field
+ * to `text` and losing the relationship — and is now refused by name before the
+ * PUT. The refusal is the better half of a bad pair: `@objectstack/spec` 17.3.0
+ * requires `reference` on `master_detail`, so that document's PUT would answer
+ * `422 INVALID_METADATA` anyway; refusing here names the field and says what to
+ * fix, and leaves the stored relationship intact instead of overwriting it.
+ * The sibling in `MetadataService.ts` has had it reachable all along, through
+ * `saveObject` — so the two writers now state ONE invariant and both exercise
+ * it.
  */
 const RELATIONSHIP_TYPES_REQUIRING_REFERENCE = ['lookup', 'master_detail'];
 
@@ -407,7 +537,15 @@ function toFieldsMap(
   next: DesignerFieldDefinition[],
   prevFields: Record<string, ServerFieldSchema>,
 ): Record<string, ServerFieldSchema> {
-  const entries: Array<[string, ServerFieldSchema]> = [];
+  // Derived HERE from the same `prevFields` this function writes back, rather
+  // than passed in from the component's render memo. The two would be computed
+  // from the same `state.raw` today, but a preserved list that could disagree
+  // with `prevFields` is a way to drop a field silently — and that is the
+  // failure mode this whole card is about.
+  const preservedByName = new Map(
+    partitionStoredFields(prevFields).preserved.map((f) => [f.name, f] as const),
+  );
+  const designedByName = new Map<string, DesignerFieldDefinition>();
   const seen = new Set<string>();
 
   next.forEach((designed, index) => {
@@ -427,7 +565,60 @@ function toFieldsMap(
           + 'silently replace the earlier. Rename or remove one of them.',
       );
     }
+    if (preservedByName.has(name)) {
+      // Reachable, not defensive: `FieldDesigner`'s add-field form takes a free
+      // text `name`, so an author can create `vec` while a preserved `vec` is
+      // sitting in the read-only list they cannot edit. A name-keyed map cannot
+      // carry both, and whichever we dropped would be dropped silently — which
+      // is the shape this whole card is about.
+      throw new Error(
+        `[MetadataFieldsPage] cannot build the object's \`fields\` map: the field \`${name}\` at index `
+          + `${index} collides with a stored field of type \`${preservedByName.get(name)!.storedType}\`, `
+          + 'which this designer cannot author and therefore carries through unchanged. A name-keyed map '
+          + 'cannot hold both, and the stored one is not editable here to make room. Rename the new field.',
+      );
+    }
     seen.add(name);
+    designedByName.set(name, designed);
+  });
+
+  // ## Ordering — the designer's list is primary, stored positions are honoured
+  //
+  // Field order is load-bearing: the spec has no field-level ordering key, so
+  // DECLARATION ORDER in the `fields` record IS the object's field order.
+  // `next` carries the author's order and must stay primary — it can hold a
+  // NEW field anywhere in the list, and objectui#6489's `__proto__` pin asserts
+  // exactly that. The carried-through fields are not in `next` at all (the
+  // designer never sees them), so each one is spliced back in at the position
+  // it holds in the STORED document — before the first designer field that
+  // stored after it. A carried-through field that jumped to the end would
+  // silently reorder the author's object.
+  const storedIndex = new Map(Object.keys(prevFields).map((name, i) => [name, i] as const));
+  const pending = [...preservedByName.values()].sort(
+    (a, b) => (storedIndex.get(a.name) ?? 0) - (storedIndex.get(b.name) ?? 0),
+  );
+  const entries: Array<[string, ServerFieldSchema]> = [];
+  let pendingAt = 0;
+  const emitPreservedBefore = (limit: number) => {
+    while (pendingAt < pending.length && (storedIndex.get(pending[pendingAt].name) ?? 0) < limit) {
+      const keep = pending[pendingAt];
+      pendingAt += 1;
+      // ⭐ The whole repair, and it is the mechanism this page ALREADY used one
+      // level down: `carryOver` is what makes unknown per-field KEYS survive an
+      // edit-and-save, and a stored `type` this designer cannot author is the
+      // same problem one level up. So the field is re-emitted from the stored
+      // document verbatim — `type` included — rather than being rebuilt from a
+      // designer model that has no way to hold it. The tombstone strip still
+      // applies, because those keys 422 whoever wrote them.
+      entries.push([keep.name, carryOver(keep.raw)]);
+    }
+  };
+
+  for (const [name, designed] of designedByName) {
+    // A field the designer ADDED is not in the stored document, so nothing
+    // stored can be said to sort after it: flush the rest of the carried-through
+    // fields first, keeping every stored field ahead of every new one.
+    emitPreservedBefore(storedIndex.get(name) ?? Number.POSITIVE_INFINITY);
     // The carried-over previous definition is read as an OWN property for the
     // same reason the map is BUILT as own properties: `prevFields[name]` answers
     // out of `Object.prototype` for the two spec-legal names that live there
@@ -438,15 +629,26 @@ function toFieldsMap(
     const prev = Object.prototype.hasOwnProperty.call(prevFields, name)
       ? prevFields[name]
       : undefined;
-    const emitted = fromDesignerField(designed, prev);
-    // Checked on the EMITTED entry, not on `designed`: `fromDesignerField`
-    // merges the carried-over server definition underneath the designer's
-    // values, so a field the author never touched can legitimately take its
-    // target from `prev`. Reading `designed.referenceTo` alone would refuse
-    // every one of those — a save the server accepts, blocked by the client.
-    assertRelationshipTargetPresent(emitted, name, '[MetadataFieldsPage]');
-    entries.push([name, emitted]);
-  });
+    entries.push([name, fromDesignerField(designed, prev)]);
+  }
+  emitPreservedBefore(Number.POSITIVE_INFINITY);
+
+  // Checked on the EMITTED entries rather than on the designer models:
+  // `fromDesignerField` merges the carried-over server definition underneath
+  // the designer's values, so a field the author never touched can legitimately
+  // take its target from `prev`; reading `designed.referenceTo` alone would
+  // refuse every one of those — a save the server accepts, blocked by the
+  // client. It runs over the PRESERVED entries too, and that half is
+  // objectui#7714's guard entry going LIVE: the guard listed `master_detail`
+  // for parity with the sibling writer while this page could never hand it one,
+  // because the flattening turned every stored master-detail into a `text`
+  // before the guard saw it. Now that the stored type survives, a stored
+  // `master_detail` arrives with its real type and a target-less one is refused
+  // BY NAME before the PUT — instead of being saved as a `text` field with the
+  // relationship gone.
+  for (const [name, field] of entries) {
+    assertRelationshipTargetPresent(field, name, '[MetadataFieldsPage]');
+  }
 
   return Object.fromEntries(entries);
 }
@@ -517,10 +719,10 @@ export function MetadataFieldsPage({
     void reload();
   }, [reload]);
 
-  const fields = useMemo<DesignerFieldDefinition[]>(() => {
-    if (!state.raw?.fields) return [];
-    return Object.entries(state.raw.fields).map(([name, f]) => toDesignerField(name, f));
-  }, [state.raw]);
+  const { designable: fields, preserved } = useMemo(
+    () => partitionStoredFields(state.raw?.fields),
+    [state.raw],
+  );
 
   const handleFieldsChange = useCallback(async (next: DesignerFieldDefinition[]) => {
     if (!state.raw) return;
@@ -570,6 +772,34 @@ export function MetadataFieldsPage({
         onFieldsChange={(next) => { void handleFieldsChange(next); }}
         readOnly={readOnly}
       />
+      {preserved.length > 0 && (
+        <section
+          data-testid="metadata-fields-page-preserved"
+          className="mt-4 rounded border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900"
+        >
+          <h3 className="mb-1 font-medium">
+            {`Carried through unchanged (${preserved.length})`}
+          </h3>
+          <p className="mb-2">
+            These fields are stored with a type this designer cannot author, so it shows them
+            rather than editing them. They are saved back exactly as stored — editing any other
+            field on this object leaves them untouched. Use metadata-admin to change them.
+          </p>
+          <ul className="space-y-1">
+            {preserved.map((f) => (
+              <li key={f.name} data-testid={`metadata-fields-page-preserved-${f.name}`}>
+                <code>{f.name}</code>
+                {' — '}
+                <span>{f.raw.label ?? f.name}</span>
+                {' · '}
+                <code data-testid={`metadata-fields-page-preserved-type-${f.name}`}>
+                  {f.storedType}
+                </code>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Fixes #8060

`MetadataFieldsPage` rewrote any stored field type outside `DESIGNER_FIELD_TYPES` to `text` on save. `toDesignerType` fell back to `'text'` on the **read** path — so the collapse happened before the author saw anything — and `fromDesignerField` emitted `type: designed.type`, so the collapsed value was written back. Relabelling one field destroyed every other field whose type this designer does not author, on the same PUT. `text` is a **legal** spec type, so the save succeeded and nothing reported it.

## Step 1 — the census (it gates the direction)

Derived, not estimated: `DESIGNER_FIELD_TYPES` has **27** members; `FieldType` in `@objectstack/spec` 17.3.0 declares **49**; all 27 are a strict subset of the 49 (`designer − spec = ∅`, and `27 + 22 = 49`).

**The difference set is 22, and each member was a distinct data-loss case:**

`secret` · `richtext` · `toggle` · `multiselect` · `radio` · `checkboxes` · `master_detail` · `tree` · `user` · `avatar` · `video` · `audio` · `summary` · `composite` · `repeater` · `record` · `json` · `signature` · `qrcode` · `progress` · `tags` · `vector`

The card confirmed two (`master_detail`, `vector`); **the other 20 are enumerated here for the first time.** The set is derived at test time and re-asserted against a literal, so a spec that grows a 50th type fails the pin instead of becoming the next silent data-loss report.

⚠️ `FieldType` lives on the `/data` subpath — the spec root export is thin, and a root import answering `undefined` is a specifier problem, not evidence the type is absent.

**Direction 1 is viable and is what shipped.** Because the designer's vocabulary is a strict subset, preserving what it cannot author narrows nothing. ⛔ Direction 2 (extending `DESIGNER_FIELD_TYPES`) is **not** taken — it widens the authoring surface and needs a maintainer ruling.

## What changed

`packages/plugin-designer/src/MetadataFieldsPage.tsx`

- `toDesignerType` is replaced by `isDesignerAuthorableType` — a **partition predicate**, not a default. `partitionStoredFields` splits the stored `fields` map into the half the designer authors and the half it only carries.
- **Read path** — a field whose stored type is outside the set is no longer handed to `FieldDesigner` as a `text` field. It is listed in a read-only section showing its **real stored type**.
- **Write path** — that field is re-emitted from the stored document **verbatim** via `carryOver`, which is the mechanism this page already used one level down for unknown per-field **keys**. Same principle, one level up. The tombstone strip still applies.
- Ordering is preserved: the designer's list stays primary (objectui#6489's `__proto__` pin asserts a new field can sit anywhere), and carried-through fields are spliced back at their stored position.
- A new field colliding with a carried-through name is refused by name — reachable, since the add-field form takes a free-text name.

### Types in neither set — the decision, stated

A stored type that is in **neither** vocabulary is **also carried through**. The predicate deliberately never asks `@objectstack/spec` whether the value is legal:

1. A **stale local vocabulary must not get a vote on destruction** — the spec is a versioned dependency and the stored document may come from a newer backend. Flattening what this build does not recognise re-creates this defect the day the spec declares its 50th type.
2. Re-sending a genuinely garbage type is the **loud** failure: a 422 naming the field, with the stored document intact and repairable. Rewriting to `text` is the silent one — the save succeeds and the evidence is gone.
3. It keeps `@objectstack/spec` out of this plugin's runtime graph.

A field with **no** stored type stays designer-owned and takes `'text'` — the defect was rewriting a type the document *held*; an absent type is not one.

## objectui#7714's marker — re-read, and it had stopped measuring

Fence honoured. The marker case in `MetadataFieldsPage.specKeyReference.test.tsx` asserted `expect(true).toBe(true)`: its `master_detail` refusal was **recorded-defensive**, green because the guard never saw a `master_detail`, not because it handled one. *A check that cannot fire is indistinguishable from one that passed.*

**This fix makes that branch live**, so the marker is now a real pin of **both** outcomes — a targeted `master_detail` reaching the wire with its real type, and a target-less one refused by name with no PUT. The `RELATIONSHIP_TYPES_REQUIRING_REFERENCE` docblock is rewritten from "recorded-defensive" to "reachable".

⚠️ **Behaviour change, named rather than absorbed:** an object holding a target-less stored `master_detail` used to save from this page by flattening the field to `text` and losing the relationship. It is now refused before the PUT. The spec requires `reference` on `master_detail`, so that document's PUT answers 422 regardless; refusing here names the field and leaves the stored relationship intact.

⚠️ **Second behaviour change:** carried-through fields are no longer editable or **deletable** from this page — deleting one was previously possible only because it had already been misrepresented as text. metadata-admin remains the surface for changing them.

⛔ The parity gate was **not** touched: `check-designer-field-key-parity.mjs` compares key sets, never values, and its own boundary section says so. A wrong-but-legal `type` **value** is outside it in both directions.

## Pins — 11 new, held to the filing's evidence bar

`packages/plugin-designer/src/MetadataFieldsPage.storedTypePreserved.test.tsx` drives the **real page** with a real `MetadataClient` over a fetch double and asserts the **captured PUT bytes**, with an untouched control field. `FieldDesigner` is the only double (a prop recorder).

| pin | asserts |
|---|---|
| **C0** | the census is non-empty, exactly 22, exact membership, and 27 + 22 = 49 |
| **P1** | **class pin, driven from the census** — every one of the 22 round-trips its stored type through the PUT bytes on an edit that only relabels an unrelated control field |
| **P2** | **the read path** — the author is *shown* `master_detail` / `vector`, and those fields are never offered as editable text fields |
| **P3** | all **27** designer types stay editable, are carried through by nothing, and round-trip |
| **P4** | a designer-owned type **change** is still honoured on the wire |
| **P5** | a type in neither set is carried through verbatim; a field with no type stays editable |
| **P6** | stored declaration order survives, new fields land after stored ones, and the name collision is refused with no PUT |

**Vacuity guard** (a census-driven pin passes over an empty set): C0 asserts size and membership, and every iterating pin counts its own iterations and asserts the count — so an emptied census fails in three places instead of passing in one.

**`undefined === undefined`** is avoided throughout: every read- and wire-side assertion compares concrete, distinguishable type strings and additionally asserts `not.toBe('text')`.

## Ablation — every leg mutated on disk, hash-verified, trap-restored, classified from vitest's JSON reporter

| leg | mutation | result |
|---|---|---|
| **A** | the bug restored (`MetadataFieldsPage.tsx` at the merge-base) | **RED ×6** — P1 at `secret` (`expected 'text' to be 'secret'`), P2, P5, P6, **and the converted #7714 marker** (`expected 'text' to be 'master_detail'`). C0/P3/P4 stay green — they measure the other axis |
| **B** | caricature: the preserve branch preserves **everything**, designer types included | **RED ×6** — P3 and **P4** (`expected 'select' to be 'number'`) |
| **C** | *(negative leg — reported as such)* inverted predicate | **did not discriminate.** The mutation accidentally repaired the read fallback too, so it modelled something other than a two-member fix. Re-modelled as leg E |
| **E** | the **faithful** two-member fix — preserve only `master_detail`/`vector`, leave the `'text'` fallback | **RED** — P1 at `secret`. This is the discriminating question answered: a fix scoped to the two known members fails the class pin |
| **D** | the census emptied | **RED ×2** — C0 (`expected 0 to be greater than 0`) and P1's counter (`expected +0 to be 22`) |

Caricature goes **RED in both directions** (A and B). No leg was void; no death strings (`Element type is invalid`, `Failed Suites`, `No test suite found in file`, `Transform failed`) appeared in any leg. After the legs, all three files are **byte-identical to HEAD** (`git hash-object` == `git rev-parse HEAD:PATH`) and `git status` is clean.

## Verification

- `pnpm exec vitest run packages/plugin-designer/` — **18 files, 140 tests, all passed** (rooted at the repo root; root-relative form).
- Cross-package: the only import of `@object-ui/plugin-designer` outside the package is one app-shell translations test (control fired on the same command shape). Narrowed set — app-shell `MetadataService.specKeyReference` / `fieldKeyCarryOver` / `retiredFieldSortOrder` / `objectPayloadFieldsMap`, `defaults-maps-mirror-en-pack`, `types` designer-field-types + tombstones — **7 files, 96 tests, all passed**.
- `pnpm --filter @object-ui/plugin-designer type-check` — **exit 0**, on a tree with the dependency closure built first (it caught a real dropped `label` line during development).
- `pnpm lint` (repo-wide, plain form) — **47/47 tasks successful, 0 errors**.
- Gates: `check:control-bytes` ✅ · `check:phantom-deps` ✅ · `check:designer-field-key-parity` ✅ (unchanged, and untouched) · `check:vi-mock-specifiers` ✅ · `check:vi-mock-inherit` ✅ · `check:spec-symbols` ✅ · `check:i18n-keys` ✅ · `check:i18n-drift` ✅ · `check:unused-deps` ✅.
- Changeset verdict line, quoted: `✅  3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/hungry-poems-shave.md.` and `✅  No changeset declares a 'major' bump.` Shipped as `minor` with the change spelled out in the body.

## Adjacent cards

⛔ #8057 (metadata-admin's `ResourceEditPage`, a third writer) and #8058 (`referenceTo`-only lookup targets on the read door) are **not** addressed here and remain open. This diff touches neither: it changes only the `type` key's read/write path plus the merge, and leaves `toDesignerField`'s `referenceTo: raw.reference` read and the `carryOver` tombstone strip exactly as they were — the two lines #8058 is about. No collision.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_