### PR TITLE
docs(core): drop the rendering claim `EXPANDABLE_FIELD_TYPES` docblock could not check, and correct its consumer list by four

### DIFF
--- a/.changeset/8693-expand-fields-rendering-claim.md
+++ b/.changeset/8693-expand-fields-rendering-claim.md
@@ -1,0 +1,12 @@
+---
+---
+
+Comment-only. `EXPANDABLE_FIELD_TYPES`' docblock in `@object-ui/core` claimed an
+unexpanded `user` id "renders as `—`". Measured false: `user` never drew the
+em-dash, and the three families that do draw it draw it only for opaque-id-shaped
+values. The rendering claim is dropped rather than corrected — it describes
+`@object-ui/fields`, which `@object-ui/core` does not depend on, so nothing that
+can reach this file can check it. The storage claim, which is what the set
+actually depends on, is kept. The consumer list is corrected by four
+(objectui#5874's own conversions were never added to it) and given a
+re-derivation recipe. No published behaviour changes.

--- a/packages/core/src/utils/expand-fields.ts
+++ b/packages/core/src/utils/expand-fields.ts
@@ -10,14 +10,52 @@ import { columnIdentity } from './column-identity.js';
 
 /**
  * Relational ("reference-bearing") field types whose stored value is a foreign
- * key into another object — and which therefore benefit from `$expand` so a
- * list / grid / detail cell can render the related record's display name
- * instead of a bare id placeholder ("—").
+ * key into another object — and which therefore benefit from `$expand`, so a
+ * response carries the related record instead of only its foreign key.
  *
  * `user` is a lookup specialised to `sys_user`: it carries the same `reference`
  * + id storage and the server resolves it through the same expand path as
  * `lookup` / `master_detail`, so a `user` column that is NOT requested for
- * expansion comes back as a raw user id and renders as "—" (objectui#2032).
+ * expansion comes back as a raw user id (objectui#2032). What a CELL then
+ * prints for that id is deliberately not stated here — see the next section.
+ *
+ * ## No rendering claim is made here, on purpose — objectui#8693
+ *
+ * Both paragraphs above used to make one: the `user` sentence ended "…and
+ * renders as '—'", and the opening one called the unexpanded cell "a bare id
+ * placeholder ('—')". Measured on `da5e4f69e` by resolving each family through
+ * `getCellRenderer` and rendering three unexpanded primitives:
+ *
+ * | unexpanded value     | `lookup` / `master_detail` / `tree` | `user`             |
+ * |----------------------|-------------------------------------|--------------------|
+ * | `'u_1'`              | `u_1`, plain truncated span         | `u_1`, same span   |
+ * | `'01HQZX9K2M4N6P8R'` | muted `—`                           | the raw ULID       |
+ * | `'Ada Lovelace'`     | `Ada Lovelace`, plain span          | the raw string     |
+ *
+ * Wrong twice over. `user` never drew the em-dash at all — `UserCellRenderer`
+ * has no resolver, no `useLookupName`, no `isLikelyOpaqueId`. And the three
+ * families that do draw it draw it ONLY for values `isLikelyOpaqueId` accepts;
+ * that qualifier is the entire content of the behaviour and the sentence never
+ * carried it, so a reader was told a human-readable id would degrade visibly
+ * when it printed as if it were a name — the defect objectui#8434 was for.
+ *
+ * It is not replaced by a corrected sentence, because a corrected sentence
+ * could not be kept true HERE. `@object-ui/core` does not depend on
+ * `@object-ui/fields` in `dependencies`, `peerDependencies` or
+ * `devDependencies` — the arrow runs the other way — so no test that can reach
+ * this file can render the cell it would describe, and nothing in this repo
+ * compares a docblock to rendered output. A replacement would be checked by
+ * whatever checked the last one: nobody. Its shelf life was measured too —
+ * while objectui#8693 was open, PR #8698 (objectui#8434) sat in the merge
+ * queue rewriting the `user` column of that very table: on its head
+ * `3692f7218` all three primitives render an unresolved-reference affordance
+ * that KEEPS the raw value. A corrected sentence would have been stale before
+ * it landed. The other three families are byte-identical on both trees.
+ *
+ * The storage claim is the half this set actually depends on, and that half IS
+ * checkable here (`__tests__/expand-fields.test.ts`, plus the identity pins
+ * below). How an unexpanded reference prints belongs next to the renderers in
+ * `@object-ui/fields`, where a test can fail.
  *
  * Note on `tree`: a self-referencing hierarchy field is a reference too, so it
  * belongs in this set; whether the backend materialises the expanded object
@@ -33,6 +71,12 @@ import { columnIdentity } from './column-identity.js';
  * claim to have converted "the LAST private copy" was false by two MORE — see
  * the falsification note at the end. Read the list below as the lineage of the
  * conversions, not as a census; the mechanical fact is the identity pins.
+ *
+ * Re-measured for objectui#8693 on `da5e4f69e`: stale again, by FOUR. The
+ * commit that corrected the "fourth and last" claim (objectui#5874 / #6064)
+ * converged four more private copies of its own and never added them here —
+ * the last four bullets below. Re-derive before trusting it; the recipe is at
+ * the end of the list.
  *
  * This is the reference-bearing FAMILY, not the `$expand` builder's private
  * list, and these concerns read it under several different words:
@@ -55,7 +99,33 @@ import { columnIdentity } from './column-identity.js';
  *  - the dashboard table's `$expand` whitelist — `computeLookupExpand` in
  *    `packages/plugin-dashboard/src/ObjectDataTable.tsx` (objectui#5692);
  *  - the dashboard's relation/link test — `isLookupType` in
- *    `packages/plugin-dashboard/src/recordFields.tsx` (objectui#5692).
+ *    `packages/plugin-dashboard/src/recordFields.tsx` (objectui#5692);
+ *  - the action-param RESOLVER (one step before `paramToField`) —
+ *    `packages/app-shell/src/utils/resolveActionParams.ts` (objectui#5874);
+ *  - the detail header's relation test — `HeaderHighlight.tsx` in
+ *    `packages/plugin-detail` (objectui#5874);
+ *  - the detail drawer's relation test — `RecordDetailDrawer.tsx` in
+ *    `packages/plugin-detail`, reading through `isExpandableFieldType`
+ *    (objectui#5874);
+ *  - the kanban board's `$expand` — `ObjectKanban.tsx` in
+ *    `packages/plugin-kanban`, reading through `buildExpandFields`
+ *    (objectui#5874).
+ *
+ * ⚠️ Re-derive rather than trust. One command, from the repo root, over the
+ * whole tree with NO pathspec. (Narrowing it to `packages/` + a `*` segment +
+ * `/src` matches ZERO files, and would drop `apps/` besides. The two-character
+ * sequence is spelled out in words here because writing it literally would end
+ * this comment.)
+ *
+ *     git grep -lE 'EXPANDABLE_FIELD_TYPES|isExpandableFieldType|buildExpandFields'
+ *
+ * 96 files on `da5e4f69e`. Drop tests, changesets and changelogs and the
+ * production readers fall into three radii, only the first of which the list
+ * above is about: this file plus 8 more naming the set directly, plus 4 more
+ * calling `isExpandableFieldType`, plus 13 more calling `buildExpandFields`.
+ * The sweep was controlled by planting a reader under `apps/console/src/` and
+ * confirming the same command found it — `apps/` holds no reader today, and a
+ * zero-hit region is otherwise indistinguishable from a blind spot.
  *
  * The third one used to be a second hand-maintained copy, and this comment used
  * to claim the set "mirrors the form layer's `DATA_SOURCE_FIELD_TYPES`


### PR DESCRIPTION
Fixes #8693

Comment-only. One file of published source in `@object-ui/core`, plus an empty-frontmatter changeset. No behaviour.

## The measurement (arm B was chosen because of it, not before it)

Four families x three unexpanded primitives, resolved through `getCellRenderer` and rendered, on `da5e4f69e`:

| unexpanded value | `lookup` / `master_detail` / `tree` | `user` |
|---|---|---|
| `'u_1'` | `u_1` — `span class="block max-w-full truncate"` | the same span, `u_1` |
| `'01HQZX9K2M4N6P8R'` | **muted em-dash** — the same span plus `text-muted-foreground` | the same span, the **raw ULID** |
| `'Ada Lovelace'` | `Ada Lovelace`, plain span | the same span, the raw string |

`isLikelyOpaqueId` measured alongside: `false` / `true` / `false` for the three values. `lookup`, `master_detail` and `tree` all resolve to `LookupCellRenderer`; `user` resolves to `UserCellRenderer`.

So the sentence was wrong twice over, and the second way is the one that matters:

- `user` never drew the em-dash at all. `UserCellRenderer` has no resolver — no `useLookupName`, no `isLikelyOpaqueId`.
- The three families that do draw it draw it **only** for values `isLikelyOpaqueId` accepts. That qualifier is the entire content of the behaviour, and the sentence never carried it. A reader was told a human-readable id would degrade visibly; it printed as if it were a name.

The opening paragraph carried the same claim in different words ("instead of a bare id placeholder") and is corrected with it — same defect, same docblock, one edit.

**The instrument was observed to move.** The same harness, same command shape, run against PR #8698's head `3692f7218`: the `user` row changes to a `data-slot="unresolved-reference"` affordance that keeps the raw value (all three primitives), and the other three families come back **byte-identical** to the table above. A table that changes in exactly one column when exactly one renderer changes is measuring the tree, not printing a constant.

## Premise check: PR #8698 has NOT landed

The dispatch said objectui#8434 / PR #8698 "has gone through the merge queue". Measured: `state: open`, `merged: false`, `merged_at: null`; timeline shows `added_to_merge_queue` at 2026-09-08T23:28:00Z with no removal and no merge. Content check agrees — `origin/main` at `da5e4f69e` contains no `8434` reference under the packages' sources, and `packages/fields`' newest commit is `da5e4f69e` itself.

It is **in** the queue, not **through** it. That does not change the ruling; it sharpens it. The table above is `main` today, and it is about to stop being `main`.

## Why B (drop the rendering claim), not A (correct it)

The brief asked, if arm A were taken, what would make the new sentence checkable. The answer is nothing, and it is mechanical rather than a matter of taste:

- `@object-ui/core`'s `package.json` lists `@object-ui/types`, `@objectstack/formula`, `@objectstack/spec` in `dependencies`; `peerDependencies` and `devDependencies` contain no `@object-ui/fields`. The arrow runs the other way: `@object-ui/fields` depends on `@object-ui/core`. **No test that can reach this file can render the cell a corrected sentence would describe.**
- Nothing in this repository compares docblock prose to rendered output. A replacement would be checked by whatever checked the last one.
- Its shelf life was measured, not guessed: PR #8698 is sitting in the queue rewriting the `user` column of that very table. A sentence written from the table above would have been stale before it landed.

So the rendering claim is dropped and the **storage** claim kept — the half the set actually depends on, and the half `__tests__/expand-fields.test.ts` and the identity pins can check. Where an unexpanded reference prints belongs next to the renderers in `@object-ui/fields`, where a test can fail. The docblock now says that in place of the claim, with the measurement, so the next reader inherits the evidence rather than the conclusion.

## The consumer list was stale by four — verified with a lit control

The docblock's enumeration of consumers is the argument for `user`'s membership, and it already carries two recorded falsifications of its own counts. It has a third.

Re-derived over the whole tree with **no pathspec**:

```
git grep -lE 'EXPANDABLE_FIELD_TYPES|isExpandableFieldType|buildExpandFields'
```

96 files on `da5e4f69e`. Dropping tests, changesets and changelogs, the production readers fall into three radii: **this file plus 8** naming the set directly, **plus 4** calling `isExpandableFieldType`, **plus 13** calling `buildExpandFields`.

**Four live readers were missing from the list**, and they share one cause: commit `7c96c9420` — *"converge four private copies of the reference-bearing field family, and correct the 'fourth and last' claim"* (objectui#5874 / #6064) — converged four more copies while correcting the previous count, and never added its own conversions here.

- `packages/app-shell/src/utils/resolveActionParams.ts` — reads the set directly
- `packages/plugin-detail/src/HeaderHighlight.tsx` — reads the set directly
- `packages/plugin-detail/src/RecordDetailDrawer.tsx` — through `isExpandableFieldType`
- `packages/plugin-kanban/src/ObjectKanban.tsx` — through `buildExpandFields`

All four are in the same commit, all four carry identity pins (`expandableFamily.identity-5874.test.*` in three packages). Added to the list in the same commit as the rendering fix — same defect class, same docblock, comment-only, no new verification surface.

**Lit control** (a zero-hit region is otherwise indistinguishable from a blind spot):

- *Population control*: `apps/` has 265 tracked files and **zero** hits for these names. The same no-pathspec command shape, run for a token known to live there (`createRoot`), fires on `apps/console/src/main.tsx` and four more. `apps/` is inside the swept population.
- *Planted-consumer control*: a file reading `EXPANDABLE_FIELD_TYPES` was written to `apps/console/src/`, the identical command re-run, and the delta was **exactly one file — the plant**. It was then removed and the sweep re-run: byte-identical to the pre-plant listing, no residue under `apps/`.
- The control script hard-fails if the baseline sweep returns zero files. That guard fired for real: the first run had its cwd outside the repo, every `git grep` failed, and the before/after comparison "passed" on `0 == 0`. The recorded reading is from the run after that was fixed.

## Other claims in the same docblock that nothing can check

Listed, not fixed — the list is the deliverable. Filed as objectui#8716 for triage.

1. **"the server resolves it through the same expand path as `lookup` / `master_detail`"** — a claim about objectql, a different repository. `expand-fields.test.ts` asserts what goes into `$expand`, never what a server does with it. Load-bearing in a way the removed sentence was not: it is the stated reason `user` is a member. Wants an anchor, probably not deletion.
2. **The `tree` note's "requesting it is harmless and forward-compatible"** — same cross-repo class, plus a prediction about servers that do not exist yet. It carries a membership decision.
3. **"That was true for 15 days."** — a hand-kept duration with no keeper. Weak, listed for completeness.
4. **The `object-ref` / `filter-condition` / `recipient-picker` exclusion** — nearly fine, and the contrast is instructive: it *is* anchored (`widgetHintOnly: true` in `app-shell/src/utils/paramValueShape.ts`, measured present). What is missing is only the reverse link.

## Verification

All at `1750d7710` unless stated. Verdict lines quoted from the tools, not from exit codes.

- `pnpm exec vitest run packages/core/` — `Test Files 132 passed (132)`, `Tests 2788 passed (2788)`.
- Identity pins across five packages, run as one invocation (app-shell, plugin-detail, plugin-kanban, plugin-dashboard, components, plugin-grid) — `Test Files 6 passed (6)`, `Tests 78 passed (78)`.
- `pnpm --filter @object-ui/core^... build` then `pnpm --filter @object-ui/core run type-check` — exit 0. The dependency closure was built first; an unbuilt tree would have reported `TS2307` for every workspace import.
- `node scripts/check-changeset-presence.mjs` — **before** the changeset: `1 source file(s) of 1 released package(s) changed, and this change adds no changeset`. **After**: `1 source file(s) ... declares 1 changeset(s) ... Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.` Its own verdict line, per the brief; the `skip-changeset` label is not used and reads nothing here.
- `node scripts/check-changeset-no-major.mjs` — `No changeset declares a major bump.`
- `pnpm check:control-bytes` — `OK (scanned 6882 tracked text file(s); skipped 85 binary)`. Additional sweep of the diff for control bytes outside the NUL class: zero hits.
- `pnpm check:comment-mask-corpus` — `1 file(s) disagree, within the residue objectui#7882 is holding open (ceiling: 1 file(s), 1517 over-masked bytes, 0 fabricated)`. Unchanged, and the one disagreeing file is not this one.
- `node scripts/check-governed-queue-guard.mjs --test packages/core/src/utils/expand-fields.ts` — `NOT GOVERNED`.
- ESLint: the whole of `@object-ui/core` via its own `lint` script with `--format json` — **231 files**, **0 errors**, 532 pre-existing warnings; the single warning in the edited file is `@typescript-eslint/no-explicit-any` at the `buildExpandFields` signature, untouched by this change. The narrowing to one package is safe to state rather than assume: `eslint.config.js` configures no `project`, `projectService` or `parserOptions`, so no type-aware rule exists and this diff cannot move the verdict on any file outside it.

### Reverse verification

`tsc` was proved to actually read this file, so the green type-check is a measurement:

- **Mutation leg.** The docblock now warns that writing a certain two-character sequence literally would end the comment. That warning was earned — the first draft of this edit contained it and would have shipped a syntax error. Re-injected deliberately: the anchor text count went 1 to 0 and the injected text count to 1 (proof it reached disk, not an editor exit code), the worktree blob hash diverged from the HEAD blob, and `type-check` went to **exit 2 with 132 `error TS` lines**, the first at `expand-fields.ts(115,65)` — the injection site.
- **Restore leg.** `git checkout HEAD -- packages/core/src/utils/expand-fields.ts`, pointed explicitly at `HEAD` rather than a bare checkout from the index. Restoration proved by content: the worktree blob hash is byte-identical to the HEAD blob, `git diff HEAD` is empty, and `type-check` is back to exit 0. The script carries a `trap ... EXIT INT TERM` with an absolute path, and it ran only after the work was committed — a restore against uncommitted edits would have deleted the change itself and left every check green.

### No pin was added, deliberately

This is a comment-only change; there is nothing to pin that would not be the same defect one level up. A test asserting "this docblock does not contain the string `renders as`" would be a pin over a claim nobody reads, and a test asserting what `UserCellRenderer` prints belongs in `@object-ui/fields` next to the renderer — where PR #8698 is already changing it, and where such a test can fail. The assertion that *was* observed to fail is the reverse verification above.

## In-flight neighbours checked

PR #8684 (`normalize-list-view.ts`) and PR #8656 (record-title tests) are both open on `packages/core`. Neither touches `expand-fields.ts` or `.changeset/8693-*`; no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_