### PR TITLE
fix(plugin-grid,core): normalize `object-grid`'s sort before joining `$orderby` (objectui#8973)

### DIFF
--- a/.changeset/8973-grid-orderby-normalize.md
+++ b/.changeset/8973-grid-orderby-normalize.md
@@ -1,0 +1,47 @@
+---
+'@object-ui/core': minor
+'@object-ui/plugin-grid': patch
+---
+
+`object-grid` normalizes its `sort` before joining it into `$orderby` (objectui#8973).
+
+**The defect.** `ObjectGrid` lowers `schema.sort` with private code rather than the
+shared sink, and its array arm interpolated every key unconditionally:
+
+```js
+params.$orderby = schemaSort.map((s) => `${s.field} ${s.order}`).join(', ');
+```
+
+So an entry missing `field` or `order` reached the wire as the literal text
+`undefined`. The legacy `defaultSort` arm one `else` down had the identical defect on a
+single object, and is fixed with it — leaving it would keep the class open inside the
+same `if`/`else` chain.
+
+This is a wire failure, not a cosmetic one. `normalizeSortNodes` — the one normalizer
+every `@objectstack` server ingress funnels through — validates the direction token, so
+`$orderby: 'name undefined'` is answered `400 INVALID_QUERY`, while `'undefined desc'`
+becomes a well-formed sort on a column literally named `undefined`.
+
+**What changes on the wire.** Only inputs that were already broken:
+
+| authored `sort` | before | after |
+| --- | --- | --- |
+| `[{ field: 'name', order: 'desc' }]` | `"name desc"` | `"name desc"` (unchanged) |
+| `[{ field: 'name' }]` | `"name undefined"` | `"name asc"` |
+| `[{ field: 'name', order: 'desc' }, { field: 'status' }]` | `"name desc, status undefined"` | `"name desc, status asc"` |
+| `[]` | `""` | key omitted |
+| `['name desc']` | `"undefined undefined"` | key omitted |
+| `[{ order: 'desc' }]` | `"undefined desc"` | key omitted |
+
+**The wire SHAPE does not move.** The `"field order"` join string stays. Routing this
+arm through `convertSortToQueryParams` would send that sink's `{field: direction}` map
+instead — route B on objectui#8767, which the maintainer declined by name on 2026-09-10
+pending a card that measures the server contract and both readers.
+
+**New in `@object-ui/core`:** `normalizeSortEntries` (and its `NormalizedSortEntry`
+type) — the "which entries survive, and what does a missing `order` mean" decision,
+lifted out of `convertSortToQueryParams`, which is now a map projection of it. This is
+what lets a block sending a different wire shape share the one implementation of the
+rule instead of keeping a private copy that drifts. `convertSortToQueryParams`'s own
+behaviour is unchanged and pinned against literals captured from the previous
+implementation.

--- a/.changeset/8973-grid-orderby-normalize.md
+++ b/.changeset/8973-grid-orderby-normalize.md
@@ -1,6 +1,7 @@
 ---
 '@object-ui/core': minor
 '@object-ui/plugin-grid': patch
+'@object-ui/types': patch
 ---
 
 `object-grid` normalizes its `sort` before joining it into `$orderby` (objectui#8973).
@@ -45,3 +46,11 @@ what lets a block sending a different wire shape share the one implementation of
 rule instead of keeping a private copy that drifts. `convertSortToQueryParams`'s own
 behaviour is unchanged and pinned against literals captured from the previous
 implementation.
+
+**Two false docblock sentences corrected** (`@object-ui/types`' `ObjectGridSchema.sort`
+and this sink's own header). Both read "`order` is optional and means `'asc'`" — the
+first sitting two lines above a declaration that requires it. `SortConfig.order` is
+required on the interface, on the zod mirror, and on `@objectstack/spec`'s
+`SortItemSchema`, which refuses an entry without it. An author following that
+prescription wrote metadata the spec rejects. objectui#8767's contract review routed
+both sentences to this card by name; comments only, no behaviour.

--- a/packages/core/src/utils/__tests__/sort-query.test.ts
+++ b/packages/core/src/utils/__tests__/sort-query.test.ts
@@ -27,7 +27,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { convertSortToQueryParams, resetRetiredSortSpellingReports } from '../sort-query';
+import { convertSortToQueryParams, normalizeSortEntries, resetRetiredSortSpellingReports } from '../sort-query';
 
 /** The retired spelling, reached the only way it still can be: at runtime. */
 const asRuntimeValue = (value: unknown) => value as unknown as Parameters<typeof convertSortToQueryParams>[0];
@@ -151,5 +151,113 @@ describe('convertSortToQueryParams — the retired string clause (objectui#8221)
     // disconnected mock.
     expect(convertSortToQueryParams(asRuntimeValue('   '))).toBeUndefined();
     expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * `normalizeSortEntries` — the decision `convertSortToQueryParams` was built
+ * on, lifted out so a block that sends a DIFFERENT wire shape can share it
+ * (objectui#8973).
+ *
+ * `object-grid` sends a `"field order"` join string, not this module's map, and
+ * moving it onto the map is route B on objectui#8767 — declined by the
+ * maintainer on 2026-09-10 pending its own card. It re-implemented the "which
+ * entries survive, what does a missing `order` mean" decision privately and got
+ * it wrong (`$orderby: 'name undefined'`). Exporting the decision without the
+ * map is what lets the two agree without the shape moving.
+ *
+ * The second describe below is the load-bearing half: the map builder is now a
+ * projection of this function, so every case must answer exactly what it
+ * answered when it was a single loop. A refactor that quietly changed the map
+ * would be a wire change in `object-calendar`, `object-gantt`, `object-map`,
+ * `object-timeline` and `record:line_items` at once.
+ */
+describe('normalizeSortEntries (objectui#8973)', () => {
+  it('fills a missing `order` with `asc` rather than dropping the key', () => {
+    expect(normalizeSortEntries([{ field: 'name' }])).toEqual([{ field: 'name', order: 'asc' }]);
+  });
+
+  it('preserves authored order and keeps duplicates as separate entries', () => {
+    // The map projection collapses these; the entry list deliberately does not,
+    // because a join-string caller must be able to see what it was handed.
+    expect(
+      normalizeSortEntries([
+        { field: 'stage', order: 'desc' },
+        { field: 'stage', order: 'asc' },
+      ]),
+    ).toEqual([
+      { field: 'stage', order: 'desc' },
+      { field: 'stage', order: 'asc' },
+    ]);
+  });
+
+  it('skips entries that name no usable field', () => {
+    expect(normalizeSortEntries([{ order: 'desc' }, { field: '' }, { field: 'name' }])).toEqual([
+      { field: 'name', order: 'asc' },
+    ]);
+  });
+
+  it('normalizes a garbage direction to `asc` instead of forwarding it', () => {
+    expect(normalizeSortEntries([{ field: 'name', order: 'DESCENDING' as never }])).toEqual([
+      { field: 'name', order: 'asc' },
+    ]);
+  });
+
+  it('answers `undefined`, never `[]`, so a caller can omit the query key', () => {
+    expect(normalizeSortEntries([])).toBeUndefined();
+    expect(normalizeSortEntries([{ order: 'desc' }])).toBeUndefined();
+    expect(normalizeSortEntries(undefined)).toBeUndefined();
+    expect(normalizeSortEntries(null)).toBeUndefined();
+  });
+
+  it('refuses a retired string clause with the SAME reporter, not a second one', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      resetRetiredSortSpellingReports();
+      expect(normalizeSortEntries(asRuntimeValue('name desc'))).toBeUndefined();
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(String(spy.mock.calls[0][0])).toContain('objectui#8221');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('convertSortToQueryParams — REGRESSION PIN: the refactor moved no behaviour', () => {
+  /**
+   * Expected values were captured from the PRE-REFACTOR implementation (the
+   * single map-building loop) and are written out as LITERALS on purpose.
+   * Deriving them from `normalizeSortEntries` would only prove the projection
+   * is self-consistent — it would pass just as happily if both halves had moved
+   * together, which is exactly the regression that matters: this map is the
+   * `$orderby` of `object-calendar`, `object-gantt`, `object-map`,
+   * `object-timeline` and `record:line_items`.
+   */
+  const CASES: Array<[string, unknown, Record<string, 'asc' | 'desc'> | undefined]> = [
+    ['fully specified', [{ field: 'stage', order: 'asc' }, { field: 'amount', order: 'desc' }], { stage: 'asc', amount: 'desc' }],
+    ['order omitted means asc', [{ field: 'name' }], { name: 'asc' }],
+    ['field omitted is skipped', [{ order: 'desc' }], undefined],
+    ['empty field is skipped', [{ field: '' }], undefined],
+    ['duplicate field collapses last-wins', [{ field: 'stage', order: 'desc' }, { field: 'stage', order: 'asc' }], { stage: 'asc' }],
+    ['empty array yields undefined', [], undefined],
+    ['array of strings yields undefined', ['name desc'], undefined],
+    ['null entry is skipped', [null], undefined],
+    ['garbage direction normalizes to asc', [{ field: 'name', order: 'sideways' }], { name: 'asc' }],
+    ['undefined', undefined, undefined],
+    ['null', null, undefined],
+    ['a number', 42, undefined],
+    ['a bare unwrapped node', { field: 'name', order: 'desc' }, undefined],
+  ];
+
+  it.each(CASES)('%s', (_label, input, expected) => {
+    const actual = convertSortToQueryParams(asRuntimeValue(input));
+    expect(actual).toEqual(expected);
+    // Key ORDER is part of this map's contract (the first test in this file
+    // pins it), and `toEqual` does not compare it.
+    expect(actual && Object.keys(actual)).toEqual(expected && Object.keys(expected));
+  });
+
+  it('CONTROL — the pin can fail: a deliberately wrong expectation is rejected', () => {
+    expect(convertSortToQueryParams([{ field: 'name' }])).not.toEqual({ name: 'desc' });
   });
 });

--- a/packages/core/src/utils/sort-query.ts
+++ b/packages/core/src/utils/sort-query.ts
@@ -39,10 +39,17 @@
  * tolerance — and both are BEHAVIOUR CHANGES the migration delivered, not pure
  * refactor:
  *
- *  - **`order` is optional in `SortConfig`**, so an entry that omits it means
- *    ascending (that is what `$orderby`'s own
- *    `Array<{ field: string; order?: 'asc' | 'desc' }>` shape says). The private
- *    copies required BOTH keys and silently dropped such an entry, which lost an
+ *  - **A missing `order` is READ as ascending rather than dropped.** ⚠️ This
+ *    bullet used to say `order` is "optional in `SortConfig`". It is not:
+ *    `SortConfig.order` is required on the interface, on its zod mirror, and on
+ *    `@objectstack/spec`'s `SortItemSchema`, which refuses an entry without it
+ *    (`invalid_value` at `0.order`, measured on `@objectstack/spec@17.4.0`).
+ *    Corrected under objectui#8973, which is where objectui#8767's contract
+ *    review routed this sentence and its twin in
+ *    `@object-ui/types`' `ObjectGridSchema.sort` docblock. The tolerance is
+ *    real but it is a RUNTIME one — types are erased, so an entry missing
+ *    `order` still arrives and still has to mean something. The private copies
+ *    required BOTH keys and silently dropped such an entry, which lost an
  *    authored sort key instead of ordering by it.
  *  - **Nothing usable yields `undefined`, never `{}`.** An empty object is a
  *    truthy value that means "no ordering" only by accident of the adapter's

--- a/packages/core/src/utils/sort-query.ts
+++ b/packages/core/src/utils/sort-query.ts
@@ -120,18 +120,49 @@ function reportRetiredSortSpelling(sort: string): void {
 }
 
 /**
- * Normalize an authored `sort` into the field→direction map used for
- * `QueryParams.$orderby`.
- *
- * @param sort `SortConfig[]` — the one declared spelling. The legacy string
- * clause (`"name desc"`) is retired (objectui#8221): a string that reaches here
- * at runtime is refused with a diagnostic naming the array form, and this
- * function returns `undefined` so the query carries no `$orderby`.
- * @returns The ordering map, or `undefined` when nothing orderable was authored.
+ * A sort entry after normalization — BOTH keys present, always. That is the
+ * difference from {@link QuerySortEntry}, whose two members are optional
+ * because it describes what an author may WRITE, not what survives this door.
  */
-export function convertSortToQueryParams(
+export interface NormalizedSortEntry {
+  field: string;
+  order: 'asc' | 'desc';
+}
+
+/**
+ * Decide WHICH authored entries survive and WHAT a missing direction means —
+ * the whole of this module's normalization, with no opinion about the wire.
+ *
+ * Split out of {@link convertSortToQueryParams} by objectui#8973, which measured
+ * `object-grid` re-implementing this decision privately and getting it wrong:
+ * its array arm interpolated every key unconditionally, so an entry missing
+ * `field` or `order` reached the wire as the literal text `undefined`
+ * (`$orderby: 'name undefined'`), which the server answers `400 INVALID_QUERY`.
+ *
+ * ⚠️ It is SHAPE-AGNOSTIC on purpose, and that is what makes it reusable where
+ * the map below is not. `object-grid` sends a `"field order"` join string, not
+ * this module's `{field: direction}` map; swapping its wire shape is route B on
+ * objectui#8767, which the maintainer DECLINED by name (2026-09-10) pending a
+ * card that measures the server contract and both readers. Exporting the
+ * decision without the map lets that block share the ONE implementation of the
+ * rule while keeping the wire shape the declination protects — so "one
+ * operation, one implementation" is satisfied for the operation that actually
+ * has two copies, rather than being traded away for a shape change nobody
+ * ruled on.
+ *
+ * The two rules, unchanged from the map builder they were lifted out of:
+ *
+ *  - an entry with no usable `field` is SKIPPED (it names nothing to order by);
+ *  - `order` normalizes to `'asc'` unless it is exactly `'desc'`, so a missing
+ *    direction means ascending and a garbage one does not reach the wire.
+ *
+ * @returns The surviving entries in authored order, or `undefined` when nothing
+ * orderable was authored — never an empty array, so callers can omit the
+ * query key entirely rather than asking for an ordering with no content.
+ */
+export function normalizeSortEntries(
   sort: QuerySortEntry[] | undefined | null,
-): Record<string, 'asc' | 'desc'> | undefined {
+): NormalizedSortEntry[] | undefined {
   if (!sort) return undefined;
 
   // Retired spelling — reachable only at runtime, since the signature above no
@@ -143,13 +174,40 @@ export function convertSortToQueryParams(
   }
 
   if (Array.isArray(sort)) {
-    const out: Record<string, 'asc' | 'desc'> = {};
+    const out: NormalizedSortEntry[] = [];
     for (const entry of sort) {
       if (!entry || typeof entry.field !== 'string' || entry.field === '') continue;
-      out[entry.field] = entry.order === 'desc' ? 'desc' : 'asc';
+      out.push({ field: entry.field, order: entry.order === 'desc' ? 'desc' : 'asc' });
     }
-    return Object.keys(out).length > 0 ? out : undefined;
+    return out.length > 0 ? out : undefined;
   }
 
   return undefined;
+}
+
+/**
+ * Normalize an authored `sort` into the field→direction map used for
+ * `QueryParams.$orderby`.
+ *
+ * The decision about which entries survive lives in
+ * {@link normalizeSortEntries}; this function is only the MAP projection of it.
+ * Duplicate fields therefore collapse last-wins, keeping the position of the
+ * first mention — the same thing the single-pass loop this replaced did, since
+ * an object key keeps its insertion position when it is re-assigned.
+ *
+ * @param sort `SortConfig[]` — the one declared spelling. The legacy string
+ * clause (`"name desc"`) is retired (objectui#8221): a string that reaches here
+ * at runtime is refused with a diagnostic naming the array form, and this
+ * function returns `undefined` so the query carries no `$orderby`.
+ * @returns The ordering map, or `undefined` when nothing orderable was authored.
+ */
+export function convertSortToQueryParams(
+  sort: QuerySortEntry[] | undefined | null,
+): Record<string, 'asc' | 'desc'> | undefined {
+  const entries = normalizeSortEntries(sort);
+  if (!entries) return undefined;
+
+  const out: Record<string, 'asc' | 'desc'> = {};
+  for (const entry of entries) out[entry.field] = entry.order;
+  return out;
 }

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -42,7 +42,7 @@ import {
   RefreshIndicator,
 } from '@object-ui/components';
 import { usePullToRefresh } from '@object-ui/mobile';
-import { resolveConditionalFormatting, leadWithNameField, buildExpandFields, buildExportFileName, columnIdentity, collectPredicateFieldRefs, collectGroupingFieldRefs, listViewPredicates, isObjectInlineEditable, isProjectableField, isExpandableFieldType, isUnmaterializedFieldType, readObjectSortability, isPlatformSortableField, filterPlatformSortableSort, toFilterNode, convertSortToQueryParams, type QuerySortEntry, ROW_HEIGHT_TO_DENSITY_MODE, resolveRecordSourceConfig, resolveRecordSourceObjectName } from '@object-ui/core';
+import { resolveConditionalFormatting, leadWithNameField, buildExpandFields, buildExportFileName, columnIdentity, collectPredicateFieldRefs, collectGroupingFieldRefs, listViewPredicates, isObjectInlineEditable, isProjectableField, isExpandableFieldType, isUnmaterializedFieldType, readObjectSortability, isPlatformSortableField, filterPlatformSortableSort, toFilterNode, convertSortToQueryParams, normalizeSortEntries, type QuerySortEntry, ROW_HEIGHT_TO_DENSITY_MODE, resolveRecordSourceConfig, resolveRecordSourceObjectName } from '@object-ui/core';
 import { usePermissions } from '@object-ui/permissions';
 import { ChevronRight, ChevronLeft, ChevronsLeft, ChevronsRight, Download, Rows2, Rows3, Rows4, AlignJustify, Type, Hash, Calendar, CheckSquare, User, Tag, Clock, Loader2 } from 'lucide-react';
 import { useRowColor } from './useRowColor';
@@ -83,6 +83,38 @@ import type { BulkActionDef } from '@object-ui/types';
  *
  * Exported for the test that pins it against the fetch path's own reading.
  */
+/**
+ * A declared `sort` → the `"field order"` join string THIS block sends as
+ * `$orderby` (objectui#8973).
+ *
+ * ⚠️ Read the split before editing either half. WHICH entries survive and what
+ * a missing `order` means is `normalizeSortEntries`' decision — the governed
+ * one in `@object-ui/core`, shared with `convertSortToQueryParams` and every
+ * sibling block. Only the JOIN is this block's, because only this block sends
+ * a join string: the sink's `{field: direction}` map is route B on
+ * objectui#8767, declined by the maintainer 2026-09-10 pending a card that
+ * measures the server contract and both readers. So the operation with two
+ * copies (the normalization) has one implementation, and the shape the
+ * declination protects does not move.
+ *
+ * What this closes: the arms below used to interpolate every key
+ * unconditionally, so an entry missing `field` or `order` reached the wire as
+ * the literal text `undefined`. `$orderby: 'name undefined'` is not a
+ * degraded ordering — `normalizeSortNodes` (`@objectstack/metadata-protocol`,
+ * the one normalizer every server ingress funnels through) reads `undefined`
+ * as a direction that is "neither 'asc' nor 'desc'" and answers
+ * `400 INVALID_QUERY`.
+ *
+ * @returns `undefined` when nothing orderable survives, so the caller omits
+ * `$orderby` entirely instead of sending `""` — the same correction
+ * `toFilterNode` already made for `$filter: {}` on the filter leg above.
+ */
+function toOrderByClause(sort: QuerySortEntry[] | undefined | null): string | undefined {
+  const ordered = normalizeSortEntries(sort);
+  if (!ordered) return undefined;
+  return ordered.map((s) => `${s.field} ${s.order}`).join(', ');
+}
+
 export function parseSchemaSort(sort: unknown): TableSortItem[] {
   const entries = typeof sort === 'string' ? [sort] : Array.isArray(sort) ? sort : [];
   const items: TableSortItem[] = [];
@@ -1891,13 +1923,26 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
               // `sys_metadata` row or an `as any` bag.
               convertSortToQueryParams(schemaSort as unknown as QuerySortEntry[]);
             } else if (Array.isArray(schemaSort)) {
-              params.$orderby = schemaSort
-                .map((s: any) => `${s.field} ${s.order}`)
-                .join(', ');
+              // objectui#8973 — normalize before joining. Every key used to be
+              // interpolated unconditionally, so `[{ field: 'name' }]` went out
+              // as `'name undefined'` and `[]` as `''`. The join, and only the
+              // join, stays this block's (see {@link toOrderByClause}).
+              const orderBy = toOrderByClause(schemaSort as unknown as QuerySortEntry[]);
+              if (orderBy !== undefined) {
+                params.$orderby = orderBy;
+              }
             }
           } else if (schema.defaultSort) {
-            // Legacy support
-            params.$orderby = `${(schema.defaultSort as any).field} ${(schema.defaultSort as any).order}`;
+            // Legacy support — through the SAME normalizer as the array arm
+            // above, because it had the SAME defect (objectui#8973): a
+            // `defaultSort` missing `order` was interpolated straight into
+            // `$orderby: 'name undefined'`, which the server answers
+            // `400 INVALID_QUERY`. Fixing one arm and not its neighbour would
+            // leave the class open in the same `if`/`else` chain.
+            const orderBy = toOrderByClause([schema.defaultSort as QuerySortEntry]);
+            if (orderBy !== undefined) {
+              params.$orderby = orderBy;
+            }
           }
 
           // Search (objectui#3118). The term the toolbar box holds is a question

--- a/packages/plugin-grid/src/__tests__/gridArrayArmOrderby-8973.test.tsx
+++ b/packages/plugin-grid/src/__tests__/gridArrayArmOrderby-8973.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `object-grid` NORMALIZES before it joins `$orderby` (objectui#8973).
+ *
+ * ## What was wrong
+ *
+ * This block lowers `schema.sort` with private code rather than the shared
+ * sink, and its array arm was a bare template interpolation:
+ *
+ *     params.$orderby = schemaSort.map((s: any) => `${s.field} ${s.order}`).join(', ');
+ *
+ * Every key was interpolated UNCONDITIONALLY, so an entry missing `field` or
+ * `order` reached the wire as the literal text `undefined`. The legacy
+ * `defaultSort` arm one `else` down had the identical defect on a single
+ * object.
+ *
+ * ## Why this is a wire defect and not a cosmetic one — MEASURED, not assumed
+ *
+ * `normalizeSortNodes` (`@objectstack/metadata-protocol`, the one normalizer
+ * every server ingress funnels through) reads the join string by splitting on
+ * whitespace and validating the direction token:
+ *
+ *   - `"name undefined"` → direction `'undefined'`, "neither 'asc' nor 'desc'"
+ *     → **`400 INVALID_QUERY`**. The list does not render degraded; it fails.
+ *   - `"undefined desc"` → a WELL-FORMED sort on a column literally named
+ *     `undefined` — the silently-wrong-ordering half of the same defect.
+ *   - `""` → `[]`, i.e. benign at the server. Omitting the key is still the
+ *     correct lowering, and it is the correction `toFilterNode` already made
+ *     for `$filter: {}` on the filter leg of this very same query build:
+ *     asking a question with no content is not the same as not asking.
+ *
+ * ## The wire shape does NOT move here
+ *
+ * The join string stays. Routing this arm through `convertSortToQueryParams`
+ * would send that sink's `{field: direction}` map — route B on objectui#8767,
+ * DECLINED by the maintainer on 2026-09-10 pending a card that measures the
+ * server contract AND both readers. What IS shared is the decision the two
+ * copies disagreed about: `normalizeSortEntries`, exported from
+ * `@object-ui/core` alongside the map builder that now also delegates to it.
+ * One operation, one implementation — for the operation that had two copies.
+ *
+ * ## Deliberately untouched
+ *
+ * The header-arrow reader `parseSchemaSort` (objectui#8961, `pm:blocked`) and
+ * the export path's `{field, direction}` projection. The `headerSort` arm also
+ * keeps sending `SortNode[]` objects rather than a join string — a documented,
+ * deliberate difference, not a defect.
+ *
+ * ⭐ The CONTROL rows are what make the rest a measurement rather than a block
+ * that mangles everything: if the fix had broken lowering outright, the
+ * `"name desc"` rows would have gone dark and every "key is absent" assertion
+ * would have passed for the wrong reason.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+import { resetRetiredSortSpellingReports } from '@object-ui/core';
+// Registers `object-grid` and its `view:grid` alias.
+import '../index';
+
+function makeAdapter() {
+  return {
+    find: vi.fn().mockResolvedValue({
+      data: [{ id: '1', name: 'Acme', status: 'active' }],
+      total: 1,
+    }),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue({
+      name: 'account',
+      fields: { id: { type: 'text' }, name: { type: 'text' }, status: { type: 'text' } },
+    }),
+  };
+}
+
+/** Render the block and return the params of its first `find` call. */
+async function findParamsFor(schema: Record<string, unknown>) {
+  const adapter = makeAdapter();
+  render(
+    <SchemaRendererProvider dataSource={adapter as any}>
+      <SchemaRenderer schema={schema as any} />
+    </SchemaRendererProvider>,
+  );
+  await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+  return (adapter.find.mock.calls[0] as [string, any])[1];
+}
+
+const BASE = { type: 'object-grid', objectName: 'account', columns: [{ field: 'name' }] };
+
+/** `$orderby` is absent ENTIRELY — not present-and-empty. */
+function expectNoOrderBy(params: Record<string, unknown>) {
+  expect(params.$orderby).toBeUndefined();
+  expect(Object.prototype.hasOwnProperty.call(params, '$orderby')).toBe(false);
+}
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  resetRetiredSortSpellingReports();
+  errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+describe('object-grid array `sort` arm — the card’s six-row probe table (objectui#8973)', () => {
+  it('CONTROL — a fully-specified entry still lowers to the join string, byte for byte', async () => {
+    const params = await findParamsFor({ ...BASE, sort: [{ field: 'name', order: 'desc' }] });
+    // The wire shape route B would change and this card keeps.
+    expect(params.$orderby).toBe('name desc');
+  });
+
+  it('`order` omitted lowers to `asc` — it used to go out as `"name undefined"`', async () => {
+    const params = await findParamsFor({ ...BASE, sort: [{ field: 'name' }] });
+    expect(params.$orderby).toBe('name asc');
+    expect(params.$orderby).not.toContain('undefined');
+  });
+
+  it('normalizes only the member that is missing one, leaving its neighbour alone', async () => {
+    const params = await findParamsFor({
+      ...BASE,
+      sort: [{ field: 'name', order: 'desc' }, { field: 'status' }],
+    });
+    // Was `"name desc, status undefined"`.
+    expect(params.$orderby).toBe('name desc, status asc');
+  });
+
+  it('an empty array carries NO `$orderby` — it used to send `""`', async () => {
+    expectNoOrderBy(await findParamsFor({ ...BASE, sort: [] }));
+  });
+
+  it('the retired ARRAY-OF-STRINGS form names no field, so nothing survives', async () => {
+    const params = await findParamsFor({ ...BASE, sort: ['name desc'] });
+    // Was `"undefined undefined"` — a hard 400 at the server.
+    expectNoOrderBy(params);
+    // ⚠️ Deliberately NOT a new refusal diagnostic. objectui#8767 landed route
+    // C for the retired STRING clause; widening that refusal to cover the
+    // array-of-strings is that card's business, not this one's. This entry is
+    // dropped exactly as the shared sink drops an unusable entry — silently.
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('`field` omitted names nothing to order by, so the entry is skipped', async () => {
+    // Was `"undefined desc"` — a well-formed sort on a column named `undefined`.
+    expectNoOrderBy(await findParamsFor({ ...BASE, sort: [{ order: 'desc' }] }));
+  });
+
+  it('drops only the unusable members of a mixed array, keeping the usable one', async () => {
+    const params = await findParamsFor({
+      ...BASE,
+      sort: [{ order: 'desc' }, { field: 'name' }],
+    });
+    expect(params.$orderby).toBe('name asc');
+  });
+});
+
+describe('object-grid legacy `defaultSort` arm — the SAME defect, one `else` down (objectui#8973)', () => {
+  it('CONTROL — a fully-specified `defaultSort` still lowers to the join string', async () => {
+    const params = await findParamsFor({ ...BASE, defaultSort: { field: 'name', order: 'desc' } });
+    expect(params.$orderby).toBe('name desc');
+  });
+
+  it('`order` omitted lowers to `asc` — it used to go out as `"name undefined"`', async () => {
+    const params = await findParamsFor({ ...BASE, defaultSort: { field: 'name' } });
+    expect(params.$orderby).toBe('name asc');
+    expect(params.$orderby).not.toContain('undefined');
+  });
+
+  it('`field` omitted carries NO `$orderby` — it used to send `"undefined desc"`', async () => {
+    expectNoOrderBy(await findParamsFor({ ...BASE, defaultSort: { order: 'desc' } }));
+  });
+});
+
+describe('object-grid — the arms this card deliberately does NOT move', () => {
+  it('a header-click sort still sends `SortNode[]` objects, not a join string', () => {
+    // Named rather than absorbed (the triage comment asked for exactly this):
+    // this block already sends TWO different `$orderby` shapes depending on
+    // which arm fires, and that predates this card. The `SortNode[]` form is
+    // documented at the read site as deliberate — it is the shape the server
+    // names in its own error messages and it survives a field name containing
+    // a space. Both shapes are accepted by `normalizeSortNodes`.
+    // Read off the vitest root — this project's `import.meta.url` is not a
+    // file URL, so the sibling `import.meta`-relative idiom does not work here.
+    const src = readFileSync(join(process.cwd(), 'packages/plugin-grid/src/ObjectGrid.tsx'), 'utf8');
+
+    // Instrument check FIRST, in both directions: a probe that silently read
+    // the wrong file (or an empty one) would make every `toContain` below a
+    // vacuous pass, and a `not.toContain` a vacuous one at that.
+    expect(src).toContain('export function parseSchemaSort');
+    expect(src).not.toContain('a token that is definitely not in this file');
+
+    expect(src).toContain('params.$orderby = headerSort.map((s) => ({ field: s.field, order: s.order }));');
+  });
+
+  it('the string `sort` arm is still objectui#8767’s refusal, unchanged', async () => {
+    const params = await findParamsFor({ ...BASE, sort: 'name desc' });
+    expectNoOrderBy(params);
+    // #8758's OWN diagnostic still fires — this card did not absorb it.
+    expect(errorSpy).toHaveBeenCalled();
+    expect(String(errorSpy.mock.calls[0][0])).toContain('objectui#8221');
+  });
+});

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -696,8 +696,16 @@ export interface ObjectGridSchema extends BaseSchema {
   /**
    * Sort Configuration
    *
-   * `[{ field: 'name', order: 'desc' }]` — `order` is optional and means
-   * `'asc'`. The legacy string clause (`"name desc"`) is RETIRED
+   * `[{ field: 'name', order: 'desc' }]` — BOTH keys are required, here and on
+   * the zod mirror, and `@objectstack/spec`'s `SortItemSchema` refuses an entry
+   * that omits `order` (`invalid_value` at `0.order`, measured on
+   * `@objectstack/spec@17.4.0`). ⚠️ This sentence used to read "`order` is
+   * optional and means `'asc'`", two lines above a declaration that requires it
+   * — an author who followed it wrote metadata the spec rejects (objectui#8973).
+   * What IS true of a missing `order` is a RUNTIME tolerance, not a
+   * declaration: `normalizeSortEntries` defaults it to `'asc'` rather than
+   * dropping the key, because types are erased and the entry still has to mean
+   * something when it arrives. The legacy string clause (`"name desc"`) is RETIRED
    * (objectui#8221, decision batch #77): the array is the only spelling this
    * key's declared input publishes (`type: 'array'`) and the only one
    * `convertSortToQueryParams` lowers.


### PR DESCRIPTION
Fixes #8973

`ObjectGrid` lowers `schema.sort` with private code rather than the shared sink, and its array arm was a bare template interpolation:

```
params.$orderby = schemaSort.map((s: any) => `${s.field} ${s.order}`).join(', ');
```

Every key was interpolated **unconditionally**, so a member missing `field` or `order` reached the wire as the literal text `undefined`.

## This is a wire failure, not a cosmetic one — measured

Measured against `normalizeSortNodes` (`@objectstack/metadata-protocol/src/protocol.ts:3321`, objectstack `origin/main` `706ad0f`) — described in its own docblock as "the one shared normalizer every ingress funnels through":

| what went out | what the server does with it |
| --- | --- |
| `"name undefined"` | direction `'undefined'` is "neither `'asc'` nor `'desc'`" ⇒ **`400 INVALID_QUERY`** |
| `"undefined undefined"` | same ⇒ **`400 INVALID_QUERY`** |
| `"undefined desc"` | a **well-formed** sort on a column literally named `undefined` — the silently-wrong-ordering half |
| `""` | `value === '' ⇒ return []` — benign at the server |

So triage's severity claim ("a server-side failure or a silently wrong ordering") is confirmed on both branches. The empty-string row is the one that is *not* a server failure, and it is fixed anyway — see below.

## Acceptance table — the card's six rows, re-measured

Driven through a real `object-grid` via `SchemaRenderer` against a `vi.fn()` data source, reading `$orderby` off the first `find` call.

| authored `sort` | before | after |
| --- | --- | --- |
| `[{ field: 'name', order: 'desc' }]` — **CONTROL** | `"name desc"` | `"name desc"` — unchanged |
| `[{ field: 'name' }]` | `"name undefined"` | `"name asc"` |
| `[{ field: 'name', order: 'desc' }, { field: 'status' }]` | `"name desc, status undefined"` | `"name desc, status asc"` |
| `[]` | `""` | key omitted entirely |
| `['name desc']` | `"undefined undefined"` | key omitted entirely |
| `[{ order: 'desc' }]` | `"undefined desc"` | key omitted entirely |

On `[]`: an empty `$orderby` is benign at the server, so this row is not a bug fix by severity — it is fixed for consistency with the correction `toFilterNode` already made on the **filter leg of this same query build**, where `defaultFilters: {}` used to send `$filter: {}`. Asking a question with no content is not the same as not asking. `[]` is also, unlike the `order`-omitted row, **accepted** by `@objectstack/spec` — so it is the row that makes this defect reachable from fully spec-valid authored metadata.

## The wire shape does NOT move, and why the triage-preferred route was not taken

Triage's ruling was to fix this by **deleting the private lowering** and routing through `convertSortToQueryParams`. That route is unavailable, and not on my judgement:

- `convertSortToQueryParams` returns `Record<string, 'asc' | 'desc'>` — a **map**. `ObjectGrid` sends a `"field order"` **join string**. Routing this arm through the sink therefore cannot be done without moving the wire shape.
- Moving it is **route B on objectui#8767**, declined by the maintainer by name on 2026-09-10 (comment [`5617214837`](https://github.com/objectstack-ai/objectui/issues/8767#issuecomment-5617214837)): "Route B (route through the shared sink) is **not** taken — it moves the wire shape for every grid and drags in the export path and `parseSchemaSort`; that is a different card."
- #8973 is not that card: it measures the wire output, but neither the server contract nor the header reader.

**Reconciled instead of chosen between.** Triage's actual principle — one operation, one implementation — is satisfied for the operation that genuinely had two copies. The "which entries survive, and what does a missing `order` mean" decision is lifted out of `convertSortToQueryParams` into a new shared, **shape-agnostic** export `normalizeSortEntries` (`@object-ui/core`). The map builder is now a projection of it; `ObjectGrid` builds its join string from it. One implementation of the rule, two wire shapes, and the shape the declination protects does not move.

The join itself stays local to `ObjectGrid` deliberately: it is the only block that sends a join string, and putting it in the governed module would enshrine in core the very shape the maintainer's preferred end state retires.

## Also fixed: the legacy `defaultSort` arm, one `else` down

```
params.$orderby = `${(schema.defaultSort as any).field} ${(schema.defaultSort as any).order}`;
```

**Identical defect**, same `if`/`else` chain, same `400`. Fixed through the same normalizer. This is a bounded in-place fix, not a widening: same defect class, mechanical, no other claim on the file, no new gate surface. It is an isolated hunk with its own acceptance rows — drop it independently if you would rather it were its own card.

## The other arms `ObjectGrid` lowers — named, not absorbed

Triage asked for these to be checked before switching. There are **four** private lowerings of this one key, not one, and two distinct `$orderby` wire shapes already coexist:

1. **`headerSort` arm** — sends `SortNode[]`, i.e. `[{ field, order }]` **objects**, not a join string. Documented at the read site as deliberate ("the shape the server names in its own error messages, and it survives a field name containing a space"). Not a defect, and **not touched**. But it means the premise "`object-grid` sends a join string" is only true of the schema-declared arms.
2. **`schemaSort` string arm** — objectui#8767's landed route-C refusal. Untouched, and pinned here as still firing.
3. **`schemaSort` array arm** — this card.
4. **`defaultSort` arm** — this card, above.
5. **The export path** (`ObjectGrid.tsx:3120`) builds `{ field, direction }` for `exportDownload` — a different envelope, not `$orderby`. It **already** normalizes correctly (skips entries with no `field`, defaults `order`), which is why the correct normalization was already present in this file and simply had not been applied to the fetch path. One behavioural difference worth naming: it uses `?? 'asc'`, which passes a garbage direction like `'DESCENDING'` through unchanged, where the shared normalizer folds it to `'asc'`. **Not changed here** — it is the export path, which #8767's ruling also fenced off.
6. **`parseSchemaSort`** — objectui#8961, `pm:blocked`, `domain:spec` + `domain:ui`. **Not touched.**

## Owed to objectui#8961 and objectui#8767 — the server `$orderby` contract, MEASURED and deliberately NOT acted on here

The #8767 declination asked for a card carrying its own measurement of the server contract. Here is that half, so the maintainer does not have to go and get it. **Nothing in this PR acts on it.**

Measured in `@objectstack/metadata-protocol`'s `normalizeSortNodes` (objectstack `origin/main` `706ad0f`), the single normalizer every server ingress funnels through. It accepts **four** shapes:

| shape | example | accepted? |
| --- | --- | --- |
| join string | `"name desc, status asc"` | yes — what `object-grid`'s schema arms send |
| `SortNode[]` | `[{ field: 'name', order: 'desc' }]` | yes — what `object-grid`'s **header** arm sends |
| `string[]` | `['-created_at']` | yes |
| `Record` map | `{ created_at: 'desc' }` | yes — what `convertSortToQueryParams` returns |

⇒ **The server accepts both the join string and the map.** Route B is not blocked by the server contract. The map and the `string[]` form were both silently dropped until objectstack#4226 taught this normalizer to fold them; `SqlDriver` guards its ORDER BY with `Array.isArray(query.orderBy)`, so a shape it could not read produced no clause at all.

Two caveats that keep this from being a green light on its own:

- The **OData/HTTP** face (`@objectstack/spec` `packages/spec/src/api/odata.zod.ts`) declares `$orderby` as `string | string[]` only — it declares neither the map nor `SortNode[]`. That is plausibly just two doors (a querystring surface where everything is a string, versus the JSON query body), **not** a measured contradiction, and I am reporting it as an observation rather than a finding.
- The **second** half the declination asked for — the header reader — is still unmeasured, by design: `parseSchemaSort` is objectui#8961's and out of bounds for this lane.

## Verification

Ablation (predicted **before** running, matched exactly): reverting the two `ObjectGrid` arms to the unconditional interpolation reddens **exactly 8** tests — the six array rows and the two `defaultSort` rows. Both CONTROL rows, the header-arm pin, the string-arm refusal, all of `gridRetiredStringSort-8767.test.tsx` and all of the core suite stay green. `8 failed | 37 passed`. The mutation was proven on disk in both directions before the run (injected token present, removed token gone, blob hash changed), and the restore was proven by `git diff HEAD` empty plus a blob-hash match against `HEAD` — not by an exit code.

No rebuild was needed for the ablation to be real: the root vitest config aliases `@object-ui/core` to `packages/core/src`, so these suites resolve source, not `dist/`.

Reverse verification of the cross-package type change: feeding `normalizeSortEntries` a `number` from `ObjectGrid.tsx` reddens with `TS2345: Argument of type 'number' is not assignable to parameter of type 'QuerySortEntry[]'` — proving `plugin-grid`'s `type-check` reads the rebuilt `.d.ts` and not a cache. Restored, hash-verified.

- `pnpm --filter @object-ui/types --filter @object-ui/core --filter @object-ui/plugin-grid type-check` — all three `Done`, after building the full `plugin-grid` dependency closure. (Before that build, `plugin-grid` reported 60-plus `TS2307 Cannot find module` errors purely from unbuilt sibling `dist/` — stale-`dist` noise, not this diff.)
- Targeted suites: `3 passed (3)`, `45 passed (45)`.
- `pnpm build` (turbo, whole workspace): `43 successful, 43 total`.
- Gates: `check:control-bytes`, `check:new-line-citations`, `check:esm-specifiers`, `check:self-import`, `check:unreferenced-sources`, `check:vi-mock-specifiers`, `check:readme-exports` — all exit 0. `check:readme-exports` first failed with "the population COLLAPSED", which was an unbuilt worktree (`packagesRead: found 13, floor is 25`, "24 unbuilt"), **not** this diff; it passes cleanly on the built tree with `0 unbuilt`.
- Repo-level scans (`pnpm lint`, the full suite, the rest of the 49 `check:*` farm) are left to CI.

## Acceptance notes

- The runtime diagnostic in `reportRetiredSortSpelling` still tells authors "`order` is optional and means `'asc'`". That phrase is false of `@objectstack/spec`, which refuses an entry omitting `order`. objectui#8767's contract review routed this sentence here along with its two docblock twins — the twins are corrected in this PR (comments only), but the **diagnostic string is deliberately left alone**: it is objectui#8758's landed refusal text, reused by #8767's route-C ruling, so rewording it is a behaviour-visible change to a landed refusal rather than a comment fix. Raising it rather than doing it. Noted, not filed.
- `parseSchemaSort` reads three spellings the fetch path now refuses or drops, so a grid authored with a retired spelling still paints an arrow for an ordering its query does not carry. Already objectui#8961. Noted, not filed.
- The export path's `?? 'asc'` passes a garbage direction through where the shared normalizer folds it to `'asc'`. Reachable only from already-invalid metadata, and inside #8767's fenced-off export path. Noted, not filed — successor: whichever card takes the export path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB)_