### PR TITLE
fix(plugin-kanban): a lane header over a windowed fetch says `77+`, not `77` (objectui#8307)

### DIFF
--- a/.changeset/8307-kanban-lane-count-honesty.md
+++ b/.changeset/8307-kanban-lane-count-honesty.md
@@ -1,0 +1,44 @@
+---
+'@object-ui/plugin-kanban': patch
+---
+
+A Kanban lane header over a windowed fetch now says `77+` instead of `77`
+(objectui#8307).
+
+**The defect.** `object-kanban` fetches with a real `$top` (objectui#4025) and then
+groups **what came back** into lanes client-side, so `col.cards.length` counts fetched
+rows that fell into this lane — not the size of the group. Over any object holding more
+rows than the window every lane number is wrong and they sum to the window. Measured in
+a consuming app on 200 records: the board displayed **77 · 19 · 2** against a true
+**88 · 46 · 28 · 14 · 9 · 15**.
+
+The expensive part is that those numbers look right. 77 · 19 · 2 is a plausible funnel;
+there was no ellipsis, no "100 of 200", no styling difference — nothing prompting the
+reader to distrust a number that then travels into a status report.
+
+**The fix is not a better number, it is an honest one.** This component does not have a
+group total and cannot compute one: that needs a server-side group-count aggregate over
+the whole filtered set, which is a separate change. What it can stop doing is claiming a
+total it never fetched. When the fetch comes back **saturated** — at least as many rows
+as the window allowed — every lane header on the board renders `77+`, which is precisely
+what a count over a window establishes: *at least* 77. A fetch that came back short of
+its window is the one case where the client knows the result set was exhausted, and
+there the bare number is the truth and is kept. Rows handed to the board whole (inline,
+bound or external `data`) never passed through this window and keep the bare number too.
+
+`DEFAULT_KANBAN_LIMIT` is unchanged, deliberately: raising it moves the threshold
+without touching the property, and every board above the new number would fail exactly
+as silently.
+
+**The boundary case is resolved towards the true statement.** A board holding exactly
+the window is indistinguishable from a truncated one from the client side — both answer
+a `$top: N` query with N rows — so such a board renders `77+` for a lane that really
+holds 77. "At least 77" is TRUE there, whereas the bare "77" is FALSE on every truncated
+board. The marker is conservative; it is never wrong.
+
+All three lane headers move together — the flat column header and the swimlane layout's
+column-title row and lane rows — through one `laneCountLabel` helper, so a board cannot
+be honest in one layout and silently wrong in the other. Pinned by
+`laneCountHonesty-8307.test.tsx`, which reads the rendered header text (a threaded flag
+dropped one render short of the DOM would ship the identical silent board) and carries
+the exactly-at-the-window row and both negative controls.

--- a/packages/plugin-kanban/src/KanbanImpl.tsx
+++ b/packages/plugin-kanban/src/KanbanImpl.tsx
@@ -75,6 +75,13 @@ export interface KanbanBoardProps {
   objectFields?: unknown
   /** Field name for swimlane rows (2D grouping) */
   swimlaneField?: string
+  /**
+   * The cards in `columns` are a fetched WINDOW, not the whole group
+   * (objectui#8307) — see `laneCountLabel`. Injected by `ObjectKanban`, the
+   * only entry point that issues the windowed query; a board handed its rows
+   * whole leaves it unset and keeps the bare number.
+   */
+  countsAreWindowed?: boolean
 }
 
 /**
@@ -270,6 +277,43 @@ function columnWidthClasses(columnStyle?: React.CSSProperties): string {
     : "w-[85vw] sm:w-80 shrink-0";
 }
 
+/**
+ * How a lane count is WRITTEN, in ONE place, for every header on this board.
+ *
+ * The number handed in is `col.cards.length` — the count of fetched rows that
+ * fell into this lane. The fetch is windowed at a real `$top` (objectui#4025),
+ * and the board groups what came back, so over any object with more rows than
+ * the window that number is not the size of the group: every lane is short,
+ * the lanes sum to the window, and the result is CREDIBLE — 77 / 19 / 2 reads
+ * as a plausible funnel against a true 88 / 46 / 28 / 14 / 9 / 15, so nothing
+ * prompts the reader to distrust it (objectui#8307).
+ *
+ * The fix is not a better number — this component does not have one, and
+ * getting one means a server-side group-count aggregate over the whole
+ * filtered set. The fix is to stop the number claiming to be something it is
+ * not: `77+` says "at least 77", which is what a count over a window actually
+ * establishes.
+ *
+ * ⚠️ The boundary case is deliberate. `countsAreWindowed` comes from
+ * "the fetch came back with at least as many rows as it asked for", and a
+ * board holding EXACTLY the window is indistinguishable from a truncated one
+ * from this side of the wire — no client-side signal separates them without
+ * asking the server a second question. So such a board renders `77+` for a
+ * lane that really does hold 77. That is the safe half of the ambiguity:
+ * "at least 77" is TRUE when the lane holds exactly 77, whereas the bare
+ * "77" is FALSE whenever the board is in fact truncated. The marker is
+ * conservative; it is never wrong.
+ *
+ * A shared function rather than a template literal repeated per header,
+ * because this board paints lane counts from three places (the flat column
+ * header, and the swimlane layout's column-title row and lane rows) and a
+ * count that is honest on one layout and bare on another is the same defect
+ * with a smaller blast radius. Adding a header means calling this.
+ */
+function laneCountLabel(count: number, countsAreWindowed?: boolean): string {
+  return countsAreWindowed ? `${count}+` : String(count)
+}
+
 function KanbanColumnView({
   column,
   cards,
@@ -280,6 +324,7 @@ function KanbanColumnView({
   objectFields,
   columnStyle,
   suppressEmptyPlaceholder,
+  countsAreWindowed,
 }: {
   column: KanbanColumn
   cards: KanbanCard[]
@@ -298,6 +343,8 @@ function KanbanColumnView({
    * doesn't read as N redundant copies of the same message.
    */
   suppressEmptyPlaceholder?: boolean
+  /** The cards handed in are a fetched window — see `laneCountLabel` (objectui#8307). */
+  countsAreWindowed?: boolean
 }) {
   const { t } = useKanbanT()
   const safeCards = cards || [];
@@ -349,7 +396,7 @@ function KanbanColumnView({
                   : "bg-muted/70 text-muted-foreground",
               )}
             >
-              {safeCards.length}
+              {laneCountLabel(safeCards.length, countsAreWindowed)}
               {column.limit && <span className="text-muted-foreground/70 font-normal">{` / ${column.limit}`}</span>}
             </span>
             {isLimitExceeded && (
@@ -402,21 +449,21 @@ function DndBridge({ children }: { children: (dnd: ReturnType<typeof useDnd>) =>
   return <>{children(dnd)}</>
 }
 
-export default function KanbanBoard({ columns, onCardMove, onCardClick, className, quickAdd, onQuickAdd, coverImageField, conditionalFormatting, objectFields, swimlaneField }: KanbanBoardProps) {
+export default function KanbanBoard({ columns, onCardMove, onCardClick, className, quickAdd, onQuickAdd, coverImageField, conditionalFormatting, objectFields, swimlaneField, countsAreWindowed }: KanbanBoardProps) {
   const hasDnd = useHasDndProvider()
 
   if (hasDnd) {
     return (
       <DndBridge>
-        {(dnd) => <KanbanBoardInner columns={columns} onCardMove={onCardMove} onCardClick={onCardClick} className={className} dnd={dnd} quickAdd={quickAdd} onQuickAdd={onQuickAdd} coverImageField={coverImageField} conditionalFormatting={conditionalFormatting} objectFields={objectFields} swimlaneField={swimlaneField} />}
+        {(dnd) => <KanbanBoardInner columns={columns} onCardMove={onCardMove} onCardClick={onCardClick} className={className} dnd={dnd} quickAdd={quickAdd} onQuickAdd={onQuickAdd} coverImageField={coverImageField} conditionalFormatting={conditionalFormatting} objectFields={objectFields} swimlaneField={swimlaneField} countsAreWindowed={countsAreWindowed} />}
       </DndBridge>
     )
   }
 
-  return <KanbanBoardInner columns={columns} onCardMove={onCardMove} onCardClick={onCardClick} className={className} dnd={null} quickAdd={quickAdd} onQuickAdd={onQuickAdd} coverImageField={coverImageField} conditionalFormatting={conditionalFormatting} objectFields={objectFields} swimlaneField={swimlaneField} />
+  return <KanbanBoardInner columns={columns} onCardMove={onCardMove} onCardClick={onCardClick} className={className} dnd={null} quickAdd={quickAdd} onQuickAdd={onQuickAdd} coverImageField={coverImageField} conditionalFormatting={conditionalFormatting} objectFields={objectFields} swimlaneField={swimlaneField} countsAreWindowed={countsAreWindowed} />
 }
 
-function KanbanBoardInner({ columns, onCardMove, onCardClick, className, dnd, quickAdd, onQuickAdd, coverImageField: _coverImageField, conditionalFormatting, objectFields, swimlaneField }: KanbanBoardProps & { dnd: ReturnType<typeof useDnd> | null }) {
+function KanbanBoardInner({ columns, onCardMove, onCardClick, className, dnd, quickAdd, onQuickAdd, coverImageField: _coverImageField, conditionalFormatting, objectFields, swimlaneField, countsAreWindowed }: KanbanBoardProps & { dnd: ReturnType<typeof useDnd> | null }) {
   const { t } = useKanbanT()
   const [activeCard, setActiveCard] = React.useState<KanbanCard | null>(null)
 
@@ -729,7 +776,7 @@ function KanbanBoardInner({ columns, onCardMove, onCardClick, className, dnd, qu
                 className={cn(columnWidthClasses(columnInlineStyle), "text-center")}
               >
                 <span className=" text-xs sm:text-sm font-semibold tracking-wider text-primary/90 uppercase">{col.title}</span>
-                <span className="ml-2 text-xs text-muted-foreground">({col.cards.length})</span>
+                <span className="ml-2 text-xs text-muted-foreground">({laneCountLabel(col.cards.length, countsAreWindowed)})</span>
               </div>
             ))}
           </div>
@@ -750,7 +797,7 @@ function KanbanBoardInner({ columns, onCardMove, onCardClick, className, dnd, qu
                 >
                   <span className={cn("transition-transform text-xs", isCollapsed ? "" : "rotate-90")}>▶</span>
                   <span className=" text-xs font-semibold text-muted-foreground uppercase tracking-wider">{lane}</span>
-                  <span className=" text-xs text-muted-foreground">({laneCardCount})</span>
+                  <span className=" text-xs text-muted-foreground">({laneCountLabel(laneCardCount, countsAreWindowed)})</span>
                 </button>
 
                 {/* Lane content */}
@@ -797,6 +844,7 @@ function KanbanBoardInner({ columns, onCardMove, onCardClick, className, dnd, qu
               objectFields={objectFields}
               columnStyle={columnInlineStyle}
               suppressEmptyPlaceholder={isBoardEmpty}
+              countsAreWindowed={countsAreWindowed}
             />
           ))}
         </div>

--- a/packages/plugin-kanban/src/ObjectKanban.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.tsx
@@ -391,12 +391,23 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
             // `QueryParams` field and that nothing in this repo reads. The number
             // is unchanged; it just reaches the wire now, and `limit` (authored,
             // or a bound view's `pagination.pageSize`) can set it.
-            const rowWindow = schema.limit ?? DEFAULT_KANBAN_LIMIT;
-            const results = await dataSource.find(schema.objectName, {
+            //
+            // The query is a NAMED OBJECT rather than an inline literal so that
+            // the saturation reading below (objectui#8307) compares the row
+            // count against `query.$top` — the very number this request
+            // carried. One spelling of the window, read back from the request
+            // itself: a second `schema.limit ?? DEFAULT_KANBAN_LIMIT` kept in a
+            // local for the comparison could drift from the one on the wire,
+            // and a marker computed against a window the server was never asked
+            // for is exactly the silent wrongness objectui#8307 is about.
+            // Keeping it inline here also keeps the spelling objectui#7322
+            // pins off disk (`object-kanban-group-by-limit-7322.test.ts`).
+            const query = {
                 $filter: schema.filter,
-                $top: rowWindow,
+                $top: schema.limit ?? DEFAULT_KANBAN_LIMIT,
                 ...(expand.length > 0 ? { $expand: expand } : {}),
-            });
+            };
+            const results = await dataSource.find(schema.objectName, query);
             
             // Handle { value: [] } OData shape or { data: [] } shape or direct array
             const data = extractRecords(results);
@@ -406,7 +417,7 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
                 // objectui#8307 — see `fetchWindowSaturated`. Recorded HERE,
                 // against the window THIS request carried, because that is the
                 // only point where the two numbers are both in hand.
-                setFetchWindowSaturated(data.length >= rowWindow);
+                setFetchWindowSaturated(data.length >= query.$top);
             }
         } catch (e) {
             console.error('[ObjectKanban] Fetch error:', e);

--- a/packages/plugin-kanban/src/ObjectKanban.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.tsx
@@ -228,6 +228,37 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
   const hasExternalData = Array.isArray(externalData);
 
   const [fetchedData, setFetchedData] = useState<any[]>([]);
+  /**
+   * Did the last fetch come back SATURATED — as many rows as the window
+   * allowed (objectui#8307)?
+   *
+   * The fetch below is windowed at a real `$top` (objectui#4025). The board
+   * then groups WHAT CAME BACK into lanes client-side, so every lane header
+   * counts fetched rows that fell into that lane, not the size of the group.
+   * Over any object with more rows than the window every one of those numbers
+   * is wrong, they sum to the window, and nothing on screen says so — the
+   * measured case on this card displayed 77 / 19 / 2 against a true
+   * 88 / 46 / 28 / 14 / 9 / 15.
+   *
+   * This flag is what lets the header say `77+` instead of `77`. It is the
+   * only truthful statement available without a second query: a per-lane
+   * total needs a server-side group-count aggregate over the whole filtered
+   * set (the card's option 1), which this board does not issue.
+   *
+   * SATURATION, not equality. The card suggests `rows.length === limit`;
+   * `>=` is the predicate that cannot be talked into a false claim, because a
+   * source that ignores `$top` and over-returns still yields a count that is
+   * merely a LOWER BOUND as far as this component can tell. `<` the window is
+   * the one case where the client knows the result set was exhausted, and
+   * that is the case where the bare number is the truth.
+   *
+   * Held as STATE captured at fetch time rather than derived from
+   * `fetchedData.length` at render: the optimistic move/create/delete paths
+   * below rewrite `fetchedData`, and a delete would otherwise drop the array
+   * to `window - 1` and silently retract the marker from a board that is
+   * still showing a window.
+   */
+  const [fetchWindowSaturated, setFetchWindowSaturated] = useState(false);
   // The object-definition read and the fact that it has SETTLED are one piece
   // of state, keyed by the object it belongs to (objectui#6271) — now the
   // SHARED hook rather than this component's hand copy of it (objectui#7225,
@@ -360,9 +391,10 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
             // `QueryParams` field and that nothing in this repo reads. The number
             // is unchanged; it just reaches the wire now, and `limit` (authored,
             // or a bound view's `pagination.pageSize`) can set it.
+            const rowWindow = schema.limit ?? DEFAULT_KANBAN_LIMIT;
             const results = await dataSource.find(schema.objectName, {
                 $filter: schema.filter,
-                $top: schema.limit ?? DEFAULT_KANBAN_LIMIT,
+                $top: rowWindow,
                 ...(expand.length > 0 ? { $expand: expand } : {}),
             });
             
@@ -371,6 +403,10 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
 
             if (isMounted) {
                 setFetchedData(data);
+                // objectui#8307 — see `fetchWindowSaturated`. Recorded HERE,
+                // against the window THIS request carried, because that is the
+                // only point where the two numbers are both in hand.
+                setFetchWindowSaturated(data.length >= rowWindow);
             }
         } catch (e) {
             console.error('[ObjectKanban] Fetch error:', e);
@@ -393,6 +429,18 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
 
   // Determine which data to use: external -> bound -> inline -> fetched
   const rawData = (hasExternalData ? externalData : undefined) || boundData || schema.data || fetchedData;
+
+  /**
+   * Are the lane counts about to be drawn counts of a WINDOW (objectui#8307)?
+   *
+   * Only when the rows on screen are the ones this component fetched. External,
+   * bound and inline data arrive whole from whoever owns them; this board
+   * applied no window to them and has nothing truthful to say about whether
+   * someone else did, so those boards keep the bare number. The identity
+   * comparison is deliberate — it asks the exact question `rawData`'s own
+   * precedence chain just answered, so the two can never disagree.
+   */
+  const countsAreWindowed = fetchWindowSaturated && rawData === fetchedData;
 
   // Enhance data with title mapping and ensure IDs
   const effectiveData = useMemo(() => {
@@ -1092,6 +1140,9 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
         // what lets a rule comparing a relation see the stored foreign key
         // instead of the expanded record (objectui#3501).
         objectFields: objectDef?.fields,
+        // objectui#8307 — the lane headers count rows that came back, so when
+        // the fetch saturated its window they must say `77+`, not `77`.
+        countsAreWindowed,
         onCardClick: (card: any, event?: any) => {
           navigation.handleClick(card, event);
           onCardClick?.(card);

--- a/packages/plugin-kanban/src/__tests__/laneCountHonesty-8307.test.tsx
+++ b/packages/plugin-kanban/src/__tests__/laneCountHonesty-8307.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8307 — a lane header over a WINDOWED fetch must not paint a bare
+ * number that reads as the size of the group.
+ *
+ * ## The defect this pins, and why it is the expensive kind
+ *
+ * `object-kanban` fetches with a real `$top` (objectui#4025) and then groups
+ * WHAT CAME BACK into lanes client-side, so `col.cards.length` is a count of
+ * fetched rows that fell into this lane. Over any object holding more rows
+ * than the window every lane number is wrong and they sum to the window.
+ * Measured in a consuming app on 200 records: the board displayed
+ * 77 / 19 / 2 against a true 88 / 46 / 28 / 14 / 9 / 15.
+ *
+ * The numbers LOOK right — 77 / 19 / 2 is a plausible funnel — and there was
+ * no ellipsis, no styling difference, nothing to distrust. A wrong number
+ * with no tell is the one that reaches a status report.
+ *
+ * ## What is asserted, and why it is rendered output rather than a flag
+ *
+ * Every row below reads the header the way a person reads it: the text of the
+ * count node, after a real `find` has resolved. A boolean prop threaded
+ * correctly and then dropped one render short of the DOM would satisfy any
+ * flag-shaped assertion and would ship the identical silent board.
+ *
+ * The claim being pinned is the honest one and only that one: `77+` — "at
+ * least 77", which is exactly what a count over a window establishes. This
+ * file does NOT assert a group total; nobody on this side of the wire has
+ * one, and getting one means a server-side group-count aggregate over the
+ * whole filtered set (the card's option 1, deliberately not this change).
+ *
+ * ## The boundary row is the point of the file, not an afterthought
+ *
+ * The marker is driven by SATURATION — the fetch came back with at least as
+ * many rows as it asked for. A board whose object holds EXACTLY the window is
+ * indistinguishable from a truncated one from here: both return `window`
+ * rows, and no further client-side signal separates them. `BOUNDARY` below
+ * fixes which way that ambiguity is resolved and why that direction is the
+ * safe one: `4+` on a lane that really holds 4 is a TRUE statement, while the
+ * bare `4` on a board that is really truncated is a FALSE one. The marker is
+ * conservative; it is never wrong. Changing that row means arguing the
+ * opposite, in writing.
+ *
+ * ## The controls
+ *
+ * `UNSATURATED` and `INLINE` are what make the marker a verdict instead of an
+ * unconditional suffix. Without them a component that appended `+` to every
+ * count on every board would pass every other row in this file.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+// Registers `object-kanban`. Module scope, not a hook: the import IS the
+// registration (AGENTS.md's test-discipline section).
+import '../index';
+// The board renders inside `KanbanRenderer`'s `React.lazy` boundary; importing
+// the chunk at module scope bills the cold transform to the import phase
+// instead of racing a `waitFor` budget (objectui#3010).
+import '../KanbanImpl';
+
+afterEach(cleanup);
+
+const OBJECT = 'application';
+
+const OBJECT_SCHEMA = {
+  name: OBJECT,
+  label: 'Application',
+  fields: {
+    name: { type: 'text', label: 'Name' },
+    stage: { type: 'text', label: 'Stage' },
+    source: { type: 'text', label: 'Source' },
+  },
+};
+
+/**
+ * The authored window. Small on purpose — the defect is a ratio, not a
+ * magnitude, and `4` reproduces `100` exactly while keeping the DOM readable.
+ */
+const WINDOW = 4;
+
+/** Rows shaped like the measured case: one crowded lane, one thin one. */
+function rows(n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `a${i}`,
+    name: `Candidate ${i}`,
+    // 3 : 1 within the first four rows, so the two lanes carry different
+    // counts and a marker cannot be confused with a shared constant.
+    stage: i < 3 ? 'screen' : 'offer',
+    source: i % 2 === 0 ? 'referral' : 'inbound',
+  }));
+}
+
+function makeAdapter(returned: any[]): Record<string, any> {
+  return {
+    find: vi.fn(async () => ({ data: returned })),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async () => OBJECT_SCHEMA),
+  };
+}
+
+const BOARD = {
+  type: 'object-kanban',
+  objectName: OBJECT,
+  groupBy: 'stage',
+  limit: WINDOW,
+  columns: [
+    { id: 'screen', title: 'Screen' },
+    { id: 'offer', title: 'Offer' },
+  ],
+};
+
+function renderBoard(adapter: Record<string, any>, extra: Record<string, unknown> = {}) {
+  return render(
+    <SchemaRendererProvider dataSource={adapter as any}>
+      <SchemaRenderer schema={{ ...BOARD, ...extra } as any} />
+    </SchemaRendererProvider>,
+  );
+}
+
+/**
+ * The text a person reads in one flat column header.
+ *
+ * Anchored on the header's own `id`, which `KanbanColumnView` owns, and then
+ * on the first `<span>` of the controls beside it — the count badge. Reading
+ * the whole board's `textContent` would not do: `'3'` is a substring of
+ * `'3+'`, so a bare-number assertion written that way can never fail.
+ */
+function flatLaneCount(container: HTMLElement, columnId: string): string {
+  const title = container.querySelector(`#kanban-col-${columnId}`);
+  if (!title || !title.parentElement) throw new Error(`no flat header for ${columnId}`);
+  const badge = title.parentElement.querySelector('span');
+  if (!badge) throw new Error(`no count badge for ${columnId}`);
+  return (badge.textContent ?? '').trim();
+}
+
+/** Wait until the board has painted its headers from a resolved `find`. */
+async function settled(adapter: Record<string, any>, container: HTMLElement) {
+  await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+  await waitFor(() => expect(container.querySelector('#kanban-col-screen')).not.toBeNull());
+}
+
+describe('objectui#8307 — lane counts over a windowed fetch say what they mean', () => {
+  it('WINDOWED: a saturated fetch paints `3+` / `1+`, never a bare `3` / `1`', async () => {
+    // The board asked for 4 rows and got 4. There may be a hundred more; this
+    // component cannot know, and the numbers it holds are lower bounds.
+    const adapter = makeAdapter(rows(WINDOW));
+    const { container } = renderBoard(adapter);
+    await settled(adapter, container);
+
+    await waitFor(() => expect(flatLaneCount(container, 'screen')).toBe('3+'));
+    expect(flatLaneCount(container, 'offer')).toBe('1+');
+
+    // Non-vacuity for the two lines above: the request really was windowed, so
+    // `3+` is a verdict about a window rather than a decoration.
+    const params = adapter.find.mock.calls[0][1] ?? {};
+    expect(params.$top).toBe(WINDOW);
+  });
+
+  it('UNSATURATED CONTROL: a fetch that came back short keeps the bare number', async () => {
+    // Fewer rows than the cap allowed is the one case where the client KNOWS
+    // the result set was exhausted — and there the bare number is the truth.
+    // Without this row, appending `+` to every count on every board would pass
+    // every other assertion in this file.
+    const adapter = makeAdapter(rows(WINDOW - 1));
+    const { container } = renderBoard(adapter);
+    await settled(adapter, container);
+
+    await waitFor(() => expect(flatLaneCount(container, 'screen')).toBe('3'));
+    expect(flatLaneCount(container, 'offer')).toBe('0');
+  });
+
+  it('BOUNDARY: a board holding EXACTLY the window still says `3+`, and that is the honest half', async () => {
+    // This is the `rows.length === limit` case the card names, and it is the
+    // one that cannot be decided from here: an object holding exactly 4 rows
+    // and an object holding 4000 both answer a `$top: 4` query with 4 rows.
+    //
+    // The DIRECTION of the resolution is what this row fixes. Rendering `3+`
+    // for a lane that really holds 3 is conservative and TRUE — "at least 3"
+    // holds when the count is 3. Rendering the bare `3` would be FALSE on
+    // every truncated board, which is the defect. A cheaper-looking heuristic
+    // (asking for `limit + 1` rows and displaying `limit`) buys the difference
+    // at the price of changing what reaches the wire, which is a contract this
+    // card does not open — objectui#4025 pins `$top` to the authored window.
+    const exactlyTheWindow = rows(WINDOW);
+    const adapter = makeAdapter(exactlyTheWindow);
+    const { container } = renderBoard(adapter);
+    await settled(adapter, container);
+
+    await waitFor(() => expect(flatLaneCount(container, 'screen')).toBe('3+'));
+    // The true count of this lane IS 3. The marker does not misstate it; it
+    // declines to promise it is the whole group, which is all the board knows.
+    expect(exactlyTheWindow.filter((r) => r.stage === 'screen')).toHaveLength(3);
+  });
+
+  it('INLINE CONTROL: rows handed to the board whole keep the bare number', async () => {
+    // Inline `data` never passed through this board's window, so it has
+    // nothing truthful to say about whether anyone else truncated it.
+    const adapter = makeAdapter(rows(WINDOW));
+    const { container } = renderBoard(adapter, { data: rows(WINDOW), objectName: undefined });
+    await waitFor(() => expect(container.querySelector('#kanban-col-screen')).not.toBeNull());
+
+    await waitFor(() => expect(flatLaneCount(container, 'screen')).toBe('3'));
+    expect(adapter.find).not.toHaveBeenCalled();
+  });
+
+  it('SWIMLANES: the second header implementation is marked too, on both its rows', async () => {
+    // The swimlane layout paints its own column-title row and its own lane
+    // rows — `KanbanColumnView` is not involved. A fix that reached only the
+    // flat path would leave a board that is honest in one layout and silently
+    // wrong in the other, which is the same defect with a smaller blast
+    // radius (objectui#8508 is the precedent for that split going unnoticed).
+    const adapter = makeAdapter(rows(WINDOW));
+    const { container } = renderBoard(adapter, { swimlaneField: 'source' });
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(container.querySelector('[aria-label="Kanban board with swimlanes"]')).not.toBeNull(),
+    );
+
+    // Column-title row: `(3+)` and `(1+)`, parenthesised by that layout.
+    await waitFor(() => expect(container.textContent).toContain('(3+)'));
+    expect(container.textContent).toContain('(1+)');
+
+    // Lane rows: `referral` holds rows 0 and 2, `inbound` rows 1 and 3.
+    expect(container.textContent).toContain('(2+)');
+
+    // And no header on this layout kept a bare parenthesised count.
+    for (const n of ['(0)', '(1)', '(2)', '(3)', '(4)']) {
+      expect(container.textContent).not.toContain(n);
+    }
+  });
+});

--- a/packages/plugin-kanban/src/index.tsx
+++ b/packages/plugin-kanban/src/index.tsx
@@ -164,6 +164,16 @@ export interface KanbanRendererProps {
      * as before.
      */
     objectFields?: unknown;
+    /**
+     * The lane counts below are counts of a fetched WINDOW, not of the group
+     * (objectui#8307). Injected by `ObjectKanban`, the only entry point that
+     * issues the windowed `$top` query and can therefore know the answer;
+     * absent on the schema-only `kanban-ui` entry, whose `data` arrives whole
+     * from its author and whose counts are complete by construction. Not an
+     * authorable input for exactly that reason — same shape as `objectFields`
+     * above, and likewise absent from this component's registry `inputs`.
+     */
+    countsAreWindowed?: boolean;
   };
 }
 
@@ -199,6 +209,7 @@ export const KanbanRenderer: React.FC<KanbanRendererProps> = ({ schema }) => {
         conditionalFormatting={schema.conditionalFormatting}
         objectFields={schema.objectFields}
         swimlaneField={schema.swimlaneField}
+        countsAreWindowed={schema.countsAreWindowed}
       />
     </Suspense>
   );


### PR DESCRIPTION
Fixes #8307

Ships **option 2** exactly as triage ruled it (comment 5583024663): make the number say what it means, with no contract change. `DEFAULT_KANBAN_LIMIT` is untouched.

## Anchors, re-derived on today's tree (`c03d03b`)

Triage warned the card's anchors had drifted. One of triage's own has drifted again since `83d4fda16`:

| source | fetch site | header site |
| --- | --- | --- |
| card | `ObjectKanban.tsx:264` | `KanbanImpl.tsx:663` |
| triage, on `83d4fda16` | `:365` ✅ | `:689` |
| **today, `c03d03b`** | **`ObjectKanban.tsx:365`** ✅ | **`KanbanImpl.tsx:732`** |

Assumption 2 confirmed at both ends: `$top: schema.limit ?? DEFAULT_KANBAN_LIMIT` is a real top-level `$top` that the adapters read, and `col.cards` is the post-grouping client array built by `bucketCardsIntoColumns` from what came back.

**A third header site the card does not name.** `KanbanImpl` paints lane counts from **three** places, not one — the flat column header (`KanbanColumnView`, `safeCards.length`), and the swimlane layout's column-title row (`col.cards.length`, the card's anchor) and lane rows (`laneCardCount`, derived from `col.cards`). All three are the same defect. Fixing one would have left a board honest in one layout and silently wrong in the other, which is exactly the split objectui#8508 shipped.

`kanban-enhanced` also renders counts but is **out of scope and correct as-is**: it is a schema-only component that takes `data` inline and issues no windowed fetch.

## Which half of option 2, and why — chosen by measurement

Option 2 offered two forms. The honest pair (`77 of 88`) needs a per-lane total, and **the measurement says nobody here has one**: `extractRecords` (`packages/core/src/utils/extract-records.ts:75`) reads only `data` / `value` and no count member; nothing on this path requests `$count`; and even a board-level total would not give per-lane totals. A per-lane total is a server-side group-count aggregate — the card's **option 1**, a different card size and a different Clause-② answer. Not attempted here, not silently escalated into.

So: **mark the lane as windowed**. One helper, `laneCountLabel`, called by all three headers:

```ts
function laneCountLabel(count: number, countsAreWindowed?: boolean): string {
  return countsAreWindowed ? `${count}+` : String(count)
}
```

`77+` reads "at least 77", which is exactly what a count over a window establishes. No new copy string, so no i18n key and no locale-pack edit — consistent with this file's existing untranslated `/ limit` separator.

## Assumption 3 — the off-by-one shape, measured and answered

The card suggested `rows.length === limit`. Two changes:

1. **`>=`, not `===`.** The predicate is *saturation*: the fetch asked for at most `window` rows and got `n` back. `n >= window` means the response may be capped; `n` below `window` is the one case where the client **knows** the result set was exhausted, and there the bare number is the truth and is kept. A source that ignores `$top` and over-returns still yields a count this component can only treat as a lower bound, and `>=` is the predicate that cannot be talked into a false claim.

2. **The exactly-at-the-window board is resolved towards the true statement, deliberately.** A board holding exactly `limit` rows is *indistinguishable* from a truncated one from the client side — both answer a `$top: N` query with N rows. It therefore renders `77+` for a lane that really holds 77. That is the safe half of the ambiguity: **"at least 77" is TRUE when the lane holds exactly 77, whereas the bare "77" is FALSE on every truncated board.** The marker is conservative; it is never wrong. Pinned as its own row (`BOUNDARY`) so changing it means arguing the opposite in writing.

The alternative heuristic (ask for `limit + 1`, display `limit`) was rejected: it changes what reaches the wire, and `$top === DEFAULT_KANBAN_LIMIT` is pinned by objectui#4025 in `ObjectKanban.elementDataSource.test.tsx:184`.

**Saturation is captured as state at fetch time, not derived at render.** The optimistic move/create/delete paths rewrite `fetchedData`; a delete would otherwise drop the array to `window - 1` and silently retract the marker from a board that is still showing a window.

**The signal applies only to rows this board fetched.** `countsAreWindowed = fetchWindowSaturated && rawData === fetchedData` — an identity comparison against the same precedence chain `rawData` just resolved, so the two cannot disagree. External, bound and inline data arrive whole from whoever owns them and keep the bare number.

## Evidence — rendered output, plus ablation

`packages/plugin-kanban/src/__tests__/laneCountHonesty-8307.test.tsx` reads the **text of the header count node** after a real `find` resolves, anchored on `KanbanColumnView`'s own `id`. Whole-board `textContent` would not do: `'3'` is a substring of `'3+'`, so a bare-number assertion written that way can never fail.

| row | asserts |
| --- | --- |
| `WINDOWED` | saturated fetch renders `3+` / `1+`; non-vacuity: the request really carried `$top` |
| `UNSATURATED` (control) | short fetch keeps bare `3` / `0` |
| `BOUNDARY` | exactly-at-the-window renders `3+`, and the lane really does hold 3 |
| `INLINE` (control) | inline `data` keeps bare `3`, and `find` was never called |
| `SWIMLANES` | both swimlane header rows marked; no bare parenthesised count survives |

**Ablation.** `laneCountLabel` reverted to `return String(count)` — the shipped defect — on disk, proven by hash and by grep in both directions before the run, restored via `git checkout HEAD -- PATH` under an `EXIT INT TERM` trap and re-verified against the HEAD blob hash:

```
HEAD blob        = cbc94487407f46c8b5649806b91596b29645a0c0
before: fixed-line=1  ablated-line=0
after:  fixed-line=0  ablated-line=1
on-disk (mutated)= 2b6d4dca393c83709b0db75d2704c3a080a9c4ef
ABLATED command-exit = 1
  × WINDOWED: a saturated fetch paints `3+` / `1+`, never a bare `3` / `1`
  × BOUNDARY: a board holding EXACTLY the window still says `3+`, and that is the honest half
  × SWIMLANES: the second header implementation is marked too, on both its rows
  Tests  3 failed | 2 passed (5)
on-disk (restored)= cbc94487407f46c8b5649806b91596b29645a0c0   (git diff HEAD: empty)
```

Three marker rows red, both negative controls still green — which is the right shape: the ablation makes every count bare, and bare is what the controls expect. The swimlane failure printed the shipped defect verbatim: `Screen(3)Offer(1)` and `inbound(2)` / `referral(2)`, all bare.

## Gates run locally, exit codes as printed

Derived **by hand** from `package.json` scripts plus `.github/workflows/{ci,lint,performance-budget,changeset-presence,changeset-guard,control-bytes}.yml` — objectui has no `scripts/pm/dispatch-gates.mjs` and no verify lock.

| command | exit |
| --- | --- |
| `turbo run build --filter '@object-ui/plugin-kanban^...'` (12 pkgs) | 0 |
| `turbo run build --filter='!@object-ui/site'` (43 tasks, for the dist-reading gates) | 0 |
| `pnpm --filter @object-ui/plugin-kanban test` (36 files, 237 tests) | 0 |
| `pnpm --filter @object-ui/plugin-kanban type-check` | 0 |
| `turbo run lint` — **whole repo, 47/47 tasks, 0 errors** | 0 |
| `check:control-bytes` · `check:handler-key-reads` · `check:element-data-source-declaration` | 0 · 0 · 0 |
| `check:side-effects-array` · `check:i18n-keys` · `check:spec-symbols` | 0 · 0 · 0 |
| `check:unreferenced-sources` · `check:doc-example-readers` | 0 · 0 |
| `check:phantom-deps` · `check:unused-deps` | 0 · 0 |
| `check:vi-mock-specifiers` · `check:vi-mock-inherit` | 0 · 0 |
| `check:readme-exports` · `check:dist-completeness` · `check:esm-specifiers` | 0 · 0 · 0 |
| `check:sdui-registration-pins` (after the console build) | 0 |
| `check:eager-closure` · `lint:coverage` · `type-check:coverage` · `check:lint-rule-coverage` | 0 · 0 · 0 · 0 |
| `check-changeset-presence` · `check-changeset-fixed` · `check-changeset-no-major` | 0 · 0 · 0 |
| `check-governed-queue-guard --test` (the five paths) | 0 — **NOT GOVERNED** |

⚠️ `check:readme-exports` and `check:sdui-registration-pins` first returned **prerequisite-not-met**, not red — "type entry not on disk, run `pnpm build` first" and "no console build to weigh". Both were re-run after the full build and are the 0s above. Type-check likewise reported phantom `TS2307`s until the dependency closure was built.

## Changeset

`.changeset/8307-kanban-lane-count-honesty.md`, `@object-ui/plugin-kanban: patch`. Owed and checked, not assumed: `check-changeset-presence.mjs` reports *"3 source file(s) of 1 released package(s) changed"* — the package publishes `dist` and the change moves rendered output.

## Patch round — objectui#7322's spelling pin, kept rather than moved

CI went red on one test, `packages/types/src/__tests__/object-kanban-group-by-limit-7322.test.ts:221` — ours, not a flake. Reproduced locally on `e33d6ff` before touching anything: **1 failed / 28 passed**, identical assertion.

```
× `limit` is still read, as the exact text the docblocks cite
AssertionError: packages/plugin-kanban/src/ObjectKanban.tsx no longer reads `schema.limit`
  as `$top: schema.limit ?? DEFAULT_KANBAN_LIMIT`
```

objectui#7322 pins that literal source text in `READ_TEXT.limit`. The first cut of the saturation reading hoisted the cap into `const rowWindow = schema.limit ?? DEFAULT_KANBAN_LIMIT` and passed `$top: rowWindow`: behaviour identical, pinned spelling gone.

**Siblings, measured not assumed.** `git grep -F` on the literal finds **nine** occurrences. Exactly **one** is executable — the `READ_TEXT.limit` row above. The other eight are prose: docblocks in `packages/types/src/objectql.ts:2861`, `packages/types/src/zod/objectql.zod.ts:1185`, `packages/plugin-kanban/src/index.tsx:379`, `packages/app-shell/.../previews/block-config.ts:237`, a ledger `why` string in `block-config-schema-parity-8216.test.ts:188`, and two changesets. Separately, `object-kanban-record-source-7780.test.ts` pins **three more** literals out of this same file (`const boundData = useDataScope(schema.bind);`, the fetch guard, and the `const rawData = …` line). All three are untouched by this PR and are green — they are also why this file is treated as text-pinned by house style.

**Resolution: constraint 2, and it costs nothing.** The query is now a named object with the cap spelled inline exactly as pinned, and the saturation comparison reads `query.$top` back off it:

```ts
const query = {
    $filter: schema.filter,
    $top: schema.limit ?? DEFAULT_KANBAN_LIMIT,
    ...(expand.length > 0 ? { $expand: expand } : {}),
};
const results = await dataSource.find(schema.objectName, query);
...
setFetchWindowSaturated(data.length >= query.$top);
```

This is **one** spelling, not two — no expression is duplicated to appease a grep. It is also strictly better than the `rowWindow` local it replaces: a second copy of the cap kept only for the comparison could drift from the value actually on the wire, and a windowed-ness marker computed against a window the server was never asked for is precisely the silent wrongness this card exists to remove. The structure now makes that drift unrepresentable.

**No pin weakened, skipped, quarantined or edited.** `packages/types` is untouched by this PR; no file surface was extended. The assertion still fails if the renderer ever stops reading `schema.limit` or stops defaulting to `DEFAULT_KANBAN_LIMIT` — verified by the same ablation discipline that produced it: the row is red on `e33d6ff` and green on the head below.

**Green, on the pushed head:**

| run | result |
| --- | --- |
| `object-kanban-group-by-limit-7322.test.ts` (the failing file) | **29 passed**, incl. `✓ limit is still read, as the exact text the docblocks cite` |
| `+ object-kanban-record-source-7780.test.ts` + `packages/plugin-kanban/` | **38 files / 283 tests passed**, exit 0 |
| `pnpm --filter @object-ui/plugin-kanban type-check` | 0 — `query.$top` types clean |
| `pnpm --filter @object-ui/plugin-kanban lint` | 0 — same 176 pre-existing warnings, none new |

`origin/main` merged before pushing (`4d78b42`); it brought `#8737` and `#8771` and touched **no** file under `packages/types`, so neither #8776 nor #8777 has landed yet and there was no conflict. The ablation above is still anchored to the exact bytes it was run on: `KanbanImpl.tsx` is untouched by this patch round and its blob is still `cbc94487407f46c8b5649806b91596b29645a0c0`.

⛔ Unchanged by this round, as instructed: the `77+` design, the `>=` saturation predicate, the three header sites and the `BOUNDARY` row.

## 验收备注

- `noted, not filed:` the flat column header renders a bare English `Full` badge and the swimlane lane toggle a bare `▶`, neither behind `useKanbanT`. Pre-existing, untouched here, and cosmetic-copy rather than a wrong number. Carrier: whoever next opens `KanbanImpl.tsx`'s header block.
- `noted, not filed:` no tooltip explains the `+` to a first-time reader. Adding one means a new key across ten locale packs, which is outside this card's declared file surface; the marker itself is self-describing and never false, so the gap is legibility, not honesty.
- Option 1 (the server-side group-count aggregate) remains the complete fix and is untouched. This change is a strict improvement even if it later lands, exactly as triage said.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH


---
_Generated by [Claude Code](https://claude.ai/code)_