### PR TITLE
feat(create-plugin): ask for the licence and ship the text it claims (objectui#8041)

### DIFF
--- a/.changeset/8041-create-plugin-licence-prompt.md
+++ b/.changeset/8041-create-plugin-licence-prompt.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/create-plugin': minor
+---
+
+Ask for the plugin's licence and ship the text it claims (objectui#8041, director
+decision batch #91, 2026-09-08).
+
+**The defect.** `buildPackageJson` wrote `license: 'MIT'` into every generated
+manifest — unconditionally, and without ever asking — while `buildPluginFiles`
+emitted nine files, none of them a LICENSE. The generated manifest declares no
+`files` array, so `npm pack` takes npm's default set, which packs `LICENSE*`
+whether or not anything lists it; the file simply was not on disk to pack. An
+author who published a freshly scaffolded plugin therefore shipped a tarball that
+**claimed a licence it did not carry**, on a choice made for them by this
+generator.
+
+**What changes, for a scaffolded package.**
+
+- The scaffolder now asks `License:` as a chooser over `MIT`, `Apache-2.0`,
+  `BSD-3-Clause` and `ISC`, with **MIT preselected**. It is the fourth question,
+  after plugin name, description and author; the first three are unchanged.
+- The emitted file set goes from **nine files to ten** — a `LICENSE` carrying the
+  full text of whatever was chosen, with the copyright line filled in from the
+  author and the current year. When the author prompt was left blank the holder
+  reads `the <package name> authors` rather than trailing off after the year.
+- The manifest's `license`, the README's `## License` section and the licence
+  named in the four emitted source-file headers all follow the choice, instead of
+  four of them saying MIT while the fifth says something else.
+- **A non-interactive run takes MIT and still writes the text.** A non-TTY stdin,
+  a cancelled prompt and any unrecognised value all resolve to MIT; there is no
+  input for which the generator emits a licence claim with no text beside it.
+
+Omitting `license` instead was refused on the record: an unlicensed manifest reads
+as all-rights-reserved on npm, which is the worse default for the author this
+change is written for. The four licence texts are copied verbatim from canonical
+copies rather than retyped — a paraphrased licence is not a licence, and a
+transcription typo in one is invisible to every gate this repository has.
+
+Nothing an already-generated plugin does changes; this moves what the next one is
+born with.

--- a/packages/create-plugin/README.md
+++ b/packages/create-plugin/README.md
@@ -30,6 +30,7 @@ packages/plugin-my-plugin/
 ├── tsconfig.json
 ├── vite.config.ts
 ├── vitest.setup.ts         # Registers the jest-dom matchers
+├── LICENSE                 # Full text of the licence you chose
 └── README.md
 ```
 
@@ -41,6 +42,8 @@ packages/plugin-my-plugin/
 - ✅ Runnable Vitest setup — jsdom environment, Testing Library and the jest-dom
   matchers are all declared, so `pnpm test` is green on the first run
 - ✅ Proper package.json with workspace dependencies
+- ✅ A LICENSE carrying the full text of the licence the manifest declares —
+  never a `license` field with nothing behind it
 - ✅ README template
 - ✅ Type definitions
 
@@ -56,6 +59,12 @@ You'll be prompted for:
 - Plugin name
 - Description
 - Author name
+- License — `MIT` (default), `Apache-2.0`, `BSD-3-Clause` or `ISC`
+
+The licence you pick is written to `package.json` and its **full text** is written
+to `LICENSE`, so a published tarball never claims a licence it does not carry. A
+non-interactive run (no TTY, or a cancelled prompt) takes MIT and still writes the
+text.
 
 ## Options
 

--- a/packages/create-plugin/src/__tests__/licenses.test.ts
+++ b/packages/create-plugin/src/__tests__/licenses.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Pins the scaffolder's licence contract (objectui#8041).
+ *
+ * The generator used to write `"license": "MIT"` into every manifest it
+ * produced — unconditionally, without asking — and emit no LICENSE file at
+ * all. An author who published a freshly scaffolded plugin therefore shipped a
+ * tarball that CLAIMED a licence it did not carry, on a choice nobody had made
+ * for them. The director-seat ruling (decision batch #91, 2026-09-08) settled
+ * it as option C, verbatim: *"the scaffolder asks for the licence, defaults to
+ * MIT, and writes the matching LICENSE text; non-interactive runs take the
+ * default."*
+ *
+ * ## What these tests assert, and why it is the emitted artifact
+ *
+ * `buildPluginFiles` is the map the CLI writes to disk — `index.ts` is a loop
+ * over it — so asserting over it is asserting over what a scaffolded package
+ * really contains. That is deliberate, and it is the same choice
+ * `templates.test.ts` makes: a grep of this repository's own source would go
+ * green on a template that emits nothing.
+ *
+ * The two halves of the ruling are pinned separately because they fail
+ * separately:
+ *
+ * - **the claim and the text agree** — for EVERY offered licence, not just the
+ *   default, derived from {@link PLUGIN_LICENSES} rather than listed here, so
+ *   a fifth option added without its text fails instead of shipping;
+ * - **a run that answers nothing still gets both** — `resolveLicenseId` is
+ *   total, and the default path emits the file.
+ *
+ * ## The self-test
+ *
+ * `emits no licence text when the LICENSE entry is removed` is the reverse
+ * verification: it rebuilds the pre-fix file map and asserts the invariant
+ * NAMES it. Without that, every assertion below would still pass on a
+ * generator that had quietly stopped emitting anything, because a rule that
+ * reports success over an empty result is not a rule.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  DEFAULT_LICENSE_ID,
+  LICENSE_PROMPT,
+  PLUGIN_LICENSES,
+  findLicense,
+  resolveLicenseId
+} from '../licenses';
+import {
+  buildPackageJson,
+  buildPluginFiles,
+  buildReadme,
+  licenseCopyrightHolder,
+  type PluginTemplateVars
+} from '../templates';
+
+/** The vars a default, non-interactive run produces: MIT, resolved not answered. */
+const VARS: PluginTemplateVars = {
+  packageName: '@object-ui/plugin-heatmap',
+  pluginName: 'heatmap',
+  pascalName: 'Heatmap',
+  description: 'Heatmap plugin for ObjectUI',
+  author: 'Jane Doe',
+  license: resolveLicenseId(undefined),
+  version: '0.1.0',
+  year: 2026
+};
+
+const withLicense = (id: string): PluginTemplateVars => ({ ...VARS, license: id });
+
+/**
+ * A line every one of these licences carries and no other one does, so "the
+ * text matches the claim" is an assertion about WHICH licence was emitted
+ * rather than about whether some text was emitted.
+ *
+ * Hand-written on purpose: deriving the marker from the same table the
+ * generator reads would make the check circular — it would pass for any two
+ * texts as long as they were consistently swapped.
+ */
+const DISTINCTIVE_LINE: Record<string, string> = {
+  MIT: 'Permission is hereby granted, free of charge, to any person obtaining a copy',
+  'Apache-2.0': '                           Version 2.0, January 2004',
+  'BSD-3-Clause': '3. Neither the name of the copyright holder nor the names of its',
+  ISC: 'Permission to use, copy, modify, and/or distribute this software for any purpose'
+};
+
+describe('the scaffolder asks for a licence and defaults to MIT (objectui#8041)', () => {
+  it('offers the licence as a chooser with MIT preselected', () => {
+    expect(LICENSE_PROMPT.name).toBe('license');
+    // `select`, not free text: an answer the generator has no text for is the
+    // defect this card removes, so the prompt cannot accept one.
+    expect(LICENSE_PROMPT.type).toBe('select');
+    expect(LICENSE_PROMPT.choices.map((choice) => choice.value)).toEqual(
+      PLUGIN_LICENSES.map((license) => license.id)
+    );
+    expect(LICENSE_PROMPT.choices[LICENSE_PROMPT.initial].value).toBe(DEFAULT_LICENSE_ID);
+    expect(DEFAULT_LICENSE_ID).toBe('MIT');
+  });
+
+  it('takes MIT for every answer a non-interactive run can produce', () => {
+    // `prompts` returns a partial answer object when stdin is not a TTY or the
+    // prompt is cancelled, so `answers.license` is genuinely absent there.
+    for (const answer of [undefined, null, '', 'GPL-3.0-or-later', 42, {}]) {
+      expect(resolveLicenseId(answer), `answer ${JSON.stringify(answer)}`).toBe('MIT');
+    }
+    // An offered id is passed through unchanged — the default must not swallow
+    // a real choice.
+    for (const license of PLUGIN_LICENSES) {
+      expect(resolveLicenseId(license.id)).toBe(license.id);
+    }
+  });
+});
+
+describe('a manifest that claims a licence ships its text (objectui#8041)', () => {
+  it('emits a LICENSE beside the manifest on the default path', () => {
+    const files = buildPluginFiles(VARS);
+    const manifest = buildPackageJson(VARS) as { license: string };
+
+    expect(manifest.license).toBe('MIT');
+    expect(Object.keys(files)).toContain('LICENSE');
+    expect(files.LICENSE).toContain(DISTINCTIVE_LINE.MIT);
+    expect(files.LICENSE).toContain('Copyright (c) 2026 Jane Doe');
+  });
+
+  it('emits the text matching whatever was chosen, for every offered licence', () => {
+    // Derived from PLUGIN_LICENSES, so an option added without a usable text
+    // fails here rather than reaching an author's package.json.
+    for (const license of PLUGIN_LICENSES) {
+      const vars = withLicense(license.id);
+      const files = buildPluginFiles(vars);
+      const manifest = buildPackageJson(vars) as { license: string };
+
+      expect(manifest.license, license.id).toBe(license.id);
+      expect(files.LICENSE, license.id).toContain(DISTINCTIVE_LINE[license.id]);
+      expect(files.LICENSE.trim().length, license.id).toBeGreaterThan(400);
+    }
+  });
+
+  it('names one licence, not two: README and source headers follow the manifest', () => {
+    // A generated package that declared Apache-2.0 and told its readers MIT in
+    // four file headers and its README would be the same defect wearing a
+    // different hat.
+    const vars = withLicense('Apache-2.0');
+    const files = buildPluginFiles(vars);
+
+    expect(buildReadme(vars)).toContain('Apache-2.0 © Jane Doe');
+    for (const path of ['src/index.tsx', 'src/HeatmapImpl.tsx', 'src/types.ts', 'src/HeatmapImpl.test.tsx']) {
+      expect(files[path], path).toContain('licensed under the Apache-2.0 license');
+      expect(files[path], path).not.toContain('licensed under the MIT license');
+    }
+  });
+
+  it('never emits a copyright line with no holder', () => {
+    // The author prompt is optional and its initial value is empty, so this is
+    // a real path, not a hypothetical one.
+    const anonymous = { ...VARS, author: '   ' };
+    expect(licenseCopyrightHolder(anonymous)).toBe('the @object-ui/plugin-heatmap authors');
+    expect(buildPluginFiles(anonymous).LICENSE).toContain(
+      'Copyright (c) 2026 the @object-ui/plugin-heatmap authors'
+    );
+    expect(licenseCopyrightHolder(VARS)).toBe('Jane Doe');
+  });
+
+  it('has a text for its own default, so the fallback can never be empty', () => {
+    expect(findLicense(DEFAULT_LICENSE_ID)).toBeDefined();
+    // An id nothing offers cannot reach here through the CLI, but if it ever
+    // did the emitted file must still be a licence rather than nothing.
+    expect(buildPluginFiles(withLicense('NOT-A-LICENCE')).LICENSE).toContain(DISTINCTIVE_LINE.MIT);
+  });
+
+  it('emits no licence text when the LICENSE entry is removed', () => {
+    // Reverse verification of the fix: the pre-objectui#8041 file map is this
+    // one minus the LICENSE entry, and the guard above must NAME that, not
+    // pass over it. `buildPluginFiles` is re-derived rather than mutated, so
+    // this leaves nothing behind for the assertions above.
+    const { LICENSE, ...preFix } = buildPluginFiles(VARS);
+
+    expect(LICENSE).toBeDefined();
+    expect(Object.keys(preFix)).not.toContain('LICENSE');
+    expect(Object.keys(preFix)).toHaveLength(9);
+    // The claim survives the ablation — which is exactly the state the card
+    // exists to remove, and exactly what makes this ablation meaningful.
+    expect((buildPackageJson(VARS) as { license: string }).license).toBe('MIT');
+  });
+});

--- a/packages/create-plugin/src/__tests__/templates.test.ts
+++ b/packages/create-plugin/src/__tests__/templates.test.ts
@@ -57,6 +57,7 @@ const VARS: PluginTemplateVars = {
   pascalName: 'Heatmap',
   description: 'Heatmap plugin for ObjectUI',
   author: 'ObjectStack Team',
+  license: 'MIT',
   version: '0.1.0',
   year: 2026
 };
@@ -562,6 +563,7 @@ describe('generated file map', () => {
   it('writes the Vitest setup file next to the config that names it', () => {
     const files = buildPluginFiles(VARS);
     expect(Object.keys(files).sort()).toEqual([
+      'LICENSE',
       'README.md',
       'package.json',
       'src/HeatmapImpl.test.tsx',

--- a/packages/create-plugin/src/index.ts
+++ b/packages/create-plugin/src/index.ts
@@ -13,6 +13,7 @@ import prompts from 'prompts';
 import * as path from 'path';
 import fs from 'fs-extra';
 import { buildPluginFiles, type PluginTemplateVars } from './templates';
+import { LICENSE_PROMPT, resolveLicenseId } from './licenses';
 
 const program = new Command();
 
@@ -91,7 +92,14 @@ async function createPlugin(pluginName?: string, options: PluginOptions = {}) {
       name: 'author',
       message: 'Author name:',
       initial: options.author || ''
-    }
+    },
+    // objectui#8041: the generator used to assert `"license": "MIT"` on an
+    // author's package without asking, and then ship no LICENSE text beside
+    // the claim. The prompt is the consent half; `buildLicenseFile` is the
+    // text half. Taken from `./licenses` rather than written out here so the
+    // published prompt contract can be asserted — this module calls
+    // `program.parse()` at import time and so cannot be imported by a test.
+    LICENSE_PROMPT
   ]);
 
   const targetDir = path.join(process.cwd(), 'packages', fullPackageName);
@@ -114,6 +122,10 @@ async function createPlugin(pluginName?: string, options: PluginOptions = {}) {
     pascalName: pascalCaseName,
     description: answers.description,
     author: answers.author,
+    // Never `answers.license` directly: a non-TTY stdin or a cancelled prompt
+    // leaves it undefined, and the ruling says such a run takes MIT and still
+    // writes the text.
+    license: resolveLicenseId(answers.license),
     version: '0.1.0',
     year: new Date().getFullYear()
   };

--- a/packages/create-plugin/src/licenses.ts
+++ b/packages/create-plugin/src/licenses.ts
@@ -1,0 +1,407 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The licences `create-plugin` offers, and the full text each one obliges the
+ * package it scaffolds to ship.
+ *
+ * objectui#8041 is why this file exists. `buildPackageJson` wrote
+ * `license: 'MIT'` unconditionally and `buildPluginFiles` emitted no LICENSE,
+ * so every scaffolded plugin published a tarball that CLAIMED MIT and carried
+ * no licence text — and claimed it on behalf of an author who was never asked.
+ * The director-seat ruling (decision batch #91, 2026-09-08) settled it as
+ * option C, verbatim:
+ *
+ *   "the scaffolder asks for the licence, defaults to MIT, and writes the
+ *    matching LICENSE text; non-interactive runs take the default"
+ *
+ * Two invariants follow, and `__tests__/licenses.test.ts` pins both:
+ *
+ * 1. **Every offered licence ships its text.** {@link PLUGIN_LICENSES} is the
+ *    only source of ids the generator will write into a manifest, and each
+ *    entry carries its own text. An option whose text we could not emit would
+ *    rebuild objectui#8041 one level up — a picker manufacturing the very
+ *    claimed-but-textless state it exists to remove. That is why there is no
+ *    "other, I'll add my own" escape hatch and no free-text answer: a licence
+ *    the generator cannot write is a licence it must not offer.
+ * 2. **A non-answer is MIT, not nothing.** A non-TTY stdin, a cancelled
+ *    prompt and any future `--yes` all arrive at {@link resolveLicenseId} as a
+ *    non-answer, and it returns {@link DEFAULT_LICENSE_ID}. ⛔ Never widen it
+ *    to pass an unrecognised value through: the manifest field and the emitted
+ *    text are one decision, and a value with no text is the defect itself.
+ *    ⛔ Nor to return `undefined` and omit the field — the ruling refused that
+ *    (option B) on the record, because an unlicensed manifest reads as
+ *    all-rights-reserved on npm.
+ *
+ * ## The texts are COPIED, never retyped
+ *
+ * Each body below was taken byte-for-byte from a canonical copy on disk, with
+ * exactly one line replaced — the copyright line the licence itself asks you
+ * to fill in:
+ *
+ * | id             | sourced from                                          |
+ * | -------------- | ----------------------------------------------------- |
+ * | `MIT`          | this repository's own `LICENSE`                        |
+ * | `Apache-2.0`   | `bson`'s `LICENSE.md` (the apache.org form, 201 lines) |
+ * | `BSD-3-Clause` | `qs`'s `LICENSE.md`                                    |
+ * | `ISC`          | `tinyqueue`'s `LICENSE`                                |
+ *
+ * A licence is a legal instrument, so a paraphrase is not a licence — and a
+ * transcription typo is invisible to every gate this repository has. If a text
+ * ever needs to change, copy the canonical form again rather than editing the
+ * string in place. Apache-2.0's appendix is filled rather than left bracketed
+ * because the appendix instructs exactly that ("replaced with your own
+ * identifying information"), which is also what GitHub's licence picker emits.
+ */
+
+/** Who the emitted licence names, and for which year. */
+export interface LicenseCopyright {
+  year: number;
+  /** Never blank — see `templates.ts`' `licenseCopyrightHolder`. */
+  holder: string;
+}
+
+/** One licence the scaffolder can both declare and ship. */
+export interface PluginLicense {
+  /** SPDX identifier, written verbatim into the generated manifest's `license`. */
+  id: string;
+  /** Full name, shown under the id in the prompt. */
+  name: string;
+  /** The complete licence text, ready to be written to `LICENSE`. */
+  text: (copyright: LicenseCopyright) => string;
+}
+
+const MIT = ({ year, holder }: LicenseCopyright): string => `MIT License
+
+Copyright (c) ${year} ${holder}
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`;
+
+const APACHE_2_0 = ({ year, holder }: LicenseCopyright): string => `                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright ${year} ${holder}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+`;
+
+const BSD_3_CLAUSE = ({ year, holder }: LicenseCopyright): string => `BSD 3-Clause License
+
+Copyright (c) ${year}, ${holder}
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+`;
+
+const ISC = ({ year, holder }: LicenseCopyright): string => `ISC License
+
+Copyright (c) ${year} ${holder}
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+`;
+
+/**
+ * Every licence on offer, in the order the prompt lists them.
+ *
+ * Deliberately short. The set is the four that between them carry the
+ * overwhelming majority of the npm registry, and every one of them is a text
+ * this file can reproduce exactly — which is invariant 1 above, applied to the
+ * list rather than to a single entry. Adding a fifth means adding its verbatim
+ * text in the same edit; `__tests__/licenses.test.ts` derives its assertions
+ * from this array, so an entry with no usable text fails rather than ships.
+ */
+export const PLUGIN_LICENSES: readonly PluginLicense[] = [
+  { id: 'MIT', name: 'MIT License', text: MIT },
+  { id: 'Apache-2.0', name: 'Apache License 2.0', text: APACHE_2_0 },
+  { id: 'BSD-3-Clause', name: 'BSD 3-Clause License', text: BSD_3_CLAUSE },
+  { id: 'ISC', name: 'ISC License', text: ISC }
+];
+
+/**
+ * What a run that answers nothing gets: `npm init`'s own shape, a question
+ * with a sensible default rather than a question that must be answered.
+ */
+export const DEFAULT_LICENSE_ID = 'MIT';
+
+/** The licence with this id, or `undefined` when nothing offers it. */
+export function findLicense(id: string): PluginLicense | undefined {
+  return PLUGIN_LICENSES.find((license) => license.id === id);
+}
+
+/**
+ * The licence prompt, as data, so the published prompt contract can be
+ * asserted without executing `index.ts` (which calls `program.parse()` at
+ * import time and therefore cannot be imported at all).
+ *
+ * `select` rather than a free-text field on purpose — see invariant 1.
+ */
+export const LICENSE_PROMPT = {
+  type: 'select' as const,
+  name: 'license' as const,
+  message: 'License:',
+  choices: PLUGIN_LICENSES.map((license) => ({ title: license.id, description: license.name, value: license.id })),
+  initial: PLUGIN_LICENSES.findIndex((license) => license.id === DEFAULT_LICENSE_ID)
+};
+
+/**
+ * The licence id to write, given whatever the prompt returned.
+ *
+ * Everything that is not an offered id — `undefined` from a cancelled or
+ * non-TTY prompt, an empty string, a value from a future flag — becomes
+ * {@link DEFAULT_LICENSE_ID}. This is the "non-interactive runs take the
+ * default" half of the ruling, and it is a TOTAL function on purpose: there is
+ * no input for which the generator emits a licence claim it cannot honour.
+ */
+export function resolveLicenseId(answer: unknown): string {
+  return typeof answer === 'string' && findLicense(answer) !== undefined ? answer : DEFAULT_LICENSE_ID;
+}

--- a/packages/create-plugin/src/templates.ts
+++ b/packages/create-plugin/src/templates.ts
@@ -22,6 +22,8 @@
  * `npm test` in a freshly scaffolded plugin was red on the very first run.
  */
 
+import { DEFAULT_LICENSE_ID, findLicense } from './licenses';
+
 /** Values interpolated into the templates for one generated plugin. */
 export interface PluginTemplateVars {
   /** Full package name, e.g. `@object-ui/plugin-heatmap`. */
@@ -32,6 +34,16 @@ export interface PluginTemplateVars {
   pascalName: string;
   description: string;
   author: string;
+  /**
+   * SPDX id of the licence the author chose, e.g. `MIT` (objectui#8041).
+   *
+   * Always one of {@link PLUGIN_LICENSES}' ids — `index.ts` runs the prompt's
+   * answer through `resolveLicenseId` first, so a non-TTY run, a cancelled
+   * prompt and a junk value all arrive here as `MIT`. It is a REQUIRED field
+   * rather than an optional one with a default here, because a default in two
+   * places is two answers to one question.
+   */
+  license: string;
   version: string;
   year: number;
 }
@@ -133,7 +145,7 @@ export function buildPackageJson(vars: PluginTemplateVars): Record<string, unkno
     name: vars.packageName,
     version: vars.version,
     type: 'module',
-    license: 'MIT',
+    license: vars.license,
     description: vars.description,
     main: 'dist/index.umd.cjs',
     module: 'dist/index.js',
@@ -353,7 +365,7 @@ pnpm lint
 
 ## License
 
-MIT © ${vars.author}
+${vars.license} © ${vars.author}
 `;
 }
 
@@ -382,7 +394,7 @@ export function buildIndexFile(vars: PluginTemplateVars): string {
  * ObjectUI
  * Copyright (c) ${vars.year}-present ObjectStack Inc.
  *
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the ${vars.license} license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
@@ -418,7 +430,7 @@ export function buildImplFile(vars: PluginTemplateVars): string {
  * ObjectUI
  * Copyright (c) ${vars.year}-present ObjectStack Inc.
  *
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the ${vars.license} license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
@@ -467,7 +479,7 @@ export function buildTypesFile(vars: PluginTemplateVars): string {
  * ObjectUI
  * Copyright (c) ${vars.year}-present ObjectStack Inc.
  *
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the ${vars.license} license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
@@ -492,7 +504,7 @@ export function buildTestFile(vars: PluginTemplateVars): string {
  * ObjectUI
  * Copyright (c) ${vars.year}-present ObjectStack Inc.
  *
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the ${vars.license} license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
@@ -511,6 +523,49 @@ describe('${vars.pascalName}', () => {
 }
 
 /**
+ * Who the emitted LICENSE names as the copyright holder.
+ *
+ * The author prompt's `initial` is the empty string and nothing makes it
+ * required, so a scaffold really can arrive here with `author: ''` — and
+ * objectui#8041 moves the licence question and no other prompt, so making it
+ * required is not this change's to make. A licence with a blank holder grants
+ * nothing to nobody, which would leave the emitted text as untrue as the
+ * missing one it replaces, so the blank case names the package's authors
+ * instead of emitting a copyright line that trails off after the year.
+ */
+export function licenseCopyrightHolder(vars: PluginTemplateVars): string {
+  return vars.author.trim() || `the ${vars.packageName} authors`;
+}
+
+/**
+ * The generated plugin's `LICENSE` — the full text of whatever
+ * {@link buildPackageJson} declares (objectui#8041).
+ *
+ * The two are ONE decision read twice, which is why this reads `vars.license`
+ * rather than taking a licence of its own: the defect this file used to carry
+ * was precisely a manifest field and an emitted file set that could disagree.
+ *
+ * Falls back to {@link DEFAULT_LICENSE_ID}'s text rather than throwing or
+ * emitting nothing if an unoffered id ever reaches here. `resolveLicenseId`
+ * already makes that unreachable from the CLI; the point of the fallback is
+ * that the ONE state this card exists to remove — a manifest claiming a licence
+ * with no text beside it — must not be reachable by any route, including a
+ * future caller that builds `PluginTemplateVars` by hand. It is not a lenient
+ * alias for bad input: the manifest is written from the same resolved id, so
+ * the two still agree.
+ */
+export function buildLicenseFile(vars: PluginTemplateVars): string {
+  const license = findLicense(vars.license) ?? findLicense(DEFAULT_LICENSE_ID);
+  if (!license) {
+    throw new Error(
+      `create-plugin has no text for its own default licence (${DEFAULT_LICENSE_ID}); ` +
+        'PLUGIN_LICENSES must always carry it.'
+    );
+  }
+  return license.text({ year: vars.year, holder: licenseCopyrightHolder(vars) });
+}
+
+/**
  * The whole generated plugin as `relative path -> file contents`.
  *
  * Single source of truth for what a scaffolded plugin contains, so the writer
@@ -523,6 +578,7 @@ export function buildPluginFiles(vars: PluginTemplateVars): Record<string, strin
     'tsconfig.json': `${JSON.stringify(buildTsconfig(), null, 2)}`,
     'vite.config.ts': buildViteConfig(vars),
     [VITEST_SETUP_FILE]: buildVitestSetup(),
+    LICENSE: buildLicenseFile(vars),
     'README.md': buildReadme(vars),
     'src/index.tsx': buildIndexFile(vars),
     [`src/${vars.pascalName}Impl.tsx`]: buildImplFile(vars),


### PR DESCRIPTION
Fixes #8041

Director-seat ruling, decision batch #91 (2026-09-08), option **C**, verbatim: *"the scaffolder asks for the licence, defaults to MIT, and writes the matching LICENSE text; non-interactive runs take the default."*

## Clause-② — the published behaviour this PR moves

`Clause-②: yes`, carried from the ruling: *"the scaffolder's emitted file set and prompt sequence are its published behaviour."* Both are stated below, before and after, because both change.

**Emitted file set — nine files to ten.** The set is the same ten for every licence choice; only the LICENSE's contents vary.

| before (9) | after (10) |
| --- | --- |
| `package.json` · `tsconfig.json` · `vite.config.ts` · `vitest.setup.ts` · `README.md` · `src/index.tsx` · `src/PascalImpl.tsx` · `src/types.ts` · `src/PascalImpl.test.tsx` | the same nine, plus **`LICENSE`** |

**Prompt sequence — three questions to four.** The first three are byte-identical; the licence question is appended.

| # | before | after |
| --- | --- | --- |
| 1 | `Plugin name (without prefix):` — text, asked only when no positional argument | unchanged |
| 2 | `Plugin description:` — text | unchanged |
| 3 | `Author name:` — text | unchanged |
| 4 | — | **`License:` — select over `MIT` / `Apache-2.0` / `BSD-3-Clause` / `ISC`, `MIT` preselected** |

Nothing else moved: no other emitted file gained or lost content beyond the licence NAME it states, no other prompt changed, and no other manifest field changed. The CLI's `--description` / `--author` options are untouched and no new flag was added.

## The defect

`buildPackageJson` wrote `license: 'MIT'` into every generated manifest — unconditionally, without asking — while `buildPluginFiles` emitted nine files and none of them was a LICENSE. The generated manifest declares no `files` array, so `npm pack` takes npm's default set, which packs `LICENSE*` whether or not anything lists it; the file simply was not on disk to pack. An author publishing a freshly scaffolded plugin therefore shipped a tarball that **claimed a licence it did not carry**, on a choice this generator made for them.

Omitting `license` instead (option B) was refused on the record: an unlicensed manifest reads as all-rights-reserved on npm, the worse default for exactly the author this card was written for.

## What changed

- **`src/licenses.ts` (new)** — four licences, each carrying its full text; the prompt as data; and `resolveLicenseId`, which is **total**: `undefined`, `null`, `''` and any unrecognised value all become `MIT`. There is no input for which the generator emits a licence claim it cannot honour, which is the "non-interactive runs take the default" half of the ruling. No free-text answer and no "other" escape hatch — a licence the generator cannot write is one it must not offer, and offering one would rebuild this very card one level up.
- **`PluginTemplateVars` gains a required `license`.** The manifest field, the README's `## License` line and the licence named in the four emitted source-file headers all read it, so a scaffolded package names **one** licence rather than two. Those headers already pointed at "the LICENSE file in the root directory of this source tree" — a file that did not exist until now.
- **`buildLicenseFile`** fills the copyright line from the author and the year. The author prompt is optional with an empty initial, so the blank case names `the <package> authors` rather than emitting a copyright line that trails off after the year.
- The four licence texts are **copied verbatim** from canonical on-disk copies (this repo's own `LICENSE` for MIT; `bson`'s for Apache-2.0; `qs`'s for BSD-3-Clause; `tinyqueue`'s for ISC), with exactly one line replaced — the copyright line each licence itself asks you to fill in. A paraphrased licence is not a licence, and a transcription typo in one is invisible to every gate this repository has.

## Evidence

**End-to-end, the real CLI, driven through a pty** (built `dist/index.js`, `packages/create-plugin`):

- default path (Enter, Enter, Enter) → `✔ License: › MIT`; ten files on disk including `LICENSE`; manifest `"license": "MIT"`; `LICENSE` opens `MIT License` / `Copyright (c) 2026 the @object-ui/plugin-heatmap authors` (author left blank).
- non-default path (author `Jane Doe`, arrow-down, Enter) → `✔ License: › Apache-2.0`; manifest `"license": "Apache-2.0"`; README `Apache-2.0 © Jane Doe`; emitted headers `licensed under the Apache-2.0 license`; and the emitted `LICENSE` **diffs clean against the canonical Apache-2.0 text** once the filled appendix line is put back to `Copyright [yyyy] [name of copyright owner]`.

**The repo's own pin, used as a control and not as the acceptance criterion** (triage 5583373397 is explicit that it proves the shape locally only and says nothing about the published tarball). Scaffolding into `packages/` with the **pre-fix generator** (base sources bundled from `c03d03bb2`) and running `pnpm exec vitest run scripts/__tests__/package-files-exist.test.ts`:

```
AssertionError: A published package claims a license in package.json and ships no license text.
@object-ui/plugin-licencecontrol (packages/plugin-licencecontrol) declares "license": "MIT" but has no LICENSE file
 Tests  1 failed | 17 passed (18)        exit 1
```

Re-scaffolded with this branch's generator, same command: `Tests 18 passed (18)`, exit 0. The scratch package was removed afterwards; `git status` is clean.

**Ablation.** `LICENSE: buildLicenseFile(vars)` deleted from `buildPluginFiles` on disk, proved to have landed (anchor `grep -c` 1 → 0; blob hash `da3a0e81…` → `58a03b57…`, both non-empty and different), then `pnpm exec vitest run packages/create-plugin/`:

```
Tests  6 failed | 23 passed (29)         exit 1
```

five in `licenses.test.ts` and one in `templates.test.ts`. Restored through an `EXIT INT TERM` trap with `git checkout HEAD -- <path>` (never bare — the index was dirty), and the restore verified by hash rather than by exit code: on-disk blob `da3a0e81…` equals `HEAD:packages/create-plugin/src/templates.ts`, `git diff HEAD` empty, `git status` clean. Re-run green: `Tests 29 passed (29)`. The ablation needed no `dist` preflight — the tests import `../templates` by relative path, so the mutation is on the module actually under test.

## Gates run (derived by hand — objectui has no `dispatch-gates.mjs`)

Derived from what the diff touches (`packages/create-plugin/src/**`, its README, `.changeset/`): the package's own suite, type-check and lint; every `scripts/__tests__` file that reads `create-plugin`; the changeset trio; and the repo-wide static checks that read any edited file.

| gate | exit |
| --- | --- |
| `pnpm exec vitest run packages/create-plugin/` (29 tests, 2 files) | 0 |
| `pnpm --filter @object-ui/create-plugin type-check` (`tsc --noEmit` + `tsconfig.test.json`) | 0 |
| `pnpm --filter @object-ui/create-plugin lint` | 0 |
| `pnpm exec vitest run scripts/__tests__/{package-files-exist,one-authority-per-exported-name-6273,check-doc-snippet-emitted-census,doc-version-claims,check-published-tsconfig-tooling-exclude}.test.ts` (111 tests) | 0 |
| `node scripts/check-changeset-presence.mjs` | 0 |
| `node scripts/check-changeset-fixed.mjs` | 0 |
| `node scripts/check-changeset-no-major.mjs` | 0 |
| `node scripts/check-control-bytes.mjs` | 0 |
| `node scripts/check-package-self-import.mjs` | 0 |
| `node scripts/check-phantom-dependencies.mjs` | 0 |
| `node scripts/check-unused-dependencies.mjs` | 0 |
| `node scripts/check-unreferenced-sources.mjs` | 0 |
| `node scripts/check-published-dist-tooling.mjs` | 0 |
| `node scripts/check-published-tsconfig-tooling-exclude.mjs` | 0 |
| `node scripts/check-side-effects-array.mjs` | 0 |
| `node scripts/check-lockfile-integrity.mjs` | 0 |
| `pnpm type-check:scripts` | 0 |

Plus a manual control-byte sweep over every edited file (`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`) — no hits.

**Three gates were derived and then measured NOT-RUN, not green:** `check-readme-exports` (exit 1), `check-doc-example-types` and `check-doc-snippet-types` (both exit **2**, which those scripts define as "PRECONDITION NOT MET — the program was NOT run"). All three need a built tree and name four to thirty-four *other* packages as unbuilt; none names `create-plugin`, and this diff edits no document under `content/docs/`. A repo-wide build for a documentation check is CI's run, not this branch's — recorded here rather than reported as passing.

## Changeset

`.changeset/8041-create-plugin-licence-prompt.md` — `@object-ui/create-plugin: minor`, per the ruling. `minor` and not `major` because this repo forbids `major` outside the synchronized `@objectstack` bump (`scripts/check-changeset-no-major.mjs`); a deliberately breaking change ships `minor` with the break spelled out in the body, which it is.

## Out of scope, filed separately

objectui#8778 — the same four emitted source headers also stamp `Copyright (c) <year>-present ObjectStack Inc.` onto the author's own plugin code. Same file, one line from the line this PR moves, and **not** fixed here: the dispatch holds every emitted field outside the licence question constant, and the right value for that line is a product decision with three live candidates, not a mechanical substitution. It is now the only false statement left in that header block.

## 维护者速读(草稿)

**改了什么。** 插件脚手架现在会问一句 `License:`(四选一,默认 MIT),并把选中那份授权的**完整原文**写成 `LICENSE` 文件。生成的包从九个文件变十个;`package.json` 的 `license`、README 的授权段、四个源码文件头里写的授权名,全部跟着这一个选择走。非交互运行(没有 TTY、或按了 Ctrl-C)取 MIT,并且照样写出原文。

**为什么改。** 之前脚手架在别人的 `package.json` 里写死 `"license": "MIT"` —— 既没问过作者,也没有把那份 MIT 原文放进包里。作者拿去 npm 一发布,tarball 就声称自己是 MIT 授权而查无原文。这是维护者授权总监席按第 91 批裁决的 C 方案(问一句 + 默认 MIT + 写原文)。B 方案(干脆不写授权)当场被否:npm 上「没声明」默认读作保留所有权利,对一个只想要脚手架的作者是更坏的默认值。

**风险与代价(含回滚)。** 代价是脚手架多问一句。风险面很小:改动只在 `packages/create-plugin` 一个包内,已生成的插件不受任何影响。四份授权原文都是从磁盘上的权威副本**逐字复制**的(不是手打),Apache-2.0 那份还和原始文本做了 diff 比对、除填入的版权行外完全一致。回滚就是 revert 这一个 commit —— 它不改任何运行时代码路径,没有数据迁移,没有跨包依赖。

**席位意见。** (待评审席位填写)

**你要做的。** 一件事:确认四个授权选项(MIT / Apache-2.0 / BSD-3-Clause / ISC)这个名单合意。少了 GPL 系与 Apache 以外的长文本授权,是刻意的 —— 脚手架只提供它能**正确写出原文**的授权,提供一个写不出原文的选项,就等于把这张卡的缺陷原样搬到上一层。另外 objectui#8778 记了同一个文件头里剩下的那半个问题(版权归属写着 ObjectStack Inc.),它需要你另外拍一次板。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH)_