### PR TITLE
fix(fields): a `user` reference that resolved to nothing says so (objectui#8434)

### DIFF
--- a/.changeset/8434-unresolved-user-reference-honesty.md
+++ b/.changeset/8434-unresolved-user-reference-honesty.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/fields': patch
+'@object-ui/i18n': patch
+---
+
+A `user` reference that resolved to nothing is no longer rendered as a person
+(objectui#8434, routed from cloud#2074).
+
+`UserCellRenderer`'s first branch printed any primitive as plain truncated text
+under the comment *"Primitive value: just display the ID/username as text"*. On a
+`user` field the premise of that comment is wrong: `user` is a lookup specialised
+to `sys_user`, so a primitive arriving there means precisely that nothing turned
+the reference into a person. Printing it as displayable text rendered
+**"resolution failed" as "resolution succeeded"** — and, measured, the cell was
+**byte-identical** to what a `text` cell prints for the same string. The only
+difference from a resolved person was the *absence* of the avatar, which is a
+subtractive signal; a user who has never seen the avatar has no reason to read
+absence as failure.
+
+Such a cell now keeps the raw value **visible** and adds a stated affordance
+beside it: a muted marker glyph plus a sentence ("Unresolved reference: … was
+not resolved to a user", keyed as `detail.unresolvedReference` in all ten locale
+packs). The multi-value shape gets the same treatment, so a `user` field is not
+honest on one input shape and silent on the other.
+
+**The sentence is deliberately epistemic, not ontological.** This branch has two
+populations and the renderer cannot tell them apart — it has no resolver at all,
+unlike `LookupCellRenderer`: an unexpanded `sys_user` id is the *legitimate*
+stored form (`packages/core/src/utils/expand-fields.ts`: "a `user` column that is
+NOT requested for expansion comes back as a raw user id", objectui#2032), and a
+name written into the column is dirty data. A "not found" claim would be false
+for the first, so the affordance states only what is true of both: this screen
+did not resolve it.
+
+**Nothing else moves.** An expanded reference still renders avatar + name; a
+reference object carrying only an id still draws its avatar; `{}` still prints
+the coerced text (objectui#8596's boundary); the save-side `reference_not_found`
+refusal and the edit form are untouched — this change is display-only.

--- a/packages/fields/src/__tests__/userCell.unresolvedReference-8434.test.tsx
+++ b/packages/fields/src/__tests__/userCell.unresolvedReference-8434.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8434 — a `user` reference that resolved to nothing was rendered as a
+ * person.
+ *
+ * ── What was measured, before anything was changed ────────────────────────
+ * The card was written from source reading only ("NOT executed — no rig, no
+ * browser") and the edit-form half was INFERRED. All three readings were taken
+ * on the merged tree at `da5e4f69e` before the fix:
+ *
+ *   1. record detail, unresolvable value — `UserCellRenderer` printed
+ *      `<span class="block max-w-full truncate" title="Ada Lovelace">Ada
+ *      Lovelace</span>`: bare text, no avatar, no marker of any kind, and
+ *      BYTE-IDENTICAL to what a `text` cell prints for the same string.
+ *   2. edit form — `UserField` → `LookupField` showed `Select…`, the original
+ *      string appeared NOWHERE in the DOM, and submitting the untouched form
+ *      sent `"Ada Lovelace"` — the invisible original value. Confirmed with a
+ *      control whose `findOne` DOES resolve: that leg renders a chip reading
+ *      `Ada Lovelace` and submits `"u_1"`. (The edit form is objectui#8434's
+ *      third surface and is deliberately NOT changed here — this card is
+ *      display-only. The reading is recorded because the card had never had
+ *      it.)
+ *   3. positive control — an expanded reference object rendered avatar +
+ *      name, in the same mounted tree. Without it, (1) could not be told from
+ *      "this field is broken in general".
+ *
+ * ── The grading sentence, which this file encodes ─────────────────────────
+ * The missing avatar was the only difference, and that is a SUBTRACTIVE signal
+ * (something absent), not an ADDITIVE one (a stated warning). A user who has
+ * never seen the avatar has no reason to read absence as failure. So the pin
+ * that matters most is `ADDITIVE, NOT SUBTRACTIVE` below: it asserts that the
+ * `user` cell is no longer byte-identical to the `text` cell for the same
+ * value. On the unfixed tree those two were the same string of DOM, which is
+ * exactly why nothing anywhere said the reference was invalid.
+ *
+ * ── ⭐ The branch has TWO populations, and that is a finding ──────────────
+ * The plausible wrong fix is "treat every primitive as unresolved", which
+ * would also mark the legitimate case the old comment described. Whether such
+ * a population exists was ESTABLISHED rather than assumed, and it does:
+ *
+ *   1. an UNEXPANDED `sys_user` id — the legitimate stored form.
+ *      `packages/core/src/utils/expand-fields.ts` names it in those words:
+ *      "a `user` column that is NOT requested for expansion comes back as a
+ *      raw user id" (objectui#2032). The record exists.
+ *   2. a string that is no resolvable reference at all — a person's name
+ *      written into the column (cloud#2074), refused on save with
+ *      `reference_not_found`.
+ *
+ * Measured: `'Ada Lovelace'`, `'u_1'` and an opaque ULID rendered
+ * byte-identically, so this renderer cannot tell them apart — it has no
+ * resolver at all, unlike `LookupCellRenderer` (`useLookupName` +
+ * `isLikelyOpaqueId`). ⇒ marking BOTH is correct, and the sentence must be
+ * EPISTEMIC ("this screen did not resolve it"), never ontological ("not
+ * found" / "invalid"), which would be false for population (1) — the same
+ * class of defect this card repairs, aimed the other way. `THE SENTENCE`
+ * below pins that, and it is the assertion a careless escalation trips over.
+ *
+ * ── ⛔ What this file must NOT let pass ───────────────────────────────────
+ * The caricature is the mutation that makes the code answer the same thing
+ * for everything, and it was run in BOTH directions on the READ SITE (the
+ * branch condition in `UserCellRenderer`), never on a pin:
+ *
+ *   - `if (true)`  — everything is unresolved. `POSITIVE CONTROL` fails: an
+ *     expanded record stops drawing its avatar.
+ *   - `if (false)` — nothing is. `THE DEFECT` and `ADDITIVE, NOT SUBTRACTIVE`
+ *     fail: the raw string goes back to being indistinguishable from text.
+ *
+ * Per-test verdicts for both legs are recorded in the PR from vitest's JSON
+ * reporter.
+ *
+ * ⚠️ Counting is done at the SEAM (`querySelectorAll`), never with
+ * `queryByText`, which throws on multiple matches as well as none — and the
+ * avatar seam is `.rounded-full`, the same one objectui#8596's census uses for
+ * this renderer.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { en } from '@object-ui/i18n';
+import { getCellRenderer, resolveCellRendererType } from '../index';
+
+afterEach(() => cleanup());
+
+/** Resolve + render exactly the way a consumer builds a read-mode cell. */
+function renderCell(type: string, value: unknown, field: Record<string, unknown> = {}) {
+  const Renderer = getCellRenderer(resolveCellRendererType({ type }) || type);
+  return render(
+    <Renderer value={value as any} field={{ type, name: type, ...field } as any} />,
+  );
+}
+
+/** The unresolved-reference affordance, counted at its own seam. */
+const marks = (root: HTMLElement) =>
+  root.querySelectorAll<HTMLElement>('[data-slot="unresolved-reference"]');
+
+/**
+ * The avatar seam.
+ *
+ * ⚠️ Measured, not guessed: `.rounded-full` alone matches TWO nodes per avatar
+ * — Radix's `Avatar.Root` AND the `AvatarFallback` inside it both carry it. The
+ * objectui#8596 census navigates by `querySelector('.rounded-full')`, which
+ * takes the FIRST match and so never had to notice; counting does. Every
+ * positive-control leg here failed on `expected 1, got 2` with the bare class
+ * before this was narrowed to the Root, which is the only one that is also
+ * `overflow-hidden`. `avatarSeamCount` below pins the arithmetic so a future
+ * reader does not have to re-derive it.
+ */
+const avatars = (root: HTMLElement) =>
+  root.querySelectorAll('.rounded-full.overflow-hidden');
+
+const textOf = (root: HTMLElement) => (root.textContent ?? '').replace(/\s+/g, ' ').trim();
+
+/**
+ * The three primitives that reach this branch. Both populations are here on
+ * purpose — the renderer cannot tell them apart, so it must answer all three
+ * the same way, and the SENTENCE (not the treatment) is what stays honest.
+ */
+const UNRESOLVED_INPUTS: ReadonlyArray<readonly [label: string, value: unknown]> = [
+  ['a person name written into the column (cloud#2074 dirty row)', 'Ada Lovelace'],
+  ['an unexpanded sys_user id (objectui#2032, the legitimate stored form)', 'u_1'],
+  ['an opaque ULID-shaped id, unexpanded', '01HQZX9K2M4N6P8R'],
+];
+
+describe('objectui#8434 — THE DEFECT: an unresolved `user` reference must say so', () => {
+  it.each(UNRESOLVED_INPUTS)('%s', (label, value) => {
+    const { container } = renderCell('user', value);
+
+    // Absence of the false claim FIRST, so an unfixed tree and a harness that
+    // lost its navigation target fail on different sentences.
+    expect(
+      avatars(container),
+      `${label}: an avatar asserts a resolved person — nothing resolved here`,
+    ).toHaveLength(0);
+
+    expect(
+      marks(container),
+      `${label}: the cell must carry exactly one unresolved-reference affordance`,
+    ).toHaveLength(1);
+
+    // ⛔ The raw value stays VISIBLE. It is the only clue for diagnosing an
+    // existing dirty row, and the strong arm's cost was destroying it.
+    expect(
+      textOf(container),
+      `${label}: the raw value must remain readable on screen`,
+    ).toBe(String(value));
+
+    // The signal is STATED, not merely styled: a sentence a person can read.
+    const stated = marks(container)[0]!.getAttribute('title') ?? '';
+    expect(stated.length, `${label}: the affordance must state something`).toBeGreaterThan(0);
+    expect(stated, `${label}: the sentence must name the value it is about`).toContain(String(value));
+  });
+});
+
+describe('objectui#8434 — POSITIVE CONTROL: the resolvable case is untouched', () => {
+  // Without this the readings above cannot be told from "this field is broken
+  // in general", and the `if (true)` caricature would pass everything else.
+  it.each([
+    ['an expanded record with an image', { id: 'u_1', name: 'Ada Lovelace', image: 'https://x/a.png' }],
+    ['an expanded record without one (initials fallback)', { id: 'u_1', name: 'Ada Lovelace' }],
+  ] as const)('%s still renders avatar + name', (label, value) => {
+    const { container } = renderCell('user', value);
+
+    expect(marks(container), `${label}: a resolved person is not unresolved`).toHaveLength(0);
+    expect(avatars(container), `${label}: a resolved reference still draws its avatar`).toHaveLength(1);
+    expect(avatars(container)[0]!.textContent, `${label}: initials`).toBe('AL');
+    expect(textOf(container), `${label}: avatar initials + the resolved name`).toBe('ALAda Lovelace');
+  });
+
+  it('the avatar seam counts one node per avatar (the instrument, checked)', () => {
+    const { container } = renderCell('user', { id: 'u_1', name: 'Ada Lovelace' });
+    expect(
+      container.querySelectorAll('.rounded-full'),
+      'the bare class matches Avatar.Root AND AvatarFallback — do not count with it',
+    ).toHaveLength(2);
+    expect(avatars(container), 'the narrowed seam matches the Root alone').toHaveLength(1);
+  });
+
+  it('a reference carrying only an id still draws its avatar — objectui#8596 boundary, unmoved', () => {
+    const { container } = renderCell('user', { id: 'u_1' });
+    expect(marks(container)).toHaveLength(0);
+    expect(avatars(container), 'a populated reference object is not this card`s subject').toHaveLength(1);
+  });
+
+  it('`{}` still prints the coerced text — objectui#8596`s ruling, unmoved', () => {
+    const { container } = renderCell('user', {});
+    expect(marks(container), 'an object literal is objectui#8596`s subject, not this one').toHaveLength(0);
+    expect(textOf(container)).toBe('[Object]');
+  });
+});
+
+describe('objectui#8434 — THE SENTENCE: honest about WHICH population it cannot name', () => {
+  // The renderer has no resolver, so it cannot know whether the record exists.
+  // A "not found" claim would be FALSE for the unexpanded-id population — the
+  // same class of defect this card repairs, in the other direction.
+  it.each(UNRESOLVED_INPUTS)('%s — states unresolved, never non-existence', (label, value) => {
+    const { container } = renderCell('user', value);
+    const stated = marks(container)[0]!.getAttribute('title') ?? '';
+    expect(
+      stated,
+      `${label}: this renderer cannot know the record is absent — it only knows it did not resolve it`,
+    ).not.toMatch(/not found|does not exist|no such|invalid|missing/i);
+    expect(stated, `${label}: it must say what it DOES know`).toMatch(/unresolved/i);
+  });
+
+  // The English fallback lives in code (the provider-less path) and the `en`
+  // pack serves the same sentence. `check:i18n-keys` compares an inline
+  // `defaultValue` against the pack, but this call site's fallback is not that
+  // shape, so the gate cannot see it — this pin is the comparison instead.
+  it('the provider-less sentence is byte-equal to the `en` pack value', () => {
+    const { container } = renderCell('user', 'Ada Lovelace');
+    const stated = marks(container)[0]!.getAttribute('title');
+    const packed = (en as any).detail.unresolvedReference.replace('{{value}}', 'Ada Lovelace');
+    expect(stated, 'the code fallback and the en pack must not drift apart').toBe(packed);
+  });
+});
+
+describe('objectui#8434 — ADDITIVE, NOT SUBTRACTIVE: the sentence that graded this card', () => {
+  // On the unfixed tree these two produced the SAME string of DOM, and that
+  // identity is the whole defect: the only thing separating "we resolved a
+  // person" from "we resolved nothing" was the ABSENCE of an avatar.
+  it.each(UNRESOLVED_INPUTS)('%s no longer renders identically to a `text` cell', (label, value) => {
+    const asUser = renderCell('user', value).container.innerHTML;
+    cleanup();
+    const asText = renderCell('text', value).container.innerHTML;
+
+    expect(asText, 'control: a text cell prints the bare string, unchanged by this card').toBe(
+      `<span class="block max-w-full truncate" title="${String(value)}">${String(value)}</span>`,
+    );
+    expect(
+      asUser,
+      `${label}: a user cell that is byte-identical to a text cell states nothing`,
+    ).not.toBe(asText);
+  });
+
+  it('the multi-value shape is not left silent while the scalar one speaks', () => {
+    // One unresolved entry and one resolved entry in ONE cell: the resolved
+    // half is this render's own positive control.
+    const { container } = renderCell('user', ['Ada Lovelace', { id: 'u_2', name: 'Grace Hopper' }]);
+    expect(marks(container), 'the unresolved entry says so').toHaveLength(1);
+    expect(avatars(container), 'the resolved entry still draws its avatar').toHaveLength(1);
+    expect(marks(container)[0]!.textContent, 'and keeps its raw value').toBe('Ada Lovelace');
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -15,7 +15,7 @@ import { ComponentRegistry, percentDisplayValue, getRecordDisplayName, humanizeL
 import { valueSchemaFor } from '@objectstack/spec/data';
 import { useLocalization, useDisplayLocale, formatDisplayNumber } from '@object-ui/i18n';
 import { Badge, Avatar, AvatarImage, AvatarFallback, Button, Checkbox, EmptyValue, cn } from '@object-ui/components';
-import { Check, Copy, Phone as PhoneIcon, MapPin } from 'lucide-react';
+import { Check, Copy, Phone as PhoneIcon, MapPin, CircleQuestionMark } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/react';
 import { SchemaRendererContext as _SchemaRendererContext } from '@object-ui/react';
 import { useRelatedRecordActions } from '@object-ui/react';
@@ -2218,6 +2218,91 @@ export function FormulaCellRenderer({ value }: CellRendererProps): React.ReactEl
 }
 
 /**
+ * A `user` reference this screen did NOT resolve to a person (objectui#8434).
+ *
+ * ## Why a primitive here is never "the ID or username"
+ *
+ * `user` is a lookup specialised to `sys_user`: `@objectstack/spec` puts it in
+ * `REFERENCE_VALUE_TYPES`, whose stored form is a record id and whose expanded
+ * form is the related record OBJECT. So the object branches below are the
+ * resolved case, and a primitive reaching this renderer means exactly one
+ * thing — nothing on this screen turned that reference into a person.
+ *
+ * The branch this replaces printed it as bare text, byte-identical to what a
+ * `text` cell prints. Measured on the merged tree: `'Ada Lovelace'` (a name
+ * written into the column), `'u_1'` and an opaque ULID all rendered as
+ * `<span class="block max-w-full truncate" title="…">…</span>` — while an
+ * expanded object rendered avatar + name. The ONLY difference between "we
+ * resolved this person" and "we resolved nothing" was the ABSENCE of the
+ * avatar, and a user who has never seen the avatar has no reason to read
+ * absence as a failure. A subtractive signal is not a signal.
+ *
+ * ## Why the sentence says "unresolved" and not "not found"
+ *
+ * Measured, not assumed: this branch has TWO populations and cannot tell them
+ * apart.
+ *
+ *   1. a `sys_user` id that arrived UNEXPANDED — the legitimate stored form.
+ *      `packages/core/src/utils/expand-fields.ts` names it in those words:
+ *      "a `user` column that is NOT requested for expansion comes back as a
+ *      raw user id" (objectui#2032). The record exists.
+ *   2. a string that is not a resolvable reference at all — a person's name
+ *      written into the column (cloud#2074), which the save path refuses with
+ *      `reference_not_found`.
+ *
+ * Both arrive as the same primitive, so a "not found" claim would be FALSE for
+ * (1) — the same class of defect this card repairs, aimed the other way. What
+ * is true of both is epistemic: this screen did not resolve it. The affordance
+ * says that and nothing more.
+ *
+ * ⛔ The raw value stays VISIBLE and un-elided. It is the only clue for
+ * diagnosing an existing dirty row, so this is deliberately NOT
+ * `LookupCellRenderer`'s muted em-dash for opaque ids — that treatment buys
+ * tidiness by destroying the evidence.
+ *
+ * ⚠️ No `pointer-events-none` here, unlike `EmptyValue`: that utility stops the
+ * span being a hit target, so a `title` on it never renders a tooltip
+ * (objectui#8506). The stated sentence has to be reachable by hovering.
+ */
+function UnresolvedUserReference({
+  value,
+  className,
+}: {
+  value: unknown;
+  className?: string;
+}): React.ReactElement {
+  const t = useFieldTranslate();
+  const raw = String(value);
+  // The key is written as a LITERAL at both sites on purpose:
+  // `check:i18n-keys` judges a literal key against the `en` pack and checks
+  // that the arguments here are exactly the holes that value has, and it
+  // downgrades a key read from a constant to report-only. A shared constant
+  // would have bought tidiness at the cost of the gate.
+  const translated = t?.('detail.unresolvedReference', { value: raw });
+  // Same provider-less rule `useFieldLabel` documents: i18next echoes the key
+  // when nothing resolves it, and the English fallback applies then. That
+  // fallback is held byte-equal to the `en` pack's value by a pin, since this
+  // shape is invisible to the inline-`defaultValue` half of `check:i18n-keys`.
+  const hint =
+    !translated || translated === 'detail.unresolvedReference'
+      ? `Unresolved reference: ${raw} was not resolved to a user`
+      : translated;
+  return (
+    <span
+      data-slot="unresolved-reference"
+      className={cn(
+        'inline-flex min-w-0 max-w-full items-center gap-1 text-muted-foreground',
+        className,
+      )}
+      title={hint}
+    >
+      <CircleQuestionMark className="size-3.5 shrink-0" aria-hidden="true" />
+      <span className="truncate">{raw}</span>
+    </span>
+  );
+}
+
+/**
  * User/Owner field cell renderer (with avatars)
  */
 export function UserCellRenderer({ value }: CellRendererProps): React.ReactElement {
@@ -2225,18 +2310,26 @@ export function UserCellRenderer({ value }: CellRendererProps): React.ReactEleme
   // branch below and rendered an empty stack (objectui#8481).
   if (!value || isEmptyMultiValue(value)) return <EmptyValue />;
 
-  // Primitive value: just display the ID/username as text
+  // A primitive is an UNRESOLVED reference, not "the ID/username" (objectui#8434).
+  // The comment that stood here stated the branch's premise, and the premise was
+  // wrong: printing the raw string as displayable text renders "resolution
+  // failed" as "resolution succeeded". See `UnresolvedUserReference` for the two
+  // populations that reach here and why the sentence is epistemic.
   if (typeof value !== 'object') {
-    return <TruncatedText text={String(value)} />;
+    return <UnresolvedUserReference value={value} />;
   }
   
   if (Array.isArray(value)) {
     return (
       <div className="flex -space-x-2">
         {value.slice(0, 3).map((user, idx) => {
-          // Primitive user in array
+          // The same ruling as the scalar branch above, one input-shape over
+          // (objectui#8434): an entry that is not an expanded record is a
+          // reference this screen did not resolve, and it said so by drawing
+          // nothing. A multi-value `user` field must not be honest on its
+          // single-value shape and silent on this one.
           if (typeof user !== 'object' || user === null) {
-            return <TruncatedText key={idx} text={String(user)} className="text-sm" />;
+            return <UnresolvedUserReference key={idx} value={user} className="text-sm" />;
           }
           // An entry carrying nothing names no person (objectui#8596) — the
           // same ruling as the scalar branch below, one input-shape over.

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -1090,6 +1090,7 @@ const ar = {
     showEmptyFields: "إظهار {{count}} حقل(حقول) فارغة",
     hideEmptyFields: "إخفاء الحقول الفارغة",
     noValue: "لا قيمة",
+    unresolvedReference: "مرجع غير مُحلّل: لم يتم تحويل {{value}} إلى مستخدم",
     // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
     // used no translation hook at all, so every one of these read English in
     // every session; swept in one pass rather than converting the timestamps

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -1083,6 +1083,7 @@ const de = {
     showEmptyFields: "{{count}} leere Felder anzeigen",
     hideEmptyFields: "Leere Felder ausblenden",
     noValue: "Kein Wert",
+    unresolvedReference: "Nicht aufgelöste Referenz: {{value}} wurde keinem Benutzer zugeordnet",
     // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
     // used no translation hook at all, so every one of these read English in
     // every session; swept in one pass rather than converting the timestamps

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1239,6 +1239,7 @@ const en = {
     showEmptyFields: 'Show {{count}} empty fields',
     hideEmptyFields: 'Hide empty fields',
     noValue: 'No value',
+    unresolvedReference: 'Unresolved reference: {{value}} was not resolved to a user',
     // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
     // used no translation hook at all, so every one of these read English in
     // every session; swept in one pass rather than converting the timestamps

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1087,6 +1087,7 @@ const es = {
     showEmptyFields: "Mostrar {{count}} campos vacíos",
     hideEmptyFields: "Ocultar campos vacíos",
     noValue: "Sin valor",
+    unresolvedReference: "Referencia sin resolver: {{value}} no se resolvió como un usuario",
     // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
     // used no translation hook at all, so every one of these read English in
     // every session; swept in one pass rather than converting the timestamps

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -1085,6 +1085,7 @@ const fr = {
     showEmptyFields: "Afficher {{count}} champs vides",
     hideEmptyFields: "Masquer les champs vides",
     noValue: "Aucune valeur",
+    unresolvedReference: "Référence non résolue : {{value}} n'a pas été résolue en utilisateur",
     // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
     // used no translation hook at all, so every one of these read English in
     // every session; swept in one pass rather than converting the timestamps

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -1083,6 +1083,7 @@ const ja = {
     showEmptyFields: "{{count}} 件の空フィールドを表示",
     hideEmptyFields: "空フィールドを非表示",
     noValue: "値なし",
+    unresolvedReference: "未解決の参照: {{value}} はユーザーとして解決されませんでした",
     // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
     // used no translation hook at all, so every one of these read English in
     // every session; swept in one pass rather than converting the timestamps

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -1083,6 +1083,7 @@ const ko = {
     showEmptyFields: "{{count}}개의 빈 필드 표시",
     hideEmptyFields: "빈 필드 숨기기",
     noValue: "값 없음",
+    unresolvedReference: "확인되지 않은 참조: {{value}}을(를) 사용자로 확인하지 못했습니다",
     // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
     // used no translation hook at all, so every one of these read English in
     // every session; swept in one pass rather than converting the timestamps

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1082,6 +1082,7 @@ const pt = {
     showEmptyFields: "Mostrar {{count}} campos vazios",
     hideEmptyFields: "Ocultar campos vazios",
     noValue: "Sem valor",
+    unresolvedReference: "Referência não resolvida: {{value}} não foi resolvida como um usuário",
     // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
     // used no translation hook at all, so every one of these read English in
     // every session; swept in one pass rather than converting the timestamps

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -1093,6 +1093,7 @@ const ru = {
     showEmptyFields: "Показать {{count}} пустых полей",
     hideEmptyFields: "Скрыть пустые поля",
     noValue: "Нет значения",
+    unresolvedReference: "Неразрешённая ссылка: {{value}} не удалось сопоставить с пользователем",
     // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
     // used no translation hook at all, so every one of these read English in
     // every session; swept in one pass rather than converting the timestamps

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1122,6 +1122,7 @@ const zh = {
     showEmptyFields: '显示 {{count}} 个空字段',
     hideEmptyFields: '隐藏空字段',
     noValue: '无',
+    unresolvedReference: '未解析的引用：{{value}} 未能解析为用户',
     // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
     // used no translation hook at all, so every one of these read English in
     // every session; swept in one pass rather than converting the timestamps


### PR DESCRIPTION
Fixes #8434

`UserCellRenderer`'s first branch printed any primitive as plain truncated text, under a comment stating its premise: *"Primitive value: just display the ID/username as text"*. On a `user` field that premise is wrong — `user` is a lookup specialised to `sys_user`, so a primitive arriving there means precisely that nothing turned the reference into a person. It rendered **"resolution failed" as "resolution succeeded."**

## ⭐ Step one was reproduction — the card had never been executed

The card said so twice ("NOT executed — no rig, no browser"; the edit-form half "inferred"). All three readings triage required were taken on the merged tree at `da5e4f69e`, **before** anything was changed.

**Reading 1 — what an unresolvable `user` value actually renders in record detail.** Confirmed, and worse than "no avatar": byte-identical to a `text` cell.

```
value 'Ada Lovelace'  ->  <span class="block max-w-full truncate" title="Ada Lovelace">Ada Lovelace</span>
value 'u_1'           ->  <span class="block max-w-full truncate" title="u_1">u_1</span>
value ULID            ->  <span class="block max-w-full truncate" title="01HQZX9K2M4N6P8R">01HQZX9K2M4N6P8R</span>
```

**Reading 2 — the edit form. The one behaviour nobody had confirmed in code.** Confirmed, with a control. Mounting `UserField` in a form host holding the value in state:

| leg | trigger text | original string anywhere in the DOM | what a submit sent |
|---|---|---|---|
| `'Ada Lovelace'`, `findOne` resolves nothing | `Select…` | **false** | `"Ada Lovelace"` |
| `'u_1'`, `findOne` DOES resolve it | a chip: avatar `AL` + `Ada Lovelace` | true | `"u_1"` |

So yes — the form really is blank, and it really does submit the invisible original value. ⚠️ My first attempt at this reading was **void**: both legs printed `Select…` because my `findOne` stub returned `null` on both. Re-run with a discriminating control; the table above is the second run. The edit form is **not changed** here — this card is display-only — but the reading is recorded because it had never been taken.

**Reading 3 — the positive control**, in the same mounted tree: an expanded reference object renders avatar (initials `AL`) + name. Without it, readings 1 and 2 could not be told from "this field is broken in general."

## ⚠️ Re-located on the merged tree; #8679 did not move the branch

| address | tree |
|---|---|
| `~2067` | the card body |
| `:2112` | triage, at `f76f4362` |
| `:2151` | `HEAD~1` (pre-#8679) |
| **`:2228`** | **`da5e4f69e`, the merged tree — this PR's base** |

`git diff HEAD~1 HEAD -- packages/fields/src/index.tsx` contains **zero** occurrences of `typeof value !== 'object'`: #8679 added 77 lines above the branch and left it byte-identical, as expected — its subject is `{}`, this card's is a string that failed to resolve.

## The fix — the weak arm, as called

Keep the raw value **visible** and add a stated affordance beside it: a muted marker glyph plus a sentence, keyed `detail.unresolvedReference` in all ten locale packs. The multi-value shape gets the same treatment, so the field is not honest on one input shape and silent on the other.

```
<span data-slot="unresolved-reference" class="… text-muted-foreground"
      title="Unresolved reference: Ada Lovelace was not resolved to a user">
  <svg class="lucide lucide-circle-question-mark size-3.5 shrink-0" aria-hidden="true">…</svg>
  <span class="truncate">Ada Lovelace</span>
</span>
```

Strictly information-adding: nothing that was on screen is removed, no other surface changes, and the raw string — the only clue for diagnosing an existing dirty row — stays readable.

## ⭐ The branch has TWO populations, and saying so is the finding

The PM asked me to *establish* whether the legitimate case the old comment describes exists before assuming the branch has only one population. It does, and the repo names it:

> `packages/core/src/utils/expand-fields.ts` — "a `user` column that is **NOT requested for expansion** comes back as a raw user id" (objectui#2032)

1. an **unexpanded `sys_user` id** — the legitimate stored form. The record exists.
2. a **string that is no resolvable reference at all** — a name written into the column (cloud#2074), refused on save with `reference_not_found`.

Measured: `'Ada Lovelace'`, `'u_1'` and an opaque ULID render **byte-identically**. `UserCellRenderer` has no resolver at all — no `useLookupName`, no `isLikelyOpaqueId`, unlike `LookupCellRenderer` — so it cannot tell them apart.

⇒ **Marking both is correct, but the sentence must be epistemic.** "Not found" would be *false* for population 1 — the same class of defect this card repairs, aimed the other way. So the affordance states only what is true of both: this screen did not resolve it. `THE SENTENCE` in the pin asserts the wording does **not** match `/not found|does not exist|no such|invalid|missing/i`, which is the assertion a careless escalation trips over.

⚠️ This also means the plausible wrong fix the PM named — *"treat every primitive as unresolved"* — is **not** wrong in its extension, only in what it would be entitled to say. The non-regression axis is therefore the wording plus the expanded-object case, not the primitive/non-primitive split.

## Verification

Everything asserts **rendered output**, never that a branch exists. Counting is at the seam, never `queryByText`.

⚠️ **The avatar seam was itself a measurement.** `.rounded-full` matches **two** nodes per avatar — Radix's `Avatar.Root` *and* the `AvatarFallback` inside it. objectui#8596's census navigates with `querySelector` (first match) and so never had to notice; counting does. All five positive-control legs failed `expected 1, got 2` before the seam was narrowed to `.rounded-full.overflow-hidden`. `the avatar seam counts one node per avatar` pins the arithmetic so the next reader does not re-derive it.

### Ablation — read site mutated, three legs, all from the committed tree

Mutations land on the **read site** in `UserCellRenderer`, never on a pin. Each leg proves the mutation on disk in both directions (anchor count 1→0, marker 0→1), against `git hash-object` vs the HEAD blob `0d6307af…`, plus a line-total gate (3584 unchanged), and restores **by state** (`git diff HEAD` empty **and** the blob back to the HEAD blob). Per-test classification from vitest's **JSON** reporter.

| leg | mutation | per-test | which group died |
|---|---|---|---|
| **BUG** | the pre-fix `return <TruncatedText text={String(value)} />` | 10 failed / 6 passed | THE DEFECT ×3, THE SENTENCE ×4, **ADDITIVE ×3** |
| **ALL** | `if (true)` — everything is unresolved | 6 failed / 10 passed | POSITIVE CONTROL ×5, multi-value control ×1 |
| **NONE** | `if (false)` — nothing is | 7 failed / 9 passed | THE DEFECT ×3, THE SENTENCE ×4 |

`ALL` / `NONE` are the caricature — the mutation that makes the code answer the same thing for everything — run both ways. **`BUG` is the leg that matters**: it is the only one that kills `ADDITIVE, NOT SUBTRACTIVE`, on the death string

```
a user cell that is byte-identical to a text cell states nothing
```

which is the card's grading sentence, observed failing. Across the three legs **all 16 assertions have been observed to fail**; none is a leg that landed without discriminating, and none is void.

Death strings counted separately per leg; `NONE` produced `TypeError: Cannot read properties of undefined (reading 'getAttribute')` ×4 — a navigation-target death, distinct from the assertion deaths, which is why the pins assert the false claim's **absence first**.

### Runs

- `packages/fields` + `packages/i18n`: **212 files / 3636 tests passed**, `VERDICT command-exit 0`.
- downstream cell-render consumers (`plugin-dashboard`, `plugin-grid`, `plugin-detail`, `plugin-list`): **365 files / 3441 tests passed**, `VERDICT command-exit 0`.
- `type-check` for both packages: `tsc --noEmit && tsc -p tsconfig.test.json`, Done. The new pin **is** in that program — confirmed with `--listFiles` (1 hit), so this is not a NOT MEASURED.
- eslint over the **whole repo** (`eslint .`, no narrowing needed): **4574 files, 0 errors**, exit 0.
- gates: `check:i18n-keys` ✅ (and it now *judges* this call site — literal keys resolving went 2734 → 2735, dynamic report-only 66 → 65), `check:i18n-drift` ✅, `check:i18n-dead-keys` ✅, `check:control-bytes` ✅ (+ a manual control-byte scan of every changed file), `check:icon-record-names` ✅, `check:phantom-deps` ✅, `check:unused-deps` ✅, `changeset:check` ✅, `check-changeset-presence` ✅.
- ⚠️ `check:eager-closure` — **NOT MEASURED**, exit 2 with *"No eager-closure report at apps/console/dist/eager-closure.json"*: a missing prerequisite, not a red gate. Declared to CI. The expected delta is one additional lucide icon from a module `index.tsx` already imports eagerly, plus ten one-line locale strings, against ~45.8 KB gzipped of headroom (ceiling 3,597,000 over baseline 3,551,191).

⚠️ `CircleHelp` was the first choice and is **retired** from lucide's runtime `icons` record while still importing and rendering fine as a component. `CircleQuestionMark` is the live spelling; `check:icon-record-names` documents exactly this failure mode.

## The three fences

1. **Not tolerance.** Nothing here makes the renderer accept the bad value more gracefully — no alias, no coercion, no `??` fallback. It changes what the screen *says* about a value it already received. Honest display, not tolerance.
2. **The save-side refusal is untouched.** No file outside `packages/fields/src/index.tsx` and the locale packs changes; `reference_not_found` is not in the diff.
3. **"The producer is already fixed" does not close this.** Population 1 above is produced by *this repo's own read path* whenever a `user` column is not requested for expansion — no dirty data required. Existing rows, hand-authored metadata and future generators supply population 2.

## Out of scope, filed not fixed

- **#8693** — `expand-fields.ts` documents a rendering behaviour `UserCellRenderer` has never had (the `"—"` clause). Measured false on this base; the `"—"` belongs to `LookupCellRenderer`. Comment-only, but in `@object-ui/core`, which would pull a second published package into this diff for a comment.
- **#8695** — `LookupCellRenderer` answers the same epistemic state two opposite ways: a name-shaped unresolvable reference prints as a confident name (this card's defect verbatim, one renderer over), while an opaque-shaped one loses its raw value to a muted dash (the evidence-destruction triage warned about). Bigger surface — `lookup` / `master_detail` / `tree` — and it has a resolver `user` does not, so it is a genuinely different decision.

Dedup channel declared: `/search/*` is refused by the egress proxy and `search_issues` returns false zeros on this repo, so this was REST label-scoped listing (`package: fields`, `package: core`, `state=all`) plus local grep over titles and bodies, with issue 8434 itself as the control word that must hit — it did. 30 unique issues; no duplicate of either finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_