### PR TITLE
docs(toast): delete the retired `action` key from the ToastSchema fence

### DIFF
--- a/content/docs/components/feedback/toast.mdx
+++ b/content/docs/components/feedback/toast.mdx
@@ -37,12 +37,6 @@ interface ToastSchema {
   description?: string;           // Toast message
   variant?: 'default' | 'success' | 'warning' | 'error' | 'info';
   
-  // Action button
-  action?: {
-    label: string;
-    onClick: () => void;
-  };
-  
   // Timing
   duration?: number;              // Auto-dismiss time in ms
 }


### PR DESCRIPTION
Fixes #8539

`content/docs/components/feedback/toast.mdx` publishes an illustrative `ToastSchema` interface in a `plaintext` fence. Six lines of that fence taught a member that both published faces have retired.

## What a reader hits today

Both faces reject, and have done since objectui#8338 landed:

| face | where | what it says now |
| --- | --- | --- |
| TypeScript | `packages/types/src/feedback.ts:163` | `action?: never;` |
| Zod | `packages/types/src/zod/feedback.zod.ts:89` | `action: retirementTombstone('RETIRED (objectui#8338, ADR-0049 enforce-or-remove) ...')` |

So a reader who copied the fence got `tsc` refusing the literal **and** `safeParse` refusing it with the tombstone's guidance — and nothing on the page told them the docs were the wrong party. That is an active error, not staleness.

⚠️ The failure mode has moved since the card was filed (2026-09-08). At that time objectui#8338 had not landed, so the card describes a **split** answer: `safeParse` green, `tsc` red. Today it is a **consistent** refusal on both faces. The deletion is the correct remedy under either state.

## What this PR does — and deliberately does not

**Does:** deletes the `action` block from the fence. Six lines removed, one file, nothing else:

```
-  // Action button
-  action?: {
-    label: string;
-    onClick: () => void;
-  };
-
```

**Does not document a replacement — there is none.** objectui#6250 moved all seven toast demos off in-toast action entirely, and the capability was never implemented. No "not yet supported" line and no pointer at a future shape: that would be a promise with no owner. An in-toast action button is a capability expansion with zero runtime and needs its own card.

**Does not tidy the rest of the fence.** The card names, and deliberately declines, the fence's other omissions (`position`, `buttonLabel`, `buttonVariant`, and the `onDismiss` tombstone). That is a hand-maintained subset; completing it is a different decision — should this fence claim to be complete? This PR deletes exactly one retired key.

**Same-name trap avoided:** `EmptySchema.action` (`feedback.ts:283`, `feedback.zod.ts:157`) is a different key on a different card (objectui#7105) that merely happens to spell the same shape. Confirmed by interface boundaries: `ToastSchema` spans `feedback.ts:115-201`, `EmptySchema` spans `:231-288`. Untouched.

## ⚠️ Acceptance — no gate proves this, by measurement

`scripts/check-doc-component-types.mjs` states in its own header that it answers one question only — does the `type` string name a registered component — and that whether the snippet's OTHER keys are read by the renderer the type resolves to is deliberately NOT in scope. **CI is green whether or not this fence is fixed.** That is exactly why this needed a card rather than a red build, and it is why "gates green" is not offered below as evidence for the change.

The evidence is the deletion plus one reading with a lit control.

### Subject — occurrences of `action` in `toast.mdx`

Card's measured baseline: **2**.

```
BEFORE  (e9d92120a)                              AFTER  (0b1588c90)
27:  SchemaExample id="…/toast-with-action"      27:  SchemaExample id="…/toast-with-action"
41:  action?: {                                  —
count: 2                                         count: 1
```

(Angle brackets elided from the line-27 element above; the GitHub body sanitizer eats tag-shaped fragments.)

The surviving occurrence is the `SchemaExample id` at `:27`, which the card ring-fenced. It is untouched.

### Lit control — a key that IS still declared

Run in the same probe over the same file, to prove the probe runs rather than that the file was emptied:

| key | before | after |
| --- | --- | --- |
| `variant` | 3 | 3 |
| `duration` | 2 | 2 |

Both still present and unchanged. ⇒ the probe reached the file; only the retired key left.

### Corroboration — the page and its own example data now agree

`:27`'s id names `examples/schema-catalog/src/schemas/components-feedback-toast/toast-with-action.json`, which authors **no** `action` key at all (re-measured here: 0). Prose and fixture have disagreed for a while; deleting restores agreement rather than removing a capability.

## Gates run (reported as status, not as proof of the fix)

Run on the final commit `0b1588c90`:

| gate | verdict |
| --- | --- |
| `pnpm check:doc-types` | exit 0 — "Every documented component type is registered." |
| `pnpm check:doc-fences` | exit 0 — 227 documents; `toast.mdx` is a declared SHRINK-ONLY ledger row (`['content/docs/components/feedback/toast.mdx', 1]`) and its block count is unchanged at 1, so no ledger edit is owed |
| `pnpm check:doc-snippets` | exit 0 — "Every covered documentation snippet compiles against the built types." (first run exited 2 = PREREQUISITE NOT MET, unbuilt tree; re-run after the gate's own `--build-filter` closure build, 35 tasks successful) |
| `pnpm check:doc-examples` | exit 0 — "Every covered `@example` compiles, or fails exactly as its ledger row declares." (same prerequisite) |
| `node scripts/check-doc-links.mjs` | exit 0 — "Links are valid across 17 scan roots." |
| `pnpm check:control-bytes` | exit 0 — 7041 tracked text files scanned |

`toast.mdx` carries exactly one fence and it is `plaintext`, and the file appears in neither the `doc-snippets` nor the `doc-examples` coverage ledger ⇒ those two gates structurally carry no verdict about this edit. They are reported because the card named the family, not as evidence.

## Changeset — measured, not assumed

```
node scripts/check-changeset-presence.mjs   → exit 0
Compared the working tree with e9d92120a (merge-base with origin/main): 1 file(s) changed,
0 of them published source of a package the release covers, 0 of them a manifest whose
published contract moved, 0 under a package changesets ignores, 0 changeset(s) added.
✅  No source or published contract of a released package changed in this range, so no
    changeset is owed.
```

⇒ no changeset added. `content/docs/**` is not published source of any release-group package.

## Governed surface — read with a lit control

```
node scripts/check-governed-queue-guard.mjs --test content/docs/components/feedback/toast.mdx AGENTS.md
  → exit 3 · "1 of 2 path(s) are on a governed surface: AGENTS.md"

node scripts/check-governed-queue-guard.mjs --test content/docs/components/feedback/toast.mdx
  → exit 0 · "NOT GOVERNED — 1 path(s) checked against 5 governed surface(s); none matched."
```

The lit control (`AGENTS.md`) fired, so the instrument runs; this PR's only path did not match. ⇒ ordinary review and merge-queue route applies.

## Clause-②: no

`Contract-text:` the published contract this change touches is already closed against `action`, and this PR moves none of it — it deletes prose that contradicts it:

- `packages/types/src/feedback.ts:163` — `action?: never;`, with `@deprecated Not part of this contract — the key never had an inhabitant.`
- `packages/types/src/zod/feedback.zod.ts:89` — `action: retirementTombstone('RETIRED (objectui#8338, ADR-0049 enforce-or-remove) ...')`

The diff is one `.mdx` file under `content/docs/components/`. No exported symbol, no key on a published payload, no `package.json` publish-contract field, and no `packages/**` file is touched — confirmed by the changeset gate's own reading above (0 published-source files, 0 moved manifests).

## Boundaries observed

- `content/docs/releases/` — not touched. Release notes are written centrally at release time.
- `packages/types/**` — not touched. The retirement already landed as objectui#8338; this is the prose half its closed file surface could not reach.
- The other six toast demos and their fixtures — not touched. objectui#6250 already handled them.

## 验收备注

No out-of-scope findings were filed. The fence's other omissions (`position`, `buttonLabel`, `buttonVariant`, the `onDismiss` tombstone) are recorded here as noted-not-filed: the card names them and rules them out on purpose, and the question they raise — should this hand-maintained fence claim to be complete, or become derived? — is a decision, not a defect.

---
_Generated by [Claude Code](https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH)_