### PR TITLE
test(console): pin object-calendar member shapes (objectui#8071 slice 5)

### DIFF
--- a/.changeset/object-calendar-member-pins-8071.md
+++ b/.changeset/object-calendar-member-pins-8071.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change: `object-calendar`'s `calendar` and `dataSource` gain per-block member pins (objectui#8071 slice 5), closing out the block entirely, and the member-pin exemption ledger in the console's registry/spec parity gate moves with them. No published behaviour changes — no runtime source, build entry, `files[]` payload or published-contract field is touched.

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -2193,9 +2193,17 @@ const MEMBER_PINS: Record<string, MemberPin> = {
     file: 'packages/components/src/__tests__/text-input-inputs-spec-parity.test.ts',
     pins: 'The I18nLabel trio — see `element:text_input.description` (objectui#5717).',
   },
+  'object-calendar.calendar': {
+    file: 'packages/plugin-calendar/src/__tests__/objectCalendarConfigMembers-8071.test.tsx',
+    pins: 'Members are FIELD NAMES the calendar projects onto an event: `startDateField` and `endDateField` name the record fields that become the event\'s `start`/`end` (an unauthored `endDateField` leaves `end` undefined rather than inventing one), and `titleField` OUTRANKS the object\'s own default display-name resolution (`getRecordDisplayName`) rather than only supplementing it. The sharp claim is PRECEDENCE: `getCalendarConfig` returns `schema.calendar` OUTRIGHT the moment it is set — never merged against the flat legacy spelling (`startDateField/endDateField/titleField/colorField` authored directly on the schema) it falls back to only when `calendar` is absent — so a schema carrying BOTH, with the two disagreeing, is read entirely from the nested object and not at all from the flat siblings, even for the keys the nested object leaves unset. `colorField`\'s own resolution ladder and `allDayField` (an objectui-local extra key inside the same object) are each pinned narrowly already and are not re-asserted here: `ObjectCalendar.colorFieldLadder-7243.test.tsx`, `ObjectCalendar.allDayFieldIsHonoured-8026.test.tsx`. The spec side is a `strictObject` of exactly the four documented keys, so it fixes the NAMES but nothing about how they are used once read — the read site is the whole member contract (objectui#8071).',
+  },
   'object-calendar.data': {
     file: 'packages/plugin-calendar/src/__tests__/ObjectCalendar.recordSourceMembers-8314.test.tsx',
     pins: 'The members are RECORDS, and the keys read inside one are the fields the declared `calendar` config names plus `id`: every member arrives in authored order, `allDay` is derived PER MEMBER from the declared end field, a member with no value in the start field is counted in the unscheduled area rather than dropped or given a fabricated date (objectui#7071 at the member level), and a member with no `id` gets a synthesised one rather than being discarded. Asserted through the REAL `SchemaRenderer`, because this key\'s sink is the props channel `index.tsx` resolves (`resolveExternalData`), not the schema. ⛔ NOT pinned on "the internal query is skipped": an authored array reaches this renderer on BOTH carriers, and the schema-channel one returns it as a config with no `provider`, so no query is issued on a tree where the boundary drops `data` either — measured by ablation, that row stays green while the ROWS-ARE-DRAWN rows go red, so it is kept as a labelled companion and the rows carry the claim. The spec side cannot supply any of it: the row is `z.array(z.unknown())`, so every coarse member kind parses and the read site is the whole member contract (objectui#8314).',
+  },
+  'object-calendar.dataSource': {
+    file: 'packages/plugin-calendar/src/ObjectCalendar.elementDataSource.test.tsx',
+    pins: 'The per-element binding\'s own members, read through the REAL `ElementDataSourceGate` + renderer pair and the same shared mapping mechanism `element:record_picker.dataSource` and `record:related_list.dataSource` already pin: `object` WRITES onto `objectName` (this block\'s own top-level key), a named `view`\'s `filter`/`sort` reach the fetch as `$filter`/`$orderby`, a `sort` member missing `order` reads as ascending rather than dropped (the shared `QueryParams.$orderby` member contract, objectui#4022), an unresolvable `view` reports instead of fetching the whole object, and a calendar carrying no binding at all behaves exactly as it did before one existed. `columns` and a row cap are deliberately UNMAPPED and asserted absent from the mapping\'s own declaration (`OBJECT_CALENDAR_DATA_SOURCE = { filter: true, sort: true }` in `index.tsx`) rather than pinned here, because this block projects fields off its own `calendar` config and fetches the whole window — neither key has a read site to write to. Pre-existing file, promoted to a pin here after being read end to end (objectstack#6953, objectui#8071).',
   },
   'object-calendar.filter': {
     file: 'packages/plugin-calendar/src/__tests__/ObjectCalendar.filterIsNotAConfigSlot-7711.test.tsx',
@@ -2502,27 +2510,37 @@ const MEMBER_PIN_EXEMPTIONS: Record<string, string> = {
   // DIFFERENT reason: see the constant.
   'record:related_list.actions': NO_READ_SITE_TO_PIN,
 
-  // objectui#8176 — the four this direction could not see. See
+  // object-calendar — objectui#8176 brought both `calendar` and `dataSource`
+  // into this population (see `NEWLY_JUDGED_UNPINNED_MEMBERS`'s docblock);
+  // objectui#8071 slice 5 pinned both, so the block is now fully pinned and
+  // this header stays only as a note for the next reader who greps for it.
+
+  // objectui#8176 — the other two this direction could not see. See
   // `NEWLY_JUDGED_UNPINNED_MEMBERS` below, which pins them BY NAME so the
   // ceiling correction cannot absorb anything else.
-  'object-calendar.calendar': AWAITING_A_PIN_NEWLY_JUDGED,
-  'object-calendar.dataSource': AWAITING_A_PIN_NEWLY_JUDGED,
   'object-kanban.columns': AWAITING_A_PIN_NEWLY_JUDGED,
   'object-kanban.dataSource': AWAITING_A_PIN_NEWLY_JUDGED,
 };
 
 /**
- * The four ids the ceiling below moves for, named so the move is auditable.
+ * The ids the ceiling below moved for, named so the move is auditable, MINUS
+ * whichever of them objectui#8071 has since converted to a real pin.
  *
  * A ceiling that goes up is worth exactly as much as the account of why, and
  * "+4, trust me" is not an account. Pinning the four by name means the
- * correction admits four SPECIFIC pre-existing keys and nothing else: a fifth
- * entry cannot hide inside the same headroom, because `the member-pin exemption
- * list only ratchets DOWN` still reads the total.
+ * correction admitted four SPECIFIC pre-existing keys and nothing else: a
+ * fifth entry cannot hide inside the same headroom, because `the member-pin
+ * exemption list only ratchets DOWN` still reads the total.
+ *
+ * This list is CHECKED against the live `MEMBER_PIN_EXEMPTIONS` state (`the
+ * ceiling correction admits exactly the four keys objectui#8176 made
+ * visible`), so it shrinks as the four are pinned rather than staying a
+ * frozen record of four forever — the frozen record of WHY the ceiling went
+ * up is `MEMBER_PIN_EXEMPTION_CEILING`'s own docblock below, not this array.
+ * objectui#8071 slice 5 pinned `object-calendar.calendar` and
+ * `object-calendar.dataSource`, so two of the original four remain here.
  */
 const NEWLY_JUDGED_UNPINNED_MEMBERS = [
-  'object-calendar.calendar',
-  'object-calendar.dataSource',
   'object-kanban.columns',
   'object-kanban.dataSource',
 ];
@@ -2629,11 +2647,43 @@ const NEWLY_JUDGED_UNPINNED_MEMBERS = [
  * suite is an ActionDef's own PER-ACTION field, a different mechanism — so it
  * is a new file.
  *
+ * ## 48 -> 46, the fifth slice, and a whole `object-calendar` block closed
+ *
+ * objectui#8071's fifth slice converted the two keys objectui#8176 had left
+ * unpinned on `object-calendar` — `calendar` and `dataSource` — and deleted
+ * their two entries, so the ceiling follows to 46 in the same commit. Every
+ * OTHER key this block declares (`data`, `filter`, `sort`, `staticData`) was
+ * already pinned, so the block now carries zero exemptions, the same shape
+ * `element:record_picker` (slice 3) and `record:quick_actions` (slice 4)
+ * closed in — chosen for exactly that reason: a two-key remainder on one
+ * already-mostly-pinned block, closeable outright rather than left with a
+ * straggler.
+ *
+ * `dataSource` is the per-element binding every `elementDataSourceBlock`
+ * publishes (`ELEMENT_DATA_SOURCE_INPUT`, `@object-ui/core`) — the same
+ * mechanism `element:record_picker.dataSource` and
+ * `record:related_list.dataSource` already pin — and it PROMOTES a
+ * pre-existing file, `ObjectCalendar.elementDataSource.test.tsx`, read end to
+ * end before being credited: it already drove the binding's `object` write
+ * onto `objectName`, `filter`/`sort` read off the named view, an unresolvable
+ * `view` reporting instead of fetching unfiltered, and a calendar with no
+ * binding behaving exactly as before. `calendar` had no single candidate that
+ * covered its own member set (which keys of the config object become which
+ * part of an event, and which of the two spellings — the nested object or the
+ * flat legacy fields `getCalendarConfig` falls back to — wins when a schema
+ * somehow carries both) — the ladder and all-day pieces of that config were
+ * each already pinned narrowly (`ObjectCalendar.colorFieldLadder-7243.test.tsx`,
+ * `ObjectCalendar.allDayFieldIsHonoured-8026.test.tsx`) but neither, nor
+ * anything else, asserted `startDateField`/`endDateField` reaching an event's
+ * `start`/`end`, `titleField` outranking the object's own display-name
+ * resolution, or the object-vs-flat precedence — so it is a new file,
+ * `objectCalendarConfigMembers-8071.test.tsx`.
+ *
  * ⇒ The rule for every future slice of objectui#8071: delete the entry, register
  * the pin, and set this constant to the new count. Not to the new count plus
  * room.
  */
-const MEMBER_PIN_EXEMPTION_CEILING = 48;
+const MEMBER_PIN_EXEMPTION_CEILING = 46;
 
 /**
  * Every test file a member pin can live in, as LAZY `?raw` loaders.

--- a/packages/plugin-calendar/src/__tests__/objectCalendarConfigMembers-8071.test.tsx
+++ b/packages/plugin-calendar/src/__tests__/objectCalendarConfigMembers-8071.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8071 slice 5 — the member shape of `object-calendar.calendar`.
+ *
+ * The registration declares `{ name: 'calendar', type: 'object', description:
+ * '`startDateField`, endDateField, titleField, colorField' }` and says nothing
+ * about how those four names are used once inside the object — that is exactly
+ * what a member pin has to state (objectui#8068's criterion: constrain the
+ * shape the RENDERER reads, not the declaration).
+ *
+ * `getCalendarConfig` (`ObjectCalendar.tsx`) reads the whole object as one unit
+ * — `if (schema.calendar) return schema.calendar` — with NO merge against the
+ * flat legacy spelling the same function falls back to when `calendar` is
+ * absent. So the sharp claim this file makes, that no other file makes, is
+ * PRECEDENCE: an authored `calendar` object wins OUTRIGHT over a conflicting
+ * flat spelling on the same schema, rather than the two being merged key by
+ * key. `ObjectCalendar.unconfiguredRefusal-7029.test.tsx`'s last control shows
+ * the nested block working; it never puts a CONFLICTING flat spelling next to
+ * it, so it cannot show which one wins.
+ *
+ * The other two claims — that `startDateField` / `endDateField` NAME the record
+ * fields that become an event's `start` / `end`, and that `titleField` OUTRANKS
+ * the object's own default display-name resolution — are read directly off the
+ * emitted event objects, which nothing else in this package's suite asserts
+ * numerically (the 7243 ladder file and the 8026 all-day file both drive real
+ * renders through this same config, but assert `color`/DOM-lane placement, never
+ * `start/end/title` values).
+ *
+ * ⛔ NOT re-pinned here, because each already has its own file and re-testing it
+ * would just be a second copy to drift from the first:
+ *   - `colorField`'s resolution ladder — `ObjectCalendar.colorFieldLadder-7243.test.tsx`.
+ *   - `allDayField` — `ObjectCalendar.allDayFieldIsHonoured-8026.test.tsx`.
+ *   - the required-ness of `startDateField` (no config at all → refusal screen) —
+ *     `ObjectCalendar.unconfiguredRefusal-7029.test.tsx`.
+ */
+
+import React from 'react';
+import { render, waitFor, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectCalendar } from '../ObjectCalendar';
+
+vi.mock('@object-ui/plugin-detail', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@object-ui/plugin-detail')>()),
+  RecordDetailDrawer: () => null,
+  deriveRecordPageHref: () => null,
+}));
+
+let lastEvents: any[] = [];
+
+vi.mock('../CalendarView', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return {
+    ...actual,
+    CalendarView: ({ events }: any) => {
+      lastEvents = events;
+      return <div data-testid="calendar-view" data-event-count={String(events.length)} />;
+    },
+  };
+});
+
+const OBJECT_SCHEMA = {
+  name: 'duly_task',
+  // The object's OWN default title pointer (ADR-0079) — deliberately a
+  // DIFFERENT field than the one each fixture's `titleField` names, so a title
+  // pin can only pass by reading the declared key, never by coincidence.
+  nameField: 'subject',
+  fields: {
+    id: { name: 'id', type: 'text' },
+    subject: { name: 'subject', type: 'text' },
+    nickname: { name: 'nickname', type: 'text' },
+    kickoff: { name: 'kickoff', type: 'datetime' },
+    wrapup: { name: 'wrapup', type: 'datetime' },
+    other_start: { name: 'other_start', type: 'datetime' },
+    other_title: { name: 'other_title', type: 'text' },
+  },
+};
+
+const ROW = {
+  id: 'r1',
+  subject: 'Default display name',
+  nickname: 'Authored event title',
+  kickoff: '2026-03-01T09:00:00.000Z',
+  wrapup: '2026-03-02T17:00:00.000Z',
+  other_start: '2099-12-31T00:00:00.000Z',
+  other_title: 'WRONG — from the flat spelling',
+};
+
+function makeDataSource(rows: any[] = [ROW]) {
+  return {
+    find: vi.fn(async () => ({ data: rows, total: rows.length })),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async () => OBJECT_SCHEMA),
+  } as any;
+}
+
+/** Renders `schema` and waits for the mocked `CalendarView` to receive events. */
+async function eventsFor(schema: Record<string, unknown>, rows: any[] = [ROW]) {
+  lastEvents = [];
+  render(
+    <ObjectCalendar
+      schema={{ type: 'object-calendar', objectName: 'duly_task', ...schema } as any}
+      dataSource={makeDataSource(rows)}
+    />,
+  );
+  await waitFor(() => expect(lastEvents.length).toBe(rows.length));
+  return lastEvents;
+}
+
+describe('object-calendar.calendar — member shape (objectui#8071 slice 5)', () => {
+  it('`startDateField` and `endDateField` name the record fields that become the event span', async () => {
+    const [event] = await eventsFor({
+      calendar: { startDateField: 'kickoff', endDateField: 'wrapup', titleField: 'nickname' },
+    });
+    expect(event.start).toEqual(new Date(ROW.kickoff));
+    expect(event.end).toEqual(new Date(ROW.wrapup));
+  });
+
+  it('CONTROL: an unauthored `endDateField` leaves the event with no end at all', async () => {
+    const [event] = await eventsFor({
+      calendar: { startDateField: 'kickoff', titleField: 'nickname' },
+    });
+    expect(event.start).toEqual(new Date(ROW.kickoff));
+    expect(event.end).toBeUndefined();
+  });
+
+  it('`titleField` outranks the object\'s own default display-name field', async () => {
+    const [event] = await eventsFor({
+      calendar: { startDateField: 'kickoff', titleField: 'nickname' },
+    });
+    // `nameField: 'subject'` would resolve to ROW.subject ("Default display
+    // name") if `titleField` were not read first — see `resolveTitle` in
+    // `ObjectCalendar.tsx`.
+    expect(event.title).toBe(ROW.nickname);
+  });
+
+  it('CONTROL: with no `titleField` authored, the object\'s default display name is used', async () => {
+    const [event] = await eventsFor({
+      calendar: { startDateField: 'kickoff' },
+    });
+    expect(event.title).toBe(ROW.subject);
+  });
+
+  it('an authored `calendar` object wins OUTRIGHT over a conflicting flat legacy spelling', async () => {
+    // Both spellings are present and DISAGREE. `getCalendarConfig` returns
+    // `schema.calendar` unconditionally when it is set — it never merges the
+    // two — so every field must come from the nested object and NONE from the
+    // flat siblings, not even the ones the nested object leaves unset.
+    const [event] = await eventsFor({
+      calendar: { startDateField: 'kickoff', titleField: 'nickname' },
+      startDateField: 'other_start',
+      titleField: 'other_title',
+      endDateField: 'wrapup',
+    });
+    expect(event.start).toEqual(new Date(ROW.kickoff));
+    expect(event.title).toBe(ROW.nickname);
+    // The flat `endDateField` is NOT absorbed piecemeal: the nested object
+    // omits it, and the object as a whole is what wins, so the event still has
+    // no end — the flat sibling's `wrapup` never reaches this record.
+    expect(event.end).toBeUndefined();
+  });
+
+  it('CONTROL: with no `calendar` object authored, the flat legacy spelling is read instead', async () => {
+    const [event] = await eventsFor({
+      startDateField: 'other_start',
+      titleField: 'other_title',
+    });
+    expect(event.start).toEqual(new Date(ROW.other_start));
+    expect(event.title).toBe(ROW.other_title);
+  });
+});

--- a/packages/plugin-calendar/src/__tests__/objectCalendarConfigMembers-8071.test.tsx
+++ b/packages/plugin-calendar/src/__tests__/objectCalendarConfigMembers-8071.test.tsx
@@ -42,7 +42,7 @@
  */
 
 import React from 'react';
-import { render, waitFor, screen } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { ObjectCalendar } from '../ObjectCalendar';
 


### PR DESCRIPTION
Refs objectstack-ai/objectui#8071

## What

Converts both remaining `object-calendar` `MEMBER_PIN_EXEMPTIONS` entries (`calendar`, `dataSource`) into real per-block member pins and lowers `MEMBER_PIN_EXEMPTION_CEILING` 48 -> 46 in the same commit. This closes `object-calendar` outright — every other key it declares (`data`, `filter`, `sort`, `staticData`) was already pinned by earlier slices — the same shape `element:record_picker` (slice 3) and `record:quick_actions` (slice 4) closed in.

| | before | after |
|---|---|---|
| `MEMBER_PINS` | 42 | **44** |
| `MEMBER_PIN_EXEMPTIONS` | 48 | **46** |
| `MEMBER_PIN_EXEMPTION_CEILING` | 48 | **46** |
| population | 90 | 90 |

Census by **TypeScript AST walk** (`ts.createSourceFile`, visiting `VariableDeclaration`/`PropertyAssignment` — not brace-depth counting), taken at BASE (`42ddd7f71`) and on the current tree; both match the dispatched ledger exactly.

## Why this batch

`object-calendar`'s only two remaining exemptions were both left over from objectui#8176 (`AWAITING_A_PIN_NEWLY_JUDGED`), on a block where the other four keys were already pinned — a two-key remainder on an already-mostly-pinned block, closeable outright rather than skimmed for the easy key and left with a straggler. `NEWLY_JUDGED_UNPINNED_MEMBERS` shrinks from 4 to 2 (only `object-kanban`'s pair remain) — that array is checked against the live `MEMBER_PIN_EXEMPTIONS` state by the gate's own `the ceiling correction admits exactly the four keys objectui#8176 made visible` test, so it has to shrink in the same commit, not just the docblock prose.

- `dataSource` — the shared `elementDataSourceBlock` per-element binding (`ELEMENT_DATA_SOURCE_INPUT`, `@object-ui/core`), the same mechanism `element:record_picker.dataSource` and `record:related_list.dataSource` already pin. Promotes a **pre-existing file**, `ObjectCalendar.elementDataSource.test.tsx`, read end to end before being credited.
- `calendar` — had no existing candidate covering its own member set. New file: `packages/plugin-calendar/src/__tests__/objectCalendarConfigMembers-8071.test.tsx`, asserting `startDateField`/`endDateField` reaching an event's `start`/`end`, `titleField` outranking the object's own display-name resolution, and the sharp claim nothing else tests — `getCalendarConfig` returns `schema.calendar` **outright** when set, never merged against the flat legacy spelling it falls back to otherwise. `colorField`'s resolution ladder and `allDayField` are each already pinned narrowly elsewhere (`ObjectCalendar.colorFieldLadder-7243.test.tsx`, `ObjectCalendar.allDayFieldIsHonoured-8026.test.tsx`) and are not re-asserted.

## Corrected instruction applied

Per the dispatch correction: `MEMBER_PIN_EXEMPTION_CEILING` is a single constant with a single symbolic assertion (`:3992` region). The "BOTH assertions must move together" sentence belongs to objectui#8176's `UNPUBLISHED_EXEMPTIONS`/`LAZY_REGISTERED_BLOCKS` backlog ceiling, a different constant — not touched here, and no second assertion was added or hunted for.

## Verification

- **Gate**: `pnpm exec vitest run apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` — exit 0, 198 tests passed.
- **Full `plugin-calendar` suite**: exit 0, 33 files / 232 tests passed.
- **Typecheck** (via `turbo run type-check`, dependency closure built first): `@object-ui/plugin-calendar` exit 0 (15/15 tasks); `@object-ui/console` exit 0 (36/36 tasks).
- **Changeset presence check**: exit 0 — empty-frontmatter changeset declared, matching PR #8860's (slice 4) shape.

### Ablation 1 (gate mechanism)
Re-added `'object-calendar.calendar': AWAITING_A_PIN` to `MEMBER_PIN_EXEMPTIONS` without touching the ceiling. Mutation proven on disk first (anchor grep count + blob hash changed: `f7bce6b1b...` -> `cca09e53a...`). Gate went red on **4** rows: the non-vacuity census, `carries no stale member-pin exemption`, `the member-pin exemption list only ratchets DOWN` (47 > 46), and — because this key sits on a `LAZY_REGISTERED_BLOCKS` member — `the ceiling correction admits exactly the four keys objectui#8176 made visible`. Restored via `git checkout HEAD -- <abs path>` from a `trap ... EXIT INT TERM`, restoration proven by blob hash (`f7bce6b1b...` exactly, matching `HEAD`'s tree object). Gate re-ran green (198/198) after restoration.

### Ablation 2 (each new pin is non-vacuous)
- **`calendar`**: reversed `getCalendarConfig`'s precedence (flat legacy fields checked before the nested `calendar` object, instead of the object short-circuiting outright). Ran the new pin file alongside the FULL `plugin-calendar` suite (33 files): **exactly 1 of 6 rows** in the new file went red (the precedence claim); the other 5 rows in the same file and **all 231 other tests across 32 files** — including the `dataSource` pin file, the colorField ladder file, and the allDayField file — stayed green. Mutation proven on disk (blob hash `5ede88b2...` -> `821e1dc4...`), restored via the same trap+`git checkout HEAD`, verified back to `5ede88b2...`.
- **`dataSource`**: neutered the mapping (`mapping={OBJECT_CALENDAR_DATA_SOURCE}` -> `mapping={{}}`) in `index.tsx`. Ran the promoted pin file alongside its neighbours (`object-calendar-renderer.propsContract.test.tsx`, `registration.test.tsx` — the latter authors an unrelated `dataSource: {...}` shape, the same-named-but-different-mechanism control). **Exactly 2 of 4 rows** went red (the filter/view and sort/view rows); the unresolvable-view row, the no-binding control, and both neighbour files (all green) were unaffected. Mutation proven on disk (blob hash `ac9230f3...` -> `16a1d716...`), restored and verified back to `ac9230f3...`.

Non-vacuity: gate exit 0 at rest both before and after each ablation.

### Ledger hazard (objectui#8614 `UNGATED_EXAMPLES`)
Grepped `scripts/check-doc-example-types.mjs` for any row citing a file this diff shifts lines in. Control (`packages/auth/src/AuthGuard.tsx:`, a real ledger key) fires: 1 hit. Target files — the gate file, the new test file, and the promoted `dataSource` file — 0 hits each. No re-keying needed.

### Base -> main pre-flight
`origin/main` is unchanged at `42ddd7f71` (the dispatched ledger commit) as of this push — **the window is empty**, so this is not evidence of no collision, only that none is measurable yet.

### Live-branch file-surface measurement
`claude/kanban-gantt-family-retirement` (still open on origin at `c695a1c8d`) touches `packages/plugin-kanban/**`, `packages/types/src/complex.ts`, `packages/types/src/zod/complex.zod.ts`, and console/docs/examples files — measured via `git diff --name-only origin/main...FETCH_HEAD`, re-fetched fresh at push time. Zero overlap with this PR's three files (the gate file, `packages/plugin-calendar/src/__tests__/objectCalendarConfigMembers-8071.test.tsx`, `.changeset/object-calendar-member-pins-8071.md`).

## Repair round — `@object-ui/plugin-calendar#lint`

This PR was RED from the moment it opened: 29 checks green, 3 skipped, `Lint` failed. turbo named exactly one task, `@object-ui/plugin-calendar#lint`, `235 problems (1 error, 234 warnings)` (the `ELIFECYCLE` lines other packages printed were tasks CANCELLED when that one failed — no eslint output of their own). Reproduced locally on head `603f4da8`, exit code redirected to a file and captured before any pipe:

```
packages/plugin-calendar/src/__tests__/objectCalendarConfigMembers-8071.test.tsx
  45:27  error  'screen' is defined but never used. Allowed unused vars must match /^_/u  object-ui/no-unused-imports
```

Whose failure: **mine**. `object-ui/no-unused-imports` is an **error** in this repo, while the paired `@typescript-eslint/no-unused-vars` report on the very same token is only a warning — which is why 234 warnings sat above it in the log and the single error was easy to miss.

| lint run | exit | problems |
|---|---|---|
| head `603f4da8` | **1** | 235 (1 error, 234 warnings) |
| same tree, added file excluded — byte-equivalent to base `42ddd7f71`, where this file is the sole `plugin-calendar` delta (`git diff --name-status` returns one `A` row) | **0** | 226 (0 errors, 226 warnings) |
| head `0987aee1a` (fixed) | **0** | 233 (0 errors, 233 warnings) |

**The fix**: delete the `screen` specifier from line 45. One token — that is the whole repair. **No `eslint-disable`**: the rule is reporting a genuinely dead import (`screen` occurs twice in the file — the import itself, and the English word "screen" inside a docblock sentence), and the sibling pin files that do not use it simply do not import it (`ObjectCalendar.allDayFieldIsHonoured-8026.test.tsx`, `ObjectCalendar.expandFls-7230.test.tsx`, `ObjectCalendar.expandGate-6453.test.tsx` all import `{ render, waitFor, cleanup }` only). There is no `no-unused-imports` disable anywhere under `packages/plugin-calendar/src/`.

**What the pins assert is unchanged.** `screen` appeared in no assertion — the file reads its three claims off the captured event objects, never off the DOM. Re-verified at `0987aee1a`, every exit code captured before any pipe: the gate `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` exit 0, **198 passed** (identical to the prior head); the full `plugin-calendar` suite exit 0, **33 files / 232 tests passed** — 33 being every `*.test.ts*` on disk in that package, so the new pin file did run.

The ablation blob hashes quoted above are unaffected: all three name files this repair did not touch (`registry-inputs-spec-parity.test.ts`, `ObjectCalendar.tsx`, `index.tsx`). The pin file's own blob moved `652ebc163` -> `f766cfec6`, differing by that one import specifier and nothing else.

⚠️ The "Base -> main pre-flight" reading above was taken at `603f4da8`. `origin/main` has since advanced past `42ddd7f71` to `93127bd6`; `mergeable_state: behind` is the merge queue's to rebuild, per the dispatch.

## 维护者速读(草稿)

- **改了什么**:把 `object-calendar` 剩下的两个成员豁免(`calendar`、`dataSource`)转成真实的逐块成员 pin,同一提交里把豁免上限 48 降到 46,该 block 现在零豁免、完全 pin 住。
- **为什么改**:承接 objectui#8071 的过渡计划,这两个 key 是 objectui#8176 遗留的最后两个"新发现但未 pin"的成员,选它是因为能一次性关掉整个 block,而不是挑软柿子留硬骨头。
- **风险与代价(含回滚)**:纯测试改动,`Clause-②: no`,不涉及任何声明面变化,没有运行时源码被触碰。回滚只需 revert 这一个 commit,不影响其它 slice。
- **席位意见**:(留空,供评审席位填写)
- **你要做的**:确认两个新断言文件的行文与命名符合仓库既有 pin 文件的风格;确认 `NEWLY_JUDGED_UNPINNED_MEMBERS` 收缩到只剩 `object-kanban` 两项没有引入遗漏。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_

---
_Generated by [Claude Code](https://claude.ai/code)_