### PR TITLE
fix(types,plugin-ai): retire the seven zero-read AI schema members (objectui#8178)

### DIFF
--- a/.changeset/8178-ai-schemas-retire-zero-read-members.md
+++ b/.changeset/8178-ai-schemas-retire-zero-read-members.md
@@ -1,0 +1,64 @@
+---
+'@object-ui/types': minor
+'@object-ui/plugin-ai': minor
+---
+
+Retire the seven zero-read members of the three AI schemas, and the designer
+inputs that advertised them (objectui#8178, ADR-0049 enforce-or-remove,
+director decision batch #78, 2026-09-07, maintainer verbatim 「同意」).
+
+**Breaking, deliberately — and scored `minor` per this repo's convention**
+(objectui#3161 family: a `major` in the fixed group pushes all 39 packages off
+`@objectstack`'s cadence, so breaking semantics are spelled out here instead;
+`scripts/check-changeset-no-major.mjs` enforces it).
+
+`AIFormAssistSchema.formId` / `.objectName` / `.fields` / `.autoFill`,
+`AIRecommendationsSchema.objectName` / `.maxResults` and `NLQuerySchema.objectName`
+are `?: never` retirement tombstones. A node that carries one is now a
+compile-time error on the published `.d.ts`; a stored JSON document that carries
+one keeps parsing exactly as it did, and the value keeps being ignored, exactly
+as it was. Seven `inputs` entries across the three `ComponentRegistry`
+registrations are gone, so the field designer no longer offers the keys, and the
+`packages/plugin-ai/README.md` examples that taught them are rewritten.
+
+**Nothing behavioural changes.** Not one of the seven had a reader. The census
+was re-derived per key on this branch's base with a lit control beside every
+zero — `AIFormAssist` 0 for `formId`/`objectName`/`fields` against `suggestions`
+9 and `showConfidence` 2; `AIRecommendations` 0 for `objectName`/`maxResults`
+against `recommendations` 8; `NLQueryInput` 0 for `objectName` against `result`
+14 — plus the two channels that consume a key without naming it: zero
+`{...props}` / `{...rest}` spreads in all four of the package's sources (control:
+`collapsible.tsx` matches the same patterns) and zero dynamic `schema[…]` access
+(control: four files under `packages/` use that form). `autoFill` was the one
+non-zero: destructured with a default and never referenced again, so nothing was
+ever auto-filled.
+
+`maxResults` is the member that made this user-visible. It was documented as
+"Maximum number of results to display" and read by nothing, so `maxResults: 5`
+against a fifty-item list rendered fifty rows with no diagnostic.
+`AIRecommendations` now STATES in its docblock that it renders every item and
+that there is no cap, and a fifty-item render pins it in both layouts.
+
+**Migration.** Slice `recommendations` before handing it over; pass
+`suggestions` in and act on `onApply` instead of `formId` / `fields` /
+`autoFill`; scope a query by object in the host that answers it instead of
+`objectName`. The README carries the same table.
+
+**Why not Enforce.** Implementing reads nobody asked for is capability growth
+without pull, and nothing in the repo pulls on these. An AI backend that later
+wants `objectName` / `fields` as call context is a feature card with its own
+business case.
+
+**Why tombstones and not deletions.** All three schemas extend `BaseSchema`,
+which carries `[key: string]: any`: a deleted optional member is absorbed
+silently at any value, defeating both excess-property checking and the weak-type
+check. Deletion would have left precisely the silent no-op this retirement ends,
+and the ruling's first pin — refused by the schema types, at compile time —
+would have been unsatisfiable. `packages/plugin-ai/README.md` taught all seven as
+working, which is prong 2 of the tombstone discriminator (objectui#5941, #7526,
+#7678) on its own.
+
+`AIInsightsSchema.objectName` is deliberately untouched: the ruling names three
+schemas, and that fourth one was neither screened nor decided. A pin holds it at
+`string | undefined` so a later sweep of "the AI `objectName`s" cannot take it
+quietly.

--- a/packages/plugin-ai/README.md
+++ b/packages/plugin-ai/README.md
@@ -39,9 +39,9 @@ declare const recommendationsData: AIRecommendationItem[];
 
 const contactAssist: AIFormAssistSchema = {
   type: 'ai-form-assist',
-  formId: 'new-contact',
-  objectName: 'Contact',
-  fields: ['name', 'email', 'company'],
+  suggestions: [
+    { fieldName: 'company', value: 'ObjectStack Inc.', confidence: 0.92 },
+  ],
   showConfidence: true,
 };
 
@@ -55,8 +55,6 @@ function SmartForm() {
 
 const productPicks: AIRecommendationsSchema = {
   type: 'ai-recommendations',
-  objectName: 'Product',
-  maxResults: 5,
   layout: 'grid',
   recommendations: recommendationsData,
 };
@@ -67,7 +65,6 @@ function RecommendationsPanel() {
 
 const orderSearch: NLQuerySchema = {
   type: 'nl-query',
-  objectName: 'Order',
   placeholder: 'Ask a question about your orders...',
   suggestions: ['Show orders from last week', 'Top customers by revenue'],
 };
@@ -90,10 +87,9 @@ import type { AIFormAssistSchema } from '@object-ui/types';
 
 const leadAssist: AIFormAssistSchema = {
   type: 'ai-form-assist',
-  formId: 'new-lead',
-  objectName: 'Lead',
-  fields: ['name', 'email', 'phone'],
-  autoFill: false,
+  suggestions: [
+    { fieldName: 'phone', value: '+86 21 0000 0000', confidence: 0.71, reasoning: 'Matched the company record' },
+  ],
   showConfidence: true,
   showReasoning: false,
 };
@@ -119,9 +115,7 @@ declare const data: AIRecommendationItem[];
 
 const productPicks: AIRecommendationsSchema = {
   type: 'ai-recommendations',
-  objectName: 'Product',
-  recommendations: data,
-  maxResults: 10,
+  recommendations: data.slice(0, 10), // every item handed over is rendered
   layout: 'list', // 'list' | 'grid' | 'carousel'
   showScores: false,
   emptyMessage: 'No recommendations available',
@@ -143,7 +137,6 @@ import type { NLQuerySchema } from '@object-ui/types';
 
 const orderSearch: NLQuerySchema = {
   type: 'nl-query',
-  objectName: 'Order',
   placeholder: 'Ask anything...',
   suggestions: ['Recent orders', 'Revenue by month'],
   showHistory: false,
@@ -167,12 +160,30 @@ registers as `nl-query`:
 ```json
 {
   "type": "ai-form-assist",
-  "formId": "new-contact",
-  "objectName": "Contact",
-  "fields": ["name", "email"],
-  "showConfidence": true
+  "showConfidence": true,
+  "showReasoning": true
 }
 ```
+
+## What these components do not do
+
+They are **presentation only**: each one renders the data on its schema and
+reports the user's decisions through its callbacks. None of them fetches, none
+of them queries, and none of them caps a list.
+
+`formId`, `objectName`, `fields`, `autoFill` and `maxResults` were declared,
+offered in the designer and taught here — and read by nothing, at any depth.
+They are retired (objectui#8178, ADR-0049, director decision batch #78,
+2026-09-07) and are refused by the schema types now, so a node that carries one
+is a compile error rather than a silent no-op:
+
+| Key | Was on | Instead |
+|---|---|---|
+| `formId` | `AIFormAssistSchema` | the host owns the form; pass `suggestions` in and act on `onApply` |
+| `objectName` | all three schemas | scope the query in the host that answers it |
+| `fields` | `AIFormAssistSchema` | each suggestion names its own `fieldName` |
+| `autoFill` | `AIFormAssistSchema` | apply the suggestions you want from `onApply` |
+| `maxResults` | `AIRecommendationsSchema` | slice `recommendations` before handing it over — **every item is rendered** |
 
 ## Links
 

--- a/packages/plugin-ai/package.json
+++ b/packages/plugin-ai/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "build": "vite build",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit && tsc -p tsconfig.test.json",
     "clean": "rm -rf dist",
     "test": "vitest run --passWithNoTests --root ../.. packages/plugin-ai/",
     "lint": "eslint ."

--- a/packages/plugin-ai/src/AIFormAssist.tsx
+++ b/packages/plugin-ai/src/AIFormAssist.tsx
@@ -21,14 +21,23 @@ export interface AIFormAssistProps {
 
 /**
  * AIFormAssist - AI-powered form filling assistant
- * Provides intelligent field suggestions based on context and historical data.
+ *
+ * Renders the `suggestions` it is handed and reports the author's decisions
+ * through `onApply`; it generates nothing and fetches nothing. The whole read
+ * surface is the destructure below — `suggestions`, `showConfidence`,
+ * `showReasoning`.
+ *
+ * `autoFill` used to be destructured here with a default and never referenced
+ * again, so nothing was ever filled automatically. It is retired along with
+ * `formId`, `objectName` and `fields` (objectui#8178, ADR-0049, director
+ * decision batch #78) and is a `?: never` tombstone on `AIFormAssistSchema`.
+ * Applying a suggestion is the author's act, through `onApply`.
  */
 export const AIFormAssist: React.FC<AIFormAssistProps> = ({ schema, onApply, onRefresh }) => {
   const {
     suggestions: initialSuggestions = [],
     showConfidence = true,
     showReasoning = false,
-    autoFill = false,
   } = schema;
 
   const [suggestions, setSuggestions] = useState<AIFieldSuggestion[]>(initialSuggestions);

--- a/packages/plugin-ai/src/AIRecommendations.rendersEveryItem-8178.test.tsx
+++ b/packages/plugin-ai/src/AIRecommendations.rendersEveryItem-8178.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `AIRecommendations` renders EVERY item it is handed, in both layouts, and its
+ * docblock says so (objectui#8178, ADR-0049, director decision batch #78).
+ *
+ * ## The promise this replaces
+ *
+ * `AIRecommendationsSchema.maxResults` was documented as *"Maximum number of
+ * results to display"*, offered as a designer input, and read by nothing: a
+ * node carrying `maxResults: 5` against a fifty-item list rendered fifty rows
+ * with no diagnostic. The ruling retired the key rather than implementing the
+ * slice — nothing pulled on it — and required the component to STATE what it
+ * does instead of promising a cap it never honoured.
+ *
+ * Both halves are owed, because either alone rots. This file is the
+ * behavioural half — fifty items in, fifty rendered. The documentary half (the
+ * docblock says so, and no cap survives in the code) reads the component source
+ * off disk, which needs the node project, so it lives in
+ * `registrationInputs-8178.test.ts`. A contributor who implements a cap breaks
+ * this file; one who deletes the sentence breaks that one.
+ *
+ * The count is fifty on purpose: it is the finding's own example, and it is
+ * comfortably past any plausible default cap someone might reintroduce.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import type { AIRecommendationItem, AIRecommendationsSchema } from '@object-ui/types';
+import { AIRecommendations } from './AIRecommendations';
+
+const ITEM_COUNT = 50;
+
+const items: AIRecommendationItem[] = Array.from({ length: ITEM_COUNT }, (_, i) => ({
+  id: `rec-${i + 1}`,
+  title: `Recommendation ${i + 1}`,
+  score: 0.5,
+}));
+
+describe.each(['list', 'grid'] as const)(
+  'every item reaches the DOM in the `%s` layout',
+  (layout) => {
+    it(`renders all ${ITEM_COUNT} titles`, () => {
+      const schema: AIRecommendationsSchema = {
+        type: 'ai-recommendations',
+        recommendations: items,
+        layout,
+      };
+      render(<AIRecommendations schema={schema} />);
+      expect(screen.getAllByText(/^Recommendation \d+$/)).toHaveLength(ITEM_COUNT);
+      // The first and the last, by name: a length check alone would pass on a
+      // component that rendered the same item fifty times.
+      expect(screen.getByText('Recommendation 1')).toBeTruthy();
+      expect(screen.getByText(`Recommendation ${ITEM_COUNT}`)).toBeTruthy();
+      cleanup();
+    });
+
+    it('reports that same count in the header badge', () => {
+      const schema: AIRecommendationsSchema = {
+        type: 'ai-recommendations',
+        recommendations: items,
+        layout,
+      };
+      render(<AIRecommendations schema={schema} />);
+      expect(screen.getByText(String(ITEM_COUNT))).toBeTruthy();
+      cleanup();
+    });
+  },
+);
+
+describe('the control — the instrument counts what is rendered, not a constant', () => {
+  it('renders three when handed three', () => {
+    const schema: AIRecommendationsSchema = {
+      type: 'ai-recommendations',
+      recommendations: items.slice(0, 3),
+    };
+    render(<AIRecommendations schema={schema} />);
+    expect(screen.getAllByText(/^Recommendation \d+$/)).toHaveLength(3);
+    cleanup();
+  });
+
+  it('renders the empty message when handed none', () => {
+    const schema: AIRecommendationsSchema = {
+      type: 'ai-recommendations',
+      recommendations: [],
+      emptyMessage: 'Nothing yet',
+    };
+    render(<AIRecommendations schema={schema} />);
+    expect(screen.getByText('Nothing yet')).toBeTruthy();
+    expect(screen.queryAllByText(/^Recommendation \d+$/)).toHaveLength(0);
+    cleanup();
+  });
+});

--- a/packages/plugin-ai/src/AIRecommendations.tsx
+++ b/packages/plugin-ai/src/AIRecommendations.tsx
@@ -21,7 +21,20 @@ export interface AIRecommendationsProps {
 
 /**
  * AIRecommendations - AI-powered recommendation component
- * Displays intelligent recommendations based on context and user behavior.
+ *
+ * Renders EVERY item in `schema.recommendations`, in both the `list` and the
+ * `grid` layout, and the count badge in the header reports that same length.
+ * There is no cap: the caller decides how many items to hand over, and slicing
+ * — if it is wanted — happens before the array reaches this component.
+ *
+ * That sentence replaces a promise this component never honoured.
+ * `AIRecommendationsSchema.maxResults` was declared as *"Maximum number of
+ * results to display"*, offered in the designer, and read by nothing: a node
+ * carrying `maxResults: 5` against a 50-item list rendered 50 rows with no
+ * diagnostic. The key is retired (objectui#8178, ADR-0049, director decision
+ * batch #78) rather than implemented, because nothing pulled on it; it is a
+ * `?: never` tombstone on the schema now, and the behaviour stated here is
+ * pinned by `AIRecommendations.rendersEveryItem-8178.test.tsx`.
  */
 export const AIRecommendations: React.FC<AIRecommendationsProps> = ({ schema, onSelect, onDismiss }) => {
   const {

--- a/packages/plugin-ai/src/index.tsx
+++ b/packages/plugin-ai/src/index.tsx
@@ -6,6 +6,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/**
+ * The three AI components' registrations.
+ *
+ * Every `inputs` entry below names a key the component beneath it actually
+ * reads. Seven entries used to sit here that no renderer read — `formId`,
+ * `objectName`, `fields`, `autoFill` on `ai-form-assist`, `objectName` and
+ * `maxResults` on `ai-recommendations`, `objectName` on `nl-query` — so the
+ * designer offered them from a list, the JSON validated, and the runtime
+ * dropped them silently. They are retired (objectui#8178, ADR-0049, director
+ * decision batch #78, 2026-09-07) and are `?: never` tombstones on their
+ * schemas; their absence from these lists is pinned by
+ * `registrationInputs-8178.test.ts`.
+ */
+
 import { ComponentRegistry } from '@object-ui/core';
 import { AIFormAssist } from './AIFormAssist';
 import { AIRecommendations } from './AIRecommendations';
@@ -21,11 +35,7 @@ ComponentRegistry.register(
     label: 'AI Form Assist',
     category: 'AI',
     inputs: [
-      { name: 'formId', type: 'string' },
-      { name: 'objectName', type: 'string' },
-      { name: 'fields', type: 'array' },
       { name: 'suggestions', type: 'code' },
-      { name: 'autoFill', type: 'boolean' },
       { name: 'showConfidence', type: 'boolean' },
       { name: 'showReasoning', type: 'boolean' },
     ]
@@ -40,9 +50,7 @@ ComponentRegistry.register(
     label: 'AI Recommendations',
     category: 'AI',
     inputs: [
-      { name: 'objectName', type: 'string' },
       { name: 'recommendations', type: 'code' },
-      { name: 'maxResults', type: 'number' },
       { name: 'showScores', type: 'boolean' },
       { name: 'layout', type: 'enum', enum: [
         { label: 'List', value: 'list' },
@@ -62,7 +70,6 @@ ComponentRegistry.register(
     label: 'Natural Language Query',
     category: 'AI',
     inputs: [
-      { name: 'objectName', type: 'string' },
       { name: 'placeholder', type: 'string' },
       { name: 'suggestions', type: 'array' },
       { name: 'showHistory', type: 'boolean' },

--- a/packages/plugin-ai/src/registrationInputs-8178.test.ts
+++ b/packages/plugin-ai/src/registrationInputs-8178.test.ts
@@ -1,0 +1,166 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Every designer input the three AI registrations advertise names a key the
+ * component beneath it actually reads (objectui#8178, ADR-0049, director
+ * decision batch #78, 2026-09-07).
+ *
+ * ## What this closes
+ *
+ * The finding's sharpest half was not the declaration — it was the PUSH. Seven
+ * `inputs` entries across the three registrations (five distinct names:
+ * `formId`, `objectName`, `fields`, `autoFill`, `maxResults`) offered keys the
+ * renderers never read, so the field designer put them in a list for an author
+ * to pick, the JSON validated, and the runtime dropped the value in silence. An
+ * author who chose `maxResults: 5` against a fifty-item list got fifty rows and
+ * no diagnostic.
+ *
+ * ## Two assertions, and why the second one exists
+ *
+ * The absence pin alone would go green if the whole registration disappeared,
+ * and it says nothing about the NEXT key someone adds. So the second block
+ * derives the property the retirement was really about — a declared input names
+ * a key its component reads — from the component sources themselves, with a
+ * name no component reads as the control that the derivation is a real reading.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ComponentRegistry } from '@object-ui/core';
+import './index';
+
+/**
+ * This file is `.test.ts` (the node project) rather than `.test.tsx`, on
+ * purpose: it reads sibling sources off disk, and under the happy-dom project
+ * `import.meta.url` is not a `file:` URL — `new URL('./x', import.meta.url)`
+ * resolves against the document base and the read fails. The behavioural half
+ * of this card's third pin, which needs a DOM, is
+ * `AIRecommendations.rendersEveryItem-8178.test.tsx`.
+ */
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** The seven entries this card removed, by registration. */
+const RETIRED: Record<string, readonly string[]> = {
+  'ai-form-assist': ['formId', 'objectName', 'fields', 'autoFill'],
+  'ai-recommendations': ['objectName', 'maxResults'],
+  'nl-query': ['objectName'],
+};
+
+/** The component each registration renders, for the read census below. */
+const SOURCE: Record<string, string> = {
+  'ai-form-assist': 'AIFormAssist.tsx',
+  'ai-recommendations': 'AIRecommendations.tsx',
+  'nl-query': 'NLQueryInput.tsx',
+};
+
+const inputNamesOf = (type: string): string[] =>
+  (ComponentRegistry.getMeta(type)?.inputs ?? []).map((input) => input.name);
+
+/**
+ * The component's CODE, with comments stripped.
+ *
+ * Load-bearing: each of these files now names the retired keys in its docblock,
+ * on purpose — that is where the retirement is explained to the next reader.
+ * A census over raw source would read those sentences as reads and report the
+ * exact opposite of the truth.
+ */
+const readSource = (file: string): string => readFileSync(join(HERE, file), 'utf8');
+
+const stripComments = (src: string): string =>
+  src.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/^[ \t]*\/\/.*$/gm, ' ');
+
+const codeOf = (type: string): string => stripComments(readSource(SOURCE[type]));
+
+describe.each(Object.keys(RETIRED))('`%s` no longer advertises its retired keys', (type) => {
+  it('offers none of them to the designer', () => {
+    const names = inputNamesOf(type);
+    // Lit control FIRST: an empty list would satisfy the absence check below
+    // for the wrong reason — a registration that failed to load reads as clean.
+    expect(names.length, `\`${type}\` declares no inputs at all — the reading is vacuous`)
+      .toBeGreaterThan(0);
+    expect(names).toEqual(expect.not.arrayContaining([...RETIRED[type]]));
+  });
+
+  it('still offers exactly the keys its component reads — the census, not a snapshot', () => {
+    const src = codeOf(type);
+    const undeclared = inputNamesOf(type).filter((name) => !new RegExp(`\\b${name}\\b`).test(src));
+    expect(undeclared, `advertised to the designer but unread by ${SOURCE[type]}`).toEqual([]);
+  });
+
+  it('CONTROL — the same instrument reports an unread name as unread', () => {
+    // Without this, the census above would pass on a matcher that matches
+    // everything (a source that failed to read, a stripper that ate the code).
+    const src = codeOf(type);
+    expect(new RegExp('\\bbogusUnreadKey\\b').test(src)).toBe(false);
+    // …and it still sees the code: a key the component DOES read is found.
+    const live = inputNamesOf(type)[0];
+    expect(new RegExp(`\\b${live}\\b`).test(src), `the stripped code lost \`${live}\``).toBe(true);
+    for (const retired of RETIRED[type]) {
+      // …and every key this card retired is genuinely absent from the source
+      // too, `autoFill`'s dead destructure included. This is the read half of
+      // the retirement, measured rather than assumed.
+      expect(new RegExp(`\\b${retired}\\b`).test(src), `${retired} still appears in ${SOURCE[type]}`)
+        .toBe(false);
+    }
+  });
+});
+
+describe('the registrations themselves are intact', () => {
+  it('registers all three components with their labels', () => {
+    expect(Object.keys(RETIRED).map((type) => ComponentRegistry.getMeta(type)?.label)).toEqual([
+      'AI Form Assist',
+      'AI Recommendations',
+      'Natural Language Query',
+    ]);
+  });
+
+  it('keeps the live inputs each designer needs', () => {
+    expect(inputNamesOf('ai-form-assist')).toEqual([
+      'suggestions',
+      'showConfidence',
+      'showReasoning',
+    ]);
+    expect(inputNamesOf('ai-recommendations')).toEqual([
+      'recommendations',
+      'showScores',
+      'layout',
+      'emptyMessage',
+    ]);
+    expect(inputNamesOf('nl-query')).toEqual(['placeholder', 'suggestions', 'showHistory']);
+  });
+});
+
+describe('`AIRecommendations` states what it does instead of promising a cap', () => {
+  // The behavioural half — fifty items in, fifty rendered, both layouts — is
+  // pinned next door in `AIRecommendations.rendersEveryItem-8178.test.tsx`.
+  // This half is the sentence, and both are owed: a contributor who implements
+  // a cap breaks that file, one who deletes the sentence breaks this one.
+  const source = readSource('AIRecommendations.tsx');
+  const docblock =
+    /\/\*\*[\s\S]*?\*\/\s*export const AIRecommendations/.exec(source)?.[0] ?? '';
+
+  it('found the component docblock — the lit control for the reads below', () => {
+    expect(docblock).toContain('AIRecommendations - AI-powered recommendation component');
+  });
+
+  it('says every item is rendered, and that there is no cap', () => {
+    expect(docblock).toContain('Renders EVERY item');
+    expect(docblock).toContain('There is no cap');
+  });
+
+  it('carries no surviving cap in the code', () => {
+    const code = stripComments(source);
+    expect(/\bmaxResults\b/.test(code)).toBe(false);
+    expect(/\.slice\(/.test(code)).toBe(false);
+    // Lit control: the stripper left the code intact.
+    expect(/\brecommendations\b/.test(code)).toBe(true);
+  });
+});

--- a/packages/plugin-ai/tsconfig.test.json
+++ b/packages/plugin-ai/tsconfig.test.json
@@ -1,0 +1,40 @@
+{
+  // Type-checks this package's TESTS, which `tsconfig.json` excludes.
+  // See `packages/types/tsconfig.test.json` for why that exclusion is a hole on
+  // its own: the build correctly keeps tests out of `dist`, but nothing else
+  // compiled them, so a test could assert a contract the compiler never checked
+  // and then read as evidence that the contract holds (objectui#3009, #2911).
+  //
+  // That hole was live here. `packages/plugin-ai/src` contained no test file at
+  // all, so this package's test coverage was vacuously complete; objectui#8178
+  // added the first two, and without this project `node
+  // scripts/check-type-check-coverage.mjs` exits 1 naming both of them.
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    // `registrationInputs-8178.test.ts` reads the three component sources off
+    // disk (`node:fs` / `node:path` / `node:url`) to derive the keys each
+    // renderer really reads, instead of trusting a list a re-key could hold
+    // constant. Naming `types` at all switches off automatic `@types/*`
+    // inclusion -- which is why `@testing-library/jest-dom` is NOT named
+    // alongside `node` the way `plugin-kanban` names it: neither test file here
+    // uses a jest-dom matcher, and declaring one this package does not depend on
+    // is the objectui#8714 divergence pointing the other way. `@types/react`
+    // still reaches the `.tsx` test through ordinary module resolution
+    // (`react/jsx-runtime`, under the root config's `"jsx": "react-jsx"`).
+    "types": ["node"],
+    // Drop the root tsconfig's source-tree `paths` so `@object-ui/types` and
+    // `@object-ui/core` resolve through the workspace dependency's built
+    // `.d.ts` instead of pulling sibling sources in as program inputs (TS6059).
+    "paths": {}
+    // No `composite: false` override, unlike 32 of the 36 siblings that carry
+    // one: it is inert in all of them. These projects extend the ROOT config,
+    // which sets no `composite`, so a package BUILD config's value is never
+    // inherited -- `packages/types` has `"composite": true` in its build and
+    // omits the override with no effect. Here it is moot twice over, since this
+    // package builds with `vite build` and sets no `composite` either. The
+    // other non-composite builds (`layout`, `create-plugin`,
+    // `vscode-extension`) likewise omit it.
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/packages/types/src/__tests__/ai-zero-read-members-retired-8178.test.ts
+++ b/packages/types/src/__tests__/ai-zero-read-members-retired-8178.test.ts
@@ -1,0 +1,253 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The seven zero-read members of the three AI schemas are ADR-0049 RETIREMENT
+ * TOMBSTONES (objectui#8178, director decision batch #78, 2026-09-07,
+ * maintainer verbatim 「同意」), and their refusal is TYPE-LEVEL ONLY.
+ *
+ * ## The seven, and what was measured on each
+ *
+ * `AIFormAssistSchema.formId` / `.objectName` / `.fields` / `.autoFill`,
+ * `AIRecommendationsSchema.objectName` / `.maxResults`, `NLQuerySchema.objectName`.
+ * Each was declared by this file's neighbour `../ai`, five of the names were
+ * offered as designer `inputs` by `@object-ui/plugin-ai`'s registrations
+ * (seven entries across the three), all seven were taught by that package's
+ * README — and no component read any of them.
+ *
+ * The census was re-derived on this branch's base rather than inherited, per
+ * key, with a LIT CONTROL beside every zero so a nil reading cannot be a broken
+ * matcher (`git grep -c -w KEY` over the component that each schema drives):
+ *
+ *   | schema             | zero reads                              | lit control                                    |
+ *   |--------------------|-----------------------------------------|------------------------------------------------|
+ *   | `AIFormAssist`     | `formId` 0, `objectName` 0, `fields` 0  | `suggestions` 9, `showConfidence` 2            |
+ *   | `AIFormAssist`     | `autoFill` 1 — the destructure, unused  | `showReasoning` 2 (destructure PLUS a read)    |
+ *   | `AIRecommendations`| `objectName` 0, `maxResults` 0          | `recommendations` 8, `showScores` 2, `layout` 2|
+ *   | `NLQueryInput`     | `objectName` 0                          | `placeholder` 2, `result` 14, `history` 3      |
+ *
+ * Two channels that could have consumed a key WITHOUT naming it were measured
+ * too, because "no `schema.KEY` read site" does not imply inert (objectui#8410):
+ * `@object-ui/plugin-ai` has zero `{...props}` / `{...rest}` spreads in all
+ * four of its sources (control: `components/src/renderers/disclosure/collapsible.tsx`
+ * matches the same two patterns once), and zero dynamic `schema[…]` access
+ * (control: four files under `packages/` do use that form). The shared
+ * record-source ladder that reads `schema.objectName` structurally for the
+ * grid/tree/map/calendar/gantt blocks is not reachable either — none of its
+ * call sites takes an AI schema, and this package imports nothing from
+ * `@object-ui/core` except `ComponentRegistry`.
+ *
+ * ## Why tombstones and not deletions — the carrier decides
+ *
+ * All three schemas extend {@link BaseSchema}, which carries
+ * `[key: string]: any`. On such a carrier a DELETED optional member is absorbed
+ * silently at any value: the index signature defeats excess-property checking
+ * on a fresh literal and the weak-type check on a widened one. Deletion would
+ * therefore have left exactly the silent no-op the retirement exists to end,
+ * and the ruling's first pin — *refused by the schema types (compile-time)* —
+ * would have been unsatisfiable. The routes are loud-vs-silent here, not
+ * louder-vs-quieter, which is the discriminator's carrier branch as corrected
+ * on objectui#7678; PRONG 2 licenses it independently, since
+ * `packages/plugin-ai/README.md` taught every one of the seven as working.
+ *
+ * The `@ts-expect-error` directives below are REAL enforcement: this package
+ * type-checks its tests through `tsconfig.test.json`, which its `type-check`
+ * script chains, so re-widening any of the seven fails on the now-unused
+ * directive. A green `vitest` run says nothing about them — type assertions are
+ * erased before it runs. The "deleted" row is pinned LIVE, as an undeclared key
+ * carrying no directive, so the contrast cannot rot into prose.
+ *
+ * ⛔ Not Enforce. Implementing reads nobody asked for is capability growth
+ * without pull; an AI backend that later needs `objectName` / `fields` as
+ * context is a feature card with its own business case.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type {
+  AIFieldSuggestion,
+  AIFormAssistSchema,
+  AIRecommendationItem,
+  AIRecommendationsSchema,
+  NLQuerySchema,
+} from '../ai';
+
+/* ── type-level pins: the `tsc` channel ──────────────────────────────────── */
+
+/** Invariant equality — `extends` both ways would accept a narrowing. */
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+/**
+ * What each retired member READS as under the tombstone: `undefined`, not
+ * `never` — `?: never` without `exactOptionalPropertyTypes` is
+ * `never | undefined`, which collapses. `Equal` still separates that from the
+ * `any` a DELETION leaves behind on this carrier, so every row below reddens on
+ * a deletion as well as on a re-widening.
+ */
+export type assertionRetiredMembersReadAsTombstones = [
+  Expect<Equal<AIFormAssistSchema['formId'], undefined>>,
+  Expect<Equal<AIFormAssistSchema['objectName'], undefined>>,
+  Expect<Equal<AIFormAssistSchema['fields'], undefined>>,
+  Expect<Equal<AIFormAssistSchema['autoFill'], undefined>>,
+  Expect<Equal<AIRecommendationsSchema['objectName'], undefined>>,
+  Expect<Equal<AIRecommendationsSchema['maxResults'], undefined>>,
+  Expect<Equal<NLQuerySchema['objectName'], undefined>>,
+];
+
+/**
+ * The non-vacuity twin of the block above: keys the components DO read still
+ * carry their real types, so the seven rows are a measurement of those seven
+ * members and not of a file that stopped resolving.
+ */
+export type assertionLiveMembersKeepTheirTypes = [
+  Expect<Equal<AIFormAssistSchema['showConfidence'], boolean | undefined>>,
+  Expect<Equal<AIRecommendationsSchema['layout'], 'list' | 'grid' | 'carousel' | undefined>>,
+  Expect<Equal<NLQuerySchema['showHistory'], boolean | undefined>>,
+];
+
+/**
+ * `AIInsightsSchema.objectName` is NOT in this retirement — the ruling names
+ * three schemas and that fourth one was neither screened nor decided. Pinned so
+ * a later sweep of "the AI `objectName`s" cannot quietly take it too.
+ */
+export type assertionInsightsObjectNameUntouched = Expect<
+  Equal<import('../ai').AIInsightsSchema['objectName'], string | undefined>
+>;
+
+const suggestions: AIFieldSuggestion[] = [
+  { fieldName: 'company', value: 'ObjectStack Inc.', confidence: 0.92 },
+];
+const recommendations: AIRecommendationItem[] = [{ id: 'r1', title: 'Renew', score: 0.8 }];
+
+describe('the seven tombstones make authoring a `tsc` error, on a fresh literal', () => {
+  it('refuses all four retired `ai-form-assist` members — presence is the error, not the value', () => {
+    const node: AIFormAssistSchema = {
+      type: 'ai-form-assist',
+      suggestions,
+      // @ts-expect-error `formId` is a retirement tombstone (objectui#8178) — the host owns the form
+      formId: 'new-contact',
+      // @ts-expect-error `objectName` is a retirement tombstone (objectui#8178) — nothing read it
+      objectName: 'Contact',
+      // @ts-expect-error `fields` is a retirement tombstone (objectui#8178) — each suggestion names its own `fieldName`
+      fields: ['name', 'email'],
+      // @ts-expect-error `autoFill` is a retirement tombstone (objectui#8178) — apply suggestions through `onApply`
+      autoFill: true,
+    };
+    expect(node.type).toBe('ai-form-assist');
+  });
+
+  it('refuses both retired `ai-recommendations` members', () => {
+    const node: AIRecommendationsSchema = {
+      type: 'ai-recommendations',
+      recommendations,
+      // @ts-expect-error `objectName` is a retirement tombstone (objectui#8178)
+      objectName: 'Product',
+      // @ts-expect-error `maxResults` is a retirement tombstone (objectui#8178) — every item is rendered; slice before handing over
+      maxResults: 5,
+    };
+    expect(node.type).toBe('ai-recommendations');
+  });
+
+  it('refuses the retired `nl-query` member', () => {
+    const node: NLQuerySchema = {
+      type: 'nl-query',
+      placeholder: 'Ask anything...',
+      // @ts-expect-error `objectName` is a retirement tombstone (objectui#8178) — scope the query in the host that answers it
+      objectName: 'Order',
+    };
+    expect(node.type).toBe('nl-query');
+  });
+
+  it('refuses a WRONG-TYPED value too — the row that goes silent under deletion', () => {
+    const node: AIRecommendationsSchema = {
+      type: 'ai-recommendations',
+      recommendations,
+      // @ts-expect-error `maxResults` is a retirement tombstone (objectui#8178)
+      maxResults: 'five',
+    };
+    expect(node.type).toBe('ai-recommendations');
+  });
+});
+
+describe('the tombstones survive the shape no excess-property check reaches', () => {
+  it('refuses a WIDENED value carrying a retired key, on each of the three schemas', () => {
+    const rawAssist = { type: 'ai-form-assist' as const, suggestions, formId: 'new-lead' };
+    // @ts-expect-error `formId` is a retirement tombstone (objectui#8178), reached through a widened value
+    const assist: AIFormAssistSchema = rawAssist;
+    const rawRecs = { type: 'ai-recommendations' as const, recommendations, maxResults: 10 };
+    // @ts-expect-error `maxResults` is a retirement tombstone (objectui#8178), reached through a widened value
+    const recs: AIRecommendationsSchema = rawRecs;
+    const rawQuery = { type: 'nl-query' as const, objectName: 'Order' };
+    // @ts-expect-error `objectName` is a retirement tombstone (objectui#8178), reached through a widened value
+    const query: NLQuerySchema = rawQuery;
+    expect([assist.type, recs.type, query.type]).toEqual([
+      'ai-form-assist',
+      'ai-recommendations',
+      'nl-query',
+    ]);
+  });
+});
+
+describe('the controls — without these, a broken import would satisfy every pin above', () => {
+  it('keeps every key the three components DO read writable', () => {
+    const assist: AIFormAssistSchema = {
+      type: 'ai-form-assist',
+      suggestions,
+      showConfidence: true,
+      showReasoning: false,
+    };
+    const recs: AIRecommendationsSchema = {
+      type: 'ai-recommendations',
+      recommendations,
+      showScores: true,
+      layout: 'grid',
+      loading: false,
+      emptyMessage: 'Nothing yet',
+    };
+    const query: NLQuerySchema = {
+      type: 'nl-query',
+      placeholder: 'Ask anything...',
+      suggestions: ['Recent orders'],
+      showHistory: true,
+      history: [{ query: 'Recent orders', timestamp: '2026-09-09T00:00:00.000Z' }],
+    };
+    expect([assist.showConfidence, recs.layout, query.showHistory]).toEqual([true, 'grid', true]);
+  });
+
+  it('an UNDECLARED key rides both shapes on this carrier — the DELETED row, live', () => {
+    // No directive on purpose: this is where each of the seven would sit had it
+    // been deleted instead of tombstoned. `BaseSchema`'s `[key: string]: any`
+    // absorbs it at any value in every shape, so a deletion produces no
+    // diagnostic at all — it is not a quieter refusal, it is none.
+    const fresh: AIFormAssistSchema = { type: 'ai-form-assist', suggestions, bogusUndeclared: 1 };
+    const raw = { type: 'ai-recommendations' as const, recommendations, bogusUndeclared: 1 };
+    const widened: AIRecommendationsSchema = raw;
+    expect([fresh.type, widened.type]).toEqual(['ai-form-assist', 'ai-recommendations']);
+  });
+
+  it('…and the same undeclared key IS refused on a carrier without an index signature — the instrument control', () => {
+    // `AIFieldSuggestion` and `AIRecommendationItem` declare no index
+    // signature, so the compiler's two ordinary guards fire here: excess-property
+    // checking on a fresh literal (TS2353) and the weak-type check on a
+    // lone-key widened value (TS2559). Their firing proves the silence above is
+    // the index signature and not a blind run.
+    const fresh: AIFieldSuggestion = {
+      fieldName: 'company',
+      value: 'ObjectStack Inc.',
+      confidence: 0.92,
+      // @ts-expect-error TS2353 — `AIFieldSuggestion` has no index signature, so a fresh undeclared key is refused
+      bogusUndeclared: 1,
+    };
+    const loneKey = { bogusUndeclared: 1 };
+    // @ts-expect-error TS2559 — the weak-type check fires on a lone-key widened value without an index signature
+    const widened: AIRecommendationItem = loneKey;
+    expect(fresh.fieldName).toBe('company');
+    expect(widened).toBeDefined();
+  });
+});

--- a/packages/types/src/ai.ts
+++ b/packages/types/src/ai.ts
@@ -92,19 +92,55 @@ export interface AIFormAssistSchema extends BaseSchema {
   type: 'ai-form-assist';
 
   /**
-   * Target form identifier
+   * RETIRED (objectui#8178, ADR-0049, director decision batch #78, 2026-09-07) —
+   * `AIFormAssist` takes `({ schema, onApply, onRefresh })` and never reads
+   * `formId`: the key named a form nothing looked up. Measured on the retiring
+   * branch's own head, whole package: zero occurrences of the identifier in
+   * `AIFormAssist.tsx`, with the sibling `showConfidence` (2 occurrences: the
+   * destructure and its read) lit as the control, and zero `{...props}` /
+   * `{...rest}` spreads anywhere in `@object-ui/plugin-ai` — the
+   * `SchemaRenderer` prop channel objectui#8410 found (a renderer consuming a
+   * key it never names) does not exist in this package, with
+   * `components/src/renderers/disclosure/collapsible.tsx` lit as that
+   * instrument's control.
+   *
+   * A tombstone rather than a plain removal on PRONG 2 of the discriminator
+   * (objectui#5941, #7526, #7678): this package's README taught the key as
+   * working, in the Quick Start, in the `AIFormAssist` API example and in the
+   * schema-driven JSON example. {@link BaseSchema} carries `[key: string]: any`,
+   * so a DELETED member is absorbed silently at ANY value — deletion here is not
+   * a quieter refusal, it is no refusal — and the tombstone is what makes the
+   * compile-time refusal exist, by name.
+   *
+   * ⛔ Not enforced instead (the ruling's words): implementing reads nobody asked
+   * for is capability growth without pull. If an AI backend later needs the
+   * form's identity as context, that is a feature card with its own business
+   * case.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  formId?: string;
+  formId?: never;
 
   /**
-   * Object name for context
+   * RETIRED (objectui#8178, ADR-0049, director decision batch #78, 2026-09-07) — see
+   * {@link AIFormAssistSchema.formId} for the measurement and the tombstone's
+   * grounds. `AIFormAssist.tsx` has zero occurrences of `objectName`; the
+   * component reaches no data source at all (it imports nothing from
+   * `@object-ui/core`, so the shared record-source ladder that reads
+   * `schema.objectName` for the grid/tree/map/calendar/gantt blocks is not on
+   * any path a node of this type can take).
+   * @deprecated Not part of this contract — the value was inert.
    */
-  objectName?: string;
+  objectName?: never;
 
   /**
-   * Fields to provide suggestions for
+   * RETIRED (objectui#8178, ADR-0049, director decision batch #78, 2026-09-07) — see
+   * {@link AIFormAssistSchema.formId}. Zero occurrences in `AIFormAssist.tsx`:
+   * the suggestions the component renders come in already-formed on
+   * `suggestions`, each carrying its own `fieldName`, so this key never chose
+   * anything.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  fields?: string[];
+  fields?: never;
 
   /**
    * Additional context for generating suggestions
@@ -122,9 +158,15 @@ export interface AIFormAssistSchema extends BaseSchema {
   suggestions?: AIFieldSuggestion[];
 
   /**
-   * Automatically fill fields with suggestions
+   * RETIRED (objectui#8178, ADR-0049, director decision batch #78, 2026-09-07) — see
+   * {@link AIFormAssistSchema.formId}. This one was a DEAD DESTRUCTURE rather
+   * than an absent one: `AIFormAssist.tsx` destructured `autoFill = false` and
+   * never referenced the binding again — the single occurrence of the identifier
+   * in the file was that line, against `showConfidence` and `showReasoning` at
+   * two each (destructure plus read). Nothing was ever filled automatically.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  autoFill?: boolean;
+  autoFill?: never;
 
   /**
    * Show confidence scores for suggestions
@@ -204,9 +246,13 @@ export interface AIRecommendationsSchema extends BaseSchema {
   type: 'ai-recommendations';
 
   /**
-   * Object name for context
+   * RETIRED (objectui#8178, ADR-0049, director decision batch #78, 2026-09-07) — see
+   * {@link AIFormAssistSchema.formId} for the measurement and the tombstone's
+   * grounds. Zero occurrences in `AIRecommendations.tsx`, which renders the
+   * `recommendations` it is handed and fetches nothing.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  objectName?: string;
+  objectName?: never;
 
   /**
    * Additional context for generating recommendations
@@ -224,9 +270,21 @@ export interface AIRecommendationsSchema extends BaseSchema {
   recommendations?: AIRecommendationItem[];
 
   /**
-   * Maximum number of results to display
+   * RETIRED (objectui#8178, ADR-0049, director decision batch #78, 2026-09-07) — the
+   * sharpest member of the seven, and the reason the finding was filed. Its doc
+   * comment read *"Maximum number of results to display"*, and
+   * `AIRecommendations` renders EVERY item in `recommendations` — no slice, no
+   * cap, zero occurrences of the identifier in the component. An author who
+   * wrote `maxResults: 5` against a 50-item list got 50 rows and no diagnostic.
+   *
+   * ⛔ Not implemented as a slice instead: that is the Enforce direction the
+   * ruling declined — nothing in the repo pulls on it. The renderer's docblock
+   * now states that it renders every item, so the promise is withdrawn rather
+   * than left unhonoured, and `AIRecommendations.rendersEveryItem-8178.test.tsx`
+   * pins the behaviour. Cap the array before you hand it over.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  maxResults?: number;
+  maxResults?: never;
 
   /**
    * Show relevance scores
@@ -316,9 +374,14 @@ export interface NLQuerySchema extends BaseSchema {
   type: 'nl-query';
 
   /**
-   * Object name for context
+   * RETIRED (objectui#8178, ADR-0049, director decision batch #78, 2026-09-07) — see
+   * {@link AIFormAssistSchema.formId} for the measurement and the tombstone's
+   * grounds. Zero occurrences in `NLQueryInput.tsx`: the component collects a
+   * query string and hands it to `onSubmit`, and any object scoping belongs to
+   * the host that answers it.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  objectName?: string;
+  objectName?: never;
 
   /**
    * Input placeholder text


### PR DESCRIPTION
Fixes #8178

Executes the standing **Remove** ruling on that card (ADR-0049 enforce-or-remove, director decision batch #78, 2026-09-07, maintainer verbatim 「同意」): declared = enforced, and nothing pulls on these keys.

## The premise, re-derived on this branch's base

The objectui#8410 screen on the card was two days old, so every one of the seven was re-measured on `b6d07df4b` before anything was deleted, each zero paired with a **firing control from the same instrument** (`git grep -c -w KEY` over the component each schema drives):

| schema · component | retired — read count | firing control (same instrument) |
|---|---|---|
| `AIFormAssistSchema` · `AIFormAssist.tsx` | `formId` **0**, `objectName` **0**, `fields` **0** | `suggestions` 9, `showConfidence` 2, `showReasoning` 2 |
| `AIFormAssistSchema` · `AIFormAssist.tsx` | `autoFill` **1** — the destructure, never referenced again | `showReasoning` 2 = destructure **plus** a read |
| `AIRecommendationsSchema` · `AIRecommendations.tsx` | `objectName` **0**, `maxResults` **0** | `recommendations` 8, `showScores` 2, `layout` 2, `emptyMessage` 2 |
| `NLQuerySchema` · `NLQueryInput.tsx` | `objectName` **0** | `placeholder` 2, `result` 14, `history` 3, `suggestions` 3 |

Three channels that consume a key **without naming it** were measured too, since a missing `schema.KEY` read site does not by itself imply inertness:

- **prop spread, discriminated PER RENDER FUNCTION** — `SchemaRenderer` spreads every non-metadata node key into React props, so a renderer that forwards a rest element consumes a key it never names (objectui#8410; objectui#8236 and `CardSchema.variant` on objectui#8318 were falsified exactly that way). A file-level grep is **not** the instrument, because one file can hold a forwarder and a non-forwarder. Each of the three registered render functions was read individually:

  | render function | parameter pattern | rest element | JSX spreads in body | verdict |
  |---|---|---|---|---|
  | `AIFormAssist` | `{ schema, onApply, onRefresh }` | no | none | does not forward |
  | `AIRecommendations` | `{ schema, onSelect, onDismiss }` | no | none | does not forward |
  | `NLQueryInput` | `{ schema, onSubmit: onSubmitProp }` | no | none | does not forward |

  Their `Props` interfaces are closed to match — `schema` plus named callbacks, no index signature — and `index.tsx` registers these three functions directly, so there is no wrapper layer that could forward. A second, matcher-independent reading agrees: the **entire package contains no spread token at all**; the only `...` occurrences in all four sources are two ellipses inside string literals.

  **Firing control, and it is the discriminating one:** the same census over `packages/plugin-kanban/src/index.tsx` — the file the objectui#7742 screening seat had to correct itself on — reports `KanbanRenderer` (line 184, `{ schema }`) as **does not forward** and the `ObjectKanbanRenderer` body (line 406, `{ schema, ...props }`, spreads `props`) as **forwards**. Two registrations, one file, opposite answers: the instrument reads per function, not per file.
- **dynamic access** — zero `schema[...]` / `Object.keys(schema)` in the package. Control: four files under `packages/` do use that form.
- **the structural reader** — `resolveRecordSourceConfig` accepts any `{ objectName?: string }`, but none of its call sites (grid, tree, map, calendar, gantt) takes an AI schema, and this package imports nothing from `@object-ui/core` except `ComponentRegistry`.

Radius: the only files repo-wide that put these three types in scope are the three components, the registrations, `packages/types/src/ai.ts`, the barrel and the README. The sweep **included `apps/console`** (and `apps/` generally): the only matches there are three historical `CHANGELOG.md` lines. `@objectstack/spec` does not model these components at all — `grep -rl "ai-form-assist" node_modules/@objectstack/spec/dist` exits 1, with `object-calendar` matching 6 files as the control — so no upstream contract is being contradicted.

**No key had acquired a reader.** This is a retirement, not a regression.

## What was deleted, on each of the five surfaces

1. `packages/types/src/ai.ts` — the seven members are now `?: never` tombstones.
2. `packages/plugin-ai/src/index.tsx` — **seven** `inputs` entries across the three registrations (five distinct names; the card's "five" counts names, not entries).
3. `packages/plugin-ai/src/AIFormAssist.tsx` — the dead `autoFill = false` destructure.
4. `packages/plugin-ai/src/AIRecommendations.tsx` — the docblock now states that every item is rendered and that there is no cap.
5. `packages/plugin-ai/README.md` — every example that taught the keys, plus a new section that states what these components do not do and what to write instead.

`AIInsightsSchema.objectName` is deliberately **untouched** — the ruling names three schemas, and that fourth one was neither screened nor decided. A pin holds it at `string | undefined`.

## Why tombstones and not deletions

All three schemas extend `BaseSchema`, which carries `[key: string]: any`. On that carrier a deleted optional member is absorbed **silently at any value** — the index signature defeats excess-property checking on a fresh literal and the weak-type check on a widened one. Deletion would have left exactly the silent no-op this retirement ends, and the ruling's first pin (refused by the schema types, at compile time) would have been unsatisfiable. Prong 2 of the tombstone discriminator (objectui#5941, objectui#7526, objectui#7678) licenses it independently: the README taught all seven as working. Same shape as the kanban tombstones in `complex.ts` and objectui#7654's `displayMode`.

## The three pins the ruling names

1. **Refused by the schema types, at compile time** — `packages/types/src/__tests__/ai-zero-read-members-retired-8178.test.ts`. Real enforcement, not vitest theatre: this package type-checks its tests through `tsconfig.test.json`, which its `type-check` script chains, so a re-widened member fails on the unused `@ts-expect-error`. The DELETED row is pinned live beside it, as an undeclared key with no directive, and a carrier without an index signature (`AIFieldSuggestion`) lights TS2353/TS2559 as the instrument control.
2. **Absent from the registry's designer inputs** — `packages/plugin-ai/src/registrationInputs-8178.test.ts`. It also derives the property the retirement is about — a declared input names a key its component reads — from the component sources, with an unread name as the control.
3. **`AIRecommendations` renders every item and says so** — `packages/plugin-ai/src/AIRecommendations.rendersEveryItem-8178.test.tsx` renders fifty items in both layouts and counts fifty, with three-item and zero-item controls; the docblock half lives in the pin above (a source read needs the node project — under happy-dom `import.meta.url` is not a `file:` URL).

## Ablation — every row mutated on disk, run, restored, restoration proved

Each row: mutate, prove the mutation reached disk (blob hash **and** byte delta **and** anchor counts), run the instrument, restore with `git checkout HEAD -- ABSOLUTE_PATH`, prove the restore by blob-hash equality **and** an empty `git diff HEAD`. The harness carries `trap ... EXIT INT TERM`.

| row | mutation | on-disk proof | instrument | exit |
|---|---|---|---|---|
| A | `maxResults?: never` becomes `?: number` | blob `28b69aaf` to `068a452c`, +1 byte, anchor 1 to 0, injected 1 | `pnpm --filter @object-ui/types run type-check` | **2** — 3 errors: the `Equal` row, the fresh-literal directive, the widened-value directive |
| B | the `maxResults` member deleted outright | blob `28b69aaf` to `bbd4505d`, -22 bytes, anchor 1 to 0 | same | **2** — 4 errors: the three above **plus** the wrong-typed-value directive, which goes silent only under deletion |
| C | `maxResults` re-added to the designer inputs | blob `df8ea0bd` to `08627703`, +46 bytes, injected 1 | `vitest run packages/plugin-ai/src/registrationInputs-8178.test.ts` | **1** |
| D | a `.slice(0, 5)` cap implemented in the renderer | blob `60203916` to `5b3c71fb`, +79 bytes, injected 1 | `vitest run packages/plugin-ai/src/AIRecommendations.rendersEveryItem-8178.test.tsx` | **1** |

Row A versus row B is the measurement the docblock claims rather than asserts: re-widening leaves the wrong-typed-value directive **used**, deleting the member makes it **unused** — the deletion route is silent even about a wrong type. Every row restored clean; the tree after the harness is `git status --porcelain` empty.

## Gates, with exit codes captured **before** any pipe

| gate | exit | note |
|---|---|---|
| `vitest run` — the three new pins | **0** | 3 files, 28 tests passed, from the repo root |
| `pnpm --filter @object-ui/types run type-check` | **0** | chains `tsconfig.test.json` — the compile-time pin's real instrument |
| `pnpm --filter @object-ui/plugin-ai run type-check` | **0** | after `turbo run build --filter '@object-ui/plugin-ai...'` (exit **0**) |
| `pnpm check` | **0** | "All checks passed" — after building the cli; the first run's `MODULE_NOT_FOUND` was PRECONDITION NOT MET, not a red |
| `node scripts/check-changeset-presence.mjs` | **0** | 4 published source files, 2 released packages, 1 changeset |
| `node scripts/check-changeset-no-major.mjs` | **0** | |
| `pnpm check:control-bytes` | **0** | plus a direct `grep -naP` control-character sweep over every changed file: no match |
| `check:doc-types` · `check:doc-fences` · `check:phantom-deps` · `check:designer-field-key-parity` · `check:published-tsconfig-exclude` · `check:unreferenced-sources` | **0** | |
| `eslint --no-inline-config` over the changed files | **0** | 8 pre-existing warnings, none introduced here |
| `node scripts/check-governed-queue-guard.mjs --test` | **0** | not a governed surface |
| `check:doc-snippets` · `check:readme-exports` · `check:sdui-registration-pins` | **2 / 1 / 2** | **PRECONDITION NOT MET on an unbuilt tree**, not reds — each says so in its own words. Declared narrowing: instead of the 34-package build they want, the four `tsx` fences of the rewritten README were compiled against the **built** `@object-ui/plugin-ai` and `@object-ui/types` (the same dist resolution the gate uses): `tsc` exit **0**, 4 fences found. CI runs the full versions. |

## Patch round — the two pins are now compiled by `tsc` (ceiling review, HIGH)

The contract review found one blocker, and it was PR-introduced: `node
scripts/check-type-check-coverage.mjs` exits **1** on the pre-patch head `1c03409a1` and **0** on
the base `b6d07df4b`. `packages/plugin-ai/src` held no test file before this card, so the
package's test-type-check coverage was *vacuously* complete; the two pins added here are its
first, and no `tsc` invocation read either — they ran under vitest alone. That is exactly the
objectui#3009 / #2911 shape this guard exists to catch: a test asserts a contract the compiler
never checked and then reads as evidence that the contract holds.

It would also have reddened the merge queue rather than just this PR. Re-derived here rather
than taken on report: `ci.yml` guards the step with `should_run`, and the first branch of the
`relevant` step (lines 186-190) forces `should_run=true` whenever `github.event_name` is not
`pull_request` — which includes `merge_group: checks_requested`.

**The fix is config only.** The retirement, the tombstones, the pins, the docblocks, the README
and the changeset are untouched:

- new `packages/plugin-ai/tsconfig.test.json`;
- `packages/plugin-ai/package.json` → `"type-check": "tsc --noEmit && tsc -p tsconfig.test.json"`,
  the spelling 35 of the 36 chaining siblings already carry.

### Readings — every exit code captured before any pipe

| instrument | exit | reading |
|---|---|---|
| `check-type-check-coverage.mjs` @ `1c03409a1` (pre-patch) | **1** | names both pins as `Unread:` |
| `check-type-check-coverage.mjs` @ patched head | **0** | `43/43 packages compile their tests`, 0 declared debt |
| **firing control** — drop the `*.test.tsx` glob from the new config | **1** | names *only* `AIRecommendations.rendersEveryItem-8178.test.tsx`; `registrationInputs-8178.test.ts` is 0 hits, so the gate discriminates instead of having stopped looking. Restored: blob hash back to the `HEAD` value, `git diff HEAD` for the file empty |
| `tsc -p packages/plugin-ai/tsconfig.test.json --listFiles` | **0** | both pins present (1 hit each) in a 1303-file program, alongside the three component sources they import; 0-hit control on a path that does not exist |
| `pnpm --filter @object-ui/plugin-ai run type-check` | **0** | runs both invocations |
| **firing control** — type error injected into `registrationInputs-8178.test.ts` (a file the *build* config excludes, so only the chained project reads it) | **2** | TS2322 naming that file, proving the second invocation is live and not a no-op; restored, hash matches `HEAD`, tree clean |
| **firing control** — same injection into `AIRecommendations.tsx` | **2** | TS2322, proving the leading `tsc --noEmit` still runs; restored, tree clean |
| `pnpm --filter @object-ui/plugin-ai test` | **0** | 2 files, 20 tests — the pins still pass |
| `check:published-tsconfig-exclude` · `check:published-dist` · `check:self-import` · `check:control-bytes` · `check:phantom-deps` · `check:unused-deps` | **0** each | the gates that actually read a `tsconfig.test.json` or a manifest. Each printed a populated verdict, so none is an exit-0 that measured nothing |
| `scripts/tsconfig-test-parity-census.mjs` (a report, not a gate) | **0** | 39 projects, up from 38 |

`check:phantom-deps` is the one worth naming: the `.tsx` pin imports `@testing-library/react`,
which `plugin-ai` does not declare. Its verdict line resolves it — *"4186 tooling import(s) are
declared only by the workspace root"* — that is a permitted route, not an undeclared dep.

### Why this config diverges from `plugin-kanban` in two places

Derived from the tree rather than copied, and the census puts the result in the **majority
bucket on every axis** (`types` `["node"]` x11, `include` x29, `lib` x29, `exclude` unset x36):

- **`types: ["node"]`, without `@testing-library/jest-dom`.** Measured: neither pin uses a
  jest-dom matcher (grep for the matcher names returns nothing, against a control showing 8
  `expect` calls in the file). `node` is required because `registrationInputs-8178.test.ts`
  reads the three component sources off disk. Declaring a matcher package `plugin-ai` does not
  depend on would be the objectui#8714 divergence pointing the other way.
- **No `composite: false`,** which 32 of 36 siblings carry. It is inert in all of them: these
  projects extend the ROOT config, which sets no `composite`, so a package build config's value
  is never inherited — `packages/types` has `"composite": true` in its build, omits the
  override, and compiles. Here it is moot twice over, since `plugin-ai` builds with `vite build`.
  The three other non-composite builds (`layout`, `create-plugin`, `vscode-extension`) omit it too.

### No changeset is owed for this patch

Judged against `scripts/check-changeset-presence.mjs`, which is the authoritative statement, and
confirmed by running it (**exit 0**). Neither changed path is published executable source: the
new `tsconfig.test.json` is not under `src/`, is not `index.html`, and is not published verbatim
by `files` (`["dist", "README.md", "CHANGELOG.md", "LICENSE"]`). The manifest edit touches
`scripts`, which is not one of the eight publish-contract fields — the gate's own summary line
reports *"0 of them a manifest whose published contract moved"*. The card's existing changeset
still covers the 7 published source files it does change.

### Drift check against `main`

`git diff --name-only b6d07df4b origin/main` is a **7-file** window, so the control can fire —
and it does: a token from that window greps back at 1 hit. None of the 7 is under
`packages/plugin-ai`, and none is one of the three sources the pin reads off disk
(`AIFormAssist.tsx`, `AIRecommendations.tsx`, `NLQueryInput.tsx`), so nothing the pins read has
moved. One entry is worth flagging for the merge, not for this round:
`apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` changed on `main` while this PR
removes registry `inputs`. It names none of the AI registrations (control: 71 `inputs` hits in
the same file), so there is no name-level coupling; whether its generic iteration reaches them is
settled by CI on the merged head.

## Changeset

`.changeset/8178-ai-schemas-retire-zero-read-members.md` — **`minor`** for `@object-ui/types` and `@object-ui/plugin-ai`. Never `major`: in this repo's fixed group a `major` pushes all 39 packages off `@objectstack`'s cadence, so a breaking change is scored `minor` with the breaking semantics written into the body (`scripts/check-changeset-no-major.mjs` enforces it, exit 0 above). Both packages are named because both ship changed published source. The body carries the migration table and the reason Enforce was declined.

## Landing

⛔ **Stays draft.** `Clause-②: yes` on the published face — the `@object-ui/types` accept set narrows on a published `.d.ts`, which is the ruling's own reading and the same shape as objectui#8221's retirement. `needs:contract-review` is hung on this PR; the PM runs a transcript-verified ceiling review. Not enqueued, no auto-merge.

## 验收备注

- **Noted, not filed:** `getConfidenceBadge` in `AIFormAssist.tsx` is defined and never called — dead local code that predates this card, not an authorable metadata key, so it is neither this card's defect class nor a fileable class. Left untouched.
- **Noted, not filed:** the `ai-insights` component type is declared in `@object-ui/types` and registered nowhere in this repo, so `AIInsightsSchema` has no renderer at all. That is a different question from this card's (declared-and-advertised versus unread) and it was not screened, priced or ruled. No action taken, deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_

---
_Generated by [Claude Code](https://claude.ai/code)_