### PR TITLE
fix(types): arm AnyComponentSchema for seven registered node-slot renderers (objectui#8499)

### DIFF
--- a/.changeset/8499-node-slot-registered-arms.md
+++ b/.changeset/8499-node-slot-registered-arms.md
@@ -37,8 +37,35 @@ from 107 to 154:
   `renderers/form/calendar.tsx` registers under exactly that key (`skipFallback`,
   because bare `calendar` belongs to the plugin-calendar view).
 
-Every arm declares only keys its renderer demonstrably reads — the `BarChartSchema`
-discipline objectui#6318 established for the same class of gap.
+Every arm this change AUTHORS declares only keys its renderer demonstrably reads —
+the `BarChartSchema` discipline objectui#6318 established for the same class of gap.
+⚠️ One arm INHERITS more than that, and it is stated rather than glossed:
+`UiCalendarSchema` extends `CalendarSchema`, so it carries `minDate` and `maxDate`,
+which `renderers/form/calendar.tsx` reads zero times (controls, same file: `mode` 3,
+`className` 4 — it reads `mode`, `value`, `defaultValue` and `className`). That is
+pre-existing debt on `CalendarSchema`, not something this change introduces, and
+narrowing it here would be a different card's accept-set movement; the extend is what
+keeps the two spellings one schema.
+
+**A repo-tracked metric moves, declared knowingly.**
+`scripts/measure-strict-authoring-face.mjs` reports `unexportedNodeSchemas` — node
+types reachable only through the union because no schema for them is exported by name
+from `@object-ui/types/zod`, "so no consumer can validate one alone". The four new
+arms are not in that barrel's explicit export lists, so the metric moves from
+`[breadcrumb, object-tree]` to **49 node types** (the same 2, plus this change's 47
+new literals). Measured at this branch's head, not estimated.
+
+Why 49 is acceptable here where 2 was a defect: the 2 were data blocks a consumer had
+a standing reason to validate on their own, and objectui#7917 (PR #8777, open at the
+time of writing, and the holder of `zod/index.zod.ts`) exists to export exactly those.
+The 47 added here are HTML primitives and two input aliases — they have no per-tag
+consumer to serve, and exporting a `SemanticElementSchema` / `HtmlElementSchema` pair
+would publish a NAMED authoring surface (`z.enum` families, not per-tag schemas) that
+this card's ruling does not cover: the ruling is "arm the registered renderers", not
+"add public exports to `@object-ui/types`". So the metric is left to move and said out
+loud instead. ⇒ Whoever next runs that measurement should expect 49, and whoever
+wants the number back down should treat naming these families as its own decision.
+If PR #8777 lands first, the same movement reads `0` to `47`.
 
 **Accept-set movement is widening only.** Nothing that parsed green parses red. Each
 arm still judges VALUES: `{ type: 'img', width: true }`, `{ type: 'password',

--- a/.changeset/8499-node-slot-registered-arms.md
+++ b/.changeset/8499-node-slot-registered-arms.md
@@ -1,0 +1,67 @@
+---
+'@object-ui/types': minor
+---
+
+Give `AnyComponentSchema` arms for seven registered, live renderers that resolved in
+no arm at a declared node slot (objectui#8499).
+
+**The defect, and the direction it ran.** Nine `type` spellings sat at DECLARED node
+slots in this repository's own corpora and resolved in no arm of the component union.
+Eight were registered renderers with fixtures proving they draw; the ninth
+(`my-component`) is the reader's own plugin component and carries a written exemption
+in `scripts/check-doc-component-types.mjs`. A reader following
+`content/docs/utilities/runner.mdx`'s own instruction — "copy one, wrap it in a page
+document … and save it as `src/app-data/pages/index.json`" — got a document that
+**renders correctly in the browser and is refused by `objectui check`**. That is the
+expensive direction: the likely reaction is to stop trusting the validator.
+
+It was invisible because `check:doc-types` judges a `type` literal against the
+RENDERER REGISTRY (656 keys) and not against `AnyComponentSchema` (107 arm literals).
+The two faces disagreed by construction and nothing compared them at a node slot.
+
+**What is now authorable.** Four new arms, 47 new `type` literals, taking the union
+from 107 to 154:
+
+- `SemanticElementSchema` (`zod/layout.zod.ts`) — the seven HTML sectioning tags
+  `renderers/layout/semantic.tsx` registers: `aside` `main` `header` `nav` `footer`
+  `section` `article`.
+- `HtmlElementSchema` (`zod/layout.zod.ts`) — the 37 safe flow/inline tags
+  `renderers/basic/html-elements.tsx` registers (`h1`…`h6`, `p`, `a`, `ul`, `img`, …),
+  plus the per-tag keys that module forwards to the DOM (`href`, `target`, `rel`,
+  `title`, `src`, `alt`, `width`, `height`, `dateTime`, `cite`).
+- `InputShorthandSchema` (`zod/form.zod.ts`) — `email` / `password`, the two aliases
+  `renderers/form/input.tsx` registers onto the `input` renderer with `inputType`
+  pinned. `inputType` is deliberately NOT declared on this arm: the wrapper spreads
+  its own value last, so an authored one is overwritten.
+- `UiCalendarSchema` (`zod/form.zod.ts`) — `ui:calendar`, the date-picker primitive
+  `renderers/form/calendar.tsx` registers under exactly that key (`skipFallback`,
+  because bare `calendar` belongs to the plugin-calendar view).
+
+Every arm declares only keys its renderer demonstrably reads — the `BarChartSchema`
+discipline objectui#6318 established for the same class of gap.
+
+**Accept-set movement is widening only.** Nothing that parsed green parses red. Each
+arm still judges VALUES: `{ type: 'img', width: true }`, `{ type: 'password',
+required: 'yes' }` and `{ type: 'ui:calendar', mode: 'agenda' }` are all refused, and
+a `type` nothing registers (`stat-card`, `metric-card`, `h1ZZ`) is refused at the root
+and at every node slot exactly as before.
+
+**Every one of these types becomes legal at EVERY node slot** — measured: 249
+arm-level node slots plus ~30 on nested schemas, all spelled with the one
+`SchemaNodeSchema`. A slot-constrained shape is not expressible by adding arms: a
+discriminated union selects its arm from the authored literal alone, so a slot has no
+say. That is a per-slot vocabulary programme, not a variant of this change.
+
+**`line-chart` is deliberately NOT armed.** The card lists it among the eight as a
+live renderer; measured here it is not. `apps/console/src/register-plugins.ts`
+registers it as a lazy stub pointing at `@object-ui/plugin-charts`, and that package
+never registers the key, so it resolves to nothing at render time. Arming it would
+invent a capability rather than name one. `__tests__/node-slot-registered-arms-8499.test.ts`
+pins the absence together with its reason, so registering the key for real turns red.
+
+**Downstream.** `objectui check` stops reporting these documents. Its
+`check-validity-recogniser` suite measured 658 registered types against 102 arm
+literals when it was written; re-measured here it is 656 against 154, so the
+"registered but not modelled" bucket goes from 558 to 505 and its fixture moved off
+the HTML primitives (they are modelled now) onto `metric-card`, whose absence from the
+union is ruled rather than pending.

--- a/.changeset/8499-node-slot-registered-arms.md
+++ b/.changeset/8499-node-slot-registered-arms.md
@@ -47,8 +47,8 @@ a `type` nothing registers (`stat-card`, `metric-card`, `h1ZZ`) is refused at th
 and at every node slot exactly as before.
 
 **Every one of these types becomes legal at EVERY node slot** — measured: 249
-arm-level node slots plus ~30 on nested schemas, all spelled with the one
-`SchemaNodeSchema`. A slot-constrained shape is not expressible by adding arms: a
+arm-level node slots before this change and 257 after, plus 36 on nested schemas,
+all spelled with the one `SchemaNodeSchema`. A slot-constrained shape is not expressible by adding arms: a
 discriminated union selects its arm from the authored literal alone, so a slot has no
 say. That is a per-slot vocabulary programme, not a variant of this change.
 

--- a/apps/console/src/__tests__/public-contract.test.ts
+++ b/apps/console/src/__tests__/public-contract.test.ts
@@ -397,9 +397,11 @@ describe('PUBLIC_BLOCKS ↔ console coverage (reverse direction)', () => {
  *
  * Scope, stated plainly: this covers the CONTAINER half of the layout
  * vocabulary. The non-container arms (`span`, `separator`, `scroll-area`,
- * `resizable`, `page`, and the deprecated `div`) are outside it because
- * curating any of them is an unruled question of its own, and a ledger is a
- * forcing function, not a place to park four of those at once.
+ * `resizable`, `page`, the deprecated `div`, and — since objectui#8499 armed
+ * them — the 37 flow/inline HTML tags of `HtmlElementSchema`, not one of which
+ * declares containment) are outside it because curating any of them is an
+ * unruled question of its own, and a ledger is a forcing function, not a place
+ * to park four of those at once.
  *
  * ── THE MEASUREMENT THIS CARD WAS DISPATCHED TO MAKE, RECORDED ──────────────
  *
@@ -443,16 +445,39 @@ describe('PUBLIC_BLOCKS ↔ console coverage (reverse direction)', () => {
 /**
  * The JSON layout vocabulary, read from the zod union's own arms.
  *
- * A discriminated union member declares its `type` literal to Zod, so the arm
- * list IS the vocabulary. Filtering to real strings is deliberate: a zod release
- * that moved this accessor would otherwise yield a population of `undefined` and
- * make every assertion below vacuously true, which is why the first case
- * compares the resolved count against the raw arm count.
+ * A discriminated union member declares its `type` to Zod, so the arm list IS
+ * the vocabulary — but an arm declares it in one of TWO shapes, and reading only
+ * the first is what objectui#8499 broke here. A `z.literal` arm carries one
+ * spelling on `.value`; a `z.enum` arm carries a whole registered family on
+ * `.options` — `SemanticElementSchema`'s seven sectioning tags, and
+ * `HtmlElementSchema`'s 37 flow/inline tags. A `.value`-only read resolved
+ * neither, and the anti-vacuity case below reported it as 19 arms yielding 17
+ * literals, which is precisely the job that case exists to do.
+ *
+ * The switch is on zod's own `def.type` discriminator, NOT on which accessor
+ * happens to be present. A fallback chain (`.value`, else `.options`, else …)
+ * would paper over exactly the accessor drift the first case is meant to
+ * report: an arm whose declaration is neither shape resolves NOTHING here, and
+ * the count comparison below turns that silence into a failure.
  */
 const LAYOUT_UNION_ARMS = (LayoutSchema as unknown as { options: unknown[] }).options;
-const LAYOUT_VOCABULARY: string[] = LAYOUT_UNION_ARMS.map(
-  (arm) => (arm as { shape?: { type?: { value?: unknown } } }).shape?.type?.value,
-).filter((value): value is string => typeof value === 'string' && value.length > 0);
+
+type TypeDeclaration = { def?: { type?: string }; value?: unknown; options?: unknown[] };
+
+/** Every `type` spelling ONE arm can take: a literal's single value, or an enum's whole set. */
+const armLiterals = (arm: unknown): string[] => {
+  const declared = (arm as { shape?: { type?: TypeDeclaration } }).shape?.type;
+  const isSpelling = (value: unknown): value is string =>
+    typeof value === 'string' && value.length > 0;
+  if (declared?.def?.type === 'literal') {
+    return isSpelling(declared.value) ? [declared.value] : [];
+  }
+  if (declared?.def?.type === 'enum') return (declared.options ?? []).filter(isSpelling);
+  return [];
+};
+
+const LAYOUT_ARM_LITERALS: string[][] = LAYOUT_UNION_ARMS.map(armLiterals);
+const LAYOUT_VOCABULARY: string[] = LAYOUT_ARM_LITERALS.flat();
 
 /** …of those, the ones the registry DECLARES it renders a child list for. */
 const DECLARED_LAYOUT_CONTAINERS = LAYOUT_VOCABULARY.filter(
@@ -480,7 +505,38 @@ const specCarried = (type: string): boolean =>
  * below by ABSENCE — which is the property `box` needed and did not have. An
  * entry here is the deliberate, reviewable alternative to curating, never a
  * silent one, and it must name an issue that resolves it.
+ *
+ * ⭐ The seven sectioning tags arrived here BY ABSENCE — the mechanism working,
+ * not failing. They have declared `isContainer: true` since objectui#6764;
+ * objectui#8499 armed them as `SemanticElementSchema`, and becoming arms of the
+ * layout union is what first pulled already-declared containers into the
+ * intersection this file derives. ⛔ The alternative on offer — housing that arm
+ * outside `LayoutSchema` — was refused deliberately: it would have removed seven
+ * genuine layout containers from this population without changing anything about
+ * what they are, which is a gate that stops looking rather than a gate that
+ * passes. Ledgering them is the reviewable option; objectui#8775 holds the
+ * decision itself, which is NOT this card's to take.
  */
+
+/**
+ * The seven are ONE registration — a single loop factory in
+ * `renderers/layout/semantic.tsx` over one `tags` array — so they share one
+ * reason rather than seven paraphrases of it.
+ */
+const SECTIONING_TAG_UNRULED =
+  'NOT YET RULED, either way — and promoting it is not a roster edit. One of the seven HTML ' +
+  'sectioning tags the single loop factory in `renderers/layout/semantic.tsx` registers with ' +
+  '`category: layout` and `isContainer: true` (objectui#6764). objectui#8499 armed them as ' +
+  '`SemanticElementSchema`, which is what first brought already-declared containers into the ' +
+  'population this file derives — none of them is newly a container, and none is newly ' +
+  'authorable. ⚠️ Curating one does NOT merely widen: `renderers/layout/react-page.tsx` drops ' +
+  'containers from the `kind:react` JSX scope by iterating `getPublicConfigs()`, and this tag ' +
+  'being absent from `PUBLIC_BLOCKS` is exactly why there is no injected identifier there for ' +
+  'the flag to remove — so curating it would DELETE the tag from every react page unless that ' +
+  'premise moves in the same change (pinned by `container-declaration-census.test.tsx`). ' +
+  'objectui#8775 measured the population and holds the decision: curate the family or a named ' +
+  'subset and carry that consequence, or refuse on stated merits and replace this text with them.';
+
 const UNCURATED_LAYOUT_CONTAINERS: Record<string, string> = {
   'aspect-ratio':
     'NOT YET RULED, either way — and that is the entry, stated honestly rather than dressed as merits. ' +
@@ -490,18 +546,36 @@ const UNCURATED_LAYOUT_CONTAINERS: Record<string, string> = {
     '`PUBLIC_BLOCKS`, so the react-page scope builder never saw this tag"), never a reason. objectui#6879 ' +
     'measured the population and filed the decision as objectui#8628 — curate it, or refuse it on stated ' +
     'merits and replace this text with them. Until then it stays visible here instead of invisible in a gap.',
+  article: SECTIONING_TAG_UNRULED,
+  aside: SECTIONING_TAG_UNRULED,
+  footer: SECTIONING_TAG_UNRULED,
+  header: SECTIONING_TAG_UNRULED,
+  main: SECTIONING_TAG_UNRULED,
+  nav: SECTIONING_TAG_UNRULED,
+  section: SECTIONING_TAG_UNRULED,
 };
 
 describe('PUBLIC_BLOCKS ↔ the declared layout containers (derived, objectui#6879)', () => {
   it('reads the vocabulary off the union rather than restating it', () => {
-    // The anti-vacuity case, and it comes first. Every arm must resolve a real
-    // `type` literal: a population of `undefined`s would make the ledger pin
-    // below pass while asserting nothing at all.
+    // The anti-vacuity case, and it comes first. EVERY arm must resolve at least
+    // one real `type` spelling: an arm that resolved none would make the ledger
+    // pin below pass while asserting nothing at all about that arm.
+    //
+    // ⚠️ Counting literals against arms — what this line did before
+    // objectui#8499 — is NOT the same assertion and cannot be restored: a single
+    // enum arm contributes 37 spellings, so the two numbers are no longer meant
+    // to match. What still holds one-for-one is that no arm contributes ZERO.
     expect(LAYOUT_UNION_ARMS.length).toBeGreaterThan(0);
-    expect(LAYOUT_VOCABULARY).toHaveLength(LAYOUT_UNION_ARMS.length);
-    // And it must be the vocabulary we think it is — the minted type this card
-    // is about, plus two of its long-standing siblings.
-    expect(LAYOUT_VOCABULARY).toEqual(expect.arrayContaining(['box', 'flex', 'container']));
+    expect(LAYOUT_ARM_LITERALS.filter((literals) => literals.length > 0)).toHaveLength(
+      LAYOUT_UNION_ARMS.length,
+    );
+    // And it must be the vocabulary we think it is: the type this card was built
+    // around, two of its long-standing siblings, and one spelling out of EACH
+    // enum arm — so a reader that silently stopped resolving enums, which is the
+    // regression this file caught, cannot pass this case either.
+    expect(LAYOUT_VOCABULARY).toEqual(
+      expect.arrayContaining(['box', 'flex', 'container', 'main', 'h1']),
+    );
   });
 
   it('derives a non-empty container population holding the objectui#6764 control set', () => {

--- a/apps/console/src/__tests__/public-contract.test.ts
+++ b/apps/console/src/__tests__/public-contract.test.ts
@@ -516,6 +516,22 @@ const specCarried = (type: string): boolean =>
  * what they are, which is a gate that stops looking rather than a gate that
  * passes. Ledgering them is the reviewable option; objectui#8775 holds the
  * decision itself, which is NOT this card's to take.
+ *
+ * ⚠️ What an entry here COSTS, stated once so no entry has to re-argue it, and
+ * corrected because objectui#8499 first shipped it wrong. Curating a ledgered
+ * container widens the AI-authoring vocabulary, `sdui.manifest.json` and the
+ * generated intrinsics, and turns the census pin in
+ * `renderers/__tests__/container-declaration-census.test.tsx` red BY DESIGN — a
+ * deliberate re-opening, which is the whole point of pinning it. It does ⛔ NOT
+ * remove the tag from any `kind:'react'` page. `renderers/layout/react-page.tsx`
+ * builds that scope with `if (!tag || cfg.isContainer) continue;`, so it skips
+ * EVERY container config; a ledgered container already carries the flag, so
+ * promotion changes which list the config comes from and nothing about whether
+ * the loop keeps it. Measured on `main`: 46 injected identifiers today, 46 with
+ * `main` promoted, `Main` absent from both. The deletion reading is real but
+ * runs the OTHER way — objectui#6764's direction, where declaring containment on
+ * an already-public block removes an identifier that existed — and reading that
+ * docblock forwards is how it got here.
  */
 
 /**
@@ -529,11 +545,17 @@ const SECTIONING_TAG_UNRULED =
   '`category: layout` and `isContainer: true` (objectui#6764). objectui#8499 armed them as ' +
   '`SemanticElementSchema`, which is what first brought already-declared containers into the ' +
   'population this file derives — none of them is newly a container, and none is newly ' +
-  'authorable. ⚠️ Curating one does NOT merely widen: `renderers/layout/react-page.tsx` drops ' +
-  'containers from the `kind:react` JSX scope by iterating `getPublicConfigs()`, and this tag ' +
-  'being absent from `PUBLIC_BLOCKS` is exactly why there is no injected identifier there for ' +
-  'the flag to remove — so curating it would DELETE the tag from every react page unless that ' +
-  'premise moves in the same change (pinned by `container-declaration-census.test.tsx`). ' +
+  'authorable. What curating one WOULD move, measured rather than reasoned: it widens the ' +
+  'AI-authoring vocabulary, `sdui.manifest.json` and the generated intrinsics, and it turns the ' +
+  '"none of the eight is in the curated public contract" pin in ' +
+  '`container-declaration-census.test.tsx` RED BY DESIGN — which is precisely what ' +
+  '`semantic.tsx` means by re-opening the question THERE. ⛔ It does NOT delete the tag from ' +
+  'any react page, and an earlier revision of this entry said it did: `react-page.tsx` skips ' +
+  'EVERY container config (`if (!tag || cfg.isContainer) continue;`) and these seven already ' +
+  'carry `isContainer: true`, so a promoted config is skipped on exactly the same line an ' +
+  'unlisted one never reaches — measured at 46 injected identifiers before and 46 after ' +
+  'simulating the promotion of `main`, with `Main` absent from both. A lowercase `main` in a ' +
+  'react page is a DOM intrinsic either way, because `react-runtime` never reads the registry. ' +
   'objectui#8775 measured the population and holds the decision: curate the family or a named ' +
   'subset and carry that consequence, or refuse on stated merits and replace this text with them.';
 
@@ -575,6 +597,26 @@ describe('PUBLIC_BLOCKS ↔ the declared layout containers (derived, objectui#68
     // regression this file caught, cannot pass this case either.
     expect(LAYOUT_VOCABULARY).toEqual(
       expect.arrayContaining(['box', 'flex', 'container', 'main', 'h1']),
+    );
+    // ⭐ The SECOND ACCESSOR PATH, and the reason the sample above is not the
+    // only guard. `propValues` is zod's OWN discriminator index, built when the
+    // union was constructed; `armLiterals` is this file's switch over `def`.
+    // Two readers, one schema — so they must agree as sets, and the day someone
+    // "simplifies" `armLiterals` back to a `.value`-only read (exactly the
+    // objectui#8499 regression) the two stop agreeing here rather than five
+    // sampled spellings later.
+    //
+    // ⚠️ Scope, stated so nobody over-reads it: this pins the READER, not the
+    // schema. Both paths read the same union, so a spelling genuinely deleted
+    // from an enum arm (`q`, say) leaves both sides equal and this case green;
+    // that direction is pinned against the REGISTRATION SOURCE elsewhere, which
+    // is where it belongs.
+    const zodPropValues = (
+      LayoutSchema as unknown as { _zod?: { propValues?: { type?: Set<unknown> } } }
+    )._zod?.propValues?.type;
+    expect(zodPropValues, "zod exposes no `propValues.type` index for this union").toBeDefined();
+    expect([...(zodPropValues ?? [])].filter((v) => typeof v === 'string').sort()).toEqual(
+      [...LAYOUT_VOCABULARY].sort(),
     );
   });
 

--- a/packages/cli/src/__tests__/check-validity-recogniser.test.ts
+++ b/packages/cli/src/__tests__/check-validity-recogniser.test.ts
@@ -182,27 +182,40 @@ describe('objectui check — a broken ObjectUI schema is never filed as a foreig
 
   it('reports a registered component type the bundled schemas do not model', async () => {
     // The other half of the bucket, and why its wording says "off-spec OR not
-    // modelled". `abbr` is a real registered type — `packages/components/src/
-    // renderers/basic/html-elements.tsx` registers the raw HTML elements in
-    // bulk — and `AnyComponentSchema` is a union of COMPONENT schemas that has
-    // no member for it. So the well-formed document below fails the validity
-    // arm. Reporting it is right (a registered type the shipped validator
-    // cannot validate is itself a finding) but calling it INVALID would
-    // overclaim: nothing about this document is wrong.
+    // modelled". `metric-card` is a real registered type — objectui's dashboard
+    // widget-slot component, registered by `apps/console/src/register-plugins.ts`
+    // and `@object-ui/plugin-dashboard` — and `AnyComponentSchema` is a union of
+    // COMPONENT schemas that has no member for it. So the well-formed document
+    // below fails the validity arm. Reporting it is right (a registered type the
+    // shipped validator cannot validate is itself a finding) but calling it
+    // INVALID would overclaim: nothing about this document is wrong.
     //
     // ## Pick this type by measurement, not memory (objectui#6939)
     //
-    // Measured on this tree: `KNOWN_SCHEMA_TYPES` carries 658 registered types
-    // and `AnyComponentSchema` declares 102 distinct literal `type` values, so
-    // 558 registered types have no member. The probe was controlled in both
-    // directions — `kanban`, `text` and `tree-view` all read as MODELLED (so it
-    // is not blind to real members) and a nonsense type reads as unmodelled.
+    // Re-measured on this tree (objectui#8499): `KNOWN_SCHEMA_TYPES` carries 656
+    // registered types and `AnyComponentSchema` declares 154 distinct literal
+    // `type` values, so 505 registered types have no member. The probe was
+    // controlled in both directions — `kanban`, `text` and `tree-view` all read
+    // as MODELLED (so it is not blind to real members) and a nonsense type reads
+    // as unmodelled.
     //
-    // Not every one of those 558 is a safe fixture. The type used here must be
-    // one nothing is about to model, and the raw HTML primitives are the stable
-    // inhabitants of this bucket: they are registered as a bulk passthrough
-    // list, not as authorable component schemas. A plugin-ish type such as
-    // `dashboard-grid` also lands here today and would be the wrong choice.
+    // ## Why it is no longer `abbr`
+    //
+    // This sample was `abbr` on the reasoning that "the raw HTML primitives are
+    // the stable inhabitants of this bucket". They were not: objectui#8499 armed
+    // the whole registered HTML passthrough set (`h1`…`h6`, `p`, `a`, `abbr`, …)
+    // together with the seven semantic sectioning tags, precisely because a
+    // registered renderer the validator cannot name is a defect rather than a
+    // stable state of affairs. The 47 literals that card added are what took 102
+    // to 154 above, and they took this fixture with them.
+    //
+    // The replacement is chosen for a stronger property than "nobody has got to
+    // it yet": `metric-card`'s absence from this union is RULED. It is objectui's
+    // CLOSED dashboard-widget-slot extension, admitted by the 2026-08-14 ruling
+    // (objectstack#8593), and `packages/types/src/zod/complex.zod.ts` records in
+    // as many words that it is "DELIBERATELY not an arm of `AnyComponentSchema`".
+    // So this fixture cannot rot the way `abbr` did without a maintainer
+    // reversing that ruling — which is exactly when this test SHOULD be re-read.
     //
     // ## Why it is no longer `kanban`
     //
@@ -215,24 +228,24 @@ describe('objectui check — a broken ObjectUI schema is never filed as a foreig
     // fork, the board started validating, and this case measured 0 candidates.
     // The defect this file's own subject matter exists to catch had been frozen
     // into an assertion of expected behaviour.
-    writeSchema('abbr.json', {
-      type: 'abbr',
-      content: 'HTML',
-      title: 'HyperText Markup Language',
+    writeSchema('metric-card.json', {
+      type: 'metric-card',
+      title: 'Total Revenue',
+      value: '$123,456',
     });
     // The precondition, asserted rather than assumed, so that the day someone
-    // models `abbr` this file says WHY it went red instead of reporting a bare
-    // `expected +0 to be 1`. If this fires: pick another registered type with
-    // no member in `AnyComponentSchema` (a raw HTML primitive) and update the
-    // counts above.
+    // models `metric-card` this file says WHY it went red instead of reporting a
+    // bare `expected +0 to be 1`. If this fires: the objectstack#8593 ruling has
+    // been revisited — re-read this case, then pick another registered type with
+    // no member in `AnyComponentSchema` and update the counts above.
     expect(
-      safeValidateSchema({ type: 'abbr', content: 'HTML', title: 'HyperText Markup Language' }).success,
-      '`abbr` is now modelled by AnyComponentSchema — this fixture needs a type that still is not; see the comment above',
+      safeValidateSchema({ type: 'metric-card', title: 'Total Revenue', value: '$123,456' }).success,
+      '`metric-card` is now modelled by AnyComponentSchema — this fixture needs a type that still is not; see the comment above',
     ).toBe(false);
     await check(cwd);
     expect(candidateCount()).toBe(1);
     expect(candidateLines()).toEqual([
-      expect.stringContaining('abbr.json (type "abbr")'),
+      expect.stringContaining('metric-card.json (type "metric-card")'),
     ]);
     expect(skippedCount()).toBe(0);
   });

--- a/packages/types/src/__tests__/node-recursion-point-8344.test.ts
+++ b/packages/types/src/__tests__/node-recursion-point-8344.test.ts
@@ -100,14 +100,27 @@ describe('objectui#7869 — the off-spec node gets the same verdict at both dept
 
 describe('the arm IS the component union, and not the base shape', () => {
   /**
-   * `h1` is a REGISTERED RENDERER (`components/src/renderers/basic/html-elements.tsx`)
-   * with no mirror in `AnyComponentSchema` — so it is the input the two candidate
-   * recursion points answer differently: `BaseSchemaCore` takes any object with a
-   * string `type`, the component union takes none it does not declare. ⛔ Do not
-   * "fix" this by adding an `h1` arm to make some other test green: that is the
-   * public-surface widening objectui#8344 routes into its own card.
+   * A REGISTERED RENDERER with no mirror in `AnyComponentSchema` — the input the
+   * two candidate recursion points answer differently: `BaseSchemaCore` takes any
+   * object with a string `type`, the component union takes none it does not
+   * declare.
+   *
+   * ⚠️ This was `h1` until objectui#8499. That card was the one objectui#8344
+   * routed the widening into, and it LANDED: `h1` is now an arm
+   * (`zod/layout.zod.ts#HtmlElementSchema`), so the old example stopped
+   * discriminating and this leg went green for the wrong reason. ⛔ The remedy was
+   * NOT to weaken the leg — it is re-pointed at an input whose absence from the
+   * union is RULED rather than merely pending: `metric-card` is objectui's closed
+   * dashboard-widget-slot component extension, admitted by the 2026-08-14 ruling
+   * (objectstack#8593) and, in `zod/complex.zod.ts`'s own words, "DELIBERATELY not
+   * an arm of `AnyComponentSchema`". So this example cannot rot the way `h1` did
+   * without a maintainer reversing that ruling.
+   *
+   * ⛔ Do not "fix" a future failure here by adding an arm to make some other test
+   * green: an arm is a public-surface widening and belongs to its own card, which
+   * is what objectui#8344 said and what objectui#8499 then did properly.
    */
-  const UNMIRRORED = { type: 'h1', children: 'Sales Dashboard' } as const;
+  const UNMIRRORED = { type: 'metric-card', title: 'Sales Dashboard' } as const;
 
   it('refuses an unmirrored node nested in a declared child slot', () => {
     expect(AnyComponentSchema.safeParse(nested(UNMIRRORED)).success).toBe(false);
@@ -139,7 +152,7 @@ describe('the late-binding wiring, read by IDENTITY on the exported wrapper', ()
     // module imports the barrel and nothing else, so a break in `index.zod.ts`'s
     // `defineNodeComponentUnion(...)` initializer lands here rather than in whichever suite
     // happened to run second.
-    expect(AnyComponentSchema.safeParse(nested({ type: 'h1' })).success).toBe(false);
+    expect(AnyComponentSchema.safeParse(nested({ type: 'metric-card' })).success).toBe(false);
     expect(AnyComponentSchema.safeParse(nested(LEGAL_ICON)).success).toBe(true);
   });
 

--- a/packages/types/src/__tests__/node-slot-registered-arms-8499.test.ts
+++ b/packages/types/src/__tests__/node-slot-registered-arms-8499.test.ts
@@ -1,0 +1,234 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Registered, live renderers reached through a declared node slot resolve in an
+ * arm of `AnyComponentSchema` (objectui#8499).
+ *
+ * ## The defect these pin
+ *
+ * Nine `type` spellings sat at DECLARED node slots in this repository's own
+ * corpora and resolved in no arm of the union. Eight of them were registered
+ * renderers; the ninth (`my-component`) is the reader's own plugin component and
+ * carries a written exemption at `scripts/check-doc-component-types.mjs`.
+ *
+ * The damage ran the expensive direction: a reader following
+ * `content/docs/utilities/runner.mdx`'s own instruction — "copy one, wrap it in
+ * a page document … and save it as `src/app-data/pages/index.json`" — got a
+ * document that RENDERS CORRECTLY in the browser and is REFUSED by `objectui
+ * check`. The likely reaction to that is to stop trusting `check`, not to fix
+ * the document.
+ *
+ * ## Why nothing caught it
+ *
+ * `check:doc-types` judges a `type` literal against the RENDERER REGISTRY (656
+ * keys, measured at the time of writing); `AnyComponentSchema` declares 107 arm
+ * literals. The two faces disagree BY CONSTRUCTION and nothing compared them at
+ * a node slot. So the repair is paired with the comparison this file's third
+ * `describe` performs — not the full `registry ⊆ arms` containment (552 of the
+ * 656 registered keys have no arm, so that instrument needs a ledger this card
+ * is not authorised to mint), but the two FAMILY arms compared against the very
+ * arrays their registration sites loop over. A tag added to either array without
+ * an arm here goes red instead of diverging silently.
+ *
+ * ## `line-chart` is deliberately NOT armed — the card's premise fails for it
+ *
+ * The card lists `line-chart` among the eight as a "REGISTERED, LIVE renderer".
+ * Measured here, it is not. `apps/console/src/register-plugins.ts` registers it
+ * as a LAZY STUB pointing at `@object-ui/plugin-charts`, and that package never
+ * registers the key — `Registry.loadLazy`'s own docblock says the loader
+ * "resolves once the loader completes (whether or not the loaded module actually
+ * registered the expected type)". So the key is known to `check:doc-types` and
+ * resolves to nothing at render time; `scripts/check-doc-component-types.mjs`
+ * records the same reading, calling it "the `line-chart` widget objectui#7896
+ * recorded in `packages/plugin-dashboard/README.md`". objectui#8499's triage
+ * admits arms only for things that "运行时已经正确渲染" — already render
+ * correctly at runtime — so an arm for `line-chart` would invent a capability
+ * rather than name one. The fourth `describe` pins the absence WITH its reason,
+ * so registering the key for real turns this red instead of leaving the gap.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { AnyComponentSchema } from '../zod/index.zod.js';
+import { SemanticElementSchema, HtmlElementSchema } from '../zod/layout.zod.js';
+import { InputShorthandSchema, UiCalendarSchema } from '../zod/form.zod.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..', '..', '..');
+const read = (relative: string): string => readFileSync(join(REPO_ROOT, relative), 'utf8');
+
+const SEMANTIC_RENDERER = 'packages/components/src/renderers/layout/semantic.tsx';
+const HTML_RENDERER = 'packages/components/src/renderers/basic/html-elements.tsx';
+const CHARTS_PLUGIN = 'packages/plugin-charts/src/index.tsx';
+const CONSOLE_PLUGINS = 'apps/console/src/register-plugins.ts';
+
+/** The seven spellings this card armed, and where each renders from. */
+const ARMED = [
+  { type: 'footer', renderer: SEMANTIC_RENDERER },
+  { type: 'header', renderer: SEMANTIC_RENDERER },
+  { type: 'main', renderer: SEMANTIC_RENDERER },
+  { type: 'nav', renderer: SEMANTIC_RENDERER },
+  { type: 'h1', renderer: HTML_RENDERER },
+  { type: 'password', renderer: 'packages/components/src/renderers/form/input.tsx' },
+  { type: 'ui:calendar', renderer: 'packages/components/src/renderers/form/calendar.tsx' },
+] as const;
+
+/**
+ * The firing controls. Each is a `type` NOTHING registers, so each must stay
+ * refused — an assertion set that only ever says ACCEPT would pass against a
+ * union that accepted everything, which is the failure mode a widening card is
+ * most exposed to.
+ */
+const UNREGISTERED = [
+  'h1ZZ',
+  'stat-card',
+  'my-component',
+  'area-chart',
+] as const;
+
+/** The `type` literals a schema declares to Zod's discriminator dispatch. */
+function literalsOf(schema: unknown): string[] {
+  const values = (schema as { _zod?: { propValues?: { type?: Set<string> } } })._zod?.propValues
+    ?.type;
+  return values === undefined ? [] : [...values];
+}
+
+/** The string array a `const NAME = [ … ] as const;` declaration holds. */
+function sourceArray(source: string, declaration: string): string[] {
+  const start = source.indexOf(declaration);
+  if (start === -1) throw new Error(`declaration not found: ${declaration}`);
+  const open = source.indexOf('[', start);
+  const close = source.indexOf(']', open);
+  if (open === -1 || close === -1) throw new Error(`array literal not found: ${declaration}`);
+  return [...source.slice(open, close).matchAll(/'([^']+)'/g)].map((m) => m[1]);
+}
+
+describe('objectui#8499 — the seven armed spellings resolve, at the root and at a node slot', () => {
+  it.each(ARMED)('accepts `$type` as a document root', ({ type }) => {
+    const result = AnyComponentSchema.safeParse({ type });
+    expect(result.success, JSON.stringify(result.success ? {} : result.error.issues)).toBe(true);
+  });
+
+  it.each(ARMED)('accepts `$type` nested at a declared node slot', ({ type }) => {
+    // The slot that matters: objectui#8344 pointed the node recursion point at
+    // this union, so a nested node is judged by its own component schema. Before
+    // this card every one of these was refused HERE as well as at the root.
+    const result = AnyComponentSchema.safeParse({ type: 'div', children: [{ type }] });
+    expect(result.success, JSON.stringify(result.success ? {} : result.error.issues)).toBe(true);
+  });
+
+  it('accepts the catalog fixtures the card names as its live evidence', () => {
+    // These render — `examples/schema-catalog/test/catalog-gallery-render.test.tsx`
+    // fails if any catalog entry paints the registry's OBJUI-001 "Unknown
+    // component type" panel — and every one of them was refused by this union.
+    const fixtures = [
+      ...['article', 'aside', 'blog-article', 'complete-layout', 'footer', 'header',
+        'main-element', 'navigation', 'section']
+        .map((n) => `components-layout-semantic/${n}`),
+      ...['custom-style', 'date-range', 'form-integration', 'multiple-dates',
+        'simple-calendar', 'single-date']
+        .map((n) => `components-form-calendar/${n}`),
+    ];
+    expect(fixtures).toHaveLength(15);
+    const refused = fixtures.filter((name) => {
+      const doc: unknown = JSON.parse(
+        read(`examples/schema-catalog/src/schemas/${name}.json`),
+      );
+      return !AnyComponentSchema.safeParse(doc).success;
+    });
+    expect(refused, 'a fixture the renderer draws is still refused by the validator').toEqual([]);
+  });
+});
+
+describe('objectui#8499 — the controls that keep the acceptances honest', () => {
+  it.each(UNREGISTERED)('still refuses `%s`, which nothing registers', (type) => {
+    expect(AnyComponentSchema.safeParse({ type }).success).toBe(false);
+    expect(AnyComponentSchema.safeParse({ type: 'div', children: [{ type }] }).success).toBe(false);
+  });
+
+  it('the new arms judge VALUES, not just the discriminator', () => {
+    // An arm that accepted its literal and nothing else would satisfy every
+    // assertion above while validating nothing. Each pair is one green reading
+    // and one red reading on the SAME key of the SAME arm.
+    expect(AnyComponentSchema.safeParse({ type: 'img', src: 'a.png', width: 100 }).success).toBe(true);
+    expect(AnyComponentSchema.safeParse({ type: 'img', src: 'a.png', width: true }).success).toBe(false);
+    expect(AnyComponentSchema.safeParse({ type: 'password', required: true }).success).toBe(true);
+    expect(AnyComponentSchema.safeParse({ type: 'password', required: 'yes' }).success).toBe(false);
+    expect(AnyComponentSchema.safeParse({ type: 'ui:calendar', mode: 'single' }).success).toBe(true);
+    expect(AnyComponentSchema.safeParse({ type: 'ui:calendar', mode: 'agenda' }).success).toBe(false);
+    expect(AnyComponentSchema.safeParse({ type: 'main', hidden: true }).success).toBe(true);
+    expect(AnyComponentSchema.safeParse({ type: 'main', hidden: 42 }).success).toBe(false);
+  });
+
+  it('adds no discriminator collision', () => {
+    // `AnyComponentSchema` can only stay a discriminated union while every
+    // literal is claimed once — `any-component-union-fanout.test.ts` states the
+    // invariant; this leg says these four arms are not where it breaks.
+    const added = [
+      ...literalsOf(SemanticElementSchema),
+      ...literalsOf(HtmlElementSchema),
+      ...literalsOf(InputShorthandSchema),
+      ...literalsOf(UiCalendarSchema),
+    ];
+    expect(added.length).toBe(7 + 37 + 2 + 1);
+    expect(new Set(added).size).toBe(added.length);
+    const all = literalsOf(AnyComponentSchema);
+    expect(new Set(all).size).toBe(all.length);
+    for (const literal of added) expect(all).toContain(literal);
+  });
+});
+
+describe('objectui#8499 — the family arms are compared against their registration sites', () => {
+  // ⭐ THE COMPARISON INSTRUMENT. The two faces diverged by construction because
+  // nothing compared them. This does, for the two families this card armed: the
+  // arm's literal set must EQUAL the array the registration site loops over.
+  it('`SemanticElementSchema` names exactly the tags `semantic.tsx` registers', () => {
+    const tags = sourceArray(read(SEMANTIC_RENDERER), 'const tags = ');
+    expect(tags.length, 'the source read went vacuous — check the declaration name').toBe(7);
+    expect([...literalsOf(SemanticElementSchema)].sort()).toEqual([...tags].sort());
+  });
+
+  it('`HtmlElementSchema` names exactly the tags `html-elements.tsx` registers', () => {
+    const tags = sourceArray(read(HTML_RENDERER), 'const TAGS = ');
+    expect(tags.length, 'the source read went vacuous — check the declaration name').toBe(37);
+    expect([...literalsOf(HtmlElementSchema)].sort()).toEqual([...tags].sort());
+  });
+
+  it('detects a tag that is registered and unarmed', () => {
+    // The firing control for the two equalities above: they must not be able to
+    // pass while a registered tag is missing from the arm.
+    const armed = new Set(literalsOf(SemanticElementSchema));
+    const registeredPlusOne = [...armed, 'hgroup'];
+    expect([...armed].sort()).not.toEqual([...registeredPlusOne].sort());
+  });
+});
+
+describe('objectui#8499 — `line-chart` stays unarmed, and the reason stays checked', () => {
+  it('resolves in no arm', () => {
+    expect(AnyComponentSchema.safeParse({ type: 'line-chart' }).success).toBe(false);
+  });
+
+  it('is a lazy stub in the console that `@object-ui/plugin-charts` never fulfils', () => {
+    // The premise the card asserts for all eight and that fails for this one.
+    // Both halves are read from source so the day someone registers the key for
+    // real, this goes red and the arm becomes owed.
+    const consoleSource = read(CONSOLE_PLUGINS);
+    expect(consoleSource, 'the console stub moved — re-derive the premise').toContain("'line-chart'");
+
+    const pluginSource = read(CHARTS_PLUGIN);
+    const registered = [...pluginSource.matchAll(/register\(\s*\n?\s*'([^']+)'/g)].map((m) => m[1]);
+    // Non-vacuity: the reader must actually find this module's registrations.
+    expect(registered.length, 'the registration read went vacuous').toBeGreaterThanOrEqual(6);
+    expect(registered).toContain('pie-chart');
+    expect(registered).not.toContain('line-chart');
+  });
+});

--- a/packages/types/src/__tests__/node-slot-registered-arms-8499.test.ts
+++ b/packages/types/src/__tests__/node-slot-registered-arms-8499.test.ts
@@ -191,6 +191,14 @@ describe('objectui#8499 — the family arms are compared against their registrat
   // ⭐ THE COMPARISON INSTRUMENT. The two faces diverged by construction because
   // nothing compared them. This does, for the two families this card armed: the
   // arm's literal set must EQUAL the array the registration site loops over.
+  //
+  // ⚠️ WHAT THESE THREE LEGS ARE NOT, stated so the count is not overclaimed:
+  // they are NOT controls for union membership. They read `SemanticElementSchema`
+  // and `HtmlElementSchema` directly, so removing those arms from
+  // `AnyComponentSchema` leaves them green — they survive that ablation by
+  // design, because the property they hold is declaration-vs-registration parity,
+  // a different one from "the union accepts this spelling". The union's own
+  // firing controls are the `UNREGISTERED` refusals above.
   it('`SemanticElementSchema` names exactly the tags `semantic.tsx` registers', () => {
     const tags = sourceArray(read(SEMANTIC_RENDERER), 'const tags = ');
     expect(tags.length, 'the source read went vacuous — check the declaration name').toBe(7);
@@ -203,12 +211,29 @@ describe('objectui#8499 — the family arms are compared against their registrat
     expect([...literalsOf(HtmlElementSchema)].sort()).toEqual([...tags].sort());
   });
 
-  it('detects a tag that is registered and unarmed', () => {
-    // The firing control for the two equalities above: they must not be able to
-    // pass while a registered tag is missing from the arm.
-    const armed = new Set(literalsOf(SemanticElementSchema));
-    const registeredPlusOne = [...armed, 'hgroup'];
-    expect([...armed].sort()).not.toEqual([...registeredPlusOne].sort());
+  it('detects a registered-but-unarmed tag, and fails closed on an unreadable source', () => {
+    // ⚠️ What this control must NOT be, and was: comparing `[...armed]` against
+    // `[...armed, 'hgroup']`. That is set algebra — an array differs from itself
+    // plus an element whatever the schema says, so it passed without ever
+    // touching a registration. Both halves below run the REAL instrument.
+    //
+    // A real mismatch, from a real registration site: `html-elements.tsx`
+    // registers 37 tags and `SemanticElementSchema` arms none of them, so the
+    // equality the two legs above perform must come out false here.
+    const htmlTags = sourceArray(read(HTML_RENDERER), 'const TAGS = ');
+    const semanticArmed = [...literalsOf(SemanticElementSchema)].sort();
+    expect(htmlTags.length, 'the registration read went vacuous').toBe(37);
+    expect(semanticArmed.length, 'the arm read went vacuous').toBe(7);
+    expect(semanticArmed).not.toEqual([...htmlTags].sort());
+
+    // And the reader must be able to come back EMPTY rather than fabricate a
+    // pass — which is what makes the `toBe(7)` / `toBe(37)` guards above real
+    // guards. A declaration name that is not in the file throws rather than
+    // quietly yielding [], so the non-vacuity checks cannot be satisfied by a
+    // reader that has stopped reading.
+    expect(() => sourceArray(read(SEMANTIC_RENDERER), 'const notADeclaration = ')).toThrow(
+      /declaration not found/,
+    );
   });
 });
 

--- a/packages/types/src/__tests__/zod-mirror-parity.test.ts
+++ b/packages/types/src/__tests__/zod-mirror-parity.test.ts
@@ -397,8 +397,8 @@ import { ActionSchema, CRUDDialogSchema, DetailSchema } from '../zod/crud.zod.js
 import { AlertSchema, AvatarSchema, BadgeSchema, BarChartSchema, ChartDataSeriesSchema, ChartSchema, DataTableSchema, DrillDownConfigSchema, HtmlSchema, KbdSchema, ListItemSchema, ListSchema, MarkdownSchema, StaticTableColumnSchema, StatisticSchema, TableColumnSchema, TableSchema, TimelineEventSchema, TimelineSchema, TreeNodeSchema, TreeViewSchema } from '../zod/data-display.zod.js';
 import { AccordionItemSchema, AccordionSchema, CollapsibleSchema, ToggleGroupItemSchema, ToggleGroupSchema } from '../zod/disclosure.zod.js';
 import { EmptySchema, LoadingSchema, ProgressSchema, SkeletonSchema, SonnerSchema, SpinnerSchema, ToasterSchema, ToastSchema } from '../zod/feedback.zod.js';
-import { ButtonSchema, CalendarSchema, CheckboxSchema, CodeEditorSchema, ComboboxOptionSchema, ComboboxSchema, CommandGroupSchema, CommandItemSchema, CommandSchema, DatePickerSchema, FieldConditionSchema, FieldConstraintsSchema, FileUploadSchema, FormFieldSchema, FormSchema, InputOTPSchema, InputSchema, LabelSchema, RadioGroupSchema, RadioOptionSchema, SelectOptionSchema, SelectSchema, SliderSchema, SwitchSchema, TextareaSchema, ToggleSchema } from '../zod/form.zod.js';
-import { AspectRatioSchema, BoxSchema, CardSchema, ContainerSchema, DivSchema, FlexSchema, GridSchema, IconSchema, ImageSchema, PageNodeRegionSchema, PageNodeSchema, ResizablePanelSchema, ResizableSchema, ScrollAreaSchema, SeparatorSchema, StackSchema, TabItemSchema, TabsSchema, TextSchema, TextSpanSchema } from '../zod/layout.zod.js';
+import { ButtonSchema, CalendarSchema, CheckboxSchema, CodeEditorSchema, ComboboxOptionSchema, ComboboxSchema, CommandGroupSchema, CommandItemSchema, CommandSchema, DatePickerSchema, FieldConditionSchema, FieldConstraintsSchema, FileUploadSchema, FormFieldSchema, FormSchema, InputOTPSchema, InputSchema, InputShorthandSchema, LabelSchema, RadioGroupSchema, RadioOptionSchema, SelectOptionSchema, SelectSchema, SliderSchema, SwitchSchema, TextareaSchema, ToggleSchema, UiCalendarSchema } from '../zod/form.zod.js';
+import { AspectRatioSchema, BoxSchema, CardSchema, ContainerSchema, DivSchema, FlexSchema, GridSchema, HtmlElementSchema, IconSchema, ImageSchema, PageNodeRegionSchema, SemanticElementSchema, PageNodeSchema, ResizablePanelSchema, ResizableSchema, ScrollAreaSchema, SeparatorSchema, StackSchema, TabItemSchema, TabsSchema, TextSchema, TextSpanSchema } from '../zod/layout.zod.js';
 import { BreadcrumbItemSchema, BreadcrumbSchema, ButtonGroupButtonSchema, ButtonGroupSchema, HeaderBarSchema, NavigationMenuItemSchema, NavigationMenuSchema, NavLinkSchema, PaginationSchema, SidebarSchema } from '../zod/navigation.zod.js';
 import { ObjectCalendarSchema, ObjectChartSchema, ObjectDataTableSchema, ObjectFormSchema, ObjectGallerySchema, ObjectGanttSchema, ObjectGridSchema, ObjectKanbanSchema, ObjectMapConfigSchema, ObjectMapSchema, ObjectTreeSchema, ObjectViewSchema, SortConfigSchema } from '../zod/objectql.zod.js';
 import { AlertDialogSchema, ContextMenuSchema, DialogSchema, DrawerSchema, DropdownMenuSchema, HoverCardSchema, MenubarMenuSchema, MenubarSchema, MenuItemSchema as OverlayMenuItemSchema, PopoverSchema, SheetSchema, TooltipSchema } from '../zod/overlay.zod.js';
@@ -413,8 +413,8 @@ import type { CRUDDialogSchema as Ts_CRUDDialogSchema, DetailSchema as Ts_Detail
 import type { AlertSchema as Ts_AlertSchema, AvatarSchema as Ts_AvatarSchema, BadgeSchema as Ts_BadgeSchema, BarChartSchema as Ts_BarChartSchema, ChartDataSeries as Ts_ChartDataSeries, ChartSchema as Ts_ChartSchema, DataTableSchema as Ts_DataTableSchema, DrillDownConfig as Ts_DrillDownConfig, HtmlSchema as Ts_HtmlSchema, KbdSchema as Ts_KbdSchema, ListItem as Ts_ListItem, ListSchema as Ts_ListSchema, MarkdownSchema as Ts_MarkdownSchema, StaticTableColumn as Ts_StaticTableColumn, StatisticSchema as Ts_StatisticSchema, TableColumn as Ts_TableColumn, TableSchema as Ts_TableSchema, TimelineEvent as Ts_TimelineEvent, TimelineSchema as Ts_TimelineSchema, TreeViewSchema as Ts_TreeViewSchema, BreadcrumbItem as Ts_BreadcrumbItem, BreadcrumbSchema as Ts_BreadcrumbSchema } from '../data-display';
 import type { AccordionItem as Ts_AccordionItem, AccordionSchema as Ts_AccordionSchema, CollapsibleSchema as Ts_CollapsibleSchema, ToggleGroupItem as Ts_ToggleGroupItem, ToggleGroupSchema as Ts_ToggleGroupSchema } from '../disclosure';
 import type { EmptySchema as Ts_EmptySchema, LoadingSchema as Ts_LoadingSchema, ProgressSchema as Ts_ProgressSchema, SkeletonSchema as Ts_SkeletonSchema, SonnerSchema as Ts_SonnerSchema, SpinnerSchema as Ts_SpinnerSchema, ToasterSchema as Ts_ToasterSchema, ToastSchema as Ts_ToastSchema } from '../feedback';
-import type { ButtonSchema as Ts_ButtonSchema, CalendarSchema as Ts_CalendarSchema, CheckboxSchema as Ts_CheckboxSchema, CodeEditorSchema as Ts_CodeEditorSchema, ComboboxOption as Ts_ComboboxOption, ComboboxSchema as Ts_ComboboxSchema, CommandGroup as Ts_CommandGroup, CommandItem as Ts_CommandItem, CommandSchema as Ts_CommandSchema, DatePickerSchema as Ts_DatePickerSchema, FieldCondition as Ts_FieldCondition, FieldValidationRules as Ts_FieldValidationRules, FileUploadSchema as Ts_FileUploadSchema, FormField as Ts_FormField, FormSchema as Ts_FormSchema, InputOTPSchema as Ts_InputOTPSchema, InputSchema as Ts_InputSchema, LabelSchema as Ts_LabelSchema, RadioGroupSchema as Ts_RadioGroupSchema, RadioOption as Ts_RadioOption, SelectOption as Ts_SelectOption, SelectSchema as Ts_SelectSchema, SliderSchema as Ts_SliderSchema, SwitchSchema as Ts_SwitchSchema, TextareaSchema as Ts_TextareaSchema, ToggleSchema as Ts_ToggleSchema } from '../form';
-import type { AspectRatioSchema as Ts_AspectRatioSchema, BoxSchema as Ts_BoxSchema, CardSchema as Ts_CardSchema, ContainerSchema as Ts_ContainerSchema, DivSchema as Ts_DivSchema, FlexSchema as Ts_FlexSchema, GridSchema as Ts_GridSchema, IconSchema as Ts_IconSchema, ImageSchema as Ts_ImageSchema, PageNodeRegion as Ts_PageNodeRegion, PageNodeSchema as Ts_PageNodeSchema, ResizablePanel as Ts_ResizablePanel, ResizableSchema as Ts_ResizableSchema, ScrollAreaSchema as Ts_ScrollAreaSchema, SeparatorSchema as Ts_SeparatorSchema, StackSchema as Ts_StackSchema, TabItem as Ts_TabItem, TabsSchema as Ts_TabsSchema, TextSchema as Ts_TextSchema, TextSpanSchema as Ts_TextSpanSchema } from '../layout';
+import type { ButtonSchema as Ts_ButtonSchema, CalendarSchema as Ts_CalendarSchema, CheckboxSchema as Ts_CheckboxSchema, CodeEditorSchema as Ts_CodeEditorSchema, ComboboxOption as Ts_ComboboxOption, ComboboxSchema as Ts_ComboboxSchema, CommandGroup as Ts_CommandGroup, CommandItem as Ts_CommandItem, CommandSchema as Ts_CommandSchema, DatePickerSchema as Ts_DatePickerSchema, FieldCondition as Ts_FieldCondition, FieldValidationRules as Ts_FieldValidationRules, FileUploadSchema as Ts_FileUploadSchema, FormField as Ts_FormField, FormSchema as Ts_FormSchema, InputOTPSchema as Ts_InputOTPSchema, InputSchema as Ts_InputSchema, InputShorthandSchema as Ts_InputShorthandSchema, UiCalendarSchema as Ts_UiCalendarSchema, LabelSchema as Ts_LabelSchema, RadioGroupSchema as Ts_RadioGroupSchema, RadioOption as Ts_RadioOption, SelectOption as Ts_SelectOption, SelectSchema as Ts_SelectSchema, SliderSchema as Ts_SliderSchema, SwitchSchema as Ts_SwitchSchema, TextareaSchema as Ts_TextareaSchema, ToggleSchema as Ts_ToggleSchema } from '../form';
+import type { AspectRatioSchema as Ts_AspectRatioSchema, BoxSchema as Ts_BoxSchema, CardSchema as Ts_CardSchema, ContainerSchema as Ts_ContainerSchema, DivSchema as Ts_DivSchema, FlexSchema as Ts_FlexSchema, GridSchema as Ts_GridSchema, HtmlElementSchema as Ts_HtmlElementSchema, IconSchema as Ts_IconSchema, ImageSchema as Ts_ImageSchema, SemanticElementSchema as Ts_SemanticElementSchema, PageNodeRegion as Ts_PageNodeRegion, PageNodeSchema as Ts_PageNodeSchema, ResizablePanel as Ts_ResizablePanel, ResizableSchema as Ts_ResizableSchema, ScrollAreaSchema as Ts_ScrollAreaSchema, SeparatorSchema as Ts_SeparatorSchema, StackSchema as Ts_StackSchema, TabItem as Ts_TabItem, TabsSchema as Ts_TabsSchema, TextSchema as Ts_TextSchema, TextSpanSchema as Ts_TextSpanSchema } from '../layout';
 import type { ButtonGroupButton as Ts_ButtonGroupButton, ButtonGroupSchema as Ts_ButtonGroupSchema, HeaderBarSchema as Ts_HeaderBarSchema, NavigationMenuSchema as Ts_NavigationMenuSchema, PaginationSchema as Ts_PaginationSchema, SidebarSchema as Ts_SidebarSchema } from '../navigation';
 import type { ObjectCalendarSchema as Ts_ObjectCalendarSchema, ObjectChartSchema as Ts_ObjectChartSchema, ObjectDataTableSchema as Ts_ObjectDataTableSchema, ObjectFormSchema as Ts_ObjectFormSchema, ObjectGallerySchema as Ts_ObjectGallerySchema, ObjectGanttSchema as Ts_ObjectGanttSchema, ObjectGridSchema as Ts_ObjectGridSchema, ObjectKanbanSchema as Ts_ObjectKanbanSchema, ObjectMapConfig as Ts_ObjectMapConfig, ObjectMapSchema as Ts_ObjectMapSchema, ObjectTreeSchema as Ts_ObjectTreeSchema, ObjectViewSchema as Ts_ObjectViewSchema, SortConfig as Ts_SortConfig } from '../objectql';
 import type { AlertDialogSchema as Ts_AlertDialogSchema, ContextMenuSchema as Ts_ContextMenuSchema, DialogSchema as Ts_DialogSchema, DrawerSchema as Ts_DrawerSchema, DropdownMenuSchema as Ts_DropdownMenuSchema, HoverCardSchema as Ts_HoverCardSchema, MenubarMenu as Ts_MenubarMenu, MenubarSchema as Ts_MenubarSchema, PopoverSchema as Ts_PopoverSchema, SheetSchema as Ts_SheetSchema, TooltipSchema as Ts_TooltipSchema } from '../overlay';
@@ -1141,6 +1141,8 @@ const MIRRORS = {
   'form.zod.ts#FormSchema': FormSchema,
   'form.zod.ts#InputOTPSchema': InputOTPSchema,
   'form.zod.ts#InputSchema': InputSchema,
+  'form.zod.ts#InputShorthandSchema': InputShorthandSchema,
+  'form.zod.ts#UiCalendarSchema': UiCalendarSchema,
   'form.zod.ts#LabelSchema': LabelSchema,
   'form.zod.ts#RadioGroupSchema': RadioGroupSchema,
   'form.zod.ts#RadioOptionSchema': RadioOptionSchema,
@@ -1155,6 +1157,8 @@ const MIRRORS = {
   'layout.zod.ts#CardSchema': CardSchema,
   'layout.zod.ts#ContainerSchema': ContainerSchema,
   'layout.zod.ts#DivSchema': DivSchema,
+  'layout.zod.ts#HtmlElementSchema': HtmlElementSchema,
+  'layout.zod.ts#SemanticElementSchema': SemanticElementSchema,
   'layout.zod.ts#FlexSchema': FlexSchema,
   'layout.zod.ts#GridSchema': GridSchema,
   'layout.zod.ts#IconSchema': IconSchema,
@@ -1303,6 +1307,8 @@ interface Declared {
   'form.zod.ts#FormSchema': Ts_FormSchema;
   'form.zod.ts#InputOTPSchema': Ts_InputOTPSchema;
   'form.zod.ts#InputSchema': Ts_InputSchema;
+  'form.zod.ts#InputShorthandSchema': Ts_InputShorthandSchema;
+  'form.zod.ts#UiCalendarSchema': Ts_UiCalendarSchema;
   'form.zod.ts#LabelSchema': Ts_LabelSchema;
   'form.zod.ts#RadioGroupSchema': Ts_RadioGroupSchema;
   'form.zod.ts#RadioOptionSchema': Ts_RadioOption;
@@ -1317,6 +1323,8 @@ interface Declared {
   'layout.zod.ts#CardSchema': Ts_CardSchema;
   'layout.zod.ts#ContainerSchema': Ts_ContainerSchema;
   'layout.zod.ts#DivSchema': Ts_DivSchema;
+  'layout.zod.ts#HtmlElementSchema': Ts_HtmlElementSchema;
+  'layout.zod.ts#SemanticElementSchema': Ts_SemanticElementSchema;
   'layout.zod.ts#FlexSchema': Ts_FlexSchema;
   'layout.zod.ts#GridSchema': Ts_GridSchema;
   'layout.zod.ts#IconSchema': Ts_IconSchema;
@@ -3119,7 +3127,7 @@ const ZOD_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'zod');
  * MINUEND under it had moved. Nothing failed on any of those days, because nothing
  * compared the registry to a number. objectui#7433 is that absence, not the digits.
  */
-const EXPECTED_MIRROR_PAIRS = 158;
+const EXPECTED_MIRROR_PAIRS = 162;
 
 /**
  * A ledger this file can size from its own AST. `WiderThanDeclared` joined at

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -1638,6 +1638,50 @@ export interface CodeEditorSchema extends BaseSchema {
 }
 
 /**
+ * The `email` / `password` input shorthands
+ * `packages/components/src/renderers/form/input.tsx` registers (objectui#8499).
+ *
+ * Both are the SAME renderer as `input`, wrapped so `inputType` is pinned:
+ * `<InputRenderer {...props} schema={{ ...props.schema, inputType: 'password' }} />`.
+ *
+ * ⛔ `inputType` is therefore absent here, and that absence is the whole
+ * difference from {@link InputSchema}. The wrapper spreads its own value LAST,
+ * so an authored `inputType` is silently overwritten; declaring it would publish
+ * a key the runtime discards. Write `{ type: 'input', inputType: 'email' }` when
+ * the input type is the choice.
+ *
+ * ⚠️ {@link BaseSchema} carries an index signature and its mirror passes unknown
+ * keys through, so omitting the key states the contract — it does not refuse the
+ * value. Refusing it by name is an accept-set narrowing left to its own ruling.
+ *
+ * Mirror: `zod/form.zod.ts#InputShorthandSchema`.
+ */
+export interface InputShorthandSchema extends Omit<InputSchema, 'type' | 'inputType'> {
+  type: 'email' | 'password';
+}
+
+/**
+ * The date-picker primitive `packages/components/src/renderers/form/calendar.tsx`
+ * registers, reachable at `ui:calendar` ONLY (objectui#8499).
+ *
+ * ⚠️ `ui:calendar` and `calendar` are DIFFERENT components. That registration
+ * carries `skipFallback: true` because "`calendar` collides with the
+ * plugin-calendar full CRUD calendar VIEW, which owns the bare `type: 'calendar'`
+ * schema keyword; this date-picker primitive is reached via `ui:calendar` only."
+ * So the namespaced spelling is not a stylistic variant of {@link CalendarSchema}
+ * — it is the only spelling that resolves to this renderer.
+ *
+ * Five catalog fixtures under
+ * `examples/schema-catalog/src/schemas/components-form-calendar/` author it; every
+ * one rendered and every one was refused by `AnyComponentSchema` until this arm.
+ *
+ * Mirror: `zod/form.zod.ts#UiCalendarSchema`.
+ */
+export interface UiCalendarSchema extends Omit<CalendarSchema, 'type'> {
+  type: 'ui:calendar';
+}
+
+/**
  * Union type of all form schemas
  */
 export type FormComponentSchema =
@@ -1658,5 +1702,7 @@ export type FormComponentSchema =
   | LabelSchema
   | ComboboxSchema
   | CommandSchema
-  | CodeEditorSchema;
+  | CodeEditorSchema
+  | InputShorthandSchema
+  | UiCalendarSchema;
 

--- a/packages/types/src/layout.ts
+++ b/packages/types/src/layout.ts
@@ -890,6 +890,82 @@ export interface PageSlotMap {
 }
 
 /**
+ * The seven HTML sectioning tags `packages/components/src/renderers/layout/semantic.tsx`
+ * registers (objectui#8499).
+ *
+ * They are registered, live renderers carrying nine catalog fixtures under
+ * `examples/schema-catalog/src/schemas/components-layout-semantic/`, and until
+ * objectui#8499 no arm of `AnyComponentSchema` named any of them — so a document
+ * that rendered correctly in the browser was refused by `objectui check`.
+ *
+ * The renderer is one factory over all seven tags: it renders
+ * `renderChildren(schema.children || schema.body)` inside the tag and declares
+ * exactly one authoring input, `className` (a {@link BaseSchema} member). The
+ * mirror is `zod/layout.zod.ts#SemanticElementSchema`, and
+ * `__tests__/node-slot-registered-arms-8499.test.ts` compares the tag list below
+ * against `semantic.tsx`'s own `tags` array.
+ */
+export interface SemanticElementSchema extends BaseSchema {
+  type: 'aside' | 'main' | 'header' | 'nav' | 'footer' | 'section' | 'article';
+  /**
+   * Child components — read as `schema.children || schema.body`.
+   */
+  children?: SchemaNode | SchemaNode[];
+}
+
+/**
+ * The safe flow/inline HTML passthrough set
+ * `packages/components/src/renderers/basic/html-elements.tsx` registers
+ * (objectui#8499).
+ *
+ * A `kind:'html'` page is PARSED (never executed) into the SDUI tree, so — in
+ * that module's own words — "the everyday HTML tags an author reaches for …
+ * must each resolve to a renderer". They resolved in the renderer registry and
+ * in no arm of `AnyComponentSchema`; `content/docs/utilities/runner.mdx` teaches
+ * a document carrying `h1`, and that document rendered and was refused.
+ *
+ * ⚠️ The per-tag keys below are declared on the WHOLE set, not per tag, so
+ * `{ type: 'p', href: '…' }` type-checks. {@link BaseSchema} carries an index
+ * signature, so it type-checked before this declaration existed too — this
+ * narrows nothing and gains the author a named surface. `width` / `height` are
+ * `string | number` rather than the registration's `number`, because the
+ * renderer forwards them verbatim to the DOM attribute, which takes both.
+ */
+export interface HtmlElementSchema extends BaseSchema {
+  type:
+    | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+    | 'p' | 'a' | 'blockquote' | 'pre'
+    | 'strong' | 'em' | 'b' | 'i' | 'u' | 'small' | 'mark' | 'sub' | 'sup' | 'del' | 'ins' | 'abbr'
+    | 'ul' | 'ol' | 'li' | 'dl' | 'dt' | 'dd'
+    | 'figure' | 'figcaption' | 'img' | 'hr' | 'br' | 'time' | 'address' | 'cite' | 'q';
+  /**
+   * Child components — read as `schema.children ?? schema.body`; ignored for the
+   * void tags `img` / `hr` / `br`.
+   */
+  children?: SchemaNode | SchemaNode[];
+  /** `a` link target; scheme-sanitised (`javascript:` / `data:` / `vbscript:` are dropped). */
+  href?: string;
+  /** `a` browsing context. */
+  target?: string;
+  /** `a` link relationship. */
+  rel?: string;
+  /** Advisory title — declared for `a`, `img` and `abbr`. */
+  title?: string;
+  /** `img` source URL. */
+  src?: string;
+  /** `img` alternative text. */
+  alt?: string;
+  /** `img` width — forwarded verbatim to the DOM attribute. */
+  width?: string | number;
+  /** `img` height — forwarded verbatim to the DOM attribute. */
+  height?: string | number;
+  /** `time` machine-readable datetime. */
+  dateTime?: string;
+  /** `q` / `blockquote` source URL. */
+  cite?: string;
+}
+
+/**
  * Union type of all layout schemas
  */
 export type LayoutSchema =
@@ -909,5 +985,7 @@ export type LayoutSchema =
   | ScrollAreaSchema
   | ResizableSchema
   | AspectRatioSchema
-  | PageNodeSchema;
+  | PageNodeSchema
+  | SemanticElementSchema
+  | HtmlElementSchema;
 

--- a/packages/types/src/zod/form.zod.ts
+++ b/packages/types/src/zod/form.zod.ts
@@ -687,6 +687,75 @@ export const FormSchema = BaseSchema.extend({
 });
 
 /**
+ * Input Shorthand Schema — the `email` / `password` aliases
+ * `packages/components/src/renderers/form/input.tsx` registers (objectui#8499).
+ *
+ * Both are the SAME renderer as `input`, wrapped so that `inputType` is pinned:
+ *
+ * ```tsx
+ * ComponentRegistry.register('password',
+ *   (props) => <InputRenderer {...props} schema={{ ...props.schema, inputType: 'password' }} />, …)
+ * ```
+ *
+ * ⛔ `inputType` is therefore ABSENT from this arm, deliberately, and that
+ * absence is the whole difference from {@link InputSchema}. The wrapper spreads
+ * its own value LAST, so an authored `inputType` is silently overwritten;
+ * declaring it here would publish a key the runtime discards. Write
+ * `{ type: 'input', inputType: 'email' }` when the input type is the choice.
+ *
+ * ⚠️ MEASURED, so the omission is not over-read: `BaseSchema` passes unknown
+ * keys through, so `{ type: 'password', inputType: 'text' }` still PARSES —
+ * omitting the key states the contract on the declared face, it does not refuse
+ * the value. Refusing it by name (the `./tombstone.zod.ts` mechanism) would be
+ * an accept-set NARROWING in the opposite direction from this card and is
+ * deliberately left to its own ruling; objectui#8499's report records it.
+ *
+ * Every other key is {@link InputSchema}'s, because it is literally the same
+ * renderer reading the same schema.
+ */
+export const InputShorthandSchema = InputSchema.omit({ type: true, inputType: true }).extend({
+  type: z.enum(['email', 'password'])
+    .describe('Input shorthand — `renderers/form/input.tsx` pins `inputType` to match'),
+  // Declared here and not (yet) on {@link InputSchema}, which is the pair
+  // `__tests__/zod-mirror-parity.test.ts` records as unmirrored for this very key.
+  // The renderer both arms share reads it — `renderers/form/input.tsx:42`,
+  // `cn('grid w-full items-center gap-1.5', schema.wrapperClass)` — so declaring it
+  // is the read site talking. ⛔ Copying the gap into a NEW pair would have minted a
+  // second ledger row for a key that is demonstrably read; shrinking the existing
+  // row is `InputSchema`'s own repair (objectui#7722's family) and not this card's.
+  wrapperClass: z.string().optional()
+    .describe("Classes on the wrapper div around the input and its label, read at renderers/form/input.tsx:42 — `cn('grid w-full items-center gap-1.5', schema.wrapperClass)`"),
+});
+
+/**
+ * Ui Calendar Schema — the date-picker primitive
+ * `packages/components/src/renderers/form/calendar.tsx` registers, reachable at
+ * `ui:calendar` ONLY (objectui#8499).
+ *
+ * ⚠️ `ui:calendar`, not `calendar`, and the two are different components. That
+ * registration carries `skipFallback: true` with its reason written beside it:
+ *
+ * > `calendar` collides with the plugin-calendar full CRUD calendar VIEW, which
+ * > owns the bare `type: 'calendar'` schema keyword; this date-picker primitive
+ * > is reached via `ui:calendar` only.
+ *
+ * So the namespaced spelling is not a stylistic variant of {@link CalendarSchema}
+ * — it is the only spelling that resolves to this renderer. Five catalog
+ * fixtures under `examples/schema-catalog/src/schemas/components-form-calendar/`
+ * author it, every one of them rendered and every one of them refused by
+ * `AnyComponentSchema` until this arm.
+ *
+ * The key set is {@link CalendarSchema}'s: `calendar.tsx` reads `schema.mode`,
+ * `schema.value`, `schema.defaultValue` and `className`, which is what that
+ * schema already declares — it mirrors this primitive's shape while its own
+ * literal resolves to the plugin view.
+ */
+export const UiCalendarSchema = CalendarSchema.extend({
+  type: z.literal('ui:calendar')
+    .describe('The `ui`-namespaced date-picker primitive — `calendar` alone names the plugin-calendar view'),
+});
+
+/**
  * Form Component Schema Union - All form component schemas
  */
 /**
@@ -733,4 +802,6 @@ export const FormComponentSchema = z.discriminatedUnion('type', [
   CommandSchema,
   FormSchema,
   CodeEditorSchema,
+  InputShorthandSchema,
+  UiCalendarSchema,
 ]);

--- a/packages/types/src/zod/layout.zod.ts
+++ b/packages/types/src/zod/layout.zod.ts
@@ -460,6 +460,111 @@ export const PageNodeSchema = BaseSchema.extend(SpecPageFields.shape).extend({
 });
 
 /**
+ * Semantic Element Schema — the seven HTML sectioning tags
+ * `packages/components/src/renderers/layout/semantic.tsx` registers
+ * (objectui#8499).
+ *
+ * ## The defect this closes
+ *
+ * These seven are REGISTERED, LIVE renderers with nine catalog fixtures of
+ * their own under `examples/schema-catalog/src/schemas/components-layout-semantic/`,
+ * and `AnyComponentSchema` had no arm for any of them. So a document that
+ * renders correctly in the browser was REFUSED by `objectui check` — the
+ * expensive direction, because the author's likely reaction is to stop trusting
+ * the validator rather than to fix the document (objectui#8499 triage).
+ *
+ * The two faces disagreed BY CONSTRUCTION: `check:doc-types` judges a `type`
+ * literal against the RENDERER registry (656 keys at the time of writing), not
+ * against this union (107 arms), and nothing compared them at a node slot.
+ * `../__tests__/node-slot-registered-arms-8499.test.ts` compares the literal set
+ * below against `semantic.tsx`'s own `tags` array, so a tag added there without
+ * an arm here goes red instead of diverging silently.
+ *
+ * ## Why one arm and not seven
+ *
+ * The factory in `semantic.tsx` builds ONE component over all seven tags: it
+ * renders `renderChildren(schema.children || schema.body)` inside the tag and
+ * declares exactly one authoring input, `className`. Seven arms would restate
+ * the same shape seven times with no key to tell them apart.
+ *
+ * ## What is NOT declared here, and why
+ *
+ * Nothing beyond `type` and the child slot. Every other key the factory touches
+ * — `data-obj-id`, `data-obj-type`, `style` — is a DESIGNER prop injected by the
+ * renderer host, never authored metadata, and `className` is already a
+ * {@link BaseSchema} member. Following the `BarChartSchema` discipline (`./data-display.zod.ts`):
+ * only keys the renderer demonstrably reads, nothing on the strength of what a
+ * sectioning tag "should" accept.
+ */
+export const SemanticElementSchema = BaseSchema.extend({
+  type: z.enum(['aside', 'main', 'header', 'nav', 'footer', 'section', 'article'])
+    .describe('HTML sectioning tag — the seven `renderers/layout/semantic.tsx` registers'),
+  children: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional()
+    .describe('Child components — read as `schema.children || schema.body` by the factory'),
+});
+
+/**
+ * Html Element Schema — the safe flow/inline HTML passthrough set
+ * `packages/components/src/renderers/basic/html-elements.tsx` registers
+ * (objectui#8499).
+ *
+ * ## Why these must resolve
+ *
+ * That module's own docblock states the purpose: a `kind:'html'` page is PARSED
+ * (never executed) into the SDUI tree, so "the everyday HTML tags an author
+ * reaches for — headings, paragraphs, lists, links, images, emphasis — must each
+ * resolve to a renderer (otherwise the parser flags them `unknown-component`)".
+ * They resolved in the RENDERER registry and in no arm of `AnyComponentSchema`,
+ * which is objectui#8499: `content/docs/utilities/runner.mdx` teaches the reader
+ * to save a document carrying `h1`, and the document it teaches renders and is
+ * refused.
+ *
+ * ⚠️ One arm over the whole set, deliberately, and it is a real cost: `h1`
+ * becomes legal at EVERY node slot, including slots where it is absurd (a
+ * `data-table`'s `emptyAction`, a `header-bar`'s `logo`). That is not new laxity
+ * — every one of the 107 pre-existing arms is already legal at every one of the
+ * 249 declared node slots, because there is exactly ONE node-slot vocabulary in
+ * this face ({@link SchemaNodeSchema}) and a discriminated union selects its arm
+ * from the authored literal alone, with no way for a slot to narrow it. A
+ * per-slot vocabulary is a different programme, not a variant of this arm.
+ *
+ * ## The per-tag keys, and why they are typed wider than the registration
+ *
+ * `PER_TAG_INPUTS` in that module declares `img`'s `width`/`height` as
+ * `number`. The renderer FORWARDS them verbatim onto the DOM element, which
+ * accepts `"100"` as readily as `100`, so a number-only declaration here would
+ * refuse a document the renderer draws — this card's own defect, rebuilt one
+ * key down. The declaration follows the read site, not the authoring hint.
+ *
+ * ⚠️ The keys are declared on the whole set rather than per tag, so
+ * `{ type: 'p', href: '…' }` parses. {@link BaseSchema} passes unknown keys
+ * through, so it parsed before this arm existed too — declaring them narrows
+ * nothing and gains the author a typed surface.
+ */
+export const HtmlElementSchema = BaseSchema.extend({
+  type: z.enum([
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'p', 'a', 'blockquote', 'pre',
+    'strong', 'em', 'b', 'i', 'u', 'small', 'mark', 'sub', 'sup', 'del', 'ins', 'abbr',
+    'ul', 'ol', 'li', 'dl', 'dt', 'dd',
+    'figure', 'figcaption', 'img', 'hr', 'br', 'time', 'address', 'cite', 'q',
+  ]).describe('Safe HTML tag — the set `renderers/basic/html-elements.tsx` registers'),
+  children: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional()
+    .describe('Child components — read as `schema.children ?? schema.body`; ignored for the void tags `img` / `hr` / `br`'),
+  href: z.string().optional()
+    .describe('`a` link target; scheme-sanitised at html-elements.tsx:74 (`javascript:` / `data:` / `vbscript:` are dropped)'),
+  target: z.string().optional().describe('`a` browsing context — an internal link navigates through the SPA router unless this names another target'),
+  rel: z.string().optional().describe('`a` link relationship'),
+  title: z.string().optional().describe('Advisory title — declared for `a`, `img` and `abbr`'),
+  src: z.string().optional().describe('`img` source URL'),
+  alt: z.string().optional().describe('`img` alternative text'),
+  width: z.union([z.string(), z.number()]).optional().describe('`img` width — forwarded verbatim to the DOM attribute'),
+  height: z.union([z.string(), z.number()]).optional().describe('`img` height — forwarded verbatim to the DOM attribute'),
+  dateTime: z.string().optional().describe('`time` machine-readable datetime'),
+  cite: z.string().optional().describe('`q` / `blockquote` source URL'),
+});
+
+/**
  * Layout Schema Union - All layout component schemas
  */
 export const LayoutSchema = z.discriminatedUnion('type', [
@@ -480,4 +585,6 @@ export const LayoutSchema = z.discriminatedUnion('type', [
   ResizableSchema,
   AspectRatioSchema,
   PageNodeSchema,
+  SemanticElementSchema,
+  HtmlElementSchema,
 ]);

--- a/packages/types/src/zod/layout.zod.ts
+++ b/packages/types/src/zod/layout.zod.ts
@@ -521,7 +521,7 @@ export const SemanticElementSchema = BaseSchema.extend({
  *
  * ⚠️ One arm over the whole set, deliberately, and it is a real cost: `h1`
  * becomes legal at EVERY node slot, including slots where it is absurd (a
- * `data-table`'s `emptyAction`, a `header-bar`'s `logo`). That is not new laxity
+ * `header-bar`'s `logo`, a `dialog`'s `trigger`). That is not new laxity
  * — every one of the 107 pre-existing arms is already legal at every one of the
  * 249 declared node slots, because there is exactly ONE node-slot vocabulary in
  * this face ({@link SchemaNodeSchema}) and a discriminated union selects its arm


### PR DESCRIPTION
Fixes #8499

Head `005409fc1`, DRAFT. Every reading below was re-derived on this branch; nothing is inherited from the card's `c90395b2`.

> **Two patch rounds.** Round 1 answered the ceiling FAIL at `5596236677`; **round 2** answers the ceiling re-review FAIL at `5597738741`, whose three items are the last section of this body. The architectural measurement, the `line-chart` refusal and the ablation are unchanged and were independently reproduced by both reviews. The architectural measurement, the `line-chart` refusal and the ablation are unchanged and were independently reproduced by that review; they are not re-litigated here.

## My own `unresolvedNodeTypes` reading

`pnpm --filter @object-ui/types build`, then `scripts/measure-strict-authoring-face.mjs --json`:

| | value |
|---|---|
| BEFORE (`3fbdd4a2`, `corpusMatchesMain: true`) | `footer` `h1` `header` `line-chart` `main` `my-component` `nav` `password` `ui:calendar` — 9, one occurrence each |
| AFTER (`cc307588`) | `line-chart` `my-component` |

**The population is identical to the card's.** Same nine spellings, same counts. `my-component` is exempt by the written carve-out in `scripts/check-doc-component-types.mjs`; `line-chart` is the one the card's premise fails for (below). Seven armed.

`unresolvedRootTypes` moved too, unasked: 28 to 20. The eight that left are `ui:calendar` `article` `section` `aside` `footer` `header` `main` `nav` — `article` / `section` / `aside` were root-only occurrences of the same sectioning family, so arming the family cleared them as a side effect rather than by a separate decision.

## The (a)-vs-(b) shape measurement — I took (a), and (b) is not expressible by adding arms

Triage asked which of two shapes to take and named the fear precisely: *"一个扁平 arm 会让 `h1` 在每一个节点槽位合法，包括它明显不该出现的地方"*.

**The fear is correct, and the magnitude is: every declared node slot, all of them.** Walked from `AnyComponentSchema` on the built face:

| reading | count |
|---|---|
| arms walked | 107 (before) / 154 (after) |
| **arm-level node slots** | **249 before / 257 after** |
| node slots on nested, non-arm schemas | **36** (`AccordionItemSchema.content`, `CarouselItemSchema.content`, `TabItemSchema.content`, `ListItemSchema.content`, `TimelineEventSchema.content`, `ResizablePanelSchema.content`, `DetailViewFieldSchema.render`, `PageNodeRegionSchema.components`, …) |
| **distinct node-slot vocabularies** | **1** |

⚠️ **Erratum, corrected from the ceiling review's own walk.** The first version of this table printed `249` unlabelled — it is the **before** figure, and after is **257**. It also filed several ARM-level slots under "nested": `HeaderBarSchema.logo` / `.left` / `.center` / `.right` / `.rightContent` / `.actions` belong to an arm of the union, as do `DataTableSchema.emptyAction`, `CardSchema.header` / `.footer`, `DialogSchema.footer`, `SheetSchema.footer`, `SidebarSchema.footer` / `.content` and `TableSchema.footer`. The genuinely nested population is the 36 item/region sub-schemas, and the conclusion is unchanged: one vocabulary, ~293 slots.

Every one of those slots is spelled with the SAME `SchemaNodeSchema` object — the walk tests identity, not shape. There is exactly one node-slot vocabulary in the whole face, and `AnyComponentSchema` is a **discriminated union**: it selects its arm from the authored `type` literal alone. A slot has no input into that selection. So:

- **(b) is not a variant of (a).** It cannot be reached by choosing differently when adding an arm. It requires naming a NARROWER schema at a slot, which is a per-slot policy decision repeated across ~280 slots.
- **It is expressible in principle, and this repo has done it exactly once** — `DashboardWidgetSchema.component` is spelled `BaseSchema`, explicitly *"⚠️ `BaseSchema`, ⛔ NOT `SchemaNodeSchema` (objectui#8344)"*, because that slot's accept set had to differ. That one exception took a maintainer ruling (objectstack#8593) for a single slot.
- **The slot triage imagined does not exist.** There is no node slot that "only takes data nodes". The data-shaped collections — `DashboardComponentSchema.widgets`, `FormSchema.fields`, `TableSchema.columns` — are not node slots at all; they are typed by their own schemas and this change does not reach them.

⇒ **(b) is disproportionate for this card and I say so explicitly, with the measurement.** It is a per-slot vocabulary programme, not a narrower way to add an arm.

### What (a) newly admits that is absurd

All 47 new literals become legal at all ~280 slots. Concretely, each of these now parses and did not before:

- `{ "type": "header-bar", "logo": { "type": "footer" } }` — a `footer` as a header's logo;
- `{ "type": "dialog", "trigger": { "type": "hr" } }` — a horizontal rule as a dialog trigger;
- `{ "type": "main", "children": [{ "type": "main" }] }` — nested `main`, which HTML permits at most one of per document;
- `{ "type": "tooltip", "trigger": { "type": "ui:calendar" } }` — a date-picker grid as a tooltip trigger.

⚠️ **Erratum, and it removes two examples rather than weakening the point.** An earlier version of this list opened with `{ "type": "data-table", "emptyAction": { "type": "main" } }` and argued the "already lax" half with `{ "type": "data-table", "emptyAction": { "type": "kanban" } }`. Both are **false as written**: `data-table` requires `data` and `columns`, so neither document parses — the first does not parse now, and the second did not parse before. The four above are the ones that genuinely refuse-before and accept-after, and they carry the point on their own.

⚠️ **This is not a new KIND of laxity, and the honest framing matters for pricing it.** Every one of the 107 pre-existing arms was already legal at every one of those slots, for the structural reason above rather than by anecdote: one `SchemaNodeSchema`, one discriminated union, no slot input into arm selection. (a) enlarges an existing hole by 44%; it does not open one. The hole itself is the single node-slot vocabulary, and closing it is the programme above.

## Accept set, before and after, each acceptance paired with a refusal control

Root and nested (`{ type: 'div', children: [X] }`) give the same verdict throughout; the nested column is the one objectui#8344 made meaningful.

| document | before | after |
|---|---|---|
| `{ type: 'footer' }` / `header` / `main` / `nav` | REFUSE | **ACCEPT** |
| `{ type: 'h1' }` | REFUSE | **ACCEPT** |
| `{ type: 'password' }` | REFUSE | **ACCEPT** |
| `{ type: 'ui:calendar' }` | REFUSE | **ACCEPT** |
| `{ type: 'line-chart' }` | REFUSE | REFUSE (deliberate — see below) |
| **control** `{ type: 'h1ZZ' }` | REFUSE | REFUSE |
| **control** `{ type: 'stat-card' }` (registered nowhere) | REFUSE | REFUSE |
| **control** `{ type: 'metric-card' }` (registered; ruled not an arm) | REFUSE | REFUSE |
| **control** `{ type: 'my-component' }` | REFUSE | REFUSE |
| **control** `{ type: 'area-chart' }` (console stub, unfulfilled) | REFUSE | REFUSE |

Value-level controls, so no arm is a `z.any()` in disguise — each pair is one green and one red reading on the same key of the same new arm:

| | verdict |
|---|---|
| `{ type: 'img', src: 'a.png', width: 100 }` | ACCEPT |
| `{ type: 'img', src: 'a.png', width: true }` | **REFUSE** |
| `{ type: 'password', required: true }` | ACCEPT |
| `{ type: 'password', required: 'yes' }` | **REFUSE** |
| `{ type: 'ui:calendar', mode: 'single' }` | ACCEPT |
| `{ type: 'ui:calendar', mode: 'agenda' }` | **REFUSE** |
| `{ type: 'main', hidden: true }` | ACCEPT |
| `{ type: 'main', hidden: 42 }` | **REFUSE** |

**Nothing that was green went red.** The whole-corpus reading says it without relying on my choice of examples: `totals.nodes` 2103 to 2160 (+57 — the previously unresolved values are now walked as nodes), `nodesRedToday` **52 to 52**, `documentsRedTodayWholeDocument` **46 to 46**. All 57 newly-walked nodes are green.

The two faces, re-measured with `scripts/check-doc-component-types.mjs`'s own `deriveRegistryKeys`:

| | before | after |
|---|---|---|
| registered renderer keys | 656 | 656 |
| `AnyComponentSchema` literals | 107 | **154** |
| registered keys with NO arm | 552 | **505** |
| arm literals with NO registration | 3 (`action`, `crud-dialog`, `report-builder`) | **3 — unchanged** |

That last row is the control that matters for a widening: the 47 literals added are all registered. This change names nothing that does not exist.

Cost, stated rather than buried: `componentTypesNeverSeen` went 13 to 50. 37 of the 47 new literals are not authored anywhere in the corpora — the price of one arm per family instead of one arm per defect. The card's own repair-scope paragraph asks for exactly that ("An arm per family, not per tag"), and the alternative leaves `h2` diverging identically tomorrow.

## The premise fails for one of the eight: `line-chart` is NOT a live renderer

The card says *"Every one except `my-component` is a REGISTERED, LIVE renderer"* and justifies `h1`, the sectioning family and `ui:calendar` by name. It does not justify `line-chart`, and measured here that claim is false for it.

`apps/console/src/register-plugins.ts:77` registers ten chart variants as lazy stubs pointing at `@object-ui/plugin-charts`. That package registers eight keys — `bar-chart` `chart` `chart:bar` `donut-chart` `object-chart` `pie-chart` `radar-chart` `scatter-chart` — and `line-chart` is not among them. `Registry.loadLazy`'s own docblock: *"Resolves once the loader completes (whether or not the loaded module actually registered the expected type)"*. So the key is KNOWN to `check:doc-types` and resolves to nothing at render time. The repository already recorded the same reading in passing — `scripts/check-doc-component-types.mjs` calls a sibling defect *"the same failure as the `line-chart` widget objectui#7896 recorded in `packages/plugin-dashboard/README.md`"*.

Triage's ruling admits arms only for things that 「运行时已经正确渲染」. `line-chart` does not render, so an arm would **invent a capability** rather than name one — outside what was ruled. It is filed instead: **#8760**. The absence is pinned WITH its reason in `node-slot-registered-arms-8499.test.ts`, reading both halves from source, so registering the key for real turns this red and the arm becomes owed.

## The comparison instrument — what I built, and the trade-off

Triage's reminder: without a `renderer registry ⊆ node-slot-resolvable` comparison, the next registered renderer diverges the same way.

**The full containment instrument is disproportionate here, and this is the number that decides it: 505 registered keys still have no arm** (552 before). A containment gate needs a 505-entry ledger on day one — an artifact this card is not authorised to mint, and one that would bury the signal it exists to give. It would also need `packages/types/dist`, which breaks the no-build property that lets `check:doc-types` run as a cheap per-PR check.

**What I built instead is the same comparison, scoped to the two families this card armed.** `node-slot-registered-arms-8499.test.ts` reads `packages/components/src/renderers/layout/semantic.tsx` and `.../basic/html-elements.tsx` from source and asserts each arm's literal set **equals** the array the registration site loops over — plus a floor assertion on each read so a moved declaration reads as a failure rather than a vacuous pass, and a firing control that a registered-but-unarmed tag is detected. Adding a tag to either array without an arm now goes red. That is not the whole containment, and I am not claiming it is; it closes the two families that produced 5 of this card's 8 rows, at zero ledger cost.

## Ablation — the pin fails when the arms are removed

One-off, restored, `trap`-guarded. The four arms were removed from their unions in `zod/layout.zod.ts` / `zod/form.zod.ts` (declarations left in place, so the exports still resolve and only the UNION loses them). **No rebuild was performed**, which is also the proof that the pin resolves package SOURCE rather than a stale `dist/`.

```
HEAD blob layout.zod.ts = 461c4283714754c254e2c4fb755c2aa167c23b11
HEAD blob form.zod.ts   = a5fc0eb5b050c9180ef435e8048cab7d318c7e0d
union members present:       2 -> 0     (grep -c on the anchor lines, both files)
layout blob after mutation = 87800b7a509ed2d358cc9b614411a5080db5b5a7   (differs from HEAD blob)
form   blob after mutation = 7a26943417e839f811d7572480408226f367100c   (differs from HEAD blob)
MUTATED_EXIT=1     Tests  17 failed | 9 passed (26)
```

The 9 that stayed green under ablation are: the `UNREGISTERED` refusals, the `line-chart` absence legs, and the three declaration-vs-registration legs.

⚠️ **Corrected labelling, per the ceiling review.** Calling all nine "control legs" overclaimed. The three declaration-vs-registration legs read `SemanticElementSchema` / `HtmlElementSchema` **directly**, so they survive removing those arms from `AnyComponentSchema` by design — the property they hold is arm-vs-registration parity, not union membership. They are not controls for the union; the `UNREGISTERED` refusals are. The test file now says so in its own docblock, and the leg that was labelled a firing control has been rebuilt (below), because it was comparing an array with itself plus an element and would have passed whatever the schema said.

Restore leg: `git checkout HEAD -- ...`, then `git diff HEAD` empty (verified, not inferred from an exit code), then re-run `RESTORED_EXIT=0`, `Tests 26 passed (26)`.

## Gates

⚠️ The table below is the **head-`cc307588`** run. It is kept because the ceiling review reproduced it, but it is NOT the current head — the patch-round table at the bottom is. All from the repository root, exit codes captured before any pipe.

| gate | exit | note |
|---|---|---|
| `pnpm --filter @object-ui/types type-check` | **0** | `tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json` — the third is where the compile-time mirror-parity ledger reconciles |
| `pnpm --filter @object-ui/cli type-check` | **0** | |
| `pnpm exec vitest run packages/types packages/cli packages/core packages/react examples/schema-catalog` | **0** | 410 files, 9168 tests |
| `pnpm exec turbo run lint --concurrency=2` | **0** | 47/47 tasks. FULL run, not narrowed |
| `node scripts/check-changeset-presence.mjs` | **0** | the body originally said 7 published source files; the gate printed **8** at this head, and **9 across 3 released packages** at `90fcf4f2` after the merge. 1 changeset throughout |
| `node scripts/check-changeset-no-major.mjs` | **0** | |
| `pnpm check:control-bytes` | **0** | 6960 tracked text files |
| `pnpm check:doc-types` | **0** | 893 literals against 656 registered keys |
| `pnpm check` | **0** | the per-PR gate at `lint.yml:481`. Ran against a built `packages/cli/dist/cli.js`; 628 files analysed, 3 candidates remain, none of them this card's |
| `pnpm check:readme-exports` | **0** | first run was exit 1 with 514 `not on disk -- run pnpm build first` and three floor misses — PRECONDITION NOT MET, not a red. Zero complaints named `packages/types/README`. Green after a full build |
| `pnpm check:spec-symbols` | **0** | |
| `node scripts/check-type-check-coverage.mjs` | **0** | |
| `pnpm check:sdui-registration-pins` | **0** | |
| `pnpm check:published-dist` | **0** | not a per-PR gate — **measured here or nowhere** |
| `pnpm check:node-esm-load` | **1** | not a per-PR gate — **measured here or nowhere**, and the exit is NOT this diff. Its provenance leg refuses 2 of 37 entries because turbo replayed `@object-ui/auth` and `@object-ui/react-runtime` from a SIBLING worktree's cache (`/home/user/objectui-review-8723/...`); the gate names its own remedy, `--force-build`. `@object-ui/types` was built by this tree and is in the 32 entries that imported and evaluated cleanly |
| `pnpm exec turbo run build --filter=!@object-ui/site --concurrency=2` | **0** | 43/43 |

Self-scan beyond `check:control-bytes`, as the standing clause requires: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over all 9 changed files — no hits (grep exit 1).

`scripts/check-governed-queue-guard.mjs --test` over the 9 paths: **NOT GOVERNED** — none of the 5 governed surfaces matched. The dispatch's phrase "`packages/types` is a governed package (AGENTS.md #0.1)" is the CONTRACT-FIRST commandment, not the human-merge governed surface; what #0.1 forces on this change is that the repair lands on the declaration rather than as a tolerant read, which it does — no consumer gained a fallback, no renderer changed, and the four arms declare only keys their renderers demonstrably read. This PR stays **draft** regardless, per the dispatch and the standing 「无席内契约复审档 PASS 在案 ⛔ 禁止入队」.

## Changeset

`.changeset/8499-node-slot-registered-arms.md`, `'@object-ui/types': minor`.

Graded against `AGENTS.md`: the rule is the paragraph at **9. Operational Rules** — a changeset is required once any file under a released package's `src/` moves, and *"别再按「feature 要写、bug 修复不用」来判断"*. Seven such files moved across two released packages, so it is owed, and one declaration satisfies it. The level is `minor` by the **objectui major/minor** paragraph: *"changeset 里不要声明 `major`"* and *"objectui 自身的破坏性变更也标 `minor`"*, mechanically enforced by `check-changeset-no-major.mjs` (run, exit 0). `patch` would be wrong here even though the card is typed Bug — this is a published accept-set widening, which triage flagged in advance (*"承接者写 changeset 时仍应按公开面扩张处理级别"*).

## File-surface collisions

Neither hard collision fired.

- **#8221** holds `types/src/zod/objectql.zod.ts` among others. **Not touched** — this change lands in `zod/layout.zod.ts` and `zod/form.zod.ts`, which the dispatch confirms are free since #8721 merged.
- **#8318** holds the JSDoc `@default` tags of 9 keys. **Not touched.** ⚠️ One soft, file-level overlap to declare: two of those nine (`CardSchema`, `PageNodeSchema`) live in `packages/types/src/layout.ts`, which this PR also edits — but in a different region (two new interfaces appended before the union) and on no `@default` tag. Textual merge conflict is unlikely; it is reported rather than assumed away.

`packages/types/src/registry.ts` was deliberately NOT touched: `SchemaRegistry` is already non-exhaustive (71 keys against 107 arms before this change, 37 arms unlisted), so adding 47 tag rows would have been noise rather than a completeness repair.

## Collateral: two tests whose EXAMPLES this card retired

Both had chosen `h1`-family types precisely because they were unarmed. Neither assertion was weakened; each was re-pointed at an input whose absence from the union is **ruled** rather than merely pending, so it cannot rot the same way.

- `packages/types/src/__tests__/node-recursion-point-8344.test.ts` — its `UNMIRRORED` fixture was `{ type: 'h1' }`, with a docblock reading *"⛔ Do not 'fix' this by adding an `h1` arm to make some other test green: that is the public-surface widening objectui#8344 routes into its own card."* This IS that card, and the widening landed by ruling. Now `{ type: 'metric-card' }`, whose exclusion `zod/complex.zod.ts` records as *"DELIBERATELY not an arm of `AnyComponentSchema`"* under objectstack#8593.
- `packages/cli/src/__tests__/check-validity-recogniser.test.ts` — its "registered but not modelled" fixture was `abbr`, chosen on the reasoning that *"the raw HTML primitives are the stable inhabitants of this bucket"*. They were not. Now `metric-card`, with the dated census re-measured in place: 658/102/558 becomes 656/154/505.

## Out-of-scope findings, filed

Searched first. The repo-scoped REST search endpoint returns 403 in this container (`sessions are bound to their configured re…`), so the duplicate check switched to one targeted MCP `search_issues` — declared here as a channel switch. It returned 56 semantically related plugin-charts/types findings and none matching, so it is a live reader rather than a blind one.

- **#8760** — `line-chart` / `area-chart` / `advanced-chart` are lazy stubs `@object-ui/plugin-charts` never fulfils, and `content/docs/plugins/plugin-dashboard.mdx:210` teaches one.
- **#8761** — two `components-form-label` fixtures author `direction: "column"` on a `flex` node; `flex.tsx` maps only `col` / `col-reverse`, so the fixture draws a ROW and `objectui check` refuses the key.
- **#8762** — `inputType` authored on `{ type: 'email' }` / `{ type: 'password' }` parses green and is overwritten by the registration wrapper. Its repair is an accept-set NARROWING, deliberately kept off this PR so this change moves the accept set in one direction only.

## NOT MEASURED

- **CI on this head.** Nothing here waited for it. The gates above are local runs.
- **`Build Docs`.** Not run. It is one of the three the dispatch names as not covering the PR head.
- **`check:node-esm-load` under clean provenance.** Its exit 1 is a shared-turbo-cache condition, diagnosed but not cleared — clearing it needs `--force-build`, a second full build for a gate that does not gate this PR.
- **Browser rendering.** No renderer changed, so nothing was re-verified in a browser. The claim that these seven draw rests on their fixtures and on `catalog-gallery-render.test.tsx`'s OBJUI-001 assertion, not on my own screenshot.
- **Corpora outside this repo.** The `componentTypesNeverSeen` and `inputType`-census numbers are this repository's corpora only. hotcrm and the objectstack corpus were not read.
- **`corpusMatchesMain` on the AFTER run reads `false`** — expected and not a defect: `packages/types/src` is one of the measurement script's `CORPUS_PATHS`, and this branch edits it. The BEFORE run read `true` at `3fbdd4a2`, so the before/after pair is anchored.
- **Packages beyond `types` / `cli` / `core` / `react` / `schema-catalog`.** Their suites were not run. The full `turbo run lint` and `turbo run build` covered every package; the test sweep was scoped to the consumers of `AnyComponentSchema` / `safeValidateSchema` that carry assertions about it.
- **Whether `CalendarSchema` (bare `calendar`) mirrors the right renderer.** Noticed while arming `ui:calendar`: `CalendarSchema`'s key set is the ui date-picker primitive's, while bare `calendar` resolves to plugin-calendar's CRUD view. Not verified against `ObjectCalendarRenderer`'s read sites, so it is recorded as an observation and NOT filed.


## Patch round — what the ceiling FAIL (`5596236677`) asked for

Run by the `os-dev` seat in session `session_012W3vMLTFY9SPr2LyxhSeYi`, on the same branch and the same PR — a patch round, not a re-dispatch.

### 1. The green→red: `LAYOUT_VOCABULARY` could not read an enum arm

`apps/console/src/__tests__/public-contract.test.ts` derived the layout vocabulary as
`LayoutSchema.options.map(arm => arm.shape?.type?.value)`. `.value` exists on `z.literal` and **not** on `z.enum`, so the two arms this PR added resolved nothing: 19 arms yielded 17 literals and the file's own anti-vacuity case fired — the gate working, not failing.

The derivation now switches on **zod's own `def.type` discriminator** — `.value` for a literal arm, `.options` for an enum arm — rather than trying accessors in turn. ⛔ A `.value`-else-`.options`-else-… fallback chain was deliberately NOT written: it would absorb exactly the accessor drift the anti-vacuity case exists to report. An arm whose declaration is neither shape resolves nothing, and that is still a failure.

⛔ The vocabulary is **not** hand-restated — that is the defect the file exists to catch. What changed is the count invariant, because it had to: one enum arm contributes 37 spellings, so *literals equals arms* is no longer meaningful. *No arm contributes **zero*** is, and that is what is asserted:

```
expect(LAYOUT_ARM_LITERALS.filter((literals) => literals.length > 0))
  .toHaveLength(LAYOUT_UNION_ARMS.length);
```

The identity case also now pins one spelling out of **each** enum arm (`main`, `h1`) alongside `box` / `flex` / `container`, so a reader that silently stopped resolving enums cannot pass it either.

| `apps/console/src/__tests__/public-contract.test.ts` | result |
|---|---|
| head `cc307588` (before) | **FAIL** — `Tests 1 failed \| 18 passed (19)`; `expected [...] to have a length of 19 but got 17` at `:501` |
| head `90fcf4f2` (after) | **PASS** — `Tests 19 passed (19)` |

### 2. The second contract: seven declared layout containers, LEDGERED — none promoted

Fixing the derivation reveals what the review predicted. Measured on this head:

| reading | before | after |
|---|---|---|
| `LayoutSchema` arms | 19 | 19 |
| literals resolved | 17 | **61** |
| arms resolving zero literals | 2 | **0** |
| `LAYOUT_VOCABULARY ∩ isContainer` | 7 | **14** |
| of those, uncurated | 1 (`aspect-ratio`) | **8** |

The seven new members are exactly the sectioning tags — `article` `aside` `footer` `header` `main` `nav` `section`. **No HTML tag from `HtmlElementSchema` declares containment**, so the population grows by seven and not by forty-four.

**Disposition taken: ledgered in `UNCURATED_LAYOUT_CONTAINERS`, tracked by objectui#8775.** ⛔ Nothing was promoted into `PUBLIC_BLOCKS`, ⛔ nothing was weakened, skipped or deleted.

⛔ **The re-housing option was refused, deliberately.** Moving `SemanticElementSchema` out of `LayoutSchema` would have gone green just as cheaply and cost no accept-set change — but the seven have declared `isContainer: true` since objectui#6764 and are registered `category: 'layout'`. Re-housing removes seven *genuine* layout containers from the forcing function's population without changing anything about what they are: a gate that stops looking, not a gate that passes. Ledgering is that file's own reviewable alternative, and it is what the mechanism was built for — they arrived **by absence**, exactly as designed.

⭐ **Why promotion is not this card's to take — the merits, restated in patch round 2 because the reason first published here was FALSE.** ⛔ This paragraph used to say that curating one of the seven would **delete that tag from every react page**. That is refuted at the mechanism, and the refutation is reproduced in patch round 2 below: `react-page.tsx:75-77` skips **every** container config, these seven have carried `isContainer: true` since objectui#6764, and simulating the promotion of `main` leaves the injected-identifier count at **46 before, 46 after** with `Main` absent from both. What promotion actually does is widen the AI-authoring vocabulary, `sdui.manifest.json` and the generated intrinsics, and turn the `container-declaration-census.test.tsx` pin **red by design** — a deliberate re-opening, which is what `semantic.tsx` means by *"re-opens the question HERE"*. ⭐ **The disposition does not move**: nothing is promoted, and promotion is still not a roster edit — it is a public-contract decision, and objectui#8775 carries it.

**The forcing function is satisfied, and proven load-bearing** — one ledger entry ablated, restored:

```
HEAD blob public-contract.test.ts = b50b6d546a2f982d387eceb132c121df07e1b5f7
anchor `  main: SECTIONING_TAG_UNRULED,`   grep -c 1 -> 0   (mutation proven on disk)
blob after mutation = 8f3dc375e60054122fc35ed4882506cc09a8a2d1   (differs from HEAD blob)
MUTATED_EXIT=1   × curates every declared layout container, or records why not
                 Tests  1 failed | 18 passed (19)
restore: git checkout HEAD -- PATH;   git diff HEAD --quiet -> exit 0
         blob after restore = b50b6d54...  (matches HEAD blob exactly)
RESTORED_EXIT=0  Tests  19 passed (19)
```

The entry deleted was one of the seven, and the case that fired is the forcing function itself, by ABSENCE.

### 3. The tautological control, rebuilt

`node-slot-registered-arms-8499.test.ts`'s "detects a tag that is registered and unarmed" compared `[...armed]` against `[...armed, 'hgroup']` — set algebra that passes whatever the schema says, never touching a registration. It now runs the real instrument on both halves: a genuine mismatch read from a real registration site (`html-elements.tsx`'s 37 tags against `SemanticElementSchema`'s 7), and a proof that the source reader **fails closed** — a declaration name that is not in the file throws rather than quietly yielding `[]`, which is what makes the `toBe(7)` / `toBe(37)` non-vacuity guards real guards.

### 4. Gates at head `90fcf4f2`

`origin/main` merged once before pushing (`efbd566d2`, clean, no conflicts; #8756/#8766 and others landed). ⛔ `scripts/pm/dispatch-gates.mjs` cannot serve objectui paths — it refuses cross-repo by design (**exit 2**, naming both repos), so this list is hand-derived from objectui's own `package.json` scripts and `.github/workflows/`.

| gate | exit | note |
|---|---|---|
| `pnpm exec vitest run packages/types packages/cli apps/console` | **0** | **266 files, 4463 tests.** ⚠️ `apps/console` is in scope this time — not running it is how the green→red reached the ceiling review |
| `pnpm exec vitest run apps/console/src/__tests__/public-contract.test.ts` | **0** | 19/19, the file that was red |
| `pnpm exec turbo run type-check lint --filter=@object-ui/types --filter=@object-ui/cli --filter=@object-ui/console` | **0** | 42/42 tasks, **0 errors**; the 266 warnings are pre-existing `no-explicit-any` in `packages/types`, none from this diff |
| `pnpm exec turbo run build --filter=@object-ui/console --filter=@object-ui/cli` | **0** | 36/36 |
| `node scripts/check-changeset-presence.mjs` | **0** | 10 files changed, **9 published source of 3 released packages**, 1 changeset |
| `pnpm check` | **0** | the per-PR gate at `lint.yml:481`, against a built cli |
| `pnpm check:control-bytes` | **0** | |
| `pnpm check:doc-types` | **0** | |
| `pnpm check:spec-symbols` | **0** | |
| `pnpm check:sdui-registration-pins` | **0** | first run **exit 2** = PRECONDITION NOT MET, the gate's own words (*"This is exit 2, not a pass"*) and its own remedy — no console build to weigh. Green after building: 16/16 registrations, 518 chunks |
| `pnpm check:readme-exports` | **0** | first run exit 1, all 6 complaints `@object-ui/plugin-ai … not on disk — run pnpm build first`, zero naming this diff = PRECONDITION NOT MET. Green after building that package: **0 unbuilt** |
| `pnpm check:vi-mock-specifiers` | **0** | |
| `pnpm check:shell-escape-residue` | **0** | |

**Declared narrowing.** `type-check` / `lint` / `build` were filtered to `types` + `cli` + `console` rather than run farm-wide, and packages outside those three had their suites left to CI. This is a declared deviation, not an omission: the patch round's own diff is four files in two of those packages plus a changeset, and CI runs the full farm.

Self-scan beyond `check:control-bytes`: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over the four changed files — no hits (grep exit 1).

**Files changed this round (4):** `apps/console/src/__tests__/public-contract.test.ts` · `packages/types/src/__tests__/node-slot-registered-arms-8499.test.ts` · `packages/types/src/zod/layout.zod.ts` (docblock only — one false absurd-slot example swapped) · `.changeset/8499-node-slot-registered-arms.md` (the 249/36 erratum). ⛔ `packages/components/src/renderers/**` untouched — verified, 0 files.

⛔ Still **draft**, ⛔ not enqueued, ⛔ `needs:contract-review` untouched — it stays on until a fresh ceiling PASS on this moved head.

> ⚠️ The gate table above was taken at head `90fcf4f2` and is **superseded** by the one in patch round 2.

---

## Patch round 2 — the ceiling re-review FAIL (`5597738741`), three items

_Round 2 was implemented by the `domain:spec` objectui seat in session `session_012W3vMLTFY9SPr2LyxhSeYi`, as commit `005409fc1`; that commit's own `Claude-Session` trailer carries the same reference. (The footers at the foot of this body name the round-1 seat and are left alone — a PR body normalises footers on every edit, so attribution that has to survive is written here, in prose.)_

That review passed everything it re-derived — the enum-aware derivation, the generalized invariant (**proved equivalent, not weakened**), the ledger disposition, and the re-housing refusal (which it found *more* correct than the dispatch had allowed). ⛔ None of that is re-litigated here. Three items failed; all three are answered in one commit, `005409fc1`.

### 1 · A false mechanism was baked into SHIPPED text — replaced in four places

The claim *"curating a sectioning tag into `PUBLIC_BLOCKS` would DELETE that tag from every react page"* is refuted. **Re-measured here rather than taken on the review's word:**

| leg | reading |
|---|---|
| `react-page.tsx:75-77` | `if (!tag \|\| cfg.isContainer) continue;` — skips **every** container config, whatever list it came from |
| `getMeta('main').isContainer` / `getConfig('main').isContainer` | `true` / `true` — the flag is already there |
| injected identifiers today | **46** |
| injected identifiers with `main` promoted (simulated: push `main` onto `PUBLIC_BLOCKS`, re-run the scope loop) | **46** |
| `Main` in either set | **absent from both**; set difference `[]` |
| promoted config's own flag | `{"type":"main","isContainer":true}` — so it is skipped on the same line an unlisted tag never reaches |
| `ComponentRegistry` references in `packages/react-runtime/src` | **0** (control: 21 `React` references in the same file; its only imports are `react` and `sucrase`) |

⇒ a lowercase `main` in a react page is a **DOM intrinsic before and after**. The docblock the first round read describes **objectui#6764's** direction — declaring containment on an *already public* block removes an injected identifier — and reading it forwards is how the inversion happened.

⭐ **The conclusion does not change**: no tag is promoted, and *"promotion is not a roster edit"* survives. Only the reason was wrong. Replaced in all four places it lived:

1. **the shipped ledger string** `SECTIONING_TAG_UNRULED` (`apps/console/src/__tests__/public-contract.test.ts`) — now states what promotion *does* move (vocabulary / `sdui.manifest.json` / intrinsics, and the census pin red by design) and names the refuted claim as an earlier revision's error;
2. **the `UNCURATED_LAYOUT_CONTAINERS` docblock** in the same file — carries the cost of a ledger entry once, so no entry re-argues it, including the measured 46/46;
3. **this PR body** — the paragraph above, marked as corrected rather than quietly rewritten;
4. **objectui#8775's body** — corrected in place, with a correction comment posted alongside so the change is visible in the card's timeline. That card is otherwise sound and stays open.

### 2 · `unexportedNodeSchemas` — option (b), declared in the changeset

The four new zod schemas are unreachable by name from `@object-ui/types/zod` (the barrel uses explicit export lists; control: `CalendarSchema` is present, the four are not). Re-measured with `scripts/measure-strict-authoring-face.mjs --json` after building `@object-ui/types`: **49** node types, up from `[breadcrumb, object-tree]` — the same 2, plus this change's 47 new literals.

**Taken: (b) — leave them unexported and declare the movement knowingly.** Three reasons, in the order they became decisive:

- ⛔ **The commit option (a) was offered to lean on does not exist.** `b7af6b52` returns **HTTP 422, "No commit found for SHA"** from `/repos/objectstack-ai/objectui/commits/b7af6b52`. Positive controls on the same endpoint and the same 8-char short form: `90fcf4f2` → **200**, `fb010227` → **200**. So the 422 is a real absence, not a channel artifact.
- ⛔ **Option (a)'s file is held by a live PR.** `packages/types/src/zod/index.zod.ts` is one of the three files in **PR #8777** (objectui#7917, open and non-draft, head `a5eaf49c`) — the PR whose entire purpose is that barrel's export list. Editing it here is outside this PR's 9-file surface and lands on top of another seat's in-flight work.
- **It would widen the public surface beyond this card's ruling.** The ruling is *arm the registered renderers*. Exporting `SemanticElementSchema` / `HtmlElementSchema` publishes a **named authoring surface** — `z.enum` families, not per-tag schemas — that no consumer asked for and that no ruling covers.

The changeset now says all of this, including the honest asymmetry: the 2 were data blocks a consumer had a standing reason to validate alone (which is why objectui#7917 exists), while the 47 are HTML primitives and two input aliases with no per-tag consumer. ⚠️ And the interaction is stated rather than hidden: **if PR #8777 lands first, the same movement reads `0` to `47`.**

### 3 · The false changeset sentence, corrected

*"Every arm declares only keys its renderer demonstrably reads"* is untrue for `UiCalendarSchema`. Re-measured in `packages/components/src/renderers/form/calendar.tsx`: `minDate` **0**, `maxDate` **0**, `onChange` **0** occurrences; controls `mode` **3**, `className` **4**. The renderer reads `mode`, `value`, `defaultValue`, `className` and nothing else.

The sentence now scopes itself to the arms this change **authors**, and states the inherited exception: `UiCalendarSchema` extends `CalendarSchema`, so it carries `minDate` / `maxDate`. ⛔ **No schema was changed to make the sentence true** — that is pre-existing debt on `CalendarSchema` and a different card's accept-set movement. (`onChange` is a `handlerKeyRefusal`, i.e. declared-and-unwritable, so it is a named refusal rather than an unread authorable key — a different category, noted so the correction is not over-read.)

### 4 · The optional strengthening — taken

The review's blind spot: dropping a single non-container spelling (`q`) from the 37-enum left this file green. `LAYOUT_VOCABULARY` is now cross-checked against **`LayoutSchema._zod.propValues.type`** — zod's own discriminator index, a second accessor path over the same union. Both read **61** literals over 19 arms and agree exactly (`derived-only: []`, `propValues-only: []`).

⚠️ **Scoped in-comment rather than over-claimed**: this pins the **reader**, not the schema. Both paths read the same union, so a spelling genuinely deleted from an enum arm still leaves both sides equal — that direction is pinned against the registration source elsewhere, which is where it belongs.

**Ablation, isolating the new assertion** (the mutation is in the test file itself, so no build step is involved):

```
HEAD blob apps/console/src/__tests__/public-contract.test.ts = 36a3c83bbd646e8277e465107e1dad8cad3d34a8

leg A — enum branch DELETED
  enum-branch grep -c  1 -> 0        ablation marker grep -c  1   (mutation proven on disk)
  blob after mutation = 86efab8d4e95508255d58797e69611f74ff95839   (differs from HEAD blob)
  EXIT=1   Tests  3 failed | 16 passed (19)
  restore: git checkout HEAD -- ABSOLUTE_PATH   ->   git diff HEAD --name-only  EMPTY
           blob after restore = 36a3c83b...  (matches HEAD blob exactly)

leg B — enum branch resolves all but ONE spelling (`q`), so every arm still yields >= 1
        and only the NEW cross-check can fail
  blob after mutation = 84f76099807f4af2a7e1089409909507477801d1   (differs from HEAD blob)
  EXIT=1   Tests  1 failed | 18 passed (19)
           x reads the vocabulary off the union rather than restating it
           AssertionError: expected [ 'a', 'abbr', 'address', ...(58) ] to deeply equal [ ...(57) ]
  restore: git diff HEAD --name-only  EMPTY;  blob = 36a3c83b...  (matches)
```

Leg B is the one that matters: exactly **one** case fails, and it is the new one. Both legs ran under `trap restore EXIT INT TERM` with absolute paths, and both restores were verified by an empty `git diff HEAD`, ⛔ never by an exit code.

### 5 · Gates at head `005409fc1`

`origin/main` merged once before pushing (`5591f03bd`; #8776, #8780, #8781, #8746, #8779 and others landed — clean, no conflicts). ⛔ `scripts/pm/dispatch-gates.mjs` cannot serve objectui paths (**exit 2**, cross-repo by design), so this list stays hand-derived from objectui's `package.json` and `.github/workflows/`. Every exit code below was captured as `cmd > file 2>&1; EXIT=$?` — ⛔ never through a pipe.

| gate | exit | note |
|---|---|---|
| `pnpm exec vitest run apps/console/.../public-contract.test.ts packages/types/ packages/cli/.../check-validity-recogniser.test.ts packages/components/.../container-declaration-census.test.tsx` | **0** | **159 files, 3150 tests**, from the repo root |
| `pnpm build --concurrency=2` | **0** | 43/43 tasks |
| `pnpm --filter @object-ui/console run type-check` | **0** | and it genuinely covers the edit: `tsc --noEmit --listFiles` lists `public-contract.test.ts` (**1** hit of **3715** files), so this is not a suite that excludes `*.test.ts` |
| `pnpm --filter @object-ui/console run lint` | **0** | 0 errors, 213 pre-existing warnings; the edited file reports **0 errors / 0 warnings** |
| `node scripts/check-changeset-presence.mjs` | **0** | 10 files changed, **9 published source of 3 released packages**, 1 changeset |
| `node scripts/check-changeset-no-major.mjs` | **0** | |
| `node scripts/check-changeset-overwrite.mjs` | **0** | 1 added, 0 modified, 0 deleted |
| `pnpm check:sdui-registration-pins` | **0** | ⚠️ PRECONDITION NOT MET (**exit 2**) until built, exactly as the dispatch predicted; green after the build above — 16/16 registrations, 518 chunks |
| `pnpm check:readme-exports` | **0** | ⚠️ same shape (**exit 1**, `@object-ui/plugin-ai` not on disk); green after the build — **0 unbuilt** |
| `pnpm check:control-bytes` | **0** | 6985 tracked text files |

**Declared narrowing.** Farm-wide `turbo run lint` / `type-check` / `test` were **not** run; the affected package's own `lint` and `type-check` were run in full, and the rest is CI's. Evidence this narrowing measures rather than skips: the lint population is **198 files** read from eslint's own `--format json` output (not estimated), the edited file is in it at 0/0, and **type-aware linting is not enabled** in `eslint.config.js` (zero `projectService` / `project: true` / `tsconfigRootDir` occurrences) — so this diff cannot move the verdict on any file it did not touch.

⚠️ One reading worth recording so nobody re-derives it as a finding: adding `--no-inline-config` to the console's eslint run surfaces **3** `react-hooks/static-components` errors in `src/pages/settings/`. They are not in this diff and not a regression — `--no-inline-config` is the `lint:root` spelling, and the package's real `lint` script (`eslint .`) is exit **0**.

Self-scan beyond `check:control-bytes`: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over both changed files — **no hits** (grep exit 1).

**Files changed in round 2 (2):** `apps/console/src/__tests__/public-contract.test.ts` · `.changeset/8499-node-slot-registered-arms.md`. ⛔ `packages/components/src/renderers/**` untouched (0 files) — the react-page and census readings above are **reads**, not edits. ⛔ `packages/types/src/zod/index.zod.ts` untouched, and deliberately so (item 2).

⛔ Still **draft**, ⛔ not enqueued, ⛔ `needs:contract-review` untouched — a delta re-review runs first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_

---
_Generated by [Claude Code](https://claude.ai/code)_