### PR TITLE
test(components): measure the three declared alert-dialog footer keys through the DOM (objectui#7963 step 3)

### DIFF
--- a/.changeset/alert-dialog-footer-keys-liveness-7963.md
+++ b/.changeset/alert-dialog-footer-keys-liveness-7963.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: a runtime liveness probe for `AlertDialogSchema`'s `cancelLabel` /
+`confirmLabel` / `confirmVariant` (objectui#7963 step 3). No published
+behaviour changes — no renderer, type or spec file is touched.

--- a/packages/components/src/__tests__/alert-dialog-footer-keys-liveness-7963.test.tsx
+++ b/packages/components/src/__tests__/alert-dialog-footer-keys-liveness-7963.test.tsx
@@ -1,0 +1,310 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7963 step 3 — does `AlertDialogSchema`'s `cancelLabel` /
+ * `confirmLabel` / `confirmVariant` move the rendered DOM? MEASURED here,
+ * through the real `SchemaRenderer` and the real registry, one key varied per
+ * fixture, reading the DOM. Nothing in this file is inferred from a grep.
+ *
+ * ## Why a grep could not answer it
+ *
+ * The card inferred "nothing reads them" from the absence of a `schema.KEY`
+ * read in `packages/components/src/renderers/overlay/alert-dialog.tsx`. That
+ * inference is UNSOUND for this renderer, and the repo has falsified the same
+ * shape of zero twice:
+ *
+ *  - objectui#8236 — `CollapsibleSchema.open` was called unread and turned out
+ *    to control expansion, override `defaultOpen` and freeze the trigger.
+ *  - objectui#8318 — 16 keys called unread, 9 measured live.
+ *
+ * The unsoundness has a mechanism, and both halves of it are re-derived on this
+ * branch rather than inherited (the line numbers move):
+ *
+ *  1. `SchemaRenderer` strips schema METADATA before spreading the rest of the
+ *     node as React props (`packages/react/src/SchemaRenderer.tsx`, the
+ *     `const { … , ...componentProps } = evaluatedSchema` destructure). The
+ *     three keys are NOT on that strip list, so they survive into
+ *     `componentProps` and are spread onto the registered component.
+ *  2. The `alert-dialog` renderer destructures `({ schema, className,
+ *     ...props })` and forwards `{...props}` straight onto the `AlertDialog`
+ *     primitive. So all three keys DO reach a primitive without any
+ *     `schema.KEY` read — the same shape as `disclosure/collapsible.tsx`, where
+ *     that channel turned out to be live.
+ *
+ * ⇒ neither "it forwards, so it is live" nor "no `schema.KEY`, so it is dead"
+ * is a verdict. objectui#8318 settled that in both directions at once: its nine
+ * live readers were direct named reads the sweep never opened, while
+ * `CardSchema.variant`, which DID reach its primitive through the spread, had
+ * no reader at all. Only the DOM reading below is a verdict.
+ *
+ * ## The controls, and what each one buys
+ *
+ * A null result ("the DOM did not move") is worthless without evidence that the
+ * harness COULD have seen a move. Four controls, each closing a different way
+ * this file could be green while measuring nothing:
+ *
+ *  - `IDEMPOTENT` — the same node rendered twice reads IDENTICAL. Radix mints
+ *    fresh `useId()` values per mount, so without the normaliser below every
+ *    comparison would differ and every reading would read "live". This control
+ *    is what makes an equality assertion meaningful.
+ *  - `SENSITIVE` — a `className` difference DOES move the normalised dialog
+ *    HTML. This is the other side of `IDEMPOTENT`: it proves the normaliser is
+ *    not so blunt that it erases real attribute changes inside the dialog.
+ *  - `CHANNEL` — `open`, which the renderer never reads as `schema.open`,
+ *    reaches the `AlertDialog` primitive through THE SAME rest-spread and moves
+ *    the DOM (no dialog -> dialog mounted). This is the positive control the
+ *    three readings need: it proves the spread channel is live end to end
+ *    (`SchemaRenderer` -> `componentProps` -> the renderer's `...props` ->
+ *    the primitive), so a null reading is about the KEY, not about the channel.
+ *    It is a valid control precisely because it is the objectui#8236 key: an
+ *    unstripped, never-`schema.`-read key that the primitive itself consumes.
+ *  - `WIRED` — `cancelText` / `actionText` (the sibling half, read at the
+ *    renderer's `schema.cancelText` / `schema.actionText` lines) draw the two
+ *    footer buttons. This proves the fixture, the registry and the renderer are
+ *    wired at all, and that this file can see a footer button when one exists.
+ *  - `VARIANT_INSTRUMENT` — inside ONE dialog, the cancel button's class
+ *    already differs from the action button's class (`buttonVariants({ variant:
+ *    'outline' })` vs `buttonVariants()`). So the class reading used for the
+ *    `confirmVariant` row demonstrably distinguishes one button variant from
+ *    another on this very DOM.
+ *
+ * ⛔ This file measures. It does not retire anything, it does not teach the
+ * renderer a new key, and it does not animate `confirmVariant` — whether a
+ * footer button variant is a capability this project wants is the maintainer
+ * ruling objectui#7963 asks for, and this reading is that ruling's INPUT.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import React from 'react';
+import { SchemaRenderer } from '@object-ui/react';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout` (objectui#3010/#3021).
+import '../renderers';
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Harness
+ * ───────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Radix derives `contentId` / `titleId` / `descriptionId` from React's
+ * `useId()`, which mints a fresh value on every mount. Two renders of the very
+ * same node therefore differ byte-for-byte in `id` and every `aria-*` that
+ * points at one. Normalise exactly that noise and nothing else — the
+ * `IDEMPOTENT` and `SENSITIVE` controls below hold this function honest from
+ * both sides.
+ */
+function normalise(html: string): string {
+  return html
+    .replace(/«[^«»]*»/g, '«ID»')
+    .replace(/:r[0-9a-z]+:/g, ':ID:')
+    .replace(/\bradix-[A-Za-z0-9_-]+/g, 'radix-ID');
+}
+
+interface Reading {
+  /** The dialog element's `outerHTML`, id noise normalised; `null` when the dialog is not mounted. */
+  dialogHtml: string | null;
+  /** The WHOLE document body — the content is portalled out, the trigger half is not. */
+  bodyHtml: string;
+  /** Text of every button inside the dialog content. An `alert-dialog` has no close affordance of its own, so these ARE the footer buttons. */
+  footerLabels: string[];
+  /** `class` of the button whose text matches, or `null` when it is not drawn. */
+  classOf: Record<string, string | null>;
+}
+
+/** Render one node through the REAL renderer and read the DOM back. */
+function probe(node: Record<string, unknown>, classesFor: readonly string[] = []): Reading {
+  cleanup();
+  render(<SchemaRenderer schema={node as never} />);
+  // Radix portals the content to `document.body`, so the RTL container is empty
+  // by construction — query the dialog itself.
+  const dialog = document.body.querySelector('[role="alertdialog"]');
+  const buttons = dialog ? Array.from(dialog.querySelectorAll('button')) : [];
+  const classOf: Record<string, string | null> = {};
+  for (const label of classesFor) {
+    const hit = buttons.find((b) => (b.textContent ?? '').trim() === label);
+    classOf[label] = hit ? hit.getAttribute('class') : null;
+  }
+  const reading: Reading = {
+    dialogHtml: dialog ? normalise(dialog.outerHTML) : null,
+    bodyHtml: document.body.innerHTML,
+    footerLabels: buttons.map((b) => (b.textContent ?? '').trim()),
+    classOf,
+  };
+  cleanup();
+  return reading;
+}
+
+const CANCEL = 'Keep it';
+const CONFIRM = 'Delete';
+
+/**
+ * The fixture every reading varies ONE key against: a complete alert-dialog in
+ * the dialect the renderer reads, forced open so the footer exists to measure.
+ */
+function baseNode(): Record<string, unknown> {
+  return {
+    type: 'alert-dialog',
+    title: 'Delete this account?',
+    description: 'This action cannot be undone.',
+    trigger: { type: 'button', label: 'Delete account' },
+    content: [{ type: 'text', content: 'Everything under the account goes with it.' }],
+    cancelText: CANCEL,
+    actionText: CONFIRM,
+    defaultOpen: true,
+  };
+}
+
+/** `baseNode()` plus exactly one key. */
+function withKey(key: string, value: unknown): Record<string, unknown> {
+  return { ...baseNode(), [key]: value };
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Controls — run these first; every reading below is void if one of them reds
+ * ───────────────────────────────────────────────────────────────────────── */
+
+describe('objectui#7963 — controls: this harness can see a DOM move when there is one', () => {
+  it('WIRED: the sibling half (`cancelText` / `actionText`) draws both footer buttons', () => {
+    const reading = probe(baseNode(), [CANCEL, CONFIRM]);
+
+    expect(reading.dialogHtml).not.toBeNull();
+    // Renderer order: `AlertDialogCancel` then `AlertDialogAction`.
+    expect(reading.footerLabels).toEqual([CANCEL, CONFIRM]);
+  });
+
+  it('IDEMPOTENT: the same node rendered twice reads identical', () => {
+    // Without the id normaliser this fails, and with it failing every equality
+    // assertion below would report "the DOM moved" for every key.
+    expect(probe(baseNode()).dialogHtml).toEqual(probe(baseNode()).dialogHtml);
+  });
+
+  it('SENSITIVE: a `className` difference DOES move the normalised dialog HTML', () => {
+    // The normaliser is not blunt: a real attribute change inside the dialog
+    // survives it.
+    const plain = probe(baseNode()).dialogHtml;
+    const marked = probe(withKey('className', 'os-7963-probe-marker')).dialogHtml;
+
+    expect(plain).not.toBeNull();
+    expect(marked).toContain('os-7963-probe-marker');
+    expect(marked).not.toEqual(plain);
+  });
+
+  it('CHANNEL: `open`, read by no `schema.open`, still moves the DOM through the SAME rest-spread', () => {
+    // The objectui#8236 key. The renderer reads `schema.defaultOpen` and never
+    // `schema.open`; `open` reaches the `AlertDialog` primitive ONLY by being
+    // absent from `SchemaRenderer`'s strip list and riding the `{...props}`
+    // spread this renderer forwards. It moves the DOM, so that channel is live
+    // end to end and a null reading below is about the key.
+    const closed = probe({ ...baseNode(), defaultOpen: undefined });
+    const opened = probe({ ...baseNode(), defaultOpen: undefined, open: true }, [CANCEL, CONFIRM]);
+
+    expect(closed.dialogHtml).toBeNull();
+    expect(opened.dialogHtml).not.toBeNull();
+    expect(opened.footerLabels).toEqual([CANCEL, CONFIRM]);
+  });
+
+  it('VARIANT_INSTRUMENT: the class reading distinguishes two button variants on this very DOM', () => {
+    // `AlertDialogCancel` ships `buttonVariants({ variant: 'outline' })`,
+    // `AlertDialogAction` ships `buttonVariants()`. If the `confirmVariant` row
+    // below reads "class unchanged", it is not because class strings are
+    // invisible to this harness.
+    const { classOf } = probe(baseNode(), [CANCEL, CONFIRM]);
+
+    expect(classOf[CANCEL]).toBeTruthy();
+    expect(classOf[CONFIRM]).toBeTruthy();
+    expect(classOf[CANCEL]).not.toEqual(classOf[CONFIRM]);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * The step-3 readings — one key varied per fixture, DOM diffed
+ * ───────────────────────────────────────────────────────────────────────── */
+
+describe('objectui#7963 — the three declared footer keys, one varied per fixture', () => {
+  it('`cancelLabel` does not move the DOM', () => {
+    const without = probe(baseNode(), [CANCEL, CONFIRM]);
+    const withIt = probe(withKey('cancelLabel', 'os-7963-cancelLabel'), [CANCEL, CONFIRM]);
+
+    expect(withIt.dialogHtml).toEqual(without.dialogHtml);
+    expect(withIt.dialogHtml).not.toContain('os-7963-cancelLabel');
+    expect(withIt.footerLabels).toEqual([CANCEL, CONFIRM]);
+  });
+
+  it('`confirmLabel` does not move the DOM', () => {
+    const without = probe(baseNode(), [CANCEL, CONFIRM]);
+    const withIt = probe(withKey('confirmLabel', 'os-7963-confirmLabel'), [CANCEL, CONFIRM]);
+
+    expect(withIt.dialogHtml).toEqual(without.dialogHtml);
+    expect(withIt.dialogHtml).not.toContain('os-7963-confirmLabel');
+    expect(withIt.footerLabels).toEqual([CANCEL, CONFIRM]);
+  });
+
+  it('`confirmVariant` does not move the DOM, and does not touch the confirm button class', () => {
+    const without = probe(baseNode(), [CANCEL, CONFIRM]);
+    const withIt = probe(withKey('confirmVariant', 'destructive'), [CANCEL, CONFIRM]);
+
+    expect(withIt.dialogHtml).toEqual(without.dialogHtml);
+    expect(withIt.dialogHtml).not.toContain('destructive');
+    // The reading the key's NAME promises: the confirm button's variant.
+    expect(withIt.classOf[CONFIRM]).toEqual(without.classOf[CONFIRM]);
+  });
+
+  it('none of the three lands on the DOM as an attribute either', () => {
+    // The keys DO reach the `AlertDialog` primitive (step 2). This is where
+    // they stop: that primitive's root renders a context provider, not an
+    // element, so an unknown prop is dropped without reaching any node. Read
+    // over the WHOLE body, not just the dialog, because the trigger half of the
+    // tree lives in the RTL container while the content is portalled out.
+    const reading = probe({
+      ...baseNode(),
+      cancelLabel: 'os-7963-cancelLabel',
+      confirmLabel: 'os-7963-confirmLabel',
+      confirmVariant: 'destructive',
+    });
+
+    // Live control on the SAME string: keys the renderer DOES read are present
+    // in it, so the `not.toContain` rows below are not being asked of an empty
+    // document.
+    expect(reading.bodyHtml).toContain(CANCEL);
+    expect(reading.bodyHtml).toContain(CONFIRM);
+
+    expect(reading.bodyHtml).not.toContain('cancelLabel');
+    expect(reading.bodyHtml).not.toContain('confirmLabel');
+    expect(reading.bodyHtml).not.toContain('confirmVariant');
+    expect(reading.bodyHtml).not.toContain('os-7963-');
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * The user-visible consequence the card reported
+ * ───────────────────────────────────────────────────────────────────────── */
+
+describe('objectui#7963 — a document written strictly against the declared keys', () => {
+  it('renders an EMPTY footer', () => {
+    // The card's headline claim, measured rather than reasoned: an author who
+    // writes only what `AlertDialogSchema` declares for the footer gets no
+    // footer buttons at all. Paired with `WIRED` above, which is the same node
+    // in the read dialect drawing two.
+    const declaredOnly = {
+      type: 'alert-dialog',
+      title: 'Delete this account?',
+      trigger: { type: 'button', label: 'Delete account' },
+      cancelLabel: 'Keep it',
+      confirmLabel: 'Delete',
+      confirmVariant: 'destructive',
+      defaultOpen: true,
+    };
+
+    const reading = probe(declaredOnly);
+
+    expect(reading.dialogHtml).not.toBeNull(); // the dialog itself DID mount
+    expect(reading.footerLabels).toEqual([]); // …with nothing in its footer
+  });
+});


### PR DESCRIPTION
Part of #7963 — deliberately `Part of` and not a closing keyword: this PR **measures**, it does not answer the maintainer ruling the card asks for, and the card must survive the merge.

## What this PR is, and what it is not

`AlertDialogSchema` declares `cancelLabel`, `confirmLabel` and `confirmVariant`. The card says nothing reads them and **infers** it from the absence of a `schema.KEY` read in `packages/components/src/renderers/overlay/alert-dialog.tsx`.

This adds one file — `packages/components/src/__tests__/alert-dialog-footer-keys-liveness-7963.test.tsx` — that replaces that inference with a **runtime probe through the real `SchemaRenderer` and the real registry, one key varied per fixture, reading the DOM**.

- ⛔ It does **not** retire the three keys (ADR-0049 retirement without this reading is how objectui#8236 was burned).
- ⛔ It does **not** animate `confirmVariant`, which is a Feature on the manual floor.
- ⛔ It does **not** answer the card's ruling — *"both need a maintainer ruling on whether a footer button variant is a capability this project wants at all."* This reading is that ruling's **input**.
- ⛔ No renderer, type, zod or spec file is touched. `packages/types/src/overlay.ts` and `packages/types/src/zod/overlay.zod.ts` were read only.

## Why a grep could not answer it

The same zero has been falsified twice in this repo: objectui#8236 (`CollapsibleSchema.open` was called unread, and controls expansion, overrides `defaultOpen` and freezes the trigger) and objectui#8318 (16 keys called unread, 9 measured live).

Both halves of the screening test were **re-derived on this branch head** rather than inherited, because the line numbers had moved:

**Step 1 — the strip list.** `packages/react/src/SchemaRenderer.tsx`, the `const { … , ...componentProps } = evaluatedSchema` destructure, now at **lines 1451–1481** (the card's comment cited `1455-1481`). Its 16 stripped keys are `type`, `children`, `body`, `schema`, `visible`, `visibleWhen`, `visibleOn`, `visibility`, `hidden`, `hiddenOn`, `disabled`, `disabledOn`, `dataSource`, `_hidden`, `_disabled`, `responsiveStyles`. **None of the three keys is on it**, so all three survive into `componentProps`, which is spread onto the registered component at the `React.createElement(Component, { schema, ...componentProps, … })` call (now **line 1574**).

**Step 2 — the forward.** `alert-dialog.tsx` **lines 25–26**, unchanged in shape from the card's citation:

```tsx
({ schema, className, ...props }: { schema: AlertDialogSchema; className?: string; [key: string]: any }) => (
  <AlertDialog defaultOpen={schema.defaultOpen} {...props}>
```

Byte-for-byte the shape of `disclosure/collapsible.tsx:22-23`. ⇒ **the screening test HITS**: the three keys really do reach a primitive with no named read.

⇒ neither *"it forwards, so it is live"* nor *"no `schema.KEY`, so it is dead"* is a verdict. objectui#8318 settled that in both directions at once — its nine live readers were direct named reads the sweep never opened, while `CardSchema.variant`, which **did** reach its primitive through the spread, had no reader at all.

## Step 3 — the DOM readings

Fixture: one complete alert-dialog in the dialect the renderer reads (`title`, `description`, `trigger`, `content`, `cancelText: 'Keep it'`, `actionText: 'Delete'`, `defaultOpen: true`), rendered through `SchemaRenderer`; the Radix content is portalled, so the reading is taken from `document.body.querySelector('[role="alertdialog"]')`. Ids are normalised (Radix mints fresh `useId()` values per mount) and the normaliser is held honest from both sides by the `IDEMPOTENT` and `SENSITIVE` controls below.

| key varied | dialog HTML vs. base | footer labels | confirm button `class` | verdict |
| --- | --- | --- | --- | --- |
| `cancelLabel: 'os-7963-cancelLabel'` | **identical** | `["Keep it","Delete"]` | unchanged | **DEAD** |
| `confirmLabel: 'os-7963-confirmLabel'` | **identical** | `["Keep it","Delete"]` | unchanged | **DEAD** |
| `confirmVariant: 'destructive'` | **identical** | `["Keep it","Delete"]` | unchanged — still `bg-primary text-primary-foreground hover:bg-primary/90`, never `bg-destructive` | **DEAD** |

None of the three reaches the DOM as an attribute either: the whole `document.body` string contains `Keep it` and `Delete` (the live control on the same string) and contains none of `cancelLabel`, `confirmLabel`, `confirmVariant`, `os-7963-`.

**No key is LIVE.** The card's premise holds — but it now holds as a measurement, not as an inference.

### The mechanism, for the record

The keys do reach `AlertDialog`, which is `AlertDialogPrimitive.Root`. That component forwards everything to `DialogPrimitive.Root`, which destructures exactly `__scopeDialog`, `children`, `open`, `defaultOpen`, `onOpenChange`, `modal` and renders a **context provider — not an element**. Unknown props are dropped there, before any DOM node exists. That is the difference from `collapsible.tsx`, where the forwarded key is one the primitive itself consumes.

Independently: `AlertDialogAction` hard-codes `cn(buttonVariants(), className)` and `AlertDialogCancel` hard-codes `cn(buttonVariants({ variant: 'outline' }), …)`, so there is no seam a `confirmVariant` could reach even in principle without a renderer change.

## The controls — why a null reading here is a reading

A "no difference" result is worthless without evidence the harness could have seen a difference. Five controls, each closing a different way this file could be green while measuring nothing. All five are green:

| control | what it rules out | observed |
| --- | --- | --- |
| `WIRED` | fixture/registry/renderer not wired; this file cannot see a footer button at all | two buttons, `["Keep it","Delete"]`, in renderer order |
| `IDEMPOTENT` | the id normaliser is absent or wrong, so *every* comparison would differ and every key would read "live" | same node twice reads identical |
| `SENSITIVE` | the normaliser is so blunt it erases real attribute changes inside the dialog | a `className` difference **does** move the normalised HTML, and the marker appears in it |
| `CHANNEL` **(the positive control)** | the rest-spread path is dead, so the null reading is about the channel rather than the key | `open`, which the renderer likewise **never** reads as `schema.open`, reaches the same `AlertDialog` primitive through the **same** `{...props}` spread and moves the DOM: no dialog → dialog mounted with both footer buttons |
| `VARIANT_INSTRUMENT` | the class reading is blind to button variants, which would make the `confirmVariant` row vacuous | within one dialog the cancel button's class already differs from the action button's |

`CHANNEL` is a valid positive control precisely because `open` is the objectui#8236 key: an unstripped key with no `schema.KEY` read, consumed by the primitive itself. It exercises `SchemaRenderer` → `componentProps` → the renderer's `...props` → the primitive, end to end — the identical path the three keys take.

## Falsification (one-off, not committed)

The controls prove the harness can see a move. This proves the three rows would **catch** a live key. The renderer was mutated on disk to make all three live — `schema.cancelLabel ?? schema.cancelText`, `schema.confirmLabel ?? schema.actionText`, and a `confirmVariant`-driven class — then the probe was re-run:

- on-disk proof of the mutation: file blob `77968a92…` → `04ffd668…`; the three new anchors each `grep -c` = 1 on the mutated file;
- result: **4 failed | 6 passed (10)** — the three key rows and the attribute row red, **all five controls still green**;
- restored with `git checkout HEAD -- packages/components/src/renderers/overlay/alert-dialog.tsx` under a `trap … EXIT INT TERM`, verified by blob hash back to `77968a92…` **and** `git diff HEAD` empty.

No mutation or ablation file is committed.

## The consequence the card reported, measured

A document written **strictly against the declared keys** (`cancelLabel` / `confirmLabel` / `confirmVariant`, no `cancelText` / `actionText`) mounts the dialog and renders an **empty footer**:

```html
<div class="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2"></div>
```

The same node in the read dialect draws two buttons (`WIRED`). This is the objectui#7104 note — *"a document written strictly against the shipped type renders an EMPTY footer"* — now pinned as a DOM reading rather than prose.

## Gates

Run in this worktree at `89f1bcae`, exit codes captured **before any pipe**.

| gate | command | exit |
| --- | --- | --- |
| probe suite | `pnpm exec vitest run packages/components/src/__tests__/alert-dialog-footer-keys-liveness-7963.test.tsx` (repo root) | **0** — `Test Files 1 passed (1) · Tests 10 passed (10)` |
| neighbouring suites | `pnpm exec vitest run …/disabled-verdict-one-carrier.test.tsx examples/schema-catalog/test/alert-dialog-footer-read-dialect-7693.test.tsx packages/types/src/__tests__/alert-dialog-read-dialect-7104.test.ts` | **0** — `Test Files 3 passed (3) · Tests 80 passed (80)` |
| type-check | `pnpm --filter @object-ui/components type-check` | **0** |
| lint | `pnpm --filter @object-ui/components lint` | **0** — `935 problems (0 errors, 935 warnings)`, all pre-existing; **0** attributed to the new file |
| changeset presence | `node scripts/check-changeset-presence.mjs` | **0** |
| control bytes | `pnpm check:control-bytes` | **0** — `scanned 6922 tracked text file(s)` |
| `pnpm check` | `node packages/cli/dist/cli.js check` | **0** — `✓ All checks passed` |

⚠️ `type-check` first failed with **exit 2** and ~hundreds of `TS2307: Cannot find module '@object-ui/…'`. That was **PRECONDITION NOT MET**, not a red: the workspace dependency closure had no built `dist/*.d.ts` in a fresh worktree. After `pnpm --filter '@object-ui/components^...' build` (exit 0) it is 0. Same class as the `pnpm check` / unbuilt-cli note in the dispatch — `pnpm --filter @object-ui/cli build` ran first (exit 0).

## Changeset grade

`.changeset/alert-dialog-footer-keys-liveness-7963.md`, **empty frontmatter**.

The rule applied is clause **(a)** of `scripts/check-changeset-presence.mjs`: a changed file counts as published source when it is under `<pkg>/src/`, and `<pkg>/src/` is explicitly **exempt from the docs/licence subtraction** — tests under `src/` are not carved out. So "a test-only change owes no changeset" is *false in this repo*: the file is at `packages/components/src/__tests__/`, the gate demands a **declaration**, and since nothing published changes behaviour the correct declaration is the empty frontmatter. Verified both ways: gate red before the changeset (`1 source file(s) … adds no changeset`), green after.

## Draft, and staying that way

Draft PR. ⛔ Not enqueued, ⛔ auto-merge not armed, ⛔ not flipped ready, ⛔ no `needs:contract-review` label touched. `Clause-②: no` per the dispatch, and confirmed here: a probe moves no published surface — `node scripts/check-governed-queue-guard.mjs --test …` reports `✅ NOT GOVERNED — 2 path(s) checked`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_