### PR TITLE
fix(plugin-dashboard,core,plugin-charts): route a structured metric `groupBy` to the spec-shape wire (objectui#8613)

### DIFF
--- a/.changeset/8613-metric-structured-groupby.md
+++ b/.changeset/8613-metric-structured-groupby.md
@@ -1,0 +1,42 @@
+---
+"@object-ui/core": minor
+"@object-ui/plugin-charts": minor
+"@object-ui/plugin-dashboard": minor
+---
+
+fix(plugin-dashboard,core,plugin-charts): route a structured `aggregate.groupBy` on `object-metric` to the spec-shape wire
+
+An authored `aggregate.groupBy` is a union — a bare field name, or the
+structured date-bucketing node `{ field, dateGranularity?, alias? }` — and the
+two need different queries. The spec-shape
+`{ groupBy: GroupByNode[], aggregations, where }` reaches `engine.aggregate` and
+runs the server-side date-bucket engine; the legacy
+`{ field, function, groupBy, filter }` query reaches the cube/analytics wire,
+whose `dimensions` the contract declares as an array of dimension NAMES and
+which does not honour `dateGranularity` at all.
+
+`ObjectChart.runAggregate` has routed between the two since objectui#7946.
+`ObjectMetricWidget.computeOne` had no such branch: it forwarded the authored
+value straight through, so a metric widget carrying a structured node posted
+`dimensions: [{ field: 'closed_at', dateGranularity: 'month' }]` — an object
+where a name is declared. Nothing refused it and nothing reported it, so the
+author asked for one question and the platform answered another (objectui#8613).
+
+- The routing test and the payload are now one function,
+  `objectAggregateSpecQuery` (with `isStructuredGroupBy`) in `@object-ui/core`.
+  `ObjectChart.runAggregate` and `ObjectMetricWidget.computeOne` both call it,
+  so the two renderers cannot post different wires for one authored shape. The
+  measure alias is `chartMeasureKey`'s answer, i.e. what the chart's own
+  `aggregateValueKey` already delegated to — the chart's posted payload is
+  unchanged.
+- `ObjectMetricWidgetProps.aggregate.groupBy` said `string`. That was a claim
+  about the author which nothing upstream backed: the value crosses two `any`
+  seams on the way in, so the declaration refused the node at neither compile
+  time nor runtime. It is now the contract's union, taken by reference through
+  `ObjectChartSchema['aggregate']`.
+
+Unchanged, and pinned as controls: a plain string `groupBy` and an absent one
+(floored at the single `'_all'` bucket) still take the legacy query byte for
+byte, and an ARRAY `groupBy` still travels there too — it is not this union's
+object arm, and it must keep reaching the producer-side refusal objectui#6864
+landed in the adapter.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,11 @@ export * from './utils/chart-measure-key.js';
 // floor the x-axis binding on a literal the aggregate contradicts
 // (objectui#8269).
 export * from './utils/chart-category-key.js';
+// "Which CALL does an object-bound aggregate make when its `groupBy` is the
+// structured date-bucketing node?" — the same move on the REQUEST rather than
+// on a result column, so the chart and the metric cannot post two different
+// wires for one authored shape (objectui#8613).
+export * from './utils/object-aggregate-query.js';
 // The AUTHORED half of a dataset-bound chart (objectui#4229's data/presentation
 // split), shared by the dashboard widget and the report's embedded chart so the
 // same spec keys are lowered identically on both (objectui#4877).

--- a/packages/core/src/utils/object-aggregate-query.test.ts
+++ b/packages/core/src/utils/object-aggregate-query.test.ts
@@ -1,0 +1,96 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `objectAggregateSpecQuery` / `isStructuredGroupBy` — the shared answer to
+ * "which call does an object-bound `aggregate` make when its `groupBy` is the
+ * structured node?" (objectui#8613).
+ *
+ * The payload itself had NO pin before this file: it was spelled inline in
+ * `ObjectChart.runAggregate`, and the chart's structured-`groupBy` tests
+ * (objectui#7946) all observe the RESULT columns — the drill key, the reverse
+ * label map — never the request. So a change to what is posted was invisible to
+ * the suite, which is part of why the metric path could disagree with it for as
+ * long as it did.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isStructuredGroupBy, objectAggregateSpecQuery } from './object-aggregate-query.js';
+
+describe('isStructuredGroupBy', () => {
+  it('says yes to the date-bucketing node', () => {
+    expect(isStructuredGroupBy({ field: 'closed_at', dateGranularity: 'month' })).toBe(true);
+    // `dateGranularity` is optional on the node; the node is still the node.
+    expect(isStructuredGroupBy({ field: 'closed_at' })).toBe(true);
+  });
+
+  it('says no to the union`s STRING arm, and to absence', () => {
+    expect(isStructuredGroupBy('stage')).toBe(false);
+    expect(isStructuredGroupBy('')).toBe(false);
+    expect(isStructuredGroupBy(undefined)).toBe(false);
+    expect(isStructuredGroupBy(null)).toBe(false);
+  });
+
+  it('says no to an ARRAY, which is an object but not this arm', () => {
+    // The adapter's own `looksLikeSpecShape` already treats an array `groupBy`
+    // as the spec shape and refuses the analytics keys beside it
+    // (objectui#6864). Answering `true` here would wrap it a second time.
+    expect(isStructuredGroupBy(['stage'])).toBe(false);
+    expect(isStructuredGroupBy([])).toBe(false);
+  });
+});
+
+describe('objectAggregateSpecQuery', () => {
+  const MONTHLY = { field: 'closed_at', dateGranularity: 'month' } as const;
+
+  it('projects the measure under the contract`s own value column', () => {
+    expect(objectAggregateSpecQuery({ field: 'amount', function: 'sum' }, MONTHLY, undefined))
+      .toEqual({
+        groupBy: [MONTHLY],
+        aggregations: [{ function: 'sum', alias: 'amount', field: 'amount' }],
+        where: undefined,
+      });
+  });
+
+  it('omits `field` for a count, and aliases a FIELDLESS count `count`', () => {
+    expect(objectAggregateSpecQuery({ function: 'count' }, MONTHLY, undefined))
+      .toEqual({
+        groupBy: [MONTHLY],
+        aggregations: [{ function: 'count', alias: 'count' }],
+        where: undefined,
+      });
+  });
+
+  it('omits `field` for a count that NAMES one, keeping the field as the alias', () => {
+    // `count(*)` either way — the relays default `field: 'value'` for a widget
+    // with no measure column, and `count(value)` is a driver error. The alias
+    // still follows the field, because that is the column the caller's readback
+    // and any series binding name.
+    const q = objectAggregateSpecQuery({ field: 'id', function: 'count' }, MONTHLY, undefined);
+    expect(q.aggregations).toEqual([{ function: 'count', alias: 'id' }]);
+  });
+
+  it('forwards the node VERBATIM, `alias` and all', () => {
+    // The projected group column is the node's `alias` when it declares one.
+    // Rebuilding the node instead of forwarding it would drop the member and
+    // key every result row wrong.
+    const aliased = { field: 'closed_at', dateGranularity: 'quarter', alias: 'q' } as const;
+    expect(objectAggregateSpecQuery({ field: 'amount', function: 'avg' }, aliased, undefined).groupBy)
+      .toEqual([aliased]);
+  });
+
+  it('puts the filter in `where`, the spec Query DSL`s position — never `filter`', () => {
+    // `filter` is the ANALYTICS branch's key. A spec-shape query carrying it is
+    // refused by the adapter rather than silently dropped (objectui#6864), so
+    // the position is load-bearing and not a rename.
+    const where = { stage: { $ne: 'closed' } };
+    const q = objectAggregateSpecQuery({ field: 'amount', function: 'sum' }, MONTHLY, where);
+    expect(q.where).toBe(where);
+    expect(Object.keys(q).sort()).toEqual(['aggregations', 'groupBy', 'where']);
+  });
+});

--- a/packages/core/src/utils/object-aggregate-query.ts
+++ b/packages/core/src/utils/object-aggregate-query.ts
@@ -1,0 +1,132 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * object-aggregate-query — the ONE answer to "which CALL does an object-bound
+ * `aggregate` make when its authored `groupBy` is the structured node?"
+ * (objectui#8613).
+ *
+ * ## The two wires, and why the choice is not cosmetic
+ *
+ * An authored `aggregate.groupBy` is a union: a bare field name, or the
+ * structured date-bucketing node `{ field, dateGranularity?, alias? }` — the
+ * union `ChartGroupBySchema` declares and `GroupByNodeSchema` (the query AST)
+ * mirrors. The adapter routes on the SHAPE of the params it is handed, not on
+ * the shape of the authored value:
+ *
+ *   - `{ groupBy: GroupByNode[], aggregations, where }` — the spec-shape query,
+ *     which reaches `engine.aggregate` and runs the server-side date-bucket
+ *     engine;
+ *   - `{ field, function, groupBy, filter }` — the legacy cube/analytics query,
+ *     whose `dimensions` the contract declares as an array of dimension NAMES
+ *     and which does NOT honour `dateGranularity` at all.
+ *
+ * So a structured node forwarded on the legacy wire is posted as a dimension
+ * OBJECT where a name is declared: the author asks for monthly buckets and the
+ * platform answers a different question, with no diagnostic on the way. That is
+ * the defect objectui#8613 records on the metric path, and it was reachable
+ * there only because this payload was spelled INSIDE one renderer
+ * (`ObjectChart.runAggregate`) rather than anywhere a second renderer could
+ * reuse it.
+ *
+ * ## Why a shared module rather than a second copy
+ *
+ * The alternative was to transcribe the eight lines into the metric widget.
+ * That is the objectui#5042 / #7544 / #8193 / #8266 / #8269 drift shape — a
+ * second opinion of one question, with nothing keeping the two in agreement —
+ * and it is the same shape those cards' fixes (`chartMeasureKey`,
+ * `chartCategoryKey`) exist to end, one column at a time. This module is that
+ * move applied to the REQUEST rather than to a result column.
+ *
+ * ## What is NOT here
+ *
+ * The legacy bag itself. The two renderers do not agree on it and should not be
+ * made to: a chart passes the authored `groupBy` through untouched, while a
+ * metric floors an absent one at `'_all'` (one bucket) because it paints a
+ * single number. Folding that difference into a shared builder would put a
+ * renderer's own default into a module that has no business holding one, so the
+ * shared part stops exactly where the agreement stops.
+ */
+
+import type { ChartGroupBy } from '@objectstack/spec/ui';
+import { chartMeasureKey, type ChartAggregateLike } from './chart-measure-key.js';
+
+/**
+ * The STRUCTURED arm of the contract's `groupBy` union — the date-bucketing
+ * node, as distinct from the bare field name the same union admits.
+ *
+ * Extracted from `ChartGroupBy` rather than restated, so a member added to the
+ * node upstream (as `alias` once was) arrives here without an edit.
+ */
+export type StructuredGroupBy = Extract<ChartGroupBy, { field: string }>;
+
+/**
+ * The spec-shape aggregate query's `aggregations[]` entry, as
+ * `AggregationNodeSchema` declares it: `alias` is REQUIRED (it names the column
+ * the measure is projected under), `field` is optional because a `count` counts
+ * rows rather than a column.
+ */
+export interface ObjectAggregationNode {
+  function?: string;
+  alias: string;
+  field?: string;
+}
+
+/** The spec-shape query body — `{ groupBy: GroupByNode[], aggregations, where }`. */
+export interface ObjectAggregateSpecQuery {
+  groupBy: StructuredGroupBy[];
+  aggregations: ObjectAggregationNode[];
+  where: unknown;
+}
+
+/**
+ * Is this authored `aggregate.groupBy` the structured node rather than a bare
+ * field name?
+ *
+ * ⚠️ An ARRAY answers `false`. It is an object, but it is not this union's
+ * object arm — neither `ChartGroupBySchema` nor `ObjectMetricPropsSchema`'s
+ * `aggregate` admits one at this position, and `data-objectstack`'s adapter
+ * already refuses it at the wire (objectui#6864). Letting it through here would
+ * wrap it into `groupBy: [[…]]` and turn a producer-side refusal into a
+ * malformed query.
+ */
+export function isStructuredGroupBy(groupBy: unknown): groupBy is StructuredGroupBy {
+  return !!groupBy && typeof groupBy === 'object' && !Array.isArray(groupBy);
+}
+
+/**
+ * The spec-shape aggregate query for an object-bound `aggregate` whose
+ * `groupBy` is the structured node.
+ *
+ * The measure is projected under {@link chartMeasureKey}'s answer — the raw
+ * field name, or the literal `'count'` for a fieldless count — so a caller's
+ * existing result readback finds the value under the key it already looks for,
+ * and a chart's series binding names the column the rows actually carry.
+ *
+ * `field` is omitted for `count` so the engine emits `count(*)`: the dashboard
+ * relays default `field: 'value'` for a widget with no explicit measure column,
+ * and `count(value)` crashes SQL drivers with "no such column: value" on the
+ * count-the-rows case that is the common one.
+ *
+ * @param aggregate the authored inline aggregate
+ * @param groupBy   its `groupBy`, already narrowed by {@link isStructuredGroupBy}
+ * @param where     the resolved filter, in the spec Query DSL's `where` position
+ */
+export function objectAggregateSpecQuery(
+  aggregate: ChartAggregateLike,
+  groupBy: StructuredGroupBy,
+  where: unknown,
+): ObjectAggregateSpecQuery {
+  const aggFn = aggregate.function;
+  const node: ObjectAggregationNode = {
+    function: aggFn,
+    alias: chartMeasureKey(aggregate, aggFn || 'count'),
+  };
+  if (aggFn !== 'count' && aggregate.field) node.field = aggregate.field;
+  return { groupBy: [groupBy], aggregations: [node], where };
+}

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useContext, useCallback, useMemo } from 're
 import { useDataScope, SchemaRendererContext, SchemaRenderer, useDrillNavigation, useFilterScope, ElementDataSourceGate, type ElementDataSourceMapping } from '@object-ui/react';
 import { ChartRenderer } from './ChartRenderer';
 import { normalizeChartSchema } from './normalizeChartSchema';
-import { ComponentRegistry, chartMeasureKey, humanizeLabel, extractRecords, computeDrillFilter, composeDrillFilter, isDrillEnabled, resolveDrillTitle, resolveFilterPlaceholders, resolveContextTokens, shiftFilterByCompareTo, compareToTrendLabelKey, buildChartSeries, buildOptionColorMap, deriveDimensionLabelMaps, dimensionOptionTranslator, loadDimensionFieldMeta, relabelDimensions, localizeFieldOptions, elementDataSourceBlock, type DimensionFieldMeta, type CompareToConfig, type DrillEvent, type ChartResultField, type ChartSegmentClickEvent } from '@object-ui/core';
+import { ComponentRegistry, chartMeasureKey, isStructuredGroupBy, objectAggregateSpecQuery, humanizeLabel, extractRecords, computeDrillFilter, composeDrillFilter, isDrillEnabled, resolveDrillTitle, resolveFilterPlaceholders, resolveContextTokens, shiftFilterByCompareTo, compareToTrendLabelKey, buildChartSeries, buildOptionColorMap, deriveDimensionLabelMaps, dimensionOptionTranslator, loadDimensionFieldMeta, relabelDimensions, localizeFieldOptions, elementDataSourceBlock, type DimensionFieldMeta, type CompareToConfig, type DrillEvent, type ChartResultField, type ChartSegmentClickEvent } from '@object-ui/core';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, Dialog, DialogContent, DialogHeader, DialogTitle, RefreshIndicator, Button, ChartSkeleton, DataEmptyState } from '@object-ui/components';
 import { AlertCircle, ArrowUpRight, Inbox } from 'lucide-react';
 import { builtinAggregateLabels, useSafeFieldLabel, useSafeTranslate, useObjectTranslation, pickLocalized } from '@object-ui/i18n';
@@ -674,26 +674,19 @@ export const ObjectChart = (props: ObjectChartProps) => {
       // where }` payload so the server-side date-bucket engine kicks in.
       // The legacy `{ field, function, groupBy, filter }` cube/analytics
       // path does NOT honour `dateGranularity`.
-      const isStructured = gb && typeof gb === 'object' && !Array.isArray(gb);
-      if (isStructured) {
-        const aggField = schema.aggregate.field;
-        const aggFn = schema.aggregate.function;
-        // Project the measure under its plain field name so downstream
-        // (xAxisKey + series.dataKey lookups) finds it unchanged — the
-        // object-bound result-column convention (framework#3701).
-        const alias = aggregateValueKey(schema.aggregate);
-        // For `count`, omit `field` so the engine emits `count(*)` /
-        // `COUNT(*)`. The upstream dashboard wiring defaults `field: 'value'`
-        // for charts without an explicit valueField, which crashes on SQL
-        // drivers ("no such column: value") since dashboards typically
-        // count rows, not a measure column.
-        const aggregationNode: Record<string, unknown> = { function: aggFn, alias };
-        if (aggFn !== 'count' && aggField) aggregationNode.field = aggField;
-        const results = await ds.aggregate(schema.objectName, {
-          groupBy: [gb],
-          aggregations: [aggregationNode],
-          where: filterForRun,
-        });
+      //
+      // Both halves — the test and the payload — now live in
+      // `objectAggregateSpecQuery` (`@object-ui/core`, objectui#8613), because
+      // the metric family needs the identical call and a transcription there
+      // was the second opinion that let the two wires disagree. The alias it
+      // projects is `chartMeasureKey`'s answer, i.e. what `aggregateValueKey`
+      // above already delegates to, so the column this branch produces is
+      // unchanged.
+      if (isStructuredGroupBy(gb)) {
+        const results = await ds.aggregate(
+          schema.objectName,
+          objectAggregateSpecQuery(schema.aggregate, gb, filterForRun),
+        );
         return Array.isArray(results) ? results : [];
       }
       const results = await ds.aggregate(schema.objectName, {

--- a/packages/plugin-dashboard/src/ObjectMetricWidget.tsx
+++ b/packages/plugin-dashboard/src/ObjectMetricWidget.tsx
@@ -8,8 +8,8 @@
 
 import React, { useState, useEffect, useContext, useCallback, useMemo } from 'react';
 import { SchemaRendererContext, useFilterScope } from '@object-ui/react';
-import { isDrillEnabled, resolveDrillTitle } from '@object-ui/core';
-import type { DrillDownConfig, I18nLabel } from '@object-ui/types';
+import { isDrillEnabled, resolveDrillTitle, isStructuredGroupBy, objectAggregateSpecQuery } from '@object-ui/core';
+import type { DrillDownConfig, I18nLabel, ObjectChartSchema } from '@object-ui/types';
 import { useLocalization, resolveFieldCurrency, useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import { MetricWidget } from './MetricWidget';
 import { DrillDownDrawer } from './DrillDownDrawer';
@@ -48,8 +48,32 @@ const METRIC_DRILL_PAGE_SIZE = 25;
 export interface ObjectMetricWidgetProps {
   /** The object/resource name to query */
   objectName: string;
-  /** Aggregation config (field, function, groupBy) */
-  aggregate?: { field: string; function: string; groupBy?: string };
+  /**
+   * Aggregation config (field, function, groupBy).
+   *
+   * `groupBy` is the contract's own union — BY REFERENCE through
+   * `ObjectChartSchema['aggregate']`, which holds `ChartAggregate` from
+   * `@objectstack/spec/ui` by reference in turn, never a local near-copy of it
+   * (`check:spec-symbols`). It is the same authored key both dashboard relays
+   * compose for the `object-metric` and the `object-chart` node out of one
+   * provider block, so a second spelling here could only be a way for the two
+   * to disagree.
+   *
+   * It used to say `string`, which was a claim about the AUTHOR that nothing
+   * upstream backed: the value crosses two `any` seams on its way in
+   * (`isObjectProvider` narrows the widget data to `aggregate?: any`, and
+   * `computeOne` takes the datasource untyped), so the declaration refused the
+   * structured `{ field, dateGranularity }` node at neither compile time nor
+   * runtime — it merely hid it from the reader, and from anyone asking whether
+   * `computeOne` handled it (objectui#8613). Optional here, unlike the chart's,
+   * because a metric paints ONE number and floors an absent `groupBy` at
+   * `'_all'`.
+   */
+  aggregate?: {
+    field: string;
+    function: string;
+    groupBy?: NonNullable<ObjectChartSchema['aggregate']>['groupBy'];
+  };
   /** Filter conditions */
   filter?: any;
   /**
@@ -252,12 +276,31 @@ export const ObjectMetricWidget: React.FC<ObjectMetricWidgetProps> = ({
   // between the current-period and comparison-period queries.
   const computeOne = useCallback(async (ds: any, filterForRun: any): Promise<number | string | null> => {
     if (aggregate && typeof ds.aggregate === 'function') {
-      const results = await ds.aggregate(objectName, {
-        field: aggregate.field,
-        function: aggregate.function,
-        groupBy: aggregate.groupBy || '_all',
-        filter: filterForRun,
-      });
+      const groupBy = aggregate.groupBy;
+      // Two authored `groupBy` shapes, two wires — the SAME routing the chart
+      // family has had since objectui#7946, shared out of `@object-ui/core` so
+      // there is one answer rather than two (objectui#8613).
+      //
+      // A structured node (`{ field, dateGranularity }`) needs the spec-shape
+      // `{ groupBy: GroupByNode[], aggregations, where }` query, because that
+      // is the one the server's date-bucket engine runs. Forwarded on the
+      // legacy bag below it became `dimensions: [ <the node> ]` on the
+      // analytics wire, where the contract declares dimension NAMES and
+      // `dateGranularity` is not honoured at all: the author asked for monthly
+      // buckets and got a different question answered, silently.
+      //
+      // The readback below is unchanged and needs no branch of its own: the
+      // measure is projected under `chartMeasureKey`'s alias — the raw `field`,
+      // or the literal `'count'` for a fieldless count — and both are limbs the
+      // two chains already try (`row[field]`, `r.count`).
+      const results = isStructuredGroupBy(groupBy)
+        ? await ds.aggregate(objectName, objectAggregateSpecQuery(aggregate, groupBy, filterForRun))
+        : await ds.aggregate(objectName, {
+            field: aggregate.field,
+            function: aggregate.function,
+            groupBy: groupBy || '_all',
+            filter: filterForRun,
+          });
       const data = Array.isArray(results) ? results : [];
       if (data.length === 0) return 0;
       if (aggregate.function === 'count') {

--- a/packages/plugin-dashboard/src/__tests__/objectMetricStructuredGroupBy-8613.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/objectMetricStructuredGroupBy-8613.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8613 — an authored structured `aggregate.groupBy` on an
+ * `object-metric` reaches the SPEC-SHAPE wire, not the analytics one.
+ *
+ * ## The defect, stated so an ablation reads cleanly
+ *
+ * `aggregate.groupBy` is a union: a bare field name, or the structured
+ * date-bucketing node `{ field, dateGranularity?, alias? }`. The two need
+ * DIFFERENT wires, and the adapter picks by the shape of the params it is
+ * handed rather than by the shape of the authored value:
+ *
+ *   - `{ groupBy: GroupByNode[], aggregations, where }` reaches
+ *     `engine.aggregate` and runs the server-side date-bucket engine;
+ *   - `{ field, function, groupBy, filter }` reaches the cube/analytics wire,
+ *     whose `dimensions` the contract declares as an array of dimension NAMES
+ *     and which does not honour `dateGranularity` at all.
+ *
+ * `ObjectChart.runAggregate` has routed between them since objectui#7946.
+ * `ObjectMetricWidget.computeOne` had no such branch: it forwarded the authored
+ * value straight through, so the node was posted as
+ * `dimensions: [{ field: 'closed_at', dateGranularity: 'month' }]` — an OBJECT
+ * where a name is declared. Nothing refused it and nothing said so; the author
+ * asked for monthly buckets and the platform answered a different question.
+ *
+ * ## Why the assertions are on the POSTED BODY
+ *
+ * The symptom is not a visible one — that is the whole complaint. A test that
+ * asserted "the card no longer shows a wrong number" would pass on a metric
+ * whose number happens to be right for the wrong reason, and every version of
+ * this defect paints SOME number. So the oracle is what reaches the wire: the
+ * whole options bag, by `toEqual`, so a member silently added to or dropped
+ * from the call is red in either direction — the convention
+ * `objectMetricQueryMembers-8071.test.tsx` set for this same call.
+ *
+ * ## ⭐ The controls are load-bearing, not decoration
+ *
+ * A repair that routed EVERYTHING through the spec-shape query would satisfy
+ * every "the bad shape is gone" assertion while breaking the ordinary metric —
+ * the one authoring shape that is actually shipped. So the plain string
+ * `groupBy`, the absent one (`'_all'`), and the fieldless-count readback are
+ * pinned here at the same fidelity, and they must stay green on BOTH ablation
+ * legs. The array case is the third boundary: it is not this union's object arm
+ * and must keep travelling to the producer-side refusal objectui#6864 landed in
+ * the adapter, rather than being wrapped into a `groupBy: [[…]]` nobody can
+ * refuse.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+// Registers `object-metric` at MODULE scope, never inside a hook —
+// object-ui/no-dynamic-import-in-test-hook.
+import '../index';
+
+afterEach(cleanup);
+
+type Params = Record<string, unknown>;
+
+/** An adapter that can aggregate — the only path this file exercises. */
+const aggregatingAdapter = (rows: Record<string, unknown>[]) => ({
+  aggregate: vi.fn(async (_object: string, _params: Params) => rows),
+  find: vi.fn(async (_object: string, _params: Params) => ({ data: [] as unknown[] })),
+});
+
+const mount = (schema: Record<string, unknown>, adapter: unknown) =>
+  render(
+    <SchemaRendererProvider dataSource={adapter as never}>
+      <SchemaRenderer schema={{ type: 'object-metric', label: 'Pipeline', ...schema } as never} />
+    </SchemaRendererProvider>,
+  );
+
+/** The options bag of the first `aggregate()` call. */
+const bagOf = (adapter: ReturnType<typeof aggregatingAdapter>): Params =>
+  adapter.aggregate.mock.calls[0][1];
+
+/** A predicate already in filter-AST form, so no lowering is in play. */
+const OPEN = { stage: { $ne: 'closed' } };
+
+/** The authored date-bucketing node, in the spelling `ChartGroupBySchema` admits. */
+const MONTHLY = { field: 'closed_at', dateGranularity: 'month' };
+
+describe('object-metric — a structured `aggregate.groupBy` takes the spec-shape wire (objectui#8613)', () => {
+  it('posts `{ groupBy: [node], aggregations, where }` — and none of the analytics keys', async () => {
+    const adapter = aggregatingAdapter([{ closed_at: '2026-01-01', amount: 120 }]);
+    mount(
+      {
+        objectName: 'deal',
+        aggregate: { field: 'amount', function: 'sum', groupBy: MONTHLY },
+        filter: OPEN,
+      },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalled());
+    expect(adapter.aggregate.mock.calls[0][0]).toBe('deal');
+    // The WHOLE bag. `alias` is REQUIRED by `AggregationNodeSchema` and names
+    // the column the measure comes back under; the node itself travels
+    // VERBATIM, which is what carries `dateGranularity` to the engine.
+    expect(bagOf(adapter)).toEqual({
+      groupBy: [MONTHLY],
+      aggregations: [{ function: 'sum', alias: 'amount', field: 'amount' }],
+      where: OPEN,
+    });
+    // Spelled out separately: the pre-fix call carried these three and no
+    // `aggregations` at all, and a bag that grew the spec keys while KEEPING
+    // the analytics ones is a third, worse state — the adapter refuses that
+    // combination outright (objectui#6864).
+    expect(Object.keys(bagOf(adapter)).sort()).toEqual(['aggregations', 'groupBy', 'where']);
+  });
+
+  it('omits `field` on a count so the engine emits `count(*)`', async () => {
+    // The dashboard relays default `field: 'value'` for a widget with no
+    // explicit measure column, and `count(value)` is "no such column: value" on
+    // a SQL driver. The alias is then the literal `'count'`.
+    const adapter = aggregatingAdapter([{ closed_at: '2026-01-01', count: 7 }]);
+    mount(
+      { objectName: 'deal', aggregate: { function: 'count', groupBy: MONTHLY } },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalled());
+    expect(bagOf(adapter)).toEqual({
+      groupBy: [MONTHLY],
+      aggregations: [{ function: 'count', alias: 'count' }],
+      where: undefined,
+    });
+    expect(Object.keys((bagOf(adapter).aggregations as Params[])[0])).not.toContain('field');
+  });
+
+  it('carries the node`s own `alias` through untouched', async () => {
+    // `alias` renames the projected GROUP column. It is the author's, not the
+    // renderer's, so a builder that rebuilt the node instead of forwarding it
+    // would drop it — and every row key would then be wrong.
+    const aliased = { field: 'closed_at', dateGranularity: 'quarter', alias: 'q' };
+    const adapter = aggregatingAdapter([{ q: '2026-Q1', amount: 5 }]);
+    mount(
+      { objectName: 'deal', aggregate: { field: 'amount', function: 'avg', groupBy: aliased } },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalled());
+    expect(bagOf(adapter).groupBy).toEqual([aliased]);
+  });
+
+  it('reads the bucketed rows back under the alias it asked for', async () => {
+    // The request half is only half the contract: the measure comes back under
+    // `chartMeasureKey`'s answer, and the existing readback has to find it
+    // there. Two rows, `sum` — so the first bucket is the answer and a readback
+    // that summed them would say 320.
+    const adapter = aggregatingAdapter([
+      { closed_at: '2026-01-01', amount: 120 },
+      { closed_at: '2026-02-01', amount: 200 },
+    ]);
+    mount(
+      { objectName: 'deal', aggregate: { field: 'amount', function: 'sum', groupBy: MONTHLY } },
+      adapter,
+    );
+
+    expect(await screen.findByText('120')).toBeTruthy();
+    expect(screen.queryByText('320')).toBeNull();
+  });
+
+  it('sums a fieldless count back across EVERY bucket, under the `count` alias', async () => {
+    const adapter = aggregatingAdapter([
+      { closed_at: '2026-01-01', count: 3 },
+      { closed_at: '2026-02-01', count: 4 },
+    ]);
+    mount({ objectName: 'deal', aggregate: { function: 'count', groupBy: MONTHLY } }, adapter);
+
+    expect(await screen.findByText('7')).toBeTruthy();
+  });
+});
+
+describe('object-metric — the shapes that must NOT move (objectui#8613 controls)', () => {
+  it('CONTROL — a plain string `groupBy` still takes the legacy analytics bag', async () => {
+    const adapter = aggregatingAdapter([{ amount_sum: 120 }]);
+    mount(
+      {
+        objectName: 'deal',
+        aggregate: { field: 'amount', function: 'sum', groupBy: 'stage' },
+        filter: OPEN,
+      },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalled());
+    expect(bagOf(adapter)).toEqual({
+      field: 'amount',
+      function: 'sum',
+      groupBy: 'stage',
+      filter: OPEN,
+    });
+  });
+
+  it('CONTROL — an absent `groupBy` still floors at the single `_all` bucket', async () => {
+    const adapter = aggregatingAdapter([{ amount_sum: 120 }]);
+    mount({ objectName: 'deal', aggregate: { field: 'amount', function: 'sum' } }, adapter);
+
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalled());
+    expect(bagOf(adapter)).toEqual({
+      field: 'amount',
+      function: 'sum',
+      groupBy: '_all',
+      filter: undefined,
+    });
+  });
+
+  it('BOUNDARY — an ARRAY `groupBy` is not this union`s object arm and is not wrapped', async () => {
+    // It travels on the legacy bag exactly as before, where the adapter's own
+    // `looksLikeSpecShape` picks it up and refuses it at the producer
+    // (objectui#6864). Wrapping it here would produce `groupBy: [[…]]` — a
+    // query no gate is written to refuse.
+    const adapter = aggregatingAdapter([{ amount_sum: 120 }]);
+    mount(
+      {
+        objectName: 'deal',
+        aggregate: { field: 'amount', function: 'sum', groupBy: ['stage'] },
+      },
+      adapter,
+    );
+
+    await waitFor(() => expect(adapter.aggregate).toHaveBeenCalled());
+    expect(bagOf(adapter)).toEqual({
+      field: 'amount',
+      function: 'sum',
+      groupBy: ['stage'],
+      filter: undefined,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #8613

## What was wrong

An authored `aggregate.groupBy` is a union: a bare field name, or the structured
date-bucketing node `{ field, dateGranularity?, alias? }`. The two need
different queries, and the adapter picks by the shape of the params it is handed
rather than by the shape of the authored value:

| query | route | honours `dateGranularity` |
| --- | --- | --- |
| `{ groupBy: GroupByNode[], aggregations, where }` | `engine.aggregate` | yes |
| `{ field, function, groupBy, filter }` | cube / analytics | no |

`ObjectChart.runAggregate` has routed between the two since objectui#7946.
`ObjectMetricWidget.computeOne` had no such branch — it forwarded the authored
value straight through — so a metric widget carrying a structured node posted
`dimensions: [ THE-NODE ]` on the analytics wire, where the contract declares an
array of dimension NAMES. Nothing refused it and nothing reported it: the author
asked for monthly buckets and the platform answered a different question.

(Placeholders are written as capitalised words rather than in angle brackets on
purpose — GitHub's body sanitiser eats tag-shaped spans, including inside code
spans and fenced blocks.)

## What changed

- **`@object-ui/core` — new `object-aggregate-query.ts`.** `isStructuredGroupBy`
  plus `objectAggregateSpecQuery`: the ONE answer to "which call does an
  object-bound aggregate make when its `groupBy` is the structured node?" Both
  renderers now call it, so they cannot post two different wires for one
  authored shape. This is the `chartMeasureKey` / `chartCategoryKey` move
  (objectui#8266, objectui#8269) applied to the REQUEST rather than to a result
  column.
- **`plugin-charts/ObjectChart.tsx`** — `runAggregate`'s inline structured
  branch becomes a call to it. The alias it projects is `chartMeasureKey`'s
  answer, which is exactly what the file's own `aggregateValueKey` already
  delegated to, so **the chart's posted payload is unchanged**.
- **`plugin-dashboard/ObjectMetricWidget.tsx`** — `computeOne` gains the branch.
  The result readback is untouched and needs none: the measure comes back under
  the alias, which is the raw `field` (or the literal `count` for a fieldless
  count), and both are limbs the two existing chains already try.
- **The declaration.** `ObjectMetricWidgetProps.aggregate.groupBy` said
  `string`. That was a claim about the author which nothing upstream backed: the
  value crosses two `any` seams on the way in (`isObjectProvider` narrows the
  widget data to `aggregate?: any`, and `computeOne` takes the datasource
  untyped), so it refused the node at neither compile time nor runtime. It is
  now the contract's union, taken BY REFERENCE through
  `ObjectChartSchema['aggregate']`, never a local near-copy
  (`check:spec-symbols`).

## The floor this had to clear

The ruling on the card was a floor plus a ranking: it must stop being *silently*
wrong; prefer routing if the chart's existing structured branch is reusable as a
bounded change, otherwise refuse prescriptively. Routing was reusable — the
branch reads only `aggregate.field`, `aggregate.function`, the node and the
filter, with no chart-specific state — so this takes the preferred route and
completes a contract the platform already implemented one block over.

⚠️ Refusing would additionally have been the wrong shape here, and the installed
spec says why: `ObjectMetricPropsSchema.aggregate` is `z.unknown()`, so the
producer neither admits nor refuses this key — there is no contract statement to
refuse *on behalf of*. Refusing in the renderer what the producer is silent
about is the renderer-side dialect AGENTS.md §5 #0.1 rules out.

## Tests

`packages/plugin-dashboard/src/__tests__/objectMetricStructuredGroupBy-8613.test.tsx`
drives the registered `object-metric` block against a stubbed data source and
asserts **what reaches the wire** — the whole options bag by `toEqual`, so a
member silently added or dropped is red in either direction. The symptom is
invisible by construction (every version of this defect paints *some* number),
so "the bad shape is gone" was not available as an oracle.

Three controls, which must stay green on both ablation legs, because a repair
that routed *everything* through the spec-shape query would satisfy every
positive assertion while breaking the one authoring shape that is actually
shipped:

- a plain string `groupBy` still takes the legacy query byte for byte;
- an absent `groupBy` still floors at the single `_all` bucket;
- an ARRAY `groupBy` still travels on the legacy query — it is not this union's
  object arm, and it must keep reaching the producer-side refusal
  objectui#6864 landed in the adapter, rather than being wrapped into a doubly
  nested `groupBy` nobody is written to refuse.

`packages/core/src/utils/object-aggregate-query.test.ts` pins the builder
directly. Worth noting: **the posted payload had no pin at all before this PR.**
objectui#7946's chart tests all observe the RESULT columns (the drill key, the
reverse label map), never the request — which is part of why the metric path
could disagree with the chart for as long as it did.

## Measurements taken against `origin/main`, not inherited from the card

- The card's `path:line` anchors are stale, as expected. Re-derived by symbol:
  `computeOne` and the props interface have both moved since `ce45a0306`
  (objectui#8999's shared-drawer reroute landed in between). No line citation in
  this diff.
- Wire shapes verified against the **installed** `@objectstack/spec@17.4.0`, not
  the card's quotation: `GroupByNodeSchema` is `string` or
  `{ field, dateGranularity?, alias? }`; `AggregationNodeSchema` requires
  `alias`; `AnalyticsQuerySchema.dimensions` is an array of plain strings.
- Both `any` seams the card names are still present, unchanged.
- Reachability re-measured and **still latent**: over 6981 tracked
  `.json/.ts/.tsx/.mdx/.md/.yaml/.yml` files, 34 mention `dateGranularity` (lit
  control on the same command shape: 226 files mention `groupBy`). Intersecting
  those 34 with the 115 files naming a metric widget leaves changelogs, one
  docs table, the dataset widget and its test — no shipped app metadata declares
  a structured `aggregate.groupBy` on a metric widget. Nothing here upgrades the
  card's severity claim.

Verification status is recorded in a follow-up comment on this PR.

Session: `session_01MPaVWWMuWeT5LgB1qoXjVB`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB


---
_Generated by [Claude Code](https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB)_