### PR TITLE
fix(site): drop the count-based claims from the homepage, fix the dead catalog link, add page metadata

### DIFF
--- a/apps/site/app/(home)/page.tsx
+++ b/apps/site/app/(home)/page.tsx
@@ -1,7 +1,23 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { LiveSplitDemo } from '@/app/components/LiveSplitDemo';
 import { ReactVsObjectUI } from '@/app/components/ReactVsObjectUI';
 
+const TITLE = 'Object UI — schema-driven UI engine for React';
+const DESCRIPTION =
+  'AI writes the schema; Object UI renders it — production React from JSON, Tailwind and Shadcn native, any backend.';
+
+// The route had no metadata at all, so the homepage shipped with no <title>,
+// no description and no link-preview fields. Open Graph and Twitter carry no
+// image: the site ships none, and naming one it does not serve would render a
+// broken preview. No `metadataBase` is needed here either — nothing below
+// resolves against an origin (no OG image, no `alternates.canonical`).
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  openGraph: { type: 'website', title: TITLE, description: DESCRIPTION },
+  twitter: { card: 'summary', title: TITLE, description: DESCRIPTION },
+};
 
 export default function HomePage() {
   return (
@@ -111,7 +127,7 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* React vs ObjectUI — line-count contrast */}
+      {/* React vs ObjectUI — the same dashboard, written both ways */}
       <ReactVsObjectUI />
 
       {/* Features Section */}
@@ -138,7 +154,7 @@ export default function HomePage() {
                 Blazing Fast
               </h3>
               <p className="text-fd-muted-foreground">
-                3x faster page loads and 6x smaller bundle sizes compared to traditional low-code platforms. Built on React 18+ with automatic optimizations.
+                Lazy-loaded plugins and tree-shakable packages: a page pays for the components it renders, nothing else.
               </p>
             </div>
 
@@ -183,7 +199,7 @@ export default function HomePage() {
                 Production Ready
               </h3>
               <p className="text-fd-muted-foreground">
-                85%+ test coverage, enterprise security built-in, comprehensive documentation, and active development support.
+                TypeScript end to end, a CI suite on every change, and documentation that is gated against the code.
               </p>
             </div>
 
@@ -198,7 +214,7 @@ export default function HomePage() {
                 Modular Architecture
               </h3>
               <p className="text-fd-muted-foreground">
-                Tree-shakable packages, lazy-loaded plugins, and support for Server Components. Only load what you need.
+                Tree-shakable packages and lazy-loaded plugins. Only load what you need.
               </p>
             </div>
 
@@ -220,72 +236,6 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* Stats Section */}
-      <section className="bg-gradient-to-r from-blue-600 to-violet-600 py-24 sm:py-32 dark:from-blue-700 dark:to-violet-700">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="grid grid-cols-1 gap-8 sm:grid-cols-3 text-center text-white">
-            <div>
-              <div className="text-5xl font-bold mb-2">60+</div>
-              <div className="text-xl opacity-90">Components</div>
-            </div>
-            <div>
-              <div className="text-5xl font-bold mb-2">85%+</div>
-              <div className="text-xl opacity-90">Test Coverage</div>
-            </div>
-            <div>
-              <div className="text-5xl font-bold mb-2">50KB</div>
-              <div className="text-xl opacity-90">Bundle Size</div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Use Cases Section */}
-      <section className="py-24 sm:py-32 bg-fd-muted/30">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8">
-          <div className="mx-auto max-w-2xl text-center mb-16">
-            <h2 className="text-3xl font-bold tracking-tight text-fd-foreground sm:text-4xl">
-              What Can You Build?
-            </h2>
-            <p className="mt-4 text-lg text-fd-muted-foreground">
-              From admin panels to dashboards, ObjectUI handles it all
-            </p>
-          </div>
-          
-          <div className="mx-auto grid max-w-6xl grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {[
-              { icon: "📊", title: "Dashboards", desc: "Data visualization and analytics" },
-              { icon: "⚙️", title: "Admin Panels", desc: "Complete CRUD interfaces" },
-              { icon: "📝", title: "Forms", desc: "Complex multi-step forms" },
-              { icon: "📄", title: "CMS", desc: "Content management systems" },
-              { icon: "🔧", title: "Internal Tools", desc: "Business applications" },
-            ].map((useCase) => (
-              <div key={useCase.title} className="rounded-xl border border-fd-border bg-fd-card p-6">
-                <div className="text-4xl mb-3">{useCase.icon}</div>
-                <h3 className="text-lg font-semibold text-fd-foreground mb-1">
-                  {useCase.title}
-                </h3>
-                <p className="text-fd-muted-foreground text-sm">
-                  {useCase.desc}
-                </p>
-              </div>
-            ))}
-            <Link 
-              href="/docs/guide/interactive-demos"
-              className="rounded-xl border border-fd-border bg-fd-card p-6 transition-all hover:shadow-lg hover:border-fd-primary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-primary focus-visible:ring-offset-2"
-            >
-              <div className="text-4xl mb-3">✨</div>
-              <h3 className="text-lg font-semibold text-fd-foreground mb-1">
-                Interactive Examples
-              </h3>
-              <p className="text-fd-muted-foreground text-sm">
-                Explore 30+ components with live demos
-              </p>
-            </Link>
-          </div>
-        </div>
-      </section>
-
       {/* CTA Section */}
       <section className="py-24 sm:py-32">
         <div className="mx-auto max-w-7xl px-6 lg:px-8">
@@ -297,12 +247,18 @@ export default function HomePage() {
               <p className="mx-auto mt-6 max-w-2xl text-lg text-white/90">
                 Join developers who are building faster with ObjectUI. Get started in minutes with our comprehensive documentation.
               </p>
-              <div className="mt-10 flex items-center justify-center gap-4">
+              <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
                 <Link
                   href="/docs"
                   className="rounded-lg bg-fd-background px-8 py-3.5 text-base font-semibold text-fd-foreground shadow-lg transition-all hover:bg-fd-background/90"
                 >
                   Get Started Now
+                </Link>
+                <Link
+                  href="/docs/guide/schema-catalog"
+                  className="rounded-lg border border-white/40 px-8 py-3.5 text-base font-semibold text-white transition-all hover:bg-white/10"
+                >
+                  Browse the schema catalog
                 </Link>
               </div>
             </div>

--- a/apps/site/app/(home)/page.tsx
+++ b/apps/site/app/(home)/page.tsx
@@ -10,8 +10,9 @@ const DESCRIPTION =
 // The route had no metadata at all, so the homepage shipped with no <title>,
 // no description and no link-preview fields. Open Graph and Twitter carry no
 // image: the site ships none, and naming one it does not serve would render a
-// broken preview. No `metadataBase` is needed here either — nothing below
-// resolves against an origin (no OG image, no `alternates.canonical`).
+// broken preview. Nothing here resolves against an origin, so this object needs
+// no `metadataBase` of its own; `app/layout.tsx` sets one for the docs pages,
+// whose OG images are site-relative.
 export const metadata: Metadata = {
   title: TITLE,
   description: DESCRIPTION,

--- a/apps/site/app/components/ReactVsObjectUI.tsx
+++ b/apps/site/app/components/ReactVsObjectUI.tsx
@@ -2,7 +2,7 @@
  * Side-by-side comparison: the same stats-card dashboard written in
  * traditional React + Shadcn versus the ObjectUI JSON equivalent.
  *
- * The whole point of this section is the line-count delta — keep both
+ * The section contrasts two authoring models side by side — keep both
  * snippets honest (no cheating by omitting imports, no padding the
  * React side with formatting).
  *
@@ -20,9 +20,10 @@
  *    leaked into the DOM as `props="[object Object]"` (same defect class as the
  *    `cols` fix in objectui#4011 / PR #4785).
  *
- * `OBJECTUI_LINES` feeds `REDUCTION_PCT`, shown on the page as "N lines" and
- * "X% less code" — keep this snippet at 18 lines so a correctness fix never
- * silently moves the marketing number (the constraint PR #4785 established).
+ * Copy-runnability is the whole constraint on this snippet, and now the only
+ * one: the panel renders no line counts and no percentage, so a correctness
+ * fix here is free to change its length (objectui#8948 — the homepage stopped
+ * leaning on counts, so there is no number left for an edit to move).
  */
 
 const REACT_CODE = `import {
@@ -88,29 +89,21 @@ const OBJECTUI_CODE = `{
   ]
 }`;
 
-const REACT_LINES = REACT_CODE.split('\n').length;
-const OBJECTUI_LINES = OBJECTUI_CODE.split('\n').length;
-const REDUCTION_PCT = Math.round(
-  ((REACT_LINES - OBJECTUI_LINES) / REACT_LINES) * 100,
-);
-
 function CodePanel({
   label,
   badge,
   badgeTone,
-  lines,
   code,
 }: {
   label: string;
   badge: string;
   badgeTone: 'muted' | 'primary';
-  lines: number;
   code: string;
 }) {
   const lineNumbers = code.split('\n').map((_, i) => i + 1);
   return (
     <div className="flex min-w-0 flex-col overflow-hidden rounded-xl border border-fd-border bg-fd-card shadow-sm">
-      <div className="flex items-center justify-between border-b border-fd-border bg-fd-muted/40 px-4 py-2.5">
+      <div className="flex items-center border-b border-fd-border bg-fd-muted/40 px-4 py-2.5">
         <div className="flex items-center gap-2">
           <span className="text-sm font-semibold text-fd-foreground">{label}</span>
           <span
@@ -123,9 +116,6 @@ function CodePanel({
             {badge}
           </span>
         </div>
-        <span className="text-xs font-mono text-fd-muted-foreground">
-          {lines} lines
-        </span>
       </div>
       <div className="flex max-h-[460px] overflow-auto text-[12.5px] leading-[1.55]">
         <pre
@@ -153,7 +143,7 @@ export function ReactVsObjectUI() {
           <h2 className="text-3xl font-bold tracking-tight text-fd-foreground sm:text-4xl">
             Same UI.{' '}
             <span className="bg-gradient-to-r from-blue-600 to-violet-600 bg-clip-text text-transparent dark:from-blue-400 dark:to-violet-400">
-              {REDUCTION_PCT}% less code.
+              Written as JSON.
             </span>
           </h2>
           <p className="mt-4 text-lg text-fd-muted-foreground">
@@ -168,14 +158,12 @@ export function ReactVsObjectUI() {
             label="React + Shadcn"
             badge="StatsCards.tsx"
             badgeTone="muted"
-            lines={REACT_LINES}
             code={REACT_CODE}
           />
           <CodePanel
             label="ObjectUI"
             badge="stats-cards.schema.json"
             badgeTone="primary"
-            lines={OBJECTUI_LINES}
             code={OBJECTUI_CODE}
           />
         </div>
@@ -183,14 +171,13 @@ export function ReactVsObjectUI() {
         <div className="mx-auto mt-10 grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-3">
           <div className="rounded-xl border border-fd-border bg-fd-card p-5">
             <div className="text-xs font-medium uppercase tracking-wide text-fd-muted-foreground">
-              Lines of code
+              What you maintain
             </div>
             <div className="mt-1 text-2xl font-bold text-fd-foreground">
-              {REACT_LINES} <span className="text-fd-muted-foreground">&rarr;</span>{' '}
-              <span className="text-fd-primary">{OBJECTUI_LINES}</span>
+              One JSON file
             </div>
             <p className="mt-1 text-sm text-fd-muted-foreground">
-              {REDUCTION_PCT}% smaller, no build step.
+              No component code, no build step.
             </p>
           </div>
           <div className="rounded-xl border border-fd-border bg-fd-card p-5">

--- a/apps/site/app/layout.tsx
+++ b/apps/site/app/layout.tsx
@@ -1,6 +1,16 @@
+import type { Metadata } from 'next';
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import './global.css';
 import { ObjectUIProvider } from '@/app/components/ObjectUIProvider';
+
+// `app/docs/[[...slug]]/page.tsx` sets `openGraph.images` to the site-relative
+// `/og/docs/...` route. Without a `metadataBase` Next resolves that against
+// `http://localhost:3000` and says so at build time — so every docs page has
+// been shipping an Open Graph image URL pointing at localhost. The origin is
+// the one the published packages already name in their `homepage` fields.
+export const metadata: Metadata = {
+  metadataBase: new URL('https://www.objectui.org'),
+};
 
 
 export default function Layout({ children }: LayoutProps<'/'>) {


### PR DESCRIPTION
Fixes #8948

Maintainer instruction this implements, verbatim and untranslated: 「建议首页也是非必要不强调数字，省的一直要改。」 — the homepage half of the same ruling PR #8947 applies to the README.

## What changed

**Features grid** (`apps/site/app/(home)/page.tsx`) — three card bodies rewritten:

| Card | Before | After |
|---|---|---|
| Blazing Fast | "3x faster page loads and 6x smaller bundle sizes compared to traditional low-code platforms. Built on React 18+ with automatic optimizations." | "Lazy-loaded plugins and tree-shakable packages: a page pays for the components it renders, nothing else." |
| Production Ready | "85%+ test coverage, enterprise security built-in, …" (the root `vitest.config.mts` thresholds are 40%) | "TypeScript end to end, a CI suite on every change, and documentation that is gated against the code." |
| Modular Architecture | "…lazy-loaded plugins, and support for Server Components." (nothing in `packages/react` implements RSC support) | the Server Components clause is dropped |

**Stats section deleted.** "60+ Components / 85%+ Test Coverage / 50KB Bundle Size" — none of the three had a source in the repo.

**"What Can You Build?" section deleted**, including the "Interactive Examples" card whose `href` was `/docs/guide/interactive-demos` — a route with no source page (`content/docs/guide/` holds no such file, and the built tree emits no such HTML). The one door that section held open now lives in the CTA as a secondary "Browse the schema catalog" link.

**`ReactVsObjectUI.tsx`** keeps both code panels and the line-number gutters, and loses the `{REDUCTION_PCT}% less code` heading, the `{lines} lines` panel counters, the `REACT_LINES → OBJECTUI_LINES` summary tile, and the three now-unread constants. The heading is now "Same UI. Written as JSON."; the first summary tile is "What you maintain / One JSON file / No component code, no build step."

**`REACT_CODE` and `OBJECTUI_CODE` are byte-identical to `origin/main`** — verified by SHA-256 over the extracted template literals: `REACT_CODE` `8dd87f528c186051` (1333 bytes) and `OBJECTUI_CODE` `7ec25447c78f461f` (674 bytes), the same before and after. The module header no longer says the 18-line snippet constraint exists to keep "the marketing number" stable; copy-runnability is now stated as the whole and only constraint, which is what it always actually was.

**Page metadata.** The route now exports `metadata` with `title`, `description`, `openGraph` (`type: 'website'`) and `twitter` (`card: 'summary'`). No image: the site ships none, and naming one it does not serve renders a broken preview.

## The catalog route resolves — how that was checked

`apps/site/lib/source.ts` loads `content/docs` (per `source.config.ts`) at `baseUrl: '/docs'`, so `content/docs/guide/schema-catalog.mdx` serves `/docs/guide/schema-catalog`. Confirmed in the built site rather than inferred: `apps/site/.next/server/app/docs/guide/schema-catalog.html` is prerendered, no `interactive-demos` artifact exists anywhere under `.next/server/app`, and the prerendered `index.html` contains the new `href="/docs/guide/schema-catalog"`. A sweep of every internal `href` in the site's `.ts`/`.tsx` surface against the built route table returns two hrefs, both resolving: `/docs` and `/docs/guide/schema-catalog`.

## In-scope fix beyond the card's five sites: `metadataBase`

The card authorised `apps/site/app/layout.tsx` "only if `metadataBase` is needed". The build says it is, and not for this page — it printed, twice:

```
⚠ metadataBase property in metadata export is not set for resolving social open
  graph or twitter images, using "http://localhost:3000"
```

`apps/site/app/docs/[[...slug]]/page.tsx` sets `openGraph.images` to the site-relative `/og/docs/.../image.png`, so **every docs page has been shipping an Open Graph image URL pointing at localhost**. The homepage metadata added here contributes no image and cannot raise that warning. Fixed in the root layout with the origin the published packages already name in their `homepage` fields (`https://www.objectui.org`).

Evidence, before → after on the same tree: metadataBase warnings in the site build **2 → 0**, and `.next/server/app/docs/guide/schema-catalog.html` now carries `og:image="https://www.objectui.org/og/docs/guide/schema-catalog/image.png"`.

## Gates (all on `34c8ba3`, the final commit)

| Gate | Result |
|---|---|
| `pnpm --filter @object-ui/site type-check` | exit 0 — `✓ Types generated successfully`, no `tsc` diagnostics |
| `pnpm --filter @object-ui/site lint` | exit 0 — `✖ 9 problems (0 errors, 9 warnings)` |
| `pnpm docs:check-links` | exit 0 — `Links are valid across 17 scan roots.` |
| `pnpm --filter @object-ui/site build` (under the shared verify lock) | `VERDICT command-exit 0` — `✓ Compiled successfully`, 559/559 static pages |
| `node scripts/check-changeset-presence.mjs` | exit 0 — `No source or published contract of a released package changed in this range, so no changeset is owed.` |

No changeset: `@object-ui/site` is `private: true` and outside the changesets `fixed` group. Measured, not assumed — the line above is the gate's own verdict.

Two notes on the readings:

- The **first** `type-check` run failed with 21 `TS2307`/`TS2882` "cannot find module `@object-ui/*`" errors. That was a stale-`dist` artifact of a fresh worktree, not this diff: `pnpm --filter '@object-ui/site^...' build` (the dependency closure) then took it to exit 0 with no source change in between.
- lint went 8 → 9 warnings. The added one is `react-refresh/only-export-components` on `app/layout.tsx:11` (`export const metadata`), and the homepage picked up the same one. That warning is unavoidable for any Next.js route file that exports `metadata` beside a component, and it is the established shape here: `app/docs/[[...slug]]/page.tsx` and `app/og/docs/[...slug]/route.tsx` already carry it on `origin/main`. Zero errors either way.

## Acceptance notes

Findings outside this card's scope, noted rather than filed:

- **Cards 1 and 5 now state the same mechanism.** "Blazing Fast" carries the wording the card body prescribes verbatim ("Lazy-loaded plugins and tree-shakable packages…") and "Modular Architecture", after only the instructed removal of the Server Components clause, reads "Tree-shakable packages and lazy-loaded plugins. Only load what you need." Both instructions were followed literally rather than reconciled by inventing copy; the redundancy is real and is the maintainer's to resolve. Taker: whoever reviews this PR.
- **`scripts/check-doc-links.mjs` cannot see hrefs written in `apps/site/**/*.tsx`.** `walk()` takes only `.md`/`.mdx` files at every depth, so no `SCAN_ROOTS` row reaches a TSX file — which is why the dead `/docs/guide/interactive-demos` link survived. Not filed as a card, and the reason is a measurement rather than a shrug: the entire exposed surface is **two** internal hrefs in all of the site's `.ts`/`.tsx`, both of which resolve after this PR. Extending the gate is neither mechanical (the route rule and the file walk both need work) nor pulled by anything today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gFSzdPX4324QMRKCjccTc

---
_Generated by [Claude Code](https://claude.ai/code/session_016gFSzdPX4324QMRKCjccTc)_