### PR TITLE
docs(devx): the port-pin rationale in `check-bash32-floor.mjs` described a retired field

### DIFF
--- a/.changeset/8385-bash32-floor-port-rationale.md
+++ b/.changeset/8385-bash32-floor-port-rationale.md
@@ -1,0 +1,27 @@
+---
+---
+
+Correct the "Why this port is not YET pinned in
+`scripts/upstream-port-pin.json`" section of `scripts/check-bash32-floor.mjs`
+(objectui#8385). Prose only in a repo-internal gate script; no package source
+and no published contract is touched, so nothing is released by this change.
+
+The section argued from `pin.upstream.ref`, a single ledger-wide field. It no
+longer exists: objectui#8288 made `ref` a required key on each `files[]` entry,
+`validatePin` now REFUSES a pin that still carries `upstream.ref`, and
+`resyncedPin` writes only the re-synced entry's own `ref` and digest. So the
+section did not merely describe a blocker that had lifted — it sent a reader
+looking for a field that would be rejected if they wrote it.
+
+The rewrite states the blocker is gone, and states what registration still
+costs (per-file work: upstream blob at a named ref, its digest, and each
+divergence declared as an exact text pair with a `why`). The one conclusion
+that was still true is kept: this file has NO drift gate until it is
+registered.
+
+⛔ No revision is written into the new prose, on purpose. That section had
+already gone stale twice by the same mechanism — objectui#7749 moved the global
+ref out from under the sentence describing it, and objectui#8288 then deleted
+the field that sentence named — so the new wording points at
+`scripts/upstream-port-pin.json`, where each entry now carries its own `ref`,
+instead of restating one and going stale a third time.

--- a/scripts/check-bash32-floor.mjs
+++ b/scripts/check-bash32-floor.mjs
@@ -159,7 +159,7 @@
  * closure needed is written at the row itself rather than here, because that is
  * where a future reader tempted to loosen the pattern will be standing.
  *
- * ## Why this port is not pinned in `scripts/upstream-port-pin.json`
+ * ## Why this port is not YET pinned in `scripts/upstream-port-pin.json`
  *
  * That ledger is how this repository stops a ported copy drifting into a
  * confident-but-stale report — `scripts/pm/check-half-states.mjs` reached a
@@ -167,39 +167,50 @@
  * applies to this file with force: its whole subject is that "an absence from a
  * denylist reads as an approval", and upstream actively sweeps the table.
  *
- * It is still NOT registered, and the blocker is structural rather than a
- * judgement about value. Read off the pin's own schema and
- * `check-upstream-port-parity.mjs`: the ref is a SINGLE GLOBAL field
- * (`pin.upstream.ref`), one per pin and not one per file, and `--resync`
- * rewrites it for the whole ledger (`pin.upstream.ref = ref;`). The ledger
- * currently names `bf10deb`. This port was taken from `6136293`. So the only
- * two ways to register it are:
+ * It is still NOT registered, but the blocker that kept it out was structural
+ * and is GONE. The pin used to carry ONE ledger-wide `upstream.ref` beside
+ * per-file digests, and `--resync` rewrote that global field on every run. So
+ * registering this port at the revision it was actually taken from meant one of
+ * two bad trades: port from the older revision the ledger happened to name —
+ * deliberately shipping a WEAKER construct table so a provenance field stayed
+ * true, which inverts the point of the gate — or drag every other pinned file
+ * to a new ref, an unrelated rewrite of other ported tooling. A third route,
+ * pinning this file's digest while the global ref named a different revision,
+ * was the one that must never be taken: the digest would verify and the
+ * provenance line would be false.
  *
- *   1. port from `bf10deb` instead. Measured over the API: the upstream file
- *      exists at that ref at 55,415 bytes against 62,481 at `6136293`. The
- *      7 KB in between is the `-v` unary widening and the 4.0 operator sweep —
- *      i.e. registering would mean deliberately shipping a WEAKER construct
- *      table so the ledger's provenance field stays true. That inverts the
- *      point of the gate.
- *   2. bump the global ref to `6136293`, which forces a re-sync of all three
- *      files already pinned. That is a change to unrelated ported tooling and
- *      is out of scope for objectui#7692.
+ * objectui#8288 retired the field and all three trades with it. Read off
+ * `check-upstream-port-parity.mjs`: `ref` is now a REQUIRED key on each
+ * `files[]` entry beside the digest it was taken with, `validatePin` REFUSES a
+ * pin that still carries `upstream.ref`, and `resyncedPin` writes only the
+ * re-synced entry's own `ref` and digest while returning every other entry
+ * untouched. `upstream` keeps `repo` alone. Entries at different refs now
+ * coexist by design, so this file can be registered at its own revision without
+ * disturbing anything already pinned.
  *
- * ⛔ The third option — register against `6136293`'s digest while the global ref
- * still reads `bf10deb` — is the one that must not be taken. The digest would
- * verify and the provenance line would be false, which is this repository's
- * worst failure direction and precisely what the parity gate exists to stop.
+ * ⛔ Do not write a revision into this prose. A port's ref lives on that port's
+ * entry in `scripts/upstream-port-pin.json`; read it from there, where
+ * `--resync` keeps it correct. This section has already gone stale TWICE by
+ * naming one: objectui#7749 moved the global ref out from under the sentence
+ * describing it, and objectui#8288 then deleted the field that sentence named.
+ * Both times the prose stayed confident and wrong — which is this file's own
+ * subject, aimed at itself.
  *
- * ⚠️ The single-global-ref limitation is NOT a new discovery and must not be
- * re-filed: objectui#7953 already owns it, measured from the other direction —
- * two ported `.claude/hooks/**` files cannot be registered because they do not
- * exist upstream at `bf10deb` at all. This file is the same gap's other shape:
- * it DOES exist at that ref, but only in a weaker revision.
+ * What registration still costs is per-file work rather than a schema change,
+ * which is why it did not ride along with objectui#8288 and is a card of its
+ * own: read the upstream blob at a named ref, compute its SHA-256, and declare
+ * every divergence as an exact `upstream`/`ported` text pair with a stated
+ * `why`. The same unblocking reaches the ported `.claude/hooks/**` files that
+ * objectui#7953 recorded from the other direction — a per-file ref can name a
+ * revision where each of them exists — with one extra cost there and not here:
+ * those are GOVERNED surface, so `--resync` refuses to write them without
+ * `--rewrite-governed-file`.
  *
- * Consequence, stated so it is inherited rather than rediscovered: this file
- * has NO drift gate. Upstream improvements to `CONSTRUCTS` arrive here only if
- * someone carries them by hand. That is a real cost and it is accepted here
- * rather than paid for by weakening either gate.
+ * Consequence, stated so it is inherited rather than rediscovered: until that
+ * registration lands, this file has NO drift gate. Upstream improvements to
+ * `CONSTRUCTS` arrive here only if someone carries them by hand. That cost was
+ * once accepted because paying it meant weakening a gate; it is now simply
+ * unpaid, and the work to pay it is ordinary.
  *
  * ## Population
  *


### PR DESCRIPTION
Fixes #8385

## This is prose with no gate over it — the diff is the evidence

Nothing in this repository reads the text of this section. Measured, with a control in the same class and same run:

```
$ git grep -n -F "Why this port is not pinned" -- .
scripts/check-bash32-floor.mjs:162: * ## Why this port is not pinned in `scripts/upstream-port-pin.json`
hunt_exit=0                      # one hit, the file itself — nothing quotes it

$ git grep -c -F "check-bash32-floor" -- .       # control: the pattern class does find things
.github/workflows/lint.yml:3
package.json:1
scripts/__tests__/bash32-floor-wiring.test.ts:5
scripts/check-bash32-floor.mjs:13
... 9 files
control_exit=0
```

`scripts/__tests__/bash32-floor-wiring.test.ts` uses the file only as a path and a spawn target (`GATE`, `node ${GATE} --self-test`, `import(GATE)`); no pin reads its docblock. So no check can turn red or green on this change — **read the diff**. What the checks below prove is only that the docblock edit did not break the parse.

## What was wrong

The section's whole argument rested on `pin.upstream.ref`, a single ledger-wide field. objectui#8288 retired it. On `origin/main` `da5e4f69e`:

| clause in the old prose | tree today |
|---|---|
| "the ref is a SINGLE GLOBAL field (`pin.upstream.ref`), one per pin and not one per file" | FALSE. `scripts/upstream-port-pin.json` → `upstream: {repo}` only. `ref` is a **required** key on each `files[]` entry (`check-upstream-port-parity.mjs`: `typeof f.ref !== 'string' \|\| !HEX40.test(f.ref)` → `bad(...)`), and `validatePin` **refuses** a pin that still carries `upstream.ref`. |
| "`--resync` rewrites it for the whole ledger (`pin.upstream.ref = ref;`)" | FALSE. `resyncedPin` maps `files` and touches only the matching entry: `f.ported === portedPath ? { ...f, ref, upstreamSha256 } : f`. |
| "The ledger currently names `bf10deb`" | FALSE, and **already false before objectui#8288** — objectui#7749 had moved the global ref. There is now no ledger-wide ref to name at all. |
| both enumerated registration options, and the "third option that must not be taken" | all three were consequences of the single global field; none exists as a trade any more. |
| "objectui#7953 already owns [the single-global-ref limitation] … must not be re-filed" | the limitation is gone; the pointer is kept, its reasoning replaced. |

⇒ this was not prose "about to go stale". A reader following it went looking for a field that **would be rejected if they wrote it**.

## ⛔ Why the new wording names no revision

This is the load-bearing constraint on the rewrite, and the reason it exists:

That section had **already gone stale twice by the same mechanism** — objectui#7749 moved the global ref out from under the sentence describing it, then objectui#8288 deleted the field the sentence named. Both times the prose stayed confident and wrong. Restating a SHA now would make it stale a **third** time, by that exact mechanism, inside the paragraph explaining that mechanism.

So the new text points at `scripts/upstream-port-pin.json`, where each entry now carries its own `ref` that `--resync` keeps correct, and adds a ⛔ note telling the next editor not to write one back in. Verified, hunt and in-class control in one run:

```
$ grep -conP '\b[0-9a-f]{7,40}\b' <the rewritten section>
0                       hunt_exit=1
$ grep -cnP '\b[0-9a-f]{7,40}\b' scripts/check-bash32-floor.mjs
4                       control_exit=0     # the pattern does find SHAs, elsewhere in the same file
```

## What is kept

Triage flagged one clause as the real reason the section exists, and it survives:

> Consequence, stated so it is inherited rather than rediscovered: … this file has NO drift gate.

Kept, with "until that registration lands" added, and the trade-off sentence corrected: that cost was once *accepted* because paying it meant weakening a gate; it is now simply *unpaid*.

## Scope

Item 1 of objectui#8385 only, as triage narrowed it. Items 2 and 3 are filed and **not** touched here — they change the pin ledger, which is not a prose fix:

- #8694 — register `check-bash32-floor.mjs` at its own ref.
- #8696 — re-triage objectui#7953's ported `.claude/hooks/**` files per file (governed surface; `--resync` needs `--rewrite-governed-file` there).

The pin ledger is unchanged by this PR (`scripts/upstream-port-pin.json` is not in the diff).

## Checks

Run on `a1fdcc5d3`:

| check | exit | verdict line |
|---|---|---|
| `node scripts/check-bash32-floor.mjs --self-test` | 0 | `✓ check-bash32-floor self-test: 160 cases pass.` — the parse proof |
| `node scripts/check-bash32-floor.mjs` | 0 | `✓ check-bash32-floor: 13 tracked shell file(s) … name no bash 4+ construct …` |
| `vitest run scripts/__tests__/bash32-floor-wiring.test.ts` | 0 | `Test Files 1 passed (1) · Tests 9 passed (9)` (under the shared verify lock, `VERDICT command-exit 0`) |
| `node scripts/check-upstream-port-parity.mjs` | 0 | `✓ … 3 ported file(s) match … each at its own pinned ref (2 distinct: …)` — also the live evidence for the new prose |
| `node scripts/check-control-bytes.mjs` | 0 | `✅ check-control-bytes: OK (scanned 6881 tracked text file(s))` |
| `node scripts/check-changeset-presence.mjs` | 0 | `No source or published contract of a released package changed … no changeset is owed` |
| `node scripts/check-changeset-no-major.mjs` | 0 | `✅ No changeset declares a `major` bump.` |
| `node scripts/check-pre-install-import-graph.mjs` | 0 | `✅ … 26 pre-install step(s) … every non-relative leaf a node builtin` |
| `node scripts/check-governed-queue-guard.mjs --self-test` | 0 | `OK … 132 cases pass` |
| `eslint --no-inline-config --format json` on the 2 changed files | 0 | 2 files linted, 0 errors (the `.md` reports "File ignored because no matching configuration was supplied") |

Exit codes were captured before any pipe.

**Not measured, and why:** `check:node-esm-load` exits 1 in this worktree with `✗ 2 of 37 entries REFUSED` — `@object-ui/plugin-dashboard` and `@object-ui/plugin-map`, both `ERR_UNKNOWN_FILE_EXTENSION` on a `.css` import from `node_modules`. The gate says in those words that it "does not grade what this tree did not produce": the build leg was not run here. `grep -c 'bash32-floor'` over its 9k-line output is **0**, so the refusal names nothing in this diff. CI runs it after a build.

## Changeset

`.changeset/8385-bash32-floor-port-rationale.md`, **empty frontmatter** — AGENTS.md §9's first-class "declare once, release nothing" form. Nothing here is published source of a released package and no `package.json` publish-contract field moved; `check-changeset-presence` agrees none is owed, and the declaration is added anyway so the reason is on record.

## 维护者速读(草稿)

**改了什么** — `scripts/check-bash32-floor.mjs` 顶部 docblock 里那一节「为什么这个 port 没有登记进 pin 台账」的散文,约 40 行重写为 53 行。加一个空 frontmatter 的 changeset。⛔ 没有改任何代码、没有改 pin 台账、没有改门禁行为。

**为什么改** — 那段论证的整个前提是 `pin.upstream.ref` 这个全局字段。objectui#8288 已经把它退役,并且 `validatePin` 现在会**主动拒绝**还带着它的 pin。所以那段散文不是「将来会过时」,它现在就是错的,而且是最坏的错法:照它去理解的人,会去找一个写进去就会被拒的字段。

**风险与代价(含回滚)** — 风险接近零:改的是注释,没有任何门禁读它的文本,门禁跑绿只证明 `.mjs` 没被改坏。回滚 = revert 这一个 commit,不影响任何别的东西。代价是这一节现在**不再声称**「没有 drift gate 是可接受的」——它现在如实说这笔债是**欠着的**,并指向 #8694 去还。

**席位意见** — (留空,待定稿)

**你要做的** — 读 diff 本身(没有门禁能替你读)。特别请确认两件事:① 新措辞里一个 SHA 都没有,是**故意**的硬约束,因为这一节已经因为写死 SHA 过时过两次;② 拆出去的 #8694 / #8696 是刚被 #8288 解锁的真实工作,不要随本卡一起关掉。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_