### PR TITLE
feat(types): declare the filter/sort members both renderers read (objectui#8174)

### DIFF
--- a/.changeset/8174-kanban-calendar-filter-sort.md
+++ b/.changeset/8174-kanban-calendar-filter-sort.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/types': minor
+---
+
+Declare the query members both renderers already read on `ObjectKanbanSchema` and
+`ObjectCalendarSchema` — `filter` on both, `sort` on the calendar
+(objectstack-ai/objectui#8174).
+
+`filter` had four declaration faces and only three of them named it:
+`@objectstack/spec` declares it (`ComponentPropsMap['object-kanban']` and
+`['object-calendar']`), both plugins' registration `inputs` publish it, and both
+renderers read it — `ObjectKanban.tsx` lowers `schema.filter` onto `$filter`,
+`ObjectCalendar.tsx` lowers `schema.filter` onto `$filter` and `schema.sort` onto
+`$orderby` through `convertSortToQueryParams`. This package's own published faces
+(the TypeScript interface and its zod mirror) named none of them, so an authored
+value reached the renderer only through `BaseSchema`'s index signature and the
+mirror's `.passthrough()` — admitted, never examined. That is the same reasoning
+objectstack-ai/objectui#7322 used to move `groupBy` and `limit` into this same
+interface.
+
+Spelled exactly as `ObjectGanttSchema` spells them, so the views' query
+vocabularies cannot fork: `filter?: any[]` mirrored as `z.array(z.any())`, and
+`sort?: SortConfig[]` mirrored as `z.array(SortConfigSchema)`. Both members are
+optional on both faces, so no node that omits them changes verdict.
+
+Additive on the type face and on the accept set; nothing that validated before is
+refused now. What does change verdict is a WRONG-TYPED value at a correctly
+spelled key, which the index signature and `.passthrough()` used to admit
+unexamined: `filter: 'status = open'` and the objectstack-ai/objectui#8221-retired
+string clause `sort: 'name asc'` are now refused at authoring time instead of
+type-checking green, parsing green, and then being dropped at runtime by
+`convertSortToQueryParams` — which is why this is a `minor` and not a `patch`.
+
+No `sort` on the kanban board: `ObjectKanban.tsx` has zero `schema.sort` read
+sites and the spec's `object-kanban` entry declares no `sort` either.
+
+The `BaseSchema` index-signature ceiling measured by
+objectstack-ai/objectui#7927 is unchanged — a MISSPELLED key is still admitted on
+both faces, and the accompanying pin asserts that rather than claiming otherwise.

--- a/packages/types/src/__tests__/kanban-calendar-filter-sort-8174.test.ts
+++ b/packages/types/src/__tests__/kanban-calendar-filter-sort-8174.test.ts
@@ -1,0 +1,350 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#8174 — `ObjectKanbanSchema.filter`, `ObjectCalendarSchema.filter`
+ * and `ObjectCalendarSchema.sort` declared, on both faces.
+ *
+ * ## The defect
+ *
+ * `filter` had FOUR faces and only three of them named it. `@objectstack/spec`
+ * declares it (`ComponentPropsMap['object-kanban']`,
+ * `ComponentPropsMap['object-calendar']`); both plugins' registration `inputs`
+ * publish it; both renderers READ it — `plugin-kanban/src/ObjectKanban.tsx`
+ * lowers `schema.filter` onto `$filter` at its `dataSource.find` call, and
+ * `plugin-calendar/src/ObjectCalendar.tsx` does the same and additionally
+ * lowers `schema.sort` onto `$orderby` through `convertSortToQueryParams`. The
+ * declaration face of `@object-ui/types` named none of them: an authored value
+ * reached the renderer through `BaseSchema`'s `[key: string]: any` on the TS
+ * side and through `.passthrough()` on the mirror — admitted, never examined.
+ *
+ * That is verbatim the reasoning objectui#7322 used to move `groupBy` and
+ * `limit` into `ObjectKanbanSchema`, one key over on the same interface.
+ *
+ * ## What declaring buys — and what it does NOT, measured not assumed
+ *
+ * objectui#7927 measured the ceiling: `BaseSchema` ends in `[key: string]: any`,
+ * so no annotation on any node schema can catch a MISSPELLED key. That ceiling
+ * is real and this card does not lift it — `filtr` stays admitted on both
+ * faces, and the control assertions below PIN that, so nobody reads this file as
+ * claiming more than it does.
+ *
+ * What the ceiling does not cap is the VALUE dimension, and that is the half
+ * this file pins:
+ *
+ * - TS: the member narrows `any` to `any[]` / `SortConfig[]`. `filter: 'a = b'`
+ *   and `sort: 'name asc'` were assignable through the index signature and are
+ *   now type errors. Each `@ts-expect-error` below goes UNUSED — TS2578, a hard
+ *   type-check failure — the moment its member is deleted, which is what makes
+ *   these pins rather than restatements.
+ * - Mirror: under `.passthrough()` a DECLARED key is value-validated where an
+ *   undeclared one rides through unexamined, and this mirror reaches
+ *   `safeValidateSchema` through `AnyComponentSchema`, so the refusal reaches
+ *   the CLI's `validate` / `check`.
+ *
+ * The `sort` half carries the sharpest case. objectui#8221 retired the legacy
+ * string clause: `convertSortToQueryParams` no longer admits a string in its
+ * signature and, when one arrives anyway, reports the retired spelling and
+ * returns `undefined`. So `sort: 'name asc'` on an `object-calendar` node
+ * type-checked green, parsed green, and then silently produced an UNSORTED
+ * calendar. Declaring the member is what makes that retirement audible at the
+ * authoring boundary; the core-side behaviour is pinned off disk below so the
+ * docblock's claim cannot rot.
+ *
+ * ## Instruments, borrowed from `object-kanban-group-by-limit-7322.test.ts`
+ *
+ * Membership is asserted on the mirror's OWN `.shape`, never on parse
+ * acceptance (under `.passthrough()` acceptance cannot tell "declared" from
+ * "admitted unexamined"). Type-level pins use invariant equality, so a member
+ * that fell back to the index signature reads as `any` and therefore as a
+ * failure. And every claim carries a CONTROL that is asserted to stay
+ * undeclared — including the deliberate absence of `sort` on the kanban board,
+ * which is measured off the renderer rather than assumed.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { ComponentPropsMap } from '@objectstack/spec/ui';
+
+import { ObjectCalendarSchema, ObjectKanbanSchema, safeValidateSchema } from '../zod/index.zod';
+import type {
+  ObjectCalendarSchema as TsObjectCalendarSchema,
+  ObjectKanbanSchema as TsObjectKanbanSchema,
+  SortConfig,
+} from '../objectql';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..', '..', '..');
+
+const KANBAN_READER = 'packages/plugin-kanban/src/ObjectKanban.tsx';
+const CALENDAR_READER = 'packages/plugin-calendar/src/ObjectCalendar.tsx';
+const SORT_QUERY = 'packages/core/src/utils/sort-query.ts';
+
+/**
+ * A key neither renderer reads and neither face declares. It is the non-vacuity
+ * control for every "declared" assertion below: it must stay `any` on the TS
+ * face and stay out of both mirror shapes, while still being ADMITTED — which
+ * is the objectui#7927 ceiling, pinned rather than claimed away.
+ */
+const CONTROL_KEY = 'whereClause';
+/** A declared-keys-only control of the read census: read, declared, untouched. */
+const READ_CONTROL_KEY = 'objectName';
+/** The misspelling objectui#7927's ceiling still admits. Pinned, not fixed here. */
+const MISSPELLING = 'filtr';
+
+/** The documented nodes; every assertion below is a delta on one of them. */
+const KANBAN_NODE = { type: 'object-kanban', objectName: 'opportunity', groupBy: 'stage' } as const;
+const CALENDAR_NODE = { type: 'object-calendar', objectName: 'event' } as const;
+
+/** A well-formed value for each declared member. */
+const FILTER_VALUE = [['status', '=', 'open']];
+const SORT_VALUE: SortConfig[] = [{ field: 'start_date', order: 'asc' }];
+
+/* ── Type-level pins (invariant equality, house form) ─────────────────────── */
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+/** The canonical `any` detector: only `any` absorbs `1 &` down to something `0` extends. */
+type IsAny<T> = 0 extends (1 & T) ? true : false;
+/** An object with no keys is assignable to `Pick<T, K>` only when `K` is optional on `T`. */
+type IsOptional<T, K extends keyof T> = Record<string, never> extends Pick<T, K> ? true : false;
+
+// `filter` on BOTH interfaces: declared `any[]`, optional, not `any`. Delete
+// either member and the indexed access falls back to `[key: string]: any`,
+// making `IsAny` true and `Equal<any, any[] | undefined>` false.
+export type _KanbanFilterIsArray = Expect<Equal<TsObjectKanbanSchema['filter'], any[] | undefined>>;
+export type _KanbanFilterIsNotAny = Expect<Equal<IsAny<TsObjectKanbanSchema['filter']>, false>>;
+export type _KanbanFilterIsOptional = Expect<IsOptional<TsObjectKanbanSchema, 'filter'>>;
+export type _CalendarFilterIsArray = Expect<Equal<TsObjectCalendarSchema['filter'], any[] | undefined>>;
+export type _CalendarFilterIsNotAny = Expect<Equal<IsAny<TsObjectCalendarSchema['filter']>, false>>;
+export type _CalendarFilterIsOptional = Expect<IsOptional<TsObjectCalendarSchema, 'filter'>>;
+// `sort` on the CALENDAR only: declared `SortConfig[]`, optional, not `any`.
+export type _CalendarSortIsSortConfigArray = Expect<Equal<TsObjectCalendarSchema['sort'], SortConfig[] | undefined>>;
+export type _CalendarSortIsNotAny = Expect<Equal<IsAny<TsObjectCalendarSchema['sort']>, false>>;
+export type _CalendarSortIsOptional = Expect<IsOptional<TsObjectCalendarSchema, 'sort'>>;
+// …and DELIBERATELY not on the kanban board, whose renderer issues no
+// `$orderby`. It still falls through to the index signature. Declaring it turns
+// this red — which is the point: this card declares what is read, nothing more.
+export type _KanbanSortStaysUndeclared = Expect<IsAny<TsObjectKanbanSchema['sort']>>;
+// The control key is undeclared on both, exactly as `filter` was before this
+// card. Same instrument, opposite verdict.
+export type _KanbanControlKeyFallsThrough = Expect<IsAny<TsObjectKanbanSchema['whereClause']>>;
+export type _CalendarControlKeyFallsThrough = Expect<IsAny<TsObjectCalendarSchema['whereClause']>>;
+// objectui#7927's ceiling, pinned rather than claimed away: a MISSPELLED key
+// still resolves to `any` and still type-checks. This card does not fix that,
+// and this line is what stops anyone reading it as if it had.
+export type _MisspellingStillAdmitted = Expect<IsAny<TsObjectCalendarSchema['filtr']>>;
+
+// The TS face ACCEPTS the documented shapes on a literal…
+const kanbanLiteral: TsObjectKanbanSchema = { ...KANBAN_NODE, filter: FILTER_VALUE };
+const calendarLiteral: TsObjectCalendarSchema = { ...CALENDAR_NODE, filter: FILTER_VALUE, sort: SORT_VALUE };
+
+// …and REFUSES wrong-typed values that the index signature used to admit. Each
+// directive goes unused — TS2578, a hard failure — if its member is deleted.
+// @ts-expect-error — `filter` is `any[]`; a string clause is not a JSON-Rules filter
+const kanbanBadFilter: TsObjectKanbanSchema = { ...KANBAN_NODE, filter: 'status = open' };
+// @ts-expect-error — `filter` is `any[]`; a string clause is not a JSON-Rules filter
+const calendarBadFilter: TsObjectCalendarSchema = { ...CALENDAR_NODE, filter: 'status = open' };
+// @ts-expect-error — the legacy string `sort` clause is RETIRED (objectui#8221); author `[{ field, order }]`
+const calendarRetiredSort: TsObjectCalendarSchema = { ...CALENDAR_NODE, sort: 'start_date asc' };
+// @ts-expect-error — `order` is `'asc' | 'desc'`; the member is `SortConfig[]`, not `any[]`
+const calendarBadSortOrder: TsObjectCalendarSchema = { ...CALENDAR_NODE, sort: [{ field: 'start_date', order: 'sideways' }] };
+
+/* ── Off-disk derivations ─────────────────────────────────────────────────── */
+
+function readRepo(rel: string): string {
+  return readFileSync(join(REPO_ROOT, rel), 'utf8');
+}
+
+/** Every `schema.KEY` read in a renderer, off disk. */
+function rendererReads(rel: string): Set<string> {
+  return new Set([...readRepo(rel).matchAll(/\bschema\.([A-Za-z_$][\w$]*)/g)].map((m) => m[1]));
+}
+
+function shapeKeys(schema: unknown): string[] {
+  return Object.keys((schema as { shape: Record<string, unknown> }).shape);
+}
+
+function specShapeKeys(type: string): string[] {
+  const entry = (ComponentPropsMap as unknown as Record<string, any>)[type];
+  const def = entry._def;
+  const shape = typeof def.shape === 'function' ? def.shape() : def.shape;
+  return Object.keys(shape);
+}
+
+interface Issue {
+  path?: readonly (string | number)[];
+  message?: string;
+  /** zod 4 `invalid_union`: the issues of every option that was tried. */
+  errors?: readonly (readonly Issue[])[];
+}
+
+function issuePaths(issues: readonly Issue[], prefix: readonly (string | number)[] = []): string[] {
+  const out: string[] = [];
+  for (const issue of issues) {
+    const path = [...prefix, ...(issue.path ?? [])];
+    out.push(path.join('.'));
+    for (const nested of issue.errors ?? []) out.push(...issuePaths(nested, path));
+  }
+  return out;
+}
+
+/* ── The reads: the fact the declarations record ──────────────────────────── */
+
+describe('objectui#8174 — the renderers read these keys, which is what the declarations record', () => {
+  it('the kanban renderer reads `filter` and lowers it onto `$filter`', () => {
+    const reads = rendererReads(KANBAN_READER);
+    expect(reads.has('filter'), `${KANBAN_READER} no longer reads schema.filter`).toBe(true);
+    // The positive control: the query that returns a verdict for `sort` below
+    // is the same query that returns `objectName`, so that verdict is a reading.
+    expect(reads.has(READ_CONTROL_KEY)).toBe(true);
+    expect(readRepo(KANBAN_READER)).toContain('$filter: schema.filter');
+  });
+
+  it('…and reads NO `sort`: the board groups records into lanes and issues no `$orderby`', () => {
+    // The measured premise for leaving `sort` off `ObjectKanbanSchema`. If the
+    // board ever starts ordering, this turns red BEFORE the declaration faces
+    // fork again.
+    expect(rendererReads(KANBAN_READER).has('sort')).toBe(false);
+  });
+
+  it('the calendar renderer reads BOTH, and lowers them onto `$filter` / `$orderby`', () => {
+    const reads = rendererReads(CALENDAR_READER);
+    expect(reads.has('filter'), `${CALENDAR_READER} no longer reads schema.filter`).toBe(true);
+    expect(reads.has('sort'), `${CALENDAR_READER} no longer reads schema.sort`).toBe(true);
+    expect(reads.has(READ_CONTROL_KEY)).toBe(true);
+    const src = readRepo(CALENDAR_READER);
+    expect(src).toContain('$filter: schema.filter');
+    expect(src).toContain('$orderby: convertSortToQueryParams(schema.sort)');
+  });
+
+  it('neither renderer reads the control key, so its undeclared verdict stays non-vacuous', () => {
+    expect(rendererReads(KANBAN_READER).has(CONTROL_KEY)).toBe(false);
+    expect(rendererReads(CALENDAR_READER).has(CONTROL_KEY)).toBe(false);
+  });
+
+  it('the retired string `sort` clause is still retired in core, so the `sort` docblock stays true', () => {
+    // objectui#8221. This is what makes an undeclared string `sort` produce an
+    // UNSORTED calendar rather than an error — the reason declaring the member
+    // is worth more than editor completion.
+    const src = readRepo(SORT_QUERY);
+    expect(src).toContain('sort: QuerySortEntry[] | undefined | null,');
+    expect(src).toContain('reportRetiredSortSpelling(sort as unknown as string);');
+  });
+});
+
+/* ── The upstream contract: the spec already declares these ───────────────── */
+
+describe('objectui#8174 — the declarations agree with `@objectstack/spec`, which is the producer contract', () => {
+  it('the spec declares `filter` on both blocks, and `sort` on the calendar only', () => {
+    const kanban = specShapeKeys('object-kanban');
+    const calendar = specShapeKeys('object-calendar');
+    expect(kanban).toContain('filter');
+    // The spec is the reason `sort` is absent from the kanban interface: it is
+    // not declared upstream either, so declaring it here would be this repo
+    // inventing a key (Commandment #0).
+    expect(kanban).not.toContain('sort');
+    expect(calendar).toContain('filter');
+    expect(calendar).toContain('sort');
+    // Non-vacuity: the same extraction that returns those verdicts returns a
+    // key both blocks certainly declare.
+    expect(kanban).toContain(READ_CONTROL_KEY);
+    expect(calendar).toContain(READ_CONTROL_KEY);
+  });
+});
+
+/* ── The zod mirrors ──────────────────────────────────────────────────────── */
+
+describe('objectui#8174 — the mirrors declare what the interfaces declare', () => {
+  it('membership, read off the mirror shapes (acceptance cannot tell declared from admitted under passthrough)', () => {
+    expect(shapeKeys(ObjectKanbanSchema)).toContain('filter');
+    expect(shapeKeys(ObjectKanbanSchema)).not.toContain('sort');
+    expect(shapeKeys(ObjectCalendarSchema)).toContain('filter');
+    expect(shapeKeys(ObjectCalendarSchema)).toContain('sort');
+    // The control stays out of both, which is what keeps the four assertions
+    // above from being satisfied by a shape that simply contains everything.
+    expect(shapeKeys(ObjectKanbanSchema)).not.toContain(CONTROL_KEY);
+    expect(shapeKeys(ObjectCalendarSchema)).not.toContain(CONTROL_KEY);
+  });
+
+  it('accepts the documented shapes, and the values SURVIVE the parse', () => {
+    const k = ObjectKanbanSchema.safeParse({ ...KANBAN_NODE, filter: FILTER_VALUE });
+    expect(k.success, JSON.stringify(k.error?.issues)).toBe(true);
+    if (k.success) expect((k.data as Record<string, unknown>).filter).toEqual(FILTER_VALUE);
+
+    const c = ObjectCalendarSchema.safeParse({ ...CALENDAR_NODE, filter: FILTER_VALUE, sort: SORT_VALUE });
+    expect(c.success, JSON.stringify(c.error?.issues)).toBe(true);
+    if (c.success) {
+      expect((c.data as Record<string, unknown>).filter).toEqual(FILTER_VALUE);
+      expect((c.data as Record<string, unknown>).sort).toEqual(SORT_VALUE);
+    }
+  });
+
+  it('…and through the published union entry point, so the right arms are the ones reached', () => {
+    expect(safeValidateSchema({ ...KANBAN_NODE, filter: FILTER_VALUE }).success).toBe(true);
+    expect(safeValidateSchema({ ...CALENDAR_NODE, filter: FILTER_VALUE, sort: SORT_VALUE }).success).toBe(true);
+  });
+
+  it('both members stay OPTIONAL: the nodes without them parse green — this adds no requiredness', () => {
+    expect(ObjectKanbanSchema.safeParse(KANBAN_NODE).success).toBe(true);
+    expect(ObjectCalendarSchema.safeParse(CALENDAR_NODE).success).toBe(true);
+    expect(safeValidateSchema(KANBAN_NODE).success).toBe(true);
+    expect(safeValidateSchema(CALENDAR_NODE).success).toBe(true);
+  });
+
+  it.each([
+    ['object-kanban', 'filter', 'status = open'],
+    ['object-kanban', 'filter', 42],
+    ['object-calendar', 'filter', 'status = open'],
+    // The objectui#8221 string clause. Undeclared, it parsed green here and was
+    // then dropped by `convertSortToQueryParams`, drawing an unsorted calendar.
+    ['object-calendar', 'sort', 'start_date asc'],
+    ['object-calendar', 'sort', [{ field: 'start_date', order: 'sideways' }]],
+    ['object-calendar', 'sort', [{ order: 'asc' }]],
+  ] as const)('%s refuses a wrong-typed `%s` (%j) AT the key — the verdict declaring MOVES', (type, key, value) => {
+    // Before this card every one of these rode `.passthrough()` unexamined.
+    const node = type === 'object-kanban' ? KANBAN_NODE : CALENDAR_NODE;
+    const arm = type === 'object-kanban' ? ObjectKanbanSchema : ObjectCalendarSchema;
+    const r = arm.safeParse({ ...node, [key]: value });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      // The refusal must land ON the key (or inside it, e.g. `sort.0.field`) —
+      // not merely somewhere in the node — which is what distinguishes value
+      // validation from an unrelated refusal.
+      const paths = issuePaths(r.error.issues as readonly Issue[]);
+      expect(paths.some((p) => p.split('.').includes(key)), JSON.stringify(paths)).toBe(true);
+    }
+    // …and the same refusal through `safeValidateSchema`, which is the path the
+    // CLI's `validate` / `check` reach.
+    expect(safeValidateSchema({ ...node, [key]: value }).success).toBe(false);
+  });
+
+  it('the objectui#7927 ceiling is UNCHANGED: a misspelled key is still admitted on both mirrors', () => {
+    // This card buys value validation, not misspelling detection. Pinning the
+    // ceiling here is what stops the change being read as more than it is — and
+    // turns red if `.passthrough()` is ever tightened, which would be #7927's
+    // job and would need this file revisited.
+    expect(ObjectKanbanSchema.safeParse({ ...KANBAN_NODE, [MISSPELLING]: FILTER_VALUE }).success).toBe(true);
+    expect(ObjectCalendarSchema.safeParse({ ...CALENDAR_NODE, [MISSPELLING]: FILTER_VALUE }).success).toBe(true);
+    expect(ObjectKanbanSchema.safeParse({ ...KANBAN_NODE, [CONTROL_KEY]: FILTER_VALUE }).success).toBe(true);
+  });
+});
+
+/* ── Keep the type-level consts referenced (they are the pins) ─────────────── */
+
+describe('objectui#8174 — the TS face accepts the documented nodes', () => {
+  it('the accepted literals carry the values they were authored with', () => {
+    expect(kanbanLiteral.filter).toEqual(FILTER_VALUE);
+    expect(calendarLiteral.filter).toEqual(FILTER_VALUE);
+    expect(calendarLiteral.sort).toEqual(SORT_VALUE);
+    // The refused literals exist only so their `@ts-expect-error` directives do;
+    // referencing them keeps `noUnusedLocals` off this file's back.
+    expect([kanbanBadFilter, calendarBadFilter, calendarRetiredSort, calendarBadSortOrder]).toHaveLength(4);
+  });
+});

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -2771,6 +2771,43 @@ export interface ObjectCalendarSchema extends BaseSchema {
    * and the enforcement points read only these three values.
    */
   defaultView?: 'month' | 'week' | 'day';
+  /**
+   * Query filter (JSON Rules format), forwarded verbatim as `$filter` on the
+   * calendar's own fetch — `plugin-calendar/src/ObjectCalendar.tsx` reads
+   * `schema.filter` at the `dataSource.find` call and again in that effect's
+   * dependency list.
+   *
+   * Undeclared here until objectui#8174, so an authored value reached the
+   * renderer only through {@link BaseSchema}'s `[key: string]: any` — admitted,
+   * never examined. That is verbatim the reasoning objectui#7322 used to move
+   * `ObjectKanbanSchema.groupBy` into its interface, and this is the same
+   * situation one key over: `@objectstack/spec` declares it
+   * (`ComponentPropsMap['object-calendar']`), the plugin's registration
+   * `inputs` declares it, the renderer reads it — this declaration face was the
+   * only one that stayed silent.
+   *
+   * Spelled exactly as {@link ObjectGanttSchema.filter}, so the two views'
+   * query keys cannot fork.
+   */
+  filter?: any[];
+  /**
+   * Sort configuration, forwarded as `$orderby` via `convertSortToQueryParams`
+   * (`plugin-calendar/src/ObjectCalendar.tsx`, the same `dataSource.find` call
+   * as {@link filter} and the same effect dependency list).
+   *
+   * Array only — the legacy string clause is retired (objectui#8221), and
+   * declaring the member is what makes that retirement audible HERE. Undeclared,
+   * `sort: 'name asc'` type-checked green on {@link BaseSchema}'s index
+   * signature, parsed green through the mirror's `.passthrough()`, and was then
+   * DROPPED at runtime: `convertSortToQueryParams` (`@object-ui/core`,
+   * `utils/sort-query.ts`) no longer admits a string in its signature and
+   * returns `undefined` for one after reporting the retired spelling. So the
+   * calendar rendered unsorted with nothing refusing the node.
+   *
+   * Spelled exactly as {@link ObjectGanttSchema.sort}, so the two views' sort
+   * vocabularies cannot fork.
+   */
+  sort?: SortConfig[];
 }
 
 /**
@@ -2867,6 +2904,31 @@ export interface ObjectKanbanSchema extends BaseSchema {
    * @default 100 — `DEFAULT_KANBAN_LIMIT`
    */
   limit?: number;
+  /**
+   * Query filter (JSON Rules format), forwarded verbatim as `$filter` on the
+   * board's own fetch — `plugin-kanban/src/ObjectKanban.tsx` reads
+   * `schema.filter` at the `dataSource.find` call, alongside the `$top` that
+   * {@link limit} feeds, and again in that effect's dependency list.
+   *
+   * Undeclared here until objectui#8174, so an authored value reached the
+   * renderer only through {@link BaseSchema}'s `[key: string]: any` — admitted,
+   * never examined. That is verbatim the reasoning objectui#7322 used to move
+   * {@link groupBy} and {@link limit} into this interface; this is the same
+   * situation one key over. `@objectstack/spec` declares it
+   * (`ComponentPropsMap['object-kanban']`), the plugin's registration `inputs`
+   * declares it, the renderer reads it — this declaration face was the only one
+   * that stayed silent.
+   *
+   * Spelled exactly as {@link ObjectGanttSchema.filter}, so the two views'
+   * query keys cannot fork.
+   *
+   * ⚠️ There is deliberately NO `sort` twin on this interface, and its absence
+   * is measured rather than overlooked: `ObjectKanban.tsx` has ZERO
+   * `schema.sort` read sites (the board groups records into lanes and issues no
+   * `$orderby`), and the spec's `object-kanban` entry declares no `sort`
+   * either. Only {@link ObjectCalendarSchema} declares both keys.
+   */
+  filter?: any[];
   /** Field for card title */
   titleField?: string;
   /** Fields to display on card */

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -1079,6 +1079,27 @@ export const ObjectCalendarSchema = BaseSchema.extend({
   endDateField: z.string().optional().describe('End date field'),
   titleField: z.string().optional().describe('Title field'),
   defaultView: z.enum(['month', 'week', 'day']).optional().describe("Default view — 'month' | 'week' | 'day', the renderer's rendered set ('agenda' was retired: objectui#5784)"),
+  // objectui#8174 — the two query keys `ObjectCalendar.tsx` lowers onto its own
+  // `dataSource.find` (`$filter: schema.filter`,
+  // `$orderby: convertSortToQueryParams(schema.sort)`). The spec declares both
+  // on `ComponentPropsMap['object-calendar']` and the plugin's registration
+  // `inputs` publishes both, but neither published face of THIS package named
+  // them: they rode `BaseSchema`'s `.passthrough()` here and its
+  // `[key: string]: any` on the TS side. Spelled exactly as
+  // `ObjectGanttSchema` above spells them, and mirrored at the SAME
+  // requiredness as `../objectql.ts` (both optional) so the zod-mirror-parity
+  // ratchet stays at zero drift for this pair.
+  //
+  // What declaring buys under `.passthrough()` is NOT capped by objectui#7927's
+  // index-signature ceiling: that ceiling is about a MISSPELLED key, which
+  // stays admitted either way. A DECLARED key is now VALUE-validated, and this
+  // mirror reaches `safeValidateSchema` through `AnyComponentSchema` and so
+  // reaches the CLI's `validate` / `check` — `sort: 'name asc'`, the string
+  // clause objectui#8221 retired, moves from "parses green here, then silently
+  // dropped by `convertSortToQueryParams` at runtime" to "refused at authoring
+  // time".
+  filter: z.array(z.any()).optional().describe('Query filter, forwarded verbatim as $filter'),
+  sort: z.array(SortConfigSchema).optional().describe('Sort configuration, forwarded as $orderby (array only; the legacy string clause is retired — objectui#8221)'),
 }).superRefine(requireRecordSource('object-calendar'));
 
 /**
@@ -1195,6 +1216,20 @@ export const ObjectKanbanSchema = BaseSchema.extend({
   groupBy: z.string().describe('Field whose value places a record in a lane — the lane key the object-kanban renderer reads (ObjectKanban.tsx, thirteen sites); required, as the retired groupField was'),
   groupField: retirementTombstone('RETIRED (objectui#7322) — `groupField` is not read by the object-kanban renderer; author `groupBy`. (The view-level `kanban.groupField` alias is unaffected.)'),
   limit: z.number().int().positive().optional().describe('Row cap — the most records the board fetches, sent as a real $top on the query (ObjectKanban.tsx:264); default 100 (DEFAULT_KANBAN_LIMIT)'),
+  // objectui#8174 — the query key `ObjectKanban.tsx` lowers onto its own
+  // `dataSource.find` (`$filter: schema.filter`), alongside the `$top` that
+  // `limit` above feeds. Same position `groupBy` and `limit` were in before
+  // objectui#7322: declared by the spec (`ComponentPropsMap['object-kanban']`)
+  // and by the plugin's registration `inputs`, read by the renderer, and named
+  // by neither published face of this package. Spelled exactly as
+  // `ObjectGanttSchema` above spells it, and mirrored at the SAME requiredness
+  // as `../objectql.ts` (optional) so the zod-mirror-parity ratchet stays at
+  // zero drift for this pair.
+  //
+  // ⚠️ No `sort` twin here, and the absence is measured: `ObjectKanban.tsx` has
+  // ZERO `schema.sort` read sites and the spec's `object-kanban` entry declares
+  // no `sort` either. Only `ObjectCalendarSchema` above carries both.
+  filter: z.array(z.any()).optional().describe('Query filter, forwarded verbatim as $filter'),
   titleField: z.string().optional().describe('Title field'),
   cardFields: z.array(z.string()).optional().describe('Card fields'),
   quickAdd: z.boolean().optional().describe('Enable Quick Add button at column bottom'),


### PR DESCRIPTION
Fixes objectstack-ai/objectui#8174

`ObjectKanbanSchema` gains `filter`. `ObjectCalendarSchema` gains `filter` and `sort`. Both published faces of `@object-ui/types` — the TypeScript interface in `packages/types/src/objectql.ts` and its hand-written zod mirror in `packages/types/src/zod/objectql.zod.ts`.

## Re-measured on `fb0102271`, not inherited from the card's `9bfd618`

`main` moved a great deal between the filing and this branch, so every anchor below was re-derived; the card's `:2744` / `:2698` line addresses no longer hold.

**Member lists, pulled from the interface bodies** — the full list per interface is its own control that the extraction works:

- `ObjectKanbanSchema` (`objectql.ts:2779-2900`), 11 members: `type`, `objectName?`, `groupBy`, `groupField?`, `limit?`, `titleField?`, `cardFields?`, `quickAdd?`, `coverImageField?`, `allowCollapse?`, `conditionalFormatting?` — no `filter`, no `sort`.
- `ObjectCalendarSchema` (`objectql.ts:2733-2774`), 8 members: `type`, `objectName?`, `data?`, `staticData?`, `startDateField?`, `endDateField?`, `titleField?`, `defaultView?` — no `filter`, no `sort`.

**Read census** — `schema.KEY` occurrences off disk, with `objectName` as the positive control that the query reaches the file:

| file | `schema.filter` | `schema.sort` | control `schema.objectName` |
|---|---|---|---|
| `plugin-kanban/src/ObjectKanban.tsx` | 2 | **0** | 26 |
| `plugin-calendar/src/ObjectCalendar.tsx` | 7 (2 live, 5 inside a docblock) | 2 | 19 |

The live sites: `$filter: schema.filter` on the kanban `dataSource.find` and again in that effect's dependency list; `$filter: schema.filter` and `$orderby: convertSortToQueryParams(schema.sort)` on the calendar's, and both again in its dependency list.

**The other two faces**, re-read rather than quoted: `@objectstack/spec` 17.3.0's `ComponentPropsMap` declares `filter` on `object-kanban` (13 keys) and `filter` plus `sort` on `object-calendar` (9 keys), and declares no `sort` on `object-kanban`. Both plugins' registration `inputs` publish the same set — `plugin-kanban/src/index.tsx:523`, `plugin-calendar/src/index.tsx:400-401`, all `type: 'array'`.

So the key had four declaration faces and this package's two were the silent ones. An authored value reached the renderer through `BaseSchema`'s `[key: string]: any` (`base.ts:467`, the interface's last member) and through the mirror's `.passthrough()` — admitted, never examined. That is verbatim objectui#7322's reasoning for moving `groupBy` and `limit` into this same interface, one key over.

**No `sort` on the board, and the absence is measured rather than overlooked**: zero `schema.sort` read sites in `ObjectKanban.tsx`, and the spec declares none either. Declaring it would be this repo inventing a key.

## The judgement the card delegated to the taker

The card asks whether this is worth the edit at all, or whether it should wait behind objectui#7927 — which measured that `BaseSchema` ends in an index signature, so no annotation on any node schema catches a MISSPELLED key.

**Proceeding. The ceiling is real, and it caps a different dimension from the one this buys.**

1. objectui#7927 caps the KEY dimension. A misspelling stays admitted on both faces either way, and this branch pins that rather than claiming otherwise.
2. What it does not cap is the VALUE dimension. `filter: 'status = open'` type-checked green through the index signature and parsed green through `.passthrough()`; it is now a type error and a named refusal. That is a measurable acquisition, not editor completion.
3. The `sort` half is the sharpest case, and it is a live silent failure. objectui#8221 retired the legacy string clause: `convertSortToQueryParams` no longer admits a string in its signature and returns `undefined` for one after reporting the retired spelling (`core/src/utils/sort-query.ts:133,141`). So `sort: 'start_date asc'` on an `object-calendar` node type-checked green, parsed green, and then drew an UNSORTED calendar with nothing refusing it anywhere. Declaring the member is what makes that retirement audible at the authoring boundary.
4. Ordering runs the opposite way from "wait behind it". If objectui#7927 ever tightens `BaseSchema`, it tightens the KEY dimension — and a tightening that lands while these three members are still undeclared turns every correctly authored `filter` / `sort` node into a refusal. Declaring them is a prerequisite for that card, not a duplicate of it.
5. The precedent settles the rest: objectui#7322 weighed this same trade on this same interface under this same ceiling and went ahead.

## The pin, and the ablation that shows it can fail

`packages/types/src/__tests__/kanban-calendar-filter-sort-8174.test.ts` asserts membership on the mirror's own `.shape` rather than on parse acceptance — under `.passthrough()` acceptance cannot tell "declared" from "admitted unexamined". Type-level pins use invariant equality, so a member that fell back to the index signature reads as `any` and therefore as a failure. A control key must stay undeclared on both faces, and a misspelling must stay admitted.

That file IS compiled. `packages/types`' package tsconfig excludes the test tree, but `type-check` runs a third program, `tsconfig.test.json`, that includes it — verified with `--listFiles` rather than assumed: the pin is line 413 of that program's file list and absent from the main program's.

Three ablation legs. Each proved the mutation reached disk before its run was read, and each restored, with the restore proved by an empty `git diff HEAD` and a hash equal to the HEAD blob:

| leg | mutation | measured |
|---|---|---|
| 1 | delete `ObjectCalendarSchema.sort` from `objectql.ts` (anchor count 4 to 3) | type-check **exit 2**, 5 errors: 3 x TS2344 on the invariant-equality pins, 2 x TS2578 unused `@ts-expect-error` (the retired string clause, and the bad `order` value) |
| 2 | delete `sort` from the calendar mirror (anchor count 4 to 3) | vitest **exit 1**, 4 failures: shape membership, plus the three refusals at the key |
| 3 | same mutation as leg 2, judged by `tsc` instead | type-check **exit 2**, one error: `zod-mirror-parity.test.ts` TS2322, that pair not assignable to `never` |

Leg 3 is the one worth reporting. Leg 2 alone would have read as "the mirror half is covered only by my own new file", because the parity ledger stayed green under vitest. It is not: the ledger's unmirrored-declared half is a TYPE-level operator, so it lands on `tsc` and not on the test runner. The mirror edit is mandatory rather than a courtesy — and mandatory in a way a vitest-only run cannot see.

A first attempt at leg 1 was a no-op: the slice anchor was off by one newline, nothing changed on disk, and the script's own before/after count refused to run the leg. Reported because the failure mode it caught is exactly the one that otherwise reads as a passing ablation.

Nothing in the parity ledger needed editing: mirroring at the same requiredness as the interface — both optional on both faces — leaves it at zero drift for these pairs. `__tests__/zod-mirror-parity.test.ts` is untouched, as are `zod/layout.zod.ts`, `zod/form.zod.ts`, `layout.ts` and `form.ts`, all held by PR objectui#8763.

## Gates

Run in this worktree at `a9c30cb`, on a merge of `origin/main` `fb0102271`. Exit codes captured by redirecting first and reading the status after, never through a pipe.

| command | exit |
|---|---|
| `pnpm --filter @object-ui/types type-check` (all three programs) | 0 |
| `pnpm exec vitest run packages/types/` from the repo root | 0 — 156 files, 3091 tests |
| `pnpm exec vitest run` over plugin-kanban, plugin-calendar, the console registry/spec parity file and the two app-shell block-config files | 0 — 70 files, 711 tests |
| `pnpm --filter @object-ui/types build` | 0 — dist completeness, 128 emitted files |
| `pnpm --filter @object-ui/types lint` | 0 — 271 pre-existing warnings, 0 errors |
| `node scripts/check-changeset-fixed.mjs` | 0 |
| `node scripts/check-changeset-no-major.mjs` | 0 |
| `node scripts/check-control-bytes.mjs` | 0 |
| `node scripts/check-spec-symbol-derivation.mjs` | 0 |
| `node scripts/check-doc-component-types.mjs` | 0 |
| `node scripts/check-unreferenced-sources.mjs` | 0 |
| `node scripts/check-element-data-source-declaration.mjs` | 0 |
| `node scripts/check-governed-queue-guard.mjs --test` over the four changed paths | 0 — NOT GOVERNED |

Four whole-tree scans returned a prerequisite complaint instead of a verdict, because they need every package built and this worktree builds only the affected one: `check:doc-snippets`, `check:doc-examples` and `check:sdui-registration-pins` (exit 2 each, each printing the build it wants), and `check:readme-exports` (exit 1, its own message being "run `pnpm build` first" for five documented types across four packages, followed by a collapsed-population report). Those read here as NOT MEASURED, not as green and not as red; they belong to CI, which builds the tree.

## Scope

Additive only: 4 files, +486 / −0, all inside the claimed surface. The changeset is `minor` for `@object-ui/types` — the accept set only widens, but a wrong-typed value at a correctly spelled key changes verdict, which is more than a patch. `major` is refused by `check-changeset-no-major`, and `skip-changeset` does not apply because `packages/types` ships these declarations.

`BaseSchema`'s index signature is untouched — that is objectui#7927. No other undeclared member on these two interfaces was touched: objectui#7742 and objectui#7780 are censuses over the same two interfaces on different keys, and they are not this card.

## Merge posture

DRAFT, and it stays draft. Clause-② applies — this adds declared members to a published interface — so it carries `needs:contract-review` and a ceiling review runs before it may be enqueued. Not flipped ready, not enqueued, no auto-merge.

Session: `https://claude.ai/code/session_012W3vMLTFY9SPr2LyxhSeYi`

---
_Generated by [Claude Code](https://claude.ai/code/session_012W3vMLTFY9SPr2LyxhSeYi)_