### PR TITLE
feat(types,plugin-view,plugin-tree): export the host `tree` view config as `TreeViewConfig` (objectui#8253)

### DIFF
--- a/.changeset/8253-export-tree-view-config.md
+++ b/.changeset/8253-export-tree-view-config.md
@@ -1,0 +1,54 @@
+---
+'@object-ui/types': minor
+'@object-ui/plugin-view': minor
+'@object-ui/plugin-tree': patch
+---
+
+Export the host `tree` view config as `TreeViewConfig` (objectui#8253, director
+decision batch #78, 2026-09-07, maintainer 「同意」 on option (a)).
+
+**What was wrong.** `tree` is a host-composition-only view type — ruled deliberate on
+objectui#5321, it is a member of neither `ObjectViewSchema.defaultViewType` nor
+`NamedListView.type`, so the branch runs only when a host passes a `views` prop. On
+that path a per-view `tree` block is read at four sites, and its only description
+anywhere was a module-local, non-exported `interface TreeConfig` inside
+`plugin-tree/src/ObjectTree.tsx`. The live host is the console: it stores view records
+and passes them as `views`, and its create-view dialog offers `tree`. So a real
+consumer wrote this block with no type to write it against, and a misspelled
+`parentFeild` was admitted by the views entry's `[key: string]: any`, stored, read by
+nobody and reported by nothing. Declared ≠ enforced on a surface a non-author
+re-writes.
+
+**The grades, and why.**
+
+- `@object-ui/types` — **minor**: one new name, `TreeViewConfig`, becomes reachable
+  from the package entry. Nothing existing is renamed, retyped or removed, and no
+  value's validation changes anywhere in this package.
+- `@object-ui/plugin-view` — **minor**: `ObjectViewProps.views[n].tree` is now
+  declared `TreeViewConfig` where it previously resolved to `any` through the entry's
+  index signature. On a face that already admitted every spelling a declaration
+  **cannot widen — it can only narrow**, and this one does: a host composing the entry
+  as an object literal now gets `parentFeild` reported as an excess property instead
+  of silently dropped. The index signature itself is untouched, so every other
+  undeclared key a host puts on the entry still type-checks exactly as before.
+- `@object-ui/plugin-tree` — **patch**: the module-local interface becomes an import
+  of the exported one and the resolver's own type is `Pick`ed off it. No runtime
+  behaviour changes, and no key is added to or removed from what the renderer reads.
+
+**`titleField` is declared, not deleted — and that was a measurement.** The ruling put
+this key to a test: declare it if the console writes it, else remove the read. The
+console's create-view dialog does **not** offer it (its `tree` slot collects
+`parentField` alone), but the console's own host composition reads it by name, so do
+the `ListView` and `ObjectView` tree branches, and the rung is pinned as live behaviour
+by objectui#6557 ("the tree's second view-declared rung … still answers"). Deleting the
+read would have reversed a recorded ruling and reddened its pin. Declaring it makes
+declared = enforced at all four read sites at once. `labelField` remains canonical and
+wins wherever both are present.
+
+**Migration.** None required. Hosts that already compose a `tree` block keep working;
+hosts that annotate one against `TreeViewConfig` start getting a compile error for a
+misspelled key instead of a view that silently ignores it.
+
+⛔ This does not make `tree` an authorable view type. objectui#5321 is untouched: the
+block is host config, written by a host and never by a document author, and the
+authored node remains the flat `ObjectTreeSchema`.

--- a/packages/plugin-tree/README.md
+++ b/packages/plugin-tree/README.md
@@ -66,13 +66,45 @@ declares no `views` member at all. The `tree` branch runs only when a **host**
 composes `ObjectView` with a `views` prop, whose entries carry `id` and `label`
 and are typed `ViewType`. That was ruled deliberate on objectui#5321
 (2026-08-20): `tree` and `chart` are recorded as host-composition-only surfaces
-rather than added to the authored unions. The per-view `tree` config block that
-path reads is host config, so it is not documented here as authoring surface.
+rather than added to the authored unions.
 
 The live consumer is the console: it passes stored view records to `ObjectView`
 as `views`, and its create-view dialog offers `tree` among the types a console
 user can create. To render a tree from authored metadata, write the
 `object-tree` node above.
+
+#### The host config has a type — `TreeViewConfig`
+
+Host config is **not** untyped config. A block a host stores and re-writes is a
+contract, so the per-view `tree` block is exported from `@object-ui/types` and
+is the single declaration of that shape — the renderer imports it rather than
+keeping a private copy (objectui#8253, ruled 2026-09-07):
+
+```ts
+import type { TreeViewConfig } from '@object-ui/types';
+
+// The block a host writes as `tree` on a `views` entry, or as `options.tree`
+// on a stored view record. Every key is optional; a host writes the subset it
+// means.
+const treeConfig: TreeViewConfig = {
+  parentField: 'parent',        // single-parent pointer (auto-detected if omitted)
+  labelField: 'name',           // indented first column
+  fields: ['name', 'manager'],  // additional flat columns
+  defaultExpandedDepth: 1,      // 0 = roots only; omit = expand all
+};
+```
+
+Annotating the block is what turns a typo into a diagnostic: `parentFeild` used
+to be stored, read by nobody and reported by nothing, because the `views` entry
+admits any key. Against this type it is a compile error.
+
+`titleField` is also declared — a legacy second rung for `labelField`, kept
+because the console's own composition still reads it. Prefer `labelField`,
+which wins wherever both are present.
+
+⛔ This does not make `tree` an authorable view type. objectui#5321 is
+unchanged: the block is written by a **host**, never by a document author, and
+the authored node is the flat `object-tree` schema at the top of this file.
 
 ## License
 

--- a/packages/plugin-tree/src/ObjectTree.hostConfigExported-8253.test.ts
+++ b/packages/plugin-tree/src/ObjectTree.hostConfigExported-8253.test.ts
@@ -1,0 +1,158 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8253 — the host `tree` view config is EXPORTED, and this file is
+ * what stops the next refactor un-exporting it in silence.
+ *
+ * ## What was wrong
+ *
+ * `tree` is a host-composition-only view type (objectui#5321, ruling B): it is
+ * on neither authored union, so the branch runs only when a host passes a
+ * `views` prop. On that path a per-view `tree` block is read — and its only
+ * description anywhere was the module-local, non-exported `interface TreeConfig`
+ * in `ObjectTree.tsx`. The live host is the console: it stores view records and
+ * passes them as `views`, and its create-view dialog offers `tree`. So a real
+ * consumer wrote this block with no type to write it against, and a misspelled
+ * `parentFeild` was admitted by the views entry's `[key: string]: any`, read by
+ * nobody, and reported by nothing. Declared ≠ enforced, class (c).
+ *
+ * Ruled on objectui#8253 (director seat, decision batch #78, 2026-09-07,
+ * maintainer 「同意」), option (a): `packages/types` exports the config, the
+ * module-local copy becomes an import of it, and ⛔ there is no second copy.
+ *
+ * ## Why the import below says `@object-ui/types` and not `../../types/src`
+ *
+ * This is the load-bearing part of the pin, not a style choice. This package's
+ * `tsconfig.test.json` sets `"paths": {}` precisely so `@object-ui/*` resolves
+ * through the WORKSPACE DEPENDENCY rather than through the root tsconfig's
+ * source-tree mapping — so the specifier below is resolved the way a published
+ * consumer resolves it: `packages/types/package.json` `exports["."].types` →
+ * `dist/index.d.ts`. A pin that imported `'../../types/src/views'` would never
+ * touch `dist` or the `exports` map and would stay green through a barrel that
+ * had stopped re-exporting the name, or an `exports` map that had stopped
+ * publishing the entry. This one goes red for both.
+ *
+ * ⚠️ Consequence, and it is deliberate: `@object-ui/types` must be BUILT before
+ * `pnpm --filter @object-ui/plugin-tree type-check` means anything. A stale
+ * `dist/*.d.ts` lies in both directions.
+ *
+ * ## The assertions are compile-time; vitest alone would not catch a broken pin
+ *
+ * Same mechanism as `types/src/__tests__/drill-down-config-declared-keys.test.ts`:
+ * `tsconfig.json` excludes tests (they must not emit into `dist`) and
+ * `tsconfig.test.json` picks them back up, chained off the package's
+ * `type-check` script. Vitest strips types without checking them. The runtime
+ * `expect` at the foot of each type-level case is a marker, ⛔ never the pin.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Through the PACKAGE ENTRY — see the header. ⛔ Do not relax this to a
+// relative path into `packages/types/src`.
+import type { TreeViewConfig } from '@object-ui/types';
+
+/* -------------------------------------------------------------------------- */
+/* Compile-time pins — compiled by tsconfig.test.json, chained off type-check. */
+/* -------------------------------------------------------------------------- */
+
+type Assert<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+/**
+ * The keys `getTreeConfig` in `ObjectTree.tsx` reads off this block, and the
+ * ones the ruling says the type carries EXACTLY. Pinned as a `keyof` equality
+ * rather than a bag of `HasKey` checks, because equality is the only spelling
+ * that fails in BOTH directions — a key added here without a reader is as much
+ * a defect as a key removed from under one.
+ */
+type DeclaredKey =
+  | 'parentField'
+  | 'labelField'
+  | 'titleField'
+  | 'fields'
+  | 'defaultExpandedDepth';
+
+describe('objectui#8253 — TreeViewConfig is reachable through @object-ui/types', () => {
+  it('is pinned at compile time', () => {
+    // Non-vacuity. `keyof any` is `string | number | symbol`, and every
+    // `Equal<…>` below would report whatever an `any` made convenient. If the
+    // import ever resolves to `any` — a broken export map degrades exactly
+    // this way — this line fails FIRST and names the reason.
+    type _ConfigIsReal = Assert<Equal<IsAny<TreeViewConfig>, false>>;
+
+    // The census, total in both directions. This ALSO refuses an index
+    // signature: `[key: string]: any` would put `string` into `keyof` and this
+    // equality would fail. That matters more than it looks — an index
+    // signature here would re-open the exact hole the card was filed for, by
+    // making every misspelling assignable again.
+    type _Census = Assert<Equal<keyof TreeViewConfig, DeclaredKey>>;
+
+    // Every key is optional: a host writes the subset it means. `Partial<T>`
+    // is structurally identical to `T` only when nothing is required.
+    type _AllOptional = Assert<Equal<TreeViewConfig, Partial<TreeViewConfig>>>;
+
+    // Per-key types, read against the sibling node schema's spelling.
+    type _ParentField = Assert<Equal<TreeViewConfig['parentField'], string | undefined>>;
+    type _LabelField = Assert<Equal<TreeViewConfig['labelField'], string | undefined>>;
+    type _TitleField = Assert<Equal<TreeViewConfig['titleField'], string | undefined>>;
+    type _Fields = Assert<Equal<TreeViewConfig['fields'], string[] | undefined>>;
+    type _Depth = Assert<Equal<TreeViewConfig['defaultExpandedDepth'], number | undefined>>;
+
+    expect(true).toBe(true);
+  });
+
+  it('refuses the misspelling the card was filed for, at compile time', () => {
+    // ⭐ A FRESH object literal is the right instrument HERE, and it is the
+    // wrong one in `types/src/__tests__/menu-item-union.test.ts` — worth
+    // saying why, because the two files disagree on purpose. That file pins a
+    // `?: never` TOMBSTONE, where a fresh literal's excess-property rejection
+    // would be evidence-identical to the key simply not being declared. This
+    // file pins the opposite property: that an UNDECLARED key is refused at
+    // all. Excess-property checking on a fresh literal IS that property, and
+    // it is the diagnostic a host composing a view entry inline actually
+    // receives.
+    //
+    // `@ts-expect-error` is self-firing: if the line below ever STOPS being an
+    // error — an index signature added, the type widened to `any`, the export
+    // replaced by a looser one — this file fails with "unused
+    // '@ts-expect-error' directive" rather than passing quietly.
+    //
+    // `parentFeild` is the triage comment's own example of the silently-dropped
+    // misspelling. Refusing it here is the entire point of exporting this type.
+    // ⚠️ The directive must be the LAST comment line before the offending
+    // property — TypeScript matches it to the line that follows it, so prose
+    // underneath it would disarm the pin silently.
+    const misspelled: TreeViewConfig = {
+      // @ts-expect-error objectui#8253 — an undeclared key on the host tree config is refused.
+      parentFeild: 'parent',
+    };
+
+    // The correctly-spelled twin, so the refusal above is a statement about
+    // the SPELLING and not about the type refusing objects in general. If this
+    // line ever fails, the pin above stops being evidence of anything.
+    const spelled: TreeViewConfig = { parentField: 'parent' };
+
+    expect(spelled.parentField).toBe('parent');
+    expect(misspelled).toBeTruthy();
+  });
+});
+
+/*
+ * ⚠️ The off-disk reader census that belongs beside these pins does NOT live
+ * here, and the reason is mechanical rather than aesthetic: this package's
+ * `tsconfig.test.json` carries no `"types": ["node"]`, so `node:fs` is not a
+ * name this project can resolve, and adding it would put a Node API within
+ * reach of a package that ships to browsers. The census lives in
+ * `packages/types/src/__tests__/tree-view-config-readers-8253.test.ts`, beside
+ * the declaration it is total over, in a project that already declares `node`
+ * for exactly this purpose. What stays HERE is the half only this package can
+ * assert: that the name resolves through the published `exports` map.
+ */

--- a/packages/plugin-tree/src/ObjectTree.tsx
+++ b/packages/plugin-tree/src/ObjectTree.tsx
@@ -20,7 +20,7 @@
  */
 
 import React, { useEffect, useMemo, useState } from 'react';
-import type { DataSource } from '@object-ui/types';
+import type { DataSource, TreeViewConfig } from '@object-ui/types';
 import {
   useNavigationOverlay,
   useSafeFieldLabel,
@@ -78,12 +78,26 @@ export interface ObjectTreeProps {
   loading?: boolean;
 }
 
-interface TreeConfig {
-  parentField?: string;
-  labelField: string;
-  fields: string[];
-  defaultExpandedDepth?: number;
-}
+/**
+ * The RESOLVED form of the host's `tree` block — what `getTreeConfig` hands the
+ * renderer after flooring, ⛔ not a second declaration of the config's shape.
+ *
+ * The shape itself is `TreeViewConfig` in `@object-ui/types`, exported for this
+ * card (objectui#8253, ruling batch #78, option (a)): the module-local
+ * `interface TreeConfig` that used to stand here was the ONLY description of a
+ * block a real host stores and re-writes. Every key name and every key TYPE
+ * below is `Pick`ed off that one declaration, so a key added, renamed or
+ * retyped there arrives here without an edit — which is the property a
+ * hand-copied interface cannot have, and the reason #7646's private copy is the
+ * shape to avoid.
+ *
+ * The only thing this adds is REQUIREDNESS, and only for the two keys the
+ * resolver floors: `labelField` falls back to `'name'` and `fields` to `[]`, so
+ * the renderer below indexes both without a guard.
+ */
+type ResolvedTreeConfig =
+  Required<Pick<TreeViewConfig, 'labelField' | 'fields'>>
+  & Pick<TreeViewConfig, 'parentField' | 'defaultExpandedDepth'>;
 
 interface TreeNode {
   id: string;
@@ -105,8 +119,8 @@ function fieldKey(f: any): string | undefined {
   return columnIdentity(f) || (f && typeof f === 'object' ? f.key : undefined) || undefined;
 }
 
-function getTreeConfig(schema: any): TreeConfig {
-  const nested = (schema.tree || schema.filter?.tree || {}) as Partial<TreeConfig>;
+function getTreeConfig(schema: any): ResolvedTreeConfig {
+  const nested = (schema.tree || schema.filter?.tree || {}) as TreeViewConfig;
   const rawFields = Array.isArray(schema.fields)
     ? schema.fields
     : Array.isArray(nested.fields)

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -33,6 +33,7 @@ import type {
   NamedListView,
   ViewNavigationConfig,
   ObjectMapConfig,
+  TreeViewConfig,
 } from '@object-ui/types';
 import { ObjectGrid } from '@object-ui/plugin-grid';
 import { ObjectForm } from '@object-ui/plugin-form';
@@ -307,6 +308,32 @@ export interface ObjectViewProps {
     columns?: string[];
     sort?: Array<{ field: string; order: 'asc' | 'desc' }>;
     filter?: any[];
+    /**
+     * Per-view `tree` config — the block the `'tree'` branch of
+     * `generateViewSchema` below reads (objectui#8253, ruling batch #78,
+     * option (a), maintainer 「同意」).
+     *
+     * ⭐ This declaration can only NARROW, and that is the whole of its value.
+     * The `[key: string]: any` on the line under it already ADMITTED a `tree`
+     * key of any shape, so nothing that used to be refused becomes accepted;
+     * what changes is that a host writing this entry as an object LITERAL now
+     * gets `parentFeild` reported as an excess property instead of stored,
+     * dropped and never mentioned. That is the class-(c) defect this card was
+     * filed for.
+     *
+     * ⛔ Declared, ⛔ not re-declared: the shape is `TreeViewConfig` in
+     * `@object-ui/types`, which `plugin-tree`'s resolver imports as well. One
+     * declaration, three readers.
+     *
+     * ⚠️ Reach, measured on this tree and NOT claimed wider than it is: the
+     * console's own call site passes `mergedViews`, built by
+     * `app-shell/src/views/ObjectView.tsx` as `views.map((v: any) => …)` over
+     * STORED view records, so it arrives here as `any[]` and this declaration
+     * reports nothing about it. It bites a host that composes the entry inline
+     * against this prop's type. Typing the stored-record path is a separate
+     * change on app-shell, recorded rather than smuggled in here.
+     */
+    tree?: TreeViewConfig;
     [key: string]: any;
   }>;
 

--- a/packages/plugin-view/src/__tests__/ObjectView.treeViewConfigDeclared-8253.test.ts
+++ b/packages/plugin-view/src/__tests__/ObjectView.treeViewConfigDeclared-8253.test.ts
@@ -1,0 +1,121 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8253 — `ObjectViewProps.views[n].tree` is DECLARED, so a host that
+ * composes the entry gets a compile error instead of a silently dropped key.
+ *
+ * ## Which direction this declaration moves, measured rather than asserted
+ *
+ * The views entry closes with `[key: string]: any`. On a face like that a
+ * declaration CANNOT widen — every spelling was already admitted, so no value
+ * that used to be refused becomes accepted. It can only NARROW, by putting
+ * validation where there was none. That is what happens here, and the two pins
+ * below measure both halves of it:
+ *
+ *   - the LEG THAT NARROWS — a misspelled key inside `tree` is now an
+ *     excess-property error on a host's object literal;
+ *   - the LEG THAT DOES NOT MOVE — every OTHER undeclared key on the entry is
+ *     still admitted through the index signature, exactly as before. Without
+ *     this second leg "it narrows" would be indistinguishable from "the index
+ *     signature was removed", which would be a breaking change to every host.
+ *
+ * ⚠️ Reach, stated because a pin that overclaims is worse than none. The
+ * console's own call site does NOT receive this diagnostic today:
+ * `app-shell/src/views/ObjectView.tsx` builds `mergedViews` as
+ * `views.map((v: any) => …)` over STORED view records, so it arrives typed
+ * `any[]` and nothing here reports on it. The diagnostic reaches a host that
+ * writes the entry inline against this prop's declared type. Typing the
+ * stored-record path is an app-shell change and was recorded, ⛔ not smuggled
+ * into this card.
+ *
+ * ## `@object-ui/types`, not a relative path
+ *
+ * This package's `tsconfig.test.json` sets `"paths": {}`, so the specifier
+ * resolves through the workspace dependency's `exports` map to
+ * `packages/types/dist/index.d.ts` — the surface a published consumer sees.
+ * ⚠️ `@object-ui/types` must therefore be BUILT for this file to mean anything.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { TreeViewConfig } from '@object-ui/types';
+import type { ObjectViewProps } from '../ObjectView';
+
+type Assert<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+/** One element of the `views` prop — the shape a host composes. */
+type ViewEntry = NonNullable<ObjectViewProps['views']>[number];
+
+describe('objectui#8253 — the views entry declares its `tree` block', () => {
+  it('is pinned at compile time', () => {
+    // Non-vacuity: before this card `tree` resolved to `any` through the index
+    // signature, and `any` satisfies every assignability pin below. This line
+    // is what tells the two apart, and it is the line that would have failed
+    // on the parent commit.
+    type _TreeIsNotAny = Assert<Equal<IsAny<ViewEntry['tree']>, false>>;
+
+    // ⛔ One declaration, not two: the entry's `tree` IS the exported type.
+    // A structurally-equal local twin would pass an `extends` check, so this
+    // is pinned as invariant equality.
+    type _SameDeclaration = Assert<Equal<ViewEntry['tree'], TreeViewConfig | undefined>>;
+
+    expect(true).toBe(true);
+  });
+
+  it('NARROWS: a misspelled key inside `tree` is now a compile error', () => {
+    // The class-(c) defect in its original spelling — the console user writes
+    // `parentFeild`, the block is stored, nothing reads it, nothing says so.
+    // ⚠️ The directive must be the LAST comment line before the property.
+    const composed: ViewEntry = {
+      id: 'tree',
+      label: 'Hierarchy',
+      type: 'tree',
+      tree: {
+        // @ts-expect-error objectui#8253 — an undeclared key on the tree block is refused.
+        parentFeild: 'parent',
+      },
+    };
+
+    expect(composed.type).toBe('tree');
+  });
+
+  it('DOES NOT WIDEN OR BREAK: an undeclared key elsewhere on the entry is still admitted', () => {
+    // The control leg. The index signature is untouched, so a host's own
+    // bookkeeping key on the ENTRY still type-checks. If this line ever starts
+    // failing, the change stopped being a narrowing of one key and became a
+    // breaking change to every host that composes `views`.
+    const withHostKey: ViewEntry = {
+      id: 'tree',
+      label: 'Hierarchy',
+      type: 'tree',
+      someHostBookkeepingKey: { anything: true },
+    };
+
+    expect(withHostKey.someHostBookkeepingKey).toEqual({ anything: true });
+  });
+
+  it('accepts every declared key, so the refusal above is about spelling', () => {
+    const full: ViewEntry = {
+      id: 'tree',
+      label: 'Hierarchy',
+      type: 'tree',
+      tree: {
+        parentField: 'parent',
+        labelField: 'name',
+        titleField: 'subject',
+        fields: ['name', 'manager'],
+        defaultExpandedDepth: 1,
+      },
+    };
+
+    expect(full.tree).toMatchObject({ parentField: 'parent', defaultExpandedDepth: 1 });
+  });
+});

--- a/packages/types/src/__tests__/tree-view-config-readers-8253.test.ts
+++ b/packages/types/src/__tests__/tree-view-config-readers-8253.test.ts
@@ -1,0 +1,225 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8253 — `TreeViewConfig`'s key census is total over its readers, and
+ * the module-local copy it replaced is GONE rather than shadowed.
+ *
+ * ## The card
+ *
+ * `tree` is a host-composition-only view type (objectui#5321 ruling B): on
+ * neither authored union, reached only when a host passes a `views` prop. The
+ * per-view `tree` block that path reads had NO exported type — its only
+ * description was the module-local `interface TreeConfig` in
+ * `plugin-tree/src/ObjectTree.tsx`. The live host is the console, which stores
+ * view records and passes them as `views`, so a real consumer wrote this block
+ * against nothing and a misspelled key was stored, dropped and never reported.
+ * Ruled option (a) on objectui#8253 (decision batch #78, 2026-09-07, maintainer
+ * 「同意」): export the config, import it at the reader, ⛔ no second copy.
+ *
+ * ## What this file owns, and what it deliberately does not
+ *
+ * It owns the DERIVED half — the part a type-level pin cannot see:
+ *
+ *   - the private interface is gone from the reader;
+ *   - the reader imports the exported name instead;
+ *   - the resolver's local `ResolvedTreeConfig` is `Pick`ed off the one
+ *     declaration rather than hand-written beside it;
+ *   - all four reader sites are where this census says they are.
+ *
+ * It does NOT own reachability through the published `exports` map. That is
+ * unassertable from inside this package — `tsconfig.test.json` here sets
+ * `"paths": {}` AND there is no self-link in `packages/types/node_modules`, so
+ * `@object-ui/types` is not a specifier this project can resolve at all. It is
+ * pinned from a CONSUMER instead, in
+ * `plugin-tree/src/ObjectTree.hostConfigExported-8253.test.ts`, whose own
+ * `"paths": {}` sends the specifier through the workspace dependency to
+ * `packages/types/dist/index.d.ts`. Two files, two halves, neither redundant.
+ *
+ * ## Every zero below has a firing control
+ *
+ * A `not.toMatch` is worth nothing until the same instrument is shown matching
+ * something that IS there. Each negative assertion is paired with a positive
+ * one on the same regex family and the same file.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { TreeViewConfig } from '../index';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..', '..', '..');
+const read = (rel: string) => readFileSync(join(REPO_ROOT, rel), 'utf8');
+
+const RESOLVER = 'packages/plugin-tree/src/ObjectTree.tsx';
+const VIEW_BRANCH = 'packages/plugin-view/src/ObjectView.tsx';
+const LIST_BRANCH = 'packages/plugin-list/src/ListView.tsx';
+const CONSOLE_COMPOSITION = 'packages/app-shell/src/views/ObjectView.tsx';
+
+/** The declared keys, as a value — so the runtime census and the type agree. */
+const DECLARED = [
+  'parentField',
+  'labelField',
+  'titleField',
+  'fields',
+  'defaultExpandedDepth',
+] as const;
+
+/* -------------------------------------------------------------------------- */
+/* Compile-time: the value list above IS the type's key set, not a copy of it. */
+/* -------------------------------------------------------------------------- */
+
+type Assert<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+// Without this, `DECLARED` is a second hand-maintained key list — the exact
+// artefact this card removed from `ObjectTree.tsx`. It is checked in BOTH
+// directions, so a key added to the interface without being added here fails
+// as loudly as the reverse.
+type _CensusMatchesType = Assert<Equal<(typeof DECLARED)[number], keyof TreeViewConfig>>;
+
+describe('the module-local copy is gone, not shadowed (objectui#8253)', () => {
+  const src = read(RESOLVER);
+
+  // ⚠️ Anchored at the start of a line, and that is load-bearing rather than
+  // tidy. The first spelling of this pin was an unanchored
+  // `/interface\s+TreeConfig\b/`, and it went RED on a green tree: the
+  // replacement docblock in `ObjectTree.tsx` says the words "interface
+  // TreeConfig" while EXPLAINING that the interface is gone. An unanchored
+  // regex over a source file cannot tell a declaration from prose about a
+  // declaration. A declaration starts its line; a docblock line starts with
+  // ` * `.
+  const DECLARATION = (name: string) =>
+    new RegExp(String.raw`^\s*(export\s+)?interface\s+${name}\b`, 'm');
+
+  it('declares no private `TreeConfig` interface any more', () => {
+    expect(src).not.toMatch(DECLARATION('TreeConfig'));
+  });
+
+  it('CONTROL: the same instrument still finds an interface that IS there', () => {
+    // `TreeNode` is declared in the same file, two statements from where
+    // `TreeConfig` stood. If the regex family has stopped matching interface
+    // declarations at all, this fails and the negative above stops counting.
+    expect(src).toMatch(DECLARATION('TreeNode'));
+  });
+
+  it('CONTROL: and the anchor is what does the work', () => {
+    // Pins the trap itself, so the next person to "simplify" this regex is
+    // told why it is shaped this way: the prose IS in the file, and only the
+    // anchor keeps it from reading as a declaration.
+    expect(src).toMatch(/interface TreeConfig/);
+    expect(src).not.toMatch(DECLARATION('TreeConfig'));
+  });
+
+  it('imports the exported type from the package entry', () => {
+    expect(src).toContain("TreeViewConfig } from '@object-ui/types'");
+  });
+
+  it('derives its resolved form from the one declaration instead of restating it', () => {
+    // `ResolvedTreeConfig` may add REQUIREDNESS (the resolver floors
+    // `labelField` and `fields`) but must not respell a key or a key's type —
+    // a structurally-equal hand-written twin type-checks fine and would defeat
+    // the export entirely.
+    expect(src).toMatch(/Required<Pick<TreeViewConfig,\s*'labelField' \| 'fields'>>/);
+    expect(src).toMatch(/Pick<TreeViewConfig,\s*'parentField' \| 'defaultExpandedDepth'>/);
+  });
+
+  it('CONTROL: and the resolver still returns that type', () => {
+    // Proves the derived type is WIRED IN, not merely declared and orphaned.
+    expect(src).toMatch(/function getTreeConfig\(schema: any\): ResolvedTreeConfig/);
+  });
+});
+
+describe('every declared key has a reader (objectui#8253)', () => {
+  const resolver = read(RESOLVER);
+  /** `getTreeConfig`'s body — the block the ruling scoped the census to. */
+  const fn = (() => {
+    const from = resolver.slice(resolver.indexOf('function getTreeConfig'));
+    return from.slice(0, from.indexOf('\n}\n') + 3);
+  })();
+
+  it('the resolver body was actually located', () => {
+    // The slice above is derived from source text; if the function is renamed
+    // the slice silently becomes the whole file and every assertion under it
+    // passes for the wrong reason. Bound it explicitly.
+    expect(fn.length).toBeGreaterThan(80);
+    expect(fn.length).toBeLessThan(resolver.length / 2);
+    expect(fn).toContain('function getTreeConfig');
+  });
+
+  it.each(DECLARED)('reads `%s`', (key) => {
+    expect(fn).toContain(key);
+  });
+
+  it('CONTROL: a key that is neither declared nor read is absent', () => {
+    // If this ever appears in the resolver, the census has stopped being total
+    // and the type owes a decision — declare the key, or delete the read. That
+    // is the card's own rule, applied to itself.
+    expect(fn).not.toContain('sortField');
+  });
+});
+
+describe('`titleField` stays DECLARED — the measurement the ruling asked for', () => {
+  // The ruling put this key to a measurement: declare it if the console writes
+  // it, else delete the read. The answer came back split, and the READ side
+  // decides.
+  //
+  //   - the console's create-view dialog does NOT offer it: its `tree` slot
+  //     collects `parentField` alone (asserted below);
+  //   - but the console's own host composition reads it BY NAME, as do the
+  //     `ListView` and `ObjectView` tree branches;
+  //   - and objectui#6557 pinned the rung as live behaviour in
+  //     `app-shell/src/views/ObjectView.titleFieldConvergence.test.tsx`
+  //     ("the tree's second view-declared rung … still answers"), a regression
+  //     pin landed precisely so a later edit could not collapse the tree's two
+  //     view-declared rungs into one.
+  //
+  // ⇒ Deleting the read would reverse a recorded ruling and redden its pin —
+  // a maintainer's call, not a rider on this card. Declaring the key is what
+  // makes declared = enforced at all four sites at once.
+
+  it('the console composition reads it', () => {
+    expect(read(CONSOLE_COMPOSITION)).toContain('tree?.titleField');
+  });
+
+  it('the plugin-view tree branch reads it', () => {
+    expect(read(VIEW_BRANCH)).toContain('viewOptions.tree?.titleField');
+  });
+
+  it('the plugin-list tree branch reads it', () => {
+    expect(read(LIST_BRANCH)).toContain('treeCfg.titleField');
+  });
+
+  it("objectui#6557's pin on the rung is still in the tree", () => {
+    // Named explicitly: if this file is ever deleted, whoever deletes it is
+    // told here that this declaration's justification went with it.
+    expect(read('packages/app-shell/src/views/ObjectView.titleFieldConvergence.test.tsx'))
+      .toContain('tree.titleField');
+  });
+
+  it("CONTROL: the console's create-view dialog still does NOT offer it for `tree`", () => {
+    // The other half of the measurement, and the half that would have argued
+    // for deleting the read. `titleField` IS collected — for calendar,
+    // timeline and gantt — so a zero for the `tree` slot is a reading about
+    // the tree slot and not about a broken instrument.
+    const dialog = read('packages/app-shell/src/views/CreateViewDialog.tsx');
+    const treeSlot = (() => {
+      const from = dialog.slice(dialog.indexOf('\n  tree: ['));
+      return from.slice(0, from.indexOf('\n  ],') + 5);
+    })();
+
+    expect(treeSlot).toContain("key: 'parentField'");
+    expect(treeSlot).not.toContain("key: 'titleField'");
+    // FIRING CONTROL: the same instrument, on a slot that does collect it.
+    expect(dialog).toContain("key: 'titleField'");
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -879,6 +879,10 @@ export type {
 export type {
   // View System Enhancements
   ViewType,
+  // Host-composition config for the `tree` view type (objectui#8253). The
+  // ONE declaration of the block `ObjectViewProps.views[n].tree` carries;
+  // `plugin-tree` imports it instead of re-deriving a module-local copy.
+  TreeViewConfig,
   DetailViewSchema,
   DetailViewField,
   DetailViewSection,

--- a/packages/types/src/views.ts
+++ b/packages/types/src/views.ts
@@ -53,6 +53,100 @@ import type { ListView as SpecListView } from '@objectstack/spec/ui';
 export type ViewType = NonNullable<SpecListView['type']> | 'list' | 'detail';
 
 /**
+ * Per-view `tree` configuration — the HOST-composition contract (objectui#8253).
+ *
+ * This is the block a host writes as `tree` on a `views` entry
+ * (`ObjectViewProps.views[n].tree`, or `options.tree` on a stored view record),
+ * and it is the ONE declaration of that shape. ⛔ Do not re-derive a private
+ * copy of it: the module-local `TreeConfig` in `plugin-tree/src/ObjectTree.tsx`
+ * that used to be the only description of these keys is now an import of this
+ * type, and objectui#7646 is the shape a second copy takes.
+ *
+ * ## Why it is declared here, and what it is NOT
+ *
+ * `tree` is a HOST-COMPOSITION-ONLY view type, ruled deliberate on objectui#5321
+ * (maintainer ruling B, 2026-08-20): it is a member of neither
+ * `ObjectViewSchema.defaultViewType` nor `NamedListView.type`, so no AUTHORED
+ * document selects a tree view and the branch runs only when a host passes a
+ * `views` prop. ⛔ That ruling is untouched by this declaration — typing the
+ * host path does not put `tree` on an authored union, and this type is NOT the
+ * `object-tree` NODE schema. The node an author writes is `ObjectTreeSchema`
+ * (`./objectql.ts`), whose keys sit FLAT on the node; this block sits nested
+ * under a view entry and is written by a host, never by a document author.
+ *
+ * ## Why it is a contract at all (objectui#8253, ruling batch #78, 2026-09-07)
+ *
+ * Maintainer 「同意」 on option (a): a configuration a real host STORES and
+ * RE-WRITES is a contract and has a type. The live host is the console — it
+ * passes stored view records to `ObjectView` as `views`, and its create-view
+ * dialog offers `tree`. Until this declaration existed a console user's
+ * misspelled `parentFeild` was admitted by the `[key: string]: any` on the
+ * views entry, read by nobody, and reported by nothing: declared ≠ enforced on
+ * a surface a non-author re-writes.
+ *
+ * ## The reader census these keys are exactly total over
+ *
+ * Every key below is read, and every read of this block is of a key below:
+ *
+ *   - `plugin-tree/src/ObjectTree.tsx`      `getTreeConfig` — the resolver
+ *   - `plugin-view/src/ObjectView.tsx`      the `'tree'` branch of `generateViewSchema`
+ *   - `plugin-list/src/ListView.tsx`        the `'tree'` branch
+ *   - `app-shell/src/views/ObjectView.tsx`  `options.tree`, the console's own composition
+ *
+ * ⚠️ `fields` is `string[]`, matching `ObjectTreeSchema.fields`, even
+ * though `ObjectTree`'s `fieldKey` also normalises a column OBJECT
+ * (`{ name | fieldName | field | key }`). That tolerance exists because hosts
+ * like `ListView` forward their own already-resolved column entries into the
+ * same slot; it is a reader's resilience, ⛔ not an invitation to write column
+ * objects here, and declaring the wider form would widen the accept set past
+ * what the sibling node schema admits.
+ */
+export interface TreeViewConfig {
+  /**
+   * Field holding the parent record reference (single-parent pointer).
+   * When omitted, the renderer auto-detects the object's `tree` /
+   * self-reference field.
+   */
+  parentField?: string;
+  /** Field rendered (indented) in the tree's first column. Floored at `name`. */
+  labelField?: string;
+  /**
+   * Legacy second rung for {@link TreeViewConfig.labelField}, kept DECLARED
+   * rather than removed — measured, objectui#8253.
+   *
+   * The ruling put this key to a measurement: declare it if the console writes
+   * it, else delete the read. The measurement came back split, and the half
+   * that decides is the READ side. The console's create-view dialog does NOT
+   * offer it — `CreateViewDialog.tsx`'s `tree` slot collects `parentField` and
+   * nothing else, while `titleField` is what its calendar / timeline / gantt
+   * slots collect. But the console's own host composition reads it BY NAME
+   * (`app-shell/src/views/ObjectView.tsx`, `viewDef.tree?.titleField`), so do
+   * `ListView` and `ObjectView`'s tree branches, and the rung is PINNED as live
+   * behaviour by `app-shell/src/views/ObjectView.titleFieldConvergence.test.tsx`
+   * — "the tree's second view-declared rung (`tree.titleField`) still answers",
+   * a regression pin objectui#6557 landed precisely so a later edit could not
+   * collapse the tree's two view-declared rungs into one.
+   *
+   * ⇒ Deleting the read would reverse a recorded ruling and redden its pin,
+   * which is a maintainer's call and not a rider on this card. Declaring it is
+   * what makes declared = enforced across all four read sites at once.
+   *
+   * ⛔ Not a tolerant dual-read to be extended: `labelField` is the canonical
+   * spelling and wins wherever both are present.
+   */
+  titleField?: string;
+  /**
+   * Additional fields rendered as flat columns alongside the label column.
+   * When omitted the host's own column list is used.
+   */
+  fields?: string[];
+  /**
+   * Initial expansion depth. `0` = roots only; omitted = expand everything.
+   */
+  defaultExpandedDepth?: number;
+}
+
+/**
  * Detail View Field Configuration
  */
 export interface DetailViewField {

--- a/scripts/check-doc-example-types.mjs
+++ b/scripts/check-doc-example-types.mjs
@@ -815,19 +815,19 @@ export const UNGATED_EXAMPLES = {
     reason:
       'usage fragment: references `myAdapter`, `report`, which the example never declares',
   },
-  'packages/plugin-view/src/ObjectView.tsx:591 ObjectView': {
+  'packages/plugin-view/src/ObjectView.tsx:618 ObjectView': {
     card: null,
     codes: [2304],
     reason:
       'usage fragment: references `dataSource`, which the example never declares',
   },
-  'packages/plugin-view/src/ObjectView.tsx:605 ObjectView': {
+  'packages/plugin-view/src/ObjectView.tsx:632 ObjectView': {
     card: null,
     codes: [2304],
     reason:
       'usage fragment: references `dataSource`, which the example never declares',
   },
-  'packages/plugin-view/src/ObjectView.tsx:622 ObjectView': {
+  'packages/plugin-view/src/ObjectView.tsx:649 ObjectView': {
     card: null,
     codes: [2304],
     reason:

--- a/scripts/check-spec-symbol-derivation.mjs
+++ b/scripts/check-spec-symbol-derivation.mjs
@@ -882,9 +882,6 @@ const DEBT = {
   "@object-ui/plugin-detail": [
     "RecordAlertProps",
   ],
-  "@object-ui/plugin-tree": [
-    "TreeConfig",
-  ],
 };
 
 // Files under these paths are not objectui's own authored surface.


### PR DESCRIPTION
Fixes #8253

Implements the recorded ruling — **option (a): export the host `tree` view config type** (director seat, decision batch #78, 2026-09-07, maintainer 「同意」). ⛔ Not re-opened, not re-routed.

## What was wrong

`tree` is a **host-composition-only** view type (objectui#5321 ruling B): it is a member of neither `ObjectViewSchema.defaultViewType` nor `NamedListView.type`, so no authored document reaches that branch — it runs only when a host passes a `views` prop. On that path a per-view `tree` block is read at four sites, and its only description anywhere was the module-local, non-exported `interface TreeConfig` in `plugin-tree/src/ObjectTree.tsx`.

The live host is the console: it stores view records and passes them as `views`, and its create-view dialog offers `tree`. So a real consumer wrote this block with **no type to write it against**, and a misspelled `parentFeild` was admitted by the views entry's `[key: string]: any`, stored, read by nobody and reported by nothing.

## The widening statement (强制条款②), in strict/lenient terms

**Names that become reachable to a consumer that could not reach them before: exactly one — `TreeViewConfig`,** exported from `@object-ui/types` (declared in `src/views.ts`, re-exported from the barrel, present in `dist/index.d.ts`). Nothing else is added, renamed, retyped or removed on any published face.

**Does anything's *value* validation change? Yes — in the narrowing direction only, on exactly one key.**

The brief's direction rule was checked against this face rather than assumed, and this card is the **narrowing** case, not the retirement case:

- `ObjectViewProps.views[n]` closes with `[key: string]: any`. On such a face a declaration **cannot widen** — every spelling was already admitted, so no value that used to be refused becomes accepted. It can only **narrow**, by adding validation where there was none.
- Declaring `tree?: TreeViewConfig` does exactly that: a host composing the entry as an object literal now gets `parentFeild` reported as an excess property instead of silently dropped.
- The index signature itself is **untouched**, so every *other* undeclared key a host puts on the entry still type-checks exactly as before. Both halves are pinned (`ObjectView.treeViewConfigDeclared-8253.test.ts`) — without the second, "it narrows" would be indistinguishable from "the index signature was removed", which would break every host.

⚠️ This is **not** the tombstone case. No key is being retired, so no `?: never` and no deletion-absorption problem arises.

⚠️ **Reach, stated rather than overclaimed.** The console's own call site does **not** receive this diagnostic today: `app-shell/src/views/ObjectView.tsx` builds `mergedViews` as `views.map((v: any) => …)` over stored view records, so it arrives typed `any[]`. The diagnostic reaches a host that composes the entry inline against the declared prop type. Typing the stored-record path is an app-shell change and was **recorded, not smuggled in here**.

## `titleField`: declared, not deleted — and that was a measurement

The ruling put this key to a test: declare it if the console writes it, else remove the read. The measurement came back **split**, and the READ side decides.

| Question | Measurement |
| --- | --- |
| Does the console's create-view dialog offer it? | **No.** `CreateViewDialog.tsx`'s `tree` slot collects `parentField` alone. `titleField` is what its **calendar / timeline / gantt** slots collect — so the zero is about the tree slot, not a broken instrument. |
| Is it read on the console's own host path? | **Yes, by name** — `app-shell/src/views/ObjectView.tsx` (`viewDef.tree?.titleField`), with a comment naming it. |
| Read anywhere else? | `plugin-view/src/ObjectView.tsx` (`viewOptions.tree?.titleField`) and `plugin-list/src/ListView.tsx` (`treeCfg.titleField`). |
| Is the rung pinned? | **Yes** — `app-shell/src/views/ObjectView.titleFieldConvergence.test.tsx`: *"CONTROL: the tree's second view-declared rung (`tree.titleField`) still answers"*, landed by **objectui#6557** precisely so a later edit could not collapse the tree's two view-declared rungs into one. |

⇒ Deleting the read would have **reversed a recorded ruling and reddened its pin** — a maintainer's call, not a rider on this card. Declaring it makes *declared = enforced* at all four read sites at once. `labelField` stays canonical and wins wherever both are present; ⛔ it is not extended into a tolerant dual-read.

Note the ruling's own scope, `ObjectTree.tsx:116-120`, **contains** the `titleField` read (at :118 on this head, cited as :119 in the ruling), so "exactly the keys that range reads" is five keys, not four.

## Unplanned finding: the export pays off a recorded spec-name-collision debt

`check:spec-symbols` keeps a per-package DEBT ledger of local declarations that reuse a `@objectstack/spec` export name. `@object-ui/plugin-tree` carried exactly one row: **`TreeConfig`**. Retiring that declaration made the gate fail the other way (a debt row that no longer collides), and the row is deleted here.

Measured on the installed `@objectstack/spec@17.3.0` dist: `TreeConfig` appears **38** times, `TreeViewConfig` **zero**. The ruling's suggested name is therefore not merely a rename — it is the one that leaves this package's ledger empty.

## The pin, and what it would catch

Two files, two halves, neither redundant:

1. **`plugin-tree/src/ObjectTree.hostConfigExported-8253.test.ts`** — reachability through the **published** surface. The import says `@object-ui/types`, and that is load-bearing: this package's `tsconfig.test.json` sets `"paths": {}` so the specifier resolves through the workspace dependency's `exports` map to `packages/types/dist/index.d.ts`, the way a published consumer resolves it. A pin importing `'../../types/src/views'` would never touch `dist` or the `exports` map and would stay green through a barrel that had stopped re-exporting the name. It pins: non-vacuity (`IsAny` false), the `keyof` census in **both** directions (which also refuses an index signature — one here would re-open the whole hole), all-keys-optional, each key's type, and `@ts-expect-error` on `parentFeild`.
2. **`types/src/__tests__/tree-view-config-readers-8253.test.ts`** — the derived half a type-level pin cannot see: the private interface is gone, the reader imports the exported name, `ResolvedTreeConfig` is `Pick`ed off the one declaration rather than hand-written beside it, all four reader sites exist, and the `titleField` measurement above is pinned with its firing control. It cannot live in plugin-tree (no `"types": ["node"]` there) and cannot import `@object-ui/types` (no self-link in `packages/types/node_modules`).

**What they catch:** un-exporting the name, dropping the barrel re-export, breaking the `exports` map, re-deriving a private copy in the renderer, adding an index signature, adding a key with no reader, removing a key from under one, or hand-writing a twin of the resolved type.

⚠️ Both require `@object-ui/types` to be **built** — a stale `dist/*.d.ts` lies in both directions. Stated in both headers.

## Verification

### Ablation — delete the export, prove the mutation on disk *before* reading any result

Target: the barrel re-export in `packages/types/src/index.ts`. Mutation, rebuild and restore ran in **one** shell under a `trap … EXIT INT TERM`.

```
MUTATION LANDED: 2319b593… -> 3e06ec34… ; anchor count 0 (was 1)
ABL_BUILD_EXIT=0
dist still exports it? 0                 (0 = the ablation reached dist, not just src)
ABLATED_PLUGIN_TREE_TYPECHECK_EXIT=2
  src/ObjectTree.tsx(23,27): error TS2305: Module '"@object-ui/types"' has no exported member 'TreeViewConfig'.
=== RESTORATION PROOF ===
RESTORED=2319b593… ; HEAD_BLOB=2319b593… ; match=YES
git diff HEAD empty = YES
```

Restored via `git checkout HEAD -- ABSOLUTE_PATH` and verified by **blob hash against `HEAD`**, not by an exit code. `dist` was rebuilt afterwards so no mutated artifact survives.

### Non-vacuity — the red is a change of state, not the resting colour

| Leg | `pnpm --filter @object-ui/plugin-tree type-check` |
| --- | --- |
| at head, **before** the ablation | **0** |
| with the export deleted | **2** (TS2305) |
| at head, **after** restoration | **0** |

### The console call-site diagnostic, compiled against built `dist`

The README fence extracted verbatim and compiled with `tsc --strict` resolving through the `exports` map:

```
LEG 1: the snippet as written                      EXIT=0
LEG 2 (firing control): parentField -> parentFeild  EXIT=2
  error TS2561: Object literal may only specify known properties,
  but 'parentFeild' does not exist in type 'TreeViewConfig'.
  Did you mean to write 'parentField'?
```

That is the class-(c) defect from the triage comment, now a compile error. The probe file was removed under a trap (`git status` clean).

### Gates — every exit code captured **before** any pipe (`cmd > file; rc=$?`), at final head `49f36c3b8`

| Gate | Exit |
| --- | --- |
| `check:control-bytes` · `check:spec-symbols` · `check:doc-examples` · `check:doc-snippets` | 0 · 0 · 0 · 0 |
| `check:readme-exports` · `check:doc-fences` · `check:doc-types` · `check:doc-example-readers` | 0 · 0 · 0 · 0 |
| `check:phantom-deps` · `check:unused-deps` · `check:self-import` | 0 · 0 · 0 |
| `check:published-tsconfig-exclude` · `check:unreferenced-sources` | 0 · 0 |
| `type-check` (types + plugin-tree + plugin-view) | 0 |
| `lint` (types + plugin-tree + plugin-view) | 0 — 0 errors, warnings pre-existing |

`check:doc-snippets` reports **637 of 637 blocks judged, 0 failed** — that is the ruling's "the plugin README's example type-checks against the exported type", measured.

⚠️ `check:readme-exports`, `check:doc-snippets` and `check:doc-examples` first came back **red for one shared reason — 22 unbuilt packages** ("run the build first"), a *prerequisite miss*, not a verdict. All three were re-run green after building the 34 packages the snippet gate's own `--build-filter` names.

**Lint is a declared narrowing, and here is its evidence.** (i) The config has **no type-aware linting** (`grep -nE "projectService|project:" eslint.config.js` → exit 1; firing control `parser` → 1 hit), so this diff cannot move any untouched file's verdict. (ii) File count read from `eslint --format json`: 8 files. (iii) Same five shared files linted at **BASE** and at **HEAD** with the same instrument: **1 error / 84 warnings at both** — the ratchet is flat, and the three new test files contribute **0 / 0**. That lone "error" is an artefact of my stricter `--no-inline-config`; it lands on a deliberate documented `/* eslint-disable no-restricted-imports */`, and the repo's own `pnpm lint` (`turbo run lint` → per-package `eslint .`) honours it and exits **0**.

### Tests

| Suite | Result |
| --- | --- |
| `packages/types/` + `packages/plugin-tree/` | **174 files, 3213 tests, 0 failed** |
| `packages/plugin-view/` | **37 files, 313 tests, 0 failed** |
| `apps/console/` (full) | **95 files, 1116 tests, 0 failed** |
| `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` — **run explicitly**, because a whole-suite pass is not a reading for one file | **1 file, 198 tests, 0 failed** |
| `scripts/__tests__/check-doc-example-types.test.ts` + `…-shared-reader.test.ts` (owed for touching a gate script) | **2 files, 73 tests, 0 failed** |
| the three new pin files | **24 tests, 0 failed** |

### Base→main pre-flight

`git diff --name-only BASE origin/main` → **39 files** moved on main since this branch's base, so the control **can** fire (verified: `packages/types/src/complex.ts` is in the window). Intersection with the six source files my pins read off disk: **0**. The empty result is a reading, not a vacuum.

## 验收备注

- **The card's "recorded, not carded" rider is resolved, not dropped.** The triage asked the implementer to check `ObjectTree.tsx:119`'s `schema.titleField` read against `ObjectTreeSchema`, which does not declare it. Answer: the key is now **declared on the host config** (`TreeViewConfig.titleField`) on the evidence in the table above. `ObjectTreeSchema` — the *authored node* face — is deliberately left alone: that is a different surface, and adding a key there would widen authored metadata, which no ruling authorises.
- **A reader asymmetry, recorded not carded.** `ObjectTree.getTreeConfig` reads `titleField` off the **node** (`schema.titleField`) but not off the **nested** block (`nested.titleField`). On every real host path this is invisible, because `ObjectView` / `ListView` / app-shell all spread the block flat onto the node before the renderer sees it. Closing it would mean *adding* an accepted spelling — a widening — so it is left exactly as measured. ⛔ Not filed: no reproducible defect and no contract violated.
- **`ResolvedTreeConfig` is not a second copy.** Every key name and type is `Pick`ed off `TreeViewConfig`; it adds only requiredness, and only for the two keys the resolver floors (`labelField` → `'name'`, `fields` → `[]`). A structurally-equal hand-written twin would type-check fine and defeat the export, so the derivation is pinned by shape.
- **⚠️ File-surface note for the PM — please sequence.** My measured surface has **zero** intersection with the three enumerated held sets (#8799, #8807, #8478); the instrument was verified firing (self-intersection = 18). But measuring #8807's *actual* branch shows it is wider than the list I was given: it also touches **`scripts/check-doc-example-types.mjs`**, which this PR touches too. The hunks are ~190 lines apart and non-overlapping — #8807 re-keys one `objectql.ts` row, this PR re-keys three `plugin-view/src/ObjectView.tsx` rows — and both are the same maintenance that line-keyed ledger demands of any PR inserting a line above an `@example`. Mine is **not deferrable**: #8807 does not touch `plugin-view/src/ObjectView.tsx`, so only a PR that moves those lines can re-key those rows. Flagging rather than deciding.

## 维护者速读（草稿）

**改了什么** — 把宿主写的 per-view `tree` 配置块从「一个藏在渲染器里、没导出的私有 interface」提升为 `@object-ui/types` 的正式导出类型 `TreeViewConfig`，渲染器改为 import 它（⛔ 不留第二份副本），并在 `ObjectViewProps.views` 条目上声明 `tree?: TreeViewConfig`。

**为什么改** — console 今天就在存这份配置、并让用户反复改写它。可它没有任何类型可对着写：用户把 `parentField` 拼成 `parentFeild`，配置照存不误，没人读、也没有任何提示。「被存下来、由非作者再写一遍」的东西就是契约，契约必须有类型 —— 这是 #8253 的裁决原话。

**风险与代价（含回滚）** — 风险很低，方向是**收紧**而非放宽。

那个 views 条目本来就带一个开放的索引签名（index signature，值类型 any），所以以前能通过的值现在没有一个被拒绝，变化只是**多了一处校验**；索引签名原样保留，宿主的其它自定义键照旧。

回滚方式是 revert 本 PR 的三个 commit；没有数据迁移，也没有任何运行期行为改变（titleField 的读取原样保留，理由见上表）。附带收益：plugin-tree 与上游 spec 的那笔命名冲突欠账就此还清。

**席位意见** — _（留空，待 contract-review 席位定稿）_

**你要做的** — 确认两件事即可：① `titleField` **保留声明**而非删除读取（依据是 #6557 已有的 pin 与 console 自身的读取，删它等于推翻旧裁决）；② PM 需要为上面那条 `scripts/check-doc-example-types.mjs` 与 #8807 的先后顺序做个安排。

---

⛔ **Do not enqueue.** `Clause-②: yes` — this enlarges the published type face, so an in-seat **contract-review-tier** PASS is required first. `needs:contract-review` is hung on **both** carriers (card #8253 and this PR); a legitimate clear removes both together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w


---
_Generated by [Claude Code](https://claude.ai/code)_