### PR TITLE
fix(i18n): built-in record-detail tabs and two landmark names speak the session locale (objectui#4645)

### DIFF
--- a/.changeset/record-detail-builtin-label-i18n-4645.md
+++ b/.changeset/record-detail-builtin-label-i18n-4645.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/components': patch
+'@object-ui/plugin-detail': patch
+'@object-ui/i18n': minor
+---
+
+The built-in record-detail tab labels and the last two English landmark names now speak the session locale (objectui#4645).
+
+`buildDefaultPageSchema` synthesizes the record-detail tab strip with plain
+English tokens on the nodes (`Details`, `Related`, `Attachments`, `Activity`,
+`History`, `Approvals`), and three of its own comments said those tokens
+"localize through the tab strip's `KNOWN_LABEL_DICT`". That dict shipped
+exactly two arms — `zh-CN` and `zh-TW` — so the claim held for Chinese and
+silently failed for the eight other shipped packs: a ja-JP or es-ES record
+detail rendered `Details / Related / Attachments` inside otherwise fully
+localized chrome, measured in a real browser on `@objectstack/console` 17.0.0
+GA and re-measured red on current `main`.
+
+Every one of those strings was already in all ten packs (`detail.details`,
+`detail.related`, `detail.activity`, `detail.history`, `detail.attachments`,
+`detail.approvalsPanelTitle`); the strip simply never asked. It asks now,
+BEHIND the exact-locale dict, which stays first because `zh-TW` has no pack of
+its own — i18next resolves it to the Simplified `zh` resource, so the dict is
+the only source of the Traditional forms — and because it carries tokens
+(`Notes`, `Files`, `Tasks`, `Events`, object names) that no pack does. `en` and
+`zh` render byte-identically to before; the other eight locales change from the
+English token to their pack value. `page:accordion` reads the same lookup, so
+the two renderers cannot answer differently for one token.
+
+Alongside it, the two `aria-label`s that were English in *every* locale —
+`HeaderHighlight`'s `Record highlights` and `RecordActivityTimeline`'s
+`Discussion` — now route through the bundle. Both sections carry no visible
+label, so the `aria-label` is the landmark as far as assistive tech is
+concerned (the argument objectui#4024 made for the dialog `Close` label, and
+objectui#5956 made for `record:path`'s own container name). `detail.discussion`
+already existed in all ten packs; `detail.highlightsLabel` is the single new
+key, added to all ten and mirrored byte-identically into
+`DETAIL_DEFAULT_TRANSLATIONS`.

--- a/packages/components/src/__tests__/page-tabs-builtin-label-i18n-4645.test.tsx
+++ b/packages/components/src/__tests__/page-tabs-builtin-label-i18n-4645.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The built-in record-detail tab labels announce themselves in the session
+ * locale — objectui#4645.
+ *
+ * `buildDefaultPageSchema` synthesizes the record-detail tab strip with plain
+ * ENGLISH tokens on the nodes (`label: 'Details'`, `'Related'`,
+ * `'Attachments'`, `'Activity'`, `'History'`, `'Approvals'`), and three of its
+ * own comments say those tokens "localize through the tab strip's
+ * KNOWN_LABEL_DICT". That dict shipped exactly two arms — `zh-CN` and `zh-TW`
+ * — so the claim held for Chinese and silently failed for the eight other
+ * shipped packs: a ja-JP / es-ES record detail rendered `Details / Related /
+ * Attachments` inside otherwise fully-localized chrome.
+ *
+ * The packs already carry every one of these strings (`detail.details`,
+ * `detail.related`, `detail.activity`, `detail.history`,
+ * `detail.attachments`, `detail.approvalsPanelTitle` — all ten locales, no key
+ * added by this change). The gap was purely that the tab strip never asked
+ * them. It does now, BEHIND the exact-locale dict so `zh-TW` keeps the
+ * Traditional forms it is the only source of.
+ *
+ * ── Direction of these assertions ─────────────────────────────────────────
+ * `en` and `zh` were GREEN before this change and stay green — they pin that
+ * routing through the packs did not move what an English or a Simplified
+ * Chinese session reads (the dict's zh rows and the pack's zh rows are
+ * byte-identical for these six tokens). The other eight packs were RED: every
+ * one of them rendered the English token. `ja` and `es` are the two the card
+ * measured in a real browser on 17.0.0 GA.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { I18nProvider, builtInLocales } from '@object-ui/i18n';
+import { SchemaRenderer } from '@object-ui/react';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../renderers';
+
+/** Exactly the tokens `buildDefaultPageSchema` writes onto its tab nodes. */
+const SYNTHESIZED_TABS: Array<{ token: string; packKey: keyof typeof builtInLocales.en.detail }> = [
+  { token: 'Details', packKey: 'details' },
+  { token: 'Related', packKey: 'related' },
+  { token: 'Attachments', packKey: 'attachments' },
+  { token: 'Activity', packKey: 'activity' },
+  { token: 'History', packKey: 'history' },
+  { token: 'Approvals', packKey: 'approvalsPanelTitle' },
+];
+
+const textChild = (content: string) => [{ type: 'element:text', properties: { content } }];
+
+function renderSynthesizedStrip(language: string) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      <SchemaRenderer
+        schema={{
+          type: 'page:tabs',
+          id: 'tabs',
+          items: SYNTHESIZED_TABS.map(({ token }) => ({
+            label: token,
+            value: token.toLowerCase(),
+            children: textChild(`${token} BODY`),
+          })),
+        }}
+      />
+    </I18nProvider>,
+  );
+}
+
+const tabTexts = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll('[role="tab"]')).map((el) => el.textContent?.trim() ?? '');
+
+afterEach(() => cleanup());
+
+describe('page:tabs — built-in record-detail labels speak the session locale (objectui#4645)', () => {
+  for (const language of Object.keys(builtInLocales) as Array<keyof typeof builtInLocales>) {
+    it(`renders the ${language} pack values for every synthesized tab`, () => {
+      const { container } = renderSynthesizedStrip(language);
+      const pack = builtInLocales[language].detail as Record<string, string>;
+
+      expect(tabTexts(container)).toEqual(
+        SYNTHESIZED_TABS.map(({ packKey }) => pack[packKey as string]),
+      );
+    });
+  }
+
+  /**
+   * The derived assertion above compares render output against the pack, so it
+   * would pass vacuously for a pack whose values happened to BE the English
+   * tokens. These two literals are the control: they are the exact strings the
+   * card measured as missing in a real browser, written out rather than
+   * derived.
+   */
+  it('renders the ja-JP strings the card measured as English (lit control)', () => {
+    const { container } = renderSynthesizedStrip('ja');
+    const texts = tabTexts(container);
+
+    expect(texts).toContain('詳細');
+    expect(texts).toContain('関連');
+    expect(texts).toContain('添付ファイル');
+    expect(texts).not.toContain('Details');
+    expect(texts).not.toContain('Related');
+    expect(texts).not.toContain('Attachments');
+  });
+
+  it('renders the es-ES strings the card measured as English (lit control)', () => {
+    const { container } = renderSynthesizedStrip('es');
+    const texts = tabTexts(container);
+
+    expect(texts).toContain('Detalles');
+    expect(texts).toContain('Relacionados');
+    expect(texts).toContain('Adjuntos');
+    expect(texts).not.toContain('Details');
+    expect(texts).not.toContain('Related');
+    expect(texts).not.toContain('Attachments');
+  });
+
+  /**
+   * `zh-TW` has no pack of its own — i18next resolves it to the Simplified
+   * `zh` resource — so the exact-locale dict is the ONLY source of Traditional
+   * forms for these tokens. It therefore stays AHEAD of the pack lookup, and
+   * this is the assertion that says so.
+   */
+  it('keeps the zh-TW Traditional forms the dict is the only source of', () => {
+    const { container } = renderSynthesizedStrip('zh-TW');
+    const texts = tabTexts(container);
+
+    expect(texts).toContain('詳情');
+    expect(texts).toContain('相關');
+    // The Simplified pack values, which a pack-first order would have produced.
+    expect(texts).not.toContain('详情');
+    expect(texts).not.toContain('相关');
+  });
+
+  /**
+   * An author-supplied label is not a well-known token and must survive
+   * untouched — the strip localizes the synthesizer's English, never the
+   * author's copy.
+   */
+  it('leaves an authored label alone', () => {
+    const { container } = render(
+      <I18nProvider config={{ defaultLanguage: 'ja', detectBrowserLanguage: false }}>
+        <SchemaRenderer
+          schema={{
+            type: 'page:tabs',
+            id: 'tabs',
+            items: [
+              { label: 'Invoices', value: 'a', children: textChild('A') },
+              { label: 'Details', value: 'b', children: textChild('B') },
+            ],
+          }}
+        />
+      </I18nProvider>,
+    );
+
+    expect(tabTexts(container)).toEqual(['Invoices', '詳細']);
+  });
+});

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -153,16 +153,31 @@ const labelText = (label: any): string => {
 };
 
 /**
- * Lightweight built-in translation for well-known English tab/accordion
- * labels used by Lightning-style record pages (Details / Related /
- * Activity / History / Notes / Files / Tasks / Events / Attachments /
- * Chatter / Discussion). Keeps `@object-ui/components` free of an i18n
- * dependency while closing the gap between custom Page schemas (often
- * authored in English) and the localised default detail view.
+ * EXACT-LOCALE overrides for well-known English tab/accordion labels used by
+ * Lightning-style record pages (Details / Related / Activity / History /
+ * Notes / Files / Tasks / Events / Attachments / Chatter / Discussion),
+ * consulted AHEAD of `KNOWN_LABEL_KEYS` below.
+ *
+ * It shipped as the only source, with exactly two arms — and that was
+ * objectui#4645: `buildDefaultPageSchema` writes plain English tokens onto the
+ * synthesized record-detail tabs and three of its comments say they "localize
+ * through the tab strip's KNOWN_LABEL_DICT", which was true for Chinese and
+ * silently false for the eight other shipped packs. A ja-JP / es-ES record
+ * detail rendered `Details / Related / Attachments` inside otherwise fully
+ * localized chrome.
+ *
+ * What stays here is what the packs cannot answer:
+ *   - `zh-TW`. There is no `zh-TW` pack; i18next resolves it to the
+ *     SIMPLIFIED `zh` resource, so this map is the only source of the
+ *     Traditional forms. It must therefore win over the pack lookup, which is
+ *     why the dict is consulted first rather than second.
+ *   - the tokens no pack carries (`Notes`, `Files`, `Tasks`, `Events`,
+ *     `Overview`, and the object-name rows) — dropping them would take
+ *     coverage AWAY from zh.
  *
  * Authors can always override by passing a localised `label` (string or
- * `{ default, zh-CN, ... }` shape) directly in their schema; the map is
- * only consulted when the input matches a known English token.
+ * `{ default, zh-CN, ... }` shape) directly in their schema; neither map is
+ * consulted unless the input matches a known English token.
  */
 const KNOWN_LABEL_DICT: Record<string, Record<string, string>> = {
   'zh-CN': {
@@ -230,6 +245,29 @@ const KNOWN_LABEL_DICT: Record<string, Record<string, string>> = {
 };
 
 /**
+ * The other half of the same lookup: the well-known English tokens the ten
+ * shipped packs ALREADY translate, mapped to the key that carries them
+ * (objectui#4645). No pack key is minted here — every row below was in all ten
+ * packs before this change; the tab strip simply never asked for them.
+ *
+ * These are exactly the tokens `buildDefaultPageSchema` writes onto its
+ * synthesized tab nodes, plus the two `record:discussion` spellings, so the
+ * built-in record detail is covered end to end. A token absent from this map
+ * (an authored `Invoices` tab) is left alone, which is the contract the dict
+ * already had.
+ */
+const KNOWN_LABEL_KEYS: Record<string, string> = {
+  Details: 'detail.details',
+  Related: 'detail.related',
+  Activity: 'detail.activity',
+  History: 'detail.history',
+  Attachments: 'detail.attachments',
+  Approvals: 'detail.approvalsPanelTitle',
+  Discussion: 'detail.discussion',
+  Comments: 'detail.comments',
+};
+
+/**
  * `locale` is passed in rather than re-detected. Both call sites already
  * resolve it from `useObjectTranslation().language`; this function used to
  * call `detectLocale()` and read `document.documentElement.lang` on its own,
@@ -238,26 +276,46 @@ const KNOWN_LABEL_DICT: Record<string, Record<string, string>> = {
  * in-app, because the DOM attribute and the i18n instance update
  * independently (objectui#2871).
  */
-const translateLabel = (text: string, locale: string): string => {
+const translateLabel = (
+  text: string,
+  locale: string,
+  tt: (keyOrKeys: string | string[], fallback: string) => string,
+): string => {
   if (!text) return text;
   // Match `zh-CN`, `zh-TW`, then base `zh` → `zh-CN`.
   const exact = KNOWN_LABEL_DICT[locale];
   const base = locale.split('-')[0];
   const fallback = base === 'zh' ? KNOWN_LABEL_DICT['zh-CN'] : undefined;
   const dict = exact || fallback;
-  if (!dict) return text;
+  /**
+   * One token, in lookup order: the exact-locale dict, then the pack.
+   *
+   * `undefined` means "this token has no translation in this locale" — NOT
+   * "the pack answered with the English token". `tt` falls back to its second
+   * argument, so a pack miss and an `en` session both come back as `text`
+   * itself; collapsing them here is what keeps the compound path below from
+   * claiming a translation it does not have.
+   */
+  const one = (token: string): string | undefined => {
+    const hit = dict?.[token];
+    if (hit !== undefined) return hit;
+    const key = KNOWN_LABEL_KEYS[token];
+    if (key === undefined) return undefined;
+    const translated = tt(key, token);
+    return translated === token ? undefined : translated;
+  };
   // Direct hit on the full string.
-  if (dict[text] !== undefined) return dict[text];
+  const direct = one(text);
+  if (direct !== undefined) return direct;
   // Try splitting on " & " / " 和 " / " and " separators so labels like
   // "Notes & Attachments" translate piece-wise to "备注 & 附件" without
   // requiring every concrete combination to be enumerated in the dict.
   const sepRe = /\s*(?:&|and|和)\s*/i;
   if (sepRe.test(text)) {
-    const parts = text.split(sepRe);
-    const allKnown = parts.every((p) => dict[p.trim()] !== undefined);
-    if (allKnown) {
+    const parts = text.split(sepRe).map((p) => p.trim()).map(one);
+    if (parts.every((p) => p !== undefined)) {
       const sep = locale.startsWith('zh') ? '与' : ' & ';
-      return parts.map((p) => dict[p.trim()]).join(sep);
+      return (parts as string[]).join(sep);
     }
   }
   return text;
@@ -426,6 +484,11 @@ const PageTabsRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   // `useObjectTranslation`), so the count-badge copy and the tab-label
   // localization below read the same session locale from one hook.
   const { t: tTabs, language } = useTabsTranslation();
+  // The pack half of `translateLabel` (objectui#4645). Per-call rather than a
+  // second defaults map: these keys carry no interpolation, and the English
+  // token IS the fallback, so `useSafeTranslate`'s (keys, fallback) shape is
+  // exactly the lookup.
+  const ttLabel = useSafeTranslate();
   const rawItems: PageTabsItem[] = schema?.items || [];
   // Tab visual style lives at `properties.type` ('line'|'card'|'pill') — the
   // outer `schema.type` is always 'page:tabs' (the component dispatch key).
@@ -633,7 +696,7 @@ const PageTabsRenderer: React.FC<any> = ({ schema, className, ...props }) => {
     value: typeof (it as any).value === 'string' && (it as any).value !== '' ? (it as any).value : `tab-${idx}`,
     // pickLocalized first (honours `{ en, zh }` / `{ default }`); translateLabel
     // then maps any plain-English well-known token (Details/Related/…) to the locale.
-    labelStr: translateLabel(pickLocalized(it.label, language), language),
+    labelStr: translateLabel(pickLocalized(it.label, language), language, ttLabel),
     // Explicit spec count wins; otherwise fall back to the derived probe.
     count: it.count !== undefined && it.count !== null && it.count !== ''
       ? it.count
@@ -880,6 +943,10 @@ interface PageAccordionItem {
 const PageAccordionRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   const { designer } = splitDesignerProps(props);
   const { language } = useObjectTranslation();
+  // Same lookup the tab strip reads (objectui#4645) — `page:accordion` is the
+  // other renderer that localizes well-known English section labels, and the
+  // two must not answer differently for the same token.
+  const ttLabel = useSafeTranslate();
   const items: PageAccordionItem[] = schema?.items || [];
   const allowMultiple = !!schema?.allowMultiple;
   // Variants:
@@ -895,7 +962,7 @@ const PageAccordionRenderer: React.FC<any> = ({ schema, className, ...props }) =
   const itemsWithValue = items.map((it, idx) => ({
     ...it,
     value: `panel-${idx}`,
-    labelStr: translateLabel(pickLocalized(it.label, language), language),
+    labelStr: translateLabel(pickLocalized(it.label, language), language, ttLabel),
   }));
 
   const defaultOpen = itemsWithValue

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -1074,6 +1074,7 @@ const ar = {
     sortBy: "ترتيب حسب",
     filterPlaceholder: "تصفية…",
     highlightFields: "الحقول الرئيسية",
+    highlightsLabel: "الحقول الرئيسية للسجل",
     createdBy: "أنشأه",
     updatedBy: "حدّثه",
     // objectui#3863 — base key, and in ar this is the slot users actually hit: `zero`,

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -1068,6 +1068,7 @@ const de = {
     sortBy: "Sortieren nach",
     filterPlaceholder: "Filtern…",
     highlightFields: "Schlüsselfelder",
+    highlightsLabel: "Schlüsselfelder des Datensatzes",
     createdBy: "Erstellt von",
     updatedBy: "Aktualisiert von",
     created: "Erstellt",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1114,6 +1114,7 @@ const en = {
     sortBy: 'Sort by',
     filterPlaceholder: 'Filter…',
     highlightFields: 'Key Fields',
+    highlightsLabel: 'Record highlights',
     // Comments
     comments: 'Comments',
     searchComments: 'Search comments…',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1072,6 +1072,7 @@ const es = {
     sortBy: "Ordenar por",
     filterPlaceholder: "Filtrar…",
     highlightFields: "Campos clave",
+    highlightsLabel: "Campos clave del registro",
     createdBy: "Creado por",
     updatedBy: "Actualizado por",
     created: "Creado",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -1070,6 +1070,7 @@ const fr = {
     sortBy: "Trier par",
     filterPlaceholder: "Filtrer…",
     highlightFields: "Champs clés",
+    highlightsLabel: "Champs clés de l'enregistrement",
     createdBy: "Créé par",
     updatedBy: "Mis à jour par",
     // objectui#3863 — base key. fr has a third category, `many`, which CLDR uses from

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -932,6 +932,7 @@ const ja = {
     sortBy: "並べ替え",
     filterPlaceholder: "フィルター…",
     highlightFields: "主要フィールド",
+    highlightsLabel: "レコードの主要フィールド",
     comments: "コメント",
     searchComments: "コメントを検索…",
     addCommentPlaceholder: "コメントを追加… (Ctrl+Enterで送信)",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -1068,6 +1068,7 @@ const ko = {
     sortBy: "정렬 기준",
     filterPlaceholder: "필터…",
     highlightFields: "주요 필드",
+    highlightsLabel: "레코드 주요 필드",
     createdBy: "작성자",
     updatedBy: "업데이트한 사람",
     created: "작성됨",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1069,6 +1069,7 @@ const pt = {
     sortBy: "Ordenar por",
     filterPlaceholder: "Filtrar…",
     highlightFields: "Campos principais",
+    highlightsLabel: "Campos principais do registro",
     createdBy: "Criado por",
     updatedBy: "Atualizado por",
     // objectui#3863 — base key. pt's third category `many` starts at a million, where

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -940,6 +940,7 @@ const ru = {
     sortBy: "Сортировать по",
     filterPlaceholder: "Фильтр…",
     highlightFields: "Ключевые поля",
+    highlightsLabel: "Ключевые поля записи",
     comments: "Комментарии",
     searchComments: "Поиск комментариев…",
     addCommentPlaceholder: "Добавить комментарий… (Ctrl+Enter для отправки)",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1001,6 +1001,7 @@ const zh = {
     sortBy: '排序',
     filterPlaceholder: '筛选…',
     highlightFields: '关键字段',
+    highlightsLabel: '记录关键字段',
     // Comments
     comments: '评论',
     searchComments: '搜索评论…',

--- a/packages/plugin-detail/src/HeaderHighlight.tsx
+++ b/packages/plugin-detail/src/HeaderHighlight.tsx
@@ -82,7 +82,7 @@ export const HeaderHighlight: React.FC<HeaderHighlightProps> = ({
           '@container border-b border-border/60 pb-4',
           className,
         )}
-        aria-label="Record highlights"
+        aria-label={t('detail.highlightsLabel')}
       >
         <div className={cn('flex flex-wrap gap-y-4')}>
           {visibleFields.map((field) => {

--- a/packages/plugin-detail/src/RecordActivityTimeline.tsx
+++ b/packages/plugin-detail/src/RecordActivityTimeline.tsx
@@ -311,7 +311,7 @@ export const RecordActivityTimeline: React.FC<RecordActivityTimelineProps> = ({
         'border-t border-border/60 pt-5',
         className,
       )}
-      aria-label="Discussion"
+      aria-label={t('detail.discussion')}
     >
       <header className="mb-4">
         <div className="flex items-center justify-between">

--- a/packages/plugin-detail/src/__tests__/detail-landmark-aria-i18n-4645.test.tsx
+++ b/packages/plugin-detail/src/__tests__/detail-landmark-aria-i18n-4645.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The two remaining English landmark names on a record detail speak the
+ * session locale — objectui#4645.
+ *
+ * `HeaderHighlight`'s `<section aria-label="Record highlights">` and
+ * `RecordActivityTimeline`'s `<section aria-label="Discussion">` were the last
+ * purely-ASCII accessible names on a record detail page, measured English in
+ * zh-CN, ja-JP **and** es-ES — in es-ES sitting among 30+ correctly-Spanish
+ * siblings (`Copiar ID de registro`, `Filtrar actividad`, `Alternar barra
+ * lateral`). Both sections carry no visible label of their own, so the
+ * `aria-label` IS the landmark as far as assistive tech is concerned — the
+ * argument objectui#4024 made for the dialog `Close` label, and #5956 made for
+ * `record:path`'s own container name (`detail.pathLabel`, which this change
+ * copies).
+ *
+ * Keys: `detail.discussion` already existed in all ten packs (the DetailView
+ * tab reads it). `detail.highlightsLabel` is new and is the ONLY key this
+ * change mints — added to all ten packs and mirrored byte-identically into
+ * `DETAIL_DEFAULT_TRANSLATIONS`, which `defaults-maps-mirror-en-pack` enforces.
+ *
+ * ── Direction of these assertions ─────────────────────────────────────────
+ * The `en` cases were GREEN before AND after: they pin that routing the names
+ * through `t()` did not change what an English session hears. The zh / ja / es
+ * cases were RED — both names read English in every locale, which is the whole
+ * defect. The provider-less fallback is NOT asserted here: mounting an
+ * `I18nProvider` installs a module-level i18next instance, so a no-provider
+ * assertion in this file would read whichever instance a sibling test left
+ * behind. It is covered instead by
+ * `app-shell/src/__tests__/defaults-maps-mirror-en-pack.test.tsx`, which pins
+ * every row of `DETAIL_DEFAULT_TRANSLATIONS` against the `en` pack.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import type { HighlightField } from '@object-ui/types';
+import { I18nProvider } from '@object-ui/i18n';
+import { HeaderHighlight } from '../HeaderHighlight';
+import { RecordActivityTimeline } from '../RecordActivityTimeline';
+
+function renderIn(language: string, node: React.ReactNode) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      {node}
+    </I18nProvider>,
+  );
+}
+
+const highlights = (
+  <HeaderHighlight
+    fields={[{ name: 'owner', label: 'Owner' }] satisfies HighlightField[]}
+    data={{ owner: 'Alice' }}
+  />
+);
+
+const timeline = <RecordActivityTimeline items={[]} />;
+
+/** The accessible name of the one `<section>` each render puts on screen. */
+const sectionLabel = (container: HTMLElement) =>
+  container.querySelector('section')?.getAttribute('aria-label') ?? null;
+
+afterEach(() => cleanup());
+
+describe('record-detail landmark names (objectui#4645)', () => {
+  describe('HeaderHighlight — the highlights strip', () => {
+    it('still reads English under an en session', () => {
+      const { container } = renderIn('en', highlights);
+      expect(sectionLabel(container)).toBe('Record highlights');
+    });
+
+    /**
+     * Each value is the locale's OWN `detail.highlightFields` phrase ("Key
+     * Fields" — this section is that strip) carrying the locale's own
+     * record-possessive as `detail.pathLabel` already spells it. Derived from
+     * two shipped rows rather than invented, so a reviewer can check them
+     * against the pack instead of against a dictionary.
+     */
+    it.each([
+      ['zh', '记录关键字段'],
+      ['ja', 'レコードの主要フィールド'],
+      ['es', 'Campos clave del registro'],
+      ['de', 'Schlüsselfelder des Datensatzes'],
+      ['fr', "Champs clés de l'enregistrement"],
+      ['ko', '레코드 주요 필드'],
+      ['pt', 'Campos principais do registro'],
+      ['ru', 'Ключевые поля записи'],
+      ['ar', 'الحقول الرئيسية للسجل'],
+    ])('reads the %s pack value', (language, expected) => {
+      const { container } = renderIn(language, highlights);
+      expect(sectionLabel(container)).toBe(expected);
+    });
+  });
+
+  describe('RecordActivityTimeline — the discussion landmark', () => {
+    it('still reads English under an en session', () => {
+      const { container } = renderIn('en', timeline);
+      expect(sectionLabel(container)).toBe('Discussion');
+    });
+
+    it.each([
+      ['zh', '讨论'],
+      ['ja', 'ディスカッション'],
+      ['es', 'Discusión'],
+      ['de', 'Diskussion'],
+      ['fr', 'Discussion'],
+      ['ko', '토론'],
+      ['pt', 'Discussão'],
+      ['ru', 'Обсуждение'],
+      ['ar', 'المناقشة'],
+    ])('reads the %s pack value', (language, expected) => {
+      const { container } = renderIn(language, timeline);
+      expect(sectionLabel(container)).toBe(expected);
+    });
+  });
+});

--- a/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
+++ b/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
@@ -833,7 +833,10 @@ export function buildDefaultTabs(
   // dead tab. A peer of Details/Related for the same reason as Attachments
   // below: footer placement buried the one thing a submitter opens the
   // record to learn ("who is this waiting on"). The English label localizes
-  // through the tab strip's KNOWN_LABEL_DICT (→ 审批 etc.).
+  // in the tab strip, which reads the pack key for a well-known token
+  // (`detail.approvalsPanelTitle` → 审批 / 承認 / Aprobaciones …). That claim
+  // used to name `KNOWN_LABEL_DICT`, which shipped zh arms only and so was
+  // true for Chinese and silently false everywhere else — objectui#4645.
   if (options.approvals) {
     items.push({
       label: 'Approvals',
@@ -847,7 +850,9 @@ export function buildDefaultTabs(
   // widget buried under the discussion feed. `PageTabsRenderer` derives the
   // count badge from the `record:attachments` node the same way it counts
   // `record:related_list` tabs. The English label goes through the tab
-  // strip's KNOWN_LABEL_DICT (→ 附件 etc.), matching its sibling tabs.
+  // strip's pack lookup (`detail.attachments` → 附件 / 添付ファイル /
+  // Adjuntos …), matching its sibling tabs — see the Approvals tab above for
+  // why this no longer names `KNOWN_LABEL_DICT` (objectui#4645).
   if (def?.enable?.files === true && !options.hideAttachments) {
     items.push({ label: 'Attachments', value: 'attachments', children: [buildDefaultAttachments()] });
   }

--- a/packages/plugin-detail/src/useDetailTranslation.ts
+++ b/packages/plugin-detail/src/useDetailTranslation.ts
@@ -114,6 +114,11 @@ export const DETAIL_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'detail.sortBy': 'Sort by',
   'detail.filterPlaceholder': 'Filter…',
   'detail.highlightFields': 'Key Fields',
+  // objectui#4645 — `HeaderHighlight`'s own container name. The strip is a
+  // bare `<section>` with no visible label of its own, so this `aria-label`
+  // IS the landmark to a screen reader; it was an English literal in every
+  // locale. Same shape and same argument as `detail.pathLabel` (#5956).
+  'detail.highlightsLabel': 'Record highlights',
   // Comments
   'detail.comments': 'Comments',
   'detail.searchComments': 'Search comments…',


### PR DESCRIPTION
Fixes #4645

## Zone 1 first: the gap is still live on current `main`

The card's readings are from `@objectstack/console` 17.0.0 GA and are ~3.5 weeks old, so the first action was a re-measurement, not a fix. It reproduces, and it is wider than the card could see.

Both new test files were written **before** the fix and run red on `b6d07df4b` (the branch point):

| run | before | after |
|---|---|---|
| `page-tabs-builtin-label-i18n-4645.test.tsx` | 11 failed / 3 passed (14) | 14 passed |
| `detail-landmark-aria-i18n-4645.test.tsx` | 17 failed / 3 passed (20) | 20 passed |

The per-locale breakdown of the "before" run is the measurement itself:

```
× renders the ja pack values for every synthesized tab
× renders the ko pack values for every synthesized tab
× renders the de pack values for every synthesized tab
× renders the fr pack values for every synthesized tab
× renders the es pack values for every synthesized tab
× renders the pt pack values for every synthesized tab
× renders the ru pack values for every synthesized tab
× renders the ar pack values for every synthesized tab
× renders the ja-JP strings the card measured as English (lit control)
× renders the es-ES strings the card measured as English (lit control)
```

`en` and `zh` were the two that passed — exactly the card's zh-CN-is-fine reading.

## Locale audit — all ten shipped packs, stated so the boundary is readable

The card measured zh / ja / es only and asked for the rest to be audited. **Ten locales ship** (`packages/i18n/src/locales/`): `en zh ja ko de fr es pt ru ar`. Every one was measured, and **eight of ten** carried the tab gap (all but `en` and `zh`); **nine of ten** carried both aria-label gaps (all but `en`, plus `fr` which reads `Discussion` for `detail.discussion` anyway, so it passed vacuously — that is stated in the test file rather than counted as coverage). No locale outside this set ships.

## Root cause — the attribution was one layer deeper than "missing bundle entries"

The card's suggested fix was to *add* the missing ja-JP / es-ES entries. Measuring first showed there is nothing to add: **all ten packs already carry every one of these strings.**

`buildDefaultPageSchema` writes plain English tokens onto the synthesized tab nodes (`Details`, `Related`, `Attachments`, `Activity`, `History`, `Approvals`), and three of its own comments say those tokens "localize through the tab strip's `KNOWN_LABEL_DICT`". That dict, in `packages/components/src/renderers/layout/containers.tsx`, shipped exactly two arms — `zh-CN` and `zh-TW` — and its own header claimed it existed to keep `@object-ui/components` free of an i18n dependency, which has not been true for some time (the file already imports `useObjectTranslation`, `useSafeTranslate` and `createSafeTranslation`).

So the strip never asked the packs. Adding pack rows would have added a second, drifting copy of translations that were already there.

## What changed

**1. `translateLabel` consults the packs (`packages/components/src/renderers/layout/containers.tsx`).** A new `KNOWN_LABEL_KEYS` maps each well-known token to the key that already carries it: `detail.details`, `detail.related`, `detail.activity`, `detail.history`, `detail.attachments`, `detail.approvalsPanelTitle`, `detail.discussion`, `detail.comments`. **No pack key is minted for this half.**

The exact-locale dict stays **first**, deliberately, and there is a test that says so:

- `zh-TW` has no pack of its own. i18next resolves it to the **Simplified** `zh` resource, so the dict is the only source of the Traditional forms — a pack-first order would have silently replaced 詳情 / 相關 with 详情 / 相关.
- The dict also carries tokens no pack does (`Notes`, `Files`, `Tasks`, `Events`, `Overview`, object names). Dropping it would have taken coverage *away* from zh.

`page:accordion` reads the same lookup, so the two renderers cannot answer differently for one token.

**2. The two aria-labels route through the bundle.** `HeaderHighlight`'s `Record highlights` and `RecordActivityTimeline`'s `Discussion`. Both sections carry no visible label, so the aria-label is the landmark as far as assistive tech is concerned — objectui#4024's argument for the dialog `Close` label, and objectui#5956's for `record:path`'s own container name (`detail.pathLabel`, whose shape this copies). Both files already had `t` in scope from `useDetailTranslation()`.

`detail.discussion` already existed in all ten packs. **`detail.highlightsLabel` is the single new key in this PR** — added to all ten and mirrored byte-identically into `DETAIL_DEFAULT_TRANSLATIONS`, which `defaults-maps-mirror-en-pack` enforces. Each translation is derived from two rows the pack already ships rather than invented: the locale's own `detail.highlightFields` phrase ("Key Fields" — this section is that strip) carrying the locale's own record-possessive as `detail.pathLabel` spells it. That is written into the test so a reviewer can check them against the pack instead of against a dictionary.

**3. Three comments in `buildDefaultPageSchema.ts` corrected.** They named `KNOWN_LABEL_DICT` as the thing that localizes these labels, which was the false premise this card is about. Comment-only.

## Verification

Ran from the repo root (never `cd` into a package — objectui#3378), heavy runs through the shared verify lock.

| step | command | result |
|---|---|---|
| dependency closure | `pnpm --workspace-concurrency=2 --filter '@object-ui/components^...' --filter '@object-ui/plugin-detail^...' --filter '@object-ui/i18n^...' build` | exit 0 |
| tests, `@object-ui/i18n` + `@object-ui/plugin-detail` | `pnpm exec vitest run packages/i18n/ packages/plugin-detail/` | 215 files / **2482 passed** |
| tests, `@object-ui/components` | `pnpm exec vitest run packages/components/` | 248 files / **2288 passed** |
| tests, `@object-ui/app-shell` | `pnpm exec vitest run packages/app-shell/` | 665 files / **6425 passed**, 1 skipped |
| tests, `@object-ui/console` | `pnpm exec vitest run apps/console/` | 95 files / **1116 passed** |
| type-check | `pnpm --filter @object-ui/components --filter @object-ui/i18n --filter @object-ui/plugin-detail run type-check` | 3 × `Done` |
| lint | same three packages, `run lint` | exit 0, **0 errors** (963 pre-existing warnings; the new files contribute none) |

app-shell and console are not edited by this PR but are run anyway: they are the two consumers that render both surfaces, and the published behaviour of `@object-ui/components` and `@object-ui/plugin-detail` moves for eight and nine locales respectively.

Gates, all exit 0 — quoting each gate's own verdict line rather than a bare exit code:

- `check:i18n-keys` — *"Factory defaults tables: 32 createSafeTranslation site(s) … 847 row(s) compared against their en value, 847 matching, 0 on a key en does not define"*. This is the gate that proves the new `DETAIL_DEFAULT_TRANSLATIONS` row mirrors the `en` pack.
- `check:i18n-drift` — *"0 en value(s) changed (1 key(s) added, 0 removed …)"*. The one added key is `detail.highlightsLabel`; no existing English value moved.
- `check:i18n-dead-keys` — exit 0.
- `check:control-bytes` — *"OK (scanned 6994 tracked text file(s); skipped 85 binary)"*, plus a manual `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over the changed files (no match) and a scan for bidi/invisible codepoints (the four hits in `ar.ts` are pre-existing, lines 2826-3642, nowhere near the inserted line 1077).
- `check-changeset-presence` — *"14 source file(s) of 3 released package(s) changed, and this change declares 1 changeset(s)"*.
- `check-changeset-fixed`, `check-changeset-no-major`, `check-changeset-overwrite`, `check:vi-mock-specifiers`, `check:lint-rule-coverage` — exit 0.
- `check-governed-queue-guard --test` over the 17 changed paths — *"NOT GOVERNED — 17 path(s) checked against 5 governed surface(s); none matched."* Read with `AGENTS.md` as a lit control on the same command shape, which fired *"GOVERNED — 1 of 1 path(s)"*, so the zero is a reading and not a silent no-op.

Repo-wide `turbo run lint` and the full suite are CI's.

## Changeset

`.changeset/record-detail-builtin-label-i18n-4645.md` — `@object-ui/components` patch, `@object-ui/plugin-detail` patch, `@object-ui/i18n` minor (one new pack key). This is user-visible in eight to nine of ten locales, so an empty-frontmatter declaration would have been wrong.

## 验收备注

Observations found while working, **not** filed and **not** fixed here:

- `packages/components/src/renderers/basic/record-picker.tsx` carries a comment about a known `translateLabel` gap at its own `label` read site, tracked at objectui#5637. This PR does not touch it and the comment stays accurate.
- `KNOWN_LABEL_DICT` still covers `Notes` / `Files` / `Tasks` / `Events` / `Overview` / `Summary` and the object-name tokens in zh only, because no pack carries them. That surface is **author-supplied** labels, not the built-in record-detail tabs this card fences, and the behaviour there is unchanged by this PR (an authored English label stays English in a non-zh locale, exactly as before). The successor who will meet it is whoever next extends that dict, or objectui#5637.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH


---
_Generated by [Claude Code](https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH)_