### PR TITLE
test(plugin-detail): pin the member shapes record:related_list reads (objectui#8071 slice 2)

### DIFF
--- a/.changeset/related-list-member-pins-8071.md
+++ b/.changeset/related-list-member-pins-8071.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change: `record:related_list`'s `columns`, `dataSource`, `filter` and `sort` gain per-block member pins (objectui#8071 slice 2), and the member-pin exemption ledger in the console's registry/spec parity gate moves with them. No published behaviour changes — no runtime source, build entry, `files[]` payload or published-contract field is touched.

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -1994,14 +1994,46 @@ const MULTI_KIND_MEMBER_CONTRACTS: Record<string, string> = {
 // both `object-form` and `fields` — which is the concrete reason `MEMBER_PINS`
 // is reviewed rather than computed.
 //
-// 58 is the transition case, and this file already owns the pattern for it —
+// ⚠️ SECOND SLICE, AND THE FIRST ONE TAKEN A BLOCK AT A TIME. objectui#8071's
+// second slice converted four keys on ONE block — `record:related_list`'s
+// `columns`, `dataSource`, `filter` and `sort` — chosen for a coherent file
+// surface rather than for near-miss tests: one renderer
+// (`renderers/record-related-list.tsx` over `RelatedList.tsx`) and one existing
+// spec-parity file. Measured over this file's own ledger, before and after: 90
+// array/object-armed inputs, 32 pinned, 58 exempt -> 90, 36 pinned, 54 exempt,
+// and `MEMBER_PIN_EXEMPTION_CEILING` follows 58 -> 54 in the same commit.
+//
+// ⭐ Two of the four were PROMOTED pre-existing files, and slice 1's trap is the
+// reason that sentence needs the qualifier. `RelatedList.listFilter.test.tsx`
+// and `RecordRelatedListRenderer.elementDataSource.test.tsx` were read end to
+// end before being credited, and they really do pin the member shape their key
+// names. The second one ALSO names `columns` and `sort` — it asserts a saved
+// view's `columns`/`sort` reach the list — so the locator would have accepted it
+// for those two keys as well, on its strings, while pinning nothing about what
+// an authored member of either key IS. Those two got new behavioural files
+// instead. That is `sectionFields.spec-parity.test.ts` one slice on, in the same
+// file the correct credit came from.
+//
+// ⛔ AND THE BLOCK IS NOT EMPTY. `record:related_list.actions` stays exempt on a
+// reason of its own: nothing reads it. The registration declares it
+// (`of: 'string'`, "Action IDs available for related records"), the SPEC
+// declares it (`RecordRelatedListProps.actions`), and the renderer never touches
+// `schema.actions` — the row and toolbar actions it draws come from the host
+// bridge `useRelatedRecordActions()`. A member pin constrains what the RENDERER
+// READS, so there is nothing here to constrain; the honest pin available is "the
+// key is dead", which is a statement that the contract is wrong rather than a
+// member shape, and fixing it is an ADR-0049 enforce-or-remove decision the spec
+// owns. See `NO_READ_SITE_TO_PIN`.
+//
+// A list this size is the transition case, and this file already owns the
+// pattern for it —
 // `OFF_SPEC_EXEMPTIONS` / `UNPUBLISHED_EXEMPTIONS` / `OFF_SPEC_ARM_EXEMPTIONS`
 // are explicit, reasoned, issue-backed, and go RED once stale. This is the same
-// mechanism, not a second one: `MEMBER_PIN_EXEMPTIONS` below lists all 58 BY
-// NAME, every entry cites objectui#8071 (which owns writing the pins), and an
+// mechanism, not a second one: `MEMBER_PIN_EXEMPTIONS` below lists all 54
+// remaining keys BY NAME, every entry cites an issue, and an
 // entry whose key acquires a pin is reported STALE and must be deleted in the
 // same change. The list has a CEILING as well as a stale check, because the
-// cheap way to green a new array key is to add a 59th entry rather than a pin.
+// cheap way to green a new array key is to add a 55th entry rather than a pin.
 //
 // ## WHAT IS DELIBERATELY NOT IN THE POPULATION, stated rather than dropped
 //
@@ -2210,6 +2242,22 @@ const MEMBER_PINS: Record<string, MemberPin> = {
     file: 'packages/plugin-detail/src/__tests__/recordRelatedListInputs.spec-parity.test.ts',
     pins: 'Every spec member key of `add` must be discoverable from its description, the published defaults must be the RENDERER\'s rather than the spec\'s prose, and `picker.filter` must be documented as a real restriction (objectui#3808).',
   },
+  'record:related_list.columns': {
+    file: 'packages/plugin-detail/src/__tests__/RecordRelatedListRenderer.columnMembers.test.tsx',
+    pins: 'THE `page:header.actions` HOLE ON THIS KEY, asserted as the gap it is: the registration declares `of: \'string\'` and the block folds FIVE member spellings — a bare string, the spec-canonical `{ field }`, the legacy `{ name }` / `{ fieldName }`, and `{ key }`, a tail fallback that is this block\'s alone (`columnIdentity` REFUSES it, asserted next to it, which is the whole content of "tail"). Canonical-first is proven both ways on one mixed `{ field, name }` member, so a fold reading either key alone fails. Two rows carry the sharp edge: a member whose identity does not resolve is KEPT rather than dropped, so an entry the fold cannot name is an entry it cannot filter (`accessorKey` is the instance — excluded from `columnIdentity` on purpose, read by `RelatedList` as `accessorKey || columnIdentity`, so a redacted column authored that way is kept AND rendered: filed as objectui#8793, and this row reds when it lands), and a mixed set must come back SHORTER and in order, which is the non-vacuity a single-member array cannot give. Every positive carries its control in the same call (the member survives when a DIFFERENT field is redacted), and the instrument itself — `redactFields`, a renderer-only key on neither the spec nor `inputs` — is asserted to be undeclared so the file cannot be read as licensing it. The end-to-end half (an object member reaching the screen with VALUES) is objectui#5022\'s file, which drives `RelatedList` directly and never runs this fold (objectui#8071).',
+  },
+  'record:related_list.dataSource': {
+    file: 'packages/plugin-detail/src/__tests__/RecordRelatedListRenderer.elementDataSource.test.tsx',
+    pins: 'The per-element binding\'s own members, each read through the REAL renderer and asserted at what reaches `RelatedList`: `object` becomes the `objectName` this block lists, `view` resolves a saved view whose `columns` / `sort` / row cap land on the three keys `RECORD_RELATED_LIST_DATA_SOURCE` maps, an authored key WINS over the same key from the view, an unresolvable `view` reports instead of listing every child row, and the binding\'s own `filter` arrives ANDed with the view\'s rather than replacing it — so the mapping can never widen a named view. `baseFilter` is asserted to stay undefined in the same row, because routing the list scope onto the add-picker\'s restriction would filter the dialog and leave the list wide. Pre-existing file, promoted to a pin here after being READ rather than credited on its strings: it also names `columns` and `sort`, which it does NOT pin — those two are the objectui#8071 slice-1 trap, one slice on (objectui#8071).',
+  },
+  'record:related_list.filter': {
+    file: 'packages/plugin-detail/src/__tests__/RelatedList.listFilter.test.tsx',
+    pins: 'Members are spec `ViewFilterRule` entries, pinned at the WIRE rather than at a prop: `{ field, operator, value }` reaches `dataSource.find` as `[[field, operator, value]]` through the shared sink, ANDed BEHIND the parent relationship so "additional criteria" can only ever narrow this record\'s children. The negatives are what make it a member contract: an empty `filter: []` is unauthored (the query stays the byte-identical MongoDB-style object, not a freshly lowered AST that means the same), the composed AST a binding leaves on this key is accepted WITHOUT being converted twice, the filter survives onto the windowed fetch, and on the raw-URL fallback — a channel that cannot carry an operator — the block REFUSES to fetch rather than answering wider than the metadata asked. Pre-existing file, promoted after being read (objectui#8071).',
+  },
+  'record:related_list.sort': {
+    file: 'packages/plugin-detail/src/__tests__/RecordRelatedListRenderer.sortMembers.test.tsx',
+    pins: 'Members are `{ field, order }` and reach `$orderby` verbatim and IN ORDER, driven through the block to the wire because `normalizeSortSpec` — not the block — is what reads them. The rows a declaration reading only "array" can never publish: a member with no `field` is dropped SILENTLY while its siblings survive (a two-key order quietly becomes one-key), an all-unusable array sends no `$orderby` rather than an empty clause, and the STRING arm the registration does not declare at all is read as the OData-ish `field` / `-field` — deliberately NOT `ListView.sort`\'s legacy space-separated clause, which the same spec union spells the same way and means differently (objectui#8221 retired that one at the derivation boundary only, and this key still accepts what it accepts). A CONTROL row pins the declaration as a bare array with no `of` and no description, so making it honest reds this file and forces the pins to be re-read (objectui#8071).',
+  },
 };
 
 /**
@@ -2255,6 +2303,48 @@ const AWAITING_A_PIN_NEWLY_JUDGED =
   'objectui#8071 owns writing the pin; delete this entry in the same change that registers it.';
 
 /**
+ * The reason a key carries when there is no read site for a pin to constrain.
+ *
+ * The `Record<string, string>` shape exists for exactly this: a key that needs a
+ * DIFFERENT reason gets its own string rather than a second mechanism.
+ * `AWAITING_A_PIN` says "objectui#8071 owns writing the pin", and for this key
+ * that sentence would be FALSE in a way nothing else here could report — a
+ * member pin constrains the shape the RENDERER READS (objectui#8068's
+ * criterion), and this key is not read at all.
+ *
+ * Measured on `record:related_list.actions` while writing slice 2's four pins:
+ * `renderers/record-related-list.tsx` never touches `schema.actions`, and the
+ * row actions it does render come from `useRelatedRecordActions()` — the HOST's
+ * bridge, keyed on the child object, not on this array. The declaration
+ * (`type: 'array', of: 'string'`, "Action IDs available for related records")
+ * and the spec key `RecordRelatedListProps.actions` therefore both publish an
+ * authoring surface that changes nothing: no diagnostic, no `unknown-prop`, and
+ * a page that behaves identically with the key and without it.
+ *
+ * ⛔ NOT convertible by writing a better test. The honest pin available today is
+ * "this key is dead", which is a pin on CURRENT behaviour whose whole content is
+ * that the contract is wrong — and whether that is fixed by giving the key a
+ * read site or by retiring it is an ADR-0049 enforce-or-remove question the SPEC
+ * owns, not one a renderer-side member pin should settle.
+ *
+ * NOT filed as a card of its own, deliberately: objectui#7300 is open on the
+ * same mechanism from the other side — a page cannot declare its related lists
+ * read-only BECAUSE the affordances are host-resolved from the child object
+ * rather than from the node. This key is what that mechanism looks like on the
+ * authoring surface, so it belongs to that decision rather than beside it. This
+ * entry moves when it lands, in whichever direction it lands.
+ */
+const NO_READ_SITE_TO_PIN =
+  'No member pin is possible: nothing reads this key. A member pin constrains the shape the ' +
+  'RENDERER reads (objectui#8068), and `renderers/record-related-list.tsx` never touches ' +
+  '`schema.actions` — the row/toolbar actions it renders come from the host bridge ' +
+  '`useRelatedRecordActions()`, keyed on the child object. Declared by the registration AND by ' +
+  'the spec (`RecordRelatedListProps.actions`) while changing nothing that renders. Measured by ' +
+  'objectui#8071 slice 2; the fix is an ADR-0049 enforce-or-remove decision the spec owns ' +
+  '(give the key a read site, or retire it), not a pin. Same mechanism as objectui#7300, which ' +
+  'is open on the affordance side of it.';
+
+/**
  * Array/object-armed inputs accepted WITHOUT a member pin for now, each with the
  * reason. Key format: `BLOCK.INPUT`.
  *
@@ -2267,7 +2357,7 @@ const AWAITING_A_PIN_NEWLY_JUDGED =
  *
  * The ceiling below is the other half, and it is what makes this a transition
  * rather than an allowlist: a NEW array-typed key cannot be absorbed by adding a
- * 59th entry, because the count may only go down.
+ * 55th entry, because the count may only go down.
  */
 const MEMBER_PIN_EXEMPTIONS: Record<string, string> = {
   // element:button
@@ -2349,12 +2439,10 @@ const MEMBER_PIN_EXEMPTIONS: Record<string, string> = {
   'record:quick_actions.actionNames': AWAITING_A_PIN,
   'record:quick_actions.requiredPermissions': AWAITING_A_PIN,
 
-  // record:related_list
-  'record:related_list.actions': AWAITING_A_PIN,
-  'record:related_list.columns': AWAITING_A_PIN,
-  'record:related_list.dataSource': AWAITING_A_PIN,
-  'record:related_list.filter': AWAITING_A_PIN,
-  'record:related_list.sort': AWAITING_A_PIN,
+  // record:related_list — objectui#8071 slice 2 pinned `columns`, `dataSource`,
+  // `filter` and `sort`. `actions` is the one left, and it is left for a
+  // DIFFERENT reason: see the constant.
+  'record:related_list.actions': NO_READ_SITE_TO_PIN,
 
   // objectui#8176 — the four this direction could not see. See
   // `NEWLY_JUDGED_UNPINNED_MEMBERS` below, which pins them BY NAME so the
@@ -2430,11 +2518,24 @@ const NEWLY_JUDGED_UNPINNED_MEMBERS = [
  * shortens it. That is what "may only ever go DOWN" has to mean to be worth
  * anything — a number nobody lowers is a budget, not a ratchet.
  *
+ * ## 58 -> 54, the second slice, and the rule applied rather than restated
+ *
+ * objectui#8071's second slice converted four keys on ONE block —
+ * `record:related_list`'s `columns`, `dataSource`, `filter` and `sort` — and
+ * deleted their four entries, so the ceiling follows to 54 in the same commit.
+ * Nothing about the argument above changes; this is the paragraph existing to
+ * show it is a rule and not a one-off.
+ *
+ * ⚠️ The block is NOT emptied: `record:related_list.actions` stays exempt, and
+ * on a reason of its own (`NO_READ_SITE_TO_PIN`) rather than the shared one. A
+ * ceiling of 54 counts it like any other entry — a key that cannot be pinned
+ * still occupies a slot, because the ratchet counts EXEMPTIONS, not excuses.
+ *
  * ⇒ The rule for every future slice of objectui#8071: delete the entry, register
  * the pin, and set this constant to the new count. Not to the new count plus
  * room.
  */
-const MEMBER_PIN_EXEMPTION_CEILING = 58;
+const MEMBER_PIN_EXEMPTION_CEILING = 54;
 
 /**
  * Every test file a member pin can live in, as LAZY `?raw` loaders.
@@ -2451,7 +2552,7 @@ const MEMBER_PIN_EXEMPTION_CEILING = 58;
  * LAZY on purpose. `eager: true` would inline the raw text of every test file in
  * the repo — 2,000+ files, ~3 MB — into this module on every run of a gate that
  * already loads the whole registration graph. Lazy hands back loaders, so the
- * cost is the glob itself plus one read per REGISTERED pin (32 today).
+ * cost is the glob itself plus one read per REGISTERED pin (36 today).
  */
 const PIN_SOURCES = import.meta.glob(
   [
@@ -3787,7 +3888,7 @@ describe('registry `inputs` vs `@objectstack/spec` ComponentPropsMap (repo-wide)
 
   it('the member-pin exemption list only ratchets DOWN', () => {
     // The other half. A new array-typed key must be answered with a pin, not
-    // with a 59th entry carrying the same reason as its neighbours — that move
+    // with a 55th entry carrying the same reason as its neighbours — that move
     // is what made the discipline voluntary in the first place, one layer in.
     expect(Object.keys(MEMBER_PIN_EXEMPTIONS).length).toBeLessThanOrEqual(
       MEMBER_PIN_EXEMPTION_CEILING,

--- a/packages/plugin-detail/src/__tests__/RecordRelatedListRenderer.columnMembers.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RecordRelatedListRenderer.columnMembers.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `record:related_list.columns` — the MEMBER shape the renderer reads
+ * (objectui#8068 / objectui#8071).
+ *
+ * ## Why this key is the exact defect objectui#8068 was built for
+ *
+ * The registration declares `{ name: 'columns', type: 'array', of: 'string' }`
+ * — members are STRINGS — and the renderer reads them as objects in four more
+ * spellings. That is the `page:header.actions` / objectstack#11592 shape word
+ * for word: a declaration that says `of: 'string'` while the code folds
+ * `{ field }`, `{ name }`, `{ fieldName }` and `{ key }`. `of` carries a member
+ * KIND and nothing finer (objectui#8067), so nothing in the published surface
+ * can state the union — which is why it is pinned here, against the read site.
+ *
+ * ## The read site this file drives
+ *
+ * `renderers/record-related-list.tsx`'s `colName`:
+ *
+ *     columnIdentity(entry) || (entry && typeof entry === 'object' ? entry.key : null) || null
+ *
+ * and it runs over EVERY member whenever the block filters columns. That fold
+ * is the block's own member read — `columnIdentity` (objectui#3104) supplies
+ * the canonical-first `field` / `name` / `fieldName` resolution shared with the
+ * rest of the repo, and `key` is a tail fallback this block adds on top.
+ *
+ * The end-to-end half — an object column reaching the screen with VALUES rather
+ * than a header over blank cells — is pinned next door in
+ * `RelatedList.columnIdentityAccessor.test.tsx` (objectui#5022), which renders
+ * the real `data-table`. This file pins the BLOCK's fold, which that file
+ * cannot see: it drives `RelatedList` directly and never runs `colName`.
+ *
+ * ## ⚠️ The probe key, stated rather than smuggled
+ *
+ * `redactFields` is the channel used below, because the block folds members
+ * ONLY when it filters — with nothing to filter, `columns` is handed down by
+ * reference and no member is ever read. `redactFields` and
+ * `enforceFieldSecurity` are renderer-only keys: measured against
+ * `RecordRelatedListProps` (`@objectstack/spec`), whose top-level keys are
+ * actions/add/aria/columns/filter/limit/objectName/relationshipField/
+ * relationshipValueField/showViewAll/sort/title, they are on NEITHER the spec
+ * nor this block's `inputs`. They are used here as an instrument for a fold
+ * that is otherwise unobservable, never as evidence that they are an authoring
+ * surface — the first assertion below states that so a later reader cannot take
+ * this file as licensing them.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { RecordContextProvider } from '@object-ui/react';
+import { ComponentRegistry, columnIdentity } from '@object-ui/core';
+import { RecordRelatedListRenderer } from '../renderers/record-related-list';
+import '../index';
+
+// Capture the column array the BLOCK hands down — the output of its own fold.
+const h = vi.hoisted(() => ({ captured: null as any }));
+vi.mock('../RelatedList', () => ({
+  RelatedList: (props: any) => {
+    h.captured = props;
+    return <div data-testid="related-list" />;
+  },
+}));
+
+const makeDS = () => ({
+  find: vi.fn(async () => []),
+  getObjectSchema: vi.fn(async (name: string) => ({ name, fields: {} })),
+});
+
+/** Render the block with only `columns` (and the redact probe) varying. */
+async function columnsAfterFold(columns: unknown[], redactFields?: string[]): Promise<any[]> {
+  // Unmount whatever a previous call in this test mounted, and clear the
+  // capture, so `waitFor` below can never resolve on the PREVIOUS render's
+  // props — several cases here render twice and compare the two results.
+  cleanup();
+  h.captured = null;
+  render(
+    <RecordContextProvider objectName="account" recordId="ACC-1" dataSource={makeDS() as any}>
+      <RecordRelatedListRenderer
+        schema={
+          {
+            objectName: 'contact',
+            relationshipField: 'account',
+            columns,
+            ...(redactFields ? { redactFields } : {}),
+          } as any
+        }
+      />
+    </RecordContextProvider>,
+  );
+  await waitFor(() => expect(h.captured).toBeTruthy());
+  return h.captured.columns;
+}
+
+/**
+ * Does the block resolve this member to the identity `status`? Measured by
+ * redacting `status` and seeing the member go — with the CONTROL in the same
+ * call, so a member that vanished for any other reason cannot read as a
+ * resolution.
+ */
+async function resolvesToStatus(member: unknown): Promise<boolean> {
+  const kept = await columnsAfterFold([member], ['some_other_field']);
+  expect(kept, 'control: the member survives when a DIFFERENT field is redacted').toEqual([member]);
+  h.captured = null;
+  const dropped = await columnsAfterFold([member], ['status']);
+  return dropped.length === 0;
+}
+
+const input = (name: string) =>
+  ComponentRegistry.getConfig('record:related_list')?.inputs?.find((i) => i.name === name);
+
+beforeEach(() => {
+  h.captured = null;
+});
+
+describe('record:related_list — the `columns` MEMBER shape the renderer reads (objectui#8068)', () => {
+  it('THE HOLE — the declaration says members are STRINGS, and the code reads objects', () => {
+    // Both halves in one assertion, because the pin is the GAP between them and
+    // either half alone is unremarkable. If a later change makes the declaration
+    // honest, this reddens and the pins below must be re-read rather than
+    // assumed still current.
+    expect(input('columns')?.type).toBe('array');
+    expect(input('columns')?.of).toBe('string');
+    // …and the shared resolver this block folds through accepts object members.
+    expect(columnIdentity({ field: 'status' })).toBe('status');
+  });
+
+  it('resolves the spec-canonical `{ field }` member', async () => {
+    expect(await resolvesToStatus({ field: 'status', label: 'Status' })).toBe(true);
+  });
+
+  it('resolves the legacy `{ name }` and `{ fieldName }` members', async () => {
+    // objectui-side legacy that stored host metadata can still carry; the fold
+    // accepts them and the identity ratchet counts them.
+    expect(await resolvesToStatus({ name: 'status' })).toBe(true);
+    h.captured = null;
+    expect(await resolvesToStatus({ fieldName: 'status' })).toBe(true);
+  });
+
+  it('resolves a bare STRING member — the one shape the declaration admits', async () => {
+    expect(await resolvesToStatus('status')).toBe(true);
+  });
+
+  it("resolves `{ key }`, a tail fallback that is THIS BLOCK's alone", async () => {
+    // The member spelling the shared resolver deliberately refuses: `key` is a
+    // generic entry key, not ObjectStack metadata identity (objectui#3104), so
+    // `columnIdentity` returns undefined for it and `colName` adds it after.
+    // Both halves asserted, because "the block resolves it" and "the shared
+    // resolver does not" is the whole content of "tail fallback".
+    expect(columnIdentity({ key: 'status' })).toBeUndefined();
+    expect(await resolvesToStatus({ key: 'status' })).toBe(true);
+  });
+
+  it('is canonical-FIRST — `field` wins over a disagreeing `name`', async () => {
+    // A mixed-key member is the shape that makes the renderer and the data
+    // request resolve two different fields. Both directions, because a fold
+    // that read only `name` would satisfy a one-sided assertion.
+    const mixed = { field: 'status', name: 'subject' };
+    expect(await columnsAfterFold([mixed], ['status'])).toEqual([]);
+    h.captured = null;
+    expect(await columnsAfterFold([mixed], ['subject'])).toEqual([mixed]);
+  });
+
+  it('keeps a member whose identity it cannot resolve, rather than dropping it', async () => {
+    // `colName` returns null and the filter's else-branch keeps the entry
+    // (`return n ? allowed.has(n) : true`). Pinned because it is the member
+    // contract's sharp edge: an entry the fold cannot NAME is an entry the fold
+    // cannot filter, so whatever the entry means downstream is unfiltered.
+    // `accessorKey` is the concrete instance — the table LIBRARY's own key,
+    // excluded from `columnIdentity` on purpose (objectui#3104) and read by
+    // `RelatedList` as `c?.accessorKey || columnIdentity(c)`. So a column
+    // authored that way is kept by this fold AND rendered by the table: filed
+    // as objectui#8793. Pinned as the CURRENT behaviour it is, which means this
+    // row reds when that lands — deliberately, so the fix cannot be quiet.
+    expect(columnIdentity({ accessorKey: 'status' })).toBeUndefined();
+    expect(await columnsAfterFold([{ accessorKey: 'status' }], ['status'])).toEqual([
+      { accessorKey: 'status' },
+    ]);
+  });
+
+  it('folds a MIXED-spelling column set member by member, not all-or-nothing', async () => {
+    // Non-vacuity for the whole file: every case above uses a single-member
+    // array, which a fold that returned its input unchanged would also satisfy
+    // for the "kept" half. Here the array must come back SHORTER and in order.
+    const set = ['subject', { field: 'status' }, { name: 'owner' }];
+    expect(await columnsAfterFold(set, ['status'])).toEqual(['subject', { name: 'owner' }]);
+  });
+
+  it('COUNTER-PROBE — with nothing redacted the array is handed down untouched', async () => {
+    // The fold only runs when the block filters. Stated so the instrument's
+    // limits are on the record: with no `redactFields` and no
+    // `enforceFieldSecurity`, no member is read at all and this pin's read site
+    // never executes.
+    const set = ['subject', { field: 'status' }];
+    expect(await columnsAfterFold(set)).toEqual(set);
+  });
+
+  it('CONTROL — `redactFields` is an instrument here, not an authoring surface', async () => {
+    // See the file docblock. The block's published `inputs` do not declare it,
+    // and this assertion is what stops a later reader citing this file as
+    // evidence that it is declared.
+    expect(input('redactFields')).toBeUndefined();
+    expect(input('enforceFieldSecurity')).toBeUndefined();
+  });
+});

--- a/packages/plugin-detail/src/__tests__/RecordRelatedListRenderer.sortMembers.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RecordRelatedListRenderer.sortMembers.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `record:related_list.sort` — the MEMBER shape the renderer reads
+ * (objectui#8068 / objectui#8071).
+ *
+ * The per-block member pin objectui#8068 requires: what this block does with
+ * the ELEMENTS of its `sort` array, not a restatement of the registration.
+ * The registration declares `{ name: 'sort', type: 'array' }` and stops there —
+ * no `of`, no description — so the published surface says "an array" and says
+ * nothing whatever about what an element is. `ComponentInput` cannot say more
+ * (`of` carries a member KIND and nothing finer, objectui#8067), which is
+ * exactly why the shape has to be pinned against the READ SITE instead.
+ *
+ * ## Where the read actually happens
+ *
+ * `renderers/record-related-list.tsx` hands `schema.sort` to `RelatedList` as
+ * `defaultSort`, and `RelatedList`'s `normalizeSortSpec` is the function that
+ * reads the members. It lowers them into the `$orderby` this block puts on the
+ * wire, so the wire is where the member contract is observable — a prop-level
+ * assertion would only pin that a value was threaded somewhere.
+ *
+ * ## ⚠️ The same spec union, two different string arms
+ *
+ * `ListView.sort` and `record:related_list.sort` declare the SAME union in
+ * `@objectstack/spec` (`string | Array<{field, order}>`) and mean DIFFERENT
+ * things by the string arm: ListView's string is the legacy space-separated
+ * clause (`'seq_no desc'`), while this block's `normalizeSortSpec` reads the
+ * OData-ish `'field'` / `'-field'`. objectui#8221 retired the legacy clause AT
+ * THE DERIVATION BOUNDARY (`deriveRelatedLists` refuses it out loud rather than
+ * translating it); it did not change what THIS key accepts, and the pins below
+ * are about this key. The divergence is stated here because a reader who knows
+ * one arm will assume the other.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { RecordContextProvider } from '@object-ui/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { RecordRelatedListRenderer } from '../renderers/record-related-list';
+import '../index';
+
+const rows = [{ id: 'c1', name: 'Alice' }];
+
+const makeDS = () => ({
+  find: vi.fn(async () => rows),
+  getObjectSchema: vi.fn(async (name: string) => ({ name, fields: {} })),
+});
+
+/** Render the BLOCK (not `RelatedList` directly) with only `sort` varying. */
+function renderBlock(sort: unknown, ds = makeDS()) {
+  render(
+    <RecordContextProvider objectName="account" recordId="ACC-1" dataSource={ds as any}>
+      <RecordRelatedListRenderer
+        schema={{ objectName: 'contact', relationshipField: 'account', columns: ['name'], sort } as any}
+      />
+    </RecordContextProvider>,
+  );
+  return ds;
+}
+
+/** The `$orderby` this block put on the wire, or `undefined` when it sent none. */
+async function orderbyOf(sort: unknown): Promise<unknown> {
+  const ds = renderBlock(sort);
+  await waitFor(() => expect(ds.find).toHaveBeenCalled());
+  return (ds.find.mock.calls[0] as any[])[1].$orderby;
+}
+
+const input = (name: string) =>
+  ComponentRegistry.getConfig('record:related_list')?.inputs?.find((i) => i.name === name);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('record:related_list — the `sort` MEMBER shape the renderer reads (objectui#8068)', () => {
+  it('CONTROL — the key is declared as a bare array, so the members are undescribed', () => {
+    // Calibration for everything below: this pin exists BECAUSE the published
+    // surface stops at the kind. If a future change gives `sort` an `of` or a
+    // member description, this assertion reddens and whoever wrote it must
+    // re-read the pins below rather than assume they still say something new.
+    expect(input('sort')).toBeDefined();
+    expect(input('sort')?.type).toBe('array');
+    expect(input('sort')?.of).toBeUndefined();
+    expect(input('sort')?.description).toBeUndefined();
+  });
+
+  it('SUBJECT — an array member is `{ field, order }`, and it reaches $orderby verbatim', async () => {
+    // The member vocabulary, asserted where it lands. `toEqual` on the whole
+    // array, not a `field` spot-check: a member re-spelled on the way down
+    // (`{ name, direction }`, `'-created'`) would be the drift this pin exists
+    // to catch, and a spot-check would not see it.
+    expect(await orderbyOf([{ field: 'created', order: 'desc' }])).toEqual([
+      { field: 'created', order: 'desc' },
+    ]);
+  });
+
+  it('keeps multi-key order, in the order authored', async () => {
+    // Members are ORDERED — a sort is a sequence, and a member reader that
+    // reduced it to one key would still pass the assertion above.
+    expect(
+      await orderbyOf([
+        { field: 'stage', order: 'asc' },
+        { field: 'created', order: 'desc' },
+      ]),
+    ).toEqual([
+      { field: 'stage', order: 'asc' },
+      { field: 'created', order: 'desc' },
+    ]);
+  });
+
+  it('⚠️ DROPS a member with no `field`, silently and without refusing the rest', async () => {
+    // `normalizeSortSpec` is `sort.filter((s) => !!s?.field)`. The member the
+    // author got wrong disappears with no diagnostic while its siblings survive,
+    // so a two-key order silently becomes a one-key order. Pinned as the
+    // behaviour it is — this is the half of the member contract an author
+    // cannot discover from a declaration that says only "array".
+    expect(
+      await orderbyOf([{ order: 'desc' }, { field: 'created', order: 'desc' }]),
+    ).toEqual([{ field: 'created', order: 'desc' }]);
+  });
+
+  it('sends NO $orderby when every member is unusable, rather than an empty clause', async () => {
+    expect(await orderbyOf([{ order: 'desc' }])).toBeUndefined();
+  });
+
+  it('reads the STRING arm as `field` / `-field`, the OData-ish spelling', async () => {
+    // The arm the registration does not declare at all (`type: 'array'`) and the
+    // renderer nevertheless reads. Both directions, because the sign is the
+    // whole content of the arm.
+    expect(await orderbyOf('created')).toEqual([{ field: 'created', order: 'asc' }]);
+    expect(await orderbyOf('-created')).toEqual([{ field: 'created', order: 'desc' }]);
+  });
+
+  it('COUNTER-PROBE — no `sort` authored sends no $orderby at all', async () => {
+    // Non-vacuity: without this, every assertion above would be satisfied by a
+    // block that never sends `$orderby` and a helper that reads `undefined`.
+    expect(await orderbyOf(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Refs #8071

Second slice of objectui#8071's transition: four keys converted from member-pin exemption to member pin, and `MEMBER_PIN_EXEMPTION_CEILING` moved down with the list in the same commit.

## The ledger, re-derived on this branch's base (`b6d07df4`)

Re-measured with an independent brace-depth counter rather than taken from the card — whose body says "58 to write", a number that is the REMAINDER, not the starting point.

| reading | at base | after this PR |
|---|--:|--:|
| `MEMBER_PINS` | 32 | **36** |
| `MEMBER_PIN_EXEMPTIONS` | 58 | **54** |
| `MEMBER_PIN_EXEMPTION_CEILING` | 58 | **54** |
| population (array/object-armed inputs on covered blocks) | 90 | **90** |

The counter was controlled at two commits so it demonstrably fires: it answers `28 / 62 / 62` at slice 1's parent (`240c6059^1`) and `32 / 58 / 58` at both the slice 1 merge (`240c6059`) and this branch's base — so the reading is a measurement, and the merge introduced no ledger drift.

Population does not move, because a pin and an exemption are the two halves of one partition. ⭐ The ceiling follows the list to 54 rather than staying at 58: four banked slots would let the next genuinely new array-typed key be greened with an exemption entry instead of a pin, which is the exact thing the ratchet exists to deny.

## Which keys, and why these

`record:related_list` — `columns`, `dataSource`, `filter`, `sort`.

Chosen for a **coherent file surface** rather than for near-miss hints: one block, one renderer (`renderers/record-related-list.tsx` over `RelatedList.tsx`), and one existing spec-parity file already registered for this block's `add`. Every pin below reads one of those two source files.

### Per key — where the renderer was read, and the shape found

| key | read site | shape the renderer actually reads |
|---|---|---|
| `columns` | `record-related-list.tsx` `colName` = `columnIdentity(entry) \|\| entry.key`, folded over every member whenever the block filters | Five spellings: bare string, spec-canonical `{ field }`, legacy `{ name }` / `{ fieldName }`, and `{ key }` — a tail fallback this block adds and `columnIdentity` refuses. Canonical-first. A member whose identity does not resolve is **kept**. |
| `dataSource` | `ElementDataSourceGate` + `RECORD_RELATED_LIST_DATA_SOURCE` mapping | Binding members `{ object, view, filter }`; `object` becomes `objectName`, `view` supplies columns/sort/row-cap, an authored key wins over the view's, the binding's `filter` arrives ANDed rather than replacing. |
| `filter` | `RelatedList` `listFilterNode` → `dataSource.find` `$filter` | Spec `ViewFilterRule` members `{ field, operator, value }`, lowered by the shared sink and ANDed **behind** the parent scope; `[]` is unauthored; a pre-composed AST is not converted twice. |
| `sort` | `RelatedList` `normalizeSortSpec` → `$orderby` | `{ field, order }` members, verbatim and in order; a member with no `field` is dropped silently; the string arm is the OData-ish `field` / `-field`. |

### ⚠️ Two of the four were pre-existing files — READ before being credited

Slice 1's lesson applied. `RelatedList.listFilter.test.tsx` (`filter`) and `RecordRelatedListRenderer.elementDataSource.test.tsx` (`dataSource`) genuinely pin the member shape their key names, so they are promoted rather than duplicated.

The second one is also the trap, one slice on: it names `columns` and `sort` too — it asserts a saved view's columns and sort reach the list — so objectui#8068's mechanical locator **would have accepted it for both**, on its strings, while pinning nothing about what an *authored* member of either key is. Those two got new behavioural files instead.

### ⛔ The block is not emptied — `actions` stays exempt, on a reason of its own

`record:related_list.actions` is declared by the registration (`of: 'string'`, "Action IDs available for related records") **and** by the spec (`RecordRelatedListProps.actions`), and the renderer never touches `schema.actions` — the row and toolbar actions it draws come from the host bridge `useRelatedRecordActions()`, keyed on the child object. Measured with a positive control (the same grep finds `schema.columns` / `.filter` / `.sort`).

A member pin constrains what the renderer **reads**, so there is nothing here to constrain. It moves from the shared `AWAITING_A_PIN` to a new `NO_READ_SITE_TO_PIN` — the `Record<string, string>` shape exists for exactly this. Not filed separately: objectui#7300 is open on the same mechanism from the affordance side. The ceiling of 54 still counts it, because the ratchet counts exemptions, not excuses.

## Ablation table

Each mutation was proven on disk before the run (anchor count 1→0, injected count 0→1, byte delta, blob hash changed), restored via `git checkout HEAD -- <abs path>`, and the restoration proven by blob-hash equality **and** an empty `git diff HEAD`. An empty hash was treated as failure. No build step is involved: the pins import the renderer by relative path, so vitest transforms the mutated source directly.

| # | target (RENDERER, not the test) | mutation | result |
|---|---|---|---|
| 1 | `RelatedList.tsx` `normalizeSortSpec` | `return sort.filter((s) => !!s?.field)` → `return sort` | **2 failed / 5 passed** — "DROPS a member with no `field`" and "sends NO `$orderby` when every member is unusable" |
| 2 | `record-related-list.tsx` `colName` | drop the `entry.key` tail fallback | **1 failed / 9 passed** — "resolves `{ key }`, a tail fallback that is THIS BLOCK's alone" |
| 3 | the gate's ledger (control on the other half) | rename `'record:related_list.sort'` to a probe key | **4 failed / 194 passed** — the census, the per-block red, the locator, and the dangling-pin check |

Ablation 3 is there because the pins and the ledger are two halves: it proves the four entries are load-bearing rather than decorative.

## Base → `origin/main` window check

`git diff --name-only b6d07df4 origin/main` is **empty** — `origin/main` has not moved since this branch's base.

An empty reading needs a control, so the same command was run over a window known to be non-empty (`240c6059..b6d07df4`, 58 files), and the intersection grep was proven to fire by adding a file known to be in that window. Result: **none of the files these pins read off disk moved** — `record-related-list.tsx`, `RelatedList.tsx`, `plugin-detail/index.tsx`, `core/utils/column-identity.ts`, the two promoted pin files, or the gate itself.

⚠️ Point-in-time. Ablation 2 and the `columns` pin's last row describe **current** behaviour that objectui#8793 proposes to change; if that lands first, this PR's `columns` pin reddens on the merged-with-main candidate and the row must be re-read. That is the pin working, not a flake.

## Gates

| gate | exit | note |
|---|--:|---|
| `vitest run` — the gate + all four pinned files (240 tests, 6 files) | **0** | includes `apps/console`, which is where the fed gate lives |
| `pnpm --filter @object-ui/plugin-detail run type-check` | **0** | after building the dep closure; `--listFiles` proves both new pins are in the `tsconfig.test.json` program (2 hits, control 0) |
| `pnpm --filter @object-ui/console run type-check` | **0** | |
| `pnpm check` (per-PR gate, `lint.yml:481`) | **0** | required building `packages/cli` first — before that it was PRECONDITION NOT MET, not a red |
| `node scripts/check-changeset-presence.mjs` | **0** | empty-frontmatter changeset: test-only, releases nothing |
| `pnpm check:control-bytes` | **0** | 6994 → 6997 tracked files after commit, i.e. it really scanned the three new files |
| `pnpm check:element-data-source-declaration` | **0** | |
| `eslint` (narrowed to the 3 changed files) | **0** | 0 errors, 8 `no-explicit-any` warnings, matching the neighbouring suites' house style |
| `pnpm check:sdui-registration-pins` | **2** | PRECONDITION NOT MET — needs the console bundle; no registration is touched by this diff |

Exit codes captured before any pipe (`cmd > log 2>&1; EXIT=$?`). Repo-wide `pnpm lint` and the full `pnpm test` are CI-owned runs and were not taken locally.

## Out-of-scope findings

- **Filed as objectui#8793** — a `record:related_list` column entry whose identity does not resolve (`{ accessorKey: 'salary' }`) is kept by the block's `enforceFieldSecurity` / `redactFields` fold and then rendered through `RelatedList`'s own `accessorKey || columnIdentity` read. Two measured legs: the keep is pinned by this PR's `columns` pin, the render by the existing objectui#5022 suite.
- **Noted, not filed** — `enforceFieldSecurity` and `redactFields` are read by this renderer and declared by neither the spec nor the block's `inputs`, so no parity direction in the repo can see them. Recorded in the new pin's docblock, with an assertion that they are undeclared so the file cannot be read as licensing them. Whoever takes objectui#8793 touches exactly this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_