### PR TITLE
test(plugin-list): date the two query-absence controls to a settle window, not to mount (objectui#8705)

### DIFF
--- a/.changeset/8705-listview-absence-settle-window.md
+++ b/.changeset/8705-listview-absence-settle-window.md
@@ -1,0 +1,10 @@
+---
+---
+
+Date the two query-absence controls in
+`ListView.objectProviderBinding-7477.test.tsx` to a bounded settle window
+rather than to mount (objectui#8705). Both `not.toHaveBeenCalled()` pins sat
+straight after a `waitFor` that is satisfied on the first commit, so an
+implementation that starts a query 50ms after mount passed them; under the
+repair that same forced implementation turns them red. Test only; no published
+behaviour changes and no package is released by this change.

--- a/packages/plugin-list/src/__tests__/ListView.objectProviderBinding-7477.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.objectProviderBinding-7477.test.tsx
@@ -48,11 +48,40 @@
  * handed `objectName: undefined` and nothing is fetched; without the
  * `specType` leg the page renders `object-grid` instead of `object-kanban`.
  * The `provider: 'value'` case is the control that stays green either way.
+ *
+ * ## Dating the two query-absence controls (objectui#8705)
+ *
+ * `invents NO binding …` and `leaves the value provider alone …` each assert
+ * that NO query is started. Read straight after their `waitFor`, that absence
+ * was dated to MOUNT rather than to a settled load: on both of those paths the
+ * view spy's props land on the FIRST commit, so `not.toHaveBeenCalled()` was
+ * being evaluated before a deferred query could have run. Both pins stayed
+ * GREEN against an implementation strictly worse than the bug — one line in
+ * `ListView.tsx` that fires `dataSource.find` 50ms after every mount — so they
+ * could not tell "starts no query" from "starts a query a tick later", which
+ * is exactly the regression shape that would reach them.
+ *
+ * There is no anchor to prefer here, and that was checked before reaching for
+ * a timer. An anchor needs a positive signal the implementation must emit
+ * AFTER any query would have started. On the `value` path nothing settles at
+ * all: `loading` is false from the first commit and never flips. On the
+ * `object`-provider-without-object path the one transition that exists —
+ * `loading` going false — is set from the very branch a query would start
+ * from, so it postdates a synchronous query and not a deferred one. The
+ * absence is therefore watched over a bounded window; see `ABSENCE_SETTLE_MS`.
+ *
+ * The other three absence reads in this file are NOT this shape, and that is
+ * measured, not assumed: at `expect(gridProps).toHaveLength(0)` and at both
+ * `expect(kanbanProps).toHaveLength(0)` sites, `dataSource.find` has ALREADY
+ * been called when the line runs. Those three cases bind an object, and
+ * `ListView` withholds the view spy behind its loading skeleton
+ * (`loading && data.length === 0`) until the query resolves — so they are
+ * already dated to a resolved query and are left exactly as they were.
  */
 
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, waitFor, cleanup } from '@testing-library/react';
+import { render, waitFor, cleanup, act } from '@testing-library/react';
 import { ComponentRegistry } from '@object-ui/core';
 import { SchemaRenderer, SchemaRendererProvider, AdapterCtx } from '@object-ui/react';
 // Registers the page renderers (`type:'page'` / `'home'`), which dispatch
@@ -140,6 +169,29 @@ function renderListView(schema: Record<string, any>) {
   return dataSource;
 }
 
+/**
+ * How long a query-absence is watched before it is believed.
+ *
+ * REAL time, on purpose, and deliberately larger than any deferral the test
+ * environment drains for free: RTL's `asyncWrapper` already flushes one
+ * macrotask before `waitFor` returns, so a `setTimeout(…, 0)` regression sits
+ * INSIDE the pre-existing window and a 0ms settle would prove nothing at all.
+ * objectui#8705's forced leg defers its query by 50ms; this window is 5x that
+ * and still an order of magnitude inside vitest's 5s default test timeout.
+ */
+const ABSENCE_SETTLE_MS = 250;
+
+/**
+ * Advance past `ABSENCE_SETTLE_MS` of real time so a deferred query has run
+ * before an absence is read. Wrapped in `act` so that a regression which does
+ * land state during the window is flushed into React rather than warned about.
+ */
+async function settleAbsenceWindow(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ABSENCE_SETTLE_MS));
+  });
+}
+
 beforeEach(() => {
   kanbanProps = [];
   gridProps = [];
@@ -201,6 +253,11 @@ function Page() {
     const dataSource = renderListView({ data: { provider: 'object' }, specType: 'kanban' });
 
     await waitFor(() => expect(kanbanProps.length).toBeGreaterThan(0));
+    // Both reads below are ABSENCES, and the props above arrive on the first
+    // commit — so date them to the end of a settle window, not to mount
+    // (objectui#8705). A late `objectName` would push a fresh props entry and
+    // a deferred query would have called `find` by the time this returns.
+    await settleAbsenceWindow();
     expect(kanbanProps[kanbanProps.length - 1].schema.objectName).toBeUndefined();
     expect(dataSource.find).not.toHaveBeenCalled();
   });
@@ -214,6 +271,10 @@ function Page() {
     });
 
     await waitFor(() => expect(kanbanProps.length).toBeGreaterThan(0));
+    // Same dating as the control above, and this is the path with NO settle of
+    // its own: an inline-items provider leaves `loading` false from the first
+    // commit, so without this window the absence is dated to mount.
+    await settleAbsenceWindow();
     expect(kanbanProps[kanbanProps.length - 1].schema.objectName).toBeUndefined();
     expect(dataSource.find).not.toHaveBeenCalled();
   });

--- a/packages/plugin-list/src/__tests__/ListView.objectProviderBinding-7477.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.objectProviderBinding-7477.test.tsx
@@ -53,9 +53,11 @@
  *
  * `invents NO binding …` and `leaves the value provider alone …` each assert
  * that NO query is started. Read straight after their `waitFor`, that absence
- * was dated to MOUNT rather than to a settled load: on both of those paths the
- * view spy's props land on the FIRST commit, so `not.toHaveBeenCalled()` was
- * being evaluated before a deferred query could have run. Both pins stayed
+ * was dated to MOUNT rather than to a settled load. Measured, not assumed: in
+ * BOTH of those tests the kanban spy has already recorded two props entries by
+ * the time `render` returns, so `waitFor` is satisfied without ever yielding
+ * and `not.toHaveBeenCalled()` was evaluated before a deferred query could
+ * have run. Both pins stayed
  * GREEN against an implementation strictly worse than the bug — one line in
  * `ListView.tsx` that fires `dataSource.find` 50ms after every mount — so they
  * could not tell "starts no query" from "starts a query a tick later", which
@@ -66,8 +68,10 @@
  * AFTER any query would have started. On the `value` path nothing settles at
  * all: `loading` is false from the first commit and never flips. On the
  * `object`-provider-without-object path the one transition that exists —
- * `loading` going false — is set from the very branch a query would start
- * from, so it postdates a synchronous query and not a deferred one. The
+ * `loading` going false, per the `useState` initializer in `ListView.tsx` — is
+ * set from the very branch a query would start from, and the measurement above
+ * shows it has already happened before `render` returns. It postdates a
+ * SYNCHRONOUS query and never a deferred one, which is the shape at issue. The
  * absence is therefore watched over a bounded window; see `ABSENCE_SETTLE_MS`.
  *
  * The other three absence reads in this file are NOT this shape, and that is


### PR DESCRIPTION
Fixes #8705

`packages/plugin-list/src/__tests__/ListView.objectProviderBinding-7477.test.tsx` asserts at two sites that **no query is started** — the `object` provider naming no object must invent no binding, and the `value` provider must never gain an `objectName`. Both `expect(dataSource.find).not.toHaveBeenCalled()` reads sat straight after a `waitFor` satisfied on the **first commit**, so the absence was dated to **mount**. The assertions themselves are objectui#7477's contract and are unchanged; what changes is when they are read.

## The card's ablation, reproduced on today's `main`

Reproduced, not reinvented. Base `645087cd3`; pristine `ListView.tsx` blob `ef7cf802d719944519bb11d1891904c14b5cb078` — byte-identical to the blob the card recorded, so no drift on the mutated file. Every leg mutates from a committed tree, proves the mutation landed by `git hash-object` differing from the HEAD blob plus anchor counts and a line-total gate, and proves the restore **by state** (`git diff HEAD --quiet`), under `trap … EXIT INT TERM` with absolute paths.

| leg | mutation | ListView.tsx blob | result (JSON reporter) | card said |
| --- | --- | --- | --- | --- |
| 1 | probe only | `f0e80896a9d1d6d16a0d63efba8bac0b3e66d7d4` | 7 passed / 0 failed | 7 of 7 pass |
| 2 | probe + 300ms diagnostic | `f0e80896…` | 7 passed / 0 failed | 7 of 7 pass |
| 3 | diagnostic only, pristine `ListView.tsx` | `ef7cf802…` (untouched) | 6 passed / **1 failed** — `AssertionError: expected "vi.fn()" to be called at least once` | 6 passed / 1 failed, same message |

All three hold. Zero suite-death strings in every run. One provenance note: the leg 2/3 test-file blob is `121aa643e0cf062b05c1f660a09847b1cc8bb8c2`, not the card's `9b245eda9bde4e8921531a66ea84ca61c6665ab1` — the same two-line diagnostic, placed against the existing pin line rather than re-emitted with the card's exact surrounding whitespace. Same mutation semantically, same outcome in both legs; the blob is not reproduced and is not claimed to be.

## Anchor or timer — the ruling applied

First, the mount-dating itself is **measured**, not inferred from the source. A temporary diagnostic reading `kanbanProps.length` synchronously, immediately after `render` returns and before the `waitFor`, reports **2 entries in both named tests** — so the `waitFor` is satisfied without ever yielding, and both absences were being read at mount.

An anchor was looked for first and does not exist on either path:

- **`value` provider** — an inline-items provider leaves `loading === false` from the first commit and it never flips. Nothing settles, so there is no positive signal to anchor on at all.
- **`object` provider naming no object** — `loading` starts `true` and flips `false` (read from the `useState` initializer in `ListView.tsx`; not separately forced), but it is set from `fetchData`'s own `!dataSource || !schema.objectName` branch — the very branch a query would start from, and the diagnostic above shows it has already happened before `render` returns. It postdates a *synchronous* query, never a deferred one, so it cannot date this absence.

So a **bounded wait**, and it is justified by the forced leg rather than by taste: `ABSENCE_SETTLE_MS = 250`, real time. It has to clear a deferral the environment already drains for free — RTL's `asyncWrapper` flushes one macrotask before `waitFor` returns, so a `setTimeout(…, 0)` regression sits *inside* the pre-existing window and a 0ms settle would prove nothing. 250ms is 5x the card's probe and an order of magnitude inside vitest's 5s default test timeout. The wait is wrapped in `act` so a regression that lands state during the window is flushed into React rather than warned about.

The window is placed before **both** absences in each test, so the `toBeUndefined()` companion is re-dated too: a late `objectName` would push a fresh props entry that `kanbanProps[kanbanProps.length - 1]` then reads.

## The repaired pins, forced

Repaired test blob `ca9e0e64dfafb964d34204437ffea968e0e5c117` — the blob at the branch's final commit `c78a74fd9`, committed before either leg ran, so both read the same bytes. (Both legs were first run at blob `92318e56ffd4b2c653ffb26008cc1c4f449772a0` and then re-run unchanged on the final blob after the header comment was corrected; the counts below are from the final run.)

- **RED under the card's own 50ms-deferred probe** — `ListView.tsx` at `f0e80896a9d1d6d16a0d63efba8bac0b3e66d7d4`: **5 passed / 2 failed**, both failures being exactly the two pins, both `AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times`. Zero death strings.
- **GREEN under pristine `ListView.tsx`** — blob `ef7cf802d719944519bb11d1891904c14b5cb078`: **7 passed / 0 failed**. A settle window that reddened on correct behaviour would be worse than the vacuous pin it replaced; it does not.

## Same-file sweep

The file has five absence reads besides the two named pins' `find` assertions. Classification is **measured**, not read off the source: a temporary diagnostic asserting `dataSource.find` has *already* been called at each pin line was applied to the three `toHaveLength(0)` sites and run.

| site | shape | verdict |
| --- | --- | --- |
| `objectName` `toBeUndefined()` in both named tests | same statement group, same mount dating | **repaired** — the settle window precedes them |
| `expect(gridProps).toHaveLength(0)` (kanban-from-react-page case) | view-spy absence | **not this shape** — diagnostic passed: `find` already called when the line runs |
| `expect(kanbanProps).toHaveLength(0)` (grid-by-default case) | view-spy absence | **not this shape** — diagnostic passed |
| `expect(kanbanProps).toHaveLength(0)` (explicit `viewType` wins case) | view-spy absence | **not this shape** — diagnostic passed |

Those three cases all bind an object, and `ListView` withholds the view spy behind its loading skeleton (`loading && data.length === 0`) until the query resolves — so they already sit behind a positive anchor and are left exactly as they were. What is **NOT MEASURED**: whether they would survive a differently-shaped regression that re-renders into the *other* view spy after a delay. That is a different forced leg and a different population; it is declared, not silently repaired.

No third `not.toHaveBeenCalled()` exists in the file. Scope stayed inside this one file.

## Verification

All of the below were run at the branch's final commit, `git rev-parse --short HEAD` = `c78a74fd9`. Run from the repo root with file paths; per-test classification from vitest's JSON reporter (`--reporter=json --outputFile`), never the text reporter, with suite-level messages counted explicitly as death strings.

- Whole package suite — `pnpm exec vitest run packages/plugin-list/`: **72 files, 888 passed / 0 failed / 0 pending, success=true, 0 death strings**.
- Type-check including tests — `pnpm --filter @object-ui/plugin-list run type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`): exit 0. Coverage of the edited file is proven, not assumed: `tsc -p tsconfig.test.json --listFiles` names it among 1503 program inputs, 0 errors. Dependency closure built first (`turbo run build --filter='@object-ui/plugin-list^...'`) and the `dist/*.d.ts` verified on disk rather than trusted from a replayed turbo log.
- `node scripts/check-control-bytes.mjs` — `✅ check-control-bytes: OK (scanned 6935 tracked text file(s); skipped 85 binary).`
- `pnpm --filter @object-ui/plugin-list run lint` — 0 errors. The six `no-explicit-any` warnings on this file are all pre-existing lines; the new code adds none.
- `node scripts/check-governed-queue-guard.mjs --test` on both changed paths — `✅ NOT GOVERNED — 2 path(s) checked against 5 governed surface(s); none matched.`

## Changeset

Empty frontmatter, which is this gate's explicit exemption for a test-only change. `node scripts/check-changeset-presence.mjs` verdict:

> ✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/8705-listview-absence-settle-window.md.
> Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.

`check-changeset-no-major.mjs` and `check-changeset-fixed.mjs` both green.

Draft on purpose — left for the PM to flip and to arm auto-merge after contract review.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_

---
_Generated by [Claude Code](https://claude.ai/code)_