### PR TITLE
fix(plugin-grid): document exportOptions.streaming on object-grid/view:grid

### DIFF
--- a/.changeset/8731-exportoptions-streaming-doc.md
+++ b/.changeset/8731-exportoptions-streaming-doc.md
@@ -1,0 +1,12 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+`object-grid` / `view:grid`'s `exportOptions` registration description now names
+`streaming`, the fifth member `ObjectGrid` reads off `schema.exportOptions`
+(objectui#8731). The prose previously enumerated only `formats`, `maxRecords`,
+`includeHeaders` and `fileNamePrefix`, so an author reading the only authoring-facing
+statement of this key's shape could not discover `streaming` — even though
+`exportConfig?.streaming !== false` is a real behaviour fork (server-side streaming
+vs. browser-side assembly for the export), not decoration. `ObjectGrid`'s behaviour
+is unchanged; only the description text moves.

--- a/packages/plugin-grid/src/__tests__/ObjectGrid.exportOptionsKeys.test.ts
+++ b/packages/plugin-grid/src/__tests__/ObjectGrid.exportOptionsKeys.test.ts
@@ -265,21 +265,6 @@ function documentedMemberKeys(line: string): string[] {
   return inner ? inner.split(',').map((k) => k.trim()).filter(Boolean) : [];
 }
 
-/**
- * The read set MINUS the documented set, as of objectui#8071's measurement.
- *
- * ⚠️ NOT a tolerance. `streaming` decides whether an export streams from the
- * server or is assembled in the browser (`exportConfig?.streaming !== false`),
- * and the registration does not mention it — so an author reading the only
- * member enumeration this block publishes cannot know the key exists. That is
- * objectstack#8010's defect exactly, one layer out: honoured by the renderer,
- * invisible on the authoring surface. Filed as objectui#8731; this entry is
- * what makes it a measurement instead of a memory, and it is asserted as an
- * EXACT set so a second undocumented key cannot join it quietly and so landing
- * the fix reds this row and deletes it.
- */
-const UNDOCUMENTED_BUT_READ = ['streaming'];
-
 describe('object-grid `exportOptions` — members the BLOCK declares vs members the renderer reads (objectui#8071)', () => {
   const line = objectGridInputLine('exportOptions');
 
@@ -303,11 +288,17 @@ describe('object-grid `exportOptions` — members the BLOCK declares vs members 
     expect(advertisedButUnread).toEqual([]);
   });
 
-  it('reads exactly one member key it does not advertise, and it is named', () => {
+  it('reads no member key it does not advertise (objectui#8731)', () => {
+    // Until objectui#8731, this asserted an EXACT non-empty gap
+    // (`UNDOCUMENTED_BUT_READ = ['streaming']`): the registration's prose
+    // enumeration was missing a key the renderer honours, and the assertion
+    // named it so the fix would have to touch this file. The description now
+    // enumerates `streaming` too, so the gap this pin measures is empty — the
+    // regression this guards against is a FUTURE undocumented-but-read key,
+    // caught the same way objectstack#8010 was: named, not just counted.
     const read = readKeys(gridSource);
     const documented = new Set(documentedMemberKeys(line!));
-    expect([...read].filter((k) => !documented.has(k)).sort()).toEqual(
-      [...UNDOCUMENTED_BUT_READ].sort(),
-    );
+    const undocumentedButRead = [...read].filter((k) => !documented.has(k)).sort();
+    expect(undocumentedButRead).toEqual([]);
   });
 });

--- a/packages/plugin-grid/src/index.tsx
+++ b/packages/plugin-grid/src/index.tsx
@@ -245,7 +245,7 @@ const GRID_QUERY_INPUTS: ComponentInput[] = [
   { name: 'singleClickEdit', type: 'boolean', description: 'With `editable`, a single click opens the cell instead of a double-click. Has no effect on a non-editable grid.' },
   { name: 'navigation', type: 'object', description: 'What a row click does, `{ mode: "page" | "drawer" | "modal" | "split" | "none", … }`.' },
   { name: 'operations', type: 'object', description: 'Toggles for the built-in create/read/update/delete/export/import affordances, e.g. `{ delete: false }`.' },
-  { name: 'exportOptions', type: 'object', description: 'Export config, `{ formats, maxRecords, includeHeaders, fileNamePrefix }`. Needs `operations.export` to be reachable from the toolbar.' },
+  { name: 'exportOptions', type: 'object', description: 'Export config, `{ formats, maxRecords, includeHeaders, fileNamePrefix, streaming }`. `streaming` (default true) picks server-side streaming vs browser-side assembly for the export — a behaviour fork, not decoration; set it to `false` to force browser-side assembly. Needs `operations.export` to be reachable from the toolbar.' },
 ];
 
 ComponentRegistry.register('object-grid', ObjectGridRenderer, {


### PR DESCRIPTION
Fixes #8731

## What changed

`GRID_QUERY_INPUTS`' `exportOptions` input (shared by the `object-grid` and `view:grid` registrations, `packages/plugin-grid/src/index.tsx`) now enumerates `streaming` in its `description`, alongside the four members it already named. `Clause-②: no` — description text only, no accept-set/key/shape/arm change.

## Why

Re-derived independently on `origin/main` (did not trust the card's cited line numbers, which were from an older commit):

- **Described set** (regex on the registration's backticked `{ … }` enumeration): `formats, maxRecords, includeHeaders, fileNamePrefix` — 4 members.
- **Read set** (instrument: `/(?:schema\.exportOptions|exportConfig)\?\.(\w+)/g` over `ObjectGrid.tsx`; **positive control**: the pattern matches the known `schema.exportOptions?.formats` occurrence at line 2988 — confirms the regex fires; **negative control**: a fabricated member name is absent from the result set — confirms it doesn't over-match): `formats` (:2988, :2997), `streaming` (:2992, :3035), `maxRecords` (:3013), `includeHeaders` (:3014), `fileNamePrefix` (:3020) — 5 members.
- **Gap** = read − described = `{streaming}`, matching the card's claim exactly (current line numbers differ from the card's `2f881a90` citation, as expected — main has moved).

`streaming` is a real behaviour fork, not decoration: `exportConfig?.streaming !== false` (read at two sites) chooses server-side streaming (via `dataSource.exportDownload`) vs. browser-side assembly.

## The required red-then-green pair (pin coupling)

`packages/plugin-grid/src/__tests__/ObjectGrid.exportOptionsKeys.test.ts` pinned this exact gap by name (objectui#8071): `UNDOCUMENTED_BUT_READ = ['streaming']`, asserting `read − documented` equals exactly that set.

1. **RED, description fixed, constant still present** — `read − documented` becomes `[]`, but the assertion still expects `['streaming']`:
   ```
   AssertionError: expected [] to deeply equal [ 'streaming' ]
   - Expected: ["streaming"]
   + Received: []
   ❯ …ObjectGrid.exportOptionsKeys.test.ts:309
   Test Files  1 failed (1) · Tests  1 failed | 7 passed (8)
   ```
   That red is the proof the pin was doing its job — it named the stale constant, not a symptom.
2. **GREEN, constant removed in the same commit**, the third `describe` block's final `it` rewritten to assert the general invariant (no undocumented-but-read member) instead of the now-resolved named gap:
   ```
   Test Files  1 passed (1) · Tests  8 passed (8)
   ```

Both runs are in the report below verbatim.

## Third surface (out of scope — reported, not touched)

Confirmed the card's claim: `ComponentPropsMap['object-grid'].exportOptions` in `@objectstack/spec` (`packages/spec/src/ui/component.zod.ts:2527`, sibling `objectstack` checkout) is `z.unknown().optional().describe('Export config ({ formats, streaming })')` — a **third**, also-incomplete account (2 of 5 members: `formats`, `streaming`; missing `maxRecords`, `includeHeaders`, `fileNamePrefix`). Not edited — different repo, out of this card's scope; reading it back to the PM for an upstream card.

Also worth noting: `packages/types/src/zod/objectql.zod.ts:212` (this repo) already carries the full, correct 5-member enumeration including `streaming` — only the `plugin-grid` registration prose was stale.

## Ledger hazard check (objectui#8614 shape)

`scripts/check-doc-example-types.mjs`'s `UNGATED_EXAMPLES` is keyed `file:line`. Grepped the ledger for rows citing either edited file: the only `plugin-grid` row is `packages/plugin-grid/src/VirtualGrid.tsx:49` — a different file entirely from both files this PR touches (`index.tsx`, `ObjectGrid.exportOptionsKeys.test.ts`). Net line-shift in `index.tsx` is 0 (single line replaced in place); the test file shrank by 11 lines, but no ledger row keys off it. **Hazard does not apply to this change.**

## Base→main pre-flight

`git fetch origin main` immediately before finishing: `origin/main` is still `e9d92120a…`, identical to the worktree's base commit — the window `BASE..origin/main` is **empty** (0 commits). Per the moved-base trap, an empty window means that control **cannot fire**; own commits isolated with `git log --no-merges BASE..HEAD --not origin/main` → exactly the one commit this PR contains.

## Gates run (exit codes captured before any pipe)

- `node scripts/check-changeset-presence.mjs` → **0** (1 changeset added, `.changeset/8731-exportoptions-streaming-doc.md`, `@object-ui/plugin-grid: patch`).
- Dependency closure build, `pnpm --filter '@object-ui/plugin-grid^...' build` → **0** (needed before typecheck — a fresh worktree has no `dist/`, and a stale/missing `.d.ts` lies in both directions).
- `pnpm exec vitest run packages/plugin-grid/src/__tests__/ObjectGrid.exportOptionsKeys.test.ts` (red, then green) → **1** then **0**, per above.
- `pnpm exec vitest run packages/plugin-grid/` (full package) → **0** (120 test files, 1064 tests).
- `pnpm --filter @object-ui/plugin-grid type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) → **0**, after the dependency build.
- `pnpm exec vitest run apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` (sweep includes `apps/console` per dispatch; this file's `MEMBER_PINS['object-grid.exportOptions']` ledger entry checks the pin file still names the block and the key — unaffected by the content edit) → **0** (198 tests).

All reverification ran serialized through `/home/user/objectstack/scripts/pm/os-verify-lock.sh` (this repo has no local copy of that lock by design — the container is the shared resource).

## Scope

One description string + its coupled test constant + a changeset. No schema, accept-set, key or shape moved (`Clause-②: no`). `@object-ui/plugin-grid` is published and `inputs[].description` is the only authoring surface for this key, so a changeset is required and included.

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_