### PR TITLE
docs(skills): author `object-kanban` / `object-gantt` in the page-builder guide — governed half split out of objectui#8865

### DIFF
--- a/skills/objectui/guides/page-builder.md
+++ b/skills/objectui/guides/page-builder.md
@@ -254,7 +254,7 @@ renderers do (`schema.objectName`, `schema.columns`, `schema.fields`,
 <!-- os:check -->
 ```json
 {
-  "type": "kanban",
+  "type": "object-kanban",
   "objectName": "tasks",
   "groupBy": "status",
   "bind": "tasks"
@@ -265,7 +265,7 @@ renderers do (`schema.objectName`, `schema.columns`, `schema.fields`,
 <!-- os:check -->
 ```json
 {
-  "type": "gantt",
+  "type": "object-gantt",
   "objectName": "project_task",
   "gantt": {
     "titleField": "name",


### PR DESCRIPTION
Refs objectui#8802
Refs objectui#8257
Refs objectui#8008

⛔ **This PR deliberately carries no closing keyword.** The three cards above belong to objectui#8865 and retire there, not here — this is the governed half that was split out of it, and it must not take those cards with it when a human merges it. They are referenced, never claimed.

## What this is

The single **governed-surface** file split out of objectui#8865 under the maintainer's ruling of 2026-09-09, **byte-identical**.

`skills/objectui/guides/page-builder.md` is on the published skills catalog — `GOVERNED_SURFACES` → `skills-catalog` in `scripts/check-governed-queue-guard.mjs`. One governed path governs a whole PR, with no proportion judgement, so as 1 file of 50 it made objectui#8865 un-landable by any agent seat while that PR held `packages/types/src/complex.ts`, `zod/complex.zod.ts` and `packages/plugin-kanban/**` against every other slice.

Splitting it lets the other **49** files take the normal queue path. This one waits for a human.

## The change

The guide's two `os:check`-marked JSON fences authored the **bare** `kanban` and `gantt` node type keys, which objectui#8865 retires — `kanban` becomes a named refusal, `gantt` loses its registration. They now author the surviving `object-kanban` and `object-gantt` spellings.

(The marker is an HTML comment. It is spelled here in words rather than literally because this repository's recorded body-sanitizer behaviour eats angle-bracket-shaped tokens out of stored PR bodies.)

⚠️ **This is the NODE TYPE KEY layer only.** The stored `NamedListView.type` value `"kanban"` is a *different* layer, written by `CreateViewDialog` and persisted in every tenant's database. It is **not** retired and is untouched here. Nothing in this diff should be read as licence to rewrite a stored view type.

## Byte-identity with objectui#8865 — the proof

The requirement was that the change move branches without its content changing. That is asserted by blob hash, not by eyeball:

| reading | value |
| --- | --- |
| blob of the path on objectui#8865's head `c695a1c8d` | `ac30a6e6c0efd7a58e217ccbcc351c7f7f73438c` |
| blob of the path at this branch's HEAD | `ac30a6e6c0efd7a58e217ccbcc351c7f7f73438c` |
| verdict | **EQUAL** |

The pre-image matches too, so the *diff* is identical and not merely the end state: this branch is based on `origin/main` `348725a7c`, where the path carries blob `6df13594df8dc6bd4abe2d0db491045eceb29b99` — the same blob it had at objectui#8865's merge-base `42df92809`. Main has not touched this file: **0** of the 159 files in the 20-commit base-to-main window are under `skills/`, against a control of **6** `content/docs/` paths in that same window, so the empty result is a reading rather than a filter that matched nothing.

## Skills line budget

Both required readings, plus the whole tree:

| reading | before | after | net |
| --- | --- | --- | --- |
| the changed file, whole-file | 331 | 331 | **0** |
| the package, every `SKILL.md` summed (1 file) | 137 | 137 | **0** |
| the whole `skills/` tree, 27 tracked files | 5,189 | 5,189 | **0** |

Two one-word type-literal corrections inside existing fences. ⛔ No new content, so no ratchet is spent.

## Accept sets — measured, and the reason this PR carries no `needs:contract-review`

The label goes on only if the change itself moves an accept set. Measured rather than assumed:

- The path is read by **no** code. A tree-wide grep for `page-builder` across `packages/`, `apps/`, `scripts/`, `examples/` returns 5 hits, and every one is unrelated: a `plugin-designer` `package.json` keyword, and `check-skill-eval-tokens` fixtures that write a *fixture* path `skills/fixture/guides/page-builder.md`. Control on the same instrument: `complex.zod` returns **172** hits, so the grep is live.
- The file declares no schema face: **0** `z.` schema constructors, **0** `registerComponent`, **0** `SchemaRegistry`.
- `check:skill-examples` **parses** marked JSON fences and explicitly does not validate them against `@object-ui/types`' schemas — its own docblock states this under "Deliberately NOT answered here".

⇒ The accept set is moved by objectui#8865's `complex.zod.ts`, which is on that PR and carries `needs:contract-review` there. This PR is a documentation guide and moves none, so ⛔ no `needs:contract-review` is hung here.

`node scripts/check-changeset-presence.mjs` exits **0**: "1 file(s) changed, 0 of them published source of a package the release covers … no changeset is owed."

## Verification

`check:skill-examples` is the only gate that reads this file's fences — `check-doc-component-types.mjs`, `check-doc-snippet-types.mjs`, `check-doc-links.mjs` and `check-doc-fence-languages.mjs` all exclude `skills/**` by construction. Three points on that one instrument, against a **built** tree:

| the file's content | gate exit | JSON phase |
| --- | --- | --- |
| bare `kanban` / `gantt` (this PR's pre-image) | **0** | 70 parsed, 0 failed |
| `object-kanban` / `object-gantt` (this PR's post-image) | **0** | 70 parsed, 0 failed |
| deliberately invalid JSON at the same fence | **1** | 70 parsed, **1 failed**, naming `page-builder.md:255` |

The third row is the firing control: it proves the two zeros are measurements of *these* fences and not a gate that skipped the file. The mutation was proven on disk before the gate was read (injected token 0 → 1; blob `6df13594d` → `f98e4541d`), restored by blob hash from a `trap … EXIT INT TERM`, never by an exit code.

Build-free gates on this branch: `check:skills-paths` **0**, `check:skill-eval-tokens` **0**, `check:doc-fences` **0**, `check-changeset-presence` **0**. Every exit code was captured into a variable before any pipe.

## Governed surface — how this PR lands

`node scripts/check-governed-queue-guard.mjs --test skills/objectui/guides/page-builder.md` → **GOVERNED**, exit 3. The paired control on the same probe: objectui#8865's remaining 49 paths return **NOT GOVERNED**, exit 0.

⇒ This PR stays **draft**. ⛔ Not flipped ready, ⛔ not enqueued, ⛔ no auto-merge, and ⛔ no approving review from any agent seat. **A human merge is itself the review record.**

## 维护者速读(草稿)

**改了什么** — 把 objectui#8865 里唯一一个受管面文件 `skills/objectui/guides/page-builder.md` 原封不动搬到这个独立 PR。改动本身只有两处:技能指南里两个 JSON 示例把已退休的 `kanban` / `gantt` 节点类型键改写成仍然存活的 `object-kanban` / `object-gantt`。整个 PR 一个文件、两行。

**为什么改** — 受管面 PR 只能由人类合并,agent 席位既不能合也不能批准。这一个文件卡在 50 个文件的 PR 里,等于把 `packages/types`、`plugin-kanban` 那 49 个文件一起扣住,谁也落不了地。拆开之后,那 49 个走正常队列,这一个单独等你合并,两边互不拖累。

**风险与代价(含回滚)** — 风险很低:这是一份给 AI 读的文档,没有任何代码引用它(实测 0 处),不声明任何 schema,不移动任何 accept set,因此不需要 changeset,也没挂 `needs:contract-review`。真正的代价是**顺序**:这个 PR 描述的是 objectui#8865 落地之后的世界。如果先合这个、objectui#8865 却迟迟不合,指南就会在一段时间里教一个当时还没生效的拼写(`object-kanban` 当下已经可用,所以只是提前,不是错误)。回滚就是 revert 这一个 commit,单文件两行,无依赖。

**席位意见** —

**你要做的** — 确认这两处拼写符合 kanban/gantt 退休的裁决方向,然后**由你来合并**这个 PR(席位不能合、也不能批准)。合并顺序上建议排在 objectui#8865 之后或与之相近。⚠️ 注意这个 PR 不带任何关单关键词,合并它**不会**关掉 objectui#8802 / objectui#8257 / objectui#8008 —— 那三张卡由 objectui#8865 关闭,这是有意为之。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_