### PR TITLE
fix(plugin-chatbot): fold an authored 'tool' role before it seeds the AI SDK store

### DIFF
--- a/.changeset/8443-chatbot-runtime-role-fold.md
+++ b/.changeset/8443-chatbot-runtime-role-fold.md
@@ -1,0 +1,36 @@
+---
+'@object-ui/plugin-chatbot': patch
+---
+
+Fold an authored `role: 'tool'` before it seeds the AI SDK store, instead of asserting
+it away (objectui#8443).
+
+`useObjectChat`'s `aiInitialMessages` builder wrote `as 'user' | 'assistant' | 'system'`
+over the role at both of its arms. The authoring contract accepts `role: 'tool'`,
+`normalizeMessages` deliberately does not narrow it, and `renderer.tsx` passes
+`schema.messages` straight through as `initialMessages` — so in API mode the store was
+seeded with a value outside its own union, declared as one of three roles it was not.
+
+Measured against the real `@ai-sdk/react` 4.0.68 / `ai` 7.0.65 before the change: the
+client store holds the out-of-union role verbatim — nothing recognises it, nothing
+renders it distinctly — and the SDK's own downstream entry points then reject it.
+`convertToModelMessages` throws `AI_MessageConversionError: Unsupported role: tool`, and
+`validateUIMessages` throws `AI_TypeValidationError` naming `["system","user","assistant"]`
+at `[0].role`. Both legs were read with an in-union control on the identical shape, which
+converted and validated cleanly.
+
+Both arms now call `toRuntimeRole(...)` — the package's single expression of this fold
+and the named decision of objectui#4399, the same one the render seam already applies:
+`'tool'` renders as an assistant bubble. **Behaviour change on the API-mode leg**: an
+authored `'tool'` message now seeds the store as `'assistant'` rather than `'tool'`. Its
+content, parts and tool invocations are untouched, and the other three roles are
+unchanged — `'system'` in particular keeps its own role and its centred pill.
+
+Local mode is deliberately unaffected: an authored `'tool'` role still reaches the hook's
+own `messages` surface unchanged and is folded only at the render seam, which is what
+`ObjectChatMessage` is a statement about.
+
+Deleting the assertions also re-arms the compile-time tripwire the seam was built to
+provide — `chatMessageAdapter.ts` records that "a new authored `role` makes
+`toRuntimeRole` unassignable", and an `as` let a future role past these two lines
+silently.

--- a/packages/plugin-chatbot/src/__tests__/chat-message-contract.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/chat-message-contract.test.ts
@@ -398,7 +398,14 @@ describe('the Date → ISO absorption is expressed once', () => {
   });
 
   it('routes the hook through the adapter instead of restating the coercion', () => {
-    expect(source).toMatch(/import \{ toRuntimeTimestamp \} from '\.\/chatMessageAdapter';/);
+    // Matched by MEMBERSHIP of the import list, not by its exact spelling. The
+    // hook imports a second fold from the same module since objectui#8443
+    // (`toRuntimeRole`), and a guard that pins the whole line fires on a
+    // COMPANION fold arriving — the opposite of what it exists to catch, which
+    // is this coercion being restated inline.
+    expect(source).toMatch(
+      /import \{[^}]*\btoRuntimeTimestamp\b[^}]*\} from '\.\/chatMessageAdapter';/,
+    );
     expect(source).toContain('timestamp: toRuntimeTimestamp(msg.timestamp)');
     expect(
       source.includes('toISOString()'),

--- a/packages/plugin-chatbot/src/__tests__/useObjectChat.runtimeRole-8443.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/useObjectChat.runtimeRole-8443.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `useObjectChat` — the API-mode builder PERFORMS the `'tool'` -> `'assistant'`
+ * fold instead of asserting it away (objectui#8443).
+ *
+ * ## Why this file exists at all
+ *
+ * The authoring contract accepts `role: 'tool'`, `normalizeMessages`
+ * deliberately does not narrow it, and `renderer.tsx` hands `schema.messages`
+ * straight through as `initialMessages`. So an authored `'tool'` message
+ * reaches the `aiInitialMessages` builder, and in API mode the builder's output
+ * is what seeds the AI SDK store. Until this card the builder wrote
+ * `as 'user' | 'assistant' | 'system'` over it — the store was handed a value
+ * out of its own union with the compiler told not to look.
+ *
+ * `useObjectChat.honestMessages.test.tsx:157-167` already authors a `'tool'`
+ * message, but in LOCAL mode, where the builder's output never reaches
+ * `useChat`. That is the leg this file adds: `api` IS set, so the assertions
+ * below read the seed the store actually receives.
+ *
+ * ## What was measured before the fold was chosen
+ *
+ * Against the real `@ai-sdk/react` (4.0.68) / `ai` (7.0.65), an authored
+ * `role: 'tool'`:
+ *
+ *   - is held by the client store VERBATIM — nothing recognises it, nothing
+ *     renders it distinctly, nothing folds it (lit control: three in-union
+ *     roles read back distinct through the same instrument);
+ *   - is REJECTED by the SDK's own two downstream entry points, both of which
+ *     a backend route calls on exactly these values — `convertToModelMessages`
+ *     throws `AI_MessageConversionError: Unsupported role: tool`, and
+ *     `validateUIMessages` throws `AI_TypeValidationError` naming
+ *     `["system","user","assistant"]` at `[0].role`.
+ *
+ * So the fold is a fix and not a regression. The third test below keeps that
+ * measurement in the suite rather than in a commit message: it runs the SDK's
+ * OWN validator over the builder's output, with the pre-fix value as its
+ * control.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { validateUIMessages } from 'ai';
+import { useObjectChat } from '../useObjectChat';
+
+const API = 'https://example.test/api/v1/ai/agents/build/chat';
+
+/** What the builder handed `useChat` on the render under test. */
+type SeededMessage = { id: string; role: string; parts: Array<Record<string, unknown>> };
+
+const { seen } = vi.hoisted(() => ({ seen: { messages: undefined as SeededMessage[] | undefined } }));
+
+vi.mock('@ai-sdk/react', () => ({
+  // The store seed is the thing under test, so the double captures the option
+  // rather than inventing a thread: `messages` IS what `useChat` initialises
+  // its store from (measured on the real SDK — it is held verbatim).
+  useChat: (options: { messages?: SeededMessage[] }) => {
+    seen.messages = options?.messages;
+    return {
+      messages: [],
+      status: 'ready',
+      error: undefined,
+      sendMessage: vi.fn(),
+      regenerate: vi.fn(),
+      stop: vi.fn(),
+      setMessages: vi.fn(),
+    };
+  },
+}));
+
+beforeEach(() => {
+  seen.messages = undefined;
+});
+
+describe("API mode: an authored 'tool' role is folded before it seeds the store", () => {
+  it('folds it on the content path (the branch that goes through normalizeMessages)', () => {
+    const { result } = renderHook(() =>
+      useObjectChat({
+        api: API,
+        initialMessages: [
+          { id: 'a-tool', role: 'tool', content: 'tool said x' },
+        ],
+      }),
+    );
+
+    expect(result.current.isApiMode).toBe(true);
+    // The seed the SDK store receives. Before objectui#8443 this read 'tool' —
+    // a value outside the store's own union, declared as one of three roles it
+    // is not.
+    expect(seen.messages?.[0]).toMatchObject({ id: 'a-tool', role: 'assistant' });
+    // The fold moves the ROLE only; the content still renders.
+    expect(seen.messages?.[0]?.parts).toEqual([{ type: 'text', text: 'tool said x' }]);
+  });
+
+  it('folds it on the pre-built `parts` path too (the other assertion)', () => {
+    // The builder has two arms and the card names both: an authored message
+    // that already carries `parts` short-circuits `normalizeMessages`. Fixing
+    // one arm and not the other would leave the defect reachable from any
+    // schema that authors `parts`.
+    renderHook(() =>
+      useObjectChat({
+        api: API,
+        initialMessages: [
+          {
+            id: 'a-tool-parts',
+            role: 'tool',
+            content: '',
+            parts: [{ type: 'text', text: 'already parted' }],
+          },
+        ],
+      }),
+    );
+
+    expect(seen.messages?.[0]).toMatchObject({ id: 'a-tool-parts', role: 'assistant' });
+  });
+
+  it('LIT CONTROL — the other three roles reach the store unchanged', () => {
+    // Without this the two assertions above are satisfied by a builder that
+    // hard-codes 'assistant', which would destroy the centred system pill and
+    // mis-attribute every user turn. `'system'` is the one that matters most:
+    // `<Chatbot>` renders it distinctly, so folding it would be a real
+    // regression rather than a no-op.
+    renderHook(() =>
+      useObjectChat({
+        api: API,
+        initialMessages: [
+          { id: 'a-user', role: 'user', content: 'u' },
+          { id: 'a-assistant', role: 'assistant', content: 'a' },
+          { id: 'a-system', role: 'system', content: 's' },
+          { id: 'a-tool', role: 'tool', content: 't' },
+        ],
+      }),
+    );
+
+    expect(seen.messages?.map((m) => m.role)).toEqual(['user', 'assistant', 'system', 'assistant']);
+  });
+
+  it("the seed passes the SDK's OWN UIMessage validator — with the pre-fix value as control", async () => {
+    renderHook(() =>
+      useObjectChat({
+        api: API,
+        initialMessages: [
+          { id: 'a-user', role: 'user', content: 'u' },
+          { id: 'a-tool', role: 'tool', content: 'tool said x' },
+        ],
+      }),
+    );
+
+    const seeded = seen.messages ?? [];
+    expect(seeded).toHaveLength(2);
+
+    // SUBJECT: `validateUIMessages` is the SDK's own statement of what its
+    // store may hold, and it is what a backend route runs over these values.
+    await expect(
+      validateUIMessages({ messages: seeded as never }),
+    ).resolves.toHaveLength(2);
+
+    // CONTROL: the SAME call over the SAME messages with the role the builder
+    // used to emit. If this ever stops rejecting, the SDK has started accepting
+    // a fourth role and this card's premise has changed — which is a review
+    // conversation, not something to discover by the subject going quiet.
+    const preFix = seeded.map((m) => (m.id === 'a-tool' ? { ...m, role: 'tool' } : m));
+    await expect(validateUIMessages({ messages: preFix as never })).rejects.toThrow(
+      /role/i,
+    );
+  });
+});
+
+/**
+ * ## Ground 2 — the compile-time tripwire — is NOT pinned here, on purpose
+ *
+ * Deleting the two `as` casts did more than fix a runtime lie: it put
+ * `toRuntimeRole` back on the builder's path, and `chatMessageAdapter.ts`
+ * records what that buys — "a new authored `role` makes {@link toRuntimeRole}
+ * unassignable". An `as 'user' | 'assistant' | 'system'` let a future role past
+ * these two lines silently; the fold does not.
+ *
+ * That alarm needs no assertion from this file, because it is not a claim about
+ * values — it is the type-check gate itself. MEASURED by ablation on this
+ * branch: widening `ChatMessage['role']` with one extra member and rebuilding
+ * `@object-ui/types` makes `pnpm --filter @object-ui/plugin-chatbot type-check`
+ * fail with
+ *
+ *   src/chatMessageAdapter.ts(188,42): error TS2322: Type '"system" | "user" |
+ *   "assistant" | "<new>"' is not assignable to type '"system" | "user" |
+ *   "assistant"'.
+ *
+ * — the doc's sentence, verbatim, from the compiler.
+ *
+ * A separate type-level pin was written here and then REMOVED, because the only
+ * shape it could take encodes the wrong invariant. `Exclude<AuthoredRole,
+ * 'tool'> extends RuntimeRole` says "the fold handles exactly `'tool'`", not
+ * "the fold is total": a contributor who meets the new role correctly — by
+ * folding it too — makes `toRuntimeRole` compile again and makes that pin red.
+ * A pin that reddens on the correct fix is a nuisance, not an alarm, and the
+ * union's own spelling is already pinned by
+ * `chat-message-contract.test.ts`'s `Equal<AuthoredChatMessage['role'], …>`.
+ */

--- a/packages/plugin-chatbot/src/useObjectChat.ts
+++ b/packages/plugin-chatbot/src/useObjectChat.ts
@@ -12,7 +12,7 @@ import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
 import { generateUniqueId } from './utils';
 import { uiMessagesToChatMessages } from './mapMessages';
-import { toRuntimeTimestamp } from './chatMessageAdapter';
+import { toRuntimeRole, toRuntimeTimestamp } from './chatMessageAdapter';
 import type { SeamChatMessage } from './chatMessageAdapter';
 
 /**
@@ -541,14 +541,37 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
   const modeRef = useRef<'api' | 'local'>(api ? 'api' : 'local');
   const isApiMode = modeRef.current === 'api';
 
-  // Convert OUI messages to vercel/ai v3 UIMessage format for initialMessages
+  // Convert OUI messages to vercel/ai v3 UIMessage format for initialMessages.
+  //
+  // The `role` is FOLDED, not asserted (objectui#8443). Both lines below used to
+  // read `as 'user' | 'assistant' | 'system'`, which was wrong twice over:
+  //
+  //   - at runtime, an authored `role: 'tool'` (legal on the authoring contract,
+  //     and deliberately not narrowed by `normalizeMessages`) reached the SDK
+  //     store verbatim while DECLARING one of three roles it is not. Measured on
+  //     the real `@ai-sdk/react`: the store holds it unchanged, and the SDK's own
+  //     downstream entry points then reject it — `convertToModelMessages` throws
+  //     `AI_MessageConversionError: Unsupported role: tool` and
+  //     `validateUIMessages` throws `AI_TypeValidationError` naming exactly
+  //     `["system","user","assistant"]`. Nothing anywhere recognises `'tool'`.
+  //   - at compile time, the assertion switched OFF the tripwire the seam exists
+  //     to provide: `chatMessageAdapter.ts` records that "a new authored `role`
+  //     makes {@link toRuntimeRole} unassignable", so adding a role to the
+  //     authoring type is supposed to break here and force someone to handle it.
+  //     An `as` let that future role through silently.
+  //
+  // `toRuntimeRole` is the package's ONE expression of this fold — the named
+  // decision of objectui#4399 ("`'tool'` renders as an assistant bubble"), which
+  // the render seam already applies. This builder now performs it instead of
+  // asserting it, same as objectui#4424 and objectui#8342 each did for one other
+  // instance of this class.
   const aiInitialMessages = useMemo(
     () =>
       (initialMessages ?? []).map((msg, idx) => {
         if (Array.isArray(msg.parts) && msg.parts.length > 0) {
           return {
             id: msg.id || `msg-${idx}`,
-            role: (msg.role || 'user') as 'user' | 'assistant' | 'system',
+            role: toRuntimeRole(msg.role || 'user'),
             parts: msg.parts,
           };
         }
@@ -573,7 +596,7 @@ export function useObjectChat(options: UseObjectChatOptions = {}): UseObjectChat
         }
         return {
           id: normalized.id || `msg-${idx}`,
-          role: normalized.role as 'user' | 'assistant' | 'system',
+          role: toRuntimeRole(normalized.role),
           parts: parts.length > 0 ? parts : [{ type: 'text', text: '' }],
         };
       }),


### PR DESCRIPTION
Fixes #8443

`useObjectChat`'s `aiInitialMessages` builder **asserted** the authoring role into the SDK's three roles at both of its arms instead of **performing** the fold this package already owns by name. Both `as 'user' | 'assistant' | 'system'` casts are gone; both arms now call `toRuntimeRole(...)` — objectui#4399's named decision, the same fold the render seam already applies.

## The zone-2 measurement, first

The card was explicit that it had **not** measured what the AI SDK store does with an out-of-union role, and the ruling made proceeding conditional on that reading. Measured on `origin/main` before anything was changed, against the **real** `@ai-sdk/react` 4.0.68 / `ai` 7.0.65 (`@ai-sdk/react` deliberately unmocked):

| instrument | authored `role: 'tool'` | lit control (same shape, in-union role) |
|---|---|---|
| the `useChat` store itself | held **verbatim** — `[{"id":"m-tool","role":"tool"}]` | `["user","system","assistant"]` read back **distinct** ⇒ the instrument reads the authored role, not a constant |
| through `useObjectChat({api})` | reaches the hook's `messages` as `role: 'tool'`, end to end | `user` / `system` arrive as themselves |
| `convertToModelMessages` | **throws** `AI_MessageConversionError: Unsupported role: tool` | `assistant` on the identical shape converts: `ok:[{"role":"assistant","content":[…]}]` |
| `validateUIMessages` | **throws** `AI_TypeValidationError` — `invalid_value` at `[0].role`, `values: ["system","user","assistant"]` | same call on `assistant` resolves |

**Branch selected: the first one.** Nothing recognises `'tool'`, nothing renders it distinctly, nothing folds it — the client store is a plain container, and the SDK's own two downstream entry points (the ones a backend route runs over exactly these values) reject it. So folding to `'assistant'` is a fix and not a regression, and the ruling stands as written.

That measurement is now **in the suite** rather than in a commit message: the fourth test runs the SDK's own `validateUIMessages` over the builder's output, with the pre-fix value as its control.

## The API-mode test leg

`useObjectChat.honestMessages.test.tsx:157-167` already authors a `'tool'` message, but in **LOCAL** mode, where the builder's output never reaches `useChat`. `useObjectChat.runtimeRole-8443.test.tsx` adds the leg that was missing: `api` **is** set, and the double captures the `messages` option — the store seed — so the assertions read what the store actually receives.

Four tests: the content path (through `normalizeMessages`), the pre-built `parts` path (**the card names both arms**; fixing one would leave the defect reachable from any schema that authors `parts`), a **lit control** that the other three roles arrive unchanged (`'system'` in particular keeps its centred pill — a builder that hard-coded `'assistant'` would satisfy the first two assertions and destroy that), and the SDK-validator leg above.

### Reverse verification

Direction predicted **before** the run: **red**. Run under the shared verify lock at `4cb197732`:

```
anchors BEFORE mutation : toRuntimeRole( = 2 · as 'user'|'assistant'|'system' = 0
anchors AFTER  mutation : toRuntimeRole( = 0 · as 'user'|'assistant'|'system' = 2
HEAD blob               = 5b604f133a59815a19e9130722eaa6aacc69d6f4
post-mutation on-disk   = cee063c9f6780f1ec589de46d7b90985f656ab7e   ⇒ MUTATION REACHED DISK
Test Files  1 failed (1) · Tests  4 failed (4) · MUTATED_LEG_EXIT=1
```

Every one of the four legs reddened, naming the value: `expected { id: 'a-tool', role: 'tool' } to match object { id: 'a-tool', role: 'assistant' }`, and the validator leg with `AI_TypeValidationError … invalid_value at [1].role`. Restore proven by state, not by exit code: `git diff HEAD` empty, on-disk blob back to `5b604f133a…`, `git status` clean. The mutation script carries a `trap` on `EXIT INT TERM` that restores from `HEAD`, with an absolute path.

## Ground 2 — measured, and deliberately NOT given an assertion of its own

The ruling's second ground is that the casts also switched off the alarm `chatMessageAdapter.ts:60-61` says the seam exists to provide: *"a new authored `role` makes {@link toRuntimeRole} unassignable"*. With the casts deleted, `toRuntimeRole` is back on the builder's path, so that alarm is armed.

**Ablated to check it is real, not just documented.** Widening `ChatMessage['role']` by one member and rebuilding `@object-ui/types` (marker proven present in `packages/types/dist/complex.d.ts:922` before reading any result — the first attempt of this ablation was **caught as a phantom** by that preflight, because the marker had reached `dist/complex.d.ts` and not the `dist/index.d.ts` I first grepped):

```
src/chatMessageAdapter.ts(188,42): error TS2322: Type '"system" | "user" | "assistant" | "ablation-role"'
  is not assignable to type '"system" | "user" | "assistant"'.
ABLATION_TYPECHECK_EXIT=2
```

The doc's sentence, verbatim, from the compiler. Restored and rebuilt: source marker 0 hits, **dist marker 0 hits**, `git diff HEAD -- packages/types` empty. (Restoring source alone would have left the mutated types in force for every later run in this tree.)

⚠️ **I wrote a separate compile-time pin for this and then removed it**, which is the honest answer to the bonus rather than a manufactured one. The only shape it could take — an `Exclude` of the authored union minus `'tool'` constrained to extend the runtime union — encodes *"the fold handles exactly `'tool'`"*, not *"the fold is total"*. A contributor who meets a new authored role **correctly**, by folding it too, makes `toRuntimeRole` compile again and makes that pin red. A pin that reddens on the correct fix is a nuisance, not an alarm. The union's own spelling is already pinned by `chat-message-contract.test.ts`'s exact-equality pin on `AuthoredChatMessage['role']`, and the tripwire itself is the type-check gate — which the ablation above shows fires. The reasoning is written into the test file so the next reader does not re-derive it.

## The one collateral edit

`chat-message-contract.test.ts`'s import pin matched the whole line `import { toRuntimeTimestamp } from './chatMessageAdapter';`. It guards against the Date→ISO coercion being **restated inline**; a second fold arriving from the same module is the opposite of that, so the regex now matches by **membership** of the import list. Nothing else about the guard moved.

## Gate verdicts

Package build / type-check / test / lint run **whole**, each quoting its own verdict line. Heavy runs went through the container's shared verify lock (`OS_VERIFY_LOCK_SLOT=dev-8443-objectui`).

| gate | command | verdict |
|---|---|---|
| dependency closure | `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-chatbot^...' build` | `os-verify-lock: VERDICT command-exit 0 · held the lock 48s` |
| package build | `pnpm --filter @object-ui/plugin-chatbot build` | `VERDICT command-exit 0 · held the lock 11s` · `✓ built in 9.10s` |
| type-check | `pnpm --filter @object-ui/plugin-chatbot type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | `VERDICT command-exit 0` |
| test | `pnpm --filter @object-ui/plugin-chatbot test` | `VERDICT command-exit 0` · **`Test Files 43 passed (43)` · `Tests 490 passed (490)`** |
| lint | `pnpm --filter @object-ui/plugin-chatbot lint` | `LINT_EXIT=0` · `✖ 88 problems (0 errors, 88 warnings)` — all pre-existing `react-hooks/refs` / `set-state-in-effect`, **zero on any changed file** |
| governed-surface guard | `check-governed-queue-guard --test` on the 4 changed paths | `✅ NOT GOVERNED — 4 path(s) checked against 5 governed surface(s); none matched.` (exit 0) |
| ↳ **lit control** | same script, `--test AGENTS.md` | `⛔ GOVERNED — 1 of 1 path(s)` (exit **3**) ⇒ the instrument distinguishes, so the `NOT GOVERNED` above is a reading |
| control bytes | `grep -naP` over the 4 changed paths for the C0 range | no matches |

`type-check` really covers the new file — proven with `tsc -p tsconfig.test.json --listFiles`, which names `useObjectChat.runtimeRole-8443.test.tsx`, rather than assumed.

**Not run locally, left to CI:** the repo-wide `pnpm lint` / `pnpm test` farm. This PR's changes are confined to one package; CI owns the full sweep.

## 验收备注

Observations found in passing, **not** filed and **not** fixed — each with the successor that will meet it:

- **`mapMessages.ts:862` — `role: (msg.role ?? 'assistant') as ChatMessage['role']`.** The inbound mirror of the same class: a cast where the union is already right, so it asserts nothing but disables the same tripwire on the way in. *Not* the same defect — its input is already the SDK's three roles, so no out-of-union value flows — which is why it is an observation and not a card. **Successor: objectui#8426**, which is in this same `useMemo`'s neighbourhood and already owns the `parts` half.
- **`useObjectChat.ts:712`'s `messages: … as any` stays.** Its own comment says it absorbs `parts` being an array of `Record` of `string` to `unknown`, and that is objectui#8426's, not this card's. Deleting it here would turn the call red with TS2322. **Successor: objectui#8426**, by name, in its own comment.
- **API mode and local mode now differ for an authored `'tool'` role** on the hook's own `messages` surface: local keeps `'tool'` (pinned, `honestMessages.test.tsx:157-167`), API mode now shows `'assistant'`. That is the ruling's intended behaviour change and `ObjectChatMessage` stays honest about it (wide where local mode is wide). Recorded because it is the fact a reader of the two tests together will notice. **Successor: none needed** — it is the changeset's headline.

## 维护者速读(草稿)

**改了什么** — `plugin-chatbot` 的 `useObjectChat` 在 API 模式下,把作者写的 `role: 'tool'` 消息交给 AI SDK 之前,原来是用一个类型断言「宣称」它是三种角色之一,实际值原封不动传了下去。现在改成真正做一次折叠:`'tool'` → `'assistant'`(这是本包早就有名字的既定决定,渲染层一直在用)。另外补了一条以前完全没人跑过的测试腿。

**为什么改** — 动手前先实测了「这个值传下去到底会怎样」:客户端 store 原样存着,谁都不认识它;而 SDK 自己的两个下游入口(后端路由正是拿这些值去调的)直接拒绝——一个抛 `Unsupported role: tool`,一个抛类型校验错误并点名只接受三种角色。同一形状换成合法角色则一切正常。所以这不是「可能有问题」,是一个已经会炸的值,只是被断言挡住了编译器的视线。断言还顺手关掉了这个接缝专门装的编译期报警器:以后谁给作者类型加一个新角色,本该在这里编译不过、逼人处理,断言会让它静默溜过去。这一条也做了消融实测:临时加一个角色,`type-check` 确实红,报错句子和文档写的一模一样。

**风险与代价(含回滚)** — 有一个**行为变化**,范围很窄:API 模式下,作者写的 `'tool'` 消息现在以 `'assistant'` 身份进入会话线程,内容、`parts`、工具调用全部不动;另外三种角色不受影响(`'system'` 仍然是居中的那个 pill,有专门的对照测试守着)。本地模式完全没动。这个变化本来就是卡片和裁决明确要的,changeset 里写成了标题。回滚成本低:一次 revert 即可,改动只有一个包的四个文件,没有新导出、没有新 prop、没有数据迁移。

**席位意见** —

**你要做的** — 确认那条行为变化可以接受(作者写的 `'tool'` 消息在 API 模式下会显示成 assistant 气泡,这与它在本地模式渲染出来的样子一致)。除此之外没有需要你决定的东西。本 PR 不在受管面上(已用 `check-governed-queue-guard --test` 测过,并用 `AGENTS.md` 做了亮对照),走正常评审与合并队列即可。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH)_