### PR TITLE
docs(plugin-form): describe object-form's top-level `fields` member vocabulary

### DIFF
--- a/.changeset/8738-object-form-fields-description.md
+++ b/.changeset/8738-object-form-fields-description.md
@@ -1,0 +1,18 @@
+---
+'@object-ui/plugin-form': patch
+---
+
+`object-form`'s top-level `fields` input now documents its member vocabulary
+(objectui#8738, route 2 of 2 — route 1, a diagnostic `console.warn`, is a
+separate ruling still pending).
+
+The registration declared `{ name: 'fields', type: 'array' }` with no
+description, so an author had nowhere to read that this key's members are
+**bare field names** — a different vocabulary from `sections[].fields`, which
+also accepts the spec `FormFieldSchema` object (identity key `field`, e.g.
+`{ field: 'note', colSpan: 2 }`). Moving one of those objects to the top-level
+`fields` resolves to no name and is silently skipped by `SimpleObjectForm`
+(`ObjectForm.tsx`) and by `buildFlatFields` (`flatFields.ts`, shared by the
+drawer/modal presentations) — no throw, no warning, no empty-state. Behaviour
+is unchanged; this only adds the description text an author would need to
+avoid the drop before writing it.

--- a/packages/plugin-form/src/index.tsx
+++ b/packages/plugin-form/src/index.tsx
@@ -229,7 +229,7 @@ ComponentRegistry.register('object-form', ObjectFormRenderer, {
   category: 'plugin',
   inputs: [
     { name: 'objectName', type: 'string', required: true },
-    { name: 'fields', type: 'array' },
+    { name: 'fields', type: 'array', description: 'Bare field names to show, in order (each looked up in the object schema; `{ name }` is tolerated). NOT the same vocabulary as `sections[].fields`, which also accepts the spec `FormFieldSchema` object (identity key `field`, e.g. `{ field: "note", colSpan: 2 }`) — that shape resolves to no name HERE and is silently skipped (SimpleObjectForm in ObjectForm.tsx; buildFlatFields in flatFields.ts for the drawer/modal presentations).' },
     { name: 'mode', type: 'enum', enum: ['create', 'edit', 'view'] },
     { name: 'formType', type: 'enum', enum: ['simple', 'tabbed', 'wizard', 'split', 'drawer', 'modal'] },
     { name: 'sections', type: 'array' },


### PR DESCRIPTION
Refs objectstack-ai/objectui#8738

## What

`object-form`'s registration input `{ name: 'fields', type: 'array' }` gets a
`description`. Members are **bare field names** (`{ name }` tolerated); the
spec `FormFieldSchema` object (`{ field: 'note', colSpan: 2 }`, identity key
`field`) — legal in `sections[].fields` — resolves to no name here and is
silently skipped, with no throw / warning / empty-state (`SimpleObjectForm` in
`ObjectForm.tsx`; `buildFlatFields` in `flatFields.ts`, shared by the
drawer/modal presentations).

This is **route 2 of 2** from #8738's dispatch — the claim comment
([#8738 comment](https://github.com/objectstack-ai/objectui/issues/8738#issuecomment-5602768772))
splits the card: route 2 (this PR) is a docs fix already covered by an
on-record maintainer ruling (objectstack#17031 — "a manual diverged from a
ruled implementation defaults to a doc fix, not a decision-box item"); route 1
(a diagnostic `console.warn` on the silent-drop path) is a **behaviour**
change to a published component and is still unruled. **This PR does not
implement route 1** — no warn, no lenient `?? f.field` fallback, no change to
`normalizeSectionField` / `buildFlatFields` / `SimpleObjectForm`'s loop.
Description text only.

Read sites re-derived against current `main` (`e9d92120a`, the card's
measurement was from a since-moved `2f881a90`):
- `packages/plugin-form/src/ObjectForm.tsx:764-778` — `SimpleObjectForm`'s
  `fieldsToShow` loop: `const name = typeof fieldName === 'string' ? fieldName
  : (fieldName as any).name; if (!name) return;`
- `packages/plugin-form/src/flatFields.ts:57-65` — `buildFlatFields` (shared
  by `ModalForm`/`DrawerForm`): identical `typeof entry === 'string' ? entry :
  (entry as any)?.name; if (!name) continue;`
- Contrast surface — `packages/plugin-form/src/sectionFields.ts:148`
  (`normalizeSectionField`) and `ObjectForm.tsx:1376`
  (`(f as any).field ?? f.name`) — the spec `FormFieldSchema` object (`field`
  identity key) IS canonical there.

## Why

Nothing on either declared side refuses the spec shape at the top level: the
registration had no `description` and no `of`, and `@objectstack/spec`'s
`ComponentPropsMap['object-form'].fields` is `z.array(z.unknown())` with only
"Limit/order the fields shown". An author who read `sections[].fields`'s
documentation and moved the same `{ field: 'note', colSpan: 2 }` entry to the
top level got a silent drop with no authoring surface anywhere that would
have warned them first. The added description is that surface.

## Tests

- `packages/plugin-form/src/__tests__/objectFormFieldsMembers-8071.test.tsx`
  (the existing pin, unmoved) — `pnpm exec vitest run
  packages/plugin-form/src/__tests__/objectFormFieldsMembers-8071.test.tsx` —
  **6/6 passed**, exit 0. Assertions 4 and 5 (both directions: the spec
  `{ field }` object dropped silently at top level, the identical entry
  resolves inside `sections[].fields`) are unmoved.
- `pnpm --filter @object-ui/plugin-form test` — 877 passed, 1 skipped
  (pre-existing), exit 0.
- `pnpm --filter @object-ui/plugin-form run type-check` — clean, exit 0
  (after building the dependency closure: `pnpm --filter
  '@object-ui/plugin-form^...' build`, exit 0).
- `apps/console` sweep (dependency direction: `pnpm --filter
  '@object-ui/console^...' build`, exit 0 first):
  - `pnpm --filter @object-ui/console run type-check` — clean, exit 0.
  - `pnpm exec vitest run apps/console/src/__tests__/registry-inputs-spec-parity.test.ts`
    — 198 passed, exit 0.
  - `pnpm --filter @object-ui/console test` (full suite) — 97 files / 1127
    tests passed, exit 0.
- `node scripts/check-doc-component-types.mjs` — ✅ (registered-key
  population unchanged; only a description string was added to an existing
  key).
- `node scripts/check-control-bytes.mjs` — ✅ clean.
- `node scripts/check-changeset-presence.mjs` / `-no-major` / `-overwrite` /
  `-fixed` — ✅ all clean; 1 changeset declared for `@object-ui/plugin-form`
  (patch).
- `node scripts/check-governed-queue-guard.mjs --test <changed paths>` — ✅
  NOT GOVERNED (ordinary review/merge-queue route applies).
- Scoped `eslint --no-inline-config packages/plugin-form/src/index.tsx
  --format json` — 0 errors, 25 pre-existing warnings, none on the touched
  line (232); confirmed via `sed -n` diff against `origin/main`'s copy of the
  same file.

## Ledger hazard (objectui#8614 shape) check

`scripts/check-doc-example-types.mjs`'s `UNGATED_EXAMPLES` is keyed by
`file:line`. `grep -n "plugin-form/src/index.tsx" scripts/check-doc-example-types.mjs`
— **no match**, and the edit is a same-line string replacement (line 232 stays
line 232, no lines shift), so the ledger hazard does not apply here either
way.

## Base→main pre-flight

Worktree base `e9d92120a`. First pre-flight (pre-commit): `origin/main` still
at `e9d92120a` — empty window. Second pre-flight (pre-push): `origin/main`
advanced to `bddf1cf70`, one commit
(`fix(plugin-chatbot): fold an authored 'tool' role before it seeds the AI SDK
store (#8837)`), zero overlap with the touched files (`packages/plugin-form/src/index.tsx`,
`ObjectForm.tsx`, `flatFields.ts`) — no rebase needed.

## Scope note for the PM

Re-deriving the read sites surfaced that the identical `fields` registration
entry — same code path, same silent-drop behaviour — also exists at
`packages/plugin-form/src/index.tsx:292` (`ComponentRegistry.register('form',
...)`, the `view:form` alias of the same `ObjectFormRenderer`) and, via a
straight pass-through, on `object-master-detail-form`'s parent `fields` at
line ~430 (which already carries a *different*, incomplete description). Left
untouched this round: the dispatch and the pinned probe both scope to
`object-form` specifically, and widening the diff wasn't authorized. Reported
in the `os-dev-report` for the PM's disposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_