### PR TITLE
fix(ci): live-e2e's run conclusion must agree with its job (objectui#8084)

### DIFF
--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -10,14 +10,35 @@
 # lazily-loaded widget's suspension unwound to the host's route boundary and
 # tore down the flow dialog; zero unit test could see it).
 #
-# ⚠️ INFORMATIONAL, NON-REQUIRED lane — `continue-on-error: true` keeps a
-# failure here from failing the workflow run, so it never blocks a merge and
-# never ejects unrelated PRs from the queue (objectstack#4850 is the prior
-# art for why a new lane must prove itself outside the merge gate first).
-# Do NOT add this job to required checks, and do not remove
-# `continue-on-error`, until the lane has run clean for long enough to trust
-# (watch the nightly schedule). Failures still surface: red step + job summary
-# + the `live-e2e-artifacts` upload. That upload carries `test-results/` (the
+# ⚠️ INFORMATIONAL, NON-REQUIRED lane. What keeps it non-blocking is what it
+# is NOT wired into, and ⛔ never a `continue-on-error:` on the job:
+#   - it is not in the required-check set — ⛔ do not add this job to required
+#     checks until the nightly record proves the lane stable; and
+#   - it declares no `merge_group` trigger, so a queue build never waits on it
+#     and it cannot eject an unrelated pull request from the queue.
+# (objectstack#4850 is the prior art for why a new lane must prove itself
+# outside the merge gate first.)
+#
+# ⛔ Do NOT re-add `continue-on-error: true` to this job (objectui#8084). It
+# bought none of the non-blocking above, and it cost this lane the one reading
+# a monitor, a digest or an agent takes cheaply. Measured on the 2026-09-06
+# nightly, while the job still carried the flag:
+#
+#     step 7 `Start ObjectStack backend`    failure
+#     job 101442890465                      failure
+#     check run `Live E2E (informational)`  failure   <- the flag did not move it
+#     check suite 92170955546               success   <- asserts the negation
+#     workflow run 34017174769              success   <- asserts the negation
+#
+# The flag moved neither the job nor its check run — the two readings a merge
+# gate and a reviewer actually consult — and inverted only the aggregate. So an
+# outage detector reported `success` for a day while the E2E had not executed
+# at all, which is how the backend outage carded as objectui#8084's defect ①
+# ran unseen. Without the flag the run conclusion simply agrees with the job it
+# contains, and the lane stays exactly as advisory as it was.
+#
+# Failures surface as a red step, a red job, a red run, a job summary and the
+# `live-e2e-artifacts` upload. That upload carries `test-results/` (the
 # failure screenshots and videos `use.screenshot` / `use.video` write) and the
 # two server logs — it does NOT carry a Playwright HTML report, because
 # `playwright.live.config.ts` declares `reporter: [['list']]` and the `list`
@@ -61,8 +82,10 @@ jobs:
     name: Live E2E (informational)
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    # Non-blocking by construction — see the header comment before touching.
-    continue-on-error: true
+    # ⛔ There is deliberately no `continue-on-error:` here, and ⛔ nothing may
+    # add one back: it never made this job or its check run any less red, it
+    # only made the workflow-run conclusion contradict them (objectui#8084).
+    # The header carries the measurement.
 
     # ⚠️ Do NOT add a `runner.*` expression to this job-level `env:` block.
     # The `runner` context does not exist yet when job-level env is evaluated

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -43,7 +43,7 @@ one has its own section below.
 | `docs-route-eager-closure.yml` | Docs Route Eager Closure Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a package named in `apps/site/app/components/registerCatalogBlocks.ts` is not already reachable from the docs route's module graph (exit 1), or when the gate's own gauge cannot be trusted (exit 2) |
 | `governed-surface-guard.yml` | Governed Surface Queue Guard | PR to `main`, `develop` (incl. `ready_for_review`) — **no path filter**; merge-queue builds | **Yes on a queue build only** — a governed-surface diff with no authorized approval record (on any commit) is refused there; on the pull request itself it is deliberately green and prints an early warning |
 | `performance-budget.yml` | Bundle Analysis | Push / PR touching `packages/**`, `apps/console/**`, `pnpm-lock.yaml` | **Yes** — the console entry gzip budget |
-| `live-e2e.yml` | Live E2E (informational) | PR to `main`, `develop` (code paths); nightly cron `30 6 * * *`; manual | No — informational lane, `continue-on-error` |
+| `live-e2e.yml` | Live E2E (informational) | PR to `main`, `develop` (code paths); nightly cron `30 6 * * *`; manual | No — informational lane: not in the required-check set, and it declares no `merge_group` trigger |
 | `labeler.yml` | Auto Label PRs | PR `opened`, `synchronize`, `reopened` | No |
 | `dependabot-auto-merge.yml` | Dependabot Auto-merge | PR to `main`/`develop` authored by `dependabot[bot]` | No — but it gates *its own* merge, and goes red instead of merging when the check set is not green |
 | `cross-repo-issue-closer.yml` | Cross-repo Issue Closer | PR `closed` (acts only when merged) | No — runs after merge |
@@ -162,8 +162,10 @@ Two things follow for anyone editing this directory:
     so on a PR that touches none of those four neither of its contexts is created at all.
   - **Bundle Analysis** (`performance-budget.yml`) — an ordinary path filter on the same
     trigger, with the same consequence for every PR that matches none of its paths.
-  - **Live E2E (informational)** (`live-e2e.yml`) — the job carries `continue-on-error: true`,
-    so the run is green whatever the specs did; it cannot serve as a guarantee of anything.
+  - **Live E2E (informational)** (`live-e2e.yml`) — an **exclusion** path filter:
+    `paths-ignore:` on the same trigger, declaring `**/*.md`, `content/**`, `docs/**`,
+    `apps/site/**` and `.changeset/**`, so a docs-only or changeset-only pull request never
+    creates the context at all and a required one would wait for it forever.
   - **Close issues referenced in other repositories** (`cross-repo-issue-closer.yml`) — its only
     trigger is `pull_request_target` with `types: [closed]`, and the job additionally requires
     `github.event.pull_request.merged == true`, so it runs only *after* a merge.
@@ -171,10 +173,13 @@ Two things follow for anyone editing this directory:
   Each of those properties is pinned against the YAML in
   `scripts/__tests__/ci-cd-pipeline-doc.test.ts`: change one of them without editing its line
   here and that test fails, naming the workflow
-  ([#4170](https://github.com/objectstack-ai/objectui/issues/4170)). The `live-e2e.yml` line is
-  the one already scheduled to become false — that workflow's header says `continue-on-error`
-  comes off once the lane has run clean long enough to trust, and the day it does, the lane
-  becomes requirable and this line is wrong. Then delete the line and its entry in that test;
+  ([#4170](https://github.com/objectstack-ai/objectui/issues/4170)). The `live-e2e.yml` line has
+  already outlived one property: it used to quote `continue-on-error: true` on that job, and
+  [#8084](https://github.com/objectstack-ai/objectui/issues/8084) took the flag off after
+  measuring that it left the job and its check run red and inverted only the run conclusion —
+  so it had never been what made the context unrequirable. Removing it did **not** promote the
+  lane, so the line was re-pointed at the property that still blocks it. Retire a line here only
+  when its workflow carries no such property at all, and delete its entry in that test with it;
   do not soften it in place.
 
 ## Core CI Workflow (`ci.yml`)
@@ -500,10 +505,21 @@ reviewers; exceeding any of them turns no check red and blocks no merge:
 **Trigger:** PRs to `main` / `develop` (same code-path filter as `ci.yml` — docs-only and
 changeset-only PRs skip it), a nightly cron (`30 6 * * *`) on `main`, and manual dispatch.
 
-**Blocks a merge: no.** The job runs with `continue-on-error: true` by construction — a red run
-is informational and never ejects a PR from the merge queue. Do not add it to required checks
-(and do not remove `continue-on-error`) until the nightly record proves the lane stable; see the
-header comment in the workflow file (#2835).
+**Blocks a merge: no** — because the job is not in the required-check set and `live-e2e.yml`
+declares no `merge_group` trigger, so a queue build never waits on it and it cannot eject a PR
+from the queue. Do not add it to required checks until the nightly record proves the lane
+stable; see the header comment in the workflow file (#2835).
+
+**Advisory, and honest about it: the run conclusion agrees with the job conclusion.** The job
+carries no `continue-on-error`, so a failing spec fails the workflow run as well as the job. It
+used to carry `continue-on-error: true`, and that flag moved neither the job nor its check run —
+both stayed red — while flipping the run and check-suite conclusions to `success`. Three
+consecutive nightlies reported `success` at the run level with a red job inside one of them, so
+every monitor, digest and agent reading run-level conclusions was told the negation of what had
+happened, and the backend outage underneath ran a day unseen
+([#8084](https://github.com/objectstack-ai/objectui/issues/8084)). Advisory and honest are
+different axes: this lane is the first without giving up the second, and nothing may re-add that
+flag to buy back a green aggregate.
 
 What it does: runs an allowlist of the live specs (`pnpm test:e2e:live:ci`) against a real
 `objectstack dev` backend booted from **published** `@objectstack/*` packages serving the

--- a/scripts/__tests__/ci-cd-pipeline-doc.test.ts
+++ b/scripts/__tests__/ci-cd-pipeline-doc.test.ts
@@ -1092,9 +1092,12 @@ const readWorkflow = (file: string): string => fs.readFileSync(path.join(workflo
 
 /**
  * A workflow's YAML with whole-line comments removed. Load-bearing, not
- * cosmetic: `live-e2e.yml`'s header discusses `continue-on-error` for eight
- * lines and `changeset-guard.yml`'s explains why `.changeset/**` is filtered the
- * way it is, so a scan that counted comments would report properties from prose.
+ * cosmetic: `live-e2e.yml`'s header argues at length about `continue-on-error`
+ * — more so since objectui#8084 took the flag off its job and wrote the
+ * measurement into the header — and `changeset-guard.yml`'s explains why
+ * `.changeset/**` is filtered the way it is, so a scan that counted comments
+ * would report properties from prose. ⛔ No line count is stated here on
+ * purpose: a hand-written count of prose lines is a claim nothing asserts.
  */
 function withoutComments(yaml: string): string {
   return yaml
@@ -1163,6 +1166,20 @@ function pullRequestPaths(file: string): string[] {
   return listEntries(trigger.slice(at));
 }
 
+/**
+ * The `paths-ignore:` globs a workflow's `pull_request` trigger declares — the
+ * exclusion half of the same structural property. A context the filter keeps
+ * from being created is a context a required check waits on forever, exactly as
+ * for `paths:`; `ci.yml` keeps its own `paths-ignore` on the push trigger ONLY
+ * for that reason (objectui#3523).
+ */
+function pullRequestPathsIgnore(file: string): string[] {
+  const trigger = nestedBlock(topLevelBlock(withoutComments(readWorkflow(file)), 'on'), 'pull_request');
+  const at = trigger.search(/^ {4}paths-ignore:\s*$/m);
+  if (at === -1) return [];
+  return listEntries(trigger.slice(at));
+}
+
 interface StructuralBlock {
   /** The property, named the way a failure message should name it. */
   readonly property: string;
@@ -1223,25 +1240,28 @@ const STRUCTURAL_BLOCKS = new Map<string, StructuralBlock>([
   [
     'live-e2e.yml',
     {
-      property: '`continue-on-error: true` on the `live-e2e` job',
+      property: '`paths-ignore:` on the `pull_request` trigger',
       broken() {
-        const job = nestedBlock(topLevelBlock(withoutComments(readWorkflow('live-e2e.yml')), 'jobs'), 'live-e2e');
-        if (job === '') return 'the `live-e2e` job is gone from live-e2e.yml';
-        return /^\s*continue-on-error:\s*true\s*$/m.test(job)
+        const ignored = pullRequestPathsIgnore('live-e2e.yml');
+        return ignored.length > 0
           ? null
-          : 'the `live-e2e` job no longer carries `continue-on-error: true`, so a failing spec ' +
-              'now fails the run — the lane has been promoted';
+          : 'its `pull_request` trigger no longer declares `paths-ignore:`, so Live E2E now ' +
+              'reports on every pull request and the page is denying a guardrail that exists';
       },
-      quotes() {
-        const job = nestedBlock(topLevelBlock(withoutComments(readWorkflow('live-e2e.yml')), 'jobs'), 'live-e2e');
-        return [(job.match(/^\s*(continue-on-error:\s*true)\s*$/m)?.[1] ?? '').replace(/\s+/g, ' ')];
-      },
+      quotes: () => pullRequestPathsIgnore('live-e2e.yml'),
       whenItBreaks:
-        'THIS ONE IS SCHEDULED, and its red is the point of this pin rather than an accident: ' +
-        "live-e2e.yml's header says `continue-on-error` comes off once the lane has run clean " +
-        'long enough to trust. When it does, DELETE the `live-e2e.yml` line from the bullet and ' +
-        'this entry from STRUCTURAL_BLOCKS — the lane is requirable now and the page must stop ' +
-        'saying it can never be. Do not soften the wording and do not relax this check.',
+        'THIS LINE HAS ALREADY OUTLIVED ONE PROPERTY, which is the thing to read before editing ' +
+        'it again. It used to quote `continue-on-error: true` on the job, on the reasoning that ' +
+        'a job which cannot fail cannot gate anything. objectui#8084 measured that reasoning ' +
+        'false in both halves: the flag left the JOB and its CHECK RUN red — job 101442890465 ' +
+        'and check run `Live E2E (informational)` both reported `failure` on run 34017174769 — ' +
+        'so it never made the context unrequirable; it only inverted the aggregate, which is the ' +
+        'defect that card was filed for. Taking it off therefore did NOT promote the lane, and ' +
+        'this entry was re-pointed rather than deleted: the `paths-ignore:` filter quoted here is ' +
+        'what still keeps the context from being created on a docs-only pull request, and a ' +
+        'required check cannot survive a context that is never created. Retire this entry when ' +
+        'live-e2e.yml carries no such property at all — never because one was replaced by ' +
+        'another, and never by softening the line in place.',
     },
   ],
   [
@@ -1987,5 +2007,125 @@ describe('ci-cd-pipeline.md + live-e2e.yml — the Playwright report claim (#823
         'who does not know that will write a check against artefact contents that can only ever ' +
         'be read on a red run. objectui#8084 did exactly that. Say it on the page.',
     ).toContain('failure()');
+  });
+});
+
+/**
+ * objectui#8084 defect ② — the lane's RUN conclusion asserted the negation of its JOB's.
+ *
+ * Measured on the 2026-09-06 nightly, while `live-e2e.yml`'s job carried
+ * `continue-on-error: true`:
+ *
+ *     step 7 `Start ObjectStack backend`    failure
+ *     job 101442890465                      failure
+ *     check run `Live E2E (informational)`  failure
+ *     check suite 92170955546               success
+ *     workflow run 34017174769              success
+ *
+ * The flag moved neither the job nor its check run — the two readings a merge gate and a
+ * reviewer consult — and inverted only the aggregate. This is worse than an omission: any
+ * monitor, digest or agent reading run-level conclusions was told `success` while the live
+ * E2E had not executed at all, which is why the backend outage carded as that issue's defect
+ * ① ran a full day unseen. An outage detector that reports the negation of what it detects.
+ *
+ * ⛔ The repair is NOT to make the lane blocking, and this pin does not ask for that: what
+ * makes the lane non-blocking is that it is not in the required-check set and declares no
+ * `merge_group` trigger, neither of which `continue-on-error` had anything to do with. The
+ * two are compatible; conflating them is the trap the card names.
+ *
+ * ## Why this is scoped to the job's OWN keys, and why the control below is not optional
+ *
+ * The entry this replaces in STRUCTURAL_BLOCKS asked `/^\s*continue-on-error:\s*true\s*$/m`
+ * of the whole job block and promised, in writing, to go red the day the flag came off the
+ * job. It could not: objectui#7048 later split both caches into bounded `save` STEPS that
+ * each carry `continue-on-error: true` at step level, and `\s*` matches their indentation
+ * just as happily. Two step-level flags kept that assertion green for a property that no
+ * longer existed — an assertion that cannot fail, which is this card's own defect one level
+ * down.
+ *
+ * So the matcher here is anchored to four spaces, the indentation of a job's own keys, and
+ * the discrimination is EXERCISED rather than assumed: the control asserts that step-level
+ * flags really are present in this job and really are not matched. If those saves are ever
+ * removed, the control goes red and says so, rather than leaving a matcher that discriminates
+ * against nothing.
+ */
+describe('live-e2e.yml — the run conclusion may not contradict the job (#8084)', () => {
+  const liveJob = nestedBlock(topLevelBlock(withoutComments(readWorkflow('live-e2e.yml')), 'jobs'), 'live-e2e');
+  const jobOwnKeys = liveJob.split('\n').filter((line) => /^ {4}[a-z]/i.test(line));
+  const section = sectionForWorkflow('live-e2e.yml');
+
+  it('has a job block and a page section to read — neither may be empty', () => {
+    // The vacuity legs. A renamed job or heading would make every assertion below pass while
+    // reading an empty string, which is the failure shape this whole file exists against.
+    expect(
+      liveJob,
+      'the `live-e2e` job is gone from live-e2e.yml (or `jobs:` no longer parses), so the ' +
+        'assertions below would compare nothing. Re-point them at wherever the lane now lives.',
+    ).not.toBe('');
+
+    expect(
+      jobOwnKeys.map((line) => line.trim().split(':')[0]),
+      "the job-level key scan found no four-space keys at all, so 'no continue-on-error here' " +
+        'would be true of every possible file. Re-derive it from the current indentation.',
+    ).toContain('timeout-minutes');
+
+    expect(
+      section,
+      'No heading on this page names `live-e2e.yml`, so the page half of this claim reads an ' +
+        'empty string and passes vacuously.',
+    ).not.toBe('');
+  });
+
+  it('discriminates job level from step level — the control, exercised not assumed', () => {
+    // Without this, the assertion below is indistinguishable from one that would also pass on
+    // the broken file: the two cache saves are the exact lines that kept the old pin green.
+    const anywhereInJob = liveJob.split('\n').filter((line) => /^\s*continue-on-error:\s*true\s*$/.test(line));
+
+    expect(
+      anywhereInJob.length,
+      'live-e2e.yml no longer carries any step-level `continue-on-error: true` (the two bounded ' +
+        'cache saves objectui#7048 added). Those lines are what made a whole-job regex unable ' +
+        'to notice the job-level flag leaving. With them gone the control below no longer ' +
+        'proves the matcher discriminates — either restore a control, or state here that the ' +
+        'distinction has stopped mattering.',
+    ).toBeGreaterThan(0);
+
+    expect(
+      anywhereInJob.filter((line) => /^ {4}\S/.test(line)),
+      'a four-space `continue-on-error: true` slipped through the step-level filter, which ' +
+        'means the two matchers no longer disagree and the control is measuring nothing.',
+    ).toEqual([]);
+  });
+
+  it('declares no `continue-on-error` on the job itself', () => {
+    const jobLevel = jobOwnKeys.filter((line) => /^ {4}continue-on-error\s*:/.test(line));
+
+    expect(
+      jobLevel,
+      'The `live-e2e` job has `continue-on-error` back on it:\n' +
+        jobLevel.map((l) => `  ${l.trim()}`).join('\n') +
+        '\n\nThat flag does not make this lane advisory — it is advisory because it is not a ' +
+        'required check and declares no `merge_group` trigger. What it does is make the ' +
+        'workflow-run and check-suite conclusions report `success` while the job and its check ' +
+        'run report `failure`, so every run-level reader is told the negation of what happened ' +
+        '(objectui#8084, measured on run 34017174769). If the lane must stop failing runs, fix ' +
+        'the lane or narrow what it asserts; ⛔ do not restore the flag that made the aggregate ' +
+        'disagree with its own job. Step-level `continue-on-error:` on the cache saves is a ' +
+        'different thing and stays.',
+    ).toEqual([]);
+  });
+
+  it('says on the page that the two conclusions agree', () => {
+    // The map -> page direction, so the sentence cannot be dropped while this stays green.
+    for (const phrase of ['continue-on-error', 'run conclusion']) {
+      expect(
+        section,
+        `The Live E2E section of content/docs/guide/ci-cd-pipeline.md no longer mentions ` +
+          `"${phrase}". That section is where a reader learns this lane is advisory AND honest ` +
+          `— that its run conclusion agrees with its job — and unpinned prose about this exact ` +
+          `property is what objectui#8084 was filed about. Say it there, or retire this pin ` +
+          `with it.`,
+      ).toContain(phrase);
+    }
   });
 });

--- a/scripts/dependabot-merge-gate.mjs
+++ b/scripts/dependabot-merge-gate.mjs
@@ -233,7 +233,7 @@ export const NOT_A_GATE = Object.freeze({
   'Test (coverage shard 3/4)': COVERAGE_SHARD_NOT_A_GATE,
   'Test (coverage shard 4/4)': COVERAGE_SHARD_NOT_A_GATE,
   'Live E2E (informational)':
-    'live-e2e.yml is declared INFORMATIONAL and NON-REQUIRED in its own header and runs `continue-on-error: true`; ci-cd-pipeline.md says in as many words not to add it to required checks.',
+    'live-e2e.yml is declared INFORMATIONAL and NON-REQUIRED in its own header, and ci-cd-pipeline.md says in as many words not to add it to required checks. It carries no `continue-on-error` since objectui#8084 — that flag left this check run red anyway and only inverted the workflow-run conclusion — so a red here is a real red, ignored because the lane is advisory and never because the check could not fail.',
   label:
     'labeler.yml applies labels. It is a mutation, not a verdict — nothing about the change is judged by it.',
   'Changeset Overwrite Report':


### PR DESCRIPTION
Fixes #8084

`live-e2e`'s job carried `continue-on-error: true`. That flag never softened the job or its
check run — it inverted only the **aggregate**, so the workflow run asserted the *negation* of
what the job reported. Measured directly at job level on the 2026-09-06 nightly (⛔ never read
back through the instrument under repair):

| reading | run 34017174769 |
|---|---|
| step 7 `Start ObjectStack backend (published packages)` | `failure` |
| job `101442890465` | `failure` |
| check run `Live E2E (informational)` | `failure` |
| check suite `92170955546` | **`success`** |
| workflow run `34017174769` | **`success`** |

So every monitor, digest or agent reading run-level conclusions was told this lane was green on
a day it had not executed at all. An outage detector reporting the negation of what it detects.

## The change, and why it does not cross the fence

⛔ The lane is **not** made blocking. What keeps it non-blocking was never the flag:

- it is not in the required-check set (the page still says in as many words not to add it), and
- `live-e2e.yml` declares **no `merge_group` trigger**, so a queue build never waits on it and it
  cannot eject an unrelated PR from the queue — the header credited `continue-on-error` with
  that, and the trigger list is what actually carries it.

The flag's only observable effect was the aggregate, so removing it changes the aggregate only.
The measurement below shows the check-run column — the reading a merge gate and a reviewer
consult — is **byte-identical between the fixed lane and the bug**.

## The discriminating evidence: three real runs of this workflow, both directions

A fix seen only against a green lane is untested by construction, so the failing case was
produced deliberately (a `run: exit 1` step injected first, on throwaway branches) and the
**run** conclusion read:

| leg | workflow under test | injected failure | JOB | check run | **RUN** | suite |
|---|---|---|---|---|---|---|
| 1 — healthy | this PR's | none | `success` | `success` | **`success`** | `success` |
| 2 — failing | this PR's | yes | `failure` | `failure` | **`failure`** | `failure` |
| 3 — control | flag put back | yes, identical | `failure` | `failure` | **`success`** | `success` |

Runs [34287391923](https://github.com/objectstack-ai/objectui/actions/runs/34287391923),
[34287393681](https://github.com/objectstack-ai/objectui/actions/runs/34287393681),
[34287395351](https://github.com/objectstack-ai/objectui/actions/runs/34287395351).

Legs 2 and 3 are the pair that decides it: **identical injected failure, identical job and
check-run conclusions, opposite run conclusions.** The one variable is the job-level flag. Leg 3
is the bug itself reproduced on demand, and it fails leg 2's criterion — so an implementation no
better than the bug cannot pass. Leg 1 answers the caricature the fence exists to stop: the
healthy case is not reddened.

## A second finding, inside the blast radius: the pin that promised this red could not produce it

`STRUCTURAL_BLOCKS` in `scripts/__tests__/ci-cd-pipeline-doc.test.ts` carried a written promise
that it would redden the day `continue-on-error` came off the job ("THIS ONE IS SCHEDULED, and
its red is the point of this pin rather than an accident"). It asked
`/^\s*continue-on-error:\s*true\s*$/m` of the **whole job block** — and objectui#7048 later split
both caches into bounded `save` **steps** that each carry `continue-on-error: true`. `\s*`
matches their indentation just as happily, so two step-level flags kept the assertion green for
a property that no longer existed.

Measured, not inferred: `main`'s pin + `main`'s doc + this PR's fixed workflow ⇒ **exit 0, 8
passed** — the scheduled red never fires. An assertion that cannot fail, which is this card's own
defect one level down.

The replacement is anchored to job-level indentation (`^ {4}continue-on-error:`) and carries a
**control that exercises the distinction** rather than assuming it: it asserts the step-level
flags really are present and really are not matched, and goes red with an explanation if those
cache saves ever disappear. Ablated from a committed tree (mutation and restore both proven on
disk, `git diff HEAD` empty after restore): re-adding the flag to the job turns the new pin red
(2 failed / 56 passed), restoring turns it green (58 passed).

## Documentation

The page's structural-unrequirability bullet quoted the flag as live-e2e's reason for never
being requirable. That reason was **wrong even before this PR** — the check run is red, so
requiring the context would have blocked — and the pin's instruction to delete the line on
removal rests on "the lane is requirable now", which is false: the `pull_request` trigger's
`paths-ignore:` still keeps the context from being created on a docs-only PR, and a required
check cannot survive a context that is never created. So the line was **re-pointed at the
property that still holds** rather than deleted, and its pin re-derived from the YAML. That
deviation from the pin's written instruction is deliberate and is argued in the entry's
`whenItBreaks`.

`scripts/dependabot-merge-gate.mjs`'s `NOT_A_GATE` reason for this context also asserted the
flag; it is updated in place (that gate reads **check runs**, so its behaviour is unchanged).
The hand-written "for eight lines" count in the `withoutComments` header is removed rather than
re-counted — ⛔ no new unasserted count.

## Verification

- `pnpm exec vitest run scripts/__tests__` — **3701 passed, 2 skipped, 0 failed** (127 files).
- `check:control-bytes` OK (6881 files), `check:shell-escape-residue` OK, `check:doc-fences` OK.
- Changeset: the gate's own verdict — *"No source or published contract of a released package
  changed in this range, so no changeset is owed."* (`scripts/check-changeset-presence.mjs`,
  exit 0). ⛔ No `skip-changeset` label applied: that label is inert in this repo.
- `check-governed-queue-guard --test` on all four paths: `NOT GOVERNED`.

## ⚠️ Cleanup a maintainer has to do

The two throwaway probe branches that produced legs 2 and 3 could **not** be deleted from here —
both `DELETE /git/refs/heads/…` and `git push --delete` return **HTTP 403** (an egress-policy
denial, not retried). Please delete `claude/issue-8084-probe-fail` and
`claude/issue-8084-probe-control`; the runs they produced survive branch deletion, so the
evidence above stays readable.

## Out of scope, deliberately

The Live E2E section still says failures surface "as a red step, a job summary and a
`live-e2e-artifacts` upload" — the Playwright-report half of that family is objectui#8238's, and
`backend.env` / `start-backend.sh` / `better-auth-pin.mjs` are ①'s landed work fenced by
objectui#7689. Untouched.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_