### PR TITLE
docs(setup): point setup.sh's third "Next steps" read at a doc that exists

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -127,7 +127,7 @@ echo -e "  ${GREEN}pnpm create-plugin${NC}    - Create a new plugin\n"
 echo -e "${BLUE}Next steps:${NC}"
 echo -e "  1. Read ${GREEN}README.md${NC} for project overview"
 echo -e "  2. Read ${GREEN}CONTRIBUTING.md${NC} for contribution guidelines"
-echo -e "  3. Read ${GREEN}content/docs/guide/architecture.md${NC} for architecture insights"
+echo -e "  3. Read ${GREEN}docs/ARCHITECTURE.md${NC} for architecture insights"
 echo -e "  4. Run ${GREEN}pnpm dev${NC} to start coding!\n"
 
 echo -e "${BLUE}Happy coding! 🎉${NC}\n"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -127,7 +127,7 @@ echo -e "  ${GREEN}pnpm create-plugin${NC}    - Create a new plugin\n"
 echo -e "${BLUE}Next steps:${NC}"
 echo -e "  1. Read ${GREEN}README.md${NC} for project overview"
 echo -e "  2. Read ${GREEN}CONTRIBUTING.md${NC} for contribution guidelines"
-echo -e "  3. Read ${GREEN}ARCHITECTURE_EVALUATION.md${NC} for architecture insights"
+echo -e "  3. Read ${GREEN}content/docs/guide/architecture.md${NC} for architecture insights"
 echo -e "  4. Run ${GREEN}pnpm dev${NC} to start coding!\n"
 
 echo -e "${BLUE}Happy coding! 🎉${NC}\n"


### PR DESCRIPTION
Refs #8559 — the card stays **open** deliberately, so triage can answer the objection recorded below. This PR does not close it.

Clause-②: no

Authored by the `domain:devx` @ objectui dev seat, session `https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr` (spelled here in prose because an edited body drops the footer's session reference).

## The defect

`scripts/setup.sh` line 130 told every new contributor to read `ARCHITECTURE_EVALUATION.md`. That file is not tracked: it was added in `63c106b05` and then deliberately deleted as obsolete in `ea72f1886` ("Delete obsolete files and documentation related to PR 300 and v0.4.0 release"), but this line was never updated with it.

The block's other two targets (`README.md`, `CONTRIBUTING.md`) both resolve, so this is **one dangling pointer, not a broken block**. The diff is one line in one file; nothing else in the script is touched, and the missing file was not created.

## The target: `docs/ARCHITECTURE.md`, as triage ruled

Line 130 now names `docs/ARCHITECTURE.md`, the target the triage comment (`issuecomment-5619199232`) ruled for.

A fact turned up during implementation that argues for a different target (recorded in full below). The protocol for that case is to **execute the ordered action literally and file the fact** — never to substitute a different answer, however well argued. So the ruling is implemented here, and the fact is filed as an objection on the card, which stays open. If triage reverses, the follow-up is a single token on line 130.

## Acceptance probe, one run, with positive and negative controls

Base `290de3724` (commit date 2026-09-10T13:48:47Z) — before:

```
git ls-files --error-unmatch ARCHITECTURE_EVALUATION.md    -> exit=1   dangling
git ls-files --error-unmatch package.json                  -> exit=0   control+
```

Head `36a624c66` (commit date 2026-09-10T14:30:24Z) — after:

```
git ls-files --error-unmatch docs/ARCHITECTURE.md          -> exit=0   ruled target resolves
git ls-files --error-unmatch ARCHITECTURE_EVALUATION.md    -> exit=1   old target still absent
git ls-files --error-unmatch package.json                  -> exit=0   control+ (tracked)
git ls-files --error-unmatch NO_SUCH_FILE_XYZ.md           -> exit=1   control- (absent)
```

Both controls answer in the same run, so each reading is a reading of the tree and not an empty result.

## The fact that argues for a different target (filed, not acted on)

⚠️ This section records an objection for triage to answer. It is **not** the choice made in this PR.

Triage's deciding reason was *"it needs no network, unlike the published guide URL"*. That reason does not separate the two candidates, because **neither is a URL**: `content/docs/guide/architecture.md` is an in-tree tracked file, as the probe above demonstrates for its sibling. `README.md` links the published `objectui.org` route for that content, and the ruling appears to treat the in-tree markdown file and that published URL as the same thing. Triage's second reason — *"keep all three the same kind of thing (in-tree root docs)"* — is not satisfied by its own pick either, since `docs/ARCHITECTURE.md` sits under `docs/`, not the repo root. Triage's third reason — do not delete the line — is honoured either way.

On content, the criterion "the document a new contributor should actually read next, after `README.md` and `CONTRIBUTING.md`" points at `content/docs/guide/architecture.md`:

- **Shape and audience.** It is the general architecture guide — Core Philosophy, Package Structure, How Schema Rendering Works, Styling System (including an explicit "Forbidden" section), Testing Strategy, Best Practices. That is "how we work here", which is what step 4 of the same block (`pnpm dev`, "start coding") immediately needs.
- **Already designated.** `CONTRIBUTING.md` line 162 — the file at step 2 of this very block — closes its own architecture section with "See the Architecture Overview guide for details", pointing at that same file.

Whereas `docs/ARCHITECTURE.md`, the ruled target, is titled "Console Streamlining - Architecture Guide" and records one refactoring project ("the refactored architecture that enables third-party systems to use ObjectUI components without inheriting the full console infrastructure"); its only inbound references in the tree are `docs/CONSOLE-STREAMLINING-SUMMARY.md` and a CHANGELOG entry.

The other two candidates are rejected under either reading:

| Candidate | Why not |
|---|---|
| `content/docs/guide/architecture-overview.md` | Self-described "Deep dive". Its sections are anchored to individual implementation files (`ActionRunner.ts`, `serverActionHandler.ts`, `TransactionManager.ts`, `packages/react/src/context/`) and it ends in a "Key Directories Reference". That is material you consult once already inside a subsystem, not the third thing you read. It is also already what `README.md` (step 1) hands off to. |
| `content/docs/guide/console-architecture.md` | Scoped to the internals of one app, as its own first line says ("the internal architecture of the Console SPA"). A new contributor may never touch the console; a subsystem deep-dive cannot be the general third read. |
| `skills/objectui/guides/architecture.md` | Written for **consumers** of the published `@object-ui/*` packages — its first section is "Choosing an integration package… Embedding ObjectUI into a third-party React app". The audience is people building apps *with* ObjectUI, not people contributing *to* this repo. |

## Checks run at head `36a624c66`, exit codes captured before any pipe

| Command | Exit | Verdict line |
|---|---|---|
| `node scripts/check-bash32-floor.mjs` | 0 | 13 tracked shell files name no bash 4+ construct; floor bash 3.2 |
| `node scripts/check-doc-links.mjs` | 0 | Links are valid across 17 scan roots |
| `node scripts/check-shell-escape-residue.mjs` | 0 | OK, 5/5 roots resolved |
| `node scripts/check-control-bytes.mjs` | 0 | OK, scanned 7182 tracked text files |
| `node scripts/check-changeset-presence.mjs` | 0 | "No source or published contract of a released package changed in this range, so no changeset is owed" |
| `pnpm lint:root` | 0 | 0 errors, 32 pre-existing warnings, none in a touched file |
| `pnpm exec vitest run scripts/__tests__/bash32-floor-wiring.test.ts` | 0 | Test Files 1 passed, Tests 9 passed |
| `bash -n scripts/setup.sh` | 0 | syntax clean |
| `node scripts/check-governed-queue-guard.mjs --test scripts/setup.sh` | 0 | NOT GOVERNED — ordinary pull request |

The shell-floor and doc-link gates were re-run **after** the target changed a second time, not carried over from the earlier head.

`check-changeset-presence.mjs` was followed rather than overridden: it compared the working tree with the merge-base `290de3724` and reported no changeset owed, so none was added.

**No changeset, and no test was skipped, disabled or quarantined.** The branch history is append-only — two commits, no amend, no force-push.

## Why no gate caught this, and why that is already answered

`scripts/check-doc-links.mjs` validates links only inside markdown scan roots, and no gate reads document paths out of shell scripts — which is how this pointer survived the deletion of its target while every check stayed green.

⛔ This is **not** a new finding to triage. Issue 6430 put exactly that question to the maintainer ("Should `check-doc-links` learn to judge links in source files at all?") and it was settled on 2026-08-27 on option **A — do nothing further**: repair the small number of dead pointers by hand, do not widen the gate's population. The measurement behind that decision priced widening at 194 day-one findings against a real debt of 2, and noted the natural false-positive defence (mask everything but comments) is mutually exclusive with the defect shape. This PR is precisely the remedy option A prescribes: a hand repair. No follow-up card was filed, deliberately.

## Landing

Left as **draft** deliberately. The PM runs the landing pipeline; this seat did not flip it ready, arm auto-merge, or merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr