### PR TITLE
fix(plugin-kanban): give the swimlane axis rows one horizontal padding (objectui#8797)

### DIFF
--- a/.changeset/8797-swimlane-axis-scroll-range.md
+++ b/.changeset/8797-swimlane-axis-scroll-range.md
@@ -1,0 +1,19 @@
+---
+"@object-ui/plugin-kanban": patch
+---
+
+Fix swimlane column titles sliding 9px off their columns at the right end of the board
+
+A swimlane board scrolls on one horizontal axis: a scroll handler copies
+`scrollLeft` from whichever row the user drove onto every other row. Equal
+`scrollLeft` is equal alignment only while the rows have the same scrollable
+range, and they did not — the lane content rows carried `px-2` that the
+column-header row did not, making their maximum `scrollLeft` larger. Scrolled
+fully right, the header row clamped at its own smaller maximum and every column
+title sat 9px off its column until the user scrolled back.
+
+The column-header row and the lane content rows now take their horizontal
+padding from one shared constant, so the two ranges cannot drift apart. Measured
+in Chromium at 1600x1000: the worst title/cell offset across the whole range,
+including the extreme right, drops from 9px to the 1px lane-border baseline.
+Card layout inside the lanes is unchanged.

--- a/packages/plugin-kanban/src/KanbanImpl.tsx
+++ b/packages/plugin-kanban/src/KanbanImpl.tsx
@@ -84,6 +84,40 @@ const UNCATEGORIZED_LANE = 'Uncategorized'
  */
 const SWIMLANE_SCROLL_ROW_ATTR = 'data-swimlane-scroll-row'
 
+/**
+ * The horizontal padding carried by EVERY row on the swimlane board's shared
+ * horizontal axis — the column-header row and each lane content row alike.
+ *
+ * It is one constant, used twice, because equal `scrollLeft` is only equal
+ * ALIGNMENT while the two kinds of row have the same scrollable RANGE, and the
+ * range is `scrollWidth - clientWidth` — which horizontal padding moves
+ * (objectui#8797). The rows carried different padding before this: the lane
+ * rows had `px-2`, the header row had none, so the lane rows' `scrollWidth` was
+ * 8px larger. objectui#8448's sync copies one `scrollLeft` onto every row, so
+ * driving a lane to its own maximum asked the header row for a position past
+ * ITS maximum, the header row CLAMPED, and every column title stopped tracking
+ * its column — permanently, until the user scrolled back.
+ *
+ * ⚠️ `pl-36 sm:pl-44` must stay AFTER `px-2`, and both must stay in this one
+ * string. Tailwind emits `pl-*` after `px-*`, so the indent wins the left side
+ * and `px-2`'s only live effect is the 8px on the RIGHT — measured, both rows
+ * read `padding-left: 176px` at `sm`. Splitting them across two class lists is
+ * what let them drift apart in the first place.
+ *
+ * Measured in Chromium 1194 at 1600x1000, five columns and six swimlanes, the
+ * axis driven through the real input pipeline with `mouse.wheel`:
+ *
+ *   before  header max scrollLeft 288, lane max 298 -> worst title/cell dx 9px
+ *   after   header max scrollLeft 296, lane max 298 -> worst title/cell dx 1px
+ *
+ * ⚠️ The residual 2px of range is NOT padding and cannot be closed from here:
+ * each lane row sits inside the lane's `border rounded-lg` wrapper, so its
+ * `clientWidth` is 1550 against the header row's 1552. That same 1px border is
+ * the 1px title/cell baseline objectui#7303 and objectui#8448 already record.
+ * Reported on objectui#8797 rather than compensated for with a magic offset.
+ */
+const SWIMLANE_AXIS_X_PADDING = 'px-2 pl-36 sm:pl-44'
+
 // `KanbanCard` / `KanbanColumn` have ONE authority in this package: `./types`
 // (objectui#6172 / #6155). This file used to redeclare both, and the copies had
 // drifted — the local `KanbanCard` carried `cardSubtitle` / `cardFieldCells` /
@@ -877,9 +911,13 @@ function KanbanBoardInner({ columns, onCardMove, onCardClick, className, dnd, qu
               a title's own centre returning the lane-collapse `<button>` behind
               it. Pinned by `__tests__/swimlaneColumnHeaderRow-7303.test.tsx`.
 
-              The `pl-36 sm:pl-44` indent is shared with the lane content rows
-              below and is what lines the titles up with their columns — it must
-              move on both rows or neither.
+              The horizontal padding is shared with the lane content rows
+              below, as the single `SWIMLANE_AXIS_X_PADDING` constant both class
+              lists interpolate — the `pl-36 sm:pl-44` half is what lines the
+              titles up with their columns, and the `px-2` half is what keeps
+              the two rows' scroll RANGES equal (objectui#8797). It must move on
+              both rows or neither, which is now a property of the source rather
+              than of two class lists agreeing by hand.
 
               `pt-3 sm:pt-4` is the region's former TOP padding, moved onto this
               row on purpose. A scroll container's padding is inside its
@@ -904,7 +942,7 @@ function KanbanBoardInner({ columns, onCardMove, onCardClick, className, dnd, qu
               a sticky box is still in flow — so `shrink-0` above stays exactly
               as load-bearing as objectui#7303's pin says it is. */}
           <div
-            className="flex shrink-0 gap-3 sm:gap-4 pl-36 sm:pl-44 pt-3 sm:pt-4 overflow-x-auto sticky top-0 z-10 bg-background"
+            className={`flex shrink-0 gap-3 sm:gap-4 ${SWIMLANE_AXIS_X_PADDING} pt-3 sm:pt-4 overflow-x-auto sticky top-0 z-10 bg-background`}
             ref={adoptSwimlaneScroll}
             onScroll={syncSwimlaneScroll}
             data-swimlane-scroll-row=""
@@ -943,7 +981,7 @@ function KanbanBoardInner({ columns, onCardMove, onCardClick, className, dnd, qu
                 {/* Lane content */}
                 {!isCollapsed && (
                   <div
-                    className="flex gap-3 sm:gap-4 overflow-x-auto px-2 pb-3 pl-36 sm:pl-44"
+                    className={`flex gap-3 sm:gap-4 overflow-x-auto ${SWIMLANE_AXIS_X_PADDING} pb-3`}
                     ref={adoptSwimlaneScroll}
                     onScroll={syncSwimlaneScroll}
                     data-swimlane-scroll-row=""

--- a/packages/plugin-kanban/src/__tests__/swimlaneAxisScrollRange-8797.test.tsx
+++ b/packages/plugin-kanban/src/__tests__/swimlaneAxisScrollRange-8797.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8797 — every row on the swimlane axis has the SAME scroll RANGE.
+ *
+ * ## What broke
+ *
+ * objectui#8448 gave the board one horizontal axis: a scroll handler copies
+ * `scrollLeft` from whichever row the user drove onto every other row. Equal
+ * `scrollLeft` is equal ALIGNMENT only while the rows have the same scrollable
+ * RANGE, and they did not. The lane content rows carried `px-2`; the header row
+ * did not. `scrollLeft`'s maximum is `scrollWidth - clientWidth`, so the lane
+ * rows' maximum was larger. Driven to a lane's maximum, the header row CLAMPED
+ * at its own smaller one and every column title sat off its column — and stayed
+ * there, because nothing moves again until the user scrolls back.
+ *
+ * Measured in Chromium 1194 at 1600x1000, five columns and six swimlanes, real
+ * Tailwind CSS, the axis driven through the real input pipeline (`mouse.wheel`,
+ * not an assignment — see the warning below):
+ *
+ *   before   header max scrollLeft 288 | lane max 298 | worst title/cell dx 9px
+ *   after    header max scrollLeft 296 | lane max 298 | worst title/cell dx 1px
+ *
+ * 1px is the baseline objectui#7303 and objectui#8448 already record: the lane
+ * content row sits inside the lane's `border rounded-lg` wrapper, so it starts
+ * 1px right of the header row. That same border is why the two maxima are still
+ * 2px apart after the fix — `clientWidth` 1550 against 1552. That 2px is NOT
+ * padding and is not closable from the class lists this file guards; it is
+ * reported on objectui#8797 rather than papered over with a magic offset.
+ *
+ * ## ⚠️ What this file can and cannot measure — read before extending it
+ *
+ * Vitest runs here in happy-dom, which performs NO layout and applies NO CSS.
+ * `scrollWidth`, `clientWidth` and every `scrollLeft` MAXIMUM are therefore
+ * indistinguishable between the broken build and the fixed one — the numbers
+ * above cannot be reproduced here, and asserting them would be a pin that
+ * cannot fail. That half is out-of-band browser work and is reported in the PR,
+ * exactly as objectui#7303, objectui#8448 and objectui#8449 all document for
+ * this surface.
+ *
+ * What IS mechanically true here is the CLASS CONTRACT that decides the range.
+ * This file pins it as an INVARIANT rather than a spelling: it never asserts
+ * that a row carries `px-2`, only that every row on the axis carries the SAME
+ * horizontal padding as every other. A future re-spelling of the padding stays
+ * green; a future DIVERGENCE between the two kinds of row goes red, which is
+ * the whole defect class.
+ *
+ * ## ⚠️ Why this file does NOT re-assert propagation
+ *
+ * objectui#8448's pin drives a `fireEvent.scroll` and asserts the rows end up
+ * with equal `scrollLeft`. That is exactly the assertion that could not see
+ * this bug: a clamp only happens PAST the header row's own maximum, and
+ * happy-dom has no maxima, so propagation is satisfied at every value. Pinning
+ * propagation again here would reproduce the blind spot that let objectui#8797
+ * through. Propagation stays objectui#8448's; range is this file's.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup, within } from '@testing-library/react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+// Registers `object-kanban`. Module scope, not a hook: the import IS the
+// registration (AGENTS.md's test-discipline section).
+import '../index';
+// Same specifier as `index.tsx`'s lazy factory, so ESM's module cache resolves
+// the chunk immediately instead of racing a `waitFor` budget (objectui#3010).
+import '../KanbanImpl';
+
+afterEach(cleanup);
+
+/** The viewport the browser numbers in the docblock were read at. */
+const VIEWPORT = { width: 1600, height: 1000 };
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: VIEWPORT.width });
+  Object.defineProperty(window, 'innerHeight', { configurable: true, writable: true, value: VIEWPORT.height });
+  // Collapsed lanes persist per swimlane field; a leaked entry would silently
+  // change how many rows the next case renders.
+  try { window.localStorage.clear(); } catch { /* ignore */ }
+});
+
+const OBJECT = 'deal';
+
+const DEAL_SCHEMA = {
+  name: OBJECT,
+  label: 'Deal',
+  fields: {
+    name: { type: 'text', label: 'Name' },
+    status: { type: 'text', label: 'Status' },
+    owner: { type: 'text', label: 'Owner' },
+  },
+};
+
+function makeAdapter(): Record<string, any> {
+  return {
+    find: vi.fn(async () => ({ data: [] })),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async () => DEAL_SCHEMA),
+  };
+}
+
+const ROWS = [
+  { id: 'a', name: 'Alpha deal', status: 'open', owner: 'ann' },
+  { id: 'b', name: 'Beta deal', status: 'won', owner: 'bob' },
+];
+
+const BOARD = {
+  type: 'object-kanban',
+  objectName: OBJECT,
+  groupBy: 'status',
+  columns: [
+    { id: 'open', title: 'Open' },
+    { id: 'qualified', title: 'Qualified' },
+    { id: 'proposal', title: 'Proposal' },
+    { id: 'won', title: 'Won' },
+    { id: 'lost', title: 'Lost' },
+  ],
+};
+
+const SWIMLANES = { grouping: { fields: [{ field: 'owner' }] } };
+
+/** Every row that declares itself part of the board's shared horizontal axis. */
+const axisRows = (root: ParentNode): HTMLElement[] =>
+  [...root.querySelectorAll<HTMLElement>('[data-swimlane-scroll-row]')];
+
+/** `sm:pl-44` -> `pl-44`; a bare utility is returned unchanged. */
+const utility = (token: string): string => token.slice(token.lastIndexOf(':') + 1);
+
+/**
+ * The classes that move a box's HORIZONTAL padding, and therefore its
+ * `scrollWidth`: `p-*`, `px-*`, `pl-*`, `pr-*`, `ps-*`, `pe-*`. Deliberately
+ * NOT `py-*` / `pt-*` / `pb-*` — the header row's `pt-3 sm:pt-4` and the lane
+ * rows' `pb-3` are vertical, legitimately differ, and are objectui#8449's.
+ */
+const isHorizontalPadding = (token: string): boolean => /^p(?:[xlrse])?-/.test(utility(token));
+
+/** Whatever decides the gap between columns, which also moves `scrollWidth`. */
+const isGap = (token: string): boolean => /^gap(?:-x)?-/.test(utility(token));
+
+const classesMatching = (el: HTMLElement, pred: (t: string) => boolean): string[] =>
+  el.className.split(/\s+/).filter(Boolean).filter(pred).sort();
+
+/**
+ * Render a swimlane board and prove it is a real one before anything is read
+ * off it: the region, both lanes, and a card INSIDE a lane.
+ */
+async function renderSwimlaneBoard() {
+  const { container } = render(
+    <SchemaRendererProvider dataSource={makeAdapter() as any}>
+      <SchemaRenderer schema={{ ...BOARD, data: ROWS, ...SWIMLANES } as never} />
+    </SchemaRendererProvider>,
+  );
+
+  await waitFor(() => expect(container.textContent).toContain('Alpha deal'));
+  const region = container.querySelector('[role="region"]') as HTMLElement;
+  expect(region?.getAttribute('aria-label')).toBe('Kanban board with swimlanes');
+
+  const laneButtons = [...region.querySelectorAll('button[aria-expanded]')];
+  expect(laneButtons.map((b) => b.textContent)).toEqual(['▶ann(1)', '▶bob(1)']);
+
+  const laneList = region.querySelector('[role="list"][aria-label="Open - ann cards"]');
+  expect(
+    within(laneList as HTMLElement).queryByText('Alpha deal'),
+    'the swimlane cell should hold its card',
+  ).not.toBeNull();
+
+  return { container, region };
+}
+
+describe('objectui#8797 — every row on the swimlane axis has the same scroll range', () => {
+  it('RANGE — the header row and every lane row carry the SAME horizontal padding', async () => {
+    const { region } = await renderSwimlaneBoard();
+
+    const rows = axisRows(region);
+    // CONTROL — one header row + one row per lane, header row first.
+    expect(rows.length, 'header row + one row per lane').toBe(3);
+    expect(rows[0]).toBe(region.firstElementChild);
+
+    const [headerRow, ...laneRows] = rows;
+    const headerPadding = classesMatching(headerRow, isHorizontalPadding);
+
+    // NON-VACUITY — "the sets agree" is trivially true of two empty sets. The
+    // rows are indented off the lane labels, so this can never legitimately be
+    // empty; if it is, the pin below is comparing nothing.
+    expect(
+      headerPadding.length,
+      'the axis rows must carry horizontal padding at all, or this pin compares two empty sets',
+    ).toBeGreaterThan(0);
+
+    // THE INVARIANT. Not "the header row carries px-2" — that would pin a
+    // spelling. Every row on one axis must agree with every other, whatever
+    // the spelling, because that agreement IS the equal range.
+    for (const [i, laneRow] of laneRows.entries()) {
+      expect(
+        classesMatching(laneRow, isHorizontalPadding),
+        `lane row ${i} must carry the same horizontal padding as the column-header row, ` +
+          'or its scrollable range differs and the shared scrollLeft clamps on one of them (objectui#8797)',
+      ).toEqual(headerPadding);
+    }
+  });
+
+  it('RANGE — the axis rows also agree on the gap, the other class-level input to scrollWidth', async () => {
+    const { region } = await renderSwimlaneBoard();
+
+    const [headerRow, ...laneRows] = axisRows(region);
+    const headerGap = classesMatching(headerRow, isGap);
+
+    expect(headerGap.length, 'the columns are laid out with a gap utility').toBeGreaterThan(0);
+
+    // Padding is what objectui#8797 actually caught, but it is not the only
+    // class that moves `scrollWidth`. A divergent gap would reintroduce the
+    // same clamp by a different route. (Column WIDTH is objectui#8508's, which
+    // pins both rows onto one `columnWidthClasses` source.)
+    for (const [i, laneRow] of laneRows.entries()) {
+      expect(
+        classesMatching(laneRow, isGap),
+        `lane row ${i} must space its columns exactly as the header row does (objectui#8797)`,
+      ).toEqual(headerGap);
+    }
+  });
+
+  it('NON-VACUITY — the rows are still scroll containers, so they still HAVE a range', async () => {
+    const { region } = await renderSwimlaneBoard();
+
+    // A row that cannot scroll has no range, and two rows that cannot scroll
+    // agree about their padding for free. objectui#8448 refused "make the
+    // header row unscrollable" as arm C and objectui#7303's shrink arithmetic
+    // depends on these rows being scroll containers; this re-reads that so the
+    // equality above cannot be satisfied by deleting the axis.
+    for (const row of axisRows(region)) {
+      expect(
+        row.className.split(/\s+/).some((t) => /^(?:[a-z]+:)*overflow(?:-x)?-(?:auto|scroll)$/.test(t)),
+        `a row on the shared axis must still be a scroll container; class was ${JSON.stringify(row.className)}`,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #8797

Implements the 裁决 in comment 5599302310: **equalise the horizontal padding between the header row and the lane rows.** The scaling arm was refused and is not used here.

Based on `f3ee5845f` (objectui#8449 / PR #8798), per the dispatch's branch precondition — verified before writing anything: `sticky top-0` read **3** in the base, with `export` at 6 as a lit control on the same command shape.

## What changed

`packages/plugin-kanban/src/KanbanImpl.tsx`, swimlane layout only. Both axis rows now interpolate one constant instead of spelling their padding out twice:

```
const SWIMLANE_AXIS_X_PADDING = 'px-2 pl-36 sm:pl-44'
```

| element | before | after |
|---|---|---|
| column-header row | `... gap-3 sm:gap-4 pl-36 sm:pl-44 pt-3 ...` | `... gap-3 sm:gap-4 ${SWIMLANE_AXIS_X_PADDING} pt-3 ...` |
| lane content row | `... overflow-x-auto px-2 pb-3 pl-36 sm:pl-44` | `... overflow-x-auto ${SWIMLANE_AXIS_X_PADDING} pb-3` |

One constant used twice, rather than two class lists that have to agree by hand — the drift is what the defect was.

⚠️ Class ORDER inside that constant is load-bearing: `pl-36 sm:pl-44` must stay AFTER `px-2`. Tailwind emits `pl-*` after `px-*`, so the indent wins the left side and `px-2`'s only live effect is the 8px on the RIGHT. Measured, not assumed: both rows read `padding-left: 176px` at `sm` before and after.

## ⚠️ The card's stated cause is falsified — the 10px is 8px padding PLUS 2px border

The card reads "The 10px shortfall is exactly the header row's missing horizontal padding." Measured, it is not. `px-2` is 8px, and the other 2px is a different thing:

```
                    padding-left  padding-right  clientWidth  scrollWidth  max scrollLeft
header row (before)     176px           0px          1552         1840          288
lane rows  (before)     176px           8px          1550         1848          298
```

`clientWidth` differs by 2 because each lane content row sits inside the lane's `border rounded-lg` wrapper, so its scrollport is 2px narrower than the header row's. Range = `scrollWidth - clientWidth`, so the 10px gap = 8 (padding) + 2 (border).

⇒ **equalising the padding closes 8 of the 10px, not 10.** After this change the maxima are 296 and 298. That residue is the same 1px lane border the acceptance criterion already names as the baseline, and it cannot be closed from a padding class list. Reported rather than papered over with a magic offset — see 验收备注.

## The 前提, measured in both directions before implementing

The 前提 was *the lane rows' `px-2` is horizontal padding with no other job*. It **holds**, and both directions leave card layout identical — cards at x=209 w=304, lane cells at 201/537/873/1209/1545 w=320 in every variant, unchanged from baseline.

So card layout did not pick the direction. Driving the real input pipeline did:

| direction | header max | lane max | Δrange | worst title/cell dx | lane trailing gap |
|---|---|---|---|---|---|
| baseline (defect) | 288 | 298 | 10 | **9px** | 8px |
| **A — header gains the padding** | 296 | 298 | 2 | **1px** | **8px** |
| B — lane rows lose `px-2` | 288 | 290 | 2 | 1px | **0px** |

**Arm B was rejected on measurement**: removing `px-2` from the lane rows collapses the 8px of trailing space after the last column's cards, so scrolled fully right the cards butt against the lane's own border. Arm A adds that padding to a row where nothing is rendered past the last title, so nothing visible moves. Arm A is what shipped.

## The card's table, inverted — in a real browser

Chromium 1194 at 1600x1000, real Tailwind CSS, the real `object-kanban` board in a height-bounded pane (five columns, six swimlanes, two cards per cell).

⚠️ Both a scripted drive and a wheel drive are reported, because a scripted scroll is not a reachability measurement where `overflow` is involved (objectui#8449's lesson). The `worst dx` column is the largest distance between any column title's centre and its own lane cell's centre, over every lane and column.

```
asked      BEFORE rows land at            dx      AFTER rows land at             dx
    0      [0,0,0,0,0,0,0]                1px     [0,0,0,0,0,0,0]                1px
  100      [100,100,100,100,100,100,100]  1px     [100,100,100,100,100,100,100]  1px
  200      [200,200,200,200,200,200,200]  1px     [200,200,200,200,200,200,200]  1px
  288      [288,288,288,288,288,288,288]  1px     [288,288,288,288,288,288,288]  1px
  296      [288,296,296,296,296,296,296]  7px     [296,296,296,296,296,296,296]  1px
  298      [288,298,298,298,298,298,298]  9px     [296,298,298,298,298,298,298]  1px
 1000      [288,298,298,298,298,298,298]  9px     [296,298,298,298,298,298,298]  1px

mouse.wheel x25 through the real input pipeline:
  before   landed [288,298,298,298,298,298,298]   worst dx 9px   trailing gap 8px
  after    landed [296,298,298,298,298,298,298]   worst dx 1px   trailing gap 8px
```

⭐ **Acceptance, on the half that is user-visible: met.** The worst title/cell delta is **1px across the whole range including the extreme right**, where it was 9px — that 1px being the lane's own border, exactly the baseline the criterion names.

⚠️ **Acceptance, on the literal half: not met, and cannot be by this arm.** `header row max scrollLeft` is 296 against the lane rows' 298. Closing that last 2px means matching the lane wrapper's border inset on the header row, which is not horizontal padding and was not ruled. Measured for the record — adding a 1px transparent horizontal border to the header row alongside this change takes Δrange to **0** and worst dx to **0px** — but that is a second mechanism, so it is reported for the PM to rule on, not shipped unasked.

## Tests

New: `packages/plugin-kanban/src/__tests__/swimlaneAxisScrollRange-8797.test.tsx` (3 cases).

⚠️ **What it does and does not claim.** Vitest runs in happy-dom, which performs no layout and applies no CSS, so `scrollWidth`, `clientWidth` and every `scrollLeft` maximum are indistinguishable between the broken and fixed builds. No geometry is asserted there — that would be a pin that cannot fail. The geometry is the browser table above, exactly as objectui#7303, objectui#8448 and objectui#8449 all document for this surface.

⚠️ **The pin asserts RANGE, not propagation, deliberately.** objectui#8448's pin drives a `fireEvent.scroll` and asserts equal `scrollLeft` — the assertion structurally blind to this bug, since a clamp only happens past the header row's own maximum and happy-dom has no maxima. Re-asserting propagation here would reproduce the blind spot that let objectui#8797 through. Propagation stays objectui#8448's.

The pin is an **invariant, not a spelling**: it never asserts that a row carries `px-2`, only that every row on the axis carries the same horizontal padding as every other, whatever the spelling. A future re-spelling stays green; a future divergence goes red.

**Ablation — every pin proven able to fail.** Each leg mutates the committed source, proves the mutation reached disk (anchor count to 0, new text present, on-disk blob hash printed and compared against the HEAD blob), runs the pins, then restores with `git checkout HEAD --` and proves the restore by blob hash plus an empty `git diff HEAD`:

```
control  unmutated tree                              -> 5 files passed
leg A    header row back to its pre-fix padding      -> 1 failed | 4 passed   (this PR's RANGE/padding case)
leg B    header row's gap diverges from the lanes'   -> 1 failed | 4 passed   (this PR's RANGE/gap case)
leg C    header row stops being a scroll container   -> 3 failed | 2 passed   (this PR's non-vacuity case
                                                                              AND objectui#8448's arm C
                                                                              AND objectui#8449's non-regression)
```

⚠️ A first ablation attempt reported "mutation did not reach disk" and was correctly voided rather than read: `perl -0pi -e 's/\Q...\E/'` still interpolates `${SWIMLANE_AXIS_X_PADDING}` as a perl variable, so the substitution was a no-op that exits 0. The legs above use literal-string replacement. No leg was re-run until something landed — the void reading is reported, not hidden.

**objectui#7303, objectui#8448 and objectui#8449 — unweakened.** None touched. Leg C reddens objectui#8448's and objectui#8449's cases together with this PR's, which is the demonstration that all three still guard this flex column.

**Gates, all green, read from each gate's own verdict line:**

```
pnpm exec vitest run packages/plugin-kanban/            39 files, 247 tests passed (was 38/244)
pnpm --filter @object-ui/plugin-kanban type-check       exit 0  (tsc --noEmit && tsc -p tsconfig.test.json)
pnpm --filter @object-ui/plugin-kanban lint             0 errors, 182 warnings (180 pre-existing + 2 no-explicit-any
                                                        on the adapter stub, the house pattern copied from #8448's pin)
node scripts/check-governed-queue-guard.mjs --test      NOT GOVERNED (3 paths, 0 matches)
  lit control: same command on AGENTS.md                GOVERNED, exit 3 — so the zero is a reading
node scripts/check-changeset-presence.mjs               OK — 1 changeset for 1 released package
pnpm check:control-bytes                                OK (6998 tracked text files)
pnpm changeset:check / check:self-import                OK
```

Read at `4f83e274c`. Repo-wide `turbo run lint` and the full suite are CI's; the affected package's own lint, tests and type-check were run whole, not narrowed.

## Not in scope, deliberately

- The `pl-36 sm:pl-44` indent with nothing rendered in it is untouched, as the dispatch requires — it is objectui#7303's pin's subject and is the left side, not the differing side.
- The lane wrapper's `border rounded-lg` is untouched; it is the source of both the 1px alignment baseline and the residual 2px of range, and changing it is a visual decision, not this defect.

## 验收备注

- **noted, not filed (needs a PM ruling, not a card): the residual 2px of range.** `header max scrollLeft` 296 vs lane 298 after this change. Cause measured: the lane wrapper's 1px horizontal borders make the lane rows' `clientWidth` 1550 against the header row's 1552. The user-visible effect is nil — worst dx is 1px across the whole range, the stated baseline — so this is a discrepancy against the literal wording of the acceptance criterion, not a residual defect. A 1px transparent horizontal border on the header row measures Δrange 0 and dx 0px if the PM wants exact equality; it is a second mechanism and was not ruled, so it is not shipped here. Carried in the report rather than filed, because the deciding party is the PM seat that wrote the 裁決.
- noted, not filed: the card's Dedup section and the 裁决 both attribute the whole 10px to the missing padding. Only 8px is. Nothing downstream depends on that number, and the card is being closed by this PR, so there is nothing to correct in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH)_