### PR TITLE
fix(components): emit no `for` when the built-in select renders no control (objectui#3991)

### DIFF
--- a/.changeset/3991-builtin-select-empty-state-label-for.md
+++ b/.changeset/3991-builtin-select-empty-state-label-for.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/components': patch
+---
+
+The built-in `select`'s empty / dependency-gated branch renders no form control, so its
+visible label now emits no `for` (objectui#3991).
+
+`for` may only reference a labelable element (`button`, `input`, `meter`, `output`,
+`progress`, `select`, `textarea`). When a built-in `{ type: 'select' }`'s option list
+resolves empty — unconfigured, or a `dependsOn` gate still withholding it
+(objectui#2284) — the branch renders `BuiltinSelectEmptyState`, a `<div>` carrying the
+status text and no control at all, and `<FormControl>`'s Slot put the field's id on that
+`div`. The label's `for` therefore named a non-labelable element. Measured before the
+fix, for `{ name: 'empty', label: 'Empty', type: 'select', options: [] }`:
+
+```
+label for="_r_2_-form-item"  ->  ownerTag = DIV
+```
+
+**Impact is author- and test-side, not user-side.** No focusable control exists anywhere
+in that state, so neither "clicking the label does nothing" nor "the control has no
+accessible name" can occur — the thing a name would name does not exist. What was wrong
+is inert, invalid HTML, plus a Testing Library failure that reads like a broken
+renderer: `getByLabelText('Empty')` threw *"the element associated with this label
+(`<div />`) is non-labellable"*, whose own remedy line then points authors at
+`aria-label` / `aria-labelledby` on a `div`.
+
+**What changes in your DOM.** For that branch only, the `<label>` loses its `for`
+attribute; it stays visible and still reads as the field's name, and the empty-state
+message renders beside it unchanged. A `select` WITH options is byte-identical — its
+label still resolves to the trigger `button` (objectui#3976). `getByLabelText` on the
+empty branch still finds nothing, now failing with the truthful *"no form control was
+found associated to that label"*; there is no control to resolve to, and giving the
+empty state an `aria-labelledby` target or a synthetic role was refused as naming a
+thing that is not a control.
+
+**Not changed: the registered-widget path.** `field:select` (`@object-ui/fields`'
+`SelectField` / `OptionsEmptyState`) has the same fault by a different mechanism — the
+branch belongs to a component the registry resolves, and a third-party `field:select`
+may render a real control for an empty list, so suppressing the `for` on a host-side
+guess would break a widget that had it right. Tracked separately.

--- a/packages/components/src/renderers/form/__tests__/form-builtin-select-empty-default.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-builtin-select-empty-default.test.tsx
@@ -21,7 +21,15 @@
  * The second assertion pins something the fix could plausibly have broken: the
  * empty state moved from an inline `<div>` to a small component, and
  * `<FormControl>` is a Radix `Slot` that hands the control its `id` — drop the
- * rest props and the field's `<label for>` points at nothing.
+ * rest props and the box stops receiving the id and the description link.
+ *
+ * ⚠️ That assertion used to read `expect(label).toHaveAttribute('for', box.id)`,
+ * which pinned the very association objectui#3991 removed: this branch renders
+ * NO control, and `for` may only reference a labelable element, so a `for`
+ * naming this `<div>` was inert HTML. The Slot half — the id and the
+ * `aria-describedby` reaching the box — is what #3263 actually needed to keep
+ * true, and it still is; the `for` half is now pinned from the other side, in
+ * `form-builtin-select-empty-label-association.test.tsx`.
  */
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -46,14 +54,18 @@ describe('form renderer — built-in select empty state without an I18nProvider 
     expect(screen.getByText('No options available')).toBeInTheDocument();
   });
 
-  it('is still the labelled form control, not a detached box', () => {
+  it('still receives the Slot props, and carries no label association (objectui#3991)', () => {
     renderForm(unconfiguredSelect);
 
     const box = screen.getByText('No options available');
     const label = screen.getByText('Province');
 
+    // The #3263 half: the rest props still reach the box, so the component
+    // boundary did not swallow what `<FormControl>`'s Slot hands down.
     expect(box.id).toBeTruthy();
-    expect(label).toHaveAttribute('for', box.id);
     expect(box).toHaveAttribute('aria-describedby');
+    // The #3991 half: no control renders here, so the label names nothing —
+    // a `for` pointing at this `<div>` would be inert HTML.
+    expect(label).not.toHaveAttribute('for');
   });
 });

--- a/packages/components/src/renderers/form/__tests__/form-builtin-select-empty-label-association.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-builtin-select-empty-label-association.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The built-in `select` branch renders NO control when its option list is
+ * empty, so its visible label emits no `for` — objectui#3991.
+ *
+ * `for` may only reference a labelable element (`button`, `input`, `meter`,
+ * `output`, `progress`, `select`, `textarea`). When the branch's option list
+ * resolves empty — unconfigured, or a `dependsOn` gate withholding it (#2284) —
+ * it returns `BuiltinSelectEmptyState`, a `<div>` carrying the status text, and
+ * `<FormControl>`'s Slot put the field's id on that `div`. Measured on
+ * `origin/main` @ `b6d07df4b`, for `{ name: 'empty', label: 'Empty', type:
+ * 'select', options: [] }`:
+ *
+ * ```
+ *   label for="_r_2_-form-item"  ->  ownerTag = DIV
+ *   getByLabelText('Empty')      ->  throws "…the element associated with this
+ *                                    label (<div />) is non-labellable…"
+ * ```
+ *
+ * ## What this defect is, and what it is NOT
+ *
+ * Zero user-facing harm, and the fix is worth landing without inflating it:
+ * there is no focusable control anywhere in this state, so neither "clicking
+ * the label does nothing" nor "the control has no accessible name" can occur —
+ * the thing a name would name does not exist. The cost is inert, invalid HTML
+ * plus an author/test-side error that reads like a broken renderer when it is a
+ * correctly-rendered empty state, and whose remedy line ("you can use
+ * aria-label or aria-labelledby instead") points at a `div`.
+ *
+ * ## What the fix does NOT achieve, measured
+ *
+ * `getByLabelText('Empty')` still THROWS after the fix — with the truthful
+ * "no form control was found associated to that label" instead of the
+ * misleading "non-labellable" one. That is inherent and not a shortfall of the
+ * fix: Testing Library throws for any label whose text matches while it
+ * associates no control, and the only way to make it resolve is to give the
+ * empty state an associable target — an `aria-labelledby` IDREF or a synthetic
+ * role. Both were refused on objectui#3991: in this branch there is no control
+ * at all, so either one would name a thing that is not a control — the same
+ * category error as the `for`, spelled differently. The pins below therefore
+ * assert the DOM, and assert the DEFECT-SPECIFIC phrase is gone rather than
+ * pinning Testing Library's full wording (a third-party string).
+ */
+
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope, not `beforeAll` — the cold transform must not be billed to
+// `hookTimeout`. See object-ui/no-dynamic-import-in-test-hook (objectui#3010).
+import '../../../renderers';
+
+/** HTML's labelable elements — the only ones a `<label for>` may address. */
+const LABELABLE = new Set(['button', 'input', 'meter', 'output', 'progress', 'select', 'textarea']);
+
+/**
+ * Stands in for a registered option widget (`@object-ui/components` tests never
+ * load `@object-ui/fields`). It renders a REAL control even for an empty option
+ * list — deliberately, because that is the case the host must not break: see
+ * the last describe block.
+ */
+function SelectWidgetProbe(props: any) {
+  const { name, value: _value, onChange: _onChange, field: _field, error: _error, options: _options, ...rest } = props;
+  return <button type="button" role="combobox" data-testid={`probe-${name}`} {...rest} />;
+}
+
+beforeAll(() => {
+  ComponentRegistry.register('select', SelectWidgetProbe, { namespace: 'field' });
+}, 30000);
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderForm(fields: any[], defaultValues: Record<string, unknown> = {}) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: false,
+        showCancel: false,
+        defaultValues,
+        fields,
+        onSubmit: () => {},
+      }}
+    />,
+  );
+}
+
+/** The `<label>` rendered for `data-field="<name>"`. */
+function labelOf(name: string): HTMLLabelElement {
+  const el = document.querySelector(`[data-field="${name}"] label`);
+  if (!el) throw new Error(`no label rendered for field "${name}"`);
+  return el as HTMLLabelElement;
+}
+
+/**
+ * Every `<label for=…>` in the document, with what its `for` actually reaches.
+ * Read from the DOM rather than through a query helper: the defect is a
+ * property of the emitted attribute, and a helper that throws would hide which
+ * of the two failures (dangling vs non-labelable) is present.
+ */
+function labelTargets(): Array<{ text: string; forId: string; resolves: boolean; labelable: boolean }> {
+  return Array.from(document.querySelectorAll('label'))
+    .map((el) => {
+      const forId = el.getAttribute('for') ?? '';
+      const target = forId ? document.getElementById(forId) : null;
+      return {
+        text: (el.textContent ?? '').trim(),
+        forId,
+        resolves: !!target,
+        labelable: !!target && LABELABLE.has(target.tagName.toLowerCase()),
+      };
+    })
+    .filter((l) => l.forId !== '');
+}
+
+/** The message `getByLabelText` threw, or `''` when it resolved. */
+function labelTextError(text: string): string {
+  try {
+    screen.getByLabelText(text);
+    return '';
+  } catch (e) {
+    return String((e as Error).message);
+  }
+}
+
+const EMPTY_FIELD = { name: 'empty', label: 'Empty', type: 'select', options: [] };
+
+describe('built-in select, empty option list — no control, so no `for` (objectui#3991)', () => {
+  it('emits a label with no `for` at all', () => {
+    renderForm([EMPTY_FIELD]);
+
+    const label = labelOf('empty');
+    // The defect verbatim: `for="_r_N_-form-item"` naming the status `div`.
+    expect(label.hasAttribute('for')).toBe(false);
+    // The label is still there, and still reads as the field's name.
+    expect(label.textContent?.trim()).toBe('Empty');
+  });
+
+  it('leaves no `for` in the document pointing at a non-labelable element', () => {
+    renderForm([EMPTY_FIELD]);
+
+    // Document-wide, not just this field's label: the invariant is that a
+    // `for` this renderer emits always reaches a labelable element.
+    expect(labelTargets().filter((l) => !l.labelable)).toEqual([]);
+  });
+
+  it('still renders the empty-state message beside the label', () => {
+    renderForm([EMPTY_FIELD]);
+
+    // The fix must not have removed the branch's actual output — only the
+    // association to it.
+    expect(screen.getByText('No options available')).toBeTruthy();
+  });
+
+  it('no longer fails `getByLabelText` with the misleading non-labelable error', () => {
+    renderForm([EMPTY_FIELD]);
+
+    const message = labelTextError('Empty');
+    // Negative assertion on the ONE phrase the defect uniquely produced —
+    // Testing Library emits it only when a label's `for` reaches an element
+    // that cannot be labelled. Deliberately not a pin on its full wording.
+    expect(message).not.toMatch(/non-labellable/i);
+    // And the honest residue, asserted so it cannot be mistaken for a
+    // regression later: with no control in the branch there is nothing to
+    // resolve to, so the query still finds nothing. See the file header.
+    expect(screen.queryAllByLabelText('Empty')).toHaveLength(0);
+  });
+});
+
+describe('built-in select, dependency-gated option list (objectui#2284 + #3991)', () => {
+  const GATED = [
+    { name: 'parent', label: 'Parent', type: 'select', options: [{ label: 'A', value: 'a' }] },
+    {
+      name: 'child',
+      label: 'Child',
+      type: 'select',
+      dependsOn: 'parent',
+      options: [{ label: 'X', value: 'x', visibleWhen: "parent == 'a'" }],
+    },
+  ];
+
+  it('drops the `for` on the gated field while it renders the gate hint', () => {
+    renderForm(GATED);
+
+    expect(labelOf('child').hasAttribute('for')).toBe(false);
+    expect(labelTargets().filter((l) => !l.labelable)).toEqual([]);
+  });
+
+  it('leaves the CONTROLLING field, which does render a control, untouched', () => {
+    renderForm(GATED);
+
+    // The no-collateral half: suppression is keyed to the empty branch, not to
+    // the field being a `select`, so a populated sibling keeps its association.
+    const parent = labelOf('parent');
+    expect(parent.hasAttribute('for')).toBe(true);
+    const target = document.getElementById(parent.getAttribute('for')!);
+    expect(target).toBeTruthy();
+    expect(LABELABLE.has(target!.tagName.toLowerCase())).toBe(true);
+  });
+});
+
+describe('built-in select WITH options — association unchanged (objectui#3976 stays green)', () => {
+  it('resolves the label to the labelable trigger', () => {
+    renderForm([{ name: 'status', label: 'Status', type: 'select', options: [{ label: 'Open', value: 'open' }] }]);
+
+    const labelled = screen.getAllByLabelText('Status');
+    expect(labelled).toHaveLength(1);
+    expect(LABELABLE.has(labelled[0].tagName.toLowerCase())).toBe(true);
+    expect(labelTargets().filter((l) => !l.labelable)).toEqual([]);
+  });
+});
+
+describe('the registered-widget path is deliberately NOT suppressed (objectui#3991)', () => {
+  it('keeps the `for` for a `field:select` widget that renders a control on an empty list', () => {
+    // Why the host does not extend the suppression across the registry
+    // boundary: what a widget renders in its empty state is the WIDGET's
+    // business (`labelling`, objectui#3961), and a third-party `field:select`
+    // may render a real control for an empty option list — as this probe does.
+    // Suppressing the `for` on a host-side guess about a component the registry
+    // resolved would break the association for a widget that had it right.
+    renderForm([{ name: 'wempty', label: 'WEmpty', type: 'field:select', options: [] }]);
+
+    const label = labelOf('wempty');
+    expect(label.hasAttribute('for')).toBe(true);
+    const labelled = screen.getAllByLabelText('WEmpty');
+    expect(labelled).toHaveLength(1);
+    expect(labelled[0]).toBe(screen.getByTestId('probe-wempty'));
+    expect(labelTargets().filter((l) => !l.labelable)).toEqual([]);
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -478,6 +478,72 @@ function resolvesToRegisteredFieldWidget(type: string): boolean {
 }
 
 /**
+ * Will this field render {@link BuiltinSelectEmptyState} — the built-in
+ * `select` branch's CONTROL-LESS output — objectui#3991?
+ *
+ * `<FormLabel>` emits `htmlFor={formItemId}` for every field by default, and
+ * `for` may only reference a LABELABLE element (`button`, `input`, `meter`,
+ * `output`, `progress`, `select`, `textarea`). When the built-in `select`
+ * branch's option list resolves empty — unconfigured, or a `dependsOn` gate
+ * withholding it (#2284) — the branch returns a `<div>` carrying the status
+ * text and NO control at all, so that `for` lands on a `div`. Measured on
+ * `origin/main` @ `b6d07df4b`, for `{ name: 'empty', label: 'Empty', type:
+ * 'select', options: [] }`:
+ *
+ * ```
+ *   label for="_r_2_-form-item"  ->  ownerTag = DIV
+ *   getByLabelText('Empty')      ->  throws "the element associated with this
+ *                                    label (<div />) is non-labellable"
+ * ```
+ *
+ * Inert HTML, and a test-side error that reads like a broken renderer when it
+ * is a correctly-rendered empty state. The honest output is a label with no
+ * `for` and the message beside it: nothing is lost, because nothing was ever
+ * associated — there is no focusable control in this state for a name to name.
+ *
+ * ## Why the answer is knowable HERE, and only here
+ *
+ * This is the third mirror of `renderFieldComponent`'s resolution, alongside
+ * `resolveFieldLabelling` and `resolvesToRegisteredFieldWidget`, and it is a
+ * mirror for the same reason: producer and consumer must not be able to
+ * disagree about which component actually renders.
+ *
+ *  - WHICH component: decided on the RAW type against `BUILTIN_FIELD_TYPES`,
+ *    exactly as there — a bare `select` renders this branch and the registry is
+ *    never consulted, while a `field:`-qualified `field:select` resolves to the
+ *    registered widget and never reaches it;
+ *  - WHETHER it takes the empty branch: read from `options`, which the call
+ *    site passes down as the very argument `renderFieldComponent`'s
+ *    `!options || options.length === 0` tests. One expression, two readers.
+ *
+ * ## ⛔ Deliberately NOT extended to the registered-widget path
+ *
+ * `@object-ui/fields`' `OptionsEmptyState` is the same FAULT on the
+ * `field:select` path (measured: the `for` dangles there instead, pointing at
+ * an id no element carries) but it is NOT the same mechanism, so it is not
+ * fixed by this predicate:
+ *
+ *  - the branch belongs to a component `ComponentRegistry` resolves, not to
+ *    this file. Any third party may register a `field:select` that renders a
+ *    real control for an empty list, and suppressing the `for` on a host-side
+ *    GUESS would break the association for a widget that had it right;
+ *  - what a widget renders is a widget DECLARATION (`labelling`,
+ *    objectui#3961), which is why the three group-labelled option widgets
+ *    (`radio` / `checkboxes` / `multiselect`) are already correct in this state
+ *    — they publish the label's id and answer with `aria-labelledby`
+ *    (objectui#3990 / #4005). Single `select` declares `labelling: 'control'`
+ *    and has no such channel; giving it one is a ruling, not a mirror.
+ */
+function rendersBuiltinSelectEmptyState(
+  type: string,
+  options: readonly unknown[] | undefined,
+): boolean {
+  if (!BUILTIN_FIELD_TYPES.has(type)) return false;
+  if (type !== 'select') return false;
+  return !options || options.length === 0;
+}
+
+/**
  * The container a registered field widget's replacement-display output is
  * wrapped in, so the field's visible label NAMES and its visible help text
  * DESCRIBES the surface that replaced the control (objectui#4788, maintainer
@@ -2724,6 +2790,27 @@ ComponentRegistry.register('form',
       // double channel #3978 removed.
       const groupLabelId = groupLabelled ? hostLabelId : undefined;
 
+      // The option set the field will actually be rendered with. Hoisted to a
+      // single const because TWO readers need the identical value: it is passed
+      // down as `options` below, and `rendersBuiltinSelectEmptyState` reads it
+      // here to decide whether the branch about to render has a control at all
+      // (objectui#3991). Two spellings of one expression is exactly how the
+      // label and the branch would come to disagree.
+      const resolvedOptions = isOptionField ? effectiveOptions : fieldProps.options;
+
+      // The built-in `select` branch renders `BuiltinSelectEmptyState` — a
+      // `<div>`, no control — when that set is empty, so the `for` `<FormLabel>`
+      // emits by default would name a non-labelable element: inert HTML
+      // (objectui#3991). No control ⇒ no `for`. ⛔ Not an `aria-labelledby`
+      // IDREF and ⛔ not a synthetic role: both name a thing that is not a
+      // control, which is the same category error spelled differently. See
+      // {@link rendersBuiltinSelectEmptyState} for why this is knowable here
+      // and why the registered-widget path is deliberately excluded.
+      const builtinBranchHasNoControl = rendersBuiltinSelectEmptyState(
+        resolvedType,
+        resolvedOptions as readonly unknown[] | undefined,
+      );
+
       return (
         <FormField
           key={fieldKey}
@@ -2755,6 +2842,18 @@ ComponentRegistry.register('form',
                   // reason: it was measurably DANGLING there, pointing at an
                   // id no element in the document carried.
                   {...(hostLabelId ? { id: hostLabelId, htmlFor: undefined } : null)}
+                  // No control renders in this branch, so there is nothing a
+                  // `for` could legally name (objectui#3991). `htmlFor:
+                  // undefined` is not a no-op — `<FormLabel>` sets
+                  // `htmlFor={formItemId}` BEFORE spreading its props, so this
+                  // key removes the attribute; the label stays visible text
+                  // beside the message. Mutually exclusive with the branch
+                  // above by construction: `hostLabelId` needs `groupLabelled`
+                  // or `hostWrappedDisplay`, and a BUILTIN type is neither
+                  // (`resolveFieldLabelling` answers `'control'` for it and
+                  // `resolvesToRegisteredFieldWidget` answers `false`) — pinned
+                  // from the DOM, not assumed.
+                  {...(builtinBranchHasNoControl ? { htmlFor: undefined } : null)}
                 >
                   {label}
                   {required && (
@@ -2805,7 +2904,7 @@ ComponentRegistry.register('form',
                   // accessible name. Renderer-only: both strips drop it, so it
                   // reaches no DOM attribute and no registered widget.
                   label,
-                  options: isOptionField ? effectiveOptions : fieldProps.options,
+                  options: resolvedOptions,
                   placeholder: fieldProps.placeholder ?? (resolvedType === 'select' ? t('common.selectOption') : undefined),
                   // `disabled` means "not interactive, muted"; `readonly` means
                   // "shown plainly, not editable" — keep them distinct so widgets


### PR DESCRIPTION
Fixes #3991

The built-in `select` branch renders no form control when its option list resolves empty, so
its visible label now emits no `for`. Arm 1 of the ruling on objectui#3991 comment 5599614790.

## The defect

`for` may only reference a labelable element (`button`, `input`, `meter`, `output`, `progress`,
`select`, `textarea`). When a built-in `{ type: 'select' }`'s option list resolves empty —
unconfigured, or a `dependsOn` gate still withholding it (objectui#2284) — the branch renders
`BuiltinSelectEmptyState`, which is a `div` carrying the status text and no control at all, and
`FormControl`'s Radix Slot put the field's id on that `div`. Re-measured on `origin/main` @
`b6d07df4b` (⚠️ the six triage passes on the card recorded `:2198`/`:2477`, then `:2210`/`:2489`,
then `form.tsx:453` — all stale; the real anchors today are the component at `form.tsx:3501` and
the render site at `:3873`):

```
{ name: 'empty', label: 'Empty', type: 'select', options: [] }

  label "Empty"  for="_r_2_-form-item"  ->  ownerTag = DIV
  getByLabelText('Empty') throws:
    "Found a label with the text of: Empty, however the element associated with
     this label (div) is non-labellable"
```

The dependency-gated branch measures identically (a `dependsOn` child whose parent is unset).

## Impact — author- and test-side, not user-side

**Zero user-facing harm**, exactly as the card measured and six triage passes upheld. No focusable
control exists anywhere in that state, so neither "clicking the label does nothing" nor "the
control has no accessible name" can occur — the thing a name would name does not exist. What is
actually wrong is inert, invalid HTML plus a Testing Library failure that reads like a broken
renderer when it is a correctly-rendered empty state, and whose own remedy line then points
authors at `aria-label` / `aria-labelledby` on a `div` — i.e. at the two arms the ruling refused.

⚠️ This is deliberately **not** written as a screen-reader failure. One comment on the card
(5596312425, the hold-audit release) frames it that way; that framing is not what the card
measured and not what six passes concluded.

## The fix

`rendersBuiltinSelectEmptyState` is the third mirror of `renderFieldComponent`'s resolution,
alongside `resolveFieldLabelling` and `resolvesToRegisteredFieldWidget`, and it is a mirror for
the same reason those two are: producer and consumer must not be able to disagree about which
component actually renders.

- **which** component: decided on the RAW type against `BUILTIN_FIELD_TYPES`, exactly as there —
  a bare `select` renders this branch and the registry is never consulted;
- **whether** it takes the empty branch: read from the option set the call site itself passes
  down, which is the very value `renderFieldComponent`'s `!options || options.length === 0`
  tests. Hoisted to one `const` so the label and the branch cannot read two spellings of it.

The suppression reuses the existing channel — `htmlFor: undefined` in the props `FormLabel`
spreads after its own `htmlFor`, the same key objectui#3961 / #4788 / #4857 already use. **No new
prop is threaded through the form stack.**

### PM premise check (asked for explicitly, measured before writing anything)

The dispatch premise was *"the `for` is emitted by `FormLabel` unconditionally, and the branch
that renders `BuiltinSelectEmptyState` is knowable at the point `FormLabel` decides."*

- first half — **falsified, in the helpful direction**: the call site already suppresses `for`
  conditionally for group-labelled and host-wrapped display widgets, so the channel exists;
- second half — **holds**: both halves of the branch condition are already computed in the outer
  render scope, above the label's JSX.

## What this does NOT achieve, stated because it was an acceptance criterion

`getByLabelText('Empty')` **still throws** after the fix — now with the truthful *"no form control
was found associated to that label"* instead of the misleading *"non-labellable"* one. That is
inherent, not a shortfall: Testing Library throws for any label whose text matches while it
associates no control, and the only way to make it resolve is to give the empty state an
associable target — an IDREF or a synthetic role. Both were refused on the card, and correctly:
there is no control in this branch, so either would name a thing that is not a control. The
acceptance wording "`getByLabelText` no longer throws" is achievable **only** under the refused
arms; the ruling wins, and the pins assert the DOM instead.

## Tests

New pin `form-builtin-select-empty-label-association.test.tsx` (8 cases) asserts the **rendered
DOM**, never the source text:

- the empty branch's label carries no `for`, and still reads as the field's name;
- document-wide, no `label[for]` points at a non-labelable element;
- the empty-state message still renders beside it;
- the `getByLabelText` failure no longer contains the defect-specific `non-labellable` phrase
  (a negative substring assertion — deliberately not a pin on a third-party library's wording);
- the dependency-gated branch behaves the same, while its **controlling** sibling, which does
  render a control, keeps a `for` resolving to the labelable trigger;
- a populated `select` still resolves its label to the trigger (objectui#3976 stays green);
- a registered `field` + colon + `select` widget that renders a real control on an empty list
  **keeps** its `for` — the positive pin for why the suppression stops at the registry boundary.

⚠️ `form-builtin-select-empty-default.test.tsx` asserted `expect(label).toHaveAttribute('for',
box.id)` — the exact association this card removes. Re-judged rather than deleted: what
objectui#3263 needed that case to keep true is that the Slot's props still reach the box (its
`id` and `aria-describedby`), which is unchanged and still asserted; only the `for` expectation
is inverted.

### Reverse verification (direction predicted first, then measured)

Predicted RED. Removing only the suppression line, with the mutation proven on disk (anchor
count 1 -> 0, blob `00b1869b` -> `59b9e3d2`) and restored under a `trap` verified byte-identical
to `HEAD`:

```
4 failed | 4 passed (8)
  x emits a label with no `for` at all
  x leaves no `for` in the document pointing at a non-labelable element
  x no longer fails getByLabelText with the misleading non-labelable error
  x drops the `for` on the gated field while it renders the gate hint
```

The four that stayed green are the no-collateral pins (populated select, controlling sibling,
registered-widget path, message still rendered) — they are not accidentally coupled to the fix.

### Gates run locally

| check | result |
|---|---|
| `pnpm --workspace-concurrency=2 --filter '@object-ui/components^...' build` | `VERDICT command-exit 0` (8 projects) |
| `pnpm --filter @object-ui/components type-check` | `VERDICT command-exit 0` |
| `pnpm --filter @object-ui/components test` | `VERDICT command-exit 0` — 249 files, 2288 tests, all passed |
| `check:control-bytes` | OK, 6995 tracked text files |
| `check:vi-mock-specifiers` / `check:vi-mock-inherit` | OK |
| `check:unreferenced-sources` | OK |
| `check:governed-queue-guard --test` (changed paths) | NOT GOVERNED, exit 0 — with `AGENTS.md` as a lit control returning exit 3 on the same command shape |
| eslint, narrowed to the 3 changed files | 0 errors; `form.tsx` warning count identical to its base revision (70 -> 70), so this diff adds none. The config is not type-aware (no `parserOptions.project`), so it cannot move a verdict on any untouched file. Repo-wide `lint` is CI's. |

`packages/fields` is **not** owed locally and is declared to CI: this package's published surface
is byte-unchanged (no export moves), and the suppression can only fire for a RAW `select` type,
which none of that package's suites register.

## 验收备注

- `noted, not filed`: `BuiltinSelectEmptyState` still receives the Slot's `id` and
  `aria-describedby` on a role-less `div`, where both are inert by this repo's own repeated
  reasoning (objectui#3990 / #4005). Removing them is not this card's ruling and giving the box a
  role is arm 3, explicitly refused — left exactly as it was. 承接者: whoever takes #8803, which
  reaches the same surface.
- `filed as #8803`: the registered-widget twin. `@object-ui/fields`' `OptionsEmptyState` on the
  single `field` + colon + `select` path is the same fault by a **different mechanism** — measured,
  not assumed: there the `for` **dangles** (owner NONE) rather than naming a `div`, because
  `SelectField`'s empty branch drops the pass-through entirely. It is not fixed here because the
  host does not own that branch: a third-party `field` + colon + `select` may render a real control for an
  empty list, and suppressing the `for` on a host-side guess would break a widget that had it
  right. The other three option widgets (`multiselect` / `radio` / `checkboxes`) are already
  correct in this state — they declare `labelling: 'group'` and were repaired by objectui#3990 /
  #4005; measured a real `field` + colon + `radio` with zero options and its label correctly publishes an
  id and emits no `for`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH)_