### PR TITLE
fix(fields): honour `relative` and `short` on a datetime cell, as the date cell already did (objectui#8853)

### DIFF
--- a/.changeset/datetime-cell-format-vocabulary-8853.md
+++ b/.changeset/datetime-cell-format-vocabulary-8853.md
@@ -1,0 +1,68 @@
+---
+'@object-ui/fields': minor
+---
+
+A `datetime` grid cell now honours the same authored `field.format` words a `date` cell already honoured (objectui#8853).
+
+`DateCellRenderer` and `DateTimeCellRenderer` are neighbours reading ONE authored key
+and handing it to two formatters with different vocabularies: `formatDate` honours
+`'short'` and `'relative'`, `formatDateTime`'s `options.style` honours `'compact'`
+alone. So `format: 'relative'` painted the relative face on a `date` column and the
+verbose absolute face on a `datetime` one — no error, no warning, no fallback.
+Measured end to end through a real `ObjectGrid` column before anything was changed:
+one object, one row, one instant (`2026-09-11T09:30:00.000Z`, clock pinned to
+`2026-09-09T12:00:00.000Z`, `en-US`), `format: 'relative'` authored on both fields,
+the grid's own body cells read
+
+    ["1Open", "Row One", "In 2 days", "Sep 11, 2026, 09:30 AM"]
+
+with the `date` column honouring the key and the `datetime` column beside it dropping
+it. After this change the same run reads `["1Open", "Row One", "In 2 days", "In 2
+days"]`.
+
+The cell now SELECTS a formatter instead of threading one, the way objectui#8352
+already ruled for `formatMeasureDate`'s datetime arm — the same defect class one
+surface over:
+
+- `'relative'` resolves through `formatRelativeDate`, the same function the `date`
+  cell reaches, so one calendar day reads the same phrase in either column.
+- `'short'` resolves to the dense face of this type, which for a `datetime` cell is
+  the compact face it already paints — the time of day is kept, and it stays
+  byte-identical to an unstyled cell.
+- every other string, `'compact'` and date patterns such as `'YYYY-MM-DD'` included,
+  falls to the default face exactly as before.
+
+**Behaviour change, spelled out.** Two authored spellings render differently than they
+did, and one of them loses a component:
+
+- `format: 'relative'` on a `datetime` field: was the verbose absolute face
+  (`Sep 11, 2026, 09:30 AM`), is now the relative phrase (`In 2 days`).
+- `format: 'short'` on a `datetime` field: was that same verbose face, is now the
+  compact face (`9/11/2026 9:30 am`).
+- ⚠️ **Beyond the ±7-day window a `'relative'` datetime now shows no time of day.**
+  `formatRelativeDate` falls back to an absolute DATE face out there, so
+  `2026-09-20T09:30:00.000Z` renders `Sep 20` where it rendered
+  `Sep 20, 2026, 09:30 AM` before. That window belongs to `formatRelativeDate` and is
+  inherited rather than re-decided at the call site — re-deciding it would put a
+  second copy of the convention in the renderer, which is objectui#4576. `'relative'`
+  is day-granular by construction (it shows no time inside the window either), and
+  any other fallback would make the two columns unequal again, which is the defect
+  being closed.
+
+Note what the delta is and is not: this renderer ignored both words outright before,
+so nothing was taken from a working feature — it starts honouring a request whose
+granularity is days. It reaches only a `datetime` field whose author actually wrote
+one of those two words. An unstyled `datetime` cell, an explicit `'compact'` one, an
+authored empty string, and any other spelling all render exactly as they did.
+
+No published signature moved. `formatDateTime(value, options?)` is unchanged and
+still ignores `'relative'` and `'short'` in its `options.style` key — threading the
+authored word into it would have honoured `'compact'`, the one word the `date` cell
+does NOT honour, while still ignoring both words it does, which is the defect
+inverted rather than closed. No spelling that rendered before is refused now; adding
+a refusal would be a breaking narrowing of a published metadata surface.
+
+`dueLike` is deliberately not threaded and is filed separately as objectui#8958: it
+is a different authored key whose affordance travels with red styling and a
+field-name heuristic, and acquiring a second key's behaviour while honouring the
+first would be an unruled change.

--- a/packages/fields/src/__tests__/datetimeCell.formatVocabulary-8853.test.tsx
+++ b/packages/fields/src/__tests__/datetimeCell.formatVocabulary-8853.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8853 — ONE authored `field.format`, one meaning, across the two
+ * neighbouring date cell renderers.
+ *
+ * ## What was measured, before anything was changed
+ *
+ * Driven end to end through a REAL `ObjectGrid` column (not inferred from a
+ * source read): one object with a `date` field and a `datetime` field, BOTH
+ * authored `format: 'relative'`, one row, one instant
+ * (`2026-09-11T09:30:00.000Z`), clock pinned to `2026-09-09T12:00:00.000Z`,
+ * `en-US`. The grid's own body cells came back as
+ *
+ *   ["1Open", "Row One", "In 2 days", "Sep 11, 2026, 09:30 AM"]
+ *                         ^ date       ^ datetime, same key, dropped
+ *
+ * and after the call-site mapping, as
+ *
+ *   ["1Open", "Row One", "In 2 days", "In 2 days"]
+ *
+ * The defect's whole signature is a SILENT drop — the runtime accepts the key,
+ * parses it, drops it, and renders something that still looks like a
+ * legitimate date — so a green suite proves nothing by itself. Every case
+ * below therefore asserts a rendered FACE, with controls that say what the
+ * probe would have shown had it been fooled.
+ *
+ * ## The controls, and why each one is here
+ *
+ * - **Positive control** — the `date` cell, in the SAME run, on the SAME
+ *   instant. It already honoured `'relative'`, so it is what "honoured" looks
+ *   like; without it, a datetime assertion could be measuring a broken clock
+ *   or a dead locale channel rather than the vocabulary.
+ * - **Negative control** — an OUT-OF-WINDOW value. `formatRelativeDate` falls
+ *   back to the absolute form beyond ±7 days, so out there `format:
+ *   'relative'` and no format at all render IDENTICALLY on the fully working
+ *   `date` cell. That is the trap objectui#8352's card recorded: a probe built
+ *   on an out-of-window value reports "identical" on a working path and on a
+ *   broken one alike. The pin below asserts that collapse explicitly, so the
+ *   in-window choice everywhere else is a measured decision rather than luck.
+ *
+ * ## Directions
+ *
+ * Reverting the call-site mapping in `DateTimeCellRenderer` turns the repro,
+ * the `'short'` face and the out-of-window datetime face RED, and leaves every
+ * control and regression pin GREEN — the controls measure surfaces this change
+ * does not touch, which is exactly why they can vouch for the run. Widening
+ * `formatDateTime`'s published signature instead (the refused route) turns the
+ * "published signature untouched" pins RED. Adding a refusal for a spelling
+ * that renders today turns the regression pins RED.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { I18nProvider, LocalizationProvider } from '@object-ui/i18n';
+import { DateCellRenderer, DateTimeCellRenderer, formatDateTime, formatDateTimeCompactParts } from '../index';
+
+/** The pinned clock, and two values chosen on either side of the ±7-day window. */
+const CLOCK = '2026-09-09T12:00:00.000Z';
+/** +2 days: inside the window, so the relative face is a PHRASE and discriminates. */
+const IN_WINDOW = '2026-09-11T09:30:00.000Z';
+/** +11 days: outside it, where the relative face collapses onto the absolute one. */
+const OUT_OF_WINDOW = '2026-09-20T09:30:00.000Z';
+
+/** `en-US` plus one NON-US locale, the same pairing the #7443 pins use. */
+const LOCALES = ['en-US', 'zh', 'de-DE'];
+
+/**
+ * Same session harness as `datetime-compact-style-7443.test.tsx`: the tag is
+ * set as the TENANT locale because that is the channel objectui#4468 made
+ * every date branch read, and `persistLanguage={false}` keeps each case on its
+ * own language instead of inheriting the previous one's.
+ */
+function renderSession(locale: string, node: React.ReactElement) {
+  return render(
+    <I18nProvider
+      config={{ defaultLanguage: 'en', detectBrowserLanguage: false }}
+      persistLanguage={false}
+    >
+      <LocalizationProvider value={{ locale }}>{node}</LocalizationProvider>
+    </I18nProvider>,
+  );
+}
+
+/** Render one cell at the pinned clock and return its text, nothing retained. */
+function faceOf(node: React.ReactElement, locale = 'en-US'): string {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(CLOCK));
+  try {
+    const { container } = renderSession(locale, node);
+    return container.textContent ?? '';
+  } finally {
+    cleanup();
+    vi.useRealTimers();
+  }
+}
+
+const dateCell = (value: string, format?: string) => (
+  <DateCellRenderer
+    value={value}
+    field={{ type: 'date', name: 'follow_up_on', ...(format === undefined ? {} : { format }) } as any}
+  />
+);
+
+const dateTimeCell = (value: string, format?: string) => (
+  <DateTimeCellRenderer
+    value={value}
+    field={{ type: 'datetime', name: 'follow_up_at', ...(format === undefined ? {} : { format }) } as any}
+  />
+);
+
+/** The compact face as the cell paints it — two spans, so no separating space. */
+function compactCellText(value: string, locale: string): string {
+  const parts = formatDateTimeCompactParts(value, { locale })!;
+  return `${parts.date}${parts.time}`;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('THE REPRO — `format: relative` means the same thing in both cells (#8853)', () => {
+  it('a datetime cell honours `relative`, and renders the phrase its date sibling renders', () => {
+    const dateFace = faceOf(dateCell(IN_WINDOW, 'relative'));
+    const dateTimeFace = faceOf(dateTimeCell(IN_WINDOW, 'relative'));
+
+    // The anchor, so a redesign that moved both sides together cannot pass.
+    expect(dateFace).toBe('In 2 days');
+    expect(dateTimeFace).toBe('In 2 days');
+    // The claim itself: ONE authored key, ONE meaning, across the two cells.
+    expect(dateTimeFace).toBe(dateFace);
+    // And what it used to be, named — not merely "something else".
+    expect(dateTimeFace).not.toBe('Sep 11, 2026, 09:30 AM');
+  });
+
+  it.each(LOCALES)('%s — the two cells agree in a non-US locale too', (locale) => {
+    expect(faceOf(dateTimeCell(IN_WINDOW, 'relative'), locale)).toBe(
+      faceOf(dateCell(IN_WINDOW, 'relative'), locale),
+    );
+  });
+
+  it('`short` reaches the dense face of THIS type — the time of day is kept', () => {
+    // objectui#8352 mapped `'short'` to the arm's own narrow face: `formatDate`'s
+    // `'short'` for a date, the compact datetime face for a datetime. Here that
+    // face is the one this cell already paints, so a measure tile and a grid
+    // cell showing the same instant agree.
+    expect(faceOf(dateTimeCell(IN_WINDOW, 'short'))).toBe(compactCellText(IN_WINDOW, 'en-US'));
+    expect(faceOf(dateTimeCell(IN_WINDOW, 'short'))).toBe('9/11/20269:30 am');
+    expect(faceOf(dateTimeCell(IN_WINDOW, 'short'))).not.toBe('Sep 11, 2026, 09:30 AM');
+  });
+
+  it('the relative face is painted in ONE span, not the compact two', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(CLOCK));
+    const { container } = renderSession('en-US', dateTimeCell(IN_WINDOW, 'relative'));
+    expect(container.querySelectorAll('span > span')).toHaveLength(0);
+    vi.useRealTimers();
+  });
+});
+
+describe('POSITIVE CONTROL — the date cell, unchanged, in the same run', () => {
+  it('still honours `relative` and `short`, and still defaults to relative', () => {
+    expect(faceOf(dateCell(IN_WINDOW, 'relative'))).toBe('In 2 days');
+    expect(faceOf(dateCell(IN_WINDOW, 'short'))).toBe("Sep 11, '26");
+    expect(faceOf(dateCell(IN_WINDOW, undefined))).toBe('In 2 days');
+  });
+
+  it("`compact` stays inert on a date cell — the vocabulary was widened on ONE side", () => {
+    // The reverse asymmetry the card names. Honouring it here would be a
+    // second, unruled change: `'compact'` falls to the date arm's default
+    // face, exactly as objectui#8352 declared for the measure path.
+    expect(faceOf(dateCell(IN_WINDOW, 'compact'))).toBe('Sep 11');
+    expect(faceOf(dateCell(IN_WINDOW, 'compact'))).toBe(faceOf(dateCell(IN_WINDOW, 'no-such-face')));
+  });
+});
+
+describe('NEGATIVE CONTROL — out of the ±7-day window the probe cannot discriminate', () => {
+  it('on the WORKING date cell, `relative` and no format render identically out there', () => {
+    // This is the trap. Had the cases above used this value, "identical"
+    // would have been the answer on a working path and a broken one alike.
+    const authored = faceOf(dateCell(OUT_OF_WINDOW, 'relative'));
+    const absent = faceOf(dateCell(OUT_OF_WINDOW, undefined));
+    expect(authored).toBe(absent);
+    expect(authored).toBe('Sep 20');
+  });
+
+  it('the in-window value DOES discriminate on that same cell — the probe has teeth', () => {
+    expect(faceOf(dateCell(IN_WINDOW, 'relative'))).not.toBe('Sep 11');
+  });
+
+  it('an out-of-window datetime renders the absolute DATE face — the declared cost', () => {
+    // ⚠️ The time of day is gone. `formatRelativeDate`'s out-of-window branch
+    // renders through `toLocaleDateString` and has no time component to add;
+    // that window belongs to that function and is INHERITED here rather than
+    // re-decided at this call site (objectui#4576). `'relative'` is day-granular
+    // by construction, so its degraded form is a day face — and nothing was
+    // taken from a working feature, since this cell ignored the word outright
+    // before. Pinned so the cost cannot drift silently in either direction.
+    expect(faceOf(dateTimeCell(OUT_OF_WINDOW, 'relative'))).toBe('Sep 20');
+    expect(faceOf(dateTimeCell(OUT_OF_WINDOW, 'relative'))).toBe(
+      faceOf(dateCell(OUT_OF_WINDOW, 'relative')),
+    );
+  });
+});
+
+describe('REGRESSION — every datetime cell that rendered before renders the same', () => {
+  it.each(LOCALES)('%s — no format is still the compact face', (locale) => {
+    expect(faceOf(dateTimeCell(IN_WINDOW, undefined), locale)).toBe(
+      compactCellText(IN_WINDOW, locale),
+    );
+  });
+
+  it('an explicit `compact` is still the compact face', () => {
+    expect(faceOf(dateTimeCell(IN_WINDOW, 'compact'))).toBe(compactCellText(IN_WINDOW, 'en-US'));
+  });
+
+  it('an authored EMPTY string is still the compact face, not the verbose one', () => {
+    // `||`, not `??` — the spelling objectui#7443 chose so an authored empty
+    // string stays on the compact face. The mapping above must not disturb it.
+    expect(faceOf(dateTimeCell(IN_WINDOW, ''))).toBe(compactCellText(IN_WINDOW, 'en-US'));
+  });
+
+  it('an unrecognised spelling still falls to the verbose default — no refusal was added', () => {
+    // ⛔ Rejecting a currently-accepted spelling would be a breaking narrowing
+    // of a published metadata surface. It renders, as it always did.
+    expect(faceOf(dateTimeCell(IN_WINDOW, 'default'))).toBe('Sep 11, 2026, 09:30 AM');
+    expect(faceOf(dateTimeCell(IN_WINDOW, 'YYYY-MM-DD'))).toBe('Sep 11, 2026, 09:30 AM');
+  });
+
+  it('an absent field is still tolerated, on the compact face', () => {
+    expect(faceOf(<DateTimeCellRenderer value={IN_WINDOW} field={undefined as any} />)).toBe(
+      compactCellText(IN_WINDOW, 'en-US'),
+    );
+  });
+});
+
+describe('the PUBLISHED signature was not moved — the mapping lives at the call site', () => {
+  it('formatDateTime still declares exactly two parameters', () => {
+    // `(value, options?)` is 2; the refused `(value, style?, options?)` is 3.
+    expect(formatDateTime.length).toBe(2);
+  });
+
+  it("formatDateTime's own vocabulary is untouched: it still ignores `relative` and `short`", () => {
+    // The function was NOT widened. It answers the verbose face for both
+    // words, and the CELL is what maps them — which is why this file and the
+    // function's own pins can disagree about `'relative'` without either being
+    // wrong.
+    const verbose = formatDateTime(IN_WINDOW, { locale: 'en-US' });
+    expect(formatDateTime(IN_WINDOW, { locale: 'en-US', style: 'relative' })).toBe(verbose);
+    expect(formatDateTime(IN_WINDOW, { locale: 'en-US', style: 'short' })).toBe(verbose);
+    expect(verbose).toBe('Sep 11, 2026, 09:30 AM');
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -967,7 +967,71 @@ export function DateTimeCellRenderer({ value, field }: CellRendererProps): React
   // `format`, so the bare property read is `TS2339` — SOME cast is load-bearing.
   // `DateTimeFieldMetadata` is the narrowest one that carries it (objectui#7747);
   // `as any` would also silence a typo in the property name, this does not.
-  const style = (field as DateTimeFieldMetadata | undefined)?.format || 'compact';
+  const authoredFormat = (field as DateTimeFieldMetadata | undefined)?.format || 'compact';
+
+  // ── The authored vocabulary is mapped HERE (objectui#8853) ──────────────
+  // `field.format` is ONE authored key, and until this mapping it meant two
+  // different things depending on which of two neighbouring cell renderers
+  // read it. Measured end to end through a real `ObjectGrid` column, one row,
+  // one instant, `format: 'relative'` on both fields: the `date` cell painted
+  // `In 2 days` and the `datetime` cell beside it painted
+  // `Sep 11, 2026, 09:30 AM` — no error, no warning, no fallback. The runtime
+  // accepted the key, parsed it, dropped it, and rendered something that still
+  // looks like a legitimate date, which is why a reader cannot tell an
+  // honoured style from a dropped one by looking at the cell.
+  //
+  // The two words are SELECTED here rather than threaded onward, and that is
+  // the ruling objectui#8352 already made for `formatMeasureDate`'s datetime
+  // arm — the same defect class one surface over. Threading `format` into
+  // `formatDateTime`'s `options.style` is NOT the fix and was measured there:
+  // that key's vocabulary is `'compact'` alone, so a pass-through would honour
+  // the one word the `date` cell does NOT honour while still ignoring both
+  // words it does — the defect inverted, not closed. Widening
+  // `formatDateTime(value, options?)` is refused for the reason it was refused
+  // there and in objectui#7443 ruling B: it is a PUBLISHED signature, and the
+  // parity this card asks for is reachable from the call site without moving
+  // it. Rejecting the currently-accepted spelling is refused too — that would
+  // be a breaking narrowing of a published metadata surface.
+  //
+  //   `'relative'` -> `formatRelativeDate`, the SAME function `formatDate`
+  //                   resolves `'relative'` to, so one calendar day reads the
+  //                   same phrase in either column.
+  //   `'short'`    -> the dense face of THIS type, which for a `datetime` cell
+  //                   is the compact face painted below. `formatDate`'s
+  //                   `'short'` is a narrow DATE face; the datetime equivalent
+  //                   keeps the time of day, exactly as #8352 mapped it.
+  //   anything else, `'compact'` and date patterns such as `'YYYY-MM-DD'`
+  //                   included, falls through unchanged to the default face.
+  //
+  // ⚠️ Beyond the ±7-day window `formatRelativeDate` renders an absolute DATE
+  // face, so an out-of-window `'relative'` datetime shows no time of day. That
+  // window belongs to that function and is INHERITED here, not re-decided —
+  // re-deciding it would put a second copy of the convention in this file,
+  // which is objectui#4576 exactly. `'relative'` is day-granular by
+  // construction (it shows no time inside the window either), and any other
+  // fallback would make the two columns unequal again, which is the defect
+  // being closed. Nothing is taken away from a working feature: this renderer
+  // ignored the word outright before, so it starts honouring a request whose
+  // granularity is days.
+  //
+  // ⚠️ `dueLike` is deliberately NOT threaded, and this is a bounded gap
+  // rather than an oversight. The `date` cell's overdue affordance — the
+  // "Overdue Nd" wording AND the red styling — is gated by a DIFFERENT
+  // authored key plus a field-name heuristic, and this renderer has never read
+  // either. Honouring `format` must not silently acquire a second key's
+  // behaviour; whether a `datetime` cell should paint overdue is its own call,
+  // filed rather than guessed (objectui#8958). `t` stays on the
+  // `formatDateTime` call below exactly as before, and is left off this branch
+  // because `formatRelativeDate` reads it only through `dueLike`.
+  const style = authoredFormat === 'short' ? 'compact' : authoredFormat;
+
+  if (style === 'relative') {
+    return (
+      <span className="tabular-nums text-sm whitespace-nowrap">
+        {formatRelativeDate(date, { locale })}
+      </span>
+    );
+  }
 
   // The compact face is painted in two halves — the time is muted and offset
   // — so this branch asks the shared module for the halves rather than the


### PR DESCRIPTION
Fixes #8853

`DateCellRenderer` and `DateTimeCellRenderer` are neighbours reading ONE authored `field.format` and handing it to two formatters with different vocabularies: `formatDate` honours `'short'` and `'relative'`, while `formatDateTime`'s `options.style` honours `'compact'` alone. So `format: 'relative'` painted the relative face on a `date` column and the verbose absolute face on a `datetime` one — no error, no warning, no fallback.

## The premise was driven out end to end BEFORE anything changed

The card declared its own gap: *"A browser run through a real `datetime` grid column has not been done… the end-to-end claim is inference from a measured formatter plus a read pass-through."* So it was driven, not inferred — a real `ObjectGrid` over an object carrying a `date` field and a `datetime` field, both authored `format: 'relative'`, one row, one instant (`2026-09-11T09:30:00.000Z`), clock pinned to `2026-09-09T12:00:00.000Z`, `en-US`, `TZ=UTC`. The grid's own body cells:

| run | grid body cells |
|:--|:--|
| before | `["1Open", "Row One", "In 2 days", "Sep 11, 2026, 09:30 AM"]` |
| after | `["1Open", "Row One", "In 2 days", "In 2 days"]` |

Third cell is the `date` column, fourth is the `datetime` column beside it. Same key, same instant, same row — honoured on one, dropped on the other. Premise confirmed.

## The fix, and the three routes

The card left the fix shape to a ruling and listed three routes. This is **route 2**, and it is inherited rather than newly decided: this card is, in its own first line, "the same defect class" as objectui#8352, which shipped via PR #8852. That ruling was re-measured on `origin/main` rather than taken from the card's transcription — `formatDateTime`'s published signature is still `(value, options?)` with no style parameter, and `formatMeasureDate`'s datetime arm carries its own comment saying it honours the same two words "by choosing a formatter here".

The `datetime` cell now SELECTS a formatter instead of threading one:

- `'relative'` resolves through `formatRelativeDate`, the same function the `date` cell reaches, so one calendar day reads the same phrase in either column.
- `'short'` resolves to the dense face of this type — the compact face this cell already paints, which keeps the time of day.
- everything else, `'compact'` and date patterns such as `'YYYY-MM-DD'` included, falls to the default face exactly as before.

⛔ `formatDateTime`'s published signature was **not** widened (route 1) — expanding a published surface is a manual floor. ⛔ No refusal was added for a currently-accepted spelling (route 3) — that would be a breaking narrowing of a published metadata surface. Both refusals are pinned by tests.

## The break, spelled out

Two authored spellings render differently than they did, and one loses a component. All three are in the changeset body and each is pinned:

- `format: 'relative'` on a `datetime` field: was `Sep 11, 2026, 09:30 AM`, is now `In 2 days`.
- `format: 'short'` on a `datetime` field: was that same verbose face, is now the compact face — `9/11/2026 9:30 am` on the measured instant.
- ⚠️ **Beyond the ±7-day window a `'relative'` datetime now shows no time of day** — `Sep 20` where it was `Sep 20, 2026, 09:30 AM`. `formatRelativeDate` falls back to an absolute DATE face out there; that window belongs to that function and is inherited rather than re-decided at the call site (re-deciding it would put a second copy of the convention in the renderer — objectui#4576). `'relative'` is day-granular by construction, and any other fallback would make the two columns unequal again, which is the defect this change closes.

Nothing was taken from a working feature: this renderer ignored both words outright before, so it starts honouring a request whose granularity is days, and only for a field whose author actually wrote one of them.

## Discriminating power, proven both ways

The defect's signature is a **silent drop** — the runtime accepts the key, parses it, drops it, and renders something that still looks like a legitimate date — so a green suite proves nothing by itself.

Reverting the call-site change to the pinned base commit and re-running, then restoring:

| leg | result |
|:--|:--|
| mutated | `Tests 6 failed \| 14 passed (20)` |
| restored | `Tests 20 passed (20)` |

The six that went RED are the repro, the three locale-agreement cases, the `'short'` face and the out-of-window datetime cost. The fourteen that stayed GREEN are the controls and regression pins — they measure surfaces this change does not touch, which is exactly why they can vouch for the run.

The mutation was proven to reach disk before any result was read (blob hash moved `9e593ba1…` to `8e9e7621…`, both source anchors dropped to 0), and the restore was proven **by state** — `git diff HEAD` empty and the on-disk blob back to `9e593ba1…` — never by an exit code. The test imports the renderer by relative source path, so no rebuild sits between the mutation and the assertion.

## Controls in the committed test

- **Positive control** — the `date` cell, same run, same instant. It already honoured `'relative'`, so it is what "honoured" looks like; without it a datetime assertion could be measuring a broken clock rather than the vocabulary.
- **Negative control** — an out-of-window value, where `format: 'relative'` and no format at all render **identically** on the fully working `date` cell. That is the trap objectui#8352's card recorded: a probe built out there reports "identical" on a working path and a broken one alike. It is pinned explicitly, so the in-window choice everywhere else is a measured decision rather than luck.

## Gates

`scripts/pm/dispatch-gates.mjs` does not exist in this repo, so the families were derived **by hand** from the changed-file set (`packages/fields/src/index.tsx`, one new test, one changeset) and are declared as such.

| gate | exit |
|:--|:--|
| `pnpm --workspace-concurrency=2 --filter '@object-ui/fields...' build` | 0 |
| `pnpm --filter @object-ui/fields type-check` (`tsc --noEmit` + `tsconfig.test.json`) | 0 |
| `pnpm --filter @object-ui/fields lint` | 0 (990 pre-existing warnings, 0 errors) |
| `pnpm exec vitest run packages/fields/` (repo ROOT) | 0 — 155 files, 2658 tests |
| `pnpm exec vitest run packages/plugin-grid/ packages/plugin-detail/ packages/core/src/utils/` | 0 — 339 files, 3792 tests |
| `node scripts/check-control-bytes.mjs` | 0 |
| `node scripts/check-changeset-presence.mjs` | 0 |
| `node scripts/check-changeset-no-major.mjs` | 0 |
| `node scripts/check-governed-queue-guard.mjs --test …` | 0 — NOT GOVERNED, ordinary route |

The consumer suites are run because the *rendered output* changed even though the exported byte surface did not, and both packages render datetime cells.

## Acceptance notes

- **No docblock was made false.** `DateDisplayOptions.style`'s docblock states the split for the **functions** ("that function's default face"), and the functions are untouched — the mapping is at the cell. `DateTimeCellRenderer`'s own `||`-not-`??` note still holds: an authored empty string still lands on the compact face, and that is pinned.
- **`dueLike` is deliberately not threaded**, and it is filed rather than guessed as objectui#8958. Measured while here: `dueLike: true` on a `datetime` cell is byte-identical to no `dueLike` (`3 days ago`, no red class) while the `date` cell paints `Overdue 3d` in `text-red-600` — and the Zod `describe` text for that key names "date/datetime". It is a different authored key whose affordance travels with red styling and a field-name heuristic; acquiring a second key's behaviour while honouring the first would be an unruled change.
- **Serial constraint re-derived**, not taken from the claim's snapshot: across all 12 currently-open pull requests, zero touch `packages/fields/src/index.tsx`. Two touch `packages/fields/package.json` only (the lucide bumps, #8941 and #7058); the release bot's `changeset-release/main` is stale relative to `main` rather than a concurrent editor. Lit control on the same probe: every branch measured returns a non-zero total changed-file count, so those zeroes are readings. The claim's snapshot named #8951, which is no longer open, and predates nine of the twelve.
- `objectui#8263` holds `formatMeasureDate` in `packages/core` — a different file and package, untouched here.
- One repair after publication: a bullet above quoted the `'short'` face as `9:00 am`; the measured face is `9:30 am`, as the changeset body and the pins both say. Corrected in place rather than left standing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB