### PR TITLE
fix(create-plugin): refuse an unoffered licence id instead of answering it with MIT text (objectui#8892)

### DIFF
--- a/.changeset/8892-create-plugin-licence-refusal.md
+++ b/.changeset/8892-create-plugin-licence-refusal.md
@@ -1,0 +1,18 @@
+---
+'@object-ui/create-plugin': patch
+---
+
+create-plugin: refuse a licence id the generator has no text for, instead of scaffolding a plugin whose LICENSE contradicts its own manifest
+
+`buildLicenseFile` used to answer an unoffered licence id with MIT's text. The id
+reaches a scaffolded plugin through six statements and that was the only one
+that resolved it — `package.json`, the README's `## License` line and four
+source-file headers take it verbatim — so the substitution did not remove the
+"a manifest claiming a licence with no text beside it" state its docblock
+promised to remove. It authored a worse one: a plugin naming one licence five
+times and carrying a different licence's text, which the author then publishes.
+
+The unoffered id is refused now, with an error naming the offending id and the
+ids that would be accepted. Nothing reachable changes: `resolveLicenseId` is
+total onto the four offered ids and the CLI is the only caller, so no scaffold
+that works today starts failing.

--- a/packages/create-plugin/src/__tests__/cli-cancel-and-nontty-8786.test.ts
+++ b/packages/create-plugin/src/__tests__/cli-cancel-and-nontty-8786.test.ts
@@ -61,6 +61,8 @@ const BUILD_ENV: NodeJS.ProcessEnv = (() => {
 const CTRL_C = String.fromCharCode(3);
 /** Enter, as a tty delivers it. */
 const ENTER = '\r';
+/** Arrow-down, spelled the same way as CTRL_C so this file stays greppable. */
+const DOWN = `${String.fromCharCode(27)}[B`;
 /** CSI sequences a pty echoes, stripped before any assertion reads the transcript. */
 const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;?]*[a-zA-Z]`, 'g');
 
@@ -92,6 +94,8 @@ interface Run {
   readonly files: string[] | null;
   readonly manifest: Record<string, unknown> | null;
   readonly license: string | null;
+  /** Every emitted file's text, keyed the same way as {@link Run.files}. */
+  readonly contents: Record<string, string> | null;
 }
 
 function listFiles(dir: string): string[] {
@@ -159,8 +163,12 @@ function driveCli(args: string[], steps: Step[], opts: { pty: boolean }): Promis
           ? (JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8')) as Record<string, unknown>)
           : null;
       const license = files?.includes('LICENSE') === true ? readFileSync(join(dir, 'LICENSE'), 'utf-8') : null;
+      const contents =
+        files === null
+          ? null
+          : Object.fromEntries(files.map((name) => [name, readFileSync(join(dir, name), 'utf-8')]));
       rmSync(cwd, { recursive: true, force: true });
-      resolvePromise({ code, transcript, stderr, files, manifest, license });
+      resolvePromise({ code, transcript, stderr, files, manifest, license, contents });
     });
   });
 }
@@ -270,6 +278,79 @@ describe('create-plugin CLI — cancelling and non-TTY runs (objectui#8786)', ()
       );
       expect(order.every((at) => at >= 0)).toBe(true);
       expect([...order].sort((a, b) => a - b)).toEqual(order);
+    }, 60_000);
+  });
+
+  /**
+   * The whole emitted plugin names ONE licence (objectui#8892).
+   *
+   * Lives in this file, not beside the other licence tests, because those stop
+   * at `buildPluginFiles`: they can assert what the templates would produce,
+   * never what a scaffold on disk actually says. It shares this file's single
+   * unconditional `beforeAll` build on purpose — vitest runs test FILES in
+   * parallel worker threads (`pool: 'threads'`, `isolate: true`), and `tsup`
+   * cleans `dist/` before it writes, so a second file building this same
+   * package would delete the bin out from under the runs here.
+   *
+   * ⚠️ Every other run in this file ends at MIT — the default, and what a
+   * cancel or a non-TTY run takes. A template that hard-coded "MIT" in five of
+   * the six places the id is emitted would be green in all of them. So this one
+   * CHOOSES a different licence and asserts the six agree as a RELATION, read
+   * off the manifest rather than compared to a constant.
+   */
+  describe('a plugin scaffolded with a non-default licence', () => {
+    /**
+     * The four ids the prompt offers, and a line unique to Apache-2.0's text.
+     *
+     * Hand-written rather than imported from `../licenses`, for the reason
+     * `licenses.test.ts` gives about its own copy: a marker derived from the
+     * table the generator reads passes for any two texts as long as they were
+     * consistently swapped.
+     */
+    const OFFERED = ['MIT', 'Apache-2.0', 'BSD-3-Clause', 'ISC'] as const;
+    const APACHE_ONLY_LINE = '                           Version 2.0, January 2004';
+    const MIT_ONLY_LINE = 'Permission is hereby granted, free of charge, to any person obtaining a copy';
+    const SOURCE_FILES = ['src/index.tsx', 'src/DemoImpl.tsx', 'src/types.ts', 'src/DemoImpl.test.tsx'] as const;
+
+    it('agrees with itself across the manifest, the LICENSE, the README and four headers', async () => {
+      // One arrow-down off MIT is Apache-2.0; `prompts` is a `select`, so this
+      // is the only way a run reaches a non-default licence today.
+      const run = await driveCli(
+        ['demo'],
+        [
+          { waitFor: 'Plugin description:', send: ENTER },
+          { waitFor: 'Author name:', send: `Ada${ENTER}` },
+          { waitFor: 'License:', send: `${DOWN}${ENTER}` },
+        ],
+        { pty: true },
+      );
+
+      expect(run.code).toBe(0);
+      expect(run.files).toEqual([...EXPECTED_FILES]);
+
+      // The manifest is the subject, not a constant to compare against: every
+      // assertion below reads the id back off it.
+      const claimed = run.manifest?.license;
+      expect(OFFERED).toContain(claimed);
+      expect(claimed).not.toBe('MIT');
+
+      // The LICENSE carries THAT licence's text, and no other's.
+      expect(claimed).toBe('Apache-2.0');
+      expect(run.license).toContain(APACHE_ONLY_LINE);
+      expect(run.license).not.toContain(MIT_ONLY_LINE);
+
+      // The README and the four source headers name the same id and no other.
+      const readme = run.contents?.['README.md'] ?? '';
+      expect(readme).toContain(`${claimed as string} © Ada`);
+
+      for (const path of SOURCE_FILES) {
+        const header = (run.contents?.[path] ?? '').split('\n').find((line) => line.includes('licensed under'));
+        expect(header, path).toBeDefined();
+        expect(header, path).toContain(claimed as string);
+        for (const other of OFFERED.filter((id) => id !== claimed)) {
+          expect(header, `${path} must not also name ${other}`).not.toContain(other);
+        }
+      }
     }, 60_000);
   });
 

--- a/packages/create-plugin/src/__tests__/licenses.test.ts
+++ b/packages/create-plugin/src/__tests__/licenses.test.ts
@@ -27,6 +27,12 @@
  * - **a run that answers nothing still gets both** — `resolveLicenseId` is
  *   total, and the default path emits the file.
  *
+ * A third half arrived with objectui#8892: **an id nothing offers is refused,
+ * not answered with MIT's text.** The id is emitted SIX times — the manifest,
+ * the README's `## License` line and four source headers take it verbatim, and
+ * only `buildLicenseFile` resolves it — so substituting a default at that one
+ * place did not remove the disagreement, it authored one.
+ *
  * ## The self-test
  *
  * `emits no licence text when the LICENSE entry is removed` is the reverse
@@ -45,6 +51,7 @@ import {
   resolveLicenseId
 } from '../licenses';
 import {
+  buildLicenseFile,
   buildPackageJson,
   buildPluginFiles,
   buildReadme,
@@ -159,11 +166,50 @@ describe('a manifest that claims a licence ships its text (objectui#8041)', () =
     expect(licenseCopyrightHolder(VARS)).toBe('Jane Doe');
   });
 
-  it('has a text for its own default, so the fallback can never be empty', () => {
+  it('has a text for its own default, so the default path can never be empty', () => {
+    // `resolveLicenseId` answers every unanswered run with this id, so a table
+    // that lost it would turn EVERY default scaffold into the refusal below.
     expect(findLicense(DEFAULT_LICENSE_ID)).toBeDefined();
-    // An id nothing offers cannot reach here through the CLI, but if it ever
-    // did the emitted file must still be a licence rather than nothing.
-    expect(buildPluginFiles(withLicense('NOT-A-LICENCE')).LICENSE).toContain(DISTINCTIVE_LINE.MIT);
+    expect(buildPluginFiles(VARS).LICENSE).toContain(DISTINCTIVE_LINE.MIT);
+  });
+
+  it('refuses an id nothing offers instead of answering it with MIT (objectui#8892)', () => {
+    // This id used to be answered with MIT's TEXT while `buildPackageJson`,
+    // `buildReadme` and the four source headers kept it verbatim — six licence
+    // statements, five naming an id and the LICENSE beside them carrying
+    // another licence entirely. Measured on 4d65991c5: manifest
+    // `"NOT-A-LICENCE"`, README `NOT-A-LICENCE (c) Jane Doe`, four headers
+    // `licensed under the NOT-A-LICENCE license`, LICENSE `MIT License`.
+    //
+    // Only ONE of the six resolves the id, so agreement cannot be restored from
+    // this end for the other five; the id is refused for all six instead.
+    let thrown: unknown;
+    try {
+      buildPluginFiles(withLicense('NOT-A-LICENCE'));
+    } catch (error) {
+      thrown = error;
+    }
+
+    // ⛔ Not `.toThrow()` on its own. The pre-fix code threw here too — for a
+    // DIFFERENT reason (a licence table with no text for its own default), with
+    // a message that names neither the offending id nor a way out — so a bare
+    // throw assertion is green on both sides of this change.
+    expect(thrown).toBeInstanceOf(Error);
+    const message = (thrown as Error).message;
+    expect(message).toContain('NOT-A-LICENCE');
+    expect(message).toContain('resolveLicenseId');
+    for (const license of PLUGIN_LICENSES) {
+      expect(message, `offered id ${license.id} named in the refusal`).toContain(license.id);
+    }
+
+    // ⭐ The assertion this card is actually about: NOTHING is emitted. A
+    // repair that resolved the id a second time inside `buildPackageJson`
+    // instead would leave this call RETURNING a map — one whose README and four
+    // headers still disagreed with its LICENSE.
+    expect(() => buildPluginFiles(withLicense('NOT-A-LICENCE'))).toThrow();
+    expect(() => buildLicenseFile(withLicense('NOT-A-LICENCE'))).toThrow();
+    // An offered id is untouched by the refusal.
+    expect(() => buildLicenseFile(withLicense('ISC'))).not.toThrow();
   });
 
   it('emits no licence text when the LICENSE entry is removed', () => {

--- a/packages/create-plugin/src/templates.ts
+++ b/packages/create-plugin/src/templates.ts
@@ -22,7 +22,7 @@
  * `npm test` in a freshly scaffolded plugin was red on the very first run.
  */
 
-import { DEFAULT_LICENSE_ID, findLicense } from './licenses';
+import { PLUGIN_LICENSES, findLicense } from './licenses';
 
 /** Values interpolated into the templates for one generated plugin. */
 export interface PluginTemplateVars {
@@ -42,6 +42,11 @@ export interface PluginTemplateVars {
    * prompt and a junk value all arrive here as `MIT`. It is a REQUIRED field
    * rather than an optional one with a default here, because a default in two
    * places is two answers to one question.
+   *
+   * ENFORCED, not merely documented: {@link buildLicenseFile} refuses anything
+   * else (objectui#8892). Five of the six places this id is emitted interpolate
+   * it verbatim, so a value the licence table has no text for would ship a
+   * plugin whose LICENSE contradicts its own manifest, README and headers.
    */
   license: string;
   version: string;
@@ -545,21 +550,34 @@ export function licenseCopyrightHolder(vars: PluginTemplateVars): string {
  * rather than taking a licence of its own: the defect this file used to carry
  * was precisely a manifest field and an emitted file set that could disagree.
  *
- * Falls back to {@link DEFAULT_LICENSE_ID}'s text rather than throwing or
- * emitting nothing if an unoffered id ever reaches here. `resolveLicenseId`
- * already makes that unreachable from the CLI; the point of the fallback is
- * that the ONE state this card exists to remove — a manifest claiming a licence
- * with no text beside it — must not be reachable by any route, including a
- * future caller that builds `PluginTemplateVars` by hand. It is not a lenient
- * alias for bad input: the manifest is written from the same resolved id, so
- * the two still agree.
+ * REFUSES an id nothing offers instead of substituting the default licence's
+ * text for it (objectui#8892). The substitution used to be defended here as
+ * making one state unreachable — a manifest claiming a licence with no text
+ * beside it — and it did, by making a worse one reachable in its place.
+ * `vars.license` reaches a scaffolded plugin through SIX statements and this is
+ * the only one that resolves it: {@link buildPackageJson}, {@link buildReadme}
+ * and the four source headers interpolate it verbatim. So an unoffered id used
+ * to emit a package whose manifest, README and four file headers all named that
+ * id while the LICENSE beside them carried MIT — the author then carries the
+ * disagreement into their own distribution. Agreement cannot be restored at
+ * this end for the other five, so the id is refused for all six.
+ *
+ * Refusing costs nothing that the fallback bought. `resolveLicenseId` is total
+ * onto the offered ids and `index.ts` is the only caller, so the CLI cannot
+ * produce this throw; nothing outside this package can call it at all
+ * (`package.json` declares `bin` only — no `exports`, `main` or `types` — and
+ * the build emits one bundled `dist/index.js`); and {@link buildPluginFiles}
+ * runs before `index.ts` creates anything on disk (objectui#8786), so the throw
+ * lands on a run that has written nothing rather than half a plugin.
  */
 export function buildLicenseFile(vars: PluginTemplateVars): string {
-  const license = findLicense(vars.license) ?? findLicense(DEFAULT_LICENSE_ID);
+  const license = findLicense(vars.license);
   if (!license) {
     throw new Error(
-      `create-plugin has no text for its own default licence (${DEFAULT_LICENSE_ID}); ` +
-        'PLUGIN_LICENSES must always carry it.'
+      `create-plugin has no text for licence "${vars.license}", so it will not scaffold a ` +
+        'plugin whose manifest, README and source headers name a licence its LICENSE file ' +
+        `does not carry. Offered ids: ${PLUGIN_LICENSES.map((offered) => offered.id).join(', ')}. ` +
+        'Resolve the answer with resolveLicenseId() before building PluginTemplateVars.'
     );
   }
   return license.text({ year: vars.year, holder: licenseCopyrightHolder(vars) });


### PR DESCRIPTION
Fixes #8892

## The contract, and what the code did

`buildLicenseFile`'s docblock declared one state unreachable — *"a manifest claiming a licence with no text beside it"* — and defended the MIT fallback as what kept it so, ending: *"the manifest is written from the same resolved id, so the two still agree."* That last sentence was false, and the fallback made a **worse** state reachable in its place.

Per the triage ruling the disagreement is fixed, **not** the docblock. The docblock here is rewritten to describe the refusal that replaces the fallback — never to describe the defect.

## Both code paths — and the assumption that was falsified

The dispatching seat assumed two paths that can disagree only via the fallback. Measured on `4d65991c5`, it is **five against one**, not one against one. `vars.license` reaches a scaffolded plugin through **six** statements; exactly one of them resolves the id:

| Emitted statement | Builder | Treatment of `vars.license` |
|---|---|---|
| `package.json` `license` field | `buildPackageJson` | verbatim |
| `README.md` `## License` line | `buildReadme` | verbatim |
| `src/index.tsx` header | `buildIndexFile` | verbatim |
| `src/NAMEImpl.tsx` header | `buildImplFile` | verbatim |
| `src/types.ts` header | `buildTypesFile` | verbatim |
| `src/NAMEImpl.test.tsx` header | `buildTestFile` | verbatim |
| **`LICENSE`** | **`buildLicenseFile`** | **totalised — the divergence point** |

There is no *second* divergence point; there are four *additional* divergent outputs sharing the same one point. Measured directly against `origin/main`, with `license: 'NOT-A-LICENCE'`:

```
manifest.license           = "NOT-A-LICENCE"
README ## License line     = "NOT-A-LICENCE © Jane Doe"
header src/index.tsx       = "licensed under the NOT-A-LICENCE license"
header src/HeatmapImpl.tsx = "licensed under the NOT-A-LICENCE license"
header src/types.ts        = "licensed under the NOT-A-LICENCE license"
header src/HeatmapImpl.test.tsx = "licensed under the NOT-A-LICENCE license"
LICENSE first line         = "MIT License"
```

## Is the unoffered id reachable? Measured, not assumed

- **Not from the CLI.** `index.ts` passes `resolveLicenseId(answers.license)`, total onto the four offered ids; there is no `--license` flag (commander declares only `-d/--description` and `-a/--author`).
- **Not from any import.** `package.json` declares `bin` only — no `exports`, no `main`, no `module`, no `types` — and `tsup` emits a single bundled `dist/index.js` (plus a 20-byte `index.d.ts` that is just the shebang). Probed with the package linked into a scratch consumer: a bare `import` and a deep `dist/templates.js` import both give `ERR_MODULE_NOT_FOUND`.
- **Reachable only** from an in-repo caller that builds `PluginTemplateVars` by hand — today the tests, tomorrow a future in-repo caller or a `--license` flag wired past `resolveLicenseId`.

⇒ This **falsifies the card's stated cost for direction 2** ("changes a published function's failure mode"): there is no published function to change.

## Which fix, and why

**Direction 2 — refuse the unoffered id** — not direction 1 (resolve a second time inside `buildPackageJson`). Three reasons:

1. **Direction 1 repairs 1 of 6.** It would leave the README and four source headers still naming an id the LICENSE beside them does not carry — the same defect one file over.
2. **Four of the five it cannot repair are the copyright-header block**, which objectui#8778 queues behind this card and whose direction is unruled. Refusal closes all six at one point and touches none of that surface.
3. **AGENTS.md #0.1 (contract-first).** Silently rewriting a caller's declared id into MIT across six emitted files is exactly the lenient coercion that rule bans. The producer (`resolveLicenseId`) is already total; the consumer-side `??` was the defect.

Refusing costs nothing the fallback bought: the CLI cannot produce the throw, nothing outside the package can call it, and `buildPluginFiles` runs **before** `index.ts` creates anything on disk (objectui#8786), so the throw lands on a run that has written nothing rather than half a plugin.

## Tests

- **End-to-end, the real scaffolder** (`cli-cancel-and-nontty-8786.test.ts`): drives the built `dist/index.js` into a scratch cwd under a pty, selects a **non-default** licence (one arrow-down off MIT), and asserts the six statements agree **as a relation read back off the emitted manifest** — not compared to a constant. Every other run in that file ends at MIT, so a template hard-coding "MIT" in five of the six places was green in all of them. It shares that file's single unconditional `beforeAll` build on purpose: vitest runs test files in parallel worker threads (`pool: 'threads'`, `isolate: true`) and `tsup` cleans `dist/` before writing, so a second file building this package would delete the bin out from under these runs.
- **Refusal** (`licenses.test.ts`): the pin that asserted the MIT fallback pinned exactly the branch this PR deletes, so it is replaced rather than edited. The replacement asserts the refusal names the offending id, names every offered id, points at `resolveLicenseId` — and, the point of the card, that **nothing at all is emitted**. A bare `.toThrow()` would be green on both sides: the pre-fix code also threw here, for a different reason and with a message naming neither the offending id nor a way out.

## Ablation — two arms, both predicted before running

Each arm: mutate, prove it landed on disk (occurrence counts of injected and removed text), run, restore, prove the restore landed (`git hash-object` against the HEAD blob **and** an empty `git diff HEAD`). Restore is `git checkout HEAD -- PATH` with absolute paths in an `EXIT INT TERM` trap.

| Arm | Mutation | Predicted | Observed |
|---|---|---|---|
| A | reinstate the deleted MIT fallback in `buildLicenseFile` | only the new refusal test reddens; all 8 spawn tests stay green | `1 failed \| 37 passed` — the refusal test; all 8 spawn tests green |
| B | `index.ts` ignores the licence answer | only the new end-to-end test reddens; every unit test stays green | `1 failed \| 37 passed` — the end-to-end test; every unit test green |

Arm A's *narrowness is the finding*, not a weak test: the eight spawn tests staying green is the measurement that the defect is unreachable from the CLI. Arm B exists because arm A cannot witness the end-to-end assertion — its mutation was confirmed to reach `dist/index.js` (the suite rebuilds it unconditionally), and it reddens **only** the end-to-end case, proving that assertion catches a divergence no builder-level test can see.

## Gates

Exit codes captured to disk before reading, never through a pipe.

| Gate | Exit | Note |
|---|---|---|
| `pnpm exec vitest run packages/create-plugin/` (repo root) | 0 | `3 files / 38 tests` |
| affected suite + the two `scripts/__tests__` files that read this tree | 0 | `5 files / 76 tests` |
| `pnpm --filter @object-ui/create-plugin run type-check` | 0 | `tsc --noEmit` + `tsconfig.test.json` |
| `pnpm --filter @object-ui/create-plugin run lint` | 0 | |
| `check-control-bytes.mjs` | 0 | plus a direct control-byte scan of the four changed files: no hits |
| `check-changeset-presence.mjs` | 0 | 1 changeset declared for 3 published source files |
| `check-governed-queue-guard.mjs --test` (my four paths) | 0 | NOT GOVERNED — ordinary merge-queue route |
| `check:doc-snippets` | 2 then 0 | exit 2 was PREREQUISITE NOT MET; re-run green after the scoped build it names (35 tasks, 6m38s) |
| `check:doc-examples` | 2 then 0 | same prerequisite, same scoped build; `124 blocks — 35 compile, 89 fail, 89 declared in the ledger` |
| `check:doc-types` | 0 | |
| `check:new-line-citations` | 0 | `0 new citation(s)` |

Heavy runs went through `../objectstack/scripts/pm/os-verify-lock.sh` (slot `objectui-8892`); every verdict above is the wrapper's own `VERDICT command-exit` line.

## Serial adjacency — re-derived here, not cited

Enumerated all 11 currently-open PRs and read each one's file list: **none** touches `packages/create-plugin/` or this changeset. objectui#8778 has no open PR, so the emitted-template surface is uncontended — and its copyright-header block is untouched by this diff. `origin/main` had not moved from the branch point when this was pushed.

## Out of scope, noted and not filed

`scripts/__tests__/one-authority-per-exported-name-6273.test.ts` carries a provenance comment citing `create-plugin/src/templates.ts:417`; that line has never held the quoted text (checked at the branch point, before this diff). A stale pointer in a fixture comment — no behaviour, no reproduction, and `check:new-line-citations` explicitly warns against shifting existing addresses by a hunk delta. Nobody is queued on that file. Left alone deliberately.

Session reference, as a code span so it survives a body edit: `https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB)_