### PR TITLE
test(plugin-map,plugin-timeline): pin what these two contractEnvelope-6839 waits were standing on

### DIFF
--- a/.changeset/pin-unpinned-wait-preconditions-8709.md
+++ b/.changeset/pin-unpinned-wait-preconditions-8709.md
@@ -1,0 +1,10 @@
+---
+---
+
+Test-only (no release). `ObjectMap.contractEnvelope-6839` and
+`ObjectTimeline.contractEnvelope-6839` each waited on something that could not
+fail: the map's absence-shaped wait was satisfied by a mount that never showed
+the loading panel and by a `setData` that had not committed yet, and the
+timeline's `data-item-count` not-null clause was inert — `getByTestId` throwing
+was the whole gate, so `"0"` satisfied it. Both waits now observe the
+transition and gate on a settled row count. No package source changed.

--- a/packages/plugin-map/src/ObjectMap.contractEnvelope-6839.test.tsx
+++ b/packages/plugin-map/src/ObjectMap.contractEnvelope-6839.test.tsx
@@ -34,10 +34,30 @@
  * ⚠️ The refusal case is ALSO satisfied by an `extractRecords` that returns
  * `[]` for everything — an implementation strictly worse than the bug. The
  * `data` and bare-array cases refuse it: same rows, same mount.
+ *
+ * ## The two things this file's wait used to STAND ON without saying so (objectui#8709)
+ *
+ * This is the family's only ABSENCE-shaped wait, and an absence carries two
+ * unstated preconditions. Both are now assertions in `markersThrough`, and both
+ * were measured failing first:
+ *
+ *   1. **The panel was ever on screen.** An absence nothing entered is
+ *      satisfied by a mount that never started. With the component mutated to
+ *      `return null` unconditionally the refusal case PASSED — "render nothing,
+ *      ever" is strictly worse than the bug and cleared the old bar.
+ *   2. **`setData` and `setLoading(false)` commit TOGETHER.** The panel is a
+ *      settle signal, not a rows signal; it is only a usable proxy for "the
+ *      rows are on screen" because the two `setState` calls land in one commit.
+ *      With `setData` deferred by 50ms and the `records` arm restored to
+ *      `extractRecords`, the refusal case read zero markers and PASSED while
+ *      the settled map plotted two.
+ *
+ * ⭐ Neither gate subsumes the other: (1) alone still lets a split commit
+ * through, and (2) alone still passes a component that renders nothing.
  */
 
 import React from 'react';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { act, render, screen, waitFor, cleanup } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
 // The MapLibre canvas, replaced by DOM the test can count. Copied from
@@ -72,6 +92,17 @@ const schema: any = {
   data: { provider: 'object', object: 'store' },
 };
 
+/**
+ * The window held open AFTER the loading panel clears, to prove no markers
+ * arrive behind it.
+ *
+ * ⚠️ 50ms, not 0ms. RTL's `asyncWrapper` drains one macrotask before it
+ * returns, so a commit scheduled with `setTimeout(…, 0)` lands INSIDE that
+ * drain window — a 0ms window cannot tell a deferred commit from a
+ * same-commit one, and reports "stable" for both (measured on objectui#8664).
+ */
+const POST_SETTLE_MS = 50;
+
 /** How one case wraps its rows on the way back out of `find()`. */
 type Envelope = (rows: unknown[]) => unknown;
 
@@ -105,6 +136,17 @@ async function markersThrough(envelope: Envelope): Promise<number> {
     })),
   };
   render(<ObjectMap schema={schema} dataSource={ds} enableClustering={false} />);
+  // ① The transition's START, observed — the half an ABSENCE-shaped wait cannot
+  // supply for itself. "The panel has cleared" and "nothing was ever rendered"
+  // are the SAME DOM, so without this line the wait below is satisfied by a
+  // mount that never started. MEASURED, not argued: with `ObjectMap` mutated to
+  // `return null` unconditionally — an implementation strictly worse than the
+  // bug — the refusal case below still PASSED (objectui#8709 leg B). It does
+  // not survive this line.
+  expect(
+    screen.getByText('Loading map...'),
+    'the loading panel must be on screen BEFORE the absence wait — an absence nothing entered is satisfied by never having started',
+  ).toBeInTheDocument();
   await waitFor(() => expect(find).toHaveBeenCalled());
   // `find`'s OWN answer, settled — a pure read of the mock's call record that
   // touches no DOM. Without it "no markers" is satisfied by the mount's
@@ -114,7 +156,29 @@ async function markersThrough(envelope: Envelope): Promise<number> {
   // rather than a rows signal, which is exactly what makes it usable as the
   // one wait shared by the live cases and the refusal case.
   await waitFor(() => expect(screen.queryByText('Loading map...')).toBeNull());
-  return screen.queryAllByTestId('map-marker').length;
+  const atPanelClear = screen.queryAllByTestId('map-marker').length;
+  // ② The unstated precondition the line above STANDS ON, now pinned:
+  // `setData(capped.rows)` and `setLoading(false)` reach the DOM in ONE commit.
+  // React 18 batches them today because they sit in one `await` continuation —
+  // true, load-bearing, and asserted by nothing else in this repo. The day they
+  // split (a transition, an async boundary, a `startTransition`) the panel
+  // clears over an EMPTY `data` and the count read above is the INTERMEDIATE
+  // state. MEASURED: with `setData` deferred by 50ms and the `records` arm
+  // restored to `extractRecords`, the refusal case read zero markers and PASSED
+  // while the settled map plotted two — the bug went undetected (leg A).
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, POST_SETTLE_MS));
+  });
+  // A dependency landing mid-window (`objectSchema`, `perms`) re-runs the fetch
+  // effect and re-raises the panel, so re-settle before re-reading: the claim is
+  // about the SETTLED count, not about a moment inside a refetch.
+  await waitFor(() => expect(screen.queryByText('Loading map...')).toBeNull());
+  const settled = screen.queryAllByTestId('map-marker').length;
+  expect(
+    settled,
+    'markers must not arrive AFTER the loading panel clears — the count read at the transition must already be the settled one',
+  ).toBe(atPanelClear);
+  return settled;
 }
 
 afterEach(() => {

--- a/packages/plugin-timeline/src/ObjectTimeline.contractEnvelope-6839.test.tsx
+++ b/packages/plugin-timeline/src/ObjectTimeline.contractEnvelope-6839.test.tsx
@@ -32,10 +32,27 @@
  * The `data` and bare-array cases are the ones that refuse it: they push the
  * SAME rows through the SAME mount, so an arm that delivers nothing delivered
  * nothing because the envelope was refused.
+ *
+ * ## What this file's wait used to STAND ON without saying so (objectui#8709)
+ *
+ * The wait named `data-item-count` and did not gate on it. `getByTestId`
+ * THROWING inside `waitFor` was the entire gate; by the time the attribute was
+ * read the node existed and the renderer double writes the attribute
+ * unconditionally, so `.not.toBeNull()` could never be the clause that failed.
+ * ⭐ That is worse than no clause: it reads like a row-count gate and is a
+ * mount signal, satisfied the instant the renderer appears — `"0"` included.
+ *
+ * MEASURED, not argued: with `setFetchedData` deferred by 50ms and the
+ * `records` arm restored to `extractRecords`, the wait was satisfied at
+ * `data-item-count="0"` and the refusal case PASSED while the settled timeline
+ * drew two rows. `itemsThrough` now gates on the count the wait names AND on
+ * that count surviving a settle window, with the loading skeleton observed
+ * first so a renderer mounted empty on the first paint is not read as a
+ * settled zero.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, waitFor, cleanup, screen } from '@testing-library/react';
+import { act, render, waitFor, cleanup, screen } from '@testing-library/react';
 import React from 'react';
 
 // The timeline's own visualisation is orthogonal to what this file observes
@@ -55,6 +72,17 @@ const ROWS = [
   { id: 't2', subject: 'Ship it again', starts_at: '2026-01-02T09:00:00Z' },
 ];
 
+/**
+ * The window held open AFTER the renderer reports the expected count, to prove
+ * no further rows arrive behind it.
+ *
+ * ⚠️ 50ms, not 0ms. RTL's `asyncWrapper` drains one macrotask before it
+ * returns, so a commit scheduled with `setTimeout(…, 0)` lands INSIDE that
+ * drain window — a 0ms window cannot tell a deferred commit from a same-commit
+ * one, and reports "stable" for both (measured on objectui#8664).
+ */
+const POST_SETTLE_MS = 50;
+
 /** How one case wraps its rows on the way back out of `find()`. */
 type Envelope = (rows: unknown[]) => unknown;
 
@@ -69,8 +97,14 @@ const schema: any = {
   startDateField: 'starts_at',
 };
 
-/** Mount the timeline over a `find()` answering `envelope`, return rows drawn. */
-async function itemsThrough(envelope: Envelope): Promise<number> {
+/**
+ * Mount the timeline over a `find()` answering `envelope`, return rows drawn.
+ *
+ * `expectedItems` is the count this arm claims the envelope produces, and it is
+ * what the wait GATES on — see the comments in the body for why the count has
+ * to be named here rather than merely read at the end.
+ */
+async function itemsThrough(envelope: Envelope, expectedItems: number): Promise<number> {
   const ds: Record<string, any> = {
     find: vi.fn(async () => envelope(ROWS)),
     findOne: vi.fn(),
@@ -87,15 +121,56 @@ async function itemsThrough(envelope: Envelope): Promise<number> {
     })),
   };
   render(<ObjectTimeline schema={schema} dataSource={ds as any} />);
+  // ① The transition's START, observed. Without it a component that mounts the
+  // renderer EMPTY on its first paint and fetches afterwards clears every bar
+  // below on the refusal arm — `"0"`, stable, forever. The skeleton is the
+  // proof that this mount actually went through a loading phase.
+  //
+  // ⚠️ `toBeTruthy`, not `toBeInTheDocument`: this package's
+  // `tsconfig.test.json` does not name `@testing-library/jest-dom` in `types`
+  // (the sibling `plugin-map` one does), so that matcher is green under vitest
+  // and TS2339 under `tsc -p tsconfig.test.json`. `getByTestId` THROWING when
+  // the skeleton is absent is the assertion either way; the matcher only
+  // attaches the message.
+  expect(
+    screen.getByTestId('timeline-loading'),
+    'the loading skeleton must be on screen first — a renderer mounted empty from the first paint is not a settled zero',
+  ).toBeTruthy();
   await waitFor(() => expect(ds.find).toHaveBeenCalled());
   // `find`'s OWN answer, settled — a pure read of the mock's call record that
   // touches no DOM. Without it the assertion can be satisfied by the mount's
   // initial empty state, which every arm renders identically.
   await ds.find.mock.results[0].value;
+  // ② Gate on the count this wait NAMES, at the value this arm claims.
+  //
+  // The clause here used to be `.not.toBeNull()`, and it was INERT: the
+  // attribute is written unconditionally by the renderer double, so once
+  // `getByTestId` stops throwing the attribute is always a string. The THROW
+  // was the whole gate, which made this a bare mount signal wearing the
+  // vocabulary of a row count — `"0"` satisfied it, so an arm expecting rows
+  // and an arm expecting none waited on exactly the same event.
   await waitFor(() =>
-    expect(screen.getByTestId('timeline-renderer').getAttribute('data-item-count')).not.toBeNull(),
+    expect(
+      screen.getByTestId('timeline-renderer').getAttribute('data-item-count'),
+      'the renderer must report the row count this envelope produces, not merely exist',
+    ).toBe(String(expectedItems)),
   );
-  return Number(screen.getByTestId('timeline-renderer').getAttribute('data-item-count'));
+  // ③ … and it must STILL be that count after the settle window. This is the
+  // half ② cannot supply on the refusal arm, where the expected value is `"0"`
+  // and `"0"` is also what an unpopulated renderer reports. MEASURED: with
+  // `setFetchedData` deferred by 50ms and the `records` arm restored to
+  // `extractRecords`, the old wait was satisfied at `data-item-count="0"` and
+  // the refusal case PASSED while the settled timeline drew two rows
+  // (objectui#8709 leg A).
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, POST_SETTLE_MS));
+  });
+  const settled = screen.getByTestId('timeline-renderer').getAttribute('data-item-count');
+  expect(
+    settled,
+    'rows must not arrive AFTER the count was read — a count that moves in the settle window was an intermediate state',
+  ).toBe(String(expectedItems));
+  return Number(settled);
 }
 
 beforeEach(() => {
@@ -113,18 +188,18 @@ describe('ObjectTimeline — the find() envelope it reads (objectui#6839)', () =
     // (objectui#7802): it renders, and `waitFor` re-runs its callback on DOM
     // mutations, so the predicate feeds itself and leaks a container div per
     // run. The render happens once, out here, and the case reads its answer.
-    expect(await itemsThrough(asData), 'the declared rows member must still draw').toBe(2);
+    expect(await itemsThrough(asData, 2), 'the declared rows member must still draw').toBe(2);
   });
 
   it('still reads a bare array — the live non-envelope shape fakes answer with', async () => {
-    expect(await itemsThrough(asBareArray), 'the bare-array arm must still draw').toBe(2);
+    expect(await itemsThrough(asBareArray, 2), 'the bare-array arm must still draw').toBe(2);
   });
 
   it('does NOT read `records` — not a QueryResult member', async () => {
     // Before the fix these two rows drew off a key `QueryResult` does not
     // declare, and did so AHEAD of `data`.
     expect(
-      await itemsThrough(asRecords),
+      await itemsThrough(asRecords, 0),
       'a `records` envelope must reach the rail as zero rows, not as the rows it names',
     ).toBe(0);
   });


### PR DESCRIPTION
Fixes #8709

Test-only. No component changed. Final head `3df35c668`.

## Both diagnoses reproduced first — one of them needed a correction

The card asked me to re-derive at the component before repairing, because its parent card's list was half wrong. Both readings hold, and the timeline one holds **more narrowly** than stated.

**map — CONFIRMED, and worse than the card said.** The absence-shaped wait (`queryByText('Loading map...')` is null) is satisfied by a mount that never started. With `ObjectMap` mutated to return null unconditionally — "render nothing, ever", strictly worse than the bug — the refusal case still **passed**. And the panel is a settle signal, not a rows signal: it substitutes for "the rows are on screen" only because `setData(capped.rows)` and `setLoading(false)` sit in one `await` continuation and React 18 batches them. Nothing asserted that. With `setData` deferred by 50ms **and** the `records` arm restored to `extractRecords`, the refusal case read zero markers and **passed while the settled map plotted two** — the bug the file exists to catch went undetected.

**timeline — CONFIRMED in substance, CORRECTED in reach.** The `data-item-count` not-null clause is inert exactly as described: the renderer double writes the attribute unconditionally, so once `getByTestId` stops throwing the attribute is always a string, and the throw was the entire gate. Under the same deferral the wait was satisfied at `data-item-count="0"` while the settled timeline drew two rows. **But** the card's framing that this is a bare mount signal overshoots in one direction: `getByTestId` throwing *is* a real mount gate, so this pin does **not** pass "render nothing, ever" — under that mutation its refusal case went red pre-fix. Its exposure is narrower and specific: **mounted-but-not-yet-populated**, not never-rendered. The repair is aimed at that, and the mount-transition guard is added because a renderer mounted empty on the first paint would still slip through.

## What changed

`markersThrough` (map) — chose **both** options the card offered, because the legs show neither alone closes it:
1. asserts the loading panel is on screen **before** the absence wait (kills "never started" / "render nothing, ever");
2. reads the marker count at the transition, holds a 50ms settle window, and requires the count to be unchanged — which **pins the co-commit invariant** the card flagged as real and defended by nothing.

Gate 1 alone still lets a split commit through; gate 2 alone still passes a component that renders nothing. Measured, both directions, below.

`itemsThrough` (timeline) — gates on the count the wait **names**, at the value the arm claims, then requires that value to survive the same 50ms window, with the loading skeleton observed first. The inert clause is replaced rather than deleted, per the card.

50ms rather than 0ms: RTL's `asyncWrapper` drains one macrotask before returning, so a `setTimeout(..., 0)` commit hides inside the window meant to detect it.

## Evidence — refusal-arm classification, from vitest's JSON reporter

Read sites mutated, never a pin. `M1` = the `records` arm restored ahead of `data` in `extractRecords`; `M2` = the data commit deferred 50ms in the component; `M3` = the component returns null unconditionally.

| leg | pin | mutation | map refusal arm | timeline refusal arm |
|---|---|---|---|---|
| baseline | pre-fix | none | PASS | PASS |
| A | pre-fix | M1+M2 | **PASS** (bug undetected) | **PASS** (bug undetected) |
| B / G | pre-fix | M3 | **PASS** (bug undetected) | FAIL |
| clean | post-fix | none | PASS | PASS |
| C | post-fix | M1+M2 | **FAIL** | **FAIL** |
| D | post-fix | M3 | **FAIL** | FAIL |
| E | post-fix | M1 only | FAIL | FAIL |

Leg E is the no-regression leg: the plain bug, with commits still batched, is caught before and after — so this is a strengthening, not a relocation.

The failing assertions in leg C carry the reading themselves:

```
AssertionError: markers must not arrive AFTER the loading panel clears — the count
read at the transition must already be the settled one: expected 2 to be +0
AssertionError: rows must not arrive AFTER the count was read — a count that moves
in the settle window was an intermediate state: expected '2' to be '0'
```

`expected 2 to be 0` is the whole finding in one line: the old wait read 0 while the settled component held 2.

**Control (the PR #8702 shape).** Legs F and G restore the **pre-fix pin from the base blob** and run it under the identical mutation. Provenance by `git hash-object`, not by assertion:

```
packages/plugin-map/src/ObjectMap.contractEnvelope-6839.test.tsx
  base blob      : 829e417b5fb200705378cf7323d06f0b977e74e0
  on disk now    : 829e417b5fb200705378cf7323d06f0b977e74e0
  HEAD (post-fix): ea263b3e6e8313f0614358a7808d86a79f684d1e
packages/plugin-timeline/src/ObjectTimeline.contractEnvelope-6839.test.tsx
  base blob      : e5e244554e66ad1f7c3b7bfb2b72edba7351a151
  on disk now    : e5e244554e66ad1f7c3b7bfb2b72edba7351a151
  HEAD (post-fix): ec53eac846d208a209c05504fc553e7625aa0f45
```

Every ablation ran from a committed tree, proved its mutation on disk in both directions (anchor counts, `git hash-object` against the HEAD blob, and a line-total gate), and restored **by state** under an EXIT/INT/TERM trap with absolute paths — `git diff HEAD` empty and disk hash equal to the HEAD blob after each leg.

**Harness hazards the card warned about, both carried.** The `react-map-gl/maplibre` mock the pin owns is untouched, and every map measurement ran through the pin itself rather than a substitute. Container leakage was checked rather than assumed: three consecutive clean repetitions, all `2 / 2 / 0` — an accumulating count would have gone red on repetition two, since the pin asserts exact numbers.

## Checks run locally

- `vitest run` on both pin files, JSON reporter: 6/6 pass on the final head; stable over three repetitions.
- `pnpm --filter @object-ui/plugin-map --filter @object-ui/plugin-timeline run type-check`: both `Done`, with the dependency closure built first (`turbo run build --filter=@object-ui/plugin-map^... --filter=@object-ui/plugin-timeline^...`), so this is measured and not a TS2307 precondition failure. It found a real one: `toBeInTheDocument` is TS2339 in `plugin-timeline` because that package's `tsconfig.test.json` does not name `@testing-library/jest-dom` in `types` (the `plugin-map` one does). Swapped for `toBeTruthy` — `getByTestId` throwing is the assertion either way — and left a comment saying why. Reported as an out-of-scope finding.
- `eslint` on the two changed files: 0 errors, 9 warnings — identical to the count on the base blobs, so no new finding.
- `node scripts/check-changeset-presence.mjs`: green. Empty-frontmatter changeset, the real exemption; `skip-changeset` is a phantom label here and was not applied.

Repo-wide lint and the full suite are CI's, not narrowed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_