### PR TITLE
fix(types): drop stale source-line citations from 11 published describe() strings (form/layout)

### DIFF
--- a/.changeset/8478-zod-pins-form-layout.md
+++ b/.changeset/8478-zod-pins-form-layout.md
@@ -1,0 +1,24 @@
+---
+'@object-ui/types': patch
+---
+
+Remove stale source-line citations (`NAME.ext:NNN`) from eleven published `.describe()`
+schema descriptions in `packages/types/src/zod/form.zod.ts` (9) and
+`zod/layout.zod.ts` (2) (objectstack-ai/objectui#8478).
+
+Text only — no accept-set, key, or shape change. Each description was either trimmed to
+its author-useful sentence with no loss (e.g. dropping "read at
+renderers/form/file-upload.tsx:78" from an "appended to the renderer's own grid classes"
+sentence that stands on its own), or rewritten to cite the same fact by identifier or
+behavior instead of by file:line (e.g. "sets `required` on the Radix Checkbox and gates
+the label's `*` marker" instead of "read at renderers/form/checkbox.tsx:45 ... and :49"),
+which survives a line renumbering that a bare address would not.
+
+Two of the eleven addresses removed here were measured to have already drifted by the
+same +3 lines: `checkbox.tsx:45`/`:49` (actual `required=` site now `:48`, actual `*`
+marker site now `:52`) and `text.tsx:162,167` (actual `{schema.content}` sites now
+`:165`/`:170`). Filed back on objectstack-ai/objectui#8478 as further drift evidence for
+its own pre-committed p3-to-p2 re-grade trigger.
+
+The remaining 6 addresses (`zod/complex.zod.ts`) stay out of scope for this PR — held by
+in-flight PR objectstack-ai/objectui#8799 — and the card does not close here.

--- a/packages/types/src/zod/form.zod.ts
+++ b/packages/types/src/zod/form.zod.ts
@@ -252,7 +252,7 @@ export const TextareaSchema = BaseSchema.extend({
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
   wrapperClass: z.string().optional()
-    .describe('Classes on the wrapper div around the textarea and its label, read at renderers/form/textarea.tsx:37 — `cn("grid w-full gap-1.5", schema.wrapperClass)` (objectui#7722)'),
+    .describe('Classes on the wrapper div around the textarea and its label (objectui#7722)'),
   onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
   maxLength: z.number().optional().describe('Maximum length'),
 });
@@ -272,7 +272,7 @@ export const SelectSchema = BaseSchema.extend({
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
   wrapperClass: z.string().optional()
-    .describe('Classes on the wrapper div around the trigger and its label, read at renderers/form/select.tsx:45 — `cn("grid w-full items-center gap-1.5", schema.wrapperClass)` (objectui#7722)'),
+    .describe('Classes on the wrapper div around the trigger and its label (objectui#7722)'),
   onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
 });
 
@@ -286,9 +286,9 @@ export const CheckboxSchema = BaseSchema.extend({
   defaultChecked: z.boolean().optional().describe('Default checked state'),
   checked: z.boolean().optional().describe('Controlled checked state'),
   required: z.boolean().optional()
-    .describe("Required affordance, read at renderers/form/checkbox.tsx:45 (`required=` on the Radix Checkbox) and :49 (gates the label's `*` marker) (objectui#6150)"),
+    .describe("Required affordance — sets `required` on the Radix Checkbox and gates the label's `*` marker (objectui#6150)"),
   wrapperClass: z.string().optional()
-    .describe('Classes on the wrapper div around the box and its label, read at renderers/form/checkbox.tsx:36 — `cn("flex items-center space-x-2", schema.wrapperClass)` (objectui#6938)'),
+    .describe('Classes on the wrapper div around the box and its label (objectui#6938)'),
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
   onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
@@ -321,7 +321,7 @@ export const SwitchSchema = BaseSchema.extend({
   checked: z.boolean().optional().describe('Controlled checked state'),
   description: z.string().optional().describe('Help text'),
   wrapperClass: z.string().optional()
-    .describe("Classes on the wrapper div around the switch and its label, read at renderers/form/switch.tsx:26 — `flex items-center space-x-2 ${schema.wrapperClass || ''}` (objectui#7722)"),
+    .describe("Classes on the wrapper div around the switch and its label (objectui#7722)"),
   onChange: handlerKeyRefusal('onChange', 'retired', 'Change handler'),
 });
 
@@ -363,9 +363,9 @@ export const FileUploadSchema = BaseSchema.extend({
   name: z.string().optional().describe('Field name for form submission'),
   label: z.string().optional().describe('Upload label'),
   buttonText: z.string().optional()
-    .describe('Drop-zone label, read at renderers/form/file-upload.tsx:123 — `schema.buttonText || "DROP PAYLOAD OR CLICK TO UPLOAD"` (objectui#6150)'),
+    .describe('Drop-zone label; falls back to "DROP PAYLOAD OR CLICK TO UPLOAD" when unset (objectui#6150)'),
   wrapperClass: z.string().optional()
-    .describe('Outer wrapper classes, appended to the renderer\'s own grid classes at renderers/form/file-upload.tsx:78 (objectui#6150)'),
+    .describe('Outer wrapper classes, appended to the renderer\'s own grid classes (objectui#6150)'),
   accept: z.string().optional().describe('Accepted file types'),
   multiple: z.boolean().optional().describe('Allow multiple files'),
   maxSize: z.number().optional().describe('Maximum file size (bytes)'),
@@ -391,7 +391,7 @@ export const DatePickerSchema = BaseSchema.extend({
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
   wrapperClass: z.string().optional()
-    .describe("Classes on the wrapper div around the popover trigger and its label, read at renderers/form/date-picker.tsx:35 — `grid w-full max-w-sm items-center gap-1.5 ${schema.wrapperClass || ''}` (objectui#7722)"),
+    .describe("Classes on the wrapper div around the popover trigger and its label (objectui#7722)"),
   onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
 });
 
@@ -724,7 +724,7 @@ export const InputShorthandSchema = InputSchema.omit({ type: true, inputType: tr
   // second ledger row for a key that is demonstrably read; shrinking the existing
   // row is `InputSchema`'s own repair (objectui#7722's family) and not this card's.
   wrapperClass: z.string().optional()
-    .describe("Classes on the wrapper div around the input and its label, read at renderers/form/input.tsx:42 — `cn('grid w-full items-center gap-1.5', schema.wrapperClass)`"),
+    .describe("Classes on the wrapper div around the input and its label"),
 });
 
 /**

--- a/packages/types/src/zod/layout.zod.ts
+++ b/packages/types/src/zod/layout.zod.ts
@@ -93,7 +93,7 @@ export const TextSpanSchema = BaseSchema.extend({
 export const TextSchema = BaseSchema.extend({
   type: z.literal('text'),
   content: z.string().optional()
-    .describe('Text content — the one content spelling `text` reads, at renderers/basic/text.tsx:162,167 as `{schema.content}` (declared by objectui#6150; its `value` fallback spelling was retired by objectui#6951)'),
+    .describe('Text content — the one content spelling `text` reads (declared by objectui#6150; its `value` fallback spelling was retired by objectui#6951)'),
   // ADR-0049 RETIREMENT TOMBSTONE (objectui#6951 / objectui#7016, maintainer
   // ruling A1 of 2026-09-04). `value` was the second spelling of the one
   // content slot; the renderer now reads `content` alone, so a plain deletion
@@ -552,7 +552,7 @@ export const HtmlElementSchema = BaseSchema.extend({
   children: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional()
     .describe('Child components — read as `schema.children ?? schema.body`; ignored for the void tags `img` / `hr` / `br`'),
   href: z.string().optional()
-    .describe('`a` link target; scheme-sanitised at html-elements.tsx:74 (`javascript:` / `data:` / `vbscript:` are dropped)'),
+    .describe('`a` link target; scheme-sanitised (`javascript:` / `data:` / `vbscript:` are dropped)'),
   target: z.string().optional().describe('`a` browsing context — an internal link navigates through the SPA router unless this names another target'),
   rel: z.string().optional().describe('`a` link relationship'),
   title: z.string().optional().describe('Advisory title — declared for `a`, `img` and `abbr`'),


### PR DESCRIPTION
Refs objectstack-ai/objectui#8478

## What

Removes the stale `NAME.ext:NNN` source-line address from 11 published `.describe()` strings in `packages/types/src/zod/form.zod.ts` (9) and `zod/layout.zod.ts` (2), per the triage ruling on objectstack-ai/objectui#8478 (removal itself is certain; the remaining prose is decided per-address, not forced to one disposition).

Disposition split for this slice (all 11 kept as prose, address removed — 0 needed relocating to a code comment):

- `form.zod.ts` `TextareaSchema.wrapperClass`
- `form.zod.ts` `SelectSchema.wrapperClass`
- `form.zod.ts` `CheckboxSchema.required` — rewritten to state the behaviour ("sets `required` on the Radix Checkbox and gates the label's `*` marker") instead of citing two line numbers
- `form.zod.ts` `CheckboxSchema.wrapperClass`
- `form.zod.ts` `SwitchSchema.wrapperClass`
- `form.zod.ts` `FileUploadSchema.buttonText` — rewritten to state the fallback text instead of the code excerpt
- `form.zod.ts` `FileUploadSchema.wrapperClass`
- `form.zod.ts` `DatePickerSchema.wrapperClass`
- `form.zod.ts` `InputShorthandSchema.wrapperClass` — address already duplicated in the adjacent maintainer-facing `//` comment two lines above (which cites `renderers/form/input.tsx:42` and is unaffected by this PR, being a code comment rather than a published description), so nothing is lost by removing it from the published surface
- `layout.zod.ts` `TextSchema.content`
- `layout.zod.ts` `HtmlElementSchema.href`

Text only: no accept-set, key, or shape change. **Clause-②: no.**

## Re-derived counts (call-scoped matcher, on my own head)

Matcher: for every `.describe(` call in `packages/types/src`, extract its argument text up to the matching close-paren (so a continuation-line address is not missed), and count it if that argument contains a `NAME.ext:NNN` token.

On `origin/main` at the branch's rebase point (`dcbf0b2bc`, after PR objectstack-ai/objectui#8799 merged):

| file | addresses |
|---|---|
| `zod/form.zod.ts` | 9 |
| `zod/layout.zod.ts` | 2 |
| `zod/complex.zod.ts` | **6 — control, untouched by this PR** |
| `zod/overlay.zod.ts` / `zod/data-display.zod.ts` / `zod/objectql.zod.ts` | 0 (cleared by PR objectstack-ai/objectui#8776) |

**Firing control**, same run: the same matcher over every string literal in all of `packages/types/src` (not just `.describe()` calls) returns **199** — non-zero, confirming the matcher isn't broken.

After this PR: `form.zod.ts` and `layout.zod.ts` both read **0** by the call-scoped matcher; `complex.zod.ts` — the file this PR does not touch — still reads **6**, unchanged. That non-zero, untouched control is what makes the two zeros a removal rather than a broken matcher.

## Scope — `complex.zod.ts` deliberately excluded

The dispatch held `zod/complex.zod.ts` out of scope: PR objectstack-ai/objectui#8799 was in the merge queue modifying it at claim time. That PR (`dcbf0b2bc`, "execute the batch #70 ruling on the `kanban` arm") merged mid-round, but per the dispatch's explicit instruction the exclusion stands regardless — this PR does not touch `complex.zod.ts`, its 6 addresses stay on the card, and the card does not close on this PR (`Refs`, not `Fixes`).

## Spot-check — two more drifted addresses found

Checked all 11 addresses in scope against the files they cite (not just the requested 3–5 sample):

- **`renderers/form/checkbox.tsx:45` and `:49`** (cited by `CheckboxSchema.required`) have drifted: the actual `required={schema.required}` site is now `:48`, and the actual `after:content-['*']` label-marker site is now `:52` — both off by exactly **+3** lines.
- **`renderers/basic/text.tsx:162,167`** (cited by `TextSchema.content`) has drifted: the actual `{schema.content}` sites are now `:165` and `:170` — again off by exactly **+3**.
- The other 9 addresses checked out exactly (`textarea.tsx:37`, `select.tsx:45`, `checkbox.tsx:36`, `switch.tsx:26`, `file-upload.tsx:123`, `file-upload.tsx:78`, `date-picker.tsx:35`, `input.tsx:42`) — `html-elements.tsx:74` (cited by `HtmlElementSchema.href`) lands inside the right function (`sanitizeHref`, lines 73–79) but 3 lines short of the actual regex check at `:77`, the same +3 offset, though arguably close enough to not count as "wrong" the way the other two are.

This is further evidence for the card's own pre-committed p3-to-p2 re-grade trigger (one instance already found and recorded on the card by the previous slice: `ObjectKanban.tsx:264` → actual `:365`). Grading is the triage seat's act, not this dev seat's — reported on the card, not acted on here.

## Changeset

`.changeset/8478-zod-pins-form-layout.md` — `@object-ui/types` `patch`, matching the previous slice's precedent for this same card.

## Gates (all green on rebased head `4cc013f35`, merge-base `dcbf0b2bc`)

- `pnpm exec vitest run packages/types/` — 160 files / 3145 tests passed
- `pnpm --filter @object-ui/types build` — dist completeness OK
- `pnpm --filter @object-ui/types type-check` — `tsc --noEmit` + examples + test configs, 0 errors
- `pnpm --filter @object-ui/types lint` — 0 errors (271 pre-existing `no-explicit-any` warnings, unrelated to this diff)
- `node scripts/check-changeset-presence.mjs` — declares the changeset
- `node scripts/check-changeset-no-major.mjs`
- `node scripts/check-control-bytes.mjs`
- `pnpm run check:spec-symbols`
- `pnpm run check:designer-field-key-parity`
- `pnpm run check:handler-key-reads`
- `node scripts/check-governed-queue-guard.mjs --test THE-3-CHANGED-PATHS` — NOT GOVERNED

`apps/console` swept: no reference to the edited `.describe()` text found (`content/docs/**` doesn't embed it either — it's manually-curated prose, not generated from `.describe()` output).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_