### PR TITLE
test(components): pin the bare `text` key to `ui:text` (objectui#7450)

### DIFF
--- a/.changeset/7450-text-bare-key-resolution-pin.md
+++ b/.changeset/7450-text-bare-key-resolution-pin.md
@@ -1,0 +1,6 @@
+---
+---
+
+Pin that the bare `text` component key resolves to `ui:text`, and that
+`element:text`'s `skipFallback: true` is the single line that decides it
+(objectui#7450). Test only; no package is released by this change.

--- a/packages/components/src/__tests__/text-bare-key-resolution-7450.test.tsx
+++ b/packages/components/src/__tests__/text-bare-key-resolution-7450.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The bare `text` key belongs to `ui:text`, and ONE FLAG is why (objectui#7450).
+ *
+ * ## The hazard, measured
+ *
+ * Two production registrations claim the short name `text`:
+ *
+ *   `renderers/basic/text.tsx`     register('text', …, { namespace: 'ui' })
+ *   `renderers/basic/elements.tsx` register('text', …, { namespace: 'element',
+ *                                                        skipFallback: true })
+ *
+ * `Registry.register()` claims the bare key for a namespaced registration
+ * `if (meta?.namespace && !meta?.skipFallback)`, and its own comment says "the
+ * last registration wins for non-namespaced lookups". `renderers/basic/index.ts`
+ * imports `./text` BEFORE `./elements`, so `element:text` is the LATER
+ * registration and load order alone would hand it the bare key.
+ * `skipFallback: true` is the single line that stops it.
+ *
+ * Deleting that one line is silent in every layer that would normally catch it:
+ * `Registry.ts` only `console.warn`s on such an overwrite, no type changes, and
+ * the corpus authors the bare `text` spelling (not `ui:text`), so every
+ * `variant: 'h1'`…`'h6'` / `'overline'` node in it would start rendering through
+ * the FOUR-value `element:text` renderer — which has no entry for those values
+ * and falls through to a `<p>`. A heading that stops being a heading, with no
+ * diagnostic anywhere.
+ *
+ * Nothing pinned that resolution before this file.
+ *
+ * ## Every fact here is DERIVED, and the mechanism has a live control
+ *
+ * The load-order half is read out of `renderers/basic/index.ts` at run time
+ * rather than restated, so re-ordering those imports moves this pin with it.
+ *
+ * The mechanism half runs on a FRESH `Registry` instance, never the shared
+ * singleton: two registrations in the same order as production, once with the
+ * flag and once without. Without a control, "the bare key is `ui:text`" also
+ * passes if the fallback path stopped working altogether, or if `element:text`
+ * had quietly stopped registering — both of which would leave the assertion
+ * green while the thing it describes was gone.
+ */
+import path from 'node:path';
+import fs from 'node:fs';
+import { describe, it, expect } from 'vitest';
+import { ComponentRegistry, Registry } from '@object-ui/core';
+import { renderComponent } from './test-utils';
+// Module scope, not a hook: the cold transform is billed to the import phase,
+// which has no test/hook timeout (AGENTS.md, objectui#3010).
+import '../renderers';
+
+const BASIC_INDEX = fs.readFileSync(
+  path.resolve(import.meta.dirname, '../renderers/basic/index.ts'),
+  'utf8',
+);
+
+describe('objectui#7450 — the bare `text` key resolves to `ui:text`', () => {
+  it('both claimants are registered (reachability before any identity claim)', () => {
+    // Without this, every assertion below is satisfiable by a registration that
+    // simply is not there any more.
+    expect(ComponentRegistry.getConfig('ui:text'), 'ui:text is not registered').toBeDefined();
+    expect(
+      ComponentRegistry.getConfig('element:text'),
+      'element:text is not registered',
+    ).toBeDefined();
+  });
+
+  it('`text` resolves to `ui:text`, by component identity and not only by name', () => {
+    const bare = ComponentRegistry.getConfig('text');
+    const ui = ComponentRegistry.getConfig('ui:text');
+    const element = ComponentRegistry.getConfig('element:text');
+
+    expect(bare?.type).toBe('ui:text');
+    expect(bare?.component).toBe(ui?.component);
+    expect(bare?.component).not.toBe(element?.component);
+  });
+
+  it('load order alone would hand the bare key to `element:text`', () => {
+    // Derived from the barrel, not restated: `./text` registers `ui:text` and
+    // `./elements` registers `element:text`, so the LATER import is the later
+    // registration.
+    const uiAt = BASIC_INDEX.indexOf("import './text';");
+    const elementAt = BASIC_INDEX.indexOf("import './elements';");
+
+    expect(uiAt, "renderers/basic/index.ts no longer imports './text'").toBeGreaterThan(-1);
+    expect(
+      elementAt,
+      "renderers/basic/index.ts no longer imports './elements'",
+    ).toBeGreaterThan(-1);
+    expect(elementAt).toBeGreaterThan(uiAt);
+  });
+
+  it('`skipFallback: true` on `element:text` is what overrides that order', () => {
+    expect((ComponentRegistry.getConfig('element:text') as { skipFallback?: boolean })
+      ?.skipFallback).toBe(true);
+    expect((ComponentRegistry.getConfig('ui:text') as { skipFallback?: boolean })
+      ?.skipFallback).toBeFalsy();
+  });
+
+  it('LIVE CONTROL — the same pair without the flag hands the bare key over', () => {
+    // A fresh registry, so nothing here touches the shared singleton the rest of
+    // the suite reads. Production order: the `ui` namespace first, `element`
+    // second.
+    const First = () => null;
+    const Second = () => null;
+
+    const guarded = new Registry<unknown>();
+    guarded.register('text', First, { namespace: 'ui' });
+    guarded.register('text', Second, { namespace: 'element', skipFallback: true });
+    expect(guarded.getConfig('text')?.type).toBe('ui:text');
+
+    const unguarded = new Registry<unknown>();
+    unguarded.register('text', First, { namespace: 'ui' });
+    unguarded.register('text', Second, { namespace: 'element' });
+    // THE CONTROL FIRES: drop the flag and the later registration takes the key.
+    expect(unguarded.getConfig('text')?.type).toBe('element:text');
+  });
+
+  it('what the flag protects: an authored `text` node keeps its heading element', () => {
+    // The corpus spells the bare name, so this is the shape the flag decides for
+    // every authored text node. `ui:text` maps `h1` to an `<h1>`; `element:text`
+    // has no `h1` in its four-value vocabulary and falls through to a `<p>`.
+    const { container } = renderComponent({ type: 'text', variant: 'h1', content: 'Title' } as never);
+
+    expect(container.firstElementChild?.tagName.toLowerCase()).toBe('h1');
+  });
+});


### PR DESCRIPTION
`Part of #7450`. **#7450 remains open** — the standing ruling is deliberately **not** implemented here, and the measurement below is why.

---

## ⛔ The headline: the convergence cannot be declared in this repository

The ruling (`5565743592`, director seat, decision batch #71, 2026-09-07, maintainer verbatim 「其他同意」) is sound and is not reopened. But the card, the census (`5596105170`) and the dispatch (`5598675699`) all rest on one premise, and **that premise is false**:

> the `element:text` vocabulary was never declared, so nothing could ever refuse a wrong value

It **is** declared — not in `@object-ui/types`, but upstream in **`@objectstack/spec`**, which AGENTS.md #0 makes the binding contract for this repo. `elements.tsx`'s own file docblock already says so ("Spec-aligned renderers for the `element:*` component namespace defined by `@objectstack/spec`").

**Source of the declaration** — `framework/packages/spec/src/ui/component.zod.ts:1819`, inside `ElementTextPropsSchema`:

```ts
variant: z.enum(['heading', 'subheading', 'body', 'caption'])
  .optional().default('body').describe('Text style variant'),
```

**Measured against the installed pin (`@objectstack/spec@17.3.0`), through the schema's own verdicts:**

| `element:text` `variant` | `ElementTextPropsSchema.safeParse` |
|---|---|
| `heading` `subheading` `body` `caption` | ACCEPT |
| `h1` `h2` `h3` `h4` `h5` `h6` `overline` | **REFUSE** — `invalid_value` at `variant` |
| `nonsense` (control) | REFUSE — `invalid_value` |
| key absent | ACCEPT, materialised as `variant: 'body'` |

### The repo's own per-PR gate refuses the convergence, mechanically

`apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` judges an `enum` arm **exactly**, by its own header: *"An `enum` ARM is judged differently and exactly, because it is the one arm whose admitted set is FINITE and written down: `armAccepts` consults the input's own `enum` list, so every declared member must be a value the spec accepts."*

So I ran the convergence as an ablation — swapped the registry `inputs` enum in `elements.tsx` for the published nine and nothing else:

```
BEFORE: old-anchor=1 new-anchor=0 bytes=19663
AFTER : old-anchor=0 new-anchor=1 bytes=19686 delta=23
MUT_BLOB=3e92b4e5c177131948c71c376130788e922f6770  (HEAD_BLOB=498cbdef4e3ea8e3214ab988e023bfd939caeb78)

× element:text declares no arm the spec refuses outright
AssertionError: element:text.variant:enum — the contract refuses the declared
member(s) ["h1","h2","h3","h4","h5","h6","overline"]
Tests  1 failed | 197 passed (198)

RESTORED_BLOB=498cbdef4e3ea8e3214ab988e023bfd939caeb78 · DIFF_HEAD_EMPTY=yes
```

Baseline on the same file, unmutated: `198 passed`.

⇒ Declaring the nine here is a **consumer-side widening past the contract**, which is exactly AGENTS.md #0.1's ban, and the gate that exists to catch it does catch it. The convergence has to start in `@objectstack/spec`; this repo follows on a released pin.

**The one-line in-repo migration is blocked by the same wall.** `apps/console/src/preview-samples.ts` carries the only authored `element:text` variant, `subheading`. That value is spec-**legal** today; rewriting it to `h3` (the value that preserves today's rendered element) would make it spec-**illegal**. The migration is not a line I can write yet either.

### A second correction: "refused by nothing" is true only at the RENDER layer

Re-derived here, not quoted. Rendering `element:text` through the real registry:

| `element:text` `variant` | element | `validateTree` diagnostics |
|---|---|---|
| `heading` | `h2` | none |
| `subheading` | `h3` | none |
| `body` / `caption` | `p` | none |
| `h1` / `h4` / `overline` | **`p`**, class `text-sm text-foreground` — byte-identical to `body` | **`invalid-enum` / error** |
| absent | `p` | none |

The renderer's silent swallow is real and reproduces exactly. But `packages/sdui-parser`'s `validateTree` — the same validator behind the save gate and the JSX-page prop whitelist — already raises **`invalid-enum` at severity `error`**: `element:text prop "variant"="h1" is not one of ["heading","subheading","body","caption"]`. So the accurate statement is **"the renderer swallows what the authoring gate already refuses"**, not "nothing refuses it". Two authorities, and today they agree with each other; the objectui-only convergence would have made them disagree.

### The mapping question, answered out loud (to be carried upstream, not decided here)

The dispatch requires the `heading` / `subheading` mapping to be stated rather than chosen silently. My recommendation for the spec-side card:

- **`heading` → `h2`, `subheading` → `h3`** as the *migration hint*, **not** as an alias. Those are the elements the renderer hard-codes today (`elements.tsx`, `variant === 'heading' ? 'h2' : variant === 'subheading' ? 'h3' : 'p'`), so the hint preserves the rendered element byte-for-byte for anyone who follows it, which is the only property a migration hint owes.
- **The author then picks freely from `h1`–`h6`.** `heading` was never a *level*, it was a *role*; pinning it permanently to `h2` would import the old vocabulary's one-size assumption into the new one and re-create the expressiveness gap the ruling exists to close. The hint names `h2` because that is what the author's page renders **today** — it is a "here is where you were", not a "here is where you must stay".
- ⚠️ **The mechanism is a real upstream design question, not a rename.** `@objectstack/spec` has `retiredKey()` (ADR-0087 D2) for retiring a **key**; I found no value-level equivalent under `packages/spec/src/shared/`. "Named refusal carrying a migration hint" for two enum **values** needs either that mechanism or a per-value refinement, and it is a **narrowing** of a published, defaulted enum. That is upstream's call to score and sequence.

### ⛔ #6942's constraint was never at risk, and is untouched

`ui:text` still does not synthesise `body` for an absent `variant`; `element:text` still does (`props.variant ?? 'body'`). Nothing in this PR moves either. The ruling itself already settles the asymmetry in the same direction ("`element:text` keeps its `?? 'body'` because it is a different component"), so convergence never forced a decision about absence.

---

## ✅ What this PR does land: the pin the card owes

The dispatch calls it out directly, and it is independent of everything blocked above.

Two production registrations claim the short name `text`. `renderers/basic/index.ts` imports `./text` (which registers `ui:text`) **before** `./elements` (which registers `element:text`), and `Registry.register()` claims the bare key for a namespaced registration `if (meta?.namespace && !meta?.skipFallback)` — its own comment: *"the last registration wins for non-namespaced lookups"*. So **load order alone would hand the bare `text` key to `element:text`**; `skipFallback: true` is the single line that stops it, and `Registry.ts` only `console.warn`s on such an overwrite.

The corpus authors the **bare** `text` spelling, so that one flag decides how every authored text node renders. Nothing pinned it.

`packages/components/src/__tests__/text-bare-key-resolution-7450.test.tsx` pins it, in six parts:

1. **Reachability first** — both claimants are registered, so no later assertion can pass by absence.
2. **`text` resolves to `ui:text`**, asserted by *component identity* and not only by the type string.
3. **The load order is adverse** — derived by reading `renderers/basic/index.ts` at run time, so re-ordering those imports moves the pin with it rather than leaving it stale.
4. **`skipFallback: true` is present on `element:text`** and absent on `ui:text`.
5. **A live control on a fresh `Registry` instance** (never the shared singleton): the same pair registered in the same order keeps the bare key on `ui` *with* the flag and hands it to `element` *without* it. Without this control, "the bare key is `ui:text`" would also pass if the fallback path had stopped working or `element:text` had stopped registering.
6. **The consequence** — an authored `{ type: 'text', variant: 'h1' }` node renders an `h1` element. This is what the flag protects: `element:text` has no `h1` in its four-value vocabulary and falls through to a `p`.

### Ablation — the pin reds when the thing it describes is broken

`skipFallback: true` deleted from `element:text`'s registration and nothing else, mutation proven on disk:

```
HEAD_BLOB=498cbdef4e3ea8e3214ab988e023bfd939caeb78
BEFORE: bytes=19663 skipFallback-lines=5
ANCHOR_OCCURRENCES=1
AFTER : bytes=19641 delta=-22 skipFallback-lines=4
MUT_BLOB=bb82663583082b8f82565094d37d42aed04c29dc

× `text` resolves to `ui:text`, by component identity and not only by name
    AssertionError: expected 'element:text' to be 'ui:text'
× `skipFallback: true` on `element:text` is what overrides that order
    AssertionError: expected undefined to be true
× what the flag protects: an authored `text` node keeps its heading element
    AssertionError: expected 'p' to be 'h1'
Tests  3 failed | 3 passed (6)

RESTORED_BLOB=498cbdef4e3ea8e3214ab988e023bfd939caeb78
DIFF_HEAD_EMPTY=yes · RESTORE OK
```

Restoration proved twice over: an empty `git diff HEAD` **and** blob-hash equality with the `HEAD` blob. Both ablations ran from the committed state, under the shared verify lock, exit codes captured before any pipe.

---

## Verification

All at `12cc07f9d`.

| run | result |
|---|---|
| `vitest run packages/components apps/console` | **343 files / 3396 tests passed**, `VERDICT command-exit 0` |
| `pnpm --filter @object-ui/components --filter @object-ui/console run type-check` | both `Done`, `VERDICT command-exit 0` |
| — the new test is inside that program | `tsc -p tsconfig.test.json --listFiles`: 1 hit for the new file, control `text-variant-align-6942` also 1 |
| `eslint .` in `packages/components` (the whole package, not a narrowed slice) | 463 files, **0 errors**, 935 pre-existing warnings, 0 of them mine |
| `node scripts/check-changeset-presence.mjs` | ✅ 1 changeset, empty frontmatter — the documented exemption for a `src/__tests__/` change |
| `node scripts/check-control-bytes.mjs` | ✅ 6996 tracked text files |
| `pnpm check` (CLI built first) | `✓ All checks passed` |
| `lint:coverage` / `type-check:coverage` / `check:lint-rule-coverage` | all ✅ |
| `node scripts/check-governed-queue-guard.mjs --test` on both changed paths | `NOT GOVERNED` |

`apps/console` is in the sweep deliberately (excluding it is what reddened PR #8763 in the queue).

## Changesets

One, with **empty frontmatter**: this is a test file plus a changeset, and `@object-ui/components` ships `["dist","README.md","CHANGELOG.md","LICENSE"]` — nothing published moves. The changesets owed for `@object-ui/components` and `@object-ui/types` belong to the convergence, which is not in this diff.

## Handling

⛔ Draft. ⛔ Not flipped ready, ⛔ not enqueued, ⛔ no auto-merge. `needs:contract-review` is hung per the dispatch's 双载体 rule, though **as landed this diff moves no contract**: it is a test file and an empty-frontmatter changeset.

`Part of #7450` rather than the closing form the dispatch asked for, and that is a deliberate departure I am reporting rather than making quietly: merging a PR that does not implement the ruling must not close the card that carries it. The half left open is the whole convergence; the half delivered is the resolution pin.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_