### PR TITLE
fix(types): collapse the redundant `UserActionsSchema` extension, correct its docblock (objectui#8992)

### DIFF
--- a/.changeset/8992-user-actions-collapse-and-docblock.md
+++ b/.changeset/8992-user-actions-collapse-and-docblock.md
@@ -1,10 +1,24 @@
 ---
-'@object-ui/types': patch
+'@object-ui/types': minor
 ---
 
 Collapse the now-redundant `UserActionsSchema` extension, and correct a docblock that
 told authors an undeclared `userActions` key is silently dropped when it is refused by
 name (objectui#8992).
+
+⚠️ **Breaking, in the producer direction, which is why this is `minor` and not `patch`**
+(objectui's own breaking changes ship as `minor` with the break spelled out — AGENTS.md,
+"changeset 里不要声明 `major`"). On the published `@object-ui/types` face,
+`userActions.group` / `.hideFields` / `.rowColor` move from `z.ZodOptional[z.ZodBoolean]`
+to `z.ZodDefault[z.ZodBoolean]` in the emitted `.d.ts`, so `z.output` for those three
+goes from `boolean | undefined` to `boolean` — the key becomes REQUIRED on the output
+type. Measured with `tsc`: a value typed as the old output is **not** assignable to the
+new one (the three read as missing); the reverse direction is fine. **Readers of parsed
+output are unaffected; code that CONSTRUCTS an output-typed `userActions` value must add
+the three keys or widen its annotation.** ⛔ Nothing about what parses changes — see the
+equivalence measurement below. Precedent for the same operation on the same file:
+`ListColumnSchema`'s local `.extend()` collapsed into a plain by-reference re-export and
+shipped under 17.1.0 **Minor Changes**.
 
 `objectql.zod.ts`'s `UserActionsSchema` read
 `stripImportedDefaults(Spec).extend({ group, hideFields, rowColor })`, an extension that
@@ -31,30 +45,34 @@ keys, wrong types, non-objects) with an identical result — same success, same 
 output, same refusal codes, keys and messages — and a sentinel proving the comparison
 can see a difference when one exists.
 
-⚠️ TWO THINGS ON THE PUBLISHED SURFACE DO MOVE, both confined to those three keys, and
+⚠️ TWO THINGS ON THE PUBLISHED SURFACE MOVE, both confined to those three keys, and
 both measured by rebuilding `packages/types/dist` on each side of the change:
 
-1. They lose the three local `.describe()` strings the extension carried, because the
-   protocol declares those keys without descriptions of its own. Nothing in this
-   repository reads them, and a mirror that authors prose for a protocol key is the same
-   class of local invention the import boundary (objectui#8317) removed for defaults.
-2. In the emitted `objectql.zod.d.ts` the three move from `z.ZodOptional<z.ZodBoolean>`
-   to `z.ZodDefault<z.ZodBoolean>` — the spec's own declaration, as the compiler sees it
-   before the runtime strip. `z.input` is unchanged (`boolean | undefined` either way);
-   `z.output` for these three goes from `boolean | undefined` to `boolean`. This is the
-   import boundary's DELIBERATE and ruled property — `stripImportedDefaults` is typed
-   `T` in, `T` out, because stripping is "a property of the PARSE, not of the
-   declaration" (decision batch #90) — and it is what the OTHER EIGHT keys on this same
-   object have declared all along. The extension was making three keys the odd ones out
-   of an object whose eleven members behave identically at runtime; the collapse makes
-   the declaration uniform. ⛔ It does not change what parses: an omitted key is still
-   absent from the parsed output, measured, on all eleven.
+1. They end up carrying no `.describe()` metadata. ⛔ Not because the protocol leaves
+   them undescribed — it describes all three (`group`: "Allow users to change record
+   grouping from the toolbar. …", and likewise `hideFields` / `rowColor` in the 17.3.0
+   and 17.4.0 tarballs). The cause is objectui's own import boundary:
+   `stripImportedDefaults` unwraps each `ZodDefault` with `.removeDefault()` and
+   re-optionalises the inner node, and the description sits on the OUTER node it
+   discards. Measured on this object: all ten defaulted keys read
+   `description = undefined` after the strip, on both sides of this change, while
+   `buttons` — the one member that never carried a default — keeps its description
+   through it. So the three simply stop being an exception: before, the local extension
+   supplied descriptions the other ten defaulted keys did not have. Nothing in this
+   repository reads them.
+2. In the emitted `objectql.zod.d.ts` the three move from `z.ZodOptional[z.ZodBoolean]`
+   to `z.ZodDefault[z.ZodBoolean]` — the spec's own declaration, as the compiler sees it
+   before the runtime strip. This is the import boundary's DELIBERATE and ruled property
+   — `stripImportedDefaults` is typed `T` in, `T` out, because stripping is "a property
+   of the PARSE, not of the declaration" (decision batch #90) — and it is what SEVEN of
+   the other eight keys on this same object have declared all along (`sort`, `search`,
+   `filter`, `refresh`, `rowHeight`, `addRecordForm`, `editInline`; `buttons` is
+   `z.ZodOptional[z.ZodArray[z.ZodString]]` and never declared a default). The extension
+   was making three keys the odd ones out of an object whose eleven members behave
+   identically at runtime; the collapse makes the declaration uniform. ⛔ It does not
+   change what parses: an omitted key is still absent from the parsed output, measured,
+   on all eleven.
 
 The emitted declaration also carries `z.core.$strict` on BOTH sides of this change,
 which is the compiler restating in objectui's own published artifact what the corrected
 docblock now says in prose.
-
-⚠️ The three keys are version-borne from here on. `@object-ui/types` declares
-`@objectstack/spec: ^17.3.0` and that floor is now load-bearing for them — 17.2.0
-declares 8 keys on this object, 17.3.0 declares 11. The extension used to carry the
-three locally whatever version resolved; it no longer does.

--- a/.changeset/8992-user-actions-collapse-and-docblock.md
+++ b/.changeset/8992-user-actions-collapse-and-docblock.md
@@ -1,0 +1,60 @@
+---
+'@object-ui/types': patch
+---
+
+Collapse the now-redundant `UserActionsSchema` extension, and correct a docblock that
+told authors an undeclared `userActions` key is silently dropped when it is refused by
+name (objectui#8992).
+
+`objectql.zod.ts`'s `UserActionsSchema` read
+`stripImportedDefaults(Spec).extend({ group, hideFields, rowColor })`, an extension that
+existed only because `@objectstack/spec` did not declare those three keys while
+`normalizeListViewSchema` folded objectui's legacy `showGroup` / `showHideFields` /
+`showColor` onto them. The protocol adopted all three in 17.3.0 (objectui#5435's
+ruling), so the extension is now a second local copy of a protocol declaration — the
+shape two faces start drifting from — and it collapses into the plain by-reference
+re-export its own note always said it would become.
+
+⭐ The urgent half is the docblock. It stated that `UserActionsConfigSchema` "is NOT
+`.strict()`, so ... an author writing `userActions: { group: false }` had it silently
+stripped — valid on parse, no effect at render". Measured against the published
+artifacts of 17.0.0, 17.2.0, 17.3.0 and the resolved 17.4.0, every one of them REFUSES
+an undeclared key and NAMES it (`unrecognized_keys`, one issue). A comment promising
+silent tolerance in front of a loud-rejection runtime points an author — human or AI —
+at a config that will fail the save gate while telling them that outcome is impossible.
+`__tests__/user-actions-mirror-8992.test.ts` now pins the refusal, with firing controls
+in both directions, so the sentence cannot rot back.
+
+The accept set does not move: extended and collapsed were parsed side by side over a
+33-document corpus (every declared key in both polarities, the full block, undeclared
+keys, wrong types, non-objects) with an identical result — same success, same parsed
+output, same refusal codes, keys and messages — and a sentinel proving the comparison
+can see a difference when one exists.
+
+⚠️ TWO THINGS ON THE PUBLISHED SURFACE DO MOVE, both confined to those three keys, and
+both measured by rebuilding `packages/types/dist` on each side of the change:
+
+1. They lose the three local `.describe()` strings the extension carried, because the
+   protocol declares those keys without descriptions of its own. Nothing in this
+   repository reads them, and a mirror that authors prose for a protocol key is the same
+   class of local invention the import boundary (objectui#8317) removed for defaults.
+2. In the emitted `objectql.zod.d.ts` the three move from `z.ZodOptional<z.ZodBoolean>`
+   to `z.ZodDefault<z.ZodBoolean>` — the spec's own declaration, as the compiler sees it
+   before the runtime strip. `z.input` is unchanged (`boolean | undefined` either way);
+   `z.output` for these three goes from `boolean | undefined` to `boolean`. This is the
+   import boundary's DELIBERATE and ruled property — `stripImportedDefaults` is typed
+   `T` in, `T` out, because stripping is "a property of the PARSE, not of the
+   declaration" (decision batch #90) — and it is what the OTHER EIGHT keys on this same
+   object have declared all along. The extension was making three keys the odd ones out
+   of an object whose eleven members behave identically at runtime; the collapse makes
+   the declaration uniform. ⛔ It does not change what parses: an omitted key is still
+   absent from the parsed output, measured, on all eleven.
+
+The emitted declaration also carries `z.core.$strict` on BOTH sides of this change,
+which is the compiler restating in objectui's own published artifact what the corrected
+docblock now says in prose.
+
+⚠️ The three keys are version-borne from here on. `@object-ui/types` declares
+`@objectstack/spec: ^17.3.0` and that floor is now load-bearing for them — 17.2.0
+declares 8 keys on this object, 17.3.0 declares 11. The extension used to carry the
+three locally whatever version resolved; it no longer does.

--- a/packages/types/src/__tests__/user-actions-mirror-8992.test.ts
+++ b/packages/types/src/__tests__/user-actions-mirror-8992.test.ts
@@ -1,0 +1,151 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8992 — `userActions` refuses an undeclared key BY NAME, and the
+ * mirror carries exactly the protocol's key set.
+ *
+ * Two facts, one file, because they are the two halves of the same repair.
+ *
+ * 1. ⭐ THE REFUSAL. `objectql.zod.ts`'s `UserActionsSchema` docblock used to
+ *    tell its reader that `UserActionsConfigSchema` "is NOT `.strict()`, so ...
+ *    an author writing `userActions: { group: false }` had it silently stripped
+ *    — valid on parse, no effect at render". Measured against the published
+ *    artifacts of 17.0.0, 17.2.0, 17.3.0 and the resolved 17.4.0, every one of
+ *    them REFUSES an undeclared key and NAMES it. A comment promising silent
+ *    tolerance in front of a loud-rejection runtime is the worst direction for
+ *    a comment to be wrong in: an author — human or AI — who trusts it writes a
+ *    config that fails the save gate, having been told that outcome is
+ *    impossible. Prose cannot hold that fact down; this file does.
+ *
+ * 2. THE COLLAPSE. The same card removed the local
+ *    `.extend({ group, hideFields, rowColor })`, which existed only because the
+ *    protocol did not declare those three. It does since 17.3.0
+ *    (objectui#5435's ruling, adopted upstream), so what is asserted here is
+ *    that the mirror's key set IS the spec's — DERIVED from
+ *    `UserActionsConfigSchema` at assert time, never restated. A restated list
+ *    would pass for exactly as long as it happened to agree, which is the drift
+ *    the collapse exists to prevent.
+ *
+ * ⚠️ NOT VACUOUS BY CONSTRUCTION. "Refused" is worthless as an assertion unless
+ * the harness is shown to also report ACCEPTED, and "the key sets are equal" is
+ * worthless unless the comparison is shown to be able to see a difference. Both
+ * firing controls are below, and every population is asserted non-empty before
+ * it is used.
+ *
+ * ⚠️ These three keys are VERSION-BORNE since the collapse: `@object-ui/types`
+ * declares `@objectstack/spec: ^17.3.0` and that floor is what carries them
+ * (17.2.0 declares 8 keys, 17.3.0 declares 11). If this file ever reddens on
+ * `THE_THREE`, the reading is that the resolved spec is below the declared
+ * floor — ⛔ not that the mirror regressed.
+ */
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { UserActionsConfigSchema as SpecUserActionsConfigSchema } from '@objectstack/spec/ui';
+import { UserActionsSchema, ListViewSchema } from '../zod/objectql.zod.js';
+
+/** The three toggles objectui's legacy `show*` fold emits (objectui#5435). */
+const THE_THREE = ['group', 'hideFields', 'rowColor'] as const;
+
+/** A key no version of the protocol has ever declared on this object. */
+const NEVER_DECLARED = 'zzNeverDeclaredByAnySpec';
+
+type Parsed = { success: boolean; error?: { issues?: readonly unknown[] } };
+
+/** Unrecognized-key names a zod result refuses, flattened. */
+const refusedKeys = (r: Parsed): string[] =>
+  ((r.error?.issues ?? []) as { code?: string; keys?: string[] }[])
+    .filter((i) => i.code === 'unrecognized_keys')
+    .flatMap((i) => i.keys ?? []);
+
+const issueCount = (r: Parsed): number => (r.error?.issues ?? []).length;
+
+const keysOf = (schema: { shape: Record<string, unknown> }): string[] => Object.keys(schema.shape).sort();
+
+describe('objectui#8992 — the mirror carries the protocol key set, by reference', () => {
+  it('the key sets are equal — derived from the spec, not restated here', () => {
+    const spec = keysOf(SpecUserActionsConfigSchema as unknown as { shape: Record<string, unknown> });
+    expect(spec.length, 'a census over an empty key set passes for the wrong reason').toBeGreaterThan(0);
+    expect(keysOf(UserActionsSchema as unknown as { shape: Record<string, unknown> })).toEqual(spec);
+  });
+
+  it('FIRING CONTROL — the key-set comparison can see a difference', () => {
+    const narrowed = UserActionsSchema.omit({ group: true });
+    expect(keysOf(narrowed as unknown as { shape: Record<string, unknown> })).not.toEqual(
+      keysOf(UserActionsSchema as unknown as { shape: Record<string, unknown> }),
+    );
+  });
+
+  it('carries the three the fold emits — the whole premise of the collapse', () => {
+    const keys = keysOf(UserActionsSchema as unknown as { shape: Record<string, unknown> });
+    for (const key of THE_THREE) {
+      expect(keys, `${key} is missing — read the resolved @objectstack/spec, not this mirror`).toContain(key);
+    }
+  });
+
+  it('authors no default — an empty block stays empty (the objectui#8317 boundary)', () => {
+    const r = UserActionsSchema.safeParse({});
+    expect(r.success).toBe(true);
+    expect(r.success && r.data).toEqual({});
+  });
+
+  it('accepts each of the three, both polarities', () => {
+    for (const key of THE_THREE) {
+      for (const value of [true, false]) {
+        const r = UserActionsSchema.safeParse({ [key]: value });
+        expect(r.success, `${key}: ${value} was refused`).toBe(true);
+        expect(r.success && r.data).toEqual({ [key]: value });
+      }
+    }
+  });
+});
+
+describe('objectui#8992 — an undeclared key is REFUSED BY NAME, never dropped', () => {
+  it('the refusal names the key, and there is exactly one issue', () => {
+    const r = UserActionsSchema.safeParse({ [NEVER_DECLARED]: true });
+    expect(r.success, 'silently accepted — the corrected docblock is wrong again').toBe(false);
+    expect(refusedKeys(r)).toEqual([NEVER_DECLARED]);
+    expect(issueCount(r)).toBe(1);
+  });
+
+  it('⛔ it is NOT stripped — the refused key never comes back as parsed output', () => {
+    const r = UserActionsSchema.safeParse({ group: false, [NEVER_DECLARED]: true });
+    expect(r.success).toBe(false);
+    expect(refusedKeys(r)).toEqual([NEVER_DECLARED]);
+  });
+
+  it("objectui's own legacy toolbar spelling is refused here too — `showGroup` is not `group`", () => {
+    const r = UserActionsSchema.safeParse({ showGroup: true });
+    expect(r.success).toBe(false);
+    expect(refusedKeys(r)).toEqual(['showGroup']);
+  });
+
+  it('FIRING CONTROL — the same harness reports ACCEPTED when the key IS declared', () => {
+    const widened = UserActionsSchema.extend({ [NEVER_DECLARED]: z.boolean().optional() });
+    const r = widened.safeParse({ [NEVER_DECLARED]: true });
+    expect(r.success, 'the harness refuses everything — the refusal above proves nothing').toBe(true);
+    expect(refusedKeys(r)).toEqual([]);
+  });
+
+  it('the refusal survives to the published face — `ListViewSchema.userActions`', () => {
+    const good = ListViewSchema.safeParse({
+      type: 'list-view',
+      objectName: 'accounts',
+      userActions: { group: false, hideFields: true, rowColor: true },
+    });
+    expect(good.success, 'the three are not authorable through the published list view').toBe(true);
+
+    const bad = ListViewSchema.safeParse({
+      type: 'list-view',
+      objectName: 'accounts',
+      userActions: { [NEVER_DECLARED]: true },
+    });
+    expect(bad.success).toBe(false);
+    expect(refusedKeys(bad)).toEqual([NEVER_DECLARED]);
+  });
+});

--- a/packages/types/src/__tests__/zod-mirror-parity.test.ts
+++ b/packages/types/src/__tests__/zod-mirror-parity.test.ts
@@ -3021,7 +3021,7 @@ const EXCLUSIONS: Readonly<Record<string, string>> = {
   'objectql.zod.ts#PaginationConfigSchema':
     "spec-owned BY REFERENCE — the local `.extend(…)` adds renderer props that no TS declaration in this package restates",
   'objectql.zod.ts#UserActionsSchema':
-    "spec-owned BY REFERENCE — the local `.extend(…)` adds renderer props that no TS declaration in this package restates",
+    "spec-owned BY REFERENCE — a plain `stripImportedDefaults(Spec…)` re-export since objectui#8992 collapsed its `.extend(…)` (the protocol declares `group` / `hideFields` / `rowColor` itself from 17.3.0), and the TS name for it, `UserActionsConfig`, is re-exported FROM `@objectstack/spec/ui` by `../index.ts` rather than restated here — so there is no second definition to drift from",
   'objectql.zod.ts#ListViewSchema':
     "the DECLARATION is derived FROM this mirror — `ListViewSchema = ListViewInferred & ListViewRuntimeProps`, and `ListViewInferred = z.input<typeof ListViewSchema>` (`../objectql.ts`). Asserting parity here would be true no matter what either side said: a phantom assertion, not a check.",
   'objectql.zod.ts#ObjectQLComponentSchema':

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -590,29 +590,43 @@ const TimelineConfig = stripImportedDefaults(SpecTimelineConfigSchema).partial()
 const ViewKindEnum = SpecListViewSchema.shape.type.removeDefault();
 
 /**
- * User Actions — the spec's `UserActionsConfigSchema` plus the three toolbar
- * affordances it does not model yet (#2890 scope A step 3).
+ * User Actions — `@objectstack/spec/ui`'s `UserActionsConfigSchema`, mirrored
+ * BY REFERENCE (objectui#8992).
  *
  * The spec documents this object as "which interactive actions are available to
  * users in the view toolbar — each boolean toggles the corresponding toolbar
- * element on/off", and already carries `rowHeight` (objectui's old
- * `showDensity`). Grouping, column visibility and row coloring are the same kind
- * of toggle — the spec models all three as CONFIGURATION (`grouping`,
- * `hiddenFields`, `rowColor`) but has no "may the user change it" switch for
- * any of them, so an author cannot express a complete toolbar policy. These
- * three are named after the config key they gate, following the precedent
- * `rowHeight` set.
+ * element on/off". Grouping, column visibility and row coloring are the same
+ * kind of toggle as `rowHeight` (objectui's old `showDensity`), each named
+ * after the config key it gates (`grouping`, `hiddenFields`, `rowColor`).
  *
- * This `.extend()` is temporary: it collapses into a plain re-export once the
- * keys land upstream. Note `UserActionsConfigSchema` is NOT `.strict()`, so
- * before this extension an author writing `userActions: { group: false }` had
- * it silently stripped — valid on parse, no effect at render.
+ * This read `stripImportedDefaults(Spec).extend({ group, hideFields, rowColor })`
+ * for as long as the protocol declared none of the three while
+ * `normalizeListViewSchema` folded objectui's legacy `showGroup` /
+ * `showHideFields` / `showColor` onto them. The protocol declares all three
+ * now — the maintainer ruled option A on objectui#5435 (2026-08-22) and the
+ * spec adopted them in 17.3.0 — so the extension collapses, exactly as its own
+ * note said it would. A redundant local extension is how two faces start to
+ * drift.
+ *
+ * ⛔ AN UNDECLARED KEY IS REFUSED HERE, BY NAME (`unrecognized_keys`, one
+ * issue, the key named) — it is NOT dropped. The note this replaces claimed
+ * the opposite: "`UserActionsConfigSchema` is NOT `.strict()`, so ... an author
+ * writing `userActions: { group: false }` had it silently stripped — valid on
+ * parse, no effect at render". That was false at every published 17.x —
+ * measured by parsing a one-undeclared-key document against the published
+ * artifacts of 17.0.0, 17.2.0, 17.3.0 and the resolved 17.4.0, each of which
+ * refuses and names the key. Silent-tolerance prose in front of a
+ * loud-rejection runtime is the worst direction for a comment to be wrong in:
+ * it tells an author — human or AI — that a config which will FAIL the save
+ * gate is harmless. `__tests__/user-actions-mirror-8992.test.ts` pins the
+ * refusal so this paragraph cannot rot back into the one it replaced.
+ *
+ * ⚠️ The three keys are VERSION-BORNE from here on. `@object-ui/types` declares
+ * `@objectstack/spec: ^17.3.0`, and that floor is load-bearing for them: 17.2.0
+ * declares 8 keys, 17.3.0 declares 11. The extension used to carry the three
+ * locally whatever version resolved; it no longer does.
  */
-export const UserActionsSchema = stripImportedDefaults(SpecUserActionsConfigSchema).extend({
-  group: z.boolean().optional().describe('Allow users to group records'),
-  hideFields: z.boolean().optional().describe('Allow users to show/hide columns'),
-  rowColor: z.boolean().optional().describe('Allow users to color rows by a field value'),
-});
+export const UserActionsSchema = stripImportedDefaults(SpecUserActionsConfigSchema);
 
 export const ListViewSchema = BaseSchema
   // Spec-owned fields by reference. `specFieldsExcept` reads the spec object's


### PR DESCRIPTION
Fixes #8992

> **Repair round (contract review returned REWORK on the prose, not the code).** The changeset is regraded `minor`, and two factual claims below were measured FALSE and are corrected: the cause of the lost descriptions, and "the other eight keys". The docblock, the collapse, the new pin and the parity row were re-measured by the reviewer and are unchanged. Head: `2f430a3152f1`.

Three items from the card, in its order of urgency, plus the neighbouring floor question it handed the taker.

## 1. The false docblock — measured, corrected, pinned

`packages/types/src/zod/objectql.zod.ts` told its reader:

> Note `UserActionsConfigSchema` is NOT `.strict()`, so before this extension an author writing `userActions: { group: false }` had it silently stripped — valid on parse, no effect at render.

**Measured false at every published 17.x.** Not read from source — parsed, against each version's own published tarball (`npm pack`, then `import('./dist/ui/index.mjs')`, no workspace resolution involved):

| spec | declared keys | `{ oneUndeclaredKey: true }` |
|---|---|---|
| 17.0.0 | 8 | REFUSED · `unrecognized_keys: ['group']` |
| 17.2.0 | 8 | REFUSED, key named |
| 17.3.0 | 11 | REFUSED, key named |
| 17.4.0 (resolved) | 11 | REFUSED, key named, 1 issue |

Independent corroboration from a second instrument, in objectui's OWN published artifact: the emitted `packages/types/dist/zod/objectql.zod.d.ts` declares this object `z.core.$strict` — **on both sides of this change**. The compiler was already contradicting the comment.

The comment is now replaced by what the runtime does, and `__tests__/user-actions-mirror-8992.test.ts` pins it so it cannot rot back.

## 2. The collapse

`stripImportedDefaults(Spec).extend({ group, hideFields, rowColor })` → `stripImportedDefaults(Spec)`.

Premise re-derived rather than inherited: resolved `@objectstack/spec` is **17.4.0** (read off disk — `node_modules/.pnpm/@objectstack+spec@17.4.0_.../package.json`, exactly one copy installed — not off a declared range), and its `UserActionsConfigSchema` declares 11 keys including all three.

**The accept set does not move.** Extended and collapsed were built side by side in one process and parsed over a 33-document corpus — every declared key in both polarities, the full 11-key block, undeclared keys, objectui's legacy `showGroup` spelling, wrong types, `null` / `[]` / `'str'`:

```
CORPUS SIZE = 33  DIFFS = 0
```

Identical on every document: same success, same parsed output, same refusal `code` / `keys` / `message`. With a sentinel proving the comparison can see a difference when one exists (a `.omit({group:true})` variant diverges immediately), and a firing control proving the refusal is about the key and not a constant.

## 3. The parity exemption

`zod-mirror-parity.test.ts`'s `EXCLUSIONS` entry **survives** — the exclusion criterion still holds, because the TS name `UserActionsConfig` is re-exported FROM `@objectstack/spec/ui` by `../index.ts` rather than restated in this package, so there is still no second definition to drift from. What changed is its REASON, which named an `.extend(…)` that no longer exists.

## ⚠️ What moves on the published surface

Both confined to those three keys, both measured by rebuilding `packages/types/dist` on each side:

1. They end up carrying no `.describe()` metadata. ⛔ **Not** because the protocol leaves them undescribed — an earlier revision of this body said that and it is measured FALSE: the 17.3.0 and 17.4.0 tarballs describe all three (`group` reads "Allow users to change record grouping from the toolbar. …"). The cause is objectui's own import boundary: `stripImportedDefaults` unwraps each `ZodDefault` with `.removeDefault()` and re-optionalises the inner node, and the description sits on the OUTER node it discards. Measured on this object, on both sides of this change: all ten defaulted keys read `description = undefined` after the strip, while `buttons` — the one member that never carried a default — keeps its description through it (positive control). So the three stop being an exception: the local extension had been supplying descriptions the other ten defaulted keys never had. Nothing in this repository reads them.
2. In the emitted `.d.ts` they move `z.ZodOptional[z.ZodBoolean]` → `z.ZodDefault[z.ZodBoolean]`. `z.input` is unchanged; `z.output` for these three goes `boolean | undefined` → `boolean`, i.e. the keys become REQUIRED on the output type. **This is breaking in the producer direction**, measured with `tsc` over the two declarations built side by side: a value typed as the old output is NOT assignable to the new one (the three read as missing); the reverse compiles. The probe is not vacuous — injecting a `@ts-expect-error` where nothing was wrong made the same run fail with `TS2578`, proving the file was in the program. Readers of parsed output are unaffected; code that CONSTRUCTS an output-typed `userActions` must add the three keys or widen its annotation. That break is why the changeset is `minor` (this repo ships its own breaking changes as `minor` with the break spelled out), matching the 17.1.0 precedent for the identical `ListColumnSchema` collapse.

⭐ **(2) is the one a contract reviewer should look at. It is a normalisation of the DECLARATION — and, separately, a real producer-side break, which is what the `minor` grade is for.** `stripImportedDefaults` is deliberately typed `T` in / `T` out — stripping is "a property of the PARSE, not of the declaration" (decision batch #90, objectui#8317) — so every key that arrives from the spec declares `ZodDefault` while the runtime has the default removed. **SEVEN of the other eight keys on this same object have declared exactly that all along** — `sort`, `search`, `filter`, `refresh`, `rowHeight`, `addRecordForm`, `editInline`; `buttons` is `z.ZodOptional[z.ZodArray[z.ZodString]]` and never declared a default. The extension was making three keys the odd ones out of an object whose eleven members behave identically at runtime. ⛔ Nothing about what parses changes: an omitted key is still absent from the parsed output, measured, on all eleven.

## Verification

Every command's exit code captured to a file before any pipe; each verdict quoted from the tool's own output. Heavy runs serialised through the container's shared verify lock (slot `os-dev-8992`) — the wall-clock seconds below are shared-box readings, not idle-box ones.

| run | result |
|---|---|
| `pnpm exec vitest run packages/types/` | `Test Files 169 passed (169)` · `Tests 3350 passed (3350)` |
| `pnpm --filter @object-ui/types type-check` | exit 0 (all three tsc programs) |
| `node scripts/check-changeset-presence.mjs` | `✅ 3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-control-bytes.mjs` | `✅ OK (scanned 7210 tracked text file(s))` |
| `node scripts/check-spec-symbol-derivation.mjs` | `✅` on all three of its checks |
| `node scripts/check-new-cross-file-line-citations.mjs` | `VERDICT … 0 new citation(s) … exit 0` |
| `node scripts/check-unreferenced-sources.mjs` | `OK Every shipped source file in every covered package is reachable` |

**Non-vacuity of the suite run:** 168 `.test.ts` files are tracked under `packages/types` at the merge base and 169 are on disk, and vitest reported exactly 169 — so the new pin is inside the package run, not merely inside its own targeted one.

**Non-vacuity of the type-check:** `tsc -p tsconfig.test.json --listFiles` enumerates 635 files and contains all three changed/added files by name, so `type-check` genuinely covered them.

### Ablation — the new pin is shown to FAIL, twice, in both of its directions

Each leg: mutate → prove the mutation reached disk by counting its marker in the source → run → restore → prove the restore by comparing `git hash-object` against the `HEAD` blob **and** by `git diff HEAD` being empty. Restore points at `HEAD` (never a bare `git checkout --`), and the whole script carries `trap … EXIT INT TERM` with absolute paths.

| leg | mutation | result |
|---|---|---|
| baseline | none | `Tests 10 passed (10)` |
| **loose** | `.loose()` — recreate exactly the world the false comment described | `4 failed \| 6 passed` — all four refusal assertions redden |
| **widen** | `.extend({ zzLocalWidening })` — a local key the protocol does not declare | `1 failed \| 9 passed` — the key-set identity assertion reddens |

`HEAD` blob `67f26263…` restored byte-identical after each leg.

**The dist marker, read both ways.** `packages/types/dist` was built from `HEAD` and deliberately NOT rebuilt during the two ablation legs: the mutation markers count **0** in `dist` while the pin reddens, which is positive proof the run reads SOURCE and that a skipped rebuild cannot have measured a stale artifact here. (The root `vitest.config.mts` aliases `@object-ui/types` → `packages/types/src` explicitly, and the whole 169-file suite ran green before any `dist` existed at all.) The other direction was measured separately, WITH rebuilds, in the type-surface run above: the marker moves `0 → 2 → 0` across build-at-HEAD → build-at-pre-fix → build-at-restored.

### CI on the first head (`b4e86e41`), stated as measured

Terminal and green: 34 check runs — 31 success, 3 skipped (`Test (coverage)`, `Test (coverage shard …)`, `dependabot`), 0 failure, 0 pending. All nine merge-queue required checks green, `Type Check` among them, which is the downstream type answer this PR declared to CI.

It was not green on the first attempt, and the honest account of that is narrower than an earlier revision of this body's report claimed:

- `Test (shard 2/4)` started 18:07:31Z, its `Run tests` step went `in_progress` at 18:08:03Z and never ended, and the job was cancelled at 18:32:31Z — **exactly 25m00s against a declared `timeout-minutes: 20`**. ⛔ So "cancelled at the job bound" is *not* what the numbers say: the two do not match, this session issued no cancel, and only one CI run exists on the branch (so it was not `cancel-in-progress`). **The cause is NOT MEASURED** — the job log sits behind a blob host this container's proxy refuses.
- The re-run of the same commit passed in 15m57s (18:34:28Z → 18:50:25Z), against 15m25s–15m50s for shards 1/3/4.
- ⛔ That makes "infrastructure, not this diff" **plausible, not proven.** Re-deriving vitest's own sequencer (`BaseSequencer.shard`: sha1 of the root-relative path, sorted, then `calculateShardRange`) over the 2924 collected specs on this head puts `zod-mirror-parity.test.ts` — **a file this PR changes** — in shard 2, the shard that stalled; the new pin lands in shard 1. Control: the computation yields 731 specs per shard, matching the 731 files CI reported for the shard-2 re-run, and a non-test path resolves to no shard at all.

## ⚠️ The `@object-ui/core` floor — decided: NOT bumped here, and filed instead

The card asked the taker to decide whether `@object-ui/core`'s declared `'@objectstack/spec': '^17.2.0'` should move. **It should — but not in this PR.** Filed with the measurement as objectui#9012.

The finding is real and now measured rather than inferred: the range sits in **`dependencies`** (consumer-facing), core's fold emits `userActions.group` / `.hideFields` / `.rowColor`, and against the real 17.2.0 artifact that exact output comes back `REFUSED refused-keys=["group","hideFields","rowColor"]` while 17.3.0 accepts it — same firing control refused by both, so the difference is about the three keys and not the harness.

Why it is not a rider here:

- It is a published-surface change to a **different package** than this card's (`@object-ui/types`), and raising a declared floor narrows what consumers may resolve.
- **This diff does not move that coupling in either direction** — it is identical before and after.
- No gate in this repository would hold it. `check-spec-range-floors.mjs` judges **symbol presence in the published artifact**, and `UserActionsConfigSchema` is exported by both 17.2.0 and 17.3.0 (verified in each tarball's `dist/ui/index.d.ts`); its workflow also only triggers on changes to the gate script itself. A bump landed quietly here would be prose-backed and could drift straight back.

⛔ objectui#5435 stays open and is **not** addressed by this PR; objectui#2231 (the legacy-vocabulary migration) is out of scope, as the card directs.

## 验收备注

Observations found on the way, none filed — recorded here so the reviewing seat sees them rather than the next dev rediscovering them:

- **Six sibling `EXCLUSIONS` rows carry the same stale reason this PR fixed.** `HttpMethodSchema`, `HttpRequestSchema`, `ViewDataSchema`, `ListColumnSchema`, `SelectionConfigSchema` and `PaginationConfigSchema` are all plain `stripImportedDefaults(Spec…)` re-exports today, yet each is excluded "because the local `.extend(…)` adds renderer props". `ListColumnSchema` did once carry an `.extend` (two commits touch that spelling); the other five never did — the reason is a template that was true of the family it was written for and is now false of six of its seven members. ⛔ Not fixed here, and the reason an earlier revision of this body gave was wrong: PR #9021 (objectui#8990) does **not** touch `zod-mirror-parity.test.ts` — measured off its file list, it touches `packages/types/src/objectql.ts` and `packages/types/src/zod/objectql.zod.ts`, so the only file the two PRs share is `objectql.zod.ts`, which is not where these rows live. The reason that does hold is scope: a seventh row's repair does not license rewriting six more under a different card's claim. The taker is the next collapse card in `objectql.zod.ts` — it will read the same template.
- **The card's own anchors had drifted by three lines** on this base: the false sentence is at `:607`, not `:604`, and the declaration at `:611`, not `:608`. Re-derived rather than trusted, as the dispatch instructed. Everything else in the card held.
- **The card listed "whether collapsing changes any inferred type at a call site" as not measured.** It is measured now — see "What moves on the published surface" — and `UserActionsSchema` turns out to have exactly one consumer, `ListViewSchema.userActions` in the same file; it is not re-exported from the `@object-ui/types/zod` barrel.

## Not measured

- Downstream packages' `type-check` (`plugin-view`, `plugin-detail`, `app-shell` read `ListViewSchema`). Deliberately declared to CI's `Type Check`, which is green on the farm. ⛔ An earlier revision of this body justified that with "assignment-safe in the direction consumers care about" — that over-claims: the movement is safe for READERS of parsed output and breaking for PRODUCERS of output-typed values (measured above). In-repo there is no `z.output` / `z.infer` over these schemas to break, which is why CI is green; external producers are not covered by any run here.
- Whether any other workspace manifest has the same behavioural floor shape as `@object-ui/core`'s — 26 declare `^17.0.0`. Named as a separate job in objectui#9012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_

---
_Generated by [Claude Code](https://claude.ai/code)_