### PR TITLE
docs(ci): stop asserting the skip-changeset label object exists

### DIFF
--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -1913,14 +1913,15 @@ one by hand is what removes that guarantee.
 > `skip-changeset` or `dependencies` label. None of it existed;
 > [#3724](https://github.com/objectstack-ai/objectui/issues/3724) deleted the page.
 >
-> ⚠️ **The label object came back, and it still does nothing.** This note used to report a
-> point-in-time labels-API reading (2026-08-08: of the two names only `dependencies` existed).
-> That reading has since expired — a `skip-changeset` label now exists in this repository's
-> label set, because GitHub mints a label the first time one is applied by name, so a single
-> API call that applies it is enough to create it. By 2026-08-25 it sat on **seven** pull
-> requests, carrying the default grey `ededed` and an empty description that tell an
-> auto-minted label apart from a curated one.
-> [#4912](https://github.com/objectstack-ai/objectui/issues/4912) tracks deleting the object.
+> ⚠️ **The label object has been minted here before, and it never did anything.** This note
+> used to report a point-in-time labels-API reading (2026-08-08: of the two names only
+> `dependencies` existed), and that reading expired, because GitHub mints a label the first
+> time one is applied by name — so a single API call that applies it is enough to create it.
+> One did: by 2026-08-25 a `skip-changeset` label sat on **seven** pull requests, carrying the
+> default grey `ededed` and an empty description that tell an auto-minted label apart from a
+> curated one. [#4912](https://github.com/objectstack-ai/objectui/issues/4912) deleted that
+> object on 2026-09-09, and ⛔ that deletion is no more durable than the reading it replaced:
+> the same single API call re-mints it.
 >
 > ⛔ **Whether or not you can still see it in the picker, applying it declares nothing** — no
 > gate in this repository reads it. The real gate has no label escape hatch by design: its

--- a/scripts/__tests__/ci-cd-pipeline-doc.test.ts
+++ b/scripts/__tests__/ci-cd-pipeline-doc.test.ts
@@ -224,6 +224,12 @@ describe('ci-cd-pipeline.md — workflow inventory', () => {
    * recorded above, and the refusal was upheld on PR #6260. That is the exact harm #4912
    * predicted, arriving after the card was filed.
    *
+   * ⭐ The object was deleted under #4912 on 2026-09-09, once its stated precondition — that
+   * no open PR carried it — had been measured. ⛔ That does not retire these two pins, and
+   * they must not be read as obsolete: one API call that applies the name mints the label
+   * again, and the instruction to apply it still reaches agents from the `objectstack`
+   * sibling, so its absence is a moment and not a state this repository can hold.
+   *
    * ⛔ What these two cases can and cannot see, said plainly because the boundary is the whole
    * design of this file: **a label lives in GitHub's data, not in the tree, so nothing here
    * can assert the label object is gone.** Deleting it is an administrative act, and a test
@@ -289,9 +295,10 @@ describe('ci-cd-pipeline.md — workflow inventory', () => {
     expect(
       prose,
       'content/docs/guide/ci-cd-pipeline.md must keep stating that nothing reads the ' +
-        '`skip-changeset` label. The label object exists in this repository (auto-minted by ' +
-        'being applied, objectui#4912) and agents are being told to use it, so a page that ' +
-        'stops denying it leaves the label as the most authoritative-looking answer in reach.',
+        '`skip-changeset` label. The label object was auto-minted in this repository once by ' +
+        'being applied, and deleting it (objectui#4912) does not stop one API call from ' +
+        'minting it again while agents are still told to use it, so a page that stops ' +
+        'denying it leaves the label as the most authoritative-looking answer in reach.',
     ).toContain('no gate in this repository reads it');
 
     expect(


### PR DESCRIPTION
Fixes #4912

The `skip-changeset` repository label has been **deleted**. This PR repairs the two sentences that the deletion made false.

## The label is gone

`DELETE /repos/objectstack-ai/objectui/labels/skip-changeset` returned **HTTP 204**; a follow-up `GET` returns **404**, while `GET .../labels/domain:devx` still returns 200 — so the 404 is a reading, not a broken route.

⭐ **This falsifies a premise carried on the card since 2026-08-25.** Two earlier seats measured that no agent seat could perform this act (the MCP toolset exposes `get_label` only, and direct REST returned 403 with "GitHub access is not enabled for this session"), and the card sat in `pm:awaiting-maintainer` on that basis. The MCP half still holds — there is still no label create/update/delete tool. **The REST half has changed**: repo-scoped REST is reachable from this container now, and the delete went through. `GITHUB_TOKEN` is still the literal 14-byte string `proxy-injected`; the real credential is proxy-injected.

## Triage's precondition, re-verified immediately before deleting

Triage required, verbatim: 若是**删标签**,先确认没有任何 PR 正挂着它。

| reading | value | firing control taken on the same call |
|:--|:--|:--|
| label exists | yes (`ededed`, empty description) | — |
| **open PRs carrying it** | **0** at 17:22:44Z | same endpoint with `labels=domain:devx` returned **3** |
| workflow files reading it | **0** under `.github/` | same grep for `changeset` hits 5+ workflow files |

⚠️ The GitHub **search** API is 403 through this proxy and returns a body with no `total_count`. Read without capturing the HTTP status that is a silent zero — exactly the false negative that would have made this precondition look satisfied for the wrong reason. The counts above come from the repo-scoped `/issues?labels=` endpoint, which is 200.

Seven **closed** PRs carried the label (#4700, #4665, #4639, #4630, #4628, #4615, #4129). Nothing read it on any of them.

I also checked for a consumer outside this tree, since the `objectstack` sibling wires the name in `lint.yml`, `pr-automation.yml` and `check-empty-changeset.mjs`. Every one of those reads its **own** repo's event payload; none names `objectstack-ai/objectui` in a labels call. No cross-repo consumer.

## Why there is a diff at all

`content/docs/guide/ci-cd-pipeline.md` asserted a **live fact** about the label:

> That reading has since expired — a `skip-changeset` label now exists in this repository's label set

and pointed forward to "#4912 tracks deleting the object". The pin's failure message likewise asserted "The label object exists in this repository". All three are false once the object is gone.

⛔ **I did not replace them with the mirror-image claim that the label is gone**, and the page explains why in its own words: a point-in-time labels-API reading is not a fact this repository can keep true. That lesson is already mechanised — the third assertion in the pin is `not.toContain('checked against the labels API')`. Absence is even *less* durable than presence was: GitHub mints a label the first time one is applied by name, and the instruction to apply it still reaches agents from the `objectstack` sibling (`scripts/pm/dispatch-gates.mjs` still emits it; root cause tracked at objectstack#17017). One API call re-mints it.

So the minting **and** the deletion are both written as dated history, and the present-tense guidance is made independent of whether the object exists — consistent with the sentence already on the page, "Whether or not you can still see it in the picker, applying it declares nothing".

A note in the test records that the deletion does **not** retire the two pins, so a later reader does not remove them as obsolete.

## The three pins were never in danger

They assert tree facts, not label-object facts, so none went stale. Both strings they require are still present and the forbidden one is still absent — verified with the test's own normalization (blockquote markers stripped, whitespace collapsed), because these sentences wrap across lines and a raw substring grep reports 0 for all of them. That vacuity trap is documented in the test and I walked into it once before checking properly.

## Evidence

All on final commit `c88617f79`, clean tree, worktree from `origin/main` = `42ddd7f71`. Exit codes captured by redirect before any pipe.

- `vitest run scripts/__tests__/ci-cd-pipeline-doc.test.ts --reporter=verbose` → exit 0, `Tests 58 passed (58)`. Both #4912 cases confirmed collected **by name**, not inferred from a total: `✓ ... never wires the phantom skip-changeset label into a workflow or a gate` and `✓ ... keeps the page denying skip-changeset rather than describing it`.
- Narrowed union `vitest run scripts/` → `VERDICT command-exit 0`, `Test Files 132 passed | 2 skipped (134)`, `Tests 3833 passed (3835)`. Narrowed to `scripts/` because that is where every real reader of the changed page lives — `git grep -l ci-cd-pipeline` over source returns 20 files and every one that actually reads the file is under `scripts/__tests__/`.
- `type-check:scripts` → exit 0, pnpm echoed `tsc -p tsconfig.scripts.json` as the positive control against a zero-match no-op.
- `lint:root` unnarrowed → exit 0, `32 problems (0 errors, 32 warnings)`, none in either changed file.
- `check:control-bytes` → exit 0, `scanned 7066 tracked text file(s)`, plus an independent `grep -naP` control-byte self-scan over both changed files (no hits).
- `docs:check-links` → exit 0, `Links are valid across 17 scan roots.`
- Heavy runs went through the shared verify lock; verdicts read from its `VERDICT` line, never a bare `$?`.

**Reverse verification**, run from the committed state so restore is a `git checkout HEAD --`, each leg carrying a `trap` on EXIT/INT/TERM with absolute paths, mutation confirmed on disk by counting anchored text rather than by an editor's exit status:

1. Broke the pinned denial (`reads it` → `consults it`): anchor count 1 → 0, injected 1 → suite **exit 1**, failing with this PR's rewritten message. Restore: anchor back to 1, `git diff HEAD` empty, disk blob `9d0447795` identical to the HEAD blob.
2. Put a point-in-time reading back ("The label does not exist (checked against the labels API, 2026-09-09)"): phrase count 0 → 1 → suite **exit 1** on `do not put a point-in-time labels-API reading back on this page`. ⭐ This is the load-bearing one: it shows the obvious fix would have gone red, which is why the correction is shaped the way it is. Restore verified the same way.

No build or `dist/` is involved and I am saying so rather than omitting it: vitest transforms these tests from source, so there is no stale artifact for the ablation to hide behind.

## Housekeeping

- **Changeset: none.** `node scripts/check-changeset-presence.mjs` → exit 0, verdict line: "No source or published contract of a released package changed in this range, so no changeset is owed." A docs page and a root test file; neither is published source of any package.
- **Not governed surface**: `node scripts/check-governed-queue-guard.mjs --test` on both paths → `NOT GOVERNED — 2 path(s) checked against 5 governed surface(s); none matched`, with `AGENTS.md` as the firing control. Left as a draft per dispatch regardless.
- ⛔ No `skip-changeset` label on this PR — on this card of all cards, and the object no longer exists.
- ⛔ I removed the label from none of the seven closed PRs before deleting it, and opened none of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_