### PR TITLE
docs(app-shell,plugin-designer): retire the declared-divergence note on the `reference.trim()` guard (#8621)

### DIFF
--- a/.changeset/7714-lookup-draft-stays-client-side.md
+++ b/.changeset/7714-lookup-draft-stays-client-side.md
@@ -29,16 +29,20 @@ session's half-finished state belongs to the client, not to the metadata store.
 That shows the author a field the server never received — the silent-drop shape
 objectstack#4001 closed.
 
-⚠️ **A declared divergence: objectui is stricter than the contract here.** The
-predicate is `typeof reference === 'string' && reference.trim() !== ''`. Measured on
-the 17.3.0 artifact, at field level and again through `ObjectSchema`, the spec
-ACCEPTS a whitespace-only `reference` while refusing an absent or empty one — so
-`reference: '   '` is refused by these writers on their own authority, not the
-platform's. Kept deliberately: whitespace names no object (the spec's own
-`ObjectSchema.fields` key grammar `/^[a-z_][a-z0-9_]*$/` admits no whitespace-bearing
-name), so admitting it only moves the identical failure past the PUT and into a stored
-document, where it surfaces with no field named. Filed upstream as objectstack#16126;
-if the spec trims, behaviour here is unchanged and only the declaration retires.
+**The whitespace row follows the contract; it is not a local opinion.** The predicate
+is `typeof reference === 'string' && reference.trim() !== ''`. It was a declared
+divergence when written — 17.3.0's #13632 refinement spelled its emptiness test as an
+equality against `''`, so the spec accepted `reference: '   '` while these writers
+refused it. objectstack#16920 applies that test to the TRIMMED value, so the spec now
+refuses the identical shape under the same `custom` issue at the same `reference`
+path, and the divergence note is retired (objectui#8621). Whitespace names no object
+at either end (the spec's own `ObjectSchema.fields` key grammar
+`/^[a-z_][a-z0-9_]*$/` admits no whitespace-bearing name), so admitting it would only
+move the identical failure past the PUT and into a stored document, where it surfaces
+with no field named. ⚠️ objectstack#16920 is an unreleased `minor` upstream and this
+repo's pin is `@objectstack/spec` 17.3.0, which predates it — so until the pin moves,
+these writers are still the only thing refusing `'   '` here, and they refuse it at
+editor time either way, before the PUT rather than at the publish gate.
 
 The refusal message diagnoses which of the four states it found — absent, empty,
 non-string (`invalid_type`, a value of the wrong kind rather than a missing target),

--- a/.changeset/8621-retire-declared-divergence-note.md
+++ b/.changeset/8621-retire-declared-divergence-note.md
@@ -1,0 +1,31 @@
+---
+---
+
+Documentation only — no published behaviour changes, and no version bump is declared.
+
+objectui#7685 recorded, in both metadata writers' docblocks and in the pending
+`7714-lookup-draft-stays-client-side` changeset, that refusing a whitespace-only
+`reference` on `lookup` / `master_detail` was a **declared divergence**: stricter
+than `@objectstack/spec`, which spelled its emptiness test as an equality against
+`''` and so accepted `reference: '   '`.
+
+objectstack#16920 (merged 2026-09-08) applies that test to the trimmed value, so
+the spec refuses the identical shape under the same `custom` issue at the same
+`reference` path. The guard is therefore contract-following, and only the note
+was stale. The notes are rewritten; **the guard itself is byte-identical**
+(`assertRelationshipTargetPresent` and `describeUnusableTarget` in both
+`@object-ui/app-shell`'s `MetadataService` and `@object-ui/plugin-designer`'s
+`MetadataFieldsPage` hash the same before and after), because it still earns its
+place: it refuses at EDITOR time, before the PUT, where the author is told which
+field is wrong while it is on screen — the contract refuses at the publish gate,
+as a 422 on the whole object document with the half-filled draft riding along.
+
+⚠️ Measured, not assumed: this repo's pin is `@objectstack/spec` 17.3.0, which
+predates objectstack#16920 (an unreleased `minor` upstream). At that pin `'   '`
+still parses green at field level and through `ObjectSchema` — controls at the
+same pin refuse absent and `''` as `custom` at `reference` and accept
+`'account'`. So the docblocks say the guard matches the spec **from the release
+carrying objectstack#16920**, not "the installed spec", and the pins keep
+asserting the writer's refusal separately from the spec's verdict — the spec-half
+assertion is now labelled a tripwire that reddens on the pin bump. ⛔ Bumping the
+pin is a separate card.

--- a/packages/app-shell/src/services/MetadataService.specKeyReference.test.ts
+++ b/packages/app-shell/src/services/MetadataService.specKeyReference.test.ts
@@ -264,27 +264,29 @@ describe('objectui#6041 · saveFields PUTs the relationship target as `reference
 });
 
 /**
- * objectui#7714 — the four states of an unusable target, and the one where this
- * writer is deliberately stricter than the contract.
+ * objectui#7714 — the four states of an unusable target, and the one that used
+ * to be a declared divergence.
  *
  * ⚠️ Read the instrument note before adding a spec assertion here. This repo's
- * pin is `@objectstack/spec` **17.2.0**, where `reference` is prose-only: it
- * accepts absent, `''` AND `'   '` alike. So an assertion of the shape "the
- * spec accepts `'   '`" is TRUE here and measures nothing — it is true of every
- * value at this pin. The divergence is therefore asserted where it is real:
- * against THIS WRITER, whose refusal does not depend on the installed spec at
- * all, plus the one discriminating spec reading 17.2.0 does carry (a non-string
- * IS refused, so a value-level check exists; blankness is simply not part of
- * it, at either version).
+ * pin is `@objectstack/spec` **17.3.0** (`pnpm-lock.yaml`; the 17.2.0 this note
+ * used to name was superseded by objectui#7122). At 17.3.0 the #13632
+ * refinement refuses an absent and an EMPTY `reference` but spells its
+ * emptiness test as an equality against `''`, so `'   '` still parses green.
+ * An assertion of the shape "the spec accepts `'   '`" therefore measures the
+ * VERSION SKEW below, not a standing opinion of this repo's.
  *
- * The 17.3.0 half was measured on the built artifact and recorded in
- * `MetadataService.ts`'s docblock rather than asserted here, because it is not
- * observable from this repo's installed spec. When objectui's pin reaches
- * 17.3.0 (objectui#7122) it becomes assertable; when objectstack#16126 lands
- * upstream the whitespace row moves to "refused" and only the guard's
- * declaration retires, never its behaviour.
+ * The divergence itself is retired (objectui#8621): objectstack#16920 applies
+ * that emptiness test to the trimmed value, so upstream now refuses the same
+ * shape under the same `custom` issue at the same `reference` path, and this
+ * writer's predicate mirrors the contract instead of exceeding it. The fix is
+ * an unreleased `minor` at the time of writing, which is why the spec half
+ * below still reads `success = true`: it is pinned against the INSTALLED spec,
+ * and it is the tripwire that reddens when the pin reaches the fix. ⛔ The
+ * writer's refusal is asserted separately and does not depend on the installed
+ * spec at all — that separation is what makes the bump a one-line edit here and
+ * no behaviour change at all in `MetadataService.ts`.
  */
-describe('objectui#7714 · the target states, and the declared divergence', () => {
+describe('objectui#7714 · the target states, and the retired divergence', () => {
   const puttable = async (reference: unknown) => {
     const { adapter, puts } = makeCapturingAdapter();
     const field = { ...LOOKUP, referenceTo: reference } as DesignerFieldDefinition;
@@ -316,28 +318,42 @@ describe('objectui#7714 · the target states, and the declared divergence', () =
   it('does not rewrite a target that has surrounding whitespace but a real name', async () => {
     // `' account '` trims to a non-empty name, so the guard passes it — and
     // passes it THROUGH, unchanged. This writer's job is to refuse a draft, not
-    // to normalise author input; silently trimming would be a second, undeclared
-    // divergence hiding inside the first.
+    // to normalise author input; silently trimming would be a WRITE the author
+    // never made. The contract agrees, and says so in the same words:
+    // objectstack#16920 trims for the TEST only, so a target with surrounding
+    // whitespace is still accepted and still stored as written.
     const { refused, puts } = await puttable(' account ');
     expect(refused).toBe(false);
     expect(savedFields(puts)[0].reference).toBe(' account ');
   });
 
-  it('the divergence is real at THIS pin: the spec accepts `\'   \'`, this writer refuses it', async () => {
-    // The writer half — true regardless of which spec is installed.
+  it('the VERSION SKEW is real at THIS pin: 17.3.0 accepts `\'   \'`, this writer refuses it', async () => {
+    // The writer half — true regardless of which spec is installed, and
+    // unchanged by objectstack#16920. This is the row that must never move.
     const { refused } = await puttable('   ');
     expect(refused).toBe(true);
 
-    // The spec half, stated honestly for 17.2.0. `'   '` parses green — but so
-    // does an absent target here, so this line alone is NOT evidence of a
-    // blankness gap. The discriminating reading is the next one.
+    // The spec half, stated honestly for the INSTALLED 17.3.0, where #13632's
+    // emptiness test is an equality against `''`. Discriminating on its own at
+    // this pin — an absent target IS refused here (asserted below), so a green
+    // `'   '` isolates blankness rather than reflecting a schema that accepts
+    // everything. ⚠️ This is a TRIPWIRE, not an endorsement: objectstack#16920
+    // trims before the test, so this line reddens when the pin reaches it — at
+    // which point the reading becomes `false` and nothing else here moves.
     expect(FieldSchema.safeParse({ type: 'lookup', label: 'L', reference: '   ' }).success).toBe(true);
 
-    // Discriminating control: a value-level check on `reference` DOES exist at
-    // 17.2.0 — a non-string is refused, and refused as `invalid_type`. So the
-    // schema is being consulted and is not a passthrough; blankness is simply
-    // not among the things it tests, at either version. That is the shape
-    // objectstack#16126 reports upstream.
+    // Falsifying control for the line above: the refinement IS attached and IS
+    // consulted at this pin — an absent target is refused, as `custom` at path
+    // `reference`. A passthrough schema would have made the green above
+    // meaningless.
+    const absent = FieldSchema.safeParse({ type: 'lookup', label: 'L' });
+    expect(absent.success).toBe(false);
+    expect(absent.error!.issues.map((i) => i.code)).toContain('custom');
+
+    // Second control, at value level rather than presence level: a non-string
+    // is refused as `invalid_type` by the base schema before the refinement
+    // runs. Blankness was simply not among the things the 17.3.0 test covered —
+    // the gap objectstack#16126 reported and objectstack#16920 closed.
     const nonString = FieldSchema.safeParse({ type: 'lookup', label: 'L', reference: 42 });
     expect(nonString.success).toBe(false);
     expect(nonString.error!.issues.map((i) => i.code)).toContain('invalid_type');

--- a/packages/app-shell/src/services/MetadataService.ts
+++ b/packages/app-shell/src/services/MetadataService.ts
@@ -304,34 +304,57 @@ function describeUnusableTarget(reference: unknown): string {
  * input types on different paths and neither owns the other's. Both are pinned,
  * and each pin asserts the same four states so the copies cannot drift.
  *
- * ## The `.trim()` is a DECLARED DIVERGENCE, not an accident
+ * ## The `.trim()` MIRRORS the contract — it is no longer a local opinion
  *
- * The predicate is `typeof reference === 'string' && reference.trim() !== ''`,
- * which is STRICTER than the contract. Measured on 17.3.0, at field level and
- * again through the whole document:
+ * The predicate is `typeof reference === 'string' && reference.trim() !== ''`.
+ * It WAS a declared divergence when written: 17.3.0's #13632 refinement spelled
+ * its emptiness test as an equality against `''`, so the spec accepted a
+ * whitespace-only target while this writer refused it. objectstack#16920
+ * (merged 2026-09-08, closing objectstack#16126) applies that test to the
+ * TRIMMED value — `packages/spec/src/data/field.zod.ts`, the `FieldSchema`
+ * `superRefine`:
+ *
+ *   if (
+ *     (field.type === 'lookup' || field.type === 'master_detail') &&
+ *     (field.reference === undefined || field.reference.trim() === '')
+ *   ) { ctx.addIssue({ code: 'custom', path: ['reference'], … }); }
+ *
+ * Same `custom` issue, same `reference` path, same message as absent and `''`
+ * already got. The notion of blank is `.trim()` at both ends, so this guard and
+ * the contract refuse the identical set: nothing here is stricter any more.
+ *
+ * ⚠️ That is the spec FROM THE RELEASE CARRYING objectstack#16920, not the
+ * INSTALLED spec. This repo's pin is `@objectstack/spec` 17.3.0
+ * (`pnpm-lock.yaml`), which predates the fix; the fix is an unreleased `minor`
+ * upstream at the time of writing. Measured on the installed 17.3.0 artifact,
+ * whose shipped test still reads `field.reference === ''`:
  *
  *   FieldSchema.safeParse({ type: 'lookup', label: 'L', reference: '   ' })
  *     => success = true
  *   ObjectSchema.safeParse({ …, fields: { rel: { …, reference: '   ' } } })
  *     => success = true
  *
- * — the spec ACCEPTS a whitespace-only target and this writer refuses it.
- * objectui being stricter than the platform is a divergence, not a neutral
- * choice, so it is STATED here rather than left to be inferred from a
- * predicate: undeclared, it is indistinguishable from a bug and the next reader
- * "fixes" it.
+ * (controls at that same pin: absent and `''` are refused as `custom` at
+ * `reference`; `'account'` is accepted — so the schema is consulted and this is
+ * a real reading.) Until the pin reaches the fix, this guard is still the only
+ * thing refusing `'   '` in this repo. ⛔ Bumping the pin is not this note's
+ * business, and this note is not an argument for bumping it.
  *
- * ⭐ Kept, deliberately. A whitespace-only `reference` names no object — the
- * spec's own `ObjectSchema.fields` key grammar (`/^[a-z_][a-z0-9_]*$/`) admits
- * no whitespace-bearing name for it to resolve to — so admitting it buys the
- * author nothing and only moves the identical failure past the guard, past the
- * PUT and into a STORED document, where it surfaces with no field named and no
- * save to attach the message to.
+ * ⭐ Kept — and now kept for its OWN reason rather than the divergence's. It
+ * refuses at EDITOR time, before the PUT, naming the field while it is still on
+ * screen; the contract refuses at the publish gate, where the same shape
+ * arrives as a 422 on the whole object document with the half-filled draft
+ * riding along inside it. A whitespace-only `reference` names no object at
+ * either end — the spec's own `ObjectSchema.fields` key grammar
+ * (`/^[a-z_][a-z0-9_]*$/`) admits no whitespace-bearing name for it to resolve
+ * to — so admitting it buys the author nothing and only moves the identical
+ * failure past the guard, past the PUT and into a STORED document, where it
+ * surfaces with no field named and no save to attach the message to.
  *
- * ⚠️ Filed upstream as objectstack#16126 (open, `domain:spec`). If the spec
- * trims, this writer's behaviour is unchanged and only the declaration retires
- * — which is why the pins assert the writer's refusal separately from the
- * spec's verdict.
+ * ⚠️ The refusal MESSAGE below still says the spec ACCEPTS this value and still
+ * names objectstack#16126. That is deliberate, not an oversight: the message is
+ * version-qualified to 17.3.0, which IS the installed pin, and the pins assert
+ * it verbatim. It retires with the pin bump, not with this note.
  */
 function assertRelationshipTargetPresent(
   field: { type?: string; reference?: unknown },

--- a/packages/plugin-designer/src/MetadataFieldsPage.specKeyReference.test.tsx
+++ b/packages/plugin-designer/src/MetadataFieldsPage.specKeyReference.test.tsx
@@ -341,13 +341,17 @@ describe('objectui#6041 · WRITE — the save carries `reference`, never `refere
   });
 
   it('refuses every unusable target state, and PUTs none of them', async () => {
-    // objectui#7714, all four states plus `null`. The whitespace row is this
-    // page being deliberately STRICTER than the contract: measured on 17.3.0,
-    // `reference: '   '` parses green at field level and through `ObjectSchema`
-    // (upstream objectstack#16126). The refusal is this writer's own, declared
-    // in `MetadataFieldsPage.tsx`, and it does not depend on which spec is
-    // installed — which is why it is asserted here and the spec's verdict is
-    // not (at this repo's 17.2.0 pin the spec accepts every one of these).
+    // objectui#7714, all four states plus `null`. The whitespace row USED to be
+    // this page being stricter than the contract; objectstack#16920 applies the
+    // spec's emptiness test to the trimmed value, so upstream now refuses the
+    // same shape under the same `custom` issue and the divergence is retired
+    // (objectui#8621). It is still asserted HERE rather than against the spec,
+    // for the reason that outlives the divergence: this refusal is the page's
+    // own, raised at editor time before the PUT, and it does not depend on
+    // which spec is installed. That independence is also what keeps this row
+    // green across the pin bump — this repo's pin is `@objectstack/spec` 17.3.0
+    // (`pnpm-lock.yaml`), which predates objectstack#16920 and still parses
+    // `reference: '   '` green at field level and through `ObjectSchema`.
     //
     // One render, re-driven per state: `renderPage` per iteration would leave
     // several mounted pages in the document and `getByTestId` would then find

--- a/packages/plugin-designer/src/MetadataFieldsPage.tsx
+++ b/packages/plugin-designer/src/MetadataFieldsPage.tsx
@@ -440,31 +440,53 @@ function describeUnusableTarget(reference: unknown): string {
  * page's existing error surface — the same banner a nameless or duplicated
  * field already produces, and no new UI affordance.
  *
- * ## The `.trim()` is a DECLARED DIVERGENCE, not an accident
+ * ## The `.trim()` MIRRORS the contract — it is no longer a local opinion
  *
- * The predicate is `typeof reference === 'string' && reference.trim() !== ''`,
- * which is STRICTER than the contract. Measured on 17.3.0, at field level and
- * again through the whole document:
+ * The predicate is `typeof reference === 'string' && reference.trim() !== ''`.
+ * It WAS a declared divergence when written: 17.3.0's #13632 refinement spelled
+ * its emptiness test as an equality against `''`, so the spec accepted a
+ * whitespace-only target while this page refused it. objectstack#16920 (merged
+ * 2026-09-08, closing objectstack#16126) applies that test to the TRIMMED value
+ * — `packages/spec/src/data/field.zod.ts`, the `FieldSchema` `superRefine`:
+ *
+ *   if (
+ *     (field.type === 'lookup' || field.type === 'master_detail') &&
+ *     (field.reference === undefined || field.reference.trim() === '')
+ *   ) { ctx.addIssue({ code: 'custom', path: ['reference'], … }); }
+ *
+ * Same `custom` issue, same `reference` path, same message absent and `''`
+ * already got, so this page and the contract now refuse the identical set.
+ *
+ * ⚠️ That is the spec FROM THE RELEASE CARRYING objectstack#16920, not the
+ * INSTALLED spec. This repo's pin is `@objectstack/spec` 17.3.0
+ * (`pnpm-lock.yaml`), which predates the fix (an unreleased `minor` upstream at
+ * the time of writing). Measured on the installed 17.3.0 artifact, whose
+ * shipped test still reads `field.reference === ''`:
  *
  *   FieldSchema.safeParse({ type: 'lookup', label: 'L', reference: '   ' })
  *     => success = true
  *   ObjectSchema.safeParse({ …, fields: { rel: { …, reference: '   ' } } })
  *     => success = true
  *
- * — the spec ACCEPTS a whitespace-only target and this page refuses it.
- * objectui being stricter than the platform is a divergence, not a neutral
- * choice, so it is STATED rather than left to be inferred from a predicate;
- * undeclared, it is indistinguishable from a bug and the next reader "fixes" it.
+ * (controls at that pin: absent and `''` refused as `custom` at `reference`,
+ * `'account'` accepted.) Until the pin reaches the fix, this guard is still the
+ * only thing refusing `'   '` here. ⛔ Bumping the pin is not this note's
+ * business.
  *
- * ⭐ Kept, deliberately. A whitespace-only `reference` names no object — the
- * spec's own `ObjectSchema.fields` key grammar (`/^[a-z_][a-z0-9_]*$/`) admits
- * no whitespace-bearing name for it to resolve to — so admitting it buys the
+ * ⭐ Kept — now for its OWN reason rather than the divergence's. It refuses at
+ * EDITOR time, before the PUT, naming the field while it is still on screen;
+ * the contract refuses at the publish gate, where the same shape arrives as a
+ * 422 on the whole object document with the half-filled draft riding along. A
+ * whitespace-only `reference` names no object at either end — the spec's own
+ * `ObjectSchema.fields` key grammar (`/^[a-z_][a-z0-9_]*$/`) admits no
+ * whitespace-bearing name for it to resolve to — so admitting it buys the
  * author nothing and only moves the identical failure past the PUT and into a
  * stored document, where it surfaces with no field named.
  *
- * ⚠️ Filed upstream as objectstack#16126 (open). If the spec trims, this page's
- * behaviour is unchanged and only the declaration retires — which is why the
- * pins assert this writer's refusal separately from the spec's verdict.
+ * ⚠️ The refusal MESSAGE below still says the spec ACCEPTS this value and still
+ * names objectstack#16126. Deliberate: it is version-qualified to 17.3.0, which
+ * IS the installed pin, and the pins assert it verbatim. It retires with the
+ * pin bump, not with this note.
  */
 function assertRelationshipTargetPresent(
   field: { type?: string; reference?: unknown },


### PR DESCRIPTION
Fixes #8621

Retires the "declared divergence" note on the two metadata writers'
`typeof reference === 'string' && reference.trim() !== ''` guard. objectstack#16920
(merged 2026-09-08) applies the spec's emptiness test to the **trimmed** value, so
`@objectstack/spec` now refuses a whitespace-only `reference` on `lookup` /
`master_detail` under the same `custom` issue at the same `reference` path. The guard
became contract-following; only the note was stale.

⛔ **The guard is NOT removed and NOT touched.** It still earns its place: it refuses at
EDITOR time, before the PUT, naming the field while it is on screen — the contract
refuses at the publish gate, as a 422 on the whole object document with the half-filled
draft riding along inside it.

## The spec refinement this now cites

`packages/spec/src/data/field.zod.ts`, the `FieldSchema` `superRefine`, after
objectstack#16920:

```ts
  if (
    (field.type === 'lookup' || field.type === 'master_detail') &&
    (field.reference === undefined || field.reference.trim() === '')
  ) {
    ctx.addIssue({ code: 'custom', path: ['reference'], message: /* unchanged */ });
  }
```

The `- (field.reference === undefined || field.reference === '')` it replaces is the
whole of the divergence that was declared here.

## ⭐ The installed-spec measurement, and the wording it forced

The dispatch's condition 2 was **NOT MEASURED** upstream of me. Measured here, in this
worktree, three independent ways that agree:

| reading | value |
|---|---|
| `pnpm-lock.yaml` — every `@objectstack/spec` entry | `17.3.0` (two entries, one version) |
| `node_modules/@objectstack/spec/package.json` (root and `packages/app-shell`) | `17.3.0` |
| the shipped runtime artifact, `dist/ui/index.js:2299` | `(field.reference === void 0 \|\| field.reference === "")` — **untrimmed** |

and a live `safeParse` against that installed artifact:

```
installed @objectstack/spec version = 17.3.0
FieldSchema  reference undefined (control: must be REFUSED): success=false issues=[{"code":"custom","path":["reference"]}]
FieldSchema  reference ''        (control: must be REFUSED): success=false issues=[{"code":"custom","path":["reference"]}]
FieldSchema  reference '   '     (THE MEASUREMENT):          success=true
FieldSchema  reference 'account' (control: must be ACCEPTED): success=true
ObjectSchema reference '   '     (THE MEASUREMENT):          success=true
```

Both negative controls refuse and the positive control accepts, so the schema is
consulted and this is a real reading rather than a passthrough.

⇒ **The pin predates the fix.** Per the card's own ruling, the docblocks therefore say
the guard matches **the spec from the release carrying objectstack#16920** — an
unreleased `minor` upstream at the time of writing — and explicitly **not** "the
installed spec". ⛔ No pin bump is attempted here; a dependency bump is not this card.

The same measurement forced two more things:

- The pins keep asserting the writer's refusal **separately** from the spec's verdict.
  The spec-half assertion still reads `success = true` and is now labelled a
  **tripwire** that reddens on the pin bump, with the reading it will then take spelled
  out.
- The runtime refusal **message** (`describeUnusableTarget`) is left byte-identical. It
  says the spec ACCEPTS this value and names objectstack#16126 — both still true and
  version-qualified to 17.3.0, which IS the installed pin. Rewriting it would move a
  published surface on a `Clause-②: no` card.

## Proof the guard is byte-identical

Every changed line in both writer source files is a comment line:

```
$ git diff -U0 -- packages/app-shell/src/services/MetadataService.ts \
                  packages/plugin-designer/src/MetadataFieldsPage.tsx \
  | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-] *(\*|//)'
(no output)
```

and a line-number-independent extraction of the two executable functions hashes the
same before and after:

| file | functions | sha256 at base `ed971e8f` | sha256 at HEAD |
|---|---|---|---|
| `packages/app-shell/src/services/MetadataService.ts` | `assertRelationshipTargetPresent` + `describeUnusableTarget` | `4d0f705e…c69c4e` (1707 B) | `4d0f705e…c69c4e` (1707 B) |
| `packages/plugin-designer/src/MetadataFieldsPage.tsx` | same two | `9b947149…906e2` (1729 B) | `9b947149…906e2` (1729 B) |

## ⚠️ The card's published re-check command is UNSATISFIABLE — corrected here

The card asks for `git grep -n "divergence" -- packages/app-shell/src packages/plugin-designer/src`
to reach **0 hits**. It cannot. On this head that grep still returns **54 hit lines
across 36 files**, and only **9** of them are in files that name this guard at all. The
rest are other cards' divergence records — `__tests__/spec-symbol-parity.test.ts`,
`__tests__/widget-dom-leak-sweep.test.tsx`, `hooks/useActionModal.tsx`,
`views/ObjectView.setDefaultViewIdentity.test.tsx`, and more. Driving that grep to zero
would delete other cards' records, so it was not attempted.

**The narrowed criterion actually used** — present-tense divergence declarations, inside
the files that name this guard:

```sh
git grep -lE "objectstack#16126|objectstack#16920|reference\.trim\(\)" \
    -- . ':!*CHANGELOG.md' ':!pnpm-lock.yaml' \
  | xargs git grep -nE "is a DECLARED DIVERGENCE|is a declared divergence|is STRICTER than the contract|being deliberately STRICTER|deliberately stricter than the contract|A declared divergence:|the declared divergence"
```

| leg | reading |
|---|---|
| at base `ed971e8f` (positive control — the criterion must be able to fire) | **8 hit lines across 5 files** |
| on this head | **0** |

The four surviving `divergence` mentions in those files are all past-tense retirements
("It WAS a declared divergence when written", "USED to be…", "the divergence is
retired"), which is the intended terminal state, not a leftover.

The card's **positive control** reproduces: `git grep -c "reference.trim()" -- packages/app-shell/src`
returns `packages/app-shell/src/services/MetadataService.ts:3` (the card requires ≥ 1; it
was `:2` at base and gained one because the new docblock quotes the spec's own
`field.reference.trim() === ''` line).

## Files

| file | what changed |
|---|---|
| `packages/app-shell/src/services/MetadataService.ts` | docblock section rewritten; guard + message untouched |
| `packages/plugin-designer/src/MetadataFieldsPage.tsx` | same |
| `packages/app-shell/src/services/MetadataService.specKeyReference.test.ts` | instrument note + `describe` title retired; spec-half assertion relabelled a tripwire; one control assertion added (see below) |
| `packages/plugin-designer/src/MetadataFieldsPage.specKeyReference.test.tsx` | in-test comment retired |
| `.changeset/7714-lookup-draft-stays-client-side.md` | the ⚠️ "A declared divergence" paragraph retired (still unreleased — it appears in no CHANGELOG) |
| `.changeset/8621-retire-declared-divergence-note.md` | **new**, empty frontmatter |

**Changeset rule applied:** `AGENTS.md` line 162 / `scripts/check-changeset-presence.mjs`
— any file under a released package's `src/` needs a declaration, and an EMPTY
frontmatter is the explicit, first-class "releases nothing" answer. Four `src/` files
changed, all comment-only, so the empty frontmatter is the honest declaration rather
than a bump. The gate agrees in its own words (below).

**One assertion was added, deliberately.** The old instrument note claimed the green
`'   '` reading was not discriminating because "an absent target parses green here too".
That was true at 17.2.0 and is **false** at the actual 17.3.0 pin, where absent IS
refused. Correcting the prose without asserting it would have left a bare claim, so the
absent-target control is now asserted (`expect(absent.success).toBe(false)` plus its
`custom` code). It is test-only and adds no runtime surface.

## Gates — every run with its exit code, measured on this branch

Heavy runs went through the container's shared verification lock
(`os-verify-lock.sh`), so the seconds are shared-box seconds.

| gate | exit | evidence |
|---|---|---|
| `node scripts/check-changeset-presence.mjs` | **0** | "4 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)… Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption" |
| `pnpm check:control-bytes` | **0** | "OK (scanned 6895 tracked text file(s); skipped 85 binary)" |
| manual control-byte sweep over the 6 touched files (`grep -naP`) | **1** = no hits (clean) | the same pattern fires (exit 0) on a probe file carrying a real `0x0c`, so the sweep is not a silent no-op |
| `pnpm --filter '@object-ui/app-shell^...' --filter '@object-ui/plugin-designer^...' build` | **0** | PRECONDITION for the two type-checks |
| `pnpm --filter @object-ui/app-shell type-check` | **0** | `tsc --noEmit && tsc -p tsconfig.test.json` — the test program is type-checked too, so the edited pins are covered |
| `pnpm --filter @object-ui/plugin-designer type-check` | **0** | same two programs |
| `pnpm exec vitest run` on the two touched suites, **from the repo root** | **0** | `Test Files 2 passed (2) · Tests 31 passed (31)` |
| `pnpm --filter @object-ui/app-shell lint` | **0** | `2945 problems (0 errors, 2945 warnings)` — all pre-existing `no-explicit-any` warnings |
| `pnpm --filter @object-ui/plugin-designer lint` | **0** | `65 problems (0 errors, 65 warnings)` |
| `pnpm --filter '@object-ui/cli...' build` | **0** | PRECONDITION for `pnpm check` |
| `pnpm check` | **0** | `Analyzing 628 files… ✓ All checks passed` |
| `node scripts/check-designer-field-key-parity.mjs` | **0** | `designer-field-key-parity: OK` |
| `node scripts/check-spec-symbol-derivation.mjs` | **0** | 1358 files scanned against 5050 spec export names |
| `node scripts/check-governed-queue-guard.mjs --test` (6 paths) | **0** | `NOT GOVERNED — 6 path(s) checked against 5 governed surface(s); none matched` |

⚠️ **`pnpm --filter … type-check` first exited `2` on both packages — that was
PRECONDITION NOT MET, not a red.** The errors were `TS2307: Cannot find module
'@object-ui/components' / '@object-ui/react' / '@object-ui/fields' …` plus the
`TS7006` implicit-anys that follow from them: a fresh worktree has no workspace
`dist/*.d.ts`. After the dependency-closure build both exit `0`. Reported here
rather than silently re-run, because the `2` is in the record.

⚠️ Likewise `pnpm check` runs `node packages/cli/dist/cli.js check`, and that
file does not exist in a fresh worktree. It **is** a per-PR CI gate — `.github/workflows/lint.yml`,
step *"Verify the CLI's own check command passes on this repository"* — so the
CLI was built and the gate then ran green here.

## 验收备注

Out of scope, observed and deliberately left alone:

- `MetadataService.specKeyReference.test.ts` lines 20 and 62 still name the
  installed spec as **17.2.0**. The pin is 17.3.0 (measured above). Those two
  sentences belong to *other* assertions in the same file — the `referenceTo`
  unrecognized-key pin and the "this claim is about the PUT body" note — not to
  this guard's divergence declaration, so they are a different defect class
  (a pin bump made a version claim stale, rather than an upstream fix making a
  divergence claim stale) and were not touched. Whoever bumps
  `@objectstack/spec` past 17.3.0 lands in this exact file and this exact
  paragraph; that is the carrier. Not filed: it is stale prose, not a
  reproducible defect, not a contract violation, and not a metadata trap.
- `git grep -n "divergence" -- packages/app-shell/src packages/plugin-designer/src`
  still returns 54 lines across 36 files. Every one of them outside this guard's
  four files is another card's record and must stay.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_