### PR TITLE
test(plugin-list): measure which host owns ObjectGallery's rows — objectui#7390's route question, deliberately unresolved

### DIFF
--- a/.changeset/7390-gallery-host-ownership-pin.md
+++ b/.changeset/7390-gallery-host-ownership-pin.md
@@ -1,0 +1,8 @@
+---
+---
+
+Test-only: pins which host owns `ObjectGallery`'s rows (objectui#7390). Under
+`ListView` the host fetches one page and hands the rows down as the `data` prop,
+so the gallery issues no query of its own; an authored standalone
+`object-gallery` node owns its query and has no paging chrome above it. No
+published behaviour changes.

--- a/packages/plugin-list/src/__tests__/ObjectGallery.hostOwnsRows-7390.test.tsx
+++ b/packages/plugin-list/src/__tests__/ObjectGallery.hostOwnsRows-7390.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7390 — WHICH HOST OWNS THE GALLERY'S ROWS, and therefore which
+ * surface is able to bound them.
+ *
+ * The card asks whether `ObjectGallery`'s standalone fetch should be bounded by
+ * PAGING (it is a card grid, "page-shaped", rendered under `ListView`'s paging
+ * chrome) or by objectui#7210's platform row ceiling. The card states the
+ * precondition itself: that fetch runs ONLY when the gallery owns its data. So
+ * the two candidate answers are not both reachable, and which one is reachable
+ * is a property of the host, not of the gallery. This file measures it.
+ *
+ * The reading, and it is the opposite of what "renders under `ListView`'s
+ * paging chrome" suggests: THE TWO CONDITIONS ARE MUTUALLY EXCLUSIVE.
+ *
+ *   - Under `ListView` the gallery never queries. `ListView` fetches one page
+ *     (`$top` = `pagination.pageSize`) and hands the rows down as the `data`
+ *     PROP — `<SchemaRenderer schema={viewComponentSchema} … {...(ganttOwnsData
+ *     ? {} : { data })} />`, and `SchemaRenderer` spreads caller props onto the
+ *     component last — so `ObjectGallery`'s effect takes its `props.data`
+ *     branch and returns before `dataSource.find`. `object-gallery` is
+ *     registered as the component itself (no wrapper that drops props), which
+ *     is what makes it the opposite of the `object-gantt` case pinned in
+ *     `plugin-gantt/src/ObjectGantt.hostDataProp-7210.test.tsx`.
+ *   - Standalone — a `{ type: 'object-gallery', objectName }` node an author
+ *     writes into a page schema — the gallery owns the query, and there is no
+ *     `ListView`, hence no paging chrome, above it. Every in-repo host
+ *     (`ListView`, `plugin-view`'s `ObjectView`, `plugin-detail`'s mobile
+ *     `RelatedList`) hands rows down, so this path is reached from AUTHORED
+ *     METADATA only.
+ *
+ * ⇒ paging chrome is present exactly where the unbounded fetch is not, and the
+ * unbounded fetch is exactly where no chrome is. What bound that authored path
+ * should carry is objectui#7390's open ruling and is deliberately NOT pinned
+ * here: this file asserts that the gallery ISSUES its own query there, never
+ * what that query carries. A fix in either direction leaves every assertion
+ * below true.
+ *
+ * ⛔ Do not "simplify" case 1 by dropping the call COUNT for a shape check. The
+ * count is the whole measurement — a second call is precisely what a gallery
+ * that owns its data looks like from here.
+ *
+ * REVERSE VERIFICATION — direction predicted before running: remove `{ data }`
+ * from `ListView`'s child render (so the gallery stops being handed rows) and
+ * case 1 goes RED on the call count (1 → 2, the second call carrying the
+ * gallery's own `$expand` signature), while case 2 (a different host) and
+ * case 3 (`ListView`'s own chrome, which does not depend on who draws the rows)
+ * stay GREEN. Observed: 1 failed / 2 passed, as predicted.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { SchemaRendererProvider, SchemaRenderer } from '@object-ui/react';
+import { ListView } from '../ListView';
+// Registers `object-gallery` → the real `ObjectGallery`, the subject of both hosts.
+import '../index';
+
+/** More rows than the authored page, so "which query bounded this" is visible. */
+const TOTAL = 40;
+const PAGE_SIZE = 6;
+
+const rows = Array.from({ length: TOTAL }, (_, i) => ({
+  id: String(i + 1),
+  name: `Row ${i + 1}`,
+  owner: 'u1',
+}));
+
+const objectDef = {
+  name: 'thing',
+  label: 'Thing',
+  fields: {
+    id: { name: 'id', type: 'text' },
+    name: { name: 'name', type: 'text', label: 'Name' },
+    // A lookup, so the gallery's own query carries the `$expand` that
+    // objectui#7429 gated — the fingerprint separating it from the host's.
+    owner: { name: 'owner', type: 'lookup', label: 'Owner', reference: 'user' },
+  },
+};
+
+/** Honours `$top` so a bounded query and an unbounded one differ in the rows drawn. */
+function makeAdapter() {
+  return {
+    find: vi.fn(async (_object: string, params: any) => {
+      const top = typeof params?.$top === 'number' ? params.$top : undefined;
+      return { data: top === undefined ? rows : rows.slice(0, top), total: TOTAL };
+    }),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async () => objectDef),
+  } as any;
+}
+
+/** Every issued query's params, in order. */
+const issued = (adapter: any) =>
+  adapter.find.mock.calls.map(([, params]: [string, any]) => params ?? {});
+
+afterEach(() => cleanup());
+
+describe('objectui#7390 — the host decides whether the gallery owns its rows', () => {
+  it('under ListView the gallery draws the HOST page and issues NO query of its own', async () => {
+    const adapter = makeAdapter();
+    render(
+      <SchemaRendererProvider dataSource={adapter}>
+        <ListView
+          schema={{
+            type: 'list-view',
+            objectName: 'thing',
+            viewType: 'gallery',
+            columns: ['name'],
+            pagination: { pageSize: PAGE_SIZE },
+          } as any}
+          dataSource={adapter}
+        />
+      </SchemaRendererProvider>,
+    );
+
+    // Settle on the drawn cards, not on the first query.
+    await waitFor(() => expect(screen.getByText('Row 1')).toBeTruthy());
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+
+    // ONE query, and it is the host's paged one. A gallery owning its data here
+    // would show up as a second call — see the file header.
+    expect(issued(adapter)).toHaveLength(1);
+    expect(issued(adapter)[0].$top).toBe(PAGE_SIZE);
+
+    // …and the cards drawn are that page, not the whole filtered set.
+    expect(screen.getAllByText(/^Row \d+$/)).toHaveLength(PAGE_SIZE);
+    expect(screen.queryByText(`Row ${TOTAL}`)).toBeNull();
+  });
+
+  it('CONTROL standalone: an authored `object-gallery` node owns the query itself', async () => {
+    const adapter = makeAdapter();
+    render(
+      <SchemaRendererProvider dataSource={adapter}>
+        <SchemaRenderer
+          schema={{
+            type: 'object-gallery',
+            objectName: 'thing',
+            gallery: { titleField: 'name' },
+          } as any}
+        />
+      </SchemaRendererProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText('Row 1')).toBeTruthy());
+
+    // The gallery's own query, identified by the FLS-gated `$expand` it builds
+    // (objectui#7429) — the host never sends that. This is what makes the
+    // call-count assertion in case 1 a real reading rather than a probe that
+    // could not have seen a gallery query in the first place.
+    //
+    // ⛔ Deliberately not asserted: what bound this query carries. That is
+    // objectui#7390's open ruling — paging vs. the objectui#7210 ceiling — and
+    // pinning today's answer here would fossilise the defect.
+    expect(issued(adapter)).toHaveLength(1);
+    expect(issued(adapter)[0].$expand).toEqual(['owner']);
+    expect(issued(adapter)[0].$select).toBeUndefined();
+  });
+
+  it('the truncation disclosure lives on the SURFACE THAT BOUNDS — the host', async () => {
+    const adapter = makeAdapter();
+    render(
+      <SchemaRendererProvider dataSource={adapter}>
+        <ListView
+          schema={{
+            type: 'list-view',
+            objectName: 'thing',
+            viewType: 'gallery',
+            columns: ['name'],
+            pagination: { pageSize: PAGE_SIZE },
+          } as any}
+          dataSource={adapter}
+        />
+      </SchemaRendererProvider>,
+    );
+
+    // `ListView` bounds the query, so `ListView` is where the "you are not
+    // seeing all of it" sentence is. The authored standalone node in case 2 has
+    // neither half — that pairing is the card's escalation ground.
+    const warning = await screen.findByTestId('data-limit-warning');
+    expect(warning.textContent).toContain(String(PAGE_SIZE));
+  });
+});


### PR DESCRIPTION
Part of #7390. **No route is chosen here, and no bound is added** — the card goes back for a ruling. `#7390` remains open; this PR carries only the measurement it turns on, pinned as a test.

## The measurement the card asked for first

The card's precondition: `ObjectGallery`'s own fetch runs **only when the gallery owns its data**. Measured on `origin/main` (256c709e2) by rendering each host with one spy adapter and reading the queries it received:

| host | who issues the query | gallery's own fetch | paging chrome above it |
|---|---|---|---|
| `ListView`, `viewType: 'gallery'` (where app-shell's object views land) | `ListView` — **1** call, `$top` = `pagination.pageSize` | **never runs** — 0 calls | **yes** — `record-count-bar` + `data-limit-warning` |
| `plugin-view`'s `ObjectView` (authored `object-view` element) | `ObjectView` — passes `data={data}`, and `data` is `useState(...)` seeded `[]`, so always an array | never runs | n/a |
| `plugin-detail`'s `RelatedList` (mobile grid/table) | host — puts `data: paginatedData` on the node | never runs | `RelatedList`'s own pager |
| an **authored standalone** `{ type: 'object-gallery', objectName }` node | **the gallery** — `{ $filter, $expand }`, **no `$top`** | **runs** | **none** |

Measured numbers from the probe: under `ListView` with `pageSize: 6` over 5,000 rows — one query, `$top: 6`, six cards, footer reads *"6 records / Showing first 6 records. More data may be available."* Standalone over the same 5,000 rows — one query with no `$top`, **5,000 cards materialised into the document**, and nothing on screen that says so.

## What that does to the two routes

⭐ **The two conditions are mutually exclusive.** Wherever `ListView`'s paging chrome is above the gallery, `ListView` owns the query and the gallery issues none; wherever the gallery issues its unbounded query, there is no `ListView`, no chrome, and no host at all — that path is reached from **authored page metadata only** (no in-repo host leaves the gallery owning its data; there is no `object-gallery` node under `apps/`, `examples/` or `content/`).

⇒ **paging is not "restoring a page-shaped surface" here.** There is nothing to restore on the affected path: no chrome to page, and no authorable page size to page by. `ObjectGallerySchema` declares no `limit` / `pagination`, and `@objectstack/spec`'s `GalleryConfigSchema` is a `strictObject` of exactly five keys (`coverField`, `coverFit`, `cardSize`, `titleField`, `visibleFields`) — so a page size cannot be authored today at either declaration site.

⇒ **the #7210 ceiling is a hard stop**, and its own argument does not reach here: the four capped views cannot be paged without lying (a gantt's range, a map's camera fit, a tree's parent pointers are computed over the whole set). A gallery draws one card per record and needs no such whole-set property.

## A third shape the card and the dispatch did not consider

The two neighbours that already cap are **not** ceiling views — they are the page-shaped ones, and they cap through an **author-settable row cap with a renderer default**:

- `ObjectKanban`: `$top: schema.limit ?? DEFAULT_KANBAN_LIMIT` (100). `limit` is declared on `ObjectKanbanSchema` in `@object-ui/types` and in its zod mirror — **with no counterpart in `@objectstack/spec`'s `KanbanConfigSchema`**, which carries only `groupByField`, `summarizeField`, `columns`.
- `ObjectTimeline`: `$top: schema.limit ?? DEFAULT_TIMELINE_LIMIT` (100), `limit` declared on the component's own props interface.

So a node-level row cap that spec's view-config block does not carry is **precedented twice in this repo**, on exactly the two surfaces the card places the gallery beside. That makes a third route available that is neither paging-as-restoration nor a fifth member of #7210's ruled set — but it mints a new key on a published payload, so it is a maintainer call, not a lane call.

## The mandatory signal, restated with a measurement

The card's escalation ground holds and gets sharper: **the disclosure lives on whichever surface owns the bound.** `ListView` bounds, so `ListView` discloses (`data-limit-warning`, measured above). The authored standalone node has neither half. ⛔ Adding `$top` there without a note converts "unbounded and silent" into "bounded and silent". `@object-ui/react` already exports `NonGridRowCeilingNote`, but its copy and its `data-row-ceiling-note="non-grid"` attribute belong to #7210's vocabulary — reusing them for a gallery is itself a small naming decision worth ruling on alongside the route.

## What is in this PR

One test file and one empty-frontmatter changeset. The test pins the reading above and **is route-neutral**: it asserts that the gallery issues no query of its own under `ListView`, and that it does issue one standalone. It deliberately does **not** assert what that standalone query carries — pinning today's answer would fossilise the defect, and every assertion stays true after a fix in any of the three directions.

### Reverse verification (ablation), from the committed tree

Direction predicted before running: remove `{ data }` from `ListView`'s child render, and case 1 goes red on the call count while the other two stay green.

- On-disk proof of the mutation, before running anything: marker `': { data })}'` 1 → 0, `': {})}'` 4 → 5; blob `ef7cf802…` → `a840164f…`.
- Result: `Test Files 1 failed`, `Tests 1 failed | 2 passed` — red **by case name**, `under ListView the gallery draws the HOST page and issues NO query of its own`, with `AssertionError: expected [ …(2) ] to have a length of 1 but got 2`. Exactly the predicted 1 → 2.
- Restored **by state**: `git diff HEAD` empty and blob back to `ef7cf802d719944519bb11d1891904c14b5cb078`.

### Verification, all at final head `22dd7d212`

- `pnpm exec vitest run packages/plugin-list/` — **73 files / 891 tests passed**, exit 0.
- `pnpm --filter @object-ui/plugin-list run type-check` — exit 0 after `pnpm --filter '@object-ui/plugin-list^...' build`. Coverage of the new file proven rather than assumed: `tsc -p tsconfig.test.json --listFiles` names it (grep count 1).
- `pnpm --filter @object-ui/plugin-list run lint` (`eslint .`) — exit 0, 0 errors, 501 warnings, the package's standing level; the new file's 7 are `no-explicit-any` on schema casts, the same shape as every sibling test in the directory.
- Gates, enumerated on both axes. Content axis (what the change says): `check-changeset-presence` (red before the changeset, naming the file and the package; green after), `check-changeset-fixed`, `check-changeset-no-major`, `check-changeset-overwrite`, `check-control-bytes`, `check-vi-mock-specifiers`, `check-vi-mock-inherit`, `check-package-self-import`, `check-handler-key-read-sites` (it carries two `object-gallery` arms). Position axis (what points at this path): `check-spec-symbol-derivation` and `check-vi-mock-specifiers` are the two gates that hard-code `plugin-list/src/__tests__` paths; plus `check-unreferenced-sources` and `check-lint-rule-coverage`, both of which enumerate source trees by path. **All exit 0.**
- `scripts/pm/check-widening-tells.mjs` does not exist in this repo (only `scripts/pm/check-half-states.mjs` does), so the dispatch's objectstack-side trap has no reading to give here either way. `scripts/pm/os-verify-lock.sh` likewise does not exist here; every command above ran in the foreground.

## Clause-② — no

Judged for **this diff**, inheriting nothing: one test file plus an empty-frontmatter changeset. No new exported symbol, no new key on any published payload, no published behaviour changed (the changeset says so and `check-changeset-presence` agrees). ⚠️ Any of the three routes above **would** be `yes` — each adds either a key on a published node schema or a new rendered control — which is a further reason the route is not being chosen in this PR.

## 维护者速读(草稿)

- **改了什么** — 只加了一个测试和一个「不发版」changeset。没有改渲染行为,没有加任何上限。
- **为什么改** — 卡片和派发都假设「gallery 在 `ListView` 的分页 chrome 之下,所以分页是诚实答案」。实测把这个前提推翻了:**有 chrome 的地方 gallery 根本不发查询,gallery 发查询的地方一个 host 都没有、也没有 chrome**。那条无界查询只能由作者手写的 `object-gallery` 节点触达,而那里既没有分页控件,也没有任何可声明的页大小(`ObjectGallerySchema` 没有 `limit`,spec 的 `GalleryConfigSchema` 是五个键的 `strictObject`)。
- **风险与代价(含回滚)** — 本 PR 无运行时风险(纯测试)。回滚即 revert 两个 commit。真正的代价是**卡片仍未修**:一个作者手写的 gallery 仍会把整个过滤结果集拉进浏览器(实测 5,000 行 = 5,000 张卡),并且不告诉用户。
- **席位意见** —
- **你要做的** — 在三条路里裁一条:① 分页(要新控件 + 新的页大小常量,gallery 从来没有过分页);② 套 #7210 的天花板常量(把已裁决集合从四扩到五,而那四个的论据是「不看全集就会撒谎」,gallery 不属于这一族);③ **本席推荐** —— 走 kanban / timeline 已有的形状:`$top: schema.limit ?? DEFAULT_GALLERY_LIMIT`,把 `limit` 声明到 `ObjectGallerySchema`,再配一条「结果被截断」的可见脚注。理由:那两个邻居正是卡片用来论证「gallery 不在 #7210 那一族」的同一族,它们的上限本来就是节点级、spec 的 view-config 里没有的键 —— 所以这不是发明第五个成员,是补上第三个同族成员。⚠️ 但它在已发布载荷上新增一个键,所以是您的决定,不是执行席的。

## 验收备注

- **#7189**(`plugin-grid` 的分页作用域分组)—— 只看了,未触碰、未合卡。若最终选的路带来「这一页 vs 整个结果集」的措辞,两处口径应统一。
- `origin/copilot/standardize-gallery-timeline-config` 与 `origin/feat/gallery-cover-polish` —— 开工前读过。两者的 `ObjectGallery.tsx` 都不带 `$top`,都没有碰这条 fetch,`main` 上已含 cover-polish 的成果。无碰撞、无重复。(浅检出上 `origin/main...branch` 报 `no merge base`,所以结论取自直接读那两个分支的文件内容,不取自 ancestry。)
- 观察,未立卡:`ObjectTimeline` 的 `limit` 只声明在组件自己的 props 接口上,不在 `@object-ui/types` 的节点 schema 里,与 kanban 的声明位置不对称。承接者:实施 #7390 最终路线的那一位(若选 ③,会照抄这个形状)。
- 观察,未立卡:`ObjectGallerySchema` 把 `objectName` / `filter` 声明为自取数据的路径,但仓内没有任何 host 走它。这不是缺陷,是本卡裁决所依据的可达性事实。承接者:#7390 的裁决本身。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH)_