### PR TITLE
fix(app-shell): route the metadata-admin dataset preview through the dimension-label net (objectui#8187)

### DIFF
--- a/.changeset/8187-dataset-preview-dimension-labels.md
+++ b/.changeset/8187-dataset-preview-dimension-labels.md
@@ -1,0 +1,51 @@
+---
+'@object-ui/app-shell': minor
+---
+
+The metadata-admin dataset preview resolves its dimension values to labels, like every other analytics chart on the platform.
+
+`@object-ui/core` exports one dimension-label net (`loadDimensionFieldMeta` →
+`resolveDimensionFieldMeta` → `deriveDimensionLabelMaps` / `localizeFieldOptions`
+→ `relabelDimensions`, objectui#4030 / PR #4324, widened by objectui#4330 /
+PR #4388), with the React half — the authenticated read and its locale-free memo
+— stated once in `@object-ui/react`'s `useDatasetDimensionLabels` (objectui#4389).
+Enumerating the analytics chart producers by their every non-test call site of
+`buildChartSeries` gives exactly three, and all three relabel immediately before
+charting: `plugin-dashboard`'s `DatasetWidget`, `plugin-report`'s
+`DatasetReportRenderer`, and `plugin-charts`' `ObjectChart`.
+
+`DatasetPreview` is a fourth analytics chart on a different construction, and it
+fell outside that enumeration because it never calls `buildChartSeries` — it
+handed `state.rows` to `ChartRenderer` exactly as they arrived. Nothing was
+missing structurally: the draft carries the base object and each dimension's
+field path, and the preview already resolved its measure captions through
+`headerLabel`. The call simply was not made, and nothing in the file declared
+the omission deliberate.
+
+Two user-visible readings change, and they are two different defects:
+
+- a **dotted** dimension (`crm_account.industry`) plotted the **raw stored
+  value**. The server resolves nothing for a dotted path — the options live on
+  the relationship's target — so without the client net there was nothing on the
+  axis but the enum (`MFG`). This is objectui#4053 / #4263's shape, one surface
+  over;
+- a **local** select plotted the object's **authored English** label on every
+  locale, objectui#4330's shape.
+
+Neither threw and neither was red: the axis rendered a plausible string where a
+label belonged. That matters most on this particular surface, because it is the
+screen an author uses to decide whether their dataset is right — a raw enum here
+reads as "my dataset is wrong" and invites editing a configuration that was
+correct.
+
+The rows are relabelled ONCE and fed to both the chart and the result table
+below it, which is what `DatasetWidget` and `DatasetReportRenderer` do for the
+same reason: relabelling only the axis would put `Manufacturing` on a bar and
+`MFG` in the row directly beneath it.
+
+Behaviour is unchanged wherever the net resolves nothing. The read is
+best-effort by construction — an unreachable relationship, a field with no
+`options`, or a failed metadata read leaves the rows exactly as the server sent
+them — and `relabelDimensions` is idempotent and never touches measure columns,
+so a server-resolved value passes straight through. No new vocabulary, config
+key or public surface: this is the existing net's fourth call site.

--- a/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.measureLocale.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.measureLocale.test.tsx
@@ -28,7 +28,7 @@
  */
 
 import * as React from 'react';
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 // Same pre-warm as the sibling `DatasetPreview.test.tsx`, for the same reason:
 // the preview renders its chart behind `React.lazy(() => import(...))`, and
@@ -46,9 +46,31 @@ vi.mock('../../../providers/AdapterProvider', () => ({
   useAdapter: () => ({ queryDataset }),
 }));
 
+/**
+ * objectui#8187 — the preview now resolves its dimensions' option labels
+ * through the shared label net, which issues `GET /api/v1/meta/object/<name>`.
+ * happy-dom resolves that relative URL against `localhost:3000`, so without a
+ * double every test here reaches a real socket and the network-escape guard
+ * (objectui#6640) fails the file.
+ *
+ * The double serves the base object with NO select options, which is what these
+ * cases have always assumed: nothing resolves, `relabelDimensions` returns the
+ * server's rows by identity, and every assertion below is byte-identical to
+ * what it pinned before that card. Label resolution itself is pinned in
+ * `__tests__/DatasetPreview.dimensionLabels-8187.test.tsx`, not here.
+ */
+const realFetch = global.fetch;
+beforeEach(() => {
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ item: { name: 'opportunity', fields: {} } }),
+  })) as any;
+});
+
 afterEach(() => {
   cleanup();
   queryDataset.mockReset();
+  global.fetch = realFetch;
 });
 
 /**

--- a/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
 // DatasetPreview renders its chart behind
 // `React.lazy(() => import('@object-ui/plugin-charts'))`, and the "use the right
@@ -25,9 +25,31 @@ vi.mock('../../../providers/AdapterProvider', () => ({
   useAdapter: () => ({ queryDataset }),
 }));
 
+/**
+ * objectui#8187 — the preview now resolves its dimensions' option labels
+ * through the shared label net, which issues `GET /api/v1/meta/object/<name>`.
+ * happy-dom resolves that relative URL against `localhost:3000`, so without a
+ * double every test here reaches a real socket and the network-escape guard
+ * (objectui#6640) fails the file.
+ *
+ * The double serves the base object with NO select options, which is what these
+ * cases have always assumed: nothing resolves, `relabelDimensions` returns the
+ * server's rows by identity, and every assertion below is byte-identical to
+ * what it pinned before that card. Label resolution itself is pinned in
+ * `__tests__/DatasetPreview.dimensionLabels-8187.test.tsx`, not here.
+ */
+const realFetch = global.fetch;
+beforeEach(() => {
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ item: { name: 'opportunity', fields: {} } }),
+  })) as any;
+});
+
 afterEach(() => {
   cleanup();
   queryDataset.mockReset();
+  global.fetch = realFetch;
 });
 
 const baseProps = { type: 'dataset', name: 'sales', locale: 'en-US' as const };

--- a/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.tsx
@@ -25,8 +25,10 @@ import {
   formatMeasure,
   formatDimensionValue,
   buildDatasetFieldHelpers,
+  relabelDimensions,
   type DatasetResultField,
 } from '@object-ui/core';
+import { useDatasetDimensionLabels } from '@object-ui/react';
 import { builtinAggregateLabels, useSafeFieldLabel, useSafeTranslate, useDisplayLocale } from '@object-ui/i18n';
 
 // Lazy-loaded so the (recharts-backed) chart bundle only loads when a dataset
@@ -70,6 +72,43 @@ export function DatasetPreview({ draft }: MetadataPreviewProps) {
     const d = Array.isArray((draft as any).dimensions) ? ((draft as any).dimensions as Array<Record<string, unknown>>) : [];
     return d.map((x) => String(x?.name ?? '')).filter(Boolean);
   }, [draft]);
+
+  /**
+   * The dataset's `dimension name -> field path` map, read off the DRAFT.
+   *
+   * This is the same map the analytics result reports as `dimensionFields` and
+   * that the three other producers feed the net from — but the draft is the
+   * authority HERE, because this surface previews a possibly-unsaved dataset:
+   * the draft's `dimensions[].field` is present before any server round-trip,
+   * and no result echo is needed to know it. A dotted path (`crm_account
+   * .industry`) resolves against the relationship TARGET, which is the whole
+   * reason the path — not the dimension name — is what the net walks.
+   */
+  const dimensionFields = React.useMemo(() => {
+    const d = Array.isArray((draft as any).dimensions) ? ((draft as any).dimensions as Array<Record<string, unknown>>) : [];
+    const out: Record<string, string> = {};
+    for (const x of d) {
+      const name = String(x?.name ?? '');
+      const field = String(x?.field ?? '');
+      if (name && field) out[name] = field;
+    }
+    return out;
+  }, [draft]);
+
+  // objectui#8187 — the dimension-label net (objectui#4030 / PR #4324, widened
+  // by objectui#4330 / PR #4388), at its FOURTH call site. Analytics groups by
+  // a select's STORED value and resolves nothing at all for a dotted path, so
+  // without this the axis below plots `MFG` where `Manufacturing` belongs — and
+  // a local select plots the object's authored English on every locale. This is
+  // the screen an author uses to judge "is my dataset right?", so a raw enum
+  // here reads as "my dataset is wrong" and invites editing a correct one.
+  //
+  // The hook is the shared React half of that one net (`@object-ui/react`, the
+  // glue objectui#4389 stated once) — it holds the authenticated read and keeps
+  // the fetched metadata LOCALE-FREE, so switching language re-labels in place
+  // instead of re-fetching. Called above the early returns below, as the rules
+  // of hooks require; it issues no read when there is no object or no dimension.
+  const dimensionLabels = useDatasetDimensionLabels(objectName, dimensionFields, dimensionNames);
 
   const canRun = !!objectName && measureNames.length > 0;
 
@@ -147,6 +186,18 @@ export function DatasetPreview({ draft }: MetadataPreviewProps) {
     builtinAggregateLabels(tt),
   );
   const columns = [...dimensionNames, ...measureNames];
+  /**
+   * The rows as they are DISPLAYED — dimension values resolved to their option
+   * labels. Derived once and fed to BOTH the chart and the table, exactly as
+   * `DatasetWidget` and `DatasetReportRenderer` do: relabelling only the axis
+   * would put `Manufacturing` on a bar and `MFG` in the row directly beneath it.
+   *
+   * Idempotent and best-effort by construction — a value with no mapping (the
+   * server already resolved it, a lookup id, free text) passes through, and a
+   * failed metadata read leaves `dimensionLabels` null and returns `state.rows`
+   * by identity. Measure columns are never touched.
+   */
+  const displayRows = relabelDimensions(state.rows, dimensionLabels);
 
   // A ratio/percent measure (format like `0.0%`) on the same axis as a
   // magnitude measure (currency in the hundred-thousands) renders as an
@@ -209,7 +260,7 @@ export function DatasetPreview({ draft }: MetadataPreviewProps) {
               <div className="rounded-md border p-2">
                 <ChartRenderer
                   schema={{
-                    data: state.rows as Array<Record<string, unknown>>,
+                    data: displayRows,
                     xAxisKey: dimensionNames[0],
                     chartType: mixedScale ? 'combo' : 'bar',
                     series: measureNames.map((m) => ({
@@ -240,7 +291,7 @@ export function DatasetPreview({ draft }: MetadataPreviewProps) {
                 </tr>
               </thead>
               <tbody>
-                {state.rows.map((row, i) => (
+                {displayRows.map((row, i) => (
                   <tr key={i} className="border-t">
                     {columns.map((c) => (
                       <td key={c} className="px-2 py-1 tabular-nums whitespace-nowrap">

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/DatasetPreview.dimensionLabels-8187.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/DatasetPreview.dimensionLabels-8187.test.tsx
@@ -1,0 +1,310 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#8187 — the metadata-admin dataset PREVIEW goes through the
+ * dimension-label net, like the platform's three other analytics chart
+ * producers (`plugin-dashboard`'s `DatasetWidget`, `plugin-report`'s
+ * `DatasetReportRenderer`, `plugin-charts`' `ObjectChart`).
+ *
+ * ## The defect shape, and why a green suite proved nothing
+ *
+ * The preview handed `state.rows` to `ChartRenderer` exactly as they arrived,
+ * so the x axis plotted whatever the analytics layer grouped by. Nothing threw
+ * and nothing was red: the axis rendered a PLAUSIBLE string (`MFG`) where a
+ * label (`Manufacturing`) belonged. This surface is the screen an author uses
+ * to judge "is my dataset right?", so a raw enum here reads as "my dataset is
+ * wrong" and invites editing a correct configuration.
+ *
+ * ## The two arms, which are two different defects
+ *
+ *  - **dotted dimension** (objectui#4053 / #4263): the server resolves NOTHING
+ *    for a dotted path (`crm_account.industry`) — the options live on the
+ *    relationship's TARGET — so the rows carry the stored enum and only the
+ *    client net can produce a label;
+ *  - **local select** (objectui#4330): a local dimension arrives
+ *    server-resolved to the object's AUTHORED English label, which is what a
+ *    non-English session reads until the net applies the locale bundle.
+ *
+ * ## Positive control, in the same run as each arm
+ *
+ * The failure mode this guards against is a dead channel reading as a fixed
+ * defect. So each arm asserts, in the same render, something that ALREADY
+ * worked before this change and travels a channel this change does not touch:
+ *
+ *  - arm 1 pins the preview's own measure header (`headerLabel`, the field
+ *    helper the preview has always used) — if the fixture or the adapter mock
+ *    were dead, `Revenue` would not render either;
+ *  - arm 2 pins a zh-CN FIELD label out of the same bundle the option labels
+ *    come from — if the locale channel were dead, that would be English too,
+ *    and the option assertion's failure could not be read as "not relabelled".
+ *
+ * ## Where the axis is read
+ *
+ * `ChartRenderer` is recharts-backed and does not lay out in happy-dom
+ * (`clientWidth` 0, no container-size effect) — the same measurement the three
+ * reference producers' pins record, which is why each of them captures the
+ * schema handed to the chart rather than asserting on SVG. This preview does
+ * not dispatch through `ComponentRegistry`, so the equivalent capture is the
+ * lazy `@object-ui/plugin-charts` module's `ChartRenderer`. The rows fed to the
+ * chart and the rows fed to the table are ONE derivation in the component, so
+ * the table cells below — real rendered DOM — are the second, independent
+ * reading of the same fact.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
+// Same pre-warm as the sibling `DatasetPreview.test.tsx`, for the same reason:
+// the preview reaches its chart through `React.lazy(() => import(...))`, and
+// resolving that graph is unbounded work that can outlast RTL's 1000ms window.
+// Importing it here moves the cost into this file's import phase, which no test
+// or hook timeout applies to. It matters MORE here than there, because the
+// `vi.mock` factory below inherits the real module — so the module the lazy
+// factory awaits is still the full (recharts-backed) graph. Keep the specifier
+// identical to DatasetPreview.tsx's; ESM caches by resolved specifier.
+import '@object-ui/plugin-charts';
+import { DatasetPreview } from '../DatasetPreview';
+
+// Capture the schema the preview hands the chart. The component reaches
+// `ChartRenderer` through `React.lazy(() => import('@object-ui/plugin-charts'))`,
+// so the double is installed on that module and the lazy factory resolves to it.
+//
+// The factory INHERITS the real module's export surface and overrides one name
+// (objectui#6849): a hand-listed factory freezes the surface at whatever was
+// typed today, and the next export any module in this file's import graph reads
+// at module scope resolves to `undefined` — killing the file during COLLECTION,
+// where it reads as flake rather than as a test failure.
+const { capturedChartSchemas } = vi.hoisted(() => ({ capturedChartSchemas: [] as any[] }));
+vi.mock('@object-ui/plugin-charts', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ChartRenderer: ({ schema }: { schema: any }) => {
+    capturedChartSchemas.push(schema);
+    return null;
+  },
+}));
+
+// Mock the data adapter the preview pulls from AdapterProvider.
+const { queryDataset } = vi.hoisted(() => ({ queryDataset: vi.fn() }));
+vi.mock('../../../../providers/AdapterProvider', () => ({
+  useAdapter: () => ({ queryDataset }),
+}));
+
+/**
+ * Route `GET /api/v1/meta/object/<name>` to a per-object document, recording the
+ * object names asked for. A name with no document 404s the way a real server
+ * would. Installing it also keeps this file off a real socket — the preview's
+ * metadata read would otherwise resolve `/api/v1/...` against happy-dom's
+ * default `localhost:3000` origin and trip the network-escape guard.
+ */
+function installMetaRouter(docs: Record<string, unknown>) {
+  const requested: string[] = [];
+  global.fetch = vi.fn(async (input: unknown) => {
+    const url = String(input);
+    const m = /\/api\/v1\/meta\/object\/(.+)$/.exec(url);
+    const name = m ? decodeURIComponent(m[1]) : '';
+    requested.push(name);
+    const doc = docs[name];
+    if (!doc) return { ok: false, json: async () => ({}) };
+    return { ok: true, json: async () => ({ item: doc }) };
+  }) as any;
+  return { requested };
+}
+
+const realFetch = global.fetch;
+afterEach(() => {
+  cleanup();
+  queryDataset.mockReset();
+  capturedChartSchemas.length = 0;
+  global.fetch = realFetch;
+  vi.restoreAllMocks();
+});
+
+const baseProps = { type: 'dataset', name: 'sales', locale: 'en-US' as const };
+
+/** The x-axis categories the chart received, in row order. */
+function axisCategories(): unknown[] {
+  const schema = capturedChartSchemas[capturedChartSchemas.length - 1];
+  const key = schema?.xAxisKey;
+  return ((schema?.data ?? []) as Array<Record<string, unknown>>).map((r) => r[key]);
+}
+
+/** Cell texts of the result table's rows, in column order. */
+const rowCells = (i: number): string[] =>
+  Array.from(document.querySelectorAll('tbody tr')[i]?.querySelectorAll('td') ?? []).map(
+    (td) => td.textContent ?? '',
+  );
+
+// ── Arm 1 — a DOTTED dimension (objectui#4053 / #4263) ──────────────────────
+
+const INDUSTRY_OPTIONS = [
+  { value: 'MFG', label: 'Manufacturing' },
+  { value: 'FIN', label: 'Financial Services' },
+];
+
+/** Base object: the `crm_account` relationship the dotted path walks. */
+const OPPORTUNITY = {
+  name: 'crm_opportunity',
+  fields: { crm_account: { type: 'lookup', reference: 'crm_account' } },
+};
+/** The relationship's TARGET, where the dotted path's options actually live. */
+const ACCOUNT = {
+  name: 'crm_account',
+  fields: { industry: { type: 'select', options: INDUSTRY_OPTIONS } },
+};
+
+const dottedDraft = {
+  name: 'sales',
+  label: 'Sales',
+  object: 'crm_opportunity',
+  include: ['crm_account'],
+  dimensions: [{ name: 'account_industry', field: 'crm_account.industry' }],
+  measures: [{ name: 'revenue', aggregate: 'sum', field: 'amount' }],
+};
+
+/** Rows as analytics returns them for a dotted path: the STORED enum. */
+const DOTTED_RESULT = {
+  rows: [
+    { account_industry: 'MFG', revenue: 100 },
+    { account_industry: 'FIN', revenue: 50 },
+  ],
+  object: 'crm_opportunity',
+  fields: [
+    { name: 'account_industry', type: 'string', label: 'Account Industry' },
+    { name: 'revenue', type: 'number', label: 'Revenue' },
+  ],
+};
+
+describe('DatasetPreview relabels a DOTTED dimension (objectui#8187, #4053 shape)', () => {
+  it('puts the resolved label on the chart axis, not the raw stored value', async () => {
+    installMetaRouter({ crm_opportunity: OPPORTUNITY, crm_account: ACCOUNT });
+    queryDataset.mockResolvedValue(DOTTED_RESULT);
+    render(<DatasetPreview {...baseProps} draft={dottedDraft} />);
+
+    // POSITIVE CONTROL, same run: the measure header the preview already
+    // resolved through `headerLabel` before this change. A dead fixture or a
+    // dead adapter mock takes this down too, so its green is what makes the
+    // axis assertion below readable as "not relabelled" rather than "nothing
+    // rendered at all".
+    expect(await screen.findByRole('columnheader', { name: 'Revenue' })).toBeInTheDocument();
+
+    await waitFor(() => expect(axisCategories()).toEqual(['Manufacturing', 'Financial Services']));
+    // The raw enum must not survive anywhere on the surface — the table below
+    // the chart is fed from the SAME derivation and is real rendered DOM.
+    expect(rowCells(0)[0]).toBe('Manufacturing');
+    expect(rowCells(1)[0]).toBe('Financial Services');
+    expect(document.body.textContent).not.toContain('MFG');
+  });
+
+  it('walks the RELATIONSHIP TARGET for the options, not the base object', async () => {
+    // The mechanism pin: `crm_account.industry`'s options are on `crm_account`,
+    // and a base-object-only lookup is exactly how this defect class
+    // (objectui#4053) reads a plausible wrong value instead of erroring.
+    const { requested } = installMetaRouter({ crm_opportunity: OPPORTUNITY, crm_account: ACCOUNT });
+    queryDataset.mockResolvedValue(DOTTED_RESULT);
+    render(<DatasetPreview {...baseProps} draft={dottedDraft} />);
+
+    await waitFor(() => expect(axisCategories()).toEqual(['Manufacturing', 'Financial Services']));
+    expect(requested).toContain('crm_account');
+  });
+
+  it('BOUNDARY — an unresolvable path leaves the rows exactly as the server sent them', async () => {
+    // Best-effort by construction: the relationship target 404s, so nothing
+    // resolves and the preview renders what it rendered before this card. This
+    // is green on BOTH sides of the change and is labelled as such — it pins
+    // the degradation, not the defect.
+    installMetaRouter({ crm_opportunity: OPPORTUNITY });
+    queryDataset.mockResolvedValue(DOTTED_RESULT);
+    render(<DatasetPreview {...baseProps} draft={dottedDraft} />);
+
+    expect(await screen.findByRole('columnheader', { name: 'Revenue' })).toBeInTheDocument();
+    await waitFor(() => expect(axisCategories()).toEqual(['MFG', 'FIN']));
+  });
+});
+
+// ── Arm 2 — a LOCAL select on a non-English locale (objectui#4330) ───────────
+
+const CHANNEL_OPTIONS = [
+  { value: 'domestic', label: 'Domestic' },
+  { value: 'export', label: 'Export' },
+];
+
+const LOCAL_OBJECT = {
+  name: 'crm_opportunity',
+  fields: { sales_channel: { type: 'select', options: CHANNEL_OPTIONS } },
+};
+
+const ZH_BUNDLE = {
+  zh: {
+    crm: {
+      fields: { crm_opportunity: { sales_channel: '销售渠道' } },
+      fieldOptions: { crm_opportunity: { sales_channel: { domestic: '国内', export: '出口' } } },
+    },
+  },
+};
+
+const localDraft = {
+  name: 'sales',
+  label: 'Sales',
+  object: 'crm_opportunity',
+  dimensions: [{ name: 'sales_channel', field: 'sales_channel' }],
+  measures: [{ name: 'revenue', aggregate: 'sum', field: 'amount' }],
+};
+
+/**
+ * A LOCAL dimension arrives server-resolved (ADR-0021): the rows already carry
+ * the object's AUTHORED English label. That is precisely why the screen reads
+ * English on a zh session, and why the label map is keyed by the authored label
+ * as well as by the stored value.
+ */
+const LOCAL_RESULT = {
+  rows: [
+    { sales_channel: 'Domestic', revenue: 100 },
+    { sales_channel: 'Export', revenue: 50 },
+  ],
+  object: 'crm_opportunity',
+  fields: [
+    { name: 'sales_channel', type: 'string', label: 'Sales Channel' },
+    { name: 'revenue', type: 'number', label: 'Revenue' },
+  ],
+};
+
+function renderIn(language: string, ui: React.ReactElement) {
+  return render(
+    <I18nProvider
+      config={{ defaultLanguage: language, detectBrowserLanguage: false, resources: ZH_BUNDLE }}
+      persistLanguage={false}
+    >
+      {ui}
+    </I18nProvider>,
+  );
+}
+
+describe('DatasetPreview localizes a LOCAL select dimension (objectui#8187, #4330 shape)', () => {
+  it('renders the zh-CN option labels on the axis, not the authored English', async () => {
+    installMetaRouter({ crm_opportunity: LOCAL_OBJECT });
+    queryDataset.mockResolvedValue(LOCAL_RESULT);
+    renderIn('zh', <DatasetPreview {...baseProps} draft={localDraft} />);
+
+    // POSITIVE CONTROL, same run: the zh FIELD label out of the SAME bundle the
+    // option labels come from. If the locale channel were dead this header
+    // would read `Sales Channel`, and the axis assertion's failure could not be
+    // told apart from "not relabelled".
+    expect(await screen.findByRole('columnheader', { name: '销售渠道' })).toBeInTheDocument();
+
+    await waitFor(() => expect(axisCategories()).toEqual(['国内', '出口']));
+    expect(rowCells(0)[0]).toBe('国内');
+    expect(document.body.textContent).not.toContain('Domestic');
+  });
+
+  it('BOUNDARY — an untranslated session keeps the authored English exactly', async () => {
+    // Green on both sides, labelled: an app with no bundle entry for the locale
+    // must read the same as it did before this card.
+    installMetaRouter({ crm_opportunity: LOCAL_OBJECT });
+    queryDataset.mockResolvedValue(LOCAL_RESULT);
+    renderIn('en', <DatasetPreview {...baseProps} draft={localDraft} />);
+
+    expect(await screen.findByRole('columnheader', { name: 'Sales Channel' })).toBeInTheDocument();
+    await waitFor(() => expect(axisCategories()).toEqual(['Domestic', 'Export']));
+  });
+});


### PR DESCRIPTION
Fixes #8187

## What changed

`packages/app-shell/src/views/metadata-admin/previews/DatasetPreview.tsx` now resolves its dimension values through the platform's one dimension-label net, at that net's **fourth** call site. No new vocabulary, config key or public surface — the seam is `useDatasetDimensionLabels` from `@object-ui/react` (the shared React half stated once by objectui#4389, which wraps `loadDimensionFieldMeta` and `deriveDimensionLabelMaps`) plus `relabelDimensions` from `@object-ui/core`.

## The ruling this implements

Route **A**, ruled by the PM seat on the card (comment 5617492287) under a **veto window** on the maintainer's autonomous-dispatch instruction, resting on the four-axis analysis in comment 5615881188. The maintainer may still reverse it; this PR is one commit and reverts cleanly.

## Premise re-measured against `origin/main` — both load-bearing claims HOLD

The card body is a 2026-09-06 snapshot, so every claim was re-derived at base `72bcd7783`, by anchor and not by line number (every line number in the card has drifted).

- **The producer census.** Every non-test call site of `buildChartSeries` is exactly three, and all three relabel immediately before charting. Re-derived by excluding the definition site, comment lines and backticked prose, which the card's own method did not have to state: `plugin-charts/src/ObjectChart.tsx:1104` (relabels at `:1105`), `plugin-dashboard/src/DatasetWidget.tsx:1529` (relabels at `:1510`), `plugin-report/src/DatasetReportRenderer.tsx:1026` (relabels at `:1027`). `DatasetPreview` calls it zero times, which is why it fell outside that census.
- **The feasibility claim — both inputs are in hand.** `state` carries `object` (`PreviewState`, and `resultObject` derived from it) and the preview already resolves measure captions through `headerLabel` via `buildDatasetFieldHelpers`. Confirmed, and the implementation uses a stronger source for one of them: the **draft** carries both the base object and each dimension's `field` path (`DatasetDimension` is `name` plus `field`), so nothing depends on the server echoing `dimensionFields` back. That matters on this surface specifically, because it previews a possibly-unsaved draft.

## One interpretation, stated rather than assumed

The rows are relabelled **once** and fed to **both** the chart and the result table beneath it. The ruling names the chart; the comparator it names — "like the platform's three other analytics chart producers" — relabels rows, not axes: `DatasetWidget` derives `displayRows` for its table at `:1001` and `chartRows` at `:1510`, `DatasetReportRenderer` at `:572`/`:1225` and `:1027`. Relabelling only the axis would put `Manufacturing` on a bar and `MFG` in the row directly beneath it — a fresh wrong-looking-right reading introduced by the fix. It is also the narrower change: one derivation, not two.

## Acceptance — a green suite proves nothing here, so this is what was measured

The defect renders a plausible string where a label belongs, so nothing threw and nothing was red. New pins in `previews/__tests__/DatasetPreview.dimensionLabels-8187.test.tsx` cover the two distinct arms, each with a positive control **in the same run**:

| arm | assertion | positive control in the same render |
|---|---|---|
| dotted dimension (objectui#4053 / #4263) | `crm_account.industry` axis reads `Manufacturing`, `Financial Services` — never `MFG` | the preview's own measure caption `Revenue` via `headerLabel`, which already worked |
| local select (objectui#4330) | on a zh session the axis reads `国内`, `出口` — never the authored `Domestic` | the zh FIELD label `销售渠道` from the same bundle, so a dead locale channel cannot be misread as "not relabelled" |

Two further pins are **labelled green on both sides** and are boundaries, not defect pins: an unresolvable relationship target leaves the rows exactly as the server sent them, and an untranslated session keeps the authored English byte-identical. One mechanism pin asserts the walk requests `crm_account` — a base-object-only lookup is precisely how this class reads plausible and wrong.

The axis is read as the schema handed to `ChartRenderer`, which is what all three reference producers' pins do and for the reason they record: recharts does not lay out under happy-dom. The chart rows and the table rows are one derivation in the component, so the table cell assertions in the same tests are a second, independent reading of the same fact against real rendered DOM. No Chromium was needed; no layout-dependent assertion was written.

### Two-way discriminating power

Mutation = revert the call-site change (feed both consumers the raw rows). Proven **on disk before any result was read** — anchor count `displayRows` 3 to 1, and blob hash `8d7934db` to `4da1a0c1`. Restore proven **by state**: restored blob `8d7934db` equals the `HEAD` blob, and `git diff HEAD` on the file is empty.

- **MUTATED:** `Test Files 1 failed`, `Tests 3 failed | 2 passed`. The three defect pins go red with the defect's own values — `['MFG', 'FIN']` for `['Manufacturing', 'Financial Services']`, and `['Domestic', 'Export']` for `['国内', '出口']`. The two boundary pins stay green, as they are labelled to.
- **RESTORED:** `Test Files 1 passed`, `Tests 5 passed`.

## Gates

`scripts/pm/dispatch-gates.mjs` **does not exist in this repo** — it lives in the sibling `objectstack` tree and answers only about that tree. The families below were therefore **derived by hand** from the actual changed-file set, and that derivation is the thing to review rather than a tool's output. Exit codes were redirected to disk and captured before being read, never through a pipe.

| gate | exit |
|---|---|
| `@object-ui/app-shell` dependency-closure build | 0 |
| `@object-ui/app-shell` build (`tsc` plus dist completeness, 922 files) | 0 |
| `@object-ui/app-shell` `type-check` (`tsc --noEmit` **and** `tsc -p tsconfig.test.json`, so the new test is covered) | 0 |
| `@object-ui/app-shell` `lint` | 0 (0 errors; 2958 pre-existing warnings, none new) |
| `vitest run packages/app-shell/` from the repo ROOT (the whole package) | 0 — 673 files, 6514 passed, 1 skipped |
| `vitest run packages/app-shell/src/views/metadata-admin/previews/` from the repo ROOT | 0 — 55 files, 638 tests |
| `check:doc-examples` | 0 — see the note below |
| `check:designer-field-key-parity` (it reads this previews directory) | 0 |
| `check:control-bytes` | 0 |
| `changeset:check` (fixed-group plus no-`major`) | 0 |
| `check-changeset-presence.mjs` | 0 |
| `check-governed-queue-guard --test` on all changed paths | 0 — NOT GOVERNED, ordinary merge-queue route |
| `check:vi-mock-inherit` / `check:vi-mock-override-shape` / `check:vi-mock-specifiers` | 0 / 0 / 0 |
| `check:phantom-deps` / `check:self-import` | 0 / 0 |

`check:doc-examples` deserves its own line, because its FIRST reading was **not** a result. It exited **2** with `@object-ui/plugin-map … declares types at …/dist/index.d.ts and it is not on disk — run the build first` for three packages outside `@object-ui/app-shell`'s dependency closure. That is PREREQUISITE NOT MET — neither pass nor red, and it is labelled as such rather than reported as either. After running the remedy the gate itself printed (`turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter) --concurrency=2`, exit 0) it re-ran at exit **0**: 124 blocks, 89 ledger rows, every row matching. No ledger row went stale and none needed re-keying — none of the four changed files carries an `@example` docblock at all, so the line-number-keyed rows this gate holds cannot have moved.

The last four families are derived from the diff rather than from any dispatch list: this PR adds a `vi.mock` on a covered workspace specifier and a cross-package import. The chart double therefore **inherits** the real module's export surface rather than hand-listing it (objectui#6849) — a frozen factory kills the file during collection, where it reads as flake rather than as a failure.

Changeset: `.changeset/8187-dataset-preview-dimension-labels.md`, `minor` (this repo forbids `major`; `@object-ui/app-shell` is published and rendered output moves, so the empty-frontmatter form would be wrong).

## Declared deviation from the dispatched file surface

The claim declared `previews/DatasetPreview.tsx`, `previews/__tests__/` and `.changeset/`. Two files **outside** it were edited, and the edit was mechanically forced rather than chosen:

- `previews/DatasetPreview.test.tsx`
- `previews/DatasetPreview.measureLocale.test.tsx`

Resolving labels means issuing `GET /api/v1/meta/object/NAME`. happy-dom resolves that relative URL against `localhost:3000`, so the network-escape guard (objectui#6640) failed **all 13** tests in those two files — measured, not predicted: `Network escape: this test reached a REAL socket at http://localhost:3000/api/v1/meta/object/opportunity`. Their assertions never failed; only the guard's `afterEach` did. Each file gets a fetch double serving the base object with **no** select options, so nothing resolves, `relabelDimensions` returns the server's rows by identity, and every existing assertion stays byte-identical. Both files are siblings of the changed component in the same directory. Shipping without this edit would ship a red suite.

## Base

Merged `origin/main` after opening (two commits, `58be55e78` and `2c208d5bb`, touching `packages/fields` and `README.md`) — clean, no conflict, no overlap with this diff. objectui#8166, the declared serial adjacency into a different `packages/app-shell` region, had not landed at that point. The ratchet-style gates and the previews suite were re-run on the merged head `5b3ad8bc7` and all held.

## Not filed, noted

The preview's sibling surfaces (`ReportPreview`, `DashboardPreview`) were not audited — the card explicitly did not claim them and this PR does not touch them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB)_