### PR TITLE
test: audit the nine recorder-wait sites — one repaired, eight measured sound

### DIFF
--- a/.changeset/issue-8690-recorder-wait-audit.md
+++ b/.changeset/issue-8690-recorder-wait-audit.md
@@ -1,0 +1,9 @@
+---
+---
+
+Test-only (plugin-designer) plus one repo script. The `MetadataObjectsPage.lookupKeying`
+round-trip pin now reads its "no delete was issued" assertion after the page's
+`reload()` — the handler's last statement — instead of after the first PUT, so the
+emptiness is dated to the end of the write sequence rather than to its start. Adds
+`scripts/census-recorder-wait-shape.mjs`, the objectui#8690 corpus detector. No
+published behaviour changes.

--- a/packages/plugin-designer/src/MetadataObjectsPage.lookupKeying.test.tsx
+++ b/packages/plugin-designer/src/MetadataObjectsPage.lookupKeying.test.tsx
@@ -377,6 +377,18 @@ describe('objectui#6522 · SITE B — the raw-payload lookup keys every server o
     // the real payload rather than something off the prototype chain.
     expect(puts[0].body.pluralLabel).toBe('Constructors');
     expect(puts[0].body.fields).toBeDefined();
+    // COMPLETION ANCHOR (objectui#8690). The emptiness below is only worth
+    // reading once `handleObjectsChange` has run to the END: `reload()` is its
+    // last statement, so the manager receiving the re-read list is the signal
+    // that every write the handler was going to make has been made. Waiting on
+    // `puts` instead dates the absence to the FIRST write, which covers the
+    // delete scan only because that scan happens to run before the save loop —
+    // a property of the page, not one this file asserts. Measured: with a stray
+    // `reset` issued after the saves, the `puts` wait leaves the delete log
+    // green while C0/H1/H2 above — which already anchor on the reload — go red.
+    // `label` and not `name` because the name is unchanged by a rename: only
+    // the relabelled row is a value the pre-reload state cannot answer with.
+    await waitFor(() => expect(managerProps!.objects.map((o) => o.label)).toEqual(['Renamed']));
     expect(deletes).toEqual([]);
     expect(shownError()).toBeNull();
   });

--- a/scripts/census-recorder-wait-shape.mjs
+++ b/scripts/census-recorder-wait-shape.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Census: `await waitFor(...)` keyed on ONE recorder array, followed by a read
+ * of a DIFFERENT recorder array, with nothing establishing the second was
+ * filled. The shape objectui#8688 was one instance of; the corpus reading is
+ * objectui#8690, and this file is that card's detector, kept so the next person
+ * does not have to re-derive it.
+ *
+ * ⚠️ It answers WHERE TO LOOK, never WHAT IS WRONG. A flag is a site to read,
+ * not a defect: objectui#8690 read all nine of its strict-shape flags and found
+ * one worth repairing. ⛔ Never batch-repair a flag list.
+ *
+ * Algorithm (the card's four steps):
+ *   1. per file, recorders = every identifier that is the target of `.push(`
+ *   2. per `await waitFor(`, balance parens; recorders named inside = WAIT SET
+ *   3. scan forward to the next `await` (or EOF), collecting recorders READ
+ *      (a recorder's own `.push(` line does not count as a read)
+ *   4. flag any read of a recorder the wait did not name
+ *
+ * Two recorder-matching modes, because the choice moves the numbers:
+ *   --recorder-match=ident  bare identifiers (`calls`), receiver ignored
+ *   --recorder-match=path   dotted paths (`server.savedOpts`) — the default
+ *
+ * Measured on da5e4f69e, 2776 tracked `*.test.ts`/`*.test.tsx` files:
+ *   ident: 159 flags, 15 strict in 10 files
+ *   path : 167 flags, 18 strict in 12 files
+ * objectui#8690 reported 160 flags and 9 strict, so this re-derivation is one
+ * flag off its total and wider in the strict bucket — near enough to be the
+ * same instrument, ⛔ not near enough to quote its numbers as reproduced.
+ * The two modes' strict buckets differ and neither contains the other: `ident`
+ * misses a wait written `host.calls` (the receiver hides the recorder), `path`
+ * misses a recorder pushed as a bare `inits` and read as `host.inits[0]`.
+ * objectui#8690's nine sites are inside the UNION of the two, minus
+ * `packages/permissions` (which objectui#8688 / PR #8689 already hold).
+ *
+ * Usage: node scripts/census-recorder-wait-shape.mjs [--recorder-match=ident|path]
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const mode = (process.argv.find((a) => a.startsWith('--recorder-match=')) ?? '').split('=')[1] || 'path';
+if (!['ident', 'path'].includes(mode)) {
+  console.error(`unknown --recorder-match=${mode} (expected ident|path)`);
+  process.exit(2);
+}
+
+const files = execSync("git ls-files '*.test.ts' '*.test.tsx'", {
+  encoding: 'utf8',
+  maxBuffer: 64 * 1024 * 1024,
+}).split('\n').filter(Boolean);
+
+const PUSH = mode === 'ident'
+  ? /([A-Za-z_$][\w$]*)\s*\.push\s*\(/g
+  : /([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\.push\s*\(/g;
+const nameRe = (n) => new RegExp(`(?<![\\w$.])${n.replace(/\./g, '\\.')}(?![\\w$])`, 'g');
+const lineOf = (src, index) => src.slice(0, index).split('\n').length;
+
+const flags = [];
+for (const file of files) {
+  const src = readFileSync(file, 'utf8');
+  const recorders = new Set();
+  for (const m of src.matchAll(PUSH)) recorders.add(m[1]);
+  if (recorders.size === 0) continue;
+
+  for (const w of src.matchAll(/await\s+waitFor\s*\(/g)) {
+    // 2. balance parens to the end of the wait
+    const open = w.index + w[0].length - 1;
+    let depth = 0;
+    let end = -1;
+    for (let j = open; j < src.length; j++) {
+      if (src[j] === '(') depth++;
+      else if (src[j] === ')' && --depth === 0) { end = j; break; }
+    }
+    if (end < 0) continue;
+    const waitBody = src.slice(open, end + 1);
+    const waitSet = new Set([...recorders].filter((r) => nameRe(r).test(waitBody)));
+
+    // 3. forward window: end of the wait -> the next `await` (or EOF)
+    const rest = src.slice(end + 1);
+    const nextAwait = rest.search(/\bawait\b/);
+    const window = nextAwait === -1 ? rest : rest.slice(0, nextAwait);
+
+    for (const r of recorders) {
+      if (waitSet.has(r)) continue;
+      for (const hit of window.matchAll(nameRe(r))) {
+        if (/^\s*\.push\s*\(/.test(window.slice(hit.index + r.length))) continue;
+        flags.push({
+          file,
+          line: lineOf(src, end + 1 + hit.index),
+          waitLine: lineOf(src, w.index),
+          recorder: r,
+          waitSet: [...waitSet],
+        });
+        break; // one flag per (wait, recorder)
+      }
+    }
+  }
+}
+
+const strict = flags.filter((f) => f.waitSet.length > 0);
+console.log(`recorder-match: ${mode}`);
+console.log(`population:     ${files.length} test files`);
+console.log(`total flags:    ${flags.length}`);
+console.log(`  wait named a recorder (the strict shape): ${strict.length} in ${new Set(strict.map((f) => f.file)).size} files`);
+console.log(`  wait named no recorder (a DOM node, a hook result, a test id): ${flags.length - strict.length}`);
+console.log('--- strict-shape sites (READ each one; this list is not a defect list) ---');
+for (const f of strict.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line)) {
+  console.log(`${f.file}:${f.line}  wait@${f.waitLine} waits [${f.waitSet.join(', ')}] reads ${f.recorder}`);
+}


### PR DESCRIPTION
Part of objectui#8690 — the audit it asks for. **Nine strict-shape sites read and classified: 1 repaired, 8 sound.** Every verdict is a measurement, not an inspection: for each site the unfavourable ordering was forced on disk and the outcome observed.

Base: `da5e4f69e` (the card's own base, so its line numbers land unchanged).

## The nine readings

| site (line on `da5e4f69e`) | shape | verdict | what makes it so |
|---|---|---|---|
| `app-shell/…/PermissionMatrixEditor.packageDoorFacets.test.tsx:241` (and `:191`, same construction) | waits `server.saved`, reads `server.savedOpts[0]` | **sound** | the two pushes are consecutive synchronous statements in one `save` double |
| `plugin-charts/src/ObjectChart.optionColors.test.tsx:285` | waits `host.calls`, reads `host.inits[0]` | **sound** | same construction, one fetch double |
| `plugin-dashboard/…/DatasetWidget.relabel.test.tsx:206` | waits `host.calls`, reads `host.inits[0]` | **sound** | same construction, one fetch double |
| `plugin-designer/…/MetadataObjectsPage.lookupKeying.test.tsx:380` | waits `puts`, reads the delete log — an **absence** | **REPAIRED** | the absence was dated to the FIRST write; a write after it is invisible |
| `plugin-list/…/ListView.objectProviderBinding-7477.test.tsx:161, :191, :231` | waits one renderer's props, asserts the other is empty — **absence** | **sound** | the anchor is post-settle: the view surface mounts only after `loading` flips false |
| `plugin-list/…/ListView.timeline-binding.test.tsx:82` | waits `findCalls`, reads `captured` | **sound** | `captured` is itself awaited two lines above; the detector only inspects the nearest wait |
| `plugin-tree/…/ObjectTree.settledSchemaKeying-6481.test.tsx:169` | waits `findCalls`, reads `schemaRequests` | **sound** | the request record is causally upstream of the query it gates |

## The one repair

`MetadataObjectsPage.lookupKeying` — the `constructor` round-trip case asserted "no delete was issued" right after `waitFor(puts.length === 1)`. That covers the delete scan only because the scan happens to run before the save loop in `handleObjectsChange` — a property of the page, not one the file asserts. The pin now waits for the manager to receive the re-read list (`reload()` is the handler's last statement) and reads the delete log after that. `label` and not `name`, because a rename leaves the name unchanged: only the relabelled row is a value the pre-reload state cannot answer with. This is the anchor C0/H1/H2 in the same file already use.

**Evidence (all three legs, from a committed tree, mutation proved on disk in both directions — anchor counts, `git hash-object` against the HEAD blob, and a line-total gate — restored by state with `git diff HEAD` empty):**

1. **Leg 1 — the defect the old pin cannot see.** Inject a stray `client.reset('object', 'ghost_mut8690')` at the end of `handleObjectsChange`, 50ms late (RTL's `asyncWrapper` drains one macrotask, so a 0ms deferral would sit inside its own window). Pre-repair pin: **PASSES**. The C0/H1/H2 cases in the same file, already anchored on the reload: **RED** (`expected [ 'contact', 'ghost_mut8690' ] to deeply equal [ 'contact' ]`).
2. **Leg 2 — the new pin under the same forced ordering: RED.** `expected [ 'ghost_mut8690', 'ghost_mut8690' ] to deeply equal []`.
3. **Leg 3 — the new pin under the ordinary ordering: green** (whole package, 182 tests with the audited files).

**The control that separates a strengthening from a relocation** (copied from PR #8689): under the identical mutation, the pre-repair pin restored from `da5e4f69e` passes. Provenance was checked by blob, not by eye — file on disk `76b074a1…`, `da5e4f69e` blob `76b074a1…`, shipped blob `53ea1edd…`, and zero occurrences of the anchor comment in the restored copy.

**And the reachable defect class is still caught:** breaking the delete scan itself so it misses every name reds the repaired pin (`expected [ 'constructor' ] to deeply equal []`). Nothing was traded away.

## Why the other eight were left alone

**The three `calls`/`inits`-shaped pairs (app-shell, charts, dashboard).** Both recorders are filled by one statement pair inside the same double, so no ordering exists in between — single-threaded, no interleaving point. Forced two ways:

- a **slow channel** — the realistic production-side hazard: the double's response deferred 50ms with the pushes left co-located. All 15 tests stay green. The ordering is not reachable from anything the component does.
- the **only** way to create it is to edit the double: split the pair with a 50ms gap and all four reads go RED (`expected undefined to match object { mode: 'draft', packageId: 'app.a' }`, and the same for both `inits[0]` reads). That is also the vacuity check the card warns about — these reads discriminate, they do not degrade to comparing undefined with undefined.

**`ListView.timeline-binding:82`.** The read's own recorder is awaited two lines above the flagged wait; the detector only looks at the nearest one. Measured: defer the spy's record by 50ms and the file stays green (17 passed) — the wait absorbs it; remove that wait under the same forced ordering and the read is `undefined` (`TypeError: Cannot read properties of undefined (reading 'schema')`). The guard is real and it is load-bearing.

**`ObjectTree.settledSchemaKeying-6481:169`.** A query for object X can only be issued after X's schema request was recorded — the record is the first statement of the getter whose promise gates the query. Defer that push by 50ms and the pin goes RED (`expected [] to deeply equal [ 'business_unit', 'territory' ]`), so it is non-vacuous and genuinely depends on the recorder being filled. The residual — a duplicate arriving after the read — was measured too, and it is **not** the detector's shape: a late duplicate is invisible on the WAITED recorder (`findCalls`, whose exact-equality assertion sits one line above) exactly as it is on the unwaited one. Rewriting the wait would change nothing.

**The three `objectProviderBinding-7477` absences.** These are the kind objectui#8664 solved for `ObjectTree.contractEnvelope-6839` by anchoring on the "No records" panel, which only renders after `loading` flips false. The anchor here already has that property, and it was measured rather than assumed: `ListView` renders `list-loading` while `loading && data.length === 0`, so the sibling renderer's first props arrive only after the load settles. Probe inserted at each of the three anchors — `kanbanProps[0].loading` / `gridProps[0].loading` — all `false`. The emptiness is therefore read on a settled render, not on an unrendered one.

Two forcing attempts, reported as measured:

- **VOID.** Applying the author's kind late (`currentView` starts `grid`, flips 50ms after the load settles) was intended to make the grid mount before the anchor. It never mounted at all — a diagnostic probe waiting up to 3s for `gridProps` timed out. The wrong kind is replaced before the surface is ever shown, so the leg did not produce the scenario and proves nothing about the pin. Reported VOID, not green.
- **The residual, landed.** A competing renderer forced to mount 50ms AFTER the settled one is invisible to the pin — the diagnostic probe confirms it really mounted, and the absence assertion passed anyway. In the shipped component that flip needs a user action on the view switcher, and sealing it would need a sleep in the test, which this repo's test discipline rules out. Recorded, not repaired.

## The detector

Kept as `scripts/census-recorder-wait-shape.mjs`, re-derived from the card's four-step description. **Not wired into CI, deliberately** — it answers where to look, never what is wrong, and a gate on this list would institutionalise the batch repair the card exists to prevent.

Its header records what it measured rather than quoting the card as reproduced. On `da5e4f69e`, 2776 tracked test files: `--recorder-match=ident` gives 159 flags / 15 strict in 10 files, `--recorder-match=path` gives 167 / 18 in 12. The card reported 160 / 9. One flag off the total, wider in the strict bucket, and the two modes' strict buckets do not contain each other — `ident` misses a wait written as a member of a host object, `path` misses a recorder pushed bare and read through one. The card's nine sit inside the union.

The repair also removes its own flag from the census: `MetadataObjectsPage.lookupKeying` no longer appears in the strict list.

## Scope

Test-only plus one repo script. `packages/fields` and `packages/permissions` are untouched (objectui#8434 and PR #8689 are live there). The 151 flags whose wait named no recorder were not re-litigated. The census sites outside the card's nine were **not** audited and **not** folded in — reported separately as a finding.

## Verification

- `pnpm exec vitest run` from the repo root with paths, per-test classification from the JSON reporter (`--reporter=json`), never the text one.
- Whole touched package plus the seven audited files: **182 passed, 0 failed**.
- `pnpm --filter @object-ui/plugin-designer type-check` green, with the dependency closure built first (an unbuilt tree reports TS2307 for every workspace import — a precondition, not a result). `tsc -p tsconfig.test.json --listFiles` confirms the edited file is in the checked set, so this is a measurement and not an empty pass.
- `node scripts/check-changeset-presence.mjs`, `check-changeset-no-major.mjs`, `check-control-bytes.mjs`, `eslint` on the new script: all green. The changeset declares an empty frontmatter — the real exemption; `skip-changeset` is a phantom label here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_