### PR TITLE
types(plugin-kanban): declare `object-kanban.columns` with the protocol's element union

### DIFF
--- a/.changeset/8913-object-kanban-columns-declared.md
+++ b/.changeset/8913-object-kanban-columns-declared.md
@@ -1,0 +1,58 @@
+---
+'@object-ui/types': minor
+---
+
+Declare `columns` on the `object-kanban` face — the swimlane vocabulary the board
+reads and neither published face named (objectui#8913).
+
+**`minor`, and the level is reasoned rather than copied.** This is not a `patch`:
+`@object-ui/types/zod` is a published validator and its **accept set narrows**. A
+document whose `columns` was previously admitted unexamined — `columns: "todo"`,
+`columns: [42]`, a lane with no `title`, a lane card with no `title` — is now
+refused by `ObjectKanbanSchema.safeParse` and by `safeValidateSchema`, so a
+consumer's own validation can go from green to red on bytes they did not change.
+It is not a `major` either: this repository's fixed group tracks the
+`@objectstack` major (AGENTS.md §版本号策略), so breaking semantics ship as
+`minor` with the semantics spelled out — which is what this entry is.
+
+**What moved.** `ObjectKanbanSchema` gains `columns` on both halves that move
+together — the TypeScript interface (`objectql.ts`) and its Zod mirror
+(`zod/objectql.zod.ts`). Retiring the bare `kanban` node type key (objectui#8802)
+removed the only face that judged a lane, and `object-kanban` had never declared
+the key, so it rode `BaseSchema`'s `[key: string]: any` / `.passthrough()`:
+read by the renderer at three sites, named by no published face.
+
+**Declaring here can only narrow.** On a face that already carries an index
+signature there is no wider state to reach — the value was already `any` — so this
+adds validation where there was none and mints no new authoring surface.
+
+**The element is the protocol's union, not this repository's runtime lane type.**
+`@objectstack/spec` declares `ObjectKanbanPropsSchema.columns` as
+`z.array(z.unknown()).optional()` and states the element shape in its `describe`
+prose: swimlane definitions, `{ id, title }` per `groupBy` value, **or bare value
+strings**. Both arms are admitted here, and on the object arm **`cards` is
+optional**. The alternative — reusing `KanbanColumn`, whose `cards` is required —
+was measured and rejected: it is the RUNTIME lane (`bucketCardsIntoColumns` fills
+`cards` before either board implementation sees one), and as the authoring element
+it would have refused the protocol's own gate-validated `{ id, title }` example,
+the lanes the renderer materializes from a picklist, and this repository's own
+typed board fixtures.
+
+**What is judged again.** A lane is a bare string or an object with `id`
+(string or number — the renderer coerces with `String()`) and `title`, optionally
+carrying `cards`, `limit`, `className` and `collapsed` — exactly the members the
+two board implementations read. When a lane carries `cards`, each card is judged
+by the one card authority (`KanbanCardSchema`), which is what restores
+objectui#6939's finding: **a card with no `title` is refused again**.
+
+**What is deliberately NOT judged.** `cards` is not required (a swimlane does not
+carry its own cards), so an undeclared lane key such as the retired `items`
+spelling is accepted and dropped rather than refused — the strip posture
+`KanbanColumn`'s own mirror already carries. Narrowing below the protocol's union
+is an `@objectstack/spec` change, not a local one.
+
+**Migration.** Boards authored the way the docs and the schema catalog teach them
+need no change. A board whose `columns` carried a shape nothing could render —
+a non-array, a non-lane element, a lane missing `id`/`title`, a card missing
+`id`/`title` — now reports instead of validating silently and rendering an empty
+or mis-bucketed lane.

--- a/.changeset/8913-object-kanban-columns-declared.md
+++ b/.changeset/8913-object-kanban-columns-declared.md
@@ -8,9 +8,10 @@ reads and neither published face named (objectui#8913).
 **`minor`, and the level is reasoned rather than copied.** This is not a `patch`:
 `@object-ui/types/zod` is a published validator and its **accept set narrows**. A
 document whose `columns` was previously admitted unexamined — `columns: "todo"`,
-`columns: [42]`, a lane with no `title`, a lane card with no `title` — is now
-refused by `ObjectKanbanSchema.safeParse` and by `safeValidateSchema`, so a
-consumer's own validation can go from green to red on bytes they did not change.
+`columns: [42]`, a lane with no `title`, a numeric lane `id`, a mix of the two
+array shapes, a lane card with no `title` — is now refused by
+`ObjectKanbanSchema.safeParse` and by `safeValidateSchema`, so a consumer's own
+validation can go from green to red on bytes they did not change.
 It is not a `major` either: this repository's fixed group tracks the
 `@objectstack` major (AGENTS.md §版本号策略), so breaking semantics ship as
 `minor` with the semantics spelled out — which is what this entry is.
@@ -26,33 +27,57 @@ read by the renderer at three sites, named by no published face.
 signature there is no wider state to reach — the value was already `any` — so this
 adds validation where there was none and mints no new authoring surface.
 
-**The element is the protocol's union, not this repository's runtime lane type.**
+**The shape is the protocol's, not this repository's runtime lane type.**
 `@objectstack/spec` declares `ObjectKanbanPropsSchema.columns` as
-`z.array(z.unknown()).optional()` and states the element shape in its `describe`
-prose: swimlane definitions, `{ id, title }` per `groupBy` value, **or bare value
-strings**. Both arms are admitted here, and on the object arm **`cards` is
-optional**. The alternative — reusing `KanbanColumn`, whose `cards` is required —
-was measured and rejected: it is the RUNTIME lane (`bucketCardsIntoColumns` fills
-`cards` before either board implementation sees one), and as the authoring element
-it would have refused the protocol's own gate-validated `{ id, title }` example,
-the lanes the renderer materializes from a picklist, and this repository's own
-typed board fixtures.
+`z.array(z.unknown()).optional()` and states the shape in its `describe` prose:
+swimlane definitions, `{ id, title }` per `groupBy` value, **or bare value
+strings**. Both arms are admitted whole — `columns` is `string[] | Lane[]`, a
+union of two ARRAY shapes rather than an array of a per-element union — and on the
+lane arm **`cards` is optional**. The alternative — reusing `KanbanColumn`, whose
+`cards` is required — was measured and rejected: it is the RUNTIME lane
+(`bucketCardsIntoColumns` fills `cards` before either board implementation sees
+one), and as the authoring element it would have refused the protocol's own
+gate-validated `{ id, title }` example, the lanes the renderer materializes from a
+picklist, and this repository's own typed board fixtures.
 
-**What is judged again.** A lane is a bare string or an object with `id`
-(string or number — the renderer coerces with `String()`) and `title`, optionally
+**What is judged again.** A lane has `id` (**string**) and `title`, optionally
 carrying `cards`, `limit`, `className` and `collapsed` — exactly the members the
 two board implementations read. When a lane carries `cards`, each card is judged
 by the one card authority (`KanbanCardSchema`), which is what restores
 objectui#6939's finding: **a card with no `title` is refused again**.
 
+**Two shapes the protocol's literal `z.unknown()` would take are refused, because
+the renderer mishandles them.** A declaration that admits a shape nothing can
+render is the same defect one layer up, so neither is blessed:
+
+- a **numeric lane id**. `bucketCardsIntoColumns` builds its `knownIds` set from
+  the raw `col.id` and compares it with `Object.keys(groups)`, which are strings,
+  so a numeric id injects each record into its lane **and** sweeps it into
+  "Uncategorized" — measured `1:r1, 2:r2, __uncolumned__:r1+r2` against a clean
+  `one:r1` string control. The renderer defect is objectui#8993; `KanbanColumn.id`
+  and its mirror are `string` and the protocol names no type, so refusing it here
+  is not a narrowing below the protocol.
+- a **mixed array**. The renderer dispatches on `columns[0]` alone, so an
+  object-first mix pushes strings through the object branch (a blank lane, cards
+  in "Uncategorized") and a string-first mix is ignored whole. The protocol's "or"
+  names two array shapes and no mixed example.
+
+**The bare-string array is admitted for parity and is inert on this block.** The
+renderer honours it only when a board has no `groupBy`, and `groupBy` is required
+on this face — so no document that passes this schema reaches it. It is declared
+because refusing an arm the protocol names would be a second narrowing; the
+requiredness is tracked as objectui#8990.
+
 **What is deliberately NOT judged.** `cards` is not required (a swimlane does not
 carry its own cards), so an undeclared lane key such as the retired `items`
 spelling is accepted and dropped rather than refused — the strip posture
-`KanbanColumn`'s own mirror already carries. Narrowing below the protocol's union
-is an `@objectstack/spec` change, not a local one.
+`KanbanColumn`'s own mirror already carries, and the tolerant face's posture
+rather than the strict twin's, which refuses it by name. Narrowing below the
+protocol's two arms is an `@objectstack/spec` change, not a local one.
 
 **Migration.** Boards authored the way the docs and the schema catalog teach them
 need no change. A board whose `columns` carried a shape nothing could render —
-a non-array, a non-lane element, a lane missing `id`/`title`, a card missing
-`id`/`title` — now reports instead of validating silently and rendering an empty
-or mis-bucketed lane.
+a non-array, a non-lane element, a lane missing `id`/`title`, a numeric lane `id`,
+a mix of the two array shapes, or a card missing `id`/`title` — now reports
+instead of validating silently and rendering an empty, duplicated or mis-bucketed
+lane.

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -933,6 +933,7 @@ A drag-and-drop Kanban board. The `object-kanban` type key validates the shape t
 |----------|------|-------------|
 | `objectName` | `string` | Object to fetch records from. |
 | `groupBy` | `string` | **Required.** Field whose values become the lanes (maps to column ids). |
+| `columns` | `Array<string \| KanbanLane>` | Swimlane definitions — a `{ id, title }` lane per `groupBy` value, or a bare value string. **Not** a field projection (that is `cardFields`). A lane's `cards` is optional: an object-bound board buckets records into the lane by `groupBy`, and only a static board writes a lane's cards itself. |
 | `titleField` | `string` | Field used as the card title. |
 | `cardFields` | `string[]` | Fields rendered on each card. |
 | `filter` | `any[]` | Query filter, forwarded verbatim as `$filter`. |
@@ -944,7 +945,9 @@ A drag-and-drop Kanban board. The `object-kanban` type key validates the shape t
 
 > `groupField` is refused by name (objectui#7322): the renderer reads `groupBy`.
 
-> The retired `kanban` arm declared `columns`, `cardTitle`, `swimlaneField`, `grouping` and `navigation`; the `object-kanban` face never did, and it is unchanged. The renderer still reads those keys, so a board may carry them — they are simply not judged. The board's React host supplies `onCardMove` / `onCardClick` / `onQuickAdd` as props; none of the three is authorable in JSON.
+> `columns` is declared on this face since objectui#8913, with the element union `@objectstack/spec` declares — a `{ id, title }` lane or a bare value string. A lane accepts `id`, `title`, `cards`, `limit`, `className` and `collapsed`, which are the members the board implementations read; `id` may be a number, because the renderer coerces it. When a lane carries `cards`, each card is judged — a card with no `title` is refused. An undeclared lane key is accepted and dropped, not refused.
+>
+> The other keys the retired `kanban` arm alone declared — `cardTitle`, `swimlaneField`, `grouping` and `navigation` — are still undeclared on this face. The renderer reads them, so a board may carry them; they are simply not judged. The board's React host supplies `onCardMove` / `onCardClick` / `onQuickAdd` as props; none of the three is authorable in JSON.
 
 > `data` and `bind` are [`BaseSchema`](#baseschema) members, not narrowed here, but this face requires **one of** `bind`, `data`, `objectName` — the renderer's own record-source ladder (an external `data` prop → `bind` via `useDataScope` → this schema's own `data` → a fetch keyed by `objectName`). A purely static board (lanes carrying their own cards, no record source) authors `"groupBy"` and `"data": []`.
 

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -933,7 +933,7 @@ A drag-and-drop Kanban board. The `object-kanban` type key validates the shape t
 |----------|------|-------------|
 | `objectName` | `string` | Object to fetch records from. |
 | `groupBy` | `string` | **Required.** Field whose values become the lanes (maps to column ids). |
-| `columns` | `Array<string \| KanbanLane>` | Swimlane definitions — a `{ id, title }` lane per `groupBy` value, or a bare value string. **Not** a field projection (that is `cardFields`). A lane's `cards` is optional: an object-bound board buckets records into the lane by `groupBy`, and only a static board writes a lane's cards itself. |
+| `columns` | `string[] \| KanbanLane[]` | Swimlane definitions — an array of `{ id, title }` lanes (one per `groupBy` value), **or** an array of bare value strings; never a mix. **Not** a field projection (that is `cardFields`). A lane's `cards` is optional: an object-bound board buckets records into the lane by `groupBy`, and only a static board writes a lane's cards itself. |
 | `titleField` | `string` | Field used as the card title. |
 | `cardFields` | `string[]` | Fields rendered on each card. |
 | `filter` | `any[]` | Query filter, forwarded verbatim as `$filter`. |
@@ -945,7 +945,9 @@ A drag-and-drop Kanban board. The `object-kanban` type key validates the shape t
 
 > `groupField` is refused by name (objectui#7322): the renderer reads `groupBy`.
 
-> `columns` is declared on this face since objectui#8913, with the element union `@objectstack/spec` declares — a `{ id, title }` lane or a bare value string. A lane accepts `id`, `title`, `cards`, `limit`, `className` and `collapsed`, which are the members the board implementations read; `id` may be a number, because the renderer coerces it. When a lane carries `cards`, each card is judged — a card with no `title` is refused. An undeclared lane key is accepted and dropped, not refused.
+> `columns` is declared on this face since objectui#8913, as the pair of array shapes `@objectstack/spec` declares — an array of `{ id, title }` lanes, **or** an array of bare value strings. A **mixed** array is refused: the renderer decides which shape it has from the first element alone, so a mix yields a blank lane and mis-bucketed cards. A lane accepts `id`, `title`, `cards`, `limit`, `className` and `collapsed`, which are the members the board implementations read; `id` is a **string** — a non-string lane id makes the board render every card twice, once in its lane and once in "Uncategorized" (objectui#8993). When a lane carries `cards`, each card is judged — a card with no `title` is refused. An undeclared lane key is accepted and dropped, not refused, which is this tolerant face's posture; the strict authoring face refuses it by name.
+>
+> ⚠️ The **bare-string array is accepted but inert on this block.** It is declared so this package does not refuse an authoring the protocol allows. The renderer reads a bare-string lane list only when a board has no `groupBy`, and `groupBy` is required here — so on `object-kanban` the strings are always ignored and the lanes come from the group field's picklist options or from the data. Write the `{ id, title }` array to control the lanes. The requiredness of `groupBy` is tracked as objectui#8990.
 >
 > The other keys the retired `kanban` arm alone declared — `cardTitle`, `swimlaneField`, `grouping` and `navigation` — are still undeclared on this face. The renderer reads them, so a board may carry them; they are simply not judged. The board's React host supplies `onCardMove` / `onCardClick` / `onQuickAdd` as props; none of the three is authorable in JSON.
 

--- a/content/docs/plugins/plugin-kanban.mdx
+++ b/content/docs/plugins/plugin-kanban.mdx
@@ -83,24 +83,39 @@ has no function value), never a member of the schema object below —
 `packages/plugin-kanban/README.md` documents this the same way.
 
 `columns` are the board's **swimlanes**, not a field projection — the fields drawn
-on a card are `cardFields`. The element is a **union**, and it is the one
-`@objectstack/spec` declares: a `{ id, title }` lane per `groupBy` value, or a bare
-value string. `cards` is **optional** on a lane — an object-bound board buckets its
-records into the lane by `groupBy`, and only a static board writes a lane's cards
-itself. Both faces of `@object-ui/types` declare this since objectui#8913, so a
-lane and its cards are validated: a card with no `title` is refused.
+on a card are `cardFields`. It is **one of two array shapes**, the pair
+`@objectstack/spec` declares: an array of `{ id, title }` lanes (one per `groupBy`
+value), **or** an array of bare value strings. ⛔ Not a mix of the two — the
+renderer decides which shape it has by looking at the first element only, so a
+mixed array produces a blank lane and mis-bucketed cards. `cards` is **optional**
+on a lane — an object-bound board buckets its records into the lane by `groupBy`,
+and only a static board writes a lane's cards itself. Both faces of
+`@object-ui/types` declare this since objectui#8913, so a lane and its cards are
+validated: a card with no `title` is refused.
+
+<Callout type="warn">
+  **The bare-string array is accepted but has no effect on `object-kanban`.** It is
+  declared so this package does not refuse an authoring `@objectstack/spec` allows.
+  The renderer only reads a bare-string lane list when a board has **no** `groupBy`
+  — and `groupBy` is required on `object-kanban`, so on this block the strings are
+  always ignored and the lanes come from the group field's picklist options or from
+  the data. Write the `{ id, title }` array to control the lanes. The requiredness of
+  `groupBy` is tracked as objectui#8990.
+</Callout>
 
 ```plaintext
 {
   type: 'object-kanban',
   groupBy: 'status',
   data: [],
-  columns?: Array<string | KanbanLane>,
+  columns?: string[] | KanbanLane[],   // one shape or the other, never mixed
   className?: string
 }
 
+// `KanbanLane` is a name for this page only — the shape is declared inline on
+// `ObjectKanbanSchema` and is not importable.
 interface KanbanLane {
-  id: string | number         // matched against the groupBy value
+  id: string                  // matched against the groupBy value
   title: string
   cards?: KanbanCard[]        // a STATIC board's lane only
   limit?: number              // Max cards allowed (WIP limit)
@@ -123,7 +138,7 @@ interface KanbanCard {
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `columns` | `Array<string \| KanbanLane>` | Swimlane definitions — a `{ id, title }` lane per `groupBy` value, or a bare value string. NOT a field projection. |
+| `columns` | `string[] \| KanbanLane[]` | Swimlane definitions — an array of `{ id, title }` lanes (one per `groupBy` value), **or** an array of bare value strings; never a mix. NOT a field projection. The bare-string array is accepted for spec parity but is ignored on this block (see the note above). |
 | `filter` | ViewFilterRule[] | Query filter for an object-driven board, lowered to `$filter` |
 | `limit` | number | Rows fetched by an object-driven board (default 100) |
 | `className` | string | Additional Tailwind CSS classes |
@@ -134,7 +149,7 @@ An undeclared lane key is accepted and dropped, not refused.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `id` | `string \| number` | Lane identifier, matched against the `groupBy` value (the renderer coerces it with `String()`) |
+| `id` | string | Lane identifier, matched against the `groupBy` value. Strings only: a non-string id makes the board render every card twice, once in its lane and once in "Uncategorized" (objectui#8993) |
 | `title` | string | Lane title, localized against the `groupBy` picklist's option labels |
 | `cards` | KanbanCard[] | Cards this lane carries — **optional**, and a static board's option; an object-bound board's cards arrive from the record source |
 | `limit` | number | Max cards allowed (WIP limit). Never reaches the query — the fetch window is the board's `limit` |

--- a/content/docs/plugins/plugin-kanban.mdx
+++ b/content/docs/plugins/plugin-kanban.mdx
@@ -82,21 +82,30 @@ const onCardMove = (cardId: string, fromCol: string, toCol: string, index: numbe
 has no function value), never a member of the schema object below —
 `packages/plugin-kanban/README.md` documents this the same way.
 
+`columns` are the board's **swimlanes**, not a field projection — the fields drawn
+on a card are `cardFields`. The element is a **union**, and it is the one
+`@objectstack/spec` declares: a `{ id, title }` lane per `groupBy` value, or a bare
+value string. `cards` is **optional** on a lane — an object-bound board buckets its
+records into the lane by `groupBy`, and only a static board writes a lane's cards
+itself. Both faces of `@object-ui/types` declare this since objectui#8913, so a
+lane and its cards are validated: a card with no `title` is refused.
+
 ```plaintext
 {
   type: 'object-kanban',
   groupBy: 'status',
   data: [],
-  columns?: KanbanColumn[],
+  columns?: Array<string | KanbanLane>,
   className?: string
 }
 
-interface KanbanColumn {
-  id: string
+interface KanbanLane {
+  id: string | number         // matched against the groupBy value
   title: string
-  cards: KanbanCard[]
-  limit?: number              // Max cards allowed
+  cards?: KanbanCard[]        // a STATIC board's lane only
+  limit?: number              // Max cards allowed (WIP limit)
   className?: string
+  collapsed?: boolean         // honoured by the enhanced board
 }
 
 interface KanbanCard {
@@ -114,20 +123,23 @@ interface KanbanCard {
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `columns` | KanbanColumn[] | Array of column definitions |
+| `columns` | `Array<string \| KanbanLane>` | Swimlane definitions — a `{ id, title }` lane per `groupBy` value, or a bare value string. NOT a field projection. |
 | `filter` | ViewFilterRule[] | Query filter for an object-driven board, lowered to `$filter` |
 | `limit` | number | Rows fetched by an object-driven board (default 100) |
 | `className` | string | Additional Tailwind CSS classes |
 
-### Column Properties
+### Lane Properties
+
+An undeclared lane key is accepted and dropped, not refused.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `id` | string | Unique column identifier |
-| `title` | string | Column title |
-| `cards` | KanbanCard[] | Cards in this column |
-| `limit` | number | Max cards allowed (WIP limit) |
+| `id` | `string \| number` | Lane identifier, matched against the `groupBy` value (the renderer coerces it with `String()`) |
+| `title` | string | Lane title, localized against the `groupBy` picklist's option labels |
+| `cards` | KanbanCard[] | Cards this lane carries — **optional**, and a static board's option; an object-bound board's cards arrive from the record source |
+| `limit` | number | Max cards allowed (WIP limit). Never reaches the query — the fetch window is the board's `limit` |
 | `className` | string | Additional Tailwind CSS classes |
+| `collapsed` | boolean | Whether the lane renders collapsed (honoured by the enhanced board) |
 
 ### Card Properties
 

--- a/examples/schema-catalog/test/kanban-column-cards-6939.test.tsx
+++ b/examples/schema-catalog/test/kanban-column-cards-6939.test.tsx
@@ -46,6 +46,15 @@
  * published mirror's accept/reject behaviour moving, and a renamed member on a
  * published type — pinned in both directions below.
  *
+ * ⚠️ That vector has moved TWICE more since, on the surviving face rather than
+ * on this arm, and the two `it`s below carry the current reading with its
+ * reason: objectui#8802 retired the `kanban` arm (everything inside `columns`
+ * went unjudged), and objectui#8913 declared `columns` on `ObjectKanbanSchema`
+ * with the PROTOCOL's element union — a bare value string or a `{ id, title }`
+ * lane whose `cards` is OPTIONAL. So a lane card's `title` is judged again
+ * while `cards` itself is not required, and an undeclared lane key such as
+ * `items` stays accepted-and-dropped.
+ *
  * ## The harness, and why identity is claimed only within it
  *
  * `kanban` resolves to `KanbanRenderer`, which is
@@ -201,18 +210,36 @@ describe('objectui#6939 — the mirror now accepts the spelling every board read
     //     inside it is judged — not the `cards` / `items` spelling, not a
     //     card's required `title`, not `cards`'s type.
     //
-    // ⛔ NOT repaired here: declaring `columns` on `ObjectKanbanSchema` WIDENS a
-    // published accept set, which is a ruling and not a repair. Recorded as an
-    // assertion so it cannot drift back in silence, and reported on the
-    // retirement PR for the maintainer.
+    // ⭐ objectui#8913 DECLARED `columns` on `ObjectKanbanSchema` — and this leg
+    // is STILL green, which is the finding that card had to make rather than
+    // the one it was sent to make. Two corrections to the paragraph above:
+    //
+    //   1. declaring on this face NARROWS, it does not widen — `BaseSchema`
+    //      carries `[key: string]: any` / `.passthrough()`, so a declaration
+    //      can only add validation where there was none;
+    //   2. `columns[].items` was never refused BY NAME even on the retired
+    //      arm. `KanbanColumnSchema` is a plain (strip-postured) object, so
+    //      `items` was accepted and dropped there too; what refused the
+    //      document was the arm's REQUIRED `cards`. objectui#8913 could not
+    //      make `cards` required, because `@objectstack/spec` declares a lane
+    //      as `{ id, title }` per `groupBy` value — no `cards` — and the
+    //      protocol is the authority. So `items` stays accepted-and-dropped,
+    //      and the judging that came back is the one below.
     expect(reasons(toItemsSpelling(getExample(id).schema))).toEqual([]);
   });
 
-  it('⚠️ `cards` is no longer a judged declaration on the surviving arm — measured, with a firing control', () => {
+  it('⭐ `cards` is a JUDGED declaration again on the surviving arm (objectui#8913) — measured, with a firing control', () => {
     // The same four probes objectui#6939 wrote, re-read on the surviving face.
-    // Every one of them is accepted now, INCLUDING the two that are nonsense
-    // (`cards: 'nope'`, a card with no `title`) and the one objectui#6939
-    // required (`cards` present at all).
+    //
+    // The vector moved TWICE. objectui#6939 made all four judged on the
+    // `kanban` arm; objectui#8802 retired that arm and all four went green
+    // (unjudged); objectui#8913 declared `columns` on `object-kanban` and the
+    // two NONSENSE probes are refused again. `cardsAbsent` is the one that
+    // deliberately did NOT come back — and its `true` is the protocol, not an
+    // oversight: `@objectstack/spec` describes a lane as `{ id, title }` per
+    // `groupBy` value, its own gate-validated example authors three lanes with
+    // no `cards`, and `bucketCardsIntoColumns` reads `col.cards || []`. A lane
+    // is a SWIMLANE first; carrying its own cards is the static board's option.
     const col = (extra: Record<string, unknown>) => ({
       type: 'object-kanban',
       groupBy: 'status',
@@ -224,11 +251,12 @@ describe('objectui#6939 — the mirror now accepts the spelling every board read
       cardHasNoTitle: safeValidateSchema(col({ cards: [{ id: '1' }] })).success,
       cardsAbsent: safeValidateSchema(col({})).success,
       wellFormed: safeValidateSchema(col({ cards: [{ id: '1', title: 'Task' }] })).success,
-    }).toEqual({ cardsIsAString: true, cardHasNoTitle: true, cardsAbsent: true, wellFormed: true });
+    }).toEqual({ cardsIsAString: false, cardHasNoTitle: false, cardsAbsent: true, wellFormed: true });
 
-    // FIRING CONTROL on the same call: the surviving arm is not accepting
-    // everything — its own tombstone still refuses by name, so the four `true`s
-    // above are readings about `columns` and not about a dead validator.
+    // FIRING CONTROL on the same call: the surviving arm is not refusing
+    // everything either — its own tombstone refuses by name on a document whose
+    // `columns` is well-formed, so the vector above is a reading about
+    // `columns` and not about a validator stuck in one direction.
     expect(safeValidateSchema({ ...col({ cards: [] }), groupField: 'status' }).success).toBe(false);
   });
 });

--- a/packages/types/src/__tests__/object-kanban-columns-declared-8913.test.ts
+++ b/packages/types/src/__tests__/object-kanban-columns-declared-8913.test.ts
@@ -53,6 +53,49 @@
  * ⇒ `cards` is OPTIONAL and both arms are admitted. Narrowing further is an
  * `@objectstack/spec` card, not a local edit.
  *
+ * ## ⚠️ And the two shapes the first cut got WRONG in the other direction
+ *
+ * Contract review caught this file pinning two shapes as ACCEPTED that the
+ * renderer mishandles — freezing a defect as correct, which is worse than not
+ * pinning at all. Both are measured at the real `bucketCardsIntoColumns`, each
+ * against a control leg, and both now sit in `REFUSED`:
+ *
+ *   - **a NUMERIC lane id.** The first cut admitted one, justified by "the
+ *     renderer coerces with `String(col.id)`". That is true at the i18n lookup
+ *     in `localizeColumn` and FALSE where lane membership is decided: the
+ *     bucketer builds `knownIds` from the RAW `col.id` and compares it with
+ *     `Object.keys(groups)`, which are strings. Lanes `{ id: 1 }, { id: 2 }`
+ *     with records `status: 1` / `status: '2'` come back
+ *     `1:r1, 2:r2, __uncolumned__:r1+r2` — every card rendered TWICE — against
+ *     a clean `one:r1` string control. Carrier for the renderer defect:
+ *     objectui#8993. `KanbanColumn.id` and its mirror are `string`, and the
+ *     protocol names no type, so refusing it here is not a narrowing below the
+ *     protocol.
+ *   - **a MIXED array.** `columns` is a UNION OF TWO ARRAYS, not an array of a
+ *     union. `effectiveColumns` dispatches on `columns[0]` ALONE, so an
+ *     object-first mix sends every string element down the object branch and a
+ *     string-first mix is ignored whole. Measured with
+ *     `[{ id: 'done', title: 'Done' }, 'todo']`:
+ *     `done:r2, undefined:, __uncolumned__:r1` — a blank lane whose own keys
+ *     are `["0","1","2","3","cards"]` and the `todo` record in
+ *     "Uncategorized". The protocol's "or" names two array shapes and no mixed
+ *     example; if a later ruling reads it as a per-element union, that is an
+ *     `@objectstack/spec` card.
+ *
+ * ## ⚠️ The bare-string arm is admitted for PARITY and is INERT on this face
+ *
+ * The renderer honours a bare-string lane list only when no `groupBy` is
+ * authored (`ObjectKanban.tsx`, the `effectiveColumns` memo: the string branch
+ * returns only under `if (!schema.groupBy)`), and `groupBy` is REQUIRED on this
+ * face. So no document that passes this schema can reach it. It is admitted
+ * because refusing an arm the protocol names would be a second narrowing, not
+ * because it does anything; the requiredness is objectui#8990, and ⛔ this card
+ * does not wait on it.
+ *
+ * ⚠️ "Accepted and dropped" (the strip row below) is the TOLERANT face's
+ * posture. The strict authoring twin refuses the same undeclared lane key by
+ * name.
+ *
  * ## The firing control, and why it is this one
  *
  * Every refusal below is paired with the SAME lane bag written under an
@@ -139,12 +182,8 @@ describe('the protocol union is admitted whole (objectui#8913)', () => {
     ).toEqual([]);
   });
 
-  it('a NUMERIC lane id — the renderer coerces with `String(col.id)`', () => {
-    expect(reasons(board([{ id: 1, title: 'Stage one' }]))).toEqual([]);
-  });
-
-  it('the two arms mix in one array, as a partially-labelled board authors them', () => {
-    expect(reasons(board(['todo', { id: 'done', title: 'Done' }]))).toEqual([]);
+  it('an EMPTY array — neither arm is chosen and nothing is refused', () => {
+    expect(reasons(board([]))).toEqual([]);
   });
 });
 
@@ -165,6 +204,13 @@ const REFUSED: Array<readonly [string, unknown]> = [
   ['a WIP `limit` that is not a number', [{ id: 'todo', title: 'To Do', limit: 'three' }]],
   ['a `collapsed` that is not a boolean', [{ id: 'todo', title: 'To Do', collapsed: 'yes' }]],
   ['a `className` that is not a string', [{ id: 'todo', title: 'To Do', className: 42 }]],
+  // The two rows contract review moved out of the ACCEPT set. Both parsed green
+  // before this card AND under objectui#8913's first cut, which is why they
+  // belong here with the same control as every other row: the failure they
+  // guard is a declaration blessing a shape the renderer mishandles.
+  ['⭐ a NUMERIC lane id — the bucketer renders every such card twice (objectui#8993)', [{ id: 1, title: 'Stage one' }]],
+  ['⭐ a MIXED array, string first — the renderer ignores the whole list', ['todo', { id: 'done', title: 'Done' }]],
+  ['⭐ a MIXED array, object first — the renderer emits a blank lane and mis-buckets', [{ id: 'done', title: 'Done' }, 'todo']],
 ];
 
 describe('the restored refusals, each against a firing control (objectui#8913)', () => {
@@ -225,7 +271,7 @@ export const SWIMLANES: TsObjectKanbanSchema = {
   data: [],
   columns: [
     { id: 'todo', title: 'To Do' },
-    { id: 2, title: 'In Progress' },
+    { id: 'in_progress', title: 'In Progress' },
   ],
 };
 

--- a/packages/types/src/__tests__/object-kanban-columns-declared-8913.test.ts
+++ b/packages/types/src/__tests__/object-kanban-columns-declared-8913.test.ts
@@ -1,0 +1,273 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#8913 — `ObjectKanbanSchema.columns` is DECLARED on both faces, and
+ * the element is the PROTOCOL's union rather than this repository's runtime
+ * lane type.
+ *
+ * ## What was measurably wrong
+ *
+ * Retiring the bare `kanban` node type key (objectui#8802) removed the only
+ * face that judged a lane. `object-kanban` never declared `columns`, so the key
+ * rode `BaseSchema`'s `.passthrough()` on the surviving face: the renderer read
+ * it at three sites while neither published face named it, and
+ * `columns: "todo"`, `columns: [42]`, a lane with no `title` and — the one
+ * objectui#6939 was filed for — a lane card with no `title` all parsed GREEN.
+ *
+ * Declaring on a face that already carries `[key: string]: any` /
+ * `.passthrough()` can only NARROW. That direction check is the first `it`
+ * below, and it is asserted rather than asserted-in-prose.
+ *
+ * ## ⛔ Why the element is NOT `KanbanColumn`
+ *
+ * The card that dispatched this work proposed `columns: KanbanColumn[]`. That
+ * is a PROPOSAL, and it is falsified by measurement on three independent axes.
+ * `KanbanColumn` requires `cards`; it is the RUNTIME lane —
+ * `bucketCardsIntoColumns` fills `cards` before `KanbanImpl` / `KanbanEnhanced`
+ * ever see a lane — and as the AUTHORING element it would refuse:
+ *
+ *   1. **the protocol's own gate-validated example.**
+ *      `@objectstack/spec` declares this key as
+ *      `columns: z.array(z.unknown()).optional()` with its element shape stated
+ *      in `describe` prose — "Swimlane definitions ({ id, title } per `groupBy`
+ *      value, or bare value strings) — NOT a field projection" — and the
+ *      protocol's own docs author three lanes as `{ id, title }` with no
+ *      `cards`, inside an `os:check-yaml PageComponentSchema` fence;
+ *   2. **the renderer.** `bucketCardsIntoColumns` reads `col.cards || []` on
+ *      both of its legs, and the lanes `ObjectKanban` materializes from a
+ *      picklist or from the data carry no `cards` at all;
+ *   3. **this repository's own typed corpus.** Several `plugin-kanban` board
+ *      fixtures author `columns: [{ id, title }]` under
+ *      `satisfies ObjectKanbanSchema`.
+ *
+ * Refusing the bare-string arm would fail the same way, one arm over. The
+ * maintainer principle in force decides both (2026-09-09, recorded verbatim and
+ * NOT translated):
+ *
+ *   > 我们的项目以 objectstack 协议为准，文档应该以实际实现为准。协议不正确的应该先修改协议。
+ *
+ * ⇒ `cards` is OPTIONAL and both arms are admitted. Narrowing further is an
+ * `@objectstack/spec` card, not a local edit.
+ *
+ * ## The firing control, and why it is this one
+ *
+ * Every refusal below is paired with the SAME lane bag written under an
+ * UNDECLARED key. That document is ACCEPTED, because `BaseSchema` is
+ * `.passthrough()` — which is exactly the state `columns` was in before this
+ * card. So the control is not a re-implementation of the old face; it IS the
+ * old face's mechanism, reached through a key nothing declares. Delete the
+ * `columns` declaration and every refusal here goes green while the control
+ * stays green: the instrument reports its own removal.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { ObjectKanbanSchema } from '../zod/objectql.zod';
+import type { ObjectKanbanSchema as TsObjectKanbanSchema } from '../objectql';
+import type { KanbanColumn } from '../complex';
+
+/** The board every document below is a variation of. `data: []` is the record source. */
+const BOARD = { type: 'object-kanban', groupBy: 'status', data: [] } as const;
+
+const board = (columns: unknown): Record<string, unknown> => ({ ...BOARD, columns });
+
+/**
+ * The control: the same value under a key NOTHING declares. It rides
+ * `BaseSchema`'s `.passthrough()`, which is where `columns` itself sat before
+ * this card.
+ */
+const control = (columns: unknown): Record<string, unknown> => ({ ...BOARD, columnsUndeclared: columns });
+
+/** Report the issues rather than `false`, so a red run says what broke. */
+const reasons = (doc: unknown): string[] => {
+  const r = ObjectKanbanSchema.safeParse(doc);
+  return r.success ? [] : r.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+};
+
+/* ── The direction check the card owes: declaring here NARROWS, never widens ── */
+
+describe('the declaration narrows and cannot widen (objectui#8913)', () => {
+  it('the face it sits on is passthrough, so an undeclared key was already accepted', () => {
+    // If this ever fails, `columns` was not riding an index signature before
+    // this card and the whole "narrow only" reasoning has to be re-derived.
+    const r = ObjectKanbanSchema.safeParse(control('anything at all'));
+    expect(r.success).toBe(true);
+    expect(r.success && (r.data as Record<string, unknown>).columnsUndeclared).toBe('anything at all');
+  });
+
+  it('a board that authored no `columns` is untouched', () => {
+    expect(reasons({ ...BOARD })).toEqual([]);
+  });
+});
+
+/* ── ACCEPTED: the protocol's union, both arms. ⛔ Narrowing any of these is a
+      spec card, not a local edit. ────────────────────────────────────────── */
+
+describe('the protocol union is admitted whole (objectui#8913)', () => {
+  it('bare value strings — the arm the protocol names second', () => {
+    expect(reasons(board(['todo', 'in_progress', 'done']))).toEqual([]);
+  });
+
+  it('`{ id, title }` lanes with NO cards — the protocol\'s own gate-validated example', () => {
+    expect(
+      reasons(
+        board([
+          { id: 'todo', title: 'To Do' },
+          { id: 'in_progress', title: 'In Progress' },
+          { id: 'done', title: 'Done' },
+        ]),
+      ),
+    ).toEqual([]);
+  });
+
+  it('static lanes carrying their own cards — the schema-catalog fixture shape', () => {
+    expect(
+      reasons(
+        board([
+          {
+            id: 'todo',
+            title: 'To Do',
+            cards: [{ id: '1', title: 'Design new feature', description: 'Create mockups' }],
+          },
+          { id: 'done', title: 'Done', limit: 3, className: 'w-72', collapsed: true, cards: [] },
+        ]),
+      ),
+    ).toEqual([]);
+  });
+
+  it('a NUMERIC lane id — the renderer coerces with `String(col.id)`', () => {
+    expect(reasons(board([{ id: 1, title: 'Stage one' }]))).toEqual([]);
+  });
+
+  it('the two arms mix in one array, as a partially-labelled board authors them', () => {
+    expect(reasons(board(['todo', { id: 'done', title: 'Done' }]))).toEqual([]);
+  });
+});
+
+/* ── REFUSED: the judging this card restores, each with its firing control ── */
+
+/**
+ * `[document, the reason it is refused]`. Every one of these parsed GREEN
+ * before this card.
+ */
+const REFUSED: Array<readonly [string, unknown]> = [
+  ['`columns` is not an array at all', 'todo'],
+  ['an element that is neither a string nor a lane', [42]],
+  ['a lane with no `id`', [{ title: 'To Do' }]],
+  ['a lane with no `title`', [{ id: 'todo' }]],
+  ['⭐ a lane CARD with no `title` — objectui#6939\'s defect', [{ id: 'todo', title: 'To Do', cards: [{ id: '1' }] }]],
+  ['a lane CARD with no `id`', [{ id: 'todo', title: 'To Do', cards: [{ title: 'Design' }] }]],
+  ['a lane CARD that is not an object', [{ id: 'todo', title: 'To Do', cards: ['Design'] }]],
+  ['a WIP `limit` that is not a number', [{ id: 'todo', title: 'To Do', limit: 'three' }]],
+  ['a `collapsed` that is not a boolean', [{ id: 'todo', title: 'To Do', collapsed: 'yes' }]],
+  ['a `className` that is not a string', [{ id: 'todo', title: 'To Do', className: 42 }]],
+];
+
+describe('the restored refusals, each against a firing control (objectui#8913)', () => {
+  it.each(REFUSED)('REFUSES %s', (_why, columns) => {
+    expect(reasons(board(columns))).not.toEqual([]);
+  });
+
+  it.each(REFUSED)('CONTROL — the same value under an undeclared key is ACCEPTED (%s)', (_why, columns) => {
+    // The control is what makes each row above an attribution rather than an
+    // observation: the only difference between the two documents is the key
+    // name, so the refusal comes from THIS declaration and from nothing else on
+    // the face. Remove the declaration and the row above goes green while this
+    // one stays green — a pin that cannot report its own removal is not a pin.
+    expect(reasons(control(columns))).toEqual([]);
+  });
+});
+
+/* ── The premise correction this card owes back to its own issue ──────────── */
+
+describe('an undeclared LANE key is accepted and dropped, NOT refused (objectui#8913)', () => {
+  it('`columns[].items` — the retired arm\'s spelling — parses green and is stripped', () => {
+    // The dispatching card listed `columns[].items` among the refusals to
+    // restore. It is not one, and the reason is the protocol: the retired arm
+    // refused that document only because its `cards` was REQUIRED, so a lane
+    // spelling `items` and no `cards` failed the required check. `cards` cannot
+    // be required here (see this file's header), so the honest verdict for an
+    // undeclared lane key is the STRIP posture — the same one `KanbanColumn`'s
+    // own mirror carries.
+    const r = ObjectKanbanSchema.safeParse(
+      board([{ id: 'todo', title: 'To Do', items: [{ id: '1', title: 'Design' }] }]),
+    );
+    expect(r.success).toBe(true);
+    const lane = r.success ? (r.data as { columns: Array<Record<string, unknown>> }).columns[0] : {};
+    expect(lane).toEqual({ id: 'todo', title: 'To Do' });
+    expect('items' in lane).toBe(false);
+  });
+});
+
+/* ── Type-level: the TS face mirrors the zod face, arm for arm ────────────── */
+
+/** Bare value strings annotate. */
+export const STRING_LANES: TsObjectKanbanSchema = {
+  type: 'object-kanban',
+  groupBy: 'status',
+  data: [],
+  columns: ['todo', 'done'],
+};
+
+/**
+ * `{ id, title }` lanes with no `cards` annotate. This is the shape several
+ * `plugin-kanban` board fixtures already author under
+ * `satisfies ObjectKanbanSchema`, and the shape the protocol's own docs teach —
+ * `columns?: KanbanColumn[]` would have made both a compile error.
+ */
+export const SWIMLANES: TsObjectKanbanSchema = {
+  type: 'object-kanban',
+  groupBy: 'status',
+  data: [],
+  columns: [
+    { id: 'todo', title: 'To Do' },
+    { id: 2, title: 'In Progress' },
+  ],
+};
+
+/** A static board's lanes, cards and all, annotate. */
+export const STATIC_LANES: TsObjectKanbanSchema = {
+  type: 'object-kanban',
+  groupBy: 'status',
+  data: [],
+  columns: [
+    { id: 'todo', title: 'To Do', cards: [{ id: '1', title: 'Design new feature' }], limit: 5 },
+    { id: 'done', title: 'Done', cards: [], collapsed: true, className: 'w-72' },
+  ],
+};
+
+/**
+ * The RUNTIME lane type still annotates. The authoring arm is deliberately
+ * WIDER than {@link KanbanColumn} — its `cards` is optional and it carries no
+ * `color` tombstone — so a `KanbanColumn[]` remains assignable to `columns`.
+ * That assignability is what the published doc snippets rest on: both
+ * `packages/plugin-kanban/README.md` and `content/docs/plugins/plugin-kanban.mdx`
+ * hand a `KanbanColumn[]` variable straight to a board, and this board is those
+ * snippets in one line.
+ */
+const RUNTIME_LANES: KanbanColumn[] = [
+  { id: 'todo', title: 'To Do', cards: [{ id: '1', title: 'Design new feature' }], limit: 5 },
+  { id: 'done', title: 'Done', cards: [] },
+];
+
+export const RUNTIME_LANES_BOARD: TsObjectKanbanSchema = {
+  type: 'object-kanban',
+  groupBy: 'status',
+  data: [],
+  columns: RUNTIME_LANES,
+};
+
+describe('the TS face admits what the zod face admits (objectui#8913)', () => {
+  it.each([
+    ['bare strings', STRING_LANES],
+    ['swimlanes without cards', SWIMLANES],
+    ['static lanes with cards', STATIC_LANES],
+    ['a runtime KanbanColumn[] handed straight to the board', RUNTIME_LANES_BOARD],
+  ])('the annotated %s board also parses', (_name, doc) => {
+    expect(reasons(doc)).toEqual([]);
+  });
+});

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -19,6 +19,10 @@
  */
 
 import type { BaseSchema } from './base.js';
+// `KanbanCard` is the kanban CARD vocabulary, declared once in `./complex.ts`
+// and read here by `ObjectKanbanSchema.columns` (objectui#8913) so the two
+// kanban faces judge a card the same way. Type-only: no runtime edge.
+import type { KanbanCard } from './complex.js';
 import type { DrillDownConfig } from './data-display.js';
 import type { BulkActionOperation } from '@objectstack/spec/ui';
 import type { FormField } from './form.js';
@@ -2957,6 +2961,91 @@ export interface ObjectKanbanSchema extends BaseSchema {
    * @deprecated RETIRED (objectui#7322) — author `groupBy` instead.
    */
   groupField?: never;
+  /**
+   * Swimlane definitions — the lanes the board draws, NOT a field projection
+   * (the fields drawn on a card are {@link cardFields}).
+   *
+   * Declared here by objectui#8913. Until then this key rode
+   * {@link BaseSchema}'s `[key: string]: any` on this face: the renderer read
+   * it at three sites while neither published face of this package named it,
+   * so `columns: "todo"`, `columns: [42]` and a lane card with no `title` all
+   * parsed green. Declaring on a face that already carries an index signature
+   * can only NARROW — it adds validation where there was none — and that is
+   * the whole of what this member does.
+   *
+   * ## ⭐ The element is a UNION, and the shape is the protocol's, not this
+   * repository's
+   *
+   * `@objectstack/spec` declares this key on `ObjectKanbanPropsSchema`
+   * (`packages/spec/src/ui/component.zod.ts`, read at objectstack
+   * `eabdd66f45f402eba0f8404a8a9de4a501fc83a6`) as
+   * `z.array(z.unknown()).optional()` whose `describe` states the element shape
+   * in prose: "Swimlane definitions ({ id, title } per `groupBy` value, or bare
+   * value strings) — NOT a field projection". Both arms are admitted here
+   * because the protocol admits both, per the maintainer principle in force
+   * (2026-09-09, recorded verbatim and untranslated):
+   * 「我们的项目以 objectstack 协议为准，文档应该以实际实现为准。协议不正确的应该先修改协议。」
+   *
+   * ## ⛔ Why this is NOT `KanbanColumn[]`, which is what the card proposed
+   *
+   * {@link KanbanColumn} requires `cards`. It is the RUNTIME lane shape — what
+   * `bucketCardsIntoColumns` produces and what `KanbanImpl` / `KanbanEnhanced`
+   * consume, with `cards` always filled — and using it as the AUTHORING
+   * element would refuse three live shapes, each measured rather than argued:
+   *
+   *   1. the protocol's own gate-validated example
+   *      (`content/docs/protocol/objectui/layout-dsl.mdx`, under an
+   *      `os:check-yaml PageComponentSchema` fence) authors three lanes as
+   *      `{ id, title }` with no `cards`;
+   *   2. the renderer never requires `cards` — `bucketCardsIntoColumns` reads
+   *      `col.cards || []` on both of its legs, and the lanes it materializes
+   *      from a picklist or from the data carry no `cards` at all;
+   *   3. this repository's own typed corpus authors `columns: [{ id, title }]`
+   *      under `satisfies ObjectKanbanSchema` in several `plugin-kanban` board
+   *      tests.
+   *
+   * ⇒ `cards` is OPTIONAL on the authoring arm. A lane that carries it is a
+   * static board's lane and its cards are judged; a lane that does not is a
+   * swimlane and receives its cards from the record source.
+   *
+   * ## The member set is the READ set
+   *
+   * `id` / `title` / `cards` / `limit` / `className` / `collapsed` are exactly
+   * the lane members the two board implementations read, counted off
+   * `KanbanImpl`, `KanbanEnhanced`, `useColumnWidths`, `useCrossSwimlaneMove`,
+   * `useQuickAddReorder` and `bucketCardsIntoColumns`. `id` admits a number
+   * because the renderer coerces it (`String(col.id)`) rather than assuming a
+   * string, so a numeric picklist value is a live lane id.
+   *
+   * ⚠️ An undeclared lane key is ACCEPTED AND DROPPED from the parsed output,
+   * not refused — this arm is a plain (non-passthrough) object, the same
+   * posture {@link KanbanColumn}'s mirror carries. The `color` tombstone that
+   * mirror holds is deliberately NOT carried here: it retired with the
+   * `kanban` arm (objectui#7664) and refusing a key BY NAME on this face is a
+   * separate decision, not part of this declaration.
+   *
+   * Pinned in `./__tests__/object-kanban-columns-declared-8913.test.ts`.
+   */
+  columns?: Array<
+    | string
+    | {
+        /** Lane id — matched against the `groupBy` value; coerced with `String()`. */
+        id: string | number;
+        /** Lane heading; localized against the `groupBy` picklist's option labels. */
+        title: string;
+        /**
+         * Cards this lane carries. Present on a STATIC board only: an
+         * object-bound board's cards arrive from the record source and are
+         * bucketed into the lane by `groupBy`.
+         */
+        cards?: KanbanCard[];
+        /** WIP limit — the card count at which the lane warns. Never reaches the query. */
+        limit?: number;
+        className?: string;
+        /** Whether the lane renders collapsed (honoured by the enhanced board). */
+        collapsed?: boolean;
+      }
+  >;
   /**
    * Row cap — the most records the board fetches, sent as a real `$top` on
    * the query (`packages/plugin-kanban/src/ObjectKanban.tsx:264`,

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -2973,18 +2973,40 @@ export interface ObjectKanbanSchema extends BaseSchema {
    * can only NARROW — it adds validation where there was none — and that is
    * the whole of what this member does.
    *
-   * ## ⭐ The element is a UNION, and the shape is the protocol's, not this
-   * repository's
+   * ⚠️ Narrowing is not licence to bless whatever the protocol's literal
+   * `z.unknown()` would take: a shape the RENDERER mishandles must not be
+   * declared valid, or the declaration becomes a promise nothing keeps. Two
+   * such shapes were caught in contract review and are refused here — a
+   * numeric lane id (see {@link id}) and a mixed array (see below).
+   *
+   * ## ⭐ TWO ARRAY SHAPES, not a union per element — and the shape is the
+   * protocol's, not this repository's
    *
    * `@objectstack/spec` declares this key on `ObjectKanbanPropsSchema`
    * (`packages/spec/src/ui/component.zod.ts`, read at objectstack
    * `eabdd66f45f402eba0f8404a8a9de4a501fc83a6`) as
-   * `z.array(z.unknown()).optional()` whose `describe` states the element shape
-   * in prose: "Swimlane definitions ({ id, title } per `groupBy` value, or bare
+   * `z.array(z.unknown()).optional()` whose `describe` states the shape in
+   * prose: "Swimlane definitions ({ id, title } per `groupBy` value, or bare
    * value strings) — NOT a field projection". Both arms are admitted here
-   * because the protocol admits both, per the maintainer principle in force
-   * (2026-09-09, recorded verbatim and untranslated):
+   * WHOLE, per the maintainer principle in force (2026-09-09, recorded verbatim
+   * and untranslated):
    * 「我们的项目以 objectstack 协议为准，文档应该以实际实现为准。协议不正确的应该先修改协议。」
+   *
+   * ⛔ What is NOT admitted is a MIXED array, and objectui#8913's first cut
+   * admitted one by spelling this as an array of a per-element union. The
+   * protocol's "or" reads as two array shapes, it names no mixed example, and
+   * the renderer cannot serve one: `effectiveColumns` dispatches on
+   * `columns[0]` ALONE (`plugin-kanban/src/ObjectKanban.tsx`), so an
+   * object-first mix sends every string element down the object branch and a
+   * string-first mix is ignored whole. Measured on the real bucketer with
+   * `[{ id: 'done', title: 'Done' }, 'todo']`: lanes come back
+   * `done:r2, undefined:, __uncolumned__:r1` — a blank lane whose own keys are
+   * `["0","1","2","3","cards"]` (the string spread character by character) and
+   * the `todo` record in "Uncategorized" rather than its lane. Admitting a
+   * shape whose only outcome is a broken board is the declared-but-not-honoured
+   * defect this card exists to remove, one layer up. If a later ruling reads
+   * the protocol's prose as a per-element union, that is an
+   * `@objectstack/spec` card and this member follows it.
    *
    * ## ⛔ Why this is NOT `KanbanColumn[]`, which is what the card proposed
    *
@@ -3013,24 +3035,51 @@ export interface ObjectKanbanSchema extends BaseSchema {
    * `id` / `title` / `cards` / `limit` / `className` / `collapsed` are exactly
    * the lane members the two board implementations read, counted off
    * `KanbanImpl`, `KanbanEnhanced`, `useColumnWidths`, `useCrossSwimlaneMove`,
-   * `useQuickAddReorder` and `bucketCardsIntoColumns`. `id` admits a number
-   * because the renderer coerces it (`String(col.id)`) rather than assuming a
-   * string, so a numeric picklist value is a live lane id.
+   * `useQuickAddReorder` and `bucketCardsIntoColumns`. Their VALUE types come
+   * from those read sites too — see {@link id} for the one this card had to
+   * correct.
+   *
+   * ## ⚠️ The bare-string arm is admitted for PROTOCOL PARITY and is inert here
+   *
+   * The `object-kanban` renderer honours a bare-string lane list only when no
+   * `groupBy` is authored (`ObjectKanban.tsx`, the `effectiveColumns` memo:
+   * the string branch returns only under `if (!schema.groupBy)`). `groupBy` is
+   * REQUIRED on this face, so no document that passes this schema can reach
+   * that branch — the arm is admitted because refusing it would make objectui
+   * narrower than the protocol, not because it does anything. The requiredness
+   * itself is objectui#8990; ⛔ this member does not wait on it.
    *
    * ⚠️ An undeclared lane key is ACCEPTED AND DROPPED from the parsed output,
-   * not refused — this arm is a plain (non-passthrough) object, the same
-   * posture {@link KanbanColumn}'s mirror carries. The `color` tombstone that
-   * mirror holds is deliberately NOT carried here: it retired with the
-   * `kanban` arm (objectui#7664) and refusing a key BY NAME on this face is a
-   * separate decision, not part of this declaration.
+   * not refused — the lane arm is a plain (non-passthrough) object, the same
+   * posture {@link KanbanColumn}'s mirror carries. That is the TOLERANT face's
+   * posture: the strict authoring twin refuses the same key by name. The
+   * `color` tombstone that mirror holds is deliberately NOT carried here: it
+   * retired with the `kanban` arm (objectui#7664) and refusing a key BY NAME on
+   * this face is a separate decision, not part of this declaration.
    *
    * Pinned in `./__tests__/object-kanban-columns-declared-8913.test.ts`.
    */
-  columns?: Array<
-    | string
-    | {
-        /** Lane id — matched against the `groupBy` value; coerced with `String()`. */
-        id: string | number;
+  columns?:
+    | string[]
+    | Array<{
+        /**
+         * Lane id, matched against the `groupBy` value.
+         *
+         * STRING only. objectui#8913's first cut admitted a number here on the
+         * reading that "the renderer coerces with `String(col.id)`" — TRUE at
+         * the i18n lookup in `localizeColumn`, and FALSE at the site that
+         * decides lane membership: `bucketCardsIntoColumns` builds its
+         * `knownIds` set from the RAW `col.id` and compares it against
+         * `Object.keys(groups)`, which are always strings. Measured by calling
+         * the real function with lanes `{ id: 1 }, { id: 2 }` and records
+         * `status: 1` / `status: '2'`: `1:r1, 2:r2, __uncolumned__:r1+r2` —
+         * every card rendered TWICE, once in its lane and once in
+         * "Uncategorized"; the string control is a clean `one:r1`. The retired
+         * arm ({@link KanbanColumn.id}) and its mirror are `string` too, and the
+         * protocol names no type. Carrier for the bucketer defect itself:
+         * objectui#8993.
+         */
+        id: string;
         /** Lane heading; localized against the `groupBy` picklist's option labels. */
         title: string;
         /**
@@ -3044,8 +3093,7 @@ export interface ObjectKanbanSchema extends BaseSchema {
         className?: string;
         /** Whether the lane renders collapsed (honoured by the enhanced board). */
         collapsed?: boolean;
-      }
-  >;
+      }>;
   /**
    * Row cap — the most records the board fetches, sent as a real `$top` on
    * the query (`packages/plugin-kanban/src/ObjectKanban.tsx:264`,

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -1199,11 +1199,27 @@ export const KanbanConditionalFormattingRuleSchema = z.union([
  *
  * ⭐ Both arms, because `@objectstack/spec` admits both. Its
  * `ObjectKanbanPropsSchema.columns` is `z.array(z.unknown()).optional()` and
- * states the element shape in its `describe` prose — "{ id, title } per
- * `groupBy` value, or bare value strings". Admitting only the object arm would
- * make this repository NARROWER than the protocol, which the maintainer
- * principle in force forbids (2026-09-09, verbatim, untranslated):
+ * states the shape in its `describe` prose — "{ id, title } per `groupBy`
+ * value, or bare value strings". Admitting only the object arm would make this
+ * repository NARROWER than the protocol, which the maintainer principle in
+ * force forbids (2026-09-09, verbatim, untranslated):
  * 「我们的项目以 objectstack 协议为准，文档应该以实际实现为准。协议不正确的应该先修改协议。」
+ *
+ * ⛔ Both arms WHOLE, not per element: `columns` is a UNION OF TWO ARRAYS, and
+ * a MIXED array is refused. objectui#8913's first cut spelled it
+ * `z.array(z.union([...]))` and so admitted a mix. `effectiveColumns` dispatches
+ * on `columns[0]` alone, so an object-first mix pushes every string element
+ * through the object branch and a string-first mix is ignored whole; measured
+ * on the real bucketer with `[{ id: 'done', title: 'Done' }, 'todo']` the lanes
+ * are `done:r2, undefined:, __uncolumned__:r1` — a blank lane whose own keys
+ * are `["0","1","2","3","cards"]` and the `todo` record in "Uncategorized".
+ * The protocol names no mixed example. A declaration that admits a shape the
+ * renderer mishandles is the defect this card removes, so it is refused here.
+ *
+ * ⚠️ The STRING arm is admitted for protocol parity and is INERT on this face:
+ * the renderer's string branch returns only under `if (!schema.groupBy)`, and
+ * `groupBy` is required here. Its requiredness is objectui#8990; ⛔ this
+ * schema does not wait on that card.
  *
  * ⛔ NOT `KanbanColumnSchema`, whose `cards` is REQUIRED: that mirror is the
  * RUNTIME lane (`bucketCardsIntoColumns` fills `cards` before `KanbanImpl`
@@ -1219,7 +1235,7 @@ export const KanbanConditionalFormattingRuleSchema = z.union([
  * objectui#6939's judging — a lane card with no `title` is refused again.
  */
 const ObjectKanbanLaneSchema = z.object({
-  id: z.union([z.string(), z.number()]).describe('Lane id — matched against the groupBy value; the renderer coerces it with String()'),
+  id: z.string().describe('Lane id — matched against the groupBy value. STRING only: the bucketer builds knownIds from the raw col.id and compares it with Object.keys(groups), which are strings, so a numeric id buckets every card TWICE (objectui#8993)'),
   title: z.string().describe('Lane heading, localized against the groupBy picklist option labels'),
   cards: z.array(KanbanCardSchema).optional().describe('Cards this lane carries — a STATIC board only; an object-bound board buckets records into the lane by groupBy'),
   limit: z.number().optional().describe('WIP limit — the card count at which the lane warns; never reaches the query'),
@@ -1258,8 +1274,8 @@ export const ObjectKanbanSchema = BaseSchema.extend({
   // named. Mirrors `../objectql.ts` member for member; the element union, the
   // optional `cards` and the reason this is not `KanbanColumnSchema` are
   // reasoned on `ObjectKanbanLaneSchema` above and on the TS twin.
-  columns: z.array(z.union([z.string(), ObjectKanbanLaneSchema])).optional()
-    .describe('Swimlane definitions — { id, title } per groupBy value, or bare value strings; NOT a field projection (the fields drawn on a card are cardFields)'),
+  columns: z.union([z.array(z.string()), z.array(ObjectKanbanLaneSchema)]).optional()
+    .describe('Swimlane definitions — EITHER an array of { id, title } lanes per groupBy value OR an array of bare value strings; NOT a field projection (the fields drawn on a card are cardFields), and not a mix of the two, which the renderer cannot dispatch'),
   limit: z.number().int().positive().optional().describe('Row cap — the most records the board fetches, sent as a real $top on the query; default 100 (DEFAULT_KANBAN_LIMIT)'),
   // objectui#8174 — the query key `ObjectKanban.tsx` lowers onto its own
   // `dataSource.find` (`$filter: schema.filter`), alongside the `$top` that

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -42,6 +42,9 @@ import {
 import { BaseSchema, specFieldsExcept } from './base.zod.js';
 import { handlerKeyRefusal, retirementTombstone } from './tombstone.zod.js';
 import { DrillDownConfigSchema } from './data-display.zod.js';
+// The kanban CARD vocabulary has one authority (`./complex.zod.ts`); the
+// `object-kanban` lane below reads it rather than restating it (objectui#8913).
+import { KanbanCardSchema } from './complex.zod.js';
 import { ViewSwitcherSchema } from './views.zod.js';
 import { stripImportedDefaults } from './imported-defaults.js';
 
@@ -1186,6 +1189,44 @@ export const KanbanConditionalFormattingRuleSchema = z.union([
  * `__tests__/zod-mirror-parity.test.ts` reads `^export const` out of this
  * directory and would demand a registered TS counterpart for it.
  */
+/**
+ * The `object-kanban` SWIMLANE element (objectui#8913) — the mirror half of
+ * `ObjectKanbanSchema.columns` in `../objectql.ts`, whose docblock carries the
+ * measurements. Private on purpose: it publishes no new symbol, so the
+ * `zod-mirror-parity` census (which pairs `^export const` mirrors with a TS
+ * declaration) has nothing new to register, exactly as `requireKanbanRecordSource`
+ * below is a `function` for the same reason.
+ *
+ * ⭐ Both arms, because `@objectstack/spec` admits both. Its
+ * `ObjectKanbanPropsSchema.columns` is `z.array(z.unknown()).optional()` and
+ * states the element shape in its `describe` prose — "{ id, title } per
+ * `groupBy` value, or bare value strings". Admitting only the object arm would
+ * make this repository NARROWER than the protocol, which the maintainer
+ * principle in force forbids (2026-09-09, verbatim, untranslated):
+ * 「我们的项目以 objectstack 协议为准，文档应该以实际实现为准。协议不正确的应该先修改协议。」
+ *
+ * ⛔ NOT `KanbanColumnSchema`, whose `cards` is REQUIRED: that mirror is the
+ * RUNTIME lane (`bucketCardsIntoColumns` fills `cards` before `KanbanImpl`
+ * sees it), and requiring it here would refuse the protocol's own
+ * gate-validated `{ id, title }` example, the lanes the renderer materializes
+ * from a picklist, and this repository's own typed board fixtures. `cards` is
+ * therefore optional and the two mirrors stay separate rather than one being
+ * derived from the other — the faces genuinely differ, and a derivation would
+ * make a future edit to the retired arm's lane silently move this one.
+ *
+ * `cards` reuses `KanbanCardSchema` (`./complex.zod.ts`) rather than restating
+ * it: the card vocabulary has one authority, and reaching it is what restores
+ * objectui#6939's judging — a lane card with no `title` is refused again.
+ */
+const ObjectKanbanLaneSchema = z.object({
+  id: z.union([z.string(), z.number()]).describe('Lane id — matched against the groupBy value; the renderer coerces it with String()'),
+  title: z.string().describe('Lane heading, localized against the groupBy picklist option labels'),
+  cards: z.array(KanbanCardSchema).optional().describe('Cards this lane carries — a STATIC board only; an object-bound board buckets records into the lane by groupBy'),
+  limit: z.number().optional().describe('WIP limit — the card count at which the lane warns; never reaches the query'),
+  className: z.string().optional().describe('Lane class name'),
+  collapsed: z.boolean().optional().describe('Whether the lane renders collapsed (honoured by the enhanced board)'),
+});
+
 const KANBAN_RECORD_SOURCE_KEYS = ['bind', 'data', 'objectName'] as const;
 function requireKanbanRecordSource(
   schema: Partial<Record<(typeof KANBAN_RECORD_SOURCE_KEYS)[number], unknown>>,
@@ -1213,6 +1254,12 @@ export const ObjectKanbanSchema = BaseSchema.extend({
   objectName: z.string().optional().describe('ObjectQL object name — the LAST rung of the board ladder, after the pre-fetched data prop, bind and the inline row array on data; one of bind, data, objectName must be present (objectui#7780)'),
   groupBy: z.string().describe('Field whose value places a record in a lane — the lane key the object-kanban renderer reads (ObjectKanban.tsx, thirteen sites); required, as the retired groupField was'),
   groupField: retirementTombstone('RETIRED (objectui#7322) — `groupField` is not read by the object-kanban renderer; author `groupBy`. (The view-level `kanban.groupField` alias is unaffected.)'),
+  // objectui#8913 — the lane vocabulary the renderer reads and neither face
+  // named. Mirrors `../objectql.ts` member for member; the element union, the
+  // optional `cards` and the reason this is not `KanbanColumnSchema` are
+  // reasoned on `ObjectKanbanLaneSchema` above and on the TS twin.
+  columns: z.array(z.union([z.string(), ObjectKanbanLaneSchema])).optional()
+    .describe('Swimlane definitions — { id, title } per groupBy value, or bare value strings; NOT a field projection (the fields drawn on a card are cardFields)'),
   limit: z.number().int().positive().optional().describe('Row cap — the most records the board fetches, sent as a real $top on the query; default 100 (DEFAULT_KANBAN_LIMIT)'),
   // objectui#8174 — the query key `ObjectKanban.tsx` lowers onto its own
   // `dataSource.find` (`$filter: schema.filter`), alongside the `$top` that


### PR DESCRIPTION
Fixes #8913

> **Notation.** Generic parameters are spelled as UPPERCASE WORDS rather than
> literally, because GitHub silently eats tag-shaped fragments from a stored body —
> backticks and fenced blocks do not protect them, and a table written to show a type
> change renders as "nothing changed". So "ARRAY of STRING" and "ARRAY of LANE" below
> name those array types.

## What this does

`ObjectKanbanSchema` gains `columns` on both faces that move together — the TypeScript
interface (`packages/types/src/objectql.ts`) and its Zod mirror
(`packages/types/src/zod/objectql.zod.ts`).

Retiring the bare `kanban` node type key (objectui#8802) removed the only face that
judged a lane, and `object-kanban` had never declared the key, so it rode `BaseSchema`'s
index signature / `.passthrough()`: read by the renderer at three sites, named by no
published face.

**Shape.** `columns` is a union of **two array shapes** — an ARRAY of STRING, or an
ARRAY of LANE — where LANE is `{ id: string, title: string, cards?, limit?, className?,
collapsed? }`. Those six members are the read set, counted off `KanbanImpl`,
`KanbanEnhanced`, `useColumnWidths`, `useCrossSwimlaneMove`, `useQuickAddReorder` and
`bucketCardsIntoColumns`. `cards` reuses `KanbanCardSchema`, the one card authority,
which is what restores objectui#6939's finding: **a lane card with no `title` is refused
again**. No new exported symbol.

## Contract review round — the two arms this PR no longer admits

The first cut of this PR admitted two shapes the renderer mishandles, and **pinned them
as accepted**, which freezes a defect as correct. Contract review caught both; both are
re-measured here at the real `bucketCardsIntoColumns`, each against a control leg, and
both now sit in the REFUSED set.

**A numeric lane `id` — dropped, both faces.** The first cut justified it with "the
renderer coerces with `String(col.id)`". That is true at exactly one site (the i18n
lookup in `localizeColumn`) and **false** where lane membership is decided:
`bucketCardsIntoColumns` builds its `knownIds` set from the RAW `col.id` and compares it
with `Object.keys(groups)`, which are always strings, while the injection step reads
`groups[col.id]` and coerces. The two disagree:

| lanes / records | lanes returned |
|---|---|
| `{ id: 1 }, { id: 2 }` with `status: 1` / `status: '2'` | `1:r1, 2:r2, __uncolumned__:r1+r2` — **every card twice** |
| control: `{ id: 'one' }` with `status: 'one'` | `one:r1` — clean |

`KanbanColumn.id` and its mirror are `string`, and the protocol names no type for it, so
refusing a number here is **not** a narrowing below the protocol. The renderer defect is
filed as **objectui#8993** — unclaimed, unprioritised, with this probe in it. ⛔ No
renderer code is touched by this PR.

**A mixed array — refused, both faces.** `columns` is now a union of two ARRAY types
rather than an ARRAY of a per-element union. `effectiveColumns` dispatches on
`columns[0]` **alone**: an object-first mix pushes every string element through the
object branch, a string-first mix is ignored whole. Measured with
`[{ id: 'done', title: 'Done' }, 'todo']`: lanes come back
`done:r2, undefined:, __uncolumned__:r1` — a blank lane whose own keys are
`["0","1","2","3","cards"]` (the string spread character by character) and the `todo`
record in "Uncategorized". The protocol's "or" names two array shapes and no mixed
example. **Judged rather than deferred:** admitting a shape whose only outcome is a
broken board is the declared-but-not-honoured defect this card exists to remove, one
layer up. If a later ruling reads the protocol prose as a per-element union, that is an
`@objectstack/spec` card and this member follows it.

**The bare-string array is admitted for parity and is INERT here — now said out loud.**
The renderer honours it only when a board has no `groupBy`, and `groupBy` is required on
this face, so no document that passes this schema can reach it. It is declared because
refusing an arm the protocol names would be a second narrowing. Both doc pages and the
pin header now say so, with **objectui#8990** as the carrier. ⛔ This PR does not wait on
that card: objectui#8913 is maintainer-ruled and #8990 is an unruled widening.

## Direction check: this NARROWS, and cannot widen

`BaseSchema` closes with an index signature and its Zod twin ends `.passthrough()`, so
the value was already admitted-and-unexamined; a declaration on such a face can only ADD
validation. Asserted rather than argued — the first test in the pin parses an
*undeclared* key and asserts it both validates and **survives into the parsed output**.

⚠️ Narrowing is not licence to bless whatever the protocol's literal ARRAY-of-UNKNOWN
would take. That is the lesson of the two arms above, and it is written into the member
docblock so the next reader does not re-derive it.

## ⭐ The card's title is falsified — measured on disk, with the rebuild leg

The card proposed `columns: KanbanColumn` ARRAY. `KanbanColumn` requires `cards`; it is
the **runtime** lane — `bucketCardsIntoColumns` fills `cards` before either board
implementation sees one — and as the **authoring** element it refuses live shapes: the
protocol's own gate-validated example (`layout-dsl.mdx`, under an
`os:check-yaml PageComponentSchema` fence) authors three lanes as `{ id, title }` with no
`cards`; the renderer reads `col.cards || []` on both legs; and this repo's own typed
fixtures author `columns: [{ id, title }]` under `satisfies ObjectKanbanSchema`.

Both counterfactual legs were re-run after the rework, each proved on disk **and in
`dist`** before its result was read, then restored with `git checkout HEAD -- PATH` and
`dist` rebuilt so no mutated declaration could outlive the run:

| leg | dist proof | reading |
|---|---|---|
| Zod face rewritten to the card's proposal | lane marker 1 to 0 | **5 failed / 32 passed** — the bare-string arm, the protocol's own `{ id, title }` example, the strip row and the two annotated TS-face boards all REFUSED |
| TS face rewritten to the card's proposal | `KanbanColumn` marker 0 to 1, union marker 1 to 0 | **13 `error TS`** — 8× TS2741 `Property 'cards' is missing`, 5× TS2322 with the same nested cause, in five `plugin-kanban` board fixtures |

The Zod leg was 7 failures before this round; it is 5 now, because the numeric-id row and
the mixed-array row left the ACCEPT set. The count moving is the point.

⚠️ Recorded because it nearly went the other way: the **first** attempt at the TypeScript
leg exited **0 with zero errors** — a false green. `packages/plugin-kanban/tsconfig.test.json`
sets an empty `paths`, so it resolves `@object-ui/types` through the built declaration and
never saw an unbuilt mutation. Every leg above therefore carries a rebuild and a `dist`
marker reading; that reading is what makes it a measurement.

## Premise correction the card owes back to itself

The card listed `columns[].items` among the refusals to restore. **It is not one.**
`KanbanColumnSchema` is a plain strip-postured object, so `items` was accepted and dropped
even on the retired arm; what refused that document was the arm's **required `cards`** —
which cannot be required here without contradicting the protocol. So `items` stays
accepted-and-dropped, and that verdict is pinned. "Accepted and dropped" is the
**tolerant** face's posture; the strict authoring twin refuses the same key by name.

## The pin, and its firing control

`packages/types/src/__tests__/object-kanban-columns-declared-8913.test.ts` — **37 tests**
(was 32; the two ex-ACCEPT rows became three REFUSED rows, since the mixed array is
measured in both orders). Every refusal row is paired with the **same lane bag written
under an undeclared key**, which is accepted — not a re-implementation of the old face,
but the old face's own mechanism reached through a key nothing declares.

**Ablation** (declaration deleted from the mirror; source marker 1 to 0, blob hash moved,
rebuilt so the deletion reached `dist`, marker 1 to 0 there too — all proved before the
result was read; restored and rebuilt, both markers back):

| | with the declaration | ablated |
|---|---|---|
| the 13 REFUSES rows | pass | **all 13 red** |
| the 13 CONTROL rows | pass | pass |
| the strip-posture row | pass | red (nothing strips when nothing declares) |
| totals | 37 passed | 14 failed / 23 passed |

`examples/schema-catalog/test/kanban-column-cards-6939.test.tsx` carried the *loss* this
card repairs and reddened on the fix, as it was built to; its vector is updated to the
post-repair reading with its reason and its own firing control inverted.

## Verification

All at `5490145`. Exit codes captured to a file before any pipe; heavy runs through the
container's shared verify lock, each verdict read from the wrapper's own
`VERDICT command-exit` line.

| command | reading |
|---|---|
| `pnpm --filter @object-ui/types --filter @object-ui/plugin-kanban run type-check` then `vitest run` over types, plugin-kanban, schema-catalog and the two console parity files | exit 0, **0 `error TS`**; 245 files, **5935 passed** |
| `pnpm exec vitest run` the pin file alone | 37 passed |
| `pnpm exec eslint` on the changed source files | **0 errors**, 28 warnings, none on a line this branch added |
| `pnpm check:doc-snippets` | 638 of 638 blocks judged, 0 failed |
| `pnpm check:doc-examples` | every covered example compiles or fails as its ledger row declares |
| `pnpm check:doc-types` · `check:doc-fences` · `check:spec-symbols` · `check:control-bytes` · `check:new-line-citations` | exit 0 |
| `pnpm check:changeset-presence` · `check:changeset-no-major` | exit 0 |
| `pnpm check` (the CLI self-check over 629 files) | `✓ All checks passed` |

## Changeset

`minor`, and the F1 claim it carried is removed: it is the release-notes input, so it now
says `id` is a string and names both refused shapes with their measurements.
`@object-ui/types/zod` is a published validator and its accept set **narrows**, so a
consumer's own validation can move from green to red on bytes they did not change. Not
`major` — the fixed group tracks the `@objectstack` major (AGENTS.md §版本号策略).

## Scope

Out of scope and untouched:

- **the renderer.** objectui#8993 (the bucketer's numeric-id double-bucketing) is a
  behaviour change with its own blast radius and its own card. This PR moves the
  authoring boundary only.
- `object-kanban.dataSource` — the component-level binding `SchemaRenderer` strips, not a
  member of `ObjectKanbanPropsSchema`.
- `cardTitle` / `swimlaneField` / `grouping` / `navigation` — still undeclared here;
  declaring them WIDENS and is option B, which is not ruled.
- `SchemaRegistry` has no `object-kanban` entry; adding one widens `ComponentType`
  (carrier objectui#7665).
- `object-kanban.columns` stays in the console's `MEMBER_PIN_EXEMPTIONS`: that ledger is
  objectui#8071's **renderer-side member pin**, a different obligation, and no pin was
  registered here.
- `groupBy`'s requiredness versus the protocol's optional — objectui#8990, an unruled
  widening. ⛔ This PR is not blocked on it.

`needs:contract-review` stays on both carriers.

⛔ Stays **draft**. Landing is the PM seat's act.

Drafted by Claude Code for the `os-dev` seat; the session reference is `session_01Jmxdo7bmeqCQHLSfmLVX9w` — written as prose because an edit to a PR body rewrites the attribution footer, and a bare code span survives it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_


---
_Generated by [Claude Code](https://claude.ai/code)_