### PR TITLE
fix(lint): drop git-ignored build output from ESLint's own walk

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,38 @@ export default tseslint.config({
     // fumadocs-mdx codegen for apps/site (gitignored — see apps/site/.gitignore).
     // Linting generated output only reports on the generator's choices.
     '**/.source',
+    // objectui#8592 — the three remaining build artefacts that `eslint .`
+    // still walked. Same principle as `**/.source` and `**/dist` directly
+    // above: linting generated output only reports on the generator's
+    // choices, and the report names a file:line nobody wrote. Measured on
+    // 290de3724 after a full `turbo run build`:
+    // `apps/console/plugin.d.ts` reported 1 warning
+    // (`@typescript-eslint/no-explicit-any` at 41:17) while the other two
+    // reported 0 in the same invocation — the two zeros are what make the 1
+    // a reading rather than a broken invocation.
+    //
+    // Why three literal paths and not a `.gitignore` import: the claim this
+    // change has to keep true is that ONLY git-ignored build output leaves
+    // the linted population and not one source file does. A literal path is
+    // auditable one entry at a time against `git check-ignore` /
+    // `git ls-files`; a gitignore-derived ignore set is not, because it
+    // cannot see tracking — git stops ignoring a path the moment it is
+    // tracked, and a pattern-only reader would keep dropping it, silently
+    // removing a source file from the gate. Each entry below is a git-ignored,
+    // untracked, generated-by-build path, verified that way.
+    //
+    // These mirror the declarations that already exist:
+    //   - `apps/console/plugin.{js,d.ts}` — emitted by
+    //     `tsc -p tsconfig.plugin.json` (apps/console `build:plugin`),
+    //     git-ignored at `apps/console/.gitignore` under "Compiled plugin
+    //     output".
+    //   - `apps/site/next-env.d.ts` — minted by Next's build/typegen,
+    //     git-ignored at `apps/site/.gitignore`.
+    // ⛔ Not a suppression at the report's site: the files are regenerated on
+    // every build, so an inline disable would vanish and the finding return.
+    'apps/console/plugin.js',
+    'apps/console/plugin.d.ts',
+    'apps/site/next-env.d.ts',
   ],
 }, {
   // objectui#4853 — a stale `eslint-disable` is an ERROR, not a warning.


### PR DESCRIPTION
Fixes #8592

`Clause-②: no`

Base `origin/main` @ `290de3724`, commit date `2026-09-10T13:48:47+00:00`. Head `23589a462`, commit date `2026-09-10T14:38:42+00:00`.

## What was wrong

ESLint's own walk included generated, git-ignored build output, so `apps/console/plugin.d.ts` reported `@typescript-eslint/no-explicit-any` at `41:17` — a finding on a line nobody wrote, in a file every build regenerates.

Re-derived on a fresh worktree of `290de3724` after a full `turbo run build` (both legs of the build ran green), one invocation, three files:

```
pnpm exec eslint --no-inline-config --format json \
  apps/site/next-env.d.ts apps/console/plugin.d.ts apps/console/plugin.js

apps/console/plugin.d.ts   0 errors, 1 warning
                           @typescript-eslint/no-explicit-any at 41:17
apps/console/plugin.js     0 errors, 0 warnings
apps/site/next-env.d.ts    0 errors, 0 warnings
```

The two zeros are what make the 1 a reading rather than a broken invocation — the card's control, reproduced.

## The fix

Three literal paths added to the flat config's global `ignores`, mirroring declarations that already exist in the repo's `.gitignore` files, and sitting directly under the same-principle `**/dist` / `**/.source` entries. No rule's severity or configuration is touched; no finding is suppressed at its site (the files are regenerated, so an inline disable would vanish and the card would return).

## The claim this change has to keep true

**Only git-ignored build output leaves the linted population, and not one source file does.**

Measured, not asserted. Both legs are `pnpm exec eslint . --no-inline-config --format json` from the repo root on the same built tree, and the population is the set of `filePath` values ESLint itself reported.

| | before (`290de3724`) | after (`23589a462`) | delta |
|---|---|---|---|
| linted files | **4729** | **4726** | **-3** |
| errors | 95 | 95 | 0 |
| warnings | **12763** | **12762** | **-1** |

- Files **added** to the population: **0**.
- Retained files whose error or warning count moved: **0**.
- The warning delta is exactly the one warning carried by one removed file; nothing else moved.

### The full set difference — three paths, each proven ignored by asking git

Not by reading the names. `git check-ignore -v` names the ignoring file and line; `git ls-files --error-unmatch` exits 1 when the path is untracked; `git cat-file -e HEAD:path` confirms absence from `HEAD`.

| removed path | before counts | `git check-ignore -v` | `git ls-files --error-unmatch` | in `HEAD`? |
|---|---|---|---|---|
| `apps/console/plugin.d.ts` | 0 err, 1 warn | exit 0 — `apps/console/.gitignore:17:plugin.d.ts` | exit 1 (untracked) | absent |
| `apps/console/plugin.js` | 0 err, 0 warn | exit 0 — `apps/console/.gitignore:16:plugin.js` | exit 1 (untracked) | absent |
| `apps/site/next-env.d.ts` | 0 err, 0 warn | exit 0 — `apps/site/.gitignore:26:next-env.d.ts` | exit 1 (untracked) | absent |

**Control leg, same run**, so the probes are shown to discriminate rather than to always answer "ignored": `eslint.config.js` — `git check-ignore` exit **1** (not ignored), `git ls-files --error-unmatch` exit **0** (tracked).

**Whole-population control**, independent of the three names: classifying all 4729 before-files against `git ls-files -o -i --exclude-standard` and `git ls-files` found **exactly 3** git-ignored paths in the population and **0** untracked-and-not-ignored paths. So the three above are not a selected subset — they are the entire git-ignored intersection, and the removal is complete as well as narrow.

### The patterns are exact, not approximate

`apps/console/plugin.ts` — the tracked SOURCE that produces `plugin.js`/`plugin.d.ts` — is still linted. Verified in the nested run turbo actually performs (`eslint .` with cwd `apps/console`): 200 files, and `plugin.ts` is present while `plugin.js` and `plugin.d.ts` are gone. That run also confirms the root-relative global ignores resolve correctly from a package cwd.

## `pnpm lint:root` — before and after

Exit codes captured before any pipe (`cmd` redirected to a file, then `EXIT=$?`).

| | exit code | problems |
|---|---|---|
| before | **0** | 32 problems (0 errors, 32 warnings) |
| after | **0** | 32 problems (0 errors, 32 warnings) |

The two logs are **byte-identical** (`diff` reports no difference).

⚠️ Read that as a real reading, and say why it is zero rather than "expected to move by one": `lint:root` is `eslint . --ignore-pattern 'packages/*/**' --ignore-pattern 'examples/*/**' --ignore-pattern 'apps/*/**' --ignore-pattern 'docs/**'`, so **all three removed paths live under `apps/` and were never in `lint:root`'s population to begin with**. The move-by-exactly-the-removed-warnings happens in the run that does walk them — the root `eslint .` population above, 12763 to 12762, delta 1, equal to the 1 warning on `apps/console/plugin.d.ts` and to nothing else.

## Checks run

| check | exit | result |
|---|---|---|
| `pnpm exec vitest run --project unit` on the 6 test files that read `eslint.config.js` (`turbo-lint-inputs`, `lint-workflow`, `check-lint-rule-coverage`, `component-registrations`, `registry-assertion-ratchet-8316`, `shadcn-local-patches`) | 0 | 6 files, 165 tests passed |
| `pnpm lint:coverage` | 0 | 46/46 packages linted, 0 outstanding errors |
| `pnpm check:lint-rule-coverage` | 0 | pass |
| `pnpm check:control-bytes` | 0 | 7182 tracked text files scanned, OK |
| `node scripts/check-changeset-presence.mjs` | 0 | "no changeset is owed" — 1 file changed, 0 published source, 0 manifest contract |
| `node scripts/check-governed-queue-guard.mjs --test eslint.config.js` | 0 | NOT GOVERNED — ordinary PR |
| `turbo run build` (both legs) | 0 | 43 + 30 tasks successful |

### The coverage gate's census did not move — measured, not assumed

objectui#8369 taught `scripts/check-lint-rule-coverage.mjs` to drop git-ignored paths from its own census, and that gate reads the same tree, so a change here could have moved it. It did not: `pnpm check:lint-rule-coverage` and `pnpm lint:coverage` were each run twice on the same built tree, once with the pre-fix `eslint.config.js` restored from `290de3724` and once with the fix, and **both outputs are byte-identical across the two legs**. The gate asks git directly (its own output: "3 path(s) on disk are git-ignored and therefore outside the census entirely"), so the eslint `ignores` list is not an input to it. Nothing to report as a finding, and nothing silenced.

## Fences honoured

No rule severity or configuration changed · `scripts/check-lint-rule-coverage.mjs` untouched · no suppression at the report's site · nothing deleted and nothing newly gitignored (the three paths were already ignored — that is the whole proof) · `content/docs/releases/**` untouched.

## Not flipped

Left in draft. Auto-merge not armed, not merged, not queued — the PM runs the landing pipeline.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_