### PR TITLE
fix(types): give `@object-ui/types` the package-level `test` script it lacked

### DIFF
--- a/.changeset/types-test-script-8590.md
+++ b/.changeset/types-test-script-8590.md
@@ -1,0 +1,8 @@
+---
+---
+
+Test-only and docs-only. `@object-ui/types` gains a package-level `test` script
+(objectui#8590), and the one test that imports the package's own `vite.config.ts`
+now scrubs `VITEST` across that single import so the invocation guard is not
+re-entered against the worker's cwd. No published behaviour, no schema and no
+publish-contract field changes; nothing in `dist/` differs.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -67,6 +67,7 @@
     "build": "tsc && vite build && node ../../scripts/check-dist-completeness.mjs",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "type-check": "tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json",
+    "test": "vitest run --root ../.. packages/types/",
     "lint": "eslint ."
   },
   "keywords": [

--- a/packages/types/src/__tests__/zod-subpath-bundle-config-8598.test.ts
+++ b/packages/types/src/__tests__/zod-subpath-bundle-config-8598.test.ts
@@ -87,24 +87,45 @@ interface ZodBundleBuild {
  * ⚠️ ⭐ IMPORTING THE CONFIG RUNS ITS GUARD, and that is worth stating because the
  * same gate went on to break CI. `vite.config.ts` opens with
  * `if (process.env.VITEST) { assertCanonicalVitestInvocation(...) }`, and vitest
- * sets `VITEST`, so the import below EXECUTES that guard. It passes here for one
- * reason only: this file is reached through the canonical root invocation, which
- * is exactly what the guard checks for. ⛔ Run this suite from
- * `packages/types/` and the guard refuses — correctly, and loudly.
+ * sets `VITEST`, so the import below WOULD execute that guard — judging the
+ * WORKER's argv and cwd, never the invocation's. Under a repo-root run those
+ * coincide and it passes. Under the package-level `test` script objectui#8590
+ * added, they do not: the worker's `process.argv` carries no `--root` and its
+ * cwd is `packages/types`, so the guard returns `package-cwd` and its
+ * `process.exit(1)` takes this file's five cases out of a run that had already
+ * passed 3298 of them. ⛔ This header used to record that refusal as "correct,
+ * and loudly" — written when no canonical invocation stood in this directory.
+ * objectui#8590 gave it one, and the sentence is retired with this comment.
  *
- * That is the benign face of the class. Its harmful face is objectui#8598's
- * `Test (shard 2/4)` failure: `VITEST` is inherited by CHILD processes too, so a
- * test that spawns `pnpm --filter PKG run build` handed the same guard a cwd of
- * `packages/PKG` and it killed the build before the bundler started. The repair
- * landed at the spawn (`BUILD_ENV` in `packages/cli/src/__tests__/cli-bin.test.ts`)
- * and is kept there by `scripts/__tests__/spawned-build-vitest-env-8598.test.ts`.
- * ⛔ Not repaired by loosening the gate in this config: that would diverge 1 of 24
+ * So the import below scrubs `VITEST` for its own duration and restores it. That
+ * is the objectui#8598 repair in the same shape and for the same reason: the
+ * CALLER is the only place that knows its callee is a config read rather than a
+ * test run, so that is where the truth about it belongs. Every assertion below
+ * still runs against the real imported config, so no coverage moves.
+ * ⛔ Not repaired by loosening the gate in the config: that would diverge 1 of 24
  * identical guard blocks, and `scripts/__tests__/vitest-invocation-guard.test.ts`
- * refuses the divergence mechanically.
+ * refuses the divergence mechanically. ⛔ Nor by `OBJECTUI_VITEST_GUARD=off`,
+ * which stands the guard down instead of telling it the truth about one call.
+ *
+ * The harmful face of the same class is objectui#8598's `Test (shard 2/4)`
+ * failure: `VITEST` is inherited by CHILD processes too, so a test that spawns
+ * `pnpm --filter PKG run build` handed the same guard a cwd of `packages/PKG`
+ * and it killed the build before the bundler started. The repair landed at the
+ * spawn (`BUILD_ENV` in `packages/cli/src/__tests__/cli-bin.test.ts`) and is
+ * kept there by `scripts/__tests__/spawned-build-vitest-env-8598.test.ts`.
  */
 const CONFIG_SPECIFIER = '../../vite.config.ts';
-const viteConfig = ((await import(CONFIG_SPECIFIER)) as { default?: { build?: Partial<ZodBundleBuild> } })
-  .default;
+const viteConfig = await (async () => {
+  const inherited = process.env.VITEST;
+  delete process.env.VITEST;
+  try {
+    return ((await import(CONFIG_SPECIFIER)) as { default?: { build?: Partial<ZodBundleBuild> } })
+      .default;
+  } finally {
+    if (inherited === undefined) delete process.env.VITEST;
+    else process.env.VITEST = inherited;
+  }
+})();
 
 const build = (viteConfig?.build ?? {}) as ZodBundleBuild;
 

--- a/scripts/vitest-invocation-guard.mjs
+++ b/scripts/vitest-invocation-guard.mjs
@@ -123,7 +123,14 @@
  * what the package-level `test` scripts are: every one of them names the repo
  * root explicitly (`vitest run --root ../.. packages/<pkg>/`), so they satisfy
  * this comparison instead of tripping it, and `pnpm --filter <pkg> test` /
- * `turbo run test` run the same config as CI.
+ * `turbo run test` load the same config as CI. ⛔ The same config is NOT the
+ * same conclusion: objectui#3240 moved Vitest's ROOT, and `process.cwd()` does
+ * not move with it — under the package-level form the cwd is still
+ * `packages/<pkg>/`, so anything that reads it answers differently there than
+ * CI does. This guard is one of those things whenever a TEST imports a config
+ * and re-enters it (objectui#8590): the worker's `process.argv` carries no
+ * `--root`, so the cwd decides and the package-level form is refused after the
+ * run is already under way. AGENTS.md §测试纪律 carries the same correction.
  *
  * Escape hatch, documented in AGENTS.md: `OBJECTUI_VITEST_GUARD=off`.
  */


### PR DESCRIPTION
Fixes #8590

Clause-②: no — this pull request neither touches nor widens the `packages/spec` contract. Measured on the diff: **0** files under `packages/spec` (that directory does not exist in this repository; the spec arrives as the `@objectstack/spec` dependency), and no schema, no authorable surface and no dependency range moves. The four changed files are one package manifest `scripts` entry, one test, one leading comment block, and a changeset.

Session, in prose as a backticked span: `https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr`

⚠️ Placeholders below are spelled as uppercase words (PKG) rather than in angle brackets, because tag-shaped fragments are eaten on save even inside backticks. The files themselves carry the angle-bracket spelling.

## The defect

`packages/types/package.json` declared `build`, `clean`, `type-check` and `lint` — and no `test`. So `pnpm --filter @object-ui/types run test` matched zero scripts and exited **0 having printed nothing**: a silent false green over a package that is in fact heavily tested, reached by CI only through the repo-root Vitest config.

An exit code is not a cost, and a silent 0 is the most expensive kind — the missing half is visible only as an *absence* of summary lines in a log.

## What landed, in two commits

**`21638ce0d`** (2026-09-10T14:34:25+00:00) — the manifest line:

```diff
     "type-check": "tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json",
+    "test": "vitest run --root ../.. packages/types/",
     "lint": "eslint ."
```

This is the spelling objectui#3240 settled on for every package-level test entry — `vitest run --root ../.. packages/PKG/` — verbatim, not a new one. All 37 sibling `packages/*` entries that have a `test` script use it (two with an added `--passWithNoTests` because they hold no tests).

**`393dc39dd`** (2026-09-10T14:46:21+00:00) — the repair that makes the first commit actually mean something, plus the docstring correction below.

That first commit alone ran 3298 of the package's 3303 tests and then **exited 1**. `packages/types` is the only package whose own suite imports its own `vite.config.ts` (deliberately: reading the config as text is the `toContain` weakness that file's header exists to refuse). That config carries the guard block all 24 `packages/*` vite configs carry, and Vitest sets `VITEST` in its worker — so the import **re-enters the guard**, which judges the *worker's* argv and cwd, never the invocation's. Inside the worker `process.argv` no longer carries the outer `--root` and `process.cwd()` is `packages/types`, so the guard returned `package-cwd` and its `process.exit(1)` killed the file after the rest of the run had already passed.

Repaired **at the re-entering call site**, mirroring objectui#8598's `BUILD_ENV` (`1ccfc235e`) in shape and in reason — that repair also landed at the site that re-enters (the spawn), explicitly *not* in the config and *not* in the guard:

```
const CONFIG_SPECIFIER = '../../vite.config.ts';
const viteConfig = await (async () => {
  const inherited = process.env.VITEST;
  delete process.env.VITEST;
  try {
    return (await import(CONFIG_SPECIFIER)).default;
  } finally {
    if (inherited === undefined) delete process.env.VITEST;
    else process.env.VITEST = inherited;
  }
})();
```

`BUILD_ENV` scrubs `VITEST` from the environment handed to one child process; this scrubs it around one dynamic import and restores it in a `finally`, preserving the `undefined` case rather than writing an empty string. Same principle: the **caller** is the only place that knows its callee is a config read rather than a test run, so that is where the truth about it belongs.

⛔ **No guard logic changed, and none of the 24 identical guard blocks was touched** — a ratchet pins them byte-identical and `scripts/__tests__/vitest-invocation-guard.test.ts` refuses divergence mechanically. ⛔ Nor was `OBJECTUI_VITEST_GUARD=off` used: that stands the guard down instead of telling it the truth about one call. ⛔ Nothing is skipped, disabled or quarantined — the five cases now **run**, which is the whole point.

## ⭐ The same falsified claim, in two places, and only one of them was being fixed

The guard's own header (`scripts/vitest-invocation-guard.mjs`, lines 125-126 before this PR) ended with:

> and `pnpm --filter PKG test` / `turbo run test` run the same config as CI.

PR objectui#8952 (objectui#7800) is landing a correction to **that exact claim** in `AGENTS.md`: the package-level form runs the same *config*, and the same config does **not** entail the same *conclusion* — objectui#3240 moved Vitest's **root**, and `process.cwd()` did not move with it. The sentence lives in two places, and only the `AGENTS.md` copy was being corrected. The guard's own header still stated the uncorrected version, which is how the invocation guard came to refuse a run its own docstring blesses.

The measurement in this PR is a **fourth instance of that family** — after objectui#7791, objectui#7799, and the `AGENTS.md` sentence itself. So the header is corrected here, in the same substance and following objectui#8952's wording rather than inventing a second phrasing. The correction is scoped to the falsified sentence; the rest of the header is untouched, and the diff is entirely inside the leading comment block, above the imports.

Verbatim, as it now reads:

> `turbo run test` load the same config as CI. ⛔ The same config is NOT the same conclusion: objectui#3240 moved Vitest's ROOT, and `process.cwd()` does not move with it — under the package-level form the cwd is still `packages/PKG/`, so anything that reads it answers differently there than CI does. This guard is one of those things whenever a TEST imports a config and re-enters it (objectui#8590): the worker's `process.argv` carries no `--root`, so the cwd decides and the package-level form is refused after the run is already under way. AGENTS.md §测试纪律 carries the same correction.

⛔ `AGENTS.md` itself is **not** touched here — objectui#8952 owns that half.

## Before / after — measured, not asserted

Base `290de3724`, commit date `2026-09-10T13:48:47+00:00`. Head `393dc39dd`, commit date `2026-09-10T14:46:21+00:00`. Every exit code captured into a variable before any pipe; heavy runs serialised through the container's shared verify lock and read from its `VERDICT` line, never a bare `$?`.

| invocation | exit | test files | tests |
| --- | --- | --- | --- |
| BEFORE, at base `290de3724` — `pnpm --filter @object-ui/types run test` | 0 | nothing collected | nothing ran (**0 bytes of output**) |
| after `21638ce0d` only — same command | 1 | 167 collected: 166 passed, 1 failed | 3298 passed |
| **AFTER `393dc39dd`** — same command | **0** | **167 passed** | **3303 passed** |
| reference — `pnpm exec vitest run packages/types/` from the repo root | 0 | 167 passed | 3303 passed |

**The package-level form and the repo-root form now reach identical numbers: 167 files, 3303 tests.** The middle row is the proof the repair is load-bearing rather than decorative — it is a real committed state, not a hypothetical, and the `3303 - 3298 = 5` delta is exactly the five `it()` cases in the file the repair touches. Zero coverage was removed; five cases that previously never executed now do.

## Checks run

| check | exit | note |
| --- | --- | --- |
| `pnpm --filter @object-ui/types run test` | 0 | 167 files, 3303 tests passed |
| `pnpm exec vitest run packages/types/` | 0 | 167 files, 3303 tests passed |
| the four gates whose input population includes package-level `test` scripts | 0 | 4 files, 97 tests passed |
| `scripts/__tests__/spawned-build-vitest-env-8598.test.ts` | 0 | 1 file, 2 tests — the pin on the `BUILD_ENV` precedent this repair mirrors |
| `pnpm lint:root` | 0 | 32 warnings, 0 errors; zero findings name either edited file |
| `pnpm --filter @object-ui/types run type-check` | 0 | includes `tsconfig.test.json`, which compiles the edited test |
| `pnpm --filter @object-ui/types run lint` | 0 | 278 warnings, 0 errors; zero findings name the edited file |
| `node scripts/check-changeset-presence.mjs` | 0 | see below |
| `node scripts/check-changeset-no-major.mjs` | 0 | `No changeset declares a major bump.` |

The four gates are `scripts/__tests__/vitest-invocation-guard.test.ts`, `runner-package-test-entry-3746.test.ts`, `app-test-entry-8240.test.ts`, `turbo-test-inputs.test.ts`. The hijackable-entry ratchet in the third is a subset check, and this change can only shrink its population.

**On the changeset**, because the answer changed between the two commits and both answers came from the gate rather than from an assumption. After `21638ce0d` (manifest only) the gate said *no changeset is owed* — a `scripts` entry is not one of the eight publish-contract fields it guards. After `393dc39dd` the gate went **red**, because the edited test lives under `packages/types/src/` and the gate counts `src/**` as published source without subtracting tests. Its own printed remedy is an empty-frontmatter declaration, which it names as *"a pass, not a workaround"* — so `.changeset/types-test-script-8590.md` declares this releases nothing, and the gate now prints:

```
✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s).
    Every one of them has an EMPTY frontmatter — declared as releasing nothing, which
    is the explicit exemption and a complete answer to this gate.
```

No `skip-changeset` label: that label is inert in this repo, and the empty frontmatter is the mechanism here.

## The class — re-measured and reported, ⛔ not swept

Measured across every `packages/*/package.json` and `apps/*/package.json` at base `290de3724`. Membership is proven, not inferred: each was invoked and each returned exit 0 with **zero bytes** of output.

| package | directory | `test` script | probe | test files on disk |
| --- | --- | --- | --- | --- |
| `@object-ui/types` | `packages/types` | **fixed here** | was exit 0 / 0 bytes | 167 collected |
| `@object-ui/layout` | `packages/layout` | missing | exit 0 / 0 bytes | 21 |
| `@object-ui/test-support` | `packages/test-support` | missing | exit 0 / 0 bytes | 5 |
| `@object-ui/site` | `apps/site` | missing | exit 0 / 0 bytes | 0 |

`@object-ui/layout` and `@object-ui/test-support` are the same defect exactly. `@object-ui/site` is a weaker sub-case: no test files, so the shape it wants is the `--passWithNoTests` variant `@object-ui/plugin-ai` and `@object-ui/vscode-extension` already use.

⛔ **None of them is touched here**; the PM is filing that separately. This PR is itself the argument for keeping them apart: "just add the one line" was **not** sufficient for `@object-ui/types`, and only a per-package before/after measurement would have found that. The file counts above are filename globs, not Vitest collection counts.

## Scope

Four files: `packages/types/package.json`, `packages/types/src/__tests__/zod-subpath-bundle-config-8598.test.ts`, the leading comment block of `scripts/vitest-invocation-guard.mjs`, and the empty-frontmatter changeset. No governed surface in the diff. `AGENTS.md`, the root Vitest config, every other package manifest, all 24 vite-config guard blocks and `content/docs/releases/` are untouched. No amend and no force-push: `393dc39dd` is appended on top of `21638ce0d`.

This stays a **draft**. The PM runs the landing pipeline; this seat does not flip it ready, arm auto-merge, or merge.

## Observation about editing this body — ⛔ not a declaration

This body has been PATCHed after creation. Measured on read-back, and recorded here because it costs the next reader nothing and cost this one a look: the platform's attribution block, appended in its markdown-link form when the PR was created, comes back in its **bare** form after a PATCH and no longer carries the session reference. The session survives only where it was written into ordinary prose as a backticked span, which is the mitigation `AGENTS.md` prescribes for exactly this. ⛔ This is an observation about the body-rewrite behaviour and is deliberately attached to no declaration field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session, in prose so it survives: `https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr`