### PR TITLE
docs(changeset): drop the stale cardinal from the objectui#8315 changeset

### DIFF
--- a/.changeset/8315-sdui-parser-manifest-binding-field-retired.md
+++ b/.changeset/8315-sdui-parser-manifest-binding-field-retired.md
@@ -26,8 +26,9 @@ narrowing is not mistaken for a runtime rejection.
 this repo and zero in the objectstack copy of this package (measured 2026-09-09 on
 both heads, each with a firing `binding: 'object'` control), and the only manifest
 producer in either tree is `manifestFromConfigs`, whose input face was already narrow.
-The two `binding: 'field'` occurrences in this repo are `@ts-expect-error` negative
-pins asserting the refusal, not writers.
+Every `binding: 'field'` spelling left under `packages/`, `apps/` and `examples/` is
+an `@ts-expect-error` negative pin asserting the refusal, or a docblock mention of
+the retirement — not a writer.
 
 **Why not leave the reader face wide.** The counter-argument — producer → reader is a
 subset relation, so a permissive reader is not wrong — was answered rather than assumed


### PR DESCRIPTION
Fixes #8759

The migration paragraph of the unreleased objectui#8315 changeset asserted a count that
is not the count of anything on today's tree. A changeset body publishes verbatim into
the CHANGELOG, so the window to fix it closes at the next release.

## What was wrong — and what was not

The sentence made two claims at once, and only one of them was false.

- **The cardinal was wrong.** It said "two". It was true at the merge base of the pull
  request that carried the changeset, and was falsified by that same diff, which added a
  third pin. This is the ordinary failure mode of a count written into a changeset: it is
  authored against the base and describes the head.
- **The class claim was right and stays right.** None of the occurrences is a writer, and
  the migration guidance resting on it ("nothing measured has to change") is correct as
  written. It is unchanged here — not weakened, hedged or re-scoped.

There was also a noun problem underneath the number. "Occurrences" and "pins" are two
different populations, because one of the occurrences is prose inside a docblock on the
narrowed declaration, not a pin. Neither population numbered two.

## Measured on this branch's base

`git grep -n "binding: 'field'" -- packages apps examples`, exit 0, printed rather than
counted: **four** occurrences.

- Two in the sdui-parser injected-component-input pin file — each with `// @ts-expect-error`
  on the line immediately above, read off disk;
- one in the `@object-ui/types` pin file of the same name, likewise `@ts-expect-error`;
- one inside a docblock on the narrowed `ManifestInput.binding` declaration, in the
  paragraph beginning "The permissiveness protected nothing" — prose about the retirement,
  not a pin and not a writer.

⇒ three negative pins, one docblock mention, zero writers.

**Firing control.** `binding: 'object'` over the same population returns 23 occurrences
across 10 files. The matcher resolves this spelling, so the four is a reading and not a
broken query. A whole-tree sweep for the alternate quotings of the same key adds nothing
outside `.changeset/` prose.

## The repair

The replacement carries **no cardinal at all**. The card's own appetite asked for this and
the reason is the defect itself: the count is what rots, whereas the sentence's real claim
is universally quantified and stays true as pins are added or removed.

The population is named explicitly — `packages/`, `apps/` and `examples/` — rather than
left as "in this repo". That is not a re-scope of the class claim; it is what makes the
universal true, because the retired arm is also spelled in changeset prose (including this
very file), and those spellings are neither pins nor docblock mentions. The preceding
sentence still carries the repo-wide zero-writers measurement unchanged, so nothing is
lost. The wording convention matches the sibling objectui#6950 changeset, which measures
over the same three directories by name.

Bump level, frontmatter and every other paragraph are untouched. No other changeset is
touched; no pin is touched; `packages/spec` is not touched.

## Gates — and why they are not the evidence here

Nothing parses changeset prose for truth, so every gate stays green either way. They were
run because the mechanics asked, not as acceptance:

- `node scripts/check-changeset-presence.mjs` → exit 0, printed: "Compared the working tree
  with bbf068db1 (merge-base with origin/main): 1 file(s) changed, 0 of them published
  source of a package the release covers, 0 of them a manifest whose published contract
  moved, 0 under a package changesets ignores, 0 changeset(s) added." and
  "No source or published contract of a released package changed in this range, so no
  changeset is owed." ⇒ **no second changeset is added**, on the gate's own word.
- `check-changeset-no-major.mjs` → exit 0, "No changeset declares a `major` bump."
- `check-changeset-overwrite.mjs` → exit 0 (report-only gate).
- `check-changeset-fixed.mjs` → exit 0.
- `check-control-bytes.mjs` → exit 0.
- `check-governed-queue-guard.mjs --test` on the changed path → "NOT GOVERNED".

The acceptance evidence is the two things above instead: the corrected text read back from
the file, and a fresh count with its firing control.

## Scope

The mechanism question — nothing re-reads a pending changeset when a later pull request
falsifies it — is **not** carried here. It has its own entry point at objectui#9003. No
gate is built on this branch.

Draft on purpose: the PM seat lands it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_