### PR TITLE
fix(ci): give the eager-closure sensitivity check a lower bound

### DIFF
--- a/.changeset/8554-sensitivity-floor.md
+++ b/.changeset/8554-sensitivity-floor.md
@@ -1,0 +1,15 @@
+---
+---
+
+Give the eager-closure gate's ceiling-sensitivity half a LOWER bound
+(objectui#8554). It refused a ceiling that had drifted more than one regression
+ABOVE its payload and said nothing at all about one whose headroom was spent, so
+a chunk sitting one byte under its ceiling drew a green tick until an ordinary
+change turned the trunk red — and, once, turned an unrelated pull request red in
+the merge queue for another diff's bytes.
+
+The bound is a tenth of `REGRESSION_THIS_GATE_MUST_CATCH_BYTES`, which is the
+convention every deliberate re-pin in this file already sized its headroom by;
+the two rows measured under it on the day it landed are declared, at the byte, in
+a pinned allowance table that can only be paid down. CI script and its tests
+only; no package is released by this change.

--- a/.changeset/8554-sensitivity-floor.md
+++ b/.changeset/8554-sensitivity-floor.md
@@ -9,7 +9,9 @@ change turned the trunk red — and, once, turned an unrelated pull request red 
 the merge queue for another diff's bytes.
 
 The bound is a tenth of `REGRESSION_THIS_GATE_MUST_CATCH_BYTES`, which is the
-convention every deliberate re-pin in this file already sized its headroom by;
-the two rows measured under it on the day it landed are declared, at the byte, in
-a pinned allowance table that can only be paid down. CI script and its tests
-only; no package is released by this change.
+convention every deliberate re-pin in this file already sized its headroom by.
+The two rows measured under it on the day it landed are declared, at the byte, in
+a pinned allowance table that can only be paid down; those allowances are
+compared at a hundredth of a regression rather than at the byte, so a declared
+row reds only on drift the gate's own table can actually show having moved. CI
+script and its tests only; no package is released by this change.

--- a/scripts/__tests__/check-eager-closure-budget.test.ts
+++ b/scripts/__tests__/check-eager-closure-budget.test.ts
@@ -15,6 +15,8 @@ import { attachedDocs } from './helpers/attached-docs';
 // re-adding one is now itself an error (TS2578). See objectui#3494.
 import {
   BASELINE,
+  EXHAUSTED_HEADROOM_ALLOWANCES,
+  EXHAUSTED_HEADROOM_FLOOR_MULTIPLE,
   MAX_EAGER_CLOSURE_GZIP_BYTES,
   PER_CHUNK_BASELINE,
   PER_CHUNK_GZIP_CEILINGS,
@@ -710,6 +712,158 @@ describe('ceiling sensitivity, judged live (objectui#5924)', () => {
     ).toBe('pass');
     expect(evaluateClosureBudget({ report: injected }).status).toBe('fail');
   });
+
+  /**
+   * The other end of the same range (objectui#8554).
+   *
+   * The leg above answers "is this ceiling still LOW enough to mean anything?".
+   * Until this block it was the only question asked, so a ceiling with one byte
+   * left drew a green tick — and the reading that produced this card is exactly
+   * that: `framework` at 70,999 gzipped bytes against a 71,000 ceiling, across
+   * at least two merges, rendered ✅ with the run exiting 0, until an ordinary
+   * change turned `main` red.
+   */
+  describe('the exhausted end (objectui#8554)', () => {
+    /** The floor in bytes — a tenth of the regression, computed and not pinned. */
+    const FLOOR = REGRESSION_THIS_GATE_MUST_CATCH_BYTES * EXHAUSTED_HEADROOM_FLOOR_MULTIPLE;
+
+    /**
+     * The predicate as it stood before this card: one-sided, and no allowances.
+     * Passing these two makes a case a CONTROL rather than an assertion about
+     * arithmetic — the same fixture, judged by the old leg.
+     */
+    const AS_IT_STOOD = { floorMultiple: 0, allowances: {} } as const;
+
+    /**
+     * ⭐ The firing control triage asked for, on the row this card was filed
+     * about: the exact `framework` reading, red now and green before.
+     */
+    it("reds on this card's own reading — `framework` at 70,999 under a 71,000 ceiling", () => {
+      const input = {
+        report: sensitivityReport(BASELINE.gzipBytes, { framework: 70_999 }),
+        ceilings: { ...PER_CHUNK_GZIP_CEILINGS, framework: 71_000 },
+      };
+
+      // Green before, which is the defect and not a hypothetical.
+      expect(evaluateHeadroomSensitivity({ ...input, ...AS_IT_STOOD }).status).toBe('pass');
+
+      const result = evaluateHeadroomSensitivity(input);
+      expect(result.status).toBe('error');
+      expect(result.exhausted).toEqual(['framework']);
+      // Not the other leg: this row is nowhere near blind, so a green blind list
+      // is what proves the new predicate is the one that fired.
+      expect(result.blind).toEqual([]);
+      expect(result.message).toContain('EXHAUSTED');
+      // The constant to act on, so the fix is one named edit — the blind side's
+      // convention, applied to the row at the other end.
+      expect(result.message).toContain("PER_CHUNK_GZIP_CEILINGS['framework']");
+    });
+
+    it('renders the failing row ❌ rather than ✅ — the tick follows the verdict', () => {
+      const input = {
+        report: sensitivityReport(BASELINE.gzipBytes, { framework: 70_999 }),
+        ceilings: { ...PER_CHUNK_GZIP_CEILINGS, framework: 71_000 },
+      };
+      // The row renderer was a second copy of the predicate, so a floor that
+      // moved the verdict without moving the tick would print a green line under
+      // a red verdict — the same silence one indirection along.
+      expect(evaluateHeadroomSensitivity({ ...input, ...AS_IT_STOOD }).message).toContain(
+        '✅ chunk `framework`',
+      );
+      expect(evaluateHeadroomSensitivity(input).message).toContain('❌ chunk `framework`');
+    });
+
+    it('is exactly a tenth of a regression wide, from either side of the line', () => {
+      const measured = PER_CHUNK_BASELINE.framework;
+      const at = (headroom: number) =>
+        evaluateHeadroomSensitivity({
+          report: sensitivityReport(BASELINE.gzipBytes),
+          ceilings: { ...PER_CHUNK_GZIP_CEILINGS, framework: measured + headroom },
+        }).status;
+
+      expect(FLOOR).toBe(9_113.6);
+      expect(at(Math.ceil(FLOOR))).toBe('pass');
+      expect(at(Math.floor(FLOOR))).toBe('error');
+    });
+
+    /**
+     * The bound this leg must NOT own. A ceiling under its payload is an
+     * over-budget bundle: it is also under the floor, arithmetically, and
+     * counting it here would convert the size verdict's exit 1 into a gauge
+     * error and teach a reader that exit 2 does not mean what this file says.
+     */
+    it('leaves an OVER-budget ceiling to the size verdict, at this bound too', () => {
+      const result = evaluateHeadroomSensitivity({
+        report: sensitivityReport(BASELINE.gzipBytes, {
+          framework: PER_CHUNK_GZIP_CEILINGS.framework + 1,
+        }),
+      });
+      expect(result.status).toBe('pass');
+      expect(result.exhausted).toEqual([]);
+      expect(result.message).toContain('the size verdict owns this row');
+    });
+
+    it('holds a DECLARED row open at its allowance, and reds one byte tighter', () => {
+      // 394,708 is the live `ui-components` measurement the allowance was read
+      // from, so this pair is the ratchet at its own hinge rather than a
+      // rounded neighbourhood of it.
+      const at = (measuredBytes: number) =>
+        evaluateHeadroomSensitivity({
+          report: sensitivityReport(BASELINE.gzipBytes, { 'ui-components': measuredBytes }),
+        });
+
+      expect(at(394_708).status).toBe('pass');
+
+      const tighter = at(394_709);
+      expect(tighter.status).toBe('error');
+      expect(tighter.exhausted).toEqual(['ui-components']);
+    });
+
+    it('names every declared row in the PASSING verdict, not only when one fires', () => {
+      // A debt list that is only legible on the run that reds is the parenthetical
+      // this card is about: noticing stays manual, and it already failed twice.
+      const result = evaluateHeadroomSensitivity({
+        report: sensitivityReport(BASELINE.gzipBytes),
+      });
+      expect(result.status).toBe('pass');
+      for (const [name, allowance] of Object.entries(EXHAUSTED_HEADROOM_ALLOWANCES)) {
+        expect(result.message).toContain(`chunk \`${name}\``);
+        expect(result.message).toContain(`declared ${allowance}-byte allowance`);
+      }
+    });
+
+    /**
+     * The allowance table is a RATCHET, and the whole of its ratchet-ness is
+     * that these numbers can only be paid down. Nothing in the runtime can
+     * enforce that — the constant is whatever the file says — so the pin is the
+     * enforcement: an edit in either direction has to come here and be argued.
+     */
+    describe('the allowance table is a ratchet, pinned', () => {
+      it('holds exactly the rows measured under the floor on the day it landed', () => {
+        expect(EXHAUSTED_HEADROOM_ALLOWANCES).toEqual({
+          'i18n-locales': 8_804,
+          'ui-components': 4_292,
+        });
+      });
+
+      it('every entry is real debt — strictly under the floor it excuses', () => {
+        // An allowance at or above the floor is not debt, it is a second floor
+        // for one row, and the row should simply have been dropped from here.
+        for (const allowance of Object.values(EXHAUSTED_HEADROOM_ALLOWANCES)) {
+          expect(allowance).toBeLessThan(FLOOR);
+        }
+      });
+
+      it('every entry names a ceiling that exists', () => {
+        // An allowance for a key with no ceiling excuses nothing and would sit
+        // here unread, which is how a table of debt becomes a table of noise.
+        const judged = ['aggregate', ...Object.keys(PER_CHUNK_GZIP_CEILINGS)];
+        for (const key of Object.keys(EXHAUSTED_HEADROOM_ALLOWANCES)) {
+          expect(judged).toContain(key);
+        }
+      });
+    });
+  });
 });
 
 describe('renderTopChunks', () => {
@@ -928,6 +1082,20 @@ describe('main', () => {
    */
   it('exits 2 when a ceiling has drifted out of range of the regression it must catch', () => {
     const { code, outputs } = run(budgeted({}, -REGRESSION_THIS_GATE_MUST_CATCH_BYTES));
+    expect(code).toBe(2);
+    expect(outputs.closure_status).toBe('pass');
+    expect(outputs.closure_chunk_status).toBe('pass');
+    expect(outputs.closure_headroom_status).toBe('error');
+  });
+
+  /**
+   * objectui#8554: the same blind spot at the other end. `framework` one byte
+   * under its own ceiling is inside every size line in the file — both size
+   * halves pass, and every one of this gate's other exits is 0 — so the exit
+   * code here is produced by the exhausted leg alone.
+   */
+  it('exits 2 when a ceiling has no headroom left to measure with', () => {
+    const { code, outputs } = run(budgeted({ framework: PER_CHUNK_GZIP_CEILINGS.framework - 1 }));
     expect(code).toBe(2);
     expect(outputs.closure_status).toBe('pass');
     expect(outputs.closure_chunk_status).toBe('pass');

--- a/scripts/__tests__/check-eager-closure-budget.test.ts
+++ b/scripts/__tests__/check-eager-closure-budget.test.ts
@@ -804,7 +804,7 @@ describe('ceiling sensitivity, judged live (objectui#5924)', () => {
     });
 
     it('holds a DECLARED row open at its allowance, and reds one byte tighter', () => {
-      // 394,708 is the live `ui-components` measurement the allowance was read
+      // 394,711 is the live `ui-components` measurement the allowance was read
       // from, so this pair is the ratchet at its own hinge rather than a
       // rounded neighbourhood of it.
       const at = (measuredBytes: number) =>
@@ -812,9 +812,9 @@ describe('ceiling sensitivity, judged live (objectui#5924)', () => {
           report: sensitivityReport(BASELINE.gzipBytes, { 'ui-components': measuredBytes }),
         });
 
-      expect(at(394_708).status).toBe('pass');
+      expect(at(394_711).status).toBe('pass');
 
-      const tighter = at(394_709);
+      const tighter = at(394_712);
       expect(tighter.status).toBe('error');
       expect(tighter.exhausted).toEqual(['ui-components']);
     });
@@ -842,7 +842,7 @@ describe('ceiling sensitivity, judged live (objectui#5924)', () => {
       it('holds exactly the rows measured under the floor on the day it landed', () => {
         expect(EXHAUSTED_HEADROOM_ALLOWANCES).toEqual({
           'i18n-locales': 8_804,
-          'ui-components': 4_292,
+          'ui-components': 4_289,
         });
       });
 

--- a/scripts/__tests__/check-eager-closure-budget.test.ts
+++ b/scripts/__tests__/check-eager-closure-budget.test.ts
@@ -16,6 +16,7 @@ import { attachedDocs } from './helpers/attached-docs';
 import {
   BASELINE,
   EXHAUSTED_HEADROOM_ALLOWANCES,
+  EXHAUSTED_HEADROOM_ALLOWANCE_GRANULARITY_MULTIPLE,
   EXHAUSTED_HEADROOM_FLOOR_MULTIPLE,
   MAX_EAGER_CLOSURE_GZIP_BYTES,
   PER_CHUNK_BASELINE,
@@ -803,20 +804,97 @@ describe('ceiling sensitivity, judged live (objectui#5924)', () => {
       expect(result.message).toContain('the size verdict owns this row');
     });
 
-    it('holds a DECLARED row open at its allowance, and reds one byte tighter', () => {
-      // 394,711 is the live `ui-components` measurement the allowance was read
-      // from, so this pair is the ratchet at its own hinge rather than a
-      // rounded neighbourhood of it.
-      const at = (measuredBytes: number) =>
+    /**
+     * A declared row's hinge is its pinned figure LESS one grain, and the pair
+     * is taken at that exact boundary. 4,289 is the live `ui-components`
+     * headroom the allowance was read from, so this is the ratchet at its own
+     * hinge rather than a rounded neighbourhood of it.
+     */
+    describe('a declared row', () => {
+      const CEILING = PER_CHUNK_GZIP_CEILINGS['ui-components'];
+      const ALLOWANCE = EXHAUSTED_HEADROOM_ALLOWANCES['ui-components'];
+      const GRAIN =
+        REGRESSION_THIS_GATE_MUST_CATCH_BYTES * EXHAUSTED_HEADROOM_ALLOWANCE_GRANULARITY_MULTIPLE;
+
+      /** The report with `ui-components` sized to leave exactly `headroom`. */
+      const atHeadroom = (headroom: number) =>
         evaluateHeadroomSensitivity({
-          report: sensitivityReport(BASELINE.gzipBytes, { 'ui-components': measuredBytes }),
+          report: sensitivityReport(BASELINE.gzipBytes, { 'ui-components': CEILING - headroom }),
         });
 
-      expect(at(394_711).status).toBe('pass');
+      it('is held open at its pinned figure', () => {
+        expect(atHeadroom(ALLOWANCE).status).toBe('pass');
+      });
 
-      const tighter = at(394_712);
-      expect(tighter.status).toBe('error');
-      expect(tighter.exhausted).toEqual(['ui-components']);
+      /**
+       * ⭐ The reason this bound is a grain and not a byte, asserted rather than
+       * asserted-about. A byte-exact ratchet would red HERE — and the evidence
+       * table it would print is character-for-character the one the passing run
+       * prints, because every column this gate renders is rounded past a single
+       * byte. A red whose own table is identical to the green table tells its
+       * reader nothing, which is objectui#8554's defect one level in.
+       */
+      it('does NOT red on drift its own table cannot render', () => {
+        const green = atHeadroom(ALLOWANCE);
+        const oneByteTighter = atHeadroom(ALLOWANCE - 1);
+        expect(oneByteTighter.status).toBe('pass');
+
+        const rowOf = (result: { message: string }) =>
+          result.message.split('\n').find((line) => line.includes('`ui-components`'));
+        expect(rowOf(oneByteTighter)).toBe(rowOf(green));
+      });
+
+      it('reds once it has lost a whole grain, and not before', () => {
+        expect(GRAIN).toBe(911.36);
+        expect(atHeadroom(Math.ceil(ALLOWANCE - GRAIN)).status).toBe('pass');
+
+        const tightened = atHeadroom(Math.floor(ALLOWANCE - GRAIN));
+        expect(tightened.status).toBe('error');
+        expect(tightened.exhausted).toEqual(['ui-components']);
+      });
+
+      /**
+       * The remedy text is the half of this that keeps an innocent author out of
+       * their own diff. A row falling under the floor for the first time is
+       * somebody's to fix; a declared row tightening is a standing debt whose
+       * payoff is a decision that author very likely does not own, and the two
+       * verdicts must not read the same.
+       */
+      it('reds with the DEBT remedy, not the find-the-bytes remedy', () => {
+        const message = atHeadroom(Math.floor(ALLOWANCE - GRAIN)).message;
+        expect(message).toContain('ALREADY declared exhausted');
+        expect(message).toContain('BEFORE AUDITING YOUR OWN DIFF');
+        expect(message).toContain('never raise the allowance');
+        // ⛔ and NOT the text a newly-exhausted row gets, which tells its reader
+        // the bytes are theirs to find.
+        expect(message).not.toContain('The remedy is the bytes');
+      });
+
+      it('a row falling under the floor for the FIRST time still gets that one', () => {
+        const message = evaluateHeadroomSensitivity({
+          report: sensitivityReport(BASELINE.gzipBytes, { framework: 70_999 }),
+          ceilings: { ...PER_CHUNK_GZIP_CEILINGS, framework: 71_000 },
+        }).message;
+        expect(message).toContain('The remedy is the bytes');
+        expect(message).not.toContain('ALREADY declared exhausted');
+      });
+
+      it('paying the row DOWN moves its trip point up with it', () => {
+        // The grain coarsens WHEN a declared row reds; it is not a fixed pool of
+        // bytes the row keeps forever. A larger pinned figure trips sooner in
+        // absolute terms, which is what makes this a ratchet rather than a
+        // rebate.
+        const paidDown = ALLOWANCE + 2_000;
+        const at = (headroom: number, allowance: number) =>
+          evaluateHeadroomSensitivity({
+            report: sensitivityReport(BASELINE.gzipBytes, { 'ui-components': CEILING - headroom }),
+            allowances: { ...EXHAUSTED_HEADROOM_ALLOWANCES, 'ui-components': allowance },
+          }).status;
+
+        expect(at(Math.floor(paidDown - GRAIN), paidDown)).toBe('error');
+        // The same headroom was fine under the smaller pin it used to carry.
+        expect(at(Math.floor(paidDown - GRAIN), ALLOWANCE)).toBe('pass');
+      });
     });
 
     it('names every declared row in the PASSING verdict, not only when one fires', () => {
@@ -851,6 +929,33 @@ describe('ceiling sensitivity, judged live (objectui#5924)', () => {
         // for one row, and the row should simply have been dropped from here.
         for (const allowance of Object.values(EXHAUSTED_HEADROOM_ALLOWANCES)) {
           expect(allowance).toBeLessThan(FLOOR);
+        }
+      });
+
+      it('is compared at the coarser of the two grids this gate renders on', () => {
+        // The grain must be at least the coarsest rounding in the row renderer,
+        // or a red can print an evidence table identical to the green one. The
+        // two grids are one decimal of a KiB (102.4 bytes) and two decimals of a
+        // regression (911.36); the second is the binding one, and 0.01x is it.
+        const grain =
+          REGRESSION_THIS_GATE_MUST_CATCH_BYTES * EXHAUSTED_HEADROOM_ALLOWANCE_GRANULARITY_MULTIPLE;
+        expect(grain).toBeGreaterThanOrEqual(1024 / 10);
+        expect(grain).toBe(REGRESSION_THIS_GATE_MUST_CATCH_BYTES / 100);
+      });
+
+      it('is coarser than a byte but far finer than the floor it excuses', () => {
+        // Both directions matter. Too fine and the ratchet fires invisibly; as
+        // coarse as the floor and a declared row would never red at all, which
+        // is the silence this card is about.
+        const grain =
+          REGRESSION_THIS_GATE_MUST_CATCH_BYTES * EXHAUSTED_HEADROOM_ALLOWANCE_GRANULARITY_MULTIPLE;
+        const floor = REGRESSION_THIS_GATE_MUST_CATCH_BYTES * EXHAUSTED_HEADROOM_FLOOR_MULTIPLE;
+        expect(grain).toBeGreaterThan(1);
+        expect(grain).toBeLessThan(floor);
+        // Every declared row must still have a reachable trip point above zero,
+        // or its entry would be decorative.
+        for (const allowance of Object.values(EXHAUSTED_HEADROOM_ALLOWANCES)) {
+          expect(allowance - grain).toBeGreaterThan(0);
         }
       });
 

--- a/scripts/check-eager-closure-budget.mjs
+++ b/scripts/check-eager-closure-budget.mjs
@@ -1073,15 +1073,70 @@ export const EXHAUSTED_HEADROOM_FLOOR_MULTIPLE = 0.1;
  * three bytes are content and not noise, and the first reading was already stale
  * when it was taken. That is this card's whole thesis arriving during its own
  * fix: the tightest line on the board moves under ordinary traffic and nothing
- * said so. ⚠️ It is also the standing hazard of the figure below. It is pinned
- * at the byte against a live row, so an unrelated change that grows this chunk
- * reds here — correctly, and pointing at a row that is genuinely tighter, but
- * ⛔ the remedy is still never to move this number up.
+ * said so.
+ *
+ * ⇒ that reading is also why these figures are NOT compared at the byte. See
+ * {@link EXHAUSTED_HEADROOM_ALLOWANCE_GRANULARITY_MULTIPLE}, which is the unit
+ * the comparison is made in and the reason a red here is a red a reader can see.
  */
 export const EXHAUSTED_HEADROOM_ALLOWANCES = Object.freeze({
   'i18n-locales': 8_804,
   'ui-components': 4_289,
 });
+
+/**
+ * The unit a declared allowance is compared in, as a fraction of
+ * {@link REGRESSION_THIS_GATE_MUST_CATCH_BYTES}. A listed row reds when its
+ * headroom falls a whole one of these below its pinned figure — ⛔ not when it
+ * falls one BYTE below it.
+ *
+ * ## Why the byte is the wrong unit, demonstrated rather than argued
+ *
+ * This gate renders three numbers per row, and every one of them is rounded:
+ * measured and headroom through {@link kb} at one decimal of a KiB, and the
+ * multiple at two decimals of a regression. Take `ui-components` at its pinned
+ * 4,289 bytes of headroom and remove ONE byte — the boundary a byte-exact
+ * comparison would red on:
+ *
+ *     headroom 4,289  ->  385.5 KB measured / headroom 4.2 KB / 0.05x
+ *     headroom 4,288  ->  385.5 KB measured / headroom 4.2 KB / 0.05x
+ *
+ * ⇒ ⭐ identical. Every column. A byte-exact ratchet fires with a red cross above
+ * an evidence table that is character-for-character the table the green run
+ * printed, so the reader cannot see what moved, cannot tell their own diff from
+ * the drift under it, and has nothing to act on. That is the same defect
+ * objectui#8554 is about — a number nobody can read — moved one level in.
+ *
+ * ## Why a hundredth, specifically
+ *
+ * It is the coarser of this file's two rendering grids: 0.01x is 911.36 bytes,
+ * where one tenth of a KiB is 102.4. Choosing the coarser one is what makes a
+ * red visible in BOTH columns rather than only the finer of them. Across the
+ * same trip point that is:
+ *
+ *     headroom 4,289  ->  385.5 KB measured / headroom 4.2 KB / 0.05x
+ *     headroom 3,377  ->  386.4 KB measured / headroom 3.3 KB / 0.04x
+ *
+ * It is also the next decade of the unit this whole file is denominated in —
+ * 1.00x is blind, 0.10x is the floor, 0.01x is the grain — so the instrument
+ * measures at one resolution throughout instead of claiming an 89 KB question
+ * and answering a one-byte one.
+ *
+ * ## What this is NOT
+ *
+ * ⛔ Not a raise, and ⛔ not headroom to spend. The pinned figures do not move,
+ * the table stays pay-down-only, and paying a row down moves its trip point up
+ * with it. It coarsens WHEN a declared row reds, ⛔ never whether it is
+ * declared, and ⛔ never the {@link EXHAUSTED_HEADROOM_FLOOR_MULTIPLE} floor
+ * itself, which is unchanged and still reds an undeclared row at 0.10x.
+ *
+ * ⚠️ ⛔ It does not make a declared row's red CLEARABLE by the pull request that
+ * trips it — nothing at this bound can, while a row's headroom is somebody
+ * else's open decision. What it does is stop that red firing on drift too small
+ * to see, and the verdict text for a declared row says whose question it is
+ * rather than sending its author to audit their own diff.
+ */
+export const EXHAUSTED_HEADROOM_ALLOWANCE_GRANULARITY_MULTIPLE = 0.01;
 
 /**
  * The report shape this checker understands. v2 added `files[].name` — the
@@ -1516,6 +1571,7 @@ export function evaluateHeadroomSensitivity({
   regressionBytes = REGRESSION_THIS_GATE_MUST_CATCH_BYTES,
   floorMultiple = EXHAUSTED_HEADROOM_FLOOR_MULTIPLE,
   allowances = EXHAUSTED_HEADROOM_ALLOWANCES,
+  allowanceGrainMultiple = EXHAUSTED_HEADROOM_ALLOWANCE_GRANULARITY_MULTIPLE,
   reportPath = DEFAULT_REPORT_PATH,
 } = {}) {
   const base = { sites: [], blind: [], exhausted: [] };
@@ -1589,10 +1645,14 @@ export function evaluateHeadroomSensitivity({
   });
   const blind = rows.filter((row) => row.headroomBytes >= regressionBytes);
   const floorBytes = regressionBytes * floorMultiple;
+  const allowanceGrainBytes = regressionBytes * allowanceGrainMultiple;
   // The headroom this row must keep: the floor, unless it is one of the rows
   // that was already under the floor when the floor was written, in which case
-  // it is that row's own pinned figure and the floor is unreachable for it.
-  const floorFor = (row) => allowances[row.key] ?? floorBytes;
+  // it is that row's own pinned figure — less one grain, because a ratchet that
+  // fires on drift the table cannot render is a red with no readable evidence.
+  // See EXHAUSTED_HEADROOM_ALLOWANCE_GRANULARITY_MULTIPLE.
+  const floorFor = (row) =>
+    allowances[row.key] === undefined ? floorBytes : allowances[row.key] - allowanceGrainBytes;
   // ⛔ `headroomBytes >= 0` is load-bearing, not defensive. Without it every
   // OVER-budget row falls under the floor too, and this half would convert the
   // size verdict's exit 1 into a gauge error — see "What it deliberately does
@@ -1614,7 +1674,8 @@ export function evaluateHeadroomSensitivity({
             (allowance === undefined
               ? ''
               : `, under the ${floorMultiple.toFixed(2)}x floor and held open by its ` +
-                `declared ${allowance}-byte allowance, which may only be paid DOWN`);
+                `declared ${allowance}-byte allowance, which may only be paid DOWN; ` +
+                `reds below ${Math.round(allowance - allowanceGrainBytes)} bytes`);
       const failing = row.headroomBytes >= regressionBytes || exhausted.includes(row);
       return (
         `  ${failing ? '❌' : '✅'} ${row.label.padEnd(28)} ` +
@@ -1648,12 +1709,23 @@ export function evaluateHeadroomSensitivity({
     );
   }
 
+  // Two populations, two remedies. A row falling under the floor for the first
+  // time is somebody's to fix; a DECLARED row getting tighter is a standing debt
+  // whose payoff is a decision this run's author very likely does not own. Giving
+  // both the same "find the bytes" text is what sends an innocent author to audit
+  // a diff that is not the cause — the misattribution objectui#8554 documents.
+  const newlyExhausted = exhausted.filter((row) => allowances[row.key] === undefined);
+  const declaredTightened = exhausted.filter((row) => allowances[row.key] !== undefined);
+
   if (exhausted.length > 0) {
     headlines.push(
       `${exhausted.length} ceiling${exhausted.length === 1 ? ' is' : 's are'} EXHAUSTED — under ` +
-        `${floorMultiple.toFixed(2)}x of one ${kb(regressionBytes)} KB regression, or under the ` +
-        `allowance it was pinned at:`,
+        `${floorMultiple.toFixed(2)}x of one ${kb(regressionBytes)} KB regression, or a declared ` +
+        `row that has tightened by a whole ${allowanceGrainMultiple.toFixed(2)}x:`,
     );
+  }
+
+  if (newlyExhausted.length > 0) {
     prose.push(
       `A ceiling with no headroom left has stopped being a measurement of THIS bundle and become ` +
         `a measurement of the NEXT change: it passes today and reds whatever lands next, whether ` +
@@ -1669,6 +1741,25 @@ export function evaluateHeadroomSensitivity({
         `direction. ⛔ Never lower EXHAUSTED_HEADROOM_FLOOR_MULTIPLE, and ⛔ never add a row to ` +
         `EXHAUSTED_HEADROOM_ALLOWANCES to silence this: that object records debt measured on the ` +
         `day the floor landed and may only be paid down.`,
+    );
+  }
+
+  if (declaredTightened.length > 0) {
+    prose.push(
+      `${declaredTightened.map((row) => row.label).join(', ')} ` +
+        `${declaredTightened.length === 1 ? 'was' : 'were'} ALREADY declared exhausted before ` +
+        `this run, and ${declaredTightened.length === 1 ? 'has' : 'have'} now lost a further ` +
+        `${allowanceGrainMultiple.toFixed(2)}x of a regression against the pinned figure.\n` +
+        `⚠️ READ THIS BEFORE AUDITING YOUR OWN DIFF. This row's headroom is a standing debt that ` +
+        `predates this change, and it moves under traffic that has nothing to do with the chunk ` +
+        `— measured at three gzipped bytes across five unrelated merges. So this verdict is NOT ` +
+        `an accusation that your diff spent the bytes, and the amount it names is very likely ` +
+        `not yours. What it asserts is only that the row is tighter than the day it was pinned.\n` +
+        `⛔ There is therefore nothing here for this pull request to "fix", and the two edits that ` +
+        `would turn this green are both forbidden: ⛔ never raise the ceiling, and ⛔ never raise ` +
+        `the allowance. Paying the row down is the open decision on the chunk, ⛔ not a task for ` +
+        `whichever change the queue happened to weigh — take it there, and say on this pull ` +
+        `request that you did.`,
     );
   }
 

--- a/scripts/check-eager-closure-budget.mjs
+++ b/scripts/check-eager-closure-budget.mjs
@@ -612,8 +612,10 @@ export const REGRESSION_THIS_GATE_MUST_CATCH_BYTES = 89 * 1024;
  * worth under half the payload it gets blamed for. ⭐ Why `main` was one byte from
  * this line in the first place is objectui#8554: it sat at 70,999 against 71,000
  * — headroom 0.00x — and printed a GREEN sensitivity row while it did, because
- * {@link evaluateHeadroomSensitivity} has no floor. objectui#8541 recorded the
- * same red first and is closed as this card's duplicate.
+ * {@link evaluateHeadroomSensitivity} had no floor at the time. It has one now,
+ * {@link EXHAUSTED_HEADROOM_FLOOR_MULTIPLE}, so this row is loud rather than
+ * green. objectui#8541 recorded the same red first and is closed as this card's
+ * duplicate.
  *
  * ⚠️ This also makes `framework` the LOOSEST ceiling in this object, measured
  * rather than asserted. All four were read from the one `3f775eeb8` console
@@ -758,8 +760,11 @@ export const REGRESSION_THIS_GATE_MUST_CATCH_BYTES = 89 * 1024;
  * its author to investigate something that is not there. objectui#8554 is the
  * same mechanism one step earlier: `framework` sat at 70,999 against 71,000 and
  * printed a GREEN sensitivity row while it did, because
- * {@link evaluateHeadroomSensitivity} has no floor. Re-pinning to 804 bytes
- * would reproduce both inside a week.
+ * {@link evaluateHeadroomSensitivity} had no floor at the time. Re-pinning to
+ * 804 bytes would reproduce both inside a week. ⭐ That card is also where the
+ * convention this paragraph reaches for stopped being prose: the tenth chosen
+ * here is now {@link EXHAUSTED_HEADROOM_FLOOR_MULTIPLE}, and a re-pin that
+ * ignores it reds instead of merely disagreeing with a comment.
  *
  * So the size comes from this key's own convention rather than from the overage:
  * 8,804 bytes = 0.10x {@link REGRESSION_THIS_GATE_MUST_CATCH_BYTES}, against the
@@ -968,6 +973,102 @@ export const PER_CHUNK_BASELINE = Object.freeze({
   // ruling of 2026-09-08 and the rule stated under "Raising one".
   framework: 72_245,
   'ui-components': 391_095,
+});
+
+/**
+ * The LOWER bound on a ceiling's headroom, as a fraction of
+ * {@link REGRESSION_THIS_GATE_MUST_CATCH_BYTES} (objectui#8554).
+ *
+ * ## The half this closes
+ *
+ * {@link evaluateHeadroomSensitivity} asks whether a ceiling is still close
+ * enough to its payload to mean anything, and until this constant it asked that
+ * in ONE direction only: a ceiling more than one regression ABOVE its payload is
+ * blind, and every other row drew a green tick — one byte of headroom included.
+ * A spent ceiling is not a measurement of this bundle either. It is a
+ * measurement of the NEXT change, whatever that turns out to be.
+ *
+ * The cost is recorded rather than argued, twice. `framework` stood at 70,999
+ * gzipped bytes against a 71,000 ceiling across at least two merges, printing a
+ * green sensitivity row the whole time, and then `main` went red on an ordinary
+ * change. `i18n-locales` stood at 398 bytes and did something worse: this gate
+ * weighs the merge ref, so two independent, finished pull requests each added
+ * under a kilobyte to that chunk and whichever the queue weighed SECOND turned
+ * red for the other one's bytes. An exhausted ceiling does not only red the
+ * trunk — it reds an innocent diff and misnames the cause, while this half
+ * prints a green tick at the bottom of the same run.
+ *
+ * ## Why a tenth, and why that is not a reading of today's rows
+ *
+ * This file already had an answer and only ever wrote it in prose. Every
+ * deliberate re-pin in {@link PER_CHUNK_GZIP_CEILINGS} sizes the new headroom at
+ * a tenth of the regression: objectui#7399 re-pinned two keys to it, and
+ * objectui#8816 rejected the minimal raise that would have admitted its two
+ * claimants exactly — choosing, in as many words, this key's own convention over
+ * the overage, and citing objectui#8554 for why the minimal raise would
+ * reproduce both failures inside a week. The maintainer ruling that authorised
+ * that raise was taken on that reasoning.
+ *
+ * ⇒ the bound is this file's own already-taken decision, promoted from a comment
+ * into the predicate. ⛔ It was NOT picked by asking which rows are green today.
+ * What it does to today's rows is recorded, after the fact and in that order, in
+ * {@link EXHAUSTED_HEADROOM_ALLOWANCES}.
+ *
+ * ⛔ Never raise this to quiet a row. It is a floor on a floor: raising it buys
+ * silence for a ceiling that has stopped measuring, which is the defect and not
+ * the cure — the same rule the blind side states in the other direction.
+ */
+export const EXHAUSTED_HEADROOM_FLOOR_MULTIPLE = 0.1;
+
+/**
+ * Ceilings whose headroom was ALREADY under
+ * {@link EXHAUSTED_HEADROOM_FLOOR_MULTIPLE} on the day that floor landed, each
+ * pinned at the headroom it measured that day (objectui#8554).
+ *
+ * ## Why a table and not simply a lower floor
+ *
+ * Two rows were under a tenth of the regression when the floor was written. A
+ * floor low enough to clear them would be green on a board whose tightest line
+ * is the exact instance this card was filed about — it would say nothing, which
+ * is the defect wearing the cure's clothes. A floor without them reds `main` on
+ * landing, which is how a budget gets switched off rather than met. So the bound
+ * stays where this file's own convention put it, and the debt is DECLARED here,
+ * at the byte.
+ *
+ * ## What an entry does
+ *
+ * A listed ceiling passes while its headroom is at least the figure below and
+ * reds the moment it gets TIGHTER. The gate is therefore loud immediately: every
+ * listed row is named in the PASSING verdict too, not only when it fires. Each
+ * entry is a ratchet that can be paid off and never spent.
+ *
+ * ⛔ No figure here may ever be LOWERED. Lowering one turns this object from a
+ * record of debt into a supply of headroom, and the row it was written about
+ * goes exactly as silent as it was before this card.
+ *
+ * ⛔ No row may be ADDED to buy silence. A ceiling that cannot clear the floor is
+ * a ceiling set at the wrong number; the answer is the bytes, or a deliberate
+ * authorised re-pin, never a new line in this object. The unit test pins these
+ * contents exactly, so an edit in either direction is a visible, deliberate act
+ * rather than a number that drifted.
+ *
+ * ⛔ These are not ceilings and nothing may be raised to satisfy one. The
+ * `ui-components` number in particular is an open decision (objectui#7848) and
+ * this table ⛔ does not answer it — it only stops the gate being silent while
+ * that decision stands unanswered.
+ *
+ * Both figures were read from one full console build on `e8b7b0785`, from the
+ * same report the gate reads. ⚠️ `i18n-locales` carries the pair objectui#8816's
+ * maintainer ruling set eight days earlier, whose prose calls its headroom
+ * "0.10x": rendered to two decimals it is, measured it is 0.0966x, so the floor
+ * catches it by 310 bytes. That is a rounding artifact in the prose, ⛔ not a
+ * finding about the ruling, and ⛔ not a reason to bend the bound to 0.095 —
+ * bending it to clear a named row is choosing the bound by today's board, which
+ * is the one move this card may not make.
+ */
+export const EXHAUSTED_HEADROOM_ALLOWANCES = Object.freeze({
+  'i18n-locales': 8_804,
+  'ui-components': 4_292,
 });
 
 /**
@@ -1359,33 +1460,53 @@ export function evaluatePerChunkBudgets({
  * that is absent: a check that passes by measuring nothing must be LOUDER than
  * one that fails by measuring something, never quieter.
  *
+ * ## Both sides of the range (objectui#8554)
+ *
+ * A ceiling stops measuring at either end. Too far above the payload and its
+ * green tick cannot tell "no regression" from the motivating incident; too close
+ * and its green tick is about the next change rather than this one. The upper
+ * bound is one whole regression; the lower bound is
+ * {@link EXHAUSTED_HEADROOM_FLOOR_MULTIPLE} of one, with the rows that were
+ * already under it pinned at their measured headroom in
+ * {@link EXHAUSTED_HEADROOM_ALLOWANCES}. Both verdicts are the same kind — about
+ * the GAUGE, so `error` and exit 2 — because a ceiling nobody can act on until
+ * it fires is not a working ceiling in either direction.
+ *
  * ## What it deliberately does not do
  *
  * It does not treat a NEGATIVE headroom — a ceiling under the payload — as its
- * business. That is an over-budget bundle, the other two halves own it, and
- * reporting it here as well would turn one regression into an error and teach a
- * reader to distrust the exit code. Over-budget rows are still printed, marked
- * as such, so the table is a complete picture of every ceiling.
+ * business, at EITHER bound. That is an over-budget bundle, the other two halves
+ * own it, and reporting it here as well would turn one regression into an error
+ * and teach a reader to distrust the exit code. ⛔ The exhausted leg therefore
+ * tests `0 <= headroom < floor` and not `headroom < floor`: the second would
+ * swallow every over-budget row into this half and convert a size failure into a
+ * gauge error, which is precisely the confusion this paragraph exists to
+ * prevent. Over-budget rows are still printed, marked as such, so the table is a
+ * complete picture of every ceiling.
  *
  * @param {object} input
  * @param {unknown} input.report
  * @param {number} [input.budgetBytes]      the aggregate ceiling
  * @param {Record<string, number>} [input.ceilings]  the per-chunk ceilings
  * @param {number} [input.regressionBytes]  the size this gate must stay able to catch
+ * @param {number} [input.floorMultiple]    the lower bound, as a fraction of that size
+ * @param {Record<string, number>} [input.allowances]  declared already-exhausted rows
  * @param {string} [input.reportPath]
- * @returns {{ status: 'pass' | 'fail' | 'error', message: string,
+ * @returns {{ status: 'pass' | 'error', message: string,
  *             sites: { key: string, label: string, constant: string, measuredBytes: number,
  *                      ceilingBytes: number, headroomBytes: number, multiple: number }[],
- *             blind: string[] }}
+ *             blind: string[], exhausted: string[] }}
  */
 export function evaluateHeadroomSensitivity({
   report,
   budgetBytes = MAX_EAGER_CLOSURE_GZIP_BYTES,
   ceilings = PER_CHUNK_GZIP_CEILINGS,
   regressionBytes = REGRESSION_THIS_GATE_MUST_CATCH_BYTES,
+  floorMultiple = EXHAUSTED_HEADROOM_FLOOR_MULTIPLE,
+  allowances = EXHAUSTED_HEADROOM_ALLOWANCES,
   reportPath = DEFAULT_REPORT_PATH,
 } = {}) {
-  const base = { sites: [], blind: [] };
+  const base = { sites: [], blind: [], exhausted: [] };
 
   if (report === null || report === undefined) {
     return {
@@ -1455,33 +1576,54 @@ export function evaluateHeadroomSensitivity({
     return { ...site, headroomBytes, multiple: headroomBytes / regressionBytes };
   });
   const blind = rows.filter((row) => row.headroomBytes >= regressionBytes);
+  const floorBytes = regressionBytes * floorMultiple;
+  // The headroom this row must keep: the floor, unless it is one of the rows
+  // that was already under the floor when the floor was written, in which case
+  // it is that row's own pinned figure and the floor is unreachable for it.
+  const floorFor = (row) => allowances[row.key] ?? floorBytes;
+  // ⛔ `headroomBytes >= 0` is load-bearing, not defensive. Without it every
+  // OVER-budget row falls under the floor too, and this half would convert the
+  // size verdict's exit 1 into a gauge error — see "What it deliberately does
+  // not do" above.
+  const exhausted = rows.filter(
+    (row) => row.headroomBytes >= 0 && row.headroomBytes < floorFor(row),
+  );
 
   const table = rows
     .map((row) => {
+      const allowance = allowances[row.key];
       const band =
         row.headroomBytes < 0
           ? `OVER by ${kb(-row.headroomBytes)} KB — the size verdict owns this row, not this one`
           : `headroom ${kb(row.headroomBytes)} KB = ${row.multiple.toFixed(2)}x the ` +
-            `${kb(regressionBytes)} KB regression`;
+            `${kb(regressionBytes)} KB regression` +
+            // Printed on a PASSING row too: a declared exhausted ceiling that
+            // only appears when it fires is the silence this leg exists to end.
+            (allowance === undefined
+              ? ''
+              : `, under the ${floorMultiple.toFixed(2)}x floor and held open by its ` +
+                `declared ${allowance}-byte allowance, which may only be paid DOWN`);
+      const failing = row.headroomBytes >= regressionBytes || exhausted.includes(row);
       return (
-        `  ${row.headroomBytes >= regressionBytes ? '❌' : '✅'} ${row.label.padEnd(28)} ` +
+        `  ${failing ? '❌' : '✅'} ${row.label.padEnd(28)} ` +
         `${kb(row.measuredBytes).padStart(9)} KB measured / ${kb(row.ceilingBytes)} KB ceiling ` +
         `(${band})  [${row.constant}]`
       );
     })
     .join('\n');
 
+  const headlines = [];
+  const prose = [];
+
   if (blind.length > 0) {
-    return {
-      sites: rows,
-      blind: blind.map((row) => row.key),
-      status: 'error',
-      message:
-        `${blind.length} ceiling${blind.length === 1 ? '' : 's'} ` +
+    headlines.push(
+      `${blind.length} ceiling${blind.length === 1 ? '' : 's'} ` +
         `${blind.length === 1 ? 'has' : 'have'} DRIFTED more than one ` +
         `${kb(regressionBytes)} KB regression above the payload ` +
-        `${blind.length === 1 ? 'it governs' : 'they govern'}:\n${table}\n` +
-        `A ceiling that far above today's measurement cannot tell "no regression" from a repeat ` +
+        `${blind.length === 1 ? 'it governs' : 'they govern'}:`,
+    );
+    prose.push(
+      `A ceiling that far above today's measurement cannot tell "no regression" from a repeat ` +
         `of objectui#5266 — its green tick carries no information, which makes this a verdict ` +
         `about the GAUGE and not about the bundle (objectui#5924: an aggregate ceiling at 8.6x ` +
         `passed a demonstrated +154 KB eager regression).\n` +
@@ -1491,12 +1633,50 @@ export function evaluateHeadroomSensitivity({
         `⛔ Never lower a ceiling BELOW the measured figure to express an aspiration. A ceiling ` +
         `under today's reality lands red on \`main\`, which is how a budget gets switched off ` +
         `rather than met.`,
+    );
+  }
+
+  if (exhausted.length > 0) {
+    headlines.push(
+      `${exhausted.length} ceiling${exhausted.length === 1 ? ' is' : 's are'} EXHAUSTED — under ` +
+        `${floorMultiple.toFixed(2)}x of one ${kb(regressionBytes)} KB regression, or under the ` +
+        `allowance it was pinned at:`,
+    );
+    prose.push(
+      `A ceiling with no headroom left has stopped being a measurement of THIS bundle and become ` +
+        `a measurement of the NEXT change: it passes today and reds whatever lands next, whether ` +
+        `or not that diff is what grew. This gate has already been paid for twice ` +
+        `(objectui#8554): \`framework\` sat at one byte across two merges and printed a green ` +
+        `row throughout, and \`i18n-locales\` sat at 398 bytes while the merge queue weighed two ` +
+        `independent finished pull requests and turned red on whichever it happened to weigh ` +
+        `SECOND, for the other one's bytes.\n` +
+        `The remedy is the bytes: take them out of the chunk this row names, or take a ` +
+        `deliberate, authorised re-pin and say in the PR what the new headroom buys.\n` +
+        `⛔ Never raise a ceiling because this leg noticed it is full — that is how a budget gets ` +
+        `switched off rather than met, the same rule the blind-side verdict states in the other ` +
+        `direction. ⛔ Never lower EXHAUSTED_HEADROOM_FLOOR_MULTIPLE, and ⛔ never add a row to ` +
+        `EXHAUSTED_HEADROOM_ALLOWANCES to silence this: that object records debt measured on the ` +
+        `day the floor landed and may only be paid down.`,
+    );
+  }
+
+  if (headlines.length > 0) {
+    return {
+      sites: rows,
+      blind: blind.map((row) => row.key),
+      exhausted: exhausted.map((row) => row.key),
+      status: 'error',
+      // One table, however many verdicts named it: a reader comparing two
+      // renderings of the same five rows is reading for differences that are
+      // not there.
+      message: `${headlines.join('\n')}\n${table}\n${prose.join('\n')}`,
     };
   }
 
   return {
     sites: rows,
     blind: [],
+    exhausted: [],
     status: 'pass',
     message:
       `Ceiling sensitivity (${rows.length} ceilings, each weighed against the report just read):\n` +
@@ -1863,8 +2043,10 @@ function writeGithubOutput(entries, outputPath = process.env.GITHUB_OUTPUT) {
  * Exit codes: `0` within budget, `1` over budget — the aggregate ceiling or any
  * per-chunk ceiling — and `2` no trustworthy verdict (report missing,
  * stale-shaped, internally inconsistent, missing a budgeted chunk, governed by
- * a ceiling that has drifted out of range of the regression it must catch, or —
- * objectui#6245 — weighed against a ceiling the base branch has since replaced).
+ * a ceiling that has drifted out of range of the regression it must catch,
+ * governed by a ceiling with no headroom left to measure with — objectui#8554,
+ * the same verdict at the other end of the same range — or — objectui#6245 —
+ * weighed against a ceiling the base branch has since replaced).
  *
  * The last of those is the one exit 2 case with a PERFECTLY GOOD measurement
  * behind it, so nothing downstream may word exit 2 as "nothing was measured".

--- a/scripts/check-eager-closure-budget.mjs
+++ b/scripts/check-eager-closure-budget.mjs
@@ -1057,7 +1057,7 @@ export const EXHAUSTED_HEADROOM_FLOOR_MULTIPLE = 0.1;
  * this table ⛔ does not answer it — it only stops the gate being silent while
  * that decision stands unanswered.
  *
- * Both figures were read from one full console build on `e8b7b0785`, from the
+ * Both figures were read from one full console build on `2596b1b85`, from the
  * same report the gate reads. ⚠️ `i18n-locales` carries the pair objectui#8816's
  * maintainer ruling set eight days earlier, whose prose calls its headroom
  * "0.10x": rendered to two decimals it is, measured it is 0.0966x, so the floor
@@ -1065,10 +1065,22 @@ export const EXHAUSTED_HEADROOM_FLOOR_MULTIPLE = 0.1;
  * finding about the ruling, and ⛔ not a reason to bend the bound to 0.095 —
  * bending it to clear a named row is choosing the bound by today's board, which
  * is the one move this card may not make.
+ *
+ * ⭐ `ui-components` was read TWICE while this was being written, an hour apart,
+ * and it moved: 394,708 on `e8b7b0785` and 394,711 five merges later, none of
+ * them about this chunk. The console build is deterministic on a fixed tree —
+ * checked, two builds byte-identical across all four budgeted chunks — so those
+ * three bytes are content and not noise, and the first reading was already stale
+ * when it was taken. That is this card's whole thesis arriving during its own
+ * fix: the tightest line on the board moves under ordinary traffic and nothing
+ * said so. ⚠️ It is also the standing hazard of the figure below. It is pinned
+ * at the byte against a live row, so an unrelated change that grows this chunk
+ * reds here — correctly, and pointing at a row that is genuinely tighter, but
+ * ⛔ the remedy is still never to move this number up.
  */
 export const EXHAUSTED_HEADROOM_ALLOWANCES = Object.freeze({
   'i18n-locales': 8_804,
-  'ui-components': 4_292,
+  'ui-components': 4_289,
 });
 
 /**


### PR DESCRIPTION
Fixes objectui#8554

`evaluateHeadroomSensitivity` refused a ceiling that had drifted more than one regression **above** its payload and said nothing at all about one whose headroom was **spent**. Both are the same defect — a ceiling that has stopped measuring this bundle — and only one of them was loud. A row that was not blind drew a green tick whatever its headroom, one byte included, because the row renderer was a second copy of the same one-sided predicate.

## The four premises of the dispatch order, re-verified on the tree I branched from

`origin/main` = `e8b7b0785`, checked out at 16:55Z. **All four hold; none falsified.**

1. The only selection predicate is one-sided, and the renderer follows the same test. ✅
2. The only lower-side comparison that exists is the already-over case, which the size verdict owns. ✅
3. The sensitivity half's return vocabulary is `pass` | `error` only, and `error` gives exit 2. ✅ — with one correction: the half's own JSDoc `@returns` declared the union as `pass | fail | error`, and no code path has ever returned `fail`. Corrected in place, see "Bounded in-place fix" below.
4. Control that the file was being read: `evaluateHeadroomSensitivity` occurs 8× in it. ✅

## The board, re-measured — ⛔ not carried over from the order

Full `packages` + console build, reading `apps/console/dist/eager-closure.json`, the same report the gate reads. Taken **twice**: once on the commit this branch was cut from, and again after merging `main`, on the tree this pull request actually lands on.

| ceiling | ceiling | on `e8b7b0785` | on `2596b1b85` merged | headroom now | ×regression | moved |
|:--|--:|--:|--:|--:|--:|--:|
| aggregate | 3,597,000 | 3,568,028 | 3,573,919 | 23,081 | 0.253× | −5,891 |
| `vendor-objectstack` | 1,254,000 | 1,236,307 | 1,236,315 | 17,685 | 0.194× | −8 |
| `framework` | 100,000 | 74,297 | 80,096 | 19,904 | 0.218× | −5,799 |
| `i18n-locales` | 465,000 | 456,196 | 456,196 | 8,804 | 0.0966× | 0 |
| **`ui-components`** | 399,000 | **394,708** | **394,711** | **4,289** | **0.047×** | **−3** |

⭐ **Read that last row.** Five merges, none of them about `ui-components`, and the tightest line on the board lost three bytes in about an hour. The console build is deterministic on a fixed tree — checked, two consecutive builds byte-identical across all four budgeted chunks — so those three bytes are **content, not build noise**. That measurement drove a design change; see "The grain" below.

## Choosing the bound — from the gate's own logic, ⛔ before looking at those rows

This file already had an answer and only ever wrote it in prose. **Every deliberate re-pin in `PER_CHUNK_GZIP_CEILINGS` sizes the new headroom at a tenth of `REGRESSION_THIS_GATE_MUST_CATCH_BYTES`.** objectui#7399 re-pinned two keys to it. objectui#8816 then rejected the minimal raise that would have admitted its two claimants exactly, choosing — in as many words — *this key's own convention* over the overage, and citing objectui#8554 by number for why the minimal raise would reproduce both failures inside a week. The maintainer ruling that authorised that raise was taken on that reasoning.

⇒ the bound is this file's own already-taken decision, promoted from a comment into the predicate. It is `EXHAUSTED_HEADROOM_FLOOR_MULTIPLE = 0.1`.

**What it then does to today's tree, reported second and not first, as the order required:** two rows are under it — `ui-components` at 0.047× and `i18n-locales` at 0.0966×. So a bare floor (shape A) reds `main` on landing. Shape **B** is what is here.

⚠️ **`i18n-locales` is on that list one week after a maintainer ruling set it, and that deserves saying plainly.** The ruling's prose calls its headroom `0.10x`. Rendered to two decimals it is; **measured it is 0.0966×**, so the floor catches it by 310 bytes. That is a rounding artifact in the prose, ⛔ not a finding about the ruling. I considered and **rejected** bending the bound to 0.095× to clear it: that is choosing the bound by today's board, which is the one move this card may not make.

## Shape B — the floor plus a declared, measured ratchet

`EXHAUSTED_HEADROOM_ALLOWANCES` pins each of those two rows at **its measured headroom today**, to the byte. A listed row passes while its headroom is at least that figure; an unlisted row reds below the floor.

- The gate is **loud immediately**: every listed row is named in the **passing** verdict too, with its allowance, the words `which may only be paid DOWN`, and the exact byte figure it reds below.
- The trunk stays green while each line is worked.
- ⛔ No figure in it may ever be lowered, and ⛔ no row may be added to buy silence. A unit test pins the contents exactly, pins every entry as strictly under the floor (real debt, not a second floor for one row), and pins every key as naming a ceiling that exists.
- ⛔ It is **not** a widening of the accepted set: the set is frozen at measurement and can only shrink.

## ⭐ The grain — why a declared allowance is NOT compared at the byte

The first version of this branch compared at the byte. **That was wrong, and my own drift measurement is what convicts it.** Two reasons, both measured:

**1. A byte-exact red prints an evidence table identical to the green run's.** Every number this gate renders is rounded — measured and headroom to one decimal of a KiB, the multiple to two decimals of a regression. At `ui-components`' pinned figure:

```
headroom 4,289  ->  385.5 KB measured / headroom 4.2 KB / 0.05x
headroom 4,288  ->  385.5 KB measured / headroom 4.2 KB / 0.05x   ← identical, and this
                                                                     is where it would red
```

A red cross above a table character-for-character the same as the passing one tells its reader nothing — they cannot see what moved, or tell their own diff from the drift beneath it. That is objectui#8554's own defect, a number nobody can read, moved one level in.

**2. It would red an innocent pull request over drift that author did not cause and cannot clear.** `ui-components` moves under unrelated traffic (three bytes / five merges, measured, with a determinism control). Paying the row down is objectui#7848's open decision. So a byte-exact ratchet fires on someone else's bytes and offers them no legal remedy — the precise harm this card documents.

⇒ `EXHAUSTED_HEADROOM_ALLOWANCE_GRANULARITY_MULTIPLE = 0.01`. A declared row reds when it has lost a whole hundredth of a regression (911.36 bytes) against its pinned figure. That number is derived, ⛔ not chosen for today's rows: it is the **coarser of this file's two rendering grids** (0.01× = 911.36 bytes against one decimal of a KiB = 102.4), so a red is guaranteed visible in **both** columns — and it is the next decade of the unit the whole file is denominated in, 1.00× blind, 0.10× floor, 0.01× grain.

```
headroom 4,289  ->  385.5 KB measured / headroom 4.2 KB / 0.05x
headroom 3,377  ->  386.4 KB measured / headroom 3.3 KB / 0.04x   ← the trip point; visibly moved
```

⛔ **This is not a raise and not headroom to spend.** The pinned figures do not move, the table stays pay-down-only and pinned, the 0.10× floor is untouched and still reds an undeclared row, and **paying a row down moves its trip point up with it** — asserted by its own test, so the grain is a resolution and not a rebate.

⚠️ **What it honestly does not do:** it does not make a declared row's red *clearable* by the pull request that trips it. Nothing at this bound can, while a row's headroom is somebody else's open decision. It stops that red firing on drift too small to see, and — the other half — a declared row that tightens now gets **its own verdict text**, which says the debt predates the change, that the amount named is very likely not the author's, that there is nothing here for their pull request to fix, and that neither the ceiling nor the allowance may be raised to clear it. The residual exposure goes to zero when objectui#7848 is answered, ⛔ not before, and ⛔ not by anything in this diff.

## The firing controls

Every leg pairs the firing case with the pre-card predicate on the **same** fixture (`floorMultiple: 0, allowances: {}`), so what is demonstrated is that the new leg fired, not that arithmetic works.

**1. This card's own reading, as a unit test.** `framework` at 70,999 gzipped bytes under a 71,000 ceiling — the exact figures the card was filed about: `pass` and a green tick under the predicate as it stood; `error` with `exhausted === ['framework']`, `blind === []` and a red cross under the floor. The empty `blind` list proves the **new** leg fired; the renderer pair proves the tick follows the verdict rather than a stale second copy of it.

**2. The real build report.** Not a fixture — the actual `eager-closure.json` this build emitted: unmodified gives exit 0; the same report with `ui-components` tightened past the trip point gives exit 2, printing `1 ceiling is EXHAUSTED` while the per-chunk **size** half still prints a green `ui-components`. The size half staying green is the load-bearing half: the exit 2 is produced by this leg alone.

**3. Unplanned, and the one that changed the design.** The first pin (4,292, taken on `e8b7b0785`) went **red** on the merged tree at 4,289 — a firing control the tree wrote itself, and the evidence that byte-exact was wrong.

**4. Ablation of the grain.** With `EXHAUSTED_HEADROOM_ALLOWANCE_GRANULARITY_MULTIPLE` set to `0` on disk (mutation verified by blob hash against `HEAD`, restore verified by `git diff HEAD` empty and the blob matching again), the suite goes **6 failed / 115 passed** — every grain-dependent assertion fires. They are not passing vacuously.

## What this leg deliberately does not own

Negative headroom. A ceiling **under** its payload is an over-budget bundle, arithmetically also under the floor, and the size verdict owns it. The predicate is therefore `0 <= headroom < floor` and ⛔ not `headroom < floor` — the second would swallow every over-budget row into this half and convert a size failure's exit 1 into a gauge error's exit 2, which is exactly the confusion the file's existing paragraph on this exists to prevent. Pinned by its own test.

## Boundaries — what was NOT done

- ⛔ No ceiling raised, no threshold relaxed, no accepted set widened, no row removed from the table. `REGRESSION_THIS_GATE_MUST_CATCH_BYTES`, `MAX_EAGER_CLOSURE_GZIP_BYTES`, all four entries of `PER_CHUNK_GZIP_CEILINGS` and both baselines are byte-for-byte unchanged.
- ⛔ The blind-side leg was not weakened to buy room on the exhausted side — its predicate, its verdict text and its tests are unchanged.
- ⛔ Nothing is weaker than today's behaviour: today an exhausted row is **silent** with a green tick and exit 0. Every row that was silent is now named on every run, and both declared rows have a reachable trip point.
- ⛔ objectui#7848 is **not** answered.
- ⛔ `content/docs/releases/` untouched. No test skipped, disabled or quarantined.

## Bounded in-place fix, declared

The half's `@returns` JSDoc declared `status: 'pass' | 'fail' | 'error'`; no code path returns `'fail'`. Corrected to `'pass' | 'error'` in the same doc block I was editing. Same file, same defect class, mechanical, no new verification surface. Two stale header prose sites said `evaluateHeadroomSensitivity` **has** no floor — true when written, false as of this diff; both moved to past tense and now point at the constant.

## Verification — re-run in full after the coarsening

| | |
|:--|:--|
| `pnpm exec vitest run scripts/` | **exit 0** — 4017 passed, 2 skipped |
| the gate's own suite | **exit 0** — 121 passed; verbose reporter confirms every new case executed |
| grain ablation | **exit 1** — 6 failed / 115 passed, mutation and restore both verified by blob hash |
| `pnpm exec eslint .` | **exit 0** — 4,743 files, 0 errors; both edited files 0/0 |
| `pnpm exec tsc -p tsconfig.scripts.json --noEmit` | **exit 0**, `--listFiles` confirms it covered **both** edited files |
| `node scripts/check-eager-closure-budget.mjs` on a real report | **exit 0** |
| `node scripts/check-changeset-presence.mjs` | **exit 0** |
| `node scripts/check-new-cross-file-line-citations.mjs` | **exit 0** — 0 citations added |
| `node scripts/check-governed-queue-guard.mjs --test` | **NOT GOVERNED** |
| control-byte self-scan over the diff | no hits |

Changeset: empty frontmatter. The presence checker's own verdict is that **no changeset is owed** — a CI script and its tests, 0 files of published package source — so the declaration is the explicit "no release" form, and it claims nothing about any package.

## Out of scope, filed not fixed

- objectui#9006 — the exit-code fold is fail-open on any status it does not recognise: a half printing a red cross would still exit 0. Latent, not a live defect; ⛔ untouched here.

⚠️ Hot-file serial, per triage: objectui#8964 touches this same file and is a different defect. This card goes first; that one merges `main` before opening its pull request.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_