### PR TITLE
fix(plugin-grid): refuse the retired string `sort` clause at object-grid's own read site (objectui#8767)

### DIFF
--- a/.changeset/8767-object-grid-refuses-string-sort.md
+++ b/.changeset/8767-object-grid-refuses-string-sort.md
@@ -20,12 +20,38 @@ with private code, so a bare grid went on honouring at runtime a spelling
 — which is the per-block divergence the ruling declined by name when it
 rejected option A.
 
-**Migration.** Write the array: `sort: [{ field: 'name', order: 'desc' }]`
-(`order` is optional and means `'asc'`). That is the only spelling
+**Migration.** Write the array: `sort: [{ field: 'name', order: 'desc' }]`.
+**Both keys are required.** `SortConfig.order` carries no `?` in
+`@object-ui/types` (`packages/types/src/objectql.ts`) and no `.optional()` in
+its zod mirror, and the protocol's own reusable `SortItemSchema` requires
+`order` as well — measured: that schema refuses `[{ field: 'name' }]` with
+`invalid_value` at `0.order`. Do not omit it: this block's array arm
+interpolates whatever is present, so an omitted `order` lowers to
+`$orderby: 'name undefined'` today. That is pre-existing behaviour on the arm
+this change does not touch, and it is filed as a successor card rather than
+widened into here.
+
+**What the spec face does and does not say.** Measured against the installed
+`@objectstack/spec@17.4.0`: `ui.ObjectGridPropsSchema` is **value-agnostic** on
+this key — `sort` is `z.unknown().optional()`, so `safeParse` accepts
+`'name desc'`, `'name'`, `42`, `['name desc']` and `{ name: 'desc' }` alike,
+while an undeclared `bogusProp` is refused with `unrecognized_keys` (the
+control that shows those parse readings are real and not a schema that accepts
+everything). So the protocol's **validator** does not refuse the string, and
+this change is not a narrowing the validator already performed.
+
+What the protocol **declares and documents** is the array, in three places:
+that same key's own `describe` reads `Initial sort (array of { field, order })`;
+the sibling `ElementRecordPickerPropsSchema.sort` spells the identical intent as
+a typed `z.array(SortItemSchema)`, which refuses a string outright; and the
+`defaultSort` retirement text instructs authors to rename the key to `sort` and
+`wrap the value in an array`. The array is likewise the only spelling
 `ObjectGridSchema.sort` has declared since #8221, the only one the registered
-`sort` input publishes, and the only one `@objectstack/spec` accepts — so
-type-checked metadata is already on it, and only untyped JSON or a stored
-`sys_metadata` row can still carry the string.
+`sort` input publishes (`type: 'array'`), and the only one
+`convertSortToQueryParams` lowers. So type-checked metadata is already on it,
+and only untyped JSON or a stored `sys_metadata` row can still carry the string
+— which is exactly why the refusal is a loud runtime diagnostic rather than a
+type change.
 
 **What is deliberately unchanged.** The wire shape. The array arm still lowers
 to this block's own `"field order[, field order]"` join string, and the export

--- a/.changeset/8767-object-grid-refuses-string-sort.md
+++ b/.changeset/8767-object-grid-refuses-string-sort.md
@@ -1,0 +1,36 @@
+---
+'@object-ui/plugin-grid': minor
+---
+
+`object-grid` REFUSES the retired string `sort` clause at its own read site
+(objectui#8767, maintainer ruling 2026-09-10 — route C).
+
+**Breaking, deliberately.** A `sort: "name desc"` on an `object-grid` node no
+longer reaches `$orderby`. It is reported once per spelling with the diagnostic
+objectui#8221 / PR #8758 already ship — the message names the offending value
+and prescribes the array form — and the query goes out carrying no ordering at
+all, exactly as the same key already behaves on `object-view`.
+
+**Why it was still lowering.** The #8221 ruling retired the legacy string
+clause: one spelling, the array, everywhere. PR #8758 narrowed the shared sink
+`convertSortToQueryParams` and every declaration that published a string arm,
+but `ObjectGrid` never used that sink — it reads `schema.sort` and lowers it
+with private code, so a bare grid went on honouring at runtime a spelling
+`object-view` refuses. One key, two meanings, chosen by which block you are on
+— which is the per-block divergence the ruling declined by name when it
+rejected option A.
+
+**Migration.** Write the array: `sort: [{ field: 'name', order: 'desc' }]`
+(`order` is optional and means `'asc'`). That is the only spelling
+`ObjectGridSchema.sort` has declared since #8221, the only one the registered
+`sort` input publishes, and the only one `@objectstack/spec` accepts — so
+type-checked metadata is already on it, and only untyped JSON or a stored
+`sys_metadata` row can still carry the string.
+
+**What is deliberately unchanged.** The wire shape. The array arm still lowers
+to this block's own `"field order[, field order]"` join string, and the export
+path and the header-arrow reader `parseSchemaSort` still read the key exactly as
+before. Routing the whole key through the shared sink would send its
+`{ field: direction }` map where every grid today sends a string; that is a
+separate change with its own blast radius, and this ruling explicitly did not
+take it.

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -36,7 +36,7 @@ import {
   RefreshIndicator,
 } from '@object-ui/components';
 import { usePullToRefresh } from '@object-ui/mobile';
-import { resolveConditionalFormatting, leadWithNameField, buildExpandFields, buildExportFileName, columnIdentity, collectPredicateFieldRefs, collectGroupingFieldRefs, listViewPredicates, isObjectInlineEditable, isProjectableField, isExpandableFieldType, isUnmaterializedFieldType, readObjectSortability, isPlatformSortableField, filterPlatformSortableSort, toFilterNode, ROW_HEIGHT_TO_DENSITY_MODE, resolveRecordSourceConfig, resolveRecordSourceObjectName } from '@object-ui/core';
+import { resolveConditionalFormatting, leadWithNameField, buildExpandFields, buildExportFileName, columnIdentity, collectPredicateFieldRefs, collectGroupingFieldRefs, listViewPredicates, isObjectInlineEditable, isProjectableField, isExpandableFieldType, isUnmaterializedFieldType, readObjectSortability, isPlatformSortableField, filterPlatformSortableSort, toFilterNode, convertSortToQueryParams, type QuerySortEntry, ROW_HEIGHT_TO_DENSITY_MODE, resolveRecordSourceConfig, resolveRecordSourceObjectName } from '@object-ui/core';
 import { usePermissions } from '@object-ui/permissions';
 import { ChevronRight, ChevronLeft, ChevronsLeft, ChevronsRight, Download, Rows2, Rows3, Rows4, AlignJustify, Type, Hash, Calendar, CheckSquare, User, Tag, Clock, Loader2 } from 'lucide-react';
 import { useRowColor } from './useRowColor';
@@ -59,12 +59,21 @@ import type { BulkActionDef } from '@object-ui/types';
 /**
  * A view's declared `sort` → the shape the table's header indicators read.
  *
- * `@objectstack/spec` allows `"name desc"`, `["name desc", …]` and
- * `[{ field, order }, …]`, and this grid's own fetch path already reads all
- * three. The headers have to agree with it: a view that arrives sorted by
+ * `[{ field, order }, …]` is the ONE spelling `@objectstack/spec` still
+ * declares (objectui#8221 retired the string clauses). The headers have to
+ * agree with the fetch path on it: a view that arrives sorted by
  * `created_at desc` should show that arrow before anyone clicks anything —
  * otherwise the first click on that column produces `asc` while the list was
  * already `desc`, and the arrow tells the truth only from the second click on.
+ *
+ * ⚠️ This reader is WIDER than the fetch path as of objectui#8767, and the
+ * sentence this docblock used to carry — that the fetch path reads all three
+ * spellings — is no longer true. The fetch path now REFUSES a string and sends
+ * no `$orderby` at all, while this reader still parses `"name desc"` and
+ * `["name desc", …]`, so a grid authored with a retired spelling shows an
+ * arrow for an ordering its query does not carry. Narrowing this reader moves
+ * the wire shape and takes the export path with it — the route the #8767
+ * ruling deliberately did not take. It is NOT fixed here.
  *
  * Exported for the test that pins it against the fetch path's own reading.
  */
@@ -1851,7 +1860,30 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
             params.$orderby = headerSort.map((s) => ({ field: s.field, order: s.order }));
           } else if (schemaSort) {
             if (typeof schemaSort === 'string') {
-              params.$orderby = schemaSort;
+              // objectui#8767 — the legacy string `sort` clause is RETIRED
+              // (objectui#8221, decision batch #77) and is REFUSED here rather
+              // than lowered. This block owns a PRIVATE lowering, so #8758's
+              // narrowing of the shared sink never reached it: a bare
+              // `object-grid` went on honouring a spelling `object-view`
+              // already refuses — one key meaning two things depending on which
+              // block you are on, which is the per-block divergence the #8221
+              // ruling declined by name.
+              //
+              // The refusal is #8758's OWN, not a second one: calling the
+              // shared sink on this arm reports the retired spelling once per
+              // spelling and answers `undefined`, so the query carries no
+              // `$orderby`. Its return value is deliberately unused — the wire
+              // shape stays this block's, and the array arm below is untouched
+              // (with it the export path and `parseSchemaSort`). Routing the
+              // whole key through the sink is a different card: it would send
+              // the sink's `{field: direction}` map where every grid today
+              // sends a `"field order"` string.
+              //
+              // Read through `unknown`, exactly as the sink does: types are
+              // erased, so the array-only `ObjectGridSchema.sort` declaration
+              // cannot stop a string arriving from authored JSON, a stored
+              // `sys_metadata` row or an `as any` bag.
+              convertSortToQueryParams(schemaSort as unknown as QuerySortEntry[]);
             } else if (Array.isArray(schemaSort)) {
               params.$orderby = schemaSort
                 .map((s: any) => `${s.field} ${s.order}`)
@@ -4022,6 +4054,11 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
   // same sort. Without that a view arriving `created_at desc` would show no
   // arrow, and the first click on that column would ask for `asc` on a list
   // that was already `desc`.
+  //
+  // ⚠️ One spelling now escapes that agreement: since objectui#8767 the fetch
+  // path REFUSES a string `sort` and sends no `$orderby`, while
+  // {@link parseSchemaSort} still parses one. Closing that gap narrows this
+  // reader and moves the wire shape with it — the route #8767 did not take.
   //
   // A plain expression, not a `useMemo`: this sits below the component's early
   // returns, where a hook would be skipped on some renders and change the hook

--- a/packages/plugin-grid/src/__tests__/gridRetiredStringSort-8767.test.tsx
+++ b/packages/plugin-grid/src/__tests__/gridRetiredStringSort-8767.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `object-grid` REFUSES the retired string `sort` clause (objectui#8767).
+ *
+ * ## What was wrong
+ *
+ * The #8221 ruling (decision batch #77) retired the legacy OData-ish string
+ * clause: one spelling, the array, everywhere. PR #8758 narrowed the shared
+ * sink `convertSortToQueryParams` so a string that still arrives at runtime is
+ * refused out loud and the query carries no `$orderby`.
+ *
+ * `ObjectGrid` never went through that sink. It reads `schema.sort` at its own
+ * site and lowers it with private code, so after #8758 a bare `object-grid`
+ * still forwarded a string verbatim to `$orderby` while the SAME key routed
+ * through `object-view` was refused with a diagnostic — one key meaning two
+ * things depending on which block you are on. That is precisely the shape the
+ * ruling rejected when it declined option A by name:
+ *
+ *   > per-block arms would make one key mean different things on different
+ *   > blocks and keep a spelling the spec already refuses on one of them.
+ *
+ * ## What these tests pin, and what they deliberately do NOT
+ *
+ * Route C, as ruled: the string arm is refused with #8758's own reporter, and
+ * NOTHING else about this block moves. So the file has two halves, and the
+ * second is what stops it passing by refusing everything:
+ *
+ *   1. a string `sort` reaches no `$orderby`, and says so once per spelling;
+ *   2. the array arm still lowers to the very same `"field order"` join string
+ *      this block has always sent — byte for byte, single- and multi-key.
+ *
+ * The join string is the wire shape route B would change and route C keeps.
+ * The header-arrow reader `parseSchemaSort` and the export path read the same
+ * key and are untouched here; they belong to that other card.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+import { resetRetiredSortSpellingReports } from '@object-ui/core';
+// Registers `object-grid` and its `view:grid` alias.
+import '../index';
+
+function makeAdapter() {
+  return {
+    find: vi.fn().mockResolvedValue({
+      data: [{ id: '1', name: 'Acme', status: 'active' }],
+      total: 1,
+    }),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue({
+      name: 'account',
+      fields: { id: { type: 'text' }, name: { type: 'text' }, status: { type: 'text' } },
+    }),
+  };
+}
+
+/**
+ * Render the block and return the params of its first `find` call — the same
+ * harness shape as the sibling `gridDefaultFiltersLowering.test.tsx`, so both
+ * legs of this read site are observed through one lens.
+ */
+async function findParamsFor(schema: Record<string, unknown>) {
+  const adapter = makeAdapter();
+  render(
+    <SchemaRendererProvider dataSource={adapter as any}>
+      <SchemaRenderer schema={schema as any} />
+    </SchemaRendererProvider>,
+  );
+  await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+  return (adapter.find.mock.calls[0] as [string, any])[1];
+}
+
+const BASE = { type: 'object-grid', objectName: 'account', columns: [{ field: 'name' }] };
+
+/**
+ * The retired spelling, reached the only way it still can be. The declaration
+ * is `SortConfig[]` since #8221, so a string arrives from authored JSON, a
+ * stored `sys_metadata` row or an `as any` bag — never from a typed caller.
+ */
+const authoredAtRuntime = (sort: unknown) => ({ ...BASE, sort }) as Record<string, unknown>;
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  // The reporter dedupes per spelling in MODULE state. Without this reset the
+  // second test to assert the diagnostic would observe silence and pass for
+  // the wrong reason.
+  resetRetiredSortSpellingReports();
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+describe('object-grid — the retired string `sort` clause is REFUSED at this block’s own read site (objectui#8767)', () => {
+  it('carries NO `$orderby` for a string `sort`, and names the array form', async () => {
+    const params = await findParamsFor(authoredAtRuntime('name desc'));
+
+    // The defect in one line: this used to be the string `'name desc'`, i.e.
+    // the grid honoured at runtime what `object-view` refuses.
+    expect(params.$orderby).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(params, '$orderby')).toBe(false);
+
+    expect(errorSpy).toHaveBeenCalled();
+    const message = String(errorSpy.mock.calls[0][0]);
+    // #8758's OWN diagnostic, not a second one written here: it quotes the
+    // offending spelling and prescribes the array form, because a refusal with
+    // no prescription only moves the author's problem.
+    expect(message).toContain('"name desc"');
+    expect(message).toContain("[{ field: 'name', order: 'desc' }]");
+    expect(message).toContain('objectui#8221');
+  });
+
+  it('refuses a bare field string too — every retired spelling, not just the two-word one', async () => {
+    const params = await findParamsFor(authoredAtRuntime('name'));
+    expect(params.$orderby).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('reports once per spelling, not once per grid', async () => {
+    await findParamsFor(authoredAtRuntime('name desc'));
+    await findParamsFor(authoredAtRuntime('name desc'));
+    // Two blocks inheriting the same bad view sort print one line between them
+    // — the dedupe is the reporter's, and reusing it is what keeps this read
+    // site from becoming a second, differently-behaved diagnostic.
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fall through to the legacy `defaultSort` leg when it refuses', async () => {
+    // A refusal that quietly handed the query to the next arm would be a
+    // silent substitution — a different ordering than either the author asked
+    // for or the refusal announced.
+    const params = await findParamsFor({
+      ...authoredAtRuntime('name desc'),
+      defaultSort: { field: 'status', order: 'asc' },
+    });
+    expect(params.$orderby).toBeUndefined();
+  });
+});
+
+describe('CONTROL — the array arm lowers UNCHANGED (route C keeps this block’s wire shape)', () => {
+  it('still sends the single-key `"field order"` join string', async () => {
+    const params = await findParamsFor({ ...BASE, sort: [{ field: 'name', order: 'desc' }] });
+    // Byte-identical to what this block sent before #8767. Route B would send
+    // the shared sink's `{ name: 'desc' }` map here; that is a different card,
+    // and this line is what would catch it arriving by accident.
+    expect(params.$orderby).toBe('name desc');
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('still joins a multi-key array with `, `', async () => {
+    const params = await findParamsFor({
+      ...BASE,
+      sort: [
+        { field: 'status', order: 'asc' },
+        { field: 'name', order: 'desc' },
+      ],
+    });
+    expect(params.$orderby).toBe('status asc, name desc');
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-grid/src/__tests__/serverSorting.test.tsx
+++ b/packages/plugin-grid/src/__tests__/serverSorting.test.tsx
@@ -22,6 +22,7 @@ import React from 'react';
 
 import { ObjectGrid, parseSchemaSort } from '../ObjectGrid';
 import { registerAllFields } from '@object-ui/fields';
+import { resetRetiredSortSpellingReports } from '@object-ui/core';
 import { ActionProvider } from '@object-ui/react';
 
 registerAllFields();
@@ -159,15 +160,13 @@ describe('ObjectGrid — column-header sorting is server-side (#3106)', () => {
     // Otherwise the first click on that column asks for `asc` on a list that is
     // already `desc`, and the arrow only tells the truth from click two on.
     //
-    // ⚠️ This case deliberately still authors the RETIRED string spelling, and
-    // is left that way: it is the one place in the suite that shows the header
-    // reader (`parseSchemaSort`) is now WIDER than the fetch path — since
-    // objectui#8767 the query carries no `$orderby` for this schema while the
-    // arrow below still appears. Narrowing the reader moves the wire shape and
-    // the export path with it; that is the route-B card #8767 did not take, so
-    // the divergence is recorded here rather than papered over.
+    // Authored in the ONE declared spelling. This case used to author the
+    // retired string clause; the subject is the header behaviour and the
+    // spelling was incidental, so it moves to the array for the same reason
+    // the sibling case above did. What a string does to this same schema is
+    // pinned deliberately, in the case below.
     const ds = makeDataSource();
-    const { container } = renderGrid(ds, { sort: 'status desc' });
+    const { container } = renderGrid(ds, { sort: [{ field: 'status', order: 'desc' }] });
     await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
 
     expect(headerCell(container, 'Status').querySelector('[class*="chevron-down"]')).not.toBeNull();
@@ -177,6 +176,48 @@ describe('ObjectGrid — column-header sorting is server-side (#3106)', () => {
     await waitFor(() => {
       expect(lastFindParams(ds).$orderby).toEqual([{ field: 'status', order: 'asc' }]);
     });
+  });
+
+  it('DIVERGENCE, pinned not tolerated (objectui#8961): a retired STRING sort still draws the arrow while the wire carries NO ordering', async () => {
+    // objectui#8767 made the fetch path REFUSE a string `sort`. The header
+    // indicators are fed by `parseSchemaSort`, a second private reader that
+    // the ruling deliberately left alone — and it still parses a string. So
+    // the two readers of one key now disagree, and this asserts BOTH halves of
+    // that disagreement.
+    //
+    // Asserting only the arrow (which is what this file did before) leaves a
+    // green test that reads as "string sort ⇒ arrow, as intended". A green
+    // test does not make a divergence visible; it certifies it. Naming both
+    // halves is what makes the state a recorded defect instead of an expected
+    // one, and makes THIS the case that has to change when objectui#8961
+    // closes the gap — narrowing the reader moves the wire shape and takes the
+    // export path with it, the route objectui#8767 did not take.
+    resetRetiredSortSpellingReports();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const ds = makeDataSource();
+      const { container } = renderGrid(ds, { sort: 'status desc' });
+      await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+
+      // Half one — the header still tells the user this list is `status desc`.
+      expect(
+        headerCell(container, 'Status').querySelector('[class*="chevron-down"]'),
+      ).not.toBeNull();
+
+      // Half two — and the query it was fetched with carries no ordering at
+      // all. `hasOwnProperty`, not `toBeUndefined`: the key is absent, which is
+      // a different claim from "present and undefined".
+      const params = lastFindParams(ds);
+      expect(Object.prototype.hasOwnProperty.call(params, '$orderby')).toBe(false);
+
+      // …and the disagreement is announced once, by PR #8758's own reporter.
+      const retired = errorSpy.mock.calls.filter((c) =>
+        String(c[0]).includes('objectui#8221'),
+      );
+      expect(retired).toHaveLength(1);
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it('withholds the sort affordance from a relational column (#3096)', async () => {
@@ -195,7 +236,16 @@ describe('ObjectGrid — column-header sorting is server-side (#3106)', () => {
   });
 });
 
-describe('parseSchemaSort — the header reads what the fetch path reads', () => {
+/**
+ * ⚠️ This block pins the header reader's OWN contract, which since
+ * objectui#8767 is WIDER than the fetch path's — hence the renamed title. The
+ * cases below still admit the retired string spellings because this reader
+ * still admits them; the fetch path refuses them (see the divergence pin
+ * above). Re-judging these inputs belongs to objectui#8961, which narrows this
+ * reader and moves the wire shape with it. Until then they are read as "what
+ * `parseSchemaSort` accepts", never as "what the grid queries with".
+ */
+describe('parseSchemaSort — the header reader\'s own contract, wider than the fetch path (objectui#8961)', () => {
   it('reads the bare-string form', () => {
     expect(parseSchemaSort('name desc')).toEqual([{ field: 'name', order: 'desc' }]);
   });

--- a/packages/plugin-grid/src/__tests__/serverSorting.test.tsx
+++ b/packages/plugin-grid/src/__tests__/serverSorting.test.tsx
@@ -138,9 +138,14 @@ describe('ObjectGrid — column-header sorting is server-side (#3106)', () => {
 
   it('replaces the view\'s declared sort rather than stacking on it', async () => {
     const ds = makeDataSource();
-    const { container } = renderGrid(ds, { sort: 'name desc' });
+    const { container } = renderGrid(ds, { sort: [{ field: 'name', order: 'desc' }] });
     await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
-    // The declared sort goes out as the string form it was authored in.
+    // Authored in the ONE declared spelling. This case used to author the
+    // retired string clause and assert that it went out verbatim; objectui#8767
+    // made this block REFUSE a string (objectui#8221), so a string here would
+    // reach no `$orderby` at all and the click would have nothing to replace.
+    // The array arm still lowers to this block's own `"field order"` string —
+    // unchanged, which is the point of route C.
     expect(lastFindParams(ds).$orderby).toBe('name desc');
 
     fireEvent.click(headerCell(container, 'Status'));
@@ -153,6 +158,14 @@ describe('ObjectGrid — column-header sorting is server-side (#3106)', () => {
   it('shows the view\'s declared sort before anyone clicks', async () => {
     // Otherwise the first click on that column asks for `asc` on a list that is
     // already `desc`, and the arrow only tells the truth from click two on.
+    //
+    // ⚠️ This case deliberately still authors the RETIRED string spelling, and
+    // is left that way: it is the one place in the suite that shows the header
+    // reader (`parseSchemaSort`) is now WIDER than the fetch path — since
+    // objectui#8767 the query carries no `$orderby` for this schema while the
+    // arrow below still appears. Narrowing the reader moves the wire shape and
+    // the export path with it; that is the route-B card #8767 did not take, so
+    // the divergence is recorded here rather than papered over.
     const ds = makeDataSource();
     const { container } = renderGrid(ds, { sort: 'status desc' });
     await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());


### PR DESCRIPTION
Fixes #8767

Authored by the `os-dev` seat of session `https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w`. That reference is written here as prose in a code span on purpose: an attribution footer on a pull request body is normalised to the session-URL form on creation and degraded back to the bare form by every later edit, so a PR that is edited even once loses the reference from its footer. The code span survives the edit path.

Route C, as ruled by the maintainer on 2026-09-10: keep the wire shape; make `ObjectGrid` REFUSE a string `schema.sort` with PR #8758's own diagnostic, before its own lowering. Route B (routing the whole key through the shared sink) and route A (leave it) were both declined on the card and are not re-opened here.

> **Rework round — head `52d28eb4b`.** The contract review returned **`VERDICT: REWORK`** with two bounded items, adopted verbatim by the dispatching seat. The refusal mechanism, the control pins, the `minor` grading and #8961's parking were judged correct and are untouched: `ObjectGrid.tsx` is **byte-identical** to the reviewed head `76a9ead40` (`git diff --name-only 76a9ead40..HEAD` names only the changeset and one test file). What follows describes the PR as it now stands; the two repairs have their own section below.

## Rework: the two repairs

### R1 — two sentences in the changeset were false about the contract

Both were claims about the **spec**, and both were wrong. Re-derived on this branch rather than taken from the review.

**(a) "the only one `@objectstack/spec` accepts".** False. Measured against the installed `@objectstack/spec@17.4.0` by calling `ui.ObjectGridPropsSchema.safeParse` directly:

| input on `sort` | verdict |
| --- | --- |
| `'name desc'` | PARSES |
| `'name'` | PARSES |
| `42` | PARSES |
| `['name desc']` | PARSES |
| `{ name: 'desc' }` | PARSES |
| `[{ field: 'name', order: 'desc' }]` | PARSES |
| an undeclared `bogusProp` — **CONTROL** | REFUSED, `unrecognized_keys` |

The control is what makes the six PARSES a reading rather than a schema that accepts anything. The cause is in the protocol source: `ObjectGridPropsSchema.sort` is `z.unknown().optional()`, so the protocol simply does **not police** this field.

`z.unknown()` is the protocol declining to police, not the protocol blessing the string — and what the protocol **declares and documents** is the array, in three independent places, all re-read on `objectstack` for this round:

- the same key's own `describe`: `Initial sort (array of { field, order })`;
- the sibling `ElementRecordPickerPropsSchema.sort`, which spells the identical intent as a typed `z.array(SortItemSchema)` — measured: it PARSES `[{ field: 'name', order: 'desc' }]`, REFUSES `'name desc'` (`invalid_type` at the root) and REFUSES `['name desc']` (`invalid_type` at `0`);
- the `defaultSort` retirement text, which instructs authors to rename the key to `sort` and **wrap the value in an array**.

⇒ Route C moves this block **toward** the protocol's declared shape. But the sentence still had to be repaired rather than defended, because "the only one the spec accepts" is a claim about the **validator**, and the validator accepts the string. The changeset now makes the true claim — about what the protocol declares — and states plainly that the validator does not refuse the string.

**(b) "(`order` is optional and means `'asc'`)".** False twice over.

- `SortConfig.order` is **required** on both declared faces: `packages/types/src/objectql.ts` (`order: 'asc' | 'desc'`, no `?`) and its zod mirror `packages/types/src/zod/objectql.zod.ts` (`z.enum(['asc','desc'])`, no `.optional()`). The protocol agrees: its reusable `SortItemSchema` requires `order` — measured, `z.array(SortItemSchema).safeParse([{ field: 'name' }])` refuses with `invalid_value` at `0.order`.
- And on **this block** the advice is actively harmful. The untouched array arm interpolates every key unconditionally, so an omitted `order` lowers to `$orderby: 'name undefined'`. That sentence came from the shared sink's own diagnostic, which this PR now makes `object-grid` print — so the grid was prescribing a migration that produces garbage on the grid.

The changeset now says both keys are required and names that behaviour. ⛔ The defect itself is **pre-existing on the arm this PR does not touch**, and widening the diff to reach it is the direction the ruling refused. It is therefore out of scope here, and carried instead by **#8973**, which holds the full probe table. (Deliberate wording: a closing keyword must never sit near another card's number — the merge parser matches keyword-plus-reference and does not read negation, so a sentence saying a card is *not* addressed would close it anyway.)

### R2 — a defect was frozen green in `serverSorting.test.tsx`

The review is right, and right by this PR's *own* principle. The sibling case at `:141` was re-authored in the array spelling precisely so a pin would stop asserting something the wire no longer does; the arrow case was then left authoring the retired string, **green**, while the wire carries no ordering — the same shape, kept. Leaving the divergence visible was the correct instinct; leaving it visible as a green test that asserts only the arrow is not, because a green test does not expose a state, it **certifies** it.

Three edits, one stroke:

1. the arrow case's fixture is re-authored in the declared array spelling, for the same reason `:141` was;
2. the string's behaviour becomes an **explicit pin naming #8961**, asserting **both** halves — the arrow is drawn, `hasOwnProperty(params, '$orderby')` is `false`, and exactly one retired-spelling diagnostic is emitted. That case is now the one that has to change when #8961 closes the gap;
3. the `parseSchemaSort` `describe` title — *"the header reads what the fetch path reads"*, falsified by this PR and left standing while two `ObjectGrid.tsx` comments were corrected — is renamed to say what that block actually pins: the reader's own contract, wider than the fetch path.

## The measurement, re-derived on this branch's own base `72bcd7783`

Precondition, by commit and ancestry rather than by an API field:

```
git log origin/main --oneline --grep="(#8758)"                    -> rc 0, 1 match  (9a853f2f3)
git merge-base --is-ancestor 9a853f2f3abc9... origin/main          -> rc 0
git merge-base --is-ancestor <root commit> origin/main             -> rc 0   (control leg)
git rev-parse --is-shallow-repository                              -> false  (fresh full clone)
```

The control leg matters because a negative `--is-ancestor` on a shallow checkout is a false negative; this clone is not shallow and the control answers 0, so the positive reading stands on its own.

The divergence itself, on the same base:

- `convertSortToQueryParams` (`packages/core/src/utils/sort-query.ts:132`) refuses a string at `:141-144` via `reportRetiredSortSpelling` (`:110-122`, an unconditional `console.error`, deduped per spelling) and returns `undefined`.
- `packages/plugin-grid/src/ObjectGrid.tsx:1465` takes `const schemaSort = schema.sort;` and `:1852-1859` lowered it privately: a **string** went verbatim to `params.$orderby`; an **array** became a `"field order, field order"` join string.
- FIRING CONTROL, same command: `convertSortToQueryParams` lights up seven sibling packages non-test under `src/` — `plugin-calendar`, `plugin-gantt`, `plugin-map`, `plugin-timeline`, `plugin-view`, `plugin-form`, `app-shell` — and `plugin-grid` = 0, absent from `ObjectGrid.tsx:39`'s `@object-ui/core` import list. So "ObjectGrid is not among them" is a reading, not an assumption.

## What changed, and why it is the minimal route-C change

One arm moves. In `ObjectGrid`'s own query memo the string arm no longer assigns `$orderby`; it calls the shared sink for its refusal alone:

```ts
if (typeof schemaSort === 'string') {
  convertSortToQueryParams(schemaSort as unknown as QuerySortEntry[]);
} else if (Array.isArray(schemaSort)) {
  // unchanged
}
```

Three consequences worth stating explicitly:

1. **No second reporter.** `reportRetiredSortSpelling` is module-private to `sort-query.ts`, and the dispatch forbids changing that shared file. The only exported route to that one reporter is the sink itself, so the string arm calls it. The diagnostic, its wording and its once-per-spelling dedupe are all #8758's, unmodified.
2. **The wire shape does not move.** The sink's return value is deliberately unused. The array arm still emits this block's own `"field order"` join string, so the export path (`:3046`) and the header-arrow reader `parseSchemaSort` (`:4029`) read exactly what they read before. Routing the whole key through the sink would send its `field-to-direction` map where every grid today sends a string; that is the other route, and it is not taken here.
3. **The refusal does not fall through.** A refused string still consumes the `else if (schemaSort)` branch, so it does not silently hand the query to the legacy `defaultSort` arm. Pinned.

## The join-string pins — including a third one the dispatch did not name

The dispatch flagged two live `expect(params.$orderby).toBe('name desc')` pins and asked which, if any, author a **string**. Read end to end:

| pin | authored `sort` | verdict |
| --- | --- | --- |
| `ObjectGrid.elementDataSource.test.tsx:75` | `HOT_VIEW.sort = [{ field: 'name', order: 'desc' }]` — **array** | untouched, stays green |
| `gridDefaultFiltersLowering.test.tsx:275` | `defaultSort: { field: 'name', order: 'desc' }` — the **legacy `defaultSort` leg**, not `sort` | untouched, stays green |
| `gridDefaultFiltersLowering.test.tsx:286` | `sort: [{ field: 'name', order: 'desc' }]` — **array** | untouched, stays green |

Neither of the two named pins authors a string. **A third one does**, and it is not in the dispatch's list:

- `packages/plugin-grid/src/__tests__/serverSorting.test.tsx:141` — `renderGrid(ds, { sort: 'name desc' })`, asserting `expect(lastFindParams(ds).$orderby).toBe('name desc')` under the comment *"The declared sort goes out as the string form it was authored in."* That is a direct pin of the retired lowering at this exact read site — this card's own subject — and it would have gone red.

Its test name is *"replaces the view's declared sort rather than stacking on it"*: its subject is objectui#3106's header click, and the string spelling was incidental to it. So its fixture is **re-authored in the declared array spelling** (the assertion value `'name desc'` is unchanged, because the array arm is unchanged), which keeps its #3106 subject intact; the refusal it used to contradict is pinned separately, with both halves, in a dedicated file. Saying which, rather than editing quietly.

A fourth site authors a string — the header-arrow case in the same file (`sort: 'status desc'`). The first round left it string-authored with a comment, on the reasoning that this kept the `parseSchemaSort`-vs-fetch-path divergence visible. ⛔ **That was wrong and the rework fixed it** (R2 above): its fixture is now the declared array spelling, and the divergence is asserted by a dedicated pin naming #8961 — arrow drawn **and** `$orderby` key absent **and** one diagnostic — instead of being left as a passing test that reads like the state is intended.

## Two comments this change falsifies, corrected — comment only

Both are claims that were true before this commit and are not after it. Neither touches behaviour:

- `ObjectGrid.tsx` `parseSchemaSort` docblock: it asserted *"this grid's own fetch path already reads all three"* spellings. It no longer does. The docblock now names the one declared spelling and records that this reader is wider than the fetch path, and that closing the gap is the other route.
- `ObjectGrid.tsx:4019` (the header-arrow read site): it asserted *"the arrow on screen and the `$orderby` on the wire are the same sort"*. One spelling now escapes that, and the comment says so.

## Ablation — every mutation proven on disk before any result was read

Resolution path first: `plugin-grid` tests import `../ObjectGrid` by relative path, and the root vitest config aliases every `@object-ui/*` specifier to that package's `src`. Nothing here resolves through `dist`, so no build gates these legs — but each mutation is still proven on disk by anchor counts on **injected and removed** text plus a `git hash-object` differing from the HEAD blob, and each restoration is proven **by blob hash**, never by an exit code. Both legs restore from `trap ... EXIT INT TERM` using absolute paths and `git checkout HEAD -- PATH`.

HEAD blob of `packages/plugin-grid/src/ObjectGrid.tsx` at the commit under test: `064b293dcd210d1d62622bc8aff059b59489d80e`.

Predictions were recorded before each run.

**Leg 1 — delete the refusal** (restore `params.$orderby = schemaSort;`).

```
PROOF injected('ABLATION_8767_LEG1')=1  removed_text_still_present=0
      hash=fe6a396fb4b0f1abb2c9c017e23531edf791839c  head=064b293dcd...
RESTORE: hash-object=064b293dcd...  head=064b293dcd...  -> identical, git diff HEAD empty
```

Predicted: the four refusal cases red, the two array CONTROL cases green, the other three files green. Observed, exactly:

```
gridRetiredStringSort-8767.test.tsx (6 tests | 4 failed)
Test Files  1 failed | 3 passed (4)
     Tests  4 failed | 32 passed (36)
```

**Leg 2 — mutate the ARRAY arm** (` `${s.field} ${s.order}` ` becomes ` `${s.field}:${s.order}` `; a separator-only mutation would have been invisible on a single-key sort).

```
PROOF injected('ABLATION_8767_LEG2')=1  removed_text_still_present=0
      hash=930650a794ab2d40e8ef08444b52bd31b1fb275f  head=064b293dcd...
RESTORE: hash-object=064b293dcd...  head=064b293dcd...  -> identical, git diff HEAD empty
```

Predicted: the two array CONTROL cases red, both surviving join-string pins red, the re-authored `serverSorting` case red, the four refusal cases green, and — the asymmetry that makes it a control — `gridDefaultFiltersLowering:275` (the legacy `defaultSort` leg, a different code path) green. Observed, exactly:

```
gridRetiredStringSort-8767.test.tsx   (6 tests | 2 failed)   <- the two CONTROL cases
gridDefaultFiltersLowering.test.tsx  (15 tests | 1 failed)   <- :286 only; :275 green
serverSorting.test.tsx               (11 tests | 1 failed)
ObjectGrid.elementDataSource.test.tsx (4 tests | 1 failed)
Test Files  4 failed (4)
     Tests  5 failed | 31 passed (36)
```

Leg 1 says the refusal is what makes the new pin pass. Leg 2 says the array assertions really measure the join output — so "the array arm still produces the same `$orderby` it does today" is a measurement, not a vacuous claim — and that the pin cannot pass by refusing everything.

## Verification

Exit codes captured into files **before** any pipe; heavy runs serialized through the container's shared verify lock and read from its `VERDICT` line.

| run | result |
| --- | --- |
| `pnpm exec vitest run packages/plugin-grid/` | exit 0 — `Test Files 121 passed (121)`, `Tests 1070 passed (1070)` |
| `pnpm exec vitest run` on the four sort files, final tree | exit 0 — `Test Files 4 passed (4)`, `Tests 36 passed (36)` |
| cross-package readers of `ObjectGrid.tsx` plus `sort-query.test.ts` and `ObjectView.sortSink.test.tsx` | exit 0 — `Test Files 6 passed (6)`, `Tests 50 passed (50)` |
| `turbo run type-check --filter=@object-ui/plugin-grid --concurrency=2` | exit 0 — 14 tasks successful; log echoes `> @object-ui/plugin-grid@17.6.0 type-check` and `> tsc --noEmit && tsc -p tsconfig.test.json` |
| `pnpm --filter @object-ui/plugin-grid lint` | exit 0 — log echoes `> @object-ui/plugin-grid@17.6.0 lint` / `> eslint .`; `✖ 794 problems (0 errors, 794 warnings)`; **zero** lines matching the eslint severity-error shape and **zero** occurrences of the literal lowercase word `error` anywhere in the log |
| `node scripts/check-changeset-presence.mjs` | exit 0 — 2 published source files changed, 1 changeset declared |
| `pnpm changeset:check` | exit 0 — fixed group OK, no `major` declared |
| `pnpm check:control-bytes` | exit 0 — 7166 tracked text files scanned |
| `node scripts/check-governed-queue-guard.mjs --test` on all four changed paths | exit 0 — NOT GOVERNED, none of the five governed surfaces matched |

Re-run on the rework head `52d28eb4b`:

| run | result |
| --- | --- |
| the five sort-affected `plugin-grid` test files | exit 0 — `Test Files 5 passed (5)`, `Tests 45 passed (45)` |
| `turbo run type-check --filter=@object-ui/plugin-grid --concurrency=2` | exit 0 — 14 tasks successful |
| `pnpm --filter @object-ui/plugin-grid lint` | exit 0 — script name echoed; `✖ 794 problems (0 errors, 794 warnings)`; **zero** severity-error lines and **zero** occurrences of the literal lowercase word `error` |
| `node scripts/check-changeset-presence.mjs` | exit 0 — 3 published source files changed, 1 changeset declared |
| `pnpm changeset:check` | exit 0 |
| `pnpm check:control-bytes` | exit 0 — 7166 tracked text files |

⚠️ **Declared narrowing on the rework round.** The full 121-file `plugin-grid` suite was **not** re-run locally on `52d28eb4b`. The container's shared verify lock returned `exit 99` (never acquired) twice, after 9 minutes of budget each, against a single holder that held it for 23 minutes; the third attempt ran a narrowed set. The narrowing is sound rather than merely convenient: the only source file this round changed is `serverSorting.test.tsx`, which nothing imports, plus a `.changeset/*.md`; `ObjectGrid.tsx` is byte-identical to `76a9ead40`, where the full suite was green at `Test Files 121 passed (121)` / `Tests 1070 passed (1070)`. CI runs the whole farm on the pushed head.

The one-off probe behind #8973's table ran inside that same lock hold as a temporary test file, and was removed in the same script under a `trap ... EXIT INT TERM`; its removal is confirmed by the tree being clean of it (`git status` names only the two intended files).

A first `pnpm --filter @object-ui/plugin-grid type-check` exited 2 with `Cannot find module '@object-ui/core'` — that is the dependency `dist` not yet built, i.e. PREREQUISITE NOT MET, not a red gate. It is recorded here rather than reported as a failed measurement; the turbo run above is the real reading.

## Scope

`packages/plugin-grid/**` plus one `.changeset/*.md`. `packages/core/src/utils/sort-query.ts` is **read and reused, not changed**. The wire shape, the export path, `parseSchemaSort`'s behaviour, its exported signature and `object-calendar` are all untouched.

Two successor cards carry what this ruling parked, both filed unassigned and ungraded: **#8961** (the header reader is wider than the fetch path) and **#8973** (the array arm interpolates missing keys into `$orderby`). They are two halves of one question — `object-grid` still owns two private lowerings of a key every sibling block routes through the shared sink — and #8973 says so, so triage may fold it into #8961 if it prefers one card.

---
_Generated by [Claude Code](https://claude.ai/code)_