### PR TITLE
fix(console): render the public form's authored title and description (objectui#8408)

### DIFF
--- a/.changeset/8408-public-form-title-description.md
+++ b/.changeset/8408-public-form-title-description.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/console': patch
+---
+
+Public form `/f/:slug` renders its authored `title` and `description` instead of the
+object API name (objectui#8408).
+
+The one Console surface an **unauthenticated** visitor sees greeted them with a
+database table name. `GET /api/v1/forms/:slug` serves the authored copy intact
+(`{"object":"ats_inquiry","form":{"title":"Apply","description":"…"}}`), and the page
+rendered `ats_inquiry` as its `<h1>` with nothing at all where the description belongs.
+Found taking release screenshots of a real app on this Console (ats#59), in a real
+browser, in both `en-US` and `zh-CN`.
+
+Two independent read-side defects, one payload, no server change:
+
+- **`loadPublicForm`'s fallback chain** was `payload.label ?? payload.form?.label ??
+  payload.object`, and every arm missed but the last. The public resolver sends no
+  envelope `label`, and `form.label` is a key `@objectstack/spec`'s `FormViewSchema`
+  **rejects** (`unrecognized_keys`) — a form config carries `title`. So the one real,
+  typed, populated key naming the form was the only one never read. `form.title` now
+  sits ahead of the API-name arm, and ahead of the rejected `form.label` spelling so
+  that key can never outrank it. `payload.label` keeps its precedence: the fallback
+  ORDER changed, not which value wins where one already did.
+- **The subtitle slot** read `form.label` guarded by `form.label !== loaded.label`, a
+  predicate that was **dead** on this route in both directions — with no `payload.label`
+  the two operands are the same value, and with one `form.label` is undefined. It now
+  renders the form's `description`, which arrives in the payload untouched and which the
+  whole file previously never read once.
+
+Section labels on this route are still rendered raw; that is a separate seam, tracked
+on its own card.

--- a/apps/console/src/components/FormPage.publicHeading.test.tsx
+++ b/apps/console/src/components/FormPage.publicHeading.test.tsx
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#8408 — the public form `/f/:slug` renders its authored `title` and
+ * `description`, not the object API name.
+ *
+ * ## What this reproduces, in the DOM
+ *
+ * The card was found taking release screenshots of a real app on this Console
+ * (`objectstack-ai/ats`, ats#59): a member of the public opening the one
+ * anonymous Console surface was greeted by a database table name.
+ * `GET /api/v1/forms/apply` served the authored copy intact —
+ * `{"object":"ats_inquiry","form":{"title":"Apply","description":"…"}}` — and
+ * the page rendered `ats_inquiry` as its `<h1>` and nothing at all where the
+ * description belongs. The fixture below IS that payload.
+ *
+ * Two independent reads were broken, and each leg here is written against the
+ * one that a half-fix leaves standing:
+ *
+ *   1. `loadPublicForm`'s chain was `payload.label ?? payload.form?.label ??
+ *      payload.object`. Every arm missed but the last: this endpoint sends no
+ *      envelope `label`, and `form.label` is a key `@objectstack/spec`'s
+ *      `FormViewSchema` REJECTS (`unrecognized_keys`) — a form config says
+ *      `title`. So the one real, typed, populated key naming the form was the
+ *      only one never read.
+ *   2. The subtitle slot read `form.label` under `form.label !== loaded.label`,
+ *      which is DEAD on this route in BOTH directions (no `payload.label` =>
+ *      `loaded.label` IS `form.label` => inequality false; `payload.label`
+ *      present => `form.label` undefined). `description` had exactly one
+ *      occurrence in the whole 2 000-line file, inside a prose comment.
+ *
+ * ## ⭐ Which leg discriminates, said out loud
+ *
+ * `HEADING_IS_THE_AUTHORED_TITLE` alone does NOT close this card: a fix that
+ * adds a `title` arm to the chain and leaves the dead subtitle predicate
+ * standing satisfies it completely, and the author's sentence stays on the
+ * floor. `DESCRIPTION_REACHES_THE_DOM` is the leg that fails under that
+ * half-fix — it is the one that judges the predicate REPLACEMENT the card
+ * asked for rather than a second condition stacked beside it.
+ *
+ * Conversely `DESCRIPTION_REACHES_THE_DOM` alone is satisfied by a renderer
+ * that prints the description and still titles the page `ats_inquiry`. The two
+ * legs are independent defects and neither subsumes the other, so both are
+ * asserted against concrete authored strings, never against "something
+ * non-empty".
+ *
+ * `API_NAME_IS_NOWHERE_IN_THE_HEADER` is the third: it fails a fix that adds
+ * the title while leaving the API name rendered somewhere beside it, which no
+ * presence assertion can see.
+ *
+ * ## ⛔ What this file does NOT pin, on purpose
+ *
+ * i18n. The section heading is still rendered raw on this route and this card
+ * does not change that — it is the second seam, tracked separately, and
+ * asserting a translated string HERE would assert it on a harness rather than
+ * on the route (`useSafeFieldLabel` degrades to identity functions instead of
+ * throwing, so such an assertion can pass without measuring anything). The
+ * legs below are all server-supplied strings, which is exactly what this route
+ * renders today and after this card.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { FormPage } from './FormPage';
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+// ─── Fixture — the card's own payload ─────────────────────────────────────
+
+/** The authored title, verbatim from the served `/api/v1/forms/apply` body. */
+const TITLE = 'Apply';
+/** The authored description, verbatim from the same body. */
+const DESCRIPTION = 'Tell the employer who you are. They will be in touch through the platform.';
+/** The object API name — what the public page rendered as its `<h1>` before this card. */
+const API_NAME = 'ats_inquiry';
+
+const INQUIRY_SCHEMA = {
+  name: API_NAME,
+  label: 'Inquiry',
+  fields: {
+    full_name: { type: 'text', label: 'Full Name', required: true },
+    email: { type: 'text', label: 'Email', required: true },
+  },
+};
+
+/** The form config as authored — `title`/`description`, and NO `label`. */
+const APPLY_FORM = {
+  type: 'simple',
+  columns: 1,
+  title: TITLE,
+  description: DESCRIPTION,
+  sections: [{ name: 'apply', label: 'Your application', fields: ['full_name', 'email'] }],
+};
+
+interface Route_ { method?: string; match: string; body?: unknown }
+
+function stubFetch(routes: Route_[]) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const route = routes.find(
+      (r) => (r.method ?? 'GET').toUpperCase() === method && String(url).includes(r.match),
+    );
+    if (!route) throw new Error(`unstubbed fetch: ${method} ${url}`);
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => route.body,
+      text: async () => JSON.stringify(route.body),
+    } as unknown as Response;
+  });
+}
+
+/**
+ * Render the PUBLIC route over a served payload.
+ *
+ * The payload is passed whole rather than assembled from parts: which keys the
+ * resolver DOES and does NOT send is the entire subject of this card, so a
+ * helper that always filled in a `label` would have hidden the defect the same
+ * way the code did.
+ */
+function renderPublic(payload: Record<string, unknown>) {
+  vi.stubGlobal('fetch', stubFetch([{ match: '/forms/apply', body: payload }]));
+  return render(
+    <MemoryRouter initialEntries={['/f/apply']}>
+      <Routes>
+        <Route path="/f/:slug" element={<FormPage mode="public" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/** The payload the real resolver serves: no envelope `label`, no `form.label`. */
+const SERVED = {
+  slug: 'apply',
+  object: API_NAME,
+  form: APPLY_FORM,
+  objectSchema: INQUIRY_SCHEMA,
+};
+
+/**
+ * Harness-kill leg. Fires in BOTH directions — a form that never loaded and a
+ * form drawn twice — so neither can be read as a content result. Its message is
+ * unlike every content assertion in this file on purpose: a harness death must
+ * never be counted as a defect detection when the ablation legs are classified.
+ */
+async function liveHeader(): Promise<HTMLElement> {
+  await waitFor(() => expect(screen.getByLabelText(/Full Name/)).toBeInTheDocument());
+  const headers = document.body.querySelectorAll('header');
+  if (headers.length !== 1) {
+    throw new Error(`HARNESS DEAD 8408: expected exactly 1 header, found ${headers.length}`);
+  }
+  const h1s = headers[0].querySelectorAll('h1');
+  if (h1s.length !== 1) {
+    throw new Error(`HARNESS DEAD 8408: expected exactly 1 h1, found ${h1s.length}`);
+  }
+  return headers[0] as HTMLElement;
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('objectui#8408 — public form heading and description', () => {
+  it('HEADING_IS_THE_AUTHORED_TITLE — the h1 is "Apply", not the object API name', async () => {
+    renderPublic(SERVED);
+    const header = await liveHeader();
+
+    expect(header.querySelector('h1')?.textContent).toBe(TITLE);
+    expect(header.querySelector('h1')?.textContent).not.toBe(API_NAME);
+  });
+
+  it('DESCRIPTION_REACHES_THE_DOM — the authored sentence renders under the heading', async () => {
+    renderPublic(SERVED);
+    const header = await liveHeader();
+
+    // Read out of the HEADER, not the document: "the string exists somewhere on
+    // the page" would also be satisfied by a title attribute or an aria label,
+    // and the card is about the subtitle SLOT beneath the heading.
+    const subtitle = header.querySelector('h1 ~ p');
+    expect(subtitle?.textContent).toBe(DESCRIPTION);
+  });
+
+  it('API_NAME_IS_NOWHERE_IN_THE_HEADER — the table name is not rendered beside the title', async () => {
+    renderPublic(SERVED);
+    const header = await liveHeader();
+
+    expect(header.textContent).toContain(TITLE);
+    expect(header.textContent).not.toContain(API_NAME);
+  });
+
+  it('ENVELOPE_LABEL_STILL_WINS — an identity label, when one is sent, keeps its precedence', async () => {
+    // The card changed the fallback ORDER, not which value wins where one
+    // already did. This leg is the fence on that: a fix that hoisted
+    // `form.title` above `payload.label` would silently retitle every surface
+    // that does send an envelope label.
+    renderPublic({ ...SERVED, label: 'Careers — application' });
+    const header = await liveHeader();
+
+    expect(header.querySelector('h1')?.textContent).toBe('Careers — application');
+    // …and the subtitle is driven by `description`, so it renders on this
+    // branch too. Under the pre-fix predicate (`form.label !== loaded.label`)
+    // it could not: `form.label` is undefined here.
+    expect(header.querySelector('h1 ~ p')?.textContent).toBe(DESCRIPTION);
+  });
+
+  it('NO_TITLE_STILL_FALLS_BACK — a form with neither title nor label keeps the API name', async () => {
+    // The no-widening control. This card adds one arm to a fallback chain; it
+    // does not change what happens when every arm legitimately misses, and a
+    // renderer that started printing something else there would be a different
+    // change than the one that was ruled.
+    const { title, description, ...untitled } = APPLY_FORM;
+    void title;
+    void description;
+    renderPublic({ ...SERVED, form: untitled });
+    const header = await liveHeader();
+
+    expect(header.querySelector('h1')?.textContent).toBe(API_NAME);
+    expect(header.querySelector('h1 ~ p')).toBeNull();
+  });
+});

--- a/apps/console/src/components/FormPage.tsx
+++ b/apps/console/src/components/FormPage.tsx
@@ -1177,7 +1177,34 @@ async function loadPublicForm(slug: string): Promise<LoadedForm> {
   }
   const payload = (await res.json()) as PublicFormPayload;
   return {
-    label: payload.label ?? payload.form?.label ?? payload.object,
+    // objectui#8408 — `payload.form?.title` sits AHEAD of the API-name arm.
+    //
+    // Every arm of the pre-fix chain (`payload.label ?? payload.form?.label ??
+    // payload.object`) missed but the last one against what this endpoint
+    // actually serves, so the one Console surface an anonymous visitor sees
+    // greeted them with the database table name — `ats_inquiry` where the
+    // author wrote "Apply". Neither of the first two arms is reachable here:
+    //
+    //   • `payload.label` is the VIEW's identity label, carried on the
+    //     envelope; the public resolver does not send it (it is optional on
+    //     {@link PublicFormPayload} and absent from the served body).
+    //   • `payload.form.label` is reachable only on a FLATTENED runtime
+    //     overlay, where the identity and the config share one object
+    //     (`VIEW_METADATA_MEMBERS.formOverlay`). This endpoint returns the
+    //     config alone, and a form config carries `title`, NOT `label` —
+    //     `FormViewSchema` REJECTS that key outright (`unrecognized_keys`),
+    //     as the {@link FormViewBody} note above and `form-spec.ts` both
+    //     record.
+    //
+    // So the ONE real, typed, populated key naming this form was the only one
+    // never read. It is read now, and read BEFORE `form.label` because it is
+    // the spec-legal spelling of the same intent — the rejected key must never
+    // be able to outrank it (AGENTS.md #0.1).
+    //
+    // `payload.label` keeps its precedence: when an envelope identity label
+    // does arrive it is a deliberate per-view name, and this card changed the
+    // fallback ORDER, not which value wins where one already did.
+    label: payload.label ?? payload.form?.title ?? payload.form?.label ?? payload.object,
     object: payload.object,
     form: payload.form,
     objectSchema: payload.objectSchema,
@@ -1926,8 +1953,34 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
     <div className="mx-auto max-w-2xl p-4 sm:p-6">
       <header className="mb-6">
         <h1 className="text-xl font-semibold">{loaded.label}</h1>
-        {loaded.form?.label && loaded.form.label !== loaded.label && (
-          <p className="mt-1 text-sm text-muted-foreground">{loaded.form.label}</p>
+        {/*
+          * objectui#8408 — the subtitle slot renders the form's `description`.
+          *
+          * It used to read `loaded.form.label`, guarded by
+          * `loaded.form.label !== loaded.label`, and that predicate was DEAD
+          * on the public route rather than merely selective — both branches
+          * were pushed through:
+          *
+          *   • `payload.label` absent  -> `loaded.label` IS `form.label`, so
+          *     the inequality is false;
+          *   • `payload.label` present -> `form.label` is undefined, so the
+          *     first conjunct is false.
+          *
+          * Neither renders, which is why replacing the predicate is the fix
+          * and adding a second condition beside it would not have been.
+          *
+          * `description` is what a form config actually carries next to
+          * `title` (the same contract that REJECTS `label`), it arrives in the
+          * payload untouched, and before this card the whole file never read
+          * it once — the author's sentence explaining the form to an
+          * anonymous visitor was fetched and dropped on the floor.
+          *
+          * No inequality guard: `description` and the heading are different
+          * keys saying different things, so equality between them is the
+          * author's business, not this renderer's.
+          */}
+        {loaded.form?.description && (
+          <p className="mt-1 text-sm text-muted-foreground">{loaded.form.description}</p>
         )}
       </header>
       <form onSubmit={handleSubmit} className="space-y-6">


### PR DESCRIPTION
Fixes #8408

Seam 1 only, per the PM ruling on that card (comment 5600634119): the read-side **key choice**. Defect 3 (i18n) is **not** in this PR; it is filed as **#8813**, carrying the measurement the ruling asked for — see "Seam 2" below.

## What was wrong

`/f/:slug` is the one Console surface an unauthenticated member of the public sees, and it greeted them with a database table name. `GET /api/v1/forms/apply` serves the authored copy intact:

```json
{"slug":"apply","object":"ats_inquiry","form":{"type":"simple","columns":1,
 "title":"Apply","description":"Tell the employer who you are. They will be in touch through the platform.",
 "sections":[{"name":"apply","label":"Your application"}]}}
```

Two independent read-side defects, one payload, no server change.

**1. The fallback chain read a key the spec rejects.** `loadPublicForm` had

```ts
label: payload.label ?? payload.form?.label ?? payload.object,
```

and every arm missed but the last. `payload.label` is the view's identity label, carried on the envelope, and this resolver does not send it. `payload.form.label` is reachable only on a flattened runtime overlay (`VIEW_METADATA_MEMBERS.formOverlay`), a shape this endpoint does not return — and a form config carries `title`, not `label`: `FormViewSchema` **rejects** that key outright (`unrecognized_keys`), which this repo already records in this same file and in `packages/app-shell/src/views/metadata-admin/form-spec.ts`. So the one real, typed, populated key naming the form was the only one never read.

`payload.form?.title` now sits ahead of the API-name arm — and ahead of the rejected `form.label` spelling, so the key the contract refuses can never outrank the key it defines (AGENTS.md #0.1). `payload.label` keeps its precedence: this card changed the fallback **order**, not which value wins where one already did.

**2. `description` was fetched and dropped.** The subtitle slot read `form.label` under `form.label !== loaded.label`. That predicate is **dead** on this route, not merely selective, and both branches were pushed through: with no `payload.label` the two operands are the same value, so the inequality is false; with one, `form.label` is undefined. Neither renders. So it is **replaced**, not stacked on — a second condition beside it would have left the author's sentence on the floor exactly as before. Before this PR `description` occurred twice in 2 017 lines, both times inside prose comments.

## Tests

New: `apps/console/src/components/FormPage.publicHeading.test.tsx` (5 legs), fixture is the card's own payload.

The two content legs are independent and neither subsumes the other, which is stated in the file: `HEADING_IS_THE_AUTHORED_TITLE` alone is fully satisfied by a fix that adds a `title` arm and leaves the dead subtitle predicate standing; `DESCRIPTION_REACHES_THE_DOM` is the leg that judges the **replacement**. `NO_TITLE_STILL_FALLS_BACK` is the no-widening control and is green on both sides of the fix on purpose.

### Reverse verification — three legs, each proving the mutation reached disk before any result was read

Every leg: mutate, prove arrival on disk (exact-occurrence anchor counts plus `git hash-object` against the HEAD blob), run, restore with `git checkout HEAD -- path`, prove the restore by blob equality and an empty `git diff HEAD`. HEAD blob `8bd70df36818c4840d8b996eae8deef3c03898be` throughout.

**Leg A — the arm the ruling named.** Drop `payload.form?.title` from the chain.
On disk: anchor 1 to 0, injected 0 to 1, blob to `bd475874bc3d`. Result:

```
Tests  2 failed | 3 passed (5)
  × HEADING_IS_THE_AUTHORED_TITLE — the h1 is "Apply", not the object API name
  × API_NAME_IS_NOWHERE_IN_THE_HEADER — the table name is not rendered beside the title
```

**Leg B — the dead predicate restored.** Put `form.label !== loaded.label` back, keeping the title fix. This is the leg that discriminates "replaced the predicate" from "added a title read and left the dead code standing".
On disk: anchor 1 to 0, injected 0 to 1, blob to `483511ca511c`. Result:

```
Tests  2 failed | 3 passed (5)
  × DESCRIPTION_REACHES_THE_DOM — the authored sentence renders under the heading
  × ENVELOPE_LABEL_STILL_WINS — an identity label, when one is sent, keeps its precedence
```

**Leg MAIN — the acceptance criterion, literally.** `git checkout origin/main -- FormPage.tsx`, so the file under test is today's `main` byte for byte.
On disk: blob equals `origin/main`'s `c31f2ca265be`, not HEAD's. Result:

```
Tests  4 failed | 1 passed (5)
```

The single leg surviving the MAIN run is `NO_TITLE_STILL_FALLS_BACK`, the no-widening control — which is what it is for. Each leg's restore was verified: restored blob equals the HEAD blob and `git diff HEAD` is empty. Leg B's first attempt was discarded and rerun: its anchor is multi-line and `grep -c` counts matching **lines**, so the arrival check read 6 for a string present once and the script refused to mutate. The counter now counts exact occurrences.

Ablation legs are one-off proofs; no ablation artefact is committed.

### Gates — each quoted from its own verdict line, all at `fd7dc851f`

| Gate | Verdict |
|:--|:--|
| dependency closure build (`@object-ui/console^...`) | `os-verify-lock: VERDICT command-exit 0` |
| `pnpm --filter @object-ui/console test` | `Test Files 96 passed (96)` / `Tests 1121 passed (1121)`, `VERDICT command-exit 0` |
| `pnpm --filter @object-ui/console type-check` | `VERDICT command-exit 0` (script echoed `tsc --noEmit && tsc -b tsconfig.node.json --force`) |
| `pnpm --filter @object-ui/console lint` | `✖ 212 problems (0 errors, 212 warnings)`, `VERDICT command-exit 0` — 0 of them in the changed files; `FormPage.tsx:1715` is pre-existing (`a439e1673`) |
| `pnpm --filter @object-ui/console build` | `VERDICT command-exit 0` |
| `check-governed-queue-guard --test` on the 3 changed paths | `✅ NOT GOVERNED — 3 path(s) checked against 5 governed surface(s); none matched.` (exit 0) |
| …its lit control, same command shape, `AGENTS.md` | `⛔ GOVERNED — 1 of 1 path(s) are on a governed surface` (exit 3) — so the verdict above is a reading, not an unfailable one |
| `check-changeset-presence` | `✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major` | `✅ No changeset declares a major bump.` |
| `check:control-bytes` | `✅ check-control-bytes: OK (scanned 7010 tracked text file(s); skipped 85 binary)` |
| `check:vi-mock-specifiers` / `check:vi-mock-inherit` | both `OK` |
| `check:unreferenced-sources` | `OK Every shipped source file in every covered package is reachable.` |
| `check:spec-symbols` | `✅ spec member citations: … nothing cites a key its spec symbol does not declare.` |
| `check:comment-mask-corpus` | `✓ … 1 disagree`, within the residue objectui#7882 holds open — unchanged by this PR |

Type-check coverage of the new test was **measured, not assumed**: `tsc --noEmit --listFiles` names `src/components/FormPage.publicHeading.test.tsx`.

## Seam 2 — the measurement this dispatch was asked to take

The ruling asked one question before seam 2 could be scoped, because `useSafeFieldLabel` degrades to identity functions rather than throwing: a reading that cannot fail is indistinguishable from a reading that passed.

> **Is `I18nProvider` actually mounted on the `/f/:slug` route?**

**Answer: YES.** Measured at runtime, with the probe standing in `FormPage`'s exact route position — `./FormPage` was mocked, so the element `App.tsx:215` renders for `/f/:slug` **is** the probe, and the real `App` and the real `main.tsx` wrapper were used as they ship. `useI18nContext()` throws outside a provider, which is what makes this reading capable of failing.

```
LIT CONTROL (discrimination): probe with no provider above it  -> NO
LIT CONTROL (positive):       probe under a bare I18nProvider  -> YES
SUBJECT:  real App at /f/:slug, wrapped as main.tsx wraps it   -> YES
CONTROL:  real App at /f/:slug with NO wrapper, same probe     -> NO
```

The fourth line is what makes the third one mean something: the YES is caused by the provider, not by anything inside `App`. Chain: `main.tsx:134-139` renders StrictMode, MobileProvider, `I18nProvider`, `App` unconditionally; `App.tsx:215` declares `/f/:slug` as a plain route inside that subtree; no nested root or portal in between.

So **mounting a provider is not seam 2's first work item** — the ruling's conditional does not fire. What remains for seam 2 is the structural precondition, re-verified on this tree: `buildSections` returns `{ label: sec.label, … }` and `RenderableSection` has no `name` member, so the `_sections.NAME.label` key cannot be constructed at the render site at all. Both facts are written into #8813.

## 验收备注

Observations recorded, not filed and not fixed here — each with the successor that will actually reach the code:

1. **`resolveInternalForm` never reads `form.title` either.** On `/forms/:name` a form whose envelope carries no `label` heads the page with the raw view **name**. Not the same defect: on that route the envelope label is the correct heading and the flattened-overlay `form.label` arm genuinely is reachable, so this is an inconsistency rather than a rejected-key read. Successor: #8813, which edits this same header render.
2. **The `payload.form?.label` arm survives in `loadPublicForm`.** It still names a key `FormViewSchema` rejects. Left standing deliberately: the ruling scoped this change to the chain's order, `form.title` now outranks it so it can never decide the heading, and its only reachable shape is one this repo cannot exercise — the resolver serving it lives outside this tree. Successor: #8813.
3. **`FormSectionSpec.description` is declared and still never rendered** (`form-spec.ts:259-260`). Same "authored value silently dropped" shape as defect 2, one level down. Not filed because it was not reproduced here — no failing probe is named for it. Successor: #8813, which touches `buildSections`, the function that would have to carry it.
4. **`FormPage.tsx:1715` — `setLoading(true)` called synchronously in an effect body**, one of the 212 pre-existing lint warnings. Untouched. Successor: none.

## 维护者速读(草稿)

**改了什么**
公开表单页 `/f/:slug` 的标题和副标题。以前访客看到的大标题是数据库表名 `ats_inquiry`,副标题是空的;现在是作者写的 "Apply",下面跟着作者写的那句说明。只动了两处读取逻辑,服务端一个字节没动,数据本来就已经完整送到了浏览器。

**为什么改**
这是整个 Console 里唯一一个**未登录的陌生人**会看到的页面。取标题的兜底链一路读到最后一根,而中间那两根在这条路由上永远取不到值:一根是服务端不发的,另一根是 `@objectstack/spec` 明确**拒收**的键(表单配置写 `title`,不写 `label`)。于是唯一真实存在、有类型、有值的那个键从来没被读过。副标题那段判断在这条路由上两个方向都推不出来,是死代码,所以是**换掉**而不是在旁边再加一个条件。

**风险与代价(含回滚)**
风险低。改动只在一个 app(`apps/console`)的读取侧,不碰服务端、不碰任何发布库的接口、不放宽任何校验。已发布行为的唯一变化就是这两个字符串开始显示。回滚成本 = revert 本 PR 的单个 commit `fd7dc851f`,无数据迁移、无 schema 变更、无缓存残留。已经带了 changeset(`@object-ui/console` patch)。
唯一需要留意的一点写在验收备注 2:那个被 spec 拒收的 `form.label` 兜底臂**没有删**,只是被排到 `title` 后面。删它需要服务端那边的证据,而服务端不在本仓。

**席位意见**
(留给 PM 席位)

**你要做的**
1. 看一眼标题的取值顺序是否符合预期:`payload.label`(视图身份标签,若服务端发了)→ `form.title`(作者写的表单标题)→ `form.label`(被拒收的拼写,保留但排最后)→ 对象 API 名(最后兜底)。如果你认为 `form.title` 应该压过 `payload.label`,这是唯一需要你拍板的地方。
2. 缝 2(i18n)已按裁决开成 #8813,并带上了那个决定性读数:`/f/:slug` 上 `I18nProvider` **是挂着的**,所以"先挂 provider"这项工作不存在;真正的障碍是 `buildSections` 丢掉了 `sec.name`。
3. 合并本 PR 时按普通 PR 走(守卫判定 NOT GOVERNED,已附对照)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH)_