### PR TITLE
fix(plugin-detail): a masked row offers no copy affordance

### DIFF
--- a/.changeset/8440-masked-field-copy-refusal.md
+++ b/.changeset/8440-masked-field-copy-refusal.md
@@ -1,0 +1,26 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+A masked detail row no longer offers to copy its value (objectui#8440, maintainer
+ruling 2026-09-08, option A).
+
+`@object-ui/fields` renders `password` and `secret` cells as `••••••` — the cell
+deliberately refuses to show the value. `DetailSection` offered click-to-copy on that
+same row anyway and handed the **raw** credential to the clipboard: silently, with no
+error and no visible sign. A masked cell that copies in the clear is worse than an
+unmasked one, because the reader believes the value is protected.
+
+Rows whose field type is masked are now not copy-interactive at all: no row click, no
+Enter/Space, no hover copy button, in either the desktop or the mobile row layout. The
+alternative — copying the bullets — was considered and refused as a second silent wrong
+answer.
+
+The refusal is a separate gate, deliberately **not** spelled into `canCopy`: that name
+is one of the readers of the shared emptiness authority (`hasCellValue`), and a masked
+row is not an empty one. Emptiness classification, the "Show N empty fields" counter,
+the auto-hide heuristic and every ordinary row's clipboard payload are unchanged.
+
+Like the editability gates beside it, the new gate reads the view's authored `type` and
+the object schema's `type` separately and answers their **union**, so a presentation
+override can withdraw the affordance but never restore it on a credential column.

--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -41,6 +41,7 @@ import {
   enrichDetailField,
   isComputedFieldType,
   isInlineExcludedDetailFieldType,
+  isMaskedDetailFieldType,
 } from './fieldEnrichment';
 
 /**
@@ -324,6 +325,12 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
     // The container family rode the same fallback with an object-shaped value.
     // Read as the same narrow-only UNION as `isComputedFieldType` (#3355).
     const isInlineExcluded = isInlineExcludedDetailFieldType(field.type, objectDefField?.type);
+    // Types whose CELL is drawn as a mask (`password` / `secret`). Read the two
+    // types SEPARATELY for the same narrow-only union as the gates above
+    // (objectui#3355). Consumed by the copy affordance below — the mask and the
+    // clipboard are the READ direction of the same refusal, and `isInlineExcluded`
+    // (objectui#4221) already holds the WRITE direction of it.
+    const isMaskedField = isMaskedDetailFieldType(field.type, objectDefField?.type);
     const fieldEditable = !isReadonly && !isComputedField && !isSystemField && !isInlineExcluded;
     const canInlineEditField = fieldEditable && !!onEnterInlineEdit;
 
@@ -383,10 +390,28 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
     // tests were raw and agreed by coincidence; fixing only the affordance
     // would have put a copy button next to an em-dash that copies spaces.
     const canCopy = hasCellValue(value);
+    // ⭐ A MASKED row offers no copy affordance at all (objectui#8440, maintainer
+    // ruling 2026-09-08 option A). The cell deliberately refuses to render the
+    // value; the affordance on the same row handed the RAW credential to the
+    // clipboard — silently, with no error and no visible sign, which is worse
+    // than not masking at all because the reader believes the value is
+    // protected. ⛔ The refusal is NOT spelled into `canCopy`: that name is one
+    // of the readers of `hasCellValue` (objectui#8376) that MUST agree on which
+    // rows are EMPTY, and a masked row is not an empty one — it is a row whose
+    // value this surface declines to hand over. Narrowing there would move the
+    // emptiness answer for every reader of it.
+    //
+    // ⛔ Nor is it spelled into `handleCopyField`: option B — copying the
+    // bullets — was considered and refused as a second silent wrong answer, so
+    // there is nothing for the handler to write. Withdrawing the affordance is
+    // the whole fix, and it is withdrawn at EVERY site that reaches the handler
+    // (the desktop row, its Enter/Space, its hover button, and the mobile
+    // grouped-inset row's click and Enter/Space).
+    const copyOffered = canCopy && !isMaskedField;
     // An editable field surfaces the pencil (edit) affordance instead of the
     // copy affordance, and reserves single-click for text selection — so
     // click-to-copy only applies to non-editable fields.
-    const copyInteractive = canCopy && !canInlineEditField;
+    const copyInteractive = copyOffered && !canInlineEditField;
     const isCopied = copiedField === field.name;
     const fieldLabelText = fieldLabel(objectName || '', field.name, field.label || field.name);
 
@@ -400,14 +425,14 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
           key={field.name}
           className={cn(
             "flex items-baseline justify-between gap-4 py-2.5 min-h-[44px] group",
-            canCopy && "cursor-pointer active:bg-muted/40 transition-colors",
+            copyOffered && "cursor-pointer active:bg-muted/40 transition-colors",
           )}
-          onClick={canCopy ? () => handleCopyField(field.name, value) : undefined}
-          onKeyDown={canCopy ? (e: React.KeyboardEvent) => {
+          onClick={copyOffered ? () => handleCopyField(field.name, value) : undefined}
+          onKeyDown={copyOffered ? (e: React.KeyboardEvent) => {
             if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleCopyField(field.name, value); }
           } : undefined}
-          role={canCopy ? 'button' : undefined}
-          tabIndex={canCopy ? 0 : undefined}
+          role={copyOffered ? 'button' : undefined}
+          tabIndex={copyOffered ? 0 : undefined}
         >
           <span className="text-[15px] text-muted-foreground shrink-0">{fieldLabelText}</span>
           <span className="text-[15px] text-foreground text-right break-words min-w-0 leading-snug">{displayValue}</span>
@@ -499,7 +524,7 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
-          ) : canCopy ? (
+          ) : copyOffered ? (
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/packages/plugin-detail/src/__tests__/DetailSection.maskedCopyRefusal-8440.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailSection.maskedCopyRefusal-8440.test.tsx
@@ -1,0 +1,496 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A MASKED row offers no copy affordance at all (objectui#8440).
+ *
+ * ## The defect
+ *
+ * `@object-ui/fields` renders `password` and `secret` cells as `••••••` — the
+ * cell deliberately refuses to show the value. `DetailSection` offered the copy
+ * affordance on that same row anyway (`canCopy` is `hasCellValue`, true for any
+ * non-empty string, and `canInlineEditField` is false because objectui#4221 put
+ * both types in `isInlineExcludedDetailFieldType`), so the row handed the RAW
+ * credential to `navigator.clipboard.writeText`. Silently: no error, no visible
+ * sign. A masked cell that copies in the clear is worse than an unmasked one,
+ * because the reader believes the value is protected.
+ *
+ * ⇒ maintainer ruling, 2026-09-08, option A: **no copy affordance on masked
+ * field types**. ⛔ Not option B — copying the bullets was considered and
+ * refused as a second silent wrong answer, so there is nothing for the handler
+ * to write and nothing here asserts a `••••••` payload.
+ *
+ * ## Why every case carries a CONTROL in the same mounted tree
+ *
+ * The pin is ABSENCE-shaped, which is the shape that passes by never running: a
+ * "was not called" assertion is equally satisfied when the row never rendered,
+ * when the event never landed, when the component threw during mount, and when
+ * the spy was installed on the wrong object. So each masked case, in ONE render:
+ *
+ *  1. proves the masked cell RENDERED (its text contains the mask) and that the
+ *     raw value is nowhere in the document;
+ *  2. fires the SAME interaction on an ordinary text row and requires the spy to
+ *     receive that row's value — the spy is proved reachable and the interaction
+ *     shape is proved able to reach `handleCopyField`;
+ *  3. only then requires zero calls from the masked row.
+ *
+ * Absence is counted AT THE SPY (`writeText.mock.calls`), never with a text
+ * query: both masked rows draw the identical string `••••••`, and `queryByText`
+ * throws on multiple matches exactly as it does on none.
+ *
+ * ## Every path that reaches the handler — five, across two layouts
+ *
+ * The card named three (the desktop row click, Enter/Space on it, and the hover
+ * copy button). Measured on this base there are five: the mobile grouped-inset
+ * row carries its own click and Enter/Space, gated on `canCopy` alone. A fix
+ * that withdrew only the button would leave four live paths and still pass a
+ * careless pin, so all five are exercised here, on BOTH the masked rows and the
+ * control — a path that silently does nothing on EVERY row cannot read as a fix.
+ *
+ * ## The non-regression half, derived from the plausible WRONG FIX
+ *
+ * The wrong fix is gating `canCopy` / `hasCellValue`. It makes the masked row
+ * non-copy-interactive AND moves which rows count as EMPTY, because
+ * `hasCellValue` is objectui#8376's emptiness authority for this component, not
+ * a copy predicate — the toggle count, the auto-hide heuristic and the `No
+ * value` placeholder all read it. So this file also pins that a populated
+ * masked row is still classified FILLED, and that ordinary rows — including the
+ * object-valued ones objectui#8395 fixed — copy byte-for-byte what they copy
+ * today.
+ *
+ * ## Ablation directions (both measured on this file)
+ *
+ * - "nothing is ever copy-interactive" (`copyOffered = false`) reddens every
+ *   CONTROL here, loudly, in both layouts.
+ * - "everything is copy-interactive" (`copyOffered = canCopy`, i.e. the defect)
+ *   reddens every masked case.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import * as React from 'react';
+import { DetailSection } from '../DetailSection';
+import type { DetailViewSection } from '@object-ui/types';
+
+let writeText: ReturnType<typeof vi.fn>;
+
+/** The two raw credentials. Neither may reach the DOM or the clipboard. */
+const RAW_PASSWORD = 's3cret-value';
+const RAW_SECRET = 'sk_live_51H8xQ2';
+const MASK = '••••••';
+const CONTROL_VALUE = 'Plain String Value';
+
+const DESKTOP_WIDTH = 1280;
+const MOBILE_WIDTH = 375;
+
+const setWidth = (value: number) =>
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value });
+
+beforeAll(() => setWidth(DESKTOP_WIDTH));
+
+beforeEach(() => {
+  writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+});
+
+afterEach(cleanup);
+
+const objectSchema = {
+  fields: {
+    api_key: { type: 'password', label: 'API Key' },
+    token: { type: 'secret', label: 'Token' },
+    // The control, and the non-regression rows: a scalar, an object-valued cell
+    // (objectui#8395's JSON payload) and a formatted number whose rendered text
+    // differs from its stored value.
+    name: { type: 'text', label: 'Name' },
+    payload: { type: 'json', label: 'Payload' },
+    amount: { type: 'number', label: 'Amount', scale: 2 },
+  },
+};
+
+const DATA: Record<string, unknown> = {
+  api_key: RAW_PASSWORD,
+  token: RAW_SECRET,
+  name: CONTROL_VALUE,
+  payload: { a: 1, b: ['x'] },
+  amount: 16,
+};
+
+const section = {
+  title: 'Details',
+  fields: Object.entries(objectSchema.fields).map(([name, def]) => ({
+    name,
+    label: (def as { label: string }).label,
+  })),
+} as DetailViewSection;
+
+const renderAll = () =>
+  render(<DetailSection section={section} data={DATA} objectSchema={objectSchema} />);
+
+/** The row's outer container (label element + value element), by its label. */
+const rowContainer = (label: string): HTMLElement => {
+  const labelEl = screen.queryByText(label);
+  expect(labelEl, `CONTROL: a row labelled "${label}" is on screen`).not.toBeNull();
+  return (labelEl as HTMLElement).parentElement as HTMLElement;
+};
+
+/**
+ * The element that carries the row's click / Enter / Space handlers.
+ *
+ * Taken by POSITION — the label's last sibling in the desktop layout, the row
+ * itself in the mobile one — and ⛔ never by `[role="button"]`: this file exists
+ * for rows that must NOT have that role, and a locator requiring it could not
+ * address them at all (it would report "no such element" for both the fixed and
+ * the broken build).
+ */
+const desktopRow = (label: string): HTMLElement =>
+  rowContainer(label).lastElementChild as HTMLElement;
+const mobileRow = (label: string): HTMLElement => rowContainer(label);
+
+type Interaction = { path: string; fire: (row: HTMLElement) => void };
+
+/** The two interactions every row carries in BOTH layouts. */
+const ROW_INTERACTIONS: Interaction[] = [
+  { path: 'a row click', fire: (row) => fireEvent.click(row) },
+  {
+    path: 'Enter on the row',
+    fire: (row) => fireEvent.keyDown(row, { key: 'Enter', code: 'Enter' }),
+  },
+  {
+    path: 'Space on the row',
+    fire: (row) => fireEvent.keyDown(row, { key: ' ', code: 'Space' }),
+  },
+];
+
+const MASKED_ROWS = [
+  { label: 'API Key', type: 'password', raw: RAW_PASSWORD },
+  { label: 'Token', type: 'secret', raw: RAW_SECRET },
+];
+
+const cross = MASKED_ROWS.flatMap((row) =>
+  ROW_INTERACTIONS.map((interaction) => ({ ...row, ...interaction })),
+);
+
+/** What the spy received, as an array of arguments — counted at the spy. */
+const payloads = () => writeText.mock.calls.map((call) => call[0]);
+
+describe('DetailSection — a masked row offers no copy affordance (#8440)', () => {
+  it.each(cross)(
+    'MASKED — $path on the $label row ($type) writes NOTHING to the clipboard',
+    ({ label, raw, path, fire }) => {
+      renderAll();
+      const masked = desktopRow(label);
+
+      // CONTROL 1 — the masked cell RENDERED, and rendered the MASK. Without
+      // this the absence below would also pass for a row that drew nothing.
+      expect(masked.textContent, `CONTROL: the "${label}" cell drew the mask`).toContain(MASK);
+      expect(
+        document.body.textContent,
+        `CONTROL: the raw ${label} value is nowhere on screen`,
+      ).not.toContain(raw);
+
+      // CONTROL 2 — the SAME interaction on an ordinary row reaches the
+      // clipboard, in this same mounted tree. The spy is reachable and this
+      // interaction shape does reach `handleCopyField`.
+      writeText.mockClear();
+      fire(desktopRow('Name'));
+      expect(
+        payloads(),
+        `CONTROL: ${path} on the ordinary text row copies its own value`,
+      ).toEqual([CONTROL_VALUE]);
+
+      // The pin.
+      writeText.mockClear();
+      fire(masked);
+      expect(payloads(), `${path} on the "${label}" row must write nothing`).toEqual([]);
+    },
+  );
+
+  it.each(MASKED_ROWS)(
+    'MASKED — the $label row ($type) offers no hover copy BUTTON, and no button at all',
+    ({ label, raw }) => {
+      renderAll();
+
+      // CONTROL — the ordinary row DOES carry exactly one button, and clicking
+      // it copies that row's value. So the absence below is a decision about
+      // this row and not about the feature being gone.
+      const controlButton = desktopRow('Name').querySelector('button');
+      expect(controlButton, 'CONTROL: the ordinary row carries a copy button').not.toBeNull();
+      writeText.mockClear();
+      fireEvent.click(controlButton as HTMLElement);
+      expect(payloads(), 'CONTROL: the copy button copies the ordinary row').toEqual([
+        CONTROL_VALUE,
+      ]);
+
+      const masked = desktopRow(label);
+      expect(masked.textContent, `CONTROL: the "${label}" cell drew the mask`).toContain(MASK);
+      expect(
+        masked.querySelector('button'),
+        `the "${label}" row must offer no copy button`,
+      ).toBeNull();
+      expect(
+        document.body.textContent,
+        `the raw ${label} value never reaches the DOM`,
+      ).not.toContain(raw);
+    },
+  );
+
+  it.each(MASKED_ROWS)(
+    'MASKED — the $label row ($type) does not advertise itself as interactive',
+    ({ label }) => {
+      renderAll();
+
+      // CONTROL — the ordinary row is a keyboard-reachable button.
+      const control = desktopRow('Name');
+      expect(control.getAttribute('role'), 'CONTROL: the ordinary row is a button').toBe('button');
+      expect(control.getAttribute('tabindex'), 'CONTROL: the ordinary row is focusable').toBe('0');
+
+      const masked = desktopRow(label);
+      expect(masked.textContent, `CONTROL: the "${label}" cell drew the mask`).toContain(MASK);
+      expect(masked.getAttribute('role'), `the "${label}" row is not a button`).toBeNull();
+      expect(
+        masked.getAttribute('tabindex'),
+        `the "${label}" row is not in the tab order`,
+      ).toBeNull();
+    },
+  );
+});
+
+describe('DetailSection — the mobile grouped-inset row refuses too (#8440)', () => {
+  // ⚠️ The mobile layout is a SEPARATE render path with its own two reach sites,
+  // gated on `canCopy` alone rather than on `copyInteractive`. The card named
+  // only the desktop three; a fix pinned there alone would leave a credential
+  // one tap from the clipboard on the target where this layout ships.
+  beforeEach(() => setWidth(MOBILE_WIDTH));
+  afterEach(() => setWidth(DESKTOP_WIDTH));
+
+  it.each(cross)(
+    'MOBILE — $path on the $label row ($type) writes NOTHING to the clipboard',
+    ({ label, raw, path, fire }) => {
+      renderAll();
+      const masked = mobileRow(label);
+
+      // CONTROL 0 — this really is the mobile layout: its row IS the label's
+      // parent and carries the value beside the label, so `desktopRow` and
+      // `mobileRow` disagree here. Read through the copy affordance the layout
+      // offers on the control row below.
+      expect(masked.textContent, `CONTROL: the "${label}" cell drew the mask`).toContain(MASK);
+      expect(
+        document.body.textContent,
+        `CONTROL: the raw ${label} value is nowhere on screen`,
+      ).not.toContain(raw);
+
+      const control = mobileRow('Name');
+      expect(
+        control.getAttribute('role'),
+        'CONTROL: the mobile layout rendered, and its ordinary row is a button',
+      ).toBe('button');
+
+      writeText.mockClear();
+      fire(control);
+      expect(
+        payloads(),
+        `CONTROL: ${path} on the ordinary mobile row copies its own value`,
+      ).toEqual([CONTROL_VALUE]);
+
+      writeText.mockClear();
+      fire(masked);
+      expect(payloads(), `${path} on the mobile "${label}" row must write nothing`).toEqual([]);
+      expect(
+        masked.getAttribute('role'),
+        `the mobile "${label}" row is not a button`,
+      ).toBeNull();
+    },
+  );
+});
+
+describe('DetailSection — what the refusal must NOT move (#8440 non-regression)', () => {
+  /**
+   * ⭐ Derived from the plausible WRONG FIX, not from the shape of the bug.
+   *
+   * Gating `canCopy` — i.e. teaching `hasCellValue` about the mask — satisfies
+   * every vivid assertion above and silently moves the EMPTINESS answer for the
+   * whole record page: the "Show N empty fields" counter, the auto-hide
+   * heuristic, the `No value` placeholder, the highlight strip and the summary
+   * chips all read that one function (objectui#8376 / #8394). A populated
+   * credential is not an empty row; it is a row whose value this surface
+   * declines to hand over.
+   */
+  const emptinessSchema = {
+    fields: {
+      api_key: { type: 'password', label: 'API Key' },
+      name: { type: 'text', label: 'Name' },
+      notes: { type: 'text', label: 'Notes' },
+      close_date: { type: 'text', label: 'Close Date' },
+    },
+  };
+
+  const renderEmptinessFixture = () =>
+    render(
+      <DetailSection
+        section={
+          {
+            title: 'Details',
+            fields: Object.entries(emptinessSchema.fields).map(([name, def]) => ({
+              name,
+              label: (def as { label: string }).label,
+            })),
+          } as DetailViewSection
+        }
+        // 4 fields, 2 of them absent: at both auto-hide thresholds (≥4 fields,
+        // ≥25% empty), so the toggle appears and its count is readable.
+        data={{ api_key: RAW_PASSWORD, name: CONTROL_VALUE }}
+        objectSchema={emptinessSchema}
+      />,
+    );
+
+  it('EMPTINESS — a populated masked row is still counted FILLED, not empty', () => {
+    renderEmptinessFixture();
+
+    // CONTROL — the section rendered and kept its ordinary filled row.
+    expect(screen.queryByText('Details'), 'CONTROL: the section heading rendered').not.toBeNull();
+    expect(screen.queryByText(CONTROL_VALUE), 'CONTROL: the filled text row rendered').not.toBeNull();
+
+    const toggle = screen.getByRole('button', { name: /empty fields/i });
+    expect(
+      toggle.textContent,
+      'exactly the two ABSENT rows are empty — the masked row is not one of them',
+    ).toContain('Show 2 empty fields');
+
+    // It was not counted, so it was not hidden: the masked row is on screen,
+    // drawing the mask rather than the `No value` placeholder.
+    const masked = rowContainer('API Key');
+    expect(masked.textContent, 'the masked row is visible and drew the mask').toContain(MASK);
+    expect(
+      masked.querySelector('[title="No value"]'),
+      'a populated masked row must not draw the `No value` affordance',
+    ).toBeNull();
+    expect(
+      screen.queryAllByTitle('No value'),
+      'the two empty rows are hidden, so no placeholder is drawn yet',
+    ).toHaveLength(0);
+
+    // Revealing them shows exactly two placeholders — still not the masked row.
+    fireEvent.click(toggle);
+    expect(
+      screen.queryAllByTitle('No value'),
+      'revealing the empty fields draws exactly the two absent rows',
+    ).toHaveLength(2);
+    expect(
+      rowContainer('API Key').textContent,
+      'the masked row still draws the mask after the reveal',
+    ).toContain(MASK);
+  });
+
+  const UNCHANGED = [
+    { label: 'Name', rendered: CONTROL_VALUE, clipboard: CONTROL_VALUE },
+    // The object-valued kind objectui#8395 fixed: JSON of the STORED value.
+    { label: 'Payload', rendered: '{"a":1,"b":["x"]}', clipboard: '{"a":1,"b":["x"]}' },
+    // Rendered and stored differ on purpose — the payload is the stored value.
+    { label: 'Amount', rendered: '16.00', clipboard: '16' },
+  ];
+
+  it.each(UNCHANGED)(
+    'ORDINARY — the $label row still copies exactly what it copies today',
+    ({ label, rendered, clipboard }) => {
+      renderAll();
+      const row = desktopRow(label);
+
+      expect(row.textContent, `CONTROL: the "${label}" cell rendered its value`).toContain(
+        rendered,
+      );
+
+      writeText.mockClear();
+      fireEvent.click(row);
+      expect(payloads(), `"${label}" copies the STORED value, unchanged`).toEqual([clipboard]);
+    },
+  );
+});
+
+describe('DetailSection — the gate is the narrow-only UNION of the two types (#8440)', () => {
+  /**
+   * ⚠️ DECLARED DESIGN CHOICE, in the shape objectui#3355 already fixed for the
+   * editability gates: the view's authored `type` and the object schema's
+   * `type` are read SEPARATELY and the answer is their union, so a PRESENTATION
+   * override can withdraw the copy affordance but never restore it.
+   *
+   * The measured cost is the first case below: an authored `text` over an
+   * object-schema `secret` renders the value in the CLEAR (the cell renderer
+   * follows display precedence), and the copy affordance is still withheld. The
+   * alternative — following display precedence here too — would let a view
+   * author re-open one-click exfiltration of a credential column by writing one
+   * key, which is precisely the direction objectui#3355 closed.
+   */
+  const unionSchema = {
+    fields: {
+      token: { type: 'secret', label: 'Token' },
+      nickname: { type: 'text', label: 'Nickname' },
+      name: { type: 'text', label: 'Name' },
+    },
+  };
+
+  const renderUnion = () =>
+    render(
+      <DetailSection
+        section={
+          {
+            title: 'Details',
+            fields: [
+              // An authored display type over a credential column…
+              { name: 'token', label: 'Token', type: 'text' },
+              // …and the mirror: a credential type authored over a text column.
+              { name: 'nickname', label: 'Nickname', type: 'password' },
+              { name: 'name', label: 'Name' },
+            ],
+          } as unknown as DetailViewSection
+        }
+        data={{ token: RAW_SECRET, nickname: 'not-really-a-secret', name: CONTROL_VALUE }}
+        objectSchema={unionSchema}
+      />,
+    );
+
+  it('an authored display type does not restore the affordance on a credential column', () => {
+    renderUnion();
+
+    // CONTROL — the ordinary row still copies, in this same tree.
+    writeText.mockClear();
+    fireEvent.click(desktopRow('Name'));
+    expect(payloads(), 'CONTROL: the ordinary row copies its value').toEqual([CONTROL_VALUE]);
+
+    const row = desktopRow('Token');
+    // The declared cost, asserted rather than waved past: the authored `text`
+    // means the CELL shows the value. The refusal is about the copy affordance.
+    expect(
+      row.textContent,
+      'DECLARED: the authored `text` type renders the value in the clear',
+    ).toContain(RAW_SECRET);
+
+    writeText.mockClear();
+    fireEvent.click(row);
+    fireEvent.keyDown(row, { key: 'Enter', code: 'Enter' });
+    expect(payloads(), 'the object schema still says `secret`, so no copy is offered').toEqual([]);
+    expect(row.querySelector('button'), 'and no copy button either').toBeNull();
+  });
+
+  it('an authored credential type withdraws the affordance from a plain column', () => {
+    renderUnion();
+
+    writeText.mockClear();
+    fireEvent.click(desktopRow('Name'));
+    expect(payloads(), 'CONTROL: the ordinary row copies its value').toEqual([CONTROL_VALUE]);
+
+    const row = desktopRow('Nickname');
+    expect(row.textContent, 'the authored `password` type masks the cell').toContain(MASK);
+
+    writeText.mockClear();
+    fireEvent.click(row);
+    fireEvent.keyDown(row, { key: 'Enter', code: 'Enter' });
+    expect(payloads(), 'a masked cell offers no copy, whichever type spelled the mask').toEqual([]);
+    expect(row.querySelector('button'), 'and no copy button either').toBeNull();
+  });
+});

--- a/packages/plugin-detail/src/fieldEnrichment.ts
+++ b/packages/plugin-detail/src/fieldEnrichment.ts
@@ -145,6 +145,69 @@ function isExcludedForDetail(fieldType: unknown): boolean {
 }
 
 /**
+ * Field types whose CELL the fields package renders as a mask (`••••••`)
+ * instead of as the value — the read-side counterpart of the credential entry
+ * in `INLINE_EXCLUDED_FIELD_TYPES`.
+ *
+ * ## ⚠️ A MIRROR, NOT AN AUTHORITY — and that is a declared cost, not an oversight
+ *
+ * The mask itself is two anonymous renderers registered inside
+ * `getCellRenderer`'s standard map in `@object-ui/fields`
+ * (`password: () => <span>••••••</span>`, and the same for `secret`). The fields
+ * package exports NO way to ask "is type T masked?" — searched for on this card
+ * and not found — so honouring the mask on this surface at all requires naming
+ * the types once more, here. Two consequences are accepted deliberately:
+ *
+ *  - a THIRD masked type registered in `@object-ui/fields` tomorrow would render
+ *    masked and stay copy-interactive here until someone edits this line;
+ *  - `registerFieldRenderer('password', …)` can replace the mask at RUNTIME, and
+ *    no static set can see that either.
+ *
+ * Both are properties of "the mask has no queryable authority", filed as its own
+ * card. ⛔ Do not grow this set into that authority: the fix is a predicate
+ * exported by the package that OWNS the registrations, and every consumer
+ * (this one included) reading it — exactly the shape
+ * {@link isInlineExcludedDetailFieldType} already has for the write direction.
+ *
+ * ## Why RAW spellings, with no alias resolution — measured
+ *
+ * Unlike the inline-edit tables, the cell path does NOT resolve aliases:
+ * `resolveCellRendererType` only promotes a textual base type through a
+ * `format` hint (never onto a credential type), and `getCellRenderer` is an
+ * exact-key lookup into the registry and then into its standard map, falling
+ * back to `TextCellRenderer`. So EXACTLY these two spellings draw the mask, and
+ * every other spelling — including the form-alias target `field:password` —
+ * renders in the clear. Matching raw spellings is therefore the faithful
+ * mirror, and an alias-aware widening here would withdraw the affordance from
+ * rows that show their value.
+ */
+const MASKED_CELL_FIELD_TYPES = new Set<string>(['password', 'secret']);
+
+/**
+ * Is this row's cell drawn as a mask, given the type authored on the view entry
+ * and the type declared on the object schema?
+ *
+ * **Narrow-only, like {@link isComputedFieldType} and
+ * {@link isInlineExcludedDetailFieldType}** — the answer is the UNION of the
+ * two, so an authored display `type` can withdraw the copy affordance but never
+ * restore it (objectui#3355). The direction matters here more than anywhere: an
+ * object column declared `secret` keeps its refusal even when a view authors
+ * `type: 'text'` over it, because a PRESENTATION override has no business
+ * widening access to a credential. The declared cost of the union is the mirror
+ * case — an object `text` column authored as `password` masks AND refuses the
+ * copy, which is the same answer the cell already gives.
+ */
+export function isMaskedDetailFieldType(
+  viewFieldType: unknown,
+  objectFieldType: unknown,
+): boolean {
+  return (
+    MASKED_CELL_FIELD_TYPES.has(viewFieldType as string) ||
+    MASKED_CELL_FIELD_TYPES.has(objectFieldType as string)
+  );
+}
+
+/**
  * Object-metadata keys carried onto a detail-view field so the read cell and
  * the inline editor see the SAME resolved field shape the object form does.
  *


### PR DESCRIPTION
Fixes #8440

`@object-ui/fields` renders `password` and `secret` cells as `••••••` — the cell
deliberately refuses to show the value. `DetailSection` offered the copy affordance on
that same row anyway and handed the **raw** credential to `navigator.clipboard.writeText`:
silently, with no error and no visible sign. A masked cell that copies in the clear is
worse than an unmasked one, because the reader believes the value is protected.

Maintainer ruling, 2026-09-08, option A — **no copy affordance on masked field types**.
Copying the bullets was considered and refused as a second silent wrong answer, so
nothing here writes a mask to the clipboard.

## What the base actually looked like (the card's reading was stale)

The card quotes `String(value)` at line 220 and the mask registrations at
`fields/src/index.tsx:2380-2381`. On `2609812d2` the handler is the post-#8395 shape
(objects are serialized as JSON, scalars keep `String(value)`) and the mask registrations
sit at 2465-2466. The premise held in every load-bearing respect: `canCopy` is still
`hasCellValue(value)`, `canInlineEditField` is still false for both types via
`isInlineExcludedDetailFieldType`, so `copyInteractive` was still true on a credential row.

**Measured correction: there are five reach paths, not three.** The card named the desktop
row click, Enter/Space on it, and the hover copy button. `DetailSection` also renders a
**mobile grouped-inset row** whose click and Enter/Space are gated on `canCopy` alone —
two more sites reaching the same handler, on the target where a masked row is most likely
to be tapped. And the desktop hover button was gated on `canCopy` too, not on
`copyInteractive`. All five are withdrawn here.

## The change

One derived gate, five consumers:

```
canCopy       = hasCellValue(value)              // unchanged — the emptiness reader
copyOffered   = canCopy && !isMaskedField        // new
copyInteractive = copyOffered && !canInlineEditField
```

`isMaskedField` comes from a new `isMaskedDetailFieldType(viewType, objectType)` beside the
gates it belongs with in `fieldEnrichment.ts`. Like `isComputedFieldType` and
`isInlineExcludedDetailFieldType` it answers the **narrow-only union** of the two types, so
a presentation override can withdraw the affordance but never restore it on a credential
column (objectui#3355's direction). The declared cost of the union is pinned: an authored
`text` over an object-schema `secret` renders the value in the clear *and* still refuses
the copy.

⛔ The refusal is deliberately **not** spelled into `canCopy`. That name is one of the
readers of the shared emptiness authority `hasCellValue` (objectui#8376/#8394) that must
agree on which rows are EMPTY, and a masked row is not an empty one.

## ⚠️ The second-authority question — reported, not settled

The dispatch asked which of two things I did. **I mirrored; I did not invent an authority.**

Searched for an existing "is type T masked?" question in `@object-ui/fields`: none exists.
The mask is two anonymous renderers inside `getCellRenderer`'s standard map
(`password` maps to a renderer drawing a SPAN of six bullets, and `secret` to another), and
nothing exports the set or a predicate over it. Per the fence I did not mint one in
`plugin-detail`: the new set is documented **as a mirror, not an authority**, with its two
declared costs — a third masked type registered in `fields` would not reach it, and
`registerFieldRenderer('password', …)` can replace the mask at runtime, which no static set
can see. Filed separately as *"the mask has no queryable authority"*.

Measured while reading: the cell path does **not** resolve aliases (`resolveCellRendererType`
only promotes a textual base type through a `format` hint; `getCellRenderer` is an exact-key
lookup falling back to `TextCellRenderer`), so exactly those two raw spellings draw the mask
and matching raw spellings is the faithful mirror.

## Verification — by content, at the spy

`packages/plugin-detail/src/__tests__/DetailSection.maskedCopyRefusal-8440.test.tsx`, 22 cases.
The pin is absence-shaped, so every masked case carries its controls **in the same mounted
tree**: the masked cell is proved to have rendered the mask (and the raw value proved absent
from the document) *before* the absence is asserted, and the same interaction is fired on an
ordinary text row and required to reach the spy with that row's value. Absence is counted at
`writeText.mock.calls`, never with a text query — both masked rows draw the identical string.

Ablation legs, each mutating a **read site** from the committed tree, proving the mutation
landed on disk (anchor counts both directions, `git hash-object` vs the HEAD blob, line-total
gate), restoring by state (`git diff HEAD` empty), classified per test from vitest's JSON
reporter. No death string (`Element type is invalid`, `Failed Suites`, `No test suite found in
file`, `Tests  no tests`, `Transform failed`) appeared in any leg.

| leg | mutation | result |
|---|---|---|
| A | `copyOffered = canCopy` (the defect restored) | 18 red / 4 pass — every masked + union case; the ordinary-row and emptiness pins stay green |
| B | `copyOffered = false && …` (caricature: nothing is ever copy-interactive) | 21 red / 1 pass — every control reddens loudly |
| C | the desktop hover **button** alone reverted to `canCopy` | 4 red — exactly the button pins |
| D | the **mobile** block alone reverted to `canCopy` | 6 red — exactly the mobile pins; a desktop-only fix is caught |
| E | masked rows made to count as EMPTY (the wrong-fix family) | 17 red, including the emptiness non-regression pin |

Non-regression, derived from the wrong fix rather than from the shape of the bug:

- **emptiness classification is unchanged** — a populated masked row is still FILLED, the
  toggle still counts exactly the absent rows, and the masked row never draws the `No value`
  placeholder (leg E is the proof this pin discriminates);
- **ordinary rows copy byte-for-byte what they copy today**, object-valued cells included.
  objectui#8395's own pins are untouched and green.

```
pnpm exec vitest run packages/plugin-detail/                 → 149 files, 1346 tests passed
pnpm exec vitest run packages/app-shell/src/views/           → 405 files, 3893 passed, 1 skipped
pnpm --filter @object-ui/plugin-detail type-check            → exit 0 (closure built first;
                                                                the new test file is in the
                                                                program, proved by --listFiles)
pnpm --filter @object-ui/plugin-detail lint                  → 202 files, 0 errors
node scripts/check-changeset-presence.mjs                    → OK
pnpm run check:control-bytes                                 → OK (6870 files)
pnpm run check:vi-mock-specifiers / :vi-mock-inherit         → OK
pnpm run check:unreferenced-sources                          → OK
node scripts/check-governed-queue-guard.mjs --test PATHS     → NOT GOVERNED
```

**Declared narrowing.** Lint was run for the affected package only (`eslint .` inside
`packages/plugin-detail`, the same command `turbo run lint` runs for it), not repo-wide: the
diff touches files in that one package, and the flat config enables no type-aware linting
(`tseslint.configs.recommended`, no `parserOptions.project`), so it cannot move the verdict on
a file it does not contain. Repo-wide sweeps are CI's. Downstream was narrowed to
`packages/app-shell/src/views/` — the detail surface's consumers — after checking that no test
elsewhere in the affected set asserts `DetailSection` copy behaviour.

Related, none of them touched here: objectui#4221 (the write direction — its exclusion is what
left this read direction exposed), objectui#8395 (object-valued payloads), objectui#8376 /
objectui#8394 (the emptiness authority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_