### PR TITLE
docs(scripts): record the maintainer ruling the `i18n-locales` ceiling raise could not (objectui#8816)

### DIFF
--- a/.changeset/8816-i18n-locales-ceiling-provenance.md
+++ b/.changeset/8816-i18n-locales-ceiling-provenance.md
@@ -1,0 +1,22 @@
+---
+---
+
+Record the maintainer ruling behind the `i18n-locales` per-chunk ceiling in
+`scripts/check-eager-closure-budget.mjs` (objectui#8816). Prose only; no package
+is released by this change and no constant moves.
+
+The raise that landed as `fffa30d3f` rested its header provenance on the
+maintainer's _instruction_ of 2026-09-10 that red pull requests are resolved
+rather than parked — a priority instruction, and all that existed when the
+sentence was written. The route ruling exists now: director seat summon #21,
+decision batch #110 item 3, recorded on objectui#8816 at comment 5615808548 on
+2026-09-10, on the maintainer's reply to the recommendation of route A at
+comment 5615318265. The header now rests on that, quotes the ruling's own
+refusal to be read as a precedent — the next change that meets this line returns
+to the decision box — and records the sequence plainly: the pair landed as a
+rider inside PR objectui#8901 about two hours and forty minutes ahead of the
+ruling, and not in the dedicated pull request the ruling asks for.
+
+The number is right and it is ruled, so nothing moves it back: a revert to
+re-land it in the ruled shape would land `main` red on this line for form. What
+was wrong is the record, and a record is repaired by writing it.

--- a/.changeset/8816-i18n-locales-ceiling-provenance.md
+++ b/.changeset/8816-i18n-locales-ceiling-provenance.md
@@ -20,3 +20,13 @@ ruling, and not in the dedicated pull request the ruling asks for.
 The number is right and it is ruled, so nothing moves it back: a revert to
 re-land it in the ruled shape would land `main` red on this line for form. What
 was wrong is the record, and a record is repaired by writing it.
+
+Two further sentences in the same header are repaired in the same commit, for
+the same reason and by the same event. The `PER_CHUNK_BASELINE` entry for
+`i18n-locales` described itself as a FORWARD reading naming "a state `main` has
+not reached yet ... while only one claimant has landed". `main` reached it:
+`fffa30d3f` at 2026-09-10T06:05:37Z and `8ea3beee4` at 2026-09-10T06:05:40Z are
+three seconds apart and both ancestors of the tip, so the sentence was false as
+written. Both sites — the prose entry and the inline comment above the constant
+— now say what the reading now is, and neither restates a headroom the gate is
+the only thing that can keep current.

--- a/scripts/check-eager-closure-budget.mjs
+++ b/scripts/check-eager-closure-budget.mjs
@@ -653,10 +653,40 @@ export const REGRESSION_THIS_GATE_MUST_CATCH_BYTES = 89 * 1024;
  * paragraph under "Raising one" forbids. It is not "the gate fired, so the
  * number moved". objectui#8816 is a decision card opened 2026-09-09 that asks
  * exactly this question and carries three routes, and it stood unclaimed while
- * two finished pull requests queued behind it. The authorisation to take one of
- * those routes rather than wait is the maintainer's instruction of 2026-09-10
- * that red pull requests are RESOLVED rather than parked; WHICH route is the
- * measurement below, and it was taken on measurement, not on the instruction.
+ * two finished pull requests queued behind it. WHICH route is the measurement
+ * below, and it was taken on measurement. THAT one of the three could be taken
+ * at all is a MAINTAINER RULING — director seat summon #21, decision batch #110
+ * item 3, recorded on objectui#8816 at comment 5615808548 on 2026-09-10, on the
+ * maintainer's reply to the recommendation of route A at comment 5615318265.
+ * That reply, verbatim:
+ *
+ *     其他同意
+ *
+ * ⛔ The same ruling refuses to be read as a precedent, and the clause is
+ * quoted rather than paraphrased because it governs the NEXT reader of this
+ * constant rather than this one:
+ *
+ *     这是一次维护者裁决下的 ratchet 移动,⛔ 不是先例:下一次撞墙仍回决策箱。
+ *
+ * ⇒ the next change that meets this line goes back to the decision box, and
+ * ⛔ this raise is not authorisation for the one after it.
+ *
+ * ⚠️ THE CONSTANT AND ITS RULING ARRIVED IN THAT ORDER — the wrong one — and
+ * the sequence is recorded here rather than smoothed over, because a reader who
+ * finds the ruling above and the number below will otherwise reconstruct a
+ * history that did not happen. The pair landed in `fffa30d3f` at 06:05:37Z on
+ * 2026-09-10 as a RIDER inside objectui#8901 (`fix(data-objectstack): a refused
+ * view read is not an object with no saved views`), about two hours and forty
+ * minutes BEFORE the ruling was recorded, and ⛔ not in the dedicated pull
+ * request the ruling's execution clause asks for. What stood in for the ruling
+ * at that moment was the maintainer's instruction of 2026-09-10 that red pull
+ * requests are RESOLVED rather than parked — a PRIORITY instruction, read on
+ * the day as authorising the route as well as the urgency. Whether it did was
+ * named as an open fork while the fork was still open, and the maintainer then
+ * settled it as A. ⇒ the number is the ruled number, so ⛔ moving a ruled
+ * constant back in order to re-land it in the ruled shape is refused: that
+ * lands `main` red on this line for form. What was wrong is the record, and a
+ * record is repaired by writing it — objectui#8816, these paragraphs.
  *
  * ⛔ WHAT THE BYTES BUY — one console build per row, each from the repo ROOT,
  * `i18n-locales` read out of the `apps/console/dist/eager-closure.json` the
@@ -782,8 +812,14 @@ export const PER_CHUNK_GZIP_CEILINGS = Object.freeze({
   // Headroom 18,971 bytes = 0.21x REGRESSION_THIS_GATE_MUST_CATCH_BYTES, the
   // proportion the retiring pair carried (18,539 = 0.20x).
   'vendor-objectstack': 1_254_000,
-  // Raised by objectui#8816, on the maintainer's instruction of 2026-09-10 that
-  // red pull requests are resolved rather than parked, and sized by the four
+  // Raised by objectui#8816 on a MAINTAINER RULING — director seat summon #21,
+  // decision batch #110 item 3, comment 5615808548 of 2026-09-10, on the
+  // maintainer's own reply to the recommendation of route A at 5615318265 —
+  // and ⛔ not a precedent, in that ruling's own words: the next change that
+  // meets this line returns to the decision box. ⚠️ It landed BEFORE that
+  // ruling, as a rider inside objectui#8901 (`fffa30d3f`) rather than in the
+  // dedicated pull request the ruling asks for; "Why `i18n-locales` moved UP"
+  // above records that sequence and quotes the ruling. Sized by the four
   // console builds in "Why `i18n-locales` moved UP" above — ⛔ not by the
   // overage, which is the one size that card's own evidence rules out. Headroom
   // 8,804 bytes = 0.10x REGRESSION_THIS_GATE_MUST_CATCH_BYTES over the baseline

--- a/scripts/check-eager-closure-budget.mjs
+++ b/scripts/check-eager-closure-budget.mjs
@@ -865,15 +865,21 @@ export const PER_CHUNK_GZIP_CEILINGS = Object.freeze({
  *     instrument and container as the three trees it is compared against, which
  *     is what makes those deltas subtractable.
  *
- *     ⚠️ It is a FORWARD reading and the only entry here that is. It names the
- *     state `main` reaches once objectui#8901 and objectui#8888 have BOTH
- *     landed, so while only one of them has, the live payload sits below this
- *     constant (455,271 and 455,519, both measured) and
- *     `pnpm check:eager-closure` prints MORE headroom than arithmetic on these
- *     two constants gives. Read on purpose: a shared budget with two admitted
- *     claimants has no single-commit baseline that is not stale the moment the
- *     second one lands, and erring toward the larger payload is the direction
- *     that cannot hide growth.
+ *     ⚠️ It WAS a FORWARD reading — the only entry here that ever has been —
+ *     and it is not one any more. It names the state `main` reaches once
+ *     objectui#8901 and objectui#8888 have BOTH landed, and both have:
+ *     `fffa30d3f` at 2026-09-10T06:05:37Z and `8ea3beee4` at
+ *     2026-09-10T06:05:40Z, three seconds apart and both ancestors of `main`.
+ *     ⇒ the gap this entry used to describe is CLOSED, and the sentence that
+ *     described it is history: while only one claimant had landed the live
+ *     payload sat below this constant (455,271 and 455,519, both measured) and
+ *     `pnpm check:eager-closure` printed MORE headroom than arithmetic on these
+ *     two constants gives. ⛔ Do not read a current headroom out of that — the
+ *     figure in force is the one the gate prints on YOUR build. Recorded
+ *     forward on purpose, and the reason outlives the gap: a shared budget with
+ *     two admitted claimants has no single-commit baseline that is not stale
+ *     the moment the second one lands, and erring toward the larger payload is
+ *     the direction that cannot hide growth.
  *
  *     ⚠️ Unlike the entries above it, this is a reading of a tree carrying
  *     diffs of its own — the two claimants — which is the point rather than a
@@ -952,9 +958,10 @@ export const PER_CHUNK_BASELINE = Object.freeze({
   // `34a1578ef`, the same build as BASELINE above (objectui#7122).
   'vendor-objectstack': 1_235_029,
   // `ba20b0bc0` (objectui#8816) — `main` `bbe285ee7` with BOTH admitted pull
-  // requests merged in. A FORWARD reading; see the provenance note above for
-  // why this one names a state `main` has not reached yet and what that does to
-  // the printed headroom while only one claimant has landed.
+  // requests merged in. It WAS a FORWARD reading; `main` has since reached that
+  // state (`fffa30d3f` and `8ea3beee4`, both 2026-09-10, three seconds apart),
+  // so the gap the provenance note above describes is closed. ⛔ The figure in
+  // force is still the one the gate prints on your own build.
   'i18n-locales': 456_196,
   // `3f775eeb8`, its OWN console build — ⛔ not the one above it and not
   // BASELINE's. Moved with the ceiling in the same commit, per the maintainer


### PR DESCRIPTION
Fixes #8816

Docs-only, **two commits**. **No constant moves, in either direction** — all
eight budgeted values still read byte-identically to `origin/main`. What this
repairs is the **record** attached to the ruled `i18n-locales` pair
(`PER_CHUNK_GZIP_CEILINGS['i18n-locales'] = 465_000` /
`PER_CHUNK_BASELINE['i18n-locales'] = 456_196`), which is already on `main` and
stays exactly where it is.

Three sentences in one header were falsified by one event — `fffa30d3f` landing
— and all three are repaired here.

## Why

The raise landed with its header provenance resting on the maintainer's
**instruction** of 2026-09-10 that red pull requests are RESOLVED rather than
parked. That is a *priority* instruction, and when the sentence was written it
was the only thing that existed — whether it also authorised route **A** rather
than only the urgency was named as an open fork on objectui#8816 while the fork
was still open.

The route ruling exists now. The header rests on it instead. And the same
commit that carried the pair in also made the baseline's **forward reading**
obsolete, which is the second commit here.

## Evidence

| what | reading |
| --- | --- |
| the ruled pair, already on `main` | `fffa30d3f`, commit date **2026-09-10T06:05:37Z** — `-'i18n-locales': 455_000` to `+465_000`, `-446_076` to `+456_196` |
| how it landed | a **rider** inside PR objectui#8901, whose squashed subject is `fix(data-objectstack): a refused view read is not an object with no saved views` — no provenance in the subject, a feature card carried it |
| the ruling | director seat summon #21, decision batch #110 item 3, recorded on objectui#8816 at comment 5615808548 on **2026-09-10, 08:4xZ**, on the maintainer's reply to the recommendation of A at comment 5615318265 |
| the gap | about **two hours and forty minutes** — the constant preceded its ruling |
| the sibling claimant | `8ea3beee4`, **2026-09-10T06:05:40Z** (objectui#8888), three seconds later |
| both are on `main` | `git merge-base --is-ancestor` returns **exit 0** for each against `origin/main` = `18b8e0961`, tip committed **2026-09-10T08:58:15Z** — which is what makes the old "a state `main` has not reached yet" false |
| precedent for this exact repair | `57bad9b00` — `docs(scripts): record the measured framework attribution the ceiling raise could not (objectui#8542)`, literally the previous commit to touch this file, and it repaired **two** blocks in one commit |
| precedent for the subject line | `fa9e76ccd` — `ci(budget): raise the framework per-chunk ceiling to 100,000 by maintainer ruling (#8550)` |

The ruling's execution clause asked for **一张专门的 PR，提交主题带裁决出处**. Two
of its three parts are spent (the prepared branch is on `main`; both claimant
pull requests are merged, so the re-run is moot). The subject clause is the one
still available, and a dedicated follow-up whose subject carries the provenance
is the only way left to honour it.

⛔ A revert-and-re-land is **refused**: reverting a maintainer-ruled value to
re-land it in the ruled shape would land `main` red on `Bundle Analysis` for
form. The number is right and it is ruled; the record is what was wrong, and a
record is repaired by writing it.

## What changed, exactly

`scripts/check-eager-closure-budget.mjs` — **three comment blocks**, plus an
empty-frontmatter changeset declaring that no package is released.

**Commit 1, `d7549589d`** — *record the maintainer ruling the ceiling raise
could not*. The provenance, in the two places that carried it:

1. **The prose block** under `## Why \`i18n-locales\` moved UP — objectui#8816`
   (attached to `PER_CHUNK_GZIP_CEILINGS`). The instruction-based provenance is
   replaced by the ruling's own, with the maintainer's reply and the ruling's
   ⛔ 不是先例 clause quoted verbatim in the file's existing convention for
   maintainer rulings (an indented block, untranslated — rewriting the quote
   would rewrite the ruling). A new paragraph records the sequence: rider on
   objectui#8901, ahead of the ruling, not the dedicated PR.
2. **The inline comment above the ceiling.** Same provenance swap, the
   non-precedent clause, and a pointer to the sequence. ⭐ Its last four lines
   are byte-identical to `main`, deliberately: the four-build derivation, the
   8,804-byte = 0.10x headroom arithmetic and the ⛔ not-by-the-overage sizing
   survive untouched, and the diff therefore touches no line that so much as
   *names* a constant.

**Commit 2, `43eb84f25`** — *the baseline's forward reading is spent, both
sites*. Folded in on the PM's instruction after it was reported as an
out-of-scope finding; same defect, same file, same falsifying event, and the
precedent above repaired two blocks in one commit.

3. **The `PER_CHUNK_BASELINE` prose entry and the inline comment above
   `'i18n-locales': 456_196`.** Both described 456,196 as a FORWARD reading
   naming 「a state `main` has not reached yet … while only one claimant has
   landed」. `main` has reached it — `fffa30d3f` at 06:05:37Z and `8ea3beee4` at
   06:05:40Z, both ancestors of the tip — so both sentences were false in the
   present tense, six lines from the constant they describe. They now say what
   the reading now is, and ⛔ neither restates a current headroom: the old
   arithmetic is kept as history, in the past tense, with the gate's own printed
   figure named as the one in force. Both sites move together on purpose —
   repairing one and leaving the other is the split record this card exists to
   stop.

Census, against the merge-base `aeaa0f64c`:

```
 .changeset/8816-i18n-locales-ceiling-provenance.md | 32 +++++++++
 scripts/check-eager-closure-budget.mjs             | 79 +++++++++++++++++-----
 2 files changed, 93 insertions(+), 18 deletions(-)
```

## Proof that the diff is comment lines only

Re-run over the **whole branch** after the second commit (`MB` = the merge-base
`aeaa0f64c`; the same three numbers hold for `HEAD~1..HEAD` alone):

```
$ git diff -U0 $MB..HEAD -- scripts/check-eager-closure-budget.mjs \
    | grep -E '^[+-]' | grep -Ev '^(\+\+\+|---)' | sed -E 's/^[+-]//' \
    | grep -Evc '^\s*(\*|//)'
0            # non-comment changed lines

$ git diff -U0 $MB..HEAD -- scripts/check-eager-closure-budget.mjs \
    | grep -E '^[+-]' | grep -Ev '^(\+\+\+|---)' \
    | grep -cE '465_000|456_196|455_000|446_076|1_254_000|1_235_029|100_000|399_000|391_095|72_245|MAX_EAGER_CLOSURE_GZIP_BYTES|REGRESSION_THIS_GATE_MUST_CATCH_BYTES|PER_CHUNK_GZIP_CEILINGS|PER_CHUNK_BASELINE'
0            # changed lines carrying a constant name or value

$ grep -cE 'THE_SAME_ALTERNATION' scripts/check-eager-closure-budget.mjs
56           # FIRING CONTROL: the same matcher DOES hit this file
```

PROCSUB(…) is bash process substitution and CONSTANT_LINE_PATTERN /
THE_SAME_ALTERNATION are the two regexes above, both spelled out in words rather
than written: GitHub's body sanitizer eats tag-shaped fragments even inside
fenced code, so a recipe written literally would render as a recipe missing the
very thing it exists to show.

The third command is what makes the second a reading: the alternation that
returns **0** over the diff returns **56** over the file, so the zero is not a
failed grep. The alternation was widened for this run to cover all eight
budgeted values, not just the two this card is about.

Two more, on the values themselves rather than on the diff:

```
$ diff  PROCSUB(git show origin/main:$F | grep -E "CONSTANT_LINE_PATTERN") \
        PROCSUB(grep -E "CONSTANT_LINE_PATTERN" $F)
             # no output — every constant LINE is byte-identical to origin/main

$ node -e "import('./scripts/check-eager-closure-budget.mjs').then(...)"
ceilings   {"vendor-objectstack":1254000,"i18n-locales":465000,"framework":100000,"ui-components":399000}
baselines  {"vendor-objectstack":1235029,"i18n-locales":456196,"framework":72245,"ui-components":391095}
aggregate  3597000     regression 91136
CEILINGS EQUAL to origin/main: true      BASELINES EQUAL to origin/main: true
```

## Verification

Re-run in full after the second commit. Every exit code was captured before any
pipe (`cmd  1>file 2>&1; EXIT=$?`), so none of them is a `tail`'s status.

| check | result |
| --- | --- |
| `pnpm exec vitest run scripts/__tests__/check-eager-closure-budget.test.ts` | **exit 0** — `Test Files 1 passed (1)`, `Tests 104 passed (104)`. This file pins this header's prose (`565817a72`), and the sentences commit 2 touched sit directly against the baselines its objectui#7046 pins hold to live values. |
| `pnpm exec vitest run scripts/__tests__/` | **exit 0** — `Test Files 133 passed \| 2 skipped (135)`, `Tests 3883 passed \| 2 skipped (3885)` |
| `pnpm lint:root` (the root ESLint run that owns `scripts/`) | **exit 0** — `32 problems (0 errors, 32 warnings)`, all 32 pre-existing; `grep -c check-eager-closure-budget.mjs` over the lint output is **0** |
| `node scripts/check-changeset-presence.mjs` | **exit 0** — `No source or published contract of a released package changed in this range, so no changeset is owed`; the empty-frontmatter changeset is added anyway, mirroring `57bad9b00` |
| `pnpm changeset:check` | **exit 0** — fixed group OK, no `major` bump declared |
| `node scripts/check-control-bytes.mjs` | **exit 0** — `scanned 7154 tracked text file(s)` |
| `node scripts/check-governed-queue-guard.mjs --test` on both changed paths | `✅ NOT GOVERNED — 2 path(s) checked against 5 governed surface(s)` — an ordinary PR |

## Not in this change

⛔ Any constant · ⛔ the aggregate ceiling and the other three per-chunk lines ·
⛔ the `check:i18n-dead-keys` sweep and its 127 CONFIRMED dead keys (routed onto
objectui#8754) · ⛔ the `ui-components` headroom (a separate observation card) ·
⛔ `content/docs/releases/**` · ⛔ any claim that the raise makes this line safe —
the file's own arrival-rate reading still says about a week.

Left in draft. The PM runs the landing pipeline. Session for this work:
`https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr


---
_Generated by [Claude Code](https://claude.ai/code)_