### PR TITLE
fix(components): render a bare-string `data-table` emptyAction instead of dropping it

### DIFF
--- a/.changeset/8331-data-table-empty-action-primitive-node.md
+++ b/.changeset/8331-data-table-empty-action-primitive-node.md
@@ -1,0 +1,44 @@
+---
+'@object-ui/components': minor
+---
+
+`data-table`'s `emptyAction` now accepts the whole `SchemaNode` union it declares — a
+bare string node renders instead of vanishing (objectui#8331).
+
+**Behaviour change on a published surface, deliberately.** `DataTableSchema.emptyAction`
+is declared `SchemaNode` on both published faces — `packages/types/src/data-display.ts`
+and its Zod twin in `packages/types/src/zod/data-display.zod.ts` — and `SchemaNode` is
+`BaseSchema | string | number | boolean | null | undefined`. The empty-state render path
+additionally required `typeof … === 'object'`, so an authored
+`emptyAction: 'Create the first record'` rendered nothing and reported nothing: declared
+wider than enforced, failing in the direction that loses the author's content without a
+diagnostic. A node that renders nothing today therefore starts rendering.
+
+The declaration is unchanged. It was the correct side — the object-only test was not
+protecting the renderer from anything it cannot handle. What `SchemaRenderer` does with a
+primitive has been pinned since objectui#4548: a non-empty string renders as its own
+text, and `''` / `0` / `false` render nothing. The guard was discarding input the
+declaration promises to accept.
+
+Same defect, same answer, one slot over: objectui#7105 (director seat, decision batch
+#69, 2026-09-07) settled the identical shape on `EmptySchema.action` as **relax the
+renderer, do not narrow the declaration**, and shipped it through the repo's existing
+permanent bridge `toRenderableSchema`. Nothing had to be invented here either.
+
+**A second, smaller behaviour change ships with it, and it is a bug fix.** With
+`emptyAction: 0` the old `&&` chain evaluated to the number `0` itself, which React
+renders — so a stray `"0"` appeared inside the empty state. That is the numeric-falsy JSX
+trap rather than a decision, it was measured rather than assumed, and the ternary that
+replaces the chain yields `null` instead.
+
+**What did NOT change.** The slot still mounts through `SchemaRenderer` rather than
+resolving the registry itself, so the single central `visibleWhen` gate still applies to
+an authored `emptyAction` exactly as before (objectui#5926 gap 1, pinned in
+`data-table-empty-action-visible-when.test.tsx`, green on both sides of this change).
+`''` / `0` / `false` still render nothing, which is the same answer `SchemaRenderer`
+gives them: the truthiness leg is kept precisely so those two never reach the bridge,
+whose `String` mapping would otherwise turn them into the text `"0"` and `"false"`.
+
+**Migration.** Nothing has to change. Metadata that already authored an object node in
+this slot is unaffected. Metadata that authored a bare string was rendering nothing and
+now renders that string — which is what the declaration always promised.

--- a/packages/components/src/renderers/complex/__tests__/data-table-empty-action-primitive-node.test.tsx
+++ b/packages/components/src/renderers/complex/__tests__/data-table-empty-action-primitive-node.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8331 — a `data-table`'s `emptyAction` accepts any `SchemaNode`, so a
+ * bare string node must RENDER rather than be silently dropped.
+ *
+ * ## The defect this pins closed
+ *
+ * `DataTableSchema.emptyAction` is declared `SchemaNode` on both published
+ * faces — `packages/types/src/data-display.ts` and its Zod twin in
+ * `packages/types/src/zod/data-display.zod.ts` — and `SchemaNode` is
+ * `BaseSchema | string | number | boolean | null | undefined`. The render path
+ * additionally required `typeof … === 'object'`, so an authored
+ * `emptyAction: 'Create the first record'` rendered NOTHING and reported
+ * nothing: declared wider than enforced, failing in the direction that loses
+ * the author's content without a diagnostic.
+ *
+ * The object-only test was not protecting the renderer from anything it cannot
+ * handle. What `SchemaRenderer` does with a primitive is pinned in
+ * `packages/react/src/__tests__/SchemaRenderer.primitiveSchema.test.tsx`
+ * (objectui#4548): a non-empty string renders as its own text, and `''` / `0` /
+ * `false` render nothing. The guard was discarding input the declaration
+ * promises to accept.
+ *
+ * Same shape, same answer, one slot over: objectui#7105 (director seat,
+ * decision batch #69, 2026-09-07) ruled the identical defect on
+ * `EmptySchema.action` — RELAX THE RENDERER, do not narrow the declaration.
+ *
+ * ## Why the falsy primitives are pinned here too
+ *
+ * The truthiness leg of the guard is KEPT, and that is a decision, not an
+ * oversight. `0` / `false` / `''` render nothing both before and after this
+ * change, which is exactly the answer `SchemaRenderer` itself gives them
+ * (objectui#4548 pins them as "renders nothing … rather than becoming '0' /
+ * 'false'"). Routing them through the bridge instead — `toRenderableSchema`
+ * maps `number` / `boolean` onto `String(node)` — would turn them into the
+ * text "0" and "false", a SECOND behaviour change on a published surface that
+ * nothing ruled and that would contradict that pin. So the slot's answer stays
+ * the platform's uniform one, and these cases stand guard over a future
+ * "tidy" of the leg into a nullish test.
+ *
+ * ## Discriminating power
+ *
+ * The string case below FAILS on the unfixed guard — that is what makes it
+ * evidence. The object case and the sibling suite
+ * `data-table-empty-action-visible-when.test.tsx` are the regression controls
+ * and are green on both sides; every case additionally asserts the fixture
+ * really reached the EMPTY STATE, since that is the only place this slot
+ * renders and a fixture that misses it would be green for the wrong reason.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '@object-ui/react';
+import '../data-table';
+
+const CTA_TYPE = 'test:data-table-empty-action-primitive-probe';
+ComponentRegistry.register(CTA_TYPE, () => (
+  <span data-testid="empty-action-cta">Create the first record</span>
+));
+
+/** The empty state renders only with no rows, no loading and no error. */
+function renderEmptyTable(emptyAction: unknown) {
+  return render(
+    <SchemaRenderer
+      schema={{
+        type: 'data-table',
+        columns: [{ header: 'Name', accessorKey: 'name' }],
+        data: [],
+        pagination: false,
+        searchable: false,
+        selectable: false,
+        rowActions: false,
+        emptyAction,
+      } as never}
+    />,
+  );
+}
+
+/**
+ * Guard against a green-for-the-wrong-reason pass: assert the fixture really
+ * landed in the empty state, where `emptyAction` is the only thing that can
+ * render authored content.
+ */
+function expectEmptyStateReached() {
+  expect(screen.getByText(/No results found|table\.noResults/)).toBeInTheDocument();
+}
+
+describe('objectui#8331 — data-table emptyAction accepts the whole SchemaNode union', () => {
+  describe('the declared change: a bare string node renders instead of vanishing', () => {
+    it('renders a bare string emptyAction as its own text', () => {
+      const { container } = renderEmptyTable('Create the first record');
+      expectEmptyStateReached();
+      expect(container.textContent).toContain('Create the first record');
+    });
+
+    it('does not report the string as an unknown component type', () => {
+      const { container } = renderEmptyTable('Create the first record');
+      expectEmptyStateReached();
+      expect(container.textContent).not.toContain('Unknown component type');
+    });
+  });
+
+  describe('unchanged paths', () => {
+    /**
+     * The empty state's own chrome, with no authored node in the slot. Every
+     * "renders nothing" case below is asserted against THIS, not against a
+     * substring guess — the table's own text is not this suite's to predict.
+     */
+    function emptyStateBaselineText() {
+      const { container, unmount } = renderEmptyTable(undefined);
+      const text = container.textContent ?? '';
+      unmount();
+      return text;
+    }
+
+    it('still renders an object emptyAction through the registry', () => {
+      renderEmptyTable({ type: CTA_TYPE });
+      expectEmptyStateReached();
+      expect(screen.getByTestId('empty-action-cta')).toBeInTheDocument();
+    });
+
+    it('renders nothing for a nullish emptyAction', () => {
+      const baseline = emptyStateBaselineText();
+      for (const value of [null, undefined] as const) {
+        const { container, unmount } = renderEmptyTable(value);
+        expectEmptyStateReached();
+        expect(container.textContent).toBe(baseline);
+        unmount();
+      }
+    });
+
+    it('renders nothing for the falsy primitives, exactly as SchemaRenderer does', () => {
+      // objectui#4548 pins `''` / `0` / `false` as rendering nothing. The slot
+      // must keep giving them the platform's answer, not the bridge's `String()`
+      // form — this case fails the moment the truthiness leg is "tidied" into a
+      // nullish test, because `0` and `false` would arrive as the text "0" and
+      // "false".
+      const baseline = emptyStateBaselineText();
+      for (const value of ['', 0, false] as const) {
+        const { container, unmount } = renderEmptyTable(value);
+        expectEmptyStateReached();
+        expect(container.textContent).toBe(baseline);
+        unmount();
+      }
+    });
+  });
+});

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -14,7 +14,7 @@ import { useGridFieldAuthoring } from '../../context/gridFieldAuthoring';
 import { describeIgnoredBind, describeNonArrayData } from './dataTableBindDiagnostic';
 import { ComponentRegistry, compareSortValues, evalRowPredicate, formatDate, formatDateTime, getSortValue } from '@object-ui/core';
 import type { DataTableSchema, TableSortItem, TableColumnType } from '@object-ui/types';
-import { SchemaRenderer, useRowPredicate, usePredicateScope } from '@object-ui/react';
+import { SchemaRenderer, toRenderableSchema, useRowPredicate, usePredicateScope } from '@object-ui/react';
 import { createSafeTranslation } from '@object-ui/i18n';
 import { 
   Table, 
@@ -2156,10 +2156,48 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                         `type` is missing or unregistered now gets the
                         platform's uniform "unknown component type" report
                         instead of rendering as silent nothing here — one
-                        answer for malformed metadata, not a private one. */}
-                    {schema.emptyAction && typeof schema.emptyAction === 'object' && (
-                      <SchemaRenderer schema={schema.emptyAction} />
-                    )}
+                        answer for malformed metadata, not a private one.
+
+                        No object-only guard either (objectui#8331), ruled one
+                        slot over together with the declaration: objectui#7105
+                        (director seat, decision batch #69, 2026-09-07) settled
+                        the identical shape on `EmptySchema.action` as RELAX THE
+                        RENDERER, do not narrow the declaration. `emptyAction`
+                        is declared `SchemaNode` on BOTH published faces, and a
+                        `typeof === 'object'` test made this slot narrower than
+                        the thing it declares: a bare string was silently
+                        DROPPED instead of rendering as its own text.
+
+                        The truthiness leg STAYS and the `&&` chain became a
+                        ternary. Both are load-bearing, and together they make
+                        this slot behave exactly as handing the raw node to
+                        `SchemaRenderer` would - the "one answer, not a private
+                        one" rule above, extended to the non-object members of
+                        the union:
+
+                        - `toRenderableSchema` is the repo's permanent bridge
+                          onto `SchemaRendererProps['schema']`, which declares
+                          no `number` / `boolean` (objectui#4548 ruling Q2). It
+                          maps those two onto their `String` form, which is
+                          behaviour-preserving for the TRUTHY ones - that is
+                          what the renderer's own defensive branch produces -
+                          but NOT for `0` / `false`, which `SchemaRenderer`
+                          renders as nothing (pinned, objectui#4548). Gating on
+                          truthiness keeps those two away from the bridge, so
+                          they keep the platform's answer instead of arriving as
+                          the text "0" and "false". Do not "tidy" the leg into a
+                          nullish test.
+                        - The ternary replaces an `&&` chain that LEAKED: with
+                          `emptyAction: 0` the chain evaluated to the number `0`
+                          itself, which React renders as a stray "0" inside the
+                          empty state. That is the numeric-falsy JSX trap, not a
+                          decision; a ternary yields `null` instead.
+
+                        Both legs are pinned in
+                        `__tests__/data-table-empty-action-primitive-node.test.tsx`. */}
+                    {schema.emptyAction ? (
+                      <SchemaRenderer schema={toRenderableSchema(schema.emptyAction)} />
+                    ) : null}
                   </div>
                 </TableCell>
               </TableRow>


### PR DESCRIPTION
Fixes #8331

`DataTableSchema.emptyAction` is declared `SchemaNode` on **both** published faces — `packages/types/src/data-display.ts` and its Zod twin `packages/types/src/zod/data-display.zod.ts` — and `SchemaNode` is `BaseSchema | string | number | boolean | null | undefined`. The empty-state render path additionally required `typeof … === 'object'`, so an authored `emptyAction: 'Create the first record'` rendered nothing and reported nothing: **declared wider than enforced**, failing in the direction that loses the author's content without a diagnostic.

**The declaration is unchanged — it was the correct side.** The object-only test was not protecting the renderer from anything it cannot handle: what `SchemaRenderer` does with a primitive has been pinned since objectui#4548 (a non-empty string renders as its own text; `''` / `0` / `false` render nothing). The guard was discarding input the declaration promises to accept.

objectui#7105 (director seat, decision batch #69, 2026-09-07, maintainer 「其他同意」) settled the **identical shape** one slot over on `EmptySchema.action` as **relax the renderer, do not narrow the declaration**, and shipped it through the repo's permanent `toRenderableSchema` bridge. No coercion was invented here either.

## The change

One expression in `packages/components/src/renderers/complex/data-table.tsx`:

- the `typeof … === 'object'` clause is gone;
- the value goes through `toRenderableSchema`, the documented-PERMANENT bridge in `packages/react/src/schema-input.ts`;
- the truthiness leg **stays**, and the `&&` chain became a **ternary**.

Both of those last two are load-bearing, and together they make the slot behave exactly as handing the raw node to `SchemaRenderer` would — the docblock's own "one answer for malformed metadata, not a private one" rule, extended to the non-object members of the union.

## A second behaviour change ships with it, and it was measured, not assumed

With `emptyAction: 0` the old `&&` chain evaluated to the **number `0` itself**, which React renders — so a stray `"0"` appeared inside the empty state. That is the numeric-falsy JSX trap rather than a decision. It was found because a "renders nothing for the falsy primitives" case that was expected to be green on **both** sides came back **red on the unfixed guard**:

```
Expected: "NameNo results foundTry adjusting your filters or search query."
Received: "NameNo results foundTry adjusting your filters or search query.0"
```

The ternary yields `null` instead.

## Why the truthiness leg is kept rather than tidied into a nullish test

`toRenderableSchema` maps `number` / `boolean` onto their `String` form. That is behaviour-preserving for the **truthy** ones — it is what `SchemaRenderer`'s own defensive branch produces — but **not** for `0` / `false`, which `SchemaRenderer` returns `null` for at an earlier leg. Measured on this branch:

```
value=0      raw=""     bridged="0"      same=false
value=false  raw=""     bridged="false"  same=false
value=42     raw="42"   bridged="42"     same=true
value=true   raw="true" bridged="true"   same=true
```

Gating on truthiness keeps those two away from the bridge, so they keep the platform's answer instead of arriving as the text `"0"` and `"false"`. This is pinned, so a later tidy of the leg fails.

That measurement also falsifies the bridge docblock's own claim that it "changes no behaviour", which is why the shipped `empty` renderer prints a stray `"0"` for `action: 0`. That is **not** touched here — filed as **#8908**, unassigned.

## What did NOT change

The slot still mounts through `SchemaRenderer` rather than resolving the registry itself, so the single central `visibleWhen` gate still applies to an authored `emptyAction` exactly as before (objectui#5926 gap 1). **Its pin is the regression control for this PR and is green on both sides.**

## Verification

All readings quoted from the runner's own `VERDICT command-exit` line, at final commit `dbfebe786`.

**Discriminating power — the polarity flip is the evidence:**

| run | before the fix | after the fix |
|---|---|---|
| new `data-table-empty-action-primitive-node.test.tsx` | **`VERDICT command-exit 1`** — 2 failed / 8 passed | `VERDICT command-exit 0` |
| existing `data-table-empty-action-visible-when.test.tsx` (regression control) | **green** | **green** |
| objectui#4548 `SchemaRenderer.primitiveSchema.test.tsx` | green | green |
| combined, after | — | `VERDICT command-exit 0` — 3 files, **17 passed** |

**Package-level, after the fix:**

- `pnpm --filter @object-ui/components run test` → `VERDICT command-exit 0` — **253 files, 2322 tests passed**
- `pnpm --filter @object-ui/components run type-check` → `VERDICT command-exit 0` (`tsc --noEmit` **and** `tsc -p tsconfig.test.json`, so the new test is typechecked too)
- `pnpm --filter '@object-ui/components^...' run build` (dependency closure) → `VERDICT command-exit 0`
- `node scripts/check-control-bytes.mjs` → exit 0 · `node scripts/check-changeset-no-major.mjs` → exit 0
- `eslint` on both changed files → exit 0, **0 errors**; the 34 warnings are pre-existing and none land on an added line

Every heavy run went through the container's shared verify lock. The full farm is CI's.

## Changeset

`minor`, not `patch`. It is a behaviour change on a published surface — a node that renders nothing today starts rendering — and per AGENTS.md §版本号策略 this repo's fixed 39-package group **never** declares `major` (mechanically enforced by `scripts/check-changeset-no-major.mjs`), so `minor` is where a breaking-or-behavioural change lands here.

## Contract review

`Clause-②: yes`, declared by the dispatching seat on the card's claim comment with the #7105 precedent quoted verbatim. `needs:contract-review` is carried on both the card and this PR.

⚠️ This card **still owes its own tier review**. #7105 settles the *shape* of the answer and the fact that the bridge exists — it is **not** pre-authorisation for this one. If the reviewer judges the precedent non-transferable, that is **not** the implementing seat's call: it returns to the triage seat to produce a decision card.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH


---
_Generated by [Claude Code](https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH)_