### PR TITLE
fix(plugin-kanban): decline to draw a card badge with no label

### DIFF
--- a/.changeset/kanban-empty-badge-label-8489.md
+++ b/.changeset/kanban-empty-badge-label-8489.md
@@ -1,0 +1,17 @@
+---
+'@object-ui/plugin-kanban': patch
+---
+
+Kanban cards no longer draw an empty coloured badge for a card field that resolves to no label.
+
+The explicit-card-field loop's guard (`raw == null || raw === ''`) let an empty array
+through, and the branch it then took for any field carrying declared `options` never
+reached the shared `@object-ui/fields` cell renderers — it resolved a label and colour
+itself. With nothing to resolve, a fully styled, fully coloured pill was drawn with
+nothing inside it, on the most commonly authored shape of all: a picklist that declares
+its options.
+
+Both badge-push sites now decline a badge whose resolved label is empty. This also closes
+the half that has nothing to do with arrays — any value resolving to an empty label drew
+the same pill. A legitimately authored `'0'` label still renders: the test is against the
+empty string, not falsiness.

--- a/packages/plugin-kanban/src/ObjectKanban.emptyBadgeLabel.test.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.emptyBadgeLabel.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8489 — a kanban card must not draw a badge it has no label for.
+ *
+ * ── The defect ────────────────────────────────────────────────────────────
+ * `ObjectKanban`'s explicit-card-field loop opens with
+ * `if (raw == null || raw === '') continue;` — which an empty array passes —
+ * and then FORKS on `isPicklist`, true for any field carrying declared
+ * `options`. That fork never calls `getCellRenderer`, so objectui#8481's
+ * renderer fix (an empty array is not a cell value) cannot reach it: the
+ * branch resolves a label and a colour itself and pushes a plain object onto
+ * `cardBadges`. With nothing to resolve, the label came out as the empty
+ * string and the card drew a fully styled, fully coloured pill with no
+ * children in it — the most commonly authored shape of the three, because a
+ * picklist that declares its options is the normal case.
+ *
+ * ── What the repair is, and what it deliberately is NOT ───────────────────
+ * The kanban does not learn what an "empty value" is. At the push site the
+ * only question left is *is there a label to draw?*, so the branch declines
+ * to push a badge whose RESOLVED label is empty. That is strictly narrower
+ * than an emptiness judgement, and it closes both halves at once.
+ *
+ * ── Why the empty array is the easy case and not the subject ──────────────
+ * ANY value that resolves to an empty label draws the same empty pill. A fix
+ * that special-cases `[]` leaves the defect standing while reading as
+ * complete, so the DISCRIMINATING pin below is `stringifiesToNothing` — a
+ * NON-array stored value whose `String(...)` is empty. The empty array comes
+ * along for free; built the other way round, it would not.
+ *
+ * Measured while writing these: the third shape the card imagined — an
+ * OPTION whose declared `label` is the empty string — cannot reach the push
+ * site as an empty label on its own. `opt?.label || String(raw)` falls back
+ * to the stringified value, and the i18n hop cannot introduce one either:
+ * `useObjectLabel`'s `resolve()` rejects a translation that is `''` and
+ * returns its fallback (`packages/i18n/src/useObjectLabel.ts`). So the empty
+ * label always arrives through `String(raw)`, by either of the two shapes
+ * pinned here. Recorded because it is the reason there is no third case.
+ *
+ * ── Non-regression, derived from the two plausible WRONG fixes ────────────
+ * "drop any badge whose label is falsy" would also drop a legitimately
+ * authored `'0'` label, so `'0'` is pinned rendering normally, byte for
+ * byte. "drop empty arrays" leaves the second half standing, so the
+ * non-array case is pinned separately from the array one.
+ *
+ * ── Both push sites ───────────────────────────────────────────────────────
+ * `cardBadges.push` happens twice in `ObjectKanban.tsx`: the explicit
+ * `cardFields` loop, and the legacy semantic-field heuristic that runs when a
+ * board authors no `cardFields` at all. Both resolve a label exactly the same
+ * way (the file's own comment says so) and both had the defect, so both are
+ * pinned; a repair on one alone leaves the pill drawable from the other.
+ *
+ * ── Why these assertions are at the DOM ───────────────────────────────────
+ * `cardBadges` is an implementation array one refactor away from meaning
+ * nothing; the defect is what the card DRAWS. Every count below is taken
+ * from rendered nodes, scoped to one card through the `role="listitem"` /
+ * `aria-label` handle `SortableCard` gives every card. `queryByText('')`
+ * cannot express "no pill" (and `queryByText` throws on multiple matches as
+ * well as none), so the pins COUNT nodes at a selector — and the first case
+ * below verifies that selector matches exactly ONE node per badge, because
+ * `.rounded-full` alone matches two nodes per avatar elsewhere in this repo.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, waitFor, cleanup, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+// Registers `object-kanban`.
+import './index';
+// The board renders inside `KanbanRenderer`'s `React.lazy` boundary. Importing
+// the chunk at module scope bills the cold transform to the import phase
+// instead of racing a `waitFor` budget under full parallelism (objectui#3010);
+// same specifier as `index.tsx`'s factory, so ESM's module cache makes that
+// factory resolve immediately.
+import './KanbanImpl';
+
+/**
+ * A stored value that stringifies to nothing while being neither `null`,
+ * nor the empty string, nor an array — the discriminating shape. It clears
+ * the loop's `raw == null || raw === ''` guard, misses the option lookup
+ * (nothing declares the empty value), and leaves `String(raw)` as the only
+ * label the branch can resolve.
+ */
+const stringifiesToNothing = { toString: () => '' };
+
+const TAGS_FIELD = {
+  name: 'tags',
+  type: 'multiselect',
+  label: 'Tags',
+  options: [{ value: 'alpha', label: 'Alpha', color: 'indigo' }],
+};
+
+/** `'0'` is a legitimately authored label, and it is falsy. */
+const TIER_FIELD = {
+  name: 'tier',
+  type: 'picklist',
+  label: 'Tier',
+  options: [
+    { value: 'zero', label: '0', color: 'blue' },
+    { value: 'one', label: 'One', color: 'green' },
+  ],
+};
+
+const CHANNEL_FIELD = {
+  name: 'channel',
+  type: 'picklist',
+  label: 'Channel',
+  options: [{ value: 'email', label: 'Email', color: 'amber' }],
+};
+
+/** The legacy heuristic's own badge field — reached with no `cardFields`. */
+const PRIORITY_FIELD = {
+  name: 'priority',
+  type: 'picklist',
+  label: 'Priority',
+  options: [{ value: 'high', label: 'High', color: 'red' }],
+};
+
+const OBJECT_SCHEMA = {
+  name: 'test_object',
+  fields: {
+    id: { type: 'text' },
+    name: { type: 'text', label: 'Name' },
+    status: { type: 'text' },
+    tags: TAGS_FIELD,
+    tier: TIER_FIELD,
+    channel: CHANNEL_FIELD,
+    priority: PRIORITY_FIELD,
+  },
+};
+
+const ROWS: any[] = [
+  // Every badge this board can draw correctly, on one card.
+  { id: 'c1', name: 'Populated card', status: 'open', tags: ['alpha'], tier: 'zero', channel: 'email' },
+  // The easy half: an empty array clears the loop's guard.
+  { id: 'c2', name: 'Empty array card', status: 'open', tags: [] },
+  // The discriminating half: NOT an array, still resolves to no label.
+  { id: 'c3', name: 'Stringifies to nothing card', status: 'open', channel: stringifiesToNothing },
+];
+
+/** The legacy heuristic reads `priority` off the record, with no field list. */
+const LEGACY_ROWS: any[] = [
+  { id: 'l1', name: 'Legacy populated card', status: 'open', priority: 'high' },
+  { id: 'l2', name: 'Legacy empty array card', status: 'open', priority: [] },
+  { id: 'l3', name: 'Legacy stringifies to nothing card', status: 'open', priority: stringifiesToNothing },
+];
+
+const LANES = [{ id: 'open', title: 'Open' }];
+
+function makeDataSource(rows: any[]) {
+  return {
+    find: vi.fn().mockResolvedValue({ data: rows, total: rows.length }),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue(OBJECT_SCHEMA),
+  } as any;
+}
+
+/**
+ * The three populated pills, captured from a run BEFORE the repair. The
+ * repair may not move one byte of them: it only declines a push, so the
+ * markup of every badge that still has a label has to be what it was.
+ */
+const POPULATED_BADGE_HTML: string[] = [
+  '<div class="inline-flex items-center whitespace-nowrap rounded-full border px-2.5 py-0.5 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 text-xs font-normal bg-indigo-50 text-indigo-700 border-indigo-200 dark:bg-indigo-950/40 dark:text-indigo-300 dark:border-indigo-900/60">Alpha</div>',
+  '<div class="inline-flex items-center whitespace-nowrap rounded-full border px-2.5 py-0.5 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 text-xs font-normal bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-900/60">0</div>',
+  '<div class="inline-flex items-center whitespace-nowrap rounded-full border px-2.5 py-0.5 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 text-xs font-normal bg-green-50 text-green-700 border-green-200 dark:bg-green-950/40 dark:text-green-300 dark:border-green-900/60">Email</div>',
+];
+
+/** The same capture for the legacy heuristic's own pill. */
+const LEGACY_POPULATED_BADGE_HTML: string[] = [
+  '<div class="inline-flex items-center whitespace-nowrap rounded-full border px-2.5 py-0.5 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 text-xs font-normal bg-red-50 text-red-700 border-red-200 dark:bg-red-950/40 dark:text-red-300 dark:border-red-900/60">High</div>',
+];
+
+afterEach(cleanup);
+
+/**
+ * Every badge pill drawn inside one card, in document order.
+ *
+ * The selector is the `Badge` primitive's own cva base — `inline-flex` and
+ * `whitespace-nowrap` together with `rounded-full`. Radix's `Avatar.Root` and
+ * `AvatarFallback`, the two nodes that make a bare `.rounded-full` count
+ * double elsewhere in this repo, carry neither, so this matches exactly one
+ * node per badge. The `renders exactly one node per badge` case below proves
+ * that rather than asserting it.
+ */
+function badgesIn(card: HTMLElement): HTMLElement[] {
+  return Array.from(
+    card.querySelectorAll<HTMLElement>('div.inline-flex.whitespace-nowrap.rounded-full'),
+  );
+}
+
+/** The card whose accessible name is `title` — `SortableCard`'s own handle. */
+function cardNamed(title: string): HTMLElement {
+  return screen.getByRole('listitem', { name: title });
+}
+
+async function renderBoard(rows: any[], cardFields?: string[]) {
+  const adapter = makeDataSource(rows);
+  const result = render(
+    <SchemaRendererProvider dataSource={adapter as any}>
+      <SchemaRenderer
+        schema={
+          {
+            type: 'object-kanban',
+            objectName: 'test_object',
+            groupBy: 'status',
+            columns: LANES,
+            ...(cardFields ? { cardFields } : {}),
+          } as any
+        }
+      />
+    </SchemaRendererProvider>,
+  );
+  await waitFor(() => expect(result.container.textContent).toContain(rows[0].name));
+  return result;
+}
+
+describe('objectui#8489 — the card declines to draw a badge with no label', () => {
+  describe('the explicit cardFields picklist branch', () => {
+    it('renders exactly one node per badge at the counting selector', async () => {
+      await renderBoard(ROWS, ['tags', 'tier', 'channel']);
+      const populated = cardNamed('Populated card');
+
+      // Three declared, populated card fields -> three pills, and the
+      // selector resolves them one-for-one. Without this the counts below
+      // could not distinguish "no badge" from "a selector that never matched".
+      expect(badgesIn(populated).map((b) => b.textContent)).toEqual(['Alpha', '0', 'Email']);
+    });
+
+    it('draws no badge for an empty array', async () => {
+      await renderBoard(ROWS, ['tags', 'tier', 'channel']);
+
+      // Mapped to outerHTML so a failure prints the pill that should not exist.
+      expect(badgesIn(cardNamed('Empty array card')).map((b) => b.outerHTML)).toEqual([]);
+    });
+
+    it('draws no badge for a non-array value that stringifies to nothing', async () => {
+      await renderBoard(ROWS, ['tags', 'tier', 'channel']);
+
+      expect(
+        badgesIn(cardNamed('Stringifies to nothing card')).map((b) => b.outerHTML),
+      ).toEqual([]);
+    });
+
+    it('leaves every populated badge byte-identical to before the repair', async () => {
+      await renderBoard(ROWS, ['tags', 'tier', 'channel']);
+
+      expect(badgesIn(cardNamed('Populated card')).map((b) => b.outerHTML)).toEqual(
+        POPULATED_BADGE_HTML,
+      );
+    });
+
+    it("keeps a legitimately authored '0' label, which is falsy", async () => {
+      await renderBoard(ROWS, ['tags', 'tier', 'channel']);
+      const populated = cardNamed('Populated card');
+
+      const zero = badgesIn(populated).filter((b) => b.textContent === '0');
+      expect(zero).toHaveLength(1);
+    });
+  });
+
+  describe('the legacy semantic-field heuristic (no cardFields authored)', () => {
+    it('renders exactly one node per badge at the counting selector', async () => {
+      await renderBoard(LEGACY_ROWS);
+
+      expect(badgesIn(cardNamed('Legacy populated card')).map((b) => b.textContent)).toEqual([
+        'High',
+      ]);
+    });
+
+    it('leaves every populated badge byte-identical to before the repair', async () => {
+      await renderBoard(LEGACY_ROWS);
+
+      expect(badgesIn(cardNamed('Legacy populated card')).map((b) => b.outerHTML)).toEqual(
+        LEGACY_POPULATED_BADGE_HTML,
+      );
+    });
+
+    it('draws no badge for an empty array', async () => {
+      await renderBoard(LEGACY_ROWS);
+
+      expect(
+        badgesIn(cardNamed('Legacy empty array card')).map((b) => b.outerHTML),
+      ).toEqual([]);
+    });
+
+    it('draws no badge for a non-array value that stringifies to nothing', async () => {
+      await renderBoard(LEGACY_ROWS);
+
+      expect(
+        badgesIn(cardNamed('Legacy stringifies to nothing card')).map((b) => b.outerHTML),
+      ).toEqual([]);
+    });
+  });
+});

--- a/packages/plugin-kanban/src/ObjectKanban.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.tsx
@@ -626,6 +626,23 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
             const colorClass = hexBadge
               ? hexBadge.className
               : getBadgeColorClasses(opt?.color, raw);
+            // objectui#8489 — decline to draw a badge there is no label for.
+            // The loop's own `raw == null || raw === ''` guard lets an empty
+            // array through, and this branch never reaches `getCellRenderer`,
+            // so objectui#8481's rule for the shared renderers ("an empty
+            // array is not a cell value") cannot help it: with nothing to
+            // resolve, the label came out as the empty string and the card
+            // drew a fully styled, fully coloured pill with no children in it.
+            //
+            // Deliberately NOT an emptiness judgement about the VALUE — the
+            // kanban needs none. By this point the only question left is
+            // whether there is a label to draw, and asking exactly that also
+            // covers every non-array value resolving to nothing; the empty
+            // array is simply the shape that is easy to hit.
+            //
+            // Compared against the empty string, NOT for falsiness: `'0'` is a
+            // legitimately authored option label and has to keep rendering.
+            if (translatedLabel === '') continue;
             cardBadges.push({ label: translatedLabel, colorClass, colorStyle: hexBadge?.style });
           } else {
             // Route through the same registry that Grid/Gallery use so
@@ -684,6 +701,13 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
             const colorClass = hexBadge
               ? hexBadge.className
               : getBadgeColorClasses(option?.color, v);
+            // objectui#8489, same reasoning as the explicit branch above and
+            // for the same reason: this heuristic resolves its label the same
+            // way, so `[]` (or any value stringifying to nothing) reached the
+            // push with an empty label and drew the same empty pill. Skipping
+            // the push rather than breaking keeps the remaining badge fields
+            // eligible — an unlabelled one must not consume a badge slot.
+            if (label === '') continue;
             cardBadges.push({ label, colorClass, colorStyle: hexBadge?.style });
             if (cardBadges.length >= 2) break;
           }

--- a/packages/plugin-kanban/src/ObjectKanban.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.tsx
@@ -626,7 +626,7 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
             const colorClass = hexBadge
               ? hexBadge.className
               : getBadgeColorClasses(opt?.color, raw);
-            // objectui#8489 — decline to draw a badge there is no label for.
+            // objectui#8489 — decline to draw a badge with no label in it.
             // The loop's own `raw == null || raw === ''` guard lets an empty
             // array through, and this branch never reaches `getCellRenderer`,
             // so objectui#8481's rule for the shared renderers ("an empty
@@ -701,12 +701,12 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
             const colorClass = hexBadge
               ? hexBadge.className
               : getBadgeColorClasses(option?.color, v);
-            // objectui#8489, same reasoning as the explicit branch above and
-            // for the same reason: this heuristic resolves its label the same
-            // way, so `[]` (or any value stringifying to nothing) reached the
+            // objectui#8489, on the reasoning spelled out at the explicit
+            // branch above: this heuristic resolves its label exactly the same
+            // way, so `[]` — or any value stringifying to nothing — reached the
             // push with an empty label and drew the same empty pill. Skipping
             // the push rather than breaking keeps the remaining badge fields
-            // eligible — an unlabelled one must not consume a badge slot.
+            // eligible: an unlabelled one must not consume a badge slot.
             if (label === '') continue;
             cardBadges.push({ label, colorClass, colorStyle: hexBadge?.style });
             if (cardBadges.length >= 2) break;


### PR DESCRIPTION
Fixes #8489

## What was wrong

`ObjectKanban`'s explicit-card-field loop opens with `if (raw == null || raw === '') continue;` — which an empty array passes — and four lines later forks on `isPicklist`, true for **any** field carrying declared `options`. That fork never calls `getCellRenderer`, so objectui#8481's landed rule for the shared `@object-ui/fields` renderers ("an empty array is not a cell value") cannot reach it: the branch resolves a label and a colour itself and pushes a plain object onto `cardBadges`.

With nothing to resolve, the label came out as the empty string and the card drew a **fully styled, fully coloured pill with no children in it** — on the most commonly authored of the three shapes, because a picklist that declares its options is the normal case.

Addresses re-located by content on `5ece49bbc` (the card's line numbers were from `7cf6f38fb`): the guard is still at line 604, the `isPicklist` fork at 605-609, and the badge push at 629. **They match the card exactly** — nothing had moved.

## The repair

Both `cardBadges.push` sites now decline a badge whose **resolved label** is empty. That is deliberately narrower than teaching the kanban what an "empty value" is — at the push site the only question left is *is there a label to draw?* — and asking exactly that closes the half of the defect that has nothing to do with arrays: any value resolving to an empty label drew the same pill, the empty array being merely the shape that is easy to hit.

The comparison is against the empty string, **not** falsiness, so a legitimately authored `'0'` label keeps rendering.

### Second push site, repaired in the same shape (declared)

`cardBadges.push` occurs twice in this file. Besides the explicit `cardFields` loop, the **legacy semantic-field heuristic** — the branch that runs when a board authors no `cardFields` at all — resolves its label the same way (the file's own comment says so) and had the identical defect, reproduced below. It is repaired identically, skipping the push rather than breaking so an unlabelled field cannot consume one of the two badge slots. Same file, same defect class, same gate family, and it is pinned at the DOM alongside the dispatched branch; a repair on one alone leaves the pill drawable from the other.

## Evidence

All measurements at `6e3b9ffe5`. DOM shapes are spelled in words below on purpose — tag-shaped fragments are eaten from GitHub bodies even inside backticks.

### Leg 1 — reproduced before repairing

`packages/plugin-kanban/src/ObjectKanban.emptyBadgeLabel.test.tsx`, run on the unrepaired tree: **4 failed, 5 passed**. Each of the four failures printed the pill that should not exist — a lone division element whose class list is the badge primitive's own base (inline-flex, items-center, whitespace-nowrap, rounded-full, border, px-2.5, py-0.5) plus the indigo colour set, with **no children and no text at all** between its opening and closing tags. Reproduced for both shapes, on both branches.

### Leg 2 — repaired, and populated badges byte-identical

After the repair the same file is **9 passed**, and the whole package is **35 files / 232 tests passed**. Byte-identity is not asserted by construction: `POPULATED_BADGE_HTML` and `LEGACY_POPULATED_BADGE_HTML` in the test file are the outer markup of the four populated pills **captured from a run before the repair**, and the suite compares the post-repair markup against those captured strings.

### Leg 3 — non-regression, derived from the two plausible wrong fixes

Both mutate a **read site** (the new guard), never a pin, from a committed tree; each proves the mutation on disk in both directions (anchor counts plus `git hash-object` against the HEAD blob) with a line-total gate, and restores **by state** (`git diff HEAD` clean and the blob back to `ef675ce63`). Per-test classification comes from vitest's JSON reporter.

| leg | mutation | result |
|---|---|---|
| 3a | *drop any badge whose label is falsy* | **NEGATIVE** — landed, did not discriminate (9/9 passed) |
| 3b | *drop empty arrays only* | **discriminates** — 7 passed, **2 failed**: both non-array pins red, both array pins green |

**Leg 3a is reported as negative, not green.** The mutation landed (blob moved, anchors flipped, line-total held) and nothing reddened, because at this site `!label` and `label === ''` are behaviourally **equivalent**: `opt?.label || String(raw)` lets no falsy label through, so the only falsy label that can reach the push is the empty string. The plausible wrong fix therefore is not wrong here — a real measurement, and a correction to the expectation the card set. `=== ''` is kept anyway as the intent-revealing spelling, and the `'0'` pin still asserts the user-facing guarantee (it is observed red under leg 4a).

Leg 3b is the one that matters: it is exactly the fix that special-cases the empty array, and the fixture is built so that it **passes both array pins and reddens both non-array pins**. A fix pinned only on the array would have read as complete.

### Leg 4 — caricatures, both directions

| leg | mutation | result |
|---|---|---|
| 4a | *never push a badge* | 4 passed, **5 failed** — both census pins, both byte-identity pins, and the `'0'` pin |
| 4b | *always push a badge* (both guards deleted; line-total gate -2) | 5 passed, **4 failed** — all four absence pins |

Every one of the nine pins was observed red under leg 3 or leg 4. No leg was void: every mutation moved the blob, flipped its anchors and held its line-total gate, and every restore was verified by state rather than by an exit code.

### Assertions are at the DOM, not at `cardBadges`

Counts are taken from rendered nodes, scoped to one card through the accessible-name handle `SortableCard` already gives every card (list-item role plus an aria-label of the card title). `queryByText` with an empty string cannot express "no pill", and it throws on multiple matches as well as none, so the pins **count** nodes at a selector instead — and the selector is proved, not assumed, to match exactly one node per badge: the first case in each group asserts the populated card's badge text list has exactly the expected entries. The selector uses the badge primitive's own base classes (inline-flex and whitespace-nowrap together with rounded-full), which the two avatar nodes that make a bare rounded-full count double elsewhere in this repo do not carry.

## Gates run locally

| check | verdict |
|---|---|
| `vitest run packages/plugin-kanban/` | 35 files / 232 tests passed |
| adjacent kanban consumers (plugin-view, app-shell, plugin-list, types) | 5 files / 192 tests passed |
| `pnpm --filter @object-ui/plugin-kanban type-check` | exit 0, with the dependency closure built first |
| `eslint .` (whole repo, 4594 files) | **0 errors**, 12400 pre-existing warnings |
| `check-changeset-presence.mjs` | declares 1 changeset |
| `check-changeset-no-major.mjs` | no major bump |
| `check-control-bytes.mjs` | OK, 6919 tracked text files |
| `check-governed-queue-guard.mjs --test` | NOT GOVERNED — ordinary route |

The type-check genuinely covers the new test file: it is absent from the main program and present in `tsconfig.test.json`'s, verified with `--listFiles`, and `type-check` runs both.

## Notes

- One premise of the card is **corrected**: an option whose declared `label` is the empty string cannot on its own produce an empty label, because `opt?.label || String(raw)` falls back to the stringified value; the i18n hop cannot introduce one either, since `useObjectLabel`'s `resolve()` rejects a translation equal to the empty string and returns its fallback. The empty label always arrives through `String(raw)`. The card's central finding — the empty pill, and the second half being independent of arrays — is unaffected and confirmed by rendering.
- objectui#8534 (`KanbanImpl` mirroring its `columns` prop into state) is **not** folded in and the fixture did not trip over it.
- `@object-ui/fields`' renderers are untouched — objectui#8481 owns those.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_