### PR TITLE
fix(console): split the agent-key generator's two failure modes (objectui#8782)

### DIFF
--- a/.changeset/8782-agent-key-keyless-success-sentence.md
+++ b/.changeset/8782-agent-key-keyless-success-sentence.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/console': patch
+---
+
+Stop reporting a successful key-mint response that carried no key as
+`Request failed (200)` (objectui#8782).
+
+The Connect-an-agent panel guarded its key mint behind one disjunction, so both
+failure modes reached one `throw`:
+
+```ts
+if (!res.ok || !data?.key) {
+  throw new Error(json?.error?.message || `Request failed (${res.status})`);
+}
+```
+
+The second arm fires on a response that WAS `ok`, and with no `error.message` in
+the body the template interpolated the real status — a `200` whose body simply
+carried no key was reported to the developer as `Request failed (200)`. Nothing
+about the transport went wrong; the sentence named the one layer known to have
+worked. That string lands in `setError(...)` and is the entire report the
+developer gets, so the wrong pointer is the whole report — and an agent or a
+developer reading "request failed" goes and investigates the transport, which is
+the wrong layer.
+
+The two arms are now separate and say different things. `!res.ok` is unchanged,
+including its `error.message` read. The keyless-success arm gets its own
+sentence, which quotes no status: *"The request succeeded but the response
+carried no API key. Nothing failed in transit — inspect the response body of
+POST /api/v1/keys."*
+
+The arm is reachable through this consumer, not through the route. The mint
+route's only success is `201` and it always carries `data.key`, so it cannot
+emit a keyless success; the arm is where `await res.json().catch(() => ({}))`
+lands every 2xx whose body is not that envelope — an SSO or proxy interstitial
+answering `200` with HTML, an empty body, a gateway page. Those are exactly the
+responses for which "request failed" misdirects hardest.
+
+Both arms are pinned, the keyless-success case with a control that fires on the
+same command shape so its absence assertions are a reading rather than a vacuous
+pass.

--- a/apps/console/src/pages/developer/AgentConnectSection.keylessSuccess-8782.test.tsx
+++ b/apps/console/src/pages/developer/AgentConnectSection.keylessSuccess-8782.test.tsx
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#8782 — the agent-key generator's two failure modes must produce two
+ * DIFFERENT sentences.
+ *
+ * Before: one `throw` behind a disjunction —
+ *
+ *   if (!res.ok || !data?.key) {
+ *     throw new Error(json?.error?.message || `Request failed (${res.status})`);
+ *   }
+ *
+ * so a response that was `ok` but carried no key reached the same template and
+ * the real status got interpolated: a **200** was reported to the developer as
+ * `Request failed (200)`. Nothing about the transport went wrong; the sentence
+ * named the one layer known to have worked, and the thrown string is the entire
+ * report `setError(...)` shows.
+ *
+ * ── Why the keyless-success arm is reachable (measured, not assumed) ─────────
+ * The mint route cannot itself emit a keyless success: its only success is
+ * `201` and it always carries `data.key` (objectstack
+ * `packages/runtime/src/domains/keys.ts`, pinned at `expect(res.response.status)
+ * .toBe(201)` in `http-dispatcher.keys.test.ts`). The arm is reachable through
+ * the CONSUMER instead — `await res.json().catch(() => ({}))` turns every 2xx
+ * whose body is not that envelope into `{}`: an SSO or proxy interstitial
+ * answering `200` with HTML, an empty body, a gateway page. §3 drives exactly
+ * that shape.
+ *
+ * ── The control ─────────────────────────────────────────────────────────────
+ * §3's load-bearing assertions are ABSENCES (no `Request failed`, no status).
+ * An absence passes vacuously if the harness never produced an error at all —
+ * a dead selector, a click that missed, a component that never threw. So §3
+ * re-runs `errorTextFor` on a `!res.ok` response IN THE SAME TEST and requires
+ * `/Request failed \(\d+\)/` to fire: same helper, same command shape, same
+ * selector, same click. With the control lit, §3's zero is a reading. §2 is the
+ * same control standing on its own as a regression pin for the `!res.ok` arm.
+ *
+ * ⛔ Out of scope, deliberately: `error.userMessage` and `error.code`
+ * (objectui#7980, gated). The `json?.error?.message` read is pinned here
+ * UNCHANGED by §1 — this card must not move it.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { AgentConnectSection } from './AgentConnectSection';
+
+/** Discovery is answered so the mount effect settles before the click. */
+const DISCOVERY = { data: { routes: { mcp: '/api/v1/mcp' } } };
+
+interface KeysAnswer {
+  status: number;
+  /** `undefined` ⇒ a body that is not JSON at all (the proxy-page shape). */
+  body?: unknown;
+}
+
+/**
+ * ONE command shape, shared by every section below — that is what makes §3's
+ * control a control. Renders the section, clicks `Generate key`, and returns
+ * the text of the error paragraph.
+ *
+ * The selector tracks the source's own literal `className` on the error node
+ * (`<p className="mt-1 text-xs text-destructive">{error}</p>`); it is a plain
+ * string there, not a `cn()` merge, so it is exact. A selector that stopped
+ * matching would take the control down with it, which is the point.
+ */
+async function errorTextFor(keys: KeysAnswer): Promise<string> {
+  const fetchMock = vi.fn(async (url: unknown) => {
+    if (String(url).includes('/discovery')) {
+      return { ok: true, status: 200, json: async () => DISCOVERY } as unknown as Response;
+    }
+    return {
+      ok: keys.status >= 200 && keys.status < 300,
+      status: keys.status,
+      json: async () => {
+        if (!('body' in keys)) throw new SyntaxError('Unexpected token < in JSON at position 0');
+        return keys.body;
+      },
+    } as unknown as Response;
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { container } = render(<AgentConnectSection />);
+  // Let the discovery effect settle so its state update is not interleaved
+  // with the click's.
+  await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+  await userEvent.click(within(container).getByRole('button', { name: /Generate key/i }));
+
+  await waitFor(() => {
+    expect(container.querySelector('p.text-destructive')).not.toBeNull();
+  });
+  const text = container.querySelector('p.text-destructive')?.textContent ?? '';
+  cleanup();
+  return text;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('AgentConnectSection — generateKey failure sentences (objectui#8782)', () => {
+  it('§1 `!res.ok` with an envelope message — unchanged: the diagnostic message', async () => {
+    const text = await errorTextFor({
+      status: 500,
+      body: { success: false, error: { message: 'Data service not available' } },
+    });
+    expect(text).toBe('Data service not available');
+  });
+
+  it('§2 `!res.ok` with no envelope message — unchanged: `Request failed (<status>)`', async () => {
+    // The lit control, standing alone. `Request failed (n)` is CORRECT here:
+    // 503 is a real failure and the status is real evidence of it.
+    const text = await errorTextFor({ status: 503, body: { success: false } });
+    expect(text).toBe('Request failed (503)');
+  });
+
+  it('§3 a 200 that carried no key — its own sentence, and no status quoted', async () => {
+    const text = await errorTextFor({ status: 200, body: { success: true, data: {} } });
+
+    // Positive: the arm now says what actually happened.
+    expect(text).toBe(
+      'The request succeeded but the response carried no API key. '
+        + 'Nothing failed in transit — inspect the response body of POST /api/v1/keys.',
+    );
+
+    // ── The two absences this card exists for ──────────────────────────────
+    expect(text).not.toMatch(/Request failed/);
+    // ⛔ No status at all: quoting a 2xx is what made the old string read as a
+    // transport failure that never happened.
+    expect(text).not.toMatch(/\d{3}/);
+
+    // ── CONTROL, in this same test: the same helper, the same command shape,
+    // the same selector and click DO produce a `Request failed (n)` string.
+    // Without this the two absences above would also pass on a harness that
+    // rendered no error whatsoever.
+    const control = await errorTextFor({ status: 503, body: { success: false } });
+    expect(control).toMatch(/Request failed \(\d{3}\)/);
+    expect(control).toMatch(/\d{3}/);
+  });
+
+  it('§4 a 200 whose body is not JSON at all — the same sentence, not a transport failure', async () => {
+    // The measured real-world shape: `res.json()` rejects, the source's
+    // `.catch(() => ({}))` swallows it, and `!data?.key` is the arm that
+    // catches it. This is how a proxy or sign-in interstitial arrives.
+    const text = await errorTextFor({ status: 200 });
+    expect(text).toMatch(/^The request succeeded but the response carried no API key\./);
+    expect(text).not.toMatch(/Request failed/);
+  });
+});

--- a/apps/console/src/pages/developer/AgentConnectSection.tsx
+++ b/apps/console/src/pages/developer/AgentConnectSection.tsx
@@ -115,8 +115,30 @@ export function AgentConnectSection() {
       });
       const json = await res.json().catch(() => ({}));
       const data = json?.data;
-      if (!res.ok || !data?.key) {
+      // Two failure modes, two sentences (objectui#8782). They used to share
+      // one `throw`, so a SUCCESSFUL response that simply carried no key was
+      // reported as `Request failed (200)` -- naming the one layer known to
+      // have worked, and sending the reader to the transport, which is the
+      // wrong layer. A wrong pointer costs more than no pointer.
+      if (!res.ok) {
         throw new Error(json?.error?.message || `Request failed (${res.status})`);
+      }
+      if (!data?.key) {
+        // Reachability of this arm, measured rather than assumed: the mint
+        // route's ONLY success is `201` and it always carries `data.key`
+        // (objectstack `packages/runtime/src/domains/keys.ts`, pinned in
+        // `http-dispatcher.keys.test.ts`), so this is not the route emitting a
+        // keyless success -- it cannot. This is where the `.catch(() => ({}))`
+        // three lines above lands every 2xx whose body is NOT that envelope:
+        // an SSO or proxy interstitial answering `200` with HTML, an empty
+        // body, a gateway page. Those are exactly the responses for which
+        // "request failed" misdirects hardest, so the status is deliberately
+        // absent from the sentence below -- quoting a 2xx here is what made
+        // the old message read as a transport failure that never happened.
+        throw new Error(
+          'The request succeeded but the response carried no API key. '
+            + 'Nothing failed in transit — inspect the response body of POST /api/v1/keys.',
+        );
       }
       setGenerated(data as GeneratedKey);
       setDialogOpen(true);


### PR DESCRIPTION
Fixes #8782

## What changed

`apps/console/src/pages/developer/AgentConnectSection.tsx` guarded the key mint behind one disjunction, so both failure modes reached one `throw`:

```ts
if (!res.ok || !data?.key) {
  throw new Error(json?.error?.message || `Request failed (${res.status})`);
}
```

The second arm fires on a response that **was** `ok`, and with no `error.message` in the body the template interpolated the real status — a `200` whose body simply carried no key was reported as **`Request failed (200)`**. The request did not fail; the sentence named the one layer known to have worked. That string lands in `setError(...)` and is the entire report the developer gets.

The two arms are now separate:

- **`!res.ok` — unchanged, byte for byte**, including its `json?.error?.message` read. `Request failed (503)` is *correct* there: 503 is a real failure and the status is real evidence of it.
- **`ok` but no key — its own sentence, quoting no status**: *"The request succeeded but the response carried no API key. Nothing failed in transit — inspect the response body of POST /api/v1/keys."*

## Reachability was measured, not assumed

The dispatch flagged its own premise as read-off-the-source rather than observed, so it was established before the wording was written. The result **refines the mechanism while confirming the arm is real**:

The mint route **cannot** emit a keyless success. Its only success is **`201`**, and it always sets `data.key` (objectstack `packages/runtime/src/domains/keys.ts`; pinned at `expect(res.response.status).toBe(201)` in `http-dispatcher.keys.test.ts`). So this is not the route misbehaving.

The arm is reachable through **this consumer**: `await res.json().catch(() => ({}))`, three lines above, turns *every* 2xx whose body is not that envelope into `{}` — an SSO or proxy interstitial answering `200` with HTML, an empty body, a gateway page. `!data?.key` is the designated landing site for all of them, and those are exactly the responses for which "request failed" misdirects hardest. That is why the new sentence carries no status at all: quoting a 2xx is what made the old string read as a transport failure that never happened.

## Tests

New pin `apps/console/src/pages/developer/AgentConnectSection.keylessSuccess-8782.test.tsx`, four sections over one shared command shape (`errorTextFor`), so the control really is a control.

Section 3's load-bearing assertions are **absences** (no `Request failed`, no three-digit status), and an absence passes vacuously on a harness that produced no error at all — a dead selector, a click that missed. So section 3 **re-runs the same helper on a `!res.ok` response inside the same test** and requires `/Request failed \(\d{3}\)/` to fire. With the control lit, the zero is a reading. Section 2 is that same control standing alone as a regression pin for the untouched arm.

**Ablation** (mutate to the pre-fix disjunction, run, restore), from commit `a5852d65b`:

| leg | result |
|---|---|
| mutation landed on disk | injected `!res.ok \|\| !data?.key` = 1 occurrence; new sentence = 0; blob `2099805…` differs from HEAD `2a1fa4d…` |
| pin against mutated source | **2 failed / 2 passed** — sections 3 and 4 red, `Received: "Request failed (200)"` (the defect itself, reproduced) |
| control legs | sections 1 and 2 stayed **green** under the mutation — they pin unchanged behaviour, not the fix |
| restore | `git diff HEAD` empty; blob back to `2a1fa4d…`, **byte-identical** |

Green runs (all via the shared verify lock, quoting its own `VERDICT` line, on a shared box):

| command | verdict |
|---|---|
| `pnpm exec vitest run …keylessSuccess-8782.test.tsx` | `VERDICT command-exit 0` — 4 passed |
| `pnpm exec vitest run --project @object-ui/console` | `VERDICT command-exit 0` — **95 files, 1116 tests, all passed** |
| `pnpm --workspace-concurrency=2 --filter @object-ui/console type-check` | `VERDICT command-exit 0` |
| `pnpm --workspace-concurrency=2 --filter '@object-ui/console^...' build` | `VERDICT command-exit 0` |

The typecheck is a real reading over both changed files, not an assumption: `tsc --noEmit --listFiles` puts the new test file in the program (subject 1, control 1, 59 console test files total). Its first run was red purely because the workspace `dist/*.d.ts` were absent; it went green on the same source once the dependency closure was built.

**Lint is the complete CI unit, not a narrowing.** `turbo run lint` runs `eslint .` per package; the whole `apps/console` unit ran in 15s: **197 files, exit 0**, 212 warnings all pre-existing. The two changed files contribute **0 errors and 0 warnings** (targeted `--format json` run, 2 files linted).

Gates: `check:control-bytes`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:shell-escape-residue`, `check-changeset-presence`, `check-changeset-no-major` — all exit 0. `check-governed-queue-guard --test` on the three changed paths: `NOT GOVERNED`.

## Changeset

`apps/console` is **not** private and **is** in the versioned fixed group (`@object-ui/console`, `17.6.0`, listed in `.changeset/config.json`), so a real bump was owed rather than an empty declaration. `.changeset/8782-agent-key-keyless-success-sentence.md` declares `patch`; the presence gate confirms it: *"1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)"*.

## Scope

Held to the fence. `error.userMessage` and `error.code` are untouched — that is objectui#7980 and it is gated. Nothing was imported, exported, or hand-rolled from `readEnvelopeFailureText`; the `json?.error?.message` read is preserved exactly and pinned that way by section 1. No published surface moves, so this stays outside Clause-②.

The two sibling `Request failed (` sites (`PackagesPage.tsx`, `PackageFormDialog.tsx` in `app-shell`) were checked against the card's own re-check command: both sit inside a `!res.ok`-only guard and carry no keyless-success disjunction. Nothing else in the repo has this defect — objectui#7980 is referenced here for context only and is not addressed by this pull request.

Drafted by the `domain:ui` dev seat; session `https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH` (written as prose so it survives a later body edit). Landing is the PM seat's — left as draft, no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH)_