### PR TITLE
ci(vi-mock): delete the stale scope sentence from vi-mock-specifiers.yml's step comment

### DIFF
--- a/.github/workflows/vi-mock-specifiers.yml
+++ b/.github/workflows/vi-mock-specifiers.yml
@@ -108,9 +108,5 @@ jobs:
       # broken file entirely (objectui#6849). It asks whether the factory
       # OBTAINS the real module -- a callback parameter under any name, or
       # `vi.importActual` of the same specifier -- and SPREADS it.
-      #
-      # Narrow by ruling: only the covered workspace specifiers in
-      # `COVERED_SPECIFIERS` are judged. Whole-module replacement of a local
-      # module is legitimate and out of scope by construction, not by exemption.
       - name: Check every covered vi.mock factory inherits the real export surface
         run: node scripts/check-vi-mock-inherit.mjs


### PR DESCRIPTION
Fixes #8392

## What changed

One file, four deleted lines, zero added. In `.github/workflows/vi-mock-specifiers.yml`, the step comment above `node scripts/check-vi-mock-inherit.mjs` lost its scope paragraph and the `#` separator that would otherwise dangle against the step:

```diff
       # `vi.importActual` of the same specifier -- and SPREADS it.
-      #
-      # Narrow by ruling: only the covered workspace specifiers in
-      # `COVERED_SPECIFIERS` are judged. Whole-module replacement of a local
-      # module is legitimate and out of scope by construction, not by exemption.
       - name: Check every covered vi.mock factory inherits the real export surface
         run: node scripts/check-vi-mock-inherit.mjs
```

## Why the sentence was false

objectui#8141 (PR #8391) widened the resolver from "a `COVERED_SPECIFIERS` member" to "a member **or any subpath of one**". The gate's own header and its verdict line moved with it; this workflow comment did not. The gate says so itself at rest on this branch:

```
✅  check-vi-mock-inherit: OK (… 680 call site(s) on @object-ui/react, …, @object-ui/core
    and their subpaths judged (680 inherit, 0 auto-mocked); …)
```

`scripts/check-vi-mock-inherit.mjs:83` — the current statement:

```
 *     nor a SUBPATH of one.** See below, and "A member covers its subpaths".
```

## Why deleted rather than reworded (triage option 2)

Triage ruled option 2 on a fact the card supplied: the gate header is where **the last three** boundary changes were recorded, and the workflow copy was left behind all three times. A second prose site describing the same boundary is a structure that goes stale periodically, not a one-off miss — rewording fixes this instance and not the next one. Removing the duplicate leaves exactly one authoritative description.

Nothing is lost by the deletion:

- The step's `run:` line names `scripts/check-vi-mock-inherit.mjs`, so a reader landing here from a red check-run is one hop from the header.
- The whole-module-replacement carve-out the paragraph restated is already stated in full in that header, under *"Three things are therefore out of scope by construction, not by exemption"*.

Option 1's binding condition (state in the workflow that the authoritative description lives in the gate header) does not apply, because option 1 was not taken. No pointer sentence was added either: the ruling's criterion is a change that **only removes** the statement destined to go stale again.

## Pins checked before deleting

Both wiring suites that read this workflow (`scripts/__tests__/check-vi-mock-inherit.test.ts`, `scripts/__tests__/check-vi-mock-specifiers.test.ts`) assert through a `yamlOf()` helper that filters `/^\s*#/` lines before matching, so whole-line comments are structurally invisible to them. A repo-wide search found no pin on the deleted text and no line-number citation of this file:

```
$ git grep -n "Narrow by ruling"            -> only the workflow itself
$ git grep -n "covered workspace specifiers"-> only the workflow itself
$ git grep -n "vi-mock-specifiers\.yml[:# ]*[0-9]"  -> no matches
```

No pin had to change, so none did.

## Verification

All run on this branch at `ca7e77913`.

```
node scripts/check-vi-mock-inherit.mjs            EXIT=0  ✅ OK
node scripts/check-vi-mock-specifiers.mjs         EXIT=0  ✅ OK
node scripts/check-control-bytes.mjs              EXIT=0  ✅ OK (7041 tracked text files)
node scripts/check-action-ref-convention.mjs      EXIT=0  ✅ 111 refs in 36 workflow files
node scripts/check-pre-install-import-graph.mjs   EXIT=0  ✅ 27 pre-install steps in 21 jobs
node scripts/check-governed-queue-guard.mjs --self-test  EXIT=0  132 cases pass
node scripts/check-changeset-presence.mjs         EXIT=0
```

```
pnpm exec vitest run scripts/__tests__/check-vi-mock-inherit.test.ts \
  scripts/__tests__/check-vi-mock-specifiers.test.ts \
  scripts/__tests__/merge-queue-reporting.test.ts

 Test Files  3 passed (3)
      Tests  146 passed (146)
```

(The red-looking census blocks in that log are fixture output captured inside the gate's own passing ablation cases, not failures.)

## Changeset

None, and the gate is the authority per AGENTS.md §9:

```
Compared the working tree with e9d92120a (merge-base with origin/main): 1 file(s) changed,
0 of them published source of a package the release covers, 0 of them a manifest whose
published contract moved, 0 under a package changesets ignores, 0 changeset(s) added.
✅  No source or published contract of a released package changed in this range, so no
    changeset is owed.
```

No `skip-changeset` label was applied — in this repo that label exempts nothing and the gate's verdict line is what decides.

## Scope

`.github/workflows/vi-mock-specifiers.yml` only. The gate, its header, `COVERED_SPECIFIERS` and the pins under `scripts/__tests__/` are objectui#8141 / PR #8391's surface and were not touched. objectui#8117 is a different file and is not addressed here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_