### PR TITLE
fix(plugin-dashboard): route object-metric's drill through the shared DrillDownDrawer

### DIFF
--- a/.changeset/8970-object-metric-shared-drill-drawer.md
+++ b/.changeset/8970-object-metric-shared-drill-drawer.md
@@ -1,0 +1,44 @@
+---
+'@object-ui/plugin-dashboard': minor
+---
+
+Route `object-metric`'s drill-down through the shared `DrillDownDrawer` (objectui#8970).
+
+`ObjectMetricWidget` built its own drill panel inline — a Radix `Dialog` when
+`drillDown.target` was the literal `dialog`, a `Sheet` otherwise, with a record-list
+body it constructed itself. That copy read `enabled`, `target`'s two in-place arms,
+`title` and `report`, and had no read site for the rest of the `DrillDownConfig` the
+designer inspector offers. Three members were therefore accepted from the author and
+discarded on this block alone, while acting on every other block that shares the same
+config — no diagnostic, no rejection, and the identical tile on a `dataset` widget in a
+metric presentation worked.
+
+**Now delivered on `object-metric`:**
+
+- **`target: 'navigate'`** — opens the object's full list page through the host's drill
+  navigation, scoped by the metric's own filter. Previously it fell into the panel
+  branch and drew the side sheet *unconditionally*. That mattered beyond the missing
+  feature: `DrillDownConfig.target` documents this arm as falling back to `'drawer'`
+  "when none is available", so the old behaviour read as the documented one while being
+  a different one. The fallback is now genuinely conditional.
+- **`columns`** — column whitelist for the drilled record list.
+- **`maxRows`** — page size of the drilled record list.
+
+**Two deliberate behaviour changes that come with the shared component:**
+
+- The drilled record list no longer shows a search box. The inline panel never chose
+  this; it inherited the record table's default while the shared drawer opts out, so a
+  metric drill is now the same self-contained peek as a pivot, chart or dataset drill.
+- The drill sheet's widest breakpoint narrows by one step, from `lg:max-w-5xl` to the
+  shared drawer's `lg:max-w-4xl`. The centred `dialog` arm is unchanged.
+
+The list's default page size is **unchanged at 25** — the value the inline panel
+hard-coded is kept as this block's fallback, so a config that never authored `maxRows`
+drills exactly as before rather than dropping to the record table's default of 10.
+
+**Unchanged, and left to objectui#8970's own open question:** `drillDown.filter` and
+`drillDown.mode` still have no read site on this block. The drilled list stays scoped by
+the metric's resolved filter, which is what the block's registration promises ("the same
+filter narrows the drill-down list, so the number and the records behind it always
+agree"); a metric also has no click event for `${event.*}` to interpolate against. The
+shared drawer honours neither member either, so routing through it does not settle them.

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -2279,7 +2279,7 @@ const MEMBER_PINS: Record<string, MemberPin> = {
   },
   'object-metric.drillDown': {
     file: 'packages/plugin-dashboard/src/__tests__/objectMetricDrillDownMembers-8071.test.tsx',
-    pins: 'The click-through config\'s member set, read through the registered block on a LIVE drawer. `enabled` is `!== false`, not truthiness, and all four arms (absent, `{}`, `true`, `false`) are pinned against each other, so a "simplification" to `!!config.enabled` — which would silently disable every `{}` config — is red; and it is not sufficient on its own, because without an object name AND a data source the tile stays unclickable rather than opening a list it cannot fetch. `target` chooses the panel SHAPE (`\'dialog\'` = centred modal, anything else the edge-anchored sheet), each arm the other\'s control. `title` OUTRANKS the tile\'s own `title` and `label`, with the chain below it (`title`, then `label`, then the literal "Details") pinned as its fallback. `report` selects the drawer BODY by its own SHAPE — an `objectName`-bearing (or array-`columns`) report goes to a `spec-report` body while anything else falls through to the inline record list, and whether the record list is fetched at all is the observable that separates them. The invariant the key hangs off is pinned too: the drilled list is scoped by the METRIC\'s resolved filter with macros already substituted — the registration\'s own promise that the number and the records behind it agree, and a drawer listing every row of the object is the quiet failure it exists to stop. LIMIT, stated and deliberately NOT asserted: this widget hand-rolls its drawer instead of using `DrillDownDrawer`, so `columns`, `maxRows`, `target: \'navigate\'`, `filter` and `mode` have no read site on this block — filed as objectui#8970 rather than frozen into the pin, because an assertion that a member is dead has to be deleted before the gap can be closed. The spec row is `z.unknown()`, so the read site is the whole member contract. New file (objectui#8071 slice 9).',
+    pins: 'The click-through config\'s member set, read through the registered block on a LIVE drawer. `enabled` is `!== false`, not truthiness, and all four arms (absent, `{}`, `true`, `false`) are pinned against each other, so a "simplification" to `!!config.enabled` — which would silently disable every `{}` config — is red; and it is not sufficient on its own, because without an object name AND a data source the tile stays unclickable rather than opening a list it cannot fetch. `target` chooses the panel SHAPE (`\'dialog\'` = centred modal, anything else the edge-anchored sheet), each arm the other\'s control. `title` OUTRANKS the tile\'s own `title` and `label`, with the chain below it (`title`, then `label`, then the literal "Details") pinned as its fallback. `report` selects the drawer BODY by its own SHAPE — an `objectName`-bearing (or array-`columns`) report goes to a `spec-report` body while anything else falls through to the inline record list, and whether the record list is fetched at all is the observable that separates them. The invariant the key hangs off is pinned too: the drilled list is scoped by the METRIC\'s resolved filter with macros already substituted — the registration\'s own promise that the number and the records behind it agree, and a drawer listing every row of the object is the quiet failure it exists to stop. LIMIT, stated and deliberately NOT asserted: `filter` and `mode` have no read site on this block — a metric has no click event for `${event.*}` to resolve against, and its registration promises the drilled list agrees with the number — so they are left to objectui#8970\'s open question rather than frozen into the pin, because an assertion that a member is dead has to be deleted before the gap can be closed. The other three the shared component honours (`columns`, `maxRows`, `target: \'navigate\'`) were dead here for the same reason and are now LIVE: objectui#8970 routed this block through `DrillDownDrawer`, and they are pinned on their effects in `ObjectMetricWidget.drillRoutedToSharedDrawer-8970.test.tsx`. The spec row is `z.unknown()`, so the read site is the whole member contract. New file (objectui#8071 slice 9).',
   },
   'object-metric.filter': {
     file: 'packages/plugin-dashboard/src/__tests__/objectMetricQueryMembers-8071.test.tsx',
@@ -2944,13 +2944,22 @@ const NEWLY_JUDGED_UNPINNED_MEMBERS = [
  * `action-bodyShape-forward.test.tsx` mistake in a third place.
  *
  * ⚠️ `drillDown` is pinned on the members that ACT and deliberately not on the
- * ones that do not. `ObjectMetricWidget` hand-rolls its own drawer instead of
- * using the shared `DrillDownDrawer`, so five members the shared component
- * honours have no read site here (`columns`, `maxRows`, `target: 'navigate'`,
- * `filter`, `mode`). That is filed (objectui#8970) rather than frozen into the
- * pin — the same choice slice 6 made for `record:activity`'s filter members
- * (objectui#8934), and for the same reason: an assertion that a member is dead
- * has to be deleted before anyone can make it live.
+ * ones that do not. When this slice landed, `ObjectMetricWidget` hand-rolled its
+ * own drawer instead of using the shared `DrillDownDrawer`, so five members the
+ * shared component honours had no read site here (`columns`, `maxRows`,
+ * `target: 'navigate'`, `filter`, `mode`). That was filed (objectui#8970) rather
+ * than frozen into the pin — the same choice slice 6 made for
+ * `record:activity`'s filter members (objectui#8934), and for the same reason:
+ * an assertion that a member is dead has to be deleted before anyone can make it
+ * live.
+ *
+ * ⇒ That reason has since paid out. objectui#8970 routed the block through
+ * `DrillDownDrawer`, and three of the five (`columns`, `maxRows`,
+ * `target: 'navigate'`) now act; nothing had to be deleted to let them. They are
+ * pinned on their effects in
+ * `ObjectMetricWidget.drillRoutedToSharedDrawer-8970.test.tsx`. `filter` and
+ * `mode` still have no read site — the shared drawer honours neither — and are
+ * still not asserted, for the reason above.
  *
  * ⚠️ Unchanged by this slice: `NEWLY_JUDGED_UNPINNED_MEMBERS` (no block it names
  * was touched) and `record:related_list.actions`, whose `NO_READ_SITE_TO_PIN`

--- a/packages/plugin-dashboard/src/ObjectMetricWidget.tsx
+++ b/packages/plugin-dashboard/src/ObjectMetricWidget.tsx
@@ -7,13 +7,12 @@
  */
 
 import React, { useState, useEffect, useContext, useCallback, useMemo } from 'react';
-import { SchemaRendererContext, SchemaRenderer, useFilterScope } from '@object-ui/react';
-import { Sheet, SheetContent, SheetHeader, SheetTitle, Dialog, DialogContent, DialogHeader, DialogTitle } from '@object-ui/components';
+import { SchemaRendererContext, useFilterScope } from '@object-ui/react';
 import { isDrillEnabled, resolveDrillTitle } from '@object-ui/core';
 import type { DrillDownConfig, I18nLabel } from '@object-ui/types';
 import { useLocalization, resolveFieldCurrency, useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import { MetricWidget } from './MetricWidget';
-import { OpenInListButton } from './OpenInListButton';
+import { DrillDownDrawer } from './DrillDownDrawer';
 import {
   resolveFilterPlaceholders,
   shiftFilterByCompareTo,
@@ -21,6 +20,15 @@ import {
   computeMetricDelta,
   type CompareToConfig,
 } from './utils';
+
+/**
+ * Page size the drilled record list falls back to when the author declared no
+ * `drillDown.maxRows`. It is the value the hand-rolled panel this block used to
+ * carry hard-coded, kept so that routing through the shared `DrillDownDrawer`
+ * (objectui#8970) changes nothing for a config that never named the member —
+ * the shared drawer's own fallback is `data-table`'s default of 10.
+ */
+const METRIC_DRILL_PAGE_SIZE = 25;
 
 /**
  * ObjectMetricWidget — Data-bound metric widget.
@@ -388,82 +396,40 @@ export const ObjectMetricWidget: React.FC<ObjectMetricWidgetProps> = ({
     return resolveDrillTitle(drillDown, {}, titleText || labelText || 'Details');
   }, [drillDown, label, title, language]);
 
-  const drillDrawer = useMemo(() => {
-    if (!drillEnabled) return null;
-    const target = drillDown?.target ?? 'drawer';
-
-    // M3: when drillDown.report is supplied, drill into an analytical Report
-    // (Dashboard → Report → List → Record). The widget's resolvedFilter is
-    // merged into the report so the metric's scope is preserved.
-    const reportConfig = (drillDown as any)?.report;
-    const hasReport = reportConfig && typeof reportConfig === 'object'
-      && (Array.isArray((reportConfig as any).columns) || 'objectName' in reportConfig);
-
-    // Escape hatch — escalate the KPI peek to the object's full list page
-    // (scoped by the same filter the metric aggregates). Hidden for report
-    // drills and when no host navigation handler is present.
-    const escapeHatch = !hasReport
-      ? <OpenInListButton objectName={objectName} filter={resolvedFilter} onNavigate={() => setDrillOpen(false)} />
-      : null;
-
-    let body: React.ReactNode;
-    if (hasReport) {
-      const existingFilter = (reportConfig as any).filter;
-      const mergedReportFilter = existingFilter
-        ? (resolvedFilter ? { $and: [existingFilter, resolvedFilter] } : existingFilter)
-        : resolvedFilter;
-      const reportSchema = {
-        type: 'spec-report',
-        ...(reportConfig as Record<string, unknown>),
-        filter: mergedReportFilter,
-      } as any;
-      body = (
-        <div className="h-full overflow-auto">
-          <SchemaRenderer schema={reportSchema} />
-        </div>
-      );
-    } else {
-      const tableSchema = {
-        type: 'object-data-table',
-        objectName,
-        filter: resolvedFilter,
-        pageSize: 25,
-        // Complete the drill chain: a row in the KPI's record list opens that
-        // record. Dialog target so it stacks cleanly over this drill drawer.
-        drillDown: { enabled: true, mode: 'record', target: 'dialog' },
-      } as any;
-      body = (
-        <div className="h-full overflow-auto">
-          <SchemaRenderer schema={tableSchema} />
-        </div>
-      );
-    }
-
-    if (target === 'dialog') {
-      return (
-        <Dialog open onOpenChange={(v) => !v && setDrillOpen(false)}>
-          <DialogContent className="max-w-5xl">
-            <DialogHeader className="flex-row items-center justify-between gap-4 pr-8">
-              <DialogTitle>{drawerTitle}</DialogTitle>
-              {escapeHatch}
-            </DialogHeader>
-            {body}
-          </DialogContent>
-        </Dialog>
-      );
-    }
-    return (
-      <Sheet open onOpenChange={(v) => !v && setDrillOpen(false)}>
-        <SheetContent side="right" className="w-full sm:max-w-2xl md:max-w-3xl lg:max-w-5xl flex flex-col">
-          <SheetHeader className="flex-row items-center justify-between gap-4 pr-8">
-            <SheetTitle>{drawerTitle}</SheetTitle>
-            {escapeHatch}
-          </SheetHeader>
-          <div className="flex-1 overflow-hidden mt-2">{body}</div>
-        </SheetContent>
-      </Sheet>
-    );
-  }, [drillEnabled, drillDown, objectName, resolvedFilter, drawerTitle]);
+  // Routed through the shared `DrillDownDrawer` — the component every other
+  // widget in this package drills through (objectui#8970). This block used to
+  // hand-roll its own Sheet/Dialog panel, which read `enabled`, `target`'s two
+  // in-place arms, `title` and `report` and silently discarded the rest of the
+  // config an author is offered: `columns`, `maxRows` and `target: 'navigate'`
+  // acted on every other block sharing `DrillDownConfig` and did nothing here.
+  // Two implementations of one drawer was the defect — teaching the copy three
+  // more members would only have guaranteed a fourth divergence.
+  //
+  // `maxRows` now chooses the drilled list's page size, defaulting to the 25
+  // the inline panel hard-coded, so a config that never authored the member
+  // keeps the page size it had. `className` reproduces the height the inline
+  // body wrapper carried.
+  //
+  // `drillDown.filter` is deliberately NOT forwarded: the drilled list is
+  // scoped by the METRIC's own resolved filter, which is the registration's
+  // promise that the number and the records behind it agree. `mode` has no
+  // read site on the shared drawer either. Both are left to the judgement
+  // objectui#8970 asks for rather than settled here.
+  const drillDrawer = drillEnabled ? (
+    <DrillDownDrawer
+      open
+      onClose={() => setDrillOpen(false)}
+      title={drawerTitle}
+      target={drillDown?.target}
+      objectName={objectName as string}
+      filter={resolvedFilter}
+      dataSource={dataSource}
+      columns={drillDown?.columns}
+      maxRows={drillDown?.maxRows ?? METRIC_DRILL_PAGE_SIZE}
+      report={drillDown?.report as Record<string, unknown> | undefined}
+      className="h-full"
+    />
+  ) : null;
 
   return (
     <>

--- a/packages/plugin-dashboard/src/__tests__/ObjectMetricWidget.drillRoutedToSharedDrawer-8970.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectMetricWidget.drillRoutedToSharedDrawer-8970.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `object-metric.drillDown` — the members that started ACTING when this block
+ * stopped hand-rolling its drill panel (objectui#8970).
+ *
+ * `ObjectMetricWidget` used to build its own Sheet/Dialog panel inline. That
+ * copy read `enabled`, `target`'s two in-place arms, `title` and `report`, and
+ * had no read site at all for the rest of the `DrillDownConfig` the designer
+ * inspector offers — so an author who moved a tile between `object-metric` and
+ * any other block sharing that config lost behaviour with no diagnostic and no
+ * rejection. Routing the block through the shared `DrillDownDrawer` gives three
+ * of them a read site here for the first time:
+ *
+ *   - **`target: 'navigate'`** — the arm the contract describes as CONDITIONAL
+ *     ("Requires a host that provides drill navigation … falls back to
+ *     `'drawer'` when none is available"). The inline copy fell into its `else`
+ *     branch and drew the sheet unconditionally, which reads as the documented
+ *     behaviour while being a different one. Pinned in BOTH directions, because
+ *     only the pair separates "the arm is read" from "the handler happens to be
+ *     absent": with a host handler it navigates and draws nothing; without one
+ *     it still draws the sheet.
+ *   - **`columns`** — the drilled list's column whitelist.
+ *   - **`maxRows`** — the drilled list's page size.
+ *
+ * ## Why each row asserts an EFFECT and not a forwarded prop
+ *
+ * Every assertion below reads something the drilled list DID: which handler
+ * ran, how many column headers exist, how many body rows rendered. A test that
+ * only checked that a drawer appears, or that a prop reached a mock, would have
+ * passed against the hand-rolled panel too — it drew a drawer as well. Each row
+ * carries its own control (the other `target` arm, the same drill without the
+ * member) so a renderer that ignored the member cannot pass by accident.
+ *
+ * ## What is deliberately NOT asserted
+ *
+ * `filter` and `mode` still have no read site on this block, and this file does
+ * not assert that they don't. objectui#8970 asks for a judgement on them —
+ * a metric has no click event for `${event.*}` to resolve against, and its own
+ * registration promises the drilled list agrees with the number, which an
+ * author-supplied override would break — and an assertion that a member is dead
+ * has to be deleted before that judgement can be acted on. The member pin from
+ * objectui#8071 slice 9 (`objectMetricDrillDownMembers-8071.test.tsx`) states
+ * the same limit in prose for the same reason, and keeps covering `enabled`,
+ * `target`'s two in-place arms, `title`'s precedence chain, `report`'s branch
+ * selection and the metric-filter invariant, which is the net this reroute
+ * landed on top of.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor, within } from '@testing-library/react';
+import { SchemaRenderer, SchemaRendererProvider, DrillNavigationProvider } from '@object-ui/react';
+// Registers `object-metric` AND the `object-data-table` the drawer body
+// renders, at MODULE scope — object-ui/no-dynamic-import-in-test-hook.
+import '../index';
+
+afterEach(cleanup);
+
+type Params = Record<string, unknown>;
+
+/** `n` deals, each with three authorable fields the drill list could show. */
+const deals = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    id: String(i + 1),
+    name: `Deal ${i + 1}`,
+    stage: 'won',
+    amount: 100 + i,
+  }));
+
+const drillAdapter = (rows = deals(3)) => ({
+  aggregate: vi.fn(async (_object: string, _params: Params) => [{ amount_sum: 120 }]),
+  find: vi.fn(async (_object: string, _params: Params) => ({ data: rows })),
+  getObjectSchema: vi.fn(async () => ({
+    fields: {
+      name: { type: 'text', label: 'Name' },
+      stage: { type: 'text', label: 'Stage' },
+      amount: { type: 'number', label: 'Amount' },
+    },
+  })),
+});
+
+const BASE = {
+  type: 'object-metric',
+  objectName: 'deal',
+  label: 'Revenue',
+  aggregate: { field: 'amount', function: 'sum' },
+  filter: { stage: 'won' },
+} as const;
+
+const mount = (
+  schema: Record<string, unknown>,
+  adapter: unknown,
+  openRecordList?: (object: string, filter?: Record<string, unknown>) => void,
+) =>
+  render(
+    <DrillNavigationProvider value={{ openRecordList }}>
+      <SchemaRendererProvider dataSource={adapter as never}>
+        <SchemaRenderer schema={{ ...BASE, ...schema } as never} />
+      </SchemaRendererProvider>
+    </DrillNavigationProvider>,
+  );
+
+/** Click the metric tile. The tile is the only button before the drill opens. */
+const clickTile = async () => {
+  fireEvent.click(await screen.findByRole('button'));
+};
+
+/**
+ * The open drill panel, located by the ARIA role both panel shapes expose
+ * rather than by `DrillDownDrawer`'s own `data-testid`.
+ *
+ * That choice is what makes the ablation legible. The hand-rolled panel this
+ * card removed rendered no `drill-down-body` testid, so a file anchored on the
+ * testid reddens every row the moment the fix is reverted — including the
+ * control rows, and for a reason that has nothing to do with the member each
+ * row is about. Anchored on `role="dialog"`, which BOTH implementations
+ * satisfy, each control stays green under the ablation and only the three
+ * member rows turn red.
+ */
+const drillPanel = async () => screen.findByRole('dialog');
+
+/** The drilled record list, once it has rendered its rows. */
+const drillTable = async () => {
+  const panel = await drillPanel();
+  await waitFor(() => expect(within(panel).getAllByRole('row').length).toBeGreaterThan(1));
+  return panel;
+};
+
+/**
+ * Header cells of the drilled list — the observable `columns` moves.
+ *
+ * Lower-cased on purpose: the two column branches label differently (the
+ * whitelist branch carries the raw field name through `fieldLabel`, the
+ * auto-derive branch humanizes it), and that difference belongs to
+ * `ObjectDataTable`, not to the member under test here. Comparing case-folded
+ * keeps this file reading WHICH columns exist rather than how they are cased.
+ */
+const headerTexts = (body: HTMLElement) =>
+  within(body).getAllByRole('columnheader').map((th) => (th.textContent ?? '').trim().toLowerCase());
+
+/** Body rows of the drilled list — the observable `maxRows` moves. */
+const bodyRowCount = (body: HTMLElement) =>
+  within(body).getAllByRole('row').filter((r) => within(r).queryAllByRole('cell').length > 0).length;
+
+describe("object-metric — `drillDown.target: 'navigate'` reaches the host", () => {
+  it('navigates to the list page and draws NO panel when the host wired drill navigation', async () => {
+    const openRecordList = vi.fn();
+    mount({ drillDown: { enabled: true, target: 'navigate' } }, drillAdapter(), openRecordList);
+    await clickTile();
+
+    // The metric's own resolved filter travels with it, so the list page opens
+    // on the same slice the number was computed from.
+    await waitFor(() => expect(openRecordList).toHaveBeenCalledWith('deal', { stage: 'won' }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it("draws the in-place panel and does NOT navigate on target: 'drawer' — the control that makes the row above a reading of `target`", async () => {
+    // Same host handler, one member value apart. Before the reroute BOTH of
+    // these drew the sheet and neither called the handler, so this pair is what
+    // separates "the arm is read" from "a handler was present".
+    const openRecordList = vi.fn();
+    mount({ drillDown: { enabled: true, target: 'drawer' } }, drillAdapter(), openRecordList);
+    await clickTile();
+
+    expect(await drillPanel()).toBeTruthy();
+    expect(openRecordList).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the drawer on target: 'navigate' when the host provides NO handler — the contract's conditional half", async () => {
+    // `DrillDownConfig.target` promises this fallback happens only when no host
+    // navigation is available. The bug was that it happened either way.
+    mount({ drillDown: { enabled: true, target: 'navigate' } }, drillAdapter(), undefined);
+    await clickTile();
+
+    expect(await drillPanel()).toBeTruthy();
+  });
+});
+
+describe('object-metric — `drillDown.columns` whitelists the drilled list', () => {
+  it('renders ONLY the named column', async () => {
+    mount({ drillDown: { enabled: true, columns: ['name'] } }, drillAdapter());
+    await clickTile();
+    const headers = headerTexts(await drillTable());
+
+    expect(headers).toEqual(['name']);
+    expect(headers).not.toContain('stage');
+    expect(headers).not.toContain('amount');
+  });
+
+  it('auto-derives every field when the member is absent — the control', async () => {
+    mount({ drillDown: { enabled: true } }, drillAdapter());
+    await clickTile();
+    const headers = headerTexts(await drillTable());
+
+    expect(headers).toContain('name');
+    expect(headers).toContain('stage');
+    expect(headers).toContain('amount');
+  });
+});
+
+describe('object-metric — `drillDown.maxRows` caps the drilled list', () => {
+  it('renders exactly `maxRows` rows out of the records the adapter returned', async () => {
+    mount({ drillDown: { enabled: true, maxRows: 2 } }, drillAdapter(deals(12)));
+    await clickTile();
+
+    const panel = await drillTable();
+    await waitFor(() => expect(bodyRowCount(panel)).toBe(2));
+  });
+
+  it('keeps the 25 the hand-rolled panel hard-coded when the member is absent', async () => {
+    // Twelve rows is the control that makes this a reading of the block's own
+    // fallback rather than of the shared drawer's: `data-table`'s default page
+    // size is 10, so an unforwarded `maxRows` would show ten of these twelve.
+    mount({ drillDown: { enabled: true } }, drillAdapter(deals(12)));
+    await clickTile();
+
+    const panel = await drillTable();
+    await waitFor(() => expect(bodyRowCount(panel)).toBe(12));
+  });
+});

--- a/packages/plugin-dashboard/src/__tests__/objectMetricDrillDownMembers-8071.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/objectMetricDrillDownMembers-8071.test.tsx
@@ -67,15 +67,23 @@
  *
  * ## LIMITS, stated rather than frozen into an assertion
  *
- * `DrillDownConfig` is shared by five widgets, and this one hand-rolls its own
- * drawer instead of using `DrillDownDrawer`. Three members the shared component
- * honours have no read site on this block: `columns`, `maxRows`, and
- * `target: 'navigate'`. `filter` and `mode` have none either — a metric has no
- * click event to interpolate `${event.*}` against, and its whole slice is the
- * one filter. None of that is asserted here: pinning "this member is dead"
- * would freeze the gap instead of reporting it, and a pin that has to be
- * deleted before the gap can be closed is worse than no pin. Filed as
- * objectui#8970.
+ * `DrillDownConfig` is shared by five widgets, and when this pin was written
+ * this one hand-rolled its own drawer instead of using `DrillDownDrawer`. Three
+ * members the shared component honours had no read site on this block:
+ * `columns`, `maxRows`, and `target: 'navigate'`. `filter` and `mode` had none
+ * either — a metric has no click event to interpolate `${event.*}` against, and
+ * its whole slice is the one filter. None of that was asserted here: pinning
+ * "this member is dead" would freeze the gap instead of reporting it, and a pin
+ * that has to be deleted before the gap can be closed is worse than no pin.
+ * Filed as objectui#8970.
+ *
+ * ⇒ objectui#8970 has since routed the block through `DrillDownDrawer`, and the
+ * restraint paid out exactly as intended: the first three now ACT and not one
+ * assertion in this file had to be deleted to let them — every row below still
+ * passes unchanged against the shared drawer. Their effects are pinned in
+ * `ObjectMetricWidget.drillRoutedToSharedDrawer-8970.test.tsx`. `filter` and
+ * `mode` are still unread here (the shared drawer honours neither), and are
+ * still deliberately not asserted.
  *
  * ## Nothing pre-existing covered this key
  *


### PR DESCRIPTION
Fixes #8970

`ObjectMetricWidget` hand-rolled its own drill panel. Triage's ruling was to fix it by **routing the block through the shared `DrillDownDrawer`**, not by re-implementing the dropped members inline — "Two implementations of one drawer is the defect; teaching the copy five more members guarantees a sixth divergence." That is what this does.

## The member enumeration, re-measured (the card's "five" splits 3 / 2)

`DrillDownConfig` has eight members. Measured on both implementations rather than taken from the card:

| member | hand-rolled panel | shared `DrillDownDrawer` | this PR |
|---|---|---|---|
| `enabled` | read via `isDrillEnabled` | caller's `open` | unchanged |
| `target` — `drawer` / `dialog` | read | read | unchanged |
| `target: 'navigate'` | **no read site** | read via `navigateOnly` | **now acts** |
| `title` | read via `resolveDrillTitle` | caller's `title` | unchanged |
| `report` | read | read | unchanged |
| `columns` | **no read site** | read (column whitelist) | **now acts** |
| `maxRows` | **no read site** | read (page size) | **now acts** |
| `filter` | **no read site** | **no read site** — the caller computes it | still unread |
| `mode` | **no read site** | **no read site** — the drawer has no such prop | still unread |

⚠️ **The dispatching assumption that all five are "honoured by the shared `DrillDownDrawer`" does not survive measurement.** Rerouting closes **three**, not five:

- **`mode`** is not a `DrillDownDrawerProps` member at all. Its only read site in the repo is `ObjectDataTable.tsx` (`(drillDown?.mode ?? 'record') === 'record'`), where a *table row* decides drill-to-record. Routing through the drawer cannot deliver it.
- **`filter`** is read by `computeDrillFilter` in `@object-ui/core`, called by `ObjectChart` and `ObjectPivotTable` — not by the drawer, which takes an already-computed `filter` prop.

Both are exactly the two the filing seat flagged as possibly a deliberate refusal, and said "That is a judgement nobody has made." This PR does not make it. See the open question at the bottom.

## Dependency measurement

`DrillDownDrawer` lives in the **same package** (`packages/plugin-dashboard/src/DrillDownDrawer.tsx`), so the new import is relative — `./DrillDownDrawer`. Its own imports are `react` (already a peer dep), `@object-ui/components` and `@object-ui/react` (already dependencies), and two same-package siblings. **No edge added to `dependencies`, `peerDependencies` or `devDependencies`.** Not a manual-floor item.

The net import surface *shrank*: `ObjectMetricWidget` no longer imports `Sheet`/`Dialog` from `@object-ui/components`, `SchemaRenderer` from `@object-ui/react`, or `./OpenInListButton`.

## What routing through the shared drawer changed

Nothing broke. The metric tile's own layout is untouched — the hand-rolled panel was a drawer, not a tile constraint. Three differences exist between the two implementations and each is named rather than papered over:

1. **Page size — preserved, deliberately.** The inline body hard-coded `pageSize: 25`; the shared drawer passes `pageSize: maxRows`, which is `undefined` when unauthored and would fall to `data-table`'s default of **10**. A `METRIC_DRILL_PAGE_SIZE = 25` fallback keeps a config that never named `maxRows` drilling exactly as before, while an authored `maxRows` now wins.
2. **The drilled list loses its search box.** The inline table never set `searchable`, so it inherited `data-table`'s default of `true`; the shared drawer sets `searchable: false`. This is inherited-default drift, not a constraint the inline version handled, and adopting the shared value makes a metric drill the same self-contained peek as a pivot, chart or dataset drill. Adding a `searchable` prop to the shared drawer for one caller would be the sixth divergence triage warned about.
3. **The sheet's widest breakpoint narrows one step**, `lg:max-w-5xl` to the shared `lg:max-w-4xl`. The centred `dialog` arm is byte-identical between the two and is unchanged.

Two latent problems in the inline copy go away with it: the report body built `{ type: 'spec-report', ...report }`, which clobbered the inner report's own `type` and never produced the nested `report` limb `ReportRenderer` unwraps; and an explicitly-passed `dataSource` prop never reached the drilled table, because the inline path rendered a bare schema and relied on context.

## Acceptance — each member asserted on its EFFECT

`packages/plugin-dashboard/src/__tests__/ObjectMetricWidget.drillRoutedToSharedDrawer-8970.test.tsx`, mounted through the registered `object-metric` block, 7 cases. Every case reads something the drilled list *did*, never that a prop reached a mock — a test that only checked a drawer appears would have passed against the hand-rolled panel too, which also drew a drawer.

- **`target: 'navigate'`** — with a host `openRecordList`, clicking the tile calls it with the metric's own resolved filter and draws **no** panel. Two controls: the same host handler with `target: 'drawer'` draws the panel and never navigates (so the row reads `target`, not the handler's presence); and `target: 'navigate'` with **no** host handler still draws the sheet, which is the contract's conditional half — `DrillDownConfig.target` promises the fallback happens only "when none is available", and the bug was that it happened either way.
- **`columns`** — `columns: ['name']` renders exactly one column header; the control without the member auto-derives all three.
- **`maxRows`** — with twelve records and `maxRows: 2`, two body rows render. The control without the member renders all twelve, which also pins the preserved 25 (the shared drawer's own fallback of 10 would show ten of the twelve).

The panel is located by `role="dialog"`, which **both** implementations satisfy, rather than by the shared drawer's `data-testid`. That is what makes the ablation below legible.

## Ablation — the fix removed, from the committed state

`git checkout BASECOMMIT -- packages/plugin-dashboard/src/ObjectMetricWidget.tsx` (BASECOMMIT spelled as a word on purpose — this repo's body sanitizer eats tag-shaped placeholders), proven on disk before running (`DrillDownDrawer` occurrences 4 to 0, `SheetContent` 0 to 3, on-disk blob hash equal to the base blob and unequal to the HEAD blob), restored by a `trap` to the HEAD blob and verified by `git diff HEAD` being empty.

**3 red, 4 green — one red per delivered member, each with its control still green:**

| case | ablated | failure |
|---|---|---|
| `target: 'navigate'` navigates, no panel | RED | `expected "vi.fn()" to be called with arguments: [ 'deal', { stage: 'won' } ]` |
| `target: 'drawer'` control | green | — |
| `target: 'navigate'` no-handler fallback control | green | — |
| `columns: ['name']` renders one column | RED | `expected [ 'name', 'stage', 'amount' ] to deeply equal [ 'name' ]` |
| auto-derive control | green | — |
| `maxRows: 2` renders 2 rows | RED | `expected 12 to be 2` |
| preserved-25 control | green | — |

All **13** cases of the objectui#8071 slice 9 member pin pass in **both** arms. That is the point of the filing seat's restraint: nothing had to be deleted for these members to become live. ⛔ No pin asserting the dead behaviour was added.

## Gate table

| gate | exit |
|---|---|
| dependency-closure build (`--filter '@object-ui/plugin-dashboard^...'`) | 0 |
| `vitest run packages/plugin-dashboard/` | 0 — 107 files, 967 tests |
| `vitest run apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` | 0 — 198 tests |
| `turbo run type-check` (plugin-dashboard + console) | 0 — 37 tasks; plugin-dashboard's runs `tsc -p tsconfig.test.json`, so the new test file is type-checked |
| `turbo run lint` (plugin-dashboard + console + root) | 0 errors; `ObjectMetricWidget.tsx` warnings 16 to 11, `as any` 5 to 0 |
| `check-control-bytes.mjs` | 0 |
| `check-changeset-presence.mjs` | 0 |
| `check-governed-queue-guard.mjs --test` | 0 — NOT GOVERNED |
| `check:new-line-citations` | 0 |
| `check:doc-types` | 0 |
| `check:doc-snippets` | 2 (PREREQUISITE — unbuilt), then 0 after the scoped build it names |
| `check:doc-examples` | 0 — 124 blocks, 89 failing exactly as their ledger rows declare |
| `check:vi-mock-{specifiers,inherit,override-shape}` | 0 |
| `check:unreferenced-sources` | 0 |

Heavy runs were serialized through the shared verify lock.

## Acceptance notes

- **`ObjectChart` is a third implementation of this drawer** (`packages/plugin-charts/src/ObjectChart.tsx`, its own `Sheet`/`Dialog` at the tail of the file plus its own `navigateOnly`). The dispatching assumption that `object-metric` was the only block hand-rolling a drill panel is therefore **false**. It is *not* touched here and it drops no members — it reads `columns`, `maxRows`, `filter` and the `navigate` arm itself — so it is named for a follow-up rather than filed as a dropped-metadata finding. Its registration description does understate its own contract (`target?: 'drawer' | 'dialog'` while the code implements `navigate`). Successor: whoever next consolidates drill panels; objectui#8944 is already open against the same file's drill path.
- **Filed separately:** the drilled list's column headers read as raw field names whenever `columns` is authored, and as humanized labels when it is not. Both branches call `fieldLabel`; only the fallback differs (`ObjectDataTable.tsx` passes the humanized form on the auto-derive branch and the caller's `header` on the whitelist branch, and both `DrillDownDrawer` and `ObjectChart` set that `header` to the raw field name). It predates this card, belongs to the shared drawer rather than to `object-metric`, and would change headers for four widgets, so it is not fixed here. It is why the new test compares column names case-folded, with the reason written into the helper.

## Open question left to the card

`drillDown.filter` and `drillDown.mode` still have no read site on `object-metric`, and this PR does not add one — the shared drawer honours neither, so the reroute does not settle them. The card's own framing stands: a metric has no click event for `${event.*}` to interpolate against, and the block's registration promises "the same filter narrows the drill-down list, so the number and the records behind it always agree", which an author-supplied `filter` override would break. If refusal is the intent, the remedy is to say so in the registration text or the shared type rather than to implement them. That judgement is a maintainer call, and this PR does not pre-empt it. Note the trailer at the top of this body closes the card on merge, per the dispatching seat's explicit instruction; if the maintainer wants the two-member judgement tracked, it needs its own card, because a closed card drops out of every open-issue sweep. Flagged back to the dispatching seat rather than decided here.

Authored by an agent seat via Claude Code; the session reference is `https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB` (in prose and as a code span, because the footer form does not survive an edit to this body).


---
_Generated by [Claude Code](https://claude.ai/code)_