### PR TITLE
fix(plugin-kanban): one horizontal axis for a swimlane board (objectui#8448)

### DIFF
--- a/.changeset/8448-kanban-swimlane-scroll-sync.md
+++ b/.changeset/8448-kanban-swimlane-scroll-sync.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/plugin-kanban': patch
+---
+
+A horizontally scrolled swimlane Kanban board now keeps every column title over its own
+column (objectui#8448).
+
+**The defect.** The swimlane layout paints its column titles once, in a row above every
+lane, and then paints each lane's cells in a row of its own. Both rows were
+`overflow-x-auto`, so they were **independent scroll containers**: scrolling a lane
+sideways moved that lane and nothing else. Measured in Chromium at 1600x1000 with five
+columns, driving one lane to `scrollLeft: 298` left the header row at `0` — the `Open`
+title at x=200 above an Open lane cell at x=-97. The row overflows at ordinary widths
+there (`scrollWidth` 1840 against `clientWidth` 1552), so this was not an edge case at
+narrow viewports.
+
+Nothing errored. The board simply reported the wrong status for every card on screen,
+which is worse than the height-0 header row objectui#7303 fixed: that one failed loudly,
+this one reads as a working board.
+
+**The fix is one horizontal axis for the whole board.** The header row and every lane row
+now share a single scroll position: scrolling any of them scrolls all of them, in either
+direction, and a lane expanded after the board was already scrolled joins the axis where
+the board is rather than at 0. The two rows already carry the same left indent and the
+same column widths (objectui#7303, objectui#8508), so an equal scroll position *is* the
+alignment.
+
+Per-lane independent horizontal scrolling is gone. Nothing asked for it: no prop, no
+authorable schema key, no stored view setting and no test in this package held two lanes
+at different positions — the package's only other `scrollLeft` reader is the flat
+layout's mobile column indicator, which is untouched and stays off this axis.
+
+Nothing about the board's vertical arrangement changed — no `overflow-y`, no height
+bound, no sticky positioning — and the header row remains a scroll container that is not
+shrinkable, the invariant objectui#7303 pinned.

--- a/packages/plugin-kanban/src/KanbanImpl.tsx
+++ b/packages/plugin-kanban/src/KanbanImpl.tsx
@@ -49,6 +49,40 @@ const useKanbanT = createSafeTranslation(
 
 const UNCATEGORIZED_LANE = 'Uncategorized'
 
+/**
+ * Marks a swimlane row as a participant in the board's ONE horizontal axis
+ * (objectui#8448).
+ *
+ * The swimlane layout paints its column titles once, above every lane, and then
+ * paints each lane's cells in its own row. Both rows are `overflow-x-auto`, so
+ * before this attribute existed they were INDEPENDENT scroll containers: driving
+ * a lane to `scrollLeft: 298` left the header at `0`, and every column title
+ * then sat over the wrong column. Measured in Chromium 1194 at 1600x1000 with
+ * five columns — `'Open'` title at x=200, the Open lane cell at x=-97 — and the
+ * row already overflows at ordinary widths there (`scrollWidth` 1840 vs
+ * `clientWidth` 1552). Nothing errored; the board simply lied about which lane
+ * was which status, which is worse than the height-0 row objectui#7303 fixed
+ * because that one failed loudly.
+ *
+ * ⚠️ The sync is a scroll handler rather than one shared scrolling ANCESTOR,
+ * and that is a measurement, not a preference. Folding the header row and the
+ * lane rows into a single `overflow-x-auto` wrapper is refused by objectui#7303's
+ * own pin, which reads the header row as `region.firstElementChild` and asserts
+ * that its `pl-*` indent EQUALS the lane content row's. A wrapper becomes that
+ * first child, and hoisting the shared indent onto it is exactly what makes the
+ * two indents differ — so the restructuring cannot be done without editing a pin
+ * that must stay unweakened. It also drags the lane chrome (border box and
+ * collapse button) inside the scroller, where the lane's own name scrolls out of
+ * view: a second "the board no longer says which lane this is" defect, of the
+ * family this fix exists to remove.
+ *
+ * Keeping the DOM as it is has a second payoff: the header row stays a direct
+ * flex child of the swimlane region, so objectui#8449's ruled vertical arm
+ * (region scrolls, header row sticks) remains reachable without undoing any of
+ * this.
+ */
+const SWIMLANE_SCROLL_ROW_ATTR = 'data-swimlane-scroll-row'
+
 // `KanbanCard` / `KanbanColumn` have ONE authority in this package: `./types`
 // (objectui#6172 / #6155). This file used to redeclare both, and the copies had
 // drifted — the local `KanbanCard` carried `cardSubtitle` / `cardFieldCells` /
@@ -688,6 +722,63 @@ function KanbanBoardInner({ columns, onCardMove, onCardClick, className, dnd, qu
     return () => el.removeEventListener('scroll', handle)
   }, [boardColumns.length])
 
+  /**
+   * The swimlane board's single horizontal scroll position (objectui#8448).
+   *
+   * A ref, not state: this value must be readable from a `scroll` handler and
+   * from a mount-time `ref` callback without re-rendering the board on every
+   * scroll frame. Nothing renders from it.
+   */
+  const swimlaneScrollLeftRef = React.useRef(0)
+
+  /**
+   * Propagate one row's new position to every other row of the same board.
+   *
+   * Rows are found by attribute rather than collected into a ref, because a
+   * plain `ref` callback is handed `null` on unmount and cannot say WHICH
+   * element left; a DOM query is always the live set. `boardRef` scopes it to
+   * this board, and the attribute is carried only by swimlane rows, so the flat
+   * layout's own scroller can never be pulled along.
+   *
+   * The equality guards are what make this terminate. Assigning a `scrollLeft`
+   * that a row already holds fires no `scroll` event, so the echo from the rows
+   * this handler moves dies on its first hop; the shared-position guard on top
+   * makes a second row reporting the same value a no-op rather than a second
+   * pass. The one place a row can disagree is the extreme right edge: a lane row
+   * carries ~10px more scrollable width than the header row (its `pr` plus the
+   * lane's border), so a lane driven to its own maximum clamps the header to the
+   * header's, whose echo then pulls the lanes back to it. That converges in one
+   * hop and settles on the most restrictive row, which is the honest reading of
+   * "one axis for the whole board".
+   */
+  const syncSwimlaneScroll = React.useCallback((event: React.UIEvent<HTMLDivElement>) => {
+    const source = event.currentTarget
+    const next = source.scrollLeft
+    if (next === swimlaneScrollLeftRef.current) return
+    swimlaneScrollLeftRef.current = next
+    const board = boardRef.current
+    if (!board) return
+    for (const row of board.querySelectorAll<HTMLElement>(`[${SWIMLANE_SCROLL_ROW_ATTR}]`)) {
+      if (row !== source && row.scrollLeft !== next) row.scrollLeft = next
+    }
+  }, [])
+
+  /**
+   * Give a row that mounts LATE the board's current position.
+   *
+   * Expanding a collapsed lane mounts a fresh row at `scrollLeft: 0`; without
+   * this it would render one lane's cells offset from every other lane's and
+   * from the titles above them — the same defect, arriving by a different door.
+   * The callback identity is stable, so React runs it once per mount and once
+   * with `null` per unmount rather than on every render (which would reset the
+   * position mid-scroll).
+   */
+  const adoptSwimlaneScroll = React.useCallback((el: HTMLDivElement | null) => {
+    if (el && el.scrollLeft !== swimlaneScrollLeftRef.current) {
+      el.scrollLeft = swimlaneScrollLeftRef.current
+    }
+  }, [])
+
   return (
     <DndContext
       sensors={sensors}
@@ -768,7 +859,12 @@ function KanbanBoardInner({ columns, onCardMove, onCardClick, className, dnd, qu
               The `pl-36 sm:pl-44` indent is shared with the lane content rows
               below and is what lines the titles up with their columns — it must
               move on both rows or neither. */}
-          <div className="flex shrink-0 gap-3 sm:gap-4 pl-36 sm:pl-44 overflow-x-auto">
+          <div
+            className="flex shrink-0 gap-3 sm:gap-4 pl-36 sm:pl-44 overflow-x-auto"
+            ref={adoptSwimlaneScroll}
+            onScroll={syncSwimlaneScroll}
+            data-swimlane-scroll-row=""
+          >
             {boardColumns.map(col => (
               <div
                 key={col.id}
@@ -802,7 +898,12 @@ function KanbanBoardInner({ columns, onCardMove, onCardClick, className, dnd, qu
 
                 {/* Lane content */}
                 {!isCollapsed && (
-                  <div className="flex gap-3 sm:gap-4 overflow-x-auto px-2 pb-3 pl-36 sm:pl-44">
+                  <div
+                    className="flex gap-3 sm:gap-4 overflow-x-auto px-2 pb-3 pl-36 sm:pl-44"
+                    ref={adoptSwimlaneScroll}
+                    onScroll={syncSwimlaneScroll}
+                    data-swimlane-scroll-row=""
+                  >
                     {boardColumns.map(col => {
                       const laneCards = col.cards.filter(c =>
                         (c[swimlaneField!] != null ? String(c[swimlaneField!]) : UNCATEGORIZED_LANE) === lane

--- a/packages/plugin-kanban/src/__tests__/swimlaneScrollSync-8448.test.tsx
+++ b/packages/plugin-kanban/src/__tests__/swimlaneScrollSync-8448.test.tsx
@@ -1,0 +1,263 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8448 — a swimlane board has ONE horizontal axis.
+ *
+ * ## What broke
+ *
+ * The swimlane layout paints its column titles once, above every lane, and each
+ * lane paints its own row of column cells. Both were `overflow-x-auto`, so they
+ * were INDEPENDENT scroll containers: scrolling a lane sideways moved that lane
+ * and nothing else, and the titles stayed where they were. Every column label
+ * then sat over a different column's cells. Nothing threw — the board simply
+ * lied about which lane was which status, which is worse than the height-0
+ * header row objectui#7303 fixed, because that one failed loudly.
+ *
+ * Measured in Chromium 1194 at 1600x1000 with five columns: driving one lane to
+ * `scrollLeft: 298` left the header row at `0`, putting the `'Open'` title at
+ * x=200 over an Open lane cell at x=-97. The row overflows at ordinary widths
+ * there (`scrollWidth` 1840 vs `clientWidth` 1552), so this is not an 800px edge
+ * case. The ruling (comment 5597568414) is **option A — one horizontal axis for
+ * the whole board**: the header row and every lane row share a scroll position.
+ *
+ * ## ⚠️ What this file can and cannot measure — read before extending it
+ *
+ * The same limit objectui#7303's pin documents applies: Vitest runs here in
+ * happy-dom, which performs NO layout. `getBoundingClientRect()` is 0x0 for
+ * every element, so the GEOMETRIC half of the acceptance — "each column title
+ * lands over its own lane cell" — cannot be asserted here; a coordinate
+ * assertion would be a pin that cannot fail. That half was measured out of band
+ * in Chromium and is reported in the PR.
+ *
+ * What IS mechanically true in happy-dom, and is what this file pins, is the
+ * MECHANISM that decides those coordinates: `scrollLeft` is a plain settable
+ * number, so the propagation from one row to all the others is fully
+ * observable. Given the two rows carry the same left indent and the same column
+ * widths — which objectui#7303's pin asserts and this file re-reads — equal
+ * `scrollLeft` IS the alignment.
+ *
+ * ⚠️ `scrollLeft` assignment fires no `scroll` event in happy-dom (measured), so
+ * every case drives the axis with an explicit `fireEvent.scroll`. That is also
+ * why the propagation cannot loop here: the writes this handler makes are
+ * silent.
+ *
+ * ## Non-vacuity
+ *
+ * "The rows agree" is trivially true of a board with one row, or none. Every
+ * case first proves a real swimlane board — its region label, both lanes, and a
+ * card rendered INSIDE a lane — and reads a row count, so a board that stopped
+ * rendering lanes cannot read as success. The last case is the arm-C half: the
+ * ruling refused "make the header row unscrollable", and a board whose rows are
+ * no longer scroll containers would satisfy every equality above while
+ * reintroducing the collapse objectui#7303 closed.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup, fireEvent, within } from '@testing-library/react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+// Registers `object-kanban`. Module scope, not a hook: the import IS the
+// registration (AGENTS.md's test-discipline section).
+import '../index';
+// The board renders inside `KanbanRenderer`'s `React.lazy` boundary; importing
+// the chunk at module scope bills the cold transform to the import phase
+// instead of racing a `waitFor` budget (objectui#3010), same specifier as
+// `index.tsx`'s factory so ESM's module cache resolves it immediately.
+import '../KanbanImpl';
+
+afterEach(cleanup);
+
+/**
+ * The viewport this fixture states — the one the card measured at.
+ *
+ * happy-dom never applies CSS, so nothing below branches on it; it is pinned so
+ * the fixture says which world it describes (objectui#7303's pin does the same).
+ */
+const VIEWPORT = { width: 1600, height: 1000 };
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: VIEWPORT.width });
+  Object.defineProperty(window, 'innerHeight', { configurable: true, writable: true, value: VIEWPORT.height });
+  // Collapsed lanes persist per swimlane field; a leaked entry would silently
+  // change how many rows the next case renders.
+  try { window.localStorage.clear(); } catch { /* ignore */ }
+});
+
+const OBJECT = 'deal';
+
+const DEAL_SCHEMA = {
+  name: OBJECT,
+  label: 'Deal',
+  fields: {
+    name: { type: 'text', label: 'Name' },
+    status: { type: 'text', label: 'Status' },
+    owner: { type: 'text', label: 'Owner' },
+  },
+};
+
+function makeAdapter(): Record<string, any> {
+  return {
+    find: vi.fn(async () => ({ data: [] })),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async () => DEAL_SCHEMA),
+  };
+}
+
+const ROWS = [
+  { id: 'a', name: 'Alpha deal', status: 'open', owner: 'ann' },
+  { id: 'b', name: 'Beta deal', status: 'won', owner: 'bob' },
+];
+
+/**
+ * Five columns, as measured. The count is load-bearing for the card's own
+ * numbers (`scrollWidth` 1840 vs `clientWidth` 1552 at 1600px) even though
+ * happy-dom cannot reproduce them.
+ */
+const BOARD = {
+  type: 'object-kanban',
+  objectName: OBJECT,
+  groupBy: 'status',
+  columns: [
+    { id: 'open', title: 'Open' },
+    { id: 'qualified', title: 'Qualified' },
+    { id: 'proposal', title: 'Proposal' },
+    { id: 'won', title: 'Won' },
+    { id: 'lost', title: 'Lost' },
+  ],
+};
+
+function renderBoard(extra: Record<string, unknown> = {}) {
+  return render(
+    <SchemaRendererProvider dataSource={makeAdapter() as any}>
+      <SchemaRenderer schema={{ ...BOARD, data: ROWS, ...extra } as never} />
+    </SchemaRendererProvider>,
+  );
+}
+
+const SWIMLANES = { grouping: { fields: [{ field: 'owner' }] } };
+
+/** Every row that declares itself part of the board's shared horizontal axis. */
+const axisRows = (root: ParentNode): HTMLElement[] =>
+  [...root.querySelectorAll<HTMLElement>('[data-swimlane-scroll-row]')];
+
+/**
+ * Render a swimlane board and prove it is a real one before anything is
+ * measured on it: the region, both lanes, and a card inside a lane.
+ */
+async function renderSwimlaneBoard() {
+  const { container } = renderBoard(SWIMLANES);
+
+  await waitFor(() => expect(container.textContent).toContain('Alpha deal'));
+  const region = container.querySelector('[role="region"]') as HTMLElement;
+  expect(region?.getAttribute('aria-label')).toBe('Kanban board with swimlanes');
+
+  const laneButtons = [...region.querySelectorAll('button[aria-expanded]')];
+  expect(laneButtons.map((b) => b.textContent)).toEqual(['▶ann(1)', '▶bob(1)']);
+
+  const laneList = region.querySelector('[role="list"][aria-label="Open - ann cards"]');
+  expect(
+    within(laneList as HTMLElement).queryByText('Alpha deal'),
+    'the swimlane cell should hold its card',
+  ).not.toBeNull();
+
+  return { container, region, laneButtons: laneButtons as HTMLElement[] };
+}
+
+describe('objectui#8448 — the swimlane board scrolls on one horizontal axis', () => {
+  it('SYNC — a lane driven sideways takes the header row and the other lane with it', async () => {
+    const { region } = await renderSwimlaneBoard();
+
+    // CONTROL — one header row + one row per lane, in document order, and the
+    // header row is the region's first child (the layout objectui#7303 settled).
+    const rows = axisRows(region);
+    expect(rows.length, 'header row + one row per lane').toBe(3);
+    expect(rows[0]).toBe(region.firstElementChild);
+    expect(rows.every((r) => r.scrollLeft === 0), 'the board starts unscrolled').toBe(true);
+
+    // The card's own measurement, inverted. 298 is the value it drove a lane to.
+    const [headerRow, annRow, bobRow] = rows;
+    annRow.scrollLeft = 298;
+    fireEvent.scroll(annRow);
+
+    expect(
+      headerRow.scrollLeft,
+      'the column-header row must follow the lane, or every title sits over the wrong column (objectui#8448)',
+    ).toBe(298);
+    expect(bobRow.scrollLeft, 'every other lane is on the same axis').toBe(298);
+    expect(annRow.scrollLeft, 'the lane the user actually scrolled keeps its position').toBe(298);
+  });
+
+  it('SHARED, not header-follows-lane — driving the header row moves the lanes', async () => {
+    const { region } = await renderSwimlaneBoard();
+    const [headerRow, annRow, bobRow] = axisRows(region);
+    expect(axisRows(region).length).toBe(3);
+
+    // Arm B (the header tracks an "active" lane) was refused: the axis is one
+    // value, so it is drivable from either end. A one-way lane-to-header sync
+    // would leave this case red.
+    headerRow.scrollLeft = 140;
+    fireEvent.scroll(headerRow);
+
+    expect(annRow.scrollLeft).toBe(140);
+    expect(bobRow.scrollLeft).toBe(140);
+  });
+
+  it('LATE MOUNT — a lane expanded after the board was scrolled adopts its position', async () => {
+    const { region, laneButtons } = await renderSwimlaneBoard();
+
+    // Collapse the second lane, so its row unmounts and remounts later.
+    fireEvent.click(laneButtons[1]);
+    await waitFor(() => expect(axisRows(region).length).toBe(2));
+
+    const [headerRow, annRow] = axisRows(region);
+    annRow.scrollLeft = 210;
+    fireEvent.scroll(annRow);
+    expect(headerRow.scrollLeft).toBe(210);
+
+    fireEvent.click(laneButtons[1]);
+    await waitFor(() => expect(axisRows(region).length).toBe(3));
+
+    const reopened = axisRows(region)[2];
+    expect(
+      reopened.scrollLeft,
+      'a lane that mounts late must join the axis where the board already is, not at 0',
+    ).toBe(210);
+    // The rows that were already there did not get reset by the new arrival.
+    expect(axisRows(region).map((r) => r.scrollLeft)).toEqual([210, 210, 210]);
+  });
+
+  it('ARM C REFUSED / NON-REGRESSION — the rows are still scroll containers, and the flat board is not on this axis', async () => {
+    const { region } = await renderSwimlaneBoard();
+
+    // The ruling refused "remove the header row's own scrollability": the fix
+    // must not be bought by making a row unscrollable, which is the shrink
+    // arithmetic objectui#7303's pin exists to protect. Equal `scrollLeft` is
+    // trivially satisfied by rows that can never scroll at all.
+    for (const row of axisRows(region)) {
+      expect(
+        row.className.split(/\s+/).some((t) => /^(?:[a-z]+:)*overflow(?:-x)?-(?:auto|scroll)$/.test(t)),
+        `a synced row must still be a scroll container; class was ${JSON.stringify(row.className)}`,
+      ).toBe(true);
+    }
+
+    cleanup();
+
+    // The flat layout owns its own scroller (snap-scroll, mobile dot
+    // indicator). It must not be roped into the swimlane axis.
+    const { container } = renderBoard();
+    await waitFor(() => expect(container.textContent).toContain('Alpha deal'));
+    const flatRegion = container.querySelector('[role="region"]') as HTMLElement;
+    expect(flatRegion.getAttribute('aria-label')).toBe('Kanban board');
+    expect(flatRegion.hasAttribute('data-swimlane-scroll-row')).toBe(false);
+    expect(axisRows(container).length, 'a flat board has no swimlane axis rows').toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #8448

Ships **option A** exactly as ruled (comment 5597568414 plus the addendum 5597591224): one horizontal axis for the whole swimlane board. The header row and every lane row share a single scroll position, drivable from either end.

## The defect, reproduced to the pixel

The swimlane layout paints its column titles once above every lane and each lane's cells in a row of its own. Both were `overflow-x-auto`, so they were independent scroll containers. Reproduced in Chromium at 1600x1000 with five columns, against the shipped stylesheet pair, by ablating the fix on disk:

```
===== ABLATED (the shipped board) =====
  header scrollWidth/client: 1840 / 1552  (overflows: true)
  DRIVE lane 0 -> scrollLeft 298
    header scrollLeft      : 0
    lane   scrollLefts     : [298,0]
    'Open'        title x=   200  lane cell x=   -97  delta=-297
    'Qualified'   title x=   536  lane cell x=   239  delta=-297
    'Proposal'    title x=   872  lane cell x=   575  delta=-297
    'Won'         title x=  1208  lane cell x=   911  delta=-297
    'Lost'        title x=  1544  lane cell x=  1247  delta=-297
```

`1840 / 1552`, `'Open'` at `x=200`, the Open lane cell at `x=-97` — the card's own three numbers, independently reproduced. The fixture was not tuned to them; five 320px columns behind a `pl-36` indent inside a 1600px viewport simply lands there.

Note the second row of damage the card does not name: `lane scrollLefts [298,0]`. The lanes desynchronise from **each other**, not only from the titles, so two lanes on screen show different columns under the same headings.

## The same measurement, inverted

```
===== FIXED =====
  DRIVE lane 0 -> scrollLeft 298
    header scrollLeft      : 288        (follows)
    lane   scrollLefts     : [288,288]
    worst |title-x - cell-x| across 5 columns and 2 lanes: 1px

  DRIVE lane 1 -> scrollLeft 200        (inside every row's range)
    header scrollLeft      : 200        lanes [200,200]      worst delta 1px

  DRIVE header -> scrollLeft 90
    header scrollLeft      : 90         lanes [90,90]
```

The residual 1px is the lane's own 1px border, present at rest too (`'Open'` title `x=200`, lane cell `x=201` on an unscrolled board) — it is not introduced here.

⚠️ **Why 298 lands at 288.** The header row's own maximum is `1840 - 1552 = 288`, so a lane driven past it clamps the header, whose echo then pulls the lanes back to 288. One hop, no oscillation, and it settles on the most restrictive row — which is what "one axis for the whole board" means. The 200 case shows the unclamped equality.

## Zone 2 assumption 1 — 前提 measured, holds

*Nothing depends on lanes scrolling independently.* Turned from absence-of-evidence into evidence, every zero with a lit control on the same command shape:

| searched | result | lit control |
| --- | --- | --- |
| `scrollLeft` / `scrollTo` / `scrollIntoView` / `scrollWidth` / `onScroll` / `scrollbar` across `packages/plugin-kanban` | **1 hit** — `KanbanImpl.tsx:636`, the FLAT layout's mobile column-dot indicator. Not a swimlane row, untouched, and explicitly kept off this axis by a test row | same expression over `packages/plugin-gantt` returns 9 files |
| `scroll` in the kanban schema / authorable surface (`packages/types/src`) | **0** — the only swimlane keys are `swimlaneField` and `grouping` (`complex.zod.ts:177,193`) | `swimlane` in `packages/types/src` returns 3 files |
| lane + scroll in any `*.md` (docs, guides, changesets) | **0** | `swimlane` in `*.md` returns 8+ files |
| persisted UI state in the package | collapsed lanes (`objectui:kanban-collapsed:FIELD`) and per-column widths — **no scroll position** | `localStorage` in `packages/app-shell/src` returns many |

No consumer, no prop, no authorable key, no stored view setting and no pin required two lanes to hold different `scrollLeft`. ⇒ 裁决 stands, option A implemented.

## Zone 2 assumption 2 — FALSIFIED, and the falsification is mechanical

The PM assumed A was reachable without a scroll handler, by giving the header and the lanes one scrolling ancestor. It is not, and the thing that refuses it is **objectui#7303's own pin** — the one this card is told not to weaken. That pin reads:

```
const headerRow = region.firstElementChild
...
expect(indent(headerRow), 'header row indent').toEqual(indent(laneContentRow));
expect(indent(headerRow).length, 'the indent tokens must actually exist to be compared').toBeGreaterThan(0);
```

A shared scrolling wrapper **becomes** `region.firstElementChild`. Leave the shared `pl-36 sm:pl-44` on the inner rows and the wrapper's indent is empty, so the second assertion fails; hoist the indent onto the wrapper and the first fails, because the lane content row no longer carries it. Both halves red, and the only route through is editing the pin — which the brief forbids and which would be the wrong trade anyway: that indent equality is exactly the alignment property this card is about.

Two further costs, independent of the pin:

- The lane chrome (bordered box + collapse button, carrying the lane's name) sits inside the wrapper, so it becomes as wide as the scroll content and the **lane's own name scrolls out of view**. That is a second "the board no longer says which lane this is" defect, of the family this card exists to remove. Rescuing it needs `position: sticky`, which the scope fence names.
- `overflow-x: auto` computes `overflow-y` to `auto` on the same box, so the wrapper would be a new vertical scroll container spanning the whole lane stack — the surface objectui#8449 owns and the fence protects.

⇒ **The scroll handler is the finding, not the shortcut.** Jank cost, weighed: the handler runs only while a swimlane board is actually being scrolled; it does one `scrollLeft` read and at most one write per row (`1 + lane count`, typically under ten), with no layout read of `scrollWidth`, no state update and no re-render — nothing on this path reads back into React. Propagation cannot loop: assigning a `scrollLeft` a row already holds fires no `scroll` event, so the echo dies on its first hop, and a shared-position guard makes a second row reporting the same value a no-op. The repo already carries this shape — `plugin-gantt`'s `GanttView.tsx:2805` syncs its header to its timeline the same way.

## Scope fence — honoured, and measured against what comes next

No `overflow-y`, no height bound, no sticky positioning was added, removed or changed; the diff on `KanbanImpl.tsx` is a ref, an `onScroll`, and a marker attribute on two existing elements, plus the two callbacks behind them. Every existing class string is byte-identical (the two row `className` literals are unchanged; only their JSX was reflowed to multi-line).

You asked whether this rules out objectui#8449's ruled vertical arm. Measured, not asserted — the same live board with #8449-A applied as a pure CSS override (`overflow-y: auto` on the region, `position: sticky; top: 0` on the header row):

```
  region overflow-y   : auto
  header position     : sticky | height 24     (0 would be the objectui#7303 collapse)
  after lane -> 200   : header 200 | lanes [200,200]
  worst title/cell dx : 1px
```

The axis still syncs, the header still sticks, and the header row does not collapse. ⇒ **not ruled out.** Keeping the DOM as it is, rather than restructuring, is what leaves that door open: the header row remains a direct flex child of the region, which is what a sticky header needs.

## Pin

`packages/plugin-kanban/src/__tests__/swimlaneScrollSync-8448.test.tsx` — four rows, in happy-dom, where `scrollLeft` is a plain settable number and assignment fires no `scroll` event (measured), so every case drives the axis with an explicit `fireEvent.scroll`.

| row | asserts |
| --- | --- |
| `SYNC` | a lane at 298 takes the header row and the other lane with it |
| `SHARED` | the header drives the lanes too — arm B (header follows an "active" lane) would leave this red |
| `LATE MOUNT` | a lane expanded after the board was scrolled joins the axis at 210, not at 0 |
| `ARM C REFUSED` (control) | every synced row is still a scroll container, and the flat board carries no axis rows |

⚠️ **What it cannot measure, stated rather than faked.** happy-dom performs no layout, so the geometric half — "each title lands over its own lane cell" — cannot be asserted here; a coordinate assertion would be a pin that cannot fail. That is the same limit objectui#7303's pin documents for this exact surface, and it is why the geometry above is measured out of band. What happy-dom does decide is the mechanism behind those coordinates, and given the two rows carry the same indent and the same column widths (objectui#7303, objectui#8508 — both re-read by the pin), equal `scrollLeft` **is** the alignment.

Non-vacuity: every case first proves a real swimlane board — region label, both lane buttons with their counts, and a card rendered inside a lane — and reads a row count, so a board that stopped rendering lanes cannot read as success.

**Ablation**, the propagation line reverted to a no-op on disk, proven by hash and by grep in both directions, restored via `git checkout HEAD -- PATH` under an `EXIT INT TERM` trap and re-verified against the HEAD blob:

```
HEAD blob        = 0fe72ef95c09336692bfc255e6f56af91db02070
before: fixed-line=1  ablated-line=0
after:  fixed-line=0  ablated-line=1
on-disk (mutated)= 2390e74fc6d6f246e16089789b8c1a50dedb6a35
ABLATED command-exit = 1
  x SYNC — a lane driven sideways takes the header row and the other lane with it
  x SHARED, not header-follows-lane — driving the header row moves the lanes
  x LATE MOUNT — a lane expanded after the board was scrolled adopts its position
  Tests  3 failed | 1 passed (4)
on-disk (restored)= 0fe72ef95c09336692bfc255e6f56af91db02070   (git diff HEAD: empty)
```

The first failure prints the card verbatim: *"the column-header row must follow the lane, or every title sits over the wrong column: expected +0 to be 298"*. The `ARM C REFUSED` control stays green, which is the right shape — it is the one row that does not depend on propagation. The browser measurement above was produced by the same ablation, on the same bytes.

⛔ **objectui#7303's pin was not weakened, moved, edited or skipped.** `swimlaneColumnHeaderRow-7303.test.tsx` is untouched and green: the header row is still `region.firstElementChild`, still carries `shrink-0` and `overflow-x-auto`, and still shares its `pl-36 sm:pl-44` with the lane content row.

## Gates run locally, exit codes as printed

Derived by hand from `package.json` plus the workflows — objectui has no `scripts/pm/dispatch-gates.mjs`.

| command | exit |
| --- | --- |
| `turbo run build --filter '@object-ui/plugin-kanban...'` (13 tasks) | 0 |
| `turbo run build --filter='!@object-ui/site'` (43 tasks, for the dist-reading gates) | 0 |
| `vitest run packages/plugin-kanban/` — 37 files, 241 tests | 0 |
| cross-package sweep: every file outside the package naming `KanbanImpl` or `plugin-kanban/src`, plus `packages/types/src/__tests__/` — 162 files, 3393 tests | 0 |
| `pnpm --filter @object-ui/plugin-kanban type-check` | 0 |
| `turbo run lint` — whole repo, 47/47 tasks, **0 errors** · `lint:root` 0 errors | 0 · 0 |
| `check:control-bytes` · `check:shell-escape-residue` | 0 · 0 |
| `check:i18n-keys` · `check:unreferenced-sources` | 0 · 0 |
| `check:vi-mock-specifiers` · `check:vi-mock-inherit` | 0 · 0 |
| `check:phantom-deps` · `check:unused-deps` | 0 · 0 |
| `check:handler-key-reads` · `check:element-data-source-declaration` | 0 · 0 |
| `check:spec-symbols` · `check:side-effects-array` | 0 · 0 |
| `check:readme-exports` · `check:dist-completeness` · `check:esm-specifiers` | 0 · 0 · 0 |
| `check:sdui-registration-pins` · `check:eager-closure` | 0 · 0 |
| `lint:coverage` (46/46 packages, 0 errors) · `type-check:coverage` · `check:lint-rule-coverage` | 0 · 0 · 0 |
| `check-changeset-presence` · `check-changeset-fixed` · `check-changeset-no-major` | 0 · 0 · 0 |
| `check-governed-queue-guard --test` (the three paths) | 0 — **NOT GOVERNED** |

⚠️ `check:readme-exports` first returned **prerequisite-not-met**, not red — *"the population COLLAPSED, this run proves nothing: packagesRead found 14, floor is 25 ... 23 unbuilt"*. Re-run after the 43-task build and it is the 0 above. Recorded because a collapsed population is not a measurement in either direction.

Lint warnings: the package goes 176 to 178, both new ones in the new test file at the same two positions and from the same construct as its sibling `swimlaneColumnHeaderRow-7303.test.tsx` (a `makeAdapter` returning a Record keyed by string with `any` values — spelled in words here because GitHub eats tag-shaped fragments even inside backticks — and one `as any` on the schema cast). 0 errors, repo-wide.

## Changeset

`.changeset/8448-kanban-swimlane-scroll-sync.md`, `@object-ui/plugin-kanban: patch`. Owed and checked, not assumed: `check-changeset-presence.mjs` reports *"1 source file(s) of 1 released package(s) changed"* — the package publishes `dist` and this moves rendered behaviour.

## 验收备注

- `noted, not filed:` the `pl-36 sm:pl-44` indent on both rows is pure left padding with nothing rendered in it, and it scrolls away with the content. It reads like the remains of a lane-label gutter. Harmless and load-bearing for alignment as it stands, so it is not a defect — but a future objectui#8449 sticky-lane-label change would want it. Carrier: whoever implements objectui#8449.
- `noted, not filed:` the lane rows can scroll ~10px further right than the header row (their `pr` plus the lane border), which is what makes the 298 case settle at 288. Cosmetic, converges in one hop, and equalising it means touching padding shared with the alignment property. Carrier: none — recorded so the next reader does not mistake the clamp for a sync failure.
- Not addressed here and left open on purpose: objectui#8449, the vertical axis. Its ruled arm is measured compatible above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH


---
_Generated by [Claude Code](https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH)_