### PR TITLE
docs(ci): pin the vi.mock and shadcn sections of ci-cd-pipeline.md to what their jobs run

### DIFF
--- a/.changeset/8420-ci-cd-pipeline-command-parity.md
+++ b/.changeset/8420-ci-cd-pipeline-command-parity.md
@@ -1,0 +1,9 @@
+---
+---
+
+Pin the `Inert vi.mock Specifiers` and `Shadcn Component Check` sections of
+`content/docs/guide/ci-cd-pipeline.md` to the commands their jobs actually run
+(objectui#8420). The first section named one of `vi-mock-specifiers.yml`'s two
+gates — the omitted `check-vi-mock-inherit.mjs` is a blocking step of a required
+context — and the second named none of its job's three commands. Documentation
+and test only; no package is released by this change.

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -1176,11 +1176,10 @@ job, so either one failing fails the check — and `dependabot-merge-gate.mjs` c
 vi.mock Specifier Check** as a required context. (Named without its `scripts/` path on purpose: this
 section reads as this job's gate list, and that script runs in `dependabot-auto-merge.yml`, so
 spelling the path here would credit this job with a gate it does not run.) They read the same
-`vi.mock` call sites
-deliberately: a population that drifted between them would be a hole neither one reports, which is
-why they share a workflow instead of each registering a context of its own. The workflow `name:` and
-the job `name:` are therefore broader than the older of the two gates, and are left that way on
-purpose — renaming a required context silently un-requires it.
+`vi.mock` call sites deliberately: a population that drifted between them would be a hole neither
+one reports, which is why they share a workflow instead of each registering a context of its own.
+The workflow `name:` and the job `name:` are therefore broader than the older of the two gates, and
+are left that way on purpose — renaming a required context silently un-requires it.
 
 **The specifier gate.** `scripts/check-vi-mock-specifiers.mjs` walks every tracked JS/TS-family
 source file, finds each `vi.mock` / `vi.doMock` call site, and resolves the **relative** specifiers

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -1170,9 +1170,21 @@ path filter at all**. A module mock can be written into any package in any shape
 the scan costs a checkout plus one `node` call, so there is nothing to gain by hiding it behind a
 filter. It appears in the checks list as **Inert vi.mock Specifier Check**.
 
-Runs `scripts/check-vi-mock-specifiers.mjs`. It walks every tracked JS/TS-family source file, finds
-each `vi.mock` / `vi.doMock` call site, and resolves the **relative** specifiers against the calling
-file's own directory. Any that resolves to no file fails the run.
+**Two gates run here, over one population, and both block a merge.**
+`scripts/check-vi-mock-specifiers.mjs` and `scripts/check-vi-mock-inherit.mjs` are steps of the same
+job, so either one failing fails the check — and `dependabot-merge-gate.mjs` classifies **Inert
+vi.mock Specifier Check** as a required context. (Named without its `scripts/` path on purpose: this
+section reads as this job's gate list, and that script runs in `dependabot-auto-merge.yml`, so
+spelling the path here would credit this job with a gate it does not run.) They read the same
+`vi.mock` call sites
+deliberately: a population that drifted between them would be a hole neither one reports, which is
+why they share a workflow instead of each registering a context of its own. The workflow `name:` and
+the job `name:` are therefore broader than the older of the two gates, and are left that way on
+purpose — renaming a required context silently un-requires it.
+
+**The specifier gate.** `scripts/check-vi-mock-specifiers.mjs` walks every tracked JS/TS-family
+source file, finds each `vi.mock` / `vi.doMock` call site, and resolves the **relative** specifiers
+against the calling file's own directory. Any that resolves to no file fails the run.
 
 **Why it needed a gate.** A mock whose specifier names no file does **not** error. Vitest registers
 it against a module id nothing imports, the run proceeds with the *real* module everywhere, and the
@@ -1204,11 +1216,31 @@ literal is counted but not judged — an ESLint `RuleTester` code sample is sour
 misspelled too, but resolving one needs the workspace map rather than the filesystem — a different
 check with a different failure mode. Bare specifiers are counted in the census and never judged.
 
-**If it fails:** it names the file, the line and the specifier, and the first path it tried. Fix the
-specifier, then confirm the mock is really installed by reverting the code under test and checking
-that the suite goes red. Run it locally with `pnpm check:vi-mock-specifiers`, or
-`node scripts/check-vi-mock-specifiers.mjs --list` to see every call site the walk found. It needs no
-install and no build.
+**The inherit gate.** `scripts/check-vi-mock-inherit.mjs` judges the same call sites for the sibling
+property: a factory that **hand-lists** the exports it returns freezes the mock's export surface at
+whatever the author typed that day. The real module keeps growing, and the next export any module in
+the file's import graph reads *at module scope* resolves to `undefined` against the frozen stand-in —
+so the file dies during **collection**, before a single test in it runs. Measured on
+[#6768](https://github.com/objectstack-ai/objectui/issues/6768): `Test Files 3 failed | 546 passed`
+alongside `Tests 6694 passed`, with **zero** failed assertions, because the tests in those three
+files never ran. It reads as flake to whoever meets it, and the bill lands on whoever added the
+export.
+
+Its recogniser is **semantic**, never a grep for `importOriginal`: that spelling mis-counted eleven
+correct files as broken *and* missed a broken one
+([#6849](https://github.com/objectstack-ai/objectui/issues/6849)). It asks whether the factory
+*obtains* the real module — a callback parameter under any name, or `vi.importActual` of the same
+specifier — and **spreads** it. Its scope is a declared, grow-only set of covered workspace
+specifiers rather than every factory, because the failure mechanism needs an export surface that
+grows: relative specifiers (whole-module replacement) and third-party packages are counted and never
+judged. Like its sibling it is green at rest, so a collapsed population is a failure here too.
+
+**If they fail:** the specifier gate names the file, the line and the specifier, and the first path
+it tried — fix the specifier, then confirm the mock is really installed by reverting the code under
+test and checking that the suite goes red. The inherit gate names each frozen call site as
+`file:line`, with the specifier and the shape it wants instead. Run them locally with
+`pnpm check:vi-mock-specifiers` and `pnpm check:vi-mock-inherit`, either with `--list` after the
+script path to see every call site the walk found. Neither needs an install or a build.
 
 ## Shell Escape Residue (`shell-escape-residue.yml`)
 
@@ -2312,11 +2344,25 @@ instead of quietly dropping out of the wait.
 
 ### Shadcn Component Check (`shadcn-check.yml`)
 
-**Trigger:** Weekly on Monday at 9:00 AM UTC, or manual dispatch.
+**Trigger:** Weekly on Monday at 9:00 AM UTC, or manual dispatch. Nothing here blocks a merge — it
+runs on a schedule, and its alarm is an issue rather than the job colour.
 
-- Runs offline and online analysis of shadcn/ui components.
-- Creates or updates a GitHub issue if components need review or updating.
-- Uploads analysis artifacts for reference.
+Three first-party commands, in this order:
+
+- `pnpm shadcn:analyze` — the offline analysis of the vendored shadcn/ui components. Its exit code is
+  captured rather than tolerated: the one non-zero it can produce is an uncaught crash, and a crash
+  on a weekly schedule goes red where nobody looks.
+- `pnpm shadcn:check` — the online half, 46 serial registry requests. It exits non-zero for one
+  reason only, a declared local patch that is missing or no longer applies; ordinary drift and an
+  unreachable registry both stay exit 0 by design, because this gate must only ever accuse real
+  drift.
+- `node scripts/shadcn-check-report.mjs` — classifies both exit codes, the cross-run registry streak
+  and the step summary, and renders the issue body. It exits 0 for every *classified* outcome,
+  alarms included; it going red means the classifier itself crashed. It is covered by
+  `scripts/__tests__/shadcn-check-report.test.ts`.
+
+The job then creates or updates a single tracking issue when the classifier raises an alarm, and
+uploads the analysis artifacts for reference.
 
 ## Lockfile Merge Driver
 

--- a/scripts/__tests__/ci-cd-pipeline-doc.test.ts
+++ b/scripts/__tests__/ci-cd-pipeline-doc.test.ts
@@ -2136,3 +2136,221 @@ describe('live-e2e.yml — the run conclusion may not contradict the job (#8084)
     }
   });
 });
+
+/**
+ * objectui#8420: the same pairing again, on the two sections the card measured by
+ * hand — and the alias question that had to be settled before either pin could be
+ * pointed at them.
+ *
+ * ## The two instances
+ *
+ * `vi-mock-specifiers.yml` runs TWO gates in one job: `check-vi-mock-specifiers.mjs`
+ * and `check-vi-mock-inherit.mjs`. The section named only the first, and the second
+ * is a blocking step of a required context (`dependabot-merge-gate.mjs` classifies
+ * `Inert vi.mock Specifier Check`) — so a contributor reading that section to learn
+ * what CI does to their pull request did not know a gate that can stop it exists.
+ * Measured on `256c709e2`, searching the whole page for both spellings in one
+ * command: `check-vi-mock-inherit` returned 0 and `check-vi-mock-specifiers`
+ * returned 3, which is what makes the zero a reading rather than a failed probe.
+ *
+ * `shadcn-check.yml`'s section described the job in three prose bullets and named
+ * none of the three first-party commands it runs.
+ *
+ * ## ⛔ Why this is two pins and not a loop over the page
+ *
+ * The card measured the naive extension — pair every `## Heading (some.yml)`
+ * section against every job in that workflow — and it flags 24 of the 34 sections,
+ * MOST of which are not defects: a section that names a neighbouring gate for
+ * contrast (and says so), an illustrative `scripts/some-gate.mjs` placeholder
+ * inside a code block, and sections that name a `pnpm check:*` alias where the
+ * workflow invokes `node scripts/…` directly. A gate that cries wolf gets switched
+ * off rather than fixed — this repository's own words, in
+ * `check-unreferenced-sources`. So sections join this rule one at a time, each
+ * after somebody has decided what that section's documentation surface IS.
+ *
+ * ## ⭐ The alias decision, and its blast radius
+ *
+ * Settled here for these two units only: **an alias whose root `package.json`
+ * definition is exactly `node scripts/<file>` names the same gate as invoking that
+ * file directly.** `pnpm check:vi-mock-specifiers` IS
+ * `node scripts/check-vi-mock-specifiers.mjs` — same script, same population, same
+ * verdict — and the vi.mock section names the alias because that is how a
+ * contributor runs it locally. Without this, `undocumentedCommands` reads the two
+ * spellings as two commands and reports the page's own "run it locally" line as a
+ * phantom gate: cry wolf, on the first section this rule was pointed at.
+ *
+ * What the decision deliberately does NOT do:
+ *
+ *   - **It does not merge an alias that carries arguments.** `pnpm shadcn:check` is
+ *     `node scripts/shadcn-sync.js --check` and `pnpm shadcn:update` is the same
+ *     script with `--update`; collapsing both onto the script would let the page
+ *     document one and the workflow run the other. An alias with arguments selects
+ *     a MODE, and is only ever the same command as itself.
+ *   - **It does not reach the other 32 sections, nor the `ci.yml` table or the
+ *     `lint.yml` section above.** Those two were settled without it and are pinned
+ *     by the unmodified module-scope rule; re-pointing them is a separate card, not
+ *     a silent side effect of this one.
+ *   - **It does not make the pre-install distinction disappear.** Several workflows
+ *     invoke `node scripts/…` rather than the alias because the step runs BEFORE
+ *     `pnpm install`, which is real and deliberate. That is a fact about step
+ *     PLACEMENT; this rule measures which gates a job runs, and on that question
+ *     the two spellings are one gate.
+ */
+describe('ci-cd-pipeline.md — the vi-mock and shadcn sections', () => {
+  /** Root `package.json` script bodies, for resolving an alias to the gate it runs. */
+  const rootScriptBodies = (
+    JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as {
+      scripts: Record<string, string>;
+    }
+  ).scripts;
+
+  /** `scripts/<file>` -> the one root alias that is exactly `node scripts/<file>`. */
+  function aliasByScript(): Map<string, string[]> {
+    const map = new Map<string, string[]>();
+    for (const [name, body] of Object.entries(rootScriptBodies)) {
+      const wrapped = /^node\s+(scripts\/[\w./-]+)$/.exec(body.trim())?.[1];
+      if (!wrapped) continue;
+      map.set(wrapped, [...(map.get(wrapped) ?? []), name]);
+    }
+    return map;
+  }
+
+  /**
+   * One spelling per gate: the alias when the alias is a pure wrapper, otherwise the
+   * command as written. Applied to both sides of a unit, so the two are compared by
+   * one rule rather than by two spellings of it.
+   */
+  function canonical(command: string, aliases: Map<string, string[]>): string {
+    const named = aliases.get(command);
+    if (named?.length === 1) return `pnpm ${named[0]}`;
+    return command;
+  }
+
+  /** A unit with both of its sides put through `canonical`. */
+  function byGate(unit: CommandParity): CommandParity {
+    const aliases = aliasByScript();
+    return {
+      label: unit.label,
+      ran: new Set([...unit.ran].map((c) => canonical(c, aliases))),
+      named: new Set([...unit.named].map((c) => canonical(c, aliases))),
+    };
+  }
+
+  /** A `##`/`###` section of the page, up to the next heading at its level or above. */
+  function section(heading: string): string {
+    const start = doc.indexOf(heading);
+    expect(start, `the page must still have a "${heading}" section`).toBeGreaterThan(-1);
+    const level = /^#+/.exec(heading)![0].length;
+    const rest = doc.slice(start + heading.length);
+    const next = rest.search(new RegExp(`^#{1,${level}} `, 'm'));
+    return next === -1 ? rest : rest.slice(0, next);
+  }
+
+  const VI_MOCK_HEADING = '## Inert vi.mock Specifiers (`vi-mock-specifiers.yml`)';
+  const SHADCN_HEADING = '### Shadcn Component Check (`shadcn-check.yml`)';
+
+  function units(): CommandParity[] {
+    return [
+      byGate(
+        commandParity(
+          'vi-mock-specifiers.yml',
+          'vi-mock-specifiers',
+          section(VI_MOCK_HEADING),
+          'vi-mock-specifiers.yml `vi-mock-specifiers`',
+        ),
+      ),
+      byGate(
+        commandParity(
+          'shadcn-check.yml',
+          'check-components',
+          section(SHADCN_HEADING),
+          'shadcn-check.yml `check-components`',
+        ),
+      ),
+    ];
+  }
+
+  it('resolves each pure alias to exactly one gate', () => {
+    // The control on the decision above. Two root scripts spelled `node scripts/x`
+    // for the same `x` would make `canonical` pick one arbitrarily, and the pins
+    // below would then compare a spelling nobody chose. `canonical` keeps the raw
+    // command when that happens; this says so out loud instead of leaving it silent.
+    const ambiguous = [...aliasByScript()].filter(([, names]) => names.length > 1);
+    expect(
+      ambiguous.map(([script, names]) => `${script}: ${names.join(', ')}`),
+      'more than one root `package.json` script is exactly `node <script>` for the same ' +
+        'script. The alias decision documented above assumes one alias per gate; with two, ' +
+        'the parity pins below fall back to the raw spelling and stop merging the alias with ' +
+        'the path — which reads as a phantom gate on any section that names the other alias.',
+    ).toEqual([]);
+
+    // And a positive control on the resolver itself: it must actually resolve the
+    // alias this section depends on, or the pins are green for the wrong reason.
+    expect(
+      canonical('scripts/check-vi-mock-inherit.mjs', aliasByScript()),
+      '`pnpm check:vi-mock-inherit` must still be exactly `node scripts/check-vi-mock-inherit.mjs` ' +
+        'in the root package.json — the vi.mock section names the gate both ways, and the pins ' +
+        'below only agree because those two spellings resolve to one gate.',
+    ).toBe('pnpm check:vi-mock-inherit');
+  });
+
+  it('documents the only job each of the two workflows defines', () => {
+    // The units above cover one job per workflow. A second job would run gates that
+    // no assertion here reads and no section here documents, so it comes through
+    // this test first — the shape `lint.yml`'s pin uses, one workflow each.
+    for (const [file, keys] of [
+      ['vi-mock-specifiers.yml', ['vi-mock-specifiers']],
+      ['shadcn-check.yml', ['check-components']],
+    ] as const) {
+      expect(
+        jobKeys(fs.readFileSync(path.join(workflowDir, file), 'utf8'), file),
+        `${file} no longer defines exactly ${keys.join(', ')}. The section pinned below ` +
+          'documents that job alone, so a new job needs its own documentation and its own unit ' +
+          'here — otherwise its gates are unpinned and undocumented at once.',
+      ).toEqual([...keys]);
+    }
+  });
+
+  it('names every first-party command the two jobs actually run', () => {
+    const all = units();
+
+    // A parser that matched nothing would make both directions vacuously green. The
+    // floor is a control on the matcher, not a ratchet on the gate count.
+    const ran = all.reduce((n, u) => n + u.ran.size, 0);
+    expect(ran, 'the `run:` parse found implausibly few first-party commands').toBeGreaterThan(3);
+
+    const missing = undocumentedCommands(all);
+
+    expect(
+      missing,
+      `these jobs run commands that the section documenting them in ` +
+        `content/docs/guide/ci-cd-pipeline.md does not name:\n` +
+        missing.map((m) => `  - ${m}`).join('\n') +
+        `\n\nAdd each one to its section, in the order the workflow runs it. An alias and a ` +
+        `\`node scripts/…\` invocation of the same wrapper count as one gate, so either ` +
+        `spelling satisfies this — objectui#8420: \`check-vi-mock-inherit.mjs\` blocked merges ` +
+        `from a section that never mentioned it.`,
+    ).toEqual([]);
+  });
+
+  it('credits the two jobs with no first-party command they do not run', () => {
+    const all = units();
+
+    const named = all.reduce((n, u) => n + u.named.size, 0);
+    expect(named, 'the two sections parsed to implausibly few commands').toBeGreaterThan(3);
+
+    const phantom = phantomCommands(all);
+
+    expect(
+      phantom,
+      `these sections of content/docs/guide/ci-cd-pipeline.md name commands the job they ` +
+        `document does not run:\n` +
+        phantom.map((p) => `  - ${p}`).join('\n') +
+        `\n\nEither the step was removed and the prose is stale, or the command runs in another ` +
+        `workflow and belongs in that section. A section reads as its job's gate list, so ` +
+        `naming a command inside it makes the page claim a guardrail — the objectui#3451 ` +
+        `mistake. To cite a neighbouring gate for contrast, name it without its \`scripts/\` ` +
+        `path and say why, as the Lint section does for \`check-entry-guard.mjs\`.`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Refs #8420 (instances 1 and 2)

⛔ **Deliberately not `Fixes`.** #8420 is a CLASS card — its title is *every* `ci-cd-pipeline.md`
workflow section except `ci.yml` and `lint.yml`, and its body names two instances as the first two
of roughly thirty-two. This pull request pins those two. Closing the card here would retire the
remaining sections from every open-issue sweep in one move, which is the failure the card itself
warns about. On merge the card returns to `pm:queue` with a `Release:` line naming what landed and
what is left.

## What changed

Two sections of `content/docs/guide/ci-cd-pipeline.md` now name every first-party command the job
they document actually runs — and no command it does not run — and each is held there by one
`commandParity` unit in `scripts/__tests__/ci-cd-pipeline-doc.test.ts`.

1. **`## Inert vi.mock Specifiers`** — the workflow runs **two** gates in one job
   (`check-vi-mock-specifiers.mjs` at `vi-mock-specifiers.yml:96`, `check-vi-mock-inherit.mjs` at
   `:112`); the section named only the first. The omitted one is a blocking step of a required
   context, so a contributor reading this section to learn what CI does to their pull request did
   not know a gate that can stop it exists. The section now names both, says both block, and
   describes what the inherit gate catches and how its recogniser works.
2. **`### Shadcn Component Check`** — three prose bullets naming none of the job's three commands.
   It now names `pnpm shadcn:analyze` (`shadcn-check.yml:94`), `pnpm shadcn:check` (`:119`) and
   `node scripts/shadcn-check-report.mjs` (`:141`), each with what its exit code means, plus the
   fact that nothing here blocks a merge.

## The alias question, settled — and deliberately not generalised

`shadcn-check.yml` literally runs the alias `pnpm shadcn:analyze`, while the vi.mock section names
`pnpm check:vi-mock-specifiers` as the way to run a gate the workflow invokes as
`node scripts/check-vi-mock-specifiers.mjs`. The decision, written into the test's own prose so the
next reader inherits it:

> An alias whose root `package.json` definition is exactly `node` plus one `scripts/` path names the
> same gate as invoking that file directly.

Without it the two spellings read as two commands and the rule reports the page's own "run it
locally" line as a phantom gate — cry wolf, on the first section it was pointed at. Three limits are
pinned with it:

- It does **not** merge an alias that carries arguments. `pnpm shadcn:check` and `pnpm shadcn:update`
  are the same script with different flags; an alias with arguments selects a mode.
- It does **not** reach the `ci.yml` table, the `lint.yml` section, or the other 32 sections. Those
  are pinned by the unmodified module-scope rule; re-pointing them is a separate card.
- It does **not** erase the pre-install distinction (a step that runs before `pnpm install` must
  invoke node directly). That is a fact about step placement; this rule measures which gates a job
  runs.

A control test asserts the resolver is unambiguous (no two root scripts are a pure wrapper around
the same file — measured: 51 pure wrappers, 0 collisions) and that it still resolves the one alias
these pins depend on. Ambiguity would make the pins compare a spelling nobody chose.

## Not a sweep

Scope is the two named sections. The card measured the naive extension: it flags 24 of the 34
sections and most are not defects. Where this PR needed to cite a neighbouring gate, it followed the
convention the `## Lint` section already established — name the script without its `scripts/` path
and say why, so the page does not credit the job with a gate it does not run.

## Evidence

Ablation, per pin, on the committed tree (mutate, prove the mutation reached disk, run, restore, and
prove the restore by blob hash):

| leg | mutation | result |
|:--|:--|:--|
| A | delete `check-vi-mock-inherit` from the vi.mock prose (page hits 2 and 1 to 0 and 0; control `check-vi-mock-specifiers` stays 3) | **red** — `vi-mock-specifiers.yml`: `pnpm check:vi-mock-inherit` |
| B | delete `pnpm shadcn:analyze` from the shadcn prose (1 to 0; control `shadcn:check` stays 1) | **red** — `shadcn-check.yml`: `pnpm shadcn:analyze` |
| C | credit the shadcn job with `scripts/check-doc-links.mjs`, which it does not run | **red** — phantom direction: `pnpm docs:check-links` |

Each leg restored to the exact `HEAD` blob `385055f51…` and left `git diff HEAD` empty.

Checks run locally, all green:

- `pnpm exec vitest run scripts/__tests__/ci-cd-pipeline-doc.test.ts` — 62 passed (58 before).
- `pnpm exec vitest run scripts/__tests__/` — 132 files, 3837 tests passed, 2 skipped. Seventeen
  test files in that directory read this page.
- `pnpm lint:root` exit 0 (whole root scan, 9.7s; the 32 warnings are pre-existing and none is in a
  file this PR touches — targeted eslint on the changed test file reports 0 errors, 0 warnings).
- `pnpm type-check:scripts` exit 0, `pnpm docs:check-links` exit 0, `pnpm check:doc-fences` exit 0,
  `pnpm check:shell-escape-residue` exit 0, `node scripts/check-control-bytes.mjs` exit 0.
- `node scripts/check-changeset-presence.mjs` exit 0. Documentation and test only, so the changeset
  is an empty-frontmatter declaration.

## One card claim that did not reproduce

The card says `check-vi-mock-inherit.mjs` "was widened three commits ago by #8414 (`4b5e07a53`)".
Re-derived here: `git log origin/main -- .github/workflows/vi-mock-specifiers.yml` returns three
commits in that file's whole history (`6ea94b80e`, `05b832407`, `e9e55524e`), and `4b5e07a53` is not
among them. The drift-rate sentence built on it is not repeated anywhere in this PR, and neither
instance needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_

---
_Generated by [Claude Code](https://claude.ai/code)_