### PR TITLE
fix(scripts): probe a second injection candidate in check:doc-examples

### DIFF
--- a/.changeset/8743-doc-example-internal-symbol.md
+++ b/.changeset/8743-doc-example-internal-symbol.md
@@ -1,0 +1,7 @@
+---
+---
+
+CI tooling only, no published package source changed: `check:doc-examples` now
+probes a second injection candidate — the built declaration of the documented
+symbol's own module — so a deliberately package-internal symbol's `@example` can
+compile without widening any published surface (objectui#8743).

--- a/scripts/__tests__/check-doc-example-types.test.ts
+++ b/scripts/__tests__/check-doc-example-types.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -18,6 +19,7 @@ import {
   funnelLines,
   judge,
   ledgerKey,
+  builtTwinSpecifier,
   listExampleSources,
   preludeFor,
 } from '../check-doc-example-types.mjs';
@@ -130,23 +132,76 @@ describe('the exported owner is read from the AST, never from the text', () => {
 
 describe('the documented symbol import is injected only when all three conditions hold', () => {
   const block = { symbol: 'useThing', package: '@object-ui/x', body: 'const r = useThing();' };
+  const fromRoot = new Map([['@object-ui/x useThing', '@object-ui/x']]);
 
   it('injects when the block references the symbol and does not import it', () => {
-    expect(preludeFor(block, new Set())).toBe("import { useThing } from '@object-ui/x';\n");
+    expect(preludeFor(block, fromRoot)).toBe("import { useThing } from '@object-ui/x';\n");
   });
 
   it('does NOT inject when the block never references the symbol', () => {
-    expect(preludeFor({ ...block, body: 'const r = 1;' }, new Set())).toBe('');
+    expect(preludeFor({ ...block, body: 'const r = 1;' }, fromRoot)).toBe('');
   });
 
   it('does NOT inject when the block already imports the symbol itself', () => {
     expect(
-      preludeFor({ ...block, body: "import { useThing } from 'somewhere';\nuseThing();" }, new Set()),
+      preludeFor({ ...block, body: "import { useThing } from 'somewhere';\nuseThing();" }, fromRoot),
     ).toBe('');
   });
 
-  it('does NOT inject when the package entry does not export the symbol — the gate never blames an example for this transformation', () => {
-    expect(preludeFor(block, new Set(['@object-ui/x useThing']))).toBe('');
+  it('does NOT inject when NO probed specifier could import the symbol — the gate never blames an example for this transformation', () => {
+    expect(preludeFor(block, new Map())).toBe('');
+  });
+
+  it('injects the specifier the probe RESOLVED, not the package name — objectui#8743', () => {
+    const twin = '/repo/packages/x/dist/internal/thing.js';
+    expect(preludeFor(block, new Map([['@object-ui/x useThing', twin]]))).toBe(
+      `import { useThing } from '${twin}';\n`,
+    );
+  });
+});
+
+// ── instrument: the second injection candidate (objectui#8743) ───────────────
+
+describe("candidate 2: the documented symbol's own built declaration", () => {
+  const roots: string[] = [];
+  const fixture = (files: Record<string, string>) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-example-twin-'));
+    roots.push(root);
+    for (const [rel, body] of Object.entries(files)) {
+      const abs = path.join(root, rel);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, body);
+    }
+    return root;
+  };
+  afterAll(() => {
+    for (const root of roots) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('is the dist twin of the source file when that per-file declaration exists', () => {
+    const root = fixture({ 'packages/types/dist/zod/imported-defaults.d.ts': 'export {};\n' });
+    expect(builtTwinSpecifier('packages/types/src/zod/imported-defaults.ts', root)).toBe(
+      path.join(root, 'packages/types/dist/zod/imported-defaults.js'),
+    );
+  });
+
+  it('is null when the build BUNDLES its declarations, so there is no per-file twin', () => {
+    const root = fixture({ 'packages/data-objectstack/dist/index.d.ts': 'export {};\n' });
+    expect(builtTwinSpecifier('packages/data-objectstack/src/cache/MetadataCache.ts', root)).toBe(
+      null,
+    );
+  });
+
+  it('is null for a path that is not `packages/NAME/src/...`', () => {
+    const root = fixture({ 'apps/console/dist/main.d.ts': 'export {};\n' });
+    expect(builtTwinSpecifier('apps/console/src/main.ts', root)).toBe(null);
+  });
+
+  it('is an ABSOLUTE specifier, which THE BOUND never refuses', () => {
+    const root = fixture({ 'packages/types/dist/a.d.ts': 'export {};\n' });
+    const twin = builtTwinSpecifier('packages/types/src/a.ts', root);
+    expect(twin).not.toBe(null);
+    expect(path.isAbsolute(twin as string)).toBe(true);
   });
 });
 

--- a/scripts/check-doc-example-types.mjs
+++ b/scripts/check-doc-example-types.mjs
@@ -94,23 +94,58 @@
  * block almost never imports it (measured: 8 of 124 import anything at all). The
  * gate therefore prepends ONE line:
  *
- *     import { SYMBOL } from 'PACKAGE';
+ *     import { SYMBOL } from 'SPECIFIER';
  *
  * and only when all three hold, each re-checked per run:
  *
  *   - the block's text references SYMBOL;
  *   - the block does not already import SYMBOL itself;
- *   - PACKAGE's BUILT entry really exports SYMBOL — probed in the same program,
- *     never assumed. Measured: 111 of 114 documented symbols are on their
- *     package's public entry; the 3 that are not are reported by name.
+ *   - some probed SPECIFIER really exports SYMBOL — compiled in the same
+ *     program, never assumed. TWO candidates are probed, in this order, and the
+ *     first one that imports wins:
  *
- * ⚠️ The probe asks the package's ROOT specifier and only that one, so a symbol
- * published under a SUBPATH reads as "not on a public entry" here. That is a
- * deliberately conservative answer — it withholds the injection rather than
- * guessing a subpath — but it means the printed list is "symbols this gate did
- * not inject", NOT a list of defects. On this corpus 2 of the 3 are subpath
- * exports (`@object-ui/types/zod`) and both blocks compile anyway; the third,
- * `MetadataCache`, is genuinely absent from its package's only export.
+ *       1. the package's ROOT specifier, e.g. `@object-ui/types`;
+ *       2. the BUILT declaration of the symbol's OWN source file — the `dist`
+ *          twin of `packages/NAME/src/a/b.ts`, offered only when that twin is
+ *          on disk.
+ *
+ * The count reached by each candidate is printed every run, so both stay derived.
+ *
+ * ### Why candidate 2 exists, and why it widens nothing (objectui#8743)
+ *
+ * The justification above is SCOPE, not publication. Candidate 1 alone models
+ * scope as "importable from the package's public entry", which is a publication
+ * test, and it answers NO for every symbol a package exports to its own modules
+ * and to nothing else. Such a block is then judged WITHOUT the import it needs,
+ * so any example that spells its own symbol's name is TS2304 — not because the
+ * example is wrong, but because this file could not name the symbol.
+ *
+ * `stripImportedDefaults` landed exactly there and reddened `main`. It is
+ * deliberately package-internal — objectui#8317's design is that the strip
+ * happens at the import boundary, not that consumers call it — so with candidate
+ * 1 as the only route the remaining two are: EXPORT it, widening a published
+ * surface (and moving `@object-ui/types`' public API) for a docs gate; or write
+ * a ledger row, converting a checked example into an unchecked one. Both are
+ * worse than the defect. Candidate 2 is the third route: the declaring module IS
+ * an internal symbol's scope, and its built `.d.ts` is the same artifact tier
+ * candidate 1 resolves to. Nothing is exported, nothing new is published, and
+ * the example stays COMPILED.
+ *
+ * ⛔ Candidate 2 is not a licence to reference anything: it names the symbol the
+ * block documents and nothing else, which is the same one-line bound candidate 1
+ * has always had. It is not the `declare var NAME: any` pass refused below —
+ * the types come from the real built declaration, so the call is judged against
+ * the shipped signature.
+ *
+ * ⚠️ It is still PROBED, never assumed, and a bundling build has no twin to
+ * probe: `tsup`/rolldown emit one `dist/index.d.ts` and no per-file declaration,
+ * so the candidate is absent and the conservative answer stands. That is why the
+ * printed list remains "symbols this gate did not inject", NOT a list of defects.
+ *
+ * ⚠️ Neither candidate guesses a SUBPATH. A symbol published only under one
+ * (`@object-ui/types/zod`) is not reached by candidate 1 and does not need to
+ * be — those blocks import themselves, which is what a reader copying them does,
+ * and `alreadyImported` then withholds the prelude anyway.
  *
  * Prepended, not appended, because an `import` must precede the code that uses
  * it; the printed line numbers therefore carry an offset, which `formatDiagnostic`
@@ -995,55 +1030,112 @@ export const UNGATED_EXAMPLES = {
 // ── The run ──────────────────────────────────────────────────────────────────
 
 /**
- * Which documented symbols the built package entries really export.
+ * The `dist` twin of one source file, as an ABSOLUTE specifier, or `null`.
  *
- * Probed, never assumed: one throwaway module per `PACKAGE SYMBOL` pair, handed
- * to the same `compileSnippets()` the blocks go through, so the answer comes
- * from the same resolution the verdict does. A pair that cannot be imported is
- * reported by name and its block is judged WITHOUT the injected import, so the
- * gate never blames an example for this file's own transformation.
+ * `packages/NAME/src/a/b.ts` -> `ROOT/packages/NAME/dist/a/b.js`. Absolute, not
+ * relative: the virtual directory the sibling compiles blocks in is that file's
+ * private detail, and an absolute specifier is one THE BOUND never refuses
+ * (`resolvesOnlyThroughRootManifest` exempts specifiers starting with `.` or
+ * `/`), so this candidate can never be mistaken for a bare package import.
  *
- * @param {{ root: string, blocks: {package: string, symbol: string}[], paths: object, declaredSpecifiers: string[] }} options
- * @returns {Set<string>} the `PACKAGE SYMBOL` pairs that are NOT on a public entry
+ * Existence is checked on the `.d.ts` — that is what the program reads, since
+ * `moduleResolution: Bundler` maps the `.js` specifier onto it — so a package
+ * whose build BUNDLES its declarations has no twin here and is declined. This is
+ * a cheap pre-filter, not the answer: the probe below is the authority.
+ *
+ * @param {string} file repo-relative source path of the documented symbol
+ * @param {string} root
+ * @returns {string | null}
  */
-export function probeExportedSymbols({ root, blocks, paths, declaredSpecifiers }) {
-  const pairs = [...new Set(blocks.map((b) => `${b.package} ${b.symbol}`))].sort();
-  const probes = pairs.map((pair, index) => {
-    const [pkg, symbol] = pair.split(' ');
-    return {
-      doc: `probe/${pkg}`,
-      fenceLine: index,
-      language: 'ts',
-      quoteDepth: 0,
-      fragmentReason: null,
-      // `[typeof S]` rather than `typeof S`: a tuple accepts a value position for
-      // a name that is only a type, so this probe answers "is it importable"
-      // without also asking "is it a value", which is a different question.
-      body: `import { ${symbol} } from '${pkg}';\nexport type P = [typeof ${symbol}];\n`,
-      pair,
-    };
-  });
-  if (probes.length === 0) return new Set();
-  const run = compileSnippets({ root, compiled: probes, paths, declaredSpecifiers });
-  const missing = new Set();
-  for (const { block, diagnostics } of run.semanticFailures) {
-    if (diagnostics.some((d) => d.code === 2305 || d.code === 2307)) missing.add(block.pair);
+export function builtTwinSpecifier(file, root = repoRoot) {
+  const parts = file.split('/');
+  if (parts.length < 4 || parts[0] !== PACKAGES_DIR || parts[2] !== SOURCE_SUBDIR) return null;
+  const stem = parts.slice(3).join('/').replace(/\.tsx?$/, '');
+  const distDir = join(root, PACKAGES_DIR, parts[1], 'dist');
+  if (!existsSync(join(distDir, `${stem}.d.ts`))) return null;
+  return join(distDir, `${stem}.js`);
+}
+
+/**
+ * Which specifier, if any, brings each documented symbol into scope.
+ *
+ * Probed, never assumed: one throwaway module per `PAIR SPECIFIER` candidate,
+ * handed to the same `compileSnippets()` the blocks go through, so the answer
+ * comes from the same resolution the verdict does. Candidates are tried in the
+ * order `injectionCandidates` lists them and the FIRST that imports wins; a pair
+ * no candidate can import is reported by name and its block is judged WITHOUT an
+ * injected import, so the gate never blames an example for this transformation.
+ *
+ * @param {{ root: string, blocks: {package: string, symbol: string, file: string}[], paths: object, declaredSpecifiers: string[] }} options
+ * @returns {Map<string, string>} `PACKAGE SYMBOL` -> the specifier that imported it
+ */
+export function probeInjectionSpecifiers({ root, blocks, paths, declaredSpecifiers }) {
+  /** @type {Map<string, string[]>} */
+  const candidatesOf = new Map();
+  for (const block of [...blocks].sort((a, b) =>
+    `${a.package} ${a.symbol}`.localeCompare(`${b.package} ${b.symbol}`),
+  )) {
+    const pair = `${block.package} ${block.symbol}`;
+    if (!candidatesOf.has(pair)) candidatesOf.set(pair, []);
+    const list = candidatesOf.get(pair);
+    for (const candidate of [block.package, builtTwinSpecifier(block.file, root)]) {
+      if (candidate && !list.includes(candidate)) list.push(candidate);
+    }
   }
-  return missing;
+
+  const probes = [];
+  for (const [pair, candidates] of candidatesOf) {
+    const symbol = pair.split(' ')[1];
+    for (const specifier of candidates) {
+      probes.push({
+        doc: `probe/${pair}`,
+        fenceLine: probes.length,
+        language: 'ts',
+        quoteDepth: 0,
+        fragmentReason: null,
+        // `[typeof S]` rather than `typeof S`: a tuple accepts a value position for
+        // a name that is only a type, so this probe answers "is it importable"
+        // without also asking "is it a value", which is a different question.
+        body: `import { ${symbol} } from '${specifier}';\nexport type P = [typeof ${symbol}];\n`,
+        pair,
+        specifier,
+      });
+    }
+  }
+  if (probes.length === 0) return new Map();
+
+  const run = compileSnippets({ root, compiled: probes, paths, declaredSpecifiers });
+  const failed = new Set();
+  const fail = (block) => failed.add(`${block.pair}|${block.specifier}`);
+  for (const { block, diagnostics } of run.semanticFailures) {
+    if (diagnostics.some((d) => d.code === 2305 || d.code === 2307)) fail(block);
+  }
+  // A candidate this harness could not even parse or was refused by THE BOUND is
+  // not an importable specifier either; counting only the semantic arm would let
+  // one through on a technicality.
+  for (const { block } of run.parseFailures) fail(block);
+  for (const { block } of run.boundFailures) fail(block);
+
+  const resolved = new Map();
+  for (const probe of probes) {
+    if (resolved.has(probe.pair)) continue;
+    if (!failed.has(`${probe.pair}|${probe.specifier}`)) resolved.set(probe.pair, probe.specifier);
+  }
+  return resolved;
 }
 
 /**
  * The ONE transformation, applied per block. See the header.
  *
  * @param {{ symbol: string, package: string, body: string }} block
- * @param {Set<string>} missing pairs the export probe could not import
+ * @param {Map<string, string>} injectableFrom pair -> the specifier that imports it
  */
-export function preludeFor(block, missing) {
+export function preludeFor(block, injectableFrom) {
   const references = new RegExp(`\\b${block.symbol}\\b`).test(block.body);
   const alreadyImported = new RegExp(`import[^;]*\\b${block.symbol}\\b[^;]*from`).test(block.body);
-  const onPublicEntry = !missing.has(`${block.package} ${block.symbol}`);
-  return references && !alreadyImported && onPublicEntry
-    ? `import { ${block.symbol} } from '${block.package}';\n`
+  const specifier = injectableFrom.get(`${block.package} ${block.symbol}`);
+  return references && !alreadyImported && specifier
+    ? `import { ${block.symbol} } from '${specifier}';\n`
     : '';
 }
 
@@ -1213,15 +1305,20 @@ function main() {
     return EXIT_CODES.couldNotRun;
   }
 
-  const missing = probeExportedSymbols({
+  const injectableFrom = probeInjectionSpecifiers({
     root: repoRoot,
     blocks: census.blocks,
     paths: state.paths,
     declaredSpecifiers: state.declaredSpecifiers,
   });
+  const pairs = [...new Set(census.blocks.map((b) => `${b.package} ${b.symbol}`))].sort();
+  const withheld = pairs.filter((pair) => !injectableFrom.has(pair));
+  const viaTwin = pairs.filter(
+    (pair) => injectableFrom.has(pair) && injectableFrom.get(pair) !== pair.split(' ')[0],
+  );
 
   const compiled = census.blocks.map((block) => {
-    const prelude = preludeFor(block, missing);
+    const prelude = preludeFor(block, injectableFrom);
     return {
       doc: block.file,
       // `formatDiagnostic` prints `fenceLine + line`. The prelude shifts the
@@ -1306,9 +1403,16 @@ function main() {
   console.log(`  src leaks    ${run.srcLeaks.length}`);
   console.log(
     `  injection    ${compiled.filter((b) => b.injected).length} of ${compiled.length} block(s) received the documented symbol's import; ` +
-      `${missing.size} documented symbol(s) are NOT on a public entry`,
+      `${pairs.length - withheld.length} of ${pairs.length} documented symbol(s) are importable, ` +
+      `${viaTwin.length} of them only through their module's built declaration`,
   );
-  for (const pair of [...missing].sort()) console.log(`               not on a public entry: ${pair}`);
+  for (const pair of viaTwin) {
+    console.log(
+      `               via its module's built declaration: ${pair} ` +
+        `(${relative(repoRoot, injectableFrom.get(pair)).split(sep).join('/')})`,
+    );
+  }
+  for (const pair of withheld) console.log(`               NOT importable from any probed specifier: ${pair}`);
   console.log('');
 
   const clean = results.length - codesOf.size;


### PR DESCRIPTION
Fixes #8743

`check:doc-examples` was red on `main`. Reproduced first on `origin/main` (`32f100867`), unedited tree, dependency closure built — the harness's own controls are healthy, so the verdict is a fact about the corpus:

```
Controls:
  resolution   /home/user/objectui-8743/packages/types/dist/index.d.ts
  sentinel     importing a name no package exports produced 1 diagnostic(s) (TS2305)
  positive     importing a real export produced 0 diagnostic(s)
  src leaks    0
  injection    106 of 125 block(s) received the documented symbol's import; 4 documented symbol(s) are NOT on a public entry
               not on a public entry: @object-ui/data-objectstack MetadataCache
               not on a public entry: @object-ui/types safeValidateSchema
               not on a public entry: @object-ui/types stripImportedDefaults
               not on a public entry: @object-ui/types validateSchema

Examples: 125 block(s) — 34 compile, 91 fail, 90 of those declared in the ledger (90 row(s)).

UNDECLARED FAILURE  packages/types/src/zod/imported-defaults.ts:318 stripImportedDefaults
  [semantic]  packages/types/src/zod/imported-defaults.ts:319:28  TS2304: Cannot find name 'stripImportedDefaults'.
```

## What was wrong, and why neither obvious route was acceptable

The gate prepends ONE line to a block that spells its own documented symbol's name, and it probes **the package's ROOT specifier and only that one** to decide whether it may. `stripImportedDefaults` is deliberately package-internal — objectui#8317 puts the strip at the import boundary, not at a consumer — so the probe answers no, the block is judged with the name unbound, and TS2304 is **structural**: with candidate 1 as the only route, no edit to the example can make it compile while still naming the function it documents.

That left two routes, and both are worse than the defect:

- **export it** — widens a published surface, and moves `@object-ui/types`' public API, for a docs gate. Ruled out by the dispatch and I agree with the ruling.
- **declare it** — a `UNGATED_EXAMPLES` row converts a checked example into an unchecked one, on exactly the example whose static type is deliberately unchanged while its runtime behaviour is not.

## The fix: a second probed injection candidate

The gate's own justification for the injected line is **scope** ("read in the IDE beside the declaration it documents"), not publication. Candidate 1 models scope as "importable from the public entry", which is a publication test. So the probe now tries a second candidate, first-that-imports-wins:

1. the package's ROOT specifier, e.g. `@object-ui/types`;
2. the **built declaration of the symbol's own source file** — the `dist` twin of `packages/NAME/src/a/b.ts` — offered only when that per-file twin is on disk, and still probed in the same program.

Nothing is exported, nothing new is published, and the example stays compiled. A bundling build (tsup, rolldown) emits one `dist/index.d.ts` and no per-file twin, so the candidate is simply absent there and the conservative "not injected" answer stands.

## Before / after — the compiled tier grew, the ledger did not

| | before (`origin/main`) | after |
|---|---|---|
| blocks in the compiled tier | 125 | 125 |
| **compile** | **34** | **35** |
| fail | 91 | 90 |
| declared in the ledger | 90 (90 rows) | 90 (90 rows) |
| blocks receiving an injected import | 106 | 107 |
| symbols no probed specifier can import | 4 | 1 |
| exit | 1 | 0 |

A ledger declaration would have held `compile` at 34 and pushed the row count to 91. It went the other way, and the row count did not move at all — that is the difference between a repair and a mute button.

## The example is still load-bearing

Deliberate break, on the committed tree, with a restoring trap; the argument was changed so the call violates the real signature. Anchor counts proved the mutation reached disk (old anchor 1 to 0, new anchor 0 to 1; blob `aa76ce98` to `8f8889f9`):

```
GATE_EXIT=1
Examples: 125 block(s) — 34 compile, 91 fail, 90 of those declared in the ledger (90 row(s)).
UNDECLARED FAILURE  packages/types/src/zod/imported-defaults.ts:318 stripImportedDefaults
  [semantic]  ...imported-defaults.ts:319:50  TS2345: Argument of type 'string' is not assignable to parameter of type 'ZodType ...'
```

⚠️ The parameter type printed there is the generic form `ZodType` parameterised by `unknown`, `unknown` and `$ZodTypeInternals` — written out in words because GitHub's body sanitizer deletes literal angle-bracket-shaped spans. That it appears **at all** is the point: the block is being judged against the real built signature from `packages/types/dist/zod/imported-defaults.d.ts`, not against `any` and not skipped. Restore proven by blob hash back to `aa76ce98` and an empty `git diff HEAD`.

Second leg, ablating the fix itself: reverting only `scripts/check-doc-example-types.mjs` to `32f100867` brings back exit 1 and the identical `TS2304 Cannot find name 'stripImportedDefaults'` at `319:28`, with the withheld list back at 4. Restored the same way.

## The class, not the instance

The gate names the whole population every run. On `main` it was four symbols; the three siblings are **not** in one state, and only one of them was ever one edit from the same red:

- `@object-ui/types validateSchema` and `safeValidateSchema` (`zod/index.zod.ts`) — on the published **subpath** `@object-ui/types/zod`, not the root. Their blocks import themselves, so `alreadyImported` withholds the prelude and they compile on their own terms. They were never armed. After this change the probe can also reach them through candidate 2, so they drop off the withheld list; their blocks are unaffected either way.
- `@object-ui/data-objectstack MetadataCache` — genuinely on no entry, and it **already fails**: it is covered by a ledger row declaring TS2304 for two free names its example never declares. `data-objectstack` builds with `tsup` and emits no per-file declaration, so candidate 2 finds no twin, the injection stays withheld, its diagnostics are unchanged and its row still matches. **No ledger churn.**

So the fix generalises to every symbol whose package emits per-file declarations, which is the tsc-built majority; the remaining hole is bundled-declaration packages, where an internal symbol's example would still have to be declared. That is a smaller, named hole, not a live tripwire, and closing it would mean resolving a symbol inside a bundled `dist/index.d.ts` — a different instrument, out of scope here.

## Verification

- `pnpm check:doc-examples` — exit 0, run twice, identical counts both times.
- `pnpm exec vitest run scripts/__tests__/check-doc-example-types.test.ts scripts/__tests__/check-doc-snippet-types.test.ts --reporter=json` — 152/152 passed (repo root, path-filtered, JSON reporter). Four new instrument cases pin candidate 2 and one pins that `preludeFor` injects the specifier the probe **resolved**, not the package name.
- `pnpm check:doc-snippets` exit 0 (`Covered blocks: 794 — 636 to compile, 158 declared fragment(s)`), `check:doc-example-readers` exit 0, `check:readme-exports` exit 0 (population intact, not collapsed), `check:control-bytes`, `check:doc-fences`, `check:comment-mask-corpus`, `check:unreferenced-sources`, `check:esm-specifiers` all exit 0.
- `lint:root` — the full 295-file root population, exit 0, both changed files in it and clean. Not a narrowing.
- `node scripts/check-changeset-presence.mjs` — *"No source or published contract of a released package changed in this range, so no changeset is owed."* An empty-frontmatter changeset is included anyway, as an explicit "no release" declaration; `check-changeset-no-major` exit 0.

## One correction to the dispatch

The quoted gate vocabulary *"Covered blocks: 794 — 636 to compile, 158 declared fragment(s)"* is `check:doc-snippets`' output line, not this gate's. `check-doc-example-types.mjs` has **no fragment mechanism at all** — it hardcodes `fragmentReason: null` for every block it hands to the shared harness. Its only non-compiling route is the `UNGATED_EXAMPLES` ledger. So "compile as written vs declare a fragment" was really "compile vs ledger row", which is why the preference for keeping the example checked did the deciding.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: `https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S`


---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_