### PR TITLE
docs(plugin-detail): write down why an untyped RelatedList column gets no cell (objectui#8477)

### DIFF
--- a/.changeset/olive-clouds-repeat.md
+++ b/.changeset/olive-clouds-repeat.md
@@ -1,0 +1,10 @@
+---
+---
+
+`RelatedList`: document at `makeCell`'s untyped-field guard why an untyped column
+gets no cell — and therefore no objectui#8459 placeholder — and why attaching a
+"minimal cell" there is not the shortcut it looks like (the data-table's no-cell
+branch applies `String()` and `formatCellValue()`, and a cell's return value goes
+straight to React, so an object value throws instead of rendering
+`[object Object]`). Comment only; no behaviour change, nothing to release. The
+successor that can actually close the gap is objectui#8817.

--- a/packages/plugin-detail/src/RelatedList.tsx
+++ b/packages/plugin-detail/src/RelatedList.tsx
@@ -971,6 +971,63 @@ export const RelatedList: React.FC<RelatedListProps> = ({
     // auto-derived path so a `status` column reads "Planned" (badge), never the
     // raw `planned`, regardless of how the columns were supplied.
     const makeCell = (key: string, def: any): ((value: any) => any) | undefined => {
+      // ⛔ A column whose field carries no `type` gets NO cell — and therefore
+      // none of the objectui#8459 placeholder below. That boundary is
+      // DELIBERATE, and objectui#8477 is the card that measured it and chose to
+      // write it down here rather than close it.
+      //
+      // THE GAP, stated honestly: `pruneEmpty` above judges this very column
+      // with the full `isValueEmpty`, so a column survives because *some other
+      // row* has a value — and this row's whitespace-only cell then paints
+      // visually blank, the exact UI the em-dash below exists to prevent,
+      // reached through the one door that never gets a cell. Measured: an
+      // undeclared `memo` column holding `'   '` renders a blank `div.truncate`
+      // while its sibling row renders `real memo`.
+      //
+      // ⚠️ WHY "just attach a minimal cell here" IS NOT A SHORTCUT — IT SHIPS A
+      // CRASH. The data-table's no-cell branch is not a pass-through: with no
+      // `cell` it applies TWO transforms — `String(value)` for a non-null
+      // object, and `formatCellValue(value)`, the locale ISO date/datetime face
+      // objectui#7443 and objectui#7620 spent two cards folding into ONE home —
+      // whereas a `cell`'s return value is handed STRAIGHT to React, with no
+      // way to defer any single value back to that default. Measured on one
+      // untyped column, same row, `tbody` innerHTML byte for byte, no-cell
+      // versus a cell returning its argument unchanged:
+      //
+      //   `real memo` / `0` / `false`   identical
+      //   ISO date `2026-07-04`         `Jul 4`                 becomes `2026-07-04`
+      //   ISO datetime                  `Mar 5, 2024, 02:30 PM` becomes the raw ISO string
+      //   array `['a','b']`             `a,b`                   becomes `ab`
+      //   object `{latitude,longitude}` `[object Object]`       THROWS
+      //                                 "Objects are not valid as a React child"
+      //
+      // The object row is not a rendering difference, it is a crash — and
+      // untyped columns rendering `[object Object]` are precisely the
+      // population such a cell reaches first.
+      //
+      // ⛔ Choosing whether to attach a cell by INSPECTING THE VALUE is the same
+      // idea in a disguise: that is inferring a type from a value, fenced off
+      // by objectui#8477 explicitly.
+      //
+      // ⇒ SUCCESSOR — objectui#8817. The layer that owns "how a value renders
+      // when there is no cell" is the data-table itself, so it also owns "what
+      // an empty one draws"; fixing it from out here would force a SECOND
+      // spelling of `formatCellValue` (a `useCallback` inside that component,
+      // exported nowhere, closing over its own language state). That is a
+      // product-wide behaviour change with its own ruling to make — is the
+      // table's "empty" this file's `isValueEmpty`, or does the disagreement
+      // merely move up one layer? Until it lands, this boundary stands.
+      //
+      // REACHABILITY, so the next reader need not re-derive it: this line is
+      // reached only for a field that IS declared and carries no `type`. The
+      // card's own case — a column key the schema never declares — never
+      // arrives here at all: both explicit-column call sites guard with
+      // `def ? makeCell(...) : undefined`, and the auto-derived walk guards with
+      // `if (def.type)`. The `if (!CellRenderer)` line just below is, by
+      // contrast, DEAD: `getCellRenderer` is typed to return a component and
+      // ends in `standardMap[fieldType] || TextCellRenderer`, so it never
+      // returns a falsy renderer — measured over seven spellings, including
+      // ones no producer can emit, all of which resolved to `TextCellRenderer`.
       if (!def?.type) return undefined;
       const rendererType = resolveCellRendererType({ type: def.type, format: def.format }) || def.type;
       const CellRenderer = getCellRenderer(rendererType);


### PR DESCRIPTION
Fixes #8477

Comment only. One file gains 57 lines of comment; no line of code changes, nothing is removed.

## What this is

`makeCell` returns early for a field with no `type`, so that column gets no `cell`, the objectui#8459 placeholder never runs, and `pruneEmpty` goes on judging the very same column with the full `isValueEmpty`. objectui#8477 asked whether to close that or to write it down. It is now written down, at the live guard.

## Why it is written down rather than closed

The card's ruling first took the other route — attach a minimal cell that draws the placeholder when `isValueEmpty` is true and returns the value untouched otherwise — resting on one stated premise: that for a non-empty value, a cell returning the value untouched renders identically to no cell at all. That premise was measured and is **false**, so the ruling was remade (issue comment 5601241216).

The data-table's no-cell branch is not a pass-through. With no `cell` it applies **two** transforms — `String(value)` for a non-null object, and `formatCellValue(value)`, the locale ISO date/datetime face objectui#7443 and objectui#7620 folded into one home — whereas a `cell`'s return value is handed **straight to React**, with no way to defer any single value back to that default.

Measured on one untyped column, same row, `tbody` innerHTML byte for byte, no-cell versus a cell returning its argument unchanged. Lit control first, so the `identical` rows below are readings and not a disconnected instrument:

| value | no cell | with an untouched-value cell | identical |
|---|---|---|---|
| **lit control** `'   '` with the placeholder cell | text `'   '` | a muted span holding the em-dash | **no** |
| `'real memo'` / `0` / `false` | — | — | yes |
| ISO date `'2026-07-04'` | `Jul 4` | `2026-07-04` | no |
| ISO datetime | `Mar 5, 2024, 02:30 PM` | the raw ISO string | no |
| array `['a','b']` | `a,b` | `ab` | no |
| **object** `{latitude,longitude}` | `[object Object]` | **THROWS** "Objects are not valid as a React child" | no |

The object row is not a rendering difference, it is a crash — and untyped columns rendering `[object Object]` are exactly the population such a cell reaches first. That is the fact the comment exists to carry: anyone reaching for the "just attach a minimal cell" intuition later would ship a crash.

The layer that owns "how a value renders when there is no cell" is the data-table itself, so it also owns "what an empty one draws". That is **objectui#8817**, which the comment names as the successor.

## Two corrections to the record, both in the comment

- The comment sits at the `if (!def?.type)` guard. The `if (!CellRenderer)` line below it is **dead**: `getCellRenderer` is typed to return a component and ends in `standardMap[fieldType] || TextCellRenderer`, so it never returns a falsy renderer — measured over seven spellings, including ones no producer can emit, all resolving to `TextCellRenderer`.
- The card's own case, a column key the schema never declares, never enters `makeCell` at all: both explicit-column call sites guard with `def ? makeCell(...) : undefined`, and the auto-derived walk guards with `if (def.type)`. The comment says so, so the next reader does not re-derive it.

## No pin, no ablation — deliberately

A comment-only change has no behaviour to pin and nothing to ablate. Inventing a pin here would be theatre: it would assert something this diff does not change. The measurements above were taken with temporary probes that are deleted; they are recorded in objectui#8477 and transcribed into objectui#8817, which is where they belong. The behaviour those readings describe belongs to objectui#8817's verification surface, not to this PR's.

## Gates

Each gate's own exit code was captured separately, because the shared verify lock warns that a `;`-sequenced batch verdict reports only the last part's exit. Quoted below are the gates' own verdict lines.

| gate | verdict line | exit |
|---|---|---|
| dependency-closure build (`'@object-ui/plugin-detail^...'`) | `packages/fields build: Done` | `CLOSURE_EXIT=0` |
| package build | `✓ built in 7.44s` | `PKG_BUILD_EXIT=0` |
| `type-check` (this repo spells it hyphenated) | echoed `tsc --noEmit && tsc -p tsconfig.test.json` | `TYPECHECK_EXIT=0` |
| package test | `Test Files 154 passed (154)` · `Tests 1409 passed (1409)` | `TEST_EXIT=0` |
| package lint | `✖ 971 problems (0 errors, 971 warnings)` | `LINT_EXIT=0` |
| `check-changeset-presence` | `✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` · `Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.` | 0 |
| `check-governed-queue-guard --test` on the changed paths | `✅ NOT GOVERNED — 2 path(s) checked against 5 governed surface(s); none matched.` | 0 |
| the same command shape on `AGENTS.md` (**lit control**) | `⛔ GOVERNED — 1 of 1 path(s) are on a governed surface` | 3 |

The lit control is what makes the row above it a reading: the guard discriminates, so "not governed" is a measurement rather than a silent pass.

The 971 lint warnings are pre-existing package debt, not this diff's: a file-scoped `eslint --format json` on `RelatedList.tsx` reports **0 errors**, and **zero** findings on the 57 inserted lines. The three findings the JSON reports inside the neighbourhood all sit on line 973 — the unchanged `makeCell` signature and its pre-existing `any`s, one line above where the comment begins.

The changeset carries an **empty frontmatter**, verified against `scripts/check-changeset-presence.mjs`'s own header rather than assumed: it names that shape a first-class pass, because what the gate demands is a declaration by the person who still knows what the change does, not a release. There is no behaviour change to release here.

## 验收备注

Observations noted, not filed and not fixed — each with the successor who will meet it.

- **`if (!CellRenderer)` at the line below the comment is unreachable.** Dead code, an explicit do-not-file class, so no card. Successor: whoever takes objectui#8817, or the next editor of `makeCell` — the comment now tells them it is dead and why, so nobody re-derives it or writes a test for a branch that cannot run. It is left in place because deleting it is a code change and this card is comment-only.
- **The auto-derived walk is a third `makeCell` call site**, guarded by `if (def.type)` rather than by `def`. Not a defect; recorded in the comment so the reachability claim is complete rather than approximately true. Successor: same reader.
- **The comment names the call-site guards structurally, not by line number.** The re-ruling cited `RelatedList.tsx:1070` / `:1079`; on today's `main` the second is `:1080`, which is exactly why a same-file comment must not carry line numbers — they rot on the next edit. Successor: anyone diffing the ruling against the file and finding the numbers off by one.
- **The 971 package-wide lint warnings are pre-existing**, dominated by `react-hooks/set-state-in-effect` and `no-explicit-any`. Untouched here. Successor: whoever runs a lint-debt pass for `plugin-detail`; this PR neither adds to it nor is the place to pay it down.

## 维护者速读(草稿)

**改了什么** —— 只加注释,一个文件 57 行,没有一行代码改动、没有删除。注释落在 `RelatedList` 的 `makeCell` 里那个「字段没有 `type` 就不给 cell」的守卫上,写明:这条边界是**故意**的;为什么这一层关不掉它;以及真正能关掉它的后继卡是 objectui#8817。另附一个空 frontmatter 的 changeset(声明「不发版」)。

**为什么改** —— objectui#8477 原裁是「给这条路径补一个最小 cell」,前提是「非空值原样返回 = 不挂 cell」。实测该前提为假:data-table 在**没有** cell 时会施加 `String()` 与 `formatCellValue()` 两道变换,而挂上 cell 之后返回值直接交给 React,**无法把某个值退回默认分支**。后果不只是「渲染变了」——**对象值会抛错**(今天渲染成 `[object Object]` 的那些列,正是这种 cell 最先碰到的)。所以本卡退回成文记录,把这个「看起来省事、实则会崩」的坑写在下一个人一定会读到的地方。

**风险与代价(含回滚)** —— 风险接近零:注释不进运行时,构建产物的行为字节不变;缺陷本身**照旧存在**,本 PR 不宣称修好它(那是 objectui#8817)。代价是 `plugin-detail` 里多了一段长注释。回滚就是 `git revert` 这一个提交,没有数据迁移、没有 API 变更、没有发版影响(changeset 声明不发版)。

**席位意见** ——

**你要做的** —— ① 确认注释里那句判断你认可:「无类型列画不画占位符」这件事应当归 data-table 所有,而不是每个消费方各补一次;② objectui#8817 需要你的一次裁决才能动工 —— data-table 的「空」是否就等于 `RelatedList` 的 `isValueEmpty`(trim 字符串、`[]` 算空)?若两者不同,分歧只是上移一层、并没有被关掉;③ 那张卡是**产品级行为变更**(每一个 data-table 消费方都受影响),需要先普查「今天有多少消费方依赖空值渲染成空白」再动手。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH)_