### PR TITLE
fix(skills): stop teaching a retired `never` key in the plugin registration example (objectui#7493)

### DIFF
--- a/skills/objectui/guides/plugin-development.md
+++ b/skills/objectui/guides/plugin-development.md
@@ -53,9 +53,9 @@ ComponentRegistry.register('my-widget', MyWidgetRenderer, {
   category: 'plugin',             // Grouping: 'plugin' | 'view' | 'field' | 'layout'
   isContainer: false,
   inputs: [
-    { name: 'title', type: 'string', label: 'Title' },
-    { name: 'columns', type: 'array', label: 'Columns', required: true },
-    { name: 'mode', type: 'enum', label: 'Mode', enum: ['compact', 'full'] },
+    { name: 'title', type: 'string' },
+    { name: 'columns', type: 'array', required: true },
+    { name: 'mode', type: 'enum', enum: ['compact', 'full'] },
   ],
   defaultProps: { mode: 'full' },
 });


### PR DESCRIPTION
Fixes #7493

Scope is exactly triage item 3 as corrected in comment 5583571842 on the card: the **unmarked** registration fence in `skills/objectui/guides/plugin-development.md`.

## What changed

The fence wrote `label:` on three `ComponentInput` entries. `ComponentInput.label` is `never` on the published contract (`packages/types/src/base.ts`, ADR-0049 retirement tombstone): the manifest serializer forwards a fixed key list that does not include it, so an authored value was silently dropped, and authoring one is a `tsc` error today. The three keys are deleted.

```diff
-    { name: 'title', type: 'string', label: 'Title' },
-    { name: 'columns', type: 'array', label: 'Columns', required: true },
-    { name: 'mode', type: 'enum', label: 'Mode', enum: ['compact', 'full'] },
+    { name: 'title', type: 'string' },
+    { name: 'columns', type: 'array', required: true },
+    { name: 'mode', type: 'enum', enum: ['compact', 'full'] },
```

Nothing is written in their place. The marked fence's general remedy is "delete the key and say it in `description`, which IS published", but the tombstone for **this** key is narrower and is the one that applies: *"Delete the key; the input's `name` is what every consumer identifies it by."* `Title` / `Columns` / `Mode` are only the title-cased `name`, so a `description` would add prose, not information.

**Kept deliberately.** `ComponentMeta.label` at line 51 — the live key, five lines above in the same fence, recorded in this page's own options table. Two further `ComponentMeta.label` sites at lines 418 and 431 (the "Registration patterns from existing plugins" fence) are equally live and equally untouched; the dispatch expected only line 51 plus a table row, so this is a correction to that reading, not a scope change. After the edit `grep -n "label:"` on the guide returns exactly those three live sites.

**Untouched, per the card's fences.** The marked fence, `KNOWN_BARE_ANY_EXAMPLES` (an empty set is its terminal state, not a disabled gate), the retrospective sentence below the marked fence, and `packages/types`.

## The opt-in marker was measured, and declined — the other half of item 3

Triage item 3 asked for the `os:check` opt-in marker to be *considered*, conditioned on a first compile: **if the fence has another error, split it in two — fix first, mark later.** (The marker is an HTML comment; it is spelled in words here because GitHub deletes tag-shaped fragments from a body.)

It has another error, so the marker is NOT added by this PR.

`node scripts/check-skill-examples.mjs --measure` judges every candidate fence, marked or not. Run before and after the edit on the same tree; the **whole diff between the two runs** is these three lines disappearing, and nothing else:

```
  [semantic]  skills/objectui/guides/plugin-development.md:56:38  TS2322: Type 'string' is not assignable to type 'undefined'.
  [semantic]  skills/objectui/guides/plugin-development.md:57:39  TS2322: Type 'string' is not assignable to type 'undefined'.
  [semantic]  skills/objectui/guides/plugin-development.md:58:35  TS2322: Type 'string' is not assignable to type 'undefined'.
```

What survives on that fence, and is the reason the marker stays off:

```
  skills/objectui/guides/plugin-development.md:46  [typescript]          FAIL
  [semantic]  skills/objectui/guides/plugin-development.md:49:41  TS2304: Cannot find name 'MyWidgetRenderer'.
```

`MyWidgetRenderer` is the reader's own component — the fence is a fragment by construction, which is precisely the shape the gate's own header says opt-in exists for. Marking it would require declaring that symbol inside the fence, a separate editorial decision on a governed published guide. Marking is therefore still open work; see the acceptance note below.

## Gates

Union re-run at the final commit `022ea6a`, working tree clean. Exit codes captured before any pipe.

| gate | exit | its own verdict line |
|---|---|---|
| `pnpm check:skill-examples` | 0 | `Every marked skill example holds up against the built types.` — `Semantic phase: 14 of 14 ts fence(s) judged, 0 failed.` |
| `pnpm check:skills-paths` | 0 | `check-skills-paths: OK (88/89 stated path(s) resolve across 20 guide file(s); 1 baselined).` |
| `pnpm check:skill-eval-tokens` | 0 | `Every must_contain token is taught by its own skill bundle.` |
| `pnpm check:control-bytes` | 0 | `check-control-bytes: OK (scanned 6942 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-changeset-presence.mjs` | 0 | `No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `node scripts/check-governed-queue-guard.mjs --test skills/objectui/guides/plugin-development.md` | 3 | GOVERNED — quoted in full below |

The marked population is unchanged (no marker added), so `MARKED_FLOOR` is not approached from either side.

Prerequisite for the gate to be a verdict at all: the packages the marked fences import were built first (`turbo run build` over `check-skill-examples.mjs --build-filter`, 29 tasks successful) — without that this gate prints `PRECONDITION NOT MET` and exits 2, which is neither a pass nor a guide defect.

No changeset: the gate says none is owed, and the reading holds independently — `skills/**` is not published source of any released package.

### Governed surface — quoted verbatim

```
⛔ GOVERNED — 1 of 1 path(s) are on a governed surface:
   skills/** x1 — the published skills catalog
     - skills/objectui/guides/plugin-development.md

   One governed path governs the WHOLE pull request — proportion is not a question.
   ⛔ Do not flip it ready, enqueue it, or arm auto-merge. Park it as a DRAFT and leave the merge
      to the maintainer; a human merge IS the review record for a governed surface.
   The merge-queue run of "Governed Surface Queue Guard" refuses this diff unless an APPROVED review by an
   authorized approver (GOVERNED_APPROVERS: os-zhuang, hotlong) is on the pull request — on
   whichever commit it was left (maintainer ruling 2026-09-04).
```

This PR stays a **draft**. It is not flipped ready, not enqueued, no auto-merge, no seat-side approval.

## Published-skill line budget

`skills/**` is a package published to users, so both readings are reported. Lines, since `check:skill-eval-tokens` defines a taught-token oracle rather than a token count — there is no token budget in this repository to report against.

| reading | before | after | net |
|---|---|---|---|
| `skills/objectui/guides/plugin-development.md` | 481 | 481 | **0** |
| whole bundle — all 16 `.md` under `skills/objectui/` | 4587 | 4587 | **0** |

Net increase 0, within the "must be at most zero" budget. The three deletions are intra-line, and no line was added, so the diff is 3 insertions / 3 deletions with no re-wrapping used to buy room.

## 验收备注

- **Marking this fence remains open work, and this PR closes the card.** Triage phrased item 3's second half as "consider", and conditioned it on a compile that has now come back with a further error, so the mandate item 3 carries is delivered here. What is not delivered: the fence is still outside the gate, so the same class can recur on it silently. Anyone picking that up starts from the measurement above — one remaining diagnostic, `TS2304: Cannot find name 'MyWidgetRenderer'` at line 49 — and the editorial call is whether a teaching fence should declare a stand-in for the reader's own component in order to be gated.
- Not filed as separate cards, recorded here only: the guide has 12 other candidate fences that fail `--measure` today, all unmarked and all fragments by construction (undeclared `ComponentRegistry`, `ColumnDef`, `ColorField`, hook bodies continuing the block above). None of them teaches a retired or rejected key, which is what separates them from the one fixed here.

## 维护者速读(草稿)

**改了什么** — 插件开发指南里那段"注册一个组件"的示例代码,三个输入项上写了 `label:`。这个键在平台的类型上已经退役成 `never`,写了会被序列化器静默丢弃,照抄就是编译错误。三处删掉,同一段里五行之上那个仍然有效的 `ComponentMeta.label` 保留不动。

**为什么改** — 这份指南是 AI 写 ObjectUI 插件之前读的第一份材料。它教了一个平台已经明确拒收的元数据键,等于批量制造"声明了但运行时不兑现"的代码。这一段没有被 `check:skill-examples` 看着,所以同一份文件里被看着的那条已经修好了,没被看着的这条还在教错的东西。

**风险与代价(含回滚)** — 风险很低:纯文档示例,不改任何运行时代码,不发版(门禁确认不欠 changeset),整包行数净增 0。回滚就是 revert 这一个 commit,单文件三行。唯一的取舍是这段示例现在不再展示"给输入项起一个人类可读的名字",但那个能力本来就不存在——平台用 `name` 识别输入项。

**席位意见** —

**你要做的** — 这是受管面(`skills/**`),PR 停在 draft 等你合并;你的那次合并动作本身就是审核记录。另外一个可选的后续:要不要把这段示例也纳入门禁(需要先给示例里的组件名补一个声明),已在上面的验收备注里写清代价,可以单开一张卡,也可以不做。

---

Session: `https://claude.ai/code/session_01HxLw5aKDPR5RJgyUR7Exkd`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxLw5aKDPR5RJgyUR7Exkd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxLw5aKDPR5RJgyUR7Exkd)_