### PR TITLE
fix(app-shell): let a producer-marked userMessage outrank the localized 409/403 copy (objectui#8051)

### DIFF
--- a/.changeset/violet-donkeys-brake.md
+++ b/.changeset/violet-donkeys-brake.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/app-shell': patch
+---
+
+PackageFormDialog: a producer-marked `error.userMessage` now outranks the localized copy on the 409 and 403 arms
+
+Creating or saving a package refused with **409** (id taken) or **403** (no `manage_metadata` capability) answered with a localized constant and discarded the envelope's prose — including a `userMessage` the producer had marked, at throw time, as addressed to the person reading the screen (ADR-0112 / objectui#3821). Those are the two refusals an author meets most on this surface, so the one channel written for them was dropped exactly where it mattered.
+
+Both arms now render a marked sentence when the envelope carries one, and keep the localized constant as the fallback for an **unmarked** body — which is every refusal the package doors emit today, so the settled localized posture for a withheld capability (objectstack#8270) is unchanged. This also removes a divergence that depended on the transport: the same marked body used to read one way when an HTTP status survived the wire and another way when it did not.

--- a/packages/app-shell/src/views/metadata-admin/PackageFormDialog.envelopeUserMessage.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PackageFormDialog.envelopeUserMessage.test.tsx
@@ -27,14 +27,20 @@
  * every other consumer a tolerant dialect it never asked for. §6 pins that they
  * still work.
  *
- * ## ⚠️ Why no case here uses 403 or 409
+ * ## ⚠️ Why §1–§7 use neither 403 nor 409
  *
  * Unlike the page, this dialog's `catch` has two STATUS-driven arms in front of
  * the banner (409 → the localized "already exists" copy, 403 → the localized
- * capability copy, objectstack#8270). On those two statuses the envelope prose
- * is not what the person reads, whatever the ladder returned — so every case
- * about the ladder uses a status that reaches the `else` arm, and §8 pins the
- * arms themselves as untouched by this card.
+ * capability copy, objectstack#8270). §1–§7 are about the LADDER, so each
+ * uses a status that reaches the `else` arm and none of them depends on what
+ * the arms do.
+ *
+ * §8 is about the arms themselves, and objectui#8051 changed them: the ruling
+ * of record is 「本地化分支改为优先使用生产方消息」 — a producer-marked
+ * `userMessage` OUTRANKS the localized constant on both arms, and the constant
+ * stays as the fallback for an unmarked body. The pins below were written by
+ * objectui#7979 to record the arms as untouched; they are UPDATED here rather
+ * than removed, and the before/after of each is stated on the case.
  */
 
 import * as React from 'react';
@@ -197,42 +203,130 @@ describe('PackageFormDialog / apiJson — the 200 that declares failure', () => 
 });
 
 /**
- * The two localized arms this card did NOT touch, pinned so the scope is
- * visible rather than assumed. Both read `e.status`, so both are GREEN with the
- * fix reverted.
+ * objectui#8051 — the two localized arms in front of the banner, and which
+ * sentence wins on each.
  *
- * ⚠️ Consequence worth stating rather than hiding: on 409 and 403 — the two
- * most likely refusals for create/edit — a producer-marked sentence still does
- * not reach the author, because the localized copy answers first
- * (objectstack#8270, a settled posture the deployment states in the user's
- * language). Whether the mark should outrank that copy is a question about the
- * ARMS, not about the ladder this card fixed; it is filed separately rather
- * than decided here.
+ * ## The rule these pin
+ *
+ * The localized constants are a GENERIC SUBSTITUTION. objectui#3821's rule, in
+ * the envelope writer's words, is that a consumer "renders it verbatim and
+ * keeps its generic substitution for everything unmarked" — so a MARKED body
+ * outranks the constant and an UNMARKED body still gets it. objectui#7979
+ * pinned the arms as unchanged (both cases below showed the localized copy
+ * "mark or no mark"); the ruling of record on objectui#8051 changed that for
+ * the marked half only, and these cases now pin both halves.
+ *
+ * ## ⛔ Why this does not regress objectstack#8270
+ *
+ * #8270 (maintainer ruling 2026-08-13) put the localized capability copy here
+ * because "Managing packages requires the `manage_metadata` capability." was
+ * measured verbatim in a zh console. That sentence is the door's DIAGNOSTIC —
+ * `sendError(res, 403, 'FORBIDDEN', …)` in `@objectstack/rest`
+ * `package-routes.ts` passes no `extra`, so nothing marks it — and the
+ * unmarked cases below are that exact body: they still show the localized copy.
+ * The ruling's measurement is preserved, not traded away.
+ *
+ * ## What the arms hand over when the mark wins
+ *
+ * The COMPOSED sentence, i.e. the same bytes `§1–§7`'s `else` arm would show
+ * for the same body (mark, plus the declared `code` in parentheses) — not the
+ * bare `userMessage`. That is the point of the card: the divergence it measured
+ * was that a marked body read one way with a status and another way without
+ * one, and §8d pins that it now reads the SAME way. Handing over the bare
+ * sentence here would have shrunk that divergence to the code suffix rather
+ * than removing it.
  */
-describe('PackageFormDialog — the status-driven arms in front of the banner are unchanged', () => {
-  it('§8 a 409 still shows the localized "already exists" copy, mark or no mark', async () => {
-    expect(await bannerFor(409, envelope({ code: 'RESOURCE_CONFLICT', message: GENERIC, userMessage: MARKED }))).toBe(
+describe('PackageFormDialog — the status-driven arms in front of the banner (#8051)', () => {
+  it('§8a a 409 carrying a mark now shows the mark — was: the localized "already exists" copy', async () => {
+    const shown = await bannerFor(409, envelope({ code: 'RESOURCE_CONFLICT', message: GENERIC, userMessage: MARKED }));
+    expect(shown).toBe(`${MARKED} (RESOURCE_CONFLICT)`);
+    expect(shown).not.toBe(t('engine.packages.create.exists', 'en-US'));
+  });
+
+  it('§8a a 403 carrying a mark now shows the mark — was: the localized capability copy', async () => {
+    const shown = await bannerFor(403, envelope({ code: 'FORBIDDEN', message: GENERIC, userMessage: MARKED }));
+    expect(shown).toBe(`${MARKED} (FORBIDDEN)`);
+    expect(shown).not.toBe(t('engine.packages.noCapability', 'en-US'));
+  });
+
+  /**
+   * ⭐ The half objectstack#8270 ruled, and the half that carries every refusal
+   * on the wire today. GREEN both before and after objectui#8051, and
+   * load-bearing for exactly that reason: it is the pin that stops "prefer the
+   * mark" from being implemented as "read the mark INSTEAD", which would have
+   * blanked the localized posture on every real 409 and 403 this dialog serves.
+   */
+  it('§8b an UNMARKED 409 still shows the localized "already exists" copy', async () => {
+    expect(await bannerFor(409, envelope({ code: 'RESOURCE_CONFLICT', message: GENERIC }))).toBe(
       t('engine.packages.create.exists', 'en-US'),
     );
   });
 
-  it('§8 a 403 still shows the localized capability copy, mark or no mark', async () => {
-    expect(await bannerFor(403, envelope({ code: 'FORBIDDEN', message: GENERIC, userMessage: MARKED }))).toBe(
+  it("§8b an UNMARKED 403 — the door's own sentence, exactly as objectstack#8270 measured it — still shows the localized capability copy", async () => {
+    expect(
+      await bannerFor(403, envelope({ code: 'FORBIDDEN', message: 'Managing packages requires the `manage_metadata` capability.' })),
+    ).toBe(t('engine.packages.noCapability', 'en-US'));
+  });
+
+  /**
+   * The mark predicate is the shared reader's, byte for byte: a typed `string`
+   * check, not a truthiness one. Neither of these bodies is marked, so both
+   * take the localized arm — ⛔ never the raw diagnostic, which is what a
+   * truthiness check would have leaked here.
+   */
+  it('§8c a non-string mark is not a mark — the 403 arm keeps the localized copy', async () => {
+    expect(await bannerFor(403, envelope({ code: 'FORBIDDEN', message: GENERIC, userMessage: 42 }))).toBe(
       t('engine.packages.noCapability', 'en-US'),
     );
   });
 
+  it('§8c an empty-string mark is not a mark either — the 409 arm keeps the localized copy', async () => {
+    expect(await bannerFor(409, envelope({ code: 'RESOURCE_CONFLICT', message: GENERIC, userMessage: '' }))).toBe(
+      t('engine.packages.create.exists', 'en-US'),
+    );
+  });
+
   /**
-   * The measured behaviour change beyond the banner text, recorded because it
-   * is the only one: when the transport drops the status (`status: 0`), those
-   * arms fall back to probing the MESSAGE, and the message they now probe is
-   * whichever prose won. A marked refusal whose mark does not repeat the
-   * diagnostic's wording therefore reaches the author verbatim instead of being
-   * folded into the localized copy — which is what the envelope writer's rule
-   * asks for ("a consumer that sees the field renders it verbatim"), and is
-   * unreachable whenever a status is present.
+   * ⭐ The card's decisive measurement, now pinned as an EQUALITY rather than
+   * as two separate readings.
+   *
+   * Before objectui#8051 the answer to "does a producer's `userMessage` reach
+   * the author?" depended on whether an HTTP status survived the transport: with
+   * a 409 the localized copy answered, with the status dropped the arms fell
+   * back to probing the message and the mark came through. That is an accident
+   * of transport, not a posture. These two renders send the SAME body and differ
+   * only in whether the status arrived; they must now agree.
    */
-  it('§8 with no status at all, the probe reads whichever prose won', async () => {
+  it('§8d the same marked body reads the same with a status and without one', async () => {
+    const body = envelope({ code: 'RESOURCE_CONFLICT', message: "Package 'com.acme.new' already exists", userMessage: MARKED });
+    const withStatus = await bannerFor(409, body);
+    cleanup();
+    const withoutStatus = await bannerFor(0, body);
+    expect(withStatus).toBe(withoutStatus);
+    expect(withStatus).toBe(`${MARKED} (RESOURCE_CONFLICT)`);
+  });
+
+  /**
+   * The same equality against the `else` arm, which is the one place the mark
+   * always reached the author. A 503 is not 409 or 403, so it lands there; the
+   * body is identical. ⛔ If these ever diverge, the arms have grown a dialect.
+   */
+  it('§8d a marked 403 reads exactly as the same body would on a status with no arm', async () => {
+    const body = envelope({ code: 'FORBIDDEN', message: GENERIC, userMessage: MARKED });
+    const onTheArm = await bannerFor(403, body);
+    cleanup();
+    const onTheElseArm = await bannerFor(503, body);
+    expect(onTheArm).toBe(onTheElseArm);
+  });
+
+  /**
+   * objectui#7979's third §8 case, unchanged in both text and verdict: with no
+   * status the arms probe the MESSAGE, the probe reads whichever prose won, and
+   * a mark that does not repeat the diagnostic's wording reaches the author.
+   * It was the evidence that the old divergence was transport-shaped; it stays
+   * as the pin that the no-status path did not move while the status path did.
+   */
+  it('§8e with no status at all, the probe reads whichever prose won', async () => {
     expect(
       await bannerFor(0, envelope({ message: "Package 'com.acme.new' already exists", userMessage: MARKED })),
     ).toBe(MARKED);

--- a/packages/app-shell/src/views/metadata-admin/PackageFormDialog.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PackageFormDialog.tsx
@@ -50,6 +50,46 @@ export interface PackageSaveResult {
   package?: { manifest: ManifestRecord } & Record<string, unknown>;
 }
 
+/**
+ * Was this envelope's prose MARKED, i.e. did the producer address it to the end
+ * user (`error.userMessage`, #9934) rather than to whoever is debugging?
+ *
+ * ⚠️ Why this is read separately instead of taken from
+ * {@link readEnvelopeFailureText}: that reader answers *what prose to show* and
+ * deliberately collapses the two channels into one string
+ * (`userMessage || message`, plus the declared code). Its return value
+ * therefore cannot tell a caller WHICH channel won — and objectui#8051's two
+ * status arms need exactly that bit, because their localized constant is a
+ * generic substitution that objectui#3821 keeps for UNMARKED bodies only. So
+ * the mark is read here and carried across the throw; ⛔ the arms cannot
+ * re-derive it from the message they receive.
+ *
+ * ⛔ Not a second copy of the shared rule. The rule about what to SHOW stays in
+ * `readEnvelopeFailureText` and is not restated here; this answers a different
+ * question about the same body, at the one call site that asks it. Widening the
+ * shared reader's signature to return the provenance is objectui#7980's
+ * surface, not this card's.
+ *
+ * The predicate is byte-identical to the shared reader's `marked` const on
+ * purpose: a typed `string` check, not a truthiness one, so a non-string mark
+ * is not a mark (a producer bug — falling through to the diagnostic is the
+ * honest answer) and an empty-string mark is not one either.
+ */
+function readEnvelopeUserMessage(payload: unknown): string {
+  const error = (payload as { error?: unknown } | null | undefined)?.error;
+  if (!error || typeof error !== 'object') return '';
+  const { userMessage } = error as { userMessage?: unknown };
+  return typeof userMessage === 'string' ? userMessage : '';
+}
+
+/**
+ * What `apiJson` attaches to the `Error` it throws, and the whole of the
+ * contract `submit()`'s catch reads back. Named rather than cast away one
+ * property at a time so the carrier is legible from both ends: the catch cannot
+ * recover either field from the message, and objectui#8051 turns on that.
+ */
+type ApiJsonError = Error & { status: number; userMessage: string };
+
 async function apiJson<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(path, {
     credentials: 'include',
@@ -78,8 +118,15 @@ async function apiJson<T>(path: string, init?: RequestInit): Promise<T> {
       payload?.error ||
       payload?.message ||
       `Request failed (${res.status})`;
-    const err = new Error(typeof msg === 'string' ? msg : `Request failed (${res.status})`);
-    (err as any).status = res.status;
+    const err = new Error(typeof msg === 'string' ? msg : `Request failed (${res.status})`) as ApiJsonError;
+    err.status = res.status;
+    // objectui#8051 — the mark travels WITH the refusal. `msg` above already
+    // resolved to the marked sentence when there was one, but it did so
+    // irreversibly; the status arms in `submit()`'s catch have to know whether
+    // the prose they are about to discard was addressed to the person reading
+    // the screen. Empty string when unmarked, which is the overwhelmingly
+    // common case and everything the two package doors emit today.
+    err.userMessage = readEnvelopeUserMessage(payload);
     throw err;
   }
   return (payload?.data ?? payload) as T;
@@ -227,18 +274,44 @@ export function PackageFormDialog({
       onOpenChange(false);
     } catch (e: any) {
       const msg: string = e?.message ?? '';
+      // objectui#8051 — WAS this refusal marked? The two status arms below
+      // answer with a localized constant, and that constant is a GENERIC
+      // SUBSTITUTION: objectui#3821's rule, which the envelope writer states as
+      // "a consumer that sees the field renders it verbatim and keeps its
+      // generic substitution for everything unmarked", keeps it for unmarked
+      // bodies and hands a MARKED body straight to the person. Until this card
+      // both arms applied the substitution to marked bodies too, so on the two
+      // statuses an author meets most — 409 (id taken) and 403 (no ADR-0066
+      // capability) — the one sentence a producer wrote for them was dropped.
+      //
+      // Ruling of record, objectui#8051 (2026-09-09), verbatim:
+      // 「本地化分支改为优先使用生产方消息」, 「⛔ 无产品语义分叉」.
+      //
+      // ⚠️ This bit is NOT derivable from `msg`. `apiJson` resolves the
+      // envelope through `readEnvelopeFailureText`, which returns
+      // `userMessage || message` and reports no provenance — a marked sentence
+      // and a diagnostic that happens to read the same are one value by then.
+      // Hence `readEnvelopeUserMessage` at the throw site and this read here.
+      const marked: boolean = typeof e?.userMessage === 'string' && e.userMessage !== '';
       if (e?.status === 409 || /already exists/i.test(msg)) {
-        setError(t('engine.packages.create.exists', locale));
+        setError(marked ? msg : t('engine.packages.create.exists', locale));
       } else if (e?.status === 403 || /manage_metadata/i.test(msg)) {
-        // objectstack#8270 — the `else` below renders the server's own English
-        // sentence, which is how "Managing packages requires the
-        // `manage_metadata` capability." reached a zh console untranslated. A
-        // deployment that withholds the capability does so deliberately
-        // (maintainer ruling 2026-08-13), so this is a settled posture to state,
-        // not a transient failure to retry. Probed the same way as the 409 arm
-        // above — the status when the transport reports one, the message when
-        // it does not.
-        setError(t('engine.packages.noCapability', locale));
+        // objectstack#8270 — for an UNMARKED body this arm still answers
+        // exactly as it did, and that is the whole of what #8270 measured. The
+        // sentence it was ruled about, "Managing packages requires the
+        // `manage_metadata` capability.", is the door's DIAGNOSTIC:
+        // `sendError(res, 403, 'FORBIDDEN', …)` in `@objectstack/rest`
+        // `package-routes.ts` passes no `extra`, so no `userMessage` rides with
+        // it, so `marked` is false and the localized copy answers — byte for
+        // byte as the 2026-08-13 maintainer ruling requires. A deployment that
+        // withholds the capability does so deliberately, so this is a settled
+        // posture to state in the user's language, not a transient failure to
+        // retry. What changes is only the case #8270 never saw: a body a
+        // producer deliberately marked for the end user.
+        //
+        // Probed the same way as the 409 arm above — the status when the
+        // transport reports one, the message when it does not.
+        setError(marked ? msg : t('engine.packages.noCapability', locale));
       } else {
         setError(msg || t(createMode ? 'engine.packages.create.failed' : 'engine.packages.edit.failed', locale));
       }


### PR DESCRIPTION
Fixes #8051

## What changed

`PackageFormDialog`'s `submit()` catch has two status-driven arms in front of the banner: 409 answers with `engine.packages.create.exists`, 403 with `engine.packages.noCapability`. Both answered with the localized constant **even when the envelope carried a producer-marked `error.userMessage`** — the one sentence a producer wrote, at throw time, for the person reading the screen.

Ruling of record (comment 5595068828, restated in 5597587485): 「本地化分支改为优先使用生产方消息」, 「⛔ 无产品语义分叉」.

Both arms now render a marked sentence when the envelope carries one, and keep the localized constant as the fallback for an **unmarked** body — objectui#3821's "generic substitution for everything unmarked".

## 前提 — the first measurement, and it does NOT collide

The dispatch's first instruction was to read objectstack#8270's actual ruling text before writing code, and to stop if it forbids a marked producer sentence reaching that arm at all. **It does not.** The two rulings are compatible, and the measurement is stronger than a reading of the text alone:

- #8270's ruling (comment 5278891074, maintainer verbatim): 「EE 单库多租户下,workspace owner 不允许构建应用。」 The elaboration requires that "the refusal/explanation copy is localized (the measured error was untranslated English in a zh console)". It constrains the copy; it says nothing about `userMessage`, a channel this file did not read at all until objectui#7979 landed three weeks later.
- **The sentence #8270 measured is emitted UNMARKED.** `@objectstack/rest` `package-routes.ts:81` calls the shared writer with **four** arguments — response, 403, the FORBIDDEN code, and the message — and no fifth. `userMessage` only rides in that fifth `extra` argument (`response-envelope.ts:204-209`), so nothing marks it. The 409 twin, `packages/runtime/src/domains/packages.ts:626`, is `deps.error(message, 409)`, whose signature is `(message, httpStatus, details?)` — likewise no mark.

⇒ On every refusal these two doors emit today, `marked` is false and the localized copy answers, byte for byte as #8270 requires. What changes is only the case #8270 never saw: a body a producer deliberately marked for the end user. §8b pins that door sentence verbatim as a test case so the preservation is measured, not argued.

## 机制假设 falsified — the mark is NOT observable at the arms

The dispatch's second assumption was that the marked/unmarked distinction is readable at the arms purely from the parsed envelope. **It is not, and that changed the shape of the fix.** The arms never see the envelope: `apiJson` resolves it through `readEnvelopeFailureText`, which returns `userMessage || message` (plus the declared code) and reports **no provenance**. By the time `catch` runs there is one string, in which a marked sentence and a diagnostic that happens to read the same are indistinguishable.

So the mark has to be *carried*: `readEnvelopeUserMessage` reads it at the throw site and the typed `ApiJsonError` carries it across. Its predicate is byte-identical to the shared reader's `marked` const — a typed `string` check, so neither a non-string nor an empty-string mark is a mark (§8c pins both).

⛔ **No export surface moves.** `readEnvelopeFailureText` and `apiErrorEnvelope.ts` are untouched — widening the shared reader to report provenance is objectui#7980 and is gated behind `CONTRACT_REVIEW_TIER`. Both new symbols are module-local (0 added `export` lines in the diff; lit control: 86 added lines total).

## Why the arms hand over the composed sentence

The arms render the same bytes the `else` arm would for the same body (mark plus the declared `code` in parentheses), not the bare `userMessage`. The card's decisive point is that a marked body used to read one way when a status survived the transport and another way when it did not; handing over the bare sentence here would have shrunk that divergence to the code suffix rather than removing it. §8d pins it as an **equality** across both shapes.

## §8's pins — updated, never deleted

The two "mark or no mark" cases now assert the mark wins (§8a); four new cases pin the localized fallback for unmarked, non-string-marked and empty-string-marked bodies (§8b, §8c); §8d pins the transport equality; §8e is objectui#7979's no-status case, unchanged in text and verdict.

## Tests

All at `d2907dce7` (the final commit; tree verified clean at that sha).

- Build closure first: `pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build` — `VERDICT command-exit 0`.
- `pnpm exec vitest run --maxWorkers=2` over `PackageFormDialog.envelopeUserMessage.test.tsx`, `PackageFormDialog.test.tsx`, `apiErrorEnvelope.test.ts` — `Test Files 3 passed (3) / Tests 50 passed (50)`. The nine §8 cases confirmed individually with `--reporter=verbose`: all nine ran, none skipped.
- `pnpm --filter @object-ui/app-shell type-check` — exit 0. It is `tsc --noEmit && tsc -p tsconfig.test.json`, so the test file is type-checked too; not a NOT-MEASURED gap.
- Gates, all exit 0: `check:control-bytes` (6980 files), `check:i18n-keys`, `check:i18n-drift` ("0 en value(s) changed, 0 key(s) added" — no key moved), `check:i18n-dead-keys`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:comment-mask-corpus`, `check:phantom-deps`.
- `node scripts/check-governed-queue-guard.mjs --test` on all three paths: "NOT GOVERNED — 3 path(s) checked against 5 governed surface(s); none matched."

**Reverse verification, direction predicted before each run.** Predicted: ablating the mark precedence reddens exactly §8a (x2) and §8d (x2) and leaves every unmarked pin plus §1–§7 green — 4 red, 18 green.

1. *Arms ablated* (`marked ? msg : t(...)` collapsed to `t(...)`): observed `4 failed | 18 passed (22)`, exactly the four named cases. On-disk proof: ternary count 2 to 0, injected marker 0 to 2, blob hash moved off the HEAD blob.
2. *Carrier severed* (`err.userMessage = ''`, arms left intact so they still try to read the mark): observed the same `4 failed | 18 passed (22)`. This is the direct measurement that the arms cannot re-derive the mark from the message.

Both legs restored via `git checkout HEAD -- path` under an `EXIT`/`INT`/`TERM` trap using absolute paths, each verified by hash equality against the HEAD blob (`930b57b0…`) rather than by an exit code; `git diff HEAD` empty afterwards, marker residue 0 with a lit control of 3 on the same grep shape.

**Lint — a measured narrowing, not a skipped run.** Universe read from eslint's own config: `eslint --no-inline-config --format json .` selects **4626** files. The narrowed run judged **2** (the count read from the JSON output), with **0 errors**; warnings went **3 to 2** against the `origin/main` baseline of the same file, because typing the thrown error removed the pre-existing `(err as any).status` cast rather than adding a second one. Invariance: type-aware linting is **not** enabled — grep for `projectService|parserOptions|project:` in `eslint.config.js` returns 0 with a lit control of 12 for a known-present token on the same command shape — so edits to these two files cannot move the judgment of any untouched file. The repo-wide run belongs to CI.

## 验收备注

- Nothing filed as an out-of-scope issue. One observation, recorded rather than filed because no PR and no person is heading for it: `readEnvelopeFailureText`'s collapse of the two channels means **any** consumer wanting provenance must re-read the envelope, as this file now does. That is objectui#7980's subject and it already holds the surface, so a second card would be a duplicate.
- Process note: the first test invocation used `pnpm --filter PKG exec vitest`, which this repo's objectui#3378 guard rejected outright, naming the false-green it prevents (vitest re-roots to the package dir, silently runs the console project's 22 files and reports them as a pass). Re-run from the repo root as the guard directs. The guard worked exactly as designed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH)_