### PR TITLE
test(types): re-test the 16 `@default` keys objectui#8318 called unread — seven are live

### DIFF
--- a/.changeset/jsdoc-default-renderer-retest-8318.md
+++ b/.changeset/jsdoc-default-renderer-retest-8318.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: extend the JSDoc `@default` ↔ renderer pin with the seven keys objectui#8318 re-measured as live. No published surface moves — no `@default` tag, type or runtime behaviour changes.

--- a/packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts
+++ b/packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts
@@ -398,3 +398,283 @@ describe('layout.ts `@default` docs agree with the renderer, re-measured (object
     });
   });
 });
+
+/**
+ * objectui#8318 rows — the seven keys the re-test found LIVE.
+ *
+ * ## Why these rows exist at all
+ *
+ * objectui#8318 classified 16 of objectui#7735's 41 de-defaulted keys as "no
+ * registered renderer reads the key at all", so that `@default` on them
+ * describes nothing that runs. Its exemplar was `CardSchema.variant`, measured
+ * as "both files registering `card` contain no read of `schema.variant`".
+ *
+ * That sentence is true and the conclusion does not follow. `SchemaRenderer`
+ * hands a node's REMAINING keys to the component as React props (the strip list
+ * is the destructure just above `...componentProps`), so a renderer can consume
+ * a key WITHOUT NAMING IT and a `schema.KEY` grep cannot see that channel —
+ * objectui#8410. The triage seat inverted the burden of proof and required a
+ * three-question re-test of all 16: (a) is the key among `SchemaRenderer`'s
+ * stripped metadata keys, (b) does the registering renderer destructure and
+ * forward the rest-spread, (c) does the primitive actually consume the prop.
+ *
+ * The re-test found the classification wrong for SEVEN keys, and the reason is
+ * duller than the spread channel: the original sweep looked only inside
+ * `packages/components/src/renderers/`. Every reader below is a DIRECT
+ * `schema.KEY` / `action.KEY` read, in a package that sweep never opened —
+ * `packages/plugin-detail`, `packages/runner`, `packages/core/src/actions`.
+ * Each one applies EXACTLY the value its `@default` publishes, which is why
+ * these are pinnable as agreement rows rather than corrections: nothing about
+ * the documentation moves, but from here CI notices if either side does.
+ *
+ *   | member                     | tag          | the reader, and what it applies         |
+ *   |----------------------------|--------------|-----------------------------------------|
+ *   | `ActionSchema.method`      | `'POST'`     | `ActionRunner.executeAPI`: `|| 'POST'`  |
+ *   | `ActionSchema.chainMode`   | `'sequential'`| `handlePostExecution`: `|| 'sequential'`|
+ *   | `ActionSchema.reload`      | `true`       | `executeActionSchema`: `!== false`      |
+ *   | `ActionSchema.close`       | `true`       | `executeActionSchema`: `!== false`      |
+ *   | `DetailSchema.showBack`    | `true`       | `DetailView`: `(schema.showBack ?? true)`|
+ *   | `DetailViewSchema.showBack`| `true`       | the same two read sites                 |
+ *   | `AppComponentSchema.layout`| `"sidebar"`  | `LayoutRenderer`: `app.layout \|\| 'sidebar'`|
+ *
+ * `DetailSchema.showBack` and `DetailViewSchema.showBack` share one reader
+ * because `plugin-detail` registers BOTH node types onto `DetailView`
+ * (`register('detail', DetailView)` and `register('detail-view',
+ * DetailViewRenderer)`, the latter a gate wrapper around the same component).
+ * That is the `FlexLayoutProps.align` shape from the top of this file with the
+ * sign flipped: two declarations, one consumer, and the two tags AGREE — so
+ * unlike `align` a single value IS right for both, and both rows are pinned to
+ * the same derivation. If the two node types ever diverge, this pin is what
+ * says so.
+ *
+ * ## What is deliberately NOT pinned here, and why
+ *
+ * `DetailSchema.loading` and `DetailViewSchema.loading` are ALSO live —
+ * `DetailView` reads `schema.loading` at the skeleton gate — but their tag says
+ * `true` while the read is a bare `||` disjunct, so an omitted key renders NO
+ * skeleton and the effective default is `false`. That is a genuine objectui#7735
+ * instance hiding inside the population objectui#8318 called referent-less, and
+ * it is the sharpest thing the re-test found. It is not pinned because BOTH
+ * possible fixes are somebody's ruling — correct the tag to `false`, or give the
+ * reader the `?? true` the tag promises (a behaviour change) — and a pin on
+ * either side of an open question pre-empts it. Pinning the tag as it stands
+ * would pin the defect; pinning the reader as it stands would redden the fix.
+ *
+ * The other nine keys stay unpinned for the opposite reason: the re-test could
+ * not find a reader for them, and "no reader" is the input to objectui#8318's
+ * own question 1 (is the tag wrong, or is the key dead?), which is order-locked
+ * behind this measurement and reserved to the maintainer. The absence of a
+ * `crud-dialog` renderer is already recorded on the tree — see the header of
+ * `handler-keys-string-any-mirrors-7344.test.ts` and `crud.zod.ts` — and is not
+ * duplicated here.
+ *
+ * ## Derivation
+ *
+ * Same two-sided rule as every row above: the reader's fallback is extracted
+ * from the reader's own source, the tag from the declaring `.ts`, and the two
+ * are compared. Two extractions here are NEGATION-shaped (`x !== false`), where
+ * the applied default is the negation of the compared literal rather than the
+ * literal itself; the helper below does that conversion in one place so the row
+ * assertions stay readable. Two others match in more than one place, and the
+ * pin requires every site to agree — a fallback that disagrees with itself is
+ * not a fallback, and `@default` would have no single referent to describe.
+ *
+ * Quote style differs between the declaring files (`'POST'` vs `"sidebar"`), so
+ * the comparison strips the outer quotes. Quoting is not the contract; the
+ * value is. Exactly-one-tag is asserted separately, so a second tag cannot hide.
+ */
+const CRUD = 'packages/types/src/crud.ts';
+const VIEWS = 'packages/types/src/views.ts';
+const APP = 'packages/types/src/app.ts';
+const ACTION_RUNNER = 'packages/core/src/actions/ActionRunner.ts';
+const DETAIL_VIEW = 'packages/plugin-detail/src/DetailView.tsx';
+const PLUGIN_DETAIL_INDEX = 'packages/plugin-detail/src/index.tsx';
+const LAYOUT_RENDERER = 'packages/runner/src/LayoutRenderer.tsx';
+
+/** `action.method || 'POST'` — both branches of `executeAPI`. */
+const ACTION_METHOD = /action\.method \|\| '([^']+)'/g;
+/** `action.chainMode || 'sequential'` — the chain dispatch. */
+const ACTION_CHAIN_MODE = /action\.chainMode \|\| '([^']+)'/g;
+/** `result.reload = action.reload !== false` — a NEGATION-shaped default. */
+const ACTION_RELOAD = /result\.reload = action\.reload !== (true|false);/g;
+/** `result.close = action.close !== false` — the same shape. */
+const ACTION_CLOSE = /result\.close = action\.close !== (true|false);/g;
+/** `(schema.showBack ?? true)` — both read sites in `DetailView`. */
+const DETAIL_SHOW_BACK = /\(schema\.showBack \?\? (true|false)\)/g;
+/** `app.layout || 'sidebar'` — the app-shell layout selector. */
+const APP_LAYOUT = /app\.layout \|\| '([^']+)'/g;
+
+/**
+ * Every capture of `re` in `src`, asserted non-empty and unanimous.
+ *
+ * The non-empty half is the positive control this file requires of every
+ * extraction: a regex that quietly stopped matching would make its row
+ * vacuously true. The unanimity half is a claim about the code — where a
+ * fallback is written more than once, all of its spellings must agree, or
+ * "the value the renderer applies" is not a single value for `@default` to
+ * describe.
+ */
+function soleCapture(src: string, re: RegExp, where: string): string {
+  const found = [...src.matchAll(new RegExp(re.source, 'g'))].map((m) => m[1]);
+  expect(found.length, `no match for ${re.source} in ${where}`).toBeGreaterThan(0);
+  expect(new Set(found).size, `${re.source} disagrees with itself in ${where}: ${found.join(', ')}`).toBe(1);
+  return found[0];
+}
+
+/** The default a `x !== <literal>` read applies when the key is absent. */
+const negationDefault = (compared: string): string => String(compared === 'false');
+
+/** A `@default` tag's value with any outer quoting removed. */
+const unquote = (tag: string): string => tag.replace(/^['"]|['"]$/g, '');
+
+/** The single `@default` a member publishes, unquoted. */
+function soleDefaultTag(body: string, member: string): string {
+  const tags = defaultTags(docblockFor(body, member));
+  expect(tags, `${member} should publish exactly one @default`).toHaveLength(1);
+  return unquote(tags[0]);
+}
+
+describe('objectui#8318 — the `@default`s the "no renderer reads it" list got wrong', () => {
+  const crud = read(CRUD);
+  const views = read(VIEWS);
+  const app = read(APP);
+
+  describe('positive controls — every extraction still matches, and each reader is still wired', () => {
+    it('each reader still writes the shape its row is derived from', () => {
+      const runner = read(ACTION_RUNNER);
+      expect(soleCapture(runner, ACTION_METHOD, ACTION_RUNNER)).toBeTruthy();
+      expect(soleCapture(runner, ACTION_CHAIN_MODE, ACTION_RUNNER)).toBeTruthy();
+      expect(soleCapture(runner, ACTION_RELOAD, ACTION_RUNNER)).toBeTruthy();
+      expect(soleCapture(runner, ACTION_CLOSE, ACTION_RUNNER)).toBeTruthy();
+      expect(soleCapture(read(DETAIL_VIEW), DETAIL_SHOW_BACK, DETAIL_VIEW)).toBeTruthy();
+      expect(soleCapture(read(LAYOUT_RENDERER), APP_LAYOUT, LAYOUT_RENDERER)).toBeTruthy();
+    });
+
+    it('each member is still declared where this file looks for it', () => {
+      expect(() => docblockFor(interfaceBody(crud, 'ActionSchema'), 'method')).not.toThrow();
+      expect(() => docblockFor(interfaceBody(crud, 'ActionSchema'), 'chainMode')).not.toThrow();
+      expect(() => docblockFor(interfaceBody(crud, 'ActionSchema'), 'reload')).not.toThrow();
+      expect(() => docblockFor(interfaceBody(crud, 'ActionSchema'), 'close')).not.toThrow();
+      expect(() => docblockFor(interfaceBody(crud, 'DetailSchema'), 'showBack')).not.toThrow();
+      expect(() => docblockFor(interfaceBody(views, 'DetailViewSchema'), 'showBack')).not.toThrow();
+      expect(() => docblockFor(interfaceBody(app, 'AppComponentSchema'), 'layout')).not.toThrow();
+    });
+
+    /**
+     * The row-8/9 rows are only about ONE reader because both node types are
+     * registered onto it. If that ever stops being true the two `showBack`
+     * declarations acquire separate consumers and the rows below stop being
+     * derivable from a single file.
+     */
+    it('`detail` and `detail-view` both still resolve to `DetailView`', () => {
+      const index = read(PLUGIN_DETAIL_INDEX);
+      expect(index).toContain("ComponentRegistry.register('detail', DetailView");
+      expect(index).toContain("ComponentRegistry.register('detail-view', DetailViewRenderer");
+      expect(read(PLUGIN_DETAIL_INDEX)).toMatch(/<DetailView schema=\{bound as DetailViewSchema\}/);
+    });
+  });
+
+  describe('row 8 — ActionSchema.method', () => {
+    it("publishes the verb `executeAPI` falls back to", () => {
+      const applied = soleCapture(read(ACTION_RUNNER), ACTION_METHOD, ACTION_RUNNER);
+      expect(soleDefaultTag(interfaceBody(crud, 'ActionSchema'), 'method')).toBe(applied);
+    });
+
+    it('the fallback is a member of the union the type declares', () => {
+      const applied = soleCapture(read(ACTION_RUNNER), ACTION_METHOD, ACTION_RUNNER);
+      expect(interfaceBody(crud, 'ActionSchema')).toContain(`'${applied}'`);
+    });
+  });
+
+  describe('row 9 — ActionSchema.chainMode', () => {
+    it('publishes the mode the chain dispatch falls back to', () => {
+      const applied = soleCapture(read(ACTION_RUNNER), ACTION_CHAIN_MODE, ACTION_RUNNER);
+      expect(soleDefaultTag(interfaceBody(crud, 'ActionSchema'), 'chainMode')).toBe(applied);
+    });
+
+    it('the fallback is a member of the union `ActionExecutionMode` declares', () => {
+      const applied = soleCapture(read(ACTION_RUNNER), ACTION_CHAIN_MODE, ACTION_RUNNER);
+      expect(crud).toMatch(new RegExp(`export type ActionExecutionMode[^;]*'${applied}'`));
+    });
+  });
+
+  describe('row 10 — ActionSchema.reload (a negation-shaped default)', () => {
+    it('publishes what `action.reload !== false` yields on absence', () => {
+      const compared = soleCapture(read(ACTION_RUNNER), ACTION_RELOAD, ACTION_RUNNER);
+      expect(soleDefaultTag(interfaceBody(crud, 'ActionSchema'), 'reload')).toBe(negationDefault(compared));
+    });
+
+    /**
+     * The discrimination control for the negation shape. `!== false` and
+     * `!== true` are one character apart and mean opposite things, so the row
+     * above is only a measurement if the helper really distinguishes them.
+     */
+    it('the helper reads the negation in the right direction', () => {
+      expect(negationDefault('false')).toBe('true');
+      expect(negationDefault('true')).toBe('false');
+    });
+  });
+
+  describe('row 11 — ActionSchema.close (the same shape)', () => {
+    it('publishes what `action.close !== false` yields on absence', () => {
+      const compared = soleCapture(read(ACTION_RUNNER), ACTION_CLOSE, ACTION_RUNNER);
+      expect(soleDefaultTag(interfaceBody(crud, 'ActionSchema'), 'close')).toBe(negationDefault(compared));
+    });
+
+    /**
+     * `reload` and `close` are read a second time, TOGETHER, by the
+     * executability guard just above the result assembly — an action that
+     * declares neither a handler nor an api is refused rather than reported as
+     * a silent success. That read is why an EXPLICIT `true` is not redundant
+     * with the default, and it is the reason both keys are live rather than
+     * merely present.
+     */
+    it('both keys are also read by the executability guard', () => {
+      expect(read(ACTION_RUNNER)).toMatch(/action\.reload === true \|\| action\.close === true/);
+    });
+  });
+
+  describe('rows 12-13 — DetailSchema.showBack and DetailViewSchema.showBack (two declarations, one reader)', () => {
+    it('DetailSchema.showBack publishes what `DetailView` applies', () => {
+      const applied = soleCapture(read(DETAIL_VIEW), DETAIL_SHOW_BACK, DETAIL_VIEW);
+      expect(soleDefaultTag(interfaceBody(crud, 'DetailSchema'), 'showBack')).toBe(applied);
+    });
+
+    it('DetailViewSchema.showBack publishes the same value', () => {
+      const applied = soleCapture(read(DETAIL_VIEW), DETAIL_SHOW_BACK, DETAIL_VIEW);
+      expect(soleDefaultTag(interfaceBody(views, 'DetailViewSchema'), 'showBack')).toBe(applied);
+    });
+
+    /**
+     * The load-bearing half: the two declarations must keep AGREEING, because
+     * they are consumed by one component. `FlexLayoutProps.align` is what
+     * happens when that stops being true and a single tag is kept anyway.
+     */
+    it('the two declarations agree with each other', () => {
+      expect(soleDefaultTag(interfaceBody(crud, 'DetailSchema'), 'showBack'))
+        .toBe(soleDefaultTag(interfaceBody(views, 'DetailViewSchema'), 'showBack'));
+    });
+  });
+
+  describe('row 14 — AppComponentSchema.layout', () => {
+    it('publishes the strategy `LayoutRenderer` falls back to', () => {
+      const applied = soleCapture(read(LAYOUT_RENDERER), APP_LAYOUT, LAYOUT_RENDERER);
+      expect(soleDefaultTag(interfaceBody(app, 'AppComponentSchema'), 'layout')).toBe(applied);
+    });
+
+    it('the fallback is a member of the union the type declares', () => {
+      const applied = soleCapture(read(LAYOUT_RENDERER), APP_LAYOUT, LAYOUT_RENDERER);
+      expect(interfaceBody(app, 'AppComponentSchema')).toContain(`'${applied}'`);
+    });
+
+    /**
+     * The reader is typed by the declaration it describes, which is what makes
+     * it the right authority for this tag rather than a look-alike `layout` on
+     * some other schema (`DetailViewSchema.layout` and `ObjectForm`'s both
+     * exist and mean something else).
+     */
+    it('the reader is typed by AppComponentSchema, not a look-alike', () => {
+      expect(read(LAYOUT_RENDERER)).toMatch(/app:\s*AppComponentSchema/);
+    });
+  });
+});


### PR DESCRIPTION
Part of #8318

Draft. The primary deliverable of this card is the **re-test**, posted in full as a comment on #8318. This PR carries only what the re-test made pinnable. ⛔ No `@default` tag is edited or deleted, no type moves, no runtime behaviour changes — triage's ordering forbids acting on the classification until the re-test is complete, and its question 1 is reserved to the maintainer.

## ⚠️ Re-grade trigger — SEVEN of the 16 are live, and the classification is wrong

#8318 lists 16 keys as "no registered renderer reads the key at all", so that their published `@default` describes nothing that runs. The three-question re-test triage required — (a) stripped by `SchemaRenderer`? (b) rest-spread destructured and forwarded? (c) primitive consumes it? — finds **seven of the 16 are read**, each by a direct `schema.KEY` / `action.KEY` read:

| member | tag | reader | applies |
|---|---|---|---|
| `ActionSchema.method` | `'POST'` | `packages/core/src/actions/ActionRunner.ts:1787,1793` | `action.method \|\| 'POST'` |
| `ActionSchema.chainMode` | `'sequential'` | `ActionRunner.ts:1226` | `action.chainMode \|\| 'sequential'` |
| `ActionSchema.reload` | `true` | `ActionRunner.ts:1618` (+ guard `:1597`) | `action.reload !== false` |
| `ActionSchema.close` | `true` | `ActionRunner.ts:1619` (+ guard `:1597`) | `action.close !== false` |
| `DetailSchema.showBack` | `true` | `packages/plugin-detail/src/DetailView.tsx:1009,1028` | `(schema.showBack ?? true)` |
| `DetailViewSchema.showBack` | `true` | the same two sites | `(schema.showBack ?? true)` |
| `AppComponentSchema.layout` | `"sidebar"` | `packages/runner/src/LayoutRenderer.tsx:124` | `app.layout \|\| 'sidebar'` |

Every one of these tags is **correct**. The card's error is duller than the spread channel that triage suspected: its sweep looked only inside `packages/components/src/renderers/`, and every reader above lives in a package it never opened — `packages/plugin-detail`, `packages/runner`, `packages/core/src/actions`.

⚠️ Two more are live with a **wrong** tag: `DetailSchema.loading` and `DetailViewSchema.loading` are read at `DetailView.tsx:992` as `if (loading || schema.loading)`, a bare disjunct — an omitted key renders **no** skeleton, so the effective default is `false` while the tag says `true`. That is a genuine #7735 instance hiding inside the population the card called referent-less. It is reported, ⛔ not fixed and ⛔ not pinned here: both candidate fixes (correct the tag, or give the reader the `?? true` it promises) are somebody's ruling, and a pin on either side pre-empts it.

The remaining seven of the 16 had no reader the re-test could find. That is the input to the card's question 1, which is order-locked behind this measurement and ⛔ not answered here.

## What this PR changes

One test file plus one changeset. `packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts` grows from 8 pinned rows to 15, in its existing row-by-row style, both sides derived off disk so a row reddens if **either** the reader's fallback or the tag moves. Two extractions are negation-shaped (`x !== false`, where the applied default is the negation of the compared literal); two match at more than one site and the pin requires the sites to agree, because a fallback that disagrees with itself has no single value for `@default` to describe.

⛔ No general instrument was built — triage's ruling, and the shapes here confirm it: two of the seven are negation reads and one resolves through a second package's registration.

## Ablations — every new row reddened, then restored

Each leg mutated the reader on disk, proved the bytes landed with a before/after `grep -c` on both the removed and injected anchors, ran the suite, restored with `git checkout HEAD -- path`, and proved the restore by comparing `git hash-object` against the HEAD blob **and** requiring `git diff HEAD` to be empty. A `trap ... EXIT INT TERM` covered the crash path. Baseline: `Tests 49 passed (49)`.

| ablation | mutation | result |
|---|---|---|
| row 8 | `action.method \|\| 'POST'` → `'PUT'` (x2) | exit 1 — `1 failed \| 48 passed`, row 8 |
| row 9 | `action.chainMode \|\| 'sequential'` → `'parallel'` | exit 1 — `1 failed \| 48 passed`, row 9 |
| row 10 | `result.reload = action.reload !== false;` → `!== true;` | exit 1 — `1 failed \| 48 passed`, row 10 |
| row 11 | `result.close = action.close !== false;` → `!== true;` | exit 1 — `1 failed \| 48 passed`, row 11 |
| rows 12-13 | `(schema.showBack ?? true)` → `?? false` (x2) | exit 1 — `2 failed \| 47 passed`, both rows |
| row 14 | `app.layout \|\| 'sidebar'` → `'header'` | exit 1 — `1 failed \| 48 passed`, row 14 |
| negative control | `schema.justify \|\| 'start'` → `'end'` in `flex.tsx` | exit 1 — the pre-existing `FlexLayoutProps.justify` control fires |

The last leg is there because "the negative controls must keep firing" is a claim that has to be measured, not asserted: it shows the load-bearing control is still capable of failing rather than merely still green.

## Gates, each with its exit code

| gate | exit | note |
|---|---|---|
| `pnpm exec vitest run packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts` | 0 | `Test Files 1 passed`, `Tests 49 passed (49)` |
| `pnpm exec vitest run packages/types/` | 0 | `Test Files 152 passed`, `Tests 2920 passed (2920)` |
| `pnpm --filter @object-ui/types type-check` | 0 | runs `tsc -p tsconfig.test.json`; verified the new file is in that project with `--listFiles` (1 hit; control `renderers/layout/card.tsx` 0 hits) |
| `pnpm --filter @object-ui/types lint` | 0 | `266 problems (0 errors, 266 warnings)`, all pre-existing `no-explicit-any` |
| `node scripts/check-changeset-presence.mjs` | 0 | empty-frontmatter changeset accepted as the explicit no-release declaration |
| `pnpm check:control-bytes` | 0 | 6881 tracked text files; plus a direct `grep -naP` control-byte scan of both changed files (no match) |
| `pnpm check:handler-key-reads` | 0 | corroborates the `crud-dialog` half: run as a tree reader, not because the diff touches it |
| `pnpm check` | 1, **NOT MEASURED** | `MODULE_NOT_FOUND` on `packages/cli/dist/cli.js` — the CLI is unbuilt. This is the published app-validator command for user projects, not a repo gate, and it appears in no workflow. Not a failure reading. |

All the green gates above are per-PR CI checks in this repo (`ci.yml`, `lint.yml`, `control-bytes.yml`, `changeset-presence.yml`, all on `pull_request`).

## NOT MEASURED

- **(c) for `CardSchema.variant` beyond the DOM boundary.** Measured: `variant` is not stripped, `card.tsx:26-33` destructures and `:46` forwards it, and `packages/components/src/ui/card.tsx` contains **zero** occurrences of `variant` (control: the same grep finds 5 in `ui/alert.tsx`) — `Card` destructures only `className` and spreads the rest onto a `div`. ⛔ Not measured: what a browser does with the resulting unknown DOM attribute. No test was rendered.
- **Runtime confirmation of the seven live rows.** Every reading is static, off the source. No action was executed and no `DetailView` was mounted.
- **The reachability of `ActionSchema` (as opposed to `ActionDef`) at `ActionRunner`.** The keys are name- and type-identical and `packages/core/src/actions/actionKeys.ts` records that stored metadata reaches `runner.execute()` unparsed, but that path was ⛔ not exercised here.
- **Whether the seven unread keys are dead or merely mis-tagged.** That is the card's question 1 and it is not this PR's to answer.
- **CI convergence.** Reported at draft-PR time.

## 维护者速读(草稿)

**改了什么** — 只加了一个测试文件的 7 行 pin 和一个空 changeset。没有改任何 `@default` 标签、类型或运行时行为。

**为什么改** — #8318 说有 16 个键「没有任何注册渲染器读它」,所以它们发布的 `@default` 描述的东西不存在。重测发现其中 **7 个其实被读**,而且读的正是标签写的那个值;另外 2 个也被读,但标签是错的。原来那次普查只扫了 `packages/components/src/renderers/`,漏掉了 `plugin-detail` / `runner` / `core/actions` 三个包。

**风险与代价** — 近乎为零:只加测试。回滚就是 revert 这一个 commit。代价是这 7 行 pin 从此会因为读侧或标签任一侧移动而变红 —— 那正是它存在的理由。

**席位意见** — (待评审填写)

**你要做的** — 决定 #8318 的定级(重测证伪了它的核心分类,派发席说这触发 p1),以及 `DetailSchema.loading` / `DetailViewSchema.loading` 那两个错标签怎么修(改标签为 `false`,还是给读侧补上 `?? true` 这个行为变更)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_