### PR TITLE
fix(fields): an object literal is not a cell value — six renderer families invented an identity for it (objectui#8596)

### DIFF
--- a/.changeset/8596-object-literal-cell-renderers.md
+++ b/.changeset/8596-object-literal-cell-renderers.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/fields': patch
+---
+
+An object literal is no longer drawn as an invented identity in six cell-renderer
+families (objectui#8596).
+
+Measured by rendering all 53 registered field types through `getCellRenderer` against
+`[]`, `{}`, `''` and `null` — 212 cells — before and after. **14 cells moved, all in the
+`{}` column**; the `[]`, `''` and `null` columns are byte-identical.
+
+| field types | `{}` drew | `{}` now draws |
+|---|---|---|
+| `email` / `url` / `phone` | a live anchor — `mailto:[Object]`, `tel:[Object]` — plus a copy button | `[Object]`, exactly as `text` prints it |
+| `color` | a swatch whose `background` was the string `[object Object]` | `[Object]`, exactly as `text` prints it |
+| `select` / `status` / `multiselect` / `radio` / `checkboxes` / `tags` | a badge reading `[Object Object]` | a badge reading `[Object]` |
+| `user` | an avatar captioned `U`, labelled `User` | `[Object]`, exactly as `lookup` prints it |
+| `file` / `video` / `audio` | a chip named `File` | the shared "No value" affordance |
+
+The direction is the spec's, per family, not one sweep. `email` / `url` / `phone` /
+`color` are `STRING_VALUE_TYPES` ("Value is a plain string") — the same set whose `{}`
+ruling landed for `markdown` / `html` / `richtext`: the record IS storing something, so
+it prints the family's existing coercion rather than the "No value" affordance, and
+draws no affordance that asserts more (a `mailto:[Object]` cannot send mail; a copy
+button offers `[Object]` to the clipboard; `background: [object Object]` is a
+declaration the browser drops). The option families resolve to a string code, so the
+same coercion answers them and the badge stays. `user` shares its `valueSchemaFor` arm
+with `lookup`, which already answered an object it cannot name with the coerced text.
+
+`file` / `video` / `audio` are the family whose answer differs, and the spec names the
+input: the media value schema makes `url` its one required member and rejects "an empty
+object", so `{}` is a value of neither the stored nor the expanded form — the record
+holds no file, and "No value" is true of it. `image` / `avatar`, the same spec family,
+already answered `{}` that way.
+
+Deliberately not swept: `boolean` / `toggle` (already fixed), the declared json-literal
+fence on `location` / `geolocation` / `json` / `object` / `composite` / `record`, the
+`date` renderer's own dash, arrays (a one-entry array still coerces and still links), and
+any object carrying a member — a `{ name: 'contract.pdf' }` attachment and a
+`{ id: 'u_1' }` reference render exactly as before, so real data is never hidden.

--- a/packages/fields/src/__tests__/cellRenderers.objectLiteral-8596.test.tsx
+++ b/packages/fields/src/__tests__/cellRenderers.objectLiteral-8596.test.tsx
@@ -1,0 +1,702 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8596 — an object literal is not a cell value, and six renderer
+ * families invented an IDENTITY for it.
+ *
+ * The `[]` column of this census is closed (objectui#8481 → objectui#8490 →
+ * objectui#8580). This is the `{}` column. It was measured the same way, and
+ * only that way: all 53 registered field types rendered through
+ * `getCellRenderer` against `[]`, `{}`, `''` and `null` — 212 cells — on
+ * `4eb665bcf`, then re-rendered after the fix and diffed. A regex over class
+ * strings under-counted this class three separate times; the instrument is
+ * below, as `THE CENSUS`, so it stays runnable.
+ *
+ * Measured before → after, `{}` column only (14 of 212 cells moved; the `[]`,
+ * `''` and `null` columns are byte-identical):
+ *
+ * | field types                                        | renderer                  | `{}` before                                    | `{}` after                     |
+ * |----------------------------------------------------|---------------------------|------------------------------------------------|--------------------------------|
+ * | email, url, phone                                  | Email/Url/PhoneCell       | a LIVE anchor — `mailto:[Object]`, `[Object]`, `tel:[Object]` — plus a copy button | `[Object]`, as `text` prints it |
+ * | color                                              | `ColorSwatchCellRenderer` | a swatch whose `background` was `[object Object]` | `[Object]`, as `text` prints it |
+ * | select, status, multiselect, radio, checkboxes, tags | `SelectCellRenderer`      | a badge reading `[Object Object]`               | a badge reading `[Object]`     |
+ * | user                                               | `UserCellRenderer`        | an avatar captioned `U`, labelled `User`        | `[Object]`, as `lookup` prints it |
+ * | file, video, audio                                 | `FileCellRenderer`        | a chip named `File`                             | the shared `EmptyValue`        |
+ *
+ * ── Two rows the card named that are NOT here, both verified ──────────────
+ *   - `boolean` / `toggle` LANDED (objectui#8582 / PR #8594, `70c452369`).
+ *     Measured on this base, `{}` already draws the shared affordance. Not
+ *     re-ruled, and pinned unchanged in `THE CENSUS` below.
+ *   - `location` / `geolocation` (and `json` / `object` / `composite` /
+ *     `record`) print the `{}` literal behind objectui#8481's DECLARED
+ *     json-literal fence. Left alone deliberately; pinned unchanged.
+ *   - `date` still draws `formatDate`'s hand-rolled em-dash with no accessible
+ *     name — objectui#8581's subject, the same renderer. This change does not
+ *     touch it, and `THE CENSUS` pins that it did not: the row is recorded as
+ *     a dash that is NOT the affordance, so a fix landing on it here would
+ *     have to move a pin rather than pass silently.
+ *
+ * ── The direction is not open per family: `valueSchemaFor`'s arm decides ──
+ * Read from `@objectstack/spec` `src/data/field-value.zod.ts` (v17.3.0), per
+ * family, before choosing — the card's instruction, and it separated the
+ * families that print from the family that does not:
+ *
+ *   - `email` / `url` / `phone` / `color` are `STRING_VALUE_TYPES` — "Value is
+ *     a plain string", write seam `z.string()`. The SAME set objectui#8580
+ *     ruled on for `markdown` / `html` / `richtext`, and that ruling settles
+ *     `{}` away from the "no value" affordance and toward the family's
+ *     existing coercion: the record IS storing something, so "No value" would
+ *     be false. So they print `coerceToSafeValue`'s answer — pinned BYTE-EQUAL
+ *     to what `text` prints for `{}` below, so the rule cannot drift — and
+ *     they draw no affordance that asserts more than that: `mailto:[Object]`
+ *     cannot send mail, a copy button offers `[Object]` to the clipboard, and
+ *     `background: [object Object]` is a declaration the browser drops.
+ *   - the option families resolve through `SINGLE_OPTION_TYPES` /
+ *     `MULTI_OPTION_TYPES` to `z.enum(codes)` — or `z.string()` when no
+ *     options are declared. Either way the value is a STRING code, so the same
+ *     coercion answers it; the badge stays, because a badge is how this family
+ *     shows any code it was given, including one it does not recognize.
+ *     (`status` is an objectui renderer alias, not a spec `FieldType`; it
+ *     reaches `SelectCellRenderer` through this repo's own map and inherits
+ *     the ruling from it, not from the spec.)
+ *   - `user` shares `REFERENCE_VALUE_TYPES`' arm with `lookup` /
+ *     `master_detail` / `tree`: `ReferenceIdValueSchema` when stored, and in
+ *     expanded form `z.union([ReferenceIdValueSchema, z.record(…)])` — an
+ *     OPEN record, whose "shape is that object's contract, not this field's".
+ *     The spec therefore cannot tell `user` from `lookup` here, and `lookup`
+ *     already answers an object it cannot name with the coerced text. Pinned
+ *     byte-equal to `lookup` below.
+ *   - `file` / `video` / `audio` are the family where the answer DIFFERS, and
+ *     the spec names the input: `FileValueSchema` makes `url` "the one
+ *     required member" and says a value with no `url` — "an empty object, a
+ *     `{ name }` fragment, a number — is now rejected". `{}` is a value of
+ *     neither the stored (`sys_file` id) nor the expanded form, so the record
+ *     holds no file and "No value" is TRUE of it. `image` / `avatar` — the
+ *     same spec family — already answered `{}` that way; `file` now agrees,
+ *     and the two are pinned against each other.
+ *
+ * ⛔ Nothing here invents a renderer-side fallback (AGENTS.md #0.1). Every
+ * family lands on a coercion this package already had, or on the affordance a
+ * sibling in its own spec family already drew.
+ *
+ * ── Why the load-bearing cases are the ones that must NOT move ────────────
+ * The caricature is the shared `EmptyValue` drawn for every cell — "the
+ * mutation that makes the code answer the same thing for everything". It
+ * satisfies every vivid assertion in this file: the checked checkbox is gone,
+ * the `mailto:[Object]` anchor is gone, the `[object Object]` swatch is gone.
+ * What refuses it is:
+ *
+ *   1. `THE CENSUS`, whose `{}` column pins the twenty types that already
+ *      coerced correctly — `number` / `currency` / `percent` / `slider` /
+ *      `rating` / `text` / `code` / `formula` / `lookup` among them — as
+ *      printing their text, and
+ *   2. `POPULATED`, which renders a real value into all 53 types and asserts
+ *      that NONE of them draws the affordance.
+ *
+ * Both were RUN against the caricature; the observed failure sentences are
+ * recorded in the PR, per test, from vitest's JSON reporter.
+ *
+ * ⚠️ A matrix pin over an EMPTY set passes. Both matrices run through
+ * {@link assertCensusComplete}, which asserts the exact expected size before
+ * anything is rendered, and `THE CENSUS` includes a meta-test proving that
+ * guard throws when the set is emptied — a census that silently renders 0
+ * types is the failure mode this file exists to avoid.
+ *
+ * ── Assertion order ───────────────────────────────────────────────────────
+ * Each defect case asserts the ARTEFACT'S ABSENCE first (no anchor, no
+ * swatch, no avatar, no `[Object Object]`, no chip) and the replacement
+ * second, so the unfixed tree fails on a different sentence from a harness
+ * that has lost its navigation target. Both were observed.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+// Module scope, with the SAME specifier `MarkdownCellRenderer`'s `React.lazy`
+// factory uses, so the markdown pipeline is resolved before any assertion
+// waits on it — AGENTS.md 测试纪律.
+import '../widgets/MarkdownContent.js';
+import { getCellRenderer, resolveCellRendererType } from '../index';
+
+afterEach(() => cleanup());
+
+/** Resolve + render exactly the way a consumer builds a read-mode cell. */
+function renderCell(type: string, value: unknown, field: Record<string, unknown> = {}) {
+  const Renderer = getCellRenderer(resolveCellRendererType({ type }) || type);
+  return render(
+    <Renderer value={value as any} field={{ type, name: type, ...field } as any} />,
+  );
+}
+
+/** Let the (already imported) lazy markdown pipeline resolve its Suspense. */
+async function settle() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+/** The shared "No value" affordance — a muted glyph carrying an aria-label. */
+const affordance = (root: HTMLElement) =>
+  root.querySelector<HTMLElement>('[data-slot="empty-value"]');
+
+function expectAffordance(root: HTMLElement, label: string) {
+  const empty = affordance(root);
+  expect(empty, `${label}: the shared EmptyValue affordance must be present`).not.toBeNull();
+  expect(
+    empty?.getAttribute('aria-label'),
+    `${label}: the affordance must carry its accessible name`,
+  ).toBe('No value');
+}
+
+const textOf = (root: HTMLElement) => (root.textContent ?? '').replace(/\s+/g, ' ').trim();
+
+/**
+ * The emptiness guard both matrices below run through.
+ *
+ * A `for` loop over an empty table asserts nothing and reports success, which
+ * is exactly how a census stops measuring without anyone noticing. This throws
+ * on the wrong size BEFORE a single cell is rendered, and the meta-test in
+ * `THE CENSUS` pins that it does.
+ */
+function assertCensusComplete(entries: readonly unknown[], expected: number, what: string): void {
+  if (entries.length !== expected) {
+    throw new Error(
+      `${what}: expected exactly ${expected} registered field types, got ${entries.length}. ` +
+        'A census over a short or empty set passes without measuring anything.',
+    );
+  }
+}
+
+/** Every type `getCellRenderer` resolves to a renderer of its own. */
+const REGISTERED_TYPE_COUNT = 53;
+
+/**
+ * `THE CENSUS` — what every registered type draws for `{}`, on this base.
+ *
+ * `text` is the coerced face of an object with no display name: the one answer
+ * `coerceToSafeValue` has, and the string of characters every row marked
+ * `'[Object]'` below must print. `affordance` records whether the cell draws
+ * the shared "No value" glyph.
+ *
+ * ⚠️ `date` is recorded as `'—'` WITHOUT the affordance on purpose: that dash
+ * is `formatDate`'s own, and it is objectui#8581's subject, not this card's.
+ */
+const OBJECT_LITERAL_CENSUS: ReadonlyArray<readonly [type: string, text: string, hasAffordance: boolean]> = [
+  // ── the twenty that already coerced correctly — LOAD-BEARING ────────────
+  ['text', '[Object]', false],
+  ['textarea', '[Object]', false],
+  ['markdown', '[Object]', false],
+  ['html', '[Object]', false],
+  ['richtext', '[Object]', false],
+  ['code', '[Object]', false],
+  ['qrcode', '[Object]', false],
+  ['time', '[Object]', false],
+  ['auto_number', '[Object]', false],
+  ['number', '[Object]', false],
+  ['currency', '[Object]', false],
+  ['percent', '[Object]', false],
+  ['progress', '[Object]', false],
+  ['slider', '[Object]', false],
+  ['rating', '[Object]', false],
+  ['formula', '[Object]', false],
+  ['summary', '[Object]', false],
+  ['lookup', '[Object]', false],
+  ['master_detail', '[Object]', false],
+  ['tree', '[Object]', false],
+  // ── the fourteen this change moved ──────────────────────────────────────
+  ['email', '[Object]', false],
+  ['url', '[Object]', false],
+  ['phone', '[Object]', false],
+  ['color', '[Object]', false],
+  ['user', '[Object]', false],
+  ['select', '[Object]', false],
+  ['status', '[Object]', false],
+  ['multiselect', '[Object]', false],
+  ['radio', '[Object]', false],
+  ['checkboxes', '[Object]', false],
+  ['tags', '[Object]', false],
+  ['file', '—', true],
+  ['video', '—', true],
+  ['audio', '—', true],
+  // ── already the affordance before this change ───────────────────────────
+  ['boolean', '—', true],   // objectui#8582 / PR #8594 — landed, not re-ruled
+  ['toggle', '—', true],    // objectui#8582 / PR #8594 — landed, not re-ruled
+  ['datetime', '—', true],
+  ['image', '—', true],
+  ['avatar', '—', true],
+  ['signature', '—', true],
+  ['address', '—', true],
+  ['repeater', '—', true],
+  // ── objectui#8481's declared json-literal fence — deliberately untouched ─
+  ['location', '{}', false],
+  ['geolocation', '{}', false],
+  ['json', '{}', false],
+  ['object', '{}', false],
+  ['composite', '{}', false],
+  ['record', '{}', false],
+  // ── value-independent faces, unchanged ─────────────────────────────────
+  ['password', '••••••', false],
+  ['secret', '••••••', false],
+  ['vector', '[Vector]', false],
+  ['grid', '[Grid]', false],
+  // ── objectui#8581's hand-rolled dash — NOT the affordance, NOT moved here ─
+  ['date', '—', false],
+];
+
+/** A real value per type — the POPULATED half, which refuses the caricature. */
+const POPULATED_CENSUS: ReadonlyArray<readonly [type: string, value: unknown]> = [
+  ['text', 'hello'],
+  ['textarea', 'hello'],
+  ['markdown', '**bold**'],
+  ['html', '<p>hi</p>'],
+  ['richtext', '<p>hi</p>'],
+  ['code', '{"ok": true}'],
+  ['qrcode', 'QR-1'],
+  ['time', '09:30'],
+  ['auto_number', 'A-0001'],
+  ['number', 42],
+  ['currency', 42],
+  ['percent', 42],
+  ['progress', 42],
+  ['slider', 42],
+  ['rating', 4],
+  ['formula', 'computed'],
+  ['summary', 7],
+  ['lookup', 'rec_1'],
+  ['master_detail', 'rec_1'],
+  ['tree', 'rec_1'],
+  ['email', 'ada@example.com'],
+  ['url', 'https://objectstack.ai'],
+  ['phone', '+15551234567'],
+  ['color', '#ff0000'],
+  ['user', { name: 'Ada Lovelace' }],
+  ['select', 'active'],
+  ['status', 'active'],
+  ['multiselect', ['active']],
+  ['radio', 'active'],
+  ['checkboxes', ['active']],
+  ['tags', ['active']],
+  ['file', { url: 'https://cdn.example.com/c.pdf', name: 'contract.pdf' }],
+  ['video', { url: 'https://cdn.example.com/c.mp4', name: 'clip.mp4' }],
+  ['audio', { url: 'https://cdn.example.com/c.mp3', name: 'take.mp3' }],
+  ['image', { url: 'https://cdn.example.com/a.png' }],
+  ['avatar', { url: 'https://cdn.example.com/a.png' }],
+  ['signature', { url: 'https://cdn.example.com/s.png' }],
+  ['boolean', true],
+  ['toggle', true],
+  ['date', '2024-07-04'],
+  ['datetime', '2024-07-04T07:00:00.000Z'],
+  ['location', { lat: 30.2741, lng: 120.1551 }],
+  ['geolocation', { lat: 30.2741, lng: 120.1551 }],
+  ['address', { street: '1 Main St', city: 'Hangzhou' }],
+  ['json', { ok: true }],
+  ['object', { ok: true }],
+  ['composite', { ok: true }],
+  ['record', { ok: true }],
+  ['repeater', [{ a: 1 }]],
+  ['password', 'hunter2'],
+  ['secret', 'hunter2'],
+  ['vector', [1, 2, 3]],
+  ['grid', [[1]]],
+];
+
+describe('objectui#8596 — an object literal is not a cell value, and these renderers invented one', () => {
+  describe('THE CENSUS — the instrument, not a grep', () => {
+    it('THE CENSUS — the guard refuses a short or EMPTY set (a census over nothing passes)', () => {
+      // The failure mode this file exists to avoid, pinned as a behaviour:
+      // without this, deleting the table's rows turns every matrix below into
+      // a green test that renders nothing.
+      expect(() => assertCensusComplete([], REGISTERED_TYPE_COUNT, 'census')).toThrowError(
+        /expected exactly 53 registered field types, got 0/,
+      );
+      expect(() => assertCensusComplete(OBJECT_LITERAL_CENSUS, REGISTERED_TYPE_COUNT, 'census')).not.toThrow();
+      expect(new Set(OBJECT_LITERAL_CENSUS.map(([t]) => t)).size, 'the census must not repeat a type').toBe(
+        REGISTERED_TYPE_COUNT,
+      );
+    });
+
+    it('THE CENSUS — all 53 registered types draw their measured face for {}', async () => {
+      assertCensusComplete(OBJECT_LITERAL_CENSUS, REGISTERED_TYPE_COUNT, 'census');
+      let measured = 0;
+      for (const [type, text, hasAffordance] of OBJECT_LITERAL_CENSUS) {
+        const { container } = renderCell(type, {});
+        await settle();
+        expect(
+          textOf(container),
+          `${type} holding {}: the measured face moved`,
+        ).toBe(text);
+        expect(
+          affordance(container) !== null,
+          `${type} holding {}: the affordance's presence moved`,
+        ).toBe(hasAffordance);
+        // `[object Object]` is `String()`'s artefact. No cell prints it.
+        expect(
+          textOf(container),
+          `${type} holding {}: [object Object] is String()'s artefact, not a rendering`,
+        ).not.toContain('[object Object]');
+        measured += 1;
+        cleanup();
+      }
+      expect(measured, 'the census must have rendered every registered type').toBe(REGISTERED_TYPE_COUNT);
+    });
+  });
+
+  describe('THE DEFECT — {} no longer fabricates an identity', () => {
+    for (const type of ['email', 'phone'] as const) {
+      it(`THE DEFECT — \`${type}\` holding {} draws no live anchor and no copy button`, () => {
+        const { container } = renderCell(type, {});
+
+        // Defect-absence FIRST: on the unfixed tree this is the sentence that
+        // fails (`href="mailto:[Object]"` / `tel:[Object]`).
+        expect(
+          container.querySelector('a[href]'),
+          `${type}: an object is not an address — an anchor here links nowhere`,
+        ).toBeNull();
+        expect(
+          container.querySelector('button'),
+          `${type}: a copy button offers to put [Object] on the clipboard`,
+        ).toBeNull();
+        expect(
+          affordance(container),
+          `${type}: {} is not "No value" — the record is storing something`,
+        ).toBeNull();
+        expect(
+          textOf(container),
+          `${type}: an object with no display name reads as the string class reads it`,
+        ).toBe('[Object]');
+      });
+    }
+
+    it('THE DEFECT — `url` holding {} draws no `target="_blank"` anchor', () => {
+      const { container } = renderCell('url', {});
+      expect(
+        container.querySelector('a[href]'),
+        'url: an object is not a URL — an anchor here navigates nowhere',
+      ).toBeNull();
+      expect(affordance(container), 'url: {} is not "No value"').toBeNull();
+      expect(textOf(container), 'url: reads as the string class reads it').toBe('[Object]');
+    });
+
+    it('THE DEFECT — `color` holding {} draws no swatch and never prints [object Object]', () => {
+      const { container } = renderCell('color', {});
+      expect(
+        textOf(container),
+        'color: `background: [object Object]` was a declaration the browser drops',
+      ).not.toContain('[object Object]');
+      expect(
+        container.querySelector('span[aria-hidden="true"]'),
+        'color: a swatch is a claim about a colour, and [Object] is not one',
+      ).toBeNull();
+      expect(affordance(container), 'color: {} is not "No value"').toBeNull();
+      expect(textOf(container), 'color: reads as the string class reads it').toBe('[Object]');
+    });
+
+    for (const type of ['select', 'status', 'multiselect', 'radio', 'checkboxes', 'tags'] as const) {
+      it(`THE DEFECT — \`${type}\` holding {} prints [Object], not the literal [Object Object]`, () => {
+        const { container } = renderCell(type, {});
+        expect(
+          textOf(container),
+          `${type}: [Object Object] was humanizeLabel(String({})) — an option code nobody stored`,
+        ).not.toContain('[Object Object]');
+        expect(
+          affordance(container),
+          `${type}: {} is not "No value" — the record is storing something`,
+        ).toBeNull();
+        expect(
+          textOf(container),
+          `${type}: an unrecognized value reads as the string class reads it`,
+        ).toBe('[Object]');
+      });
+    }
+
+    it('THE DEFECT — `user` holding {} draws no avatar and is not captioned "User"', () => {
+      const { container } = renderCell('user', {});
+      expect(
+        textOf(container),
+        'user: "User" was a name invented for a record that has none',
+      ).not.toContain('User');
+      expect(
+        container.querySelector('.rounded-full'),
+        'user: an avatar asserts a person whose initial is U — the record names nobody',
+      ).toBeNull();
+      expect(affordance(container), 'user: {} is not "No value"').toBeNull();
+      expect(textOf(container), 'user: reads as the reference class reads it').toBe('[Object]');
+    });
+
+    for (const type of ['file', 'video', 'audio'] as const) {
+      it(`THE DEFECT — \`${type}\` holding {} draws no chip named "File"`, () => {
+        const { container } = renderCell(type, {});
+        expect(
+          textOf(container),
+          `${type}: "File" was a chip for an attachment that does not exist`,
+        ).not.toContain('File');
+        // The spec's media value requires `url`; `{}` is a value of neither
+        // form, so here "No value" is TRUE.
+        expectAffordance(container, type);
+      });
+    }
+  });
+
+  describe('THE RULE — pinned against the sibling that already answered correctly', () => {
+    it('THE RULE — `email` / `url` / `phone` / `color` / `user` read for {} EXACTLY as `text` reads it', async () => {
+      const control = renderCell('text', {});
+      const controlText = textOf(control.container);
+      const controlHtml = control.container.innerHTML;
+      // Pin the control as REAL before comparing to it: on the caricature both
+      // sides are the affordance, and the affordance equals the affordance.
+      expect(controlText, 'control: `text` must print something for {}').toBe('[Object]');
+      expect(
+        affordance(control.container),
+        'control: `text` does not draw the affordance for {}',
+      ).toBeNull();
+      cleanup();
+
+      for (const type of ['email', 'url', 'phone', 'color', 'user'] as const) {
+        const { container } = renderCell(type, {});
+        await settle();
+        expect(
+          container.innerHTML,
+          `${type}: must render BYTE-EQUAL to what \`text\` renders for {}`,
+        ).toBe(controlHtml);
+        cleanup();
+      }
+    });
+
+    it('THE RULE — `user` reads for {} exactly as `lookup` does (one spec arm, two types)', () => {
+      const control = renderCell('lookup', {});
+      const controlHtml = control.container.innerHTML;
+      expect(textOf(control.container), 'control: `lookup` must print [Object] for {}').toBe('[Object]');
+      cleanup();
+
+      const { container } = renderCell('user', {});
+      expect(container.innerHTML, 'user must render as `lookup` renders for {}').toBe(controlHtml);
+    });
+
+    it('THE RULE — `file` / `video` / `audio` read for {} exactly as `image` does (one spec family)', () => {
+      const control = renderCell('image', {});
+      const controlHtml = control.container.innerHTML;
+      expect(
+        control.container.querySelector('[data-slot="empty-value"]'),
+        'control: `image` must draw the affordance for {}',
+      ).not.toBeNull();
+      cleanup();
+
+      for (const type of ['file', 'video', 'audio'] as const) {
+        const { container } = renderCell(type, {});
+        expect(container.innerHTML, `${type} must render as \`image\` renders for {}`).toBe(controlHtml);
+        cleanup();
+      }
+    });
+
+    it('THE RULE — an object carrying a display NAME prints that name, in every moved family', async () => {
+      const named = { name: 'Ada Lovelace' };
+      for (const type of ['email', 'url', 'phone', 'color', 'select', 'tags'] as const) {
+        const { container } = renderCell(type, named);
+        await settle();
+        expect(textOf(container), `${type}: an object with a name prints its name`).toBe('Ada Lovelace');
+        expect(affordance(container), `${type}: a named object is not "No value"`).toBeNull();
+        cleanup();
+      }
+      // `user` names a person, so the named object is a POPULATED reference and
+      // keeps its avatar — the boundary this change deliberately does not cross.
+      const user = renderCell('user', named);
+      // The avatar's initials sit in the same cell, so the cell's text is
+      // `AL` + the name — asserted as the whole face rather than a substring.
+      expect(textOf(user.container), 'user: a named reference still draws its name').toBe(
+        'ALAda Lovelace',
+      );
+      expect(
+        user.container.querySelector('.rounded-full'),
+        'user: a named reference still draws its avatar',
+      ).not.toBeNull();
+    });
+  });
+
+  describe('POPULATED — these refuse an EMPTY-for-everything implementation', () => {
+    it('POPULATED — a real value in all 53 registered types NEVER draws the "No value" affordance', async () => {
+      assertCensusComplete(POPULATED_CENSUS, REGISTERED_TYPE_COUNT, 'populated census');
+      let measured = 0;
+      for (const [type, value] of POPULATED_CENSUS) {
+        const { container } = renderCell(type, value, { options: [{ value: 'active', label: 'Active' }] });
+        await settle();
+        expect(
+          affordance(container),
+          `${type} holding a real value: a populated cell must NOT draw the affordance`,
+        ).toBeNull();
+        expect(
+          container.innerHTML,
+          `${type} holding a real value: a populated cell must draw something`,
+        ).not.toBe('');
+        measured += 1;
+        cleanup();
+      }
+      expect(measured, 'the populated census must have rendered every registered type').toBe(
+        REGISTERED_TYPE_COUNT,
+      );
+    });
+
+    it('POPULATED — a real email still links and still offers its copy button', () => {
+      const { container } = renderCell('email', 'ada@example.com');
+      const anchor = container.querySelector('a[href]');
+      expect(anchor?.getAttribute('href'), 'a real address still links').toBe('mailto:ada@example.com');
+      expect(textOf(container), 'a real address still prints').toBe('ada@example.com');
+      expect(
+        container.querySelector('button[aria-label="Copy email"]'),
+        'a real address still offers its copy button',
+      ).not.toBeNull();
+    });
+
+    it('POPULATED — a real URL and a real phone number still link', () => {
+      const url = renderCell('url', 'https://objectstack.ai');
+      const urlAnchor = url.container.querySelector('a[href]');
+      expect(urlAnchor?.getAttribute('href'), 'a real URL still links').toBe('https://objectstack.ai');
+      expect(urlAnchor?.getAttribute('target'), 'a real URL still opens in a new tab').toBe('_blank');
+      cleanup();
+
+      const phone = renderCell('phone', '+15551234567');
+      expect(
+        phone.container.querySelector('a[href]')?.getAttribute('href'),
+        'a real number still dials',
+      ).toBe('tel:+15551234567');
+    });
+
+    it('POPULATED — a one-entry ARRAY still coerces and still links (the objectui#8490 ruling)', () => {
+      // Refuses an over-correction spelled "an object-ish value" rather than
+      // "a plain object": `['ada@example.com']` is a value, and it formats and
+      // links exactly as the scalar does.
+      const { container } = renderCell('email', ['ada@example.com']);
+      expect(
+        container.querySelector('a[href]')?.getAttribute('href'),
+        'a one-entry array still links',
+      ).toBe('mailto:ada@example.com');
+      expect(affordance(container), 'a one-entry array is not "No value"').toBeNull();
+    });
+
+    it('POPULATED — a real colour still draws its swatch, with the declared colour', () => {
+      const { container } = renderCell('color', '#ff0000');
+      const swatch = container.querySelector<HTMLElement>('span[aria-hidden="true"]');
+      expect(swatch, 'a real colour still draws its swatch').not.toBeNull();
+      // happy-dom keeps the declaration verbatim rather than normalising it to
+      // `rgb()`, so the hex is the byte to pin here.
+      expect(swatch?.style.backgroundColor, 'the swatch still paints the declared colour').toBe(
+        '#ff0000',
+      );
+      expect(textOf(container), 'a real colour still prints its value').toBe('#ff0000');
+    });
+
+    it('POPULATED — a real option still resolves to its declared label, and an unknown code is still humanized', () => {
+      const declared = renderCell('select', 'active', {
+        options: [{ value: 'active', label: 'Active' }],
+      });
+      expect(textOf(declared.container), 'a declared option still shows its label').toBe('Active');
+      cleanup();
+
+      // The code path `humanizeLabel` exists for: a stored code with no
+      // declared option. Untouched by this change.
+      const undeclared = renderCell('status', 'in_progress');
+      expect(textOf(undeclared.container), 'an undeclared code is still humanized').toBe('In Progress');
+    });
+
+    it('POPULATED — a real user still draws an avatar with real initials', () => {
+      const { container } = renderCell('user', { name: 'Ada Lovelace' });
+      expect(textOf(container), 'a real user still prints their name').toBe('ALAda Lovelace');
+      expect(
+        container.querySelector('.rounded-full')?.textContent,
+        'a real user still draws initials taken from their name',
+      ).toBe('AL');
+    });
+
+    it('POPULATED — a real file still shows its name, and a real file ARRAY still counts', () => {
+      const single = renderCell('file', { url: 'https://cdn.example.com/c.pdf', name: 'contract.pdf' });
+      expect(textOf(single.container), 'a real attachment still shows its name').toBe('contract.pdf');
+      expect(affordance(single.container), 'a real attachment is not "No value"').toBeNull();
+      cleanup();
+
+      const many = renderCell('file', [{ url: 'a' }, { url: 'b' }]);
+      expect(textOf(many.container), 'a real file array still counts its entries').toBe('2 files');
+    });
+  });
+
+  describe('THE BOUNDARY — what this change deliberately does and does not sweep', () => {
+    it("THE BOUNDARY — [], '' and null are unchanged in every moved family", () => {
+      const moved = [
+        'email', 'url', 'phone', 'color', 'user',
+        'select', 'status', 'multiselect', 'radio', 'checkboxes', 'tags',
+      ] as const;
+      for (const type of moved) {
+        for (const [label, value] of [['[]', []], ["''", ''], ['null', null]] as const) {
+          const { container } = renderCell(type, value);
+          expectAffordance(container, `${type} holding ${label}`);
+          cleanup();
+        }
+      }
+
+      // The media family answers `[]` with its own count sentence rather than
+      // the affordance. That is the `[]` column, which objectui#8490 /
+      // objectui#8580 closed and this card does not reopen: pinned as MEASURED
+      // so the `{}` fix above cannot be read as having moved it.
+      for (const type of ['file', 'video', 'audio'] as const) {
+        const empty = renderCell(type, []);
+        expect(textOf(empty.container), `${type} holding []: unchanged, still its count`).toBe('0 files');
+        cleanup();
+        for (const [label, value] of [["''", ''], ['null', null]] as const) {
+          const { container } = renderCell(type, value);
+          expectAffordance(container, `${type} holding ${label}`);
+          cleanup();
+        }
+      }
+    });
+
+    it('THE BOUNDARY — an object with any member is NOT swept in: real data is never hidden', () => {
+      // `AddressCellRenderer`'s rule, applied unchanged: `{}` reads as empty
+      // while `{ foo: 1 }` keeps what it holds.
+      const file = renderCell('file', { size: 12 });
+      expect(
+        affordance(file.container),
+        'file: an object carrying a member is not "No value"',
+      ).toBeNull();
+      cleanup();
+
+      const user = renderCell('user', { id: 'u_1' });
+      expect(
+        user.container.querySelector('.rounded-full'),
+        'user: a reference carrying an id still draws its avatar (unchanged)',
+      ).not.toBeNull();
+    });
+
+    it('THE BOUNDARY — a NUMBER in an email or phone cell still links (only objects moved)', () => {
+      // A stored number is not an object; a phone column holding `13800138000`
+      // still dials. Sweeping it in would be a second ruling this change does
+      // not make.
+      const phone = renderCell('phone', 13800138000);
+      expect(
+        phone.container.querySelector('a[href]')?.getAttribute('href'),
+        'phone: a stored number still dials',
+      ).toBe('tel:13800138000');
+    });
+
+    it('THE BOUNDARY — `date` still draws its own dash: objectui#8581 keeps its subject', () => {
+      const { container } = renderCell('date', {});
+      expect(textOf(container), 'date: the hand-rolled dash is unchanged here').toBe('—');
+      expect(
+        affordance(container),
+        'date: still NOT the shared affordance — objectui#8581 rules that renderer',
+      ).toBeNull();
+    });
+
+    it("THE BOUNDARY — objectui#8481's json-literal fence is not reopened", () => {
+      for (const type of ['location', 'geolocation', 'json', 'object', 'composite', 'record'] as const) {
+        const { container } = renderCell(type, {});
+        expect(textOf(container), `${type}: the {} literal stays behind the declared fence`).toBe('{}');
+        cleanup();
+      }
+    });
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -357,6 +357,44 @@ function isBlankCellText(safe: ReturnType<typeof coerceToSafeValue>): boolean {
 }
 
 /**
+ * An OBJECT LITERAL is not a value of a string-, code- or reference-typed cell
+ * (objectui#8596).
+ *
+ * The other half of the census objectui#8481 / objectui#8490 / objectui#8580
+ * ran on `[]`. Where `[]` made a renderer draw nothing or fabricate a zero,
+ * `{}` made it fabricate an IDENTITY: a live `href="mailto:[Object]"` anchor
+ * with a copy button, a swatch whose CSS background was the string
+ * `[object Object]`, an avatar captioned "U" labelled "User", the literal
+ * `[Object Object]` in a status badge.
+ *
+ * `@objectstack/spec` types every one of those families as a string or a code:
+ * `email` / `url` / `phone` / `color` are `STRING_VALUE_TYPES` ("Value is a
+ * plain string"; the write seam is `z.string()`), the option families resolve
+ * to `z.enum(codes)` or `z.string()`, and `user` shares the reference arm with
+ * `lookup`. A plain object is a value of none of them — so the cell prints the
+ * one answer this package has for "text for a value that is not a string"
+ * (`coerceToSafeValue`, exactly as `text` prints it) and draws no affordance
+ * that asserts something the record never stored. That is objectui#8580's
+ * ruling for `markdown` / `html` / `richtext`, applied to the families that
+ * still invented instead.
+ *
+ * ⛔ NOT arrays. `coerceToSafeValue` joins an array's entries, and a one-entry
+ * array of a real address still formats and still links — the objectui#8490
+ * email ruling, re-pinned by objectui#8580. `[]` itself never reaches here:
+ * it coerces to `''` and every caller below already answers it with the shared
+ * affordance. A `Date` is not a plain object either; `coerceToSafeValue`
+ * carries its own ISO branch for it.
+ */
+function isPlainObjectValue(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    !(value instanceof Date)
+  );
+}
+
+/**
  * Format currency value. When `currency` is undefined, falls back to a
  * plain number with thousands separators (no symbol). Silently assuming
  * USD for unconfigured currency fields was the #1 source of "why is my
@@ -1518,7 +1556,16 @@ export function SelectCellRenderer({ value, field }: CellRendererProps): React.R
 
   const renderOne = (val: any, key?: number): React.ReactElement => {
     const option = findOption(val);
-    const label = option?.label || humanizeLabel(String(val));
+    // An object matches no declared option code, and `String()` made one up:
+    // `humanizeLabel(String({}))` printed the literal `[Object Object]` in a
+    // status badge (objectui#8596). The option families' value is a string
+    // code (`valueSchemaFor` → `z.enum(codes)`, or `z.string()` where none are
+    // declared), so an object is read as the string class reads it — the
+    // package's one coercion, byte-equal to what `text` prints. `humanizeLabel`
+    // is deliberately skipped for it: it exists to turn a machine CODE into
+    // words (`in_progress` → `In Progress`) and rewrites anything else.
+    const label = option?.label
+      || (isPlainObjectValue(val) ? String(coerceToSafeValue(val)) : humanizeLabel(String(val)));
 
     if (appearance === 'dot') {
       // Resolve a real CSS color for the dot. Prefer explicit option color,
@@ -1593,6 +1640,12 @@ export function EmailCellRenderer({ value }: CellRendererProps): React.ReactElem
   // (objectui#8490). No address, no link.
   if (isBlankCellText(coerced)) return <EmptyValue />;
   const safe = String(coerced);
+  // An object is not an address (objectui#8596). `mailto:[Object]` was a live
+  // affordance that could not work, and the copy button offered to put
+  // `[Object]` on the clipboard. The spec's value class for `email` is a plain
+  // string, so the cell prints the coerced text exactly as `text` prints it
+  // and links nothing.
+  if (isPlainObjectValue(value)) return <TruncatedText text={safe} />;
 
   const handleCopy = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -1645,6 +1698,10 @@ export function UrlCellRenderer({ value }: CellRendererProps): React.ReactElemen
   // no link.
   if (isBlankCellText(coerced)) return <EmptyValue />;
   const safe = String(coerced);
+  // An object is not a URL (objectui#8596) — same ruling as
+  // `EmailCellRenderer`: a `target="_blank"` anchor whose `href` is `[Object]`
+  // navigates nowhere, so the coerced text prints without one.
+  if (isPlainObjectValue(value)) return <TruncatedText text={safe} />;
   return (
     <Button
       variant="link"
@@ -1677,6 +1734,9 @@ export function PhoneCellRenderer({ value }: CellRendererProps): React.ReactElem
   // (objectui#8490) — same ruling as `EmailCellRenderer`.
   if (isBlankCellText(coerced)) return <EmptyValue />;
   const safe = String(coerced);
+  // An object is not a number to dial (objectui#8596) — same ruling as
+  // `EmailCellRenderer`: no `tel:[Object]` anchor, no copy button.
+  if (isPlainObjectValue(value)) return <TruncatedText text={safe} />;
 
   const handleCopy = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -1731,6 +1791,23 @@ export function FileCellRenderer({ value, field }: CellRendererProps): React.Rea
     );
   }
   
+  // An object carrying nothing is not a file (objectui#8596). The spec's
+  // media value schema makes `url` the one required member and names "an empty
+  // object" among the values it rejects, so `{}` is a value of neither the
+  // stored (`sys_file` id) nor the expanded (`{url, name?, …}`) form: the
+  // record holds no file, and "No value" is TRUE of it. Before this it fell
+  // through to the `'File'` fallback below and drew a chip for an attachment
+  // that does not exist. `ImageCellRenderer` — the same spec family — already
+  // answers `{}` with the shared affordance; this is the same answer, and the
+  // two are pinned against each other.
+  //
+  // ⛔ Deliberately narrow: an object with any member at all still renders its
+  // name (or the `'File'` fallback), so a real `{name: 'contract.pdf'}` is
+  // never hidden. That boundary is `AddressCellRenderer`'s, stated one screen
+  // below: "an object carrying no recognized part reads as empty, while
+  // `{ foo: 1 }` keeps its JSON so real data is never hidden."
+  if (isPlainObjectValue(value) && Object.keys(value).length === 0) return <EmptyValue />;
+
   const fileName = value.name || value.original_name || 'File';
   return <TruncatedText text={String(fileName)} className="text-sm" />;
 }
@@ -2161,6 +2238,13 @@ export function UserCellRenderer({ value }: CellRendererProps): React.ReactEleme
           if (typeof user !== 'object' || user === null) {
             return <TruncatedText key={idx} text={String(user)} className="text-sm" />;
           }
+          // An entry carrying nothing names no person (objectui#8596) — the
+          // same ruling as the scalar branch below, one input-shape over.
+          if (isPlainObjectValue(user) && Object.keys(user).length === 0) {
+            return (
+              <TruncatedText key={idx} text={String(coerceToSafeValue(user))} className="text-sm" />
+            );
+          }
           const name = user.name || user.username || 'User';
           const initials = name.split(' ').map((n: string) => n[0]).join('').toUpperCase().slice(0, 2);
           
@@ -2188,6 +2272,21 @@ export function UserCellRenderer({ value }: CellRendererProps): React.ReactEleme
     );
   }
   
+  // An expanded reference carrying nothing names no person (objectui#8596).
+  // `{}` drew an avatar whose initial was `U` and whose caption was the
+  // literal `'User'` — a face and a name for a record that has neither, taken
+  // from the fallback below. `user` shares `valueSchemaFor`'s reference arm
+  // with `lookup` / `master_detail` / `tree` (a record-id string when stored,
+  // the related record object when expanded), and that family already answers
+  // an object it cannot name with the coerced text — so `user` answers it the
+  // same way, and the two are pinned byte-equal.
+  //
+  // ⛔ Deliberately narrow: `{ id: 'u_1' }` still draws its avatar, so no
+  // populated reference moves. Same boundary as `AddressCellRenderer`'s.
+  if (Object.keys(value).length === 0) {
+    return <TruncatedText text={String(coerceToSafeValue(value))} />;
+  }
+
   const name = value.name || value.username || 'User';
   const initials = name.split(' ').map((n: string) => n[0]).join('').toUpperCase().slice(0, 2);
   
@@ -2292,6 +2391,17 @@ export function JsonCellRenderer({ value }: CellRendererProps): React.ReactEleme
  */
 export function ColorSwatchCellRenderer({ value }: CellRendererProps): React.ReactElement {
   if (value == null) return <EmptyValue />;
+  // An object is not a colour (objectui#8596). `String({})` is
+  // `'[object Object]'`, which this renderer handed to `background-color` —
+  // an invalid declaration the browser drops, so the swatch drew a bordered
+  // box with no colour beside that literal. `color` is a `STRING_VALUE_TYPES`
+  // member, so a non-string prints the string class's coerced text (as `text`
+  // prints it) and gets no swatch: a swatch is a claim about a colour.
+  if (isPlainObjectValue(value)) {
+    const coerced = coerceToSafeValue(value);
+    if (isBlankCellText(coerced)) return <EmptyValue />;
+    return <TruncatedText text={String(coerced)} />;
+  }
   const color = String(value);
   // `String([])` is `''`, which used to draw a bordered swatch box with no
   // background colour beside an empty text span (objectui#8490): a swatch


### PR DESCRIPTION
Fixes #8596

## The census is the first deliverable, and it moved two rows

Re-run on my own pinned base `4eb665bcf`, not inherited from the card: all **53 registered field types** rendered through `getCellRenderer` against `[]`, `{}`, `''` and `null` — **212 cells** — then re-rendered after the fix and diffed cell by cell. **14 cells moved, all in the `{}` column. The `[]`, `''` and `null` columns are byte-identical.**

Two rows the card flagged had indeed moved before I started:

- **`boolean` / `toggle` LANDED.** objectui#8582 / PR #8594 is commit `70c452369` on this base, and `packages/fields/src/__tests__/booleanCell.nonBooleanScalar-8582.test.tsx` is in the tree. Measured, not assumed: `{}` already drew the shared affordance. ⛔ Not re-ruled here; pinned unchanged.
- **`datetime`** also already drew the affordance for `{}` (the card's table did not list it as broken, and it is not).

`location` / `geolocation` were left behind objectui#8481's declared json-literal fence, untouched and pinned unchanged.

### The measured `{}` column, before → after

| field types | renderer | `{}` before | `{}` after |
|---|---|---|---|
| `email`, `url`, `phone` | Email/Url/PhoneCellRenderer | a **live anchor** — `mailto:[Object]`, `[Object]`, `tel:[Object]` — plus a copy button | `[Object]`, byte-equal to `text` |
| `color` | `ColorSwatchCellRenderer` | a swatch whose `background` was the string `[object Object]` | `[Object]`, byte-equal to `text` |
| `select`, `status`, `multiselect`, `radio`, `checkboxes`, `tags` | `SelectCellRenderer` | a badge reading `[Object Object]` | a badge reading `[Object]` |
| `user` | `UserCellRenderer` | an avatar captioned **U**, labelled **User** | `[Object]`, byte-equal to `lookup` |
| `file`, `video`, `audio` | `FileCellRenderer` | one chip named **File** | the shared `EmptyValue` |
| `number`, `currency`, `percent`, `progress`, `slider`, `rating`, `text`, `textarea`, `code`, `qrcode`, `time`, `auto_number`, `formula`, `summary`, `lookup`, `master_detail`, `tree`, `markdown`, `html`, `richtext` | — | `[Object]` | **unchanged** (20 rows) |
| `boolean`, `toggle`, `datetime`, `image`, `avatar`, `signature`, `address`, `repeater` | — | the affordance | **unchanged** |
| `location`, `geolocation`, `json`, `object`, `composite`, `record` | — | the `{}` literal | **unchanged** (objectui#8481's fence) |
| `password`, `secret`, `vector`, `grid` | — | a value-independent face | **unchanged** (filed as objectui#8678) |
| `date` | `DateCellRenderer` | a hand-rolled em-dash, no accessible name | **unchanged** — objectui#8581's subject |

⭐ **`date` is confirmed and deliberately not touched.** My fix does not land on it, and the pin file records that row as a dash that is *not* the affordance, so a later change landing on it has to move a pin rather than pass silently.

## What `valueSchemaFor` actually says, per family

Read from `@objectstack/spec@17.3.0` `src/data/field-value.zod.ts` before choosing anything — reported for every family, including where it confirms the obvious. (The thin-root-export trap was avoided by reading the package source directly; every set below was read at its declaration site, not imported and found `undefined`.)

| family | `valueSchemaFor`'s arm | what it settles |
|---|---|---|
| `email`, `url`, `phone`, `color` | `STRING_VALUE_TYPES` → `z.string()` — *"Value is a plain string"* | The **same set** objectui#8580 ruled for `markdown`/`html`/`richtext`. `{}` is settled **away from** the "no value" affordance and **toward** the family's existing coercion: the record IS storing something. So they print `coerceToSafeValue`'s answer, and draw no affordance asserting more than that. |
| `select`, `multiselect`, `radio`, `checkboxes`, `tags` | `SINGLE_OPTION_TYPES` / `MULTI_OPTION_TYPES` → `z.enum(codes)`, or `z.string()` where no options are declared | The value is a **string code** either way, so the same coercion answers it. The badge stays: a badge is how this family shows any code it was handed, including one it does not recognise. |
| `status` | **no spec arm — `status` is not a `FieldType`** | An objectui-only renderer alias that reaches `SelectCellRenderer` through this repo's own `standardMap`. It inherits the ruling from `select` by that map, not from the spec. Reported rather than assumed. |
| `user` | `REFERENCE_VALUE_TYPES` → `ReferenceIdValueSchema` stored; expanded `z.union([ReferenceIdValueSchema, z.record(z.string(), z.unknown())])` | ⭐ **The answer was the opposite of the obvious one.** The expanded arm *admits* an object — `{}` parses green against `z.record` — and the spec says the record's "shape is that object's contract, not this field's". So the spec cannot tell `user` from `lookup` here, and `lookup` **already** answers an object it cannot name with the coerced text. `user` was the outlier, not the object. Pinned byte-equal to `lookup`. |
| `file`, `video`, `audio` | `FILE_REFERENCE_TYPES` → `FileReferenceIdValueSchema` stored; expanded `z.union([…, FileValueSchema])` | ⭐ **The family whose answer differs, and the spec names the exact input.** `FileValueSchema`'s docstring: `url` is *"the one required member"*, and *"a value with no `url` — **an empty object**, a `{ name }` fragment, a number — is now rejected"*. `{}` is a value of neither form, so the record holds no file and **"No value" is TRUE of it**. `image`/`avatar` — same spec family — already answered `{}` that way. |
| `boolean`, `toggle` | `BOOLEAN_VALUE_TYPES` → `z.boolean()` | Already executed by objectui#8582 / PR #8594. Read, confirmed, not re-ruled. |
| `location`, `geolocation`, `json`, `object`, `composite`, `record` | `LocationValueSchema` / `z.record` / `z.unknown()` | Behind objectui#8481's declared fence. ⛔ Not reopened. |

⛔ **No renderer-side fallback was invented** (AGENTS.md #0.1). Every family lands on a coercion this package already had (`coerceToSafeValue`) or on the affordance a sibling **in its own spec family** already drew. The `{}` faces are pinned byte-equal to `text`, to `lookup` and to `image` respectively, so the rule stays true without being restated anywhere.

## Ablation — three legs, each proven on disk in both directions

Every leg mutates a **read site** from a **committed** tree, with `trap … EXIT INT TERM` and absolute paths, and restores **by state** (`git diff HEAD` empty), never by an exit code. Each leg gates on: non-empty `git hash-object`, hash ≠ before, hash ≠ the HEAD blob, an **anchor count that moved**, and a **line-total floor** — the empty-file accident objectui#8490 lost a leg to, and the control objectui#8582 turned it into.

Per-test classification is from vitest's **JSON reporter** (`--reporter=json --outputFile`), never the text reporter. Harness-death signatures (`Element type is invalid`, `Failed Suites`, `No test suite found in file`, `Tests  no tests`, `Transform failed`) were counted separately and were **0 in all three legs** — no leg is void.

### LEG A — the unfixed tree (`packages/fields/src/index.tsx` restored to `4eb665bcf`)

```
hash before d26ec698…  after 48b3d279…   HEAD blob d26ec698…
lines 3491 → 3381      anchor /isPlainObjectValue/ 8 → 0
restore: hash == HEAD blob, anchor back to 8, git diff HEAD empty
```

**19 of 33 failed.** Every DEFECT case failed on its **artefact-absence** sentence — asserted first on purpose, so the unfixed tree and a harness that has lost the affordance's `data-slot` fail on textually different sentences:

- `email: an object is not an address — an anchor here links nowhere: expected <a href="mailto:[Object]" …> to be null`
- `phone: … expected <a href="tel:[Object]" …> to be null`
- `url: an object is not a URL — an anchor here navigates nowhere: expected <a href="[Object]" …> to be null`
- `color: 'background: [object Object]' was a declaration the browser drops: expected '[object Object]' not to contain '[object Object]'`
- `select: [Object Object] was humanizeLabel(String({})) — an option code nobody stored` (× 6 option types)
- `user: "User" was a name invented for a record that has none: expected 'UUser' not to contain 'User'`
- `file/video/audio: "File" was a chip for an attachment that does not exist`
- `user must render as 'lookup' renders for {}: expected '<div class="flex items-center gap-2">…' to be '<span class="block max-w-full truncat…'`

The POPULATED and BOUNDARY blocks **passed** on the unfixed tree — correct, because they are the cases that must not move.

### LEG B — the caricature: *the mutation that makes the code answer the same thing for everything*

`getCellRenderer` returns `() => <EmptyValue />` unconditionally.

```
hash before d26ec698…  after 1bebffff…
lines 3491 → 3493      anchor /CARICATURE_8596/ 0 → 1
restore: hash == HEAD blob, anchor back to 0, git diff HEAD empty
```

**28 of 33 failed**, and the two load-bearing families are exactly the ones that reddened:

- **The 20 consistent rows:** `THE CENSUS — all 53 registered types draw their measured face for {}` → `text holding {}: the measured face moved: expected '—' to be '[Object]'`.
- **Every populated value:** `POPULATED — a real value in all 53 registered types NEVER draws the "No value" affordance` → `text holding a real value: a populated cell must NOT draw the affordance: expected <span …> to be null`, plus every per-family populated case (`a real address still links: expected undefined to be 'mailto:ada@example.com'`, `a declared option still shows its label: expected '—' to be 'Active'`, `a real user still prints their name: expected '—' to be 'ALAda Lovelace'`, `a real attachment still shows its name: expected '—' to be 'contract.pdf'`, `a real colour still draws its swatch: expected null not to be null`).
- The BOUNDARY block reddened too: `date: still NOT the shared affordance` and `location: the {} literal stays behind the declared fence` — i.e. the caricature is caught erasing the two fences this card was told not to cross.

⚠️ **Reported as NEGATIVE, not hunted away:** the three `file` / `video` / `audio` DEFECT cases and `THE RULE — file/video/audio read as image does` **PASS** under the caricature. Their correct answer *is* the affordance, so the caricature satisfies them — the card's own point that *the vivid assertion is rarely the discriminating one*, measured rather than argued. Those four are discriminated by LEG A, where all four fail.

### LEG C — the emptiness control (the census guard itself)

⚠️ A matrix pin over an empty set passes. Both matrices run through `assertCensusComplete(entries, 53, …)`, which throws **before a single cell is rendered**, and the file carries a meta-test that observes it throwing. To prove that is not decoration, both census tables were emptied on disk:

```
hash before 874b38bd…  after f6ef9cef…   (the PIN file — a guard leg, not a fix leg)
lines 702 → 592        anchor /EMPTIED_CENSUS_8596/ 0 → 2
restore: hash == HEAD blob, git diff HEAD empty
```

The run went **RED, not green-with-zero-cells**: `Error: census: expected exactly 53 registered field types, got 0. A census over a short or empty set passes without measuring anything.`

### Every assertion has been observed to fail

Across the three legs, **0 of the 33 tests were never red**. An assertion never observed to fail has not been tested, and none is left in that state — including the meta-test, which LEG C reddens.

## Tests run

| command | result |
|---|---|
| `pnpm exec vitest run packages/fields/` | **147 files, 2524 tests passed** |
| `pnpm exec vitest run packages/plugin-dashboard/ packages/plugin-report/ packages/plugin-list/ packages/plugin-tree/ packages/plugin-detail/` | **347 files, 3333 tests passed** |
| `pnpm exec vitest run packages/plugin-grid/ packages/plugin-kanban/ packages/plugin-form/` | **236 files, 2105 passed, 1 skipped** |
| `pnpm --filter @object-ui/fields type-check` | **exit 0** (after `pnpm --filter '@object-ui/fields^...' build`; on an unbuilt tree it reports `TS2307` for every workspace import — a precondition, not a result) |
| `node scripts/check-control-bytes.mjs` | **OK**, 6854 tracked text files scanned |
| `node scripts/check-changeset-presence.mjs` | **OK** — 1 source file of 1 released package changed, 1 changeset declared |
| `node scripts/check-governed-queue-guard.mjs --test …` | **NOT GOVERNED** — 3 paths, none matched |

Consumer packages were chosen by `git grep` for the changed renderers, not guessed: `plugin-dashboard`, `plugin-detail`, `plugin-form`, `plugin-grid`, `plugin-kanban`, `plugin-list`, `plugin-report`, `plugin-tree`. All ran from the **repo root with paths**, per AGENTS.md — `pnpm --filter PKG exec vitest run FILE` is refused by the objectui#3378 guard, and nothing was passed after a bare `--`.

## Boundaries this change deliberately does not cross

Each is pinned in `THE BOUNDARY` block, so crossing one later has to move a pin:

- **Arrays.** `['ada@example.com']` still coerces and still links — the objectui#8490 email ruling, re-pinned. The predicate is `isPlainObjectValue`, which excludes arrays and `Date`.
- **Numbers.** A phone column holding `13800138000` still dials `tel:13800138000`. Sweeping non-strings wholesale would have been a second ruling.
- **Any object with a member.** `{ name: 'contract.pdf' }` still shows its name; `{ id: 'u_1' }` still draws its avatar. This is `AddressCellRenderer`'s existing rule in the same file, quoted rather than re-invented: *"an object carrying no recognized part reads as empty, while `{ foo: 1 }` keeps its JSON so real data is never hidden."*
- **`date`**, **`boolean`/`toggle`**, and **objectui#8481's json-literal fence** — pinned unchanged.
- **`humanizeLabel`** still runs for a stored code with no declared option (`in_progress` → `In Progress`); it is skipped only for a plain object, because it exists to turn a machine CODE into words and rewrites anything else.

## Out-of-scope findings, filed not swept

- **objectui#8677** — `signature` is a spec `STRING_VALUE_TYPES` member but renders through `ImageCellRenderer`, so `{}` draws "No value" where its own value class prints `[Object]`. It is the one `STRING_VALUE_TYPES` member this PR leaves inconsistent, and the fix could belong in the spec rather than here — so it gets a ruling, not a guess.
- **objectui#8678** — `password` / `secret` / `vector` / `grid` render a **value-independent** face: the same bytes for `[]`, `{}`, `''`, `null` and a populated value alike. An unset credential is drawn exactly like a set one.

**Dedup channel, declared:** the GitHub **search API is 403 on this seat** (*"sessions are bound to their configured repositories"*), so no search was performed — and `search_issues` is measured to return false zeros on this repo anyway. Instead: a **repo-scoped REST listing** of open issues (3 pages × 100, sorted by `updated`, 288 issues) grepped locally, with objectui#8596 itself as the **control that had to hit, and did**. That window is **bounded, not exhaustive** — no dedup claim is made beyond it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_