### PR TITLE
test(console): pin `object-metric.trend` and `.drillDown`, ceiling 33 -> 31

### DIFF
--- a/.changeset/olive-flowers-yawn.md
+++ b/.changeset/olive-flowers-yawn.md
@@ -1,0 +1,7 @@
+---
+---
+
+Test-only: converts the last two `object-metric` member-pin exemptions
+(`trend`, `drillDown`) into behaviour pins and lowers
+`MEMBER_PIN_EXEMPTION_CEILING` 33 to 31 (objectui#8071 slice 9). No published
+runtime source changes, so nothing to release.

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -2277,9 +2277,17 @@ const MEMBER_PINS: Record<string, MemberPin> = {
     file: 'packages/plugin-dashboard/src/ObjectMetric.elementDataSource.test.tsx',
     pins: 'The per-element binding\'s members as a WHITELIST in both directions. Acting: `object` is what gets aggregated, and a named `view`\'s own `filter` becomes the metric\'s scope — with an unresolvable `view` REPORTING instead of aggregating the whole object, which for a metric is the quiet failure (one number, no rows, nothing to notice). Not acting: the same view fixture declares `columns`, `sort` and `pagination`, and the aggregate options bag is asserted whole to keep all three OUT — `OBJECT_METRIC_DATA_SOURCE` names only `filter`, because a metric is one aggregated number with no projection, ordering or page for the rest to act on. A metric with NO binding behaving exactly as before is the control. Pre-existing file (objectstack#6953), promoted here after being read end to end; objectui#8071 slice 8 added the whole-bag row, without which the pin would have been satisfied by a mapping that forwarded everything.',
   },
+  'object-metric.drillDown': {
+    file: 'packages/plugin-dashboard/src/__tests__/objectMetricDrillDownMembers-8071.test.tsx',
+    pins: 'The click-through config\'s member set, read through the registered block on a LIVE drawer. `enabled` is `!== false`, not truthiness, and all four arms (absent, `{}`, `true`, `false`) are pinned against each other, so a "simplification" to `!!config.enabled` — which would silently disable every `{}` config — is red; and it is not sufficient on its own, because without an object name AND a data source the tile stays unclickable rather than opening a list it cannot fetch. `target` chooses the panel SHAPE (`\'dialog\'` = centred modal, anything else the edge-anchored sheet), each arm the other\'s control. `title` OUTRANKS the tile\'s own `title` and `label`, with the chain below it (`title`, then `label`, then the literal "Details") pinned as its fallback. `report` selects the drawer BODY by its own SHAPE — an `objectName`-bearing (or array-`columns`) report goes to a `spec-report` body while anything else falls through to the inline record list, and whether the record list is fetched at all is the observable that separates them. The invariant the key hangs off is pinned too: the drilled list is scoped by the METRIC\'s resolved filter with macros already substituted — the registration\'s own promise that the number and the records behind it agree, and a drawer listing every row of the object is the quiet failure it exists to stop. LIMIT, stated and deliberately NOT asserted: this widget hand-rolls its drawer instead of using `DrillDownDrawer`, so `columns`, `maxRows`, `target: \'navigate\'`, `filter` and `mode` have no read site on this block — filed as objectui#8970 rather than frozen into the pin, because an assertion that a member is dead has to be deleted before the gap can be closed. The spec row is `z.unknown()`, so the read site is the whole member contract. New file (objectui#8071 slice 9).',
+  },
   'object-metric.filter': {
     file: 'packages/plugin-dashboard/src/__tests__/objectMetricQueryMembers-8071.test.tsx',
     pins: 'No named member set — the renderer never inspects the predicate — so the member shape is the SPELLING it arrives under, and there are two, chosen by an adapter capability the author cannot see: FLAT under its own name inside the aggregate options bag, and WRAPPED as `$filter` on the no-`aggregate()` `find()` fallback. Collapsing them into one drops the predicate on whichever path lost and the tile counts every row — the same defect `element:number.filter` was pinned for (slice 7) on a different renderer. Two further halves: placeholders are resolved BEFORE the query (an authored `{current_quarter_start}` reaches the adapter as a real date, and a macro surviving onto the wire is a literal nobody matches), and the key is read BY VALUE rather than by identity (`JSON.stringify` memo) — a deep-equal rebuild by a re-rendering parent must NOT re-probe while a changed comparand MUST and carries the new predicate, each arm the other\'s control against a dependency "simplified" to the raw object. New file (objectui#8071 slice 8).',
+  },
+  'object-metric.trend': {
+    file: 'packages/plugin-dashboard/src/__tests__/objectMetricTrendMembers-8071.test.tsx',
+    pins: 'The static badge\'s three members, each pinned on an observable only that member can move, driven through the registered block. `value` is painted as a PERCENTAGE — the `%` is the badge\'s own, asserted beside a metric whose `format` and `suffix` shape the NUMBER differently. `direction` chooses the glyph and is pinned as a SET (`up` / `down` / `neutral`, plus the OMITTED arm, which still paints the value and draws no glyph at all), so "renders an up arrow" cannot pass on a renderer that draws one unconditionally; an off-list member is asserted not to reach the badge, and a tile with neither `trend` nor `description` draws no badge row — the file\'s non-vacuity floor. The two rows with real semantics to get wrong: the tile-level `description` OUTRANKS `trend.label` in the one caption slot they share, so a tile that authors both silently loses the trend\'s own words; and a `compareTo`-DERIVED trend REPLACES the authored badge outright (`derivedTrend ?? trend`) rather than merging with it. That override is pinned against a no-`compareTo` control on the SAME schema, where 120-vs-100 derives +20% up while the authored badge says 99% down, so neither arm can pass by painting the other\'s numbers — which is what makes the registration\'s own sentence ("Use `compareTo` instead when the trend should be computed from data") true rather than advisory. The spec row is `z.unknown()`, so the read site is the whole member contract. New file (objectui#8071 slice 9).',
   },
   'page:accordion.items': {
     file: 'packages/components/src/__tests__/pageAccordionItemMembers-8071.test.tsx',
@@ -2524,12 +2532,10 @@ const MEMBER_PIN_EXEMPTIONS: Record<string, string> = {
   'object-master-detail-form.initialValues': AWAITING_A_PIN,
   'object-master-detail-form.sections': AWAITING_A_PIN,
 
-  // object-metric — objectui#8071 slice 8 pinned the four members that shape
-  // the aggregate query behind the NUMBER (`dataSource`, `aggregate`, `filter`,
-  // `compareTo`). The two left shape what is drawn AROUND the number once it
-  // exists, and neither reaches `fetchMetric`.
-  'object-metric.drillDown': AWAITING_A_PIN,
-  'object-metric.trend': AWAITING_A_PIN,
+  // object-metric — objectui#8071 slice 8 pinned the four QUERY members
+  // (`dataSource`, `aggregate`, `filter`, `compareTo`) and slice 9 the two
+  // PRESENTATION members (`trend`, `drillDown`); the block is now fully pinned
+  // and this header stays only as a note for the next reader who greps for it.
 
   // page:accordion — objectui#8071 slice 7 pinned `items`, the block's one
   // remaining key; fully pinned.
@@ -2901,11 +2907,55 @@ const NEWLY_JUDGED_UNPINNED_MEMBERS = [
  * reading was not re-measured here because this slice took a different block —
  * slice 7's measurement stands as the last one taken.
  *
+ * ## 33 -> 31, the ninth slice, and the first multi-key block closed by halves
+ *
+ * objectui#8071's ninth slice takes what slice 8 left and named: the two
+ * PRESENTATION members of `object-metric`, `trend` and `drillDown`, so the
+ * ceiling follows to 31 in the same commit and the block drops out of
+ * `MEMBER_PIN_EXEMPTIONS` entirely — the first block closed in TWO bites rather
+ * than one, which is the shape every remaining block (`object-grid` 15,
+ * `object-form` 7, `object-master-detail-form` 6) now has to be closed in.
+ *
+ * The cut is slice 8's, restated because it is the part that is easy to get
+ * wrong: `drillDown` DOES issue a query of its own — the drawer's record list
+ * runs off the same resolved filter — so "reaches an adapter" is not the line.
+ * The line is `fetchMetric` / `computeOne`, the path that produces the NUMBER.
+ * Neither of these two can change it; they shape what is drawn around it.
+ *
+ * BOTH pins are new files, and the measurement that decided it is worth
+ * recording because it corrects the prior note rather than repeating it.
+ * `ObjectMetricWidget.i18nLabel.test.tsx` was flagged for this slice as prior
+ * art that "satisfies any mechanical locator for either" key. Re-measured here,
+ * that is true only of a locator keyed on the KEY NAME: the file contains ZERO
+ * occurrences of the string `object-metric` (control: `ObjectMetricWidget`
+ * reads 15 in the same file), and `memberPinProblem` requires the BLOCK name
+ * too, so this repo's own locator would have refused it. The substance of the
+ * warning stands — it authors `trend` and `drillDown` purely to make the drill
+ * reachable, and its subject is `I18nLabel` resolution — so it is left intact
+ * rather than promoted. The only other file naming block AND key is
+ * `ObjectMetricWidget.compareTo.test.tsx`, already the `compareTo` pin, which
+ * never authors a `trend` prop at all: crediting it would have been slice 7's
+ * `action-bodyShape-forward.test.tsx` mistake in a third place.
+ *
+ * ⚠️ `drillDown` is pinned on the members that ACT and deliberately not on the
+ * ones that do not. `ObjectMetricWidget` hand-rolls its own drawer instead of
+ * using the shared `DrillDownDrawer`, so five members the shared component
+ * honours have no read site here (`columns`, `maxRows`, `target: 'navigate'`,
+ * `filter`, `mode`). That is filed (objectui#8970) rather than frozen into the
+ * pin — the same choice slice 6 made for `record:activity`'s filter members
+ * (objectui#8934), and for the same reason: an assertion that a member is dead
+ * has to be deleted before anyone can make it live.
+ *
+ * ⚠️ Unchanged by this slice: `NEWLY_JUDGED_UNPINNED_MEMBERS` (no block it names
+ * was touched) and `record:related_list.actions`, whose `NO_READ_SITE_TO_PIN`
+ * reading was not re-measured here either — slice 7's measurement still stands
+ * as the last one taken.
+ *
  * ⇒ The rule for every future slice of objectui#8071: delete the entry, register
  * the pin, and set this constant to the new count. Not to the new count plus
  * room.
  */
-const MEMBER_PIN_EXEMPTION_CEILING = 33;
+const MEMBER_PIN_EXEMPTION_CEILING = 31;
 
 /**
  * Every test file a member pin can live in, as LAZY `?raw` loaders.

--- a/packages/plugin-dashboard/src/__tests__/objectMetricDrillDownMembers-8071.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/objectMetricDrillDownMembers-8071.test.tsx
@@ -1,0 +1,290 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `object-metric.drillDown` — the MEMBER SHAPE of the click-through config
+ * (objectui#8071).
+ *
+ * The member pin for the second of the two PRESENTATION keys objectui#8071's
+ * ninth slice takes, and the one that needs its cut stated: `drillDown` DOES
+ * issue a query of its own — the drawer's record list runs off the metric's
+ * resolved filter — so "reaches an adapter" is not what separates these two
+ * keys from slice 8's four. The line is `fetchMetric` / `computeOne`, the path
+ * that produces the NUMBER. This key cannot change the number; it decides what
+ * opens when the number is clicked.
+ *
+ * Asserted through the REGISTERED block (`type: 'object-metric'` mounted by
+ * `SchemaRenderer`) rather than on `ObjectMetricWidget` directly, so the pin
+ * covers the path an author reaches: the block's `ElementDataSourceGate` shell
+ * re-binds only `objectName` and `filter` and forwards this key untouched.
+ *
+ * ## What the protocol says, and why this pin is BEHAVIOUR
+ *
+ * `@objectstack/spec`'s `ObjectMetricPropsSchema` governs this block and
+ * declares the key as `z.unknown().optional()`, described as "Click-through
+ * drill config — opens the underlying records". The protocol deliberately does
+ * not pin the member shape, so — exactly as `object-kanban.swimlaneField`
+ * records for its own `z.unknown()` row — the READ SITE is the whole member
+ * contract this block carries, and a member pin here can only be a reading of
+ * the renderer. Declaring a narrower `object-metric` drill schema on this side
+ * would make this repo stricter than the protocol it renders, which is the
+ * wrong direction to fix anything in.
+ *
+ * ## The members `ObjectMetricWidget` actually reads
+ *
+ *   - **`enabled`** — through `isDrillEnabled`, which is `config.enabled !==
+ *     false`, NOT `!!config.enabled`. So `{}` is ENABLED and only an explicit
+ *     `false` turns it off. That distinction is the row a "simplification" to
+ *     a truthiness check silently breaks, and it is pinned with all four arms
+ *     (absent / `{}` / `true` / `false`) against each other.
+ *   - **`enabled` is not sufficient on its own.** The tile becomes clickable
+ *     only when an object name AND a data source are also present — a drill
+ *     that could not list anything is not offered, rather than offered and
+ *     empty.
+ *   - **`target`** — `'dialog'` draws a centred modal, anything else the
+ *     edge-anchored side sheet. Each arm is the other's control, so a renderer
+ *     that drew one shape for both cannot pass.
+ *   - **`title`** — through `resolveDrillTitle`, which OUTRANKS the tile's own
+ *     `title` and `label`. The fallback chain below it is `title` then `label`
+ *     then the literal "Details".
+ *   - **`report`** — its own SHAPE selects the branch: a report object carrying
+ *     an `objectName` (or an array `columns`) sends the drawer body to a
+ *     `spec-report` schema, and anything else falls through to the inline
+ *     record list. That is asserted on the observable that separates the two
+ *     branches — whether the record list is fetched at all.
+ *
+ * And the invariant the whole key hangs off: the drilled record list is scoped
+ * by the METRIC's own resolved filter, macros already substituted. The
+ * registration promises exactly this ("The same filter narrows the drill-down
+ * list, so the number and the records behind it always agree"), and a drawer
+ * that listed every row of the object would be the quiet failure — a plausible
+ * record list that answers a different question from the tile above it.
+ *
+ * ## LIMITS, stated rather than frozen into an assertion
+ *
+ * `DrillDownConfig` is shared by five widgets, and this one hand-rolls its own
+ * drawer instead of using `DrillDownDrawer`. Three members the shared component
+ * honours have no read site on this block: `columns`, `maxRows`, and
+ * `target: 'navigate'`. `filter` and `mode` have none either — a metric has no
+ * click event to interpolate `${event.*}` against, and its whole slice is the
+ * one filter. None of that is asserted here: pinning "this member is dead"
+ * would freeze the gap instead of reporting it, and a pin that has to be
+ * deleted before the gap can be closed is worse than no pin. Filed as
+ * objectui#8970.
+ *
+ * ## Nothing pre-existing covered this key
+ *
+ * Measured, then read end to end. The repo's locator (`memberPinProblem`)
+ * requires a pin file to name BOTH the block and the key; exactly ONE collected
+ * file names `object-metric` and `drillDown`, and it is
+ * `registry-inputs-spec-parity.test.ts` — the ledger itself.
+ *
+ * `ObjectMetricWidget.i18nLabel.test.tsx` is the trap slice 8 flagged, and the
+ * re-measurement corrects half of its description: it contains ZERO occurrences
+ * of the string `object-metric` (control: `ObjectMetricWidget` reads 15 in the
+ * same file), so it does not satisfy this repo's locator — only one keyed on
+ * the key name alone. It authors `drillDown: { enabled: true }` three times,
+ * purely to make the tile clickable, and its subject is `I18nLabel` resolution:
+ * that an inline per-locale map reaches the drawer heading rather than
+ * collapsing to the literal "Details". It asserts nothing about `enabled`'s
+ * three-way reading, `target`, `report`, `drillDown.title`'s precedence, or the
+ * filter the record list is scoped by — so it is not promoted, and its own
+ * subject is left intact.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+// Registers `object-metric` AND the `object-data-table` the drawer body renders,
+// at MODULE scope — object-ui/no-dynamic-import-in-test-hook.
+import '../index';
+
+afterEach(cleanup);
+
+type Params = Record<string, unknown>;
+
+/** Aggregates the number, lists the records, and answers the table's schema probe. */
+const drillAdapter = () => ({
+  aggregate: vi.fn(async (_object: string, _params: Params) => [{ amount_sum: 120 }]),
+  find: vi.fn(async (_object: string, _params: Params) => ({
+    data: [{ id: '1', name: 'Acme Renewal' }],
+  })),
+  getObjectSchema: vi.fn(async () => ({ fields: { name: { type: 'text', label: 'Name' } } })),
+});
+
+const BASE = {
+  type: 'object-metric',
+  objectName: 'deal',
+  label: 'Revenue',
+  aggregate: { field: 'amount', function: 'sum' },
+  filter: { stage: 'won' },
+} as const;
+
+const mount = (schema: Record<string, unknown>, adapter?: unknown) =>
+  render(
+    <SchemaRendererProvider dataSource={adapter as never}>
+      <SchemaRenderer schema={{ ...BASE, ...schema } as never} />
+    </SchemaRendererProvider>,
+  );
+
+/** Open the drill panel and hand back the panel element. */
+const openPanel = async () => {
+  fireEvent.click(await screen.findByRole('button'));
+  return screen.findByRole('dialog');
+};
+
+/**
+ * Which of the two panel shapes was drawn, read off the layout the primitive
+ * commits to: the dialog is centred by transform, the sheet is anchored to an
+ * edge. Returned as one value so the two `target` rows control each other.
+ */
+const panelKind = (panel: HTMLElement): 'modal' | 'sheet' | 'unknown' => {
+  const cls = panel.className;
+  if (cls.includes('translate-x-[-50%]')) return 'modal';
+  if (cls.includes('inset-y-0') && cls.includes('right-0')) return 'sheet';
+  return 'unknown';
+};
+
+/** The `$filter` of the drilled record list's fetch. */
+const drillFilterOf = (adapter: ReturnType<typeof drillAdapter>) =>
+  (adapter.find.mock.calls[0]?.[1] as { $filter?: unknown } | undefined)?.$filter;
+
+describe('object-metric — `drillDown.enabled` decides whether the number is clickable', () => {
+  it('is NOT clickable with no `drillDown` at all', async () => {
+    mount({}, drillAdapter());
+    expect(await screen.findByText('Revenue')).toBeTruthy();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('is NOT clickable when `enabled` is explicitly false', async () => {
+    mount({ drillDown: { enabled: false } }, drillAdapter());
+    expect(await screen.findByText('Revenue')).toBeTruthy();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('is clickable when `enabled` is true', async () => {
+    mount({ drillDown: { enabled: true } }, drillAdapter());
+    expect(await screen.findByRole('button')).toBeTruthy();
+  });
+
+  it('is clickable on an EMPTY config — the read is `!== false`, not truthiness', async () => {
+    // The row a "simplification" to `!!config.enabled` turns red, and the
+    // reason the four arms are pinned as a set rather than one positive.
+    mount({ drillDown: {} }, drillAdapter());
+    expect(await screen.findByRole('button')).toBeTruthy();
+  });
+
+  it('is NOT clickable when `enabled` is true but nothing could be listed', async () => {
+    // No data source: a drill that cannot fetch records is withheld rather
+    // than offered and empty.
+    mount({ drillDown: { enabled: true }, fallbackValue: 42 }, undefined);
+    expect(await screen.findByText('Revenue')).toBeTruthy();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+});
+
+describe('object-metric — `drillDown.target` chooses the panel shape', () => {
+  it('draws the edge-anchored sheet when `target` is omitted', async () => {
+    mount({ drillDown: { enabled: true } }, drillAdapter());
+    expect(panelKind(await openPanel())).toBe('sheet');
+  });
+
+  it('draws the centred modal on `target: "dialog"`', async () => {
+    mount({ drillDown: { enabled: true, target: 'dialog' } }, drillAdapter());
+    expect(panelKind(await openPanel())).toBe('modal');
+  });
+});
+
+describe('object-metric — `drillDown.title` and the chain below it', () => {
+  it('OUTRANKS both the tile `title` and the tile `label`', async () => {
+    mount(
+      {
+        title: 'Tile title',
+        drillDown: { enabled: true, title: 'Drill panel heading' },
+      },
+      drillAdapter(),
+    );
+    await openPanel();
+    const heading = await screen.findByRole('heading');
+    expect(heading.textContent).toBe('Drill panel heading');
+  });
+
+  it('falls back to the tile `title` when the config carries none', async () => {
+    mount({ title: 'Tile title', drillDown: { enabled: true } }, drillAdapter());
+    await openPanel();
+    expect((await screen.findByRole('heading')).textContent).toBe('Tile title');
+  });
+
+  it('falls back to the tile `label` when neither is authored', async () => {
+    // `label` is 'Revenue' from BASE — and the chain's last resort, the literal
+    // "Details", must NOT be what a titled tile gets.
+    mount({ drillDown: { enabled: true } }, drillAdapter());
+    await openPanel();
+    const heading = await screen.findByRole('heading');
+    expect(heading.textContent).toBe('Revenue');
+    expect(heading.textContent).not.toBe('Details');
+  });
+});
+
+describe('object-metric — the drilled list agrees with the number', () => {
+  it('scopes the record list by the METRIC filter, macros already resolved', async () => {
+    const adapter = drillAdapter();
+    mount(
+      {
+        filter: { close_date: { $gte: '{current_quarter_start}' }, stage: 'won' },
+        drillDown: { enabled: true },
+      },
+      adapter,
+    );
+    await openPanel();
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    expect(adapter.find.mock.calls[0][0]).toBe('deal');
+    const $filter = drillFilterOf(adapter) as {
+      stage?: unknown;
+      close_date?: { $gte?: unknown };
+    };
+    expect($filter.stage).toBe('won');
+    // A macro that survived onto the wire is a literal nobody matches, and the
+    // drawer would answer a different question from the tile above it.
+    expect($filter.close_date?.$gte).not.toBe('{current_quarter_start}');
+    expect(String($filter.close_date?.$gte)).toMatch(/^\d{4}-\d{2}-\d{2}/);
+  });
+});
+
+describe('object-metric — `drillDown.report` selects the drawer body by its SHAPE', () => {
+  it('sends an `objectName`-bearing report to the report body, not the record list', async () => {
+    const adapter = drillAdapter();
+    mount(
+      {
+        drillDown: {
+          enabled: true,
+          report: { name: 'pipeline', objectName: 'deal', columns: [] },
+        },
+      },
+      adapter,
+    );
+    await openPanel();
+
+    // The record-list branch is the one that fetches; the report branch hands
+    // the body to a `spec-report` schema instead.
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalled());
+    expect(adapter.find).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the record list when `report` matches neither limb', async () => {
+    // The control that makes the row above a reading of `report`'s SHAPE
+    // rather than of its mere presence.
+    const adapter = drillAdapter();
+    mount({ drillDown: { enabled: true, report: { note: 'not a report' } } }, adapter);
+    await openPanel();
+
+    await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+    expect(drillFilterOf(adapter)).toMatchObject({ stage: 'won' });
+  });
+});

--- a/packages/plugin-dashboard/src/__tests__/objectMetricTrendMembers-8071.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/objectMetricTrendMembers-8071.test.tsx
@@ -1,0 +1,269 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `object-metric.trend` — the MEMBER SHAPE of the static trend badge
+ * (objectui#8071).
+ *
+ * The member pin for the first of the two PRESENTATION keys objectui#8071's
+ * ninth slice takes. Slice 8 pinned the four members that shape the aggregate
+ * query behind the NUMBER (`dataSource`, `aggregate`, `filter`, `compareTo`);
+ * these two shape what is drawn AROUND the number once it exists, and neither
+ * reaches `fetchMetric` / `computeOne`.
+ *
+ * Asserted through the REGISTERED block (`type: 'object-metric'` mounted by
+ * `SchemaRenderer`, registered by this package's own side-effect import) rather
+ * than on `ObjectMetricWidget` directly, so the pin covers the path an author
+ * actually reaches: the block's `ElementDataSourceGate` shell re-binds only
+ * `objectName` and `filter` and forwards every other authored key untouched.
+ *
+ * ## The member set, and where each member is read
+ *
+ * The registration declares `trend` as `{ value, label, direction }`. Two
+ * different components read it, and that split is the member shape:
+ *
+ *   - `ObjectMetricWidget` reads the key ONLY to decide whether it survives at
+ *     all — `effectiveTrend = derivedTrend ?? trend`.
+ *   - `MetricWidget` reads the three members: `value` painted with a hard-coded
+ *     `%` suffix, `direction` choosing the glyph and its colour, and `label`
+ *     feeding the caption slot.
+ *
+ * Each member is pinned on an observable only that member can move, and the
+ * three `direction` values are pinned as a SET with the omitted-`direction`
+ * arm as their control — without it, "renders an up arrow" would also pass on
+ * a renderer that painted an up arrow unconditionally.
+ *
+ * ## The two rows with real semantics to get wrong
+ *
+ *   - **`description` OUTRANKS `trend.label`.** `MetricWidget` resolves one
+ *     caption for the whole badge row: `pickLocalized(description) ||
+ *     pickLocalized(trend?.label)`. A tile that authors both silently drops the
+ *     trend caption. That is a member semantic, not a layout detail: an author
+ *     who adds a `description` to an existing tile loses the trend's own words
+ *     with no diagnostic, and nothing else in the repo says so.
+ *   - **`compareTo` OVERRIDES a static `trend` outright.** `derivedTrend ??
+ *     trend` means a computed comparison does not merge with the authored badge
+ *     — it replaces it, value, direction and caption together. The registration
+ *     text tells authors to use one or the other ("Use `compareTo` instead when
+ *     the trend should be computed from data"); this file is what makes that
+ *     sentence true. The override row and its no-`compareTo` control run on the
+ *     SAME schema so only the key under test varies: 120-vs-100 derives +20%
+ *     up, and the authored badge says 99% down, so neither arm can pass by
+ *     painting the other's numbers.
+ *
+ * ## LIMIT, stated rather than asserted
+ *
+ * `trend.value` is painted as `{value}%` — the `%` is hard-coded in
+ * `MetricWidget`, so the member is a PERCENTAGE whatever the metric's own
+ * `format` / `currency` / `suffix` say. That is pinned as the live reading; it
+ * is not a claim that a non-percentage trend is expressible.
+ *
+ * ## Nothing pre-existing covered this key
+ *
+ * Measured before being decided, and each candidate read end to end rather than
+ * dismissed on its greps. The repo's own locator (`memberPinProblem`) requires
+ * a pin file to name BOTH the block and the key: exactly two collected files
+ * name `object-metric` and `trend`, and neither could carry this pin.
+ * `registry-inputs-spec-parity.test.ts` is the ledger itself.
+ * `ObjectMetricWidget.compareTo.test.tsx` is already the `compareTo` pin and
+ * never authors a `trend` prop at all — the word appears in its prose and in
+ * one title ("shows no trend without compareTo", which asserts the absence of a
+ * derived caption). Crediting it would have been slice 7's
+ * `action-bodyShape-forward.test.tsx` mistake: the locator satisfied by a file
+ * that says nothing about the key.
+ *
+ * `ObjectMetricWidget.i18nLabel.test.tsx` is the trap slice 8 flagged for this
+ * slice, and the re-measurement corrects half of its description: the file
+ * authors `trend={{ value, direction, label }}` twice, but it contains ZERO
+ * occurrences of the string `object-metric` (control: `ObjectMetricWidget`
+ * reads 15 in the same file), so it does NOT satisfy this repo's locator — only
+ * a locator keyed on the key name alone. What it asserts is `I18nLabel`
+ * resolution: that a map `trend.label` resolves to the active locale, and that
+ * the props type accepts the map. It asserts nothing about `value`,
+ * `direction`, the member set, or the two precedence rules above, so it is not
+ * promoted here; its own subject is left intact.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+// Registers `object-metric` (the `ObjectMetricBlock` shell under test) at
+// MODULE scope, never inside a hook — object-ui/no-dynamic-import-in-test-hook.
+import '../index';
+
+afterEach(cleanup);
+
+/** The adapter call signature the aggregate path uses: `(object, params)`. */
+type Params = Record<string, unknown>;
+
+/**
+ * The comparison fixture, shaped exactly as `ObjectMetricWidget.compareTo`'s:
+ * the CURRENT window answers 120 and every shifted window answers 100, so a
+ * derived trend is +20% and `direction: 'up'`.
+ */
+const quarterStart = (d: Date) => new Date(d.getFullYear(), Math.floor(d.getMonth() / 3) * 3, 1);
+const iso = (d: Date) =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+const CURRENT_FROM = iso(quarterStart(new Date()));
+
+const comparingAdapter = () => ({
+  aggregate: vi.fn(async (_object: string, q: Params) => [
+    {
+      amount_sum:
+        String((q?.filter as Record<string, { $gte?: string }> | undefined)?.close_date?.$gte) ===
+        CURRENT_FROM
+          ? 120
+          : 100,
+    },
+  ]),
+});
+
+const QUARTER_FILTER = {
+  close_date: { $gte: '{current_quarter_start}', $lte: '{current_quarter_end}' },
+};
+
+const mount = (schema: Record<string, unknown>, adapter?: unknown) =>
+  render(
+    <SchemaRendererProvider dataSource={adapter as never}>
+      <SchemaRenderer schema={{ type: 'object-metric', label: 'Revenue', ...schema } as never} />
+    </SchemaRendererProvider>,
+  );
+
+/** A static tile: no adapter, so the value is the authored fallback. */
+const staticTile = (trend: unknown, rest: Record<string, unknown> = {}) =>
+  mount({ objectName: 'deal', fallbackValue: 42, trend, ...rest });
+
+/** The three glyphs `direction` chooses between, as a set. */
+const GLYPHS = {
+  up: 'svg.lucide-arrow-up',
+  down: 'svg.lucide-arrow-down',
+  neutral: 'svg.lucide-minus',
+} as const;
+
+/** Which of the three direction glyphs the tile is painting, as a sorted list. */
+const glyphsIn = (root: HTMLElement): string[] =>
+  (Object.keys(GLYPHS) as Array<keyof typeof GLYPHS>)
+    .filter((name) => root.querySelector(GLYPHS[name]) !== null)
+    .sort();
+
+describe('object-metric — the `trend` member shape (objectui#8071)', () => {
+  it('paints `value` as a PERCENTAGE, whatever the metric formats its own number as', () => {
+    // `format`/`suffix` govern the NUMBER; the trend badge's `%` is its own.
+    const { container } = staticTile({ value: 12, direction: 'up' }, {
+      format: '$0,0',
+      suffix: ' /mo',
+    });
+    expect(screen.getByText('12%')).toBeTruthy();
+    expect(container.textContent).toContain('$42 /mo');
+  });
+
+  it('reads `direction: "up"` and no other glyph', () => {
+    const { container } = staticTile({ value: 12, direction: 'up' });
+    expect(glyphsIn(container)).toEqual(['up']);
+  });
+
+  it('reads `direction: "down"` and no other glyph', () => {
+    const { container } = staticTile({ value: 12, direction: 'down' });
+    expect(glyphsIn(container)).toEqual(['down']);
+  });
+
+  it('reads `direction: "neutral"` and no other glyph', () => {
+    const { container } = staticTile({ value: 12, direction: 'neutral' });
+    expect(glyphsIn(container)).toEqual(['neutral']);
+  });
+
+  it('with `direction` OMITTED still paints the value, and no glyph at all', () => {
+    // The control for the three rows above: without it each of them would also
+    // pass on a renderer that painted its glyph unconditionally.
+    const { container } = staticTile({ value: 12 });
+    expect(screen.getByText('12%')).toBeTruthy();
+    expect(glyphsIn(container)).toEqual([]);
+  });
+
+  it('reads `label` into the badge caption', () => {
+    staticTile({ value: 12, direction: 'up', label: 'Authored trend caption' });
+    expect(screen.getByText('Authored trend caption')).toBeTruthy();
+  });
+
+  it('lets the tile-level `description` OUTRANK `trend.label`', () => {
+    // One caption slot, resolved `description || trend.label`. A tile that
+    // authors both loses the trend's own words silently.
+    staticTile({ value: 12, direction: 'up', label: 'Authored trend caption' }, {
+      description: 'Authored tile description',
+    });
+    expect(screen.getByText('Authored tile description')).toBeTruthy();
+    expect(screen.queryByText('Authored trend caption')).toBeNull();
+  });
+
+  it('reads no member the registration does not declare', () => {
+    // The whitelist direction: an off-list member must not reach the badge.
+    const { container } = staticTile({
+      value: 12,
+      direction: 'up',
+      label: 'Authored trend caption',
+      percent: 99,
+      caption: 'Off-list caption',
+    });
+    expect(container.textContent).not.toContain('99');
+    expect(container.textContent).not.toContain('Off-list caption');
+  });
+
+  it('with NO `trend` and no `description` paints no badge at all', () => {
+    // Non-vacuity floor for every row above: the badge row is gated on the key.
+    const { container } = mount({ objectName: 'deal', fallbackValue: 42 });
+    expect(glyphsIn(container)).toEqual([]);
+    expect(container.textContent).not.toContain('%');
+  });
+
+  it('lets a `compareTo`-DERIVED trend replace the authored one outright', async () => {
+    const adapter = comparingAdapter();
+    const { container } = mount(
+      {
+        objectName: 'deal',
+        aggregate: { field: 'amount', function: 'sum' },
+        filter: QUARTER_FILTER,
+        trend: { value: 99, direction: 'down', label: 'Authored trend caption' },
+        compareTo: { kind: 'previousYear' },
+      },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalledTimes(2));
+
+    // The derived badge, all three members: 120 vs 100 is +20% and up.
+    expect(await screen.findByText('20%')).toBeTruthy();
+    expect(await screen.findByText(/vs last year/i)).toBeTruthy();
+    expect(glyphsIn(container)).toEqual(['up']);
+
+    // And NOT a merge: every member of the authored badge is gone.
+    expect(screen.queryByText('99%')).toBeNull();
+    expect(screen.queryByText('Authored trend caption')).toBeNull();
+  });
+
+  it('keeps the authored trend when `compareTo` is absent — the override control', async () => {
+    // Same schema, one key removed, so the row above cannot be read as the
+    // authored badge simply never rendering.
+    const adapter = comparingAdapter();
+    const { container } = mount(
+      {
+        objectName: 'deal',
+        aggregate: { field: 'amount', function: 'sum' },
+        filter: QUARTER_FILTER,
+        trend: { value: 99, direction: 'down', label: 'Authored trend caption' },
+      },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalledTimes(1));
+
+    expect(await screen.findByText('99%')).toBeTruthy();
+    expect(screen.getByText('Authored trend caption')).toBeTruthy();
+    expect(glyphsIn(container)).toEqual(['down']);
+    expect(screen.queryByText('20%')).toBeNull();
+  });
+});


### PR DESCRIPTION
objectui#8071 slice 9. Converts the last two `object-metric` member-pin exemptions into behaviour pins, so the block leaves `MEMBER_PIN_EXEMPTIONS` entirely.

Refs: objectui#8071 — this PR does not end that card, which still carries 31 exemptions across three blocks plus the two held keys.

## Selection rule

Slice 8 wrote it, and this slice executes it rather than re-deriving it:

> the two **PRESENTATION** members of `object-metric`

`trend` and `drillDown`. Slice 8 took the four members that shape the aggregate query behind the number the tile paints (`dataSource`, `aggregate`, `filter`, `compareTo`); these two shape what is drawn *around* the number once it exists.

The cut is **not** "reaches an adapter". `drillDown` does issue a query of its own — the drawer's record list runs off the same resolved filter. The line is `fetchMetric` / `computeOne`, the path that produces the NUMBER, and neither of these two can change it. That was recorded in the ceiling docblock by slice 8 precisely so this slice would not re-derive the wrong cut; it is restated in the new docblock section for the next reader.

## The ledger

Measured by ONE instrument in ONE pass over both revisions. No number here is inherited.

| | parent `2c208d5bb` | head `f95a52acb` | expected |
|---|---|---|---|
| `MEMBER_PIN_EXEMPTIONS` | 33 | **31** | 31 ✅ |
| `MEMBER_PIN_EXEMPTION_CEILING` | 33 (`:2908`) | **31** (`:2958`) | 31 ✅ |
| `MEMBER_PINS` | 57 | **59** | 59 ✅ |
| distinct block prefixes | 6 | **5** | 5 ✅ |
| `NEWLY_JUDGED_UNPINNED_MEMBERS` | 2 | **2** | 2 ✅ |

Exemptions −2 and pins +2 move together, so the two keys were **converted**, not dropped. `NEWLY_JUDGED_UNPINNED_MEMBERS` is byte-identical (`object-kanban.columns`, `object-kanban.dataSource`), so the held kanban pair was not disturbed.

Block breakdown of what remains, from the same reading:

`object-grid.` **15** · `object-form.` **7** · `object-master-detail-form.` **6** · `object-kanban.` **2** (held) · `record:related_list.` **1** (`NO_READ_SITE_TO_PIN`). `object-metric.` is **gone** — the first block closed in two bites rather than one, which is the shape every remaining block now has to be closed in.

## Instrument, and its controls

TypeScript AST walk, not a regex: `ts.createSourceFile` → the named `VariableDeclaration` → initializer unwrapped through `as` / `satisfies` / parentheses → **direct** `PropertyAssignment` children only, with object boundaries taken from **AST node spans**. A regex was not used to decide anything.

Controls, reported because a count is only as good as what could hide inside the span:

- `nonPropertyAssignmentMembers` is `[]` on **both** objects at **both** revisions — no spread element, getter, setter, shorthand or computed key is inside a span the counter treats as flat.
- `parseDiagnostics` is `0` at both revisions, so neither reading is of a partially-parsed file.
- The `NEWLY_JUDGED_UNPINNED_MEMBERS` element list is compared as a list, not a count, and is identical across the two revisions.
- Both revisions were read from the same working tree path, the parent via `git show REV:PATH` into a scratch file, so the shared checkout was never touched.

## Both pins are BEHAVIOUR pins, and why no declaration was added

`@objectstack/spec`'s `ObjectMetricPropsSchema` governs this block — measured on the installed `@objectstack/spec@17.4.0`: `ComponentPropsMap['object-metric']` **is** that schema, it is a `strictObject` with an 18-member shape, and both keys are declared as `z.unknown().optional()`:

- `trend` — "Static trend info ({ value, label, direction })"
- `drillDown` — "Click-through drill config — opens the underlying records"

So the protocol deliberately leaves the member shape unpinned, and the read site is the whole member contract — the same situation `object-kanban.swimlaneField` already records for its own `z.unknown()` row. Declaring a narrower `object-metric` trend/drill schema on this side would make this repo **stricter than the protocol it renders**, which is the wrong direction. Nothing was declared; both pins are readings of the renderer.

Protocol `describe` text was compared against this repo's registry `inputs` descriptions for all three related keys (`trend`, `drillDown`, `compareTo`). **No substantive divergence**: same member lists, same semantics, with this repo adding one operational sentence each (the `trend` / `compareTo` mutual-exclusion advice). That advice is now *true* rather than advisory — see the override row below. Neither side was edited.

## What the two pins assert

**`object-metric.trend`** — `packages/plugin-dashboard/src/__tests__/objectMetricTrendMembers-8071.test.tsx` (new, 11 cases)

- `value` painted as a PERCENTAGE — the `%` is the badge's own, asserted beside a metric whose `format` and `suffix` shape the NUMBER differently.
- `direction` pinned as a **set**: `up` / `down` / `neutral` each produce their glyph and *no other*, plus the OMITTED arm, which still paints the value and draws no glyph at all. Without that fourth arm "renders an up arrow" would also pass on a renderer drawing one unconditionally.
- `label` reaches the caption slot — and the tile-level `description` **OUTRANKS** it in the one slot they share, so a tile authoring both silently loses the trend's own words. Nothing in the repo said this.
- A `compareTo`-derived trend **REPLACES** the authored badge outright (`derivedTrend ?? trend`) rather than merging, pinned against a no-`compareTo` control on the SAME schema: 120-vs-100 derives +20% up while the authored badge says 99% down, so neither arm can pass by painting the other's numbers.
- Off-list members do not reach the badge; a tile with neither `trend` nor `description` draws no badge row at all (the non-vacuity floor).

**`object-metric.drillDown`** — `packages/plugin-dashboard/src/__tests__/objectMetricDrillDownMembers-8071.test.tsx` (new, 13 cases)

- `enabled` is `!== false`, **not** truthiness: all four arms (absent / `{}` / `true` / `false`) pinned against each other, so an empty config is ENABLED and a "simplification" to a truthiness check is red.
- It is not sufficient alone — without an object name AND a data source the tile stays unclickable rather than opening a list it cannot fetch.
- `target` chooses the panel SHAPE, both live arms against each other (`dialog` = centred modal, otherwise the edge-anchored sheet).
- `drillDown.title` OUTRANKS the tile's own `title` and `label`, with the chain below it (`title`, then `label`, then the literal "Details") pinned as its fallback.
- `report` selects the drawer BODY by its own SHAPE — an `objectName`-bearing report goes to a `spec-report` body, anything else falls through to the inline record list, with whether the record list is fetched at all as the separating observable.
- The invariant the key hangs off: the drilled list is scoped by the METRIC's resolved filter with macros already substituted — the registration's own promise that the number and the records behind it agree.

## Ablation — five legs, each proved on disk before its result was read

Every leg mutates a **renderer** (never a test), and each was run against a committed `HEAD` so the restore leg had somewhere to return to. Protocol per leg: HEAD blob hash equals working-tree hash before mutation; anchor `grep -c` before and after; injected-text `grep -c` before and after; blob hash after mutation must differ and be non-empty; run; restore via `git checkout HEAD -- ABSOLUTE_PATH`; then hash must equal the HEAD blob **and** `git diff HEAD -- ABSOLUTE_PATH` must be empty. A `trap RESTORE EXIT INT TERM` with an absolute path guarded every leg. An empty hash was treated as FAILURE, never as "nothing to compare".

Workspace specifiers alias to `src` in `vitest.config.mts` (every `@object-ui/*` entry resolves to that package's `src`), so no rebuild step sits between the mutation and the reading — measured, not assumed.

| leg | file | mutation | result |
|---|---|---|---|
| A1 | `MetricWidget.tsx` | swap the caption precedence to `trend.label \|\| description` | RED — exactly 1 case: "lets the tile-level `description` OUTRANK `trend.label`" |
| A2 | `ObjectMetricWidget.tsx` | `effectiveTrend = trend ?? derivedTrend` | RED — exactly 1 case: the `compareTo` override row |
| A5 | `MetricWidget.tsx` | draw `ArrowUpIcon` on `direction === 'down'` | RED — 2 cases, `expected [ 'up' ] to deeply equal [ 'down' ]` |
| A3 | `packages/core/src/utils/drill-down.ts` | `isDrillEnabled` returns `!!config.enabled` | RED — exactly 1 case: "is clickable on an EMPTY config" |
| A4 | `ObjectMetricWidget.tsx` | drop the config from `resolveDrillTitle` | RED — exactly 1 case, `expected 'Tile title' to be 'Drill panel heading'` |

All five restores verified (hash equals HEAD blob **and** `git diff HEAD` empty), the tree confirmed clean afterwards by `git status --porcelain`, and both files re-run green on the restored tree (24/24).

## The prior-art trap, re-measured — and half of it corrected

Slice 8 flagged `ObjectMetricWidget.i18nLabel.test.tsx` as prior art that "satisfies any mechanical locator for either" key. Read end to end, and measured rather than trusted:

**The correction.** That is true only of a locator keyed on the KEY NAME. The file contains **zero** occurrences of the string `object-metric` (control: `ObjectMetricWidget` reads **15** in the same file, so the grep is live), and this repo's own locator — `memberPinProblem` — requires the file to name the BLOCK *and* the key. It would have been refused with "pin file never names the block". Restated: exactly **one** collected test file names `object-metric` and `drillDown`, and it is the ledger itself.

**The substance stands.** What the file actually asserts is `I18nLabel` resolution after objectui#5264 retired the `{ key, defaultValue }` label form: that a map `label` / `description` / `trend.label` resolves to the active locale on the card; that an inline-map drill `title` reaches the drawer heading instead of collapsing to the literal "Details"; that the card and the drawer it opens agree under the retired form in both property orders; that the resolver is order-dependent (`pickLocalized` characterization, no component); and that the props type now accepts the inline map. It authors `trend={{ value, direction, label }}` and `drillDown={{ enabled: true }}` purely as fixtures to make the drill reachable. It asserts nothing about `value`, `direction`, the member set, `enabled`'s three-way reading, `target`, `report`, or `drillDown.title`'s precedence.

**So it is not promoted**, and its own subject is left intact. The only other file naming block AND key is `ObjectMetricWidget.compareTo.test.tsx` — already the `compareTo` pin, and it never authors a `trend` prop at all (the word appears in its prose and in one title asserting the *absence* of a derived caption). Crediting either would have been slice 7's `action-bodyShape-forward.test.tsx` mistake in a new place.

## Out of scope, filed rather than patched here

objectui#8970 — `ObjectMetricWidget` hand-rolls its own drill drawer instead of using the shared `DrillDownDrawer` (measured: zero `DrillDownDrawer` occurrences in that file, control `Dialog` reads 9), so five `DrillDownConfig` members the shared component honours have no read site on this block: `columns`, `maxRows`, `target: 'navigate'`, `filter`, `mode`.

The pin **deliberately does not assert** that those members are dead. An assertion that a member is inert has to be deleted before anyone can make it live — the same choice slice 6 made for `record:activity`'s filter members (objectui#8934). The limit is stated in the pin prose and in the ceiling docblock instead.

## Verification

Run on the final commit `f95a52acb`:

- `registry-inputs-spec-parity.test.ts` — **198 passed**, rc 0
- both new pin files — **24 passed** (11 + 13), rc 0
- `@object-ui/plugin-dashboard type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`, so the new tests are type-checked) — rc 0, zero `error TS` lines
- `@object-ui/console type-check` — rc 0, zero `error TS` lines
- `eslint` on the three changed files — rc 0, empty output (zero errors AND zero warnings; the literal word "error" appears 0 times in the log)
- `check-control-bytes.mjs` — rc 0, plus an explicit `grep -naP` control-character sweep of the changed files (no hits)
- `check-changeset-presence.mjs` — rc 0, 3 source files of 2 released packages declared by one empty-frontmatter changeset
- `check-changeset-no-major.mjs` — rc 0
- `check-governed-queue-guard.mjs --test` on all four paths — **NOT GOVERNED**

Every rc was written to a file before any pipe. Both type-check legs needed their dependency closure built first (`turbo run build --filter=PKG^...`); before that build they reported `Cannot find module '@object-ui/...'` in pre-existing files, which is NOT MEASURED rather than red.

Changeset: `.changeset/olive-flowers-yawn.md`, empty frontmatter — test-only, nothing published moves.

## Status

⛔ Stays **draft**. No auto-merge, no queue, not flipped ready. Landing is the dispatching seat's act.

`Clause-②: no` holds on the finished diff: nothing is declared, widened, or relaxed — three test files and one empty changeset, with the ledger ratcheting down.

Session: `session_01Jmxdo7bmeqCQHLSfmLVX9w`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_