### PR TITLE
test(app-shell): measure whether a `{ group }` form section reaches SchemaForm (#8725)

### DIFF
--- a/.changeset/quiet-pans-repeat.md
+++ b/.changeset/quiet-pans-repeat.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change: pins the objectui#8725 reachability measurement for a `{ group }` form section reaching `SchemaForm`. No published behaviour, type or API changes.

--- a/packages/app-shell/src/views/metadata-admin/SchemaForm.groupSectionReachability-8725.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/SchemaForm.groupSectionReachability-8725.test.tsx
@@ -1,0 +1,272 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * REACHABILITY MEASUREMENT for objectui#8725 — a `{ group }` form section and
+ * `SchemaForm`'s three unguarded `s.fields` reads.
+ *
+ * ⚠️ This file records a DEFECT that is still open. Its runtime pins assert what
+ * this renderer does TODAY, which is to die. They are a measurement, not an
+ * endorsement: whoever rules on the disposition (see "What is NOT decided here")
+ * is expected to turn them into pins on the chosen behaviour, and their going
+ * red is the intended signal that the ruling landed.
+ *
+ * ## Why the measurement was needed
+ *
+ * objectui#8725 was filed with reachability explicitly NOT measured, and named
+ * that as its own gap: "a defect established only by reading is the thing this
+ * queue has been wrong about before". The card guessed the inputs were "this
+ * repo's own `*.form.ts` create/edit schemas, which do not author `group`",
+ * which would have made the defect latent.
+ *
+ * That guess is FALSE, in a way that matters. This repository contains no
+ * `*.form.ts` file at all. The `form` document `SchemaForm` renders arrives on
+ * two channels, and the wider of the two is a SERVER document:
+ *
+ *   • `RichMetadataTypeEntry.form` (`useMetadata.ts`) is `Record<string,
+ *     unknown>` — the `/meta/types` registry response, deserialised with no
+ *     validation and no normalisation (`useMetadataTypes` casts the payload) —
+ *     and `ResourceEditPage.tsx` hands it to this component as
+ *     `form={... (entry?.form as any)}`. `EmbeddedItemEditor.tsx` does the same
+ *     with `subEntry?.form as any`.
+ *   • the spec-bundled forms (`getPageForm` / `getViewForm` / `getReportForm` /
+ *     `getDashboardForm`), which read `pageForm` & co. straight out of
+ *     `@objectstack/spec/ui` — an upstream, versioned document this repo does
+ *     not author either. Measured against the installed 17.3.0, none of those
+ *     four declares a `group` section today; that is a property of one spec
+ *     release, not a barrier.
+ *
+ * So the REQUIRED `fields` on {@link FormSectionSpec} stands between a
+ * TypeScript author and this renderer, and between nothing else. A section
+ * carrying `group` and no `fields` — which `FormSectionSchema` ACCEPTS, measured
+ * against the installed 17.3.0 — reaches the reads unimpeded.
+ *
+ * ## What was measured, and how the card's wording is one word off
+ *
+ * The card names three read sites and predicts `Cannot read properties of
+ * undefined (reading 'map')`. That is the diagnostic of the SECOND and THIRD
+ * sites. It is not what fires. `SchemaFormBody`'s own pre-flight loop is above
+ * both of them in the same render, and it is a `for…of`, so the throw is a
+ * TypeError naming iteration, not `.map` — see {@link readSiteThatFiresFirst}.
+ * The distinction is load-bearing for whoever fixes this: guarding only the two
+ * `.map` sites the card quotes leaves the crash exactly where it is.
+ *
+ * ## What is NOT decided here (objectui#8725's own framing)
+ *
+ * Neither half of the fix is in this file. Widening `FormSectionSpec.fields` to
+ * optional ALONE removes the compile-time barrier above without deciding what
+ * the reads do, which converts a `tsc` error into this same runtime death on a
+ * second channel; and choosing what a group-referencing section renders is a
+ * behaviour ruling on a renderer (`?? []` degrades it to an EMPTY section —
+ * today's silent drop made non-throwing) or an import of
+ * `resolveSectionGroupReferences` from `@object-ui/plugin-form`, which needs an
+ * object definition this component is not handed. ⛔ And no assembly rule may be
+ * re-implemented on the objectui side (objectui#7051, objectstack#13855).
+ *
+ * ## One thing the card could not know, measured here
+ *
+ * The trap the card names — "widening the type alone removes the compile-time
+ * barrier" — is real but LOUD, not silent. Measured by widening
+ * `FormSectionSpec.fields` to optional against this package's `type-check`:
+ * `strictNullChecks` immediately reports `TS18048: 's.fields' is possibly
+ * 'undefined'` at all three read sites (`SchemaForm.tsx` 786 / 1030 / 1147),
+ * plus collateral at `form-spec.containers.test.tsx` PIN D (whose
+ * `FormSectionSpec['fields'][number]` then needs a `NonNullable`) and four
+ * sites in `mergeServerFields.test.ts`. So part 1 cannot ship without an author
+ * confronting every read. What the compiler cannot do is stop them from typing
+ * `?? []` to silence it — which is the behaviour ruling this card is holding
+ * open, and the reason this file stops here.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { SchemaForm } from './SchemaForm';
+import type { FormSectionSpec, FormViewSpec } from './form-spec';
+import type { RichMetadataTypeEntry } from './useMetadata';
+
+afterEach(cleanup);
+
+type Assert<T extends true> = T;
+
+/**
+ * Compile-time half. Erased at runtime, so vitest proves nothing about these;
+ * `tsc -p packages/app-shell/tsconfig.test.json` (chained from this package's
+ * `type-check` script) is what judges them.
+ */
+export function groupSectionReachabilityPins(): void {
+  // ── PIN T1 — the BARRIER, as it stands today. `FormSectionSpec` re-declares
+  // `fields` as REQUIRED while `FormSectionSchema` accepts `{ group }` with no
+  // `fields` at all, so the spec-legal shape does not compile — inside a type
+  // whose own header says it "describes what an AUTHOR WROTE, so it stays as
+  // wide as the document".
+  //
+  // ⛔ This is a TWO-WAY pin and that is the point. `@ts-expect-error` is itself
+  // an error (TS2578) the moment the line below it starts compiling, so nobody
+  // can widen `fields` without this file going red and putting the runtime pins
+  // below in front of them. objectui#8725's trap is precisely that the widening
+  // reads like a one-character type fix while it REMOVES the only thing that
+  // currently keeps a TypeScript author out of the crash measured below.
+  //
+  // Whoever lands the widening TOGETHER with a disposition for the read sites
+  // should DELETE this pin — it has no value once the reads are safe.
+  // @ts-expect-error objectui#8725 — `fields` is REQUIRED here; the spec-legal
+  // `{ group }` section is refused by the type. Widening it alone is the trap.
+  const specLegalSectionIsRefused: FormSectionSpec = { group: 'contact_info' };
+  void specLegalSectionIsRefused;
+
+  // Positive control for PIN T1: `group` itself IS a declared key of this type
+  // (it is derived from the spec, and no `Omit` names it), so the refusal above
+  // is about the MISSING `fields` and not about an unknown `group`. Without this
+  // line, a type that had never heard of `group` would satisfy PIN T1 for the
+  // wrong reason.
+  const groupIsADeclaredKey: FormSectionSpec = { group: 'contact_info', fields: [] };
+  void groupIsADeclaredKey;
+  const groupIsOnTheSpecDerivedHalf: Assert<'group' extends keyof FormSectionSpec ? true : false> =
+    true;
+  void groupIsOnTheSpecDerivedHalf;
+
+  // ── PIN T2 — the barrier guards ONE channel, and it is not the one that
+  // reaches the renderer. The registry entry's `form` is an untyped server
+  // document, so the crashing shape is assignable to it.
+  //
+  // OBSERVED RED, so this is a measurement and not a tautology: retyping
+  // `RichMetadataTypeEntry.form` to `FormViewSpec` turns this line into
+  // `TS2322: Type '{ label: string; group: string; }' is not assignable to type
+  // 'FormSectionSpec'` — and, measured, into the ONLY error in the package.
+  // That is the change which would put PIN T1's barrier on the path
+  // `ResourceEditPage` actually renders (its `form={entry?.form as any}` cast
+  // would have to go with it). Until then the `as any` at that call site is not
+  // a lint smell, it is the whole reachability result.
+  const serverRegistryFormAdmitsIt: NonNullable<RichMetadataTypeEntry['form']> = {
+    type: 'simple',
+    sections: [{ label: 'Contact', group: 'contact_info' }],
+  };
+  void serverRegistryFormAdmitsIt;
+}
+
+const schema = {
+  type: 'object',
+  properties: {
+    a: { type: 'string', title: 'Field A' },
+    b: { type: 'string', title: 'Field B' },
+  },
+};
+
+/**
+ * The crashing document, spelled the way it ARRIVES: a plain deserialised
+ * object, not a `FormViewSpec` literal. `as never` at the prop is this file's
+ * stand-in for `ResourceEditPage`'s `as any` — the cast is part of the
+ * measurement, not a convenience.
+ */
+const serverFormWithGroupSection = {
+  type: 'simple',
+  sections: [{ label: 'Contact', group: 'contact_info' }],
+};
+
+function renderCatching(form: unknown): { error: Error | undefined; html: string } {
+  let error: Error | undefined;
+  let html = '';
+  try {
+    const { container } = render(
+      <SchemaForm schema={schema} form={form as never} value={{ a: '' }} onChange={() => {}} />,
+    );
+    html = container.innerHTML;
+  } catch (err) {
+    error = err as Error;
+  }
+  return { error, html };
+}
+
+describe('objectui#8725 — a `{ group }` section reaching SchemaForm', () => {
+  // ── PIN R1 — CONTROL, and the non-regression leg. A section that authors
+  // `fields` renders them. Everything below is a claim about the ABSENCE of
+  // `fields`; without this line a renderer that drew nothing at all would
+  // satisfy the whole file. This is the pin that reddens under the caricature
+  // "every section resolves to no fields".
+  it('CONTROL: a section that authors `fields` still renders them', () => {
+    const form: FormViewSpec = {
+      type: 'simple',
+      sections: [{ label: 'Basics', fields: [{ field: 'a' }] }],
+    };
+    render(<SchemaForm schema={schema} form={form} value={{ a: '' }} onChange={() => {}} />);
+    expect(screen.getByText('Field A')).toBeInTheDocument();
+    expect(screen.getByText('Basics')).toBeInTheDocument();
+  });
+
+  // ── PIN R2 — REACHED, and it throws OUT OF THE COMPONENT BODY. Not "renders
+  // an empty section", not "renders a bordered card with a heading": `render()`
+  // itself throws, so there is no partial tree to inspect and no per-section
+  // boundary could have contained it. This is the shape that blanked
+  // `SimpleObjectForm` before PR #8644.
+  it('MEASURED TODAY (defect): the render throws instead of degrading', () => {
+    const { error, html } = renderCatching(serverFormWithGroupSection);
+    expect(error).toBeInstanceOf(TypeError);
+    // The envelope, not just "it threw": the message is one of the two
+    // diagnostics the unguarded `s.fields` reads produce, which is what
+    // identifies this as that family and not some unrelated failure in the
+    // render path. WHICH of the two fires is PIN R3's business, deliberately —
+    // so a half-fix moves R3 and R5 without disturbing this line.
+    expect(error?.message).toMatch(/\bfields\b|reading ['"]map['"]/);
+    // Nothing rendered. The card's parent measurement (objectui#8641) found a
+    // VISIBLE empty bordered card for its defect; this one leaves no DOM at all.
+    expect(html).toBe('');
+  });
+
+  // ── PIN R3 — WHICH read site fires, and the correction to the card's wording.
+  //
+  // objectui#8725 quotes `Cannot read properties of undefined (reading 'map')`
+  // and names `SchemaForm.tsx:786` / `:1030` / `:1147`. `:786` is
+  // `for (const f of s.fields)` inside `SchemaFormBody`'s pre-flight
+  // "does the layout name any field this schema has" loop, and it runs BEFORE
+  // `SectionedSchemaForm` is even constructed — so the `.map` diagnostic the
+  // card predicts is never the one a user sees.
+  //
+  // ⚠️ The exact V8 text observed here is `s.fields is not iterable`; the
+  // assertions below are written so that the DISCRIMINATION (iteration site vs
+  // `.map` site) does not rest on engine-specific wording. Guarding only the two
+  // `.map` sites turns this pin red while PIN R2 stays green, which is exactly
+  // the half-fix this pin exists to catch.
+  it('MEASURED TODAY (defect): the FIRST unguarded read is the `for…of`, not a `.map`', () => {
+    const { error } = renderCatching(serverFormWithGroupSection);
+    expect(error?.message).not.toMatch(/reading ['"]map['"]/);
+    expect(error?.message).toMatch(/not iterable/);
+  });
+
+  // ── PIN R4 — one bad section takes the WHOLE form with it, including the
+  // sections that are perfectly well-formed. This is why the disposition is a
+  // ruling and not a nicety: the blast radius is the document, not the section.
+  it('MEASURED TODAY (defect): a well-formed sibling section is destroyed with it', () => {
+    const mixed = {
+      type: 'simple',
+      sections: [
+        { label: 'Basics', fields: ['a'] },
+        { label: 'Contact', group: 'contact_info' },
+      ],
+    };
+    const { error, html } = renderCatching(mixed);
+    expect(error).toBeInstanceOf(TypeError);
+    expect(html).toBe('');
+  });
+
+  // ── PIN R5 — the tabbed arm dies the same way, at the same site. `:1147` is
+  // inside the `isTabbed` branch, so a reader could reasonably expect the tabbed
+  // form to fail differently; it does not, because `:786` is upstream of both
+  // arms. Recorded so the fix is not scoped to one arm.
+  it('MEASURED TODAY (defect): the tabbed arm dies at the same upstream read', () => {
+    const tabbed = {
+      type: 'tabbed',
+      sections: [
+        { label: 'Basics', fields: ['a'] },
+        { label: 'Contact', group: 'contact_info' },
+      ],
+    };
+    const { error } = renderCatching(tabbed);
+    expect(error).toBeInstanceOf(TypeError);
+    expect(error?.message).toMatch(/not iterable/);
+  });
+});
+
+/**
+ * Named export so the compile-time block above is not dead code to the linter,
+ * mirroring `form-spec.containers.test.tsx`'s `formContainerContractPins`.
+ */
+export const readSiteThatFiresFirst = 'SchemaForm.tsx SchemaFormBody — for (const f of s.fields)';


### PR DESCRIPTION
Part of #8725 — deliberately **not** `Fixes`. This PR delivers the card's **first deliverable, the reachability measurement**, and stops there. Neither half of the fix is here: the half that remains is the type widening plus a disposition for the three read sites, which is a behaviour ruling on a renderer. See "What this PR does not do".

## Leg 1 — reachability: **YES**, and the card's guess about the inputs is false

The card was filed with reachability explicitly unmeasured and named that as its own gap. It guessed the inputs were "this repo's own `*.form.ts` create/edit schemas, which do not author `group`" — which would have made the defect latent.

**Sweep.** Population: 4,231 tracked `.ts` / `.tsx` files under `apps/` and `packages/` (`git ls-files -- 'apps/**/*.ts' 'apps/**/*.tsx' 'packages/**/*.ts' 'packages/**/*.tsx' | wc -l`). Lit control on the same command shape over the same population: 1,904 files match `git ls-files -- '*.ts'`, and `git grep -l "from 'react'"` over `packages/ apps/ examples/` lights 1,875 files. Against that non-empty population, **`git ls-files` matches 0 files named `*.form.ts` and 0 files containing `.form.` at all.** The premise names a file class this repository does not contain.

**What the inputs actually are.** A `git grep` for the JSX opening tag of `SchemaForm` over the whole tracked tree returns 13 production call sites; seven pass a `form` prop, and they take it from exactly two channels:

1. **A server document, untyped and uncast-checked.** `RichMetadataTypeEntry.form` (`useMetadata.ts:93`) is a `Record` of `string` to `unknown` — the `/meta/types` registry response, deserialised in `useMetadataTypes` with no validation and no normalisation — and `ResourceEditPage.tsx:2798` / `:2822` hand it over as `form={createMode && config.createSchema ? undefined : (entry?.form as any)}`. `EmbeddedItemEditor.tsx:76` does the same with `subEntry?.form as any`.
2. **Spec-bundled forms** — `getPageForm` / `getViewForm` / `getReportForm` / `getDashboardForm` read `pageForm` and friends straight out of `@objectstack/spec/ui`, an upstream versioned document this repo does not author either.

So the REQUIRED `fields` on `FormSectionSpec` stands between a TypeScript author and this renderer, and between nothing else. On the channel that actually reaches `ResourceEditPage`, there is no compile-time barrier at all.

**Premise re-measured against the installed `@objectstack/spec` 17.3.0** (root export is thin, so via the `/ui` subpath):

```
FormSectionSchema.safeParse({ group: 'contact_info' })  -> ACCEPT
   { collapsible: false, collapsed: false, columns: 1, group: 'contact_info' }
CONTROL FormSectionSchema.safeParse({ notAKey: 1 })     -> REJECT  ["unrecognized_keys"]
```

The control fires, so the accept is a real reading of a strict schema. Also measured on 17.3.0: none of `pageForm` / `viewForm` / `reportForm` / `dashboardForm` declares a `group` section or a section missing `fields` today — a property of one spec release, not a barrier.

## The DOM reproduction, and one word the card has wrong

Reproduced in `happy-dom` through the same untyped channel. The render **throws out of the component body**; there is no partial tree and no per-section boundary could contain it. Container `innerHTML` is the empty string — the card's parent measurement (#8641) found a *visible empty bordered card* for its defect; this one leaves no DOM at all. A well-formed sibling section in the same document dies with it, and the tabbed arm dies identically.

The card predicts `Cannot read properties of undefined (reading 'map')`. **That is not what fires.** The observed throw is:

```
TypeError: s.fields is not iterable
```

`SchemaForm.tsx:786` is `for (const f of s.fields)`, inside `SchemaFormBody`'s pre-flight "does this layout name any field the schema has" loop — upstream of `SectionedSchemaForm`, so the `.map` sites at `:1030` and `:1147` are never reached. **Guarding only the two `.map` sites the card quotes leaves the crash exactly where it is.** This is proved mechanically by ablation leg A below, not by reading.

## What this PR does not do, and why

Nothing here widens `FormSectionSpec.fields` and nothing here touches a read site.

- Widening the type **alone** removes the only thing that currently keeps a TypeScript author out of the crash above.
- `?? []` at the read sites degrades a group-referencing section to an **empty** one — today's silent drop, made non-throwing. That is a behaviour ruling on a renderer.
- Resolving the reference needs the object definition `SchemaForm` is not handed. `@object-ui/plugin-form` publishes `resolveSectionGroupReferences` for exactly that (PR #8727, still open and not merged at the time of writing), so that route is an import, never a new derivation — no assembly rule may be re-implemented on the objectui side (#7051, objectstack#13855).

**One thing the card could not know, measured here:** the trap is real but **loud**, not silent. Widening `fields` to optional makes this package's own `type-check` report, immediately:

```
SchemaForm.tsx(786,23): error TS18048: 's.fields' is possibly 'undefined'.
SchemaForm.tsx(1030,20): error TS18048: 's.fields' is possibly 'undefined'.
SchemaForm.tsx(1147,9): error TS18048: 's.fields' is possibly 'undefined'.
form-spec.containers.test.tsx(117,60): error TS2537   (PIN D needs a NonNullable)
mergeServerFields.test.ts 69/82/128/160: error TS18048
```

So part 1 cannot ship without its author confronting every read. What `strictNullChecks` cannot do is stop them from typing `?? []` to silence it — which is precisely the ruling this card is holding open.

## What landed

One new test file, `packages/app-shell/src/views/metadata-admin/SchemaForm.groupSectionReachability-8725.test.tsx`, plus an empty-frontmatter changeset. No source file, no type, no behaviour changes.

Its runtime pins assert what this renderer does **today**, which is to die. They are a measurement, not an endorsement: whoever rules on the disposition is expected to turn them into pins on the chosen behaviour, and **their going red is the intended signal that the ruling landed**.

| pin | kind | asserts |
|---|---|---|
| T1 | `tsc` | the spec-legal `{ group }` section is refused by `FormSectionSpec` (`ts-expect-error`, so it is two-way: widening `fields` reds this file and puts the runtime pins in front of the author) |
| T2 | `tsc` | the crashing shape **is** assignable to `RichMetadataTypeEntry['form']` — the barrier guards one channel and not the reaching one |
| R1 | vitest | **control / non-regression** — a section that authors `fields` still renders them |
| R2 | vitest | the render throws a `TypeError` of the `s.fields` family and leaves no DOM |
| R3 | vitest | the read that fires first is the `for…of`, **not** a `.map` |
| R4 | vitest | one bad section destroys a well-formed sibling: the blast radius is the document |
| R5 | vitest | the tabbed arm dies at the same upstream read |

T1 carries a positive control (`group` **is** a declared key, so T1's refusal is about the missing `fields` and not an unknown `group`).

## Evidence

**Every pin observed red.** Five ablation legs, each run from a committed tree, each mutation line-preserving and proved on disk in both directions (anchor counts before **and** after, `git hash-object` differing from the HEAD blob, a line-total gate), each restored **by state** (`git checkout HEAD -- ABSOLUTE_PATH`, then `git diff HEAD` empty **and** the blob hash back to the HEAD blob), each under a `trap ... EXIT INT TERM` with absolute paths. Per-test classification read from **vitest's JSON reporter**, with file-level `failureMessage` (suite death) counted separately — it was 0 in every leg, so every result below is a failing assertion and not a suite death.

| leg | mutation | result |
|---|---|---|
| A | guard read site `:786` only | **R3, R5 FAILED**; R1, R2, R4 passed. Message becomes `Cannot read properties of undefined (reading 'map')` — the card's own quote, from `:1030`. Proves the ordering claim and that a two-site fix is a non-fix. |
| B | guard all three read sites | **R2, R3, R4, R5 FAILED**; R1 passed. The "fix landed" direction. |
| C | caricature: every section resolves to no fields | **R1 FAILED**, alone. The control is real. |
| D | `FormSectionSpec.fields` widened to optional | **T1 FAILED** (`TS2578: Unused 'ts-expect-error' directive`), plus the `TS18048` inventory quoted above. |
| E | `RichMetadataTypeEntry.form` retyped to `FormViewSpec` | **T2 FAILED** (`TS2322`), and measured as the **only** error in the package — so T2 is a measurement, not a tautology. |

**Type-level pins are inside the checked program.** `tsc -p packages/app-shell/tsconfig.test.json --listFiles` reads 4,474 files and the pin file is one of them (input #4,099). Legs D and E confirm behaviourally that the project judges it.

**Non-regression, structurally.** `tsc -p packages/app-shell/tsconfig.json --noEmit --listFiles` reads 3,697 files: the new file is **not** among them, and **no** `*.test.tsx` is (control: `SchemaForm.tsx` is). The emitting program's inputs are byte-identical to `main`, so nothing any form builds can have moved. R1 is the runtime half of the same claim.

**Suites run** (from the repo root with paths, per objectui#3378):

```
packages/app-shell/src/views/metadata-admin/   832 suites, 2559 tests, 0 failed, 0 suite deaths
packages/app-shell/src/views/studio-design/    168 suites,  323 tests, 0 failed, 0 suite deaths
pnpm --filter @object-ui/app-shell type-check  exit 0   (tsc --noEmit && tsc -p tsconfig.test.json)
eslint on the new file                          0 errors, 0 warnings
node scripts/check-control-bytes.mjs           exit 0   (6922 tracked text files)
node scripts/check-changeset-presence.mjs      exit 0   "Every one of them has an EMPTY frontmatter"
node scripts/check-changeset-no-major.mjs      exit 0
```

**Declared narrowing.** The full `@object-ui/app-shell` suite exceeds this container's foreground budget, so it was narrowed to the change's measured blast radius and the remainder is declared to CI. The radius is measured, not assumed: of 41 tracked files importing `SchemaForm` or `form-spec`, **39 are under `views/metadata-admin/`** and the other two are `src/index.ts` (a re-export) and `views/studio-design/ObjectHooksPanel.tsx` — both directories were run in full above.

## Collisions

`git ls-remote --heads origin 'gh-readonly-queue/*'` at branch time listed PRs 8720, 8721, 8723, 8732, 8733. Diffing the queue tip against this branch's base gives 26 files; the intersection with this PR's two files is **empty**, and none of them is under `views/metadata-admin/`.

## The decision this PR is asking for

`{ group }` **can** reach `SchemaForm`, so parts 1 and 2 have to land together. Part 2's disposition is the ruling:

- **A — `?? []` at the three read sites.** Cheapest, no new dependency. It makes a group-referencing section render as an *empty* one: today's silent drop, no longer fatal. That is a behaviour ruling on a renderer, and it is what the compiler will tempt the next author into typing.
- **B — resolve the reference,** importing `resolveSectionGroupReferences` from `@object-ui/plugin-form` (blocked on #8727 landing). Correct, and the only route that does not re-implement an assembly rule here — but `SchemaForm` is not handed an object definition today, so it needs a new input threaded from `ResourceEditPage` / the inspectors.
- **C — put the barrier on the channel that actually reaches the renderer,** by retyping `RichMetadataTypeEntry.form` (leg E measured this as the only error in the package) and dropping the `as any` casts. This does not fix the crash — a server document can still carry the shape at runtime — but it stops the type from claiming a guarantee it does not provide.

A and B are not exclusive with C.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_