### PR TITLE
test(core): pin the list-view fold output as authorable (objectui#5435)

### DIFF
--- a/.changeset/5435-list-view-fold-output-authorable.md
+++ b/.changeset/5435-list-view-fold-output-authorable.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/core': patch
+---
+
+Pin that `normalizeListViewSchema`'s output is AUTHORABLE, and retire the stale
+"pending promotion" note on the legacy toolbar-flag fold (objectui#5435).
+
+objectui#5435 was filed against `@objectstack/spec@17.0.0`, where the fold turned
+the legacy `showGroup` / `showHideFields` / `showColor` flags into
+`userActions.group` / `.hideFields` / `.rowColor` — three keys
+`UserActionsConfigSchema` did not declare, so the fold's own output was refused BY
+NAME by the schema a stored view is validated against.
+
+The maintainer ruled Option A (2026-08-22) and the fix landed **upstream**, not here:
+the spec adopted all three, and its declaring docblock names this card by number.
+This repo resolves `@objectstack/spec@17.4.0`, so the gap is closed in objectui's
+actual installed behaviour, not merely in the protocol's source. Measured, with a
+firing control that reddens on a genuinely undeclared key — the original defect was
+that nothing ever asserted the fold's output was authorable.
+
+⛔ The three toggles are NOT retired. `ListView` honours them and the protocol now
+declares them, so tombstoning them here would leave objectui narrower than the
+protocol.
+
+No behaviour changes. The published bytes that move are one corrected docblock in
+`dist/utils/normalize-list-view.js`, which is why this is a `patch` and not a
+no-release changeset: the comment told future readers (human and AI) that the
+promotion was still pending upstream, which is now false. Graded `patch` rather than
+`minor` because no API is added, removed or reshaped.

--- a/packages/core/src/utils/__tests__/normalize-list-view.foldOutputAuthorable-5435.test.ts
+++ b/packages/core/src/utils/__tests__/normalize-list-view.foldOutputAuthorable-5435.test.ts
@@ -1,0 +1,209 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5435 — the fold's output is AUTHORABLE.
+ *
+ * The card was filed against `@objectstack/spec@17.0.0`, where
+ * `normalizeListViewSchema` folded three legacy `show*` flags onto
+ * `userActions.group` / `.hideFields` / `.rowColor` — keys
+ * `UserActionsConfigSchema` did not declare, so the fold's own output was
+ * refused BY NAME by the schema a stored view is validated against.
+ *
+ * That gap is CLOSED upstream, not here: the maintainer ruled Option A
+ * (2026-08-22), the spec adopted all three, and the declaring docblock names
+ * this card by number (`@objectstack/spec` `src/ui/view.zod.ts`, the three at
+ * `:1045` / `:1048` / `:1049`, the card named at `:1020`). ⛔ objectui does NOT
+ * retire the three toggles — the renderer honours them and the protocol now
+ * declares them, so tombstoning them here would make objectui NARROWER than the
+ * protocol.
+ *
+ * ⛔ This file therefore pins the POSITIVE fact — the fold's output is
+ * authorable — and never that the keys are dead. What it exists to catch:
+ *
+ *   · the spec dropping any of the three   ⇒ the emitted block stops parsing ⇒ RED
+ *   · the fold emitting a NEW undeclared key ⇒ the residual grows ⇒ RED
+ *   · the ON/OFF default asymmetry flipping ⇒ RED (it is LOAD-BEARING: the spec
+ *     copied it FROM `ListView.tsx`'s reads, so a flip silently changes what
+ *     the author gets without either side changing code)
+ *
+ * ⚠️ NOT VACUOUS BY CONSTRUCTION. Two firing controls below prove the harness
+ * reddens when a key genuinely is refused; without them "everything parsed" is
+ * equally consistent with a schema that refuses nothing. Every population is
+ * asserted at its exact size before it is used, because a census over an empty
+ * set passes.
+ *
+ * ⚠️ SCOPED OUT — `viewType`. The fold also writes `viewType`, objectui's
+ * legacy spelling of the spec's `type`, which the spec refuses by name. That is
+ * NOT this card: it is objectui's deliberately-declared back-compat vocabulary
+ * (`@object-ui/types` declares it on its own face) and its migration to the
+ * spec-canonical keys is deferred to #2231, which this card's body already
+ * lists as "an adjacent pair, not this one". The residual is asserted to be
+ * EXACTLY that one key, so it cannot quietly grow — and when #2231 lands and it
+ * empties, this pin reddens and gets updated deliberately.
+ *
+ * ⚠️ Requires `@objectstack/spec >= 17.3.0` (the release that adopted the
+ * three). `@object-ui/core` still declares `^17.2.0`; if this file ever reddens
+ * on a resolved 17.2.x, the reading is that the declared floor is too low, not
+ * that the fold regressed.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ListViewSchema as SpecListViewSchema, UserActionsConfigSchema } from '@objectstack/spec/ui';
+import { normalizeListViewSchema } from '../normalize-list-view.js';
+
+/** Unrecognized-key names a zod result refuses, flattened. */
+const refusedKeys = (r: { error?: { issues?: readonly unknown[] } }): string[] =>
+  ((r.error?.issues ?? []) as { code?: string; keys?: string[] }[])
+    .filter((i) => i.code === 'unrecognized_keys')
+    .flatMap((i) => i.keys ?? []);
+
+const issueCount = (r: { error?: { issues?: readonly unknown[] } }): number =>
+  (r.error?.issues ?? []).length;
+
+/**
+ * A list view spelled entirely in objectui's LEGACY toolbar vocabulary — all
+ * seven `show*` flags at once, which is the widest `userActions` block the fold
+ * can produce. The two polarities are both present on purpose: `showGroup:
+ * false` (an author turning a default-ON control off) and `showHideFields` /
+ * `showColor: true` (an author opting in to a default-OFF one).
+ */
+const LEGACY_VIEW = {
+  name: 'my_view',
+  label: 'My View',
+  type: 'grid',
+  columns: [{ field: 'name' }],
+  showSearch: true,
+  showSort: true,
+  showFilters: true,
+  showDensity: true,
+  showGroup: false,
+  showHideFields: true,
+  showColor: true,
+} as const;
+
+/** The three keys this card is about. */
+const ADOPTED_KEYS = ['group', 'hideFields', 'rowColor'] as const;
+
+describe('the fold`s output is authorable (objectui#5435)', () => {
+  beforeEach(() => {
+    // #8372's undrawable-kind warning is developer-facing noise here.
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('the populations, sized before they are used', () => {
+    it('reads a non-empty spec vocabulary that contains all three adopted keys', () => {
+      const specKeys = Object.keys(UserActionsConfigSchema.shape).sort();
+
+      expect(specKeys.length).toBe(11);
+      expect(specKeys).toEqual([
+        'addRecordForm', 'buttons', 'editInline', 'filter', 'group', 'hideFields',
+        'refresh', 'rowColor', 'rowHeight', 'search', 'sort',
+      ]);
+
+      // The card's whole subject: these were absent at 17.0.0.
+      for (const key of ADOPTED_KEYS) expect(specKeys).toContain(key);
+    });
+
+    it('folds all seven legacy flags into exactly seven canonical toggles', () => {
+      const out = normalizeListViewSchema(LEGACY_VIEW) as Record<string, unknown>;
+      const ua = out.userActions as Record<string, unknown>;
+
+      expect(Object.keys(ua).sort()).toEqual([
+        'filter', 'group', 'hideFields', 'rowColor', 'rowHeight', 'search', 'sort',
+      ]);
+      // The author's intent survives the fold, both polarities.
+      expect(ua).toEqual({
+        search: true, sort: true, filter: true, rowHeight: true,
+        group: false, hideFields: true, rowColor: true,
+      });
+    });
+  });
+
+  describe('⭐ the executed parse — the reading the card was missing', () => {
+    it('accepts the `userActions` block the fold emits, with zero issues', () => {
+      const out = normalizeListViewSchema(LEGACY_VIEW) as Record<string, unknown>;
+      const result = UserActionsConfigSchema.safeParse(out.userActions);
+
+      expect(result.success).toBe(true);
+      expect(refusedKeys(result)).toEqual([]);
+      expect(issueCount(result)).toBe(0);
+    });
+
+    it('accepts each adopted key on a whole `ListViewSchema` document', () => {
+      for (const key of ADOPTED_KEYS) {
+        const result = SpecListViewSchema.safeParse({
+          name: 'my_view', label: 'My View', columns: [{ field: 'name' }],
+          userActions: { [key]: true },
+        });
+
+        expect(result.success, `${key} must be authorable`).toBe(true);
+        expect(refusedKeys(result)).toEqual([]);
+      }
+    });
+
+    it('leaves `viewType` as the ONLY key of the fold`s output the spec refuses', () => {
+      const out = normalizeListViewSchema(LEGACY_VIEW) as Record<string, unknown>;
+      const result = SpecListViewSchema.safeParse(out);
+
+      // See the SCOPED OUT note above: #2231, not this card. Asserted exactly,
+      // so a newly-manufactured refused key cannot hide behind it.
+      expect(refusedKeys(result)).toEqual(['viewType']);
+      expect(issueCount(result)).toBe(1);
+
+      // With objectui's declared legacy spelling removed, the fold's output is
+      // a clean spec document — which is the card's headline, discharged.
+      const { viewType: _viewType, ...specSpelled } = out;
+      const clean = SpecListViewSchema.safeParse(specSpelled);
+      expect(clean.success).toBe(true);
+      expect(issueCount(clean)).toBe(0);
+    });
+  });
+
+  describe('⭐ the firing controls — proof the harness can redden', () => {
+    it('still refuses an undeclared key INSIDE `userActions`', () => {
+      const out = normalizeListViewSchema(LEGACY_VIEW) as Record<string, unknown>;
+      const { viewType: _viewType, ...specSpelled } = out;
+      const result = SpecListViewSchema.safeParse({
+        ...specSpelled,
+        userActions: { ...(out.userActions as Record<string, unknown>), notARealToggle: true },
+      });
+
+      expect(result.success).toBe(false);
+      expect(refusedKeys(result)).toEqual(['notARealToggle']);
+      expect(issueCount(result)).toBe(1);
+    });
+
+    it('still refuses an undeclared key at the TOP level', () => {
+      const out = normalizeListViewSchema(LEGACY_VIEW) as Record<string, unknown>;
+      const { viewType: _viewType, ...specSpelled } = out;
+      const result = SpecListViewSchema.safeParse({ ...specSpelled, notARealViewKey: true });
+
+      expect(result.success).toBe(false);
+      expect(refusedKeys(result)).toEqual(['notARealViewKey']);
+      expect(issueCount(result)).toBe(1);
+    });
+  });
+
+  describe('the ON/OFF default asymmetry the spec copied from the renderer', () => {
+    it('matches the polarity `ListView.tsx` reads the three toggles with', () => {
+      const defaults = UserActionsConfigSchema.parse({});
+
+      // `showGroup: ua?.group !== false`      — default ON
+      expect(defaults.group).toBe(true);
+      // `showHideFields: ua?.hideFields === true` — default OFF (opt-in)
+      expect(defaults.hideFields).toBe(false);
+      // `showColor: ua?.rowColor === true`    — default OFF (opt-in)
+      expect(defaults.rowColor).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/utils/normalize-list-view.ts
+++ b/packages/core/src/utils/normalize-list-view.ts
@@ -97,8 +97,16 @@ const isRecord = (v: unknown): v is Record<string, unknown> =>
  * available to users in the view toolbar", and already carries `rowHeight` —
  * objectui's `showDensity` under its spec name. `group` / `hideFields` /
  * `rowColor` are the same kind of toggle and are named after the config key
- * they gate (`grouping`, `hiddenFields`, `rowColor`), pending promotion into
- * `UserActionsConfigSchema` upstream.
+ * they gate (`grouping`, `hiddenFields`, `rowColor`).
+ *
+ * That promotion has LANDED (objectui#5435, ruled Option A 2026-08-22):
+ * `UserActionsConfigSchema` declares all three from `@objectstack/spec@17.3.0`,
+ * and the spec's declaring docblock names this card. Every key this table emits
+ * is therefore authorable, which
+ * `__tests__/normalize-list-view.foldOutputAuthorable-5435.test.ts` pins with a
+ * firing control. ⛔ Do not read the three as legacy-only spellings awaiting
+ * retirement — the protocol declares them, so removing them here would leave
+ * objectui narrower than the protocol.
  */
 const SHOW_FLAG_TO_USER_ACTION: Record<string, string> = {
   showSearch: 'search',


### PR DESCRIPTION
Part of #5435 — this PR delivers the **verification + pin** half. It deliberately does **not** close the card; see "What is NOT in this PR" below.

## The short version

The card's named defect is **closed upstream, and closed for objectui's installed behaviour too** — but it took two measurements the sweep had not taken to say so.

## 1. The resolved spec version (owed measurement #1)

The dispatch read only declared ranges and warned that an older resolved `17.x` would make the verdict premature for objectui. Measured on this base:

| reading | value |
| --- | --- |
| `pnpm-lock.yaml` distinct resolutions | `@objectstack/spec@17.4.0` — one, used by all 29 importers |
| on disk, root / `core` / `plugin-list` / `types` / `app-shell` / `data-objectstack` | `17.4.0` each, one physical package |

So objectui resolves **newer** than the `17.3.0` that adopted the keys. Not premature — but also **not `17.3.0`**, which is what the dispatch expected to find.

Re-derived on the installed artifact (the card's anchors were stale, filed against `17.0.0`): `src/ui/view.zod.ts:1045` / `:1048` / `:1049` declare `group` / `hideFields` / `rowColor`, and the docblock names this card at `:1020`.

## 2. The executed parse (owed measurement #2)

Run against the installed schema, with firing controls:

| probe | result |
| --- | --- |
| `ListViewSchema.safeParse(… userActions:{group\|hideFields\|rowColor})` | `success: true`, 0 issues — **each** |
| the `userActions` block the fold really emits, all seven toggles | `success: true`, 0 issues |
| **control** — undeclared key inside `userActions` | `success: false`, `unrecognized_keys: ["notARealToggle"]`, 1 issue |
| **control** — undeclared key at top level | `success: false`, `unrecognized_keys: ["notARealViewKey"]`, 1 issue |

The controls are what make the greens mean "this key is declared" rather than "this schema refuses nothing".

## 3. Two things the dispatch got wrong

**(a) The fold's output does not parse clean.** The dispatch states the fold "is no longer inventing keys the contract refuses". Measured, `ListViewSchema.safeParse` of the real fold output still fails — on exactly one key, `viewType`, which the fold writes on **every** path (including a density-only fold that never touches `userActions`).

That is **not** this card: `viewType` is objectui's deliberately-declared back-compat spelling of the spec's `type` (`@object-ui/types` declares it on its own face, and `objectql.zod.ts` defers the migration to #2231 in as many words). This card's own body already lists #2231 as "an adjacent pair, not this one". Recorded, not fixed, and the pin asserts the residual is **exactly** `["viewType"]` so a newly manufactured refused key cannot hide behind it.

**(b) `UserActionsConfigSchema` is strict.** `packages/types/src/zod/objectql.zod.ts:604` states the opposite in a docblock — "Note `UserActionsConfigSchema` is NOT `.strict()`, so before this extension an author writing `userActions: { group: false }` had it silently stripped — valid on parse, no effect at render." Measured on `17.4.0`, an undeclared key is refused by name. The card's own `17.0.0` table (`unrecognized_keys: ["group"]`) says it was refused then too, so objectui carries two internal sources that contradict each other. Reported, not edited — see below.

## What this PR contains

- **`normalize-list-view.foldOutputAuthorable-5435.test.ts`** — the pin. Populations sized before use, both firing controls, the residual asserted exactly, and the ON/OFF default asymmetry checked against the polarity `ListView.tsx:937-939` reads the three toggles with (the spec's docblock calls that asymmetry load-bearing and says it was copied **from** the renderer).
- **`normalize-list-view.ts`** — drops the now-false "pending promotion into `UserActionsConfigSchema` upstream" note. This comment ships: it is present in the published `dist/utils/normalize-list-view.js`.
- **changeset**, graded `patch` — measured, not copied. Published bytes move (that docblock is in `dist`), so a no-release changeset would be wrong; no API is added or reshaped, so `minor` would be wrong.

The three toggles are **not** retired. `ListView` honours them and the protocol declares them, so tombstoning them here would leave objectui narrower than the protocol.

## Evidence

| check | verdict line |
| --- | --- |
| `pnpm --filter @object-ui/core test` | `CORE_TEST_RC=0` — `Test Files 138 passed (138)`, `Tests 2944 passed (2944)` |
| `pnpm --filter @object-ui/core run type-check` | `TYPECHECK_RC=0` |
| the pin alone | `PIN_RC=0` — `Tests 8 passed (8)` |
| `pnpm --filter '@object-ui/core...' run build` | `BUILD_RC=0` |
| eslint, 2 changed files | `LINT_RC=0`, 0 errors / 0 warnings |

**Ablation** — the pin is proven able to fail. `showGroup: 'group'` was removed from `SHOW_FLAG_TO_USER_ACTION` **on disk** (anchor count 1 to 0; blob `59dc77b6` to `d57c30b4`), then the pin run: `ABLATION_TEST_RC=1`, `Tests 4 failed | 4 passed (8)`. The mutation also made `showGroup` leak through as an unrecognized top-level key, which the residual assertion caught — the "cannot hide behind `viewType`" property working. Restored by blob hash: disk `59dc77b6` equals HEAD `59dc77b6`, `git diff HEAD` empty. No `dist` is in the execution path — the test imports the TS source.

Repo-wide `eslint .` is CI's run. Type-aware linting is not enabled (`tseslint.configs.recommended`, no `project` / `projectService`), so this diff cannot move the verdict on any untouched file.

## What is NOT in this PR

`Part of`, not `Fixes`, because the 2026-09-02 pre-brief on the card enumerates objectui work this PR does not do:

1. collapse `UserActionsSchema` (`packages/types/src/zod/objectql.zod.ts:608`) from `stripImportedDefaults(SpecUserActionsConfigSchema).extend({ group, hideFields, rowColor })` into a plain re-export, now that the spec declares all three;
2. update or remove the matching `zod-mirror-parity.test.ts` exemption entry;
3. correct the false strictness claim in that same docblock (item 3b above).

All three change a **published** `@object-ui/types` face and sit outside the "verification + a pin" scope this dispatch set, so they are left for the seat to schedule rather than taken unilaterally.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_