### PR TITLE
chore(deps): lucide-react 1.31.0 -> 1.43.0, with the one retired spelling repaired

### DIFF
--- a/.changeset/lucide-react-1-43-0-retired-trash2.md
+++ b/.changeset/lucide-react-1-43-0-retired-trash2.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/plugin-detail': patch
+'@object-ui/components': patch
+'@object-ui/types': patch
+'@object-ui/cli': patch
+---
+
+Move `lucide-react` from `^1.31.0` to `^1.43.0` and repair the one spelling the jump
+retires, so the delete affordances that resolve their icon from a STRING keep drawing a
+glyph.
+
+Measured against the installed artifact rather than the upstream changelog. Across the
+whole 1.31.0 to 1.43.0 jump lucide removes **zero** public names — 6072 to 6230 names in
+`lucide-react`'s type surface with none dropped, 6068 to 6224 runtime exports with none
+dropped, and nothing at all removed from `lucide-react/dynamic.mjs`. Every one of the 333
+value names and the one type name this repository imports resolves in both versions
+(controls: `Trash` resolves in both, a bogus name resolves in neither). So no import
+breaks and no type breaks.
+
+Exactly one key leaves the runtime `icons` record: `Trash2`. lucide retired it in favour
+of `trash`, and it survives as a DEPRECATED EXPORT of the same object — which is why
+nothing goes red on the compiler or on a component render, and only STRING lookups
+through `renderers/action/resolve-icon.ts` are affected, because those read record
+MEMBERSHIP. Repaired at all four sites that reach that resolver, three schema-catalog
+documents and `DetailView`'s system delete action.
+
+What a user sees change:
+
+- `DetailView`'s delete action (`icon: 'trash-2'` to `'trash'`) draws its icon again
+  instead of a label with nothing beside it. The glyph is unchanged: lucide 1.43.0's
+  `trash` icon node is byte-identical to 1.31.0's `trash-2` icon node.
+- Icons that lucide has since renamed now carry an extra class per retired alias — a
+  spinner renders `class="lucide lucide-loader-circle lucide-loader-2 ..."`. This is
+  additive (248 of 1818 icon modules carry an alias), so a `.lucide-loader-circle`
+  selector still matches; a selector asserting the exact, complete class string does not.
+- The workspace stops installing two copies of the icon library. `main` resolves
+  `lucide-react` twice — 1.31.0 for this workspace and 1.35.0 for `fumadocs-ui` — and
+  both collapse onto 1.43.0 here.

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -105,7 +105,7 @@
     "@vitest/ui": "^4.1.10",
     "autoprefixer": "^10.5.4",
     "happy-dom": "^20.11.2",
-    "lucide-react": "^1.31.0",
+    "lucide-react": "^1.43.0",
     "postcss": "^8.5.26",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -36,7 +36,7 @@
     "fumadocs-core": "16.15.4",
     "fumadocs-mdx": "15.2.3",
     "fumadocs-ui": "16.15.4",
-    "lucide-react": "^1.31.0",
+    "lucide-react": "^1.43.0",
     "next": "16.3.1",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -683,7 +683,7 @@ A single-record detail view with grouped fields, actions, and tabs.
   ],
   "actions": [
     { "type": "action", "label": "Edit", "icon": "Pencil", "level": "primary" },
-    { "type": "action", "label": "Delete", "icon": "Trash2", "level": "danger", "actionType": "confirm" }
+    { "type": "action", "label": "Delete", "icon": "trash", "level": "danger", "actionType": "confirm" }
   ],
   "tabs": [
     {

--- a/content/docs/guide/schema-playground.md
+++ b/content/docs/guide/schema-playground.md
@@ -190,7 +190,7 @@ A data grid with sortable columns and row actions:
   ],
   "actions": [
     { "label": "Edit", "icon": "pencil", "action": "edit" },
-    { "label": "Delete", "icon": "trash-2", "action": "delete", "variant": "destructive" }
+    { "label": "Delete", "icon": "trash", "action": "delete", "variant": "destructive" }
   ],
   "pagination": {
     "pageSize": 10,

--- a/examples/schema-catalog/src/schemas/actions/action-button-variants.json
+++ b/examples/schema-catalog/src/schemas/actions/action-button-variants.json
@@ -23,7 +23,7 @@
           "type": "button",
           "label": "Delete",
           "variant": "destructive",
-          "icon": "trash-2"
+          "icon": "trash"
         },
         {
           "type": "button",

--- a/examples/schema-catalog/src/schemas/actions/confirmation-dialog.json
+++ b/examples/schema-catalog/src/schemas/actions/confirmation-dialog.json
@@ -35,7 +35,7 @@
           "type": "button",
           "label": "Yes, Delete",
           "variant": "destructive",
-          "icon": "trash-2"
+          "icon": "trash"
         }
       ]
     }

--- a/examples/schema-catalog/src/schemas/components-layout-card/profile-detail-card.json
+++ b/examples/schema-catalog/src/schemas/components-layout-card/profile-detail-card.json
@@ -124,7 +124,7 @@
           "label": "Delete",
           "variant": "destructive",
           "size": "sm",
-          "icon": "trash-2"
+          "icon": "trash"
         }
       ]
     }

--- a/examples/schema-catalog/test/svg-host-dom-leak-5632.test.tsx
+++ b/examples/schema-catalog/test/svg-host-dom-leak-5632.test.tsx
@@ -314,13 +314,23 @@ describe('schema-catalog — no SVG-hosted renderer leaks an authored prop to th
     // `SpinnerSchema.size` is an ENUM consumed through `sizeClasses`. Spreading
     // it handed the string to lucide's numeric `size` prop, which is how
     // `width="lg" height="lg"` reached every sized spinner in the catalog.
-    // `class` carries lucide's own two classes AND both of this renderer's —
+    // `class` carries lucide's own classes AND both of this renderer's —
     // `animate-spin` and the size class. Before this slice it carried ONLY
     // lucide's: the spread's `className` overrode the computed one, so a
     // `ui:spinner` rendered through `SchemaRenderer` did not spin.
+    //
+    // `lucide-loader-2` is lucide's own RETIRED-ALIAS class, not a leak. It
+    // appeared when `createLucideIcon` was reshaped to take an icon-data object
+    // carrying `aliases` (lucide-react 1.43.0; absent in 1.31.0, where icon
+    // modules have no `aliases` field at all) and it now emits one class per
+    // alias. Measured on the installed artifact: 248 of 1818 icon modules carry
+    // aliases, so any icon with one gains a class here. The assertion stays
+    // EXACT on purpose — this list is what catches an authored prop reaching
+    // the DOM, which is the whole point of objectui#5632; loosening it to a
+    // substring match would retire the check rather than update it.
     expect(attributesOf({ type: 'spinner', size: 'lg' })).toEqual([
       'aria-hidden="true"',
-      'class="lucide lucide-loader-circle animate-spin h-8 w-8"',
+      'class="lucide lucide-loader-circle lucide-loader-2 animate-spin h-8 w-8"',
       'data-obj-type="spinner"',
       'fill="none"',
       'height="24"',

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -86,7 +86,7 @@
     "@objectstack/spec": "^17.0.0",
     "@sentry/react": "^10.70.0",
     "jsonc-parser": "^3.3.1",
-    "lucide-react": "^1.31.0",
+    "lucide-react": "^1.43.0",
     "qrcode": "^1.5.4",
     "sonner": "^2.0.8",
     "zod": "^4.4.3"

--- a/packages/cli/src/utils/app-generator.ts
+++ b/packages/cli/src/utils/app-generator.ts
@@ -201,7 +201,7 @@ function buildRoutedAppDependencies(): Record<string, string> {
     react: REACT_RANGE,
     'react-dom': REACT_RANGE,
     'react-router-dom': '^7.18.2',
-    'lucide-react': '^1.31.0',
+    'lucide-react': '^1.43.0',
     ...Object.fromEntries(PLATFORM_RUNTIME_PACKAGES.map((name) => [name, range]))
   };
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -72,7 +72,7 @@
     "date-fns": "^4.4.0",
     "embla-carousel-react": "^8.6.0",
     "input-otp": "^1.4.2",
-    "lucide-react": "^1.31.0",
+    "lucide-react": "^1.43.0",
     "next-themes": "^0.4.6",
     "react-day-picker": "^10.0.1",
     "react-hook-form": "^7.85.0",

--- a/packages/components/src/renderers/action/action-bar.tsx
+++ b/packages/components/src/renderers/action/action-bar.tsx
@@ -30,7 +30,7 @@
  *   location: 'record_header',
  *   actions: [
  *     { name: 'mark_complete', label: 'Mark Complete', type: 'script', icon: 'check', component: 'action:button' },
- *     { name: 'delete', label: 'Delete', type: 'api', icon: 'trash-2', variant: 'destructive', component: 'action:button' },
+ *     { name: 'delete', label: 'Delete', type: 'api', icon: 'trash', variant: 'destructive', component: 'action:button' },
  *   ],
  * }} />
  * ```

--- a/packages/components/src/renderers/form/__tests__/button-shared-icon-resolver.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/button-shared-icon-resolver.test.tsx
@@ -142,8 +142,21 @@ describe('ui:button icon resolution (objectui#5993)', () => {
       // The single entry both maps carried. It is the one input whose answer
       // would have changed had the dedupe dropped the alias on the floor.
       const button = renderButton({ icon: 'home' });
-      expect(button.querySelector('svg.lucide-house')).not.toBeNull();
-      expect(button.querySelector('svg.lucide-home')).toBeNull();
+      const house = button.querySelector('svg.lucide-house');
+      expect(house).not.toBeNull();
+      // The negative half used to read `querySelector('svg.lucide-home')` is
+      // null. That form RETIRED on lucide-react 1.43.0, which reshaped
+      // `createLucideIcon` to take an icon-data object carrying `aliases` and
+      // to emit one class PER ALIAS: `house` now renders
+      // `class="lucide lucide-house lucide-home ..."` itself, so the class no
+      // longer says which glyph was drawn (measured: 248 of 1818 icon modules
+      // carry aliases; 1.31.0 icon modules have no `aliases` field at all).
+      // The discriminating form is below and still fires for the same defect:
+      // `Home` is not a key of the runtime record, so had the rename been
+      // dropped this button would render NO glyph at all, and any SECOND glyph
+      // would be a different element from `house`.
+      expect(button.querySelectorAll('svg')).toHaveLength(1);
+      expect(button.querySelector('svg.lucide-home')).toBe(house);
     });
 
     it('renders NO glyph for a retired spelling — the RECORD surface, not a fallback', () => {

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -37,7 +37,7 @@
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@objectstack/spec": "^17.0.0",
-    "lucide-react": "^1.31.0",
+    "lucide-react": "^1.43.0",
     "react-markdown": "^10.1.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1"

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -31,7 +31,7 @@
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@objectstack/spec": "^17.0.0",
-    "lucide-react": "^1.31.0",
+    "lucide-react": "^1.43.0",
     "react": "19.2.8"
   },
   "peerDependencies": {

--- a/packages/plugin-ai/package.json
+++ b/packages/plugin-ai/package.json
@@ -33,7 +33,7 @@
     "@object-ui/components": "workspace:*",
     "@object-ui/core": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "lucide-react": "^1.31.0"
+    "lucide-react": "^1.43.0"
   },
   "devDependencies": {
     "@types/node": "^26.2.0",

--- a/packages/plugin-calendar/package.json
+++ b/packages/plugin-calendar/package.json
@@ -39,7 +39,7 @@
     "@object-ui/plugin-detail": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "lucide-react": "^1.31.0"
+    "lucide-react": "^1.43.0"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/packages/plugin-charts/package.json
+++ b/packages/plugin-charts/package.json
@@ -36,7 +36,7 @@
     "@object-ui/i18n": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "lucide-react": "^1.31.0",
+    "lucide-react": "^1.43.0",
     "recharts": "^3.10.1"
   },
   "peerDependencies": {

--- a/packages/plugin-chatbot/package.json
+++ b/packages/plugin-chatbot/package.json
@@ -42,7 +42,7 @@
     "@radix-ui/react-use-controllable-state": "^1.2.6",
     "ai": "^7.0.65",
     "class-variance-authority": "^0.7.1",
-    "lucide-react": "^1.31.0",
+    "lucide-react": "^1.43.0",
     "motion": "^13.2.0",
     "nanoid": "^6.0.1",
     "shiki": "^4.4.2",

--- a/packages/plugin-dashboard/package.json
+++ b/packages/plugin-dashboard/package.json
@@ -31,7 +31,7 @@
     "@object-ui/permissions": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "lucide-react": "^1.31.0",
+    "lucide-react": "^1.43.0",
     "react": "19.2.8"
   },
   "peerDependencies": {

--- a/packages/plugin-designer/package.json
+++ b/packages/plugin-designer/package.json
@@ -42,7 +42,7 @@
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "clsx": "^2.1.1",
-    "lucide-react": "^1.31.0",
+    "lucide-react": "^1.43.0",
     "sonner": "^2.0.8",
     "tailwind-merge": "^3.6.0"
   },

--- a/packages/plugin-detail/package.json
+++ b/packages/plugin-detail/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@object-ui/i18n": "workspace:*",
     "@objectstack/spec": "^17.1.0",
-    "lucide-react": "^1.31.0"
+    "lucide-react": "^1.43.0"
   },
   "peerDependencies": {
     "@object-ui/components": "workspace:^",

--- a/packages/plugin-detail/src/DetailView.tsx
+++ b/packages/plugin-detail/src/DetailView.tsx
@@ -926,7 +926,7 @@ export const DetailView: React.FC<DetailViewProps> = ({
       items.push({
         name: 'sys_delete',
         label: t('detail.delete'),
-        icon: 'trash-2',
+        icon: 'trash',
         type: 'script',
         variant: 'destructive',
         tags: ['separator-before'],

--- a/packages/plugin-form/package.json
+++ b/packages/plugin-form/package.json
@@ -29,7 +29,7 @@
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@objectstack/spec": "^17.0.0",
-    "lucide-react": "^1.31.0"
+    "lucide-react": "^1.43.0"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/packages/plugin-gantt/package.json
+++ b/packages/plugin-gantt/package.json
@@ -40,7 +40,7 @@
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@objectstack/spec": "^17.0.0",
-    "lucide-react": "^1.31.0",
+    "lucide-react": "^1.43.0",
     "sonner": "^2.0.8"
   },
   "peerDependencies": {

--- a/packages/plugin-grid/package.json
+++ b/packages/plugin-grid/package.json
@@ -33,7 +33,7 @@
     "@objectstack/spec": "^17.0.0",
     "@tanstack/react-virtual": "^3.14.9",
     "exceljs": "^4.4.0",
-    "lucide-react": "^1.31.0"
+    "lucide-react": "^1.43.0"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/packages/plugin-kanban/package.json
+++ b/packages/plugin-kanban/package.json
@@ -44,7 +44,7 @@
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@tanstack/react-virtual": "^3.14.9",
-    "lucide-react": "^1.31.0"
+    "lucide-react": "^1.43.0"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/packages/plugin-list/package.json
+++ b/packages/plugin-list/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lucide-react": "^1.31.0"
+    "lucide-react": "^1.43.0"
   },
   "peerDependencies": {
     "@object-ui/components": "workspace:^",

--- a/packages/plugin-report/package.json
+++ b/packages/plugin-report/package.json
@@ -32,7 +32,7 @@
     "@object-ui/i18n": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "lucide-react": "^1.31.0"
+    "lucide-react": "^1.43.0"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/packages/plugin-tree/package.json
+++ b/packages/plugin-tree/package.json
@@ -38,7 +38,7 @@
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@objectstack/spec": "^17.0.0",
-    "lucide-react": "^1.31.0"
+    "lucide-react": "^1.43.0"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/packages/plugin-view/package.json
+++ b/packages/plugin-view/package.json
@@ -34,7 +34,7 @@
     "@object-ui/types": "workspace:*",
     "@objectstack/spec": "^17.0.0",
     "class-variance-authority": "^0.7.1",
-    "lucide-react": "^1.31.0"
+    "lucide-react": "^1.43.0"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -28,7 +28,7 @@
     "@object-ui/plugin-kanban": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "lucide-react": "^1.31.0",
+    "lucide-react": "^1.43.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "tailwindcss-animate": "^1.0.7"

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -481,7 +481,7 @@ export interface BulkActionDef {
   name: string;
   /** Human-readable label shown on the button + dialog header. */
   label?: string;
-  /** Lucide icon name (e.g. 'user-check', 'trash-2'); falls back to a generic icon. */
+  /** Lucide icon name (e.g. 'user-check', 'trash'); falls back to a generic icon. */
   icon?: string;
   /** Visual treatment of the action button. */
   variant?: 'primary' | 'secondary' | 'danger' | 'ghost' | 'outline';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,8 +317,8 @@ importers:
         specifier: ^20.11.2
         version: 20.11.2
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       postcss:
         specifier: ^8.5.26
         version: 8.5.28
@@ -417,16 +417,16 @@ importers:
         version: 17.4.0(ai@7.0.65(zod@4.4.3))
       fumadocs-core:
         specifier: 16.15.4
-        version: 16.15.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+        version: 16.15.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.43.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3)
       fumadocs-mdx:
         specifier: 15.2.3
-        version: 15.2.3(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.2.7)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 15.2.3(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.43.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.2.7)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       fumadocs-ui:
         specifier: 16.15.4
-        version: 16.15.4(@types/mdx@2.0.14)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)
+        version: 16.15.4(@types/mdx@2.0.14)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.43.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       next:
         specifier: 16.3.1
         version: 16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -786,8 +786,8 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -1099,8 +1099,8 @@ importers:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1283,8 +1283,8 @@ importers:
         specifier: ^17.0.0
         version: 17.4.0(ai@7.0.65(zod@4.4.3))
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -1387,8 +1387,8 @@ importers:
         specifier: ^17.0.0
         version: 17.4.0(ai@7.0.65(zod@4.4.3))
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -1471,8 +1471,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -1529,8 +1529,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -1581,8 +1581,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -1654,8 +1654,8 @@ importers:
         specifier: ^0.7.1
         version: 0.7.1
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       motion:
         specifier: ^13.2.0
         version: 13.2.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1730,8 +1730,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -1800,8 +1800,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -1849,8 +1849,8 @@ importers:
         specifier: ^17.1.0
         version: 17.4.0(ai@7.0.65(zod@4.4.3))
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -1974,8 +1974,8 @@ importers:
         specifier: ^17.0.0
         version: 17.4.0(ai@7.0.65(zod@4.4.3))
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2035,8 +2035,8 @@ importers:
         specifier: ^17.0.0
         version: 17.4.0(ai@7.0.65(zod@4.4.3))
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2102,8 +2102,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.0
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2184,8 +2184,8 @@ importers:
         specifier: ^3.14.9
         version: 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2233,8 +2233,8 @@ importers:
   packages/plugin-list:
     dependencies:
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2431,8 +2431,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2556,8 +2556,8 @@ importers:
         specifier: ^17.0.0
         version: 17.4.0(ai@7.0.65(zod@4.4.3))
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2626,8 +2626,8 @@ importers:
         specifier: ^0.7.1
         version: 0.7.1
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -2737,8 +2737,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       lucide-react:
-        specifier: ^1.31.0
-        version: 1.31.0(react@19.2.8)
+        specifier: ^1.43.0
+        version: 1.43.0(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -8739,13 +8739,8 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
-  lucide-react@1.31.0:
-    resolution: {integrity: sha512-G8u2eEtoHUnUa9f8lbvqDhCiORMnYLdUEo06EEG9MQvHQrInKcX3Pa2TH39MM5qyzRcWETxB0+aOwAPI1g1kEg==}
-    peerDependencies:
-      react: 19.2.8
-
-  lucide-react@1.35.0:
-    resolution: {integrity: sha512-yXCCWxGFYT6bLIPYC4SY6fPQPRs/d797rRIue+J9XP2Td6vQvD53gaQRBCnIVT1kTQRHtAtxlfOQNWAuIF8ELg==}
+  lucide-react@1.43.0:
+    resolution: {integrity: sha512-ubtnda1fVK5ky0PNEpOmB0wiwhpZUyJiol4K14KCm+QKvuCkfUu54Et/rIjyupJpwiJ5Hg+BLQE86/GEsS+IgQ==}
     peerDependencies:
       react: 19.2.8
 
@@ -16251,7 +16246,7 @@ snapshots:
       mkdirp: 0.5.6
       rimraf: 2.7.1
 
-  fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3):
+  fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.43.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3):
     dependencies:
       '@fumari/image-size': 0.1.0
       estree-util-value-to-estree: 3.5.0
@@ -16279,7 +16274,7 @@ snapshots:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       '@types/react': 19.2.18
-      lucide-react: 1.31.0(react@19.2.8)
+      lucide-react: 1.43.0(react@19.2.8)
       next: 16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -16288,14 +16283,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.2.3(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.2.7)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
+  fumadocs-mdx@15.2.3(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.43.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.2.7)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.2
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.15.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+      fumadocs-core: 16.15.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.43.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3)
       github-slugger: 2.0.0
       magic-string: 1.2.0
       mdast-util-mdx: 3.0.0
@@ -16321,7 +16316,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.15.4(@types/mdx@2.0.14)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3):
+  fumadocs-ui@16.15.4(@types/mdx@2.0.14)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(fumadocs-core@16.15.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.43.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3):
     dependencies:
       '@fuma-translate/react': 1.0.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@fumadocs/tailwind': 0.1.1(tailwindcss@4.3.3)
@@ -16337,8 +16332,8 @@ snapshots:
       '@radix-ui/react-tabs': 1.1.21(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority: 0.7.1
       cnfast: 0.1.0
-      fumadocs-core: 16.15.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3)
-      lucide-react: 1.35.0(react@19.2.8)
+      fumadocs-core: 16.15.4(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.43.0(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+      lucide-react: 1.43.0(react@19.2.8)
       motion: 13.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-themes: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
@@ -17229,11 +17224,7 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
-  lucide-react@1.31.0(react@19.2.8):
-    dependencies:
-      react: 19.2.8
-
-  lucide-react@1.35.0(react@19.2.8):
+  lucide-react@1.43.0(react@19.2.8):
     dependencies:
       react: 19.2.8
 

--- a/scripts/__tests__/doc-version-claims.test.ts
+++ b/scripts/__tests__/doc-version-claims.test.ts
@@ -1175,7 +1175,7 @@ const KNOWN_CLAIMS: KnownClaim[] = [
     // Reads as a `react` claim and is not one, for the same reason the plugins.md
     // `@vitejs/plugin-react` entry does: `React` is a TOOLCHAIN word and the `-` before it
     // is a word boundary, so the recorded literal is the TAIL of `lucide-react`.
-    claim: 'react": "^1.31.0',
+    claim: 'react": "^1.43.0',
     kind: 'anchored',
     skeletonDep: 'lucide-react',
     why: 'A runtime dependency of an IN-WORKSPACE plugin skeleton - the block is named @object-ui/plugin-my-widget, takes all four @object-ui dependencies at workspace:* and builds with vite build, so it resolves in this workspace and nowhere else. Anchor measured at the objectui#4981 cut: 16 of the 19 packages/plugin-<name> manifests declare lucide-react and all 16 say ^1.31.0 (23 workspace-wide, unanimous). It read ^0.400.0, which is worse than an ordinary fossil: a 0.x caret cannot cross a minor, so that range resolves inside 0.400.x forever - the trap objectui#3755 removed from create-plugin\'s own dependency map. Recorded fork, not acted on here: #3755 DELETED its lucide entry rather than re-anchoring it, on the rule that this repo declares an icon library only where it imports one, and no code on this page imports one. Deleting the line is the alternative disposition; it would retire this entry with it.',

--- a/scripts/check-eager-closure-budget.mjs
+++ b/scripts/check-eager-closure-budget.mjs
@@ -635,6 +635,48 @@ export const REGRESSION_THIS_GATE_MUST_CATCH_BYTES = 89 * 1024;
  * itself. Nothing else moved either — not the other three ceilings, not the
  * aggregate, not {@link BASELINE}. One ceiling and its baseline, in one commit.
  *
+ * ## Why `ui-components` moved UP — lucide-react 1.31.0 to 1.43.0
+ *
+ * Measured on this branch's console build: 410,904 bytes, 11,904 over the
+ * 399,000 that stood. The cause is the icon library growing, and it was ruled
+ * out as a tree-shaking regression BEFORE this number moved, because "the
+ * bundler stopped shaking" and "the dependency got bigger" want opposite fixes
+ * and only one of them is a ceiling.
+ *
+ * What was measured, and the control that fired with it:
+ *
+ *   - ALL 1,818 keys of lucide 1.43.0's runtime `icons` record appear verbatim
+ *     in the built `ui-components` chunk. Not most — all. Of 1.31.0's 1,767
+ *     keys, 1,766 appear in that same chunk; the one absent is `Trash2`, the
+ *     key lucide retired, which is what tells you the probe discriminates
+ *     rather than matching everything. A fabricated key is not found.
+ *   - So icons do not tree-shake here and did not tree-shake before either.
+ *     That is DELIBERATE, not a defect: `renderers/action/resolve-icon.ts`
+ *     imports the whole `icons` record because string lookups are resolved
+ *     against record MEMBERSHIP, which is the seam objectui#5935 consolidated
+ *     onto and `check-lucide-icon-record-names.mjs` enforces. Moving that seam
+ *     to `lucide-react/dynamic.mjs` to shed the bytes would resolve names the
+ *     record deliberately drops (`trash-2`, `edit`, `smile`), which is the
+ *     exact failure that gate's header calls worse than having no gate.
+ *   - The library itself is bigger, two independent ways. Same-artwork control:
+ *     `pencil.mjs`, whose icon node is byte-identical across the two versions,
+ *     goes 455 to 522 bytes, because 1.43.0 reshaped every icon module into an
+ *     `__iconData` object carrying `name`, `size` and `aliases`. And there are
+ *     more icons: the whole icon directory, licence headers stripped and
+ *     gzipped, goes 166,705 to 176,968 bytes (+10,263, +6.2%) from 1.31.0 to
+ *     1.43.0 — the same order as the chunk delta this raise absorbs.
+ *
+ * ⇒ the bytes are not avoidable from the import side, so the ceiling moves.
+ *
+ * Headroom 9,096 bytes = 0.10x {@link REGRESSION_THIS_GATE_MUST_CATCH_BYTES} —
+ * the proportion objectui#7399 re-pinned THIS key to, chosen deliberately over
+ * "just enough to pass". A line left with almost no headroom is the defect
+ * objectui#8816 records, and this key was the tightest of the four before this
+ * raise. ⛔ {@link REGRESSION_THIS_GATE_MUST_CATCH_BYTES} did not move, and
+ * nothing else moved: not the other three ceilings, not the aggregate, not
+ * {@link BASELINE}. The aggregate was re-read on the same build and PASSES on
+ * its own — 3,589,068 of 3,597,000, headroom 7,932 bytes — so it is left alone.
+ *
  * ## Raising one
  *
  * Same discipline as {@link MAX_EAGER_CLOSURE_GZIP_BYTES}, and the same two
@@ -663,7 +705,13 @@ export const PER_CHUNK_GZIP_CEILINGS = Object.freeze({
   // REGRESSION_THIS_GATE_MUST_CATCH_BYTES on `3f775eeb8` — the loosest of the
   // four. See "Why `framework` moved UP" above for what that costs.
   framework: 100_000,
-  'ui-components': 399_000,
+  // Raised for lucide-react 1.31.0 -> 1.43.0: the icons record ships whole by
+  // design and the library grew both in icon count and in per-icon metadata.
+  // Ruled out as a tree-shaking regression first — see "Why `ui-components`
+  // moved UP" above for the measurement and its controls. Headroom 9,096 bytes
+  // = 0.10x REGRESSION_THIS_GATE_MUST_CATCH_BYTES, the proportion objectui#7399
+  // re-pinned this key to.
+  'ui-components': 420_000,
 });
 
 /**
@@ -778,7 +826,10 @@ export const PER_CHUNK_BASELINE = Object.freeze({
   // BASELINE's. Moved with the ceiling in the same commit, per the maintainer
   // ruling of 2026-09-08 and the rule stated under "Raising one".
   framework: 72_245,
-  'ui-components': 391_095,
+  // Moved with its ceiling in the same commit, per the rule stated under
+  // "Raising one": this branch's own console build of the lucide-react 1.43.0
+  // bump. ⛔ Not `2c8474c04`'s build, which measured the 1.31.0 icon set.
+  'ui-components': 410_904,
 });
 
 /**

--- a/skills/objectui/guides/plugin-development.md
+++ b/skills/objectui/guides/plugin-development.md
@@ -379,7 +379,7 @@ double-displays it.
     "@object-ui/core": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
-    "lucide-react": "^1.31.0"
+    "lucide-react": "^1.43.0"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",


### PR DESCRIPTION
Supersedes the stale Dependabot branch objectui#7058 (`dependabot/npm_and_yarn/lucide-react-1.35.0`). That branch is not pushed to here — Dependabot force-pushes over it on every rebase — so this is a fresh branch cut from current `main`. Once this lands, objectui#7058 can be closed as superseded. It is deliberately not named with a closing keyword above; closing it is a maintainer action, not this PR's.

## 1. Which of the seven red checks were staleness, and which were real

objectui#7058's base is `4e3a4f07e` — weeks behind `main`. I brought its head up to date in a throwaway worktree, re-locked from current `main`, and re-measured. Four of the seven were artefacts of the stale base; three were real.

| Check on objectui#7058 | Verdict | Evidence |
|---|---|---|
| `Type Check` | **REAL** | The job failed at `pnpm check:icon-record-names`, not at `tsc`. `tsc` never ran. |
| `Test (shard 1/4)` | **REAL** | `packages/cli/src/__tests__/app-generator.test.ts` — the generator's literal `lucide-react` range stayed at `^1.31.0` while the 22 sibling manifests moved. |
| `Test (shard 3/4)` | **MIXED** | `check-lucide-icon-record-names.test.ts` REAL (same four sites). `ci-cd-pipeline-doc.test.ts` STALE — the lockfile carried two `@objectstack/spec` versions. |
| `Test (shard 4/4)` | **MIXED** | `doc-version-claims.test.ts` REAL (`skills/objectui/guides/plugin-development.md` still taught `^1.31.0`). `check-lockfile-integrity.test.ts` STALE — its fixture forks a `zod@4.4.3` key the stale lockfile had replaced with `4.5.4`. |
| `Lockfile Integrity Check` | **STALE** | `VERDICT 12 finding(s): 7 backward move(s), 5 duplication(s)` — Dependabot re-locked on an old base and dragged `@objectstack/client`, `core`, `formula`, `lint`, `sdui-parser`, `types` from 17.4.0 back to 17.3.0, plus a `zod` 4.4.3/4.5.4 split. |
| `Bundle Analysis` | **STALE** | `vendor-objectstack 2874.0 KB / 1224.6 KB ceiling (OVER by 1649.3 KB)` — that is the duplicated `@objectstack` tree above, which the lockfile gate itself names as the cause: *"a bundle-size red downstream of this is caused by THIS, not by the dependency being bumped."* |
| `dependabot` | STALE | Dependabot's own branch check. |

On this branch, re-locked from current `main`, `node scripts/check-lockfile-integrity.mjs` reports `VERDICT clean — no @objectstack/* identity moved backward and no package gained a copy`.

## 2. Root cause of what survives — measured against the installed artifact

The hypothesis in the dispatch was a broad source-compatibility break. **The measurement narrows it to a single retired name, and falsifies the type-checking half entirely.**

I installed 1.31.0, 1.41.0 and 1.43.0 side by side and diffed three surfaces:

| Surface | 1.31.0 | 1.43.0 | Removed |
|---|---|---|---|
| runtime exports of `lucide-react` | 6068 | 6224 | **0** |
| public names in `lucide-react.d.ts` | 6072 | 6230 | **0** |
| `iconNames` from `lucide-react/dynamic.mjs` | 2025 | 2077 | **0** |
| keys of the runtime `icons` record | 1767 | 1818 | **1 — `Trash2`** |

Then I enumerated what this repository actually imports — 4700 source files, 333 distinct value names, one type name (`LucideIcon`), six namespace or default imports — and checked every one against both artefacts. **Zero fail to resolve, in either version.** Controls fired on the same run in both worlds: `Trash` resolves in both, a fabricated name resolves in neither.

So nothing breaks at an import and nothing breaks in the compiler. `Trash2` is still exported by 1.43.0; it is simply no longer a *key of the runtime `icons` record*, and `Trash2 === Trash` there (in 1.31.0 they were distinct objects). That is exactly the class `scripts/check-lucide-icon-record-names.mjs` exists to catch: a retired spelling still imports, still type-checks, still renders as a COMPONENT, and resolves to nothing as a STRING.

Four authored sites resolve `trash-2` through `renderers/action/resolve-icon.ts`, which reads record membership:

- `examples/schema-catalog/src/schemas/actions/action-button-variants.json`
- `examples/schema-catalog/src/schemas/actions/confirmation-dialog.json`
- `examples/schema-catalog/src/schemas/components-layout-card/profile-detail-card.json`
- `packages/plugin-detail/src/DetailView.tsx` — the record delete action

All four now write `trash`. **The glyph does not change:** 1.43.0's `trash` icon node is byte-identical to 1.31.0's `trash-2` icon node (control: `pencil` is byte-identical across both versions, so the comparison is not returning equal for everything). Upstream replaced the old bin artwork under the `trash` name and kept `trash-2` as a deprecated alias.

## 3. Why 1.43.0 and not the 1.41.0 the Dependabot PR advertises

The workspace declares a caret range, so a re-lock from current `main` resolves the newest 1.x — that is 1.43.0 today, under `^1.41.0` just as much as under `^1.43.0`. Holding exactly 1.41.0 would need an exact pin or an override, which is not this repo's convention and not mine to invent. Measured, the extra two minors cost nothing in removals: **1.41.0 to 1.43.0 removes zero exports, zero record keys and zero dynamic names.**

It does bring one behavioural change that 1.41.0 does not have, and it is worth a maintainer's eye:

**1.43.0 reshaped `createLucideIcon`** to take an icon-data object carrying `aliases`, and it now emits **one CSS class per retired alias**. A spinner renders `class="lucide lucide-loader-circle lucide-loader-2 ..."`. Measured: 248 of 1818 icon modules carry an alias; 1.31.0 icon modules have no `aliases` field at all. This is additive, so a `.lucide-loader-circle` selector still matches — but a selector asserting the exact, complete class string does not, and neither does an assertion that a given `lucide-` class is ABSENT.

I censused the whole tree for both shapes, using the alias index built from the installed artefact as the oracle: **28 distinct `lucide-` class names are referenced anywhere in the repository** (all file types, snapshots included) and **exactly two are aliases in 1.43.0** — `lucide-home` (owned by `house`) and `lucide-loader-2` (owned by `loader-circle`). Controls: injecting the known alias `trash-2` into the census is found; `check` is correctly absent. Both affected pins are repaired here:

- `examples/schema-catalog/test/svg-host-dom-leak-5632.test.tsx` asserts the exact attribute set. The added class is named. The assertion stays **exact** on purpose — that list is what catches an authored prop reaching the DOM, which is the whole point of objectui#5632.
- `packages/components/src/renderers/form/__tests__/button-shared-icon-resolver.test.tsx` proved `home` resolved through the rename to `House` by asserting `svg.lucide-home` is null. `house` now emits `lucide-home` itself, so that class no longer says which glyph was drawn. Replaced with a form that still fires for the same defect: exactly one svg, and the alias class on that same element. Had the rename been dropped, `Home` is not a record key and the button would render no glyph at all.

## 4. Something the bump gives back

`main` installs **two** physical copies of the icon library: 1.31.0 for this workspace and 1.35.0 pulled by `fumadocs-ui`. On this branch both collapse onto a single 1.43.0. Lockfile resolutions go 1822 to 1821.

## 5. What was measured here

- `pnpm check:icon-record-names` — `OK ... 184 authored/declared names reaching 1 record-reading resolver are live icons keys (record 1818 keys)`.
- Reverse verification, direction predicted before running: restoring `trash-2` at `DetailView.tsx:929` turns that gate red naming **exactly that one site** and nothing else; restoring the file returns it to green. Restoration proved by blob hash equality with HEAD and an empty `git diff HEAD`, not by an exit code.
- `pnpm type-check` across the workspace — turbo `81 successful, 81 total` over 45 packages, zero `error TS`.
- `pnpm exec vitest run packages/components/ examples/schema-catalog/ packages/plugin-view/ packages/plugin-list/` — `Test Files 395 passed (395)`, `Tests 5688 passed (5688)`.
- `pnpm exec vitest run packages/plugin-detail/ packages/types/ examples/schema-catalog/` — 350 files, 6769 tests, green after the pin repair.
- `pnpm exec vitest run packages/cli/src/__tests__/app-generator.test.ts` — 43 passed.
- `pnpm exec vitest run scripts/__tests__/doc-version-claims.test.ts` — 29 passed.
- `pnpm exec vitest run scripts/__tests__/check-lucide-icon-record-names.test.ts scripts/__tests__/ci-cd-pipeline-doc.test.ts scripts/__tests__/check-lockfile-integrity.test.ts` — green.
- `node scripts/check-lockfile-integrity.mjs` — `VERDICT clean`.
- `node scripts/check-changeset-presence.mjs` and `check-changeset-no-major.mjs` — both green.

Declared narrowing: the full four-shard `pnpm test` and the repo-wide `pnpm lint` are left to CI. `eslint` over the changed source files reports one pre-existing error at `action-bar.tsx:267` in code this PR does not touch (its only change to that file is a docblock comment); that attribution is stated, not yet controlled against `main`. The `Bundle Analysis` measurement was still building locally when this was opened and is reported as NOT MEASURED rather than assumed — the stale-base cause of its red is independently established above.

## 6. Governed surface — this PR stays a draft

`node scripts/check-governed-queue-guard.mjs --test` reports `GOVERNED — 1 of 37 path(s)`: `skills/objectui/guides/plugin-development.md`, the published skills catalog. One governed path governs the whole PR. It is **not** to be flipped ready, enqueued, or armed with auto-merge; a human merge is the review record.

The changed line there is the plugin skeleton's `lucide-react` range, which `doc-version-claims.test.ts` anchors to the in-repo range. Its `KNOWN_CLAIMS` entry is keyed by the literal text, so the inventory key moved with it.

Session that produced this: `https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH

---
_Generated by [Claude Code](https://claude.ai/code/session_01611D6ZaRaMmwTNQmSbk8MH)_