### PR TITLE
fix(ci): make an unconfigured half-state anchor a supported configuration

### DIFF
--- a/.github/workflows/half-state-patrol.yml
+++ b/.github/workflows/half-state-patrol.yml
@@ -129,14 +129,39 @@ name: Half-State Patrol
 # that at length (a half-state is a fact about a live shared board, not about
 # whichever PR happens to run CI next).
 #
-# The job DOES fail when the sweep could not run, or when its report could not be
-# delivered. That is not a gate on the board; it is the patrol reporting its own
-# death. A workflow that quietly does nothing because a credential lapsed is the
-# exact shape this repo keeps having to fix (#4449, #9575), and it is doubly
-# unacceptable here: silent non-delivery would leave a stale anchor body that
-# reads exactly like a clean board — the #4690 failure ("could not read the input"
-# must never look like "input is clean") with a timestamp on it. Failing costs
-# nobody a PR: this workflow gates no branch and blocks no queue.
+# The job DOES fail when the sweep could not run, or when a CONFIGURED anchor
+# could not be written. That is not a gate on the board; it is the patrol
+# reporting its own death. A workflow that quietly does nothing because a
+# credential lapsed is the exact shape this repo keeps having to fix (#4449,
+# #9575), and it is doubly unacceptable here: silent non-delivery would leave a
+# stale anchor body that reads exactly like a clean board — the #4690 failure
+# ("could not read the input" must never look like "input is clean") with a
+# timestamp on it. Failing costs nobody a PR: this workflow gates no branch and
+# blocks no queue.
+#
+# ## NO anchor configured is a SUPPORTED configuration (objectui#8740)
+#
+# The one case deliberately carved out of the paragraph above: an install where
+# the anchor variable is UNSET delivers to the run summary, emits a `::notice::`
+# naming the variable, and exits 0. It is not a failure because there is nothing
+# to fix — this is a settled configuration here, not a lapse. objectui's
+# maintainer closed objectui#7852 and #5986 (「7852 太麻烦，直接关闭」), so the
+# anchor setup will not happen in this install, and the previous behaviour left
+# a scheduled job red four times a day forever. objectui#6596 ruled on exactly
+# that shape: A CHECK RED ON THE HEALTHY CASE TRAINS EVERYONE TO IGNORE RED —
+# permanent red is the larger defect, and it costs the sibling install its alarm
+# too, because a lane where every run is red carries no signal when a real one
+# goes red.
+#
+# ⛔ The carve-out is EMPTY-ONLY and does not widen. A configured anchor that is
+# malformed, missing, or refuses the write still fails loudly (see the "Resolve
+# the anchor" step and the guarded write below): "nobody asked for delivery" and
+# "delivery was asked for and failed" are opposite facts and must not share an
+# exit code. The ACCEPTED COST of the empty branch is written down rather than
+# discovered later: findings then live only in run summaries, which notify
+# nobody — objectui#5791 measured what that costs on this board (7 blocks whose
+# blocker had already closed, 58% of the machine-readable blocks false, one for
+# a week).
 #
 # ## Adopting this in a sibling repo (#11217)
 #
@@ -151,9 +176,12 @@ name: Half-State Patrol
 # To adopt, in the sibling repo:
 #
 #   1. copy `scripts/pm/check-half-states.mjs` and this file, unchanged;
-#   2. open one `tracking`-labeled anchor issue there and set the repository
-#      VARIABLE `HALF_STATE_ANCHOR_ISSUE` to its number
-#      (Settings → Secrets and variables → Actions → Variables).
+#   2. OPTIONAL since objectui#8740 — open one `tracking`-labeled anchor issue
+#      there and set the repository VARIABLE `HALF_STATE_ANCHOR_ISSUE` to its
+#      number (Settings → Secrets and variables → Actions → Variables). Skip it
+#      and the install still sweeps and still reports, into each run's summary
+#      only; the trade is stated under "NO anchor configured" above and it is a
+#      real one — a summary notifies nobody.
 #
 # That is the whole install. The swept repo needs no configuration at all: it is
 # `github.repository`, so the copy reads the board it lives in — a hardcoded
@@ -217,9 +245,11 @@ env:
   # input this file takes (#11217).
   #
   # Resolution: the repository variable `HALF_STATE_ANCHOR_ISSUE` if set, else
-  # this repo's own pinned number, else EMPTY — and empty makes the job refuse
-  # to write rather than guess (see the "Resolve the anchor" step). The literal
-  # is guarded by the repository name on purpose: an unguarded fallback is what
+  # this repo's own pinned number, else EMPTY — and empty makes the job report
+  # to the run summary instead of guessing a number, without failing (see the
+  # "Resolve the anchor" step). ⛔ Empty is the ONLY branch that does not fail;
+  # a number that is present and unusable still does. The literal is guarded by
+  # the repository name on purpose: an unguarded fallback is what
   # would let a verbatim copy in objectui rewrite ITS #9857 — some unrelated
   # card — with this board's findings, silently and four times a day. A number
   # is only ever meaningful in the repo it was minted in.
@@ -227,7 +257,8 @@ env:
   # TO ROTATE (here): open a new `tracking`-labeled issue, put its number below,
   # and note the handover in the OLD issue's body before closing it (its edit
   # history is the archive and does not travel).
-  # TO ADOPT (a sibling repo): change NOTHING here — set the repository variable.
+  # TO ADOPT (a sibling repo): change NOTHING here — set the repository variable,
+  # or set nothing and read the run summaries (objectui#8740).
   #
   # The anchor deliberately carries `tracking` and NO `domain:*` label: `tracking`
   # is in the sweeper's own H13_EXEMPT_LABELS, so the anchor can never appear as a
@@ -298,31 +329,57 @@ jobs:
           cat "$RUNNER_TEMP/report.err" >&2 || true
 
       - name: Resolve the anchor issue
-        # An install with no anchor configured has nowhere to land its report,
-        # and the ONLY safe behaviour is to say so loudly (#11217). The two
-        # alternatives are both the failure this file exists to prevent:
-        # guessing a number would rewrite an unrelated card in this repo, and
-        # skipping the write quietly would leave a patrol that runs, finds, and
-        # tells nobody — indistinguishable from a clean board.
+        # This step decides, ONCE, whether this install delivers to an anchor,
+        # and publishes that decision as `configured` for the steps below. ⛔ Do
+        # not re-derive emptiness anywhere else in this file: two spellings of
+        # "no anchor" drift, and the pair that matters here would drift into a
+        # run that reports "not configured" and then PATCHes issue 0.
+        #
+        # Three outcomes, and the distinction between the first two is the whole
+        # of objectui#8740:
+        #
+        #   EMPTY  — nobody asked for anchor delivery. `::notice::`, `exit 0`,
+        #            and the rendered body reaches the run summary below. Not a
+        #            failure: the maintainer declined the anchor setup here
+        #            (objectui#7852 closed 「太麻烦」), so a red run every six
+        #            hours would report a settled configuration as a defect, and
+        #            objectui#6596 already ruled that a check red on the healthy
+        #            case trains everyone to ignore red.
+        #   BAD    — an anchor WAS configured and cannot be used (non-numeric).
+        #            `::error::` and `exit 1`, unchanged. Delivery was asked for
+        #            and did not happen; that is the patrol reporting its own
+        #            death and it must never share an exit code with the branch
+        #            above. ⛔ objectui#8740 does not widen into "the anchor step
+        #            never fails".
+        #   NUMBER — deliver, and let the write's own failure fail the run.
         #
         # Placed AFTER the sweep so the run summary still carries the rendered
         # findings (the same "land the truth, then raise the alarm" order the
         # final step keeps), and skipped on a pull_request run, which never
         # writes an anchor at all.
+        id: anchor
         if: github.event_name != 'pull_request'
         run: |
           if [ -z "${ANCHOR_ISSUE//[[:space:]]/}" ]; then
-            echo "::error::No anchor issue configured for ${{ github.repository }}. The sweep RAN (see the run summary) but has nowhere to land. Open a \`tracking\`-labeled anchor issue in this repo and set the repository variable HALF_STATE_ANCHOR_ISSUE to its number (Settings -> Secrets and variables -> Actions -> Variables)."
-            exit 1
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No anchor issue configured for ${{ github.repository }}, which is a supported configuration here (objectui#8740). The sweep RAN and its rendered body is in this run's summary; nothing was written to any issue and this run is NOT a failure. To deliver findings to a pinned issue instead, open a \`tracking\`-labeled anchor issue in this repo and set the repository variable HALF_STATE_ANCHOR_ISSUE to its number (Settings -> Secrets and variables -> Actions -> Variables)."
+            exit 0
           fi
           case "$ANCHOR_ISSUE" in
             *[!0-9]*|'') echo "::error::HALF_STATE_ANCHOR_ISSUE is '$ANCHOR_ISSUE', which is not an issue number."; exit 1 ;;
           esac
+          echo "configured=true" >> "$GITHUB_OUTPUT"
           echo "anchor: #$ANCHOR_ISSUE in ${{ github.repository }}"
 
       - name: Update the pinned anchor issue
-        # A pull_request run proves the sweep; it must not touch the board.
-        if: github.event_name != 'pull_request'
+        # A pull_request run proves the sweep; it must not touch the board. And
+        # an install with no anchor has no board write to attempt at all: the
+        # guard reads the resolve step's OUTPUT rather than testing
+        # `env.ANCHOR_ISSUE` again, so this step runs exactly when that step
+        # decided delivery was asked for. Tested against `env.ANCHOR_ISSUE != ''`
+        # this would disagree with the resolve step on a whitespace-only value
+        # and PATCH `Number(' ')` = issue 0 (objectui#8740).
+        if: github.event_name != 'pull_request' && steps.anchor.outputs.configured == 'true'
         uses: actions/github-script@v9
         env:
           SWEEP_EXIT: ${{ steps.sweep.outputs.exit_code }}
@@ -397,6 +454,12 @@ jobs:
             echo
             if [ "${{ github.event_name }}" = "pull_request" ]; then
               echo "_Anchor write skipped: a pull_request run proves the sweep without touching the board._"
+              echo
+            elif [ "${{ steps.anchor.outputs.configured }}" = "false" ]; then
+              # ⛔ Only on the EXPLICIT not-configured reading. A malformed
+              # anchor sets no output and fails the run, and must not be
+              # described here as "nothing was asked for" (objectui#8740).
+              echo "_No anchor issue configured (\`HALF_STATE_ANCHOR_ISSUE\` is unset): this summary is the ONLY delivery of the findings below — it notifies nobody, by accepted trade. Set that repository variable to a \`tracking\` issue's number to have them land on a pinned card instead._"
               echo
             fi
             echo '<details><summary>Rendered anchor body</summary>'

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -56,7 +56,7 @@ one has its own section below.
 | `published-dist-gate.yml` | Published Dist Tooling Scan | Nightly cron `41 3 * * *`; push to `main` touching the gate; manual | No — the blocking copy runs on the publish path, not here |
 | `spec-range-floors.yml` | Spec Range Floor Scan | Nightly cron `11 4 * * *`; push to `main` touching the gate; manual | No — the blocking copy runs on the publish path, not here |
 | `node-esm-load-gate.yml` | Node ESM Load Scan | Nightly cron `17 4 * * *`; push to `main` touching the gate; manual | No — the per-PR half is `pnpm check:esm-specifiers` in **Type Check** |
-| `half-state-patrol.yml` | Half-State Patrol | 6-hourly cron `37 1,7,13,19 * * *`; manual; PR touching the sweeper or the workflow | No — **report-only**; it fails only when the sweep could not run |
+| `half-state-patrol.yml` | Half-State Patrol | 6-hourly cron `37 1,7,13,19 * * *`; manual; PR touching the sweeper or the workflow | No — **report-only**; it fails only when the sweep could not run, or a *configured* anchor could not be written |
 | `merge-queue-head-patrol.yml` | Merge queue head patrol | Every 15 minutes (cron `7,22,37,52 * * * *`); manual | No — it gates no branch and blocks no queue, but it **goes red on a finding**: a merge-queue head with no `merge_group` build is a live repo-wide block |
 | `hook-selftests.yml` | Hook Self-Tests | PR / push touching `.claude/hooks/**` or the workflow | **Yes** |
 
@@ -2103,16 +2103,30 @@ it found 0 half-states or 40. Its one write is the anchor issue's body, and `per
 nothing beyond `contents: read` + `issues: write`. A pull-request run proves the sweep on a real
 runner but skips the anchor write entirely, publishing the rendered body to the run summary instead.
 
-The run *does* go red when the sweep could not run or its report could not be delivered — that is
-the patrol reporting its own death, not a gate on the board. A workflow that quietly does nothing
-because a credential lapsed would leave a stale anchor body that reads exactly like a clean board.
-For the same reason the `Swept` timestamp is refreshed even when the findings are unchanged: a
-timestamp that stops advancing is how a reader learns the standing caller died.
+The run *does* go red when the sweep could not run, or when a **configured** anchor could not be
+written — that is the patrol reporting its own death, not a gate on the board. A workflow that
+quietly does nothing because a credential lapsed would leave a stale anchor body that reads exactly
+like a clean board. For the same reason the `Swept` timestamp is refreshed even when the findings
+are unchanged: a timestamp that stops advancing is how a reader learns the standing caller died.
 
-**One manual setup step.** The anchor issue is named by the repository *variable*
-`HALF_STATE_ANCHOR_ISSUE` (Settings → Secrets and variables → Actions → Variables). Until it is set
-the job fails loudly *after* sweeping, with the findings preserved in the run summary — it will not
-guess an issue number and rewrite an unrelated card.
+**The anchor is optional, and unset is a supported configuration**
+([#8740](https://github.com/objectstack-ai/objectui/issues/8740)). The anchor issue is named by the
+repository *variable* `HALF_STATE_ANCHOR_ISSUE` (Settings → Secrets and variables → Actions →
+Variables). With it unset — which is this repository's state, after the maintainer declined the
+setup on [#7852](https://github.com/objectstack-ai/objectui/issues/7852) — the job still sweeps,
+publishes the rendered body to the **run summary**, emits a `::notice::` naming the variable, and
+**exits 0**. It will not guess an issue number and rewrite an unrelated card, and it no longer goes
+red for a settled configuration: a check red on the healthy case trains everyone to ignore red
+([#6596](https://github.com/objectstack-ai/objectui/issues/6596)), and this one was red four times
+a day.
+
+⛔ That carve-out is **empty-only**. An anchor that is configured and unusable — a non-numeric
+value, an issue that is gone, a rejected write — still fails the run loudly: *nobody asked for
+delivery* and *delivery was asked for and failed* are opposite facts and do not share an exit code.
+The accepted cost of the empty branch, stated rather than discovered later, is that findings then
+live only in run summaries, which notify nobody
+([#5791](https://github.com/objectstack-ai/objectui/issues/5791) measured 58% of this board's
+machine-readable blocks false, one for a week, in exactly that silence).
 
 **Ported from objectstack, with the divergences listed in the workflow header.** The pair
 (`scripts/pm/check-half-states.mjs` + this workflow) is adopted from `objectstack-ai/objectstack`

--- a/scripts/__tests__/check-half-states.test.ts
+++ b/scripts/__tests__/check-half-states.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
 
 // Plain-JS CI helper; types are INFERRED from the .mjs by `tsconfig.scripts.json`
 // (`allowJs`), so no `@ts-expect-error` here. See objectui#3494.
@@ -315,5 +317,148 @@ describe('half-state-patrol.yml — report-only, as ruled on objectui#5791', () 
 
   it('exercises the ported helper through its paths filter', () => {
     expect(workflow).toContain("- 'scripts/invoked-as.mjs'");
+  });
+});
+
+describe('half-state-patrol.yml — an UNCONFIGURED anchor is a supported configuration (objectui#8740)', () => {
+  /**
+   * The maintainer closed objectui#7852 and #5986 verbatim with 「7852 太麻烦，
+   * 直接关闭」, so the anchor setup this install was waiting for will not happen.
+   * Until this card the empty-anchor branch emitted `::error::` and `exit 1`,
+   * which made a four-times-a-day scheduled job permanently red for a SETTLED
+   * configuration — the shape objectui#6596 already ruled on: a check red on
+   * the healthy case trains everyone to ignore red.
+   *
+   * ## Why this file executes the step instead of grepping it
+   *
+   * The acceptance criterion is about a scheduled run, and no test can start
+   * one. What it can do is take the step's own `run:` body out of the YAML and
+   * drive it, which is the same posture `ci-setup-pnpm-wiring.test.ts` takes for
+   * its shell. A pin written as `expect(workflow).toContain('::notice::')` would
+   * be satisfied by a file that emits the notice and then exits 1 anyway — it
+   * pins the spelling of the fix, not the fix.
+   *
+   * ## Both directions, because only one of them is the bug
+   *
+   * ⛔ The carve-out is EMPTY-ONLY. "Nobody asked for delivery" (exit 0) and
+   * "delivery was asked for and failed" (exit 1) are opposite facts, and a test
+   * that pinned only the first would pass on the widened change that makes the
+   * anchor step never fail — which is precisely what this card forbids. So the
+   * malformed direction is asserted here in the same shape, and a green run of
+   * this block means the empty branch was carved out of a guard that still
+   * guards.
+   *
+   * The THIRD property is the one neither direction shows on its own: exiting 0
+   * with no anchor means the job carries on into the write step, so that step
+   * must be guarded by the SAME decision this step took. Guarded instead by a
+   * second `env.ANCHOR_ISSUE != ''` test it would disagree with this step on a
+   * whitespace-only value and PATCH `Number(' ')` — issue 0.
+   */
+  const workflowSteps: { name?: string; id?: string; if?: string; run?: string }[] =
+    parseYaml(workflow).jobs.patrol.steps;
+
+  const step = (name: string) => {
+    const found = workflowSteps.find((s) => s.name === name);
+    // Anti-vacuity: a renamed step must fail this file rather than silently
+    // stop asserting anything, which is the whole failure mode of a wiring pin.
+    expect(found, `no step named "${name}" — this block would assert nothing`).toBeTruthy();
+    return found!;
+  };
+
+  const resolveStep = step('Resolve the anchor issue');
+  const writeStep = step('Update the pinned anchor issue');
+  const summaryStep = step('Publish the rendered body to the run summary');
+
+  /** The resolve step's shell, with the one Actions expression it carries bound. */
+  const resolveScript = (resolveStep.run ?? '').replace(
+    /\$\{\{\s*github\.repository\s*\}\}/g,
+    'objectstack-ai/objectui',
+  );
+
+  it('carries no unbound Actions expression into the shell this file executes', () => {
+    // `${{ … }}` is a bad substitution to bash, so an expression this helper
+    // does not bind would make every run below fail for the wrong reason.
+    expect(resolveScript).not.toContain('${{');
+    expect(resolveScript).toContain('ANCHOR_ISSUE');
+  });
+
+  /** Drive the real step body with a given anchor value. */
+  const resolve = (anchor: string) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'half-state-anchor-'));
+    const outputs = path.join(dir, 'github_output');
+    fs.writeFileSync(outputs, '');
+    const run = spawnSync('bash', ['-c', resolveScript], {
+      encoding: 'utf8',
+      env: { ...process.env, ANCHOR_ISSUE: anchor, GITHUB_OUTPUT: outputs },
+    });
+    const written = fs.readFileSync(outputs, 'utf8');
+    fs.rmSync(dir, { recursive: true, force: true });
+    return { status: run.status, out: `${run.stdout}${run.stderr}`, outputs: written };
+  };
+
+  it('EMPTY anchor: notices the variable and exits 0 — the job goes on to publish the sweep', () => {
+    for (const empty of ['', ' ', '\t', '\n  ']) {
+      const run = resolve(empty);
+      expect(run.status, `an unset anchor must not fail the run (input ${JSON.stringify(empty)})`).toBe(0);
+      expect(run.out).toContain('::notice::');
+      expect(run.out, 'the notice must name the variable that would enable delivery').toContain(
+        'HALF_STATE_ANCHOR_ISSUE',
+      );
+      // ⛔ The regression this card is: the same sentence emitted as an error.
+      expect(run.out).not.toContain('::error::');
+      expect(run.outputs.trim()).toBe('configured=false');
+    }
+  });
+
+  it('MALFORMED anchor: still `::error::` + exit 1, because delivery WAS asked for', () => {
+    for (const bad of ['abc', '#9857', '98 57', '9857x', '-1']) {
+      const run = resolve(bad);
+      expect(run.status, `a bad anchor number must still fail the run (input ${JSON.stringify(bad)})`).toBe(1);
+      expect(run.out).toContain('::error::');
+      expect(run.out).not.toContain('::notice::');
+      expect(run.outputs, 'a failed resolve must not declare a delivery target').not.toContain('configured=');
+    }
+  });
+
+  it('NUMERIC anchor: resolves to a delivery, quietly', () => {
+    const run = resolve('9857');
+    expect(run.status).toBe(0);
+    expect(run.outputs.trim()).toBe('configured=true');
+    expect(run.out).toContain('anchor: #9857');
+    expect(run.out).not.toContain('::notice::');
+    expect(run.out).not.toContain('::error::');
+  });
+
+  it('the board write is guarded by THIS step\'s decision, not by a second reading of the variable', () => {
+    // Exiting 0 with no anchor means the write step is now reachable with an
+    // empty `ANCHOR_ISSUE`; `Number('')` is 0, so an unguarded write would PATCH
+    // issue 0 on every scheduled run of an unconfigured install.
+    expect(resolveStep.id, 'the write guard names this step by id').toBe('anchor');
+    expect(writeStep.if).toContain("steps.anchor.outputs.configured == 'true'");
+    // The pull_request guard is unchanged and still first — a PR run must not
+    // touch the board whatever the anchor says.
+    expect(writeStep.if).toContain("github.event_name != 'pull_request'");
+    // ⛔ Not `env.ANCHOR_ISSUE != ''`: that is the second spelling of emptiness
+    // this step exists to prevent (the resolve step strips whitespace, the
+    // expression would not).
+    expect(writeStep.if).not.toContain('env.ANCHOR_ISSUE');
+  });
+
+  it('the run summary is the delivery when there is no anchor, and says which delivery happened', () => {
+    // `always()` is what makes the summary the fallback channel at all, and the
+    // rendered body is read from the same file the anchor write would have used.
+    expect(summaryStep.if).toBe('always()');
+    expect(summaryStep.run).toContain('$RUNNER_TEMP/report.md');
+    // ⛔ #4690 in the shape this card newly opens: a delivered run and an
+    // undelivered one must not read alike in the only place a reader looks.
+    expect(summaryStep.run).toContain("steps.anchor.outputs.configured }}\" = \"false\"");
+    expect(summaryStep.run).toContain('HALF_STATE_ANCHOR_ISSUE');
+  });
+
+  it('the sibling install keeps its literal anchor, and keeps failing loudly on it', () => {
+    // ⛔ Untouched by this card: objectstack resolves 9857 from the repository
+    // guard, so it takes the NUMERIC branch above and every anchor failure
+    // there is still a red run.
+    expect(workflow).toContain("(github.repository == 'objectstack-ai/objectstack' && '9857')");
   });
 });


### PR DESCRIPTION
Fixes #8740

## What changed

`half-state-patrol.yml` resolved `vars.HALF_STATE_ANCHOR_ISSUE` and, on an empty value, emitted `::error::` and `exit 1`. This repository has no anchor and will not get one — the maintainer closed #7852 and #5986 with 「7852 太麻烦，直接关闭」 — so a six-hourly scheduled job was permanently red for a **settled configuration**. #6596 already ruled on that shape: a check red on the healthy case trains everyone to ignore red.

An empty anchor now emits `::notice::` naming the variable and exits **0**. The sweep still runs, and its rendered body still reaches the run summary.

Three coupled edits, all in the one workflow:

1. **Resolve the anchor issue** — empty ⇒ `::notice::` + `exit 0` + `configured=false`; non-numeric ⇒ `::error::` + `exit 1`, unchanged; numeric ⇒ `configured=true`.
2. **Update the pinned anchor issue** — now gated on `steps.anchor.outputs.configured == 'true'`. Exiting 0 with no anchor makes this step *reachable* with an empty `ANCHOR_ISSUE`, and `Number('')` is `0`: unguarded, an unconfigured install would PATCH issue 0 on every run. The guard reads the resolve step's output rather than testing `env.ANCHOR_ISSUE != ''` a second time — that second spelling disagrees with the first on a whitespace-only value, and two spellings of "no anchor" drift.
3. **Publish the rendered body to the run summary** — on the explicit not-configured reading only, the summary says it is the sole delivery. Otherwise a delivered run and an undelivered one read identically in the one place a reader looks (#4690's shape, newly reachable because of this change).

## What did NOT change

- ⛔ **The carve-out is empty-only.** A configured-but-unusable anchor still fails loudly. The non-numeric guard is byte-identical.
- ⛔ **The sibling fallback is untouched**: `github.repository == 'objectstack-ai/objectstack' && '9857'` still resolves, still takes the numeric branch, still fails loudly there.
- ⛔ **`merge-queue-head-patrol.yml` is not touched.** The card's body says two workflows share this defect. Measured on `8241a4400`, that is false: that workflow reads a *different* variable (`vars.MERGE_QUEUE_ANCHOR_ISSUE`, `:127`), its refresh step is already `if: env.ANCHOR_ISSUE != ''` (`:171`), and its `exit 1` (`:267`) is the wedge verdict. It already degrades gracefully; there is nothing there to fix. (The PM's claim comment carries the same correction; this PR confirms it against the tree.)

## How this is proven

The acceptance criterion is about a scheduled run, which no test can start. The wiring test extracts the resolve step's own `run:` body out of the YAML and executes it under `bash` in **both** directions — the posture `ci-setup-pnpm-wiring.test.ts` already takes for its shell. A pin spelled `expect(workflow).toContain('::notice::')` would be satisfied by a step that emits the notice and exits 1 anyway.

Two ablations, each run from the committed tree with the mutation proven on disk (marker counts before/after + blob hash) and restored via `git checkout HEAD -- <path>` (`git diff HEAD` empty afterwards):

| ablation | expected direction | observed |
|:--|:--|:--|
| revert the workflow to `8241a4400` (the bug) | empty-anchor pins go red, malformed pin stays green | `4 failed \| 24 passed`; first failure `an unset anchor must not fail the run (input ""): expected 1 to be +0` |
| widen the fix: make the non-numeric branch `exit 0` too | malformed pin goes red | `1 failed \| 27 passed`; `a bad anchor number must still fail the run (input "abc"): expected +0 to be 1` |

The second one is why both directions are pinned: the malformed test passes on the buggy tree *and* on the fixed one, so it detects nothing about this fix — it detects the over-fix this card forbids.

## Verification

- `pnpm exec vitest run scripts/__tests__/` — `Test Files 131 passed | 2 skipped (133)`, `Tests 3778 passed | 2 skipped (3780)` at `226c7c4aa`.
- `node scripts/check-changeset-presence.mjs` — exit 0: *"0 of them published source of a package the release covers … no changeset is owed"*. No changeset, by the gate's own verdict rather than by judgement.
- `check-control-bytes`, `check-doc-fence-languages`, `check-upstream-port-parity`, `check-action-ref-convention`, `check-shell-escape-residue` — all exit 0. The port-parity gate matters here: this workflow is **not** in `scripts/upstream-port-pin.json` (only the sweeper, `invoked-as.mjs` and a hook are), so the edit does not touch a pinned ported file.
- `npx eslint --no-inline-config .` — 4,648 files linted, changed file 0 errors / 0 warnings. The 94 repo-wide errors are pre-existing and live in files this diff does not touch; `eslint.config.js` declares no `project`/`projectService`, so no untouched file's verdict can move.
- `node scripts/check-governed-queue-guard.mjs --test <the 3 paths>` — `NOT GOVERNED`.

## Documentation

`content/docs/guide/ci-cd-pipeline.md` said the run goes red "until [the variable] is set". Left alone, that sentence would have been false the moment this merged, in the file this repo's readers use to answer exactly this question — so the workflow-table row and the Half-State Patrol section now state the empty-anchor branch, its empty-only limit, and its accepted cost (findings live only in run summaries, which notify nobody — #5791 measured 58% of this board's machine-readable blocks false in exactly that silence).

⚠️ Not in this PR, and the card says so explicitly: the `SKILL.md` half — the protocol's "read the half-state anchor first" criterion, which is vacuous in an install with no anchor — is objectstack `domain:skills`, and the seat-post note is the PM's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_