### PR TITLE
test(app-shell): measure the reachability of a `dependsOn` lookup action param (objectui#8672)

### DIFF
--- a/.changeset/8672-lookup-dependson-reachability-measurement.md
+++ b/.changeset/8672-lookup-dependson-reachability-measurement.md
@@ -1,0 +1,35 @@
+---
+---
+
+Measurement-only change in `@object-ui/app-shell`: objectui#8672 asked how
+reachable a `dependsOn` lookup ACTION PARAM is, and where the surface that
+admits it lives. No behaviour changes and no disposition is chosen — the card
+names three (wire it · refuse it · declare the limit) and this pins what is true
+today so the ruling is made against something stable.
+
+New `views/ActionParamDialog.lookupDependsOnReach-8672.test.tsx`, three legs,
+each with a lit control:
+
+- **Leg A — current shape, not contract.** Driving the real `ActionParamDialog`,
+  a lookup param declaring `dependsOn` renders `lookup-trigger-gated`, disabled,
+  "Select account first", and filling the named parent does NOT lift it. A
+  control lookup identical but for `dependsOn` is asserted enabled, and the
+  keystroke is driven through a `radio` param whose `visibleWhen` DOES react to
+  it — so "the gate did not lift" is read against a keystroke proven to have
+  reached and re-rendered the dialog.
+- **Leg B — contract, version-qualified.** `@objectstack/spec`'s
+  `ActionParamSchema` (17.3.0) is `.strict()` and refuses `dependsOn` on an
+  action param of ANY type, with a positive control that parses and an
+  unknown-key negative control that is refused. `@object-ui/types`' `ActionParam`
+  derives its keys from `z.input` of that schema, so it declares none either.
+- **Leg C — current shape, not contract.** The one route the repo points authors
+  to (`RESOLVED_ONLY_PARAM_KEYS.dependsOn`: make the param field-backed) reads
+  `field.depends_on`, the SNAKE spelling `FieldSchema` refuses by name, while the
+  camel `dependsOn` it accepts is never read — so a spec-valid object field
+  declaring the cascade resolves to `dependsOn: undefined`. A sibling key off the
+  same field def is asserted to arrive in the same call, so the `undefined` is a
+  reading and not an empty fixture.
+
+Also corrects a stale sentence in `utils/paramToField.test.ts` that described
+this seam backwards ("…or the dialog's dependent lookups would have gone dead
+silently" — there has never been a working cascade here to go dead).

--- a/packages/app-shell/src/utils/paramToField.test.ts
+++ b/packages/app-shell/src/utils/paramToField.test.ts
@@ -108,7 +108,20 @@ describe('paramToField', () => {
   // and objectui#7357 added `dependsOn` to that half when it retired the
   // snake_case `depends_on` this adapter used to emit — this face was the one
   // in-repo framework producer of that spelling, so the emit had to move with
-  // the reader or the dialog's dependent lookups would have gone dead silently.
+  // the reader.
+  //
+  // ⚠️ CORRECTED (objectui#8672). This sentence used to end "…or the dialog's
+  // dependent lookups would have gone dead silently", which describes a WORKING
+  // cascade in this dialog. Measured, there has never been one: `dependsOn` is
+  // emitted onto the field bag below, but `ActionParamDialog` supplies
+  // `dependentValues` only to `CASCADE_OPTION_WIDGET_TYPES` (`select` /
+  // `multiselect` / `radio` / `checkboxes` — `lookup` is not a member), so
+  // `LookupField` resolves `{}` and the gate NEVER lifts. What moving the emit
+  // preserved is therefore the GATE, not a cascade: leaving it behind would have
+  // flipped a permanently gated picker into an ungated, UNFILTERED one — the
+  // silent behaviour change `paramToField.ts`'s own comment records. Pinned in
+  // `views/ActionParamDialog.lookupDependsOnReach-8672.test.tsx`; which
+  // disposition that gap gets is open on objectui#8672.
   // The remaining snake members below (`reference_to`, `title_format`,
   // `lookup_columns`, `lookup_page_size`) were outside both rulings and are
   // unchanged — this mixed shape is deliberate, and asserting it keeps the two

--- a/packages/app-shell/src/views/ActionParamDialog.lookupDependsOnReach-8672.test.tsx
+++ b/packages/app-shell/src/views/ActionParamDialog.lookupDependsOnReach-8672.test.tsx
@@ -1,0 +1,285 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8672 — MEASUREMENT PINS for a `dependsOn` lookup ACTION PARAM.
+ *
+ * ⭐⭐ **CURRENT SHAPE, NOT CONTRACT.** ⭐⭐ Read this before changing anything
+ * below. The card names three dispositions — wire it · refuse it · declare the
+ * limit — and **none of them is chosen here**. This file exists so that the
+ * ruling is made against a measured, stable behaviour instead of a guess; every
+ * `expect` in legs A and C records what the code does TODAY and endorses none of
+ * it. Whoever implements a disposition should expect these to go red and should
+ * **rewrite them**, not trust them: a red here is the pin doing its job, not a
+ * regression. Leg B is the exception and says so on its own describe block.
+ *
+ * ## What the three legs measure
+ *
+ * - **Leg A (current shape)** — the behaviour the card reports, made permanent:
+ *   a lookup param declaring `dependsOn` renders GATED and a keystroke in the
+ *   named parent does not lift the gate. `CASCADE_OPTION_WIDGET_TYPES` (the
+ *   dialog's `dependentValues` supply set in `ActionParamDialog.tsx`) does not
+ *   contain `lookup`, so `LookupField` resolves its record through the context
+ *   tail that is unconditionally `{}` (objectui#7206) and `dependenciesMissing`
+ *   can never go false.
+ * - **Leg B (contract, version-qualified)** — where the authoring surface is.
+ *   `@objectstack/spec`'s `ActionParamSchema` is `.strict()` and REFUSES
+ *   `dependsOn` on an action param outright. `@object-ui/types`' `ActionParam`
+ *   derives its key set from `z.input<typeof ActionParamSchema>`, so it declares
+ *   no `dependsOn` either — which is why leg A has to synthesise the resolved
+ *   `ActionParamDef` directly rather than author a param.
+ * - **Leg C (current shape)** — the ONE route the repo itself points authors to
+ *   (`RESOLVED_ONLY_PARAM_KEYS.dependsOn`: "make the param field-backed … to
+ *   pick it up") reads `field.depends_on`, the SNAKE spelling, while the spelling
+ *   `FieldSchema` accepts is camel `dependsOn`. So a spec-valid object field
+ *   declaring the cascade delivers `undefined` here.
+ *
+ * ## Every reading has a lit control beside it
+ *
+ * A gated trigger, a refused parse and an `undefined` key are all shapes a
+ * broken fixture produces for free, so none of them is asserted alone:
+ *
+ * - leg A pairs the gated lookup with a CONTROL lookup identical but for
+ *   `dependsOn` (asserted enabled), and drives the keystroke through a `radio`
+ *   param whose `visibleWhen` DOES react to it — so "the gate did not lift" is
+ *   read against a keystroke proven to have reached the dialog and re-rendered
+ *   it, not against a dialog that ignored the event;
+ * - leg B pairs each refusal with a positive control document that must PARSE,
+ *   and with an unknown-key document that must be REFUSED — so an "accept" is a
+ *   reading of a live strict schema rather than of a permissive one;
+ * - leg C pairs the `undefined` with a sibling key resolved off the SAME field
+ *   def in the same call, so an empty reading cannot come from a fixture the
+ *   resolver never saw.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { ActionParamDef } from '@object-ui/core';
+import { CASCADE_OPTION_WIDGET_TYPES } from '@object-ui/core';
+import { ActionParamSchema } from '@objectstack/spec/ui';
+import { FieldSchema } from '@objectstack/spec/data';
+// Module scope, per AGENTS.md 测试纪律: the dialog reaches `LookupField` through
+// a `React.lazy` factory inside `@object-ui/fields`, and a first dynamic
+// import() under a saturated transform pipeline can eat most of RTL's 1s
+// `findBy` budget. This barrel statically re-exports those widget modules, so
+// the lazy factories resolve in a microtask instead of racing the assertions.
+import '@object-ui/fields';
+import { ActionParamDialog } from './ActionParamDialog';
+import {
+  resolveActionParams,
+  type ResolveActionParamsContext,
+  type RawActionParam,
+} from '../utils/resolveActionParams';
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/* Leg A — the dialog's behaviour today                    CURRENT SHAPE      */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+/** The parent the child lookup names. A plain text param, so it is typable. */
+const ACCOUNT: ActionParamDef = { name: 'account', label: 'Account', type: 'text' };
+
+/**
+ * The card's shape verbatim: `{ type: 'lookup', referenceTo: 'contacts',
+ * dependsOn: ['account'] }`. Synthesised as a RESOLVED `ActionParamDef` on
+ * purpose — leg B measures that this cannot be authored as a raw param at all.
+ */
+const GATED_LOOKUP: ActionParamDef = {
+  name: 'contact',
+  label: 'Contact',
+  type: 'lookup',
+  referenceTo: 'contacts',
+  dependsOn: ['account'],
+};
+
+/** CONTROL — the same lookup, same target, differing ONLY in `dependsOn`. */
+const CONTROL_LOOKUP: ActionParamDef = {
+  name: 'control_contact',
+  label: 'Control contact',
+  type: 'lookup',
+  referenceTo: 'contacts',
+};
+
+/**
+ * CONTROL for the KEYSTROKE. A `radio` IS in `CASCADE_OPTION_WIDGET_TYPES`, so
+ * the dialog threads its in-progress values to it and this option's predicate
+ * re-resolves on every change to `account`. Without it, "the gate did not lift"
+ * would also be the reading for a dialog that never saw the keystroke.
+ */
+const KEYSTROKE_WITNESS: ActionParamDef = {
+  name: 'tier',
+  label: 'Tier',
+  type: 'radio',
+  options: [
+    { label: 'Enterprise', value: 'ent', visibleWhen: "record.account == 'acme'" },
+    { label: 'Small business', value: 'smb', visibleWhen: "record.account == 'other'" },
+  ],
+};
+
+function openDialog(params: ActionParamDef[]) {
+  render(
+    <ActionParamDialog
+      state={{ open: true, params, resolve: () => {} }}
+      onOpenChange={() => {}}
+    />,
+  );
+}
+
+const typeAccount = (value: string) =>
+  fireEvent.change(screen.getByLabelText('Account'), { target: { value } });
+
+describe('objectui#8672 leg A — a `dependsOn` lookup param is gated, permanently (CURRENT SHAPE, NOT CONTRACT)', () => {
+  it('renders the declared lookup GATED while the control lookup beside it is usable', async () => {
+    openDialog([ACCOUNT, GATED_LOOKUP, CONTROL_LOOKUP]);
+
+    // CONTROL first: an identical lookup differing only in `dependsOn` renders a
+    // normal, enabled trigger. This is what makes the gated reading below a
+    // measurement of `dependsOn` rather than of a lookup that cannot render here.
+    const control = await screen.findByTestId('lookup-trigger-control_contact');
+    expect(control).toBeEnabled();
+
+    // SUBJECT: the declared lookup renders the gate — disabled, and prompting
+    // for the very field the user is about to fill.
+    const gated = screen.getByTestId('lookup-trigger-gated');
+    expect(gated).toBeDisabled();
+    expect(gated).toHaveTextContent('Select account first');
+  });
+
+  it('does NOT lift the gate when the named parent is filled — while the same keystroke moves a witness', async () => {
+    openDialog([ACCOUNT, GATED_LOOKUP, KEYSTROKE_WITNESS]);
+
+    // Both witness options are offered before anything is typed: `record.account`
+    // is unresolvable, which fails OPEN.
+    expect(await screen.findByTestId('radio-option-ent')).toBeInTheDocument();
+    expect(screen.getByTestId('radio-option-smb')).toBeInTheDocument();
+    expect(screen.getByTestId('lookup-trigger-gated')).toBeDisabled();
+
+    typeAccount('acme');
+
+    // ⭐ The keystroke DID reach the dialog and DID re-render it: the witness's
+    // offered set narrowed. Load-bearing — it converts the assertion after it
+    // from "nothing happened" into "this specific thing did not happen".
+    await waitFor(() => expect(screen.queryByTestId('radio-option-smb')).not.toBeInTheDocument());
+    expect(screen.getByTestId('radio-option-ent')).toBeInTheDocument();
+
+    // …and the lookup is still gated on the field that now carries `acme`. This
+    // assertion is the card. ⛔ It is NOT a statement that it should stay this
+    // way — see the file docblock.
+    const stillGated = screen.getByTestId('lookup-trigger-gated');
+    expect(stillGated).toBeDisabled();
+    expect(stillGated).toHaveTextContent('Select account first');
+  });
+
+  it('records WHY: the dialog\'s `dependentValues` supply set excludes `lookup`', () => {
+    // The mechanism behind the two renders above, stated where it can be found
+    // from them. `ActionParamDialog.tsx` supplies `dependentValues` only to
+    // members of this set, so a lookup is reached without one and falls through
+    // to the context tail that objectui#7206 measured as unconditionally `{}`.
+    expect(CASCADE_OPTION_WIDGET_TYPES.has('lookup')).toBe(false);
+    // Lit control on the same read: the members that DO get the record.
+    expect(CASCADE_OPTION_WIDGET_TYPES.has('radio')).toBe(true);
+    expect(CASCADE_OPTION_WIDGET_TYPES.has('select')).toBe(true);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/* Leg B — where the authoring surface is                  CONTRACT           */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * ⚠️ Unlike legs A and C this leg pins a CONTRACT, not a current shape — but a
+ * VERSION-QUALIFIED one: it is a reading of the `@objectstack/spec` this repo
+ * has installed, and the answer moves if that schema does. It is here because it
+ * is the fact the card's disposition turns on: a refusal for `dependsOn` on an
+ * action param already exists, and it lives UPSTREAM.
+ */
+describe('objectui#8672 leg B — `@objectstack/spec` already refuses `dependsOn` on an action param', () => {
+  const param = (over: Record<string, unknown>) => ({
+    name: 'contact',
+    label: 'Contact',
+    type: 'lookup',
+    reference: 'contacts',
+    ...over,
+  });
+
+  it('POSITIVE CONTROL — a lookup action param with no cascade key parses', () => {
+    // Without this the refusals below could be a schema that refuses everything.
+    expect(ActionParamSchema.safeParse(param({})).success).toBe(true);
+  });
+
+  it('NEGATIVE CONTROL — an unknown key is refused, so the schema is live and strict', () => {
+    const r = ActionParamSchema.safeParse(param({ zzz_not_a_key: 1 }));
+    expect(r.success).toBe(false);
+    expect(r.error?.issues.some((i) => i.code === 'unrecognized_keys')).toBe(true);
+  });
+
+  it('SUBJECT — `dependsOn` on a lookup action param is an unrecognized key', () => {
+    const r = ActionParamSchema.safeParse(param({ dependsOn: ['account'] }));
+    expect(r.success).toBe(false);
+    const unrecognized = r.error?.issues.find((i) => i.code === 'unrecognized_keys');
+    expect(unrecognized).toBeDefined();
+    expect((unrecognized as { keys?: string[] } | undefined)?.keys).toContain('dependsOn');
+  });
+
+  it('the refusal is not lookup-specific — a `select` param is refused the same way', () => {
+    // Recorded so a disposition author does not read the refusal as a narrow,
+    // type-scoped rule it is not: no action param of any type admits `dependsOn`.
+    const r = ActionParamSchema.safeParse({
+      name: 'city', label: 'City', type: 'select', dependsOn: ['country'],
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────────── */
+/* Leg C — the field-backed route reads the spelling spec refuses             */
+/*                                                         CURRENT SHAPE      */
+/* ────────────────────────────────────────────────────────────────────────── */
+
+describe('objectui#8672 leg C — the field-backed route reads `depends_on`, which `FieldSchema` refuses (CURRENT SHAPE, NOT CONTRACT)', () => {
+  it('CONTROL — `FieldSchema` accepts camel `dependsOn` on a lookup field and refuses the snake twin by name', () => {
+    const base = { name: 'contact_id', label: 'Contact', type: 'lookup', reference: 'contacts' };
+    // POSITIVE CONTROL: the field def parses at all.
+    expect(FieldSchema.safeParse(base).success).toBe(true);
+    // The spelling the spec declares (objectui#7357 retired objectui's twin).
+    expect(FieldSchema.safeParse({ ...base, dependsOn: ['account_id'] }).success).toBe(true);
+    // …and the spelling `resolveActionParams` actually reads is refused here.
+    expect(FieldSchema.safeParse({ ...base, depends_on: ['account_id'] }).success).toBe(false);
+  });
+
+  const ctx = (field: Record<string, unknown>): ResolveActionParamsContext => ({
+    objectName: 'crm_case',
+    objects: [{ name: 'crm_case', fields: { contact_id: field } }] as never,
+    fieldLabel: (_o, _f, fallback) => fallback,
+  });
+
+  const FIELD_BACKED: RawActionParam[] = [{ field: 'contact_id' }];
+
+  it('a spec-valid field declaring camel `dependsOn` resolves to `dependsOn: undefined`', () => {
+    const [resolved] = resolveActionParams(
+      FIELD_BACKED,
+      ctx({ type: 'lookup', label: 'Contact', reference: 'contacts', dependsOn: ['account_id'] }),
+    );
+    // ⭐ LIT CONTROL on the same call: a sibling key off the SAME field def DOES
+    // arrive, so the `undefined` below cannot be a fixture the resolver never
+    // read. Without this the assertion would pass against an empty object.
+    expect(resolved.referenceTo).toBe('contacts');
+    expect(resolved.type).toBe('lookup');
+    // SUBJECT — the cascade key does not survive the route the repo's own
+    // `RESOLVED_ONLY_PARAM_KEYS.dependsOn` message points authors to.
+    expect(resolved.dependsOn).toBeUndefined();
+  });
+
+  it('only the snake spelling — the one the spec refuses — reaches the resolved param', () => {
+    const [resolved] = resolveActionParams(
+      FIELD_BACKED,
+      ctx({ type: 'lookup', label: 'Contact', reference: 'contacts', depends_on: ['account_id'] }),
+    );
+    expect(resolved.referenceTo).toBe('contacts');
+    expect(resolved.dependsOn).toEqual(['account_id']);
+  });
+});


### PR DESCRIPTION
Part of #8672 — **measurement only**. ⛔ No disposition is chosen here, and the card stays open: arms 1 (wire it) and 2 (refuse it) are both still on the table and choosing between them is the maintainer's, not this PR's.

## What this measures

The card asks three questions. All three now have readings, each with a lit control.

### Q1 — how many writers are there?

**Zero lookup action params declare `dependsOn` in this repository**, and zero action params declare it at *any* type. Sweeps run as `git grep -l … -- .` over 7,031 tracked files, with controls on the same command shape and population:

| reading | files |
|---|---|
| CONTROL `dependsOn` (any use) | 164 (719 entries) |
| CONTROL `'lookup'` | 284 |
| CONTROL `lookup` | 891 |
| CONTROL `ActionParamDef` | 34 |
| **SUBJECT — a lookup *action param* with `dependsOn`** | **0** |

Every co-occurrence of a lookup and `dependsOn` in the tree is **field** metadata inside test files, never an action param. Three framework code sites carry the key (`paramToField`'s emit, the resolver's `RESOLVED_ONLY_PARAM_KEYS` message, the resolver's snake read) — none is an authored document.

⚠️ **No fraction can be computed from this tree.** `git grep -lE '"params"' -- '*.json'` and the same for `"actions"` both return **0**: this repository authors *no* action metadata as data at all, so the denominator is zero rather than large.

⚠️ **What the sweep cannot see.** Metadata authored server-side — the `/api/v1/meta/object` documents the resolver actually reads, and any host app's action definitions — never appears in this tree. The honest reading is **"zero writers *in this repository*"**, not "zero writers".

### Q2 — where is the authoring surface? ⭐

**`@objectstack/spec` (17.3.0, from `pnpm-lock.yaml`), and it already refuses the key.** Measured by parsing, not by reading declarations:

| document | `ActionParamSchema.safeParse` |
|---|---|
| POSITIVE CONTROL — lookup param + `reference` | ✅ accepted |
| NEGATIVE CONTROL — unknown key | ❌ `unrecognized_keys` |
| **SUBJECT — lookup param + `dependsOn`** | ❌ **`unrecognized_keys: ['dependsOn']`** |
| `select` param + `dependsOn` | ❌ refused the same way |

`@object-ui/types`' `ActionParam` extends `Omit<z.input<typeof ActionParamSchema>, 'type'>`, so it declares no `dependsOn` either and `tsc` refuses it; the resolver names it a third time in `RESOLVED_ONLY_PARAM_KEYS`.

⇒ **Arm 2's refusal already exists, upstream, mirrored objectui-side by three independent mechanisms.** There is nothing to build here and nothing to request upstream.

### Q3 — is the gate reachable outside a probe?

**Not from any spec-valid authored metadata.** Inline authoring is refused (Q2). The one route the repo itself points authors to — `RESOLVED_ONLY_PARAM_KEYS.dependsOn`: *"make the param field-backed … to pick it up"* — reads `field.depends_on`, the **snake** spelling `FieldSchema` refuses by name (`Did you mean depends_on → dependsOn?`), while the camel `dependsOn` it accepts is never read:

| field document | `FieldSchema` | reaches the resolved param? |
|---|---|---|
| POSITIVE CONTROL — plain lookup field | ✅ | — |
| camel `dependsOn` (spec's spelling) | ✅ accepted | ❌ resolves to `undefined` |
| snake `depends_on` | ❌ refused by name | ✅ arrives |

⇒ The two spellings are disjoint: the one the spec admits is not read, and the one that is read the spec refuses.

## Pins shipped

New `packages/app-shell/src/views/ActionParamDialog.lookupDependsOnReach-8672.test.tsx`, 10 assertions in three legs. Legs A and C are labelled **CURRENT SHAPE, NOT CONTRACT** in the file docblock and on their describe blocks — whoever implements a disposition should expect them red and should **rewrite** them, not trust them. Leg B is labelled a contract pin, version-qualified.

Also corrects a stale comment in `utils/paramToField.test.ts` that described this seam backwards (the folded-in finding on the card).

## Verification — every assertion observed red

Seven ablations, each from the committed tree, each with the mutation proved on disk (`git hash-object` vs the HEAD blob, anchor counts, a line-total gate) and the restore proved **by state** (`git diff HEAD --quiet`), under `trap … EXIT INT TERM` with absolute paths. Per-test outcomes from the **JSON reporter**.

| ablation | mutation | observed red |
|---|---|---|
| ABL-1 | add `'lookup'` to `CASCADE_OPTION_WIDGET_TYPES` | leg A #2, #3 |
| ABL-2 | `LookupField` gate forced false | leg A #1, #2 |
| ABL-3 | resolver reads `field.dependsOn` instead of `field.depends_on` | leg C #2, #3 |
| ABL-4 | leg B subject document loses `dependsOn` | leg B #3 |
| ABL-5 | leg B negative control loses its unknown key | leg B #2 |
| ABL-6 | leg B `select` document loses `dependsOn` | leg B #4 |
| ABL-7 | leg C control asserts the camel spelling is refused | leg C #1 |

All 10 assertions were observed red at least once. ⛔ None of these mutations is committed; every restore is proved by state above.

Green runs: 10/10 on the pin file; **141/141** across the blast radius (`paramToField`, all three `resolveActionParams` suites, all three `ActionParamDialog` suites). `pnpm --filter @object-ui/app-shell type-check` exits **0** after building the dependency closure, and `tsc -p tsconfig.test.json --listFiles` confirms both changed files are inside that program. Targeted `eslint` on both files: 0 errors, 0 warnings.

Gate verdict lines, quoted:

- `✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` … `Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.`
- `✅  No changeset declares a 'major' bump.`
- `✅  check-control-bytes: OK (scanned 6946 tracked text file(s); skipped 85 binary).`
- `✅ NOT GOVERNED — 3 path(s) checked against 5 governed surface(s); none matched.`

## ⚠️ Two premises measurement contradicted

**1. The PM triage's argument for arm 1 being a feature.** The triage says a lookup *"has no options list; it has a query. Filtering candidate records by a dependency's value is a different mechanism that does not exist here … the gate would lift while the picker still showed every record."* That mechanism **does** exist and is shipped. `LookupField` builds `dependentFilter` from the same `dependsOn` chain and merges it into `popoverFilter`, which feeds `useRecordQuery` for all three candidate surfaces (popover, Level-2 picker, PeoplePicker). The `#7165` changeset states it directly: *"every picker takes the `dependsOn` chain as a hard `baseFilter`. The second half is host-independent and was already live."* ABL-1 measured the consequence — with `lookup` in the set, the gate **did** lift on the keystroke. ⚠️ This is not an argument *for* arm 1: which route should supply the record is still open (`CASCADE_OPTION_WIDGET_TYPES` is documented as an options-list allow-list, and the lookup-family boundary is objectui#4771). Only the stated reason is contradicted.

**2. The card's "different consumers" claim about the grid twin.** The card says the two surfaces *"have different consumers and different remedies."* They share **one** final consumer — `LookupField`, one `dependenciesMissing` gate, one `dependentFilter`. What differs is the host that supplies the record. And **objectui#7154 is CLOSED**, its `dependsOn` case rewritten by **objectui#7165**, which fixed the grid with `dependentValues={ctx.pendingRow ?? ctx.row}` — so the grid twin is not an open twin but a **landed precedent for the remedy**. The genuinely open siblings are **#7190** (detail page, pinned not fixed) and **#7206** (the unsettable context tail), both `pm:blocked`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_