### PR TITLE
fix(fields): render the shared EmptyValue for an unparsable date (objectui#8581)

### DIFF
--- a/.changeset/8581-date-cell-unparsable-value.md
+++ b/.changeset/8581-date-cell-unparsable-value.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/fields': patch
+---
+
+`DateCellRenderer`: an unparsable date value renders the shared `EmptyValue`
+affordance instead of `formatDate`'s hand-rolled em-dash (objectui#8581).
+
+A `date` column holding `not-a-date` used to reach `formatDate`, which returns
+its own `'—'` for any value whose `new Date(...)` is invalid, and the renderer
+wrapped that string in a span classed `tabular-nums`. The result was naked
+punctuation: no `data-slot` of `empty-value`, no accessible name — the same
+defect class as objectui#8475 (`RelatedList`) and objectui#8491 (`ObjectGrid`).
+objectui#8490 routed this renderer's coerced-EMPTY input (`[]`, `''`,
+whitespace) to the shared affordance and left this input for its own card.
+
+The guard is now spelled exactly as `DateTimeCellRenderer`'s one function down
+— the nearest sibling, which answers the identical input and has returned
+`EmptyValue` all along. The two date renderers no longer disagree about the
+same value, and that agreement is measured in the pin, not asserted.
+
+**Visible change.** An unparsable value now reads "No value" to a screen reader
+and is muted like every other empty cell. The raw string that was reachable on
+hover through that span's `title` is gone on this branch only — nothing in the
+tree read it (searched with lit controls before the change). A PARSEABLE value
+is untouched: it keeps its formatted face, its overdue colour and its ISO
+`title`. A numeric epoch timestamp still renders — the guard reproduces
+`formatDate`'s own parse, so it is co-extensive with the dash it replaces and
+never wider.

--- a/packages/fields/src/__tests__/cellRenderers.objectLiteral-8596.test.tsx
+++ b/packages/fields/src/__tests__/cellRenderers.objectLiteral-8596.test.tsx
@@ -36,11 +36,14 @@
  *   - `location` / `geolocation` (and `json` / `object` / `composite` /
  *     `record`) print the `{}` literal behind objectui#8481's DECLARED
  *     json-literal fence. Left alone deliberately; pinned unchanged.
- *   - `date` still draws `formatDate`'s hand-rolled em-dash with no accessible
- *     name — objectui#8581's subject, the same renderer. This change does not
- *     touch it, and `THE CENSUS` pins that it did not: the row is recorded as
- *     a dash that is NOT the affordance, so a fix landing on it here would
- *     have to move a pin rather than pass silently.
+ *   - `date` drew `formatDate`'s hand-rolled em-dash with no accessible name
+ *     — objectui#8581's subject, the same renderer. This change did not touch
+ *     it, and `THE CENSUS` pinned that it did not: the row was recorded as a
+ *     dash that is NOT the affordance, so a fix landing on it here would have
+ *     to move a pin rather than pass silently. It did: objectui#8581 landed,
+ *     `DateCellRenderer` now answers every unparsable value with the shared
+ *     affordance, and this file's two `date` assertions moved with it — the
+ *     census row to `true`, and THE BOUNDARY to the fix's own record.
  *
  * ── The direction is not open per family: `valueSchemaFor`'s arm decides ──
  * Read from `@objectstack/spec` `src/data/field-value.zod.ts` (v17.3.0), per
@@ -185,8 +188,15 @@ const REGISTERED_TYPE_COUNT = 53;
  * `'[Object]'` below must print. `affordance` records whether the cell draws
  * the shared "No value" glyph.
  *
- * ⚠️ `date` is recorded as `'—'` WITHOUT the affordance on purpose: that dash
- * is `formatDate`'s own, and it is objectui#8581's subject, not this card's.
+ * ⚠️ `date` was recorded as `'—'` WITHOUT the affordance while
+ * objectui#8581 was open: that dash was `formatDate`'s own and belonged to
+ * that card's renderer, not this one's. objectui#8581 has since landed —
+ * `DateCellRenderer` now intercepts every value it cannot parse (`{}` coerces
+ * to `[Object]`, which `new Date` rejects) and returns the shared affordance,
+ * so the row reads `true` here. Exactly as this file predicted: the fix had to
+ * MOVE this pin rather than pass silently. The `date` census row and THE
+ * BOUNDARY below are now this file's record of the other card's landing, and
+ * the reason for the `{}` face itself is unchanged — `[Object]` is not a date.
  */
 const OBJECT_LITERAL_CENSUS: ReadonlyArray<readonly [type: string, text: string, hasAffordance: boolean]> = [
   // ── the twenty that already coerced correctly — LOAD-BEARING ────────────
@@ -246,8 +256,8 @@ const OBJECT_LITERAL_CENSUS: ReadonlyArray<readonly [type: string, text: string,
   ['secret', '••••••', false],
   ['vector', '[Vector]', false],
   ['grid', '[Grid]', false],
-  // ── objectui#8581's hand-rolled dash — NOT the affordance, NOT moved here ─
-  ['date', '—', false],
+  // ── objectui#8581 LANDED: the hand-rolled dash became the affordance ──
+  ['date', '—', true],
 ];
 
 /** A real value per type — the POPULATED half, which refuses the caricature. */
@@ -682,13 +692,24 @@ describe('objectui#8596 — an object literal is not a cell value, and these ren
       ).toBe('tel:13800138000');
     });
 
-    it('THE BOUNDARY — `date` still draws its own dash: objectui#8581 keeps its subject', () => {
+    it('THE BOUNDARY — `date` now draws the shared affordance: objectui#8581 landed on its own subject', () => {
+      // This assertion is INVERTED from what it was while objectui#8581 was
+      // open, and the inversion is the point: this file predicted that a fix
+      // there would have to move a pin here rather than pass silently, and it
+      // did. `{}` coerces to `[Object]`, which `new Date` rejects, so the
+      // `date` cell takes objectui#8581's unparsable branch — the same
+      // affordance `datetime` has always drawn for the same input. The reason
+      // `{}` is not a date is unchanged; only who draws the answer moved.
       const { container } = renderCell('date', {});
-      expect(textOf(container), 'date: the hand-rolled dash is unchanged here').toBe('—');
+      expect(textOf(container), 'date: the glyph is still an em-dash').toBe('—');
       expect(
         affordance(container),
-        'date: still NOT the shared affordance — objectui#8581 rules that renderer',
-      ).toBeNull();
+        'date: the dash is now the shared affordance, not `formatDate`\'s bare one (objectui#8581)',
+      ).not.toBeNull();
+      expect(
+        affordance(container)?.getAttribute('aria-label'),
+        'date: and it carries its accessible name',
+      ).toBe('No value');
     });
 
     it("THE BOUNDARY — objectui#8481's json-literal fence is not reopened", () => {

--- a/packages/fields/src/__tests__/dateCell.unparsableValue-8581.test.tsx
+++ b/packages/fields/src/__tests__/dateCell.unparsableValue-8581.test.tsx
@@ -1,0 +1,274 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8581 — an UNPARSABLE date string drew `formatDate`'s hand-rolled
+ * em-dash, and the sibling renderer one function down already disagreed.
+ *
+ * `DateCellRenderer` handed any value to `formatDate`, which returns its own
+ * `'—'` for anything whose `new Date(...)` is invalid, and wrapped that string
+ * in a SPAN classed `tabular-nums` with the raw value as `title`. So a `date`
+ * column holding `not-a-date` painted naked punctuation: no `data-slot` of
+ * `empty-value`, no accessible name, nothing a screen reader can name. That is
+ * the objectui#8475 (`RelatedList`) / objectui#8491 (`ObjectGrid`) class of
+ * defect, and objectui#8490 routed this renderer's COERCED-EMPTY input (`[]`,
+ * `''`, whitespace) to the shared affordance while deliberately leaving this
+ * one — the other input reaching the same dash — to a card of its own.
+ *
+ * ── The ruling, and the arm that was refused ──────────────────────────────
+ * The maintainer seat ruled ARM 1: match `DateTimeCellRenderer` and render the
+ * shared `EmptyValue`, on NEAREST-SIBLING PARITY. The sibling is one function
+ * down in this same barrel, answers the IDENTICAL input
+ * (`date === null || isNaN(date.getTime())`), and has returned `EmptyValue`
+ * for it all along; two renderers of one data family disagreeing about one
+ * input is the shape this repo keeps paying for.
+ *
+ * Arm 2 — print the raw text, the way `NumberCellRenderer` and
+ * `PercentCellRenderer` print `String(safe)` on their NaN branch — is on the
+ * record as a real argument and NOT as a mistake: "No value" is a statement
+ * about a cell that does hold *something*. It lost because a *date* renderer's
+ * nearest precedent is the other *date* renderer. Both arms delete the bare
+ * dash; "leave it" was never an arm.
+ *
+ * ── The cost, measured rather than assumed ────────────────────────────────
+ * Arm 1 discards the `title` the invalid branch carried (the raw value on
+ * hover). Before implementing, the tree was searched for any consumer of it —
+ * `ByTitle` queries, `[title=...]` selectors, `getAttribute('title')` reads,
+ * snapshots, e2e specs, export paths — with lit controls on the same command
+ * shapes (`getAttribute('title')`: 33 hits elsewhere; `getAttribute('data-slot')`:
+ * 10). Zero read THIS `title`; `isoString` occurred only at its assignment and
+ * its one use. A PARSEABLE value keeps its `title`, and the POPULATED block
+ * below pins exactly that, so the half arm 1 does not touch stays measured.
+ *
+ * ── Why `DateTimeCellRenderer` runs here as a LIVE CONTROL ────────────────
+ * The claim of this card is "the two siblings now agree". Asserting it about
+ * `date` alone would be an assertion; driving BOTH through the same
+ * `renderCell` command shape, in the same file, makes it a measurement — and
+ * it is the control that refuses a harness which rendered nothing at all. The
+ * `datetime` rows below were green BEFORE this change and must stay green:
+ * they move if someone ever "unifies" the two renderers in the wrong
+ * direction. The POPULATED `datetime` row is the liveness half — a harness
+ * whose renderer silently produced an empty container would pass every
+ * absence assertion in this file and fail that one.
+ *
+ * ── One sibling pin moved with this change, by its own instruction ───────
+ * `cellRenderers.objectLiteral-8596.test.tsx` recorded `date` holding `{}` as
+ * a dash that is NOT the affordance, and said in as many words that a fix
+ * landing on this renderer "would have to move a pin rather than pass
+ * silently". It did: `{}` coerces to `[Object]`, which `new Date` rejects, so
+ * that row now reads the affordance. Its census row and its BOUNDARY case were
+ * updated with this change — the only edit outside this file and the renderer.
+ *
+ * ── Why the fix is at the RENDERER and not in `formatDate` ────────────────
+ * `formatDate` is a SHARED formatter in `@object-ui/core` with nine other call
+ * sites (`ObjectGrid`'s two, `ObjectGantt`'s two, `DateField`, `FormulaField`,
+ * `GridField`, `lookupColumnDisplay`, `dataset-format`'s measure, and
+ * `data-table`'s timestamp column) — every one of them a STRING consumer that
+ * has no `EmptyValue` to return, and two landed pins assert its `'—'` return
+ * directly (`core`'s `date-display.optionsStyle-7745` on `'not a date'`, and
+ * this package's `date-formatter-residue-4272` on the datetime twin). Moving
+ * the dash at its source would change eight faces to fix one cell. The
+ * renderer intercept is co-extensive with this cell and nothing else.
+ *
+ * ── Why the defect leg asserts the SPAN'S ABSENCE first ───────────────────
+ * Same convention as objectui#8490's pin: on the unfixed tree the first
+ * sentence to fail is "the value span must not be drawn around a value the
+ * renderer cannot format", which is textually distinct from the failure of a
+ * harness that has lost its navigation target ("the shared affordance must be
+ * present"). Observed as two different sentences, not predicted.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { getCellRenderer, resolveCellRendererType } from '../index';
+
+afterEach(() => cleanup());
+
+/** Resolve + render exactly the way a consumer builds a read-mode cell. */
+function renderCell(type: string, value: unknown, field: Record<string, unknown> = {}) {
+  const Renderer = getCellRenderer(resolveCellRendererType({ type }) || type);
+  return render(
+    <Renderer value={value as any} field={{ type, name: type, ...field } as any} />,
+  );
+}
+
+/** The shared "No value" affordance — a muted glyph carrying an aria-label. */
+const affordance = (root: HTMLElement) =>
+  root.querySelector<HTMLElement>('[data-slot="empty-value"]');
+
+function expectAffordance(root: HTMLElement, label: string) {
+  const empty = affordance(root);
+  expect(empty, `${label}: the shared EmptyValue affordance must be present`).not.toBeNull();
+  expect(
+    empty?.getAttribute('aria-label'),
+    `${label}: the affordance must carry its accessible name`,
+  ).toBe('No value');
+}
+
+/**
+ * Every em-dash in the cell must be the shared affordance. `EmptyValue` itself
+ * renders U+2014, so "no dash at all" is the wrong instrument; the defect is a
+ * dash OUTSIDE it — one a screen reader reaches as bare punctuation.
+ */
+function handRolledDashes(root: HTMLElement): HTMLElement[] {
+  return within(root)
+    .queryAllByText('—')
+    .filter((el) => el.getAttribute('data-slot') !== 'empty-value');
+}
+
+/**
+ * Values whose `new Date(...)` is invalid, each verified against V8 before
+ * being written down. `'1700000000000'` is the sharp one: the epoch as a
+ * STRING does not parse (the number does — see the BOUNDARY block), so it
+ * reached the dash too.
+ */
+const UNPARSABLE = ['not-a-date', '2024-13-45', 'tomorrow', '1700000000000'] as const;
+
+describe('objectui#8581 — an unparsable date string is not a formatted value, and `date` drew a bare dash for it', () => {
+  describe('THE DEFECT — `date` renders the shared affordance, not `formatDate`\'s hand-rolled dash', () => {
+    for (const value of UNPARSABLE) {
+      it(`THE DEFECT — \`date\` holding ${JSON.stringify(value)} draws no value span and no bare dash`, () => {
+        const { container } = renderCell('date', value);
+        expect(
+          container.querySelector('span.tabular-nums'),
+          `date holding ${JSON.stringify(value)}: the value span must not be drawn around a value the renderer cannot format`,
+        ).toBeNull();
+        expect(
+          handRolledDashes(container).length,
+          `date holding ${JSON.stringify(value)}: the em-dash must be the shared affordance, not a bare span a screen reader cannot name`,
+        ).toBe(0);
+        expectAffordance(container, `date holding ${JSON.stringify(value)}`);
+      });
+    }
+
+    it('THE DEFECT — the raw value is no longer smuggled into a `title` on a span that is gone', () => {
+      // The declared cost of arm 1, pinned so it is a decision on the record
+      // rather than an accident: no element in the cell carries the raw text.
+      const { container } = renderCell('date', 'not-a-date');
+      const titled = [...container.querySelectorAll('[title]')].map((el) => el.getAttribute('title'));
+      expect(
+        titled,
+        'date: the unformattable raw value must not survive as a hover hint on an affordance that cannot show one',
+      ).not.toContain('not-a-date');
+    });
+
+    it('THE DEFECT — a due-like unparsable value is not painted red either', () => {
+      // `isOverdue` compared an Invalid Date, which is never `<` anything, so
+      // the colour never fired — but a repair that kept the span alive could
+      // resurrect it. There is no overdue-ness in a value with no instant.
+      const { container } = renderCell('date', 'not-a-date', { name: 'due_date' });
+      expect(
+        container.querySelector('.text-red-600'),
+        'due_date: an unparsable value states no deadline, so nothing is overdue',
+      ).toBeNull();
+      expectAffordance(container, 'due_date holding an unparsable value');
+    });
+  });
+
+  describe('LIVE CONTROL — `datetime`, the sibling this card matches (green BEFORE the change, and after)', () => {
+    for (const value of UNPARSABLE) {
+      it(`LIVE CONTROL — \`datetime\` holding ${JSON.stringify(value)} already answered with the affordance`, () => {
+        const { container } = renderCell('datetime', value);
+        expect(
+          handRolledDashes(container).length,
+          `datetime holding ${JSON.stringify(value)}: the sibling has never drawn a bare dash`,
+        ).toBe(0);
+        expectAffordance(container, `datetime holding ${JSON.stringify(value)}`);
+      });
+    }
+
+    it('THE AGREEMENT — the two siblings answer the identical input with the identical DOM', () => {
+      // Measured, not asserted: same command shape, same fixture, and the
+      // rendered markup of the two cells compared directly.
+      const dateCell = renderCell('date', 'not-a-date');
+      const dateHtml = dateCell.container.innerHTML;
+      cleanup();
+      const dateTimeCell = renderCell('datetime', 'not-a-date');
+      expect(
+        dateHtml,
+        '`date` and `datetime` must now render the same answer for the same unparsable input',
+      ).toBe(dateTimeCell.container.innerHTML);
+    });
+
+    it('LIVE CONTROL (liveness) — `datetime` holding a real instant still draws its value span', () => {
+      // Refuses a harness that renders nothing: every absence assertion above
+      // would pass against an empty container, and this one would not.
+      const { container } = renderCell('datetime', '2024-07-04T07:00:00.000Z');
+      const span = container.querySelector('span.tabular-nums');
+      expect(span, 'datetime: a real instant must still draw its value span').not.toBeNull();
+      expect(span?.textContent, 'datetime: a real instant must render a formatted value').toMatch(/2024/);
+      expect(affordance(container), 'datetime: a real instant must NOT render the affordance').toBeNull();
+    });
+  });
+
+  describe('POPULATED — these refuse an EMPTY-for-everything implementation', () => {
+    it('POPULATED — a real ISO date still renders in its value span, and KEEPS its `title`', () => {
+      // The half arm 1 does not touch. The hover hint is discarded only on the
+      // branch whose span is gone; a parseable value keeps the ISO instant.
+      const { container } = renderCell('date', '2024-01-15T00:00:00.000Z', { format: 'short' });
+      const span = container.querySelector('span.tabular-nums');
+      expect(span, 'date: a real date must still draw its value span').not.toBeNull();
+      expect(span?.textContent, 'date: a real date must render a formatted value').toMatch(/24/);
+      expect(span?.getAttribute('title'), 'date: a real date keeps its ISO hover hint').toBe(
+        '2024-01-15T00:00:00.000Z',
+      );
+      expect(handRolledDashes(container).length, 'date: a real date draws no dash').toBe(0);
+      expect(affordance(container), 'date: a real date must NOT render the affordance').toBeNull();
+    });
+
+    it('POPULATED — a past due_date is still "Overdue Nd" in red', () => {
+      const past = new Date();
+      past.setDate(past.getDate() - 6);
+      const { container } = renderCell('date', past.toISOString(), { name: 'due_date' });
+      const span = container.querySelector('span.tabular-nums');
+      expect(span?.textContent, 'due_date: a real past date must still read Overdue').toMatch(/Overdue/);
+      expect(span?.className, 'due_date: a real past date must still be red').toMatch(/text-red-600/);
+      expect(affordance(container), 'due_date: a real past date must NOT render the affordance').toBeNull();
+    });
+  });
+
+  describe('THE BOUNDARY — the guard is co-extensive with the dash it replaces, never wider', () => {
+    it('THE BOUNDARY — a numeric epoch timestamp still renders (the guard must not stringify)', () => {
+      // `coerceToSafeValue` returns a number unchanged, and `new Date(number)`
+      // is valid while `new Date(String(number))` is NOT. A guard written on
+      // `String(safe)` would blank a column that renders today — this row is
+      // what catches that.
+      const { container } = renderCell('date', 1700000000000, { format: 'short' });
+      const span = container.querySelector('span.tabular-nums');
+      expect(span, 'date: a numeric timestamp must still draw its value span').not.toBeNull();
+      expect(span?.textContent, 'date: a numeric timestamp must render a formatted value').toMatch(/23/);
+      expect(affordance(container), 'date: a numeric timestamp must NOT render the affordance').toBeNull();
+    });
+
+    it('THE BOUNDARY — a `Date` instance still renders (it coerces to a parseable ISO string)', () => {
+      const { container } = renderCell('date', new Date('2024-01-15T00:00:00.000Z'), { format: 'short' });
+      const span = container.querySelector('span.tabular-nums');
+      expect(span, 'date: a Date instance must still draw its value span').not.toBeNull();
+      expect(span?.getAttribute('title'), 'date: a Date instance keeps its ISO hover hint').toBe(
+        '2024-01-15T00:00:00.000Z',
+      );
+      expect(affordance(container), 'date: a Date instance must NOT render the affordance').toBeNull();
+    });
+
+    it('THE BOUNDARY — the coerced-EMPTY inputs objectui#8490 swept still land on the same affordance', () => {
+      // The seam with the neighbouring card: `[]`, `''` and whitespace were
+      // already routed here, and this change must not move them anywhere else.
+      for (const value of [[], '', '   '] as const) {
+        const { container } = renderCell('date', value);
+        expect(
+          handRolledDashes(container).length,
+          `date holding ${JSON.stringify(value)}: objectui#8490's routing is unchanged`,
+        ).toBe(0);
+        expectAffordance(container, `date holding ${JSON.stringify(value)}`);
+        cleanup();
+      }
+    });
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -888,6 +888,33 @@ export function DateCellRenderer({ value, field }: CellRendererProps): React.Rea
   // `''`, whose own em-dash is a bare punctuation mark with no accessible
   // name (objectui#8490). The shared affordance says "No value" instead.
   if (isBlankCellText(safe)) return <EmptyValue />;
+
+  // An UNPARSABLE value reaches the same affordance (objectui#8581), and the
+  // guard is spelled EXACTLY as `DateTimeCellRenderer`'s one function down —
+  // the nearest sibling, answering the identical input, which has returned
+  // `<EmptyValue />` for it all along. Before this, `not-a-date` fell through
+  // to `formatDate`, whose own hand-rolled em-dash is a bare punctuation mark
+  // to a screen reader: no `data-slot` of `empty-value`, no accessible name.
+  // That is the objectui#8475 / objectui#8491 class of defect, and #8490
+  // already routed this renderer's coerced-EMPTY input (the line above) to
+  // the shared affordance while deliberately leaving this input for a card.
+  //
+  // Two renderers for the same data family disagreeing about the same input
+  // is the shape this repo keeps paying for, so the closer neighbour is
+  // authoritative. The cost is declared: the raw string was reachable on
+  // hover through the `title` below, and the invalid branch no longer draws
+  // that span. Measured before the change (objectui#8581): nothing in this
+  // repo reads that `title` — no test, no selector, no export path; the only
+  // occurrences of `isoString` are its assignment and its one use. A
+  // PARSEABLE value keeps its `title` unchanged.
+  //
+  // `new Date(safe)` reproduces `formatDate`'s own parse exactly (it receives
+  // `safe`, and `coerceToSafeValue` never returns a `Date`), so this branch
+  // is co-extensive with the dash it replaces — never wider. In particular a
+  // numeric timestamp stays a number through the coercion and still renders.
+  const date = safe != null ? new Date(safe as string | number) : null;
+  if (date === null || isNaN(date.getTime())) return <EmptyValue />;
+
   const dateField = field as any;
   const style = dateField.format || 'relative';
 
@@ -900,17 +927,14 @@ export function DateCellRenderer({ value, field }: CellRendererProps): React.Rea
     /(^|_)(due|deadline|expires?|expiry|expiration|expected_close|target_close|sla|return_by|renewal|next_action)(_|$)/.test(fieldName);
   const formatted = formatDate(safe as string | Date, style, { dueLike, locale, t });
 
-  const date = safe != null ? new Date(safe as string | number) : null;
-  const isValidDate = date !== null && !isNaN(date.getTime());
   const startOfToday = new Date();
   startOfToday.setHours(0, 0, 0, 0);
-  const isOverdue = dueLike && isValidDate && date! < startOfToday;
-  const isoString = isValidDate ? date!.toISOString() : String(safe);
+  const isOverdue = dueLike && date < startOfToday;
 
   return (
     <span
       className={`tabular-nums${isOverdue ? ' text-red-600' : ''}`}
-      title={isoString}
+      title={date.toISOString()}
     >
       {formatted}
     </span>


### PR DESCRIPTION
Fixes #8581

## What changed

`DateCellRenderer` (`packages/fields/src/index.tsx`) now returns the shared `EmptyValue` for any value it cannot parse, instead of handing it to `formatDate` and wrapping that formatter's own em-dash in a `tabular-nums` SPAN. A `date` column holding `not-a-date` used to paint naked punctuation: no `data-slot` of `empty-value`, no accessible name — the objectui#8475 / objectui#8491 class of defect. objectui#8490 routed this renderer's coerced-EMPTY input (`[]`, `''`, whitespace) to the shared affordance and left this input, the other one reaching the same dash, to this card.

The guard is spelled **exactly** as `DateTimeCellRenderer`'s, one function down in the same barrel — `arm 1`, on nearest-sibling parity, per the seat's ruling on the card. Arm 2 (print `String(safe)`, as the number/percent family does on its NaN branch) is recorded in the test's header as a real argument that lost on precedent, not as a mistake.

Three files: the renderer, a new pin, and one sibling pin that this change was required to move (below).

## Zone 2 — both assumptions measured before implementing

**前提: the `title` hint on that SPAN has no consumer — HOLDS.** Searched for `ByTitle` queries, `[title=...]` selectors, `getAttribute('title')` reads, snapshot files, e2e specs and export paths. Zero read this `title`; `isoString` occurs only at its assignment and its one use. **Lit controls on the same command shapes**: `getAttribute('title')` returns 33 hits elsewhere in the tree and `getAttribute('data-slot')` returns 10, so the zero is a reading. One earlier search shape (`git grep -- 'packages/*/src'`) returned a false zero because wildcards do not prefix-match in a git pathspec; it was re-run against literal directories with a control before anything was concluded from it.

Note the cost is narrower than the card assumed: arm 1 removes the SPAN only on the invalid branch, so a **parseable** value keeps its ISO `title` untouched. That half is pinned.

**Assumption: the fix belongs at the renderer, not in `formatDate` — HOLDS.** Enumerated, as the card required: the shared `formatDate` from `@object-ui/core` has nine other call sites, and every one is a **string** consumer with no `EmptyValue` to return —

| call site | renders today for an unparsable value |
|---|---|
| `plugin-grid` `ObjectGrid.tsx:4416` (date column) | the dash inside its own `tabular-nums` span |
| `plugin-grid` `ObjectGrid.tsx:4639` (mobile card, `'short'`) | the dash as card text |
| `plugin-gantt` `ObjectGantt.tsx:920` / `:927` (tooltip / bar label) | the dash as tooltip text |
| `fields` `widgets/DateField.tsx:35` (read-mode field) | the dash (it has its own `EmptyValue` for empty, not for unparsable) |
| `fields` `widgets/FormulaField.tsx:40` | the dash as the formula's display value |
| `fields` `widgets/GridField.tsx:375` | the dash in a grid cell |
| `fields` `widgets/lookupColumnDisplay.tsx:239` (`$date` wrapper) | the dash in the picker table |
| `core` `utils/dataset-format.ts:192` (measure) | `undefined` — it pre-checks with `Date.parse` and never reaches the dash |
| `components` `renderers/complex/data-table.tsx:789` | the dash in a timestamp column |

Two landed pins also assert that return string directly: `core`'s `date-display.optionsStyle-7745.test.ts:183` (`formatDate('not a date', …)` is `'—'`) and this package's `date-formatter-residue-4272.test.ts:118` (the `datetime` twin). Moving the dash at its source would change eight faces and break two pins to fix one cell, so the renderer intercept is the honest repair. It is also **co-extensive** with the dash it replaces: `formatDate` receives `safe`, `coerceToSafeValue` never returns a `Date`, so `new Date(safe)` reproduces the formatter's own parse exactly — never wider.

## Zone 3 — the pin, and the live control

`packages/fields/src/__tests__/dateCell.unparsableValue-8581.test.tsx` pins the rendered DOM, not the formatter's return string:

- **THE DEFECT** (4 unparsable fixtures, each verified against V8 first): no `span.tabular-nums`, no em-dash outside `[data-slot="empty-value"]`, and the affordance present **with its accessible name** (`aria-label="No value"`). Plus: the raw value no longer survives as a hover hint, and a due-like unparsable value is not painted red.
- **LIVE CONTROL** — `DateTimeCellRenderer` is driven through the *same* `renderCell` command shape on the *same* fixtures, so "the two siblings now agree" is measured. `THE AGREEMENT` compares the two cells' rendered markup directly. A populated `datetime` row is the liveness half: a harness that rendered nothing would pass every absence assertion in the file and fail that one.
- **POPULATED / BOUNDARY** — a real ISO date still renders its formatted face **and keeps its ISO `title`**; a past `due_date` is still "Overdue Nd" in red; a numeric epoch timestamp still renders (a guard written on `String(safe)` would blank it, since `new Date('1700000000000')` is invalid while `new Date(1700000000000)` is not); a `Date` instance still renders; objectui#8490's coerced-empty routing is unchanged.

## One sibling pin moved, by its own instruction

`cellRenderers.objectLiteral-8596.test.tsx` deliberately recorded `date` holding `{}` as a dash that is NOT the affordance, and stated that a fix landing on this renderer "would have to move a pin rather than pass silently". It did — `{}` coerces to `[Object]`, which `new Date` rejects — so its census row and its BOUNDARY case were updated to record the landing. That is the only edit outside the renderer and the new pin, and it is exactly the behaviour that file asked for.

## Reverse verification (one-shot, restored)

Run from the committed fix, twice, each leg proving the mutation reached disk by blob hash before reading any result, each with a `trap … EXIT INT TERM` restore.

**Leg 1 — remove only the new guard** (`git hash-object`: `11bff01c…` → `e86cfcc3…`, guard occurrences 2 → 1, `datetime`'s intact). Direction observed: **not the predicted plain red** — the tests failed with `RangeError: Invalid time value` from the now-unconditional `title={date.toISOString()}`. Reported as observed; because it is a crash rather than the real pre-fix tree, a second leg was run.

**Leg 2 — the genuine pre-fix renderer**, `packages/fields/src/index.tsx` at the merge base `0e3bca45d` (blob `febc56d9…` verified on disk). **7 failed | 10 passed (17).** The DEFECT rows fail on the intended first sentence —

```
AssertionError: date holding "not-a-date": the value span must not be drawn around a value
the renderer cannot format: expected SPAN.tabular-nums to be null
```

(The received element is written in words — `SPAN.tabular-nums` — because tag-shaped fragments are eaten from GitHub bodies, backticks included.)

— and the `title` row fails as `expected [ 'not-a-date' ] to not include 'not-a-date'`, direct evidence the unfixed tree really did smuggle the raw value into a hover hint. **All four `datetime` LIVE CONTROL rows and every POPULATED / BOUNDARY row stayed GREEN** under both legs: the control is a control, and the harness renders. The only LIVE CONTROL failure is `THE AGREEMENT`, which is the sibling disagreement itself.

Restored both times with `git checkout HEAD -- PATH` (never bare), verified by `git diff HEAD` empty **and** worktree blob `11bff01c…` equal to the HEAD blob. No ablation artefact remains.

## Verification

All heavy runs through the shared verify lock; verdicts read from the lock's own `VERDICT command-exit` line.

| run | result |
|---|---|
| `pnpm exec vitest run packages/fields/` (final tree) | **150 files / 2563 tests passed** — `VERDICT command-exit 0` |
| `pnpm --filter @object-ui/fields type-check` (`tsc --noEmit` + `tsconfig.test.json`) | **exit 0** |
| downstream date consumers: `plugin-detail` ×2, `plugin-grid` ×2, `core` date-display + dataset-format | **6 files / 44 tests passed** |
| `node scripts/check-changeset-presence.mjs` | ✅ 1 source file of 1 released package, 1 changeset declared |
| `node scripts/check-governed-queue-guard.mjs --test THREE-PATHS` | ✅ **NOT GOVERNED** — lit control `AGENTS.md` fired ⛔ GOVERNED (exit 3), so the reading holds |
| `pnpm exec eslint . --no-inline-config --format json` | **4637 files linted, 0 errors in all three changed files**; the 94 repo-wide errors sit in 78 files this diff does not touch |

The first `type-check` run reported `Cannot find module '@object-ui/*'` — **NOT MEASURED**, not red: the dependency closure was unbuilt. Re-run after `pnpm --workspace-concurrency=2 --filter '@object-ui/fields^...' build`, it is exit 0.

CI is the authority on the full farm; this report is written at PR-open time and does not wait for it.

## 维护者速读(草稿)

**改了什么。** `date` 列遇到无法解析的值(例如 `not-a-date`)时,不再画 `formatDate` 自己那个光秃秃的破折号,而是渲染共享的 `EmptyValue`(读屏软件读作 "No value")。写法与一函数之下的 `DateTimeCellRenderer` **逐字一致** —— 那个姐妹渲染器一直就是这么答同一个输入的。

**为什么改。** 无名可读的裸标点是缺陷,objectui#8475、objectui#8491 已经就这一类定过性;objectui#8490 修掉了同一渲染器的「空数组」入口,故意把这一个入口留给本卡。同一数据族的两个渲染器对同一输入各说各话,是这个仓反复付账的形状。

**风险与代价(含回滚)。** 代价只有一处、已实测:无法解析时,原先挂在 span `title` 上、鼠标悬停可见的原始字符串没有了 —— 全仓无任何读者(带对照的搜索)。**能解析的值一律不受影响**:同样的显示面、同样的逾期红色、同样的 ISO `title`,数字时间戳照常渲染。风险面只有 `@object-ui/fields` 一个包一个函数;回滚就是 revert 本 PR,无数据迁移、无契约变更。共享格式化函数 `formatDate` **没动**(它还有九个调用点),这是刻意的。

**席位意见。** _(留空,待席位定稿)_

**你要做的。** 确认「无法解析 = 无值」这个口径可接受 —— 另一条路(arm 2:把原始文本照原样打出来)已在测试文件头部留档,它的理由是「记录里确实存了东西,说 No value 并不诚实」。若倾向那条路,本 PR 的测试结构可直接改判,不必推倒。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH)_