### PR TITLE
test(console): pin record:quick_actions member shapes (objectui#8071 slice 4)

### DIFF
--- a/.changeset/record-quick-actions-member-pins-8071.md
+++ b/.changeset/record-quick-actions-member-pins-8071.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change: `record:quick_actions`'s `actionNames` and `requiredPermissions` gain per-block member pins (objectui#8071 slice 4), closing out the block entirely, and the member-pin exemption ledger in the console's registry/spec parity gate moves with them. No published behaviour changes — no runtime source, build entry, `files[]` payload or published-contract field is touched.

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -2042,6 +2042,24 @@ const MULTI_KIND_MEMBER_CONTRACTS: Record<string, string> = {
 // exercised — had no existing candidate anywhere in the repo, so it is a new
 // file. See `MEMBER_PIN_EXEMPTION_CEILING`'s own docblock for the accounting.
 //
+// ⭐ FOURTH SLICE, THE SECOND WHOLE BLOCK CLOSED, AND A TWO-KEY FAMILY.
+// objectui#8071's fourth slice converted both remaining keys of ONE block —
+// `record:quick_actions`'s `actionNames` and `requiredPermissions` — chosen
+// because the block's remaining population is small enough to close outright
+// (the shape this card's own dispatch names, over an arbitrary four). Neither
+// key needed `NO_READ_SITE_TO_PIN`: `actionNames` drives a real
+// `useMetadataItem` lookup against the object's own `actions`, and
+// `requiredPermissions` is a block-level gate (`required.every((p) =>
+// perms.can(objectName, p))`) that hides the whole bar before anything is
+// drawn — a DIFFERENT mechanism from an `ActionDef`'s own per-action field of
+// the same name, which a pre-existing fixture already exercised without
+// touching this key at all. Measured over this file's own ledger, before and
+// after: 90 array/object-armed inputs, 40 pinned, 50 exempt -> 90, 42 pinned,
+// 48 exempt, and `MEMBER_PIN_EXEMPTION_CEILING` follows 50 -> 48 in the same
+// commit. One of the two pins PROMOTES a pre-existing file
+// (`recordQuickActionsInputs.actionNamesFallback.test.tsx`); the other
+// (`requiredPermissions`) is new, for the reason above.
+//
 // A list this size is the transition case, and this file already owns the
 // pattern for it —
 // `OFF_SPEC_EXEMPTIONS` / `UNPUBLISHED_EXEMPTIONS` / `OFF_SPEC_ARM_EXEMPTIONS`
@@ -2271,6 +2289,14 @@ const MEMBER_PINS: Record<string, MemberPin> = {
     file: 'packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts',
     pins: 'Members are objects carrying `readonly` PER ENTRY — asserted to be per-entry rather than top-level, and every spec entry key must be discoverable from the `fields` description (objectui#3407).',
   },
+  'record:quick_actions.actionNames': {
+    file: 'packages/plugin-detail/src/__tests__/recordQuickActionsInputs.actionNamesFallback.test.tsx',
+    pins: 'Members are action-id STRINGS resolved against the object\'s own `actions` through the real renderer: with no `actionNames` (and no host `actions`) the metadata layer is NEVER queried and the bar\'s empty placeholder renders, while naming an id drives the same `useMetadataItem` lookup and the resolved action\'s button actually appears — the positive control that keeps the negative case from reading as "the wiring was never exercised". Pre-existing file, promoted to a pin here after being read end to end; it was written for objectui#4663 (the registered description promised a fallback that exists on no path) rather than for this direction, but its second case already drives the exact read this key needs pinned (objectui#8071).',
+  },
+  'record:quick_actions.requiredPermissions': {
+    file: 'packages/plugin-detail/src/renderers/__tests__/record-quick-actions.requiredPermissions-gate.test.tsx',
+    pins: 'The BLOCK-LEVEL gate (`required.every((p) => perms.can(objectName, p))`) that hides the whole bar before any action is drawn — distinct from an `ActionDef`\'s own per-action `requiredPermissions`, which `record-quick-actions.declared-action-ids-7182.test.tsx`\'s `gated` fixture already covers. No key at all: the bar renders on the (empty) grant set, so the gate is provably driven by the key\'s PRESENCE. A single held permission gates as expected, and the discriminating row is a PARTIAL grant on a two-entry array — gated only when read as `.every` over the WHOLE array rather than its first element — with the all-granted case as that row\'s own positive control. New file: no existing test drove `schema.requiredPermissions` itself, only the unrelated per-action field of the same name (objectui#8071).',
+  },
   'record:related_list.add': {
     file: 'packages/plugin-detail/src/__tests__/recordRelatedListInputs.spec-parity.test.ts',
     pins: 'Every spec member key of `add` must be discoverable from its description, the published defaults must be the RENDERER\'s rather than the spec\'s prose, and `picker.filter` must be documented as a real restriction (objectui#3808).',
@@ -2467,9 +2493,9 @@ const MEMBER_PIN_EXEMPTIONS: Record<string, string> = {
   // record:path
   'record:path.stages': AWAITING_A_PIN,
 
-  // record:quick_actions
-  'record:quick_actions.actionNames': AWAITING_A_PIN,
-  'record:quick_actions.requiredPermissions': AWAITING_A_PIN,
+  // record:quick_actions — objectui#8071 slice 4 pinned both remaining keys
+  // (`actionNames`, `requiredPermissions`); the block is now fully pinned and
+  // this header stays only as a note for the next reader who greps for it.
 
   // record:related_list — objectui#8071 slice 2 pinned `columns`, `dataSource`,
   // `filter` and `sort`. `actions` is the one left, and it is left for a
@@ -2583,11 +2609,31 @@ const NEWLY_JUDGED_UNPINNED_MEMBERS = [
  * `properties.sort` key before this slice — so it is the one genuinely new
  * file.
  *
+ * ## 50 -> 48, the fourth slice, and a two-key block closed the same way
+ *
+ * objectui#8071's fourth slice converted both remaining keys of ONE block —
+ * `record:quick_actions`'s `actionNames` and `requiredPermissions` — and
+ * deleted their two entries, so the ceiling follows to 48 in the same commit.
+ * Like `element:record_picker` (slice 3) and unlike `record:related_list`
+ * (slice 2), this block has no `NO_READ_SITE_TO_PIN` leftover: both declared
+ * keys have a real read site in `renderers/record-quick-actions.tsx` — the
+ * `actionNames` -> `useMetadataItem` lookup, and the `requiredPermissions`
+ * block-level gate that runs before any action is drawn — so the block drops
+ * out of `MEMBER_PIN_EXEMPTIONS` entirely.
+ *
+ * One of the two pins PROMOTES a pre-existing file
+ * (`recordQuickActionsInputs.actionNamesFallback.test.tsx`, written for
+ * objectui#4663 but already driving the exact `actionNames` read this key
+ * needs, read end to end before being credited); `requiredPermissions` had no
+ * candidate — every existing reference to that name in this renderer's test
+ * suite is an ActionDef's own PER-ACTION field, a different mechanism — so it
+ * is a new file.
+ *
  * ⇒ The rule for every future slice of objectui#8071: delete the entry, register
  * the pin, and set this constant to the new count. Not to the new count plus
  * room.
  */
-const MEMBER_PIN_EXEMPTION_CEILING = 50;
+const MEMBER_PIN_EXEMPTION_CEILING = 48;
 
 /**
  * Every test file a member pin can live in, as LAZY `?raw` loaders.

--- a/packages/plugin-detail/src/renderers/__tests__/record-quick-actions.requiredPermissions-gate.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-quick-actions.requiredPermissions-gate.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `record:quick_actions.requiredPermissions` — the BLOCK-LEVEL permission
+ * gate the registration describes as "Hide the whole bar unless the user
+ * holds these permissions" (objectui#8071 slice 4).
+ *
+ * Not to be confused with an `ActionDef`'s OWN `requiredPermissions` — a
+ * per-action field the `gated` fixture in
+ * `record-quick-actions.declared-action-ids-7182.test.tsx` already exercises
+ * through `ActionEngine.getActionsForLocation`'s per-action filter. This file
+ * pins the renderer's OWN read of `schema.requiredPermissions`, at
+ * `record-quick-actions.tsx`:
+ *
+ *   const required: string[] = Array.isArray(schema.requiredPermissions)
+ *     ? schema.requiredPermissions
+ *     : [];
+ *   if (required.length > 0 && objectName) {
+ *     const ok = required.every((p) => perms.can(objectName, p as any));
+ *     if (!ok) return <…Insufficient permissions…/>;
+ *   }
+ *
+ * — a gate that runs BEFORE any action is drawn, over the WHOLE array via
+ * `.every`, against the record's own `objectName`. A declaration reading only
+ * "array of string" cannot tell this from a single scalar flag; the member
+ * shape only shows up once every element is actually checked (`.every`, not
+ * `[0]`), which is what the "partial grant" case below is for.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MetadataCtx, RecordContextProvider } from '@object-ui/react';
+import type { MetadataContextValue } from '@object-ui/react';
+import { RecordQuickActionsRenderer } from '../record-quick-actions';
+
+/** Permissions the mocked `perms.can` currently grants — reassigned per test. */
+const stub = { granted: new Set<string>() };
+
+const canSpy = vi.fn((_object: string, action: string) => stub.granted.has(action));
+
+vi.mock('@object-ui/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/permissions')>();
+  return {
+    ...actual,
+    usePermissions: () => ({
+      can: canSpy,
+      cannot: (object: string, action: string) => !canSpy(object, action),
+    }),
+  };
+});
+
+/** Declared on the object, at the location this bar renders by default. */
+const APPROVE = {
+  name: 'approve',
+  label: 'Approve',
+  type: 'script',
+  locations: ['record_header'],
+};
+
+const OBJECT_META = { name: 'crm_account', actions: [APPROVE] };
+
+const getItem = vi.fn(async (type: string, name: string) =>
+  type === 'object' && name === 'crm_account' ? OBJECT_META : null,
+);
+
+/**
+ * Held at MODULE level on purpose: `getItem` is an effect dependency of
+ * `useMetadataItem`, so a value rebuilt per render spins that hook forever
+ * (the same reason `recordQuickActionsInputs.actionNamesFallback.test.tsx`
+ * does this).
+ */
+const METADATA: MetadataContextValue = {
+  apps: [],
+  objects: [OBJECT_META] as any,
+  dashboards: [],
+  reports: [],
+  pages: [],
+  loading: false,
+  error: null,
+  refresh: async () => {},
+  invalidate: () => {},
+  ensureType: async () => [],
+  getItem: getItem as unknown as MetadataContextValue['getItem'],
+  getItemsByType: () => [],
+  getTypeStatus: () => 'ready' as const,
+};
+
+function mount(schema: Record<string, unknown>) {
+  return render(
+    <MetadataCtx.Provider value={METADATA}>
+      <RecordContextProvider objectName="crm_account" recordId="rec-1" data={{ id: 'rec-1' }}>
+        <RecordQuickActionsRenderer schema={{ actionNames: ['approve'], ...schema } as any} />
+      </RecordContextProvider>
+    </MetadataCtx.Provider>,
+  );
+}
+
+beforeEach(() => {
+  stub.granted = new Set();
+  canSpy.mockClear();
+  getItem.mockClear();
+});
+
+describe('record:quick_actions.requiredPermissions — block-level gate (objectui#8071 slice 4)', () => {
+  it('CONTROL: with no `requiredPermissions` declared, the bar renders regardless of the (empty) grant set', async () => {
+    mount({});
+    expect(await screen.findByRole('button', { name: 'Approve' })).toBeInTheDocument();
+    // The gate short-circuits on `required.length > 0` — an absent key never
+    // asks the permission system at all.
+    expect(canSpy).not.toHaveBeenCalled();
+  });
+
+  it('hides the WHOLE bar when a declared permission is not held', async () => {
+    mount({ requiredPermissions: ['crm.manage'] });
+    expect(await screen.findByText(/insufficient permissions to view quick actions/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument();
+    expect(canSpy).toHaveBeenCalledWith('crm_account', 'crm.manage');
+  });
+
+  it('renders once the declared permission is granted — the same key, read for real', async () => {
+    stub.granted = new Set(['crm.manage']);
+    mount({ requiredPermissions: ['crm.manage'] });
+    expect(await screen.findByRole('button', { name: 'Approve' })).toBeInTheDocument();
+    expect(screen.queryByText(/insufficient permissions/i)).not.toBeInTheDocument();
+  });
+
+  it('every declared permission must be held — a PARTIAL grant still gates the bar', async () => {
+    // Only one of the two declared permissions is granted. A verdict driven
+    // by `required[0]` alone (or by "any", not "every") would pass this —
+    // reading `.every` over the full array is the member shape this test
+    // exists to discriminate.
+    stub.granted = new Set(['crm.manage']);
+    mount({ requiredPermissions: ['crm.manage', 'crm.export'] });
+    expect(await screen.findByText(/insufficient permissions to view quick actions/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument();
+    expect(canSpy).toHaveBeenCalledWith('crm_account', 'crm.manage');
+    expect(canSpy).toHaveBeenCalledWith('crm_account', 'crm.export');
+  });
+
+  it('granting ALL declared permissions renders the bar — the positive control for the partial-grant case above', async () => {
+    stub.granted = new Set(['crm.manage', 'crm.export']);
+    mount({ requiredPermissions: ['crm.manage', 'crm.export'] });
+    expect(await screen.findByRole('button', { name: 'Approve' })).toBeInTheDocument();
+  });
+
+  it('checks the gate against THIS record\'s own `objectName`, not a fixed string', async () => {
+    stub.granted = new Set(['crm.manage']);
+    mount({ requiredPermissions: ['crm.manage'] });
+    await screen.findByRole('button', { name: 'Approve' });
+    expect(canSpy).toHaveBeenCalledWith('crm_account', 'crm.manage');
+    expect(canSpy).not.toHaveBeenCalledWith(expect.not.stringMatching('crm_account'), 'crm.manage');
+  });
+});


### PR DESCRIPTION
Refs objectstack-ai/objectui#8071

Fourth slice of objectui#8071's transition: both remaining `record:quick_actions` keys converted from member-pin exemption to member pin, and `MEMBER_PIN_EXEMPTION_CEILING` moved down with the list in the same commit.

## Re-derived on this branch's base (`origin/main` `42df92809`)

Copied slice 3's instrument rather than a brace-depth counter: `ts.createSourceFile` + a visitor over `VariableDeclaration` nodes, counting each object literal's own `PropertyAssignment` children. Controlled at two commits:

| reading | at `origin/main` (`42df92809`, this branch's base) | after this PR |
|---|--:|--:|
| `MEMBER_PINS` | 40 | **42** |
| `MEMBER_PIN_EXEMPTIONS` | 50 | **48** |
| `MEMBER_PIN_EXEMPTION_CEILING` | 50 | **48** |
| population (array/object-armed inputs on covered blocks) | 90 | **90** |

The 50/40 base reading matches the card's claim comment (`5604086894`) and slice 3's landing note (`5603836330`) — the ledger has not moved since. Population does not move; a pin and an exemption are the two halves of one partition.

⚠️ **A correction to the dispatch's "BOTH assertions" quote.** The dispatch's blockquote — "BOTH assertions below carry the ceiling and BOTH must move together, the `toBe` is EXACT in both directions" — is a real sentence in this file, but it is not about `MEMBER_PIN_EXEMPTION_CEILING`. It sits in the *different* `the objectui#8176 backlog has a ceiling` test (`UNPUBLISHED_EXEMPTIONS` / `LAZY_REGISTERED_BLOCKS`, only `object-calendar`/`object-kanban`), which does carry two literal assertions (`toBeLessThanOrEqual(1)` and `toBe(1)`). `MEMBER_PIN_EXEMPTION_CEILING` has exactly **one** assertion (`toBeLessThanOrEqual`, `:3945`), driven symbolically off the constant — confirmed against slice 3's own merged diff (`9e9a4b6da`), which touched only the `const MEMBER_PIN_EXEMPTION_CEILING = 54` line and no assertion. This slice moves the one constant; no second assertion needed editing.

## Which keys, and why these

`record:quick_actions` — `actionNames`, `requiredPermissions`. This is the **entire remaining exemption list for the block** (both of its two array-armed keys) — a coherent whole-block closure, the shape slice 3 set with `element:record_picker`. Neither key needed `NO_READ_SITE_TO_PIN`: both have a real read site in `renderers/record-quick-actions.tsx`.

### Per key — where the renderer reads it, and the shape found

| key | read site | shape the renderer actually reads |
|---|---|---|
| `actionNames` | `resolveDeclaredActionIds` → `useMetadataItem('object', objectName)` | Action-id STRINGS resolved against the object's own `actions`; with none declared (and no host `actions`) the metadata layer is never queried and the empty placeholder renders — a fallback the *registered description* used to promise but the code never took (objectui#4663). |
| `requiredPermissions` | `required.every((p) => perms.can(objectName, p))`, evaluated **before** any action is drawn | A BLOCK-LEVEL gate — distinct from an `ActionDef`'s own per-action `requiredPermissions` field, a different mechanism the `gated` fixture in `declared-action-ids-7182.test.tsx` already exercises. The whole array must be held (`.every`, not just element 0); with none declared the gate never asks the permission system at all. |

### One promoted pre-existing file, one new

`recordQuickActionsInputs.actionNamesFallback.test.tsx` (`actionNames`) was read end to end before being credited — it was written for objectui#4663 (the registered description over-promised a fallback), not for this direction, but its second case already drives the exact `useMetadataItem` read this key needs pinned.

`requiredPermissions` had no candidate anywhere in the repo: the only prior reference to that name on this renderer's surface is an `ActionDef`'s own per-action field (a different mechanism, exercised in `declared-action-ids-7182.test.tsx`), never the block-level `schema.requiredPermissions` gate. New file: `record-quick-actions.requiredPermissions-gate.test.tsx` — a CONTROL row (no key declared → renders regardless of the grant set, `perms.can` never called), a positive read (one permission, granted → renders; denied → whole bar hidden), and the discriminating row: a **partial** grant on a two-entry array still gates the bar (`.every` over the whole array, not element 0), with the all-granted case as that row's own positive control.

## Ablation — both mutations proven on disk before being read, restored via `git checkout HEAD -- ABS_PATH` from a `trap … EXIT INT TERM`, restoration proven by blob-hash equality against `HEAD` (not exit code) plus an empty `git diff HEAD`

| # | target | mutation | on-disk proof | result |
|---|---|---|---|---|
| 1 | the gate's own ledger | re-add `'record:quick_actions.actionNames': AWAITING_A_PIN` to `MEMBER_PIN_EXEMPTIONS` **without** raising `MEMBER_PIN_EXEMPTION_CEILING` | anchor 0→1, blob `2f106ed`→`2df9d65` | **3 failed / 195 passed** (198 total) — the non-vacuity census, `carries no stale member-pin exemption`, and `the member-pin exemption list only ratchets DOWN` (49 > 48) all catch it, same three rows slice 3's ablation named |
| 2 | `record-quick-actions.tsx` (the RENDERER, not the test) | `required` forced to `[]` regardless of `schema.requiredPermissions` — the read severed at its source | anchor (live read) 1→0, blob `ea73102`→`d665dc4` | **3 failed / 11 passed** across the new pin file + its two reachability neighbours — every row that depends on the gate actually firing reds (deny, partial-grant, objectName-check); the CONTROL/positive-render rows in the same file and both neighbouring files correctly stay green |

Non-vacuity: `vitest run apps/console/.../registry-inputs-spec-parity.test.ts` is exit 0 at rest both before ablation 1 and after its restoration (198/198 both times). The three-file group for ablation 2 is exit 0 / 14 passed both before and after.

## Base → `origin/main` window check

Non-empty both times it was taken. First: `42df92809`(base)`..561abefd7` — one commit, touching only `packages/core/src/adapters/**`, `packages/fields/src/widgets/FilterConditionField.tsx` and their tests/changeset — disjoint from every file this slice reads or edits. Re-checked immediately before opening this PR: `561abefd7..8a388ee76` — one more commit, `content/docs/utilities/data-objectstack.mdx` only — again disjoint. Neither window touches the gate file, `record-quick-actions.tsx`, or any file in the `record:quick_actions` test family.

## Collision check against the two other branches named live right now

`git diff --name-only` against both: **zero files in common.** `claude/kanban-gantt-family-retirement`'s live (uncommitted) edits are `apps/console/src/register-plugins.ts` and `packages/plugin-gantt/src/index.tsx`; `claude/issue-8738-fields-warn-route1`'s are four files under `packages/plugin-form/src/`. Neither touches the gate file's `record:quick_actions` section, `record-quick-actions.tsx`, or any file this PR adds. (A **third**, later-noticed branch — `claude/issue-8738-fields-warn-route1` / draft PR #8859 — touches ONE line of this same gate file: the prose inside the pre-existing `MEMBER_PINS['object-form.fields']` entry, ~60 lines above my nearest hunk (`:2212` vs my closest hunk starting `:2271`). No semantic or textual overlap; flagged here in case #8859 lands first and this PR needs a routine merge.)

## Ledger-hazard check (`scripts/check-doc-example-types.mjs` `UNGATED_EXAMPLES`)

This diff shifts line numbers inside `registry-inputs-spec-parity.test.ts` (net +54 lines) and adds a new file. Neither is a ledger key: `grep -c "registry-inputs-spec-parity" scripts/check-doc-example-types.mjs` → **0**, same for `record-quick-actions.requiredPermissions-gate` → **0**. Firing control: the identical grep against a path that *is* a key (`AuthGuard.tsx`) → **1**. No re-keying owed.

## Gates

| gate | exit | note |
|---|--:|---|
| `vitest run apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` (the gate itself) | **0** | 198 tests, exit captured before any pipe |
| `vitest run` the new `requiredPermissions` pin file alone | **0** | 6/6 |
| `vitest run` the promoted `actionNames` file alone | **0** | 3/3 |
| `pnpm --filter '@object-ui/console^...' build`, `'@object-ui/plugin-detail^...' build` | **0** | dependency closures, needed before type-check |
| `pnpm --filter @object-ui/console run type-check` | **0** | `tsc --noEmit && tsc -b tsconfig.node.json --force` |
| `pnpm --filter @object-ui/plugin-detail run type-check` | **0** | `tsc --noEmit && tsc -p tsconfig.test.json` |
| `pnpm --filter @object-ui/console run test` (full package) | **0** | 98 files / 1132 tests |
| `pnpm --filter @object-ui/plugin-detail run test` (full package) | **0** | 155 files / 1415 tests |
| final sweep: all 8 `record:quick_actions`-family test files together | **0** | 34/34 |
| `node scripts/check-changeset-presence.mjs` | **0** | empty-frontmatter changeset: test-only, releases nothing |
| `node scripts/check-vi-mock-specifiers.mjs` / `check-vi-mock-inherit.mjs` | **0** / **0** | new file's `@object-ui/permissions` mock inherits real exports via `...actual` |
| `eslint` (narrowed to the 2 changed/new files, `--no-inline-config`) | **0** | 0 errors, 2 `no-explicit-any` warnings, matching the neighbouring suites' house style (verified: sibling files in the same family carry the identical warning) |

Every vitest run above printed `RUN v4.1.10 /home/user/objectui-issue-8071-slice4` — this worktree's own root, not a sibling's. Exit codes captured before any pipe (`cmd > log 2>&1; EXIT=$?`). Repo-wide `pnpm lint` and CI's own full-farm `check:*` sweep were not taken locally (CI-owned).

## Out-of-scope findings

None filed. No trap-shaped near-miss files were found this slice — the one promoted file pins exactly the key it is credited for, and the new file was written fresh rather than adapted from a near-miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_