### PR TITLE
docs(data-objectstack): point the two example `baseUrl`s at a reserved placeholder host

### DIFF
--- a/content/docs/utilities/data-objectstack.mdx
+++ b/content/docs/utilities/data-objectstack.mdx
@@ -152,13 +152,19 @@ function createObjectStackAdapter<T = unknown>(config: {
 import { createObjectStackAdapter } from '@object-ui/data-objectstack';
 
 const dataSource = createObjectStackAdapter({
-  baseUrl: 'https://api.objectstack.dev',
+  baseUrl: 'https://api.example.com',
   token: 'your-api-token',
   cache: { maxSize: 100, ttl: 5 * 60 * 1000 },
   autoReconnect: true,
   maxReconnectAttempts: 5,
 });
 ```
+
+`api.example.com` is a placeholder — here and in every other example on this
+page. RFC 2606 reserves `example.com` precisely so documentation can name a host
+that can never resolve to somebody's real service, so a snippet copied with it
+left in fails loudly instead of reaching a stranger's server. Replace it with
+your own ObjectStack server's URL.
 
 Pass a record type to get typed results — the default is `unknown`:
 
@@ -361,7 +367,7 @@ Pass your own `fetch` to route requests through a proxy or attach extra headers:
 import { createObjectStackAdapter } from '@object-ui/data-objectstack';
 
 const dataSource = createObjectStackAdapter({
-  baseUrl: 'https://api.objectstack.dev',
+  baseUrl: 'https://api.example.com',
   fetch: (input, init) =>
     fetch(input, { ...init, headers: { ...init?.headers, 'X-Tenant': 'acme' } }),
 });


### PR DESCRIPTION
Fixes #8381

`content/docs/utilities/data-objectstack.mdx` named `https://api.objectstack.dev` as the example API host in two copyable code fences. That domain does not resolve, so a reader who copies either snippet gets a configuration pointed at nothing — and the failure arrives as a runtime network error rather than as anything a check catches.

## What changed — the two named lines, plus the prose the ruling asked for

| site | before | after |
|---|---|---|
| `:155`, the `**Example:**` fence | `baseUrl: 'https://api.objectstack.dev',` | `baseUrl: 'https://api.example.com',` |
| `:364`, the `### Custom fetch` fence | `baseUrl: 'https://api.objectstack.dev',` | `baseUrl: 'https://api.example.com',` |

Plus one paragraph directly under the first fence stating that the host is a placeholder, why it can never resolve, and that the reader should substitute their own. Nothing else in the file, and no other file: `git diff --stat` against the branch point is `1 file changed, 8 insertions(+), 2 deletions(-)`.

### Why a reserved host, and why this one

The ruling asked for a host **reserved for documentation** and refused `api.objectstack.ai`: plausible is not established, and egress policy means nobody in these sessions can probe it. `example.com` is reserved by RFC 2606 for exactly this purpose — a documentation host that can never resolve to somebody's real service — so a reader who forgets to change it fails loudly instead of reaching a stranger's server.

Two measurements say `api.example.com` is not a new placeholder being introduced here, but the convention these two lines were the only stragglers from:

- the same file already uses `https://api.example.com` at **eleven** other `baseUrl` sites, the first at `:48` in Quick Start;
- the package's own **published** JSDoc `@example`, in the shipped `packages/data-objectstack/dist/index.d.ts`, already reads `baseUrl: 'https://api.example.com'`.

## Acceptance — three readings at `74781ff81`

No gate proves this one. Both sites sit inside code fences and the link sweep does not extract links from fences, so it was never going to name them — a class the instrument does not see, not a gap in objectui#8128's fix. CI is green either way, so the readings are the acceptance.

**Subject — `api.objectstack.dev` in that file falls to 0:**

```
$ grep -oP 'api\.objectstack\.dev' content/docs/utilities/data-objectstack.mdx | wc -l
0
$ git grep -nP 'objectstack\.dev' -- .        # repo-wide, anchored
(no output, exit 1)
```

**Lit control A — `objectstack.ai` in that file is untouched, so the probe runs rather than having purged the domain:**

```
$ grep -nP 'objectstack\.ai' content/docs/utilities/data-objectstack.mdx
505:- **[ObjectStack Documentation](https://docs.objectstack.ai)** - Learn about ObjectStack
550:- [ObjectStack Documentation](https://docs.objectstack.ai)
```

Both are objectui#8128's landed work, carried through unchanged; the line numbers moved by +6 only because the new paragraph sits above them.

⚠️ One correction to this control's expected value, and it is the ruling's own instrument trap landing on the control itself. The brief expected **3**; anchored, the file holds **2**. The third hit is only reachable with an unanchored dot:

```
$ grep -nP 'objectstack.ai' content/docs/utilities/data-objectstack.mdx   # unanchored
505:...docs.objectstack.ai...
550:...docs.objectstack.ai...
551:- [GitHub Issues](https://github.com/objectstack-ai/objectui/issues)   [objectstack-ai = the ORG name]
```

The dot matched the hyphen in `objectstack-ai`. The control is still lit either way — an over-broad edit would have moved these lines — but its true anchored value is 2, not 3.

**Lit control B — the CLI command `objectstack dev` (with a space) is byte-identical:**

```
$ git grep -nP 'objectstack dev' -- . | wc -l
11
```

11 lines across 8 files, including both sites the brief named (`content/docs/guide/ci-cd-pipeline.md:526` and `packages/auth/src/__tests__/workspaceAdminPositions-5389.test.tsx:21`) — and the brief's list was the smaller half: `.github/workflows/live-e2e.yml`, `AGENTS.md` x2, `CHANGELOG.md`, `e2e/live/ci/start-backend.sh` x3, `e2e/live/record-history-display.spec.ts` and `examples/console-starter/README.md` carry it too. That is the blast radius an unanchored `objectstack.dev` regex would have had. Every replacement here was an exact-literal match on the full line `  baseUrl: 'https://api.objectstack.dev',` with an asserted match count of 2, never a regex; the `git diff --stat` above is the proof none of the 11 moved.

## Gates run

| gate | exit | reading |
|---|---|---|
| `check:doc-snippets` | 0 | `Semantic phase: 637 of 637 block(s) judged, 0 failed.` — run after its own scoped 34-package build (35/35 tasks, exit 0); its four harness controls all lit |
| `check:doc-types` | 0 | `Every documented component type is registered.` (188 doc files, 1108 code blocks) |
| `docs:check-links` | 0 | `Links are valid across 17 scan roots.` |
| `check:doc-fences` | 0 | every TypeScript block in 227 documents correctly fenced |
| `check:doc-expression-carriage` | 0 | report-only census, unchanged |
| `check:docs-route-closure` | 0 | unchanged |
| `check:control-bytes` | 0 | 7058 tracked text files scanned |
| `check-changeset-presence` | 0 | see below |
| `check-governed-queue-guard --test` | 0 subject / 3 control | see below |

Extraction invariance was measured directly rather than assumed: the gate's own exported `scanFences()` reports the same **15 blocks and 3 markers** before and after, and the only byte difference in the whole extracted program set is the two string literals — the added paragraph moved no fence and consumed no fragment marker.

`eslint` does not cover this file at all — measured, not narrowed: `npx eslint content/docs/utilities/data-objectstack.mdx --format json` returns `File ignored because no matching configuration was supplied.`

## Changeset — measured, not assumed

None owed. `node scripts/check-changeset-presence.mjs` exits 0 with:

```
Compared the working tree with 42df92809 (merge-base with origin/main): 1 file(s) changed,
0 of them published source of a package the release covers, 0 of them a manifest whose
published contract moved, 0 under a package changesets ignores, 0 changeset(s) added.
```

## Governed surface

Not governed, with the required lit control:

```
$ node scripts/check-governed-queue-guard.mjs --test content/docs/utilities/data-objectstack.mdx
✅ NOT GOVERNED — 1 path(s) checked against 5 governed surface(s); none matched.     (exit 0)

$ node scripts/check-governed-queue-guard.mjs --test AGENTS.md
⛔ GOVERNED — 1 of 1 path(s) are on a governed surface                               (exit 3)
```

Clause-②: no
Contract-text: the published contract this page documents is `baseUrl: string` in `packages/data-objectstack/dist/index.d.ts`; substituting one string literal for another in an example neither widens an accept set nor expands a published surface, and `check-changeset-presence` measures 0 files of published source touched.

## 验收备注

- The placeholder paragraph sits under the first **changed** fence (`:155`), not under the page's first `baseUrl` example (`:48`), to stay inside the two sites this card names. A page-level note in Quick Start would read slightly better; noted, not filed — no successor PR or person is queued on this file.
- The brief's premise that a placeholder had to be chosen turned out to be already-decided by the corpus: 11 sites in this very file plus the shipped `.d.ts` example. The choice is therefore alignment, not a new convention.
- Not touched, deliberately: `:505` / `:550` (objectui#8128's landed work), `content/docs/guide/ci-cd-pipeline.md`, `packages/auth/**`, and the single `https://api.your-instance.com` at `content/docs/guide/data-source.md:72` (verified still there, 1 hit) that triage explicitly placed out of scope.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH)_