### PR TITLE
test(console): pin the four object-metric query members (objectui#8071 slice 8)

### DIFF
--- a/.changeset/8071-object-metric-query-member-pins.md
+++ b/.changeset/8071-object-metric-query-member-pins.md
@@ -1,0 +1,10 @@
+---
+---
+
+Pin the four `object-metric` members that shape the aggregate query behind the
+number — `dataSource`, `aggregate`, `filter`, `compareTo` (objectui#8071, slice
+8). `MEMBER_PIN_EXEMPTIONS` drops 37 → 33 and `MEMBER_PIN_EXEMPTION_CEILING`
+follows in the same commit; `trend` and `drillDown`, which shape what is drawn
+around the number rather than the number, stay exempt.
+
+Test only; no package is released by this change.

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -2265,6 +2265,22 @@ const MEMBER_PINS: Record<string, MemberPin> = {
     file: 'packages/plugin-kanban/src/__tests__/ObjectKanban.structuredMembersReachTheirSinks-8313.test.tsx',
     pins: 'ONE nested position and no more: `schema.grouping?.fields?.[0]?.field` is the FALLBACK source of `swimlaneField`, and that is the entire member contract this board carries for the key. Three rows make it a reading rather than a claim — the swimlane layout appears keyed by `fields[0].field` where without the key there is none; an explicit `swimlaneField` WINS over it; and a second `fields` entry changes nothing, which is what pins the read at `[0]` rather than at "the fields list". The declared description says the rest is inert precisely so the declaration does not recommend a write the renderer cannot honour — this file is what keeps that sentence true. The spec row is `z.unknown()`, so the read site is the whole member contract (objectui#8313).',
   },
+  'object-metric.aggregate': {
+    file: 'packages/plugin-dashboard/src/__tests__/objectMetricQueryMembers-8071.test.tsx',
+    pins: 'A three-member options bag whose members are read TWICE — once into the adapter call, once back out of the response. `field`/`function`/`groupBy` become `ds.aggregate(object, { field, function, groupBy, filter })` with `groupBy` OPTIONAL and defaulting to `\'_all\'` (one bucket) and an authored value outranking it; the bag is asserted AS A WHOLE so a member added to or dropped from the call is red in either direction. The readback is the half that has no second chance: `function: \'count\'` sums `<field>_count` across EVERY returned row while any other function reads the FIRST row\'s `<field>_<function>`, and the two arms run on the SAME two-row response so only a readback reading both members can answer 120 on one and 7 on the other — a `field`/`function` that reached the query but not the readback paints 0 over a response that carried the right number. `<field>` unsuffixed is pinned as the chain\'s second limb. The key\'s ABSENCE is a member semantic in its own right and is the file\'s non-vacuity floor: with no `aggregate` the query VERB changes to `find()` and the value becomes the row count. Driven through the registered block, not the bare widget. New file (objectui#8071 slice 8).',
+  },
+  'object-metric.compareTo': {
+    file: 'packages/plugin-dashboard/src/__tests__/ObjectMetricWidget.compareTo.test.tsx',
+    pins: 'The `{ kind, dimension? }` member set under objectstack#5011\'s converged shape: `kind` alone chooses BOTH the comparison window and the trend label, pinned on a QUARTER-scoped filter so the two admitted values disagree about each (`previousYear` = the same quarter one year back and "vs last year"; `previousPeriod` = the quarter before and "vs last quarter") — a year-scoped fixture would have let a `previousYear` that fell through to the other branch pass. `dimension` is CARRIED but inert on this inline path (it addresses a dataset time dimension the executor resolves), asserted by the query\'s filter keys being unchanged by it. An absent `compareTo` runs a single pass and paints no trend, which is the control that keeps the other rows from reading as a coincidence. Pre-existing file (objectui#3337), promoted here after being read end to end; objectui#8071 slice 8 added the row that mounts `type: \'object-metric\'` through `SchemaRenderer`, so the claim that the block\'s gate forwards this key untouched is asserted rather than assumed.',
+  },
+  'object-metric.dataSource': {
+    file: 'packages/plugin-dashboard/src/ObjectMetric.elementDataSource.test.tsx',
+    pins: 'The per-element binding\'s members as a WHITELIST in both directions. Acting: `object` is what gets aggregated, and a named `view`\'s own `filter` becomes the metric\'s scope — with an unresolvable `view` REPORTING instead of aggregating the whole object, which for a metric is the quiet failure (one number, no rows, nothing to notice). Not acting: the same view fixture declares `columns`, `sort` and `pagination`, and the aggregate options bag is asserted whole to keep all three OUT — `OBJECT_METRIC_DATA_SOURCE` names only `filter`, because a metric is one aggregated number with no projection, ordering or page for the rest to act on. A metric with NO binding behaving exactly as before is the control. Pre-existing file (objectstack#6953), promoted here after being read end to end; objectui#8071 slice 8 added the whole-bag row, without which the pin would have been satisfied by a mapping that forwarded everything.',
+  },
+  'object-metric.filter': {
+    file: 'packages/plugin-dashboard/src/__tests__/objectMetricQueryMembers-8071.test.tsx',
+    pins: 'No named member set — the renderer never inspects the predicate — so the member shape is the SPELLING it arrives under, and there are two, chosen by an adapter capability the author cannot see: FLAT under its own name inside the aggregate options bag, and WRAPPED as `$filter` on the no-`aggregate()` `find()` fallback. Collapsing them into one drops the predicate on whichever path lost and the tile counts every row — the same defect `element:number.filter` was pinned for (slice 7) on a different renderer. Two further halves: placeholders are resolved BEFORE the query (an authored `{current_quarter_start}` reaches the adapter as a real date, and a macro surviving onto the wire is a literal nobody matches), and the key is read BY VALUE rather than by identity (`JSON.stringify` memo) — a deep-equal rebuild by a re-rendering parent must NOT re-probe while a changed comparand MUST and carries the new predicate, each arm the other\'s control against a dependency "simplified" to the raw object. New file (objectui#8071 slice 8).',
+  },
   'page:accordion.items': {
     file: 'packages/components/src/__tests__/pageAccordionItemMembers-8071.test.tsx',
     pins: 'Which member of one panel definition becomes which part of the rendered accordion — the four `PageAccordionItem` members (`label`, `icon`, `collapsed`, `children`) asserted as a SET through the real renderer, which nothing did before: `label` becomes the trigger\'s accessible name and `children` the panel BODY, asserted against each other so a renderer painting the wrong one cannot pass. `collapsed` is the reading with real semantics to get wrong and it is strictly `=== false`: `collapsed: false` OPENS a panel while `collapsed: true` AND an omitted `collapsed` both leave it shut — the omitted-key arm is the control an "obvious" edit to `!it.collapsed` breaks, and a no-opener fixture keeps the two shut rows from passing on a renderer that opens nothing. The single/multiple split is pinned on the SAME items so only `allowMultiple` varies: single mode takes `defaultOpen[0]` and drops later openers, multiple mode opens them all without opening panels that never asked. `icon` is covered narrowly on purpose — `page-accordion-icon.test.tsx` (objectui#4721) is its pin and is not re-litigated. New file (objectui#8071 slice 7).',
@@ -2508,12 +2524,11 @@ const MEMBER_PIN_EXEMPTIONS: Record<string, string> = {
   'object-master-detail-form.initialValues': AWAITING_A_PIN,
   'object-master-detail-form.sections': AWAITING_A_PIN,
 
-  // object-metric
-  'object-metric.aggregate': AWAITING_A_PIN,
-  'object-metric.compareTo': AWAITING_A_PIN,
-  'object-metric.dataSource': AWAITING_A_PIN,
+  // object-metric — objectui#8071 slice 8 pinned the four members that shape
+  // the aggregate query behind the NUMBER (`dataSource`, `aggregate`, `filter`,
+  // `compareTo`). The two left shape what is drawn AROUND the number once it
+  // exists, and neither reaches `fetchMetric`.
   'object-metric.drillDown': AWAITING_A_PIN,
-  'object-metric.filter': AWAITING_A_PIN,
   'object-metric.trend': AWAITING_A_PIN,
 
   // page:accordion — objectui#8071 slice 7 pinned `items`, the block's one
@@ -2811,11 +2826,86 @@ const NEWLY_JUDGED_UNPINNED_MEMBERS = [
  * behaviour in the new file, which authors `bodyShape` and asserts it is
  * dropped.
  *
+ * ## 37 -> 33, the eighth slice, and the FIRST partial bite of a multi-key block
+ *
+ * objectui#8071's eighth slice is the first that could not close a block by
+ * taking its last key — slice 7 exhausted that shape — so it takes a PART of
+ * one, and the part is chosen by a rule rather than by convenience:
+ *
+ *   **every `object-metric` member that shapes the aggregate query behind the
+ *   NUMBER the tile paints.**
+ *
+ * Four qualify — `dataSource`, `aggregate`, `filter` and `compareTo` — so the
+ * ceiling follows to 33 in the same commit. The rule is mechanical, not
+ * editorial: those four are exactly the members that reach
+ * `ObjectMetricWidget`'s `fetchMetric` / `computeOne` (`dataSource` gates the
+ * effect; `aggregateKey`, `resolvedFilterKey` and `compareToKey` are its other
+ * dependencies), and the two left — `trend` and `drillDown` — reach neither.
+ * They shape what is drawn AROUND the number once it exists: a STATIC badge
+ * beside it, and a drawer opened by clicking it. Neither can change the number.
+ *
+ * ⇒ That is what the next slice inherits, and it is cheap to state: the two
+ * PRESENTATION members of `object-metric`, `trend` and `drillDown`. They were
+ * left together on purpose rather than one being swept in — `drillDown` does
+ * issue a query of its own (the drawer's record list, off the same resolved
+ * filter), so "reaches an adapter" would have been the wrong cut and is stated
+ * here so the next reader does not have to re-derive why it was not used.
+ *
+ * TWO of the four pins PROMOTE pre-existing files, each read end to end before
+ * being credited and each given the one row it was missing:
+ *
+ *   - `ObjectMetric.elementDataSource.test.tsx` (objectstack#6953) already drove
+ *     the binding's `object` and `view` members through the real renderer, with
+ *     an unresolvable `view` reporting rather than aggregating the whole object
+ *     and a binding-less metric unchanged. What it did not have was the
+ *     NEGATIVE direction, so this slice adds it: the view fixture's `columns`,
+ *     `sort` and `pagination` are asserted absent from the aggregate call.
+ *     Without that the pin would have been satisfied by a mapping that forwarded
+ *     everything, which here would mean a metric silently ordered and paged by a
+ *     list view's presentation settings.
+ *   - `ObjectMetricWidget.compareTo.test.tsx` (objectui#3337) already asserted
+ *     the `{ kind, dimension? }` member set — `kind` choosing both window and
+ *     label on a quarter-scoped fixture where the two values disagree about
+ *     each, `dimension` carried but inert, and the no-`compareTo` single-pass
+ *     control. It drove `ObjectMetricWidget` directly, so this slice adds the
+ *     row that mounts `type: 'object-metric'` through `SchemaRenderer`: the
+ *     block's `ElementDataSourceGate` shell re-binds only `objectName` and
+ *     `filter` and forwards the rest untouched, and that is now asserted rather
+ *     than assumed. ⚠️ It is also why the file names the block at all — the
+ *     locator requires it, and a docblock mention alone would have been the
+ *     locator satisfied by prose rather than by behaviour.
+ *
+ * `aggregate` and `filter` share ONE new file,
+ * `objectMetricQueryMembers-8071.test.tsx` — the shape slice 3 used for
+ * `record-picker-label-placeholder-i18n.test.tsx` and slice 6 for the
+ * chatter/discussion pair — because the two keys meet inside a single adapter
+ * call and the assertions have to be written against each other to stay
+ * independent: the `aggregate` rows author NO filter (so the bag comparison is
+ * blind to the filter spelling), and the `filter` rows are the ones that pin it.
+ *
+ * Every other candidate was read end to end and rejected with a reason, not
+ * dismissed on its greps: `public-block-binding-reach.test.tsx` states its own
+ * narrowness — one question per block, "did any call carry the object name" —
+ * and lists `aggregate` only as a plausible sample value;
+ * `widget-dom-leak-sweep.test.tsx` is the DOM-attribute canary, where
+ * `aggregate` is a stub returning `[]`; `ObjectMetricWidget.i18nLabel.test.tsx`
+ * authors `aggregate`, `trend` and `drillDown` purely to make the drill-down
+ * reachable, and its subject is `I18nLabel` resolution — crediting it for
+ * `trend` or `drillDown` would have been slice 7's
+ * `action-bodyShape-forward.test.tsx` mistake in a new place. The remaining
+ * seven files that name `object-metric` do so in prose, in a membership list,
+ * or in a designer-inspector fixture.
+ *
+ * ⚠️ Unchanged by this slice: `NEWLY_JUDGED_UNPINNED_MEMBERS` (no block it names
+ * was touched) and `record:related_list.actions`, whose `NO_READ_SITE_TO_PIN`
+ * reading was not re-measured here because this slice took a different block —
+ * slice 7's measurement stands as the last one taken.
+ *
  * ⇒ The rule for every future slice of objectui#8071: delete the entry, register
  * the pin, and set this constant to the new count. Not to the new count plus
  * room.
  */
-const MEMBER_PIN_EXEMPTION_CEILING = 37;
+const MEMBER_PIN_EXEMPTION_CEILING = 33;
 
 /**
  * Every test file a member pin can live in, as LAZY `?raw` loaders.

--- a/packages/plugin-dashboard/src/ObjectMetric.elementDataSource.test.tsx
+++ b/packages/plugin-dashboard/src/ObjectMetric.elementDataSource.test.tsx
@@ -17,6 +17,18 @@
  * `object` and `filter` are the only mapped keys: a metric is one aggregated
  * number, so there is no projection, no ordering and no page for the binding's
  * remaining keys to act on.
+ *
+ * ## Promoted to the member pin for `object-metric.dataSource` (objectui#8071)
+ *
+ * objectui#8071's eighth slice registers this file as the pin for that key. The
+ * member set it asserts is a WHITELIST in both directions: `object` and `view`
+ * are the members that act — the bound object is what gets aggregated and the
+ * named view's own `filter` becomes the metric's scope — while the view's
+ * `columns`, `sort` and `pagination` are carried in the fixture and asserted
+ * ABSENT from the call, because `OBJECT_METRIC_DATA_SOURCE` names only
+ * `filter`. Without that second direction the pin would be satisfied by a
+ * mapping that forwarded everything, which for this block would mean a metric
+ * silently ordered and paged by a list view's presentation settings.
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -97,6 +109,32 @@ describe('object-metric — dataSource: { object, view } (objectstack#6953)', ()
       expect(container.querySelector('[data-testid="object-metric-datasource-error"]')).not.toBeNull(),
     );
     expect(adapter.aggregate).not.toHaveBeenCalled();
+  });
+
+  it('maps `object` and the view’s `filter` and NOTHING else the view carries', async () => {
+    // The whitelist direction. `HOT_VIEW` declares `columns`, `sort` and
+    // `pagination`; none of the three is a member this block reads, so none may
+    // appear in the aggregate call. Asserted on the WHOLE options bag rather
+    // than key by key, so a mapping widened to forward the rest is red here.
+    const adapter = makeAdapter();
+    renderBlock(
+      {
+        type: 'object-metric',
+        label: 'Pipeline',
+        aggregate: AGGREGATE,
+        dataSource: { object: 'account', view: 'hot' },
+      },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalled());
+    const [, params] = adapter.aggregate.mock.calls[0] as [string, any];
+    expect(params).toEqual({
+      field: 'amount',
+      function: 'sum',
+      groupBy: '_all',
+      filter: [['rating', '=', 'hot']],
+    });
   });
 
   it('leaves a metric with NO dataSource exactly as it was', async () => {

--- a/packages/plugin-dashboard/src/__tests__/ObjectMetricWidget.compareTo.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectMetricWidget.compareTo.test.tsx
@@ -13,11 +13,30 @@
  * before) and the label (`vs last year` / `vs last quarter`), so each case can
  * only pass by reading `.kind`. A year-scoped filter would have let a
  * `previousYear` that fell through to the previousPeriod branch pass anyway.
+ *
+ * ## Promoted to the member pin for `object-metric.compareTo` (objectui#8071)
+ *
+ * objectui#8071's eighth slice registers this file as the pin for that key: the
+ * cases below already assert the member SET the renderer reads — `kind` selects
+ * both the comparison window and the label, `dimension` is carried but inert on
+ * this inline path, and an absent `compareTo` leaves the tile at one pass with
+ * no trend — which is what a member-shape claim has to say.
+ *
+ * The four cases above drive `ObjectMetricWidget` directly. The registered
+ * block `object-metric` is the same reader: its `ElementDataSourceGate` shell
+ * re-binds only `objectName` and `filter` and forwards every other authored key
+ * untouched, so `compareTo` arrives at this component exactly as authored. That
+ * is asserted rather than assumed by the last case in this file, which mounts
+ * `type: 'object-metric'` through `SchemaRenderer`.
  */
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
 import { ObjectMetricWidget } from '../ObjectMetricWidget';
+// Registers `object-metric` at MODULE scope, never inside a hook
+// (object-ui/no-dynamic-import-in-test-hook).
+import '../index';
 
 afterEach(cleanup);
 
@@ -100,5 +119,31 @@ describe('ObjectMetricWidget — compareTo under { kind }', () => {
     renderWidget(undefined, src);
     await waitFor(() => expect(src.aggregate).toHaveBeenCalledTimes(1));
     expect(screen.queryByText(/vs last/i)).not.toBeInTheDocument();
+  });
+
+  it('arrives unchanged through the registered `object-metric` block', async () => {
+    // What makes the four cases above a pin on the BLOCK's key rather than on
+    // one component's prop: authored on the schema, `compareTo` passes the
+    // `ElementDataSourceGate` shell untouched and shifts the window exactly as
+    // it does when handed straight to the widget.
+    const src = makeSource();
+    render(
+      <SchemaRendererProvider dataSource={src as never}>
+        <SchemaRenderer
+          schema={{
+            type: 'object-metric',
+            objectName: 'deal',
+            label: 'Revenue',
+            aggregate: { field: 'amount', function: 'sum' },
+            filter: { close_date: { $gte: '{current_quarter_start}', $lte: '{current_quarter_end}' } },
+            compareTo: { kind: 'previousYear' },
+          } as never}
+        />
+      </SchemaRendererProvider>,
+    );
+
+    await waitFor(() => expect(src.aggregate).toHaveBeenCalledTimes(2));
+    expect(comparisonFilterOf(src).$gte).toBe(PREVIOUS_YEAR_FROM);
+    expect(await screen.findByText(/vs last year/i)).toBeInTheDocument();
   });
 });

--- a/packages/plugin-dashboard/src/__tests__/objectMetricQueryMembers-8071.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/objectMetricQueryMembers-8071.test.tsx
@@ -1,0 +1,285 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `object-metric.aggregate` and `object-metric.filter` — the MEMBER SHAPES the
+ * renderer reads to build the query behind the number (objectui#8071).
+ *
+ * The member pins for the two keys objectui#8071's eighth slice takes on the
+ * QUERY half of `object-metric`. Both are asserted through the registered block
+ * (`type: 'object-metric'` mounted by `SchemaRenderer`, registered by this
+ * package's own side-effect import) rather than on `ObjectMetricWidget`
+ * directly, so the pin covers the path an author actually reaches: the block's
+ * `ElementDataSourceGate` shell forwards every key but `objectName` / `filter`
+ * untouched, and this file is what says so.
+ *
+ * ## `aggregate` — a three-member options bag, and a result readback keyed on
+ * two of them
+ *
+ * `ObjectMetricWidget.computeOne` turns the authored object into the adapter
+ * call:
+ *
+ *     ds.aggregate(objectName, {
+ *       field: aggregate.field,
+ *       function: aggregate.function,
+ *       groupBy: aggregate.groupBy || '_all',
+ *       filter: filterForRun,
+ *     })
+ *
+ * so the member shape is (a) which authored members become which call members,
+ * (b) that `groupBy` is OPTIONAL with a defined default (`'_all'` — one bucket),
+ * and (c) that the two other members are read a SECOND time on the way back:
+ * `function: 'count'` sums `<field>_count` across EVERY returned row, while any
+ * other function reads the FIRST row's `<field>_<function>`. A `field` or a
+ * `function` that reached the query but not the readback would paint `0` from a
+ * response that carried the right number — the silent-wrong-number failure this
+ * whole direction (objectui#8068) exists to make loud.
+ *
+ * The bag is asserted AS A WHOLE (`toEqual`, not per-key), so a member silently
+ * added to or dropped from the call is red in either direction. The
+ * aggregate-side bag assertions author NO `filter` on purpose: that keeps them
+ * independent of the `filter` spelling pinned below, so the two ablations these
+ * pins were verified with fail for their own reasons rather than as a pair.
+ *
+ * The key's ABSENCE is a member semantic too, not merely a control: with no
+ * `aggregate` the renderer changes the query VERB — `find()` instead of
+ * `aggregate()` — and paints the row COUNT. That row is also this file's
+ * non-vacuity floor, because it is the one case whose green requires the
+ * adapter to have been asked for something.
+ *
+ * ## `filter` — one authored predicate, two wire spellings, read by value
+ *
+ * `filter` carries no named member set of its own; the renderer never inspects
+ * it. Its member shape is therefore the SPELLING it arrives under, and there
+ * are two, chosen by an adapter capability the author cannot see:
+ *
+ *   - `aggregate(object, { …, filter })` — FLAT, under its own name.
+ *   - `find(object, { $filter })` — WRAPPED, on the no-`aggregate()` fallback.
+ *
+ * Collapsing the two into one spelling drops the predicate on whichever path
+ * lost, and a metric scoped to "hot accounts" then counts every row — the same
+ * shape `element:number.filter` was pinned for (objectui#8071 slice 7) on a
+ * different renderer.
+ *
+ * Two more halves, both load-bearing:
+ *
+ *   - Placeholders are resolved BEFORE the query, not by the server: an
+ *     authored `{current_quarter_start}` must reach the adapter as a real date.
+ *     A macro that survives into the wire is not a filter, it is a literal
+ *     nobody matches, and the metric reads 0 with no diagnostic.
+ *   - The predicate is read BY VALUE (`JSON.stringify` memo), not by identity.
+ *     A parent that rebuilds a deep-equal filter literal every render must NOT
+ *     re-query; a parent that changes one comparand MUST, and must carry the new
+ *     predicate. Each arm is the other's control: a dependency "simplified" to
+ *     the raw object passes the second and turns the first into a fetch storm.
+ *
+ * ## Nothing pre-existing covered either key
+ *
+ * Measured, then read end to end rather than dismissed on greps. Twelve
+ * collected test files name `object-metric` at all, which is the locator's own
+ * precondition. `ObjectMetric.elementDataSource.test.tsx` authors an
+ * `aggregate` in every case, but as a FIXTURE — its subject is the
+ * `dataSource` binding, and it asserts nothing about which members reach the
+ * call or how the response is read (it is credited here for `dataSource`
+ * instead). `public-block-binding-reach.test.tsx` states its own narrowness in
+ * prose — one question per block, "did any call carry the object name" — and
+ * lists `aggregate` only as a plausible sample value.
+ * `widget-dom-leak-sweep.test.tsx` is the DOM-attribute canary: its
+ * `aggregate` is a stub returning `[]` and `object-metric` is one render
+ * target among many. `ObjectMetricWidget.i18nLabel.test.tsx` authors
+ * `aggregate` and `filter`-adjacent props purely to make the drill-down
+ * reachable; its subject is `I18nLabel` resolution. The remaining seven name
+ * `object-metric` in prose, in a membership list, or in a designer-inspector
+ * fixture.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+// Registers `object-metric` (the `ObjectMetricBlock` shell under test) at
+// MODULE scope, never inside a hook — object-ui/no-dynamic-import-in-test-hook.
+import '../index';
+
+afterEach(cleanup);
+
+/** The adapter call signature both paths share: `(object, params)`. */
+type Params = Record<string, unknown>;
+
+/** An adapter that can aggregate — the primary path. */
+const aggregatingAdapter = (rows: Record<string, unknown>[]) => ({
+  aggregate: vi.fn(async (_object: string, _params: Params) => rows),
+  find: vi.fn(async (_object: string, _params: Params) => ({ data: [] as unknown[] })),
+});
+
+/** An adapter that CANNOT aggregate — the `find()` fallback path. */
+const countingAdapter = (records: unknown[]) => ({
+  find: vi.fn(async (_object: string, _params: Params) => ({ data: records })),
+});
+
+const mount = (schema: Record<string, unknown>, adapter: unknown) =>
+  render(
+    <SchemaRendererProvider dataSource={adapter as never}>
+      <SchemaRenderer schema={{ type: 'object-metric', label: 'Pipeline', ...schema } as never} />
+    </SchemaRendererProvider>,
+  );
+
+/** The options bag of the nth (default first) `aggregate()` call. */
+const bagOf = (adapter: ReturnType<typeof aggregatingAdapter>, nth = 0): Params =>
+  adapter.aggregate.mock.calls[nth][1];
+
+describe('object-metric — the `aggregate` member shape (objectui#8071)', () => {
+  it('maps its members onto the call and defaults `groupBy` to one bucket', async () => {
+    const adapter = aggregatingAdapter([{ amount_sum: 120 }]);
+    mount({ objectName: 'deal', aggregate: { field: 'amount', function: 'sum' } }, adapter);
+
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalled());
+    expect(adapter.aggregate.mock.calls[0][0]).toBe('deal');
+    // The WHOLE bag, so a member added or dropped is red in either direction.
+    // No `filter` is authored here on purpose — see the docblock.
+    expect(bagOf(adapter)).toEqual({
+      field: 'amount',
+      function: 'sum',
+      groupBy: '_all',
+      filter: undefined,
+    });
+  });
+
+  it('lets an authored `groupBy` outrank that default', async () => {
+    const adapter = aggregatingAdapter([{ amount_sum: 120 }]);
+    mount(
+      { objectName: 'deal', aggregate: { field: 'amount', function: 'sum', groupBy: 'stage' } },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalled());
+    expect(bagOf(adapter)).toEqual({
+      field: 'amount',
+      function: 'sum',
+      groupBy: 'stage',
+      filter: undefined,
+    });
+  });
+
+  it('reads a `count` back across EVERY row, under `<field>_count`', async () => {
+    // Two rows, and the count arm sums them: 3 + 4.
+    const adapter = aggregatingAdapter([{ amount_count: 3 }, { amount_count: 4 }]);
+    mount({ objectName: 'deal', aggregate: { field: 'amount', function: 'count' } }, adapter);
+
+    expect(await screen.findByText('7')).toBeTruthy();
+  });
+
+  it('reads any other function back off the FIRST row, under `<field>_<function>`', async () => {
+    // Same two-row response as the count case above, which is what makes the
+    // pair discriminate: only a readback that reads BOTH members can answer 120
+    // here and 7 there. A readback that ignored `function` would sum to 1119.
+    const adapter = aggregatingAdapter([{ amount_sum: 120 }, { amount_sum: 999 }]);
+    mount({ objectName: 'deal', aggregate: { field: 'amount', function: 'sum' } }, adapter);
+
+    expect(await screen.findByText('120')).toBeTruthy();
+    expect(screen.queryByText('1,119')).toBeNull();
+  });
+
+  it('reads the response under `<field>` when the adapter does not suffix it', async () => {
+    // The second limb of the same readback chain, and the reason `field` is a
+    // member of the RESPONSE contract and not only of the request.
+    const adapter = aggregatingAdapter([{ amount: 42 }]);
+    mount({ objectName: 'deal', aggregate: { field: 'amount', function: 'sum' } }, adapter);
+
+    expect(await screen.findByText('42')).toBeTruthy();
+  });
+
+  it('with NO `aggregate` the query verb changes to `find()` and the value is the row count', async () => {
+    // The key's absence is a member semantic, and this row is the file's
+    // non-vacuity floor: its green requires the adapter to have been asked.
+    const adapter = countingAdapter([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    mount({ objectName: 'deal' }, adapter);
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    expect(await screen.findByText('3')).toBeTruthy();
+  });
+});
+
+describe('object-metric — the `filter` member shape (objectui#8071)', () => {
+  const HOT = [['rating', '=', 'hot']];
+
+  it('reaches the aggregate FLAT, under its own name, beside the aggregate members', async () => {
+    const adapter = aggregatingAdapter([{ amount_sum: 120 }]);
+    mount(
+      { objectName: 'deal', aggregate: { field: 'amount', function: 'sum' }, filter: HOT },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalled());
+    // The whole bag again, now WITH the predicate — this is the assertion that
+    // a "tidy the two spellings into one" change has to get past.
+    expect(bagOf(adapter)).toEqual({
+      field: 'amount',
+      function: 'sum',
+      groupBy: '_all',
+      filter: HOT,
+    });
+  });
+
+  it('reaches the `find()` fallback WRAPPED as `$filter`', async () => {
+    // Same authored key, adapter without `aggregate()`, different spelling.
+    // Neither row can be satisfied by the other's spelling, which is the point.
+    const adapter = countingAdapter([{ id: 1 }]);
+    mount({ objectName: 'deal', filter: HOT }, adapter);
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    expect(adapter.find.mock.calls[0][0]).toBe('deal');
+    expect(adapter.find.mock.calls[0][1]).toEqual({ $filter: HOT });
+  });
+
+  it('resolves date placeholders BEFORE the query, not on the wire', async () => {
+    const quarterStart = new Date();
+    quarterStart.setMonth(Math.floor(quarterStart.getMonth() / 3) * 3, 1);
+    const expected = `${quarterStart.getFullYear()}-${String(quarterStart.getMonth() + 1).padStart(2, '0')}-01`;
+
+    const adapter = aggregatingAdapter([{ amount_sum: 120 }]);
+    mount(
+      {
+        objectName: 'deal',
+        aggregate: { field: 'amount', function: 'sum' },
+        filter: { close_date: { $gte: '{current_quarter_start}' } },
+      },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalled());
+    const sent = (bagOf(adapter).filter as { close_date: { $gte: string } }).close_date.$gte;
+    expect(sent).toBe(expected);
+    // Stated separately: a macro that survives onto the wire is a literal
+    // nobody matches, and the metric then reads 0 with no diagnostic.
+    expect(String(sent)).not.toContain('{');
+  });
+
+  it('is read BY VALUE — a deep-equal rebuild does not re-query, a changed comparand does', async () => {
+    const adapter = aggregatingAdapter([{ amount_sum: 120 }]);
+    const aggregate = { field: 'amount', function: 'sum' };
+    const view = (filter: unknown) => (
+      <SchemaRendererProvider dataSource={adapter as never}>
+        <SchemaRenderer
+          schema={{ type: 'object-metric', label: 'Pipeline', objectName: 'deal', aggregate, filter } as never}
+        />
+      </SchemaRendererProvider>
+    );
+
+    const { rerender } = render(view([['rating', '=', 'hot']]));
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalledTimes(1));
+
+    // A fresh, deep-equal literal — a re-rendering parent, not a new question.
+    rerender(view([['rating', '=', 'hot']]));
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalledTimes(1));
+
+    // …and a changed comparand IS a new question, carrying the new predicate.
+    rerender(view([['rating', '=', 'cold']]));
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalledTimes(2));
+    expect(bagOf(adapter, 1).filter).toEqual([['rating', '=', 'cold']]);
+  });
+});


### PR DESCRIPTION
Refs #8071

Slice 8 of the per-block member-pin transition, and the first that takes a **partial** bite of a multi-key block — slice 7 exhausted the "close a block by taking its last key" shape.

## The batch, stated as a rule

> **Every `object-metric` member that shapes the aggregate query behind the NUMBER the tile paints.**

Four qualify: **`dataSource`, `aggregate`, `filter`, `compareTo`**. The rule is mechanical, not editorial — those four are exactly the members that reach `ObjectMetricWidget`'s `fetchMetric` / `computeOne`: `dataSource` gates the effect, and `aggregateKey` / `resolvedFilterKey` / `compareToKey` are its other dependencies. The two left, `trend` and `drillDown`, reach neither. They shape what is drawn **around** the number once it exists — a static badge beside it, a drawer opened by clicking it — and neither can change the number.

⇒ What slice 9 inherits is cheap to state: **the two presentation members of `object-metric`.** They were deliberately left as a pair rather than one being swept in: `drillDown` does issue a query of its own (the drawer's record list, off the same resolved filter), so "reaches an adapter" would have been the wrong cut. That is recorded in the ceiling docblock so the next reader does not re-derive it.

## Ledger, AST-measured on this branch's own head

TypeScript AST walk — `ts.createSourceFile`, `VariableDeclaration`, initializer unwrapped through `as` / `satisfies` / parens, direct `PropertyAssignment` children, boundaries from AST node spans.

| | before (`aeaa0f64c`) | after (`04ee89741`) |
| --- | --- | --- |
| `MEMBER_PIN_EXEMPTIONS` | 37 | **33** |
| `MEMBER_PIN_EXEMPTION_CEILING` | 37 | **33** |
| `MEMBER_PINS` | 53 | **57** |
| distinct block prefixes | 6 | 6 |
| `NEWLY_JUDGED_UNPINNED_MEMBERS` | 2 | 2 (untouched) |
| `object-metric.` exemptions | 6 | **2** |

The delta balances on one instrument: −4 exemptions, −4 ceiling, +4 pins. Both initializers are plain object literals with zero non-`PropertyAssignment` members and zero keys lacking a `.`, so the prefix breakdown is the whole population.

Remaining 33: `object-grid.` 15 · `object-form.` 7 · `object-master-detail-form.` 6 · `object-kanban.` 2 (held, unruled on #8913) · `object-metric.` 2 · `record:related_list.` 1 (the `NO_READ_SITE_TO_PIN` sentinel).

**Instrument cross-check.** A key-anchored regex bounded to top-level indentation inside the AST span **agrees exactly** on both objects: 33 = 33 and 57 = 57. The value-anchored variants still disagree, as documented: `AWAITING_A_PIN` reads **38** and `AWAITING_A_PIN\b` reads **34** against a true **30** value-uses (the exemption values decompose 30 / 1 `NO_READ_SITE_TO_PIN` / 2 `AWAITING_A_PIN_NEWLY_JUDGED` = 33). The AST is what the numbers above come from.

## The four pins

Two **promote pre-existing files**, each read end to end and each given the one row it was missing.

- **`object-metric.dataSource`** — `packages/plugin-dashboard/src/ObjectMetric.elementDataSource.test.tsx`. It already drove the binding's `object` and `view` members through the real renderer, with an unresolvable `view` reporting rather than aggregating the whole object. What it lacked was the **negative** direction, added here: the view fixture's `columns`, `sort` and `pagination` are asserted **out** of the aggregate call. Without that, the pin would have been satisfied by a mapping that forwarded everything — which for a metric means one silently ordered and paged by a list view's presentation settings.
- **`object-metric.compareTo`** — `packages/plugin-dashboard/src/__tests__/ObjectMetricWidget.compareTo.test.tsx`. It already asserted the `{ kind, dimension? }` member set on a quarter-scoped fixture where the two `kind` values disagree about both window and label, plus the no-`compareTo` single-pass control. It drove the widget directly, so this PR adds the row that mounts `type: 'object-metric'` through `SchemaRenderer`. That row is why the file names the block at all: the locator requires it, and a docblock mention alone would have been the locator satisfied by prose rather than by behaviour. Ablation B4 confirms the row is load-bearing, not decorative.

Two are **new**, sharing one file — `packages/plugin-dashboard/src/__tests__/objectMetricQueryMembers-8071.test.tsx`, the shape slice 3 used for the record-picker label/placeholder pair and slice 6 for chatter/discussion:

- **`object-metric.aggregate`** — a three-member options bag whose members are read **twice**: into the call (`field` / `function` / `groupBy`, with `groupBy` optional and defaulting to one bucket, an authored value outranking it, the bag asserted whole) and back out of the response (`count` sums `FIELD_count` across every row; any other function reads the first row's `FIELD_FUNCTION`). Both arms run on the **same** two-row response, so only a readback reading both members can answer 120 on one and 7 on the other. The key's absence is a member semantic too, and the file's non-vacuity floor: with no `aggregate`, the query verb changes to `find()` and the value becomes the row count.
- **`object-metric.filter`** — no named member set, so the member shape is the **spelling**, and there are two: flat under its own name inside the aggregate bag, and wrapped as an OData-style `$filter` on the no-`aggregate()` fallback. Plus placeholders resolved before the query, and the predicate read **by value** (a deep-equal rebuild must not re-probe; a changed comparand must, and must carry the new predicate).

The aggregate rows author **no** filter on purpose, so the bag comparison is blind to the filter spelling and the two ablations fail for their own reasons rather than as a pair.

## Candidates read and rejected, per file

Twelve collected test files name `object-metric` — the locator's own precondition — and every one was read end to end.

| file | why not credited |
| --- | --- |
| `public-block-binding-reach.test.tsx` | States its own narrowness in prose: one question per block, "did any call carry the object name". Lists `aggregate` only as a plausible sample value. |
| `widget-dom-leak-sweep.test.tsx` | The DOM-attribute canary. Its `aggregate` is a stub returning `[]`; `object-metric` is one render target among many. |
| `ObjectMetricWidget.i18nLabel.test.tsx` | Authors `aggregate`, `trend` and `drillDown` purely to make the drill-down reachable; its subject is `I18nLabel` resolution. Crediting it for `trend` or `drillDown` would repeat slice 7's `action-bodyShape-forward.test.tsx` mistake in a new place. |
| `ObjectPivot.elementDataSource.test.tsx` | Names `object-metric` once, in prose, as the sibling shape. Its subject is `object-pivot`. |
| `ElementDataSourceGate.test.tsx` | Names `object-metric` once, in prose, listing which wirings share the gate. |
| `public-contract.test.ts` | Membership list plus one prose mention about lazy registration. |
| `dashboardComponents.mapParity.test.ts` | Membership list. |
| `filterIsDeclaredInput-7712.test.ts` | One prose mention; its subject is `object-calendar`. |
| `PageBlockInspector.colorLabelling.test.tsx`, `PageBlockInspector.i18n.test.tsx`, `block-config-i18n.test.ts` | Designer-inspector fixtures. |
| `registry-inputs-spec-parity.test.ts` | The gate itself, and excluded from its own glob by construction. |

## Ablations

Every leg proved the mutation on disk **before** any result was read — anchor grep counts on injected and removed text, plus a `git hash-object` differing from the HEAD blob — and restored with `git checkout HEAD -- ABSOLUTE_PATH` from a `trap … EXIT INT TERM`, with restoration proved by blob hash, never by an exit code.

**A0 — the gate mechanism.** One deleted exemption re-added, ceiling untouched. `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts`, head blob `8102fd30b`, mutated `ba6e07fea`; removed anchor 1 to 0, injected anchor 0 to 1. **3 rows red** (198 tests, 3 failed): the total-and-disjoint member-shape census, "carries no stale member-pin exemption", and "the member-pin exemption list only ratchets DOWN". Restored to `8102fd30b`, `git diff HEAD` empty.

**One ablation per new pin, the whole new pin set run together** so neighbour independence is observed rather than asserted (19 tests across the three pin files):

| leg | mutation | blob | red |
| --- | --- | --- | --- |
| **B1** `aggregate` | `groupBy: aggregate.groupBy \|\| '_all'` becomes a hard-coded `'_all'` | `a2da27d14` to `b08defb10` | **1** — "lets an authored `groupBy` outrank that default". 18 green. |
| **B2** `filter` | the aggregate bag's flat `filter` becomes `$filter` | `a2da27d14` to `3063e6ff9` | **10** across all three files — see below. |
| **B2b** `filter` | the `find()` fallback's `$filter` becomes flat `filter` | `a2da27d14` to `8e1527b57` | **1** — "reaches the `find()` fallback WRAPPED as `$filter`". 18 green. |
| **B3** `dataSource` | the gate stops re-binding the composed filter onto the widget | `1479e50aa` to `ddf23632f` | **2** — both `dataSource` rows. 17 green. |
| **B4** `compareTo` | `.kind` is ignored: every comparison forced to `previousPeriod` | `a2da27d14` to `a1248b0ab` | **3** — the two `previousYear`-reading rows plus the new registry row. The `previousPeriod` row and the no-`compareTo` control stay green, which is the discrimination. 16 green. |

**B2 is the one to read carefully, and it is reported as observed rather than smoothed.** Collapsing the two wire spellings is precisely the defect this pin exists for, and its blast radius is wide: 10 of 19 rows, spanning all three pin files, because the flat `filter` spelling is what every metric fixture in this family reads through. What it did **not** touch is the finding: all six `aggregate` rows stayed green (they author no filter, by design), and so did `reaches the find() fallback WRAPPED as $filter`. **B2b** is the other direction of the same pair and fails narrowly — exactly one row — which is what shows the two spellings are separately pinned rather than jointly.

⚠️ **One reading was taken twice and the first is reported void.** B2b's first run used a shell-mangled removed-anchor pattern that read `0 -> 0`; the mutation itself was still proven (injected anchor 0 to 1, blob differing), but a malformed anchor reading is not a reading, so the leg was re-run with a correctly escaped pattern. It reproduced identically — same mutated blob `8e1527b57`, same single red row — and the corrected counts are `1 -> 0` and `0 -> 1`.

## Verification

Every exit code captured into a variable **before** any pipe.

- **Gate** `pnpm exec vitest run apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` — **exit 0**, 198 passed (198). Baseline on `aeaa0f64c` was also 198 passed, so the count is unchanged and the population moved inside it.
- **Full suites of both touched packages** `pnpm exec vitest run packages/plugin-dashboard/ apps/console/` — **exit 0**, 202 files / **2068 tests passed**.
- **Final confirmation on the restored tree** (gate + all four pin files) — **exit 0**, 217 passed (217); `git status --porcelain` empty at `04ee89741`.
- **type-check** `pnpm --filter @object-ui/console --filter @object-ui/plugin-dashboard type-check` — **exit 0**. The log echoes both scripts (`tsc --noEmit && tsc -p tsconfig.test.json`; `tsc --noEmit && tsc -b tsconfig.node.json --force`), so the test files are type-checked, not merely collected. ⚠️ A first run exited 2 with a wall of `TS2307 Cannot find module '@object-ui/…'`; that was the unbuilt workspace closure, not this diff — it cleared after `pnpm --workspace-concurrency=2 --filter '@object-ui/console^...' --filter '@object-ui/plugin-dashboard^...' build` and the only errors that remained were five in the new file, which are fixed here.
- **lint** `pnpm --filter @object-ui/console --filter @object-ui/plugin-dashboard lint` — **exit 0**, and read for the literal word rather than trusted to the exit code: `packages/plugin-dashboard lint: ✖ 451 problems (0 errors, 451 warnings)` and `apps/console lint: ✖ 212 problems (0 errors, 212 warnings)`. The log echoes `Scope: 2 of 47 workspace projects` and both script names, so "the filter matched no script" cannot read as a pass. The new file draws no rows at all; the rows on the two edited files are the pre-existing `no-explicit-any` warnings they already carried.
- **changeset** `node scripts/check-changeset-presence.mjs` — **exit 0**: 4 source files of 2 released packages changed, 1 changeset declared, empty frontmatter (test-only, nothing released).
- **governed surface** `node scripts/check-governed-queue-guard.mjs --test …` — **exit 0**, NOT GOVERNED. The PR still stays draft per dispatch; the PM lands it.
- **control bytes** `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over all five touched paths — no matches.

## Scope

Nothing here touches `packages/plugin-kanban/**`, `packages/plugin-gantt/**`, `packages/types/src/complex.ts`, `zod/complex.zod.ts`, `packages/sdui-parser/src/kanban-quick-add.ts` or the kanban/gantt docs — the live surface of #8865. `object-kanban.columns` / `object-kanban.dataSource` stay exempt on the **ruling** ground (#8913 unruled), and `record:related_list.actions` was not re-measured here because this slice took a different block: slice 7's measurement stands as the last one taken.

## 验收备注

- `noted, not filed` — `ObjectMetricWidget.computeOne`'s `find()` fallback returns `records.length`, so on a page-limited adapter the tile would paint the page size rather than the total. Not filed: no reproduction was measured, and it is a design question about the fallback rather than a defect with a named failing probe. Successor: slice 9, which takes this block's remaining two keys, and anyone editing `ObjectMetricWidget.tsx`.
- `noted, not filed` — `ObjectMetricWidget.i18nLabel.test.tsx` mentions **both** of the keys slice 9 will take (`trend` as a props bag whose subject is the label inside it, `drillDown` as `{ enabled: true }` to make the drawer reachable). It satisfies any mechanical locator for either and asserts nothing about either member set. Not filed: it is a warning for one specific future slice, not a defect. It is written into the ceiling docblock, where that slice will read it. Successor: slice 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_