### PR TITLE
fix(i18n-gate): require a key boundary in the pack sweep's text net (objectui#8701)

### DIFF
--- a/scripts/__tests__/check-i18n-dead-keys.test.ts
+++ b/scripts/__tests__/check-i18n-dead-keys.test.ts
@@ -81,6 +81,12 @@ const EN_FIXTURE = `const en = {
   plural: { count_one: '{{count}} item', count_other: '{{count}} items' },
   bulk: { a: 'A', b: 'B' },
   dynamic: { category: { electronics: 'Electronics', books: 'Books' } },
+  boundary: {
+    onlyPrefix: 'A candidate a longer key merely STARTS with',
+    onlyDotted: 'A candidate a longer DOTTED key merely starts with',
+    onlySuffix: 'A candidate a longer key merely ENDS with',
+    realHit: 'A candidate something really does spell',
+  },
 } as const;
 export default en;
 `;
@@ -113,11 +119,29 @@ export const FIELD_CONFIG = [
 ];
 `;
 
+/**
+ * Text that is evidence about a DIFFERENT key than the one it contains — the
+ * three shapes `textFootprint()`'s key-boundary requirement must refuse
+ * (objectui#8701) — plus one occurrence that is genuine evidence and must
+ * still count. Deliberately NOT `t()` calls: the point is what the whole-repo
+ * text net does with the bytes, and a call site would take these keys out of
+ * the candidate set through the AST leg instead.
+ */
+const LONGER_KEY_MENTIONS_SOURCE = `
+export const NOT_ABOUT_THESE_KEYS = [
+  'boundary.onlyPrefixExtended',
+  'boundary.onlyDotted.detail',
+  'otherNamespace.boundary.onlySuffix',
+];
+export const ABOUT_THIS_ONE = { labelKey: 'boundary.realHit' };
+`;
+
 function fixtureRoot() {
   return repoWith({
     'packages/i18n/src/locales/en.ts': EN_FIXTURE,
     'packages/x/src/Widget.tsx': CONSUMER_SOURCE,
     'packages/x/src/fieldConfig.ts': INDIRECT_MENTION_SOURCE,
+    'packages/x/src/longerKeys.ts': LONGER_KEY_MENTIONS_SOURCE,
   });
 }
 
@@ -163,6 +187,39 @@ describe('sweep()', () => {
     // would land in needsReview and `confirmed` would always be empty.
     const { confirmed } = sweep(fixtureRoot());
     expect(confirmed.length).toBeGreaterThan(0);
+  });
+
+  it('CONFIRMS a candidate a longer key merely STARTS with (objectui#8701)', () => {
+    // The pack sweep's own tier split, not just the predicate: these three
+    // shapes are the ones that were reported as textual hits for the shorter
+    // key before the boundary became `textFootprint()`'s default, sending a
+    // reader to a line that never mentions the key they are hunting.
+    const { confirmed, needsReview } = sweep(fixtureRoot());
+    expect(confirmed).toContain('boundary.onlyPrefix');
+    expect(needsReview.map((f) => f.key)).not.toContain('boundary.onlyPrefix');
+  });
+
+  it('CONFIRMS a candidate a longer DOTTED key merely starts with (objectui#8701)', () => {
+    const { confirmed, needsReview } = sweep(fixtureRoot());
+    expect(confirmed).toContain('boundary.onlyDotted');
+    expect(needsReview.map((f) => f.key)).not.toContain('boundary.onlyDotted');
+  });
+
+  it('CONFIRMS a candidate a longer key merely ENDS with (objectui#8701)', () => {
+    const { confirmed, needsReview } = sweep(fixtureRoot());
+    expect(confirmed).toContain('boundary.onlySuffix');
+    expect(needsReview.map((f) => f.key)).not.toContain('boundary.onlySuffix');
+  });
+
+  it('still demotes a candidate a file really does spell (objectui#8701)', () => {
+    // The other direction of the same predicate: the boundary must not empty
+    // the NEEDS-REVIEW tier. Without this, a `textFootprint()` that found
+    // nothing anywhere would pass the three pins above.
+    const { confirmed, needsReview } = sweep(fixtureRoot());
+    expect(confirmed).not.toContain('boundary.realHit');
+    expect(needsReview.find((f) => f.key === 'boundary.realHit')?.hits).toEqual([
+      'packages/x/src/longerKeys.ts',
+    ]);
   });
 
   it('demotes a key to NEEDS-REVIEW when its literal string appears outside a t() call', () => {
@@ -692,23 +749,97 @@ describe('sweepDesignerTable()', () => {
   });
 });
 
-describe('textFootprint() key-boundary option', () => {
-  it('is off by default, so the pack sweep’s measured behaviour is unchanged', () => {
-    const root = repoWith({ 'packages/x/src/a.ts': "export const k = 'ns.group.leaf.detail';\n" });
-    expect(textFootprint(root, ['ns.group.leaf']).get('ns.group.leaf')).toEqual(['packages/x/src/a.ts']);
+/**
+ * The key-boundary requirement, pinned in BOTH directions (objectui#8701).
+ *
+ * The two halves catch opposite degenerate predicates, which is the point of
+ * having both: every REJECTS case below reddens for a predicate that answers
+ * `true` for everything (the shipped substring test is one such predicate, and
+ * so is `() => true`), and every ACCEPTS case reddens for a predicate that
+ * answers `false` for everything. Neither half alone is a pin — a `false`
+ * predicate would sail through the rejections while reporting no evidence
+ * about anything, which is strictly worse than the bug being fixed here.
+ *
+ * The ACCEPTS cases are also why the boundary is not "the key must be the whole
+ * line" or "the key must be quoted": a real hit arrives inside a call, inside
+ * an array, at end of line, and in prose that never quotes it, and each of
+ * those spellings is pinned separately rather than represented by one.
+ */
+describe('textFootprint() key boundary', () => {
+  const KEY = 'ns.group.leaf';
+  /** `propertyChain: false` throughout: this leg is the FULL-KEY probe, and the
+   *  chain probe would otherwise answer some of these cases for it. */
+  const footprintOf = (files: Record<string, string>, options = {}) =>
+    textFootprint(repoWith(files), [KEY], { propertyChain: false, ...options }).get(KEY);
+
+  // ── REJECTS: text about a longer key is not evidence about this key ───────
+  it('REJECTS a longer key that continues with an identifier character', () => {
+    expect(footprintOf({ 'packages/x/src/a.ts': `export const k = '${KEY}Extended';\n` })).toEqual([]);
   });
 
-  it('rejects a match that continues into a longer key when enabled', () => {
-    const root = repoWith({ 'packages/x/src/a.ts': "export const k = 'ns.group.leaf.detail';\n" });
-    expect(
-      textFootprint(root, ['ns.group.leaf'], { propertyChain: false, keyBoundary: true }).get('ns.group.leaf'),
-    ).toEqual([]);
+  it('REJECTS a longer DOTTED key — the hole `occursAtPropertyBoundary` leaves open', () => {
+    // `.` does not continue an IDENTIFIER, so the property-chain probe's guard
+    // accepts this shape. The key-boundary class is wider by exactly `.` and `-`.
+    expect(footprintOf({ 'packages/x/src/a.ts': `export const k = '${KEY}.detail';\n` })).toEqual([]);
   });
 
-  it('still matches the whole key when enabled', () => {
-    const root = repoWith({ 'packages/x/src/a.ts': "export const k = 'ns.group.leaf';\n" });
-    expect(
-      textFootprint(root, ['ns.group.leaf'], { propertyChain: false, keyBoundary: true }).get('ns.group.leaf'),
-    ).toEqual(['packages/x/src/a.ts']);
+  it('REJECTS a longer key that continues with a hyphen', () => {
+    expect(footprintOf({ 'packages/x/src/a.ts': `export const k = '${KEY}-compact';\n` })).toEqual([]);
+  });
+
+  it('REJECTS a longer key that merely ENDS with this key — the LEFT side', () => {
+    // The other hole in the chain-probe guard, and the one that is not about
+    // identifier characters at all: it checks nothing to the left. Measured on
+    // the pack sweep, this shape alone accounted for 4 of the 13 keys the
+    // boundary re-tiered, every one of them a designer-table key ending in a
+    // pack key.
+    expect(footprintOf({ 'packages/x/src/a.ts': `export const k = 'otherNs.${KEY}';\n` })).toEqual([]);
+  });
+
+  // ── ACCEPTS: a real occurrence is still evidence ──────────────────────────
+  it('ACCEPTS a quoted call-site spelling', () => {
+    expect(footprintOf({ 'packages/x/src/a.ts': `t('${KEY}');\n` })).toEqual(['packages/x/src/a.ts']);
+  });
+
+  it('ACCEPTS a double-quoted value in a data file', () => {
+    expect(footprintOf({ 'packages/x/src/a.json': `{ "labelKey": "${KEY}" }\n` })).toEqual(['packages/x/src/a.json']);
+  });
+
+  it('ACCEPTS an unquoted prose mention with ordinary sentence punctuation', () => {
+    expect(footprintOf({ 'content/docs/x.md': `See ${KEY}, which nothing renders.\n` })).toEqual([
+      'content/docs/x.md',
+    ]);
+  });
+
+  it('REJECTS the same prose mention when a full stop follows the key', () => {
+    // The cost the docstring states rather than discovers, pinned so it is a
+    // known price and not a surprise: `.` is a key character, so a sentence
+    // that ends ON the key reads as a longer key and stops counting. This is
+    // the one direction in which the boundary claims MORE evidence of deadness
+    // than the substring test did.
+    expect(footprintOf({ 'content/docs/x.md': `Nothing renders ${KEY}.\n` })).toEqual([]);
+  });
+
+  it('ACCEPTS an occurrence at end of line with no trailing character at all', () => {
+    expect(footprintOf({ 'packages/x/src/a.ts': `// ${KEY}` })).toEqual(['packages/x/src/a.ts']);
+  });
+
+  it('ACCEPTS an occurrence at the very start of a line', () => {
+    expect(footprintOf({ 'content/docs/x.md': `${KEY} — the label key\n` })).toEqual(['content/docs/x.md']);
+  });
+
+  it('ACCEPTS a real hit on a line that ALSO carries a longer key', () => {
+    // Every occurrence is checked, not just the first: one line can hold both
+    // shapes, and stopping at the first rejection would drop real evidence.
+    expect(footprintOf({ 'packages/x/src/a.ts': `const m = { '${KEY}.detail': 1, '${KEY}': 2 };\n` })).toEqual([
+      'packages/x/src/a.ts',
+    ]);
+  });
+
+  // ── the escape hatch, kept measurable ─────────────────────────────────────
+  it('reproduces the pre-objectui#8701 substring behaviour when opted out', () => {
+    expect(footprintOf({ 'packages/x/src/a.ts': `export const k = '${KEY}.detail';\n` }, { keyBoundary: false })).toEqual([
+      'packages/x/src/a.ts',
+    ]);
   });
 });

--- a/scripts/check-i18n-dead-keys.mjs
+++ b/scripts/check-i18n-dead-keys.mjs
@@ -91,20 +91,23 @@
  * (`packages/`, `apps/`, `examples/`, `e2e/`, `content/`, `scripts/` — everything
  * except the standard build/dep noise and the locale packs themselves, which by
  * definition contain every candidate's defining line and would make every
- * candidate "referenced") for the literal dotted key string. A hit means the
- * key's exact spelling appears somewhere this script's AST pass does not look —
+ * candidate "referenced") for the literal dotted key string, counting an
+ * occurrence only where the key stands ALONE — bounded on both sides by a
+ * character that cannot continue a dotted key (`occursAtKeyBoundary()`), so a
+ * longer key that merely contains this one is not read as evidence about it.
+ * A hit means the key's own spelling appears somewhere the AST pass does not look —
  * closing gap 1 (an `examples/`/`e2e/` call site would spell the key as a plain
  * string there too) and softening gap 2 (an `i18nKey: 'console.objectView.new'`
  * property literal IS a plain-text occurrence of the key, even though it is not
  * an argument of `t()`).
  *
- *   - CONFIRMED — no call site (AST) and no textual occurrence anywhere else in
- *     the repo. The tier with the MOST EVIDENCE, which is not the same claim as
+ *   - CONFIRMED — no call site (AST) and no bounded textual occurrence of the
+ *     key anywhere else in the repo. The tier with the MOST EVIDENCE, which is not the same claim as
  *     the safest to delete: what it does and does not guarantee is written out
  *     under "What CONFIRMED does NOT guarantee" below rather than left to the
  *     word "strongest". Sample-verifying before deleting (objectui#4658's own
  *     dispatch ruling) is a standing requirement, not a transitional one.
- *   - NEEDS-REVIEW — no call site, but the literal string appears somewhere
+ *   - NEEDS-REVIEW — no call site, but the whole key appears somewhere
  *     (a comment, a doc, a fixture, an indirect `i18nKey:`-style property). The
  *     candidate might still be genuinely dead; the hit just means a human has to
  *     look at it before deleting, which is exactly what "AST-dead" alone cannot
@@ -209,13 +212,23 @@
  *      modules.
  *   3. A consumer outside the AST walk's `packages/`+`apps/` scope that also
  *      never spells the key as text (gap 1 above).
+ *   4. A pack-object property reader of a TWO-SEGMENT key (objectui#8701). The
+ *      full-key probe used to catch that shape by accident, because a substring
+ *      test accepts `somePack.topNs.leaf` as an occurrence of `topNs.leaf`; the
+ *      key-boundary requirement refuses it, since a `.` on the left is exactly
+ *      what marks a longer key. The property-chain leg does not take over below
+ *      three segments (it returns `null` there on purpose), so for two-segment
+ *      keys the enumerated importer list above is the only check left, and it
+ *      is read by hand. Measured when the boundary became the default:
+ *      re-deriving that list and reading every NON-TEST importer it returns,
+ *      not one of them reads any of the keys the change re-tiered.
  *
  * The tier is therefore the one to READ FIRST, and each entry still needs a
  * human before deletion. The cost of reading it as bulk-deletable is measured:
  * on the day objectui#7592 was filed, 33 of 147 CONFIRMED entries — 22% of the
  * tier — were one live subtree (`chatbot.tool.*`, rendering in ten packs), and
  * following the tier would have reverted every AI tool card to English in nine
- * locales. That class is closed; these three are not.
+ * locales. That class is closed; these four are not.
  *
  * ## Usage
  *
@@ -320,19 +333,39 @@ const KEY_CHAR = /[A-Za-z0-9_$.-]/;
  * character — i.e. at least one occurrence is the whole key rather than a
  * prefix or suffix of a longer one.
  *
- * Opt-in (`keyBoundary`), because the two corpora want opposite defaults. The
- * pack sweep has always used a plain substring test and its measured
- * false-positive rate was taken with that behaviour; changing it here would
- * silently re-tier that report. The designer table, by contrast, is densely
- * prefix-nested — a chrome key and its own sub-keys sit in the same namespace —
- * so without this check most of its NEEDS-REVIEW tier is evidence about a
- * DIFFERENT key.
+ * ON by default, for both corpora. It arrived opt-in with the designer table
+ * (objectui#8388) and defaulted OFF for one reason only: objectui#4658's ruling
+ * rests on a false-positive rate measured with the plain substring test, and
+ * re-tiering that report inside an unrelated PR would have moved that reading
+ * with nobody re-measuring it. objectui#8701 re-measured it and flipped the
+ * default — see that PR body for the before/after rate and for the per-key
+ * reading of every candidate the flip re-tiered. `keyBoundary: false` still
+ * reaches the old behaviour, and the self-test uses it to keep the shape this
+ * guard exists to refuse demonstrable.
  *
- * ⚠️ The cost, stated rather than discovered: a prose mention that ends in a
- * full stop no longer counts as a hit, so this can move a key from
- * NEEDS-REVIEW up into CONFIRMED — the direction that claims MORE evidence of
- * deadness. That is why CONFIRMED is documented as "read this first", never as
- * "safe to bulk delete".
+ * BOTH sides are load-bearing, and `occursAtPropertyBoundary()` is NOT a
+ * substitute for this predicate — a boundary is not a boundary. That guard
+ * refuses only a next character that CONTINUES AN IDENTIFIER, which leaves two
+ * holes here: `.` continues a dotted key without continuing an identifier, so
+ * `ns.group.leaf` followed by `.detail` passes it; and it checks nothing on the
+ * LEFT, so a longer key ENDING in this key (`otherNs.group.leaf` when the key
+ * is `group.leaf`) reads as a hit for it. Measured on the pack sweep when this
+ * became the default: reusing the chain guard here would have corrected 9 of
+ * the 13 mis-demoted keys and left 4 wrong, each of those 4 demoted by a longer
+ * key ending in it — the left side alone. The right-hand `.` hole cost 0 keys
+ * on that tree; it is still guarded, because a tree where a hole costs nothing
+ * is not a tree where it cannot.
+ *
+ * ⚠️ Two costs, stated rather than discovered:
+ *
+ *   1. A prose mention that ends in a full stop no longer counts as a hit, so
+ *      this can move a key from NEEDS-REVIEW up into CONFIRMED — the direction
+ *      that claims MORE evidence of deadness. That is why CONFIRMED is
+ *      documented as "read this first", never as "safe to bulk delete".
+ *   2. For a two-segment key it withdraws the accidental cover the substring
+ *      test gave to pack-object property readers — class 4 of "What CONFIRMED
+ *      does NOT guarantee" in the header, where the remaining check is written
+ *      down.
  */
 function occursAtKeyBoundary(content, key) {
   for (let from = 0; ; from += 1) {
@@ -373,16 +406,17 @@ function occursAtKeyBoundary(content, key) {
  * @param {boolean} [options.propertyChain=true] Run the property-chain probe.
  *   Off for a corpus whose table is not exported, where no property-access
  *   reader can exist (see `DESIGNER_TABLE`).
- * @param {boolean} [options.keyBoundary=false] Require a full-key match to be
- *   bounded by non-key characters — see `occursAtKeyBoundary()` for why the two
- *   corpora want opposite defaults.
+ * @param {boolean} [options.keyBoundary=true] Require a full-key match to be
+ *   bounded by non-key characters. Pass `false` for the pre-objectui#8701
+ *   substring behaviour, which counts a longer key that merely contains this
+ *   one — see `occursAtKeyBoundary()`.
  * @returns {Map<string, string[]>} key -> repo-relative file paths that
  *   mention it outside `definitionPrefix` (deduped, sorted). A path matched
  *   only by the property-chain probe carries `PROPERTY_CHAIN_HIT_SUFFIX`. A key
  *   absent from the map, or mapped to `[]`, has no textual footprint at all.
  */
 export function textFootprint(root, keys, options = {}) {
-  const { definitionPrefix = LOCALES_DIR, propertyChain = true, keyBoundary = false } = options;
+  const { definitionPrefix = LOCALES_DIR, propertyChain = true, keyBoundary = true } = options;
   const result = new Map(keys.map((key) => [key, []]));
   if (keys.length === 0) return result;
 
@@ -803,7 +837,6 @@ export function sweepDesignerTable(root) {
   const footprints = textFootprint(root, candidates, {
     definitionPrefix: DESIGNER_TABLE,
     propertyChain: false,
-    keyBoundary: true,
   });
   const tablesOf = (key) => DESIGNER_TABLE_CONSTS.filter((name) => tables.get(name).has(key));
 
@@ -917,8 +950,9 @@ if (invokedDirectly) {
       `\n${result.candidateCount} candidate(s) with no call site this pass can see, across ` +
         `${result.byNamespace.size} namespace(s): ${result.confirmed.length} CONFIRMED (no textual ` +
         `footprint anywhere else in the repo either), ${result.needsReview.length} NEEDS-REVIEW ` +
-        '(the AST pass sees no call site, but the literal key string appears somewhere else in the ' +
-        'repo — read that occurrence before treating the key as dead).',
+        '(the AST pass sees no call site, but the whole key — not merely a longer key that contains ' +
+        'it — appears somewhere else in the repo; read that occurrence before treating the key as ' +
+        'dead).',
     );
 
     const sortedNamespaces = [...result.byNamespace.entries()].sort(


### PR DESCRIPTION
Fixes #8701

## What changed

`textFootprint()`'s full-key probe now requires a **key boundary** on the pack sweep too: `keyBoundary` flips from opt-in to **on by default**, so both corpora run with it. `sweepDesignerTable()` drops its now-redundant explicit `keyBoundary: true`; `keyBoundary: false` still reaches the substring behaviour and the self-test uses it to keep that shape demonstrable.

**Why the default rather than a `keyBoundary: true` passed from `sweep()`:** after this card both corpora want it, so the documented reason the option existed ("the two corpora want opposite defaults") is factually gone. `textFootprint()` is exported, and its default is its contract — leaving the default at the behaviour we just measured as an artefact hands it to the next caller silently. The option survives as an explicit opt-out, which is what keeps the old behaviour measurable for exactly this kind of comparison.

⛔ **No key is deleted here.** All 13 are read and classified below; the deletions are a separate, per-key decision.

## 1. The tier split, before and after

Reproduced first, on the card's own commit, by running the *shipped* script there in a throwaway worktree:

| tree | candidates | CONFIRMED | NEEDS-REVIEW |
|---|---|---|---|
| `da5e4f69e` (the card's measurement) | 361 | **114** | **247** |
| `4857776cb` (`main` today), pre-fix | 364 | 114 | 250 |
| `19ae390c8` (this branch) | 364 | **127** | **237** |

The card's 114 / 247 reproduces **exactly**. Drift from that commit to today's `main` is **+3 NEEDS-REVIEW and +3 candidates**, CONFIRMED unchanged — the three are new pack keys `notifications.arrivalMany`, `notifications.arrivalOpen`, `notifications.arrivalRepeats`, not a behaviour change.

After the fix: **exactly the 13 keys move**, the candidate set does not change, **nothing leaves CONFIRMED**, and the designer corpus is byte-identical (58 candidates, 57 CONFIRMED / 1 NEEDS-REVIEW before and after) — which is the check that dropping its explicit opt-in was a no-op.

## 2. The re-measured false-positive rate, by objectui#4658's own method

The method, recovered from PR #4731's body (the PR that landed the sweep for objectui#4658) rather than re-invented — it reports the tier split and then reads it as one number:

> Run against this PR's tree (`d3d028631`): 2927 pack keys, 13776 referenced. **626 candidates, 384 CONFIRMED, 242 NEEDS-REVIEW (38.7%)** — i.e. a naive AST-only reverse sweep (no text safety net) would have been wrong about 2 in 5 of its own candidates.

So the rate is `NEEDS-REVIEW / candidates`: the share of the AST pass's own candidates that the text safety net rescues from a false CONFIRMED. Same arithmetic, same script, run the same way:

| tree | rate |
|---|---|
| `d3d028631` (as measured in PR #4731, quoted, not re-run) | 38.7 % |
| `4857776cb` pre-fix | 250 / 364 = **68.7 %** |
| `19ae390c8` post-fix | 237 / 364 = **65.1 %** |

**Does objectui#4658's ruling still stand? Yes, and with room to spare.** The ruling is "report-only, `--strict` stays unwired, every CONFIRMED entry still needs a human before deletion", taken on a **38.7 %** reading. This change moves the rate **down 3.6 points to 65.1 %** — still nearly twice the number that already settled the question, and moving in the direction that would *loosen* it rather than tighten it. Nothing here approaches the threshold that could reopen enforcement.

Two honest readings of that 3.6-point drop:

- It is **not** the instrument getting better at finding readers. It is 13 rescues that were themselves false being withdrawn: the pre-fix 68.7 % **overstated** the AST pass's error rate by exactly those 13 candidates, because the "rescue" was evidence about a different key.
- The rate has drifted 38.7 % → 68.7 % between `d3d028631` and today with nothing to do with this change (the candidate population fell 626 → 364 while NEEDS-REVIEW's share grew). ⚠️ **NOT INVESTIGATED here** — it is a separate question about a year of tree movement, and it is not what this card asked.

## 3. All 13, classified — and none deleted

Every one of the 13 was demoted by a **longer key**, never by its own spelling. Buckets: **13 genuinely dead** (no reader by any probe available in this repo), **0 live-but-unevidenced**.

| # | key | what demoted it pre-fix (the other key) | verdict + evidence |
|---|---|---|---|
| 1 | `appDesigner.noNavItems` | `appDesigner.noNavItemsHint` — `AppCreationWizard.tsx:515`, `useDesignerTranslation.ts:60` | **dead.** The live control is `…Hint`. `DESIGNER_DEFAULT_TRANSLATIONS` is a static full-key map and has only `…Hint`; no `t()` call, no bounded text hit anywhere, no quoted call site in history. |
| 2 | `appDesigner.separator` | `appDesigner.separatorLabel` — `AppCreationWizard.tsx:529`, `NavigationDesigner.tsx:238`, hook map `:61` | **dead.** The one shape worth ruling out: `item.type === 'separator'` next door could imply a per-type lookup, but the label renders through the literal key `appDesigner.separatorLabel`, and there is no concatenation-built key anywhere in the repo (measured, control below). |
| 3 | `approvals.reject` | `approvals.rejectConfirm` — in `packages/app-shell/CHANGELOG.md` only | **dead, and its whole namespace is.** `approvals.approve`, `approvals.approveSuccess`, `approvals.comment`, `approvals.rejectSuccess` are *already* CONFIRMED today; only `reject`/`rejectConfirm` were held out, by changelog prose. The live approvals surface is a different namespace — `approvalsInbox.*` (`RecordApprovalsPanel.tsx:206`, `DeclaredActionsBar.tsx`, `ApprovalsInboxPage.tsx`). Zero live spellings of `approvals.*` anywhere. |
| 4 | `console.objectView.groupBy` | `console.objectView.groupByField`, `…GroupByFieldHelp` — `CreateViewDialog.tsx:187-188` | **dead.** Residue of the view-editor unification; the two live spellings are the `…Field` pair, reached as `i18nKey:` properties. |
| 5 | `console.objectView.toolbar` | `console.objectView.toolbarEnabledCount` — `packages/i18n/src/__tests__/i18n.test.ts:82` | **dead.** The only spelling is a longer key inside a **test**, which never establishes liveness (the script's own header says so). |
| 6 | `dashboard.removeWidget` | `engine.inspector.dashboard.removeWidget` — the **designer table**, `DashboardDefaultInspector.tsx:232-233` | **dead in the pack.** A cross-corpus collision: the live string belongs to the metadata-admin designer's own table. Corroboration: its sibling `dashboard.addWidget` is already CONFIRMED. |
| 7 | `form.addItem` | `engine.form.addItem` — designer table + `SchemaForm.tsx:2240` | **dead in the pack.** Same cross-corpus shape; the "Add item" button on screen is the designer's key, not this one. |
| 8 | `home.recent` | `engine.home.recent` (designer) and `home.recentApps.*` | **dead.** The live console spelling is `home.recentApps.title` (`HomeRail.tsx`, `RecentApps.tsx`); the `home.recentApps.itemType.*` family is template-built and already excluded from candidates by the dynamic-head leg. |
| 9 | `home.starred` | `home.starredApps.title` — `StarredApps.tsx:66` | **dead.** Same rename shape as #8. |
| 10 | `home.subtitle` | `engine.home.subtitle` — designer table + `StudioHomePage.tsx:258` | **dead.** History shows a call site in the original Home Dashboard work; nothing spells it today. The live pack sibling is `home.build.subtitle`. |
| 11 | `marketplace.pricing.free` | `marketplace.pricing.freemium` — `untranslated-identity-4376.test.ts:105` | **dead, and the whole 6-key family is.** `contact-sales`, `paid`, `subscription`, `usage-based` are already CONFIRMED; `freemium` is held out only by that test line. No pricing consumer exists in `packages/app-shell` or `apps/` at all, and no `marketplace.pricing.` template head exists (if one did, none of the family would be a candidate). |
| 12 | `sidebar.help` | `sidebar.helpTooltip` — `AppHeader.tsx:716` | **dead.** The help control renders through `…Tooltip`. |
| 13 | `workspace.create` | `workspace.createFailed` / `…Title` / `…Description` / `…Button` (`CreateWorkspaceDialog.tsx`), and `vscode.workspace.createFileSystemWatcher` in `packages/vscode-extension` | **dead.** The purest illustration in the set: one of its "textual hits" was an unrelated VS Code API call that merely contains the key's characters. |

**How each verdict was closed against the instrument's own known blind spots** (header, "What CONFIRMED does NOT guarantee"):

- *Template-built keys* — structurally impossible for all 13: any key reachable from a collected dynamic head is removed from the candidate set **before** the text net runs, so a candidate is proof no head reaches it.
- *Concatenation-built keys* — measured repo-wide: `t('ns.' + x)`-shaped call sites in `packages/`+`apps/` = **0 files**, beside a lit control of **388 files** for `t('ns.key')`. A zero with a live control beside it.
- *Pack-object property readers* — the header's own re-derivation grep was re-run (28 matches today) and **every non-test importer** it returns was read: `chrome/LoadingScreen.tsx` (whole-subtree spreads), `console/ai/outboundAgentText.ts` (dynamic `ai?.[key]`, `console.ai.*` only), the two `plugin-grid/demo/*` files (whole-pack `resources` wiring), and `react/src/utils/nonGridRowCeiling.tsx` (`common.*`, spelled literally at its `t()` call anyway). **None reads any of the 13.**
- *Consumers outside `packages/`+`apps/`* — the text net already greps the whole repo (`examples/`, `e2e/`, `content/`, `scripts/`), and after the fix none of the 13 has a bounded occurrence anywhere in it.

⚠️ **The one risk no in-repo probe can close, and it applies to all 13 equally:** `@object-ui/i18n` is a **published** package, so an out-of-repo consumer could call any of these keys. That is a deletion-time risk for whoever files the follow-up, not an instrument artefact, and it is the standing reason CONFIRMED is "read this first" rather than "safe to bulk delete".

⚠️ **Why the 13 are not pinned in a test.** Spelling them in `scripts/__tests__/` would make that file a textual hit for each of them and push all 13 straight back into NEEDS-REVIEW — the self-pollution trap this script's own header records from an earlier draft, and the reason its real-repo control group assembles keys from segments. The census-guard obligation was met where the numbers actually live instead: the measurement harness asserts the exact set sizes (13 keys, 250 NEEDS-REVIEW, 364 candidates) before reading anything, and each guard was proven to throw on an emptied set.

## 4. The boundary predicate is load-bearing in **both** directions

Eleven pins, each naming the shape it holds. Which degenerate predicate each half catches:

| pin group | what it asserts | reddens for |
|---|---|---|
| **REJECTS** (5) | identifier-continued, dot-continued, hyphen-continued, **left-side** longer key, prose ending on a full stop | a predicate that answers **`true` for everything** — including the shipped `content.includes(key)` |
| **ACCEPTS** (6) | quoted call site, double-quoted data value, unquoted prose with a comma, end-of-line with no trailing char, start of line, **a real hit on a line that also carries a longer key** | a predicate that answers **`false` for everything** |

The ACCEPTS half is also what rules out implementations *strictly worse than the bug*: "the key must be the whole line" and "the key must be quoted" both pass every REJECTS pin while reporting no evidence about anything, and each is killed by a specific ACCEPTS pin (end-of-line comment / unquoted prose). The last ACCEPTS pin kills a predicate that stops at the first occurrence on a line.

Plus four `sweep()`-level pins, so the deliverable itself is held and not just the predicate: three prefix/suffix shapes must land in **CONFIRMED**, and a genuinely-spelled key must still land in **NEEDS-REVIEW** with the file named.

### Ablation — every new pin observed red, from a committed tree

Three legs, all with `trap … EXIT INT TERM` and absolute paths, restore by `git checkout HEAD -- ABSOLUTE_PATH`, and restore proven **by state** (`git diff HEAD --quiet`), not by exit code. The script is imported by the test through a relative source specifier, so there is no `dist/` hop for a mutation to fail to reach.

| leg | provenance | red |
|---|---|---|
| **A — the real pre-fix predicate**, restored from the base blob | on-disk `git hash-object` = `30039ec6e9b6a0e8c3701c28d62482a36793beab` = `git rev-parse 4857776cb:scripts/check-i18n-dead-keys.mjs`, and ≠ the HEAD blob `f16406c5…` | **8 red** — all 5 REJECTS pins + all 3 `sweep()` CONFIRMED pins |
| **B — `occursAtKeyBoundary` returns `true`** | injected marker counted on disk (1), blob ≠ HEAD blob | **24 red** — the 5 REJECTS + 3 `sweep()` pins, plus the pre-existing property-chain and designer-table controls |
| **C — `occursAtKeyBoundary` returns `false`** | injected marker counted on disk (1), blob ≠ HEAD blob | **12 red** — all 6 ACCEPTS pins + the `sweep()` "still demotes a real hit" pin, plus pre-existing footprint controls |

After each leg: `restore proven by state: git diff HEAD --quiet is clean`, and the on-disk blob back to `f16406c5…`.

## 5. ⚠️ The chain-probe guard would **not** have done it — measured, not assumed

`occursAtPropertyBoundary()` refuses only a next character that continues an **identifier**. Re-running the full-key probe over the pre-fix 250 with four predicates, one grep pass each:

| predicate | keys still demoted (of 250) | of the 13 |
|---|---|---|
| `content.includes(key)` (shipped) | 250 | 13 still wrong |
| right-only, identifier class — *the chain guard reused* | 241 | **4 still wrong** |
| right-only, key class (adds `.` and `-` on the right) | 241 | 4 still wrong |
| **both sides, key class (this PR)** | **237** | **0** |

So reusing the chain guard corrects **9 of 13 and leaves 4 wrong** — `form.addItem`, `home.recent`, `home.subtitle`, `dashboard.removeWidget`, each demoted by a longer key that **ends** with it (`engine.form.addItem` and friends). The left side is what catches them, and no amount of widening the *right*-hand character class reaches them.

⚠️ **A refinement of the card's own reasoning, measured:** the card and the dispatch both explain the insufficiency through the right-hand hole (`.` is not an identifier character, so `ns.group.leaf` + `.detail` sails through). That hole is real, but on this tree it rescues **0 keys** — every key that has a `key.more` hit also has a `keyMore` one. The insufficiency that actually bites here is the **left** side, which the chain guard does not check at all. Both are guarded; the pins cover both; but a report that repeated only the right-hand argument would be citing the wrong half.

## 6. Isolation: the two probes still do not interact

The card claims the 13 are identical whether the property-chain probe is on or off. Confirmed **after** the change rather than inherited — one grep pass per option set over the post-fix candidate list (364, asserted before reading):

```
propertyChain=true : CONFIRMED boundary-off 114, boundary-on 127, moved 13
propertyChain=false: CONFIRMED boundary-off 114, boundary-on 127, moved 13
moved sets identical across chain on/off: true
and equal to the 13: true
```

The isolation claim still holds. One observation that falls out of it and is **not** a defect: with the chain probe off, the pack CONFIRMED count is unchanged in both worlds — the property-chain leg demotes **zero** pack keys on this tree today. That is what a safety net looks like when the shape it guards is absent (its real-repo control group in the self-test still passes, so the leg itself works), but it is worth knowing that the leg costs the pack tier nothing right now.

## 7. The one cost this change *adds*, stated rather than discovered

For a **two-segment** key the substring test used to catch a pack-object property reader by accident — `somePack.topNs.leaf` spells `topNs.leaf` with a `.` on its left — and the boundary refuses exactly that. The property-chain leg does not take over below three segments (it returns `null` there on purpose). So for two-segment keys the enumerated importer list is the only remaining check, read by hand. This is now class **4** in the header's "What CONFIRMED does NOT guarantee", and it is why every non-test pack-object importer was re-read for the 13 (section 3).

## Tests

All from the final commit — `git rev-parse --short HEAD` = **`19ae390c8`**. Per-test outcomes from the **JSON reporter**; every run from the repo root with path filters.

```
pnpm exec vitest run scripts/ --maxWorkers=3 --reporter=json
  Test Files 133   Tests 3768   passed 3766   failed 0   (2 skipped: the deliberate real-socket fixtures)   76s

pnpm exec vitest run scripts/__tests__/check-i18n-dead-keys.test.ts \
    scripts/__tests__/check-i18n-call-site-keys.test.ts \
    scripts/__tests__/check-unreferenced-sources.test.ts \
    packages/i18n/ packages/plugin-timeline/src/__tests__/timeline-relative-defaults-retired-7874.test.ts
  Test Files 67   Tests 1313   passed 1313   failed 0   23s

pnpm run type-check:scripts          # tsc -p tsconfig.scripts.json — clean, exit 0
node_modules/.bin/eslint scripts/check-i18n-dead-keys.mjs scripts/__tests__/check-i18n-dead-keys.test.ts
  (no output, exit 0)

pnpm run check:control-bytes
  ✅  check-control-bytes: OK (scanned 6955 tracked text file(s); skipped 85 binary).

node scripts/check-governed-queue-guard.mjs --test scripts/check-i18n-dead-keys.mjs scripts/__tests__/check-i18n-dead-keys.test.ts
  ✅ NOT GOVERNED — 2 path(s) checked against 5 governed surface(s); none matched.

node scripts/check-i18n-dead-keys.mjs        # the instrument itself, exit 0, report-only
```

Every exit code was captured **before** any pipe (`cmd > file 2>&1; EXIT=$?`), and each verdict above is the gate's own printed line rather than a bare `$?`.

## Changeset

None owed, and the gate says so rather than me:

```
node scripts/check-changeset-presence.mjs
Compared the working tree with 4857776cb (merge-base with origin/main): 2 file(s) changed,
0 of them published source of a package the release covers, 0 of them a manifest whose
published contract moved, 0 under a package changesets ignores, 0 changeset(s) added.
✅  No source or published contract of a released package changed in this range, so no changeset is owed.
```

`scripts/` is not under any released package's `src/`, so this needs neither a bump nor an empty-frontmatter declaration. No `skip-changeset` label is applied — that label is inert in this repo.

## Out-of-scope finding, filed not fixed

**objectui#8752** — the header's enumerated pack-object importer list is stale: its own re-derivation grep returns 28 matches and **five** non-test importers today, against the "19 matches today, of which these four" in prose. The fifth (`packages/react/src/utils/nonGridRowCeiling.tsx`) is harmless — its keys are literal `t()` arguments — so there is no wrong verdict on the tree, but a reader nobody has classified is exactly what that section exists to prevent. Not fixed here: different class from this card's predicate, and the fix is a per-importer reading rather than a mechanical edit. objectui#8752 is not addressed by this PR.

## NOT MEASURED

- The repo-wide `pnpm lint` and the full test suite — left to CI. Local coverage was `scripts/` in full plus the i18n packages, which is the population this diff can reach.
- Why the false-positive rate drifted 38.7 % → 68.7 % since PR #4731. Out of scope; flagged in section 2.
- Whether any of the 13 has a consumer **outside this repository** (published package). Unmeasurable from here; stated in section 3 as the standing deletion-time risk.
- The dedup read behind objectui#8752 is one repo-scoped REST page of the 100 most recently updated open `finding` issues, not the whole label — the global search endpoint is blocked for this session and one MCP `search_issues` returned `API rate limit already exceeded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_