### PR TITLE
chore(scripts): record what the recorder-wait census's two matchers disagree about

### DIFF
--- a/.changeset/issue-8690-recorder-wait-audit.md
+++ b/.changeset/issue-8690-recorder-wait-audit.md
@@ -1,0 +1,9 @@
+---
+---
+
+Test-only (plugin-designer) plus one repo script. The `MetadataObjectsPage.lookupKeying`
+round-trip pin now reads its "no delete was issued" assertion after the page's
+`reload()` — the handler's last statement — instead of after the first PUT, so the
+emptiness is dated to the end of the write sequence rather than to its start. Adds
+`scripts/census-recorder-wait-shape.mjs`, the objectui#8690 corpus detector. No
+published behaviour changes.

--- a/.changeset/issue-8703-matcher-dependent-strict-bucket.md
+++ b/.changeset/issue-8703-matcher-dependent-strict-bucket.md
@@ -1,0 +1,10 @@
+---
+---
+
+Repo script only. `scripts/census-recorder-wait-shape.mjs` now records, in its header,
+what its two recorder-matching modes actually disagree about (objectui#8703): the modes
+are incomparable by construction, their strict buckets are nevertheless nested on the
+current tree, and two mode-independent rules — the forward window ending at the next
+`await` in the FILE, and every textual occurrence counting as a "read" — put seven
+non-reads in a strict bucket of eighteen. It also prints a caveat next to its own
+counts. No published behaviour changes.

--- a/packages/plugin-designer/src/MetadataObjectsPage.lookupKeying.test.tsx
+++ b/packages/plugin-designer/src/MetadataObjectsPage.lookupKeying.test.tsx
@@ -377,6 +377,18 @@ describe('objectui#6522 · SITE B — the raw-payload lookup keys every server o
     // the real payload rather than something off the prototype chain.
     expect(puts[0].body.pluralLabel).toBe('Constructors');
     expect(puts[0].body.fields).toBeDefined();
+    // COMPLETION ANCHOR (objectui#8690). The emptiness below is only worth
+    // reading once `handleObjectsChange` has run to the END: `reload()` is its
+    // last statement, so the manager receiving the re-read list is the signal
+    // that every write the handler was going to make has been made. Waiting on
+    // `puts` instead dates the absence to the FIRST write, which covers the
+    // delete scan only because that scan happens to run before the save loop —
+    // a property of the page, not one this file asserts. Measured: with a stray
+    // `reset` issued after the saves, the `puts` wait leaves the delete log
+    // green while C0/H1/H2 above — which already anchor on the reload — go red.
+    // `label` and not `name` because the name is unchanged by a rename: only
+    // the relabelled row is a value the pre-reload state cannot answer with.
+    await waitFor(() => expect(managerProps!.objects.map((o) => o.label)).toEqual(['Renamed']));
     expect(deletes).toEqual([]);
     expect(shownError()).toBeNull();
   });

--- a/scripts/census-recorder-wait-shape.mjs
+++ b/scripts/census-recorder-wait-shape.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Census: `await waitFor(...)` keyed on ONE recorder array, followed by a read
+ * of a DIFFERENT recorder array, with nothing establishing the second was
+ * filled. The shape objectui#8688 was one instance of; the corpus reading is
+ * objectui#8690, and this file is that card's detector, kept so the next person
+ * does not have to re-derive it.
+ *
+ * ⚠️ It answers WHERE TO LOOK, never WHAT IS WRONG. A flag is a site to read,
+ * not a defect: objectui#8690 read all nine of its strict-shape flags and found
+ * one worth repairing. ⛔ Never batch-repair a flag list.
+ *
+ * Algorithm (the card's four steps):
+ *   1. per file, recorders = every identifier that is the target of `.push(`
+ *   2. per `await waitFor(`, balance parens; recorders named inside = WAIT SET
+ *   3. scan forward to the next `await` (or EOF), collecting recorders READ
+ *      (a recorder's own `.push(` line does not count as a read)
+ *   4. flag any read of a recorder the wait did not name
+ *
+ * Two recorder-matching modes, because the choice moves the numbers:
+ *   --recorder-match=ident  bare identifiers (`calls`), receiver ignored
+ *   --recorder-match=path   dotted paths (`server.savedOpts`) — the default
+ *
+ * Measured on da5e4f69e, 2776 tracked `*.test.ts`/`*.test.tsx` files:
+ *   ident: 159 flags, 15 strict in 10 files
+ *   path : 167 flags, 18 strict in 12 files
+ * objectui#8690 reported 160 flags and 9 strict, so this re-derivation is one
+ * flag off its total and wider in the strict bucket — near enough to be the
+ * same instrument, ⛔ not near enough to quote its numbers as reproduced.
+ * The two modes' strict buckets differ and neither contains the other: `ident`
+ * misses a wait written `host.calls` (the receiver hides the recorder), `path`
+ * misses a recorder pushed as a bare `inits` and read as `host.inits[0]`.
+ * objectui#8690's nine sites are inside the UNION of the two, minus
+ * `packages/permissions` (which objectui#8688 / PR #8689 already hold).
+ *
+ * Usage: node scripts/census-recorder-wait-shape.mjs [--recorder-match=ident|path]
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const mode = (process.argv.find((a) => a.startsWith('--recorder-match=')) ?? '').split('=')[1] || 'path';
+if (!['ident', 'path'].includes(mode)) {
+  console.error(`unknown --recorder-match=${mode} (expected ident|path)`);
+  process.exit(2);
+}
+
+const files = execSync("git ls-files '*.test.ts' '*.test.tsx'", {
+  encoding: 'utf8',
+  maxBuffer: 64 * 1024 * 1024,
+}).split('\n').filter(Boolean);
+
+const PUSH = mode === 'ident'
+  ? /([A-Za-z_$][\w$]*)\s*\.push\s*\(/g
+  : /([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\.push\s*\(/g;
+const nameRe = (n) => new RegExp(`(?<![\\w$.])${n.replace(/\./g, '\\.')}(?![\\w$])`, 'g');
+const lineOf = (src, index) => src.slice(0, index).split('\n').length;
+
+const flags = [];
+for (const file of files) {
+  const src = readFileSync(file, 'utf8');
+  const recorders = new Set();
+  for (const m of src.matchAll(PUSH)) recorders.add(m[1]);
+  if (recorders.size === 0) continue;
+
+  for (const w of src.matchAll(/await\s+waitFor\s*\(/g)) {
+    // 2. balance parens to the end of the wait
+    const open = w.index + w[0].length - 1;
+    let depth = 0;
+    let end = -1;
+    for (let j = open; j < src.length; j++) {
+      if (src[j] === '(') depth++;
+      else if (src[j] === ')' && --depth === 0) { end = j; break; }
+    }
+    if (end < 0) continue;
+    const waitBody = src.slice(open, end + 1);
+    const waitSet = new Set([...recorders].filter((r) => nameRe(r).test(waitBody)));
+
+    // 3. forward window: end of the wait -> the next `await` (or EOF)
+    const rest = src.slice(end + 1);
+    const nextAwait = rest.search(/\bawait\b/);
+    const window = nextAwait === -1 ? rest : rest.slice(0, nextAwait);
+
+    for (const r of recorders) {
+      if (waitSet.has(r)) continue;
+      for (const hit of window.matchAll(nameRe(r))) {
+        if (/^\s*\.push\s*\(/.test(window.slice(hit.index + r.length))) continue;
+        flags.push({
+          file,
+          line: lineOf(src, end + 1 + hit.index),
+          waitLine: lineOf(src, w.index),
+          recorder: r,
+          waitSet: [...waitSet],
+        });
+        break; // one flag per (wait, recorder)
+      }
+    }
+  }
+}
+
+const strict = flags.filter((f) => f.waitSet.length > 0);
+console.log(`recorder-match: ${mode}`);
+console.log(`population:     ${files.length} test files`);
+console.log(`total flags:    ${flags.length}`);
+console.log(`  wait named a recorder (the strict shape): ${strict.length} in ${new Set(strict.map((f) => f.file)).size} files`);
+console.log(`  wait named no recorder (a DOM node, a hook result, a test id): ${flags.length - strict.length}`);
+console.log('--- strict-shape sites (READ each one; this list is not a defect list) ---');
+for (const f of strict.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line)) {
+  console.log(`${f.file}:${f.line}  wait@${f.waitLine} waits [${f.waitSet.join(', ')}] reads ${f.recorder}`);
+}

--- a/scripts/census-recorder-wait-shape.mjs
+++ b/scripts/census-recorder-wait-shape.mjs
@@ -27,10 +27,63 @@
  * objectui#8690 reported 160 flags and 9 strict, so this re-derivation is one
  * flag off its total and wider in the strict bucket — near enough to be the
  * same instrument, ⛔ not near enough to quote its numbers as reproduced.
- * The two modes' strict buckets differ and neither contains the other: `ident`
- * misses a wait written `host.calls` (the receiver hides the recorder), `path`
- * misses a recorder pushed as a bare `inits` and read as `host.inits[0]`.
- * objectui#8690's nine sites are inside the UNION of the two, minus
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT THE TWO MODES DISAGREE ABOUT — and why no count printed here is a
+ * corpus fact (objectui#8703). Every claim below was FORCED on constructed
+ * fixtures, not read off the regexes; the fixtures are in that card's PR.
+ * ---------------------------------------------------------------------------
+ *
+ * A recorder's identity is its SPELLING at the `.push(` site, matched
+ * textually at the read site by a name regex whose lookbehind forbids a
+ * preceding `.`. Three consequences, each measured:
+ *
+ *  1. The modes are INCOMPARABLE BY CONSTRUCTION — each sees a shape the
+ *     other cannot:
+ *       `path` only — pushed and read as the same member path
+ *          (`server.saved.push(x)` … `server.savedOpts[0]`).
+ *       `ident` only — pushed as a member, read under a bare alias
+ *          (`host.calls.push(x)`; `const { calls } = host` … `calls.length`).
+ *     ⛔ The first version of this header also said `path` misses a recorder
+ *     pushed bare and read as `host.inits[0]`. That is WRONG: the lookbehind
+ *     blocks a dotted read in BOTH modes, so that shape is a SHARED blind
+ *     spot, and no mode of this instrument can see it.
+ *  2. On THIS corpus the buckets are nevertheless NESTED: at da5e4f69e
+ *     ident's 15 ⊂ path's 18, and ident-only is EMPTY (the three extra are
+ *     the `server.saved` / `server.savedOpts` sites in app-shell). So "their
+ *     strict buckets do not contain each other" holds in principle and is
+ *     FALSE as a measurement of this tree — the union is just `path`'s bucket.
+ *  3. ⭐ The mode choice is NOT the largest source of movement. Two rules that
+ *     are identical in both modes dominate it:
+ *       D1  the forward window ends at the next textual `await` IN THE FILE,
+ *           not at the end of the enclosing test. A wait that is the last
+ *           `await` of its test gets a window that runs on into the NEXT test
+ *           — whose opening lines are exactly where recorders get declared.
+ *       D2  ANY textual occurrence counts as a "read"; only `X.push(` is
+ *           excluded. A declaration (`const blobs: Blob[] = []`), a
+ *           destructuring (`const { requested } = …`), a reset
+ *           (`gridSchemas.length = 0`), even a parameter named `log`, all
+ *           register as reads.
+ *     Measured: of the 18 strict flags at da5e4f69e, SEVEN point at something
+ *     that is not a read at all. objectui#8703 read all seven of the sites no
+ *     one had audited and repaired NONE — six were D1+D2 artefacts, and the
+ *     seventh (`PermissionMatrixEditor.scope.test.tsx:177`) was forced and
+ *     measured SOUND. The same truncation also LOSES real hazards: a genuine
+ *     cross-recorder read one `await` further on is flagged by neither mode.
+ *
+ * ⇒ ⛔ NO COUNT THIS SCRIPT PRINTS IS A CORPUS FACT. objectui#8690's 9, this
+ *   file's 15/18, and whatever a later run prints are all readings of
+ *   (matcher mode × window rule × occurrence class × tree), and about a third
+ *   of the strict bucket is not the shape it claims to be. Quote a number as
+ *   "sites this instrument points at", never as "sites of this shape".
+ *   A matcher that could be quoted would have to resolve recorder IDENTITY
+ *   (binding/alias resolution over an AST, not name spelling), scope the
+ *   window to the enclosing test body, and classify each occurrence as
+ *   read / write / declaration — i.e. stop being a regex census. That was out
+ *   of scope for objectui#8703. ⛔ Until it exists this file stays OUT of CI:
+ *   a matcher-dependent instrument must not become a gate.
+ *
+ * objectui#8690's nine sites are inside the UNION of the two modes, minus
  * `packages/permissions` (which objectui#8688 / PR #8689 already hold).
  *
  * Usage: node scripts/census-recorder-wait-shape.mjs [--recorder-match=ident|path]
@@ -103,6 +156,11 @@ console.log(`population:     ${files.length} test files`);
 console.log(`total flags:    ${flags.length}`);
 console.log(`  wait named a recorder (the strict shape): ${strict.length} in ${new Set(strict.map((f) => f.file)).size} files`);
 console.log(`  wait named no recorder (a DOM node, a hook result, a test id): ${flags.length - strict.length}`);
+console.log(
+  '⚠️  these counts are INSTRUMENT READINGS, not corpus facts — about a third\n' +
+  '    of the strict bucket is not a read at all. Read this file\'s header\n' +
+  '    (objectui#8703) before quoting any number below.',
+);
 console.log('--- strict-shape sites (READ each one; this list is not a defect list) ---');
 for (const f of strict.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line)) {
   console.log(`${f.file}:${f.line}  wait@${f.waitLine} waits [${f.waitSet.join(', ')}] reads ${f.recorder}`);


### PR DESCRIPTION
Fixes #8703

## ⚠️ Stacked on PR #8702 — please land that one first

`scripts/census-recorder-wait-shape.mjs` exists only on `claude/issue-8690-recorder-wait-audit`, whose PR #8702 is not merged. That branch is based on the same commit as this one (`da5e4f69e`), so this branch was fast-forwarded onto it rather than duplicating the file. Until #8702 lands, this PR's diff shows its three files too. **My own change is exactly two files**: `scripts/census-recorder-wait-shape.mjs` (header, plus one printed caveat) and `.changeset/issue-8703-matcher-dependent-strict-bucket.md`. Nothing else on this branch is mine, and the plugin-designer test change belongs to #8702's card.

## Deliverable A — seven readings, zero repairs

All seven sites re-located by content on `da5e4f69e` (the addresses held). **Six of them are not reads at all**, and the seventh was forced and measured sound.

| site | flagged line is | verdict |
|---|---|---|
| `form-onchange-wiring.test.tsx:207` | `const received: Record_[] = [];` | NOT A SITE — declaration in the next `it`; the wait's test closes at 203 |
| `DatasetWidget.localSelectI18n.test.tsx:356` | `const blobs: any[] = [];` | NOT A SITE — next `it`; block closes at 347 |
| `DatasetWidget.optionLabelI18n.test.tsx:313` | `const { requested } = installMetaRouter(...)` | NOT A SITE — a different `describe`; blocks close at 304/305 |
| `DatasetWidget.tableTotalsRow.test.tsx:319` | `const blobs: Blob[] = [];` | NOT A SITE — next `it`; block closes at 313 |
| `ObjectView.tableColumnsForwarding.test.tsx:136` | `const seen: any[] = [];` | NOT A SITE — a different helper; the wait's helper closes at 132 |
| `ObjectView.tableColumnsForwarding.test.tsx:149` | `gridSchemas.length = 0;` | NOT A SITE — a reset, in yet another helper |
| `PermissionMatrixEditor.scope.test.tsx:177` | `expect(server.savedOpts[0]).toMatchObject(...)` | **SOUND** — genuine read, forced |

For each of the six, the wait's enclosing `it` or helper closes before the flagged line and the flagged recorder is never mentioned inside the wait's own block — so there is no cross-recorder read in scope to repair. This is the objectui#8704 defect class, filed separately.

### The one genuine read, forced

`PermissionMatrixEditor.scope.test.tsx:177` waits `server.saved` and reads `server.savedOpts[0]`, the same construction as the two `packageDoorFacets` sites objectui#8690 measured sound. Both pushes are consecutive synchronous statements in one `save` double (lines 72-73, no `await` between), so no ordering can exist between them — but that is a reading, and the bar is a forcing.

**Leg 1 — split the co-located pair by 50ms** (`setTimeout(() => { server.savedOpts.push(opts); }, 50)`), mutation proven on disk in both directions (blob `d86134f3…` to `5ef3556d…` vs the HEAD blob, anchor counts 1→0 and 0→1, line-total gate 263 = 263), restored by state (`git diff HEAD` empty):

```
1 of 4 failed — "lists only the package objects, then merges the slice on save"
AssertionError: expected undefined to match object { mode: 'draft', packageId: 'app.a' }
  at .../PermissionMatrixEditor.scope.test.tsx:177:33
```

Exactly the flagged line, and only it; the three other tests and the `server.saved` reads above it stayed green. So the assertion is **live** — this is not "both are undefined and nobody notices" — and since the ordering it depends on cannot occur in the real double, the site is sound. **No repair, therefore no legs 2-4**: there is no new wait to check under the forced ordering and no pre-fix pin to restore from the base blob. Saying so is more honest than manufacturing them.

Baseline before the mutation: 4 of 4 passed. Per-test classification from vitest's JSON reporter in every leg.

## ⭐ Deliverable B — the disagreement, characterised

Recorded in the script header. Summary of what was **forced on fixtures** (a throwaway git repo, five files, run through the real script in both modes — never read off the regexes):

1. **Incomparable by construction, both directions demonstrated.** A recorder's identity is its spelling at the `.push(` site, matched textually at the read site by a name regex whose lookbehind forbids a preceding `.`.
   - `path` only: pushed and read as the same member path (fixture f1 — flagged by `path`, invisible to `ident`).
   - `ident` only: pushed as a member, read under a bare alias (fixture f2 — flagged by `ident`, invisible to `path`).
2. **On this corpus the buckets are nevertheless nested.** At `da5e4f69e`: `ident` 15 strict, `path` 18 strict, `ident` minus `path` = the empty set. The three extra are the app-shell `server.saved` / `server.savedOpts` sites. So "their strict buckets do not contain each other" is true in principle and **false as a measurement of this tree** — the union is just `path`'s bucket, and no third mode is needed to cover it.
3. **The header's stated `path` blind spot was wrong.** A recorder pushed bare and read as `host.inits[0]` is missed by **both** modes (fixture f3, zero flags in either) — the lookbehind blocks the dotted read regardless of mode. Shared blind spot, not a `path` one. Corrected in the header.
4. ⭐ **The mode choice is not the largest source of movement.** Two mode-independent rules dominate it — the forward window ending at the next `await` in the FILE rather than at the end of the enclosing test, and every textual occurrence counting as a read. **Seven of the eighteen strict flags at `da5e4f69e` point at a declaration, a destructuring, a reset or a function parameter.** Fixture f4 reproduces the class in isolation; fixture f5 shows the mirror loss — a genuine cross-recorder hazard one `await` further on draws **zero flags in both modes**.

**Reported outcome: the counts are not corpus facts.** objectui#8690's 9, this file's 15/18, and the 14/17 this branch prints (one site fewer, because #8702's own repair removed it) are all readings of (matcher mode × window rule × occurrence class × tree). The script now prints that caveat next to its own numbers, and the header says what a quotable matcher would have to do instead — resolve recorder identity over an AST, scope the window to the enclosing test body, classify occurrences as read/write/declaration. Writing it was out of scope; it is filed as objectui#8704. The fence stands: this instrument stays out of CI.

Reproduction of the base numbers: a detached comparison worktree at `da5e4f69e` prints 159/15 and 167/18, matching the header exactly; the only delta on this branch is #8702's repaired plugin-designer site.

## The card's second, unmeasured observation — measured

The `provider: 'value'` control in `ListView.objectProviderBinding-7477` was checked, since the card left that to its reader. A probe that starts a query 50ms after mount leaves **both** `find`-absence pins green (7 of 7 pass), while a temporary in-test diagnostic proves the deferred query really landed inside that same test — and the identical diagnostic fails with the probe removed, so it can fail. Green-while-meaningless against a deferred query, confirmed. Filed as objectui#8705, not folded in here: it is a mock-call absence, outside this detector's population.

## Fences honoured

- Not one of the ~151 non-recorder-wait flags was re-litigated.
- The detector is **not** wired into CI.
- objectui#8665's `contractEnvelope-6839` family: no overlap. Its `plugin-dashboard` file is `ObjectPivotTable`; mine were the three `DatasetWidget.*` tests, and **no test file was edited at all** — every test-tree mutation in this PR's evidence was an ablation, restored by state.

## Verification

- `node scripts/census-recorder-wait-shape.mjs` in both modes: byte-identical site lists before and after the header edit; behaviour unchanged.
- `pnpm exec eslint scripts/census-recorder-wait-shape.mjs` — clean.
- `node scripts/check-changeset-presence.mjs` — passes; `node scripts/check-changeset-no-major.mjs` — passes. The changeset has empty frontmatter (the real exemption; `skip-changeset` is a phantom label here).
- Control-character scan over the edited file: clean.
- No package source changed, so no package test suite is affected; the ablation legs above ran the two touched test files from the repo root with paths, and both trees were restored (`git diff HEAD` empty, verified by state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_