### PR TITLE
docs(plugin-form): document embeddable-form fields member vocabulary

### DIFF
--- a/.changeset/8847-embeddable-form-fields-description.md
+++ b/.changeset/8847-embeddable-form-fields-description.md
@@ -1,0 +1,20 @@
+---
+'@object-ui/plugin-form': patch
+---
+
+`embeddable-form`'s top-level `fields` input now documents its member
+vocabulary (objectui#8847, the last of the registrations #8738 opened — the
+same trap already documented on `object-form`, `form` / `view:form`, and
+`object-master-detail-form`'s parent `fields`).
+
+The registration declared `{ name: 'fields', type: 'array' }` with no
+description, so an author had nowhere to read that this key's members are
+**bare field names** — a different vocabulary from `sections[].fields`, which
+also accepts the spec `FormFieldSchema` object (identity key `field`, e.g.
+`{ field: 'note', colSpan: 2 }`). `EmbeddableForm` passes `config.fields`
+straight through to `<ObjectForm>` with no `sections`, so it renders through
+the same `SimpleObjectForm` read path as `object-form`; moving one of those
+objects into `embeddable-form`'s `fields` resolves to no name and is silently
+skipped. Behaviour is unchanged — this only adds the description text, and
+records (measured, not assumed) that this surface already inherits the
+`console.warn` route 1 (objectui#8738/#8859) added at that same read site.

--- a/packages/plugin-form/src/index.tsx
+++ b/packages/plugin-form/src/index.tsx
@@ -343,7 +343,7 @@ ComponentRegistry.register('embeddable-form', EmbeddableFormRenderer, {
     { name: 'objectName', type: 'string', required: true },
     { name: 'title', type: 'string' },
     { name: 'description', type: 'string' },
-    { name: 'fields', type: 'array' },
+    { name: 'fields', type: 'array', description: 'Bare field names to show, in order (each looked up in the object schema; `{ name }` is tolerated). NOT the same vocabulary as `sections[].fields`, which also accepts the spec `FormFieldSchema` object (identity key `field`, e.g. `{ field: "note", colSpan: 2 }`) — that shape resolves to no name HERE and is silently skipped (`EmbeddableForm` passes this array straight through to `<ObjectForm>` with no `sections`, so it renders through the same `SimpleObjectForm` as `object-form` above — see its `fields` description).' },
     { name: 'allowMultiple', type: 'boolean' },
   ]
 });


### PR DESCRIPTION
Fixes objectstack-ai/objectui#8847

## What

Adds the missing `description` to `embeddable-form`'s top-level `fields` registration input in `packages/plugin-form/src/index.tsx`, modelled on the ones already on `object-form` (PR #8846) and `form` (PR #8859). States that members are **bare field names** (`{ name }` tolerated), and that this is **not** the `sections[].fields` vocabulary, which also accepts the spec `FormFieldSchema` object (identity key `field`, e.g. `{ field: 'note', colSpan: 2 }`) — that shape resolves to no name here and is silently skipped.

This is the remainder the corrected card (`issuecomment-5604654332`) identified: `object-master-detail-form` was never bare; the genuinely undescribed second surface was `embeddable-form`.

## Re-derived attribution table (measured on `origin/main` @ `42ddd7f71`, independently — not copied from the card)

```
registrations:  :226 object-form   :285 form   :337 embeddable-form
                :358 form-analytics   :402 object-master-detail-form   :499 line_items

:232  described (PR #8846)  -> object-form
:292  described (PR #8859)  -> form
:346  ⛔ BARE               -> embeddable-form          ← the remainder (this PR)
:430  described (PR #8859)  -> object-master-detail-form
```

Bare `{ name: 'fields', type: 'array' },` count: **1** (before this PR). Control: **4** `fields` inputs total — matcher hits everything. After this PR: **0** bare, same control of 4.

## Measurement — does #8859's warning reach `embeddable-form`?

**Yes — measured, not assumed.** `EmbeddableForm.tsx` builds `schema = { type: 'object-form', objectName, fields: config.fields, ... }` with no `sections` and no `formType`, and renders it through `<ObjectForm>` directly (not via the component registry). `ObjectForm.tsx`'s formType/sections routing (`schema.sections?.length` guards on every sectioned branch) falls through to `SimpleObjectForm` — the exact `warnUnresolvedTopLevelField` read site — regardless of the registered type key.

Confirmed with a throwaway render probe (not committed — one-time proof per this repo's reverse-verification convention):
- `fields: [{ field: 'note' }]` → `console.warn` fires **once**, with the same message text as the `object-form` pin (`objectFormFieldsMembers-8071.test.tsx` row 4): *"top-level `fields` entry { field: 'note' } resolved to no field name and was skipped... NOT the same vocabulary as `sections[].fields`..."*
- `fields: ['note']` (firing control) → **0** warnings.

So the description text says "silently skipped" (matching the established wording on `object-form`/`form`/`object-master-detail-form`, none of which mention the warning either) rather than claiming a warning this round adds — the warning already exists via inheritance and is out of scope for this PR (Clause-② no).

## Why / risk

Category-(c) trap per the card family: an author (or an AI generating metadata) writing spec-legal `sections[].fields` shape into this top-level key gets a silent drop. Pure documentation addition — no accept-set, key, shape, or arm change; no new warning; `normalizeSectionField`, `buildFlatFields`, `SimpleObjectForm`, and `warnUnresolvedTopLevelField` are untouched.

## Tests

- `pnpm exec vitest run packages/plugin-form/src/__tests__/objectFormFieldsMembers-8071.test.tsx --reporter=verbose` → **8/8 passed**, same test names/order as `main` — assertions did not move.
- `pnpm exec vitest run packages/plugin-form/` → 89 files / 883 passed, 1 skipped (884) — full package regression, exit 0.
- `pnpm exec vitest run apps/console/` → 98 files / 1132 passed — sweep per dispatch requirement, exit 0.
- `pnpm --filter '@object-ui/plugin-form' run type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) → exit 0, no output.
- Dependency closure build (`turbo run build --filter='@object-ui/plugin-form^...'`) → 11/11 successful, then `pnpm --filter '@object-ui/plugin-form' build` → exit 0; confirmed the new description string reached `packages/plugin-form/dist/index.js`.
- `node scripts/check-doc-example-types.mjs` → exit 2, but only on missing `dist/*.d.ts` for ~26 unrelated packages (workspace-wide build precondition, out of this PR's local-verification scope); the `UNGATED_EXAMPLES` ledger itself has **zero** entries for `packages/plugin-form/src/index.tsx` (grepped directly), so today's ledger re-keying by sibling PRs does not touch this file. My edit is also a net-zero line-count single-line replacement (`git diff --stat`: 1 insertion, 1 deletion), so no line-shift risk either way.
- `node scripts/check-changeset-presence.mjs` → exit 0 after adding the changeset.
- `node scripts/check-changeset-no-major.mjs` → exit 0.
- `npx eslint packages/plugin-form/src/index.tsx --no-inline-config` → exit 0, 25 pre-existing warnings (none on the touched line), 0 errors.
- Control-byte self-scan on the touched file → clean.
- Base→`origin/main` pre-flight: empty window (worktree base `42ddd7f71` == `origin/main` at push time).

## Changeset

`.changeset/8847-embeddable-form-fields-description.md` — patch bump for `@object-ui/plugin-form` (published `inputs[].description` is an authoring surface).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_