### PR TITLE
test(console,components): pin the last four one-key member blocks (objectui#8071 slice 7)

### DIFF
--- a/.changeset/member-pins-slice-7.md
+++ b/.changeset/member-pins-slice-7.md
@@ -1,0 +1,9 @@
+---
+---
+
+Test-only change (objectui#8071 slice 7): converts the last four one-key
+`MEMBER_PIN_EXEMPTIONS` blocks — `element:button.action`,
+`element:number.filter`, `page:accordion.items` and `page:tabs.items` — into
+real per-block member pins, deletes those four exemptions and lowers
+`MEMBER_PIN_EXEMPTION_CEILING` 41 -> 37 in the same commit. Adds four member-shape
+test files under `packages/components`; no published behaviour changes.

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -2149,9 +2149,17 @@ interface MemberPin {
  * was built for.
  */
 const MEMBER_PINS: Record<string, MemberPin> = {
+  'element:button.action': {
+    file: 'packages/components/src/__tests__/elementButtonActionMembers-8071.test.tsx',
+    pins: 'The inline ActionDef\'s member set as a WHITELIST, driven through the real renderer and asserted on what the ActionRunner is handed: the forwarded keys are pinned as a SORTED SET, so a member silently added to or dropped from `ElementButtonRenderer`\'s explicit forward list is red in either direction — the defect shape objectstack#6837 (`bodyExtra`) and objectstack#6938 (`bodyShape`) were both filed for, an authored key that validates, publishes and then evaporates one hop before the runner. Three off-list keys are authored alongside and asserted ABSENT: `bodyShape` (deliberately not inline vocabulary — `action-bodyShape-forward.test.tsx` argues the boundary in prose, this pins it as behaviour) plus `icon` and `variant`, the block\'s own sibling props misplaced one level in. `actionType` OUTRANKS `type` with the losing spelling\'s handler asserted un-run, an ARRAY `params` is re-routed to `actionParams` while an OBJECT `params` stays `params` (objectstack#5777 direction A) with each arm controlling the other, the navigation members reach the navigation handler, and an omitted `action` dispatches nothing at all — the non-vacuity control for every row. LIMIT: `confirmText` is on the whitelist but unexercised, because the runner awaits confirmation before the dispatch this file observes. New file (objectui#8071 slice 7).',
+  },
   'element:button.label': {
     file: 'apps/console/src/__tests__/component-input-union-specimens.test.ts',
     pins: 'The `object` arm is the inline translation map `{ en, "zh-CN" }` and nothing else — driven through the real `manifestFromConfigs` + `validateTree` pair the JSX-page compiler and the save gate use, each positive paired with a value matching NEITHER arm that must still be reported (objectui#4970).',
+  },
+  'element:number.filter': {
+    file: 'packages/components/src/renderers/basic/__tests__/elementNumberFilterMembers-8071.test.tsx',
+    pins: 'The TWO wire spellings one authored predicate takes, chosen by an adapter capability the author cannot see, plus the re-query rule — asserted through the real renderer on a stubbed adapter. `aggregate()` receives it FLAT under its own name and beside the members that make the call an aggregate (`field`, `function`, `groupBy: \'_all\'`), asserted as the whole options bag rather than the one key; the `find()` fallback receives it WRAPPED as `$filter`; and an unfiltered metric sends `undefined` rather than an empty envelope some adapters read as "match nothing". Collapsing the two spellings into one drops the predicate silently and the metric paints a confidently wrong number over every row, with no diagnostic and no empty state. The third half is that the key is read BY VALUE, not by identity (`filterKey` is a `JSON.stringify` memo): a deep-equal filter rebuilt by a re-rendering parent must NOT re-probe, while a changed comparand MUST and carries the new predicate — each arm the other\'s control, so a dependency array "simplified" to the raw object (a per-render fetch storm) is red. New file (objectui#8071 slice 7).',
   },
   'element:record_picker.dataSource': {
     file: 'packages/components/src/__tests__/record-picker-element-data-source.test.tsx',
@@ -2257,6 +2265,10 @@ const MEMBER_PINS: Record<string, MemberPin> = {
     file: 'packages/plugin-kanban/src/__tests__/ObjectKanban.structuredMembersReachTheirSinks-8313.test.tsx',
     pins: 'ONE nested position and no more: `schema.grouping?.fields?.[0]?.field` is the FALLBACK source of `swimlaneField`, and that is the entire member contract this board carries for the key. Three rows make it a reading rather than a claim — the swimlane layout appears keyed by `fields[0].field` where without the key there is none; an explicit `swimlaneField` WINS over it; and a second `fields` entry changes nothing, which is what pins the read at `[0]` rather than at "the fields list". The declared description says the rest is inert precisely so the declaration does not recommend a write the renderer cannot honour — this file is what keeps that sentence true. The spec row is `z.unknown()`, so the read site is the whole member contract (objectui#8313).',
   },
+  'page:accordion.items': {
+    file: 'packages/components/src/__tests__/pageAccordionItemMembers-8071.test.tsx',
+    pins: 'Which member of one panel definition becomes which part of the rendered accordion — the four `PageAccordionItem` members (`label`, `icon`, `collapsed`, `children`) asserted as a SET through the real renderer, which nothing did before: `label` becomes the trigger\'s accessible name and `children` the panel BODY, asserted against each other so a renderer painting the wrong one cannot pass. `collapsed` is the reading with real semantics to get wrong and it is strictly `=== false`: `collapsed: false` OPENS a panel while `collapsed: true` AND an omitted `collapsed` both leave it shut — the omitted-key arm is the control an "obvious" edit to `!it.collapsed` breaks, and a no-opener fixture keeps the two shut rows from passing on a renderer that opens nothing. The single/multiple split is pinned on the SAME items so only `allowMultiple` varies: single mode takes `defaultOpen[0]` and drops later openers, multiple mode opens them all without opening panels that never asked. `icon` is covered narrowly on purpose — `page-accordion-icon.test.tsx` (objectui#4721) is its pin and is not re-litigated. New file (objectui#8071 slice 7).',
+  },
   'page:card.title': {
     file: 'apps/console/src/__tests__/component-input-union-specimens.test.ts',
     pins: 'The `object` arm is the inline translation map, with a non-matching control that must still be reported (objectui#3832).',
@@ -2272,6 +2284,10 @@ const MEMBER_PINS: Record<string, MemberPin> = {
   'page:header.title': {
     file: 'apps/console/src/__tests__/component-input-union-specimens.test.ts',
     pins: 'The `object` arm is the inline translation map, with a non-matching control (objectui#3832).',
+  },
+  'page:tabs.items': {
+    file: 'packages/components/src/__tests__/pageTabsItemMembers-8071.test.tsx',
+    pins: 'The SIX members of one tab definition (`label`, `value`, `icon`, `count`, `visibleWhen`, `children`) mapped to the six different parts of the strip they each become, driven through the real renderer — the mapping as a set, which none of the five pre-existing `page:tabs` suites asserts (each pins one member, so none would fail if `count` and `value` swapped roles). `label` becomes the trigger name and `children` the PANEL, with the inactive tab\'s body asserted absent since Radix renders only the active one. `value` is pinned BEHAVIOURALLY through `defaultTab` — the host key app-shell restores `?tab=` with — so selecting a tab by its authored value proves the member is the tab\'s identity without reaching into Radix\'s generated ids; both fallback arms follow, an absent `value` and an EMPTY-STRING one each becoming the positional `tab-INDEX`, which is what separates the real read from a bare `typeof value === \'string\'`. `count` is gated on `Number(count) > 0`, NOT on presence: an authored `count: 0` paints no badge, with a positive count on the same strip as its control. `icon` and `count` are asserted per-item against a neighbour declaring neither, so neither can be strip-wide. `visibleWhen` is covered narrowly — `page-tabs-visibility.test.tsx` is its pin. New file (objectui#8071 slice 7).',
   },
   'record:activity.types': {
     file: 'packages/plugin-detail/src/renderers/__tests__/recordActivityFeed.test.ts',
@@ -2447,11 +2463,11 @@ const NO_READ_SITE_TO_PIN =
  * 51st entry, because the count may only go down.
  */
 const MEMBER_PIN_EXEMPTIONS: Record<string, string> = {
-  // element:button
-  'element:button.action': AWAITING_A_PIN,
+  // element:button — objectui#8071 slice 7 pinned `action`, the block's one
+  // remaining key; fully pinned, header kept as a landmark for a future grep.
 
-  // element:number
-  'element:number.filter': AWAITING_A_PIN,
+  // element:number — objectui#8071 slice 7 pinned `filter`, the block's one
+  // remaining key; fully pinned.
 
   // element:record_picker — objectui#8071 slice 3 pinned all four remaining
   // keys (`dataSource`, `label`, `placeholder`, `sort`); the block is now
@@ -2500,11 +2516,11 @@ const MEMBER_PIN_EXEMPTIONS: Record<string, string> = {
   'object-metric.filter': AWAITING_A_PIN,
   'object-metric.trend': AWAITING_A_PIN,
 
-  // page:accordion
-  'page:accordion.items': AWAITING_A_PIN,
+  // page:accordion — objectui#8071 slice 7 pinned `items`, the block's one
+  // remaining key; fully pinned.
 
-  // page:tabs
-  'page:tabs.items': AWAITING_A_PIN,
+  // page:tabs — objectui#8071 slice 7 pinned `items`, the block's one
+  // remaining key; fully pinned.
 
   // record:activity — objectui#8071 slice 6 pinned `types`, the block's one
   // remaining key; fully pinned, header kept as a landmark for a future grep.
@@ -2740,11 +2756,66 @@ const NEWLY_JUDGED_UNPINNED_MEMBERS = [
  * record:activity". That is a contract defect rather than a member shape, so it
  * is filed (objectui#8934) rather than frozen into the pin.
  *
+ * ## 41 -> 37, the seventh slice, and the LAST four one-key blocks closed
+ *
+ * objectui#8071's seventh slice applied slice 6's selection rule to what it left
+ * behind: every block whose remainder was exactly one key. Four qualified —
+ * `element:button.action`, `element:number.filter`, `page:accordion.items` and
+ * `page:tabs.items` — so the ceiling follows to 37 in the same commit, and all
+ * four blocks now carry zero exemptions.
+ *
+ * The batch is coherent rather than opportunistic on the same terms slice 6 set:
+ * one package (`packages/components`) registers all four, the two `element:*`
+ * keys sharing `renderers/basic/elements.tsx` and the two `page:*` keys sharing
+ * `renderers/layout/containers.tsx`, and the rule is stateable in a sentence.
+ *
+ * ⚠️ TWO one-key blocks were deliberately NOT taken, and neither is a leftover
+ * this slice could have absorbed:
+ *
+ *   - `record:related_list.actions` is the `NO_READ_SITE_TO_PIN` sentinel, and
+ *     the reading was RE-MEASURED here rather than inherited: on this tree
+ *     `renderers/record-related-list.tsx` still contains ZERO case-sensitive
+ *     occurrences of `actions` (control: `import` reads 9 in the same file), and
+ *     the only near-matches are `useRelatedRecordActions` / `relatedActions` —
+ *     the host bridge the constant already names. Nothing to pin, still.
+ *   - `object-kanban`'s `columns` / `dataSource` are the
+ *     `NEWLY_JUDGED_UNPINNED_MEMBERS` pair, held by an unruled contract question
+ *     (objectui#8913) about whether `columns` survives as judged structure at
+ *     all. Pinning a shape a pending ruling may delete would be worse than
+ *     leaving it exempt, so `NEWLY_JUDGED_UNPINNED_MEMBERS` is UNCHANGED by this
+ *     slice — no block it names was touched.
+ *
+ * ⇒ After this slice every remaining exemption sits on one of four
+ * MULTI-key blocks (`object-grid` 15, `object-form` 7,
+ * `object-master-detail-form` 6, `object-metric` 6) plus the two held keys. The
+ * "close a block outright by taking its last key" shape is now EXHAUSTED, and
+ * the next slice is the first that has to take a partial block or close a
+ * multi-key one whole — stated here so the next reader does not spend the
+ * search rediscovering it.
+ *
+ * Three of the four pins are new files; none of the four keys had a
+ * pre-existing file covering its member SET, and each candidate was read end to
+ * end before being rejected rather than dismissed on its greps.
+ * `element-button-action.test.tsx` drives only `type` and `to` on one
+ * navigation action; `action-bodyExtra-forward.test.tsx` pins one member across
+ * four renderers; `page-accordion-icon.test.tsx` pins `icon` alone; the five
+ * `page:tabs` suites pin one member each; and
+ * `element-number.contractEnvelope-6726.test.tsx` drives the same `find()`
+ * fallback branch but never authors a `filter`, so the locator itself would
+ * refuse it. ⚠️ `action-bodyShape-forward.test.tsx` is the one that had to be
+ * refused rather than merely passed over: it NAMES `element:button` and the key
+ * `action`, so it would satisfy the locator, while what it actually says is
+ * that `element:button` is deliberately out of its scope. Crediting it would
+ * have been a pin that asserts the opposite of its claim — the false-negative
+ * shape objectui#8068 exists to end. Its boundary is instead pinned as
+ * behaviour in the new file, which authors `bodyShape` and asserts it is
+ * dropped.
+ *
  * ⇒ The rule for every future slice of objectui#8071: delete the entry, register
  * the pin, and set this constant to the new count. Not to the new count plus
  * room.
  */
-const MEMBER_PIN_EXEMPTION_CEILING = 41;
+const MEMBER_PIN_EXEMPTION_CEILING = 37;
 
 /**
  * Every test file a member pin can live in, as LAZY `?raw` loaders.

--- a/packages/components/src/__tests__/elementButtonActionMembers-8071.test.tsx
+++ b/packages/components/src/__tests__/elementButtonActionMembers-8071.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `element:button.action` — the MEMBER SHAPE of the inline ActionDef
+ * (objectui#8071).
+ *
+ * The member pin for this key. `ElementButtonRenderer`
+ * (`renderers/basic/elements.tsx`) does NOT spread the authored `action` object
+ * into the runner. It forwards an EXPLICIT WHITELIST of members, key by key,
+ * and the registration publishes the key as `Inline ActionDef executed on click
+ * (url / navigation / api / script / modal / flow); omitted -> renders inert`.
+ * The whitelist IS the member shape: a key on it is honoured, a key off it is
+ * dropped one hop before the runner and the author gets no signal at all.
+ *
+ * That drop is the exact defect shape objectstack#6837 (`bodyExtra`) and
+ * objectstack#6938 (`bodyShape`) were filed for — an authored key that
+ * validates, publishes, and then evaporates at this seam.
+ *
+ * ## Why a new file rather than promoting one of the two that already exist
+ *
+ * Both were read end to end before this pin was written:
+ *
+ *   - `element-button-action.test.tsx` — the closest in SUBJECT (it is about
+ *     this key), but it drives exactly two members, `type` and `to`, on a
+ *     single navigation action, plus the inert path. It would not fail if any
+ *     other member left the whitelist.
+ *   - `action-bodyExtra-forward.test.tsx` — drives `element:button`'s inline
+ *     action for real and asserts `bodyExtra` survives the hop, plus the
+ *     `bodyExtra`-beats-`params` merge order on the wire. Its subject is ONE
+ *     member across four renderers, not this renderer's member set.
+ *
+ * A third file, `action-bodyShape-forward.test.tsx`, names `element:button`
+ * only to say it is deliberately NOT covered there — its forward list mirrors
+ * spec's `InlineActionSchema` pick list, which does not include `bodyShape`,
+ * and forwarding it from here would be the forbidden renderer-first direction.
+ * ⛔ That file must never be credited as this key's pin: it would satisfy the
+ * locator (it names the block and the key) while asserting the opposite. The
+ * negative row below is this file taking that reading over as a POSITIVE
+ * statement instead — `bodyShape` is authored here and its absence downstream
+ * is asserted, so the boundary is pinned rather than merely described.
+ *
+ * ## Limit, recorded rather than papered over
+ *
+ * `confirmText` is on the whitelist and is not exercised here. The runner
+ * gates on it (`if (action.confirmText)`) and awaits a confirmation handler
+ * before it ever reaches the action handler this file observes, so authoring it
+ * would suppress the very dispatch being measured. It is pinned by the runner's
+ * own confirmation suites, not by a member pin.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import type { ActionContext, ActionDef, ActionResult } from '@object-ui/core';
+import { ActionProvider } from '@object-ui/react';
+import '../renderers/basic/elements';
+
+function ElementButton({ schema }: { schema: any }) {
+  const C = ComponentRegistry.get('element:button');
+  if (!C) throw new Error('element:button not registered');
+  // eslint-disable-next-line react-hooks/static-components -- ComponentRegistry.get returns a registered component (stable), not one created during render
+  return <C schema={schema} />;
+}
+
+const button = (action: unknown, label = 'Go') => ({
+  type: 'element:button',
+  properties: { label, action },
+});
+
+describe('element:button action — member shape (objectui#8071)', () => {
+  // Typed with the signature `ActionProvider`'s `handlers` prop declares, not
+  // `ReturnType<typeof vi.fn>` (objectui#4040).
+  let api: Mock<(action: ActionDef, ctx: ActionContext) => Promise<ActionResult>>;
+  /** The members the runner was handed, snapshotted AT dispatch. */
+  let received: Record<string, unknown>;
+
+  beforeEach(() => {
+    received = {};
+    api = vi.fn(async (action: ActionDef) => {
+      // Snapshot immediately: the runner may mutate the ActionDef it holds
+      // (it merges collected params back onto `action.params`), so a read
+      // taken after the await would not be a reading of the FORWARD.
+      received = { ...(action as unknown as Record<string, unknown>) };
+      return { success: true };
+    });
+  });
+
+  /** The forwarded members that actually carry a value. */
+  const definedKeys = () =>
+    Object.entries(received)
+      .filter(([, v]) => v !== undefined)
+      .map(([k]) => k)
+      .sort();
+
+  async function click(schema: any) {
+    render(
+      <ActionProvider handlers={{ api }}>
+        <ElementButton schema={schema} />
+      </ActionProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Go/i }));
+    await waitFor(() => expect(api).toHaveBeenCalledOnce());
+  }
+
+  it('forwards the whitelisted members and DROPS every key off the list', async () => {
+    await click(
+      button({
+        // …every whitelisted member that is inert for an `api` action…
+        type: 'api',
+        name: 'close_order',
+        label: 'Close order',
+        description: 'Closes the order',
+        target: '/api/v1/order/close',
+        endpoint: '/api/v1/order/close',
+        method: 'PATCH',
+        bodyExtra: { status: 'closed' },
+        successMessage: 'Closed',
+        errorMessage: 'Failed',
+        refreshAfter: true,
+        params: { note: 'from the author' },
+        // …and three keys the forward list does not carry. `bodyShape` is the
+        // measured one (objectstack#6938): spec's InlineActionSchema pick list
+        // does not include it, so it must not arrive. `icon` and `variant` are
+        // element:button's OWN sibling props — authored one level in by
+        // mistake, they must not become action members either.
+        bodyShape: { wrap: 'data' },
+        icon: 'trash',
+        variant: 'danger',
+      }),
+    );
+
+    // The whitelist as a SET — arrival and drop in one assertion, so a member
+    // quietly added to or removed from the forward list is red either way.
+    expect(definedKeys()).toEqual([
+      'bodyExtra',
+      'description',
+      'endpoint',
+      'errorMessage',
+      'label',
+      'method',
+      'name',
+      'params',
+      'refreshAfter',
+      'successMessage',
+      'target',
+      'type',
+    ]);
+    // Named individually as well, because the sorted-list form above reads as
+    // a blob at review time and these three are the point of the row.
+    expect(received.bodyShape).toBeUndefined();
+    expect(received.icon).toBeUndefined();
+    expect(received.variant).toBeUndefined();
+    // …and the members that DID arrive kept their values, not just their names.
+    expect(received.bodyExtra).toEqual({ status: 'closed' });
+    expect(received.target).toBe('/api/v1/order/close');
+  });
+
+  it('`actionType` OUTRANKS `type` when both are authored', async () => {
+    // `type: action.actionType || action.type`. Authored with two different
+    // action kinds so a reversed read routes the click to the other handler
+    // instead of tying.
+    const onNavigate = vi.fn();
+    render(
+      <ActionProvider handlers={{ api }} onNavigate={onNavigate}>
+        <ElementButton
+          schema={button({
+            actionType: 'api',
+            type: 'navigation',
+            target: '/api/v1/order/close',
+            to: '/somewhere-else',
+          })}
+        />
+      </ActionProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Go/i }));
+
+    await waitFor(() => expect(api).toHaveBeenCalledOnce());
+    expect(received.type).toBe('api');
+    // The control that makes the line above a precedence reading rather than a
+    // coincidence: the losing spelling's handler never ran.
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('an ARRAY `params` is re-routed to `actionParams` — the collection DEFINITION', async () => {
+    // The one member whose NAME changes across the hop. Spec spells the
+    // parameter-definition array `params`; the runner disambiguates it from the
+    // static values object as `actionParams` (objectstack#5777 direction A).
+    const defs = [{ name: 'reason', type: 'string' }];
+    await click(button({ type: 'api', target: '/api/v1/order/close', params: defs }));
+
+    expect(received.actionParams).toEqual(defs);
+    // …and it does NOT also arrive under its authored name, which is what would
+    // let a downstream consumer read the definition array as a values map.
+    expect(received.params).toBeUndefined();
+  });
+
+  it('an OBJECT `params` stays `params` — the static values map', async () => {
+    // The other arm of the same branch, same shape, so the row above is a
+    // statement about ARRAY-ness and not about `params` generally.
+    await click(
+      button({ type: 'api', target: '/api/v1/order/close', params: { reason: 'duplicate' } }),
+    );
+
+    expect(received.params).toEqual({ reason: 'duplicate' });
+    expect(received.actionParams).toBeUndefined();
+  });
+
+  it('the navigation members reach the navigation handler', async () => {
+    // `to` and `opensInNewTab` are on the whitelist but inert for an `api`
+    // action, so they are pinned on the action kind that actually consumes
+    // them.
+    const onNavigate = vi.fn();
+    render(
+      <ActionProvider onNavigate={onNavigate}>
+        <ElementButton
+          schema={button({ type: 'navigation', to: '/apps/crm/contacts' })}
+        />
+      </ActionProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Go/i }));
+
+    await waitFor(() =>
+      expect(onNavigate).toHaveBeenCalledWith('/apps/crm/contacts', expect.anything()),
+    );
+  });
+
+  it('an omitted `action` leaves the button inert — no dispatch, no crash', async () => {
+    // The registration's own words ("omitted -> renders inert"), and the
+    // non-vacuity control for every row above: the dispatches they observe
+    // happen because an action was authored, not because clicking always fires.
+    render(
+      <ActionProvider handlers={{ api }}>
+        <ElementButton schema={{ type: 'element:button', properties: { label: 'Go' } }} />
+      </ActionProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Go/i }));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(api).not.toHaveBeenCalled();
+  });
+});

--- a/packages/components/src/__tests__/pageAccordionItemMembers-8071.test.tsx
+++ b/packages/components/src/__tests__/pageAccordionItemMembers-8071.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `page:accordion.items` — the MEMBER SHAPE of one panel definition
+ * (objectui#8071).
+ *
+ * The member pin for this key: which member of an authored item becomes which
+ * part of the rendered accordion. `PageAccordionRenderer`
+ * (`renderers/layout/containers.tsx`) reads exactly four members off each
+ * element of `items` — `label`, `icon`, `collapsed`, `children` — and the
+ * registration publishes that set verbatim
+ * (`[{ label, icon?, collapsed?, children }] — collapsed: false opens a panel
+ * by default`). Nothing asserted the mapping AS A SET before this file.
+ *
+ * What already existed, read end to end before this pin was written rather
+ * than trusted on its greps: `page-accordion-icon.test.tsx` (objectui#4721)
+ * pins ONE member, `icon`, and pins it well — per-item forwarding, a positive
+ * control where only some panels declare one, and the no-icon case. It asserts
+ * nothing about `label`, `collapsed` or `children`, and would not fail if those
+ * three swapped roles. So `icon` is covered narrowly below rather than
+ * re-litigated, and the members this file exists for are the other three.
+ *
+ * The `collapsed` member is the one with real semantics to get wrong, and the
+ * renderer's reading is STRICTLY `=== false`:
+ *
+ *     const defaultOpen = itemsWithValue.filter((it) => it.collapsed === false)
+ *
+ * so `collapsed: false` OPENS a panel, while `collapsed: true` AND an omitted
+ * `collapsed` both leave it shut. That is the inverse of how the member name
+ * reads at a glance, which is exactly why it is pinned: an "obvious" edit to
+ * `!it.collapsed` would open every panel that never mentioned the key.
+ *
+ * The single/multiple split is asserted too, because `allowMultiple` changes
+ * what the SAME `collapsed` members mean: single mode takes `defaultOpen[0]`
+ * (the FIRST opener wins, later ones are dropped), multiple mode takes them
+ * all. A pin that only ever rendered one open panel could not tell the two
+ * readings apart.
+ *
+ * Radix unmounts a closed panel's content, so "open" is asserted as the panel
+ * BODY being in the document — the same observation `page-tabs-*` suites make
+ * of an inactive tab, and one that cannot be satisfied by a header alone.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { SchemaRenderer } from '@object-ui/react';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../renderers';
+
+vi.mock('../lib/lazy-icon', () => ({
+  LazyIcon: ({ name, className }: { name?: string; className?: string }) => (
+    <svg data-testid="accordion-item-icon" data-name={name} className={className} />
+  ),
+}));
+
+afterEach(() => cleanup());
+
+const textChild = (content: string) => [{ type: 'element:text', properties: { content } }];
+
+const renderAccordion = (items: any[], rest: Record<string, unknown> = {}) =>
+  render(<SchemaRenderer schema={{ type: 'page:accordion', id: 'acc', items, ...rest } as never} />);
+
+describe('page:accordion items — member shape (objectui#8071)', () => {
+  it('`label` becomes the panel trigger and `children` becomes that panel BODY', () => {
+    // The two structural members, asserted against each other so a renderer
+    // that painted the wrong one cannot pass: the label text is a trigger, the
+    // child text is the panel content, and `collapsed: false` is what puts the
+    // body in the document at all.
+    const { getByRole, getByText } = renderAccordion([
+      { label: 'Details', collapsed: false, children: textChild('DETAILS BODY') },
+      { label: 'Notes', children: textChild('NOTES BODY') },
+    ]);
+
+    // `label` -> the trigger's accessible name.
+    expect(getByRole('button', { name: /Details/i })).toBeTruthy();
+    expect(getByRole('button', { name: /Notes/i })).toBeTruthy();
+    // `children` -> the open panel's body. NOT the label, and not a sibling of it.
+    expect(getByText('DETAILS BODY')).toBeTruthy();
+  });
+
+  it('`collapsed: false` opens a panel; `collapsed: true` and an OMITTED collapsed both stay shut', () => {
+    // The `=== false` reading, pinned against the two ways a panel stays
+    // closed. The omitted-key arm is the half an `!it.collapsed` edit breaks.
+    const { queryByText } = renderAccordion([
+      { label: 'Open me', collapsed: false, children: textChild('OPEN BODY') },
+      { label: 'Explicitly shut', collapsed: true, children: textChild('SHUT BODY') },
+      { label: 'Says nothing', children: textChild('SILENT BODY') },
+    ]);
+
+    expect(queryByText('OPEN BODY')).not.toBeNull();
+    expect(queryByText('SHUT BODY')).toBeNull();
+    // The control that separates "reads `=== false`" from "reads truthiness":
+    // an item with no `collapsed` at all must behave like `collapsed: true`.
+    expect(queryByText('SILENT BODY')).toBeNull();
+  });
+
+  it('every panel stays shut when NO item declares `collapsed: false` (the default)', () => {
+    // Non-vacuity for the assertion above: without this, a renderer that opened
+    // nothing ever would satisfy both "shut" rows for the wrong reason.
+    const { queryByText, getByRole } = renderAccordion([
+      { label: 'Alpha', children: textChild('ALPHA BODY') },
+      { label: 'Beta', children: textChild('BETA BODY') },
+    ]);
+
+    expect(getByRole('button', { name: /Alpha/i })).toBeTruthy();
+    expect(queryByText('ALPHA BODY')).toBeNull();
+    expect(queryByText('BETA BODY')).toBeNull();
+  });
+
+  it('single mode opens only the FIRST `collapsed: false` panel', () => {
+    // `defaultValue={defaultOpen[0]}` — later openers are dropped, because a
+    // Radix `type="single"` accordion holds one value.
+    const { queryByText } = renderAccordion([
+      { label: 'First', collapsed: false, children: textChild('FIRST BODY') },
+      { label: 'Second', collapsed: false, children: textChild('SECOND BODY') },
+    ]);
+
+    expect(queryByText('FIRST BODY')).not.toBeNull();
+    expect(queryByText('SECOND BODY')).toBeNull();
+  });
+
+  it('`allowMultiple` opens EVERY `collapsed: false` panel — same items, different reading', () => {
+    // The same two items as the row above, so the only variable is
+    // `allowMultiple`. This is what makes the previous row a statement about
+    // single mode rather than about `collapsed`.
+    const { queryByText } = renderAccordion(
+      [
+        { label: 'First', collapsed: false, children: textChild('FIRST BODY') },
+        { label: 'Second', collapsed: false, children: textChild('SECOND BODY') },
+        { label: 'Third', children: textChild('THIRD BODY') },
+      ],
+      { allowMultiple: true },
+    );
+
+    expect(queryByText('FIRST BODY')).not.toBeNull();
+    expect(queryByText('SECOND BODY')).not.toBeNull();
+    // …and `allowMultiple` does not open panels that never asked to be open.
+    expect(queryByText('THIRD BODY')).toBeNull();
+  });
+
+  it('`icon` rides on the same item as its label, per panel', () => {
+    // Narrow on purpose — `page-accordion-icon.test.tsx` (objectui#4721) is the
+    // pin for this member and is not duplicated here. This row exists so the
+    // member SET this file states is complete: four members, four assertions.
+    const { getAllByTestId } = renderAccordion([
+      { label: 'Details', icon: 'user', children: textChild('DETAILS BODY') },
+      { label: 'Notes', children: textChild('NOTES BODY') },
+    ]);
+
+    const icons = getAllByTestId('accordion-item-icon');
+    expect(icons).toHaveLength(1);
+    expect(icons[0].getAttribute('data-name')).toBe('user');
+  });
+});

--- a/packages/components/src/__tests__/pageTabsItemMembers-8071.test.tsx
+++ b/packages/components/src/__tests__/pageTabsItemMembers-8071.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `page:tabs.items` — the MEMBER SHAPE of one tab definition (objectui#8071).
+ *
+ * The member pin for this key. `PageTabsRenderer`
+ * (`renderers/layout/containers.tsx`) reads SIX members off each element of
+ * `items` — `label`, `value`, `icon`, `count`, `visibleWhen`, `children` — and
+ * the registration publishes that set verbatim (`[{ label, value?, icon?,
+ * count?, visibleWhen?, children }]`). Each becomes a DIFFERENT part of the
+ * rendered strip, and this file pins the mapping as a set: label to the trigger
+ * name, icon to the trigger's leading glyph, count to the trailing badge, value
+ * to the tab's IDENTITY, children to the panel, `visibleWhen` to the tab's
+ * existence.
+ *
+ * ## Why a new file rather than promoting one of the five that already exist
+ *
+ * All five were read end to end before this pin was written. Each is a good pin
+ * on ONE member and asserts nothing about the mapping as a whole:
+ *
+ *   - `page-tabs-visibility.test.tsx` — `visibleWhen`, and thoroughly: whole-tab
+ *     removal, live re-evaluation against page variables, the
+ *     `{ dialect, source }` envelope, the active-tab fallback, and the
+ *     deprecated `visibility` alias staying unread. It does exercise `label`
+ *     and `children` as real members, which is why the two are not re-litigated
+ *     in depth here.
+ *   - `page-tabs-count-badge-i18n.test.tsx` — the badge's ACCESSIBLE NAME and
+ *     its plural key selection, not which member feeds it.
+ *   - `pageTabsUrlSync.test.ts` — `value` as the `?tab=` URL token, one layer up
+ *     in `app-shell`, off this renderer entirely.
+ *   - `page-tabs-always-show-strip.test.tsx` — the strip-visibility rule, a
+ *     BLOCK-level key (`alwaysShowStrip`), not an item member.
+ *   - `page-tabs-builtin-label-i18n-4645.test.tsx` — `label` localization of
+ *     well-known English tokens.
+ *
+ * So no single existing file would fail if `count` and `value` swapped roles,
+ * which is the shape a member pin has to catch.
+ *
+ * ## The two readings with real semantics to get wrong
+ *
+ * `count` is NOT rendered whenever it is present. The renderer gates on
+ * `!== undefined && !== null && !== '' && Number(count) > 0`, so an authored
+ * `count: 0` paints NO badge — a zero-count tab reads as a plain tab, not as a
+ * tab wearing a `0`. And `value` is `typeof value === 'string' && value !== ''`
+ * or else `tab-INDEX`: an authored value is the stable identity, an absent one
+ * silently becomes positional. Both arms are pinned, because both are the kind
+ * of thing a tidy-up edit rewrites without noticing.
+ *
+ * `value` is asserted BEHAVIOURALLY, through `defaultTab` — the host key
+ * app-shell restores `?tab=` with, which is honoured "only when it names an
+ * actual tab". Selecting a tab by its authored value proves the member IS the
+ * identity, without reaching into Radix's generated element ids.
+ *
+ * Labels here are deliberately NOT well-known English tokens (`Details`,
+ * `Related`, …): those route through `translateLabel`'s pack lookup, which is
+ * `page-tabs-builtin-label-i18n-4645.test.tsx`'s subject. Plain names keep this
+ * file's rows about member ROUTING rather than about i18n.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { SchemaRenderer } from '@object-ui/react';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../renderers';
+
+vi.mock('../lib/lazy-icon', () => ({
+  LazyIcon: ({ name, className }: { name?: string; className?: string }) => (
+    <svg data-testid="tab-item-icon" data-name={name} className={className} />
+  ),
+}));
+
+afterEach(() => cleanup());
+
+const textChild = (content: string) => [{ type: 'element:text', properties: { content } }];
+
+const renderTabs = (items: any[], rest: Record<string, unknown> = {}) =>
+  render(<SchemaRenderer schema={{ type: 'page:tabs', id: 'tabs', items, ...rest } as never} />);
+
+describe('page:tabs items — member shape (objectui#8071)', () => {
+  it('`label` becomes the tab trigger and `children` becomes that tab PANEL', () => {
+    // The two structural members against each other. Radix renders only the
+    // ACTIVE panel, so the second tab's body being absent is part of the claim:
+    // `children` is panel content, not strip content.
+    const { getByRole, getByText, queryByText } = renderTabs([
+      { label: 'Alpha', value: 'alpha', children: textChild('ALPHA BODY') },
+      { label: 'Beta', value: 'beta', children: textChild('BETA BODY') },
+    ]);
+
+    expect(getByRole('tab', { name: /Alpha/i })).toBeTruthy();
+    expect(getByRole('tab', { name: /Beta/i })).toBeTruthy();
+    expect(getByText('ALPHA BODY')).toBeTruthy();
+    expect(queryByText('BETA BODY')).toBeNull();
+  });
+
+  it('`value` is the tab IDENTITY — `defaultTab` selects a tab by the value its item authored', () => {
+    // Behavioural pin on the member: the host restores a tab by NAME, so an
+    // authored `value` has to be what names it.
+    const { getByText, queryByText } = renderTabs(
+      [
+        { label: 'Alpha', value: 'alpha', children: textChild('ALPHA BODY') },
+        { label: 'Beta', value: 'beta', children: textChild('BETA BODY') },
+      ],
+      { defaultTab: 'beta' },
+    );
+
+    // The SECOND tab is active because its item said `value: 'beta'` — not
+    // because of its position.
+    expect(getByText('BETA BODY')).toBeTruthy();
+    expect(queryByText('ALPHA BODY')).toBeNull();
+  });
+
+  it('an item with NO `value` falls back to its positional `tab-INDEX` identity', () => {
+    // The other arm of the same read. Same shape as the row above, with the
+    // `value` members deleted — so a `defaultTab` naming the positional token
+    // is what selects the second tab.
+    const { getByText, queryByText } = renderTabs(
+      [
+        { label: 'Alpha', children: textChild('ALPHA BODY') },
+        { label: 'Beta', children: textChild('BETA BODY') },
+      ],
+      { defaultTab: 'tab-1' },
+    );
+
+    expect(getByText('BETA BODY')).toBeTruthy();
+    expect(queryByText('ALPHA BODY')).toBeNull();
+  });
+
+  it('an EMPTY-STRING `value` is not an identity — it falls back positionally too', () => {
+    // `typeof value === 'string' && value !== ''`. Without this row a read of
+    // just `typeof value === 'string'` would pass every assertion above.
+    const { getByText, queryByText } = renderTabs(
+      [
+        { label: 'Alpha', value: '', children: textChild('ALPHA BODY') },
+        { label: 'Beta', value: '', children: textChild('BETA BODY') },
+      ],
+      { defaultTab: 'tab-1' },
+    );
+
+    expect(getByText('BETA BODY')).toBeTruthy();
+    expect(queryByText('ALPHA BODY')).toBeNull();
+  });
+
+  it('`count` becomes the trailing badge, and `icon` the leading glyph, on their OWN item', () => {
+    // Per-item routing for the two decorative members, with a neighbour that
+    // declares neither — so neither can be strip-wide.
+    const { getAllByTestId, getByRole } = renderTabs([
+      { label: 'Alpha', value: 'alpha', icon: 'user', count: 7, children: textChild('ALPHA BODY') },
+      { label: 'Beta', value: 'beta', children: textChild('BETA BODY') },
+    ]);
+
+    const icons = getAllByTestId('tab-item-icon');
+    expect(icons).toHaveLength(1);
+    expect(icons[0].getAttribute('data-name')).toBe('user');
+
+    // The badge digits live inside the trigger that owns the count…
+    expect(getByRole('tab', { name: /Alpha/i }).textContent).toContain('7');
+    // …and not inside its neighbour.
+    expect(getByRole('tab', { name: /Beta/i }).textContent).not.toContain('7');
+  });
+
+  it('`count: 0` paints NO badge — presence is not the gate, a positive value is', () => {
+    // `Number(item.count) > 0`. A zero-count tab is a plain tab; the badge is an
+    // affordance for "there is something in here", not a readout of the member.
+    const { getByRole } = renderTabs([
+      { label: 'Alpha', value: 'alpha', count: 0, children: textChild('ALPHA BODY') },
+      { label: 'Beta', value: 'beta', count: 4, children: textChild('BETA BODY') },
+    ]);
+
+    expect(getByRole('tab', { name: /Alpha/i }).textContent).not.toContain('0');
+    // The positive control on the same strip, same run: the gate really does
+    // let a real count through, so the row above is a reading and not a
+    // renderer that never badges anything.
+    expect(getByRole('tab', { name: /Beta/i }).textContent).toContain('4');
+  });
+
+  it('`visibleWhen` removes the whole tab — trigger AND panel', () => {
+    // Narrow on purpose: `page-tabs-visibility.test.tsx` is the pin for this
+    // member's depth (live re-evaluation, the Expression envelope, the
+    // active-tab fallback, the unread `visibility` alias). This row is here so
+    // the member SET this file states is complete — six members, six routings.
+    const { queryByRole, queryByText, getByRole } = renderTabs([
+      { label: 'Alpha', value: 'alpha', children: textChild('ALPHA BODY') },
+      { label: 'Beta', value: 'beta', children: textChild('BETA BODY') },
+      { label: 'Gamma', value: 'gamma', visibleWhen: '1 == 2', children: textChild('GAMMA BODY') },
+    ]);
+
+    expect(getByRole('tab', { name: /Alpha/i })).toBeTruthy();
+    expect(queryByRole('tab', { name: /Gamma/i })).toBeNull();
+    expect(queryByText('GAMMA BODY')).toBeNull();
+  });
+});

--- a/packages/components/src/renderers/basic/__tests__/elementNumberFilterMembers-8071.test.tsx
+++ b/packages/components/src/renderers/basic/__tests__/elementNumberFilterMembers-8071.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `element:number.filter` — the MEMBER SHAPE this metric reads (objectui#8071).
+ *
+ * The member pin for this key. Unlike the other keys this card has pinned,
+ * `filter` carries no NAMED member set of its own: it is a query predicate
+ * `ElementNumberRenderer` (`renderers/basic/elements.tsx`) never inspects. So
+ * the member shape here is the SPELLING it arrives under downstream, and the
+ * renderer uses TWO different ones on its two paths:
+ *
+ *   - `adapter.aggregate(object, { field, function, groupBy: '_all', filter })`
+ *     — flat, under its own name, beside the three keys that make the call an
+ *     aggregate at all.
+ *   - `adapter.find(object, { $filter: filter })` — the fallback when the
+ *     adapter carries no `aggregate()`, WRAPPED under `$filter`.
+ *
+ * One authored key, two wire spellings, chosen by a capability check the author
+ * cannot see. That is precisely the kind of thing that gets "tidied" into one
+ * spelling, and either direction silently drops the predicate: a metric that
+ * should read "open opportunities" then counts EVERY row and paints a
+ * confidently wrong number. No diagnostic, no empty state — the failure mode
+ * this whole direction (objectui#8068) exists to make loud.
+ *
+ * The third member semantic is the re-query rule. The effect keys on
+ * `JSON.stringify(props.filter)`, not on the object identity:
+ *
+ *     const filterKey = React.useMemo(
+ *       () => (props.filter ? JSON.stringify(props.filter) : ''), [props.filter]);
+ *
+ * so the predicate is read BY VALUE. A parent that rebuilds an equal filter
+ * literal every render must NOT re-probe the server, and a parent that changes
+ * one comparand MUST. Both arms are asserted, because a dependency array
+ * "simplified" to `props.filter` passes the second and turns the first into a
+ * per-render fetch storm.
+ *
+ * ## Nothing pre-existing covered this
+ *
+ * Measured before writing: exactly two test files name `element:number` and
+ * touch this area, and neither can be credited.
+ * `element-number.contractEnvelope-6726.test.tsx` (read end to end) drives the
+ * SAME `find()` fallback branch but authors no `filter` at all — the word does
+ * not occur in it, so the locator itself would refuse it ("pin file never names
+ * the key"). `data-objectstack`'s `aggregate-filter-lowering.test.ts` mentions
+ * `element:number` once, in a comment, and tests the adapter's own lowering
+ * below this seam rather than what the renderer hands it.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import { AdapterCtx, SchemaRenderer } from '@object-ui/react';
+// Registers every `element:*` renderer at module scope, not in a hook
+// (object-ui/no-dynamic-import-in-test-hook, objectui#3010).
+import '../../../renderers';
+
+afterEach(cleanup);
+
+const OPEN_ONLY = { stage: { $ne: 'closed' } };
+
+const metric = (filter?: unknown) => ({
+  type: 'element:number',
+  id: 'metric',
+  // Element config lives in the `properties` bag (`readProps`), not on the
+  // node — the same door an authored page writes through.
+  properties: { object: 'opportunity', field: 'amount', aggregate: 'sum', ...(filter ? { filter } : {}) },
+});
+
+/** An adapter that CAN aggregate — the primary path. */
+const aggregating = () => ({
+  aggregate: vi.fn(async () => [{ amount_sum: 42 }]),
+  find: vi.fn(async () => ({ data: [] })),
+});
+
+/** An adapter that cannot — `find()` is the only way to a number. */
+const findingOnly = () => ({ find: vi.fn(async () => ({ data: [{ id: 'r1' }] })) });
+
+function mount(adapter: unknown, filter?: unknown) {
+  return render(
+    <AdapterCtx.Provider value={adapter as never}>
+      <SchemaRenderer schema={metric(filter) as never} />
+    </AdapterCtx.Provider>,
+  );
+}
+
+describe('element:number filter — member shape (objectui#8071)', () => {
+  it('reaches `aggregate()` FLAT, under its own name, beside the aggregate members', async () => {
+    const adapter = aggregating();
+    mount(adapter, OPEN_ONLY);
+
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalledOnce());
+    // The whole options bag, not just the filter — `groupBy: '_all'` and
+    // `function` are what make this an aggregate rather than a query, and a
+    // filter that arrived without them would be counting something else.
+    expect(adapter.aggregate).toHaveBeenCalledWith('opportunity', {
+      field: 'amount',
+      function: 'sum',
+      groupBy: '_all',
+      filter: OPEN_ONLY,
+    });
+    // Verbatim: the renderer does not normalise, wrap or re-key the predicate
+    // on this path.
+    expect((adapter.aggregate as any).mock.calls[0][1].filter).toEqual(OPEN_ONLY);
+  });
+
+  it('reaches the `find()` fallback WRAPPED as `$filter` — the other spelling', async () => {
+    // Same authored key, same value, different adapter capability. This is the
+    // row that makes "two spellings" a reading rather than an assumption.
+    const adapter = findingOnly();
+    mount(adapter, OPEN_ONLY);
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalledOnce());
+    expect(adapter.find).toHaveBeenCalledWith('opportunity', { $filter: OPEN_ONLY });
+  });
+
+  it('sends NO options at all to `find()` when no filter is authored', async () => {
+    // `props.filter ? { $filter: props.filter } : undefined`. The control for
+    // the row above: an unfiltered metric must not ship an empty envelope,
+    // which some adapters read as "match nothing".
+    const adapter = findingOnly();
+    mount(adapter);
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalledOnce());
+    expect(adapter.find).toHaveBeenCalledWith('opportunity', undefined);
+  });
+
+  it('is read BY VALUE — an equal filter rebuilt with a new identity does NOT re-probe', async () => {
+    // The re-query rule. A parent re-rendering with a fresh object literal is
+    // the normal case, not an exotic one, and a dependency on the reference
+    // would turn every such render into a server round trip.
+    const adapter = aggregating();
+    const view = mount(adapter, { stage: { $ne: 'closed' } });
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalledOnce());
+
+    view.rerender(
+      <AdapterCtx.Provider value={adapter as never}>
+        {/* Deep-equal, freshly allocated — a different object, the same predicate. */}
+        <SchemaRenderer schema={metric({ stage: { $ne: 'closed' } }) as never} />
+      </AdapterCtx.Provider>,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(adapter.aggregate).toHaveBeenCalledOnce();
+  });
+
+  it('…and a filter whose VALUE changes does re-probe, with the new predicate', async () => {
+    // The other arm, and the non-vacuity control for the row above: without it
+    // a renderer that never re-probed at all would pass that assertion.
+    const adapter = aggregating();
+    const view = mount(adapter, { stage: { $ne: 'closed' } });
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalledOnce());
+
+    view.rerender(
+      <AdapterCtx.Provider value={adapter as never}>
+        <SchemaRenderer schema={metric({ stage: { $ne: 'won' } }) as never} />
+      </AdapterCtx.Provider>,
+    );
+
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalledTimes(2));
+    expect((adapter.aggregate as any).mock.calls[1][1].filter).toEqual({ stage: { $ne: 'won' } });
+  });
+});


### PR DESCRIPTION
Refs #8071 — slice 7. The card stays open, and 37 exemptions remain.

## What this lands, in one commit

Every remaining `MEMBER_PIN_EXEMPTIONS` block whose remainder was exactly **one key** becomes a real per-block member pin. The four exemptions are deleted and `MEMBER_PIN_EXEMPTION_CEILING` moves 41 to 37 in the same commit, so the ceiling never holds an unused slot.

| key | pin file | new or promoted |
| --- | --- | --- |
| `element:button.action` | `packages/components/src/__tests__/elementButtonActionMembers-8071.test.tsx` | new |
| `element:number.filter` | `packages/components/src/renderers/basic/__tests__/elementNumberFilterMembers-8071.test.tsx` | new |
| `page:accordion.items` | `packages/components/src/__tests__/pageAccordionItemMembers-8071.test.tsx` | new |
| `page:tabs.items` | `packages/components/src/__tests__/pageTabsItemMembers-8071.test.tsx` | new |

All four blocks now carry **zero** exemptions. The batch is coherent on slice 6's terms: one package (`packages/components`) registers all four — the two `element:` keys share `renderers/basic/elements.tsx`, the two `page:` keys share `renderers/layout/containers.tsx` — and the selection rule is stateable in a sentence.

## AST ledger — measured, not inherited

TypeScript AST walk (`ts.createSourceFile`, `VariableDeclaration`, initializer unwrapped through as / satisfies / parens, `PropertyAssignment`), object boundaries from **AST node spans**. Re-derived on this branch's own head rather than taken from the dispatch.

```
                                 before (b97129e96)      after (4e4e6ca56)
MEMBER_PIN_EXEMPTIONS                    41                      37
MEMBER_PIN_EXEMPTION_CEILING             41  (:2747)             37  (:2818)
MEMBER_PINS                              49                      53
distinct block prefixes                  10                       6
NEWLY_JUDGED_UNPINNED_MEMBERS             2                       2   (untouched)
```

The delta balances on one instrument: **minus 4 exemptions, minus 4 ceiling, plus 4 pins**, with the parent holding exactly one key under each of the four prefixes taken. Parser guards clean: `parseDiagnostics` 0; exactly one `VariableDeclaration` per name, so no shadowed node was picked up; 0 non-`PropertyAssignment` members and 0 computed keys in either object; 0 non-string array elements.

### Instrument cross-check, reported rather than smoothed

A key-anchored regex **bounded to top-level indentation inside the AST span** AGREES on both objects: 37 = 37 and 53 = 53, with an empty only-in-AST and an empty only-in-regex set.

The **depth-blind** key anchor slice 6 caught still reads `MEMBER_PINS` as **159** against the AST's 53. Fully accounted for: values are objects of shape file-plus-pins, so 53 entries carry 106 nested sub-keys, and 53 + 106 = 159 matches to the unit. That is the same failure mode for the fourth time on this file, on new content — recorded, not smoothed.

## The two one-key blocks deliberately NOT taken

- **`record:related_list.actions`** is the `NO_READ_SITE_TO_PIN` sentinel, and the reading was **re-measured here rather than inherited**: on this tree `packages/plugin-detail/src/renderers/record-related-list.tsx` contains **zero** case-sensitive occurrences of `actions` (control on the same file, same run: `import` reads **9**), and the only near-matches are `useRelatedRecordActions` / `relatedActions` — the host bridge the constant already names. Nothing to pin, still. It is **not** "one easy key left".
- **`object-kanban.columns` / `object-kanban.dataSource`** are the `NEWLY_JUDGED_UNPINNED_MEMBERS` pair, held by the unruled contract question in objectui#8913 and by the live branch over `packages/plugin-kanban/**`. Pinning a shape a pending ruling may delete would be worse than leaving it exempt, so `NEWLY_JUDGED_UNPINNED_MEMBERS` is **unchanged** — no block it names was touched, and no file this PR edits is owned by that branch.

## Why four new files rather than promotions

Every candidate was **read end to end** before being rejected, not dismissed on its greps. None covered its key's member **set**: `element-button-action.test.tsx` drives only `type` and `to` on one navigation action; `action-bodyExtra-forward.test.tsx` pins one member across four renderers; `page-accordion-icon.test.tsx` pins `icon` alone; the five `page:tabs` suites pin one member each; and `element-number.contractEnvelope-6726.test.tsx` drives the same `find()` fallback branch but never authors a `filter`, so the locator itself would refuse it.

One had to be **refused** rather than merely passed over. `action-bodyShape-forward.test.tsx` NAMES `element:button` and the key `action`, so it would satisfy the locator — while what it actually says is that `element:button` is deliberately out of its scope. Crediting it would have been a pin asserting the opposite of its claim, which is the false-negative shape objectui#8068 exists to end. Its boundary is instead pinned as **behaviour** in the new file, which authors a non-whitelisted key and asserts it is dropped.

## Ablations — every mutation proven on disk BEFORE any result was read

Each run anchors grep counts on **both** the injected and the removed text, requires `git hash-object` to differ from the HEAD blob, restores with `git checkout HEAD -- ABSOLUTE_PATH` from a `trap ... EXIT INT TERM`, and proves restoration **by blob hash** — never by an exit code.

**Family 1 — the gate mechanism.** One deleted exemption re-added, ceiling untouched. Blob `c5497f50` to `c7e10387` and back to `c5497f50`.

Exactly three rows red, each for its own reason, 195 green:

```
× judges a non-vacuous member-shape census   expected [ 'element:button.action' ] to deeply equal []
× carries no stale member-pin exemption      expected [ 'element:button.action' ] to deeply equal []
× the member-pin exemption list only ratchets DOWN   expected 38 to be less than or equal to 37
```

**Family 2 — one per new pin, each failing for its own reason.** All four pin files run together each time, so "its own reason" is observable rather than asserted.

| pin ablated | mutation | rows red | other three pins |
| --- | --- | --- | --- |
| `element:button.action` | drop `bodyExtra` from the forward whitelist | 1 — the whitelist-SET row | green (23 passed) |
| `element:number.filter` | rewrite the `find()` wrapper key to the flat spelling | 1 — the wrapped-spelling row | green (23 passed) |
| `page:accordion.items` | `it.collapsed === false` becomes `!it.collapsed` | 2 | green (22 passed) |
| `page:tabs.items` | drop the positive gate on the count badge | 1 — the zero-count row | green (23 passed) |

Blob hashes: `elements.tsx` `498cbdef` to `e0e1ebbd` and to `7fcb7bfc`, restored to `498cbdef` both times; `containers.tsx` `0ba09c75` to `072638f8` and to `8fecfe8a`, restored to `0ba09c75` both times.

⭐ Worth one line for the next reader: the accordion ablation reds the two rows written **as controls** — "every panel stays shut when no item declares it" and the `allowMultiple` row — and **not** the row that names `collapsed` directly. In single mode `defaultOpen[0]` masks the difference between the two readings, so the controls are the only thing that catches it. They are load-bearing, not decoration.

## Verification

Exit codes captured into a variable **before** any pipe; readings taken from each tool's own verdict line.

| run | result |
| --- | --- |
| the gate, `registry-inputs-spec-parity.test.ts` | exit 0 — 198 passed |
| `@object-ui/console` full suite | exit 0 — 98 files, 1132 tests |
| `@object-ui/components` full suite (two shards) | exit 0 — 130 + 129 = 259 files, 2354 tests |
| `type-check`, both packages | exit 0 — 0 `error TS` rows, both echoed their script and printed Done |
| `lint`, both packages | exit 0 — **0 errors**, 948 and 212 warnings (all pre-existing) |

Notes that keep those readings honest:

- The components shard counts sum to **259**, which equals the package's actual test-file count — so the sharded run covered the package rather than half of it.
- `lint` was read for the literal word `error`, not merely a zero exit. Every hit is a `warning  Error: ...` rule message or a source line containing the word; **zero** severity-ERROR rows in either package. Both packages emitted real eslint summaries (1535 and 621 output lines), so "the filter matched no script, nothing ran, exit 0" is excluded.
- `type-check` genuinely covers the changed files rather than skipping them: `packages/components` chains `tsc -p tsconfig.test.json`, whose include globs are `src/` test patterns, and `apps/console` includes `src` with no exclude.
- The first `type-check` attempt failed with `TS2307` on unbuilt workspace siblings. The dependency closure was built and it was re-run; the table reports the run on the built tree.

`.changeset/member-pins-slice-7.md` carries an **empty frontmatter** — declared as releasing nothing, which `scripts/check-changeset-presence.mjs` accepts as a complete answer (exit 0). `scripts/check-governed-queue-guard.mjs --test` on all six paths reports **NOT GOVERNED** (exit 0).

## After this slice

Every remaining exemption sits on one of four **multi-key** blocks — `object-grid` 15, `object-form` 7, `object-master-detail-form` 6, `object-metric` 6 — plus the two held keys. The "close a block outright by taking its last key" shape is now **exhausted**: the next slice is the first that has to take a partial block or close a multi-key one whole. That is stated in the ceiling docblock too, so the next reader does not spend the search rediscovering it.

⛔ Draft on purpose — the PM lands it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_