### PR TITLE
test(permissions): wait on the array the assertion reads (objectui#8688)

### DIFF
--- a/.changeset/8688-provider-ctx-wait-alignment.md
+++ b/.changeset/8688-provider-ctx-wait-alignment.md
@@ -1,0 +1,9 @@
+---
+---
+
+Couple the `waitFor`s in `providerCtxIdentity.discarded.test.tsx` to the arrays
+their assertions read (objectui#8688). Two waits were keyed on the request `log`
+— pushed when a request is ISSUED — and then read `ctxSeen`, which only fills
+once the response has landed and `MePermissionsProvider` swaps `loadingFallback`
+for `children`; on an unfavourable ordering the read ran against an empty array.
+Test only; no package is released by this change.

--- a/packages/permissions/src/__tests__/providerCtxIdentity.discarded.test.tsx
+++ b/packages/permissions/src/__tests__/providerCtxIdentity.discarded.test.tsx
@@ -538,12 +538,23 @@ describe('MePermissionsProvider — the fetch effect survives a discarded cache 
       </MePermissionsProvider>
     );
 
-    let loaded: PermissionContextValue | undefined;
+    let loaded: PermissionContextValue | null | undefined;
     const restore = armDiscardProxy();
     try {
       const { rerender } = render(tree());
-      await waitFor(() => expect(log).toHaveLength(1));
-      loaded = ctxSeen[ctxSeen.length - 1]!;
+      // ⚠️ objectui#8688 — wait on the recorder the NEXT LINE READS, not on
+      // `log`. `log` is pushed when the request is ISSUED; `ctxSeen` only fills
+      // once the response has landed, because this provider renders
+      // `loadingFallback` — not `children` — while `loading && !data`. So a
+      // wait on `log` does not gate this read at all. Its failure here is the
+      // QUIET one: `loaded` is `undefined`, and the identity pin below then
+      // compares `undefined` to `undefined` and goes GREEN — an implementation
+      // strictly worse than the bug passes it. Measured: under a forced
+      // ordering this test failed only on `effectRuns`, with the identity pin
+      // passing vacuously. Waiting on the fetched payload's own tag couples the
+      // wait to the read so the two cannot drift apart again.
+      await waitFor(() => expect(ctxSeen[ctxSeen.length - 1]?.userId).toBe('A'));
+      loaded = ctxSeen[ctxSeen.length - 1];
 
       // Armed but NOT fired: an ordinary re-render must not refetch either, so
       // a green below cannot come from the proxy having broken caching outright.
@@ -615,13 +626,20 @@ describe('MePermissionsProvider — the fetch effect survives a discarded cache 
     );
 
     const { rerender } = render(tree(fetcherA));
-    await waitFor(() => expect(log).toHaveLength(1));
-    expect(ctxSeen[ctxSeen.length - 1]!.userId).toBe('A');
+    // ⚠️ objectui#8688 — the wait must gate the array the assertion READS.
+    // This waited on `log` and then read `ctxSeen`, a DIFFERENT array; nothing
+    // established `ctxSeen` had been filled, so `ctxSeen[-1]` was `undefined`
+    // and the `!` turned "this can be empty" into a compile-time promise that
+    // it cannot be. It threw `TypeError: Cannot read properties of undefined
+    // (reading 'userId')` on PR #8656's shard 2/4 — a red on a `packages/core`
+    // test-only PR whose diff cannot reach this package. Folding the assertion
+    // INTO the wait keeps the same predicate and makes the drift impossible.
+    await waitFor(() => expect(ctxSeen[ctxSeen.length - 1]?.userId).toBe('A'));
 
     rerender(tree(fetcherB));
     // Not merely "a request happened": the NEW fetcher's answer must reach the
     // context. This is what a driver mutated to answer one constant fails.
-    await waitFor(() => expect(ctxSeen[ctxSeen.length - 1]!.userId).toBe('B'));
+    await waitFor(() => expect(ctxSeen[ctxSeen.length - 1]?.userId).toBe('B'));
     await settle();
     expect(log).toEqual(['A /me/permissions', 'B /me/permissions']);
   });


### PR DESCRIPTION
Fixes #8688

`providerCtxIdentity.discarded.test.tsx` had **two** waits keyed on the request `log` followed by a read of `ctxSeen` — a different recorder. `log` is pushed when a request is **issued**; `ctxSeen` only fills once the response has landed, because `MePermissionsProvider` renders `loadingFallback` (not `children`) while `loading && !data`. So the wait did not gate the read, and on an unfavourable ordering the read ran against an empty array.

Both sites are repaired by folding the assertion **into** the wait, so the wait and the read cannot drift apart again. The `!` goes with them: it converted "this can be empty" — the fact the test needed to encode — into a compile-time promise that it cannot be, which is why nothing at authoring time could flag the gap.

## Not a flake — the defect was forced and observed

The file is green on most runs, so a green run proves nothing. The unfavourable ordering was **forced**: the fetch double still pushes to `log` when the request is issued, but its `Response` is deferred **50ms**, past RTL's one-macrotask `asyncWrapper` drain. (A `setTimeout(..., 0)` sits inside that drain window and does **not** reproduce the race — measured on objectui#8664, and the reason its first repro leg landed on disk without reddening.)

Every leg below is classified **per test from vitest's JSON reporter** (`--reporter=json --outputFile`), never the text reporter, with the death strings (`Element type is invalid`, `Failed Suites`, `No test suite found in file`, `Tests  no tests`, `Transform failed`) counted separately. **All five legs: 0 death strings** — every red below is a failing assertion, not a suite death.

| leg | test tree | production tree | result (13 tests in file) |
| --- | --- | --- | --- |
| baseline | pre-fix | unmutated, ordinary ordering | 13 passed |
| **1 — old wait, forced ordering** | pre-fix | unmutated | **11 passed / 2 FAILED** |
| **2 — new wait, forced ordering** | fixed | unmutated | **13 passed** |
| **3 — new wait, ordinary ordering** | fixed | unmutated | **13 passed** |

Leg 1's two reds, verbatim:

```
[FAILED] ... > still refetches exactly once when the fetcher itself is swapped
         TypeError: Cannot read properties of undefined (reading 'userId')
         at providerCtxIdentity.discarded.test.tsx:620:41
[FAILED] ... > costs no redundant round trip when a discard rebuilds the driver
         AssertionError: expected [] to have a length of 1 but got +0
         at providerCtxIdentity.discarded.test.tsx:574:24
```

Line 620 of the mutated file is line **619** of the unmutated one, column 41 — the CI failure on PR #8656's `Test (shard 2/4)`, reproduced character for character.

## The second site is the worse one

The sweep found a second instance nobody had observed, in `costs no redundant round trip ...`: the same `log` wait, then `loaded = ctxSeen[ctxSeen.length - 1]!`. Its failure mode is **quieter**: `loaded` becomes `undefined`, and the identity pin below it, `expect(ctxSeen[ctxSeen.length - 1]).toBe(loaded)`, then compares `undefined` to `undefined` and **passes**. Under leg 1 that test failed only on `effectRuns`, with the identity pin passing vacuously.

Asked of that pin — *would an implementation strictly worse than the bug pass this?* — the answer was **yes**, and it is measured rather than argued (ablation control, below).

## Ablations — read sites only, never the pin

Each mutates production code (`MePermissionsProvider.tsx`) from a committed tree, under a `trap ... EXIT INT TERM` with absolute paths, proving the mutation on disk in **both directions** (anchor counts and `git hash-object` against the `HEAD` blob) plus a line-total gate, and restoring **by state** (`git checkout HEAD -- ABSOLUTE_PATH`, then `git diff HEAD` proven empty).

| ablation | read site mutated | repaired pins |
| --- | --- | --- |
| **ABL-1** | `fetcher` dropped from the fetch effect's dependency list | **RED** — `still refetches exactly once when the fetcher itself is swapped`: `expected 'A' to be 'B'` |
| **ABL-2** | `userId: data?.userId ?? null` frozen to a constant — the provider never publishes the fetched id | **RED** — both new waits: `expected 'ablated-8688' to be 'A'` |
| **ABL-2 control, pre-fix pin** | same mutation, **old** test file restored from `HEAD~1` | `costs no redundant round trip ...` **PASSED** |

The control is the point: under a provider that never publishes the fetched payload, the **old** pin at the second site went green and the new one goes red. The repair there is a strengthening, not a relocation. And with `?.` in place, the failure is a clean assertion diff instead of a `TypeError` that reads like a broken component.

## The sweep

Population: **all 9 test files** under `packages/permissions/src/__tests__/` (the card's file plus every sibling in the package), **22 `await waitFor` sites** across the three files that have any.

```
node sweep-wait-read-drift.mjs packages/permissions/src/__tests__/*.tsx packages/permissions/src/__tests__/*.ts
```

The detector discovers recorders mechanically per file (every `X.push(` target), reads the identifiers named inside each `await waitFor(...)`, then scans forward to the next `await` and flags any recorder read that the wait did not name.

**Lit control:** run against the pre-fix tree it flags **2** sites — line 619 (the one CI observed) **and** line 546 (the one nobody had) — while leaving the other 8 `waitFor` sites in that file unflagged, including the two that legitimately wait on `ctxSeen` and read `ctxSeen`. So the sweep discriminates, and it did find a second instance rather than merely confirming the reported one. Against the fixed tree: **0 flags**.

Empirically lit as well: the leg-1 forced ordering reddened **both** flagged sites and none of the other 11 tests.

Out of the detector's reach, audited by hand instead: `MePermissionsProvider.test.tsx` (5 waits) and `MePermissionsProvider.retry.test.tsx` (7 waits) have no `push`-style recorders at all — they gate on a DOM node (`loaded` / `err` test ids) and then read other test ids from **the same render commit**, plus mock call counts that are causally upstream of that commit. The family cannot occur in that shape. `usePermissions.discardedIdentity.test.tsx` has recorders but no `waitFor` (it is entirely synchronous).

## Scope

- `MePermissionsProvider` itself is **unchanged**. The sweep found the test at fault, not the component; the provider was mutated only inside the ablation legs, and restored by state each time.
- objectui#8645's subject — the superseded `/me/permissions` request being setState-suppressed rather than aborted — is **untouched**. Nothing in this diff reaches the fetch or its cancellation token.
- Index form (`ctxSeen[ctxSeen.length - 1]?.userId`) rather than the card's suggested `ctxSeen.at(-1)?.userId`: this package's tests inherit the root `lib: ["ES2020"]`, under which `.at` is `TS2550`. The suggested shape runs green under vitest and fails `tsc -p tsconfig.test.json`, which is exactly the vitest/tsc divergence class. (`packages/app-shell/tsconfig.test.json` sets `lib: ["ES2022", ...]`, which is why `.at(-1)` is fine in 75 other test files and not here.)

## Verification

- `pnpm exec vitest run packages/permissions/` — **9 files, 123 tests, 123 passed**, 0 death strings.
- `pnpm exec tsc --noEmit` and `pnpm exec tsc -p tsconfig.test.json` in `packages/permissions` — both exit 0, run **after** `pnpm --filter '@object-ui/permissions^...' build` (on an unbuilt tree these report `TS2307` for every workspace import, which is a precondition failure and not a measurement).
- `pnpm exec eslint .` in `packages/permissions` — 0 errors (27 pre-existing `no-explicit-any` warnings, none introduced here).
- `node scripts/check-changeset-presence.mjs` — red before the changeset, green after; `node scripts/check-changeset-no-major.mjs` green. The changeset has **empty frontmatter**: test-only, releases nothing. (`skip-changeset` is a phantom label in this repo and was not applied.)
- `node scripts/check-governed-queue-guard.mjs --test ...` — **NOT GOVERNED**; both paths checked against all 5 governed surfaces, none matched.
- Control-character scan of both changed files: no hits.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_