### PR TITLE
fix(sdui-parser): retire the `binding: 'field'` arm on both manifest faces (objectui#8315)

### DIFF
--- a/.changeset/8315-sdui-parser-manifest-binding-field-retired.md
+++ b/.changeset/8315-sdui-parser-manifest-binding-field-retired.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/sdui-parser': minor
+---
+
+Retire the `binding: 'field'` arm on the manifest READER and PRODUCER faces, so
+`@object-ui/sdui-parser` states one vocabulary instead of two (objectui#8315).
+
+The 2026-09-07 maintainer ruling on objectui#6950 (director decision batch #69)
+retired the zero-writer `'field'` arm under ADR-0049 enforce-or-remove, naming
+**one** coordinate: `RegistryConfigLike.inputs[].binding`, the serializer's input
+boundary, which PR #8297 narrowed. Two declarations in `types.ts` kept the arm, so
+the published package narrowed on one face and stayed wide on the other:
+
+- `ManifestInput.binding` — now `'object'`
+- `ManifestValidationResult.bindings[].kind` — now `'object'`
+
+**Breaking for TypeScript consumers, deliberately, and compile-time only.** A
+hand-written `Manifest` literal or a `bindings[]` entry that spells `'field'` is now
+a `tsc` error. Runtime behaviour is unchanged: types are erased, this package has no
+runtime validator for a manifest it is handed, and `validateTree` still forwards
+whatever a manifest says — a pin in
+`src/__tests__/injected-component-input-6950.test.ts` states that limit so the
+narrowing is not mistaken for a runtime rejection.
+
+**Migration.** Nothing measured has to change. `binding: 'field'` has zero writers in
+this repo and zero in the objectstack copy of this package (measured 2026-09-09 on
+both heads, each with a firing `binding: 'object'` control), and the only manifest
+producer in either tree is `manifestFromConfigs`, whose input face was already narrow.
+The two `binding: 'field'` occurrences in this repo are `@ts-expect-error` negative
+pins asserting the refusal, not writers.
+
+**Why not leave the reader face wide.** The counter-argument — producer → reader is a
+subset relation, so a permissive reader is not wrong — was answered rather than assumed
+away. `ManifestInput` is not a pure reader face (`manifestFromConfigs` returns it), and
+`bindings[].kind` is a pure **producer** face where the relation inverts: a wider union
+there accepts nothing extra, it obliges every consumer to handle an arm this package
+cannot emit. The two are coupled by `validateTree`'s `kind: input.binding` assignment,
+so narrowing one alone would need a cast at the only conversion site — the lenient
+fallback AGENTS.md #0.1 bans. The reasoning now lives on the declarations themselves,
+where a later reader lands. The reopen route is the ruling's own: a measured need for
+field bindings is filed as a widening with the vocabulary decided then.

--- a/packages/sdui-parser/src/__tests__/injected-component-input-6950.test.ts
+++ b/packages/sdui-parser/src/__tests__/injected-component-input-6950.test.ts
@@ -27,10 +27,14 @@
  * `binding:` literal in `packages/`, `apps/` and `examples/` is `'object'`
  * (7 of 7 at the retiring merge-base) and nothing resolves a field binding.
  * The arm is retired at the boundary a registry config feeds the serializer
- * through; `ManifestInput.binding` (`types.ts`) is the manifest READER's
- * vocabulary and is deliberately not narrowed here. The `@ts-expect-error`
- * directives below are real enforcement — this package type-checks its tests
- * through `tsconfig.test.json`.
+ * through. objectui#8315 then retired it on the two faces `types.ts` carries —
+ * `ManifestInput.binding` and `ManifestValidationResult.bindings[].kind` —
+ * after measuring that the second of those is a PRODUCER face, where the
+ * subset relation that licenses a permissive reader does not apply, and that
+ * the two are coupled by `validateTree`'s `kind: input.binding` assignment.
+ * The pins for those two faces are at the foot of this file. The
+ * `@ts-expect-error` directives are real enforcement — this package
+ * type-checks its tests through `tsconfig.test.json`.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -41,7 +45,14 @@ import {
   elementDataSourceBlock,
   type ComponentMeta,
 } from '@object-ui/core';
-import { manifestFromConfigs, validateTree, type RegistryConfigLike } from '../index.js';
+import {
+  manifestFromConfigs,
+  validateTree,
+  type Manifest,
+  type ManifestInput,
+  type ManifestValidationResult,
+  type RegistryConfigLike,
+} from '../index.js';
 
 const NS = 'pin6950';
 const TYPE = `${NS}:probe`;
@@ -150,5 +161,84 @@ describe('a registration that authors `binding` itself fails type-check at the r
     };
     registry.register('authored', () => null, meta);
     expect(registry.getAllConfigs()).toHaveLength(1);
+  });
+});
+
+/* ── the manifest READER/PRODUCER faces, retired in objectui#8315 ──────── */
+
+describe("the manifest faces spell the vocabulary 'object' too (objectui#8315)", () => {
+  /**
+   * Each refusal below is paired with a well-formed control that still passes,
+   * so "it refused" cannot be satisfied by a face that refuses everything.
+   */
+
+  it("`ManifestInput.binding` accepts 'object' — the control", () => {
+    const input: ManifestInput = { name: 'object', type: 'string', binding: 'object' };
+    expect(input.binding).toBe('object');
+  });
+
+  it("`ManifestInput.binding` refuses the retired 'field' arm", () => {
+    const input: ManifestInput = {
+      name: 'object',
+      type: 'string',
+      // @ts-expect-error `'field'` is retired on the manifest face too (objectui#8315)
+      binding: 'field',
+    };
+    expect(input.name).toBe('object');
+  });
+
+  it("`bindings[].kind` accepts 'object' — the control", () => {
+    const site: ManifestValidationResult['bindings'][number] = {
+      tag: 'object-table',
+      input: 'object',
+      kind: 'object',
+      value: 'account',
+    };
+    expect(site.kind).toBe('object');
+  });
+
+  it("`bindings[].kind` refuses 'field' — it is a PRODUCER face, so width obliges consumers", () => {
+    const site: ManifestValidationResult['bindings'][number] = {
+      tag: 'object-table',
+      input: 'field',
+      // @ts-expect-error `validateTree` writes this key and cannot emit 'field' (objectui#8315)
+      kind: 'field',
+      value: 'revenue',
+    };
+    expect(site.tag).toBe('object-table');
+  });
+
+  it('the two faces are coupled: `validateTree` copies `binding` into `kind`', () => {
+    // The coupling is why neither could be narrowed alone without a cast at
+    // the conversion site. Driven through the real function, not asserted of
+    // the source text.
+    const manifest: Manifest = {
+      components: {
+        'object-table': {
+          type: 'object-table',
+          namespace: NS,
+          inputs: [{ name: 'object', type: 'string', binding: 'object' }],
+        },
+      },
+    };
+    const result = validateTree({ type: 'object-table', object: 'account' }, manifest);
+    expect(result.bindings).toEqual([
+      { tag: 'object-table', input: 'object', kind: 'object', value: 'account' },
+    ]);
+  });
+
+  it('the narrowing is COMPILE-TIME only — a manifest parsed from JSON still forwards what it says', () => {
+    // Stated as a pin so a later reader does not mistake the retirement for a
+    // runtime rejection. `validateTree` reads `input.binding` truthily and
+    // copies it; this package has no runtime validator for the manifest
+    // itself, so a hand-rolled JSON manifest carrying the retired arm still
+    // produces a binding site nothing downstream resolves. Closing THAT would
+    // be a new diagnostic, not a type change — deliberately not in
+    // objectui#8315's scope.
+    const rogue = JSON.parse(
+      '{"components":{"t":{"type":"t","inputs":[{"name":"f","type":"string","binding":"field"}]}}}',
+    ) as Manifest;
+    const result = validateTree({ type: 't', f: 'revenue' }, rogue);
+    expect(result.bindings).toEqual([{ tag: 't', input: 'f', kind: 'field', value: 'revenue' }]);
   });
 });

--- a/packages/sdui-parser/src/index.ts
+++ b/packages/sdui-parser/src/index.ts
@@ -97,10 +97,15 @@ export interface RegistryConfigLike {
      * side of the manifest resolved a field binding. Retired under ADR-0049
      * enforce-or-remove by the maintainer ruling of 2026-09-07 (decision
      * batch #69): a config that spells the arm is a `tsc` error here rather
-     * than an entry the server would never resolve. `ManifestInput.binding`
-     * in `types.ts` is the manifest READER's vocabulary and still reads
-     * `'object' | 'field'`; only this boundary — what a registry config may
-     * feed the serializer — narrowed.
+     * than an entry the server would never resolve.
+     *
+     * The retirement then reached the two faces the ruling did not name
+     * (objectui#8315): `ManifestInput.binding` and
+     * `ManifestValidationResult.bindings[].kind` in `types.ts` read `'object'`
+     * too, so the published package no longer narrows on one face and stays
+     * wide on the other. The argument for keeping the manifest face wide —
+     * producer → reader is a subset relation — is answered at
+     * `ManifestInput.binding`, which is where a later reader lands.
      *
      * Only the framework writes the key: `InjectedComponentInput` in
      * `@object-ui/types`, spliced by `Registry.register`. `ComponentInput`

--- a/packages/sdui-parser/src/types.ts
+++ b/packages/sdui-parser/src/types.ts
@@ -96,8 +96,51 @@ export interface ManifestInput {
   required?: boolean;
   /** allowed values for `enum` inputs */
   enum?: Array<string | { value: unknown; label?: string }>;
-  /** marks a data-binding input the server must resolve (ADR-0080 §6.3) */
-  binding?: 'object' | 'field';
+  /**
+   * Marks a data-binding input the server must resolve (ADR-0080 §6.3):
+   * `binding: 'object'` says the input NAMES an object, so the server-side
+   * binding check knows what to resolve it against. Unrelated to
+   * `type: 'object'`, the coarse control kind — a record-shaped value and an
+   * object-naming input are two different facts.
+   *
+   * ## The vocabulary is exactly `'object'` — `'field'` is retired on this face too
+   *
+   * `'field'` stood beside it from the first draft of ADR-0080 and was never
+   * written. It was retired on the serializer's INPUT boundary
+   * (`RegistryConfigLike` in `index.ts`) under ADR-0049 enforce-or-remove by
+   * the maintainer ruling of 2026-09-07 (decision batch #69), and on THIS
+   * face by objectui#8315 — the residue that ruling did not name, which left
+   * one published package narrow on one face and wide on the other.
+   *
+   * ⚠️ The argument for leaving this face wide was ANSWERED, not overlooked.
+   * It runs: producer → reader is a subset relation, so a reader accepting a
+   * value no producer emits is permissive rather than wrong. Three measured
+   * facts decided against it (objectui#8315):
+   *
+   *   1. **This is not a pure reader face.** `manifestFromConfigs` RETURNS a
+   *      `Manifest`, so `ManifestInput` is also this package's OUTPUT type,
+   *      and this key is fed straight from the already-narrowed boundary. A
+   *      union wider than the producer's is imprecision on the way out, not
+   *      permissiveness on the way in.
+   *   2. **Its sibling is a pure producer face.**
+   *      `ManifestValidationResult.bindings[].kind` is written by
+   *      `validateTree` by copying this key, so the subset relation runs the
+   *      other way there — see that declaration. The two are COUPLED by that
+   *      assignment: narrowing one alone needs a cast at the only conversion
+   *      site, which is the lenient fallback AGENTS.md #0.1 bans. So "both
+   *      narrow" and "both wide" were the only self-consistent states, and
+   *      only one of them can be justified on the producer face.
+   *   3. **The permissiveness protected nothing.** `binding: 'field'` has
+   *      zero writers here and zero in the objectstack copy of this package
+   *      (measured 2026-09-09 on both heads, each with a firing
+   *      `binding: 'object'` control), and the only manifest producer in
+   *      either tree is `manifestFromConfigs`, whose input face is narrow.
+   *
+   * The reopen route is the ruling's own: a MEASURED need for field bindings
+   * is filed as a widening with the vocabulary decided then — not
+   * pre-declared here for a producer that does not exist.
+   */
+  binding?: 'object';
   description?: string;
 }
 
@@ -134,6 +177,17 @@ export interface ManifestValidationResult {
   diagnostics: Diagnostic[];
   /** unique plugin namespaces referenced — the page's `requires` */
   requires: string[];
-  /** binding sites (object/field) the server must resolve against object schema */
-  bindings: Array<{ tag: string; input: string; kind: 'object' | 'field'; value: unknown }>;
+  /**
+   * Binding sites the server must resolve against object schema.
+   *
+   * `kind` is a PRODUCER face, not a reader face: `validateTree` writes it,
+   * copying {@link ManifestInput.binding} at the one site that builds this
+   * array. So the subset relation that licenses a permissive READER runs the
+   * other way here — a wider union accepts nothing extra, it obliges every
+   * consumer to handle an arm this package cannot emit. That is why the
+   * retired `'field'` arm (objectui#6950 on the input boundary, objectui#8315
+   * here) is gone from this end as well; the measurements are on
+   * {@link ManifestInput.binding}.
+   */
+  bindings: Array<{ tag: string; input: string; kind: 'object'; value: unknown }>;
 }


### PR DESCRIPTION
Fixes #8315

Retires the `binding: 'field'` arm on the two manifest faces that the 2026-09-07 ruling
did not name, so `@object-ui/sdui-parser` states **one** vocabulary instead of two.

## The choice, and the argument that decided it

The card admitted two outcomes: **(1)** narrow both faces, or **(2)** record the reader
face as deliberately wider and say why *in the declaration itself*. **Outcome 1 was
taken.**

### The counter-argument, answered rather than assumed away

> producer to reader is a subset relation, so a reader that accepts a value no producer
> emits is *permissive*, not wrong; and the wire vocabulary is shared with a separately
> published `@objectstack/sdui-parser`.

That argument is sound — for a **pure reader face**. Applied to the two residues it does
not carry, and the reason is decisive rather than a matter of taste:

1. **`ManifestValidationResult.bindings[].kind` is not a reader face at all.**
   `validateTree` **writes** it (`validate.ts:83`, `kind: input.binding`). For an output
   type the subset relation runs the other way: a wider union accepts nothing extra, it
   *obliges every consumer* to handle an arm this package cannot emit. So even if the
   argument fully carried on `ManifestInput.binding`, one of the two residues would
   still be wrong.

2. **The two are coupled by that assignment**, so the choice is not per-declaration.
   `kind: input.binding` means `kind` cannot narrow while `binding` stays wide, and
   `binding` cannot narrow while `kind` is asserted from it — not without a cast at the
   single conversion site, which is precisely the lenient fallback AGENTS.md #0.1 bans.
   **"Both narrow" and "both wide" were the only self-consistent states**, and outcome 2
   would have required writing a justification on `bindings[].kind` that is not true of
   a producer face. The card forbids a shrug there; there was no honest non-shrug to
   write.

3. **`ManifestInput` is not a pure reader face either.** `manifestFromConfigs` *returns*
   `Manifest`, so it is simultaneously this package's **output** type, fed straight from
   the boundary PR #8297 already narrowed.

4. **The permissiveness protected nothing, measured.** For a reader's width to protect
   anything some producer must emit the value. Zero writers on both repos (below), and
   the only manifest producer in either tree is `manifestFromConfigs`, whose input face
   is already narrow.

The reopen route is the ruling's own and is unchanged: a *measured* need for field
bindings is filed as a widening with the vocabulary decided then.

## What changed

| declaration | before | after |
|---|---|---|
| `packages/sdui-parser/src/types.ts:100` `ManifestInput.binding` | `'object' \| 'field'` | `'object'` |
| `packages/sdui-parser/src/types.ts:138` `ManifestValidationResult.bindings[].kind` | `'object' \| 'field'` | `'object'` |

Both carry the reasoning **on the declaration**, where a later reader lands — the card's
requirement for outcome 2 applied to outcome 1 as well, since the next reader's question
("why is this only `'object'`?") is the same one either way.

Two prose corrections, which are not optional: `index.ts` and the pin test's header both
stated that the reader face "still reads `'object' | 'field'`" / "is deliberately not
narrowed here". Those sentences became **false** with this change, and a confidently
false statement is this repository's worst failure direction.

## Accept-set finding (Clause ②)

The accept set **moved**, so `needs:contract-review` is hung on this PR as well as the
card. What a caller can no longer pass: `binding: 'field'` in a hand-written
`ManifestInput` / `Manifest` literal, and `kind: 'field'` in a `bindings[]` entry. Nothing
became newly *acceptable*.

**Compile-time only, and stated as a pin so nobody mistakes it for more.** Types are
erased; this package has no runtime validator for a `Manifest` it is handed, so a JSON
manifest carrying the retired arm still produces a binding site nothing resolves.
`the narrowing is COMPILE-TIME only` in `injected-component-input-6950.test.ts` drives
that through `validateTree` and pins the actual behaviour. Closing *that* would be a new
diagnostic, not a type change, and is deliberately out of scope.

Every refusal is paired with a **well-formed control that still passes**, so "it refused"
cannot be satisfied by a face that refuses everything: `ManifestInput` with
`binding: 'object'` type-checks, a `bindings[]` entry with `kind: 'object'` type-checks,
and `validateTree` still records `{ kind: 'object' }` end to end. The `@ts-expect-error`
directives are real enforcement — this package type-checks its tests through
`tsconfig.test.json`.

**Ablation, both legs, on the committed tree.** Widening the two unions back on disk
(mutation proved to have landed: blob `e5ed29a6` to `2f0ad139`, each widened spelling
grep-counted `1`) turns `tsc -p tsconfig.test.json` **RED, exit 2**, with exactly the two
new pins named and nothing else:

```
src/__tests__/injected-component-input-6950.test.ts(184,7): error TS2578: Unused '@ts-expect-error' directive.
src/__tests__/injected-component-input-6950.test.ts(204,7): error TS2578: Unused '@ts-expect-error' directive.
```

Restore leg: blob back to `e5ed29a6` (identical to the `HEAD` blob), `git diff HEAD` empty,
`tsc -p tsconfig.test.json` **exit 0**. So the refusals are the narrowing's doing and the
controls survive both legs. The mutation script carried `trap ... EXIT INT TERM`; no
mutated file is left in the tree, and nothing under `node_modules` was touched — the
ablation is a source-level mutation of this package only.

## Writer counts, re-derived on this head, each with its firing control

Discriminator `binding:\s*'(field|object)'` over `packages/ apps/ examples/`, `*.ts` +
`*.tsx`, run on each repo's own head rather than recalled from the card:

| repo | head | `binding: 'field'` | control `binding: 'object'` |
|---|---|---|---|
| objectui | `da5e4f69` (this PR's base) | **2** in 2 files — **both `@ts-expect-error` negative pins** | **19** in 9 files — control fires |
| objectstack | `eabdd66` (read-only) | **0** | **2** in 2 files — control fires |

The card's figures (`0` / `7` across 5 files) were taken at `8f9d87a` on a narrower
pattern; the reading that matters is unchanged and now re-derived rather than inherited:
**zero positive writers on either side.**

⭐ **Not a re-grade trigger.** The card's trigger is `binding: 'field'` found *written*.
Both objectui occurrences are `@ts-expect-error` lines asserting the arm is **refused** —
they are the gate, not an author. There is no positive writer in either repo.

## `check:upstream-port-parity` — read, run, and what it means here

Green (exit 0), and it **does not cover this change**. Its pin
(`scripts/upstream-port-pin.json`) carries exactly three ported files —
`scripts/pm/check-half-states.mjs`, `scripts/invoked-as.mjs`,
`.claude/hooks/guard-main-checkout.selftest.sh` — **none under `packages/sdui-parser`**.

⇒ **The card's premise that "the two copies are kept in step by some mechanism" is
measurably false.** No gate in this repo compares the two `sdui-parser` copies, and this
repo has **zero** references to `@objectstack/sdui-parser` (not a dependency, not
imported, not in any `package.json`). The two are independent copies of one design, not a
producer/consumer pair on a wire.

**So this change neither trips that gate nor forces the objectstack side.** Propagation is
a human decision on objectstack#16583, whose own writer face (`index.ts:81`) has not even
had PR #8297's narrowing applied yet — all three of its declarations are still wide, so
that repo is internally consistent today and stays so. This PR makes *this* package
internally consistent. ⛔ Nothing was pushed to objectstack.

## Gates

Every gate below was run on `4e6f977c`, this PR's head, with its exit code captured
**before any pipe**:

| gate | exit |
|---|---|
| `pnpm --filter @object-ui/sdui-parser type-check` (`tsc --noEmit` + `tsc -p tsconfig.test.json`) | **0** |
| `pnpm exec vitest run packages/sdui-parser/ packages/types/src/__tests__/injected-component-input-6950.test.ts` (repo root) | **0** — 14 files, 189 tests passed |
| `pnpm --filter @object-ui/sdui-parser lint` | **0** (7 pre-existing `no-explicit-any` warnings, none in touched files) |
| `node scripts/check-changeset-presence.mjs` | **0** |
| `pnpm check:control-bytes` | **0** |
| `node scripts/check-upstream-port-parity.mjs` | **0** |
| `node scripts/check-upstream-port-parity.mjs --self-test` | **0** (58 cases) |
| `pnpm check` (after `pnpm --filter '@object-ui/cli...' build`, exit 0) | **0** |
| `node scripts/check-type-check-coverage.mjs` | **0** |
| `pnpm check:element-data-source-declaration` | **0** |
| `pnpm check:spec-symbols` · `check:phantom-deps` · `check:self-import` · `check:unreferenced-sources` · `check:side-effects-array` | **0** each |

`pnpm check:readme-exports` is **NOT MEASURED** here: it exits 1 with its own
"the population COLLAPSED -- this run proves nothing" verdict because 31 of 40 packages
have no `dist/` in this worktree (it says `run 'pnpm build' first`). That is a
prerequisite failure, not a red — `readme-exports.yml` runs it on `pull_request` after
`turbo run build --filter='./packages/*'`, so CI judges it on a built tree.

The full report on #8315 carries the same table plus an explicit NOT MEASURED section.

## 维护者速读(草稿)

**改了什么** — `@object-ui/sdui-parser` 的 manifest 类型里,`binding` 与 `bindings[].kind`
两处的 `'field'` 分支退休,只留 `'object'`;理由写在声明本身上。

**为什么改** — 2026-09-07 的裁决只点名了一个坐标(序列化器入口,PR #8297 已收窄),
另外两处留着,同一个已发布包对同一个 wire key 说了两套话。卡片给的两个出路里,
「保留并写明理由」这条走不通:`bindings[].kind` 是**生产者面**,不是读者面 —— 在那儿写
「读者宽容是对的」是假话,而两处被 `validateTree` 的一次赋值绑死,不能只收窄一处
(除非加 cast,那正是 AGENTS.md #0.1 禁止的宽容回退)。

**风险与代价(含回滚)** — 已发布类型的 accept set 变窄 ⇒ 对 TS 使用者是 breaking,
已按 `minor` 声明 changeset 并写明迁移。实测两仓 `binding: 'field'` 写入方为 0
(objectui 的 2 处是断言「被拒」的 `@ts-expect-error`),故迁移面为空。
**仅编译期**:运行时行为未变,已用 pin 钉住这一限度。回滚 = revert 本 PR 单一 commit。

**席位意见** — (留空,待席位定稿)

**你要做的** — 确认 accept-set 变更(carrier 已挂 PR 与卡片,清除归 PM);
决定 objectstack#16583 是否同步收窄 —— 本仓没有任何机制会替它做,本 PR 也不强制它。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_