### PR TITLE
test(console): pin element:record_picker member shapes (objectui#8071 slice 3)

### DIFF
--- a/.changeset/record-picker-member-pins-8071.md
+++ b/.changeset/record-picker-member-pins-8071.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change: `element:record_picker`'s `dataSource`, `label`, `placeholder` and `sort` gain per-block member pins (objectui#8071 slice 3), closing out the block entirely, and the member-pin exemption ledger in the console's registry/spec parity gate moves with them. No published behaviour changes — no runtime source, build entry, `files[]` payload or published-contract field is touched.

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -2025,15 +2025,32 @@ const MULTI_KIND_MEMBER_CONTRACTS: Record<string, string> = {
 // member shape, and fixing it is an ADR-0049 enforce-or-remove decision the spec
 // owns. See `NO_READ_SITE_TO_PIN`.
 //
+// ⭐ THIRD SLICE, AND THE FIRST BLOCK LEFT WITH NO EXEMPTIONS AT ALL.
+// objectui#8071's third slice converted the four remaining keys of
+// `element:record_picker` — `dataSource`, `label`, `placeholder` and `sort` —
+// the batch this card's own dispatch names as the example of "one block
+// family". Unlike `record:related_list`, nothing here needed a
+// `NO_READ_SITE_TO_PIN`: every declared key on this block has a real read site,
+// so the block drops out of `MEMBER_PIN_EXEMPTIONS` entirely rather than
+// leaving one entry behind. Measured over this file's own ledger, before and
+// after: 90 array/object-armed inputs, 36 pinned, 54 exempt -> 90, 40 pinned,
+// 50 exempt, and `MEMBER_PIN_EXEMPTION_CEILING` follows 54 -> 50 in the same
+// commit. Two of the four pins PROMOTE pre-existing files (`dataSource`, and
+// one file covering both `label` and `placeholder`), read end to end first;
+// `sort` — the standalone `properties.sort` key, as opposed to the
+// `dataSource.sort` sub-member the promoted `dataSource` file already
+// exercised — had no existing candidate anywhere in the repo, so it is a new
+// file. See `MEMBER_PIN_EXEMPTION_CEILING`'s own docblock for the accounting.
+//
 // A list this size is the transition case, and this file already owns the
 // pattern for it —
 // `OFF_SPEC_EXEMPTIONS` / `UNPUBLISHED_EXEMPTIONS` / `OFF_SPEC_ARM_EXEMPTIONS`
 // are explicit, reasoned, issue-backed, and go RED once stale. This is the same
-// mechanism, not a second one: `MEMBER_PIN_EXEMPTIONS` below lists all 54
+// mechanism, not a second one: `MEMBER_PIN_EXEMPTIONS` below lists all 50
 // remaining keys BY NAME, every entry cites an issue, and an
 // entry whose key acquires a pin is reported STALE and must be deleted in the
 // same change. The list has a CEILING as well as a stale check, because the
-// cheap way to green a new array key is to add a 55th entry rather than a pin.
+// cheap way to green a new array key is to add a 51st entry rather than a pin.
 //
 // ## WHAT IS DELIBERATELY NOT IN THE POPULATION, stated rather than dropped
 //
@@ -2118,6 +2135,10 @@ const MEMBER_PINS: Record<string, MemberPin> = {
     file: 'apps/console/src/__tests__/component-input-union-specimens.test.ts',
     pins: 'The `object` arm is the inline translation map `{ en, "zh-CN" }` and nothing else — driven through the real `manifestFromConfigs` + `validateTree` pair the JSX-page compiler and the save gate use, each positive paired with a value matching NEITHER arm that must still be reported (objectui#4970).',
   },
+  'element:record_picker.dataSource': {
+    file: 'packages/components/src/__tests__/record-picker-element-data-source.test.tsx',
+    pins: 'The per-element binding\'s own members, read through the REAL renderer and asserted at the query it fires: `view` resolves a saved view whose `filter`/`sort`/row cap become the picker\'s baseline, an authored binding key WINS over the same key from the view, the binding\'s own `filter` arrives AND-combined with the view\'s rather than replacing it, and an unresolvable `view` reports instead of falling back to every record of the object — the quieter failure mode objectstack#6953 fixed, one class below the throw objectstack#5576 fixed on `list-view`. A `view`-less binding leaves every one of the four flat keys (`object`/`filter`/`sort`/`limit`) behaving exactly as it did before a `dataSource` was authored at all, which is the control that keeps the override rows from reading as a coincidence. `columns` is deliberately absent from this pin: unlike `record:related_list.dataSource` (objectui#8071 slice 2), this renderer never reads `composed.columns` at all — a select dropdown has no column list to narrow. Pre-existing file, promoted to a pin here after being read end to end (objectui#8071).',
+  },
   'element:record_picker.emptyText': {
     file: 'apps/console/src/__tests__/component-input-union-specimens.test.ts',
     pins: 'The `object` arm is the inline translation map, asserted at the render site that actually resolves one, with the non-matching controls (`42`, `["No records"]`) still reported (objectui#3832).',
@@ -2125,6 +2146,18 @@ const MEMBER_PINS: Record<string, MemberPin> = {
   'element:record_picker.filter': {
     file: 'packages/components/src/__tests__/record-picker-inputs-spec-parity.test.ts',
     pins: 'The `object` arm is `FilterConditionSchema` — field keys plus `$and`/`$or`/`$not` — with the rule-ARRAY spelling every sibling `filter` uses rejected outright, and the description pinned to the renderer\'s own precedence read (`composed?.filter ?? props.filter`), objectui#3830.',
+  },
+  'element:record_picker.label': {
+    file: 'packages/components/src/renderers/basic/__tests__/record-picker-label-placeholder-i18n.test.tsx',
+    pins: 'The I18nLabel object arm, resolved at ITS OWN read site rather than through the row-value helper `toText` it used to share: the map resolves to the active language rather than always to its `en` entry (the pre-fix harm rendered ENGLISH to a zh-CN viewer), a region tag falls back to the base language an author actually wrote, and — the quiet failure — a legal map that simply omits `en` used to delete the `<label>` element with nothing thrown and nothing logged; this pin asserts the element\'s PRESENCE first, then its text, so a fix that resolved the string but left the element gone still fails here. A plain-string control and the "absent key renders no label at all" control both stay green in every case, which is what keeps the object-arm rows from being satisfied by an always-render fix (objectui#5637).',
+  },
+  'element:record_picker.placeholder': {
+    file: 'packages/components/src/renderers/basic/__tests__/record-picker-label-placeholder-i18n.test.tsx',
+    pins: 'The I18nLabel trio\'s other object arm, on the sharper of the two pre-fix failures: an authored map THREW `Objects are not valid as a React child` at `SelectValue`, taking the whole control down rather than merely mis-rendering. Same resolver, same fallback chain and the same base-language control as `label` above; see that entry (objectui#5637).',
+  },
+  'element:record_picker.sort': {
+    file: 'packages/components/src/__tests__/record-picker-sort-members.test.tsx',
+    pins: 'An IDENTITY pin, unlike the sibling block\'s: `record-picker.tsx` assigns `query.$orderby = sort` with no `normalizeSortSpec` in between, so a member missing `field` is NOT dropped the way `record:related_list.sort` (objectui#8071 slice 2) drops one — pinned as the current, undocumented divergence between two blocks whose registrations both say only "array of objects". Order is preserved for a multi-member array, no `$orderby` is sent when the key is absent, and PRECEDENCE against `dataSource` is pinned in both directions: a binding that declares its own `sort` replaces the flat key outright, and the flat key still applies when the binding carries none — `composed?.sort ?? props.sort`, identical to `filter`\'s read (objectui#8071).',
   },
   'element:text.content': {
     file: 'apps/console/src/__tests__/component-input-union-specimens.test.ts',
@@ -2357,7 +2390,7 @@ const NO_READ_SITE_TO_PIN =
  *
  * The ceiling below is the other half, and it is what makes this a transition
  * rather than an allowlist: a NEW array-typed key cannot be absorbed by adding a
- * 55th entry, because the count may only go down.
+ * 51st entry, because the count may only go down.
  */
 const MEMBER_PIN_EXEMPTIONS: Record<string, string> = {
   // element:button
@@ -2366,11 +2399,10 @@ const MEMBER_PIN_EXEMPTIONS: Record<string, string> = {
   // element:number
   'element:number.filter': AWAITING_A_PIN,
 
-  // element:record_picker
-  'element:record_picker.dataSource': AWAITING_A_PIN,
-  'element:record_picker.label': AWAITING_A_PIN,
-  'element:record_picker.placeholder': AWAITING_A_PIN,
-  'element:record_picker.sort': AWAITING_A_PIN,
+  // element:record_picker — objectui#8071 slice 3 pinned all four remaining
+  // keys (`dataSource`, `label`, `placeholder`, `sort`); the block is now
+  // fully pinned and this header stays only as a note for the next reader who
+  // greps for it.
 
   // object-form
   'object-form.customFields': AWAITING_A_PIN,
@@ -2531,11 +2563,31 @@ const NEWLY_JUDGED_UNPINNED_MEMBERS = [
  * ceiling of 54 counts it like any other entry — a key that cannot be pinned
  * still occupies a slot, because the ratchet counts EXEMPTIONS, not excuses.
  *
+ * ## 54 -> 50, the third slice, and the first WHOLE BLOCK closed
+ *
+ * objectui#8071's third slice converted all four remaining keys of ONE block —
+ * `element:record_picker`'s `dataSource`, `label`, `placeholder` and `sort` —
+ * and deleted their four entries, so the ceiling follows to 50 in the same
+ * commit. Unlike `record:related_list` (slice 2), this block has no
+ * `NO_READ_SITE_TO_PIN` leftover: every key it declares now carries a real
+ * member pin, and the `element:record_picker` header comment above stays only
+ * as a landmark for a future grep, not because anything under it is exempt.
+ *
+ * Two of the four were PROMOTED pre-existing files, read end to end before
+ * being credited rather than trusted on their strings — the same discipline
+ * slices 1 and 2 applied: `record-picker-element-data-source.test.tsx` (for
+ * `dataSource`) and `record-picker-label-placeholder-i18n.test.tsx` (for BOTH
+ * `label` and `placeholder`, which is why those two rows in `MEMBER_PINS` point
+ * at the same file — it was written to cover the pair). `sort` had no
+ * candidate at all — nothing in the repo exercised the flat, standalone
+ * `properties.sort` key before this slice — so it is the one genuinely new
+ * file.
+ *
  * ⇒ The rule for every future slice of objectui#8071: delete the entry, register
  * the pin, and set this constant to the new count. Not to the new count plus
  * room.
  */
-const MEMBER_PIN_EXEMPTION_CEILING = 54;
+const MEMBER_PIN_EXEMPTION_CEILING = 50;
 
 /**
  * Every test file a member pin can live in, as LAZY `?raw` loaders.
@@ -2552,7 +2604,7 @@ const MEMBER_PIN_EXEMPTION_CEILING = 54;
  * LAZY on purpose. `eager: true` would inline the raw text of every test file in
  * the repo — 2,000+ files, ~3 MB — into this module on every run of a gate that
  * already loads the whole registration graph. Lazy hands back loaders, so the
- * cost is the glob itself plus one read per REGISTERED pin (36 today).
+ * cost is the glob itself plus one read per REGISTERED pin (40 today).
  */
 const PIN_SOURCES = import.meta.glob(
   [
@@ -3888,7 +3940,7 @@ describe('registry `inputs` vs `@objectstack/spec` ComponentPropsMap (repo-wide)
 
   it('the member-pin exemption list only ratchets DOWN', () => {
     // The other half. A new array-typed key must be answered with a pin, not
-    // with a 55th entry carrying the same reason as its neighbours — that move
+    // with a 51st entry carrying the same reason as its neighbours — that move
     // is what made the discipline voluntary in the first place, one layer in.
     expect(Object.keys(MEMBER_PIN_EXEMPTIONS).length).toBeLessThanOrEqual(
       MEMBER_PIN_EXEMPTION_CEILING,

--- a/packages/components/src/__tests__/record-picker-sort-members.test.tsx
+++ b/packages/components/src/__tests__/record-picker-sort-members.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `element:record_picker.sort` — the MEMBER shape the renderer reads
+ * (objectui#8068 / objectui#8071 slice 3).
+ *
+ * The registration declares `{ name: 'sort', type: 'array', of: 'object' }` —
+ * `of` names a coarse MEMBER KIND and nothing finer (objectui#8067) — so the
+ * published surface says "an array of objects" and stops there. What actually
+ * reaches the wire is answered here, against the read site, not restated from
+ * the declaration.
+ *
+ * ## Where the read happens, and why it is an IDENTITY pin
+ *
+ * `record-picker.tsx`:
+ *
+ *     const sort = composed?.sort ?? props.sort;
+ *     …
+ *     if (sort) query.$orderby = sort;
+ *
+ * There is no `normalizeSortSpec` here, unlike `record:related_list.sort`
+ * (objectui#8071 slice 2) — the array authored on `sort` is assigned to
+ * `$orderby` BY REFERENCE, unfiltered and untransformed. That is the sharp edge
+ * this file exists to pin: a malformed member (missing `field`) is NOT dropped
+ * the way the sibling block drops one, because nothing here inspects a member
+ * at all. Declaring `of: 'object'` says a member is an object; it says nothing
+ * about whether the renderer looks inside one, and for this block it does not.
+ *
+ * ## The other half — precedence against `dataSource`
+ *
+ * Identical to `filter`'s PRECEDENCE, stated in that key's own description:
+ * `composed?.sort ?? props.sort`, so a node-level `dataSource` binding (or the
+ * saved view its `view` names) REPLACES this key outright rather than merging
+ * with it, and the flat key applies only when the node carries no `dataSource`,
+ * or that `dataSource` and its view both leave `sort` unset
+ * (`composeElementDataSource`: `config.sort ?? view?.sort`). Both directions are
+ * pinned, because a renderer that always preferred one source would satisfy
+ * only one of them.
+ *
+ * No adapter's `getObjectSchema` is needed: every case below either omits
+ * `dataSource` or names no `view`, so the saved-view fetch never engages —
+ * matching the disposition `record-picker-element-data-source.test.tsx` already
+ * established for the `view`-bearing cases of this same block.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { AdapterCtx, SchemaRenderer } from '@object-ui/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Registers `element:record_picker` at module scope, not in a hook
+// (object-ui/no-dynamic-import-in-test-hook, objectui#3010).
+import '../renderers';
+
+const makeAdapter = () => ({
+  find: vi.fn().mockResolvedValue({ data: [] }),
+  getObjectSchema: vi.fn(),
+});
+
+/**
+ * `object` / `filter` / `sort` / `limit` / `label` / `placeholder` live under
+ * `schema.properties` (the spec's element config bag, `readProps` above); the
+ * per-element `dataSource` BINDING is a sibling top-level schema key, read
+ * directly off `schema.dataSource` by `useElementDataSource`. Getting the two
+ * confused is the one mistake that would make every case below fetch nothing.
+ */
+const renderPicker = (
+  properties: Record<string, unknown>,
+  adapter: ReturnType<typeof makeAdapter>,
+  dataSource?: Record<string, unknown>,
+) =>
+  render(
+    <AdapterCtx.Provider value={adapter as any}>
+      <SchemaRenderer
+        schema={
+          {
+            type: 'element:record_picker',
+            id: 'picker',
+            properties,
+            ...(dataSource ? { dataSource } : {}),
+          } as any
+        }
+      />
+    </AdapterCtx.Provider>,
+  );
+
+/** The `$orderby` this block put on the wire, or `undefined` when it sent none. */
+async function orderbyOf(
+  properties: Record<string, unknown>,
+  dataSource?: Record<string, unknown>,
+): Promise<unknown> {
+  const adapter = makeAdapter();
+  renderPicker({ object: 'account', ...properties }, adapter, dataSource);
+  await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+  return (adapter.find.mock.calls[0] as any[])[1].$orderby;
+}
+
+const input = (name: string) =>
+  ComponentRegistry.getConfig('element:record_picker')?.inputs?.find((i) => i.name === name);
+
+describe('element:record_picker — the `sort` MEMBER shape the renderer reads (objectui#8068)', () => {
+  it('CONTROL — sort is declared as an array of OBJECTS, and the declaration stops there', () => {
+    // Calibration for everything below: this pin exists BECAUSE the published
+    // surface names the member kind and nothing else. If a future change adds a
+    // description or narrows `of`, this stays true — it is the read site below
+    // that would then need re-reading, not this row.
+    expect(input('sort')).toBeDefined();
+    expect(input('sort')?.type).toBe('array');
+    expect(input('sort')?.of).toBe('object');
+  });
+
+  it('SUBJECT — an authored array reaches $orderby BY IDENTITY, not a copy', async () => {
+    // `toBe`, not `toEqual`: `query.$orderby = sort` is a reference assignment,
+    // so a fix that started cloning or lowering the array would turn this red
+    // even though `toEqual` would still pass.
+    const sort = [{ field: 'name', order: 'asc' }];
+    const adapter = makeAdapter();
+    renderPicker({ object: 'account', sort }, adapter);
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    expect((adapter.find.mock.calls[0] as any[])[1].$orderby).toBe(sort);
+  });
+
+  it('resolves the flat `object` shorthand the same way (reachability before absence)', async () => {
+    // Without this, every case below that never checks `object` reaching the
+    // query could be satisfied by a picker that never queried at all.
+    const adapter = makeAdapter();
+    renderPicker({ object: 'account' }, adapter);
+    await waitFor(() => expect(adapter.find).toHaveBeenCalledWith('account', expect.any(Object)));
+  });
+
+  it('keeps multi-member order, in the order authored', async () => {
+    // A reader who only saw the identity assertion above could still believe a
+    // reordering read the "same" array. This is the row that would catch it.
+    const sort = [
+      { field: 'stage', order: 'asc' },
+      { field: 'created', order: 'desc' },
+    ];
+    expect(await orderbyOf({ sort })).toEqual(sort);
+  });
+
+  it("passes a member missing `field` through UNFILTERED — the block does NOT drop it", async () => {
+    // The declared behavioural difference from `record:related_list.sort`
+    // (objectui#8071 slice 2), which drops such a member silently via
+    // `normalizeSortSpec`'s `.filter((s) => !!s?.field)`. This block has no
+    // equivalent filter, so the malformed member survives alongside its
+    // well-formed sibling — pinned as the current behaviour it is, because
+    // `of: 'object'` alone gives an author no way to discover which sibling
+    // block validates a member and which does not.
+    const sort = [{ order: 'desc' }, { field: 'created', order: 'desc' }];
+    expect(await orderbyOf({ sort })).toEqual(sort);
+  });
+
+  it('sends NO $orderby when `sort` is absent, rather than an empty clause', async () => {
+    // Non-vacuity for the identity/order rows above: without this, a renderer
+    // that always sent a hard-coded `$orderby` could still satisfy them by
+    // coincidence on the one case that names a real array.
+    expect(await orderbyOf({})).toBeUndefined();
+  });
+
+  it('a `dataSource` binding that declares its own `sort` REPLACES the flat key outright', async () => {
+    // PRECEDENCE, direction 1. The flat `sort` is authored too, so a renderer
+    // that merged rather than replaced — or that read the flat key first —
+    // could not pass this row.
+    const dsSort = [{ field: 'amount', order: 'desc' }];
+    const flatSort = [{ field: 'name', order: 'asc' }];
+    expect(await orderbyOf({ sort: flatSort }, { object: 'account', sort: dsSort })).toBe(dsSort);
+  });
+
+  it('the flat `sort` still applies when the `dataSource` binding carries none', async () => {
+    // PRECEDENCE, direction 2 — the complement the row above cannot exercise. A
+    // `dataSource` is present (so a renderer gating on "dataSource present ⇒
+    // ignore the flat key entirely" would fail here), but it names no `sort` and
+    // no `view`, so `composed.sort` is `undefined` and `composed?.sort ??
+    // props.sort` must fall through to the flat key.
+    const flatSort = [{ field: 'name', order: 'asc' }];
+    expect(await orderbyOf({ sort: flatSort }, { object: 'account' })).toBe(flatSort);
+  });
+});


### PR DESCRIPTION
Refs #8071

Third slice of objectui#8071's transition: the four remaining `element:record_picker` keys converted from member-pin exemption to member pin, and `MEMBER_PIN_EXEMPTION_CEILING` moved down with the list in the same commit.

## Re-derived on this branch's base (`origin/main` `e9d92120a`)

Re-measured with a TypeScript-AST walk (`ts.createSourceFile` + a visitor over `VariableDeclaration` nodes, counting each object literal's own `PropertyAssignment` children), not a brace-depth counter — the PM's own dispatch comment on this card recorded that instrument running past the object's close, confused by braces inside string/comment tokens. An AST walk counts property KEYS, not brace characters, so a `{`/`}` inside one of this file's long `pins` prose strings (there are many) cannot be miscounted as a boundary.

Controlled at two commits so it demonstrably fires:

| reading | at `origin/main` (`e9d92120a`, this branch's unmoved base) | after this PR |
|---|--:|--:|
| `MEMBER_PINS` | 36 | **40** |
| `MEMBER_PIN_EXEMPTIONS` | 54 | **50** |
| `MEMBER_PIN_EXEMPTION_CEILING` | 54 | **50** |
| population (array/object-armed inputs on covered blocks) | 90 | **90** |

The 54/36 base reading matches both the card's own claim comment (`5602705803`, cross-checked there against the gate file's own `:2032` prose) and slice 2's landing note — the ledger has not moved since. Population does not move, because a pin and an exemption are the two halves of one partition.

## Which keys, and why these

`element:record_picker` — `dataSource`, `label`, `placeholder`, `sort`. This is the **entire remaining exemption list for the block** — the coherent batch this card's own dispatch names as the example ("one block family, e.g. all of `element:record_picker.*`"). Unlike `record:related_list` (slice 2), nothing here needed a `NO_READ_SITE_TO_PIN`: every declared key on this block has a real read site in `record-picker.tsx`, so the block drops out of `MEMBER_PIN_EXEMPTIONS` entirely rather than leaving one entry behind — the first block this transition has closed all the way.

### Per key — where the renderer reads it, and the shape found

| key | read site | shape the renderer actually reads |
|---|---|---|
| `dataSource` | `useElementDataSource` + `composeElementDataSource` | The per-element binding's own members (`object`, `view`, `filter`, `sort`, `limit`): `view` resolves a saved view supplying the baseline, an authored binding key WINS over the same key from the view, the binding's `filter` AND-combines with the view's, and an unresolvable `view` reports rather than falling back to every record. `columns` is deliberately not part of this pin — this renderer never reads `composed.columns` at all, unlike the list-shaped sibling blocks. |
| `label` / `placeholder` | `pickLocalized(props.label, language)` / `pickLocalized(props.placeholder ?? 'Select a record…', language)` | The `I18nLabel` object arm (`{ en, 'zh-CN', … }`), resolved to the active language rather than to a hard-coded `en` — the pre-fix failure for `placeholder` THREW (`Objects are not valid as a React child`) and for `label` silently deleted the element for a map that omitted `en`. Both are pinned, with element-presence asserted before text. |
| `sort` | `record-picker.tsx`: `if (sort) query.$orderby = sort;` | An IDENTITY pin — no `normalizeSortSpec` sits between the authored array and the wire, so a malformed member (missing `field`) is **not** dropped, unlike `record:related_list.sort` (slice 2). PRECEDENCE is pinned in both directions against `dataSource`: a binding's own `sort` replaces the flat key outright, and the flat key still applies when the binding carries none. |

### Two of the four were pre-existing files — READ before being credited

Slice 1 and slice 2's lesson applied again. `record-picker-element-data-source.test.tsx` (`dataSource`) and `record-picker-label-placeholder-i18n.test.tsx` (`label` **and** `placeholder` — one file covers the pair, which is why those two `MEMBER_PINS` rows point at the same file) were read end to end before promotion; both genuinely pin the member shape their key names, with no neighbouring-key trap this time — neither file names a key it does not pin.

`sort` had no existing candidate anywhere in the repo: nothing exercised the flat, standalone `properties.sort` key before this slice (the only prior `sort` references in this block's tests are `dataSource.sort`, a different member position), so `record-picker-sort-members.test.tsx` is a new file.

## Ablation

Two mutations, each proven on disk before being read, restored via `git checkout HEAD -- ABS_PATH` from a `trap … EXIT INT TERM`, and the restoration proven by **blob-hash equality against `HEAD`** (not by exit code) plus an empty `git diff HEAD`.

| # | target | mutation | result |
|---|---|---|---|
| 1 | the gate's own ledger | re-add `'element:record_picker.dataSource': AWAITING_A_PIN` to `MEMBER_PIN_EXEMPTIONS` **without** raising `MEMBER_PIN_EXEMPTION_CEILING` | **3 failed / 195 passed** (198 total) — the non-vacuity census, `carries no stale member-pin exemption`, and `the member-pin exemption list only ratchets DOWN` (51 > 50) all catch it |
| 2 | `record-picker.tsx` (the RENDERER, not the test) | `if (sort) query.$orderby = sort;` → a no-op comment | **5 failed / 3 passed** in `record-picker-sort-members.test.tsx` — every row that reads `$orderby` reds; the CONTROL/reachability rows that don't touch it correctly stay green |

Non-vacuity: the same invocation (`vitest run apps/console/src/__tests__/registry-inputs-spec-parity.test.ts`) is exit 0 at rest both before ablation 1 and after its restoration (198/198 both times), so the red is a change of state, not the file's resting colour. Same shape confirmed for ablation 2 (8/8 before and after).

## Base → `origin/main` window check

This branch's base **is** `origin/main` (`e9d92120a`) — `git diff --name-only e9d92120a origin/main` is a **zero-length window**, not merely an empty result over a real interval: `origin/main` had not moved since this branch was cut, re-confirmed with a fresh `git fetch` immediately before this check. Because the window has zero length, no drift is possible in it by construction, which is a stronger statement than "no file happened to move" — there was no interval for one to move in.

An empty reading still needs a firing control, so the same instrument was run over a real, known-non-empty window (`b6d07df4`..`origin/main`, slice 2's base to now): **115 files**, confirming the diff mechanism itself is not silently broken. That window does include `registry-inputs-spec-parity.test.ts` — expected, since slice 2's own merge is inside it — which is exactly the file my own base already carries; it is not evidence of drift on top of my base.

⚠️ Between finishing local verification and pushing, `origin/main` advanced once more (`e9d92120a` → `bddf1cf70`, one commit). Re-checked: `git diff --name-only e9d92120a bddf1cf70` touches only `packages/plugin-chatbot/**` and its own changeset — disjoint from every file this slice's pins read (`record-picker.tsx`, the gate file, the four pin test files) or from the gate file itself. No re-read needed.

## Ledger-hazard check (`scripts/check-doc-example-types.mjs` `UNGATED_EXAMPLES`)

This diff shifts line numbers inside `registry-inputs-spec-parity.test.ts` (net +63 lines) and adds a new file. Neither touched path appears as a ledger key: `grep -c "'apps/console/src/__tests__/registry-inputs-spec-parity.test.ts:" scripts/check-doc-example-types.mjs` → **0**, same for both `record-picker.tsx` (reverted, no net change) and the new `record-picker-sort-members.test.tsx`. Firing control: the identical grep against a path that **is** a ledger key (`'packages/auth/src/AuthGuard.tsx:`) returns **1**, so the zero above is a real absence, not a broken grep. Neither touched/new file contains an `@example` block itself. No re-keying needed.

## Gates

| gate | exit | note |
|---|--:|---|
| `vitest run apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` (the gate itself) | **0** | 198 tests, exit captured before any pipe |
| `vitest run packages/components/src/__tests__/record-picker-sort-members.test.tsx` | **0** | 8/8, the new file in isolation |
| `vitest run` on both promoted pre-existing files | **0** | 17/17, unaffected baseline |
| `pnpm --filter '@object-ui/components...' --filter '@object-ui/console...' build` | **0** | dependency closure, needed before type-check |
| `pnpm --filter @object-ui/components run type-check` | **0** | `tsc --noEmit && tsc -p tsconfig.test.json` |
| `pnpm --filter @object-ui/console run type-check` | **0** | `tsc --noEmit && tsc -b tsconfig.node.json --force`; `--listFiles` confirms the new pin file is in the test program (1 hit, control on a nonexistent name: 0) |
| `node scripts/check-control-bytes.mjs` | **0** | 7043 tracked text files scanned |
| `node scripts/check-element-data-source-declaration.mjs` | **0** | 13 gate-consuming files checked; unaffected by this diff, run because the pins touch `dataSource` |
| final sweep: all 8 `record_picker`-family test files together | **0** | 249/249 tests |
| `node scripts/check-changeset-presence.mjs` | **0** | empty-frontmatter changeset: test-only, releases nothing; 2 published source files detected |
| `eslint` (narrowed to the 2 changed/new files) | **0** | 0 errors, 4 `no-explicit-any` warnings, matching the neighbouring suites' house style |
| `node scripts/check-doc-example-types.mjs` (`UNGATED_EXAMPLES` cross-check) | n/a (grep-based, not the full gate) | see ledger-hazard section — full gate needs a whole-repo `dist` build (`PRECONDITION NOT MET` without it) |

Exit codes captured before any pipe (`cmd > log 2>&1; EXIT=$?`). Repo-wide `pnpm lint` and the full `pnpm test` are CI-owned runs and were not taken locally.

## Out-of-scope findings

None filed. No trap-shaped near-miss files were found this slice (both promoted files pin exactly the key(s) credited, with no neighbouring key left un-pinned on their strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_