### PR TITLE
docs(guide,readme): spell the grid child list `children`, the key `grid` reads (objectui#8912)

### DIFF
--- a/.changeset/8912-grid-children-items.md
+++ b/.changeset/8912-grid-children-items.md
@@ -1,0 +1,10 @@
+---
+---
+
+Repair the three teaching surfaces that authored a `grid` node's child list as
+`items` — a key the `grid` renderer never reads, so the root README's flagship
+example drew an empty grid (objectui#8912). The root `README.md` "Basic Usage"
+fence, `content/docs/guide/schema-rendering.md` and
+`content/docs/guide/schema-playground.md` now spell it `children`, the key
+`GridSchema` declares and `grid.tsx` reads. Documentation and test only: neither
+the renderer nor `GridSchema` moves, and no package is released by this change.

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ const schema = {
   body: {
     type: "grid",
     columns: 3,
-    items: [
+    children: [
       { type: "statistic", label: "Total Users", value: "${stats.users}" },
       { type: "statistic", label: "Revenue", value: "${stats.revenue}" },
       { type: "statistic", label: "Orders", value: "${stats.orders}" }

--- a/content/docs/guide/schema-playground.md
+++ b/content/docs/guide/schema-playground.md
@@ -211,7 +211,7 @@ Schemas can be nested to build complex layouts. Here is a dashboard that combine
     "type": "grid",
     "columns": 3,
     "gap": "md",
-    "items": [
+    "children": [
       {
         "type": "card",
         "title": "Open Issues",

--- a/content/docs/guide/schema-rendering.md
+++ b/content/docs/guide/schema-rendering.md
@@ -128,7 +128,7 @@ Schemas can be nested to create complex UIs:
   "body": {
     "type": "grid",
     "columns": 2,
-    "items": [
+    "children": [
       {
         "type": "card",
         "title": "Card 1",

--- a/packages/components/src/__tests__/page-body-single-node-8310.test.tsx
+++ b/packages/components/src/__tests__/page-body-single-node-8310.test.tsx
@@ -8,70 +8,97 @@
 
 /**
  * `PageRenderer` draws a `body` given as ONE node and a `body` given as a list
- * (objectui#8310, maintainer ruling 2026-09-07, director decision batch #2).
+ * (objectui#8310, maintainer ruling 2026-09-07, director decision batch #2),
+ * and the root README's flagship example draws its CHILDREN (objectui#8912).
  *
- * ## What this half is, and what it is NOT
+ * ## Two cards share this file, and they are not the same question
  *
- * ⛔ This file is a **regression control**, not evidence for the card. The
- * ruling's repair on this side is the deletion of `FlatContent`'s
- * `content as SchemaNode` cast, which is a TYPE-LEVEL change with no runtime
- * effect at all: both arities rendered before it and both render after it. An
- * assertion green in both worlds proves nothing about a change, and this one is
- * labelled so nobody later quotes it as if it did.
+ * objectui#8310 asked the ARITY of `PageNodeSchema.body` — one node, or a list.
+ * objectui#8912 asked whether the child key the flagship example AUTHORS has
+ * any reader at all. This file now pins both, because both are properties of
+ * the same transcribed snippet, and the second was originally left visible here
+ * on purpose (see "History" below) rather than repaired.
  *
- * The discriminating half lives in
- * `packages/types/src/__tests__/page-body-arity-8310.test.ts`: the declaration
- * and the zod mirror both refused the single-node form before this card, and
- * both admit it after.
+ * ## What each leg is, and which one is evidence
  *
- * ## Why the control is worth having anyway
+ * - **objectui#8310 — a regression CONTROL, not evidence.** The ruling's repair
+ *   on this side is the deletion of `FlatContent`'s `content as SchemaNode`
+ *   cast, a TYPE-LEVEL change with no runtime effect: both arities rendered
+ *   before it and both render after it. An assertion green in both worlds
+ *   proves nothing about a change, and it is labelled so nobody quotes it as if
+ *   it did. The discriminating half lives in
+ *   `packages/types/src/__tests__/page-body-arity-8310.test.ts`.
+ * - **objectui#8912 — evidence, and it is RENDER OUTPUT.** The three
+ *   `statistic` labels the flagship authors must appear in the rendered tree.
+ *   ⛔ No compile-time check can stand in for this leg: `BaseSchema` is
+ *   `.passthrough()` with an `[key: string]: any` index signature, so the
+ *   defective key validated, type-checked, rode onto the node and drew nothing.
+ *   `check:doc-types` only asks whether a fence's `type` literal is registered
+ *   (`grid` is), and `check:doc-examples` compiles against that same index
+ *   signature. Both are green on the defect BY DESIGN (objectui#4823), so a
+ *   green from either is not a reading of this card.
  *
- * The cast is what let the single-node branch survive a declaration that
- * forbade it. Deleting the cast without a behavioural pin would leave that
- * branch guarded by nothing but the union it now leans on — and the next
- * narrowing of `PageNodeSchema.body` would delete a live code path with a green
- * suite. So this asserts against the rendered output rather than against
- * `FlatContent`'s internals, and it survives a rewrite of the normalization.
+ * ## ⚠️ Why the negative-space leg renders the OLD spelling
  *
- * ## ⚠️ Why the grid's own children are spelled `children` here, not `items`
+ * The `grid` renderer reads `schema.children` and nothing else. The third
+ * describe block renders the pre-repair shape and asserts the grid element IS
+ * drawn while its children are NOT — which is precisely why objectui#8912
+ * failed silently, and precisely why a naive "did anything render?" control
+ * passes on a broken build. It is also the floor set by coding standard #0.1
+ * (contract-first): making `grid` read `items` as an alias for `children`, or
+ * declaring `items` on `GridSchema`, were both REFUSED on objectui#8912 as the
+ * lenient-fallback shape that standard forbids by name. Either one would redden
+ * this block. ⛔ Do not "fix" it by teaching the renderer the second spelling.
  *
- * The root `README.md` flagship example spells the grid's child list `items`,
- * and `grid` reads `children` and nothing else — so that example renders an
- * EMPTY grid element. That is a real defect, measured while writing this file
- * and filed as objectui#8912; it is a DIFFERENT defect from this card (a child
- * key with no reader, versus the arity of `body`) and the ruling here forbids
- * touching the README. This file therefore asserts the two facts separately:
- * the flagship shape verbatim reaches the renderer and draws its `grid` node
- * (which is what `body`'s arity governs), and a `children`-spelled subtree
- * draws all the way down through either arity (which is what proves the whole
- * channel works). ⛔ Do not "repair" this file by moving the flagship
- * transcription to `children` — that would hide objectui#8912 inside a green.
+ * ## History — why this file once transcribed the defect on purpose
+ *
+ * Written for objectui#8310, when the README's flagship grid still spelled its
+ * child list `items`. That defect was measured while writing this file and
+ * filed as objectui#8912; the objectui#8310 ruling forbade touching the README,
+ * so the transcription deliberately preserved `items` so the defect could not
+ * hide inside a green. objectui#8912 has since repaired all three teaching
+ * surfaces to `children`, so the transcription now follows the repaired
+ * flagship — and the README-scan leg below keeps it from becoming fiction.
+ * ⛔ Do not delete or weaken these legs to make an unrelated change pass.
  */
 
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import { SchemaRenderer } from '@object-ui/react';
 // Module scope, not a hook: registers `page`, `grid` and `statistic`. A cold
 // `await import()` inside a hook is billed to `hookTimeout` and races the
 // assertions (AGENTS.md §测试纪律, objectui#3010).
 import '../renderers';
 
-/** The README's flagship grid, verbatim — child list spelled `items` (objectui#8912). */
-const flagshipGridAsAuthored = {
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..', '..', '..');
+const README = readFileSync(join(REPO_ROOT, 'README.md'), 'utf8');
+
+/** The three `statistic` labels the README's flagship example authors. */
+const LABELS = ['Total Users', 'Revenue', 'Orders'];
+
+/** The README's flagship grid, transcribed as REPAIRED — child list `children`. */
+const flagshipGrid = {
   type: 'grid',
   columns: 3,
-  items: [
+  children: [
     { type: 'statistic', label: 'Total Users', value: '1234' },
     { type: 'statistic', label: 'Revenue', value: '$56,789' },
     { type: 'statistic', label: 'Orders', value: '432' },
   ],
 };
 
-/** The same grid with its child list under the key `grid` actually reads. */
-const flagshipGridAsRead = {
+/**
+ * The same grid spelled the way it was BEFORE objectui#8912 — `items`, a key
+ * `grid` never reads. Kept as the defect shape, never as a taught shape.
+ */
+const flagshipGridPreRepair = {
   type: 'grid',
   columns: 3,
-  children: flagshipGridAsAuthored.items,
+  items: flagshipGrid.children,
 };
 
 function renderPage(body: unknown) {
@@ -81,13 +108,13 @@ function renderPage(body: unknown) {
 const gridsIn = (container: HTMLElement) => container.querySelectorAll('[data-obj-type="grid"]');
 
 describe('PageRenderer — both `body` arities reach the renderer (objectui#8310, CONTROL)', () => {
-  it('draws the node when `body` is ONE node — the README flagship shape, verbatim', () => {
-    const { container } = renderPage(flagshipGridAsAuthored);
+  it('draws the node when `body` is ONE node — the README flagship shape', () => {
+    const { container } = renderPage(flagshipGrid);
     expect(gridsIn(container)).toHaveLength(1);
   });
 
   it('draws the node when `body` is a LIST of nodes', () => {
-    const { container } = renderPage([flagshipGridAsAuthored]);
+    const { container } = renderPage([flagshipGrid]);
     expect(gridsIn(container)).toHaveLength(1);
   });
 
@@ -97,16 +124,68 @@ describe('PageRenderer — both `body` arities reach the renderer (objectui#8310
   });
 });
 
-describe('PageRenderer — the whole subtree draws through either arity (objectui#8310)', () => {
-  const labels = ['Total Users', 'Revenue', 'Orders'];
-
+describe('PageRenderer — the flagship example draws its CHILDREN (objectui#8912)', () => {
   it('renders every child of a single-node `body`', () => {
-    const { container } = renderPage(flagshipGridAsRead);
-    for (const label of labels) expect(container.textContent).toContain(label);
+    const { container } = renderPage(flagshipGrid);
+    for (const label of LABELS) expect(container.textContent).toContain(label);
   });
 
   it('renders every child of a list `body`', () => {
-    const { container } = renderPage([flagshipGridAsRead]);
-    for (const label of labels) expect(container.textContent).toContain(label);
+    const { container } = renderPage([flagshipGrid]);
+    for (const label of LABELS) expect(container.textContent).toContain(label);
+  });
+});
+
+describe('`grid` reads `children` and nothing else — the defect shape (objectui#8912)', () => {
+  it('draws the grid ELEMENT for the pre-repair `items` spelling — the firing control', () => {
+    const { container } = renderPage(flagshipGridPreRepair);
+    expect(gridsIn(container)).toHaveLength(1);
+  });
+
+  it('draws NONE of its children — the silent failure objectui#8912 repaired', () => {
+    const { container } = renderPage(flagshipGridPreRepair);
+    for (const label of LABELS) expect(container.textContent).not.toContain(label);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* README leg — the transcription above is not allowed to become fiction       */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The `const schema = {` object literal inside the README's "Basic Usage"
+ * fence, returned as source text. Scanned with brace-depth tracking rather than
+ * a regex so a nested array cannot end the span early.
+ */
+function basicUsageSchemaLiteral(): string {
+  const heading = README.indexOf('#### Basic Usage');
+  expect(heading).toBeGreaterThan(-1);
+  const start = README.indexOf('const schema = {', heading);
+  expect(start).toBeGreaterThan(-1);
+
+  let depth = 0;
+  for (let i = README.indexOf('{', start); i < README.length; i += 1) {
+    const ch = README[i];
+    if (ch === '{') depth += 1;
+    else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return README.slice(start, i + 1);
+    }
+  }
+  throw new Error('unbalanced braces in the README "Basic Usage" schema literal');
+}
+
+describe('the root README authors the grid child list `grid` actually reads (objectui#8912)', () => {
+  it('spells the flagship grid child list `children`, never `items`', () => {
+    const literal = basicUsageSchemaLiteral();
+    expect(literal).toContain('children: [');
+    expect(literal).not.toMatch(/(^|[^.\w])items\s*:/);
+  });
+
+  it('still authors the page/grid/statistic shape transcribed above', () => {
+    const literal = basicUsageSchemaLiteral();
+    expect(literal).toContain('type: "grid"');
+    expect(literal.match(/type: "statistic"/g) ?? []).toHaveLength(3);
+    for (const label of LABELS) expect(literal).toContain(`label: "${label}"`);
   });
 });

--- a/packages/types/src/__tests__/page-body-arity-8310.test.ts
+++ b/packages/types/src/__tests__/page-body-arity-8310.test.ts
@@ -60,11 +60,14 @@
  * arity of one declared key; it does not turn `PageNodeSchema` into a closed
  * surface, and nothing here should be quoted as if it did.
  *
- * ⚠️ A second, unrelated defect in the same fence, measured while writing this
- * file and filed as objectui#8912: the flagship grid spells its child list
- * `items`, a key `grid` never reads, so that example draws an EMPTY grid. It is
- * transcribed here verbatim — `items` and all — because this file asks about
- * `body`'s ARITY and must not quietly repair a defect it does not own.
+ * ⚠️ A second, unrelated defect in the same fence was measured while writing
+ * this file and filed as objectui#8912: the flagship grid SPELLED its child
+ * list `items`, a key `grid` never reads, so that example drew an EMPTY grid.
+ * That card has since repaired all three teaching surfaces to `children`, and
+ * the transcription below follows the repaired flagship. This file still asks
+ * only about `body`'s ARITY and rules on nothing else; the child key is pinned
+ * by the render pin in
+ * `packages/components/src/__tests__/page-body-single-node-8310.test.tsx`.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -85,11 +88,15 @@ const README = readFileSync(join(REPO_ROOT, 'README.md'), 'utf8');
 /* Leg 1 — compile-time, compiled by `tsc -p packages/types/tsconfig.test.json` */
 /* -------------------------------------------------------------------------- */
 
-/** The `grid` node the README's flagship example hands to `body`. */
+/**
+ * The `grid` node the README's flagship example hands to `body` — child list
+ * spelled `children`, the key `GridSchema` declares and `grid` reads
+ * (objectui#8912).
+ */
 const flagshipGrid: SchemaNode = {
   type: 'grid',
   columns: 3,
-  items: [
+  children: [
     { type: 'statistic', label: 'Total Users', value: '${stats.users}' },
     { type: 'statistic', label: 'Revenue', value: '${stats.revenue}' },
     { type: 'statistic', label: 'Orders', value: '${stats.orders}' },
@@ -221,7 +228,7 @@ describe('PageNodeSchema.body still refuses a non-node — the widening kept its
 /**
  * The `const schema = {` object literal inside the README's "Basic Usage"
  * fence, returned as source text. Scanned with brace-depth tracking rather
- * than a regex so a nested `items[]` cannot end the span early.
+ * than a regex so a nested `children[]` cannot end the span early.
  */
 function basicUsageSchemaLiteral(): string {
   const heading = README.indexOf('#### Basic Usage');


### PR DESCRIPTION
Fixes #8912

Session: `https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB` — written into the prose as a code
span because a `PATCH` of this body downgrades the session-URL footer to its bare form.

The SDUI `grid` renderer draws its child list from `schema.children` and from nothing else, and
`GridSchema` declares only `children`. Three teaching surfaces authored that list as `items` anyway —
including the flagship example on the npm/GitHub landing page — so a reader who copied any of them
got a `grid` element with no children.

Option 1 of the card, which the triage verdict had already established as the only surviving route:
the documentation is repaired, and the renderer is not. Options 2 (teach `grid` to read `items` as an
alias) and 3 (declare `items` on `GridSchema`) are the lenient-fallback shape coding standard #0.1
(contract-first) forbids by name, and each would mint a second child-key dialect on one node. ⛔ The
`grid` renderer and `GridSchema` are untouched — both are correct today.

## What changed

| file | change |
|:--|:--|
| `README.md` | the `#### Basic Usage` fence — `items:` becomes `children:` (tsx object literal, unquoted) |
| `content/docs/guide/schema-rendering.md` | the "Schemas can be nested" JSON fence — `"items"` becomes `"children"` |
| `content/docs/guide/schema-playground.md` | the "Project Dashboard" JSON fence — `"items"` becomes `"children"` |
| `packages/components/src/__tests__/page-body-single-node-8310.test.tsx` | the objectui#8310 render pin — now transcribes the **repaired** flagship, and gains the legs described below |
| `packages/types/src/__tests__/page-body-arity-8310.test.ts` | the objectui#8310 arity pin — stale-truth repair only, added in the patch round below |
| `.changeset/8912-grid-children-items.md` | empty frontmatter — docs and test only, nothing published moves |

Each documentation edit is a **one-key, one-line, line-count-preserving** replacement (`1 +, 1 -` per
file), so nothing that cites these files by line can rot.

## Every hit was judged, never bulk-replaced

The bare word `items` appears more often than the defect does. Counts re-derived on this branch's base
`aeaa0f6`, with the instrument proven on a known positive first — the quoted-JSON probe `"items"`
returns **0** on the README, because that fence is a **tsx object literal** with unquoted keys. A probe
that spans only one of the two syntaxes produces a false zero on the single most important surface.

| hit | verdict |
|:--|:--|
| `README.md:236` `items: [` | **defect** — repaired |
| `content/docs/guide/schema-rendering.md:131` `"items": [` | **defect** — repaired |
| `content/docs/guide/schema-playground.md:214` `"items": [` | **defect** — repaired |
| `content/docs/guide/schema-rendering.md:170` `Use arrays for multiple items:` | English prose — left |
| `content/docs/guide/schema-rendering.md:444` `"${items.length === 0}"` | a **data-scope** variable in an expression, not a child key — left |
| `content/docs/guide/schema-rendering.md:445` `"No items found"` | prose inside a string value — left |

A structural probe over every tracked file (a `grid` type literal in either syntax, with an `items`
key within ten lines) finds no fourth authoring surface. Its two remaining hits are window artefacts,
inspected and dismissed: a designer **palette group**'s member list in `PageDesigner.tsx`, and a
transport envelope `makeDS({ items: [VIEW] })` in a `data-objectstack` pin whose `type: 'grid'` is a
list-**view** config. The only `items` left in `grid.tsx` is the prose `Gap between items (0-12)`.

## ⚠️ The acceptance instrument is RENDER OUTPUT, and no gate in this repository can stand in for it

This is the part worth reading before trusting any green below.

- `check:doc-types` asks only whether a fence's `type` literal is a registered component. `grid` is
  registered, so the fence passes; whether the snippet's **other** keys have a reader is that gate's
  explicitly out-of-scope second dimension (objectui#4823).
- `check:doc-examples` compiles the fence against `BaseSchema`, which is `.passthrough()` with an
  `[key: string]: any` index signature. That signature **absorbs** the undeclared key: exit 0, zero
  diagnostics.

⇒ Both gates are green on the defect **by design**. Their greens appear in the table below because
they prove this change broke nothing, ⛔ never as evidence that the defect is repaired. The defect
validated, type-checked, rode onto the node and drew nothing — the only instrument that can see it is
what the renderer actually draws.

## Discriminating power — proved in both directions

Both legs mutate a **committed** tree, prove the mutation reached disk by blob hash before any result
is read, restore under a `trap` with absolute paths, and verify the restore **by state** (`git diff HEAD`
empty plus a blob comparison against the `HEAD` blob), never by an exit code.

**Leg A — revert the README to the pre-repair spelling.** The mutated blob comes out
`d086dd5d0e8383b5bd5133acfa773d432bf8ac52`, which is byte-identical to the README on `origin/main`, so
the leg really does reconstruct the pre-repair file rather than something merely similar.

```
MUTATED: children->items at :236, blob 1e4b9096 -> d086dd5d
 ❯ page-body-single-node-8310.test.tsx (9 tests | 1 failed)
   × spells the flagship grid child list `children`, never `items`
AssertionError: expected 'const schema = {\n  type: "page",\n  …' to contain 'children: ['
 Tests  1 failed | 8 passed (9)
```

**Leg B — revert the pin's own transcription to `items`.** This is the card's mechanism, and it shows
exactly why a naive control passes on a broken build:

```
 Tests  2 failed | 7 passed (9)
   × renders every child of a single-node `body`
   × renders every child of a list `body`
AssertionError: expected '' to contain 'Total Users'
```

The two render-output assertions go **red**; the grid-element assertions in the same run stay
**green** — the `page` wrapper and the `grid` element are drawn even in the broken state. The rendered
container's `textContent` is the empty string. That is the whole defect in one line.

## What the objectui#8310 render pin now guards

That file deliberately transcribed the flagship **with `items` preserved**, so this defect could not
hide inside a green, and its own source comment said not to tidy it. Converted rather than deleted or
weakened:

- the transcription now follows the **repaired** flagship, and drives the arity control unchanged;
- a new leg asserts the three `statistic` labels are actually **drawn** — the render-output evidence;
- the pre-repair spelling survives as a **labelled negative-space leg**: the grid element is drawn and
  its children are not. This is the firing control, and it is also the floor set by standard #0.1 —
  teaching `grid` the second spelling would redden it;
- a new **README-scan leg** reads the real `#### Basic Usage` fence and requires `children: [` with no
  `items` key, so the transcription cannot drift into fiction. Leg A above is the proof that this leg
  can fail.

⚠️ **An expectation carried into this card was falsified, and it matters.** Repairing the README did
**not** turn this pin red on its own: before this PR the file held only a **local** transcription and
never read `README.md` at all, so nothing tied it to the landing page's bytes. The types-side pin does
read the README, but its scan leg asserts `body` arity and the page/grid/statistic shape — never the
child key. Measured, not assumed: both pins were **green** immediately after the documentation edit.
The README-scan leg added here is what makes that expectation true from now on.

## Patch round — the arity pin's stale truths

Landing the repair above made four statements in `packages/types/src/__tests__/page-body-arity-8310.test.ts`
false, and **nothing went red**, which is exactly why it would have rotted quietly: `BaseSchema` carries
`[key: string]: any`, and that file's subject is `body` **arity**, not the child key. Repaired in the
same PR that falsified them:

| stale truth | repair |
|:--|:--|
| the transcription `items: [` at `:92` | now `children: [` |
| the docblock "the `grid` node the README's flagship example hands to `body`" | names the `children` spelling and the card |
| the header paragraph describing `items` as a **live, unrepaired** defect | now past tense, and points at the render pin as the child key's owner |
| a brace-scanner comment naming a nested `items[]` | now `children[]` |

⛔ **Stale-truth repair only — nothing this pin asserts moved.** All **28** of the file's
`it(` / `describe(` / `expect(` lines are byte-identical before and after (compared as text, since the
prose edits shifted line numbers). Outside comment lines the entire diff is two hunks: a docblock
opener reflowed from one line to a block, and `items: [` becoming `children: [`. The arity ruling this
pin enforces, and its README-scan leg's assertions about `body`'s arity, are untouched. The pin was
**not** restructured and **no leg was added** to it — the README-scan leg belongs in the render pin,
where it is.

The compile-time leg is genuinely enforced rather than merely globbed: `tsc -p tsconfig.test.json
--listFiles` lists this pin **1** time, with `packages/types/src/layout.ts` as a positive control (1)
and a components test as a negative control (0).

## Gates

⚠️ `scripts/pm/dispatch-gates.mjs` **does not exist in this repository**, so these families were
derived by hand from the actual changed-file set and are declared as such. Every exit code was
captured before any pipe.

| gate | exit | note |
|:--|:--|:--|
| `pnpm exec vitest run packages/types/` + the render pin | **0** | patch round — 167 files, 3303 tests passed |
| `pnpm --filter @object-ui/types run type-check` | **0** | patch round — includes `tsc -p tsconfig.test.json`, which compiles the arity pin |
| `pnpm exec vitest run packages/components/` | **0** | 259 files, 2358 tests, all passed |
| the two objectui#8310 pins, together | **0** | 18 tests passed |
| `check:doc-types` | **0** | ⛔ no discriminating power on this class |
| `check:doc-examples` | **0** | ⛔ no discriminating power on this class |
| `check:doc-snippets` | **0** | 638 of 638 blocks judged, 0 failed |
| `check:doc-fences` | **0** | |
| `check:control-bytes` | **0** | re-run in the patch round; plus a manual control-character sweep of both edited pins |
| `check-changeset-presence` | **0** | re-run in the patch round |
| `check-changeset-no-major` | **0** | re-run in the patch round |
| `check-governed-queue-guard --test` | **0** | **NOT GOVERNED** — none of the changed paths matched |

`check:doc-snippets` and `check:doc-examples` **first returned exit 2 = PRECONDITION NOT MET**, which
is neither a pass nor a red: the packages they resolve against were unbuilt, so the programs never
ran. The scoped build those gates name was run (35 of 35 tasks successful) and both were re-run to a
real exit 0. Heavy runs went through `scripts/pm/os-verify-lock.sh`; each reports `VERDICT
command-exit 0` from the runner's own verdict line.

⚠️ The two doc gates' verdicts are **carried forward** from that run rather than re-executed in the
patch round, and the reason is stated rather than implied: the patch round changed exactly one file, a
test under `packages/types/src/__tests__/`, which is not a documentation surface and is not part of any
package's build output — so neither gate's inputs moved. `origin/main` was merged in first (a merge, no
rebase, no force-push) and touched only `apps/site`, which those gates also do not read.

Blast radius checked by content rather than by guess: of every test that reads a file this PR edits,
exactly two exist — the two objectui#8310 pins, both of which are in this diff and both green. The
three `packages/layout` tests that mention "Basic Usage" read `content/docs/layout/app-shell.mdx` and
`content/docs/guide/layout.md`, neither of which is touched here.

## Re-grading triggers — both measured, neither fires

- **p1 (auto-copied downstream): does not fire.** No `create-*` template or scaffold inlines the
  flagship. The nearest candidate, the VS Code extension's insert-schema command, authors a different
  and correct shape — a `div` carrying Tailwind grid classes with its children on `body`, a declared
  and read channel.
- **p3 (fences unreachable): does not fire.** Both guide pages are routed in
  `content/docs/guide/meta.json`, and the README is the repository and npm landing page.

⇒ `priority:p2` stands.

## 验收备注

- **The arity pin's stale truths are repaired in this PR, not deferred.** They were reported first and
  repaired only after the file was added to this card's declared surface. Serial constraint re-derived
  independently before editing: PR #8895 touches three files under `packages/types/src/__tests__/` —
  `imported-defaults-8317.test.ts`, `object-chart-undeclared-keys-8885.test.ts` and
  `zod-mirror-parity.test.ts` — and `page-body-arity-8310.test.ts` is not among them.
- **objectui#8284 is not addressed here** and remains open. It asks which channel a renderer reads;
  this card asked whether an authored child key has any reader at all.
- **The arity ruling on objectui#8310 is untouched.** That ruling required the README example to stay
  as written with respect to its `body` **arity** — one node, not a list — and the `body` value is
  still the single `grid` node it was. Only the child key inside it moves.
- **noted, not filed:** the structural probe's two window artefacts are not defects and need no
  action — recorded above so the next seat running that probe does not re-investigate them.
- `.changeset` uses the empty-frontmatter form: the only published-source files in the diff are tests,
  and no runtime surface moves.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB