### PR TITLE
feat(scripts): gate a vi.mock override's VALUE shape against the declared export

### DIFF
--- a/.changeset/8903-vi-mock-override-value-shape-gate.md
+++ b/.changeset/8903-vi-mock-override-value-shape-gate.md
@@ -1,0 +1,13 @@
+---
+---
+
+Tooling-only change. Adds `scripts/check-vi-mock-override-shape.mjs`, a third
+gate over the `vi.mock` population: it compares an override's VALUE shape
+against the shape the real export declares. The two existing gates judge whether
+a relative specifier resolves and whether the factory inherits the real module,
+and neither judges the override's value — measured, by putting the thirteen
+drifted `useRecordPresence` stubs back on disk and watching both print a
+byte-identical verdict line and exit 0 (objectui#8083, repaired by PR #8902).
+No published package changes: the edits are the new gate, its test, a
+`package.json` script alias and one `lint.yml` step, none of which any package's
+`files[]` ships.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -381,6 +381,34 @@ jobs:
         if: steps.relevant.outputs.should_run == 'true'
         run: pnpm lint
 
+      # ── vi.mock override VALUE shapes (objectui#8903) ─────────────────────
+      # The third property of the `vi.mock` population, and the only one of the
+      # three that needs a parser. `check-vi-mock-specifiers.mjs` judges whether
+      # a relative specifier resolves; `check-vi-mock-inherit.mjs` judges whether
+      # the factory obtains and spreads the real module. Neither judges what the
+      # override is WORTH: thirteen stubs returned `{ viewers, others }` where
+      # the real hook returns `PresenceUser[]`, and putting them back on disk
+      # made both of those gates print a BYTE-IDENTICAL verdict line and exit 0
+      # (objectui#8083, fixed by PR #8902).
+      #
+      # Its two siblings live in `vi-mock-specifiers.yml`, which runs before any
+      # install so that it sees every pull request shape. This one cannot: it
+      # imports `typescript` to read declared return types, and
+      # `check-pre-install-import-graph.mjs` fails any pre-install gate that
+      # reaches a package — measured, by injecting the import into the sibling
+      # and watching that gate go from exit 0 to exit 1. So it runs here, after
+      # `pnpm install`.
+      #
+      # The `should_run` switch above is not a blind spot for it: the ignore list
+      # is Markdown plus the `content`, `docs` and `.changeset` trees, and both
+      # halves of what this gate compares — the override and the declared export
+      # — live in TypeScript files. `check-vi-mock-override-shape.test.ts` fails
+      # if a pattern matching a TypeScript file is ever added to that list.
+      - name: Check every vi.mock override matches the declared export shape
+        if: steps.relevant.outputs.should_run == 'true'
+        run: node scripts/check-vi-mock-override-shape.mjs
+
+
       # ── The cross-repo closer's outcome contract (#5261) ──────────────────
       # `cross-repo-issue-closer.yml` carries ~250 lines of inline
       # github-script, and until this step existed it was code nobody had ever

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -302,6 +302,21 @@ first, which is what stops a scanner that recognises nothing from reporting a cl
   itself live under `e2e/live/ci/`
   ([#7692](https://github.com/objectstack-ai/objectui/issues/7692)).
 - Then `pnpm lint`.
+- Then `scripts/check-vi-mock-override-shape.mjs` — a `vi.mock` factory that overrides a typed
+  export must hand back the shape that export declares. Its two siblings run in
+  `vi-mock-specifiers.yml` and judge different properties of the same call sites: whether a relative
+  specifier resolves, and whether the factory inherits the real module. Neither judges what the
+  override is **worth**, and `tsc` never looks — a `vi.mock` factory is untyped, so the compiler
+  never compares a stub against the export's type. Measured rather than argued: thirteen
+  `RecordDetailView` stubs returned `{ viewers, others }` where `useRecordPresence` is declared
+  `PresenceUser[]`, and with all thirteen back on disk both existing gates printed a **byte-identical
+  verdict line and exit 0** ([#8083](https://github.com/objectstack-ai/objectui/issues/8083), repaired
+  by [#8902](https://github.com/objectstack-ai/objectui/pull/8902)). The failure mode is the
+  asymmetric one: when the stubbed contract moves, the files that stubbed it correctly go red and the
+  drifted ones stay green. It runs **after** the install rather than beside its siblings because it
+  reads declared return types with the TypeScript parser, and every pre-install gate's import graph is
+  held to node builtins plus local modules
+  ([#8903](https://github.com/objectstack-ai/objectui/issues/8903)).
 - Then `scripts/check-cross-repo-closer-outcome.mjs` — it extracts the ~250 lines of inline
   `github-script` out of `cross-repo-issue-closer.yml` with a real parser, never a retyped copy,
   runs it under doubles the way `actions/github-script` does, and pins each exit's outcome: which

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "check:pre-install-import-graph": "node scripts/check-pre-install-import-graph.mjs",
     "check:vi-mock-specifiers": "node scripts/check-vi-mock-specifiers.mjs",
     "check:vi-mock-inherit": "node scripts/check-vi-mock-inherit.mjs",
+    "check:vi-mock-override-shape": "node scripts/check-vi-mock-override-shape.mjs",
     "check:shell-escape-residue": "node scripts/check-shell-escape-residue.mjs",
     "check:readme-exports": "node scripts/check-readme-exports.mjs",
     "check:unreferenced-sources": "node scripts/check-unreferenced-sources.mjs",

--- a/scripts/__tests__/check-vi-mock-override-shape.test.ts
+++ b/scripts/__tests__/check-vi-mock-override-shape.test.ts
@@ -95,7 +95,7 @@ function mockSource(overrides: string): string {
  */
 function fixture(
   overrides: string,
-  opts: { provider?: string; index?: string } = {},
+  opts: { provider?: string; index?: string; filler?: number } = {},
 ): { root: string; files: string[]; cleanup: () => void } {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vi-mock-override-shape-'));
   const pkg = path.join(root, 'packages', 'collaboration');
@@ -129,17 +129,37 @@ function fixture(
   fs.mkdirSync(testDir, { recursive: true });
   fs.writeFileSync(path.join(testDir, 'RecordDetailView.fixture.test.tsx'), mockSource(overrides));
 
+  const files = [
+    'packages/collaboration/package.json',
+    'packages/collaboration/src/index.ts',
+    'packages/collaboration/src/PresenceProvider.tsx',
+    'packages/app-shell/src/views/RecordDetailView.fixture.test.tsx',
+  ];
+
+  // A clean population around the one site under test, so that a red run means
+  // the MISMATCH and not the vacuity floor. Without it the probe tree collapses
+  // and both legs exit 1 -- which would make the exit code prove nothing, the
+  // exact confound this gate exists to catch one level up.
+  const filler = opts.filler ?? 0;
+  if (filler > 0) {
+    const dir = path.join(root, 'packages', 'app-shell', 'src', 'filler');
+    fs.mkdirSync(dir, { recursive: true });
+    const body = mockSource(`useRecordPresence: () => [],`);
+    for (let i = 0; i < filler; i++) {
+      fs.writeFileSync(path.join(dir, `filler-${i}.test.tsx`), body);
+      files.push(`packages/app-shell/src/filler/filler-${i}.test.tsx`);
+    }
+  }
+
   return {
     root,
-    files: [
-      'packages/collaboration/package.json',
-      'packages/collaboration/src/index.ts',
-      'packages/collaboration/src/PresenceProvider.tsx',
-      'packages/app-shell/src/views/RecordDetailView.fixture.test.tsx',
-    ],
+    files,
     cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
   };
 }
+
+/** Enough clean sites to clear every floor in `FLOORS`. */
+const CLEAN_POPULATION = 1001;
 
 /** `scan` with the vacuity floors disabled — those have their own cases. */
 function scanFixture(overrides: string, opts: Parameters<typeof fixture>[1] = {}) {
@@ -195,9 +215,14 @@ describe('the historical thirteen (objectui#8083 / PR #8902)', () => {
   it('goes GREEN on the repaired stub — the other leg of the same mutation', () => {
     const result = scanFixture(REPAIRED);
     expect(result.unregistered).toHaveLength(0);
-    expect(result.census.judged, 'the repaired site must still be JUDGED, not merely silent').toBe(1);
-    expect(result.sites[0].verdict).toBe('match');
-    expect(result.sites[0].declared).toBe('a function returning an array');
+
+    // Not merely silent: the site must still be JUDGED, and judged to the
+    // RETURN shape -- the depth the drift lives at.
+    const site = result.sites.find((x) => x.exportName === 'useRecordPresence');
+    expect(site?.verdict).toBe('match');
+    expect(site?.declared).toBe('a function returning an array');
+    expect(site?.actual).toBe('a function returning an array');
+    expect(result.census.deep).toBeGreaterThan(0);
   });
 
   it('exits 1 end to end on the drift, and 0 on the repair', () => {
@@ -205,20 +230,26 @@ describe('the historical thirteen (objectui#8083 / PR #8902)', () => {
       [DRIFTED, 1],
       [REPAIRED, 0],
     ] as const) {
-      const f = fixture(overrides);
+      const f = fixture(overrides, { filler: CLEAN_POPULATION });
       try {
         const run = runGateIn(f.root);
+        // The population clears every floor either way, so the exit code here
+        // is about the OVERRIDE and nothing else.
+        expect(run.stderr, 'the probe tree must not be vacuous, or the exit code proves nothing').not.toContain('COLLAPSED');
         expect(run.status, `${overrides} must exit ${expected}`).toBe(expected);
         if (expected === 1) {
+          expect(run.stderr).toContain('1 override(s) do not match the declared export');
           expect(run.stderr).toContain('useRecordPresence');
           expect(run.stderr).toContain('a function returning an array');
           expect(run.stderr).toContain('a function returning an object');
+        } else {
+          expect(run.stdout).toContain('check-vi-mock-override-shape: OK');
         }
       } finally {
         f.cleanup();
       }
     }
-  });
+  }, 60_000);
 });
 
 // ---------------------------------------------------------------------------
@@ -226,12 +257,11 @@ describe('the historical thirteen (objectui#8083 / PR #8902)', () => {
 // ---------------------------------------------------------------------------
 
 describe('never reddens what it cannot read with certainty', () => {
+  // Nothing about the VALUE is readable, so the site is counted and never judged.
   const opaqueOverrides = [
     ['a vi.fn()', `useRecordPresence: vi.fn(),`],
     ['an identifier', `useRecordPresence: stubPresence,`],
     ['a call', `useRecordPresence: makeStub(),`],
-    ['a function returning an identifier', `useRecordPresence: () => stubValue,`],
-    ['a function returning a call', `useRecordPresence: () => makeStub(),`],
   ] as const;
 
   for (const [label, override] of opaqueOverrides) {
@@ -239,9 +269,38 @@ describe('never reddens what it cannot read with certainty', () => {
       const result = scanFixture(override);
       expect(result.unregistered).toHaveLength(0);
       expect(result.census.overrides, 'it must still be COUNTED — an uncounted site is an invisible one').toBeGreaterThan(0);
-      expect(result.sites.some((s) => s.exportName === 'useRecordPresence' && s.verdict === 'opaque')).toBe(true);
+      const site = result.sites.find((s) => s.exportName === 'useRecordPresence');
+      expect(site?.verdict).toBe('opaque');
     });
   }
+
+  // The value IS a function, so the KIND is judged; what it returns is not.
+  // This is the honest middle of the gate's reach and is pinned as such: the
+  // stub is compared at the level the gate can read, and never below it.
+  const shallowOverrides = [
+    ['a function returning an identifier', `useRecordPresence: () => stubValue,`],
+    ['a function returning a call', `useRecordPresence: () => makeStub(),`],
+  ] as const;
+
+  for (const [label, override] of shallowOverrides) {
+    it(`judges the KIND of ${label} but never its return`, () => {
+      const result = scanFixture(override);
+      expect(result.unregistered).toHaveLength(0);
+      const site = result.sites.find((s) => s.exportName === 'useRecordPresence');
+      expect(site?.verdict).toBe('match');
+      expect(site?.declared).toBe('a function returning an array');
+      expect(site?.actual).toBe('a function returning unknown');
+    });
+  }
+
+  it('still reddens a wrong KIND even when the return is unreadable', () => {
+    // The reach above is not an escape hatch: stub the function export with a
+    // plain array and the top-level kind conflict is still a finding.
+    const result = scanFixture(`useRecordPresence: [],`);
+    expect(result.unregistered).toHaveLength(1);
+    expect(result.unregistered[0].declared).toBe('a function returning an array');
+    expect(result.unregistered[0].actual).toBe('an array');
+  });
 
   it('does not judge an export that is exported as a TYPE', () => {
     const result = scanFixture(`useRecordPresence: () => ({ viewers: [] }),`, {

--- a/scripts/__tests__/check-vi-mock-override-shape.test.ts
+++ b/scripts/__tests__/check-vi-mock-override-shape.test.ts
@@ -1,0 +1,482 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Plain-JS CI helper. Its types are INFERRED from the .mjs source by
+// `tsconfig.scripts.json` (`allowJs`), so no `@ts-expect-error` here —
+// re-adding one is now itself an error (TS2578). See objectui#3494.
+import {
+  FLOORS,
+  KNOWN_SHAPE_MISMATCHES,
+  conflicts,
+  describeShape,
+  findOverrides,
+  scan,
+  summarise,
+} from '../check-vi-mock-override-shape.mjs';
+import { COVERED_SPECIFIERS } from '../check-vi-mock-inherit.mjs';
+
+/**
+ * objectui#8903 — the test for `scripts/check-vi-mock-override-shape.mjs`.
+ *
+ * ## Why the ablation legs here are the whole point
+ *
+ * The gate is GREEN AT REST: there are zero override/declaration shape
+ * mismatches in the tree today. A green run therefore proves only that the tree
+ * is clean — it cannot tell a working gate from one that matches nothing, and
+ * "matches nothing" is exactly what the two existing `vi.mock` gates did on this
+ * class. Both printed a BYTE-IDENTICAL verdict line and exit 0 with the thirteen
+ * drifted stubs sitting on disk. A gate's green on a class it is structurally
+ * blind to is not a reading.
+ *
+ * So this file carries BOTH directions, and neither is decoration:
+ *
+ *   - the POSITIVE control (`the historical thirteen`): the real drift,
+ *     reconstructed byte-for-byte from PR #8902's pre-image
+ *     (`useRecordPresence: () => ({ viewers: [], others: [] })` against a hook
+ *     declared `PresenceUser[]`), driven end to end through the CLI for the exit
+ *     code, and through `scan()` for the message;
+ *   - the NEGATIVE controls: the repaired form, every `unknown`-side spelling,
+ *     a CALLABLE interface (which is a function at runtime and must not be read
+ *     as an object), and the real tree at scale — because a gate that reddens on
+ *     correct code gets deleted rather than fixed.
+ *
+ * ## Fixture discipline: never write a matchable call site into this source
+ *
+ * This file is inside the gate's own scan scope. The gate reads the TypeScript
+ * AST, so it sees CALL EXPRESSIONS — a `vi.mock(...)` written as real syntax
+ * here would be judged like any other. Every fixture below is therefore built as
+ * a STRING and written to a temp tree; the only occurrences in this source are
+ * inside template literals, which are not call expressions at all. Same
+ * discipline, and the same reason, as `check-vi-mock-inherit.test.ts`.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+/** A quote, from its code point — see "Fixture discipline" above. */
+const Q = String.fromCharCode(39);
+
+const GATE = 'check-vi-mock-override-shape.mjs';
+
+/** Every module the gate reaches by relative import, for the probe copies. */
+const GATE_MODULES = [GATE, 'check-vi-mock-inherit.mjs', 'invoked-as.mjs', 'js-comment-mask.mjs'];
+
+/** The drifted stub, exactly as PR #8902's pre-image carried it, all 13 times. */
+const DRIFTED = `useRecordPresence: () => ({ viewers: [], others: [] }),`;
+
+/** What PR #8902 replaced it with. */
+const REPAIRED = `useRecordPresence: () => [],`;
+
+/**
+ * A `vi.mock` factory over `@object-ui/collaboration` that INHERITS the real
+ * module (so `check-vi-mock-inherit` is satisfied) and overrides `overrides`.
+ * This is the shape all thirteen historical files had.
+ */
+function mockSource(overrides: string): string {
+  return [
+    `import { vi } from ${Q}vitest${Q};`,
+    ``,
+    `vi.mock(${Q}@object-ui/collaboration${Q}, async (importOriginal) => ({`,
+    `  ...(await importOriginal<Record<string, unknown>>()),`,
+    `  ${overrides}`,
+    `  PresenceAvatars: () => null,`,
+    `}));`,
+    ``,
+  ].join('\n');
+}
+
+/**
+ * A temp tree holding a workspace package whose export shapes are declared, and
+ * one test file carrying the mock. Returns the root and the relative file list
+ * to hand `scan`, so nothing here depends on `git ls-files`.
+ */
+function fixture(
+  overrides: string,
+  opts: { provider?: string; index?: string } = {},
+): { root: string; files: string[]; cleanup: () => void } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vi-mock-override-shape-'));
+  const pkg = path.join(root, 'packages', 'collaboration');
+  fs.mkdirSync(path.join(pkg, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify({ name: '@object-ui/collaboration' }));
+  fs.writeFileSync(
+    path.join(pkg, 'src', 'index.ts'),
+    opts.index ?? `export { useRecordPresence, PresenceAvatars } from './PresenceProvider.js';\n`,
+  );
+  fs.writeFileSync(
+    path.join(pkg, 'src', 'PresenceProvider.tsx'),
+    opts.provider ??
+      [
+        `export interface PresenceUser { userId: string }`,
+        ``,
+        `export function useRecordPresence(`,
+        `  objectName: string | undefined,`,
+        `  recordId: string | undefined,`,
+        `): PresenceUser[] {`,
+        `  return [];`,
+        `}`,
+        ``,
+        `export function PresenceAvatars(): JSX.Element | null {`,
+        `  return null;`,
+        `}`,
+        ``,
+      ].join('\n'),
+  );
+
+  const testDir = path.join(root, 'packages', 'app-shell', 'src', 'views');
+  fs.mkdirSync(testDir, { recursive: true });
+  fs.writeFileSync(path.join(testDir, 'RecordDetailView.fixture.test.tsx'), mockSource(overrides));
+
+  return {
+    root,
+    files: [
+      'packages/collaboration/package.json',
+      'packages/collaboration/src/index.ts',
+      'packages/collaboration/src/PresenceProvider.tsx',
+      'packages/app-shell/src/views/RecordDetailView.fixture.test.tsx',
+    ],
+    cleanup: () => fs.rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+/** `scan` with the vacuity floors disabled — those have their own cases. */
+function scanFixture(overrides: string, opts: Parameters<typeof fixture>[1] = {}) {
+  const f = fixture(overrides, opts);
+  try {
+    return scan(f.root, { files: f.files, floors: {} });
+  } finally {
+    f.cleanup();
+  }
+}
+
+/**
+ * A runnable copy of the gate over an arbitrary root, for the exit code. The
+ * gate resolves its own repo root from its file location, so the copy has to
+ * live in the probe. `node_modules` is symlinked rather than copied because the
+ * gate imports `typescript` — which is the whole reason it cannot live in the
+ * pre-install workflow its two siblings share.
+ */
+function runGateIn(root: string): { status: number; stdout: string; stderr: string } {
+  fs.mkdirSync(path.join(root, 'scripts'), { recursive: true });
+  for (const m of GATE_MODULES) fs.copyFileSync(path.join(repoRoot, 'scripts', m), path.join(root, 'scripts', m));
+  fs.symlinkSync(path.join(repoRoot, 'node_modules'), path.join(root, 'node_modules'), 'dir');
+  execFileSync('git', ['init', '-q'], { cwd: root });
+  execFileSync('git', ['add', '-A'], { cwd: root });
+  try {
+    const stdout = execFileSync('node', [`scripts/${GATE}`], { cwd: root, encoding: 'utf8' });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    const e = err as { status: number; stdout: string; stderr: string };
+    return { status: e.status, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The positive control — the direction that matters
+// ---------------------------------------------------------------------------
+
+describe('the historical thirteen (objectui#8083 / PR #8902)', () => {
+  it('reddens the drifted stub and names the export, the declared shape and the stub shape', () => {
+    const result = scanFixture(DRIFTED);
+
+    expect(result.unregistered, 'the drift must be a finding — a green here is the defect itself').toHaveLength(1);
+    const [m] = result.unregistered;
+    expect(m.exportName).toBe('useRecordPresence');
+    expect(m.specifier).toBe('@object-ui/collaboration');
+    expect(m.declared).toBe('a function returning an array');
+    expect(m.actual).toBe('a function returning an object');
+    expect(m.file).toContain('RecordDetailView.fixture.test.tsx');
+    expect(m.declaredAt).toContain('PresenceProvider.tsx');
+    expect(m.text).toContain('viewers');
+  });
+
+  it('goes GREEN on the repaired stub — the other leg of the same mutation', () => {
+    const result = scanFixture(REPAIRED);
+    expect(result.unregistered).toHaveLength(0);
+    expect(result.census.judged, 'the repaired site must still be JUDGED, not merely silent').toBe(1);
+    expect(result.sites[0].verdict).toBe('match');
+    expect(result.sites[0].declared).toBe('a function returning an array');
+  });
+
+  it('exits 1 end to end on the drift, and 0 on the repair', () => {
+    for (const [overrides, expected] of [
+      [DRIFTED, 1],
+      [REPAIRED, 0],
+    ] as const) {
+      const f = fixture(overrides);
+      try {
+        const run = runGateIn(f.root);
+        expect(run.status, `${overrides} must exit ${expected}`).toBe(expected);
+        if (expected === 1) {
+          expect(run.stderr).toContain('useRecordPresence');
+          expect(run.stderr).toContain('a function returning an array');
+          expect(run.stderr).toContain('a function returning an object');
+        }
+      } finally {
+        f.cleanup();
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The negative controls — a gate that reddens correct code gets deleted
+// ---------------------------------------------------------------------------
+
+describe('never reddens what it cannot read with certainty', () => {
+  const opaqueOverrides = [
+    ['a vi.fn()', `useRecordPresence: vi.fn(),`],
+    ['an identifier', `useRecordPresence: stubPresence,`],
+    ['a call', `useRecordPresence: makeStub(),`],
+    ['a function returning an identifier', `useRecordPresence: () => stubValue,`],
+    ['a function returning a call', `useRecordPresence: () => makeStub(),`],
+  ] as const;
+
+  for (const [label, override] of opaqueOverrides) {
+    it(`counts but never judges ${label}`, () => {
+      const result = scanFixture(override);
+      expect(result.unregistered).toHaveLength(0);
+      expect(result.census.overrides, 'it must still be COUNTED — an uncounted site is an invisible one').toBeGreaterThan(0);
+      expect(result.sites.some((s) => s.exportName === 'useRecordPresence' && s.verdict === 'opaque')).toBe(true);
+    });
+  }
+
+  it('does not judge an export that is exported as a TYPE', () => {
+    const result = scanFixture(`useRecordPresence: () => ({ viewers: [] }),`, {
+      index: `export type { useRecordPresence } from './PresenceProvider.js';\n`,
+    });
+    expect(result.unregistered).toHaveLength(0);
+    expect(result.census.unresolved).toBeGreaterThan(0);
+  });
+
+  it('reads a CALLABLE interface as unknown, never as an object', () => {
+    // `interface Api { (): void }` is a FUNCTION at runtime. Reading it as an
+    // object would redden a correct function stub — a false positive in exactly
+    // the direction that gets a gate deleted rather than fixed.
+    const provider = [
+      `export interface PresenceApi { (): void; reset(): void }`,
+      `export const useRecordPresence: PresenceApi = Object.assign(() => {}, { reset() {} });`,
+      `export const PresenceAvatars = () => null;`,
+      ``,
+    ].join('\n');
+    const result = scanFixture(`useRecordPresence: () => undefined,`, { provider });
+    expect(result.unregistered).toHaveLength(0);
+  });
+
+  it('reads a NON-callable interface as an object, so a wrong-kind stub still reddens', () => {
+    const provider = [
+      `export interface PresenceState { viewers: string[] }`,
+      `export const useRecordPresence: PresenceState = { viewers: [] };`,
+      `export const PresenceAvatars = () => null;`,
+      ``,
+    ].join('\n');
+    const result = scanFixture(`useRecordPresence: [],`, { provider });
+    expect(result.unregistered).toHaveLength(1);
+    expect(result.unregistered[0].declared).toBe('an object');
+    expect(result.unregistered[0].actual).toBe('an array');
+  });
+
+  it('never conflicts when either side is unknown, in either direction', () => {
+    const unknown = { kind: 'unknown' };
+    const array = { kind: 'array' };
+    const object = { kind: 'object' };
+    expect(conflicts(unknown, array)).toBe(false);
+    expect(conflicts(array, unknown)).toBe(false);
+    expect(conflicts(unknown, unknown)).toBe(false);
+    expect(conflicts(array, object)).toBe(true);
+    expect(conflicts(array, array)).toBe(false);
+    expect(conflicts({ kind: 'function', returns: array }, { kind: 'function', returns: object })).toBe(true);
+    expect(conflicts({ kind: 'function', returns: array }, { kind: 'function', returns: unknown })).toBe(false);
+    expect(conflicts({ kind: 'function', returns: unknown }, { kind: 'function', returns: object })).toBe(false);
+  });
+
+  it('describes shapes in the words the failure message uses', () => {
+    expect(describeShape({ kind: 'function', returns: { kind: 'array' } })).toBe('a function returning an array');
+    expect(describeShape({ kind: 'unknown' })).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The real tree — the negative control at scale, and the anti-vacuity floor
+// ---------------------------------------------------------------------------
+
+describe('this repository', () => {
+  const result = scan(repoRoot);
+
+  it('has no unregistered shape mismatch', () => {
+    const detail = result.unregistered.map((m) => `${m.file}:${m.line} ${m.exportName}: ${m.declared} vs ${m.actual}`);
+    expect(detail).toEqual([]);
+  });
+
+  it('actually judges a substantial population — a green over nothing is not coverage', () => {
+    // Floors with room, deliberately. These exist to catch a walk that broke,
+    // not to pin today's figures. Measured on `aeaa0f6`: 1496 overrides, 923
+    // judged, 391 of those to the RETURN shape.
+    expect(result.census.overrides).toBeGreaterThan(500);
+    expect(result.census.judged).toBeGreaterThan(300);
+    expect(result.census.deep, 'the depth THIS card’s drift lives at').toBeGreaterThan(100);
+  });
+
+  it('shares ONE covered-specifier list with check-vi-mock-inherit', () => {
+    // A population that drifted between the two gates is a hole neither one
+    // reports. This gate imports the list rather than restating it, so the only
+    // way to break the parity is to stop importing it.
+    expect(result.covered).toEqual([...COVERED_SPECIFIERS]);
+    const source = fs.readFileSync(path.join(repoRoot, 'scripts', GATE), 'utf8');
+    expect(source).toContain("import { COVERED_SPECIFIERS } from './check-vi-mock-inherit.mjs';");
+  });
+
+  it('prints a census rather than a bare OK', () => {
+    expect(summarise(result)).toContain('override(s)');
+    expect(summarise(result)).toContain('judged');
+  });
+});
+
+describe('green at rest is not green over nothing', () => {
+  it('fails when the population collapses', () => {
+    const empty = scan(repoRoot, { files: [] });
+    expect(empty.vacuous.length).toBeGreaterThan(0);
+    expect(Object.keys(FLOORS)).toContain('judged');
+  });
+
+  it('exits 1 end to end on an empty tree', () => {
+    const probe = fs.mkdtempSync(path.join(os.tmpdir(), 'vi-mock-override-shape-empty-'));
+    try {
+      const run = runGateIn(probe);
+      expect(run.status, 'an empty scan must be RED — a green here is the defect itself').toBe(1);
+      expect(run.stderr).toContain('COLLAPSED');
+    } finally {
+      fs.rmSync(probe, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The ledger — SHRINK-ONLY, or it becomes a blanket
+// ---------------------------------------------------------------------------
+
+describe('KNOWN_SHAPE_MISMATCHES', () => {
+  it('is empty — nothing in this tree had to be grandfathered', () => {
+    expect([...KNOWN_SHAPE_MISMATCHES]).toEqual([]);
+  });
+
+  it('suppresses a registered mismatch, and only that one', () => {
+    const f = fixture(DRIFTED);
+    try {
+      const bare = scan(f.root, { files: f.files, floors: {} });
+      const id = bare.mismatches[0].id;
+      const registered = scan(f.root, { files: f.files, floors: {}, baseline: [id] });
+      expect(registered.unregistered).toHaveLength(0);
+      expect(registered.mismatches, 'a registered entry is still a MISMATCH, just a tolerated one').toHaveLength(1);
+      expect(registered.stale).toEqual([]);
+    } finally {
+      f.cleanup();
+    }
+  });
+
+  it('fails on a registered entry that no longer mismatches', () => {
+    const f = fixture(REPAIRED);
+    try {
+      const result = scan(f.root, { files: f.files, floors: {}, baseline: ['a/fixed/file.test.tsx:@object-ui/collaboration:useRecordPresence'] });
+      expect(result.stale).toHaveLength(1);
+    } finally {
+      f.cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wiring — a gate nobody runs is indistinguishable from a gate that passes
+// ---------------------------------------------------------------------------
+
+describe('wiring', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as {
+    scripts: Record<string, string>;
+  };
+  const lint = fs.readFileSync(path.join(repoRoot, '.github/workflows/lint.yml'), 'utf8');
+
+  it('is reachable as a pnpm script', () => {
+    expect(pkg.scripts['check:vi-mock-override-shape']).toBe(`node scripts/${GATE}`);
+  });
+
+  it('runs in lint.yml, AFTER the install it needs', () => {
+    const gateAt = lint.indexOf(`node scripts/${GATE}`);
+    const installAt = lint.indexOf('pnpm install --frozen-lockfile');
+    expect(gateAt, 'the gate must be run by a workflow').toBeGreaterThan(-1);
+    expect(installAt).toBeGreaterThan(-1);
+    expect(gateAt, 'the gate imports `typescript`; before the install there is no node_modules').toBeGreaterThan(installAt);
+  });
+
+  it('is NOT run by the pre-install vi-mock workflow', () => {
+    // `check-pre-install-import-graph.mjs` would fail the moment it were: this
+    // gate reaches the package `typescript`, and that workflow deliberately has
+    // no install step. Measured on this tree by injecting the same import into
+    // `check-vi-mock-inherit.mjs`: that gate went from exit 0 to exit 1.
+    const sibling = fs.readFileSync(path.join(repoRoot, '.github/workflows/vi-mock-specifiers.yml'), 'utf8');
+    expect(sibling).not.toContain(GATE);
+  });
+
+  it('the lint.yml skip switch cannot hide a change this gate judges', () => {
+    // The switch skips the expensive steps when only ignored paths changed.
+    // Both halves of what this gate compares live in TypeScript files, so no
+    // ignored pattern may match one. If a pattern that does is ever added, the
+    // gate silently stops seeing the pull requests most likely to trip it.
+    const patterns = [...lint.matchAll(/:\(exclude,glob\)([^'"\s]+)/g)].map((m) => m[1]);
+    expect(patterns.length, 'the ignore list moved — re-read this switch').toBeGreaterThan(0);
+
+    const toRe = (glob: string) =>
+      new RegExp(
+        `^${glob
+          .split('**')
+          .map((part) => part.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^/]*'))
+          .join('.*')}$`,
+      );
+    const tsPaths = [
+      'packages/app-shell/src/views/RecordDetailView.headerRefresh.test.tsx',
+      'packages/collaboration/src/PresenceProvider.tsx',
+      'scripts/check-vi-mock-override-shape.mjs',
+      'packages/collaboration/src/index.ts',
+    ];
+    for (const glob of patterns) {
+      for (const p of tsPaths) {
+        expect(toRe(glob).test(p), `ignore pattern ${glob} matches ${p} — this gate would go blind`).toBe(false);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The reader — what it sees, and what it declines to see
+// ---------------------------------------------------------------------------
+
+describe('findOverrides', () => {
+  it('reads the own properties of the returned object, never the spread', () => {
+    const found = findOverrides('x.test.tsx', mockSource(REPAIRED));
+    expect(found.map((o) => o.exportName)).toEqual(['useRecordPresence', 'PresenceAvatars']);
+  });
+
+  it('ignores a mock on a specifier outside the covered list', () => {
+    const src = mockSource(REPAIRED).replace('@object-ui/collaboration', 'sonner');
+    expect(findOverrides('x.test.tsx', src)).toHaveLength(0);
+  });
+
+  it('reads a block-bodied factory as well as a concise one', () => {
+    const src = [
+      `import { vi } from ${Q}vitest${Q};`,
+      ``,
+      `vi.mock(${Q}@object-ui/collaboration${Q}, async (importOriginal) => {`,
+      `  const actual = await importOriginal<Record<string, unknown>>();`,
+      `  return { ...actual, ${REPAIRED} };`,
+      `});`,
+      ``,
+    ].join('\n');
+    expect(findOverrides('x.test.tsx', src).map((o) => o.exportName)).toEqual(['useRecordPresence']);
+  });
+
+  it('does not see a call that lives inside a string literal', () => {
+    const src = `const sample = ${Q}vi.mock("@object-ui/collaboration", () => ({ useRecordPresence: () => ({}) }))${Q};\n`;
+    expect(findOverrides('x.test.tsx', src)).toHaveLength(0);
+  });
+});

--- a/scripts/check-vi-mock-override-shape.mjs
+++ b/scripts/check-vi-mock-override-shape.mjs
@@ -499,6 +499,21 @@ function trackedFiles(root) {
     .filter(Boolean);
 }
 
+/**
+ * The one scan. `main()`, `--list`, `--json` and the test suite all go through
+ * here, so the tests exercise the real code path rather than an imitation.
+ *
+ * @param {string} root  Repository root to scan.
+ * @param {{ files?: string[] | null, floors?: Record<string, number>, covered?: readonly string[], baseline?: readonly string[] }} [options]
+ *   `files` overrides the `git ls-files` walk (fixtures pass their own list);
+ *   `floors` overrides `FLOORS` -- pass `{}` to switch the collapse check off
+ *   for a fixture tree, which is legitimately far below every repo floor;
+ *   `covered` overrides `COVERED_SPECIFIERS`, so a fixture can exercise the
+ *   scope boundary without waiting for the real list to grow;
+ *   `baseline` overrides `KNOWN_SHAPE_MISMATCHES`, so the ledger's two
+ *   behaviours -- suppress a registered entry, FAIL on a stale one -- are
+ *   testable without registering anything in the real tree.
+ */
 export function scan(root, { files = null, floors = FLOORS, covered = COVERED_SPECIFIERS, baseline = KNOWN_SHAPE_MISMATCHES } = {}) {
   const tracked = files || trackedFiles(root);
   const sources = tracked.filter((f) => SOURCE_FILE_RE.test(f) && !EXCLUDED.test(f));
@@ -584,22 +599,22 @@ function main() {
   const result = scan(repoRoot());
   const { unregistered, stale, vacuous } = result;
   if (unregistered.length === 0 && stale.length === 0 && vacuous.length === 0) {
-    console.log(`OK  check-vi-mock-override-shape: (${summarise(result)}).`);
+    console.log(`✅  check-vi-mock-override-shape: OK (${summarise(result)}).`);
     process.exit(0);
   }
   if (unregistered.length > 0) {
-    console.error(`FAIL  check-vi-mock-override-shape: ${unregistered.length} override(s) do not match the declared export\n`);
+    console.error(`❌  check-vi-mock-override-shape: ${unregistered.length} override(s) do not match the declared export\n`);
     for (const m of unregistered) {
       console.error(`    - ${m.file}:${m.line} -- vi.mock(${JSON.stringify(m.specifier)}) overrides ${m.exportName}`);
       console.error(`      declared ${m.declared} at ${m.declaredAt}, stub is ${m.actual}: ${m.text}`);
     }
   }
   if (stale.length > 0) {
-    console.error(`\nFAIL  check-vi-mock-override-shape: ${stale.length} registered baseline entry/entries no longer mismatch\n`);
+    console.error(`\n❌  check-vi-mock-override-shape: ${stale.length} registered baseline entry/entries no longer mismatch\n`);
     for (const id of stale) console.error(`    - ${id}`);
   }
   if (vacuous.length > 0) {
-    console.error('\nFAIL  check-vi-mock-override-shape: the population COLLAPSED\n');
+    console.error('\n❌  check-vi-mock-override-shape: the population COLLAPSED\n');
     for (const v of vacuous) console.error(`    - ${v.counter}: found ${v.value}, floor is ${v.floor}`);
     console.error(`\nCensus: ${summarise(result)}`);
   }

--- a/scripts/check-vi-mock-override-shape.mjs
+++ b/scripts/check-vi-mock-override-shape.mjs
@@ -1,0 +1,621 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Rejects a `vi.mock` factory whose OVERRIDE VALUE has a different shape from
+ * the export it stands in for.
+ *
+ * Run:  node scripts/check-vi-mock-override-shape.mjs
+ *       node scripts/check-vi-mock-override-shape.mjs --list   # every override, with its verdict
+ *       node scripts/check-vi-mock-override-shape.mjs --json
+ * Exit: 0 = OK, 1 = an unregistered mismatch, a stale baseline entry, or a
+ *       collapsed population.
+ *
+ * ## The defect (objectui#8903, measured on objectui#8083 / PR #8902)
+ *
+ * Thirteen `RecordDetailView` test files stubbed `useRecordPresence` as
+ * `{ viewers: [], others: [] }`. The real hook returns `PresenceUser[]`, and its
+ * only consumer reads `recordPresence.length > 0` -- an object has no `length`,
+ * so the presence row was structurally unrenderable in those files. They
+ * exercised the no-presence branch through a SHAPE MISMATCH rather than through
+ * the empty array the branch is about.
+ *
+ * Nothing saw it. `tsc` does not: a `vi.mock` factory is untyped, so the
+ * compiler never compares the stub against `PresenceUser[]`. Neither did either
+ * sibling gate, and that is not an inference -- it was measured by putting the
+ * thirteen drifted stubs back on disk and running both:
+ *
+ *     check-vi-mock-specifiers   verdict line byte-identical, exit 0
+ *     check-vi-mock-inherit      verdict line byte-identical, exit 0
+ *
+ * Byte-identical to the repaired tree, in both cases. `check-vi-mock-specifiers`
+ * judges whether a RELATIVE specifier resolves to a file, and these mock the
+ * bare specifier `@object-ui/collaboration`, which its own summary counts under
+ * `bare (out of scope)`. `check-vi-mock-inherit` judges whether the factory
+ * OBTAINS AND SPREADS the real module, and all thirteen already did -- they were
+ * fully compliant WITH the drift inside them. Two gates over the same population,
+ * neither of which judges the override's VALUE.
+ *
+ * ⚠️ The failure mode is the asymmetric one. When the stubbed contract changes,
+ * the files that stubbed it CORRECTLY go red and the drifted ones stay green:
+ * the suite splits down the middle and the majority quietly stops tracking the
+ * hook. objectui#8083 put it as "the 9 correct files move and the 13 stay green".
+ *
+ * ⭐ And the shape `{ viewers, others }` exists NOWHERE else in this tree -- a
+ * full scan found it only in those thirteen stubs. So this drift is not a
+ * misread type; it is a neighbouring-but-different shape arriving by COPY-PASTE.
+ * A guard that only asks "does the factory spread the real module" has no
+ * discriminating power over it whatever, which is precisely
+ * `check-vi-mock-inherit`'s blind spot. This gate compares the override's value
+ * shape against the export's DECLARED shape, or it is not a guard at all.
+ *
+ * ## Why a third gate, and not an extension -- measured, not preferred
+ *
+ * The natural first move is to widen `check-vi-mock-inherit.mjs`: same call
+ * sites, same covered specifiers, one fewer file to read. It is not available,
+ * and the reason is mechanical rather than aesthetic.
+ *
+ * Reading a DECLARED shape means parsing TypeScript -- return-type annotations,
+ * re-export chains, type-only exports. This file therefore imports `typescript`.
+ * `check-vi-mock-inherit.mjs` runs in `.github/workflows/vi-mock-specifiers.yml`,
+ * which deliberately carries NO install step so that it can run on every pull
+ * request shape at the cost of a checkout plus one `node` call; the import graph
+ * of every pre-install gate is enforced to be node builtins plus repo-relative
+ * modules only (objectui#6148). Adding the import to the sibling was measured
+ * rather than argued -- injected on disk, blob hash before/after recorded:
+ *
+ *     node scripts/check-pre-install-import-graph.mjs
+ *       before injection : exit 0
+ *       after  injection : exit 1 -- "scripts/check-vi-mock-inherit.mjs reaches
+ *                                     the package `typescript`"
+ *
+ * Extending the sibling would REDDEN AN EXISTING GATE. That settles the route:
+ * this is a new gate, and it lives in `lint.yml`, after `pnpm install`.
+ *
+ * `lint.yml` gates its steps behind a "needs a full run" switch, so the second
+ * half of the route question is whether that switch is a blind spot here. Its
+ * ignore list covers Markdown files anywhere, plus the `content`, `docs` and
+ * `.changeset` trees. An
+ * override lives in a `.ts`/`.tsx` file and a declared export shape lives in
+ * one too, so no change this gate can judge is reachable through those paths.
+ * `scripts/__tests__/check-vi-mock-override-shape.test.ts` pins that, and fails
+ * if a pattern matching a TypeScript file is ever added to the list.
+ *
+ * Two further properties argue the same way. `check-vi-mock-inherit` judges
+ * 100% of its population -- every covered call site gets a verdict. This
+ * predicate is PARTIAL by construction (see below), so fusing them would make
+ * one census line mean two different things about two different denominators.
+ * And its predicate is a property of the factory's own text; this one has to
+ * resolve modules. Different inputs, different failure modes, different homes.
+ *
+ * ## Certainty or nothing -- the rule that keeps this gate alive
+ *
+ * A gate that reddens correct code gets deleted rather than fixed. So both
+ * sides of every comparison are read for CERTAINTY, and anything less is
+ * `unknown` -- and `unknown` on either side is never a conflict, in either
+ * direction. Concretely:
+ *
+ *   - `T[]`, `Array<T>`, `ReadonlyArray<T>` and a tuple are certainly arrays;
+ *     an object type literal and `Record<K, V>` are certainly objects.
+ *   - A bare type reference (`PresenceUser`, `ReactNode`, `Promise<X>`) is
+ *     `unknown` unless it names an interface or type alias declared in the SAME
+ *     file, without type parameters, at most four hops deep.
+ *   - An interface or type literal carrying a CALL or CONSTRUCT signature reads
+ *     `unknown`, never "object": it is a function at runtime, and reading it as
+ *     an object would redden a correct function stub.
+ *   - A union, a conditional, a generic instantiation and an inferred return
+ *     with disagreeing `return` statements are all `unknown`.
+ *   - On the stub side: an array literal, an object literal and the string,
+ *     number and boolean literals are certain; an identifier, a call and
+ *     `vi.fn()` are `unknown`.
+ *
+ * That is why the census reports three denominators and not one. Measured on
+ * `aeaa0f6`:
+ *
+ *     1496 override(s) found on covered specifiers
+ *      923 judged            -- the DECLARED side has a certain top-level kind,
+ *                               so a stub of a different kind conflicts
+ *      391 to the RETURN shape -- the declared function's return kind is certain
+ *                               too, which is the depth THIS card's drift lives
+ *                               at (a function returning an array, stubbed as a
+ *                               function returning an object)
+ *       14 export not resolvable
+ *      559 shape not statically certain
+ *
+ * The gate is GREEN AT REST over all of it: zero mismatches in the tree today,
+ * which is why `KNOWN_SHAPE_MISMATCHES` is empty. The existing bare-specifier
+ * population is NOT reddened by this gate -- 937 of them at `aeaa0f6`, and the
+ * ruling that landed this gate named leaving them alone as a boundary. Nothing
+ * had to be grandfathered because nothing in the tree violates the predicate.
+ *
+ * ## Which direction can this gate FAIL in?
+ *
+ * It fails when a judged override's shape CONFLICTS with the declared export.
+ * That is proved, not asserted: the thirteen historical stubs, restored to disk
+ * byte-for-byte from PR #8902's pre-image, make it print thirteen findings and
+ * exit 1, each naming the file, the export, the declared shape and the stub's;
+ * repairing them returns it to exit 0. Both legs are in this gate's test file,
+ * and neither is decoration.
+ *
+ * It CANNOT fail on an `unknown`, by design -- which is a real limit and is
+ * stated here rather than hidden: an override whose value is a `vi.fn()` or a
+ * local identifier is counted and never judged.
+ *
+ * ## The ledger, and why it is SHRINK-ONLY
+ *
+ * `KNOWN_SHAPE_MISMATCHES` registers mismatches that are known and tolerated,
+ * by `<file>:<specifier>:<export>`. It is empty today. A registered entry that
+ * NO LONGER mismatches is itself a failure: that is what stops the ledger from
+ * quietly becoming a blanket over a class it was meant to be retiring. Adding
+ * an entry is a deliberate admission; it is never the way to make a red run
+ * green.
+ *
+ * ## Green at rest
+ *
+ * A scan that finds nothing reports OK and reads as coverage -- this gate's own
+ * defect, one level up. `FLOORS` therefore fails the run if the population
+ * collapses. The floors are set with room: they exist to catch a walk that
+ * broke, not to pin today's figures, which move every day.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { isEntrypoint } from './invoked-as.mjs';
+import { COVERED_SPECIFIERS } from './check-vi-mock-inherit.mjs';
+
+const SOURCE_FILE_RE = /\.[cm]?[jt]sx?$/;
+const TEST_FILE_RE = /(\.(test|spec)\.[cm]?[jt]sx?$)|((^|\/)__tests__\/)/;
+const EXCLUDED = /(^|\/)(node_modules|dist|build|\.next|\.turbo|\.wt-[^/]*)\//;
+const NUL = String.fromCharCode(0);
+
+export const FLOORS = Object.freeze({ sources: 1000, testFiles: 1000, overrides: 500, judged: 50 });
+
+export const KNOWN_SHAPE_MISMATCHES = Object.freeze([]);
+
+const UNKNOWN = Object.freeze({ kind: 'unknown' });
+const of = (kind, returns) => (returns ? { kind, returns } : { kind });
+
+export function describeShape(shape) {
+  if (!shape || shape.kind === 'unknown') return 'unknown';
+  if (shape.kind === 'function') return `a function returning ${describeShape(shape.returns)}`;
+  if (shape.kind === 'array') return 'an array';
+  if (shape.kind === 'object') return 'an object';
+  return `a ${shape.kind}`;
+}
+
+export function shapeOfTypeNode(node, resolveRef = null, depth = 0) {
+  if (!node || depth > 4) return UNKNOWN;
+  const recur = (n) => shapeOfTypeNode(n, resolveRef, depth + 1);
+  if (ts.isParenthesizedTypeNode(node)) return recur(node.type);
+  if (ts.isArrayTypeNode(node)) return of('array');
+  if (ts.isTupleTypeNode(node)) return of('array');
+  if (ts.isTypeLiteralNode(node)) return callableMembers(node.members) ? UNKNOWN : of('object');
+  if (ts.isFunctionTypeNode(node)) return of('function', recur(node.type));
+  if (node.kind === ts.SyntaxKind.StringKeyword) return of('string');
+  if (node.kind === ts.SyntaxKind.NumberKeyword) return of('number');
+  if (node.kind === ts.SyntaxKind.BooleanKeyword) return of('boolean');
+  if (ts.isTypeReferenceNode(node)) {
+    const name = node.typeName.getText(node.getSourceFile());
+    if (name === 'Array' || name === 'ReadonlyArray') return of('array');
+    if (name === 'Record') return of('object');
+    // One hop through a LOCAL declaration. Anything imported, generic,
+    // conditional or union stays `unknown` -- see "Certainty or nothing".
+    if (resolveRef && !node.typeArguments) {
+      const target = resolveRef(name);
+      if (target) return recur(target);
+    }
+    return UNKNOWN;
+  }
+  return UNKNOWN;
+}
+
+/**
+ * Does this member list make the type CALLABLE or CONSTRUCTABLE? An interface
+ * with a call signature is a function at runtime, so reading it as an object
+ * would redden a correct function stub -- a false positive in the direction
+ * that gets gates deleted.
+ */
+function callableMembers(members) {
+  return (members || []).some((m) => ts.isCallSignatureDeclaration(m) || ts.isConstructSignatureDeclaration(m));
+}
+
+/**
+ * A resolver for type names declared in `sf` itself: an interface, or a type
+ * alias. Returns the TYPE NODE to read, or null when the name is not a local
+ * declaration this gate is willing to read.
+ */
+function localTypeResolver(sf) {
+  return (name) => {
+    for (const st of sf.statements) {
+      if (ts.isInterfaceDeclaration(st) && st.name.text === name) {
+        if (st.typeParameters && st.typeParameters.length > 0) return null;
+        if (callableMembers(st.members)) return null;
+        // An interface is an object type; hand back a synthetic empty literal.
+        return ts.factory.createTypeLiteralNode([]);
+      }
+      if (ts.isTypeAliasDeclaration(st) && st.name.text === name) {
+        if (st.typeParameters && st.typeParameters.length > 0) return null;
+        return st.type;
+      }
+    }
+    return null;
+  };
+}
+
+export function shapeOfExpression(node, resolveRef = null) {
+  if (!node) return UNKNOWN;
+  if (ts.isParenthesizedExpression(node)) return shapeOfExpression(node.expression, resolveRef);
+  if (ts.isAsExpression(node)) return shapeOfExpression(node.expression, resolveRef);
+  if (ts.isSatisfiesExpression && ts.isSatisfiesExpression(node)) return shapeOfExpression(node.expression, resolveRef);
+  if (ts.isArrayLiteralExpression(node)) return of('array');
+  if (ts.isObjectLiteralExpression(node)) return of('object');
+  if (ts.isStringLiteralLike(node)) return of('string');
+  if (ts.isNumericLiteral(node)) return of('number');
+  if (node.kind === ts.SyntaxKind.TrueKeyword || node.kind === ts.SyntaxKind.FalseKeyword) return of('boolean');
+  if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
+    if (node.type) return of('function', shapeOfTypeNode(node.type, resolveRef));
+    return of('function', shapeOfFunctionBody(node.body, resolveRef));
+  }
+  return UNKNOWN;
+}
+
+function shapeOfFunctionBody(body, resolveRef = null) {
+  if (!body) return UNKNOWN;
+  if (!ts.isBlock(body)) return shapeOfExpression(body, resolveRef);
+  const shapes = [];
+  const walk = (n) => {
+    if (ts.isFunctionDeclaration(n) || ts.isFunctionExpression(n) || ts.isArrowFunction(n)) return;
+    if (ts.isReturnStatement(n)) shapes.push(n.expression ? shapeOfExpression(n.expression, resolveRef) : UNKNOWN);
+    ts.forEachChild(n, walk);
+  };
+  ts.forEachChild(body, walk);
+  if (shapes.length === 0) return UNKNOWN;
+  const first = shapes[0];
+  if (first.kind === 'unknown') return UNKNOWN;
+  return shapes.every((s) => s.kind === first.kind) ? of(first.kind) : UNKNOWN;
+}
+
+export function conflicts(declared, actual) {
+  if (!declared || !actual) return false;
+  if (declared.kind === 'unknown' || actual.kind === 'unknown') return false;
+  if (declared.kind !== actual.kind) return true;
+  if (declared.kind === 'function') return conflicts(declared.returns, actual.returns);
+  return false;
+}
+
+function parseFile(abs, cache) {
+  if (cache.has(abs)) return cache.get(abs);
+  let sf = null;
+  try {
+    const text = readFileSync(abs, 'utf8');
+    sf = ts.createSourceFile(abs, text, ts.ScriptTarget.Latest, true, /\.tsx$/.test(abs) ? ts.ScriptKind.TSX : ts.ScriptKind.TS);
+  } catch {
+    sf = null;
+  }
+  cache.set(abs, sf);
+  return sf;
+}
+
+function resolveRelative(fromFile, spec) {
+  const base = resolve(dirname(fromFile), spec.replace(/\.jsx?$/, ''));
+  for (const cand of [`${base}.ts`, `${base}.tsx`, `${base}.mts`, `${base}.d.ts`, join(base, 'index.ts'), join(base, 'index.tsx')]) {
+    if (existsSync(cand)) return cand;
+  }
+  return null;
+}
+
+export function workspaceEntries(root) {
+  const map = new Map();
+  for (const group of ['packages', 'apps']) {
+    const dir = join(root, group);
+    if (!existsSync(dir)) continue;
+    let names = [];
+    try {
+      names = readdirSync(dir);
+    } catch {
+      names = [];
+    }
+    for (const name of names) {
+      const pj = join(dir, name, 'package.json');
+      if (!existsSync(pj)) continue;
+      let parsed;
+      try {
+        parsed = JSON.parse(readFileSync(pj, 'utf8'));
+      } catch {
+        continue;
+      }
+      if (!parsed || !parsed.name) continue;
+      for (const cand of ['src/index.ts', 'src/index.tsx', 'src/index.mts']) {
+        const abs = join(dir, name, cand);
+        if (existsSync(abs)) {
+          map.set(parsed.name, abs);
+          break;
+        }
+      }
+    }
+  }
+  return map;
+}
+
+function declaredShapeIn(file, name, ctx, depth = 0) {
+  if (depth > 8 || !file) return null;
+  const key = `${file} ${name}`;
+  if (ctx.seen.has(key)) return null;
+  ctx.seen.add(key);
+  const sf = parseFile(file, ctx.files);
+  if (!sf) return null;
+
+  const localImports = new Map();
+  const starExports = [];
+
+  for (const st of sf.statements) {
+    if (ts.isImportDeclaration(st) && st.importClause && st.importClause.namedBindings && ts.isNamedImports(st.importClause.namedBindings)) {
+      const spec = st.moduleSpecifier.text;
+      for (const el of st.importClause.namedBindings.elements) {
+        localImports.set(el.name.text, {
+          spec,
+          imported: (el.propertyName || el.name).text,
+          typeOnly: st.importClause.isTypeOnly || el.isTypeOnly,
+        });
+      }
+    }
+    if (ts.isExportDeclaration(st)) {
+      if (st.exportClause && ts.isNamedExports(st.exportClause)) {
+        for (const el of st.exportClause.elements) {
+          if (el.name.text !== name) continue;
+          if (st.isTypeOnly || el.isTypeOnly) return null;
+          const source = (el.propertyName || el.name).text;
+          if (st.moduleSpecifier) return followSpecifier(file, st.moduleSpecifier.text, source, ctx, depth);
+          const here = declarationShape(sf, source);
+          if (here) return here;
+          const via = localImports.get(source);
+          if (via && !via.typeOnly) return followSpecifier(file, via.spec, via.imported, ctx, depth);
+          return null;
+        }
+      } else if (st.moduleSpecifier && !st.isTypeOnly) {
+        starExports.push(st.moduleSpecifier.text);
+      }
+    }
+  }
+
+  const direct = declarationShape(sf, name, true);
+  if (direct) return direct;
+
+  for (const spec of starExports) {
+    const found = followSpecifier(file, spec, name, ctx, depth);
+    if (found) return found;
+  }
+  return null;
+}
+
+function followSpecifier(fromFile, spec, name, ctx, depth) {
+  if (spec.startsWith('.')) {
+    const next = resolveRelative(fromFile, spec);
+    return next ? declaredShapeIn(next, name, ctx, depth + 1) : null;
+  }
+  const entry = ctx.entries.get(spec);
+  return entry ? declaredShapeIn(entry, name, ctx, depth + 1) : null;
+}
+
+function declarationShape(sf, name, exportedOnly = false) {
+  const resolveRef = localTypeResolver(sf);
+  for (const st of sf.statements) {
+    const exported = ts.canHaveModifiers(st) && (ts.getModifiers(st) || []).some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+    if (exportedOnly && !exported) continue;
+    if (ts.isFunctionDeclaration(st) && st.name && st.name.text === name) {
+      return {
+        shape: of('function', st.type ? shapeOfTypeNode(st.type, resolveRef) : shapeOfFunctionBody(st.body, resolveRef)),
+        where: `${sf.fileName}:${lineOf(sf, st)}`,
+      };
+    }
+    if (ts.isVariableStatement(st)) {
+      for (const d of st.declarationList.declarations) {
+        if (!ts.isIdentifier(d.name) || d.name.text !== name) continue;
+        if (d.type) return { shape: shapeOfTypeNode(d.type, resolveRef), where: `${sf.fileName}:${lineOf(sf, d)}` };
+        return { shape: shapeOfExpression(d.initializer, resolveRef), where: `${sf.fileName}:${lineOf(sf, d)}` };
+      }
+    }
+  }
+  return null;
+}
+
+const lineOf = (sf, n) => sf.getLineAndCharacterOfPosition(n.getStart(sf)).line + 1;
+
+function returnedObject(fn) {
+  let body = fn.body;
+  if (!body) return null;
+  if (ts.isBlock(body)) {
+    let found = null;
+    for (const st of body.statements) {
+      if (ts.isReturnStatement(st) && st.expression) {
+        found = st.expression;
+        break;
+      }
+    }
+    if (!found) return null;
+    body = found;
+  }
+  while (ts.isParenthesizedExpression(body) || ts.isAwaitExpression(body) || ts.isAsExpression(body)) body = body.expression;
+  return ts.isObjectLiteralExpression(body) ? body : null;
+}
+
+export function findOverrides(rel, source, { covered = COVERED_SPECIFIERS } = {}) {
+  const coveredSet = new Set(covered);
+  const prefixes = [...coveredSet].map((m) => `${m}/`);
+  const isCovered = (s) => coveredSet.has(s) || prefixes.some((p) => s.startsWith(p));
+  const sf = ts.createSourceFile(rel, source, ts.ScriptTarget.Latest, true, /\.tsx$/.test(rel) ? ts.ScriptKind.TSX : ts.ScriptKind.TS);
+  const out = [];
+  const visit = (n) => {
+    if (
+      ts.isCallExpression(n) &&
+      ts.isPropertyAccessExpression(n.expression) &&
+      ts.isIdentifier(n.expression.expression) &&
+      n.expression.expression.text === 'vi' &&
+      (n.expression.name.text === 'mock' || n.expression.name.text === 'doMock')
+    ) {
+      const a0 = n.arguments[0];
+      let spec = null;
+      if (a0 && ts.isStringLiteralLike(a0)) spec = a0.text;
+      else if (
+        a0 &&
+        ts.isCallExpression(a0) &&
+        a0.expression.kind === ts.SyntaxKind.ImportKeyword &&
+        a0.arguments[0] &&
+        ts.isStringLiteralLike(a0.arguments[0])
+      ) {
+        spec = a0.arguments[0].text;
+      }
+      const factory = n.arguments[1];
+      if (spec && isCovered(spec) && factory && (ts.isArrowFunction(factory) || ts.isFunctionExpression(factory))) {
+        const obj = returnedObject(factory);
+        if (obj) {
+          for (const p of obj.properties) {
+            if (!ts.isPropertyAssignment(p)) continue;
+            if (!ts.isIdentifier(p.name) && !ts.isStringLiteralLike(p.name)) continue;
+            out.push({
+              specifier: spec,
+              exportName: p.name.text,
+              line: lineOf(sf, p),
+              shape: shapeOfExpression(p.initializer, localTypeResolver(sf)),
+              text: p.initializer.getText(sf).replace(/\s+/g, ' ').slice(0, 80),
+            });
+          }
+        }
+      }
+    }
+    ts.forEachChild(n, visit);
+  };
+  visit(sf);
+  return out;
+}
+
+function trackedFiles(root) {
+  return execFileSync('git', ['ls-files', '-z'], { cwd: root, encoding: 'buffer', maxBuffer: 64 * 1024 * 1024 })
+    .toString('utf8')
+    .split(NUL)
+    .filter(Boolean);
+}
+
+export function scan(root, { files = null, floors = FLOORS, covered = COVERED_SPECIFIERS, baseline = KNOWN_SHAPE_MISMATCHES } = {}) {
+  const tracked = files || trackedFiles(root);
+  const sources = tracked.filter((f) => SOURCE_FILE_RE.test(f) && !EXCLUDED.test(f));
+  const testFiles = sources.filter((f) => TEST_FILE_RE.test(f));
+  const entries = workspaceEntries(root);
+
+  const census = { sources: sources.length, testFiles: testFiles.length, filesWithMocks: 0, overrides: 0, judged: 0, deep: 0, unresolved: 0, opaque: 0 };
+  const mismatches = [];
+  const sites = [];
+  const shapeCache = new Map();
+
+  for (const rel of sources) {
+    let text;
+    try {
+      text = readFileSync(join(root, rel), 'utf8');
+    } catch {
+      continue;
+    }
+    if (!text.includes('vi.mock') && !text.includes('vi.doMock')) continue;
+    const found = findOverrides(rel, text, { covered });
+    if (found.length === 0) continue;
+    census.filesWithMocks++;
+    for (const o of found) {
+      census.overrides++;
+      const entry = entries.get(o.specifier) || entries.get(o.specifier.split('/').slice(0, 2).join('/'));
+      const declared = entry ? declaredShapeIn(entry, o.exportName, { entries, files: shapeCache, seen: new Set() }) : null;
+      if (!declared) {
+        census.unresolved++;
+        sites.push({ file: rel, line: o.line, specifier: o.specifier, exportName: o.exportName, verdict: 'unresolved', declared: 'not found', actual: describeShape(o.shape) });
+        continue;
+      }
+      if (declared.shape.kind === 'unknown' || o.shape.kind === 'unknown') {
+        census.opaque++;
+        sites.push({ file: rel, line: o.line, specifier: o.specifier, exportName: o.exportName, verdict: 'opaque', declared: describeShape(declared.shape), actual: describeShape(o.shape) });
+        continue;
+      }
+      census.judged++;
+      const isDeep = declared.shape.kind !== 'function' || declared.shape.returns.kind !== 'unknown';
+      if (isDeep) census.deep++;
+      sites.push({ file: rel, line: o.line, specifier: o.specifier, exportName: o.exportName, verdict: conflicts(declared.shape, o.shape) ? 'mismatch' : 'match', declared: describeShape(declared.shape), actual: describeShape(o.shape) });
+      if (conflicts(declared.shape, o.shape)) {
+        mismatches.push({
+          file: rel,
+          line: o.line,
+          specifier: o.specifier,
+          exportName: o.exportName,
+          declared: describeShape(declared.shape),
+          actual: describeShape(o.shape),
+          declaredAt: declared.where.replace(`${root}/`, ''),
+          text: o.text,
+          id: `${rel}:${o.specifier}:${o.exportName}`,
+        });
+      }
+    }
+  }
+
+  const registered = new Set(baseline);
+  const unregistered = mismatches.filter((m) => !registered.has(m.id));
+  const stale = [...registered].filter((id) => !mismatches.some((m) => m.id === id));
+
+  const vacuous = [];
+  for (const [counter, floor] of Object.entries(floors)) {
+    if (census[counter] < floor) vacuous.push({ counter, value: census[counter], floor });
+  }
+
+  return { census, sites, mismatches, unregistered, stale, vacuous, covered: [...covered] };
+}
+
+export function summarise({ census }) {
+  return (
+    `${census.sources} tracked source file(s), ${census.testFiles} test-named; ` +
+    `${census.filesWithMocks} carry a covered mock; ` +
+    `${census.overrides} override(s), ${census.judged} judged, ${census.deep} to the RETURN shape ` +
+    `(${census.unresolved} export not resolvable, ${census.opaque} shape not statically certain)`
+  );
+}
+
+function repoRoot() {
+  return resolve(dirname(fileURLToPath(import.meta.url)), '..');
+}
+
+function main() {
+  const result = scan(repoRoot());
+  const { unregistered, stale, vacuous } = result;
+  if (unregistered.length === 0 && stale.length === 0 && vacuous.length === 0) {
+    console.log(`OK  check-vi-mock-override-shape: (${summarise(result)}).`);
+    process.exit(0);
+  }
+  if (unregistered.length > 0) {
+    console.error(`FAIL  check-vi-mock-override-shape: ${unregistered.length} override(s) do not match the declared export\n`);
+    for (const m of unregistered) {
+      console.error(`    - ${m.file}:${m.line} -- vi.mock(${JSON.stringify(m.specifier)}) overrides ${m.exportName}`);
+      console.error(`      declared ${m.declared} at ${m.declaredAt}, stub is ${m.actual}: ${m.text}`);
+    }
+  }
+  if (stale.length > 0) {
+    console.error(`\nFAIL  check-vi-mock-override-shape: ${stale.length} registered baseline entry/entries no longer mismatch\n`);
+    for (const id of stale) console.error(`    - ${id}`);
+  }
+  if (vacuous.length > 0) {
+    console.error('\nFAIL  check-vi-mock-override-shape: the population COLLAPSED\n');
+    for (const v of vacuous) console.error(`    - ${v.counter}: found ${v.value}, floor is ${v.floor}`);
+    console.error(`\nCensus: ${summarise(result)}`);
+  }
+  process.exit(1);
+}
+
+if (isEntrypoint(import.meta.url)) {
+  if (process.argv.includes('--json')) {
+    console.log(JSON.stringify(scan(repoRoot()), null, 2));
+  } else if (process.argv.includes('--list')) {
+    const result = scan(repoRoot());
+    for (const s of result.sites) {
+      console.log(`${s.verdict.toUpperCase().padEnd(10)}  ${s.file}:${s.line}  ${s.specifier} :: ${s.exportName}  declared=${s.declared} stub=${s.actual}`);
+    }
+    console.log(`\n${summarise(result)}`);
+  } else {
+    main();
+  }
+}


### PR DESCRIPTION
Fixes #8903

Adds `scripts/check-vi-mock-override-shape.mjs` — a third gate over the `vi.mock` population, judging the one property neither sibling judges: **what the override is worth**.

## The measurement this gate exists for

Re-derived on this branch, independently of the card. The thirteen drifted `useRecordPresence` stubs were restored to disk byte-for-byte from PR #8902's pre-image (blob hash `a3fe5953ac` on `RecordDetailView.activityMapIdentity-5878.test.tsx` — exactly the pre-image that PR's own diff header names), and both existing gates re-run:

| gate | with the drift on disk | vs. repaired tree |
|---|---|---|
| `check-vi-mock-specifiers` | exit 0 | verdict line **byte-identical** (`diff` empty) |
| `check-vi-mock-inherit` | exit 0 | verdict line **byte-identical** (`diff` empty) |

The card's central claim holds. `check-vi-mock-specifiers` judges whether a *relative* specifier resolves, and these mock the bare `@object-ui/collaboration`, which its own summary counts under `bare (out of scope)`. `check-vi-mock-inherit` judges whether the factory obtains and spreads the real module — all thirteen already did, fully compliant *with* the drift inside them.

One figure moved: the gate's own summary reads **937** bare, not the 935 the card quotes. Re-derived from `check-vi-mock-specifiers`' own output at `aeaa0f6`.

## The acceptance instrument is mutation, not green

Final run at `dac8fe6`, against the code this PR ships. Both legs prove the mutation reached disk (anchor count **and** blob hash) *before* any result is read; the restore is proved by state (`git diff HEAD` empty, every blob back to its `HEAD` hash), never by an exit code.

```
LEG 1 MUTATE   13 files, 0 failures; every blob hash changed and differs from HEAD
               13 files carry the drifted anchor on disk
               NEW GATE exit=1 — "13 override(s) do not match the declared export"
               13 findings name the expected shape; 0 mentions of COLLAPSED
               check-vi-mock-specifiers exit=0   <- still blind, side by side
               check-vi-mock-inherit    exit=0   <- still blind, side by side
LEG 2 RESTORE  13 files, 0 failures; every blob back to its HEAD hash
               git diff HEAD empty = YES
               NEW GATE exit=0
```

Each finding names *which* stub, *which* export, and *what shape was expected*:

```
- packages/app-shell/src/views/RecordDetailView.activityMapIdentity-5878.test.tsx:87
  -- vi.mock("@object-ui/collaboration") overrides useRecordPresence
  declared a function returning an array at packages/collaboration/src/PresenceProvider.tsx:101,
  stub is a function returning an object: () => ({ viewers: [], others: [] })
```

The same two legs are pinned in the test file end to end, over a **1001-file clean population** so the exit code cannot be confused with the vacuity floor — the test asserts `COLLAPSED` is absent from stderr before it reads the status. Without that filler both legs exit 1 and the exit code proves nothing; that confound is this gate's own defect, one level up.

## Which direction can this gate fail in?

It **can** fail when a judged override's shape conflicts with the declared export — proved above on thirteen real instances.

It **cannot** fail on an `unknown`, by design. That is a real limit, stated rather than hidden: an override whose value is a `vi.fn()`, an identifier or a call is counted and never judged. Certainty or nothing, because a gate that reddens correct code gets deleted rather than fixed. The honest middle is pinned too: `() => stubValue` is judged at the **kind** level (function vs function) and never below it, while `useRecordPresence: []` against a function export is still a finding.

## Route: a new gate, decided on measurement

The suggested route was to extend a sibling first. **It is not available, and that was measured rather than argued.** Reading a *declared* shape means parsing TypeScript, so this gate imports `typescript`. `check-vi-mock-inherit.mjs` runs in `vi-mock-specifiers.yml`, which deliberately carries no install step; every pre-install gate's import graph is enforced to be node builtins plus repo-relative modules only (objectui#6148). Injecting that one import into the sibling, blob hash recorded before and after:

```
node scripts/check-pre-install-import-graph.mjs
  before injection : exit 0
  after  injection : exit 1 -- "scripts/check-vi-mock-inherit.mjs reaches the package `typescript`"
```

Extending the sibling would have **reddened an existing gate**, which Zone-1 boundary 2 forbids outright. So: a new gate, homed in `lint.yml` after `pnpm install`.

⚠️ A first attempt at that measurement produced a **false green** — the injected text was mangled by shell quoting, the ts-import anchor count stayed 0, and `check-pre-install-import-graph` reported exit 0. That reading was discarded, not used. The number above comes from the re-run whose anchor count *and* blob hash both confirm the injection landed.

Two further properties argue the same way: `check-vi-mock-inherit` judges 100% of its population, while this predicate is partial by construction (923 of 1496), so fusing them would make one census line mean two things about two denominators; and its predicate is a property of the factory's own text, while this one resolves modules.

`lint.yml`'s skip switch is not a blind spot here — its ignore list is Markdown plus the `content`, `docs` and `.changeset` trees, and both halves of what this gate compares live in TypeScript files. The test pins that with a glob matcher and fails if a pattern matching a TypeScript file is ever added.

## The existing population was not reddened

Zone-1 boundary 3 held **without needing the ledger**. Measured at `aeaa0f6`:

```
1496 override(s) found on covered specifiers
 923 judged              -- declared side has a certain top-level kind
 391 to the RETURN shape -- the depth THIS card's drift lives at
  14 export not resolvable
 559 shape not statically certain
   0 mismatches
```

`KNOWN_SHAPE_MISMATCHES` is therefore **empty**: nothing in the tree violates the predicate, so nothing had to be grandfathered, and the gate is hard-red for this class from day one. The 937 bare-specifier sites are untouched — this gate judges override *values*, not specifiers. The ledger mechanism ships anyway, SHRINK-ONLY: a registered entry that no longer mismatches is itself a failure, so it can never quietly become a blanket. Both behaviours are pinned.

No stub was re-fixed; PR #8902's repair is left exactly as it stands.

## Gates

`scripts/pm/dispatch-gates.mjs` does not exist in objectui, so the families below were **derived by hand** from the changed-file set. Every exit code was written to a file before it was read.

| gate | exit |
|---|---|
| `check:vi-mock-override-shape` | 0 |
| `check:vi-mock-specifiers` | 0 |
| `check:vi-mock-inherit` | 0 |
| `check:pre-install-import-graph` | 0 |
| `check:control-bytes` | 0 |
| `check:entry-guard` | 0 |
| `check:unreferenced-sources` | 0 |
| `check:phantom-deps` / `check:unused-deps` / `check:self-import` | 0 |
| `check:doc-fences` / `check-doc-links` | 0 |
| `check-changeset-presence` / `-no-major` / `-fixed` | 0 |
| `type-check:scripts` | 0 |
| `lint:root` — **complete** 309-file population, 0 errors | 0 |
| `pnpm exec vitest run scripts/` — 134 files, 3914 tests | 0 |

`lint:root` is the eslint invocation that covers `scripts/`; it was run whole rather than narrowed, so there is no narrowing to justify. `pnpm lint` (`turbo run lint`) is per-package and structurally cannot reach `scripts/`.

## Acceptance notes

- **Deviation from the declared file surface:** `content/docs/guide/ci-cd-pipeline.md` is edited. It is not optional — `ci-cd-pipeline-doc.test.ts` fails any `lint.yml` step whose command the doc's gate list does not name, in run order, because every gate in that job blocks a merge on a required check.
- The gate imports `COVERED_SPECIFIERS` from `check-vi-mock-inherit.mjs` rather than restating it. A population that drifted between the two gates would be a hole neither reports; the test pins the import.
- `deep` (391) rose from 271 once local interface / type-alias references were resolved one hop, with a callable-interface escape so a correct function stub is never reddened. Zero mismatches appeared either way — the increase is power, not noise.
- Noted, not filed: `check-vi-mock-specifiers`' `bare (out of scope)` figure has moved 935 → 937 since the card was written. It is a census line, not a defect.

## 维护者速读(草稿)

**改了什么** — 新增第三道 `vi.mock` 门禁,判断桩的**返回值形状**是否与真实导出声明的形状一致。另配套测试、`package.json` 脚本别名、`lint.yml` 一个步骤、CI 文档的门禁清单一条、一份空声明 changeset(不发版)。零运行时改动,零已发布面改动。

**为什么改** — 现有两道门对这一类漂移**完全无判别力**:把 13 个漂移桩原样放回磁盘,两道门打印逐字相同的判定行、同样 exit 0。这类失效是最坏的一种——契约一变,桩对了的文件红、桩错了的静默绿,套件从中间裂开,多数派悄悄停止追踪那个 hook。

**风险与代价(含回滚)** — 风险集中在**误报**。控制手段是"要么确定,要么不判":任一侧读不确定就记为 `unknown`,`unknown` 两个方向都永不构成冲突;可调用的 interface 一律读作 `unknown`(它运行时是函数)。全树 923 个已判站点零误报,这是规模级的阴性对照。回滚成本极低:删掉一个脚本、一个测试、一行 `package.json`、一个 workflow 步骤和一条文档 bullet,不牵动任何产品代码。存量 937 处裸 specifier 桩未被触碰,台账为空。

**席位意见** — (留空,待维护者)

**你要做的** — 确认两点:① 新门禁落在 `lint.yml` 而非兄弟门禁所在的 `vi-mock-specifiers.yml`,是因为它需要 `typescript`,而后者按设计不装依赖(已实测:注入该 import 会让 `check-pre-install-import-graph` 从 exit 0 变 exit 1);② 台账 `KNOWN_SHAPE_MISMATCHES` 保持为空是刻意的——本轮无需赦免任何存量,门禁对这一类从第一天起就是硬红。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB


---
_Generated by [Claude Code](https://claude.ai/code)_