### PR TITLE
docs(types): point nine `@default` tags at a measured read site (objectui#8318)

### DIFF
--- a/.changeset/8318-jsdoc-default-tag-corrections.md
+++ b/.changeset/8318-jsdoc-default-tag-corrections.md
@@ -1,0 +1,51 @@
+---
+'@object-ui/types': patch
+---
+
+Nine published `@default` JSDoc tags now describe a measured read site
+(objectui#8318, maintainer ruling 2026-09-09: a documentation-vs-implementation
+mismatch is a documentation fix — no key is retired and no renderer's behaviour
+moves).
+
+`packages/types`' build carries JSDoc into `dist/*.d.ts`, and `dist` is in this
+package's `files`, so these are edits to PUBLISHED TEXT: an author reading
+`DetailSchema.loading` in an editor tooltip was being told the opposite of what
+the renderer does. No accept set, no exported symbol and no payload key changes.
+
+**Two tags were wrong** — `DetailSchema.loading` and `DetailViewSchema.loading`
+published `@default true`, while `plugin-detail/src/DetailView.tsx:995` reads the
+key as a bare disjunct, `if (loading || schema.loading)`, beside the component's
+own fetch state. An omitted key is `undefined` and contributes nothing, so the
+value applied on absence is `false`. The `true` arrived in `6f132f29`
+(2026-07-13), a bulk JSDoc pass copying the zod mirror's old `.default(true)`;
+it was never an authored intent. Giving the reader the `?? true` the tag
+promised would draw a skeleton on every detail view that omits the key — a
+behaviour change, and a product question of its own that this ruling did not
+open.
+
+**Seven tags had no reader to describe**, and they are not one fact — each
+docblock now carries its own evidence instead of a shared sentence:
+
+- `CRUDDialogSchema.size` / `.closeOnOutsideClick` / `.closeOnEscape` /
+  `.showClose` — there is no `register('crud-dialog'` anywhere, so no node of
+  that type ever reaches a renderer. Recorded once on the interface. Per key,
+  the name census differs: two spellings occur nowhere outside the declaration
+  and its zod twin, and `showClose`'s one other occurrence
+  (`renderers/overlay/drawer.tsx:38`) belongs to `DrawerSchema`.
+- `ActionSchema.level` — `type: 'action'` is not a rendered node type, and
+  `core/src/actions/ActionRunner.ts`, which is what makes `method` / `chainMode`
+  / `reload` / `close` live, does not read `level`.
+- `CardSchema.variant` — `card` IS registered, twice, and neither registration
+  reads it: the `ui` route forwards the key to `ui/card.tsx`, which spreads onto
+  a `div` and mentions `variant` nowhere, and the `page` route forwards only its
+  designer props.
+- `PageNodeSchema.isDefault` — `page` IS registered, and `PageRenderer` neither
+  reads the key nor forwards it: the wrapper element gets `toDomProps(props)`,
+  an allow-list that does not carry it.
+
+Until objectui#7735 the zod mirror's `.default()` substituted these values into
+parsed documents, which is what the tags were describing; with that gone they
+described nothing that runs.
+
+The pin `packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts` grows
+from 15 rows to 24, both sides derived off disk as before.

--- a/packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts
+++ b/packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts
@@ -447,26 +447,21 @@ describe('layout.ts `@default` docs agree with the renderer, re-measured (object
  * the same derivation. If the two node types ever diverge, this pin is what
  * says so.
  *
- * ## What is deliberately NOT pinned here, and why
+ * ## What this section deliberately did NOT pin — and what the ruling then did
  *
- * `DetailSchema.loading` and `DetailViewSchema.loading` are ALSO live —
- * `DetailView` reads `schema.loading` at the skeleton gate — but their tag says
- * `true` while the read is a bare `||` disjunct, so an omitted key renders NO
- * skeleton and the effective default is `false`. That is a genuine objectui#7735
- * instance hiding inside the population objectui#8318 called referent-less, and
- * it is the sharpest thing the re-test found. It is not pinned because BOTH
- * possible fixes are somebody's ruling — correct the tag to `false`, or give the
- * reader the `?? true` the tag promises (a behaviour change) — and a pin on
- * either side of an open question pre-empts it. Pinning the tag as it stands
- * would pin the defect; pinning the reader as it stands would redden the fix.
+ * Nine of the sixteen were left unpinned HERE, on purpose: `DetailSchema.loading`
+ * / `DetailViewSchema.loading`, whose tag said `true` against a bare `||`
+ * disjunct, and the seven keys the re-test could find no reader for. Both
+ * groups fed objectui#8318's question 1 — is the tag wrong, or is the key dead?
+ * — and a pin on either side of an open question pre-empts it: pinning those
+ * tags as they stood would have pinned the defect, pinning the readers as they
+ * stood would have reddened the fix.
  *
- * The other nine keys stay unpinned for the opposite reason: the re-test could
- * not find a reader for them, and "no reader" is the input to objectui#8318's
- * own question 1 (is the tag wrong, or is the key dead?), which is order-locked
- * behind this measurement and reserved to the maintainer. The absence of a
- * `crud-dialog` renderer is already recorded on the tree — see the header of
- * `handler-keys-string-any-mirrors-7344.test.ts` and `crud.zod.ts` — and is not
- * duplicated here.
+ * The maintainer answered on 2026-09-09: a docs-vs-implementation mismatch is a
+ * docs fix, so the tags moved and NO key was retired and NO renderer changed.
+ * Those nine rows now live in the LAST section of this file. This section is
+ * unchanged: its seven rows are the correct-tag AGREEMENT rows, and they do not
+ * overlap the nine.
  *
  * ## Derivation
  *
@@ -675,6 +670,316 @@ describe('objectui#8318 — the `@default`s the "no renderer reads it" list got 
      */
     it('the reader is typed by AppComponentSchema, not a look-alike', () => {
       expect(read(LAYOUT_RENDERER)).toMatch(/app:\s*AppComponentSchema/);
+    });
+  });
+});
+
+/**
+ * objectui#8318 ruling rows — the nine tags the re-test left for the maintainer.
+ *
+ * ## The ruling, and why these nine are one section and not one row
+ *
+ * The re-test at objectui#8318 comment 5594082411 split the sixteen keys three
+ * ways: seven live with a correct tag (pinned above), two live with a WRONG tag,
+ * and seven with no reader it could find. The maintainer ruled on 2026-09-09
+ * (decision batch #104 item 4) that a documentation-vs-implementation mismatch
+ * is a documentation fix — the tags change, ⛔ no key is retired and ⛔ no
+ * renderer's behaviour moves. Whether these keys should exist at all stays with
+ * the ADR-0049 liveness worklist (objectui#4631, objectui#7963).
+ *
+ * ⛔ The nine are NOT one fact, and this file refuses to let them be pinned as
+ * one. Writing a single sentence and applying it to nine keys is precisely the
+ * defect the whole card is about, one level up: the `@default true` on the two
+ * `loading` keys got there in `6f132f29` (2026-07-13), a BULK JSDoc pass that
+ * copied the zod mirror's `.default(true)` onto every key at once. So each row
+ * below asserts against the evidence for ITS key:
+ *
+ *   | member                              | why the old tag described nothing        |
+ *   |-------------------------------------|------------------------------------------|
+ *   | `DetailSchema.loading`              | read as a BARE `||` disjunct ⇒ `false`   |
+ *   | `DetailViewSchema.loading`          | the same reader, a second registration   |
+ *   | `CardSchema.variant`                | registered twice, read by neither        |
+ *   | `PageNodeSchema.isDefault`          | registered; not read, not on the         |
+ *   |                                     | `toDomProps` allow-list either           |
+ *   | `ActionSchema.level`                | no `action` node type, and the runner    |
+ *   |                                     | that reads its siblings does not read it |
+ *   | `CRUDDialogSchema.size`             | no `crud-dialog` registration at all;    |
+ *   | `.closeOnOutsideClick`              | plus, per key, its own name census:      |
+ *   | `.closeOnEscape`                    | zero occurrences for the middle two, and |
+ *   | `.showClose`                        | for `showClose` one occurrence that      |
+ *   |                                     | belongs to `DrawerSchema`                |
+ *
+ * ## Derivation — the two `loading` rows
+ *
+ * `DetailView` reads the key as `if (loading || schema.loading)`, with no
+ * literal anywhere near it. That is not "no default": `undefined || x` is `x`,
+ * so an omitted key contributes `||`'s IDENTITY element, and the value the
+ * reader applies on absence is `false`. The derivation is therefore two-sided
+ * like every row above, but its renderer half is a proved NEGATIVE — the gate
+ * matches, and no a `schema.loading` read with a literal fallback exists in the
+ * file — rather than a captured literal. `bareDisjunctDefault` below does that
+ * proof; it refuses to answer if a literal fallback ever appears, which is
+ * exactly the edit (giving the reader the `?? true` the old tag promised) the
+ * ruling declined to make. If someone makes it later, these rows go red and ask
+ * for the tag back — which is the correct direction.
+ *
+ * The capture is the CO-DISJUNCT's identifier, not a value: it is what proves
+ * the key is read beside the component's own fetch state rather than alone, and
+ * it is checked to be a `React.useState` local in the same file. A gate that
+ * became `if (schema.loading)` would still be a bare read, but it would no
+ * longer be the thing these docblocks describe.
+ *
+ * ## Derivation — the seven absence rows
+ *
+ * "Nothing applies a default" cannot be captured off a renderer, so each of
+ * these rows asserts the ABSENCE of a `@default` block tag plus the presence of
+ * the specific evidence its docblock owes — a hollow rewrite that dropped the
+ * tag and said nothing would pass an absence-only assertion. Every negative read
+ * carries a FIRING CONTROL from the same file, because a `grep` that stopped
+ * matching would report the same absence.
+ *
+ * ⚠️ Bounded on purpose: the repo-wide facts — `register('action'` and
+ * `register('crud-dialog'` match nothing — are NOT re-derived here, because this
+ * file reads named files and a repo-wide enumeration is a different instrument
+ * with its own failure modes (AGENTS.md's "枚举和读取必须来自不同来源"). They are
+ * recorded in the declarations' own docblocks, in `crud.zod.ts`, and in the
+ * header of `handler-keys-string-any-mirrors-7344.test.ts`. What IS derived here
+ * is everything reachable from a named file: that the `card` primitive does not
+ * consume `variant`, that `page`'s allow-list does not carry `isDefault`, that
+ * `ActionRunner` reads `method` but not `level`, and that the one `showClose`
+ * read in the tree belongs to `DrawerSchema`.
+ */
+const UI_CARD = 'packages/components/src/ui/card.tsx';
+const UI_ALERT = 'packages/components/src/ui/alert.tsx';
+const CARD_RENDERER = 'packages/components/src/renderers/layout/card.tsx';
+const CONTAINERS = 'packages/components/src/renderers/layout/containers.tsx';
+const DOM_PROPS = 'packages/core/src/utils/dom-props.ts';
+const DRAWER = 'packages/components/src/renderers/overlay/drawer.tsx';
+
+/** `if (loading || schema.loading)` — the skeleton gate; the capture is the co-disjunct. */
+const DETAIL_LOADING_GATE = /if \((\w+) \|\| schema\.loading\) \{/g;
+
+/**
+ * The value a key read as a BARE disjunct applies when it is absent.
+ *
+ * Returns `||`'s identity element, but only after proving on disk that the read
+ * really is bare: a literal fallback beside the key would make the identity
+ * argument false, and this refuses to answer rather than returning a stale
+ * `false`.
+ */
+function bareDisjunctDefault(src: string, key: string, where: string): string {
+  const withLiteral = new RegExp(`schema\\.${key}\\s*(?:\\|\\||\\?\\?)\\s*(?:true|false|['"\`]|\\d)`);
+  expect(
+    withLiteral.exec(src),
+    `${where} now gives schema.${key} a literal fallback — the bare-disjunct derivation no longer holds, ` +
+      'and the `@default` tag has to be re-read against it',
+  ).toBeNull();
+  return 'false';
+}
+
+/** A member that publishes NO `@default`, and whose prose owes named evidence. */
+function expectAbsentTagWithEvidence(body: string, member: string, evidence: string[]): void {
+  const doc = docblockFor(body, member);
+  expect(defaultTags(doc), `${member} must publish no @default block tag`).toEqual([]);
+  for (const term of evidence) {
+    expect(doc, `${member}'s docblock must name its evidence: ${term}`).toContain(term);
+  }
+}
+
+describe('objectui#8318 ruling — nine `@default`s corrected against a measured read site', () => {
+  const crud = read(CRUD);
+  const views = read(VIEWS);
+  const types = read(TYPES);
+
+  describe('positive controls — the extractions and the firing controls all match', () => {
+    it('the skeleton gate is still the shape rows 16-17 derive from', () => {
+      expect(soleCapture(read(DETAIL_VIEW), DETAIL_LOADING_GATE, DETAIL_VIEW)).toBeTruthy();
+    });
+
+    it('the co-disjunct really is the component\'s own fetch state', () => {
+      const detailView = read(DETAIL_VIEW);
+      const local = soleCapture(detailView, DETAIL_LOADING_GATE, DETAIL_VIEW);
+      expect(detailView, `${local} is not a useState local in ${DETAIL_VIEW}`)
+        .toMatch(new RegExp(`const \\[${local}, \\w+\\] = React\\.useState\\(`));
+    });
+
+    it('every member these rows read is still declared where this file looks', () => {
+      expect(() => docblockFor(interfaceBody(crud, 'DetailSchema'), 'loading')).not.toThrow();
+      expect(() => docblockFor(interfaceBody(views, 'DetailViewSchema'), 'loading')).not.toThrow();
+      expect(() => docblockFor(interfaceBody(types, 'CardSchema'), 'variant')).not.toThrow();
+      expect(() => docblockFor(interfaceBody(types, 'PageNodeSchema'), 'isDefault')).not.toThrow();
+      expect(() => docblockFor(interfaceBody(crud, 'ActionSchema'), 'level')).not.toThrow();
+      for (const member of ['size', 'closeOnOutsideClick', 'closeOnEscape', 'showClose']) {
+        expect(() => docblockFor(interfaceBody(crud, 'CRUDDialogSchema'), member)).not.toThrow();
+      }
+    });
+
+    /**
+     * The discrimination control for every absence row below. Each of them
+     * asserts an EMPTY tag list, which is also what a broken extractor returns —
+     * and these docblocks quote their own retired tags in prose, so the file
+     * really does contain the text `@default` next to these members.
+     */
+    it('the extractor still sees a real tag, and is not fooled by a quoted one', () => {
+      expect(defaultTags(docblockFor(interfaceBody(crud, 'ActionSchema'), 'method'))).toEqual(["'POST'"]);
+      expect(docblockFor(interfaceBody(types, 'CardSchema'), 'variant')).toContain('@default');
+      expect(defaultTags(docblockFor(interfaceBody(types, 'CardSchema'), 'variant'))).toEqual([]);
+    });
+  });
+
+  describe('row 16 — DetailSchema.loading (tag corrected: `true` → what the bare disjunct applies)', () => {
+    it('publishes what the reader applies when the key is absent', () => {
+      const applied = bareDisjunctDefault(read(DETAIL_VIEW), 'loading', DETAIL_VIEW);
+      expect(soleDefaultTag(interfaceBody(crud, 'DetailSchema'), 'loading')).toBe(applied);
+    });
+
+    it('no longer publishes `true`, which is the opposite of what happens', () => {
+      expect(defaultTags(docblockFor(interfaceBody(crud, 'DetailSchema'), 'loading'))).not.toContain('true');
+    });
+
+    it('names the read site and the shape that makes the default what it is', () => {
+      const doc = docblockFor(interfaceBody(crud, 'DetailSchema'), 'loading');
+      expect(doc).toContain('DetailView.tsx');
+      expect(doc).toContain('loading || schema.loading');
+    });
+
+    /**
+     * The load-bearing half. The tag is only `false` because the read is bare;
+     * a reader that acquired `?? true` would make `true` correct again, and the
+     * ruling deliberately did NOT make that change. This is what notices.
+     */
+    it('the reader really is bare — no literal fallback on the key', () => {
+      expect(read(DETAIL_VIEW)).not.toMatch(/schema\.loading\s*(\|\||\?\?)\s*(true|false)/);
+    });
+  });
+
+  describe('row 17 — DetailViewSchema.loading (the same reader, a second registration)', () => {
+    it('publishes the same value as its twin', () => {
+      const applied = bareDisjunctDefault(read(DETAIL_VIEW), 'loading', DETAIL_VIEW);
+      expect(soleDefaultTag(interfaceBody(views, 'DetailViewSchema'), 'loading')).toBe(applied);
+    });
+
+    it('the two declarations agree with each other — one component consumes both', () => {
+      expect(soleDefaultTag(interfaceBody(crud, 'DetailSchema'), 'loading'))
+        .toBe(soleDefaultTag(interfaceBody(views, 'DetailViewSchema'), 'loading'));
+    });
+
+    it('names the registration that makes it the same reader', () => {
+      const doc = docblockFor(interfaceBody(views, 'DetailViewSchema'), 'loading');
+      expect(doc).toContain("register('detail-view'");
+      expect(doc).toContain('DetailView.tsx');
+    });
+  });
+
+  describe('row 18 — CardSchema.variant (registered twice, read by neither)', () => {
+    it('publishes NO `@default` block tag, and says why', () => {
+      expectAbsentTagWithEvidence(interfaceBody(types, 'CardSchema'), 'variant', [
+        'ui/card.tsx',
+        'ui/alert.tsx',
+        'containers.tsx',
+      ]);
+    });
+
+    it('the primitive the `ui` registration forwards to does not consume it', () => {
+      expect(read(UI_CARD), `${UI_CARD} now mentions variant — re-read this row`).not.toMatch(/variant/);
+      // Firing control: the same read on a primitive that DOES consume it.
+      expect(read(UI_ALERT), `${UI_ALERT} control failed — the matcher is broken, not the claim`).toMatch(/variant/);
+    });
+
+    it('the renderer does not read it either, while its siblings are read', () => {
+      const cardRenderer = read(CARD_RENDERER);
+      expect(cardRenderer).not.toMatch(/schema\.variant/);
+      // Firing controls, from the same file: two sibling members that ARE read.
+      expect(cardRenderer).toMatch(/schema\.clickable/);
+      expect(cardRenderer).toMatch(/schema\.hoverable/);
+    });
+
+    it('the second registration forwards only the designer props', () => {
+      expect(read(CONTAINERS)).toContain("ComponentRegistry.register('card', PageCardRenderer");
+      expect(read(CONTAINERS)).toMatch(/\{\.\.\.designer\}/);
+    });
+  });
+
+  describe('row 19 — PageNodeSchema.isDefault (registered, not read, not on the allow-list)', () => {
+    it('publishes NO `@default` block tag, and says why', () => {
+      expectAbsentTagWithEvidence(interfaceBody(types, 'PageNodeSchema'), 'isDefault', [
+        'toDomProps',
+        'SDUI_DOM_PASS_THROUGH_KEYS',
+      ]);
+    });
+
+    it('the page renderer does not read it, and still reads its neighbour', () => {
+      const page = read(PAGE);
+      expect(page).not.toMatch(/schema\.isDefault/);
+      // Firing control from the same file: a member this renderer really reads.
+      expect(page).toMatch(/schema\.pageType/);
+    });
+
+    it('the wrapper element is fed an allow-list, and `isDefault` is not on it', () => {
+      expect(read(PAGE)).toContain('toDomProps(props)');
+      const domProps = read(DOM_PROPS);
+      expect(domProps).not.toContain('isDefault');
+      // Firing control: a key that IS on the list.
+      expect(domProps).toContain('className');
+    });
+  });
+
+  describe('row 20 — ActionSchema.level (no `action` node type; the runner reads its siblings, not it)', () => {
+    it('publishes NO `@default` block tag, and says why', () => {
+      expectAbsentTagWithEvidence(interfaceBody(crud, 'ActionSchema'), 'level', [
+        "register('action'",
+        'ActionRunner.ts',
+      ]);
+    });
+
+    it('the runner that makes the sibling keys live does not read this one', () => {
+      const runner = read(ACTION_RUNNER);
+      expect(runner).not.toMatch(/action\.level/);
+      // Firing control: the sibling read that row 8 is derived from.
+      expect(runner).toMatch(/action\.method/);
+    });
+  });
+
+  describe('rows 21-24 — the four `CRUDDialogSchema` keys (no registration for the node type)', () => {
+    it('the interface itself records the missing registration, once', () => {
+      expect(crud).toContain("NO RENDERER IS REGISTERED FOR `crud-dialog`");
+      expect(crud).toContain("register('crud-dialog'");
+    });
+
+    it('row 21 — `size` publishes no tag and defers to that fact', () => {
+      expectAbsentTagWithEvidence(interfaceBody(crud, 'CRUDDialogSchema'), 'size', [
+        'interface docblock',
+      ]);
+    });
+
+    it('row 22 — `closeOnOutsideClick` publishes no tag and names its empty census', () => {
+      expectAbsentTagWithEvidence(interfaceBody(crud, 'CRUDDialogSchema'), 'closeOnOutsideClick', [
+        'zod twin',
+      ]);
+    });
+
+    it('row 23 — `closeOnEscape` publishes no tag and names its empty census', () => {
+      expectAbsentTagWithEvidence(interfaceBody(crud, 'CRUDDialogSchema'), 'closeOnEscape', [
+        'zod twin',
+      ]);
+    });
+
+    /**
+     * The one of the four whose census is NOT empty, which is why its wording
+     * differs: crediting this declaration with `DrawerSchema`'s reader is the
+     * exact mistake a name-only census makes.
+     */
+    it('row 24 — `showClose` publishes no tag and names the look-alike reader', () => {
+      expectAbsentTagWithEvidence(interfaceBody(crud, 'CRUDDialogSchema'), 'showClose', [
+        'drawer.tsx',
+        'DrawerSchema',
+      ]);
+    });
+
+    it('the look-alike really exists, and really is another declaration', () => {
+      const drawer = read(DRAWER);
+      expect(drawer).toMatch(/schema\.showClose/);
+      expect(drawer).toContain('DrawerSchema');
     });
   });
 });

--- a/packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts
+++ b/packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts
@@ -828,7 +828,7 @@ describe('objectui#8318 ruling — nine `@default`s corrected against a measured
   });
 
   describe('row 16 — DetailSchema.loading (tag corrected: `true` → what the bare disjunct applies)', () => {
-    it('publishes what the reader applies when the key is absent', () => {
+    it('row 16 — `DetailSchema.loading` publishes what the reader applies when the key is absent', () => {
       const applied = bareDisjunctDefault(read(DETAIL_VIEW), 'loading', DETAIL_VIEW);
       expect(soleDefaultTag(interfaceBody(crud, 'DetailSchema'), 'loading')).toBe(applied);
     });
@@ -854,7 +854,7 @@ describe('objectui#8318 ruling — nine `@default`s corrected against a measured
   });
 
   describe('row 17 — DetailViewSchema.loading (the same reader, a second registration)', () => {
-    it('publishes the same value as its twin', () => {
+    it('row 17 — `DetailViewSchema.loading` publishes the same value as its twin', () => {
       const applied = bareDisjunctDefault(read(DETAIL_VIEW), 'loading', DETAIL_VIEW);
       expect(soleDefaultTag(interfaceBody(views, 'DetailViewSchema'), 'loading')).toBe(applied);
     });
@@ -872,7 +872,7 @@ describe('objectui#8318 ruling — nine `@default`s corrected against a measured
   });
 
   describe('row 18 — CardSchema.variant (registered twice, read by neither)', () => {
-    it('publishes NO `@default` block tag, and says why', () => {
+    it('row 18 — `CardSchema.variant` publishes NO `@default` block tag, and says why', () => {
       expectAbsentTagWithEvidence(interfaceBody(types, 'CardSchema'), 'variant', [
         'ui/card.tsx',
         'ui/alert.tsx',
@@ -901,7 +901,7 @@ describe('objectui#8318 ruling — nine `@default`s corrected against a measured
   });
 
   describe('row 19 — PageNodeSchema.isDefault (registered, not read, not on the allow-list)', () => {
-    it('publishes NO `@default` block tag, and says why', () => {
+    it('row 19 — `PageNodeSchema.isDefault` publishes NO `@default` block tag, and says why', () => {
       expectAbsentTagWithEvidence(interfaceBody(types, 'PageNodeSchema'), 'isDefault', [
         'toDomProps',
         'SDUI_DOM_PASS_THROUGH_KEYS',
@@ -925,7 +925,7 @@ describe('objectui#8318 ruling — nine `@default`s corrected against a measured
   });
 
   describe('row 20 — ActionSchema.level (no `action` node type; the runner reads its siblings, not it)', () => {
-    it('publishes NO `@default` block tag, and says why', () => {
+    it('row 20 — `ActionSchema.level` publishes NO `@default` block tag, and says why', () => {
       expectAbsentTagWithEvidence(interfaceBody(crud, 'ActionSchema'), 'level', [
         "register('action'",
         'ActionRunner.ts',

--- a/packages/types/src/crud.ts
+++ b/packages/types/src/crud.ts
@@ -44,8 +44,21 @@ export interface ActionSchema extends BaseSchema {
    */
   label: string;
   /**
-   * Action type/level
-   * @default 'default'
+   * Action type/level.
+   *
+   * NO `@default`, deliberately (objectui#8318). The tag published `'default'`
+   * and nothing applies it. `type: 'action'` is not a rendered node type --
+   * `register('action'` matches nothing repo-wide, exit 1, with
+   * `register('detail'` as the firing control (it resolves to
+   * `plugin-detail/src/index.tsx:387`). Nor does the channel that makes the
+   * neighbouring `ActionSchema` keys live read this one: in
+   * `packages/core/src/actions/ActionRunner.ts` the spellings `action.level`
+   * and `schema.level` have zero hits repo-wide, exit 1, with `action.method`
+   * as the firing control (`ActionRunner.ts:1787` and `:1793`). Until
+   * objectui#7735 the zod mirror's `.default('default')` substituted the value
+   * into a parsed document; with that gone the tag described nothing that runs.
+   * Whether the key should exist at all is the ADR-0049 liveness worklist's
+   * question (objectui#4631, objectui#7963), not this card's.
    */
   level?: 'primary' | 'secondary' | 'success' | 'warning' | 'danger' | 'info' | 'default';
   /**
@@ -307,8 +320,20 @@ export interface DetailSchema extends BaseSchema {
    */
   onBack?: () => void;
   /**
-   * Whether to show loading state
-   * @default true
+   * Force the loading skeleton.
+   *
+   * `DetailView.tsx:995` reads this key as a bare disjunct beside the
+   * component's OWN fetch state (`const [loading, setLoading] = ...`, `:269`):
+   * `if (loading || schema.loading)`. An omitted key is `undefined`, so it
+   * contributes nothing to that gate -- the value the reader applies on absence
+   * is `false`, not the `true` the tag published until objectui#8318. That
+   * `true` arrived in `6f132f29` (2026-07-13), a bulk JSDoc pass copying the
+   * zod mirror's old `.default(true)`, so it was never an authored intent, and
+   * honouring it would have drawn a skeleton on every detail view that omits
+   * the key. Giving the reader the `?? true` the old tag promised is a
+   * behaviour change and a product question of its own (maintainer ruling
+   * 2026-09-09), not opened here.
+   * @default false
    */
   loading?: boolean;
 }
@@ -316,6 +341,18 @@ export interface DetailSchema extends BaseSchema {
 /**
  * CRUD Dialog/Modal component for CRUD operations
  * Note: For general dialog usage, use DialogSchema from overlay module
+ *
+ * NO RENDERER IS REGISTERED FOR `crud-dialog` (objectui#7344, re-measured for
+ * objectui#8318): `register('crud-dialog'` matches nothing repo-wide, exit 1,
+ * with `register('detail'` as the firing control (it resolves to
+ * `plugin-detail/src/index.tsx:387`). Nothing renders a node of this type, so
+ * no member below has a reader, and a `@default` on any of them would describe
+ * something that does not run -- which is why the four keys that used to
+ * publish one no longer do (objectui#8318). This is upstream of any per-key
+ * census: a census can only report where a spelling appears, and the reason
+ * these keys have no reader is that the node type never reaches a renderer at
+ * all. Whether the type should exist is the ADR-0049 liveness worklist's
+ * question (objectui#4631, objectui#7963), not this card's.
  */
 export interface CRUDDialogSchema extends BaseSchema {
   type: 'crud-dialog';
@@ -332,8 +369,13 @@ export interface CRUDDialogSchema extends BaseSchema {
    */
   content?: SchemaNode | SchemaNode[];
   /**
-   * Dialog size
-   * @default 'default'
+   * Dialog size.
+   *
+   * NO `@default`, deliberately (objectui#8318): the tag published `'default'`
+   * with no reader to apply it. `.size` is one of the most common spellings in
+   * this tree, so a name census answers nothing here; the interface docblock
+   * above carries the fact that decides it -- there is no `crud-dialog`
+   * registration, so no node of this type is ever handed to a renderer.
    */
   size?: 'sm' | 'default' | 'lg' | 'xl' | 'full';
   /**
@@ -353,18 +395,39 @@ export interface CRUDDialogSchema extends BaseSchema {
    */
   onClose?: never;
   /**
-   * Whether clicking outside closes dialog
-   * @default true
+   * Whether clicking outside closes dialog.
+   *
+   * NO `@default`, deliberately (objectui#8318): the tag published `true` with
+   * no reader to apply it. Here the name census is decisive on its own -- the
+   * spelling `closeOnOutsideClick` occurs NOWHERE in the tree outside this
+   * declaration and its zod twin (`zod/crud.zod.ts`), so there is not even a
+   * look-alike reader on some other node type to mistake for one. The missing
+   * registration is in the interface docblock above.
    */
   closeOnOutsideClick?: boolean;
   /**
-   * Whether pressing Escape closes dialog
-   * @default true
+   * Whether pressing Escape closes dialog.
+   *
+   * NO `@default`, deliberately (objectui#8318): the tag published `true` with
+   * no reader to apply it. `closeOnEscape` is the second of the two keys on
+   * this interface whose spelling occurs nowhere outside this declaration and
+   * its zod twin -- zero repo-wide hits, so nothing reads it under any node
+   * type. The missing registration is in the interface docblock above.
    */
   closeOnEscape?: boolean;
   /**
-   * Show close button
-   * @default true
+   * Show close button.
+   *
+   * NO `@default`, deliberately (objectui#8318): the tag published `true` with
+   * no reader to apply it. This key is the one on this interface whose census
+   * is NOT empty, and that is exactly why it needs saying: `showClose` has one
+   * occurrence outside this declaration and its zod twin --
+   * `packages/components/src/renderers/overlay/drawer.tsx:38`,
+   * `{schema.showClose && ...}` -- and that read belongs to
+   * `DrawerSchema.showClose`, a different member on a different, registered
+   * node type. Counting it here would be crediting this declaration with
+   * another one's reader. The missing registration is in the interface docblock
+   * above.
    */
   showClose?: boolean;
 }

--- a/packages/types/src/layout.ts
+++ b/packages/types/src/layout.ts
@@ -427,8 +427,25 @@ export interface CardSchema extends BaseSchema {
    */
   footer?: SchemaNode | SchemaNode[];
   /**
-   * Variant style
-   * @default 'default'
+   * Variant style.
+   *
+   * NO `@default`, deliberately (objectui#8318), and for a different reason
+   * from the keys whose node type has no registration at all: `card` IS
+   * registered, twice, and neither registration reads this key, so nothing
+   * applies the `'default'` the tag used to publish.
+   * `renderers/layout/card.tsx:64` (`namespace: 'ui'`) forwards the node's
+   * remaining keys onto `<Card>` through `{...cardProps}` (`:32`, `:46`), and
+   * the primitive `ui/card.tsx` destructures only `className` and spreads the
+   * rest onto a `div`: `variant` occurs 0 times in that file, exit 1, with
+   * `ui/alert.tsx` as the firing control (5 occurrences, where the primitive
+   * really does consume it through `cva`). The second registration,
+   * `renderers/layout/containers.tsx:842` (`namespace: 'page'`,
+   * `skipFallback: true`), forwards only `{...designer}`, so on that route the
+   * key does not reach the element at all. Its siblings `clickable` and
+   * `hoverable` ARE read (`card.tsx:35-36`), which is what makes this a reading
+   * rather than a search that missed. Whether the key should exist is the
+   * ADR-0049 liveness worklist's question (objectui#4631, objectui#7963), not
+   * this card's.
    */
   variant?: 'default' | 'outline' | 'ghost';
   /**
@@ -785,8 +802,25 @@ export interface PageNodeSchema extends BaseSchema {
    */
   children?: SchemaNode | SchemaNode[];
   /**
-   * Whether this is the default page for the object/app
-   * @default false
+   * Whether this is the default page for the object/app.
+   *
+   * NO `@default`, deliberately (objectui#8318). `page` IS registered
+   * (`renderers/layout/page.tsx:692`), so the reason nothing applies the
+   * `false` this tag used to publish is neither a missing registration nor a
+   * primitive that ignores the prop: `PageRenderer` neither reads the key nor
+   * forwards it. `schema.isDefault` has zero hits repo-wide, exit 1, with
+   * `schema.pageType` as the firing control (it resolves inside the same
+   * renderer, `page.tsx:291`); and the wrapper element receives
+   * `toDomProps(props)` (`page.tsx:521`), an ALLOW-LIST --
+   * `SDUI_DOM_PASS_THROUGH_KEYS` in `core/src/utils/dom-props.ts`, plus the
+   * `aria-*` / `data-*` prefixes -- which does not contain `isDefault` (0
+   * occurrences in that file, exit 1; firing control `className`, 5). The
+   * rest-spread this renderer used to close by enumeration was replaced by that
+   * whitelist in objectui#4425 / objectui#7933. The `.isDefault` reads that do
+   * exist elsewhere in the tree are on APPS, saved views, flow edges and
+   * permission drafts -- other declarations, not this one. Whether the key
+   * should exist is the ADR-0049 liveness worklist's question (objectui#4631,
+   * objectui#7963), not this card's.
    */
   isDefault?: boolean;
   /**

--- a/packages/types/src/views.ts
+++ b/packages/types/src/views.ts
@@ -646,8 +646,20 @@ export interface DetailViewSchema extends BaseSchema {
    */
   deleteConfirmation?: string;
   /**
-   * Whether to show loading state
-   * @default true
+   * Force the loading skeleton.
+   *
+   * The same single reader as `DetailSchema.loading`, reached by a different
+   * registration: `register('detail-view', DetailViewRenderer)`
+   * (`plugin-detail/src/index.tsx:284`) is a data-source gate whose child is
+   * `<DetailView schema={bound as DetailViewSchema} ...>`, so both node types
+   * land on `DetailView.tsx:995` -- `if (loading || schema.loading)`, a bare
+   * disjunct beside the component's own fetch state (`:269`). An omitted key is
+   * `undefined` and contributes nothing to that gate, so the value applied on
+   * absence is `false`. The tag published `true` from the 2026-07-13 bulk JSDoc
+   * pass that copied the zod mirror's old `.default(true)` until objectui#8318
+   * corrected it; the two declarations must keep agreeing, because one
+   * component consumes both.
+   * @default false
    */
   loading?: boolean;
   /**


### PR DESCRIPTION
Fixes #8318

Maintainer ruling 2026-09-09 (decision batch #104 item 4, recorded at objectui#8318 comment 5595150523), verbatim and untranslated:

> 所有这种文档错的都应该改文档,没有什么好决裁的,这个应该写入技能。

Ruled **A1 + B1 — the documentation is what is wrong, so the documentation is what changes.** No key is retired, no renderer's behaviour moves, no zod file is touched. Whether these keys should exist at all stays with the ADR-0049 liveness worklist (objectui#4631, objectui#7963).

## Per-key table — every tag re-derived against a read site on this branch's base

⚠️ Re-measured on `3fbdd4a2`, ⛔ not copied from the card. Two line numbers moved since the re-test at comment 5594082411 (`DetailView.tsx:992` is `:995` today), which is the reason for re-measuring rather than quoting.

| key | read site, or the proof that there is none | firing control | new tag |
|---|---|---|---|
| `DetailSchema.loading` | `packages/plugin-detail/src/DetailView.tsx:995` — `if (loading \|\| schema.loading)`, a bare disjunct beside the component's own `useState` fetch state at `:269`. An omitted key is `undefined` and contributes nothing. | n/a (a positive read) | `@default false` |
| `DetailViewSchema.loading` | the same single site. `register('detail-view', DetailViewRenderer)` (`plugin-detail/src/index.tsx:284`) is a data-source gate whose child is `DetailView` with the bound schema, so both node types land on `:995`. | n/a | `@default false` |
| `CardSchema.variant` | registered twice, read by neither. `renderers/layout/card.tsx:64` (`namespace: 'ui'`) forwards remaining keys through `{...cardProps}`; `ui/card.tsx` destructures only `className` and spreads the rest onto a div element — `grep -c variant ui/card.tsx` = **0**, exit 1. Second registration `containers.tsx:842` (`namespace: 'page'`) forwards only `{...designer}`. | `ui/alert.tsx` = **5**, exit 0 (a primitive that really consumes it, via `cva`). Also, in-file: `schema.clickable` and `schema.hoverable` both resolve in `card.tsx:35-36`. | tag removed |
| `PageNodeSchema.isDefault` | `page` IS registered (`renderers/layout/page.tsx:692`), and `PageRenderer` neither reads nor forwards the key. `schema.isDefault` repo-wide = **0 hits**, exit 1. The wrapper element gets `toDomProps(props)` (`page.tsx:521`), an allow-list — `SDUI_DOM_PASS_THROUGH_KEYS` in `core/src/utils/dom-props.ts` — with `isDefault` absent (**0**, exit 1). | `schema.pageType` resolves, exit 0 (same renderer, `page.tsx:291`); `className` in `dom-props.ts` = **5**, exit 0. | tag removed |
| `ActionSchema.level` | no `register('action'` anywhere, exit 1 — `type: 'action'` is not a rendered node type. And the channel that makes its four siblings live never reads it: `action.level` / `schema.level` repo-wide = **0 hits**, exit 1. | `register('detail'` resolves to `plugin-detail/src/index.tsx:387`, exit 0; `action.method` resolves to `ActionRunner.ts:1787` and `:1793`, exit 0. | tag removed |
| `CRUDDialogSchema.size` | no `register('crud-dialog'` anywhere, exit 1 (also matched with a quote-agnostic regex, exit 1). `.size` is a very common spelling, so a name census answers nothing here — the decisive fact is upstream of it: no node of this type ever reaches a renderer. | `register('detail'` resolves, exit 0 (same regex shape). | tag removed |
| `CRUDDialogSchema.closeOnOutsideClick` | same missing registration, plus an empty name census: the spelling occurs **nowhere** outside `crud.ts` and its zod twin `zod/crud.zod.ts:195`. | as above | tag removed |
| `CRUDDialogSchema.closeOnEscape` | same missing registration, same empty census — `crud.ts` and `zod/crud.zod.ts:196` only. | as above | tag removed |
| `CRUDDialogSchema.showClose` | same missing registration, and the one of the four whose census is **not** empty: exactly one occurrence outside the declaration and its twin — `renderers/overlay/drawer.tsx:38`, `{schema.showClose && …}` — which reads `DrawerSchema.showClose`, a different member on a different, registered node type. | `schema.showClose` really does resolve in `drawer.tsx`, exit 0, and that file names `DrawerSchema`. | tag removed |

⛔ The nine are deliberately **not** written as one sentence. That is the same defect this card is about, one level up: the `@default true` on the two `loading` keys got there in `6f132f29` (2026-07-13), a bulk JSDoc pass that copied the zod mirror's `.default(true)` onto every key at once.

## The `dist/*.d.ts` measurement, and what it forced

⚠️ Measured, ⛔ not assumed. `packages/types`' build is `tsc && vite build`, `tsc` preserves JSDoc in the emitted declarations, and `dist` is in this package's `files` array. So these edits change **published text**.

| | before | after |
|---|---|---|
| `dist/crud.d.ts` block `@default` tags | 11 | 6 |
| `dist/layout.d.ts` block `@default` tags | 19 | 17 |
| `dist/crud.d.ts` bytes | 11,916 | 16,413 |
| `dist/layout.d.ts` bytes | 30,746 | 33,221 |

Block tags preceding each of the seven dead keys in the emitted `.d.ts`: **0** for all seven. Negative control: a string absent from source greps 0 in the emitted file, exit 1.

**What it forced:** a real `patch` changeset, not the empty-frontmatter declaration a docs-only change might otherwise take. `.changeset/8318-jsdoc-default-tag-corrections.md`. It is still **not** an accept-set change — `Clause-②: no` stands: no exported symbol, no validator behaviour, no payload key moves. Only the text an author reads in an editor tooltip, which was telling them the opposite of what the renderer does.

## The pin: 15 rows to 24

`packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts` — 49 `it(` to 75, both sides still derived off disk.

- Rows 16-17 (`loading`) derive the applied value from a proved **negative**: the gate matches, and no literal fallback exists on the key, so the omitted key contributes `||`'s identity. `bareDisjunctDefault` refuses to answer if a literal fallback ever appears — so if someone later gives the reader the `?? true` the old tag promised, these rows go red and ask for the tag back. The capture is the **co-disjunct's identifier**, checked to be a `React.useState` local in the same file.
- Rows 18-24 assert tag ABSENCE plus the specific evidence each docblock owes, so a hollow rewrite that dropped the tag and said nothing does not pass. Every negative read carries a firing control from the same file.
- ⛔ The seven pre-existing rows PR #8718 landed are untouched.
- ⚠️ Bounded on purpose: the repo-wide facts (`register('action'` / `register('crud-dialog'` match nothing) are **not** re-derived inside the test — it reads named files, and a repo-wide enumeration is a different instrument with its own failure modes. They are recorded in the declarations, in `crud.zod.ts`, and in `handler-keys-string-any-mirrors-7344.test.ts`.

### Ablation — 12 legs, each reddening its own row

Each leg: mutate, prove the bytes landed on disk (anchor counts plus a byte-length delta), run the suite, restore against the `HEAD` blob, prove restoration by an empty `git diff HEAD` **and** blob-hash equality. Baseline green, post-ablation green.

| leg | mutation | what went red |
|---|---|---|
| M1 | `DetailSchema.loading` tag back to `true` | rows 16 + the agreement assertion |
| M2 | `DetailViewSchema.loading` tag back to `true` | row 17 + the agreement assertion |
| M3 | give `DetailView.tsx` a literal fallback on the key | rows 16, 17, and the bare-read assertion |
| M4 | re-add `@default` to `CardSchema.variant` | row 18 + the extractor discrimination control |
| M5 | strip the `ui/alert.tsx` evidence term | row 18 |
| M6 | make `ui/card.tsx` mention `variant` | row 18's primitive assertion |
| M7 | re-add `@default` to `PageNodeSchema.isDefault` | row 19 |
| M8 | re-add `@default` to `ActionSchema.level` | row 20 |
| M9 | re-add `@default` to `CRUDDialogSchema.size` | row 21 |
| M10 | re-add `@default` to `closeOnOutsideClick` | row 22 |
| M11 | re-add `@default` to `closeOnEscape` | row 23 |
| M12 | strip the `drawer.tsx` evidence term | row 24 |

Rows 18-20 originally shared one assertion title, so an ablation report could not say which had reddened; a second commit gives each the member's name. That rename is why M4/M7/M8 are now distinguishable above.

## Gates, with exit codes

Every exit code captured **before** any pipe. `pnpm check` is a per-PR CI gate (`.github/workflows/lint.yml`), and its first run was **PRECONDITION NOT MET**, ⛔ not a red.

| gate | exit |
|---|---|
| `pnpm --filter @object-ui/types type-check` | **0** |
| `pnpm exec vitest run packages/types/` (repo root) | **0** — 154 files, 3062 tests |
| `pnpm exec vitest run packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts` | **0** — 75 tests (49 before) |
| `pnpm --filter @object-ui/types lint` | **0** — 266 warnings, 0 errors, all pre-existing `no-explicit-any` |
| `pnpm exec eslint` on the four changed files | **0** — 9 warnings, every one on a pre-existing `any`, none on an added line |
| eslint firing control (an `object-ui/no-dynamic-import-in-test-hook` violation) | **1** — the linter really can fail here |
| `node scripts/check-changeset-presence.mjs` | **0** — 4 published source files, 1 changeset |
| `pnpm check:control-bytes` | **0** — 6961 tracked text files |
| `grep -naP` control-byte self-scan of the 5 changed files | **1** (no hits) |
| `pnpm check` — first run, unbuilt `packages/cli/dist/cli.js` | **1**, `MODULE_NOT_FOUND` = PRECONDITION NOT MET |
| `pnpm --filter @object-ui/cli build` | **0** |
| `pnpm check` — re-run | **0**, "All checks passed" |
| `pnpm --filter @object-ui/types build` | **0** (the `dist/*.d.ts` measurement above) |

Heavy runs were serialised through the container's shared verify lock; every one printed `VERDICT command-exit 0`.

## NOT MEASURED

- **Runtime.** Nothing was mounted. Every reading here is static, off the source. In particular: what a browser does with the `variant` attribute the `ui` route spreads onto a div element is measured only as "the primitive's source contains no `variant`".
- **`Build Docs`, `check:node-esm-load`, `check:published-dist`.** Measured here or nowhere — and here they were **not** run. They are the three gates the dispatch names as not per-PR; this diff adds only comments to three `.ts` files, one test file and one changeset, so it moves no module graph, no ESM entry and no published tooling manifest. ⛔ That is a reasoned expectation, not a measurement.
- **A baseline lint run at the merge-base.** The claim that all 9 file-level warnings pre-exist rests on their rule (`no-explicit-any`) and their line numbers landing on declarations this diff does not touch — this diff adds comments only. ⛔ The base commit was not linted separately.
- **The `pnpm check` warnings** (3 files carrying a registered component type that did not validate, 46 skipped). None of them is in this diff, and no baseline run was made to prove they pre-exist.
- **`ActionSchema` vs `UIActionSchema` reachability at `ActionRunner`.** Inherited un-measured from the re-test at comment 5594082411, and untouched here.
- **The other 25 of objectui#7735's 41 keys.** This card's population is the 16.

## Anything that argues a key should be retired — ⛔ reported, not acted on

Routes to objectui#4631 / objectui#7963, ⛔ not to this PR:

1. **`CardSchema.variant` is the strongest retirement candidate of the seven, and there is a second reason beyond "nothing reads it":** on the `ui` route the key is not dropped, it is **forwarded** — `renderers/layout/card.tsx` closes its spread with a hand-rolled destructure of three designer props rather than `toDomProps`, so `variant` reaches `ui/card.tsx` and is spread onto a div element as an unknown attribute. That is the shape objectui#4425 / objectui#7933 closed elsewhere with the allow-list. ⚠️ Static reading only; nothing was mounted, and this PR ⛔ changes no renderer.
2. **The four `CRUDDialogSchema` keys are the cleanest ADR-0049 instances in the set** — their node type has no registration at all, which is a strictly stronger fact than "the renderer does not read the key". The interface already carries an `onClose?: never` tombstone for exactly this reason.
3. **`ActionSchema.level` sits on a `@deprecated` interface** whose modern twin `UIActionSchema` does not declare it.

## What this PR deliberately does NOT do

⛔ No key retired. ⛔ No renderer, registration or zod file touched. ⛔ The seven pinned rows from PR #8718 untouched (they pin the keys whose tags are correct; they do not overlap these nine). ⛔ Draft, and staying draft.

Session for this implementation, as a code span so it survives a body edit: `https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_