### PR TITLE
test(core): pin the `page` list-view residual, and report the usage census objectui#8429's grade is blocked on

### DIFF
--- a/.changeset/8429-page-view-residual-pin.md
+++ b/.changeset/8429-page-view-residual-pin.md
@@ -1,0 +1,10 @@
+---
+---
+
+Pin the `page` list-view residual objectui#8429 registers: `page` is
+simultaneously a type `@objectstack/spec`'s `ListViewSchema` accepts, a member
+of both published `@object-ui/types` faces, and absent from the set `ListView`
+draws — so a spec-valid `type: 'page'` view normalises to `viewType: 'grid'`.
+The pin states that contradiction mechanically and changes no behaviour; it
+reddens if either open disposition (growing a page renderer, or narrowing
+`ViewType`) is ever taken. Test only; no package is released by this change.

--- a/packages/core/src/utils/__tests__/normalize-list-view.pageResidual-8429.test.ts
+++ b/packages/core/src/utils/__tests__/normalize-list-view.pageResidual-8429.test.ts
@@ -1,0 +1,245 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8429 — the RESIDUAL left standing after objectui#8127 / PR #8372.
+ *
+ * #8127 was the DECLARATION gap: `ViewType` was a hand-written copy of
+ * `@objectstack/spec`'s list-view vocabulary, so every structure keyed on it
+ * was total over the COPY and compiled green while the spec's `page` had
+ * nowhere to land. PR #8372 closed exactly that — both published
+ * `@object-ui/types` faces are DERIVED from the spec now.
+ *
+ * What it did NOT close, and what this file states mechanically, is the
+ * renderer gap the derivation made visible rather than removed:
+ *
+ *   `page` is simultaneously
+ *     (a) a list-view type `@objectstack/spec`'s own `ListViewSchema` ACCEPTS,
+ *     (b) a member of `@object-ui/types`' published `ViewType` / `ViewTypeSchema`,
+ *     (c) NOT a member of the set `ListView` can draw, and therefore
+ *     (d) normalised to `viewType: 'grid'` — a DIFFERENT view kind — by
+ *         `normalizeListViewSchema`, with the `pageName` mount target left
+ *         sitting in the metadata, unread.
+ *
+ * ⛔ This file is DISPOSITION-FREE and must stay that way. It does not propose
+ * that `ListView` grow a page renderer, and it does not propose narrowing
+ * `ViewType` back — both are rulings the card deliberately leaves open, and the
+ * second would break the derivation #8372 just established. The pin asserts
+ * TODAY'S behaviour so that neither disposition can land silently:
+ *
+ *   · grow a renderer  ⇒ `page` becomes drawable ⇒ the residual set empties and
+ *                        the normalised output stops being `'grid'` ⇒ RED.
+ *   · narrow `ViewType` ⇒ the published faces stop accepting `page` ⇒ RED.
+ *
+ * ⚠️ The `console.warn` #8372 added is a signal to the DEVELOPER, not to the end
+ * user — the author still gets a grid. It is silenced here, not treated as a
+ * mitigation, and its own behaviour stays pinned in `normalize-list-view.test.ts`.
+ *
+ * ⚠️ Every set below is asserted at its EXACT size before it is used, because a
+ * census over an empty set passes. `SPEC_LIST_VIEW_TYPES` in particular is read
+ * from the installed `@objectstack/spec` at runtime, so an upstream bump that
+ * empties or reshapes the vocabulary must fail here rather than vacuously pass.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ListViewSchema as SpecListViewSchema } from '@objectstack/spec/ui';
+import { ViewTypeSchema } from '@object-ui/types/zod';
+import type { ViewType } from '@object-ui/types';
+import { normalizeListViewSchema, isListViewVisualization } from '../normalize-list-view.js';
+
+/** The spec's own list-view vocabulary, unwrapped from its `.default('grid')`. */
+const SPEC_LIST_VIEW_TYPES: readonly string[] = SpecListViewSchema.shape.type.removeDefault().options;
+
+/** objectui's published vocabulary: the spec's list plus the two local CATEGORIES. */
+const OBJECTUI_VIEW_TYPES: readonly string[] = ViewTypeSchema.options;
+
+/**
+ * A document `@objectstack/spec`'s `ListViewSchema` ACCEPTS — proven below,
+ * against three controls, before it is used as the normalizer's input.
+ *
+ * `pageName` is required on a `page` view and `columns` must be empty beside it
+ * (`checkListViewPageMount`, `@objectstack/spec@17.3.0`), so this is not a
+ * hand-waved "spec-valid": it is the only shape a page view can legally take.
+ */
+const SPEC_VALID_PAGE_VIEW = {
+  name: 'account_page',
+  type: 'page',
+  pageName: 'crm_welcome',
+  columns: [] as unknown[],
+} as const;
+
+const readViewType = (out: unknown): unknown => (out as { viewType?: unknown }).viewType;
+
+describe('the `page` residual (objectui#8429)', () => {
+  beforeEach(() => {
+    // Developer-facing noise from #8372's undrawable-kind warning. Silenced, not
+    // asserted: this file is about what the AUTHOR gets, and the author gets a grid.
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('the populations, sized before they are used', () => {
+    it('reads a non-empty, exactly-sized vocabulary from each face', () => {
+      // The spec's list-view types, as published in @objectstack/spec 17.3.0.
+      expect(SPEC_LIST_VIEW_TYPES.length).toBe(10);
+      expect([...SPEC_LIST_VIEW_TYPES].sort()).toEqual([
+        'calendar', 'chart', 'gallery', 'gantt', 'grid', 'kanban', 'map', 'page', 'timeline', 'tree',
+      ]);
+
+      // objectui's derived face: the spec's ten, plus the two local categories.
+      expect(OBJECTUI_VIEW_TYPES.length).toBe(12);
+      expect([...OBJECTUI_VIEW_TYPES].sort()).toEqual([
+        'calendar', 'chart', 'detail', 'gallery', 'gantt', 'grid',
+        'kanban', 'list', 'map', 'page', 'timeline', 'tree',
+      ]);
+
+      // The derivation itself: objectui declares a superset, never a subset.
+      // This is the leg that reddens if `ViewType` is ever narrowed back.
+      for (const kind of SPEC_LIST_VIEW_TYPES) {
+        expect(OBJECTUI_VIEW_TYPES).toContain(kind);
+      }
+    });
+
+    it('partitions objectui`s vocabulary into 9 drawable and 3 undrawable kinds', () => {
+      const drawable = OBJECTUI_VIEW_TYPES.filter((k) => isListViewVisualization(k));
+      const undrawable = OBJECTUI_VIEW_TYPES.filter((k) => !isListViewVisualization(k));
+
+      expect(drawable.length).toBe(9);
+      expect(undrawable.length).toBe(3);
+      expect(drawable.length + undrawable.length).toBe(OBJECTUI_VIEW_TYPES.length);
+      expect([...undrawable].sort()).toEqual(['detail', 'list', 'page']);
+    });
+  });
+
+  describe('⭐ the contradiction, as a set with exactly one member', () => {
+    it('leaves `page` as the ONLY spec-authorable list-view type ListView cannot draw', () => {
+      // `list` and `detail` are objectui view CATEGORIES with no spec counterpart,
+      // so they are undrawable WITHOUT being a contract violation. Subtracting the
+      // drawable set from the SPEC's vocabulary — not from objectui's — is what
+      // isolates the residual this card registers.
+      const residual = SPEC_LIST_VIEW_TYPES.filter((k) => !isListViewVisualization(k));
+
+      expect(residual).toEqual(['page']);
+
+      // Control: the subtraction is a real one, not an empty-in / empty-out
+      // identity. Nine of the spec's ten types ARE drawable.
+      expect(SPEC_LIST_VIEW_TYPES.filter((k) => isListViewVisualization(k)).length).toBe(9);
+    });
+
+    it('keeps `page` on BOTH published `@object-ui/types` faces', () => {
+      // The value face. Reddens the day `ViewTypeSchema` is narrowed.
+      expect(ViewTypeSchema.safeParse('page').success).toBe(true);
+      // Control: the vocabulary is still CLOSED, so the `true` above is a
+      // reading of an enum and not an enum that accepts anything.
+      expect(ViewTypeSchema.safeParse('nonsense-control').success).toBe(false);
+
+      // The type face. This line is a COMPILE-time assertion as much as a
+      // runtime one: narrowing `ViewType` makes the annotation itself an error.
+      const pageAsViewType: ViewType = 'page';
+      expect(OBJECTUI_VIEW_TYPES).toContain(pageAsViewType);
+    });
+  });
+
+  describe('⭐ the OUTPUT — a document the spec accepts comes back as a different view kind', () => {
+    it('confirms the input is spec-valid, against three refusal controls', () => {
+      expect(SpecListViewSchema.safeParse(SPEC_VALID_PAGE_VIEW).success).toBe(true);
+
+      // The spec's validator is not a rubber stamp — `checkListViewPageMount`
+      // refuses a page view with no mount target, refuses `pageName` on any
+      // other kind, and the enum still refuses a typo.
+      expect(SpecListViewSchema.safeParse({ name: 'account_page', type: 'page', columns: [] }).success).toBe(false);
+      expect(
+        SpecListViewSchema.safeParse({ name: 'account_board', type: 'kanban', pageName: 'crm_welcome', columns: [] })
+          .success,
+      ).toBe(false);
+      expect(SpecListViewSchema.safeParse({ name: 'account_typo', type: 'nonsense', columns: [] }).success).toBe(false);
+    });
+
+    it('normalises that spec-valid `page` view to `viewType: "grid"`', () => {
+      const out = normalizeListViewSchema({ ...SPEC_VALID_PAGE_VIEW });
+
+      // ⭐ The sharpest statement of the bug: the author declared a page and the
+      // renderer was handed a grid.
+      expect(readViewType(out)).toBe('grid');
+
+      // The mount target survives in the metadata — nothing consumed it. The
+      // degrade is not "the page could not be found"; it is "the page was never
+      // looked for".
+      expect((out as { pageName?: unknown }).pageName).toBe('crm_welcome');
+      expect((out as { type?: unknown }).type).toBe('page');
+    });
+
+    it('degrades the same way through the `specType` slot a `list-view` node uses', () => {
+      // `components/renderers/layout/react-page.tsx` parks the SDUI-tier `type`
+      // in `specType` (ADR-0078), so this is the OTHER door the same author
+      // reaches the normalizer through.
+      const out = normalizeListViewSchema({
+        type: 'list-view',
+        objectName: 'account',
+        specType: 'page',
+        pageName: 'crm_welcome',
+      });
+      expect(readViewType(out)).toBe('grid');
+    });
+
+    it('discriminates: a drawable kind keeps its own identity', () => {
+      // Without this control, the `'grid'` above would also be produced by a
+      // normalizer that answered `'grid'` for everything — an implementation
+      // strictly worse than the bug, passing a pin about the bug.
+      expect(readViewType(normalizeListViewSchema({ type: 'list-view', objectName: 'a', specType: 'kanban' }))).toBe(
+        'kanban',
+      );
+      expect(readViewType(normalizeListViewSchema({ type: 'list-view', objectName: 'a', specType: 'gantt' }))).toBe(
+        'gantt',
+      );
+      expect(readViewType(normalizeListViewSchema({ viewType: 'kanban', objectName: 'a' }))).toBe('kanban');
+    });
+  });
+
+  describe('the whole vocabulary, as a census', () => {
+    it('maps every one of the 12 declared kinds to what the renderer actually gets', () => {
+      const census = new Map<string, unknown>(
+        OBJECTUI_VIEW_TYPES.map((kind) => [
+          kind,
+          readViewType(normalizeListViewSchema({ type: 'list-view', objectName: 'account', specType: kind })),
+        ]),
+      );
+
+      // Population first: a census over an empty set passes.
+      expect(census.size).toBe(12);
+
+      expect(Object.fromEntries(census)).toEqual({
+        // The nine ListView draws — each keeps its own identity.
+        grid: 'grid',
+        kanban: 'kanban',
+        gallery: 'gallery',
+        calendar: 'calendar',
+        timeline: 'timeline',
+        gantt: 'gantt',
+        map: 'map',
+        chart: 'chart',
+        tree: 'tree',
+        // The two objectui CATEGORIES — folding to grid is correct and intended.
+        list: 'grid',
+        detail: 'grid',
+        // ⭐ THE RESIDUAL. Spec-authorable, published on both faces, and handed
+        // to the renderer as something else entirely. Not a category: a kind.
+        page: 'grid',
+      });
+
+      // Stated once more as the property rather than the table, so the
+      // contradiction survives a future reshuffle of the rows above: every
+      // SPEC-declared kind resolves to itself, except exactly one.
+      const misrouted = SPEC_LIST_VIEW_TYPES.filter((kind) => census.get(kind) !== kind);
+      expect(misrouted).toEqual(['page']);
+    });
+  });
+});


### PR DESCRIPTION
Part of #8429. ⛔ Deliberately **not** `Fixes` — that card is the registration of a residual with two open dispositions, and it must stay open until one of them is ruled. This PR takes neither.

## What this is

objectui#8429 was dispatched for a **measurement**, not a fix. Two things ship here:

1. a **usage census** of `type: 'page'` list views (the input triage's re-grading trigger needs, in both directions) — reported below;
2. a **disposition-free pin** of the residual as it stands.

⛔ No page renderer was grown. ⛔ `ViewType` was not narrowed. Both are rulings, and the second would break the derivation PR #8372 just established.

---

## ⭐ Deliverable 1 — the census

### The question

Triage wrote the trigger and then wrote that its input did not exist: *「`page` 视图的实际使用面 = 未测量。本卡没有测,本席也没有测。⛔ 按纪律不写成零。」*

A zero returned because the query was wrong reads identically to a zero returned because the feature is unused, and the two send the card in opposite directions. So every sweep below is reported with its population, its lit control, and a dark control.

### Repo half — MEASURED, result **0**

**Population:** every tracked file at `7cdd2b922` — **6,958** files (`git ls-files | wc -l`); 6,873 read as text by the classifier. Not scoped to `packages/*/src` (a form that matches nothing and excludes `apps/`, `examples/`, `content/docs/`).

Six declaration shapes swept for each candidate value, over the whole tree — TS/JS single- and double-quoted literals, JSON quoted-key, YAML, JSX attribute, and a bare quoted token — across all six view-type keys (`type`, `viewType`, `specType`, `defaultViewType`, `defaultView`, `activeView`):

```
git grep -nIE "(^|[^A-Za-z0-9_\"'])\"?(type|viewType|specType|defaultViewType|defaultView|activeView)\"?[[:space:]]*[:=][[:space:]]*[\"']<VALUE>[\"']" -- .
```

| value | files | lines |
|---|---|---|
| grid | 159 | 501 |
| kanban | 65 | 116 |
| calendar | 30 | 51 |
| timeline | 41 | 96 |
| gantt | 29 | 54 |
| chart | 43 | 77 |
| tree | 19 | 31 |
| gallery | 10 | 14 |
| map | 15 | 26 |
| **page** | **97** | **162** |
| `nonsense_control_xyz` (dark control) | 0 | 0 |

**The 162 raw `page` lines are not view declarations.** Classified mechanically (a 25-line lookback window for a list-view context, then read individually), all 162 fall into five classes, none of them an authored ListView:

- the **SDUI page component node** — `PageNodeSchema` / `OuiPageSchema`, `{ type: 'page', kind: 'html' | 'react', body/regions }`; this is `examples/schema-catalog/src/schemas/components-layout-page/*.json`, `examples/hello-world/schema.json`, and most docs fences;
- **navigation items** — `{ type: 'page', pageName }` on `NavigationItem` / `ComponentNavItem`;
- the **metadata-admin resource kind** — `registerMetadataResource({ type: 'page' })`, `<MetadataResourceEditPage type="page">`, `PagePreview`, `PageBlockInspector`;
- **route / recent-item / studio-surface descriptors** — `{ type: 'page', name }`;
- **prose** — docblocks, CHANGELOGs and one changeset describing this very defect.

Narrowing to the keys that can only mean a view type:

```
git grep -nIE "(^|[^A-Za-z0-9_])(viewType|specType|defaultViewType|defaultView|activeView)[[:space:]]*[:=][[:space:]]*[\"']page[\"']" -- .
```

returns **5 lines, all of them this repo talking about the bug**: two in `normalize-list-view.test.ts` (the existing regression test), three in docblocks (`normalize-list-view.ts`, `views.zod.ts`). `viewType: 'page'` is 2 lines, both prose; `viewType: 'grid'` is 214.

**Second, independent probe.** `@objectstack/spec@17.3.0`'s `checkListViewPageMount` *requires* `pageName` on a `type: 'page'` view, so `pageName` is a different spelling of the same question. All 108 `pageName` lines in the repo sit on navigation items and page routing; objectui's own ListView face does not declare the key at all.

**Array form** (`availableViews` / `viewTypes` / `views: [...]` carrying `'page'`): 0 hits; the same shape finds 3 for `kanban`/`calendar`, so it is lit.

**Per-subtree lit control** — every subtree containing view declarations is shown non-empty:

| subtree | tracked | files with a KNOWN view kind | files with `page` |
|---|---|---|---|
| packages | 4362 | 247 | 74 |
| examples | 499 | 37 | 6 |
| content | 203 | 17 | 10 |
| apps | 265 | 5 | 3 |
| skills | 27 | 4 | 1 |
| scripts | 234 | 5 | 1 |

⇒ **Repo half: 0 authored `type: 'page'` ListViews**, on a sweep proven to find the nine kinds that *are* authored and proven to return 0 for a value that exists nowhere.

Corroborating: `CreateViewDialog` excludes `page` **by construction** (its picker is a total `Record<ListViewVisualization, …>`), so no in-repo surface can author one.

### Published-package half — **NOT MEASURED**

The installed tree was reached: **78,690** files across **1,623** packages under `node_modules/.pnpm`. The same sweep returns 82 files for `page`, of which 56 are `@objectstack/spec` + `@objectstack/lint` — and every one of those is the **contract declaring and enforcing** `page` (the zod source, the dist bundles, `json-schema/ui/ListView.json`, the liveness ledger), never a usage. The rest are `next`, `fumadocs`, `lightningcss` — unrelated senses of the word.

⚠️ **But the zero is uninformative, and is reported as NOT MEASURED rather than folded into the repo number.** The lit control fails on this population: `"listViews"` appears in 24 installed files and `"viewType"` in 6, and *every one of them is schema machinery* (zod bundles, JSON Schemas, liveness ledgers). **No installed package ships an authored ListView document of any kind** — so "0 page views" there is a census over an empty set, which passes for free.

### What the census means for the grade — triage's own trigger, applied

- **p1 leg** (`any` real app or installed package declaring one) — **not met**; nothing found, on a lit sweep.
- **p3 leg** (zero across the repo **and** the published packages, confirmed by a lit control) — **half met.** The repo half is zero-and-lit. The published half cannot be answered from this container, because the population contains no authored views at all.

⇒ On the trigger as written, **p2 stands.** Moving to p3 needs a population this container does not have (a real tenant/app metadata corpus). ⛔ And per triage, never close either way: the contract still accepts `page` and the next author can still write one.

### ⭐ Something the census turned up that outranks it

`@objectstack/spec@17.3.0`'s liveness ledger (`liveness/view.json`) carries a **maintainer ruling of 2026-08-29** on exactly the disposition this card leaves open, verbatim:

> The enum also carries `page`, which routes nowhere in ListView by design — it delegates to the existing page renderer via the sibling `pageName` key (maintainer ruling 2026-08-29); **the mount itself is objectui's half.**

> the RENDER half is objectui's and is **delegation rather than new code** — the ruling of 2026-08-29 is explicit that a page view hands off to the existing page renderer (「渲染委托既有页面渲染器」) … Necessary-not-sufficient in the ADR-0054 sense **until the objectui mount lands**: the refusals above are measured here, the pixels are not.

Upstream also *enforces* the shape already: `checkListViewPageMount` refuses a `page` view with no `pageName`, refuses `pageName` on any other kind, and refuses a non-empty `columns` beside it.

⛔ Nothing was acted on. It is reported because it bears directly on the ruling this card is waiting for: it suggests the answer is neither of the two dispositions triage forbade, but a third — a delegating mount — and it says upstream already considers objectui the owner of that half.

---

## ⭐ Deliverable 2 — the pin

`packages/core/src/utils/__tests__/normalize-list-view.pageResidual-8429.test.ts` (9 tests). It states the contradiction mechanically instead of in prose, and changes no behaviour.

The sharpest input available: a document `@objectstack/spec`'s **own** `ListViewSchema` accepts —

```ts
{ name: 'account_page', type: 'page', pageName: 'crm_welcome', columns: [] }
```

— normalises to `viewType: 'grid'`, with the `pageName` mount target still sitting in the metadata, unread.

⚠️ It asserts the **normalised output**, never that the constant contains the key — a pin on the declaration would reproduce the defect it records.

**It reddens on either disposition, which is the point:**

- grow a page renderer ⇒ `page` becomes drawable ⇒ the residual set empties and the output stops being `grid`;
- narrow `ViewType` ⇒ the published faces stop accepting `page`.

**Guards against passing for the wrong reason:**

- every set is asserted at its **exact size** before use (spec vocabulary 10, objectui 12, drawable 9, undrawable 3) — a census over an empty set passes;
- the spec's validator is exercised against **three refusal controls**, so the `success: true` is a reading and not a rubber stamp;
- the `'grid'` reading carries a **discrimination control** (`kanban` → `kanban`, `gantt` → `gantt`), so a normalizer that answered `grid` for everything — strictly worse than the bug — would fail;
- the census is also stated as a **property**, not just a table: every spec-declared kind resolves to itself, except exactly one.

`console.warn` from #8372 is silenced, not asserted, and ⛔ not treated as a mitigation: it is a signal to the developer; the author still gets a grid. Its own behaviour stays pinned where it was.

---

## ⭐ Deliverable 3 — the sibling card: it exists, and the premise is stale

Triage asked for a card on the `defaultViewType` 7-arm family missing `chart` / `tree`, noting *「那张卡目前似乎还不存在」*.

⛔ **Not filed — one exists and it is already ruled.** **objectui#5321**, *"`ObjectViewSchema.defaultViewType` omits `tree` and `chart`, so two `generateViewSchema` branches are unreachable from authored metadata (host-prop only)"* — **closed as completed** on 2026-08-21.

Maintainer ruling of 2026-08-20 on that card (recorded verbatim in `ObjectView.tsx`): 「其他接受你的建议。」 — option B, `tree` and `chart` are **recorded as host-composition-only surfaces**, deliberately not added to the authored unions.

All three surfaces triage named are covered by it: `packages/types/src/objectql.ts:1804`, the zod twin at `zod/objectql.zod.ts:348` (whose docblock says the seven arms are *"the declaration's SEVEN-value union on purpose"*), and `plugin-view`'s registration (`OBJECT_VIEW_HOST_COMPOSITION_VIEW_TYPES`, pinned by `objectViewHostSurface.test.tsx`, which goes red the day either union grows a `tree` or `chart` member).

⇒ The observation is factually right and its reading as a gap is wrong. Filing a new card would re-litigate a standing ruling, and acting on it would redden a pin by design.

---

## Verification

**Ablation — four legs, each mutating a READ SITE (never the pin), from a committed tree, `trap` on EXIT/INT/TERM with absolute paths.** Per-test classification from vitest's JSON reporter; all five death strings counted 0 on every leg. Baseline 9/9 pass.

| leg | read site mutated | on-disk proof | result |
|---|---|---|---|
| **A** — simulate *grow a page renderer* (`page: true` into `LIST_VIEW_KINDS`) | `core/src/utils/normalize-list-view.ts` | hash `9ec9c9d6…` → `5e310ffd…`; marker 0→1; lines 529→530 (Δ+1 as declared) | **5 / 9 fail** — residual set empties (`expected [] to deeply equal [ 'page' ]`), output flips (`expected 'page' to be 'grid'`) |
| **B** — simulate *narrow `ViewType`* (drop `page` from the enum) | `types/src/zod/views.zod.ts` | hash `5c8a30dd…` → `1334e8e5…`; marker 0→1; lines 254→254 (Δ0) | **4 / 9 fail** — vocabulary 11≠12, undrawable 2≠3, face rejects `page` |
| **C** — *empty the population* (`z.enum(['grid'])`) | `types/src/zod/views.zod.ts` | hash `5c8a30dd…` → `58a0d14b…`; marker 0→1; lines 254→254 (Δ0) | **4 / 9 fail** — `expected 1 to be 12`, `expected 1 to be 9`. The census does **not** pass over an emptied set. |
| **D** — *narrow `ViewType` at the type level* | `types/src/views.ts`, **rebuilt** so it reached `dist/views.d.ts` (verified: line 50 carries the `Exclude`) | hash `7e6de89b…` → `7b331e90…`; lines 976→976 (Δ0) | `tsc -p packages/core/tsconfig.test.json` **exit 2**, error **on the pin itself**: `pageResidual-8429.test.ts(146,13): error TS2322: Type '"page"' is not assignable to type 'ViewType'` |

Every leg restored **by state**: `git hash-object` back to the HEAD blob, marker count back to 0, line total back, `git diff HEAD` empty. Leg D's rebuild was repeated after restore and `dist/views.d.ts:50` verified back to the derived form; `type-check` back to exit 0.

⚠️ Recorded because it is the honest reading: on leg D's *first* run through `pnpm --filter @object-ui/core type-check`, the failure came from `normalize-list-view.ts(197,3)` — the existing derived-record totality catches the narrowing **before** the pin's own annotation is reached (`tsc --noEmit && tsc -p tsconfig.test.json` short-circuits). The pin's compile-time leg was then isolated on the test program alone, which is where the table's leg D reading comes from.

**Gates and suites** (exit codes captured before any pipe):

| command | result |
|---|---|
| `pnpm exec vitest run packages/core/src/utils/__tests__/normalize-list-view.pageResidual-8429.test.ts` | `Test Files 1 passed (1) · Tests 9 passed (9)` |
| `pnpm exec vitest run packages/core/` | `Test Files 133 passed (133) · Tests 2797 passed (2797)` |
| `pnpm --filter '@object-ui/core^...' build` (dependency closure, run **first**) | exit 0 — `dist completeness: 126 emitted files verified` |
| `pnpm --filter @object-ui/core type-check` | exit 0 |
| `node scripts/check-changeset-presence.mjs` | `✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)… EMPTY frontmatter — declared as releasing nothing` |
| `node scripts/check-governed-queue-guard.mjs --test <both paths>` | `✅ NOT GOVERNED — 2 path(s) checked against 5 governed surface(s)` |
| `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over both changed files | no match |

The pin is confirmed **inside** the type-check program, not merely adjacent to it: `tsc -p packages/core/tsconfig.test.json --listFiles` names it among 697 files.

⚠️ `skip-changeset` is a phantom label in this repo; the real exemption is the **empty-frontmatter** changeset, which is what `.changeset/8429-page-view-residual-pin.md` is.

## Dedup

Declared, and **lit**. GitHub's `search/issues` endpoint is blocked for this session (`sessions are bound to their configured repositories`), so the channel was switched to one targeted MCP `search_issues`. It is self-controlling: it returned **#8429 itself and #8127** at the top, so this is not one of the false zeros this repo has measured. Across 15 results, **no other card records this residual** — #8127 is the declaration half and is closed.

Authored by an agent seat; session `https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S`.


---
_Generated by [Claude Code](https://claude.ai/code)_