### PR TITLE
feat(types,plugin-kanban): execute the batch #70 ruling on the `kanban` arm

### DIFF
--- a/.changeset/7742-kanban-arm-batch70.md
+++ b/.changeset/7742-kanban-arm-batch70.md
@@ -1,0 +1,66 @@
+---
+'@object-ui/types': minor
+'@object-ui/plugin-kanban': minor
+---
+
+**BREAKING (scored `minor` per this repo's version-alignment convention)** — the
+`'kanban'` arm retires four accepted spellings and declares one read it never
+named (objectui#7742, ADR-0049, maintainer decision batch #70, 2026-09-07:
+「同意」).
+
+The accept set moves in **both** directions in one change, which is why the PR
+carries `needs:contract-review`.
+
+## Narrowing — four keys the `'kanban'` arm no longer accepts
+
+Each is a `?: never` tombstone on the TypeScript face and a named refusal arm on
+the `@object-ui/types/zod` mirror, so a document that names one is **refused by
+name** with the remedy in the message. ⛔ None is dropped instead of refused:
+`BaseSchema` is `.passthrough()`, so a dropped key is *kept*, not refused — the
+failure objectui#7664's own first cut shipped at `onCardClick`.
+
+- **`allowCollapse`, `cardTemplates`, `columnWidths`** — declared on both faces
+  since the dialect was carried over, and read by **no registered board**.
+  Re-measured for this change over `packages/plugin-kanban/src`, every file
+  including tests: 0 hits / 0 files each, with `groupBy` (85 hits / 27 files),
+  `cardTitle` (18/9) and `coverImageField` (17/3) firing as controls on the same
+  instrument. An author who wrote `allowCollapse: true` validated green and got
+  a board that never collapsed off that key. Each capability exists on a
+  *different* channel, and the refusal message names it: a lane's own
+  `columns[].collapsed` for collapsing, a `templates` component prop for card
+  templates, a `useColumnWidths` hook option for widths. Wiring a board-level
+  switch to any of them would be new behaviour and is not ordered here.
+  `CardTemplate` and `ColumnWidthConfig` stay exported — the prop and the hook
+  still consume the types.
+- **`titleField`** — ⚠️ **not** an inertness retirement, and reading it as one
+  gets the mechanism backwards. `ObjectKanban` still reads the key and the read
+  stays, because the **sibling `object-kanban` arm declares it and keeps it**
+  (objectui#7322 item ②). What retires is *this* arm's acceptance of the legacy
+  spelling: one arm, one spelling, and the refusal points at `cardTitle`. A
+  `type: "object-kanban"` document naming `titleField` still validates and still
+  renders; a `type: "kanban"` one is now refused. The key was never declared on
+  this face before — it rode `BaseSchema`'s index signature — so this is the
+  first time this face judges it at all.
+
+## Widening — one key the board reads and no face named
+
+- **`navigation`** is now declared on `KanbanSchema` (both faces), on the gantt
+  precedent objectui#5903. `ObjectKanban` reads it to choose the record-detail
+  overlay mode and defaults it to a drawer; until now an authored overlay mode
+  rode `BaseSchema`'s `[key: string]: any` — admitted, never examined — and the
+  read site had to spell itself `(schema as any).navigation`. That cast is gone.
+  The member list is `@objectstack/spec`'s `NavigationConfig` by reference, not
+  restated, so the vocabulary cannot fork.
+
+## `@object-ui/plugin-kanban` — one internal channel leaves the schema bag
+
+`objectFields` (the fetched object's field definitions, which card conditional
+formatting needs so a rule comparing a relation sees the stored foreign key) is
+now a **React prop on `KanbanRendererProps`**, a sibling of `schema`, rather than
+a member of the `schema` bag. It is an internal channel from the one caller that
+fetched the object definition, never an authoring surface. Inside `schema` it was
+reachable by an *author*: on the schema-only `kanban-ui` entry, which has no
+object schema of its own to substitute, an authored `objectFields` reached
+`resolveConditionalFormatting` verbatim while no schema face declared or judged
+it. Callers that render `KanbanRenderer` directly and passed `objectFields`
+inside `schema` must move it to the prop.

--- a/.changeset/7742-kanban-arm-batch70.md
+++ b/.changeset/7742-kanban-arm-batch70.md
@@ -52,15 +52,24 @@ failure objectui#7664's own first cut shipped at `onCardClick`.
   The member list is `@objectstack/spec`'s `NavigationConfig` by reference, not
   restated, so the vocabulary cannot fork.
 
-## `@object-ui/plugin-kanban` — one internal channel leaves the schema bag
+## `@object-ui/plugin-kanban` — `objectFields` moves from the schema bag to a React prop
 
 `objectFields` (the fetched object's field definitions, which card conditional
 formatting needs so a rule comparing a relation sees the stored foreign key) is
 now a **React prop on `KanbanRendererProps`**, a sibling of `schema`, rather than
-a member of the `schema` bag. It is an internal channel from the one caller that
-fetched the object definition, never an authoring surface. Inside `schema` it was
-reachable by an *author*: on the schema-only `kanban-ui` entry, which has no
-object schema of its own to substitute, an authored `objectFields` reached
-`resolveConditionalFormatting` verbatim while no schema face declared or judged
-it. Callers that render `KanbanRenderer` directly and passed `objectFields`
-inside `schema` must move it to the prop.
+a member of the `schema` bag. `ObjectKanban` — the one caller that fetches the
+object definition — injects it there. Callers that render `KanbanRenderer`
+directly and passed `objectFields` inside `schema` must move it to the prop.
+
+⚠️ **What this closes, stated at the arm level** — measured through the real
+`SchemaRenderer`, not assumed. It closes the *schema read path*, and on the
+`'kanban'` arm that closes the key outright: `ObjectKanbanRenderer` serves that
+type key and discards its rest-spread (`void _props;`), so an authored
+`objectFields` on a `type: "kanban"` node reaches nothing. It does **not** make
+`objectFields` unreachable to an author in general. On the schema-only
+`'kanban-ui'` entry, which `KanbanRenderer` serves directly, the key is absent
+from `SchemaRenderer`'s stripped-metadata list, so it survives that renderer's
+generic prop spread and arrives on the very prop this change adds — an authored
+`objectFields` still reaches `resolveConditionalFormatting` there, as it did
+before, and no schema face declares or judges it. Closing that entry is a
+separate change and is not made here.

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -973,14 +973,14 @@ A static board carries its cards inline:
 | `columns` | `KanbanColumn[]` | Lanes, each with `id`, `title`, `cards`, and optional `limit` / `className` / `collapsed`. A card has `id`, `title`, optional `description` and `badges`. |
 | `quickAdd` | `boolean` | Show a Quick Add button at the bottom of each column. |
 | `coverImageField` | `string` | Field whose URL renders as the card cover image. |
-| `allowCollapse` | `boolean` | Allow columns to be collapsed. |
 | `conditionalFormatting` | `KanbanConditionalFormattingRule[]` | Card colouring rules — native `{ field, operator, value }` or spec `{ condition, style }`. |
-| `cardTemplates` | `CardTemplate[]` | Predefined quick-add templates. |
-| `columnWidths` | `ColumnWidthConfig` | Column width configuration. |
 | `grouping` | `GroupingConfig` | ListView grouping config; its first field is the swimlane fallback. |
+| `navigation` | `ViewNavigationConfig` | Record navigation behaviour when a card is clicked (drawer / dialog / page). Defaults to an inline right-side drawer. |
 | `onCardMove` | `function` | Runtime slot supplied by a React host, `(cardId, fromColumnId, toColumnId, newIndex)`; not authorable in JSON. |
 | `onCardClick` | `function` | Runtime slot supplied by a React host, `(card, event?)`; not authorable in JSON. On the object-bound board the host's handler runs alongside the record-detail overlay. |
 | `onQuickAdd` | `function` | Runtime slot supplied by a React host, `(columnId, title)`; not authorable in JSON. |
+
+> Four spellings the `kanban` arm once accepted are now refused by name (objectui#7742, ADR-0049). `allowCollapse`, `cardTemplates` and `columnWidths` were declared and read by no registered board — collapse a lane with `columns[].collapsed`; card templates and column widths reach the board through a component prop and a hook option, not through the node. `titleField` is the legacy spelling of `cardTitle` and is retired on this arm only: write `cardTitle`. An `object-kanban` node still accepts `titleField`.
 
 > The former `@object-ui/types` kanban dialect — `DeclarativeKanbanSchema`, with a board-level `draggable`, a column `color` and card `labels` / `priority` — was retired in objectui#7664: no registered renderer read it, so a board written that way validated and rendered empty. `draggable` and a column `color` are now refused by name; a static board written with `columns[].cards[]` as above is the same document in both dialects and renders every card.
 

--- a/packages/plugin-kanban/src/ObjectKanban.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.tsx
@@ -902,7 +902,10 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
   // CLOSED, not open — do not re-open it as a cleanup. If bucket-vocabulary
   // unification ever becomes a product direction that is a fresh ruling,
   // with visual-regression evidence across all four surfaces in one stroke.
-  const navConfig = (schema as any).navigation ?? { mode: 'drawer' };
+  // `navigation` is DECLARED on `KanbanSchema` since objectui#7742 (gantt
+  // precedent objectui#5903), so this read is typed rather than cast. It stayed
+  // `(schema as any)` for exactly as long as no schema face named the key.
+  const navConfig = schema.navigation ?? { mode: 'drawer' };
   // When this kanban is embedded in an ObjectView, the parent provides
   // `onRowClick`/`onCardClick` and owns the unified record-detail overlay.
   // We must always forward to the parent in that case — otherwise we'd open
@@ -1143,23 +1146,30 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
 
   return (
     <>
-      <KanbanRenderer schema={{
-        ...effectiveSchema,
+      <KanbanRenderer
         // Card conditional formatting evaluates against the card record, and
         // this fetch expands relations (`buildExpandFields` above) exactly as
         // the grid's does. Handing the renderer the object's field types is
         // what lets a rule comparing a relation see the stored foreign key
         // instead of the expanded record (objectui#3501).
-        objectFields: objectDef?.fields,
-        // objectui#8307 — the lane headers count rows that came back, so when
-        // the fetch saturated its window they must say `77+`, not `77`.
-        countsAreWindowed,
-        onCardClick: (card: any, event?: any) => {
-          navigation.handleClick(card, event);
-          onCardClick?.(card);
-        },
-        onCardMove: handleCardMove,
-      }} />
+        //
+        // A PROP, not a schema key (objectui#7742, decision batch #70): it is an
+        // internal channel from the one caller that fetched the object
+        // definition, never an authoring surface. On the schema bag it was
+        // reachable by an author through `BaseSchema`'s passthrough.
+        objectFields={objectDef?.fields}
+        schema={{
+          ...effectiveSchema,
+          // objectui#8307 — the lane headers count rows that came back, so when
+          // the fetch saturated its window they must say `77+`, not `77`.
+          countsAreWindowed,
+          onCardClick: (card: any, event?: any) => {
+            navigation.handleClick(card, event);
+            onCardClick?.(card);
+          },
+          onCardMove: handleCardMove,
+        }}
+      />
       {pendingMove && (
         <RequiredFieldsDialog
           open

--- a/packages/plugin-kanban/src/__tests__/objectFieldsIsAPropNotASchemaKey-7742.test.tsx
+++ b/packages/plugin-kanban/src/__tests__/objectFieldsIsAPropNotASchemaKey-7742.test.tsx
@@ -7,7 +7,7 @@
  */
 
 /**
- * `objectFields` is an INTERNAL CHANNEL, not an authoring surface
+ * `objectFields` is a PROP, no longer a key read off the `schema` bag
  * (objectui#7742, ADR-0049, maintainer decision batch #70, 2026-09-07).
  *
  * ## What moved, and why it was a defect
@@ -26,6 +26,22 @@
  * nothing judged it either: an author could hand the predicate layer a
  * fabricated field catalogue and change which cards a rule matched. Batch #70
  * ruled it an internal channel; it is now a React PROP, a sibling of `schema`.
+ *
+ * ## ⚠️ Scope — what the move closes, and what it does NOT
+ *
+ * It closes the SCHEMA READ PATH, which is exactly what the assertions below
+ * pin: `KanbanRenderer` no longer reads `schema.objectFields`. On the `'kanban'`
+ * arm that closes the key outright — `ObjectKanbanRenderer` serves that type key
+ * and discards its rest-spread (`void _props;`), so an authored `objectFields`
+ * on a `type: 'kanban'` node reaches nothing.
+ *
+ * ⛔ It does NOT make `objectFields` author-unreachable in general, and this
+ * file must not be read as claiming that. `objectFields` is absent from
+ * `SchemaRenderer`'s stripped-metadata list, so on the schema-only `'kanban-ui'`
+ * entry an authored `objectFields` survives that renderer's generic prop spread
+ * and arrives on the very prop asserted below. The tests here render
+ * `KanbanRenderer` DIRECTLY and so never exercise `SchemaRenderer`: that entry
+ * is measured but NOT pinned here, and closing it is a separate change.
  *
  * ## How this file discriminates, and why the fixture is shaped this way
  *

--- a/packages/plugin-kanban/src/__tests__/objectFieldsIsNotAuthorable-7742.test.tsx
+++ b/packages/plugin-kanban/src/__tests__/objectFieldsIsNotAuthorable-7742.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `objectFields` is an INTERNAL CHANNEL, not an authoring surface
+ * (objectui#7742, ADR-0049, maintainer decision batch #70, 2026-09-07).
+ *
+ * ## What moved, and why it was a defect
+ *
+ * `objectFields` carries the fetched object's field definitions so that a
+ * conditional-formatting rule comparing a RELATION field sees the stored
+ * foreign key rather than the record the board's `$expand` substituted for it
+ * (objectui#3501). Only `ObjectKanban` can know the answer — it is the one
+ * entry point that fetches an object definition.
+ *
+ * It used to travel INSIDE the `schema` bag. That made it reachable by an
+ * AUTHOR: `BaseSchema` is `.passthrough()`, `SchemaRenderer` hands the node
+ * down, and on the schema-only `kanban-ui` entry — which has no object schema
+ * of its own to overwrite it with — an authored `objectFields` reached
+ * `resolveConditionalFormatting` verbatim. No schema face declared the key, so
+ * nothing judged it either: an author could hand the predicate layer a
+ * fabricated field catalogue and change which cards a rule matched. Batch #70
+ * ruled it an internal channel; it is now a React PROP, a sibling of `schema`.
+ *
+ * ## How this file discriminates, and why the fixture is shaped this way
+ *
+ * The two channels are told apart by an outcome that ONLY the field catalogue
+ * can produce. The card's `owner` arrives EXPANDED (`{ _id: 'u1' }`), and the
+ * rule compares `owner` against the bare id `'u1'`:
+ *
+ *   - with a catalogue naming `owner` a `lookup`, `toPredicateRecord` collapses
+ *     the expanded value back to `'u1'`, the rule MATCHES, and the card is
+ *     painted;
+ *   - with no catalogue, `owner` stays an object, the rule does NOT match, and
+ *     the card is unpainted.
+ *
+ * So "painted" is a positive reading of the channel and "unpainted" is a
+ * negative one — and the positive case is asserted FIRST, as the firing control
+ * for the negative. Without it, "the schema key did nothing" would also be
+ * produced by a fixture that never worked on either channel, which is the
+ * failure mode this pairing exists to rule out.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { KanbanRenderer } from '../index';
+
+// Pay the board's lazy chunk at import time, not inside a `findBy` budget
+// (AGENTS.md 测试纪律). The specifier stays byte-identical to the one in
+// `../index` — ESM caches by resolved specifier, so this is what makes that
+// module's own `React.lazy` factory resolve immediately.
+import '../KanbanImpl';
+
+/** The paint the matching rule applies — a colour no other element uses. */
+const PAINT = 'rgb(255, 0, 0)';
+
+const RULE = [{ field: 'owner', operator: 'equals', value: 'u1', backgroundColor: PAINT }];
+
+/** `owner` arrives EXPANDED, the way the board's own `$expand` delivers it. */
+const CARD = { id: 'c1', title: 'Painted card', owner: { _id: 'u1', name: 'Ann' } };
+
+/** The catalogue that makes `owner` collapsible. `lookup` is an expandable type. */
+const FIELD_CATALOGUE = { owner: { type: 'lookup' } };
+
+const BOARD = {
+  type: 'kanban',
+  columns: [{ id: 'todo', title: 'To Do', cards: [CARD] }],
+  conditionalFormatting: RULE,
+} as const;
+
+/** The rendered card's own background, read off the element the title sits in. */
+async function paintOfTheCard(): Promise<string> {
+  const title = await screen.findByText('Painted card');
+  let el: HTMLElement | null = title;
+  while (el) {
+    const bg = el.style?.backgroundColor;
+    if (bg) return bg;
+    el = el.parentElement;
+  }
+  return '';
+}
+
+describe('`objectFields` reaches the predicate layer as a PROP (objectui#7742)', () => {
+  it('THE CONTROL — passed as a prop, the relation rule matches and the card is painted', async () => {
+    // ⭐ Asserted first and on purpose. It proves the fixture CAN produce a
+    // paint, so the negative below is a reading about the channel and not about
+    // a rule that never matched on any channel.
+    render(<KanbanRenderer schema={BOARD as never} objectFields={FIELD_CATALOGUE} />);
+    expect(await paintOfTheCard()).toBe(PAINT);
+  });
+});
+
+describe('`objectFields` is no longer read off the schema bag (objectui#7742)', () => {
+  it('an AUTHORED `objectFields` inside `schema` does not reach the predicate layer', async () => {
+    // The same catalogue, the same rule, the same card — written where an
+    // author can write it. It must now do nothing.
+    render(
+      <KanbanRenderer schema={{ ...BOARD, objectFields: FIELD_CATALOGUE } as never} />,
+    );
+    expect(await paintOfTheCard()).not.toBe(PAINT);
+  });
+
+  it('and with neither channel supplied the card is unpainted — the paint is not unconditional', async () => {
+    // The third leg: without it, "unpainted" above could be the board's default
+    // for every card and would say nothing about `objectFields` at all.
+    render(<KanbanRenderer schema={BOARD as never} />);
+    expect(await paintOfTheCard()).not.toBe(PAINT);
+  });
+});

--- a/packages/plugin-kanban/src/index.tsx
+++ b/packages/plugin-kanban/src/index.tsx
@@ -153,18 +153,6 @@ export interface KanbanRendererProps {
     coverImageField?: string;
     conditionalFormatting?: KanbanConditionalFormattingRule[];
     /**
-     * The object's field definitions, injected by `ObjectKanban` (the only
-     * entry point that fetches an object schema). Card conditional formatting
-     * needs them so a rule comparing a relation field sees the stored foreign
-     * key rather than the record `$expand` substituted for it — the board
-     * expands relations exactly as the grid does, so without this the SAME
-     * rule on the SAME view worked on the grid and silently never matched on
-     * the board (objectui#3501). Absent on the schema-only `kanban-ui` entry,
-     * which has no object schema to offer; there the payload is used verbatim,
-     * as before.
-     */
-    objectFields?: unknown;
-    /**
      * The lane counts below are counts of a fetched WINDOW, not of the group
      * (objectui#8307). Injected by `ObjectKanban`, the only entry point that
      * issues the windowed `$top` query and can therefore know the answer;
@@ -175,13 +163,41 @@ export interface KanbanRendererProps {
      */
     countsAreWindowed?: boolean;
   };
+  /**
+   * The object's field definitions, injected by `ObjectKanban` (the only entry
+   * point that fetches an object schema). Card conditional formatting needs
+   * them so a rule comparing a relation field sees the stored foreign key
+   * rather than the record `$expand` substituted for it — the board expands
+   * relations exactly as the grid does, so without this the SAME rule on the
+   * SAME view worked on the grid and silently never matched on the board
+   * (objectui#3501).
+   *
+   * ⛔ AN INTERNAL CHANNEL, NOT AN AUTHORING SURFACE (objectui#7742, maintainer
+   * decision batch #70, 2026-09-07). It sits HERE — a React prop, a sibling of
+   * `schema` — and deliberately NOT inside `schema`, which is where it used to
+   * live. Inside `schema` it was reachable by an AUTHOR: `BaseSchema` is
+   * `.passthrough()`, `SchemaRenderer` hands the node through, and on the
+   * schema-only `kanban-ui` entry (which has no object schema of its own to
+   * substitute) an authored `objectFields` reached
+   * `resolveConditionalFormatting` verbatim. Nothing declared it on any schema
+   * face, so nothing judged it either. As a prop the only writer is the one
+   * caller that can actually know the answer.
+   *
+   * Absent on the schema-only `kanban-ui` entry, which has no object schema to
+   * offer; there conditional formatting reads the card payload as before.
+   *
+   * ⚠️ `countsAreWindowed` above is the SAME shape and the same argument, and
+   * the batch #70 ruling did not name it — it stays on the schema bag, recorded
+   * rather than fixed here.
+   */
+  objectFields?: unknown;
 }
 
 /**
  * KanbanRenderer - The public API for the kanban board component
  * This wrapper handles lazy loading internally using React.Suspense
  */
-export const KanbanRenderer: React.FC<KanbanRendererProps> = ({ schema }) => {
+export const KanbanRenderer: React.FC<KanbanRendererProps> = ({ schema, objectFields }) => {
   const { t } = useUncolumnedT();
   // ⚡️ Adapter: Map flat 'data' + 'groupBy' to nested 'cards' structure.
   const processedColumns = React.useMemo(
@@ -207,7 +223,7 @@ export const KanbanRenderer: React.FC<KanbanRendererProps> = ({ schema }) => {
         onQuickAdd={schema.onQuickAdd}
         coverImageField={schema.coverImageField}
         conditionalFormatting={schema.conditionalFormatting}
-        objectFields={schema.objectFields}
+        objectFields={objectFields}
         swimlaneField={schema.swimlaneField}
         countsAreWindowed={schema.countsAreWindowed}
       />

--- a/packages/plugin-kanban/src/index.tsx
+++ b/packages/plugin-kanban/src/index.tsx
@@ -156,10 +156,14 @@ export interface KanbanRendererProps {
      * The lane counts below are counts of a fetched WINDOW, not of the group
      * (objectui#8307). Injected by `ObjectKanban`, the only entry point that
      * issues the windowed `$top` query and can therefore know the answer;
-     * absent on the schema-only `kanban-ui` entry, whose `data` arrives whole
-     * from its author and whose counts are complete by construction. Not an
-     * authorable input for exactly that reason — same shape as `objectFields`
-     * above, and likewise absent from this component's registry `inputs`.
+     * `ObjectKanban` supplies nothing on the schema-only `kanban-ui` entry,
+     * whose `data` arrives whole from its author and whose counts are complete
+     * by construction. Not MEANT to be an authorable input for exactly that
+     * reason — same shape and same argument as the `objectFields` prop BELOW,
+     * and likewise absent from this component's registry `inputs`. ⚠️ Unlike
+     * that prop it still rides this schema bag, so on `kanban-ui` an author can
+     * in fact write it; batch #70 did not name the key, so it is recorded here
+     * rather than moved (objectui#7742).
      */
     countsAreWindowed?: boolean;
   };
@@ -172,19 +176,32 @@ export interface KanbanRendererProps {
    * SAME view worked on the grid and silently never matched on the board
    * (objectui#3501).
    *
-   * ⛔ AN INTERNAL CHANNEL, NOT AN AUTHORING SURFACE (objectui#7742, maintainer
-   * decision batch #70, 2026-09-07). It sits HERE — a React prop, a sibling of
-   * `schema` — and deliberately NOT inside `schema`, which is where it used to
-   * live. Inside `schema` it was reachable by an AUTHOR: `BaseSchema` is
-   * `.passthrough()`, `SchemaRenderer` hands the node through, and on the
+   * ⛔ INTENDED AS AN INTERNAL CHANNEL, NOT AN AUTHORING SURFACE (objectui#7742,
+   * maintainer decision batch #70, 2026-09-07). It sits HERE — a React prop, a
+   * sibling of `schema` — and deliberately NOT inside `schema`, which is where
+   * it used to live. Inside `schema` it was reachable by an AUTHOR: `BaseSchema`
+   * is `.passthrough()`, `SchemaRenderer` hands the node through, and on the
    * schema-only `kanban-ui` entry (which has no object schema of its own to
    * substitute) an authored `objectFields` reached
    * `resolveConditionalFormatting` verbatim. Nothing declared it on any schema
-   * face, so nothing judged it either. As a prop the only writer is the one
-   * caller that can actually know the answer.
+   * face, so nothing judged it either.
    *
-   * Absent on the schema-only `kanban-ui` entry, which has no object schema to
-   * offer; there conditional formatting reads the card payload as before.
+   * ⚠️ THE MOVE CLOSES THE `kanban` ARM, NOT THE KEY — measured through the
+   * real `SchemaRenderer`, so do NOT read this prop as proof that only
+   * `ObjectKanban` can write it. `ObjectKanbanRenderer` serves `type: 'kanban'`
+   * and discards its rest-spread (`void _props;`), so an authored `objectFields`
+   * on a `'kanban'` node reaches nothing — that arm is genuinely closed. But
+   * `objectFields` is NOT on `SchemaRenderer`'s stripped-metadata list (the
+   * destructure that feeds its `...componentProps` rest), so on the `kanban-ui`
+   * registration below — which THIS component serves — an authored
+   * `objectFields` survives the generic prop spread and lands right here, and
+   * still reaches `resolveConditionalFormatting` exactly as it did before.
+   * Stripping the key at that entry is a separate change, not made here.
+   *
+   * `ObjectKanban` supplies nothing on the schema-only `kanban-ui` entry — it
+   * has no object schema to offer — so unless an author wrote the key and it
+   * arrived by the spread above, conditional formatting there reads the card
+   * payload as before.
    *
    * ⚠️ `countsAreWindowed` above is the SAME shape and the same argument, and
    * the batch #70 ruling did not name it — it stays on the schema bag, recorded

--- a/packages/types/src/__tests__/kanban-arm-batch70-7742.test.ts
+++ b/packages/types/src/__tests__/kanban-arm-batch70-7742.test.ts
@@ -1,0 +1,168 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The `'kanban'` arm's accept set after decision batch #70 (objectui#7742,
+ * ADR-0049, maintainer 2026-09-07: 「同意」).
+ *
+ * ## Why this file exists next to `kanban-plugin-dialect-authoritative-7664`
+ *
+ * That file pins the arm's declared BODY — which members exist, live or
+ * tombstoned — with a TypeScript AST census. This one pins what a DOCUMENT gets
+ * back, through `safeValidateSchema` itself. The two are not interchangeable:
+ * `BaseSchema` is `.passthrough()`, so a key can be absent from the shape and
+ * still parse green, and a key can be present in the shape as a refusal arm and
+ * make a document fail. Only a parse answers the accept-set question.
+ *
+ * ## The unusual thing about this card, stated so a reader checks both halves
+ *
+ * The accept set moves in BOTH directions in one change, which is why the PR
+ * carries `needs:contract-review`:
+ *
+ *   - NARROWER — `allowCollapse`, `cardTemplates`, `columnWidths` and
+ *     `titleField` were accepted and are now refused BY NAME.
+ *   - WIDER — `navigation` was undeclared (admitted through `BaseSchema`'s
+ *     index signature, never examined) and is now declared and JUDGED.
+ *
+ * A file that only checked the narrowing would pass on a change that forgot the
+ * widening entirely, and the reverse. Both directions are asserted here.
+ *
+ * ## Every refusal is paired with a CONTROL that fires the other way
+ *
+ * A `.passthrough()` object accepts an unknown key. So "the document failed"
+ * proves nothing on its own — it has to be shown that an ARBITRARY key does
+ * NOT fail on the same call, or the refusal could just be strictness that
+ * arrived some other way. Each refusal assertion below therefore runs against a
+ * document that also carries a bogus key, and asserts the bogus key draws NO
+ * issue while the retired key draws one at its own path.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { safeValidateSchema } from '../zod/index.zod';
+
+/** Zod 4 nests a failing `z.union` arm's issues under `invalid_union.errors`. */
+type IssueLike = { path: PropertyKey[]; message: string; errors?: IssueLike[][] };
+function flattenIssues(issues: IssueLike[]): Array<{ path: string; message: string }> {
+  return issues.flatMap((i) =>
+    i.errors
+      ? i.errors.flat().flatMap((nested) => flattenIssues([nested]))
+      : [{ path: i.path.join('.'), message: i.message }],
+  );
+}
+function refusals(schema: unknown): Array<{ path: string; message: string }> {
+  const r = safeValidateSchema(schema);
+  return r.success ? [] : flattenIssues(r.error.issues as unknown as IssueLike[]);
+}
+
+/** A board that validates today, used as the base every probe is added to. */
+const LIVE_BOARD = {
+  type: 'kanban',
+  objectName: 'tasks',
+  groupBy: 'status',
+  cardTitle: 'title',
+} as const;
+
+/**
+ * The key a control uses. It must be a name no arm of the union declares, so a
+ * `.passthrough()` accept is the only correct answer for it.
+ */
+const BOGUS = 'thisKeyIsDeclaredByNoArm';
+
+/** The four keys batch #70 retired from this arm, with what each points at. */
+const RETIRED = [
+  { key: 'allowCollapse', value: true, remedyMentions: 'collapsed' },
+  { key: 'cardTemplates', value: [{ id: 't', name: 'Bug', values: {} }], remedyMentions: 'COMPONENT PROP' },
+  { key: 'columnWidths', value: { defaultWidth: 280 }, remedyMentions: 'HOOK OPTION' },
+  { key: 'titleField', value: 'name', remedyMentions: 'cardTitle' },
+] as const;
+
+describe('batch #70 NARROWS the `kanban` arm — four keys are refused by name (objectui#7742)', () => {
+  for (const { key, value, remedyMentions } of RETIRED) {
+    it(`refuses \`${key}\` at its own path, while an undeclared key on the same call is accepted`, () => {
+      const found = refusals({ ...LIVE_BOARD, [key]: value, [BOGUS]: 'anything' });
+
+      // The retired key draws an issue AT ITS OWN PATH — so the author reads
+      // which key is wrong, not just that the document is.
+      const atKey = found.filter((f) => f.path === key);
+      expect(atKey, `no refusal at \`${key}\`: ${JSON.stringify(found)}`).not.toEqual([]);
+
+      // THE CONTROL, on the same parse: an arbitrary undeclared key draws
+      // nothing. Without this the assertion above would also pass under a
+      // validator that had simply become strict.
+      expect(
+        found.filter((f) => f.path === BOGUS),
+        'the control key drew an issue — this arm is not passthrough any more, so the refusal above is not a NAMED one',
+      ).toEqual([]);
+
+      // The message carries the remedy, not just a type complaint. This is what
+      // `retirementTombstone` exists for: zod's own text would read "expected
+      // never, received string" and tell the author nothing.
+      expect(
+        atKey.map((f) => f.message).join('\n'),
+        `\`${key}\`'s refusal does not name its remedy`,
+      ).toContain(remedyMentions);
+    });
+  }
+
+  it('the same four keys were ACCEPTED before this card — the base board without them still passes', () => {
+    // The other half of a narrowing claim: the narrowing is the KEY, not the
+    // board. A board that never named them is untouched.
+    expect(refusals(LIVE_BOARD)).toEqual([]);
+  });
+
+  it('`cardTitle` — the spelling `titleField`\'s refusal points at — still validates', () => {
+    expect(refusals({ type: 'kanban', objectName: 'tasks', cardTitle: 'name' })).toEqual([]);
+  });
+});
+
+describe('the SIBLING `object-kanban` arm keeps `titleField` (objectui#7322 item ②, PR #8153)', () => {
+  it('accepts a `titleField` document, so the retirement is arm-scoped and not global', () => {
+    // ⛔ This is the assertion that makes the `titleField` row a RETIREMENT OF A
+    // SPELLING rather than a removal of a capability. `ObjectKanban` renders
+    // both node types and still reads the key; only the `kanban` arm stops
+    // accepting it.
+    expect(refusals({ type: 'object-kanban', objectName: 'tasks', groupBy: 'status', titleField: 'name' })).toEqual([]);
+  });
+
+  it('and the `kanban` arm refuses the same key on the same call shape — the two answers differ', () => {
+    // The pair is the point: identical documents but for `type`, opposite
+    // verdicts. Asserted together so neither can drift without the other.
+    // (`groupBy` is on both because the `object-kanban` arm REQUIRES it — a
+    // control that fired on the first cut of this file and is kept here as the
+    // reason the two probes are spelled the way they are.)
+    expect(refusals({ type: 'kanban', objectName: 'tasks', groupBy: 'status', titleField: 'name' })).not.toEqual([]);
+  });
+});
+
+describe('batch #70 WIDENS the `kanban` arm — `navigation` is declared (objectui#7742, gantt precedent objectui#5903)', () => {
+  it('accepts a declared `navigation` config', () => {
+    expect(refusals({ ...LIVE_BOARD, navigation: { mode: 'drawer' } })).toEqual([]);
+    expect(refusals({ ...LIVE_BOARD, navigation: { mode: 'page' } })).toEqual([]);
+  });
+
+  it('JUDGES the value, not just the key — a bad `mode` is refused inside `navigation`', () => {
+    // ⭐ The verdict that separates "declared" from "admitted". Before this card
+    // `navigation` rode `BaseSchema`'s `[key: string]: any`, so ANY value passed
+    // — including this one. A test that only asserted the good config would
+    // have passed on `origin/main` too and pinned nothing.
+    const found = refusals({ ...LIVE_BOARD, navigation: { mode: 'not-a-mode' } });
+    expect(found, 'an invalid navigation mode was accepted — the key is admitted, not judged').not.toEqual([]);
+    expect(
+      found.some((f) => f.path.startsWith('navigation')),
+      `no issue under \`navigation\`: ${JSON.stringify(found)}`,
+    ).toBe(true);
+  });
+
+  it('and the member list is the spec\'s — a key the spec does not declare is refused inside `navigation`', () => {
+    // The vocabulary is `@objectstack/spec`'s `NavigationConfig` BY REFERENCE,
+    // not restated here, so it cannot fork. `basePath` is the name the package
+    // README once showed and the spec never declared.
+    const found = refusals({ ...LIVE_BOARD, navigation: { mode: 'drawer', basePath: '/tasks' } });
+    expect(found, 'an undeclared navigation member was accepted').not.toEqual([]);
+  });
+});

--- a/packages/types/src/__tests__/kanban-plugin-dialect-authoritative-7664.test.ts
+++ b/packages/types/src/__tests__/kanban-plugin-dialect-authoritative-7664.test.ts
@@ -220,6 +220,11 @@ describe("the 'kanban' validator arm accepts what the registered renderer reads 
       'objectName', 'groupBy', 'swimlaneField', 'cardTitle', 'cardFields', 'data', 'limit', 'columns',
       'onCardMove', 'className', 'quickAdd', 'onQuickAdd', 'coverImageField', 'allowCollapse',
       'conditionalFormatting', 'cardTemplates', 'columnWidths', 'grouping',
+      // objectui#7742 (decision batch #70): `navigation` joins as a LIVE member
+      // and `titleField` joins as a refusal arm. Both are on the shape for the
+      // same reason the four keys above still are — a REFUSED key is declared,
+      // and only a DROPPED key would be missing here.
+      'navigation', 'titleField',
     ]) {
       expect(declared, `\`${key}\` missing from the kanban mirror's shape`).toContain(key);
     }
@@ -294,17 +299,27 @@ describe('the declared body is measured, not inherited (objectui#7664)', () => {
     }));
   }
 
-  it('KanbanSchema declares 20 live members — the dialect\'s 19 (the ruling said 18; `type` is the difference) plus `onCardClick` — and exactly 3 tombstones', () => {
+  it('KanbanSchema declares 18 live members and exactly 7 tombstones after the batch #70 ruling', () => {
+    // objectui#7742 moved this count in BOTH directions in one change. It was
+    // 20 live / 3 tombstoned: three zero-read members (`allowCollapse`,
+    // `cardTemplates`, `columnWidths`) and the legacy `titleField` spelling
+    // retired, and `navigation` — a read this face never named — was declared.
+    // 20 - 3 + 1 = 18 live; 3 + 4 = 7 tombstones. `titleField` is the one that
+    // ADDS a member rather than converting one: it was never declared here at
+    // all, it rode `BaseSchema`'s index signature.
     const members = membersOf('KanbanSchema');
     const live = members.filter((m) => !m.never).map((m) => m.name);
     const tombstoned = members.filter((m) => m.never).map((m) => m.name);
     expect(live).toEqual([
       'type', 'objectName', 'groupBy', 'swimlaneField', 'cardTitle', 'cardFields', 'data', 'limit', 'columns',
-      'onCardMove', 'onCardClick', 'className', 'quickAdd', 'onQuickAdd', 'coverImageField', 'allowCollapse',
-      'conditionalFormatting', 'cardTemplates', 'columnWidths', 'grouping',
+      'onCardMove', 'onCardClick', 'className', 'quickAdd', 'onQuickAdd', 'coverImageField',
+      'conditionalFormatting', 'grouping', 'navigation',
     ]);
-    expect(live).toHaveLength(20);
-    expect(tombstoned).toEqual(['draggable', 'onColumnAdd', 'onCardAdd']);
+    expect(live).toHaveLength(18);
+    expect(tombstoned).toEqual([
+      'allowCollapse', 'cardTemplates', 'columnWidths', 'titleField',
+      'draggable', 'onColumnAdd', 'onCardAdd',
+    ]);
     // Both directions against the mirror, so the number above is the mirror's
     // too: every declared member is a key of the shape, and every shape key the
     // arm ADDS over `BaseSchema` is a declared member. (The parity ratchet,

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -22,7 +22,7 @@ import type {
   GroupingConfig,
 } from '@objectstack/spec/ui';
 import type { BaseSchema, SchemaNode } from './base.js';
-import type { KanbanConditionalFormattingRule } from './objectql.js';
+import type { KanbanConditionalFormattingRule, ViewNavigationConfig } from './objectql.js';
 
 /**
  * Kanban card — the shape the registered `'kanban'` renderer reads.
@@ -311,12 +311,6 @@ export interface KanbanSchema extends BaseSchema {
   coverImageField?: string;
 
   /**
-   * Allow columns to be collapsed/expanded.
-   * @default false
-   */
-  allowCollapse?: boolean;
-
-  /**
    * Conditional formatting rules for card coloring. Accepts the native
    * `{ field, operator, value }` shape and the spec `{ condition, style }` CEL
    * shape (issue #1584).
@@ -324,22 +318,137 @@ export interface KanbanSchema extends BaseSchema {
   conditionalFormatting?: KanbanConditionalFormattingRule[];
 
   /**
-   * Predefined card templates for quick-add.
-   * Each template pre-fills the quick-add form with default values.
-   */
-  cardTemplates?: CardTemplate[];
-
-  /**
-   * Custom column width configuration.
-   * Supports per-column overrides with min/max constraints.
-   */
-  columnWidths?: ColumnWidthConfig;
-
-  /**
    * Grouping configuration from ListView.
    * When set, the first grouping field is used as swimlaneField fallback.
    */
   grouping?: GroupingConfig;
+
+  /**
+   * Record navigation behaviour when a card is clicked (drawer / dialog /
+   * page). Defaults to an inline right-side drawer; set `{ mode: 'page' }` to
+   * route to the standalone detail page instead. Read at `ObjectKanban.tsx`
+   * (`navConfig`), which feeds it to `useNavigationOverlay`.
+   *
+   * DECLARED by objectui#7742 (decision batch #70) on the gantt precedent
+   * objectui#5903 set: the read existed and this face did not name it, so an
+   * authored overlay mode rode {@link BaseSchema}'s `[key: string]: any` —
+   * admitted, never examined — and the read site had to spell itself
+   * `(schema as any).navigation`. Declaring it WIDENS the published accept set;
+   * it is the one widening in a card whose other rows all narrow.
+   *
+   * The spec owns the member list — `mode`, `view`, `preventNavigation`,
+   * `openNewTab`, `size`, `width` — and its schema REFUSES anything else. Do
+   * not restate the vocabulary here.
+   *
+   * Same spec type as {@link ObjectGanttSchema.navigation} and
+   * {@link ObjectGridSchema.navigation} — aligned with `@objectstack/spec`
+   * `ListView.navigation` rather than restated, so the vocabulary cannot fork.
+   */
+  navigation?: ViewNavigationConfig;
+
+  /**
+   * RETIRED (objectui#7742, ADR-0049, maintainer decision batch #70,
+   * 2026-09-07) — declared on both faces and read by NO registered board.
+   *
+   * Measured on this branch over `packages/plugin-kanban/src`, every file
+   * including tests: `allowCollapse` 0 hits / 0 files, with `groupBy` (85/27),
+   * `cardTitle` (18/9) and `coverImageField` (17/3) firing as controls on the
+   * same instrument, so the zero is a reading and not a dead grep. The
+   * capability EXISTS through another channel — `KanbanEnhanced` collapses a
+   * lane off `KanbanColumn.collapsed` — so an author who wrote
+   * `allowCollapse: true` validated green and got a board that never collapsed
+   * off that key. A board-level switch wired to the per-lane mechanism is a new
+   * card if it is ever wanted; the ruling did not order one.
+   *
+   * A tombstone rather than a plain removal on PRONG 2 of the discriminator the
+   * precedent changesets state (objectui#5941, #7526): the key was TAUGHT as
+   * working — `content/docs/api/schema-reference.md` carried the row
+   * "`allowCollapse` | `boolean` | Allow columns to be collapsed." Prong 1 does
+   * not apply: there is no live replacement KEY to name, only a different
+   * channel.
+   *
+   * ⚠️ Inertness is why the key is retired, not why it is tombstoned. {@link
+   * BaseSchema} is `.passthrough()`, so dropping it from the mirror would leave
+   * a document naming it silently ACCEPTED with the value kept — the failure
+   * objectui#7664's own first cut shipped at {@link KanbanSchema.onCardClick}.
+   *
+   * ⛔ NOT the same key as `ObjectKanbanSchema.allowCollapse` (`objectql.ts`),
+   * which the batch #70 ruling did not reach and which stays declared on the
+   * `object-kanban` arm.
+   * @deprecated Not part of this contract — the value was inert.
+   */
+  allowCollapse?: never;
+
+  /**
+   * RETIRED (objectui#7742, ADR-0049, maintainer decision batch #70,
+   * 2026-09-07) — declared on both faces and read by NO registered board.
+   *
+   * Measured with the census above: `cardTemplates` 0 hits / 0 files across
+   * `packages/plugin-kanban/src`, same run and same firing controls. The
+   * capability exists through a COMPONENT PROP — `CardTemplates.tsx` takes
+   * `templates: CardTemplate[]` — never off the schema, so nothing an author
+   * wrote here ever reached it. {@link CardTemplate} itself stays exported:
+   * that prop and `plugin-kanban`'s re-export still consume the type.
+   *
+   * Tombstoned on PRONG 2, same as {@link KanbanSchema.allowCollapse}:
+   * `content/docs/api/schema-reference.md` carried the row "`cardTemplates` |
+   * `CardTemplate[]` | Predefined quick-add templates."
+   * @deprecated Not part of this contract — the value was inert.
+   */
+  cardTemplates?: never;
+
+  /**
+   * RETIRED (objectui#7742, ADR-0049, maintainer decision batch #70,
+   * 2026-09-07) — declared on both faces and read by NO registered board.
+   *
+   * Measured with the census above: `columnWidths` 0 hits / 0 files across
+   * `packages/plugin-kanban/src`, same run and same firing controls. The
+   * capability exists through a HOOK OPTION — `useColumnWidths` takes a
+   * `ColumnWidthConfig` argument — never off the schema. {@link
+   * ColumnWidthConfig} itself stays exported: that hook and `plugin-kanban`'s
+   * re-export still consume the type.
+   *
+   * ⚠️ The repo-wide name census for this key is NOT zero (22 hits / 11 files)
+   * and every one of those is a DIFFERENT key of the same spelling on the grid
+   * surface — `data-table.tsx`, `ObjectGrid.tsx`, `RecordPickerDialog.tsx`. The
+   * board's zero is the `packages/plugin-kanban/src` reading, and the grid key
+   * is untouched by this retirement.
+   *
+   * Tombstoned on PRONG 2, same as {@link KanbanSchema.allowCollapse}:
+   * `content/docs/api/schema-reference.md` carried the row "`columnWidths` |
+   * `ColumnWidthConfig` | Column width configuration."
+   * @deprecated Not part of this contract — the value was inert.
+   */
+  columnWidths?: never;
+
+  /**
+   * RETIRED on THIS arm (objectui#7742, ADR-0049, maintainer decision batch
+   * #70, 2026-09-07) — one arm, one spelling: write {@link
+   * KanbanSchema.cardTitle}.
+   *
+   * ⚠️ This tombstone is NOT an inertness finding, and reading it as one gets
+   * the mechanism backwards. `ObjectKanban.tsx` DOES read the key —
+   * `schema.cardTitle || schema.titleField` and `schema.cardTitle ??
+   * schema.titleField` — and that read is load-bearing for the SIBLING arm:
+   * `ObjectKanbanSchema` (`objectql.ts`) declares `titleField` and the batch #70
+   * ruling says in as many words that the `object-kanban` arm KEEPS it
+   * (objectui#7322 item ②, PR #8153, re-measured here from `25907cd70`). What
+   * is retired is this arm's ACCEPTANCE of the legacy spelling, not the read.
+   *
+   * So a `{ "type": "kanban" }` document naming `titleField` is now refused BY
+   * NAME and pointed at `cardTitle`; a `{ "type": "object-kanban" }` document
+   * naming it still validates and still renders. One renderer, two node types,
+   * two accept sets — which is the shape objectui#7322 item ② already gave the
+   * component's prop union.
+   *
+   * ⚠️ Never declared on this face before now: it rode {@link BaseSchema}'s
+   * `[key: string]: any`, which is why both reads were spelled `(schema as
+   * any).titleField` until PR #8153 widened the prop to the two-arm union.
+   * Declaring the tombstone is therefore the FIRST time this face judges the
+   * key at all — a narrowing, not a re-narrowing.
+   * @deprecated Not part of this contract on the `kanban` arm — write `cardTitle`.
+   */
+  titleField?: never;
 
   /**
    * RETIRED with the declarative face (objectui#7664, ADR-0049) — `draggable`

--- a/packages/types/src/zod/complex.zod.ts
+++ b/packages/types/src/zod/complex.zod.ts
@@ -24,6 +24,7 @@ import {
   DashboardWidgetSchema as SpecDashboardWidgetSchema,
   GlobalFilterSchema as SpecGlobalFilterSchema,
   GroupingConfigSchema as SpecGroupingConfigSchema,
+  NavigationConfigSchema as SpecNavigationConfigSchema,
 } from '@objectstack/spec/ui';
 import { BaseSchema, SchemaNodeSchema, specFieldsExcept } from './base.zod.js';
 import { KanbanConditionalFormattingRuleSchema } from './objectql.zod.js';
@@ -86,6 +87,36 @@ const retiredDeclarativeKanbanKey = (key: string, where: string, remedy: string)
       'kanban face), which no registered kanban renderer ever read. The `kanban` type key ' +
       'now validates the shape `@object-ui/plugin-kanban` renders: `objectName` + `groupBy` for ' +
       `an object-bound board, or \`columns[].cards[]\` for a static one. ${remedy}`,
+  );
+
+/**
+ * The ZERO-READ members this arm declared, named once so every refusal below
+ * says the same thing (objectui#7742, ADR-0049, maintainer decision batch #70,
+ * 2026-09-07: 「同意」).
+ *
+ * ⛔ Deliberately NOT {@link retiredDeclarativeKanbanKey}. That helper's message
+ * says the key "belonged to the retired `DeclarativeKanbanSchema` dialect",
+ * which is TRUE of `draggable` and the column `color` and FALSE of these three:
+ * they were members of the PLUGIN dialect objectui#7664 ruled authoritative,
+ * carried over member-for-member, and retired one card later for a different
+ * reason — declared on both faces, read by no registered board. Sharing the
+ * older message would hand the author a false history of their own document.
+ *
+ * The zeros are readings, not a dead grep: measured over
+ * `packages/plugin-kanban/src` with every file including tests, `allowCollapse`
+ * / `cardTemplates` / `columnWidths` returned 0 hits / 0 files while `groupBy`
+ * (85/27), `cardTitle` (18/9) and `coverImageField` (17/3) fired as controls on
+ * the same instrument.
+ *
+ * Refused BY NAME rather than dropped, for the reason this file states twice
+ * already: {@link BaseSchema} is `.passthrough()`, so a dropped key is KEPT,
+ * not refused.
+ */
+const retiredZeroReadKanbanKey = (key: string, taught: string, remedy: string) =>
+  retirementTombstone(
+    `\`${key}\` is RETIRED (objectui#7742, ADR-0049) — the \`kanban\` arm declared ` +
+      'it on both faces and NO registered board ever read it, so a document that set ' +
+      `it validated green and changed nothing. ${taught} ${remedy}`,
   );
 
 /**
@@ -186,11 +217,32 @@ export const KanbanSchema = BaseSchema.extend({
   quickAdd: z.boolean().optional().describe('Enable the Quick Add button at the bottom of each column'),
   onQuickAdd: handlerKeyRefusal('onQuickAdd', 'runtime-slot', 'Quick Add handler'),
   coverImageField: z.string().optional().describe('Field name to use as cover image on cards'),
-  allowCollapse: z.boolean().optional().describe('Allow columns to be collapsed/expanded'),
+  allowCollapse: retiredZeroReadKanbanKey(
+    'allowCollapse',
+    'The capability exists on another channel:',
+    'the enhanced board collapses a lane off that lane\'s own `collapsed` key, so write `columns[].collapsed`.',
+  ),
   conditionalFormatting: z.array(KanbanConditionalFormattingRuleSchema).optional().describe('Card conditional formatting rules'),
-  cardTemplates: z.array(CardTemplateSchema).optional().describe('Predefined card templates for quick-add'),
-  columnWidths: ColumnWidthConfigSchema.optional().describe('Custom column width configuration'),
+  cardTemplates: retiredZeroReadKanbanKey(
+    'cardTemplates',
+    'The capability exists on another channel:',
+    '`CardTemplates` takes its `templates` as a COMPONENT PROP, not off the board node; there is no authorable spelling for it.',
+  ),
+  columnWidths: retiredZeroReadKanbanKey(
+    'columnWidths',
+    'The capability exists on another channel:',
+    '`useColumnWidths` takes its `ColumnWidthConfig` as a HOOK OPTION, not off the board node; there is no authorable spelling for it. (The grid surface has an unrelated key of the same name — that one is untouched.)',
+  ),
   grouping: stripImportedDefaults(SpecGroupingConfigSchema).optional().describe('Grouping configuration from ListView; its first field is the swimlaneField fallback'),
+  navigation: stripImportedDefaults(SpecNavigationConfigSchema).optional().describe('Record navigation behaviour on card click (drawer/dialog/page)'),
+  titleField: retirementTombstone(
+    '`titleField` is RETIRED on the `kanban` arm (objectui#7742, ADR-0049) — one arm, one ' +
+      'spelling. Write `cardTitle`, which selects the same record field and which this arm ' +
+      'has always declared. ⛔ This is NOT an inertness retirement: `ObjectKanban` still ' +
+      'reads the key, because the SIBLING `object-kanban` arm declares it and keeps it ' +
+      '(objectui#7322 item ②). A `type: "object-kanban"` document naming `titleField` is ' +
+      'still accepted; a `type: "kanban"` one is not.',
+  ),
   draggable: retiredDeclarativeKanbanKey('draggable', 'board', 'Drag-and-drop is always on; delete the key.'),
   onColumnAdd: handlerKeyRefusal('onColumnAdd', 'retired', 'Column add handler'),
   onCardAdd: handlerKeyRefusal('onCardAdd', 'retired', 'Card add handler'),


### PR DESCRIPTION
Fixes #7742

Executes maintainer decision batch #70 (2026-09-07, verbatim 「同意」) row by row on the `'kanban'` arm.

## ⭐ Wording patch round — after the contract review PASSED

The contract review adopted the implementation whole (**PASS**, tier-verified, every leg re-derived). ⛔ Nothing about the retirement, the declaration, the refusals, the pins or the ablation is reopened, and **no behaviour changed in this round** — it is prose, one file rename, and this body. Seat session `session_01Jmxdo7bmeqCQHLSfmLVX9w`.

What the review found, and what this round did about it:

| finding | fixed by |
|---|---|
| **MEDIUM F-A** — three texts read as if `objectFields` had become author-unreachable *in general*; the changeset is the one that matters, because a changeset is this PR's input to the release notes | the changeset section, the `KanbanRendererProps` docblock and the pin file's docblock now state the scope at the **arm** level; the pin file is **renamed** (see row 4 below) |
| **LOW F-D** — the base-to-main window paragraph was stale; `origin/main` had moved | `origin/main` **merged in** (⛔ no rebase, no force-push) and the paragraph re-measured — see *Base to main window check* |

## ⚠️ Clause ② — the accept set moves in BOTH directions

`Clause-②: yes`

That line is in the fixed spelling the seat protocol reads, so the carrier requirement is machine-legible and not merely described: this PR moves a declared accept set in both directions, therefore `needs:contract-review` is hung on both the card and this PR and ⛔ stays hung — the PR remains **draft** and is ⛔ not enqueued.

Most cards move one way. This one narrows **and** widens, and a reviewer must check each half separately.

| direction | keys | face |
|---|---|---|
| **NARROWS** — four spellings the arm accepted are now refused BY NAME | `allowCollapse`, `cardTemplates`, `columnWidths`, `titleField` | `?: never` on `complex.ts` + named refusal on `complex.zod.ts` |
| **WIDENS** — one key the board reads and no face named is now declared | `navigation` | `complex.ts` + `complex.zod.ts`, spec type by reference |

Neither half is a drop. `BaseSchema` is `.passthrough()`, so a dropped key is **kept**, not refused — the failure objectui#7664's own first cut shipped at `onCardClick`.

Both directions are pinned in one file, `packages/types/src/__tests__/kanban-arm-batch70-7742.test.ts`, because a file that pinned only one half would pass on a change that forgot the other.

## The four rows

### 1. `allowCollapse` / `cardTemplates` / `columnWidths` — RETIRE

Tombstone + named refusal on both faces. Each refusal message names the channel the capability actually lives on: `columns[].collapsed` for collapsing, the `templates` component prop for card templates, the `useColumnWidths` hook option for widths. `CardTemplate` / `ColumnWidthConfig` stay exported — the prop and the hook still consume them.

⛔ A **new** refusal factory (`retiredZeroReadKanbanKey`), not the existing `retiredDeclarativeKanbanKey`. That helper's message says the key "belonged to the retired `DeclarativeKanbanSchema` dialect", which is true of `draggable` and **false** of these three: they were members of the plugin dialect objectui#7664 ruled authoritative. Sharing the message would hand the author a false history of their own document.

### 2. `titleField` on the `kanban` arm — RETIRE THE FALLBACK

⚠️ **Not an inertness retirement.** The read stays — `ObjectKanban.tsx` reads `schema.cardTitle || schema.titleField` and it is load-bearing for the **sibling** arm. What retires is *this* arm's acceptance of the legacy spelling. Pinned as a PAIR: two documents identical but for `type`, opposite verdicts.

### 3. `navigation` — DECLARE

`ObjectKanban.tsx` reads it to choose the record-detail overlay and defaults it to a drawer; the `(schema as any).navigation` cast is gone. Member list is `@objectstack/spec`'s `NavigationConfig` by reference, not restated. The pin asserts the value is **judged**, not merely admitted — a bad `mode` and an undeclared member both draw refusals, which a test asserting only the good config would not have caught (it would have passed on `main` too).

### 4. `objectFields` — off the `schema` bag, onto a React prop

Moved off the `schema` bag onto `KanbanRendererProps` as a real React prop, a sibling of `schema`, injected by `ObjectKanban` — the one caller that fetches the object definition. Inside `schema` it was reachable by an **author**: on the schema-only `kanban-ui` entry, which has no object schema of its own to substitute, an authored `objectFields` reached `resolveConditionalFormatting` verbatim while no schema face declared or judged it.

⚠️ **Scope — the ruled `kanban` arm is closed, the KEY is not.** Measured through the real `SchemaRenderer`, and stated because the first cut of this PR read as if it were:

| node | authored `objectFields` | outcome |
|---|---|---|
| `kanban-ui` | absent | unpainted |
| `kanban-ui` | present | **painted `rgb(255, 0, 0)`** |
| `kanban` | present | unpainted |

`SchemaRenderer` strips a fixed metadata list that does **not** include `objectFields`, then spreads the rest as React props — and `KanbanRenderer`, registered for **`kanban-ui`**, now reads that prop. So on `kanban-ui` an authored value still arrives, on the very prop this change adds. The ruled **`kanban`** arm *is* genuinely closed: `ObjectKanbanRenderer` serves that type key and discards its rest-spread (`void _props;`), so an authored `objectFields` there reaches nothing. ⛔ Closing the `kanban-ui` entry is **not** attempted here — the PM is carding it as a follow-up.

⚠️ Nothing went red when this moved — no test pinned the channel. `packages/plugin-kanban/src/__tests__/objectFieldsIsAPropNotASchemaKey-7742.test.tsx` now does, behaviourally: an expanded relation collapses to its stored id only when the field catalogue arrives, so the paint is a positive reading of the channel. The **prop leg is asserted first as the firing control** for the schema leg's negative, plus a third leg proving the paint is not unconditional. It renders `KanbanRenderer` **directly**, so it never exercises `SchemaRenderer`: the `kanban-ui` rows in the table above are measured, not pinned by this file, and its docblock says so.

⭐ **The file was renamed this round**, from `objectFieldsIsNotAuthorable-7742.test.tsx`. Its `describe`s were always accurate ("reaches the predicate layer as a PROP", "is no longer read off the schema bag"); only the **name** claimed the general unreachability the measurement refutes, and a filename is the widest-reach text this PR ships — it prints in every vitest run, in `git log --stat`, and in this PR's own file list. Cost of the rename: `git mv` alone — nothing in the repo referenced the old path (`git grep` → 0 hits outside the file), the two imports are same-directory relative and still resolve, and `check-type-check-coverage` enumerates test files from the package root rather than a list, so it re-derives coverage from disk (re-run: exit 0, **42/42 packages compile their tests**).

## ⭐ The re-derived objectui#8410 screen — and a correction to it

The screen recorded on the card (2026-09-07, `fff250f`) reached the right answer through a **wrong discrimination**, and the dispatch repeats the error, so it is worth stating.

The screen says `KanbanRenderer` — which destructures only `schema` — is "this card's `KanbanSchema` (`type: 'kanban'`)", and that `ObjectKanbanRenderer` (which DOES rest-spread) is "the `object-kanban` registration, not this card's".

**Measured on this branch, that is inverted.** `KanbanRenderer` is registered for **`kanban-ui`**. `ObjectKanbanRenderer` is registered for **BOTH `object-kanban` AND `kanban`** — so this card's type key IS served by the rest-spreading renderer.

The zeros survive anyway, for a different reason: **the spread terminates.** Full channel, traced end to end —

1. `SchemaRenderer.tsx` spreads every non-metadata node key as a React prop;
2. `ObjectKanbanRenderer` takes `({ schema, ...props })` and forwards `props` to `ObjectKanban`;
3. `ObjectKanban` takes `({ schema, dataSource, className, data, loading, onRowClick, onCardClick, ..._props })` and the very next statement is **`void _props;`** — the rest is discarded, never spread onward;
4. the schema channel continues (`effectiveSchema` into `KanbanRenderer`), but `KanbanRenderer` destructures only `schema` and **names** each key it forwards to `LazyKanban`.

⇒ no forwarded rest-spread reaches a sink for any of the three keys. This is a retirement, not a regression.

⭐ The screen's own lesson holds and is **strengthened**: `grep -l` for a spread is not the instrument, and neither is the render function's signature **alone** — you must also read which type key that function is REGISTERED for, and follow the spread to where it terminates.

### Read census — every zero paired with a firing control on the same instrument

`git grep -n -w KEY -- packages/plugin-kanban/src`, every file including tests:

| key | hits / files | verdict |
|---|---|---|
| `allowCollapse` | **0 / 0** | zero |
| `cardTemplates` | **0 / 0** | zero |
| `columnWidths` | **0 / 0** | zero |
| control `groupBy` | 85 / 27 | FIRES |
| control `cardTitle` | 18 / 9 | FIRES |
| control `coverImageField` | 17 / 3 | FIRES |

⚠️ Repo-wide, `columnWidths` is **not** zero (22 hits / 11 files) — every one is a different key of the same spelling on the grid surface (`data-table.tsx`, `ObjectGrid.tsx`, `RecordPickerDialog.tsx`), untouched here.

## The two faces the screen did NOT cover, measured here

- **`titleField`, re-measured from `25907cd70`:** both reads are now **cast-free** (`schema.cardTitle || schema.titleField`, `schema.cardTitle ?? schema.titleField`) because PR #8153 widened the prop to `KanbanSchema | ObjectKanbanSchema`. `ObjectKanbanSchema` (`objectql.ts`) declares `titleField?: string` and **this PR does not touch it** — the `object-kanban` arm still declares it, asserted at runtime by the sibling-arm pin.
- **Registry `inputs` face — ⛔ a divergence this PR creates and does NOT close.** `OBJECT_KANBAN_INPUTS` is ONE shared array spread into both registrations and it declares `titleField`; objectui#8201 pins that sharing *structurally*, and `ComponentPropsMap` has an `object-kanban` entry but **no `kanban` entry** to compare a split list against. So a `type: 'kanban'` node naming `titleField` is now **accepted by the html tier and refused by the zod tier**, and every pin stays green. Un-sharing the array would redden a landed pin and re-open a landed ruling, so it is reported, not done: **filed as objectui#8802 with four options and a recommendation.** This is the one thing on this PR a reviewer should rule on.

## Ablation — every named refusal, mutation proven on disk

Each leg: replace the arm with a permissive declaration, prove the mutation landed (anchor gone, injected text present, byte delta non-zero), run the pin, restore with `git checkout HEAD -- ABSOLUTE_PATH`, prove restoration by blob-hash equality AND an empty `git diff HEAD`.

| leg | anchor | injected | byte delta | mutated exit | which row reddened | restored |
|---|---|---|---|---|---|---|
| `allowCollapse` | 1 to 0 | present | −159 | 1 (1 failed / 10 passed) | its own named row | blob==HEAD ✅, diff empty ✅ |
| `cardTemplates` | 1 to 0 | present | −171 | 1 (1 failed / 10 passed) | its own named row | blob==HEAD ✅, diff empty ✅ |
| `columnWidths` | 1 to 0 | present | −270 | 1 (1 failed / 10 passed) | its own named row | blob==HEAD ✅, diff empty ✅ |
| `titleField` | 1 to 0 | present | −499 | 1 (2 failed / 9 passed) | its own row **and** the arm-pair row | blob==HEAD ✅, diff empty ✅ |
| `navigation` (the WIDENING) | 1 to 0 | line removed | −151 | 1 (2 failed / 9 passed) | accept + value-judged rows | blob==HEAD ✅, diff empty ✅ |

⚠️ **The first cut of this ablation is recorded as VOID, not as a pass.** It replaced only the opening line of each multi-line refusal call, leaving the rest dangling, so the test file failed to **load** — vitest printed `Tests  no tests` with a non-zero exit. A collection error is NOT a red; it is NOT MEASURED, and reading it as a red would have credited the pins with a failure they never demonstrated. The table above is the second cut, which replaces each arm as a whole expression so the file still parses and real assertions fail.

## Base to main window check — ⚠️ RE-MEASURED; the window is NO LONGER empty

**The earlier reading is superseded, not repaired.** It recorded `origin/main` at the same sha as `BASE` and the window at **0 files**, and noted that an empty window means its own control cannot fire. That was true when written. It is now stale: `origin/main` has moved to `0e3bca45d` over three commits (#8795, #8794, #8798), and `git diff --name-only b6d07df4 origin/main` returns **9 files**.

⛔ Do not carry over its conclusion that "no file any pin reads off disk can have moved" — two of the nine are exactly such files:

| moved file | why it matters to this PR |
|---|---|
| `packages/plugin-kanban/src/KanbanImpl.tsx` | the `objectFields` pin imports it at module scope (the lazy-chunk prepay) |
| `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` | the console registry-parity pin |

So `origin/main` is **merged into this branch** (ordinary merge commits; ⛔ no rebase, no force-push, the branch is only ever appended to), and every gate in the table below was re-run **on the merged tree**. The window control now fires: non-empty, and the pins were re-run against the moved files instead of being reasoned about.

⚠️ **`main` moved a second time while this round was verifying, so there are TWO merges — and a stopping rule.**

| merge | `origin/main` at | window | conflicts | intersection with this PR's 9 diff paths |
|---|---|---|---|---|
| first | `0e3bca45d` (3 commits: #8795, #8794, #8798) | 9 files / 1052 insertions | **0** | `KanbanImpl.tsx` + the console registry-parity pin — both read by pins here |
| second | `5dee0146d` (3 commits: #8804, #8796, #8744) | 16 files | **0** | ⭐ **none** — `git diff --name-only` of that window, intersected with this PR's paths, is **empty** |

Head is `1ecfafae5` and `git merge-base --is-ancestor origin/main HEAD` exits **0**: the branch is level with `main` as of `5dee0146d`. ⛔ There is no third merge, and that is deliberate rather than an omission — a branch cannot be held permanently level with a moving `main` from inside one round, and each merge costs a full re-verification. The stopping rule taken here: merge, re-verify, record the sha, and leave any later movement to the queue at land time. The second window is recorded above precisely so the next reader can see it moved *and* that it could not have touched this PR.

## Verification

### Re-run on the MERGED tree — the wording round

Exit codes captured **before any pipe** (`cmd > file 2>&1; EXIT=$?`), heavy runs serialised through the container's shared verify lock, and each verdict read off the gate's own printed line rather than a bare `$?`. ⭐ Every row below was re-run on the **final head `1ecfafae5`** — i.e. after *both* merges, not just the first — so no number here predates a merge.

| gate | exit | verdict |
|---|---|---|
| `pnpm --filter @object-ui/types build` | 0 | PASS |
| `pnpm --filter '@object-ui/plugin-kanban^...' build` (dep closure) | 0 | PASS |
| `turbo run type-check --filter types --filter plugin-kanban` | 0 | PASS — 15 tasks successful |
| vitest — the **three pin files** by path | 0 | PASS — 3 files / **25 tests** |
| vitest `packages/types/` + `packages/plugin-kanban/` | 0 | PASS — **199 files / 3392 tests** (198 / 3384 before the second merge; the +1 file / +8 tests are `ai-zero-read-members-retired-8178.test.ts`, arriving from `main`) |
| vitest `apps/console/` | 0 | PASS — **95 files / 1116 tests** |
| `pnpm --filter '@object-ui/console^...' build` + `--filter @object-ui/console build` | 0 | PASS |
| `check:sdui-registration-pins` | 0 | PASS — 16 registrations, 518 chunks weighed. Its first attempt was **exit 2, PRECONDITION NOT MET** (its own words: "No console build to weigh … This is exit 2, not a pass"), recorded as NOT MEASURED rather than as a red; the console was built and the gate re-run, and then built and re-run **again** on the final head |
| `check-changeset-presence.mjs` | 0 | PASS — merge-base `5dee0146d`, 9 files changed, 7 published source, **1 changeset** |
| `check-changeset-no-major.mjs` | 0 | PASS — no changeset declares `major` |
| `check-type-check-coverage.mjs` | 0 | PASS — 45/46 via `type-check`; **43/43 packages compile their tests** (this is the gate the rename had to keep resolving; it was 42/42 before `main` brought `plugin-ai` a test project) |
| `check-unreferenced-sources.mjs` | 0 | PASS — 208 shipped sources, 208 reached |
| `check-control-bytes.mjs` | 0 | PASS — 7011 tracked text files scanned |
| `check-governed-queue-guard.mjs --test` over the 9 diff paths | 0 | **NOT GOVERNED** — 9 paths against 5 governed surfaces, none matched |
| `pnpm --filter types --filter plugin-kanban run lint` | 0 | PASS — **0 errors**; 271 + 179 warnings, all pre-existing `no-explicit-any` / `react-refresh`, none on a line this round touched |
| control-byte self-scan (`grep -naP`) over the 3 edited files | 1 (no match) | PASS — no control bytes |

⚠️ The per-package `eslint .` warning counts above (271 + 179) are **not** comparable with the 63 quoted in the previous round's narrowed run: that run linted only the 7 diff files, these lint the whole of both packages. Both readings are exit 0 with 0 errors; only the population differs.

### First round — the implementation, on the pre-merge tree

| gate | exit | verdict |
|---|---|---|
| `pnpm --filter @object-ui/types build` | 0 | PASS |
| `pnpm --filter '@object-ui/plugin-kanban^...' build` (dep closure) | 0 | PASS |
| `pnpm --filter '@object-ui/console^...' build` | 0 | PASS |
| `pnpm --filter @object-ui/console build` | 0 | PASS |
| scoped doc build (35 tasks, the gate's own `--build-filter`) | 0 | PASS |
| `pnpm --filter @object-ui/cli build` | 0 | PASS |
| `type-check` — types + plugin-kanban | 0 | PASS |
| vitest `packages/types/` + `packages/plugin-kanban/` | 0 | PASS — 197 files / 3381 tests |
| vitest `apps/console/` | 0 | PASS — 95 files / 1116 tests |
| vitest `packages/cli/ scripts/ examples/schema-catalog/` | 0 | PASS — 178 files / 6174 tests |
| `pnpm check` (the per-PR gate) | 0 | PASS — 628 files analysed |
| `pnpm --filter @object-ui/types --filter @object-ui/plugin-kanban run lint` | 0 | PASS — 0 errors, 177 pre-existing warnings |
| `check:control-bytes` | 0 | PASS |
| `check:spec-symbols` | 0 | PASS |
| `check:doc-types` | 0 | PASS |
| `check:doc-snippets` | 0 | PASS — 636 of 636 blocks judged |
| `check:doc-examples` | 0 | PASS — 125 blocks, every failure ledger-declared |
| `check:doc-fences` | 0 | PASS |
| `check:doc-example-readers` | 0 | PASS |
| `check:handler-key-reads` | 0 | PASS |
| `check:sdui-registration-pins` | 0 | PASS — 16 registrations, 518 chunks weighed |
| `check:element-data-source-declaration` | 0 | PASS |
| `check:readme-exports` | 0 | PASS — 3321 symbols from 36 of 40 packages |
| `check:unreferenced-sources` | 0 | PASS |
| `check:changeset-no-major` | 0 | PASS |
| `check-changeset-presence.mjs` | 0 | PASS — 4 published source files, 1 changeset |
| `check:lint-coverage` | 0 | PASS |
| `check:governed-queue-guard --test` over the 9 diff paths | 0 | **NOT GOVERNED** — ordinary PR |
| control-byte self-scan over the diff | 1 (no match) | PASS — no control bytes |

⚠️ `check:doc-snippets`, `check:doc-examples`, `check:sdui-registration-pins` and `check:readme-exports` each returned **PRECONDITION NOT MET** on the first attempt, naming unbuilt packages in their own output. Those are not reds and are not recorded as passes either — the required builds were run and the gates re-run; the table shows the real verdicts, each with a population that fires (636 blocks, 518 chunks, 3321 symbols).

### The eslint narrowing, with its three readings

`turbo run lint` over the whole farm belongs to CI. The narrowed run is a measurement, not a skip:

1. **Population, read from eslint itself** (not guessed): a full `eslint . --no-inline-config --format json` reports **4634 files** linted.
2. **Files in the narrowed run, from `--format json`**: **7** — every `.ts` / `.tsx` in the diff, and all 7 are present in the 4634. Exit **0**, 0 errors, 63 warnings, all pre-existing `no-explicit-any` / `react-refresh` on untouched lines.
3. **Invariance**: `eslint.config.js` declares no `parserOptions.project` and no `projectService` anywhere, so **type-aware linting is not enabled** — this diff cannot move the verdict on any file it does not itself contain.

For completeness the full run was executed: exit 1, **94 errors across 78 files, none of them mine** (verified by set intersection against the 7). Those are pre-existing `react-hooks/static-components` / `no-console` findings under bare `eslint .`, which is not this repo's gate — `pnpm lint` is `turbo run lint`, i.e. the per-package scripts, and both of mine exit 0.

## Changeset

`.changeset/7742-kanban-arm-batch70.md` — `minor` for `@object-ui/types` and `@object-ui/plugin-kanban`, spelling out the breaking semantics in the body. ⛔ Never `major`: this repo's fixed group tracks `@objectstack`'s major, and `check-changeset-no-major.mjs` enforces it.

## Found and deliberately NOT done

- **objectui#8801 — FILED.** `ObjectKanbanSchema.allowCollapse` is the same zero-read key one arm over, declared on both `objectql` faces, read by nothing, and outside batch #70's reach. After this PR the two arms of one renderer disagree about the key.
- **objectui#8802 — FILED.** The registry `inputs` divergence described above.
- **`countsAreWindowed` — noted, not filed.** Same shape and same argument as `objectFields`: internal, injected by `ObjectKanban`, absent from the registry `inputs`, and still riding the `schema` bag where an author can reach it on the `kanban-ui` entry. The ruling did not name it, so it stays. Its successor is named: the `KanbanRendererProps` docblock in `index.tsx` records it in as many words, and objectui#8307 owns the key.
- **⚠️ objectui#8652 is OPEN and overlaps row 3.** "`navigation` is read off the kanban node and declared on neither arm" — the same subject batch #70 already ruled. This PR executes the ruling and ⛔ does not close that card; a triage seat should reconcile the two, since a later card appears to re-ask a settled question.
- ⛔ `onColumnToggle` / `enableVirtualScrolling` / `virtualScrollThreshold` are out of scope here — they belong to `'kanban-enhanced'`, which has no arm, and objectui#8257 carries them. The root README example is out of scope here — objectui#8256 carries it. The `filter` key is out of scope here — objectui#7712 carries it. None of those three is addressed by this change.

## 维护者速读（草稿）

**改了什么** — 按 batch #70 裁决逐行执行 `kanban` 臂：退役 `allowCollapse` / `cardTemplates` / `columnWidths`（两面声明、无渲染器读取）与 `titleField`（`cardTitle` 的旧拼法；兄弟臂 `object-kanban` 保留自己的），四者都是具名拒绝而非删除；声明 `navigation`（板子一直在读、两面都没声明）；把 `objectFields` 从 schema 袋子挪到真正的 React prop。

**为什么改** — ADR-0049 enforce-or-remove。作者写 `allowCollapse: true` 今天校验通过、板子却永不折叠；写 `navigation` 则相反，板子会兑现而校验器看不见。两种都是「声明与实现脱节」，方向相反。

**风险与代价（含回滚）** — accept set 双向移动：四个拼法从「通过」变成「按名拒绝」，一个键从「不可见」变成「被校验」。今天写了这四个键的板子会开始报错——这正是裁决要的响亮失败，但它是**破坏性**的。回滚成本低：整个改动是声明面加一个 prop 位置，`git revert` 一笔即可，无数据迁移、无存储格式变化。⚠️ 一处残留分歧未关：`titleField` 在注册表 `inputs` 面仍对 `kanban` 声明着（共享数组，objectui#8201 结构性钉住），于是 html 层接受、zod 层拒绝，且所有钉子照常绿。拆开那个数组要动一条已落地的裁决，故已立卡 objectui#8802 报告、未擅动。

⚠️ **另一处已实测、本轮明确不关的洞** —— `objectFields` 只在被裁的 `kanban` 臂上关死了；在 `kanban-ui` 入口上，作者写的 `objectFields` 仍会经 `SchemaRenderer` 的通用 prop 展开抵达渲染器（实测：卡片会被上色）。合同评审 PASS 之后的这一轮**只改文案口径**，把三处「读起来像是彻底不可达」的措辞改成按臂陈述，不动任何行为、拒绝、声明、钉子或消融；关掉那个入口是 PM 另行立卡的后续。

**席位意见** — （待定稿）

**你要做的** — 只需裁一件事：objectui#8802 里那处 `titleField` 的注册表分歧，选 A（接受、另卡跟进）、B（拆共享数组）、C（不退役）还是 D（上游给 spec 加 `kanban` 条目）。本席建议 A 现在、D 是真答案。其余四行按裁决原样执行，无需选择。

---
_Generated by [Claude Code](https://claude.ai/code)_