### PR TITLE
fix(types)!: narrow the body-wide `record:details` `columns` to the spec's string enum

### DIFF
--- a/.changeset/8604-record-details-columns-enum.md
+++ b/.changeset/8604-record-details-columns-enum.md
@@ -1,0 +1,46 @@
+---
+'@object-ui/types': minor
+---
+
+**BREAKING** — the body-wide `RecordDetailsComponentProps.columns` is the
+contract's string enum, not a number.
+
+**FROM** `columns: 2` **TO** `columns: '2'`.
+
+```ts
+// before — compiled here, refused at publish
+const props: RecordDetailsComponentProps = { columns: 2 };
+// after
+const props: RecordDetailsComponentProps = { columns: '2' };
+```
+
+`@objectstack/spec` declares the top-level key as
+`z.enum(['1','2','3','4']).default('2')` — a closed set of **string** literals.
+This type declared `columns?: number`, the wrong primitive type rather than
+merely a wider range, so `{ columns: 2 }` type-checked locally and the contract
+refused it at publish with `invalid_value` at `columns`. Measured on the
+installed pin, `@objectstack/spec` 17.4.0, against a control that fires on the
+same instrument: `{ columns: '2' }` parses green and its value survives; the
+declaration is byte-identical to the 17.3.0 the card was filed against.
+Contract-first (Commandment #0.1): the code moves to the contract's spelling,
+and the spec is not widened.
+
+⚠️ `sections[].columns` one level down is **unchanged and stays `number`**. The
+per-section key is `z.number().int().min(1).max(4)`, so a section takes `2` and
+refuses `'2'` — exactly inverting the body-wide key. The same word names two
+different types one level apart, which is why this is not a sweep: copying
+either declaration onto the other is refused at publish, in one direction or
+the other. Both levels, and their non-equality, are pinned against the installed
+spec in `record-details-columns-8604.test.ts`.
+
+⚠️ The census behind this narrowing covers this repository only: one in-repo
+call site wrote the number (`p1-spec-alignment.test.ts`), and it is corrected in
+the same change. A TypeScript consumer of `@object-ui/types` outside this repo
+that wrote `columns: 2` is not observable from here and gets a compile error
+(TS2322) naming the key — which is why the FROM/TO is spelled out above. Nothing
+to migrate at runtime: the renderer passes the authored value straight through,
+and the registry manifest (`@object-ui/plugin-detail`) already published this
+key as `type: 'enum', enum: ['1','2','3','4']`, so the published TypeScript face
+was the only layer that disagreed.
+
+objectui#8604.

--- a/packages/types/src/__tests__/p1-spec-alignment.test.ts
+++ b/packages/types/src/__tests__/p1-spec-alignment.test.ts
@@ -526,8 +526,15 @@ describe('P1.4 Page Composition Spec Alignment', () => {
 // ============================================================================
 describe('P1.5 Record Components', () => {
   it('should define RecordDetailsComponentProps', () => {
+    // `columns` is the STRING `'2'`, not the number, since objectui#8604: the
+    // contract declares the body-wide key as `z.enum(['1','2','3','4'])` and
+    // refuses `2` with `invalid_value`. The number spelling this literal
+    // carried compiled here and was refused at publish — the exact defect the
+    // card was filed for. `sections[].columns` one level down keeps `number`
+    // (`z.number().int().min(1).max(4)`); the two are pinned side by side in
+    // `record-details-columns-8604.test.ts`.
     const props: RecordDetailsComponentProps = {
-      columns: 2,
+      columns: '2',
       layout: 'stacked',
       sections: [
         { label: 'Basic Info', fields: ['name', 'email', 'phone'], collapsible: true },
@@ -536,7 +543,7 @@ describe('P1.5 Record Components', () => {
       fields: ['name', 'email'],
       aria: { ariaLabel: 'Account Details' },
     };
-    expect(props.columns).toBe(2);
+    expect(props.columns).toBe('2');
     expect(props.sections).toHaveLength(2);
     expect(props.layout).toBe('stacked');
   });

--- a/packages/types/src/__tests__/record-details-columns-8604.test.ts
+++ b/packages/types/src/__tests__/record-details-columns-8604.test.ts
@@ -1,0 +1,196 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8604 — the BODY-WIDE `RecordDetailsComponentProps.columns` is the
+ * contract's string enum, and `sections[].columns` one level down is still a
+ * number. One word, two types, one level apart.
+ *
+ * The defect: this package declared the top-level key as `columns?: number`,
+ * while `@objectstack/spec` declares it `z.enum(['1','2','3','4'])`. So
+ * `{ columns: 2 }` type-checked here and was refused at publish with
+ * `invalid_value` — a green local build and a rejection at the only point that
+ * matters. Direction is contract-first (Commandment #0.1, and triage's ruling
+ * on the card): the code moves to the contract, the contract is not widened.
+ *
+ * ⚠️ The near-miss this file exists to make un-repeatable: `sections[].columns`
+ * is `z.number().int().min(1).max(4)`, so `number` is CORRECT there — verified
+ * key-for-key on objectui#8583 / PR #8601. A fix that copied either
+ * declaration onto the other would be refused at publish in the opposite
+ * direction. Both levels are pinned below, in both directions, so a future
+ * "consistency" edit that unifies them turns this file red.
+ *
+ * Two instruments, deliberately:
+ *   - `tsc` sees the `@ts-expect-error` legs and the `Equal` assertions. Those
+ *     are the half that reaches a TypeScript author, and they mean nothing
+ *     unless `type-check` runs — vitest strips types.
+ *   - vitest runs the `safeParse` legs against the INSTALLED published spec
+ *     artifact, each with a control that would have fired.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { z } from 'zod';
+import { RecordDetailsProps } from '@objectstack/spec/ui';
+import type { RecordDetailsComponentProps } from '../record-components';
+
+/** What an author writes for the spec's `record:details` props bag. */
+type SpecProps = z.input<typeof RecordDetailsProps>;
+
+/** One authored `sections[]` entry, on each of the two faces. */
+type Section = NonNullable<RecordDetailsComponentProps['sections']>[number];
+type SpecSection = NonNullable<SpecProps['sections']>[number];
+
+/** Invariant type equality. `A extends B` is NOT this: `never` and `any` pass that. */
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+/** The only assertion form used here — its constraint is what refuses `false`. */
+type Expect<T extends true> = T;
+
+/* ── Direction proofs: a broken instrument makes THIS file red ─────────────── */
+
+// @ts-expect-error objectui#8604 — `Expect` must refuse `false`. Widen its constraint and this directive goes unused (TS2578).
+type _ExpectRefusesFalse = Expect<false>;
+
+// @ts-expect-error objectui#8604 — `never` must NOT read as equal to `true`. An `extends`-shaped comparison would let it through.
+type _EqualRefusesNever = Expect<Equal<never, true>>;
+
+// @ts-expect-error objectui#8604 — `any` must NOT read as equal to `true`, for the same reason.
+type _EqualRefusesAny = Expect<Equal<any, true>>;
+
+/* ── The fix: the top-level key carries the contract's own authoring type ──── */
+
+/** RED before objectui#8604 (`number` vs the string enum), green after. */
+type _TopLevelColumns = Expect<
+  Equal<RecordDetailsComponentProps['columns'], SpecProps['columns']>
+>;
+
+/** The per-section key was already right, and must stay right. */
+type _SectionColumns = Expect<Equal<Section['columns'], SpecSection['columns']>>;
+
+/**
+ * The near-miss, asserted as a NON-equality: the two `columns` are different
+ * types. A future edit that "makes them consistent" — in either direction —
+ * turns this line red before it can reach publish.
+ */
+type _TwoLevelsDisagree = Expect<
+  Equal<Equal<RecordDetailsComponentProps['columns'], Section['columns']>, false>
+>;
+
+/* ── Literals: what a TypeScript author can and cannot write ───────────────── */
+
+/** The contract's spelling compiles. */
+const bodyWidthAccepted: RecordDetailsComponentProps = { columns: '2' };
+
+/**
+ * The card's repro. `2` compiled before objectui#8604 and was refused at
+ * publish; now `tsc` refuses it here, which is the whole point of the change.
+ * Revert the narrowing and this directive goes unused (TS2578).
+ */
+const bodyWidthNumberRefused: RecordDetailsComponentProps = {
+  // @ts-expect-error objectui#8604 — the body-wide `columns` is `'1'|'2'|'3'|'4'`, never the number `2`.
+  columns: 2,
+};
+
+/** The section key takes the number, and refuses the string — the inverse. */
+const sectionWidthAccepted: RecordDetailsComponentProps = {
+  sections: [{ fields: ['phone'], columns: 2 }],
+};
+
+const sectionWidthStringRefused: RecordDetailsComponentProps = {
+  // @ts-expect-error objectui#8604 — `sections[].columns` is `number`; the string spelling belongs to the body-wide key only.
+  sections: [{ fields: ['phone'], columns: '2' }],
+};
+
+/** A value outside the closed set is refused on both faces. */
+const bodyWidthOutOfRange: RecordDetailsComponentProps = {
+  // @ts-expect-error objectui#8604 — `'5'` is outside the contract's closed set.
+  columns: '5',
+};
+
+describe('objectui#8604 — record:details `columns`, both levels, against the installed spec', () => {
+  it('the PREMISE: the two levels really are declared with different primitive types', () => {
+    // Read off the live schema object rather than transcribed, so a spec that
+    // converges the two spellings fails HERE first — before the pins below
+    // start asserting a shape the contract no longer has.
+    const body = RecordDetailsProps.safeParse({ columns: '3' });
+    const section = RecordDetailsProps.safeParse({ sections: [{ fields: ['a'], columns: 3 }] });
+    expect(body.success).toBe(true);
+    expect(section.success).toBe(true);
+
+    // And each refuses the other's spelling. Without this half, "different
+    // types" would be satisfied by a contract that accepted both everywhere.
+    expect(RecordDetailsProps.safeParse({ columns: 3 }).success).toBe(false);
+    expect(
+      RecordDetailsProps.safeParse({ sections: [{ fields: ['a'], columns: '3' }] }).success,
+    ).toBe(false);
+  });
+
+  it("the body-wide key refuses the NUMBER with `invalid_value` at `columns` — the card's repro", () => {
+    const refused = RecordDetailsProps.safeParse({ columns: 2 });
+    expect(refused.success).toBe(false);
+    const issue = refused.error?.issues.find((i) => i.path.join('.') === 'columns');
+    expect(issue).toBeDefined();
+    expect(issue?.code).toBe('invalid_value');
+
+    // THE CONTROL, on the same instrument: the string the contract declares
+    // parses green and its value survives. A refusal with no control that
+    // would have fired is not a measurement — it is also what a schema that
+    // refused everything would produce.
+    const accepted = RecordDetailsProps.safeParse({ columns: '2' });
+    expect(accepted.success).toBe(true);
+    expect(accepted.data?.columns).toBe('2');
+    expect(typeof accepted.data?.columns).toBe('string');
+  });
+
+  it('the body-wide key is a CLOSED set, and omitting it applies the schema default', () => {
+    expect(RecordDetailsProps.safeParse({ columns: '5' }).success).toBe(false);
+    expect(RecordDetailsProps.safeParse({ columns: '1' }).success).toBe(true);
+    expect(RecordDetailsProps.safeParse({ columns: '4' }).success).toBe(true);
+
+    // `.default('2')` — an omitted key is not an absent one downstream, which
+    // is why the input face is optional while the output face is not.
+    const omitted = RecordDetailsProps.safeParse({});
+    expect(omitted.success).toBe(true);
+    expect(omitted.data?.columns).toBe('2');
+  });
+
+  it('`sections[].columns` takes the NUMBER, refuses the string, and bounds 1-4', () => {
+    const accepted = RecordDetailsProps.safeParse({ sections: [{ fields: ['phone'], columns: 2 }] });
+    expect(accepted.success).toBe(true);
+    expect(accepted.data?.sections?.[0]?.columns).toBe(2);
+
+    const stringRefused = RecordDetailsProps.safeParse({
+      sections: [{ fields: ['phone'], columns: '2' }],
+    });
+    expect(stringRefused.success).toBe(false);
+    const issue = stringRefused.error?.issues.find(
+      (i) => i.path.join('.') === 'sections.0.columns',
+    );
+    expect(issue?.code).toBe('invalid_type');
+
+    // The range, so "number" is not mistaken for "any number".
+    expect(
+      RecordDetailsProps.safeParse({ sections: [{ fields: ['phone'], columns: 5 }] }).success,
+    ).toBe(false);
+    expect(
+      RecordDetailsProps.safeParse({ sections: [{ fields: ['phone'], columns: 0 }] }).success,
+    ).toBe(false);
+  });
+
+  it('the literals above are real values, not type-only decoration', () => {
+    // vitest strips types, so these expectations are NOT the assertion — the
+    // annotations are. They exist so the file also fails visibly if the
+    // literals are ever silently emptied out.
+    expect(bodyWidthAccepted.columns).toBe('2');
+    expect(bodyWidthNumberRefused.columns as unknown).toBe(2);
+    expect(bodyWidthOutOfRange.columns as unknown).toBe('5');
+    expect(sectionWidthAccepted.sections?.[0]?.columns).toBe(2);
+    expect(sectionWidthStringRefused.sections?.[0]?.columns as unknown).toBe('2');
+  });
+});

--- a/packages/types/src/record-components.ts
+++ b/packages/types/src/record-components.ts
@@ -37,8 +37,29 @@ export interface RecordComponentAriaProps {
  * Aligned with @objectstack/spec RecordDetailsProps.
  */
 export interface RecordDetailsComponentProps {
-  /** Number of columns for field layout (1-4) */
-  columns?: number;
+  /**
+   * Field-grid width for the WHOLE body, as the STRING the contract declares
+   * (`@objectstack/spec` `RecordDetailsProps.columns` is
+   * `z.enum(['1','2','3','4'])`, schema default `'2'`).
+   *
+   * It was `number` here until objectui#8604, which is the wrong PRIMITIVE
+   * TYPE, not merely a wider range: `{ columns: 2 }` compiled locally and the
+   * contract refused it at publish with `invalid_value` at `columns` (measured
+   * on the installed pin, 17.4.0, against a control — `columns: '2'` — that
+   * parses green on the same instrument). Contract-first (Commandment #0.1):
+   * the code moves to the contract's spelling, and today's `columns: 2`
+   * authors are the defect surfacing rather than collateral damage.
+   *
+   * WARNING — this is NOT the spelling `sections[].columns` uses one level
+   * down. That key is `z.number().int().min(1).max(4)`, so a section takes the
+   * NUMBER `2` and refuses the string, exactly inverting this key. The same
+   * word names two different types one level apart; copying either declaration
+   * onto the other is refused at publish. See the `columns` member on the
+   * `sections[]` entry below, and
+   * `__tests__/record-details-columns-8604.test.ts`, which pins both directions
+   * against the installed spec.
+   */
+  columns?: '1' | '2' | '3' | '4';
   /** Detail layout mode */
   layout?: 'stacked' | 'inline' | 'compact';
   /** Sections to organize fields */
@@ -75,6 +96,13 @@ export interface RecordDetailsComponentProps {
      * and `DetailSection` derives the width from the field count. Permitted
      * beside `group`: it describes how this page lays the section out, not
      * anything the group itself declares.
+     *
+     * WARNING — `number` is correct HERE and only here (objectui#8604): the
+     * per-section key is `z.number().int().min(1).max(4)`, while the body-wide
+     * `columns` at the top of this interface is a string enum. A section
+     * carrying `columns: '2'` is refused with `invalid_type` at
+     * `sections.N.columns`; the top-level key refuses `2`. Two types, one word,
+     * one level apart.
      */
     columns?: number;
     /**


### PR DESCRIPTION
Fixes #8604

`RecordDetailsComponentProps.columns` declared `columns?: number`. `@objectstack/spec` declares the same **top-level** key as `z.enum(['1','2','3','4']).default('2')` — a closed set of **string** literals. So `{ columns: 2 }` type-checked in this repo and the contract refused it at publish: a green local build and a rejection at the only point that matters.

Direction is contract-first (Commandment #0.1, and the triage ruling on the card): the code moves to the contract's spelling. The spec is not widened, and the loose type is not kept to protect callers.

## The measurement, re-derived on this branch with a firing control

Instrument: the **installed** published artifact, `@objectstack/spec` **17.4.0** (`RecordDetailsProps` from `@objectstack/spec/ui`), resolved from `packages/types`. The card was filed against 17.3.0 and the installed floor has since moved, so both declarations were re-derived by content.

| probe | verdict |
|---|---|
| `{ columns: 2 }` | **RED** — `invalid_value` at path `columns`, "Invalid option: expected one of `1` / `2` / `3` / `4`" |
| `{ columns: '2' }` — **the control** | **GREEN**, `data.columns === '2'`, `typeof` string |
| `{ columns: '5' }` | RED — same code, so the set really is closed |
| `{}` | GREEN, `data.columns === '2'` from the schema default |
| `{ sections: [{ fields: ['a'], columns: 2 }] }` | **GREEN**, value survives as the number `2` |
| `{ sections: [{ fields: ['a'], columns: '2' }] }` | **RED** — `invalid_type` at `sections.0.columns`, "expected number" |
| `{ sections: [{ fields: ['a'], columns: 5 }] }` | RED — `too_big`, so the range really is 1-4 |

The control is the point: a refusal with nothing that would have fired on the same instrument is indistinguishable from a schema that refuses everything.

## The near-miss, and why a copy-paste fix would have been wrong

| key | spec 17.4.0 declares | this PR |
|---|---|---|
| `RecordDetailsProps.columns` (**top level**) | `z.enum(['1','2','3','4']).default('2')` | narrowed to `'1' \| '2' \| '3' \| '4'` |
| `RecordDetailsProps.sections[].columns` (**per section**) | `z.number().int().min(1).max(4).optional()` | **unchanged, stays `number`** |

The two spellings are mutually exclusive in both directions, as the probe table shows. Copying either declaration onto the other is refused at publish.

**Did 17.x move either declaration?** No — measured by content, not from the changelog: the whole `RecordDetailsProps` block is **byte-identical** between 17.3.0 (fetched from the registry for this comparison) and the installed 17.4.0 — 16891 bytes each, string-equal. The 17.4.0 changelog section additionally contains zero occurrences of `record:details` or `RecordDetails`. So the card's 17.3.0 reading stands on the moved floor, and no floor bump is owed.

## Caller census

Two sweeps, unioned, then confirmed by the compiler.

- **Sweep A — authored metadata.** 106 files in the repo mention the literal `record:details`; every occurrence was scanned with a 48-line window for `columns`. Every hit is the **per-section** key or an unrelated `columns` (a related list's field projection, a dashboard grid, a form). **Zero** top-level authoring sites. The synth producer confirms it independently: `buildDefaultDetails` emits only `sections` and `hideFields`, and the `columns` it computes is written onto each **section**.
- **Sweep B — the TypeScript face.** 17 references to `RecordDetailsComponentProps`. Exactly **one** wrote the top-level key: `packages/types/src/__tests__/p1-spec-alignment.test.ts`, `columns: 2` plus its `expect(props.columns).toBe(2)`.
- **After:** 1 site, corrected to `columns: '2'` in this PR. Census after the change: **zero** in-repo callers writing the number.
- **Confirmation:** the ablation below reddens exactly that site (`TS2322` at `p1-spec-alignment.test.ts` line 537) and nothing else outside the new pin file, which is the compiler agreeing with the grep.

**Packages:** the narrowing is reachable only through the symbol, and the symbol is named in two packages — `@object-ui/types` (declaration, re-export, tests) and `@object-ui/plugin-detail` (one type annotation on the renderer's `schema` prop). No other package names it, and no exported type embeds it, so no other package's type-check can move. `@object-ui/plugin-detail` type-checks green against the narrowed face with its dependency closure built.

**Runtime:** unchanged, and measured rather than assumed. `RecordDetailsRenderer` passes the authored value straight through to the synthesized `detail-view` node, where `DetailSection` runs it through `Math.min(...)` before every comparison. Feeding `'2'` and `2` through the real expressions produces byte-identical output at every step — same `effectiveColumns`, same grid class, same responsive span class. Nothing to migrate at runtime.

## Is there a zod mirror of this key?

**No** — searched by content, not by filename. `packages/types/src/zod/` declares no schema for the `record:details` props bag: no `sections` + `hideFields` + `inlineEdit` shape exists anywhere in the tree. The nearest neighbour is `DetailViewSchema` in `zod/views.zod.ts`, and it is a **different surface** — the `detail-view` node this renderer synthesizes internally, whose own `columns: z.number()` is correct for it and which sits on no `record:details` parse path (its only consumers are the package's export list and one unit test).

The **third** declared face is already correct and worth naming, because it corroborates the direction: `@object-ui/plugin-detail`'s registry manifest publishes this key as `{ name: 'columns', type: 'enum', enum: ['1','2','3','4'] }`. The published TypeScript face was the only layer that disagreed.

## Docs sweep

**Nothing to change, and nothing held is blocked by this PR.** Every numeric `columns` literal under `content/docs/` was enumerated and read in context: they belong to `form`, `object-form`, `dashboard`, `grid` and `detail-view` — never to a `record:details` block. Only one document mentions `record:details` at all (`content/docs/guide/react-pages.md`), and it does not mention its `columns`.

Specifically on the held file: `content/docs/api/schema-reference.md` (held by #9021) carries **no** `record:details` section whatsoever, so the doc row this sweep was told to expect does not exist there. Reported, not edited, as instructed. No held file needs to move for this change.

## Changeset level

`'@object-ui/types': minor`, with **BREAKING** and a FROM/TO in the body.

Precedent checked by content rather than guessed, and it is close to exact: `.changeset/retire-record-details-section-collapsed.md` narrows **this same interface** (removing `sections[].collapsed`), opens with `**BREAKING**`, spells out FROM/TO, and declares `minor`. `AGENTS.md` states the governing convention — this repo's fixed version group tracks `@objectstack`'s major, so objectui's own breaking changes are declared `minor` with the breaking semantics written into the body, and `scripts/check-changeset-no-major.mjs` enforces it mechanically. Both changeset gates run green here (`check-changeset-presence` and `check-changeset-no-major`).

## Verification

All commands run on this branch, at `399ebdc5`.

- `pnpm --filter @object-ui/types test` — **exit 0**, 170 files / 3357 tests passed (includes the new pin file).
- `pnpm --filter @object-ui/types type-check` — **exit 0** (`tsc --noEmit` + `tsconfig.examples.json` + `tsconfig.test.json`).
- `pnpm --filter @object-ui/types lint` — **exit 0**, its own verdict line reads `278 problems (0 errors, 278 warnings)`; the warnings are the package's pre-existing `no-explicit-any` population.
- `pnpm --filter '@object-ui/plugin-detail^...' build` then `pnpm --filter @object-ui/plugin-detail type-check` — **exit 0**. The first attempt without the closure was `exit 2` with `TS2307 Cannot find module '@object-ui/core'`: a prerequisite failure, NOT MEASURED, not a red gate.
- Gates run: `check:control-bytes`, `check:doc-types`, `check:spec-symbols`, `check:new-line-citations`, `check:unreferenced-sources` — all **exit 0**. Plus a manual control-byte scan of the three changed files.
- `check:doc-examples`, `check:doc-snippets`, `check:spec-floors` — **exit 2 / 2 / 1, all PRECONDITION NOT MET**: each printed that the packages it judges are not built and that it did not run. Read as NOT MEASURED, deferred to CI, which builds the workspace.
- **Lint, whole population.** `eslint . --no-inline-config --format json` at the repo root, run to completion: population **4755 files** (read from eslint's own config resolution, not estimated), of which my three changed files are three. Those three carry **0 errors**. The 95 errors elsewhere are pre-existing on the base and are inline-disabled in the real per-package runs, which is why the package's own `lint` is exit 0.

**Ablation — the pins can fail.** Committed first, then the narrowing alone was reverted to `columns?: number` on disk (mutation proven on disk before running: the narrowed spelling went 1 to 0 occurrences, the reverted spelling 0 to 1, and the blob hash moved off the HEAD blob), a `trap` restored it, and the restore was proven byte-identical afterwards — `git diff HEAD` empty and the file's hash back to the HEAD blob. With the narrowing reverted, `type-check` goes **exit 2** with five distinct failures:

```
p1-spec-alignment.test.ts(537,7): error TS2322: Type 'string' is not assignable to type 'number'.
record-details-columns-8604.test.ts(70,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
record-details-columns-8604.test.ts(82,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
record-details-columns-8604.test.ts(88,58): error TS2322: Type 'string' is not assignable to type 'number'.
record-details-columns-8604.test.ts(96,3): error TS2578: Unused '@ts-expect-error' directive.
```

Line 70 is the parity assertion against the spec's own `z.input` type; line 82 is the near-miss assertion that the two levels are **not** the same type; line 96 is the `@ts-expect-error` on `columns: 2` going unused, which is the compile-time half of the fix. The direction observed is the expected one: **turns red**.

⚠️ The type-level half of the new file is only real if `tsc` actually sees it. Verified with `tsc --listFiles`: the file appears in the `tsconfig.test.json` program (1 hit) and in neither of the other two, and `type-check` runs that config. Measured, not assumed.

## Out-of-scope findings

**Filed as #9040** — `RecordDetailsComponentProps`'s **top level** diverges from the contract in both directions, one key over from this card and one level up from #8583: it declares `layout` (which the spec refuses by name as a `retiredKey`, measured `invalid_type` with the removal prescription as its message, against a control loop where every other top-level key accepts a plausible value), and it omits `hideFields` / `inlineEdit` / `showHeader`, which the spec declares, the renderer honours and the registry manifest already publishes. Filed rather than carried here: `layout` is a **retirement** with its own conversion obligations, the three omissions are additive design, and this card is scoped to one key. Dedup ran on a targeted search that returned 35 on-topic neighbours — the neighbours are the control that the query was live.

## 验收备注

- **`needs:contract-review` is hung on this PR as well as on the card.** The dispatch brief said not to touch labels; this repo's own half-state sweeper overrides that for this one label, and says so explicitly: `scripts/pm/check-half-states.mjs` finding H31 documents it as a **dual-carrier** gate (maintainer ruling 2026-08-22, 「两边都挂好」) whose two carriers are hung and cleared in one stroke, and fires precisely when the card carries it and the PR does not. Opening this PR bare would have manufactured the half-state that check exists to catch. Written additively, then read back. No other label was touched.
- The claim declared `Clause-②: yes`. The pairing-exit-code check the dispatch protocol asks for is an `objectstack`-side tool; this repository has no `--pair` mode — `scripts/pm/check-half-states.mjs` is a report-only sweeper with no such flag. The gate is carried by the two labels instead.
- Noted, not filed: `content/docs/api/schema-reference.md` documents `detail-view` but has no `record:details` section at all, so the block's whole authoring surface is undocumented in the API reference. That is an absence, not an error, and the file is held by #9021.
- Noted, not filed: the `detail-view` zod mirror (`DetailViewSchema.columns: z.number()`) receives the authored `record:details` value, which is now typed as a string. It is inert — the synthesized node is never parsed by that mirror, and the renderer coerces identically either way (measured above) — so there is no failing path to file.
- PR left in **draft**, per the brief. No auto-merge, no enqueue, no ready flip.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_