### PR TITLE
test(console,plugin-detail): pin the five one-key record:* panel members, ceiling 46 -> 41 (objectui#8071 slice 6)

### DIFF
--- a/.changeset/record-panel-member-pins-8071.md
+++ b/.changeset/record-panel-member-pins-8071.md
@@ -1,0 +1,21 @@
+---
+---
+
+Test-only change (objectui#8071, sixth declared slice). Registers per-block
+member pins for the five `record:*` detail-panel blocks that each carried
+exactly ONE unpinned array/object key — `record:activity.types`,
+`record:alert.action`, `record:chatter.feed`, `record:discussion.feed` and
+`record:path.stages` — deletes their five `MEMBER_PIN_EXEMPTIONS` entries and
+lowers `MEMBER_PIN_EXEMPTION_CEILING` 46 -> 41 in the same commit. All five
+blocks now carry zero exemptions; this is the first slice to close more than one
+block.
+
+`record:chatter.feed` and `record:discussion.feed` are one key on one renderer
+(`RecordChatterRenderer` is registered under both names against the same
+`CHATTER_INPUTS`), so both rows point at a single file that runs every case
+against both names. `record:activity.types` PROMOTES the pre-existing
+`recordActivityFeed.test.ts`, read end to end before being credited; the other
+three files are new.
+
+Every touched file is a `__tests__` file; no published runtime source, no
+`package.json` publish-contract field, no behaviour change.

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -2273,6 +2273,14 @@ const MEMBER_PINS: Record<string, MemberPin> = {
     file: 'apps/console/src/__tests__/component-input-union-specimens.test.ts',
     pins: 'The `object` arm is the inline translation map, with a non-matching control (objectui#3832).',
   },
+  'record:activity.types': {
+    file: 'packages/plugin-detail/src/renderers/__tests__/recordActivityFeed.test.ts',
+    pins: 'The allow-list\'s MEMBERS, asserted on `applyFeedConfig` — the call `record-activity.tsx` makes on every render — rather than through a DOM: each entry must name a `FeedItemType` the spec declares (the vocabulary is read from `@objectstack/spec`, never re-typed), a recognised list narrows the timeline to exactly those kinds, and the three ways a list can fail to name anything are kept APART from "no filter at all" (objectui#5841): `types: []`, an all-unrecognised list, and a non-array `types: \'comment\'` each render an EMPTY timeline, while an omitted `types` renders every kind. A mixed list keeps the recognised members and drops the rest. Both diagnostic channels are asserted in both directions with controls that a well-formed filter stays silent — including the objectui#5877 channel for a declared kind no producer emits, whose populations are derived from the producers rather than hand-listed. Pre-existing file, promoted to a pin here after being read end to end (objectui#8071 slice 6).',
+  },
+  'record:alert.action': {
+    file: 'packages/plugin-detail/src/renderers/__tests__/recordAlertActionMembers-8071.test.tsx',
+    pins: 'The CTA member object `{ actionName, label?, variant? }`, read through the real renderer with only `useMetadataItem` doubled. `actionName` is a REFERENCE resolved against the object metadata `actions[]`, so a name resolving to nothing renders NO button rather than an inert one — controlled by emptying `actions[]`, and by declaring a second action to show the named one is what dispatches. `label` OVERRIDES the resolved `ActionDef.label`, falls back to it and then to the action NAME, and accepts an inline translation map resolved to the session language (controlled against the same map under a second language). `variant` reaches the button\'s paint and OUTRANKS the severity-derived default, pinned on the discriminating case where the two disagree — an `error` banner with an authored `variant` (objectui#8071 slice 6).',
+  },
   'record:alert.body': {
     file: 'apps/console/src/__tests__/component-input-union-specimens.test.ts',
     pins: 'The `object` arm is the inline translation map, with a non-matching control (objectui#3832).',
@@ -2280,6 +2288,10 @@ const MEMBER_PINS: Record<string, MemberPin> = {
   'record:alert.title': {
     file: 'apps/console/src/__tests__/component-input-union-specimens.test.ts',
     pins: 'The `object` arm is the inline translation map, with a non-matching control (objectui#3832).',
+  },
+  'record:chatter.feed': {
+    file: 'packages/plugin-detail/src/renderers/__tests__/recordChatterFeedMembers-8071.test.tsx',
+    pins: 'The nested activity-feed config\'s MEMBERS, and the fact that authoring the object REPLACES rather than merges. `record-chatter.tsx` composes `{ position, collapsible, feed: DEFAULTS, ...schema }` — a shallow spread — so an authored `feed` displaces the renderer\'s three defaults wholesale and every member not restated falls back to `RecordActivityTimeline`\'s own default. Those defaults are NOT uniform, which is the trap this pin exists for and is asserted per member: `showCommentInput` is `!== false` (ON when absent) while `enableReactions` and `enableThreading` are `?? false` (OFF), so `feed: {}` silently takes reactions and threading down while leaving the composer up. Each of the three carries its own observable — composer placeholder, the `Add reaction` affordance, and whether a reply is pulled out of the ROOT row list — each with the absent-`feed` control (objectui#8071 slice 6).',
   },
   'record:details.fields': {
     file: 'packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts',
@@ -2293,9 +2305,17 @@ const MEMBER_PINS: Record<string, MemberPin> = {
     file: 'packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts',
     pins: 'Members are OBJECTS: every spec member key must be discoverable from the description, the retired section-id spelling must be ruled out by name, and the three renderer-only keys the spec refuses (`title`, `showBorder`, `hideEmpty`) may not be taught — filtered through the spec at runtime so a stale prohibition drops out on its own (objectui#3807).',
   },
+  'record:discussion.feed': {
+    file: 'packages/plugin-detail/src/renderers/__tests__/recordChatterFeedMembers-8071.test.tsx',
+    pins: 'The same key on the same renderer under its other registered name — `record:chatter` and `record:discussion` are one `RecordChatterRenderer` sharing `CHATTER_INPUTS`, so both rows point at the one file, which runs every case against BOTH names. See `record:chatter.feed` for what it constrains (objectui#8071 slice 6).',
+  },
   'record:highlights.fields': {
     file: 'packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts',
     pins: 'Members are objects carrying `readonly` PER ENTRY — asserted to be per-entry rather than top-level, and every spec entry key must be discoverable from the `fields` description (objectui#3407).',
+  },
+  'record:path.stages': {
+    file: 'packages/plugin-detail/src/renderers/__tests__/recordPathStagesMembers-8071.test.tsx',
+    pins: 'The stage member set `{ value, label, terminal? }`, read through the real renderer. `value` is stage IDENTITY — compared against the record\'s `statusField` to choose the current stage, controlled by moving the RECORD rather than the array, by an unmatched value leaving NO stage current, and by a record carrying some stage\'s LABEL still matching nothing. `label` is the rendered text and the `value` behind it never appears. `terminal` OUTRANKS the `WON_TOKENS`/`LOST_TOKENS` heuristic, pinned only on fixtures where the member CONTRADICTS the heuristic and each paired with the identical stage minus `terminal` to show which way the heuristic was pointing, plus an unclassified control. Deliberately the DESKTOP row only: `record-path.crossRowClassification.test.tsx` owns the cross-row agreement invariant, which is a different claim (objectui#8071 slice 6).',
   },
   'record:quick_actions.actionNames': {
     file: 'packages/plugin-detail/src/__tests__/recordQuickActionsInputs.actionNamesFallback.test.tsx',
@@ -2486,20 +2506,18 @@ const MEMBER_PIN_EXEMPTIONS: Record<string, string> = {
   // page:tabs
   'page:tabs.items': AWAITING_A_PIN,
 
-  // record:activity
-  'record:activity.types': AWAITING_A_PIN,
+  // record:activity — objectui#8071 slice 6 pinned `types`, the block's one
+  // remaining key; fully pinned, header kept as a landmark for a future grep.
 
-  // record:alert
-  'record:alert.action': AWAITING_A_PIN,
+  // record:alert — objectui#8071 slice 6 pinned `action`, joining the `title`
+  // and `body` pins this block already carried; fully pinned.
 
-  // record:chatter
-  'record:chatter.feed': AWAITING_A_PIN,
+  // record:chatter / record:discussion — ONE renderer under two names, so
+  // objectui#8071 slice 6 pinned both `feed` keys in one file; both fully
+  // pinned.
 
-  // record:discussion
-  'record:discussion.feed': AWAITING_A_PIN,
-
-  // record:path
-  'record:path.stages': AWAITING_A_PIN,
+  // record:path — objectui#8071 slice 6 pinned `stages`, the block's one
+  // remaining key; fully pinned.
 
   // record:quick_actions — objectui#8071 slice 4 pinned both remaining keys
   // (`actionNames`, `requiredPermissions`); the block is now fully pinned and
@@ -2679,11 +2697,54 @@ const NEWLY_JUDGED_UNPINNED_MEMBERS = [
  * resolution, or the object-vs-flat precedence — so it is a new file,
  * `objectCalendarConfigMembers-8071.test.tsx`.
  *
+ * ## 46 -> 41, the sixth slice, and FIVE whole blocks closed at once
+ *
+ * objectui#8071's sixth slice took the five `record:*` detail-panel blocks that
+ * each carried exactly ONE unpinned key — `record:activity.types`,
+ * `record:alert.action`, `record:chatter.feed`, `record:discussion.feed` and
+ * `record:path.stages` — and pinned all five, so the ceiling follows to 41 in
+ * the same commit. Every one of the five blocks now carries zero exemptions,
+ * the shape `element:record_picker` (slice 3), `record:quick_actions` (slice 4)
+ * and `object-calendar` (slice 5) each closed in; this slice is the first to
+ * close more than one block, and the batch is coherent rather than opportunistic
+ * — one package (`packages/plugin-detail`), one family, and the selection rule
+ * is stateable in a sentence (every block whose remainder was exactly one key).
+ *
+ * `record:chatter.feed` and `record:discussion.feed` are ONE key on ONE
+ * renderer: the console registers `RecordChatterRenderer` under both names
+ * against the same `CHATTER_INPUTS`, so both rows point at one file that runs
+ * every case against both names — the shape slice 3 used for
+ * `record-picker-label-placeholder-i18n.test.tsx`, which covered `label` and
+ * `placeholder` together.
+ *
+ * One of the five PROMOTES a pre-existing file: `recordActivityFeed.test.ts`
+ * for `record:activity.types`, read end to end before being credited rather
+ * than trusted on its greps — it already asserts the allow-list's member
+ * semantics directly on `applyFeedConfig` (the call the renderer makes on every
+ * render), including objectui#5841's three distinct ways an authored list can
+ * name nothing and why none of them is "no filter". The other three files are
+ * new: the six existing `record:path` suites all use `stages[]` as a FIXTURE
+ * for a different subject (accessible names, the container label, the readout's
+ * inertness, cross-row agreement) and none would fail if `value`, `label` and
+ * `terminal` swapped roles; the six `record:alert` suites reference `action`
+ * only inside a props bag whose subject is `resultDialog` or the `visible`
+ * predicate; and the one `record:chatter` suite is about the host's `loading`
+ * signal and never authors `feed` at all.
+ *
+ * ⚠️ The `feed` pin records a LIMIT rather than pretending the key is uniform:
+ * `config.feed` reaches `RecordActivityTimeline`, which reads the five
+ * AFFORDANCE members only. `record:activity`'s FILTER members (`types`,
+ * `limit`, `showCompleted`, `unifiedTimeline`) are applied by `applyFeedConfig`,
+ * which only `record-activity.tsx` calls — so they are inert nested inside
+ * `feed`, even though the registration describes it as "same shape as
+ * record:activity". That is a contract defect rather than a member shape, so it
+ * is filed (objectui#8934) rather than frozen into the pin.
+ *
  * ⇒ The rule for every future slice of objectui#8071: delete the entry, register
  * the pin, and set this constant to the new count. Not to the new count plus
  * room.
  */
-const MEMBER_PIN_EXEMPTION_CEILING = 46;
+const MEMBER_PIN_EXEMPTION_CEILING = 41;
 
 /**
  * Every test file a member pin can live in, as LAZY `?raw` loaders.

--- a/packages/plugin-detail/src/renderers/__tests__/recordAlertActionMembers-8071.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/recordAlertActionMembers-8071.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * ══════════════════════════════════════════════════════════════════════════
+ * `record:alert.action` — the CTA's MEMBER shape (objectui#8071)
+ * ══════════════════════════════════════════════════════════════════════════
+ *
+ * The per-block member pin objectui#8068 asks for on this key. `action` is
+ * declared as a bare `type: 'object'` whose member set lives only in the
+ * registration's description — `{ actionName, label?, variant? }` — and until
+ * this file nothing asserted which of those three `record-alert.tsx` reads or
+ * what each one decides.
+ *
+ * ## Why the existing `record:alert` suites are not this pin
+ *
+ * All six were read end to end before this file was written rather than
+ * credited on a grep. `record-alert.resultDialog.test.tsx` mounts
+ * `action: { actionName, label }` and is nonetheless about something else
+ * entirely: whether `ActionRunner.handlePostExecution` honours the ACTION
+ * DEFINITION's `resultDialog` through the ambient provider. It would stay green
+ * if `label` were ignored, if `variant` did not exist, and if an unresolvable
+ * `actionName` rendered a button anyway. `rowBinding` and
+ * `degenerateProperties` reference `action` only as part of a props bag whose
+ * subject is the `visible` predicate's row and the `properties` envelope;
+ * `severityIcons`, `loadingFrameDiagnostic` and `visibleWhen.evidence` never
+ * touch it. So this is a new file rather than a promotion.
+ *
+ * ## What is pinned, member by member
+ *
+ *   • `actionName` — the CTA's IDENTITY. It is resolved against the OBJECT's
+ *     metadata `actions[]`, so it is a reference and not a definition: a name
+ *     that resolves to nothing renders NO button rather than an inert one.
+ *   • `label` — an OVERRIDE over the resolved `ActionDef.label`, resolved
+ *     through `pickLocalized` so an inline translation map works. Falls back
+ *     to the ActionDef's own label, then to its name.
+ *   • `variant` — reaches the button and OUTRANKS the severity-derived default
+ *     (`error` -> destructive, everything else -> default).
+ *
+ * ## Doubles, and what is deliberately NOT doubled
+ *
+ * Only `useMetadataItem` is stubbed — the one fetch behind the CTA — matching
+ * the surgical posture of the sibling `record-alert.resultDialog` suite. The
+ * resolution (`objectMeta.actions.find`), the label ladder, the variant choice
+ * and the dispatch are the real shipped code.
+ *
+ * ## Resolution
+ *
+ * Nothing resolves through any `dist/`: `../record-alert` is this package's own
+ * source and `@object-ui/react` / `@object-ui/i18n` are mapped to their `src`
+ * by the root `vitest.config.mts` alias table, so an ablation of
+ * `record-alert.tsx` is visible here without a rebuild.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+const primarySpy = vi.fn();
+const neighbourSpy = vi.fn();
+
+/** The action the CTA names. Its own label is what an absent `label` falls back to. */
+const PRIMARY_ACTION = {
+  name: 'verify_email',
+  label: 'Verify email address',
+  onClick: primarySpy,
+};
+
+/** A second declared action, so "the right one fired" is a real question. */
+const NEIGHBOUR_ACTION = {
+  name: 'resend_invite',
+  label: 'Resend invite',
+  onClick: neighbourSpy,
+};
+
+/** Declared with NO label of its own — the bottom rung of the label ladder. */
+const UNLABELLED_ACTION = {
+  name: 'rotate_api_key',
+  onClick: vi.fn(),
+};
+
+const stub = { metadataItem: undefined as any };
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/react')>();
+  return {
+    ...actual,
+    useMetadataItem: (_type: string, _name: string | null) => ({ item: stub.metadataItem }),
+  };
+});
+
+import { RecordAlertRenderer } from '../record-alert';
+import { RecordContextProvider } from '@object-ui/react';
+import { I18nProvider } from '@object-ui/i18n';
+
+type ActionMember = { actionName?: unknown; label?: unknown; variant?: unknown };
+
+function mount(action: ActionMember | undefined, severity = 'warning', language = 'en') {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      <RecordContextProvider objectName="sys_user" recordId="u1" data={{ id: 'u1' }}>
+        <RecordAlertRenderer
+          schema={{ properties: { title: 'Account security', severity, action } } as any}
+        />
+      </RecordContextProvider>
+    </I18nProvider>,
+  );
+}
+
+/** The CTA is the only button in the banner unless `dismissible` is authored. */
+const cta = (): HTMLElement | null => screen.queryByRole('button');
+
+beforeEach(() => {
+  stub.metadataItem = { actions: [PRIMARY_ACTION, NEIGHBOUR_ACTION, UNLABELLED_ACTION] };
+  primarySpy.mockClear();
+  neighbourSpy.mockClear();
+  cleanup();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('`record:alert.action` member `actionName` is a REFERENCE, not a definition (objectui#8071)', () => {
+  it('resolves against the object metadata `actions[]` and renders that CTA', () => {
+    mount({ actionName: 'verify_email' });
+    expect(cta()).toHaveTextContent('Verify email address');
+  });
+
+  it('an `actionName` that resolves to NOTHING renders no button at all', () => {
+    // The member is looked up, not trusted: an author's typo produces no CTA
+    // rather than a button that cannot do anything when pressed.
+    mount({ actionName: 'verify_emial' });
+    expect(cta()).toBeNull();
+    // …and the banner itself still renders, so "no button" is not "no banner".
+    expect(screen.getByText('Account security')).toBeTruthy();
+  });
+
+  it('CONTROL — with the metadata EMPTIED, even a correct name renders no CTA', () => {
+    // Proves the resolution really runs against `actions[]`. Without this,
+    // "a typo renders nothing" is satisfiable by a renderer that never draws
+    // a CTA in this harness at all.
+    stub.metadataItem = { actions: [] };
+    mount({ actionName: 'verify_email' });
+    expect(cta()).toBeNull();
+  });
+
+  it('omitting the whole `action` member renders no CTA', () => {
+    mount(undefined);
+    expect(cta()).toBeNull();
+    expect(screen.getByText('Account security')).toBeTruthy();
+  });
+
+  it('dispatches the action it NAMES, not a neighbouring declared one', () => {
+    // Identity, the half a presence check cannot see: two actions are declared
+    // and exactly one must fire.
+    mount({ actionName: 'verify_email' });
+    fireEvent.click(cta() as HTMLElement);
+    expect(primarySpy).toHaveBeenCalledTimes(1);
+    expect(neighbourSpy).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL — naming the OTHER action fires the other spy', () => {
+    // The mirror, so the leg above is not satisfied by "the first spy always wins".
+    mount({ actionName: 'resend_invite' });
+    fireEvent.click(cta() as HTMLElement);
+    expect(neighbourSpy).toHaveBeenCalledTimes(1);
+    expect(primarySpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('`record:alert.action` member `label` OVERRIDES the resolved action label (objectui#8071)', () => {
+  it('an authored `label` wins over the ActionDef\'s own label', () => {
+    mount({ actionName: 'verify_email', label: 'Confirm your address' });
+    expect(cta()).toHaveTextContent('Confirm your address');
+    expect(cta()).not.toHaveTextContent('Verify email address');
+  });
+
+  it('CONTROL — omitting `label` falls back to the ActionDef\'s own label', () => {
+    // What makes the override a measurement: the fallback really is a
+    // different string, so the leg above could not have read it.
+    mount({ actionName: 'verify_email' });
+    expect(cta()).toHaveTextContent('Verify email address');
+  });
+
+  it('falls back to the action NAME when neither the member nor the ActionDef has a label', () => {
+    // The bottom rung of the ladder, which no other suite reaches.
+    mount({ actionName: 'rotate_api_key' });
+    expect(cta()).toHaveTextContent('rotate_api_key');
+  });
+
+  it('an inline translation map is resolved to the session language', () => {
+    // `label` goes through `pickLocalized`, the same resolution `title` and
+    // `body` get — so the member accepts `{ en, 'zh-CN' }`, not only a string.
+    mount({ actionName: 'verify_email', label: { en: 'Verify now', 'zh-CN': '立即验证' } });
+    expect(cta()).toHaveTextContent('Verify now');
+  });
+
+  it('CONTROL — the SAME map under a different language resolves to the other entry', () => {
+    // Without this, "Verify now" is satisfiable by a renderer that prints
+    // whichever entry happens to be first.
+    mount({ actionName: 'verify_email', label: { en: 'Verify now', 'zh-CN': '立即验证' } }, 'warning', 'zh-CN');
+    expect(cta()).toHaveTextContent('立即验证');
+  });
+});
+
+describe('`record:alert.action` member `variant` OUTRANKS the severity default (objectui#8071)', () => {
+  // The variant reaches the DOM as the cva class the button is painted with,
+  // the same observable `HistoryTimeline.test.tsx` reads for this design system.
+  const classOf = () => (cta() as HTMLElement).className;
+
+  it('an authored `variant` paints the button with it', () => {
+    mount({ actionName: 'verify_email', variant: 'secondary' });
+    expect(classOf()).toContain('bg-secondary');
+  });
+
+  it('CONTROL — with no `variant`, a non-error banner takes the default paint', () => {
+    mount({ actionName: 'verify_email' });
+    expect(classOf()).toContain('bg-primary');
+    expect(classOf()).not.toContain('bg-secondary');
+  });
+
+  it('CONTROL — with no `variant`, an ERROR banner derives `destructive`', () => {
+    // The severity-derived default this member has to outrank, pinned first so
+    // the outranking leg below has something to be measured against.
+    mount({ actionName: 'verify_email' }, 'error');
+    expect(classOf()).toContain('bg-destructive');
+  });
+
+  it('the member beats the severity default — `error` + an authored `variant`', () => {
+    // The discriminating case for the whole describe: the two sources of a
+    // variant disagree, and the authored member is the one that wins.
+    mount({ actionName: 'verify_email', variant: 'secondary' }, 'error');
+    expect(classOf()).toContain('bg-secondary');
+    expect(classOf()).not.toContain('bg-destructive');
+  });
+});

--- a/packages/plugin-detail/src/renderers/__tests__/recordChatterFeedMembers-8071.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/recordChatterFeedMembers-8071.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * ══════════════════════════════════════════════════════════════════════════
+ * `record:chatter.feed` / `record:discussion.feed` — the nested config's
+ * MEMBER shape, and the fact that authoring it REPLACES (objectui#8071)
+ * ══════════════════════════════════════════════════════════════════════════
+ *
+ * The per-block member pin objectui#8068 asks for on these two keys. They are
+ * ONE key on ONE renderer: `record:chatter` and `record:discussion` are the
+ * same `RecordChatterRenderer` registered under two names against the same
+ * `CHATTER_INPUTS`, so one file pins both — the shape
+ * `record-picker-label-placeholder-i18n.test.tsx` already set for a pair of
+ * keys covered by a single mechanism (objectui#8071 slice 3).
+ *
+ * `feed` is declared a bare `type: 'object'` — "Activity-feed config nested
+ * inside the panel". The only prior coverage, `record-chatter.loading.test.tsx`
+ * (read end to end before this file was written), is about the host's `loading`
+ * signal reaching the panel and never authors `feed` at all.
+ *
+ * ## The member fact that matters most: authoring `feed` REPLACES it
+ *
+ * `record-chatter.tsx` composes its config as
+ *
+ *     { position, collapsible, feed: {DEFAULTS}, ...(schema) }
+ *
+ * — a SHALLOW spread. So an authored `feed` does not merge with the renderer's
+ * three defaults (`enableReactions` / `enableThreading` / `showCommentInput`,
+ * all true), it displaces them wholesale, and every member the author did not
+ * restate falls back to `RecordActivityTimeline`'s own `?? false`. An author
+ * who writes `feed: { showCommentInput: true }` meaning "and keep the rest"
+ * turns reactions and threading OFF. That is the whole reason this key needs a
+ * member pin rather than a presence check, and it is asserted below in both
+ * directions rather than described here.
+ *
+ * ## LIMIT — which members of `feed` are live on THIS path
+ *
+ * Stated rather than assumed, because the registration's description ("same
+ * shape as record:activity") reads wider than the read site is. `config.feed`
+ * is handed straight to `RecordActivityTimeline`, which reads exactly the five
+ * AFFORDANCE members (`showFilterToggle`, `showCommentInput`, `enableReactions`,
+ * `enableThreading`, `showSubscriptionToggle`). The FILTER members of
+ * `record:activity` (`types` / `limit` / `showCompleted` / `unifiedTimeline`)
+ * are applied by `applyFeedConfig`, which only `record-activity.tsx` calls —
+ * so they do nothing nested inside `feed` (filed as objectui#8934). This file pins the live members and
+ * does NOT pin the inert ones: "this member is dead" is a claim about a
+ * contract defect, which objectui#8071 slice 6 filed separately rather than
+ * freezing here.
+ *
+ * ## Resolution
+ *
+ * Nothing resolves through any `dist/`: `../record-chatter` is this package's
+ * own source and `@object-ui/react` is mapped to its `src` by the root
+ * `vitest.config.mts` alias table, so an ablation of `record-chatter.tsx` is
+ * visible here without a rebuild.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { DiscussionContextProvider } from '@object-ui/react';
+import type { FeedItem } from '@object-ui/types';
+import { RecordChatterRenderer } from '../record-chatter';
+
+/** The composer's placeholder in the `en` pack — `showCommentInput`'s observable. */
+const COMPOSER = /Leave a comment/;
+/** The empty-state reaction button's accessible name — `enableReactions`'s observable. */
+const ADD_REACTION = 'Add reaction';
+
+/** A root comment plus a REPLY to it: `enableThreading`'s observable is whether
+ *  the reply is pulled out of the root list and under its parent. */
+const ITEMS: FeedItem[] = [
+  { id: 'c-1', type: 'comment', actor: 'Ada', body: 'Root comment', createdAt: '2026-01-02T00:00:00.000Z' },
+  { id: 'c-2', type: 'comment', actor: 'Grace', body: 'A threaded reply', parentId: 'c-1', createdAt: '2026-01-03T00:00:00.000Z' },
+];
+
+const handlers = {
+  onAddComment: vi.fn(),
+  onAddReply: vi.fn(),
+  onToggleReaction: vi.fn(),
+};
+
+/** Both registered names resolve to this one renderer — every case runs on both. */
+const BLOCK_NAMES = ['record:chatter', 'record:discussion'] as const;
+
+function mount(feed: unknown, opts: { authored?: boolean } = {}) {
+  const schema: Record<string, unknown> = { position: 'bottom' };
+  if (opts.authored !== false) schema.feed = feed;
+  return render(
+    <DiscussionContextProvider items={ITEMS as any} loading={false} {...handlers}>
+      <RecordChatterRenderer schema={schema as any} />
+    </DiscussionContextProvider>,
+  );
+}
+
+/** Root-level feed rows, i.e. bodies rendered outside a threaded reply block. */
+const rootBodies = () => screen.queryAllByText(/Root comment|A threaded reply/).map((el) => el.textContent);
+
+beforeEach(() => {
+  cleanup();
+  handlers.onAddComment.mockClear();
+  handlers.onAddReply.mockClear();
+  handlers.onToggleReaction.mockClear();
+});
+
+describe.each(BLOCK_NAMES)('%s `feed` members reach the timeline (objectui#8071)', (blockName) => {
+  it(`${blockName}: with NO \`feed\` authored, the renderer's three defaults are in force`, () => {
+    // The baseline the displacement case below is measured against: reactions
+    // and the composer are ON without the author writing anything.
+    mount(undefined, { authored: false });
+    expect(screen.getByPlaceholderText(COMPOSER)).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: ADD_REACTION }).length).toBeGreaterThan(0);
+  });
+
+  it(`${blockName}: \`showCommentInput: false\` withholds the composer`, () => {
+    mount({ showCommentInput: false, enableReactions: true, enableThreading: false });
+    expect(screen.queryByPlaceholderText(COMPOSER)).toBeNull();
+    // CONTROL — the panel still rendered, so "no composer" is not "no panel".
+    expect(screen.getByText('Root comment')).toBeTruthy();
+  });
+
+  it(`${blockName}: \`enableReactions: false\` withholds the reaction affordance`, () => {
+    mount({ showCommentInput: true, enableReactions: false, enableThreading: false });
+    expect(screen.queryAllByRole('button', { name: ADD_REACTION })).toHaveLength(0);
+    expect(screen.getByPlaceholderText(COMPOSER)).toBeTruthy();
+  });
+
+  it(`${blockName}: \`enableThreading\` decides whether a reply is a ROOT row`, () => {
+    // The member with a structural effect rather than an affordance one: with
+    // threading ON the reply is grouped under its parent and leaves the root
+    // list; with it OFF the same item is rendered as another top-level row.
+    mount({ showCommentInput: false, enableReactions: false, enableThreading: true });
+    expect(rootBodies()).toEqual(['Root comment']);
+
+    cleanup();
+    mount({ showCommentInput: false, enableReactions: false, enableThreading: false });
+    expect(rootBodies()).toEqual(['Root comment', 'A threaded reply']);
+  });
+});
+
+describe('an authored `feed` REPLACES the defaults rather than merging (objectui#8071)', () => {
+  // The shallow-spread consequence, and the reason this key earns a member pin.
+  it.each(BLOCK_NAMES)('%s: restating ONE member drops the other two defaults', (_blockName) => {
+    mount({ showCommentInput: true });
+    // The member the author restated is honoured…
+    expect(screen.getByPlaceholderText(COMPOSER)).toBeTruthy();
+    // …and the two they did not are NOT inherited from the renderer's default
+    // `feed`, because the whole object was displaced.
+    expect(screen.queryAllByRole('button', { name: ADD_REACTION })).toHaveLength(0);
+    expect(rootBodies()).toEqual(['Root comment', 'A threaded reply']);
+  });
+
+  it.each(BLOCK_NAMES)('%s: CONTROL — the SAME three affordances are on when `feed` is absent', (_blockName) => {
+    // Without this control the case above is satisfiable by a renderer in which
+    // reactions and threading are simply never on in this harness.
+    mount(undefined, { authored: false });
+    expect(screen.getByPlaceholderText(COMPOSER)).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: ADD_REACTION }).length).toBeGreaterThan(0);
+    expect(rootBodies()).toEqual(['Root comment']);
+  });
+
+  it.each(BLOCK_NAMES)('%s: an EMPTY `feed` displaces all three, and they land DIFFERENTLY', (_blockName) => {
+    // `feed: {}` is an authored object, so the spread replaces the renderer's
+    // defaults with nothing. What each member then falls back to is
+    // `RecordActivityTimeline`'s OWN default, and those are not uniform:
+    //
+    //   showCommentInput  `config?.showCommentInput !== false`  -> ON when absent
+    //   enableReactions   `config?.enableReactions ?? false`     -> OFF when absent
+    //   enableThreading   `config?.enableThreading ?? false`     -> OFF when absent
+    //
+    // So displacing the default `feed` silently turns reactions and threading
+    // off while leaving the composer up. Measured, not assumed: the first shape
+    // of this case asserted all three went off and went red on the composer.
+    // Pinned per member so the asymmetry cannot drift unnoticed in either
+    // direction — a future uniform `?? false` would take the composer down, and
+    // a future deep merge would bring all three back.
+    mount({});
+    expect(screen.getByPlaceholderText(COMPOSER)).toBeTruthy();
+    expect(screen.queryAllByRole('button', { name: ADD_REACTION })).toHaveLength(0);
+    expect(rootBodies()).toEqual(['Root comment', 'A threaded reply']);
+  });
+
+  it.each(BLOCK_NAMES)('%s: only an EXPLICIT `false` withholds the composer', (_blockName) => {
+    // The other side of that asymmetry, and the control that stops the case
+    // above from reading as "the composer ignores `feed` entirely".
+    mount({ showCommentInput: false });
+    expect(screen.queryByPlaceholderText(COMPOSER)).toBeNull();
+  });
+});

--- a/packages/plugin-detail/src/renderers/__tests__/recordPathStagesMembers-8071.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/recordPathStagesMembers-8071.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * ══════════════════════════════════════════════════════════════════════════
+ * `record:path.stages` — the MEMBER shape, not the row layout (objectui#8071)
+ * ══════════════════════════════════════════════════════════════════════════
+ *
+ * The per-block member pin objectui#8068 asks for on this key: `stages` is
+ * declared `type: 'array', of: 'object'` with the member set spelled only in
+ * its description (`[{ value, label }]`), and until this file nothing asserted
+ * WHICH members `record-path.tsx` reads or what each one decides.
+ *
+ * ## Why the existing `record:path` suites are not this pin
+ *
+ * Six of them mount `stages[]` and were read end to end before this file was
+ * written rather than credited on their fixtures: `stageStateAccessibleName`
+ * (+`.i18n`), `wonTerminusAccessibleName`, `containerLabel`, `inertReadout`
+ * and `crossRowClassification`. Every one uses `stages` as a FIXTURE for a
+ * different subject — an accessible name's composition, the container's label,
+ * the readout staying non-interactive, the two rows agreeing with each other.
+ * `crossRowClassification` comes closest and is still explicitly a CROSS-ROW
+ * invariant: it asserts desktop and mobile report the SAME classification, a
+ * property that holds just as well if both rows read the wrong member. None
+ * asserts the precedence below, and none would fail if `value`, `label` or
+ * `terminal` swapped roles. So this is a new file rather than a promotion.
+ *
+ * ## What is pinned, member by member
+ *
+ *   • `value`   — stage IDENTITY. It is compared against the record's
+ *                 `statusField` value to choose the current stage, and it is
+ *                 not what the user reads.
+ *   • `label`   — the stage's rendered TEXT, and only that.
+ *   • `terminal`— `'won' | 'lost'`, honoured BEFORE the label/value heuristic.
+ *
+ * Each leg carries the counter-probe that makes it a measurement. The
+ * `terminal` legs matter most: `classify()` tries `s.terminal` first and falls
+ * back to `WON_TOKENS` / `LOST_TOKENS` over `value + label`, so a fixture whose
+ * explicit `terminal` AGREES with what the heuristic would have guessed cannot
+ * tell the two apart. Both `terminal` cases below therefore CONTRADICT the
+ * heuristic, and each is paired with the identical stage minus `terminal` to
+ * show the heuristic really was pointing the other way.
+ *
+ * ## Resolution
+ *
+ * Nothing here resolves through any `dist/`: `../record-path` is this package's
+ * own source and `@object-ui/react` / `@object-ui/i18n` are mapped to their
+ * `src` by the root `vitest.config.mts` alias table. An ablation of
+ * `record-path.tsx` is visible to this suite without a rebuild.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, cleanup, within, type RenderResult } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
+import { RecordContextProvider } from '@object-ui/react';
+import { RecordPathRenderer } from '../record-path';
+
+type Stage = { value: string; label: string; terminal?: 'won' | 'lost' };
+
+function mount(stages: readonly Stage[], status: string | undefined = 'draft'): RenderResult {
+  return render(
+    <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false }}>
+      <RecordContextProvider objectName="crm_quote" recordId="q1" data={{ id: 'q1', status }}>
+        <RecordPathRenderer schema={{ statusField: 'status', stages } as never} />
+      </RecordContextProvider>
+    </I18nProvider>,
+  );
+}
+
+/**
+ * The DESKTOP row only. Both rows are in the DOM at once (they are separated by
+ * a CSS breakpoint jsdom does not apply) and `crossRowClassification` already
+ * owns the invariant that they agree — reading one row here keeps this file
+ * about the member shape instead of re-pinning that.
+ */
+const stagesOf = (r: RenderResult): HTMLElement[] => {
+  const row = r.container.querySelectorAll('[role="list"]')[0] as HTMLElement;
+  return within(row).getAllByRole('listitem');
+};
+
+const stateOf = (el: HTMLElement) => el.getAttribute('data-stage-state');
+const terminalOf = (el: HTMLElement) => el.getAttribute('data-stage-terminal');
+
+beforeEach(() => {
+  cleanup();
+});
+
+describe('`record:path.stages` member `value` is the stage IDENTITY (objectui#8071)', () => {
+  const STAGES: Stage[] = [
+    { value: 'draft', label: 'Drafting' },
+    { value: 'review', label: 'In review' },
+    { value: 'signed', label: 'Signed off' },
+  ];
+
+  it('the stage whose `value` equals the record\'s statusField is the current one', () => {
+    const items = stagesOf(mount(STAGES, 'review'));
+    expect(items.map(stateOf)).toEqual(['completed', 'current', 'upcoming']);
+  });
+
+  it('CONTROL — moving the RECORD, not the array, moves `current`', () => {
+    // Without this the leg above is satisfiable by "index 1 is always current".
+    // Same `stages[]`, a different record value, a different current stage.
+    expect(stagesOf(mount(STAGES, 'draft')).map(stateOf))
+      .toEqual(['current', 'upcoming', 'upcoming']);
+    expect(stagesOf(mount(STAGES, 'signed')).map(stateOf))
+      .toEqual(['completed', 'completed', 'current']);
+  });
+
+  it('a statusField value matching no `value` leaves NO stage current', () => {
+    // The member is matched, not merely counted: an unrecognised record value
+    // selects nothing rather than defaulting to the first stage.
+    const items = stagesOf(mount(STAGES, 'archived_elsewhere'));
+    expect(items.map(stateOf)).toEqual(['upcoming', 'upcoming', 'upcoming']);
+  });
+
+  it('`value` is matched, NOT `label` — the two are not interchangeable', () => {
+    // The discriminating fixture: the record carries a string that is some
+    // stage's LABEL. If the renderer matched on `label` this would go current.
+    const items = stagesOf(mount(STAGES, 'In review'));
+    expect(items.map(stateOf)).toEqual(['upcoming', 'upcoming', 'upcoming']);
+  });
+});
+
+describe('`record:path.stages` member `label` is the rendered TEXT (objectui#8071)', () => {
+  const STAGES: Stage[] = [
+    { value: 'stage_one_value', label: 'Qualification' },
+    { value: 'stage_two_value', label: 'Proposal' },
+  ];
+
+  it('renders every `label`, and never the `value` that carries it', () => {
+    const items = stagesOf(mount(STAGES, 'stage_one_value'));
+    expect(items.map((el) => el.textContent)).toEqual(['Qualification', 'Proposal']);
+    // The counter-probe: the values are deliberately distinguishable strings,
+    // so "the label is shown" cannot be satisfied by showing both.
+    for (const el of items) {
+      expect(el.textContent).not.toContain('stage_one_value');
+      expect(el.textContent).not.toContain('stage_two_value');
+    }
+  });
+
+  it('renders one listitem per member, in the authored order', () => {
+    // Non-vacuity for the whole file: an empty or dropped array would make
+    // every `toEqual([])` above pass on nothing.
+    expect(stagesOf(mount(STAGES, 'stage_one_value'))).toHaveLength(2);
+    // The record points at the FIRST member of the reversed array on purpose:
+    // a `completed` stage also renders a `\u2713` glyph inside its listitem, so a
+    // fixture with a completed stage would be asserting the checkmark here
+    // rather than the order. Nothing is completed in this arrangement.
+    const reversed = [...STAGES].reverse();
+    expect(stagesOf(mount(reversed, 'stage_two_value')).map((el) => el.textContent))
+      .toEqual(['Proposal', 'Qualification']);
+  });
+});
+
+describe('`record:path.stages` member `terminal` OUTRANKS the heuristic (objectui#8071)', () => {
+  // `WON_TOKENS` matches `完成`; `LOST_TOKENS` matches `失败`. Both fixtures
+  // below therefore set `terminal` to the OPPOSITE of what the tokens say, so a
+  // renderer that ignored the member would produce the other answer.
+  const WON_LABEL_MARKED_LOST: Stage[] = [
+    { value: 'draft', label: '草稿' },
+    { value: 'done', label: '完成', terminal: 'lost' },
+  ];
+  const LOST_LABEL_MARKED_WON: Stage[] = [
+    { value: 'draft', label: '草稿' },
+    { value: 'failed', label: '失败', terminal: 'won' },
+  ];
+
+  it('an explicit `terminal: \'lost\'` beats a label the WON heuristic matches', () => {
+    const items = stagesOf(mount(WON_LABEL_MARKED_LOST, 'draft'));
+    expect(terminalOf(items[1])).toBe('lost');
+  });
+
+  it('CONTROL — the same stage WITHOUT `terminal` is classified `won` by the label', () => {
+    // This is what makes the leg above a measurement rather than a coincidence:
+    // it shows the heuristic really was pointing at `won`, so `lost` could only
+    // have come from the member.
+    const withoutMember = WON_LABEL_MARKED_LOST.map(({ terminal: _terminal, ...rest }) => rest);
+    expect(terminalOf(stagesOf(mount(withoutMember, 'draft'))[1])).toBe('won');
+  });
+
+  it('an explicit `terminal: \'won\'` beats a label the LOST heuristic matches', () => {
+    const items = stagesOf(mount(LOST_LABEL_MARKED_WON, 'draft'));
+    expect(terminalOf(items[1])).toBe('won');
+  });
+
+  it('CONTROL — the same stage WITHOUT `terminal` is classified `lost` by the label', () => {
+    const withoutMember = LOST_LABEL_MARKED_WON.map(({ terminal: _terminal, ...rest }) => rest);
+    expect(terminalOf(stagesOf(mount(withoutMember, 'draft'))[1])).toBe('lost');
+  });
+
+  it('a stage with neither an explicit `terminal` nor a matching label is unclassified', () => {
+    // The third arm of `classify()`, and the control that stops "terminal is
+    // always set" from satisfying the four legs above.
+    const plain: Stage[] = [
+      { value: 'draft', label: 'Drafting' },
+      { value: 'review', label: 'In review' },
+    ];
+    expect(stagesOf(mount(plain, 'draft')).map(terminalOf)).toEqual([null, null]);
+  });
+});


### PR DESCRIPTION
**Refs #8071** — objectui#8071 slice 6. This card does **not** close: 41 member-pin exemptions remain.

Converts the five `record:*` detail-panel blocks that each carried exactly **one** unpinned array/object key into real per-block member pins, deletes their five `MEMBER_PIN_EXEMPTIONS` entries, and lowers `MEMBER_PIN_EXEMPTION_CEILING` **46 -> 41 in the same commit**.

| key | pin file | new or promoted |
| --- | --- | --- |
| `record:activity.types` | `recordActivityFeed.test.ts` | **promoted** |
| `record:alert.action` | `recordAlertActionMembers-8071.test.tsx` | new |
| `record:chatter.feed` | `recordChatterFeedMembers-8071.test.tsx` | new |
| `record:discussion.feed` | `recordChatterFeedMembers-8071.test.tsx` | new (same file, same renderer) |
| `record:path.stages` | `recordPathStagesMembers-8071.test.tsx` | new |

## Why this batch

Selection criterion 1 was "a block you can close **outright**". This batch closes **five** — the first slice to close more than one — and the batch is a stateable RULE rather than a pick: *every block whose remainder was exactly one key*. All five live in `packages/plugin-detail`, off every live branch.

`record:chatter.feed` and `record:discussion.feed` are one key on one renderer: `RecordChatterRenderer` is registered under both names against the same `CHATTER_INPUTS`, so both rows point at one file that runs **every case against both names** — the shape slice 3 used for `record-picker-label-placeholder-i18n.test.tsx`.

⛔ `object-kanban.columns` / `object-kanban.dataSource` were not touched: `NEWLY_JUDGED_UNPINNED_MEMBERS` is unchanged at 2 and `LAZY_REGISTERED_BLOCKS` needed no edit.

## Promotion discipline

`recordActivityFeed.test.ts` (955 lines) was **read end to end** before being credited, not trusted on its greps. It already asserts the allow-list's member semantics directly on `applyFeedConfig` — the call `record-activity.tsx` makes on every render — including objectui#5841's three distinct ways an authored list can name nothing (`types: []`, an all-unrecognised list, a non-array `types`) and why none of them means "no filter".

The other three are **new files** because every existing candidate was read and rejected: the six `record:path` suites use `stages[]` as a FIXTURE for accessible names / container label / inertness / cross-row agreement and none would fail if `value`, `label` and `terminal` swapped roles; the six `record:alert` suites reference `action` only inside a props bag whose subject is `resultDialog` or the `visible` predicate; the one `record:chatter` suite is about the host's `loading` signal and never authors `feed`.

## AST ledger — re-derived on this branch's own head, not inherited

`ts.createSourceFile` -> `VariableDeclaration` -> `PropertyAssignment`, object boundaries from **AST node spans**. ⛔ Not brace counting, ⛔ not a bare regex.

| | before (`bbe285ee7`) | after |
| --- | --- | --- |
| `MEMBER_PIN_EXEMPTIONS` | **46** | **41** |
| `MEMBER_PIN_EXEMPTION_CEILING` | **46** (`:2686`) | **41** (`:2747`) |
| `MEMBER_PINS` | 44 | 49 |
| `NEWLY_JUDGED_UNPINNED_MEMBERS` | 2 | 2 (untouched) |

**Cross-check, anchored on the KEY as instructed.** Key-anchored regex inside the AST span read **46** before and **41**/**49** after — agreeing with the AST in every case. The value-anchored form read **43**, disagreeing by 3, and the disagreement is reported rather than smoothed: `AWAITING_A_PIN\b` misses the one `NO_READ_SITE_TO_PIN` key AND the two `AWAITING_A_PIN_NEWLY_JUDGED` keys (`\b` does not match before `_`). Same trap slice 5 hit from a different angle.

Only **one** symbolic assertion carries this ceiling, as corrected at comment `5604719868`. No second one was hunted for and none was added.

## Verification — every exit code captured BEFORE any pipe (`cmd > out 2>&1; RC=$?`)

| run | exit | reading |
| --- | --- | --- |
| `vitest run apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` | **0** | 198 passed |
| `pnpm --filter @object-ui/plugin-detail lint` | **0** | `977 problems (0 errors, 977 warnings)` |
| `pnpm --filter @object-ui/console lint` | **0** | `212 problems (0 errors, 212 warnings)` |
| `type-check` (both packages) | **0** | zero `error TS`; plugin-detail also runs `tsc -p tsconfig.test.json`, so the new files are type-checked |
| `node scripts/check-control-bytes.mjs` | **0** | 7130 tracked text files scanned |
| `node scripts/check-changeset-no-major.mjs` | **0** | no `major` bump declared |
| `pnpm --filter @object-ui/plugin-detail test` | **0** | 158 files, **1457 passed** |
| `pnpm --filter @object-ui/console test` | **0** | 98 files, **1132 passed** |

⭐ **The lint step is the instrument slice 5 lacked**, and it was read for the word `error`, not merely for a zero exit: both packages report **0 errors**. Both logs echo the script name (`> @object-ui/console@17.6.0 lint`), which is what rules out the "filter matched zero scripts, exits 0, nothing ran" reading.

⚠️ The first `type-check` run exited **2** with ~200 `Cannot find module '@object-ui/…'` rows. That is **NOT MEASURED**, not red: the sibling packages were unbuilt, so `tsc` never reached its body. Re-run after `pnpm --filter 'PKG^...' build` (exit 0) it is a real 0.

## Ablations

Every one: mutate -> **prove the mutation on disk before reading any result** (grep counts on the removed and injected text, plus a `git hash-object` differing from the HEAD blob) -> run -> restore via `git checkout HEAD -- ABSOLUTE_PATH` from a `trap … EXIT INT TERM` -> **prove restoration by blob hash**, never by an exit code.

### A. The gate mechanism — re-add one deleted exemption, leave the ceiling alone

`registry-inputs-spec-parity.test.ts` `c5e76b6b…` -> `b338f228…` (injected-text 0 -> 1). **3 red, 195 green**, exactly:

- `carries no stale member-pin exemption — a pinned key must lose its entry`
- `judges a non-vacuous member-shape census — every covered block, every array/object input`
- `the member-pin exemption list only ratchets DOWN`

That third row is the one that proves the ceiling moved **with** the list: at a ceiling left on 46 it would have stayed green. Restored to `c5e76b6b…`.

### B. One ablation per new pin — each fails for **its own** reason

All four run the **whole set of four pin files**, so neighbour independence is visible rather than asserted.

| pin | mutation | blob | red | neighbours |
| --- | --- | --- | --- | --- |
| `record:path.stages` | drop `if (s.terminal) return s.terminal;` | `844c7441…` -> `ccfbd2bf…` | **2** — both `terminal` OUTRANKS legs. Their two CONTROLs stayed green, which is what shows the heuristic was pointing the other way | 3 files green |
| `record:alert.action` | ignore the authored `label` in the ladder | `a11b10f9…` -> `22410551…` | **3** — the override leg + both translation-map legs. The ActionDef and NAME fallback legs stayed green | 3 files green |
| `record:chatter.feed` / `.discussion.feed` | deep-merge `feed` instead of letting the spread displace it | `8292defa…` -> `39d8eb29…` | **4** — both displacement cases, under **both** registered names, so the `record:discussion.feed` row is non-vacuous in its own right. The explicit per-member legs stayed green | 3 files green |
| `record:activity.types` | restore objectui#5841: "nothing survived" reads as "no filter" | `5ab2ef32…` -> `5bb7827a…` | **4** — the three narrow-vs-widen legs + the distinguishing leg. `types` that is not a list at all stayed **green**, because that refusal returns from a different branch | 3 files green |

Every target restored to its HEAD blob, verified by hash **and** by an empty `git diff HEAD` for the path; `git status` is clean.

⚠️ Honest note on one instrument: `grep -cF` with a multi-line pattern treats the newline as an alternation, so it counts matching LINES, not occurrences of the whole block. For ablation A that reads `2 -> 0`, and for B3 — where the injected text is a superset of the removed text — the removed count stays `2 -> 2`. In both the load-bearing proof is the **blob hash change** plus the injected-text count, and the exact-occurrence check is a separate `str.count(...) == 1` assertion that aborts the run when it fails.

## Out-of-scope finding, filed not fixed

**objectui#8934** — `feed` is declared "same shape as record:activity", but only the five AFFORDANCE members reach `RecordActivityTimeline`. The FILTER members (`types`, `limit`, `showCompleted`, `unifiedTimeline`) are applied by `applyFeedConfig`, whose only non-test call site is `record-activity.tsx` — so they are silently discarded nested inside `feed`, with no diagnostic even for a correctly spelled value. Category (c): a trap that leads an author to write metadata the runtime drops. The pin records this as a stated LIMIT rather than freezing "this member is dead", which is the reasoning `NO_READ_SITE_TO_PIN` already carries for `record:related_list.actions`.

## Landing

⛔ Stays **draft**. The governed-surface guard reports `NOT GOVERNED — 5 path(s) checked … none matched`, so the ordinary self-merge route would apply, but this slice's dispatch reserves landing to the PM seat. No auto-merge, no enqueue, no ready flip.

Test-only: every touched file is a `__tests__` file plus one changeset. No published runtime source, no publish-contract field, no behaviour change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_