### PR TITLE
fix(scripts): derive the dead-keys pack-object importer population, pin its readings

### DIFF
--- a/scripts/__tests__/check-i18n-dead-keys.test.ts
+++ b/scripts/__tests__/check-i18n-dead-keys.test.ts
@@ -5,8 +5,10 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  ANALYSED_PACK_OBJECT_IMPORTERS,
   DESIGNER_TABLE,
   collectDesignerKeys,
+  derivePackObjectImporters,
   propertyChainProbe,
   sweep,
   sweepDesignerTable,
@@ -926,5 +928,158 @@ describe('textFootprint() key boundary', () => {
     expect(footprintOf({ 'packages/x/src/a.ts': `export const k = '${KEY}.detail';\n` }, { keyBoundary: false })).toEqual([
       'packages/x/src/a.ts',
     ]);
+  });
+});
+
+/**
+ * objectui#8752 — the enumeration is DERIVED and PINNED, never hand-counted.
+ *
+ * The header section "The pack-object importers, enumerated" told readers to
+ * re-derive the class and then stated a match total in prose. The total was
+ * true when written and decayed in place — 19 in the comment, 28 when the
+ * drift was filed, 31 when it was corrected — and the bullet list decayed with
+ * it, carrying four entries for a population of five. That is a worse failure
+ * than an uncounted list: the section ships its own re-derivation command, so a
+ * reader who trusts the number is a reader who skips the check.
+ *
+ * The count is gone from the prose and computed on every run. This block pins
+ * the half a count cannot cover: that every non-test importer in the live
+ * population has a BULLET, i.e. that somebody read the file and wrote down what
+ * its shape means for the property-chain leg. A sixth importer fails here, by
+ * name, instead of joining the silence.
+ */
+describe('the pack-object importer enumeration is derived, and pinned to the readings (objectui#8752)', () => {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+  const scriptPath = path.join(repoRoot, 'scripts', 'check-i18n-dead-keys.mjs');
+  const derived = derivePackObjectImporters(repoRoot);
+
+  it('does not collapse — a broken derivation must not read as a clean enumeration', () => {
+    // The assertion that keeps every other assertion in this block honest. A
+    // grep that matched nothing (a moved directory, a changed specifier, an IO
+    // error swallowed somewhere) returns two empty sets, and two empty sets
+    // satisfy "every importer is analysed" vacuously — the most reassuring
+    // possible rendering of an instrument that stopped looking. Same discipline
+    // as the CLI block's own collapse guards.
+    expect(derived.nonTest.length, 'this repo ships pack-object importers; zero means the derivation broke').toBeGreaterThan(0);
+    expect(derived.test.length, 'test importers vastly outnumber non-test ones here; a handful means the walk broke').toBeGreaterThan(10);
+  });
+
+  it('classifies the locale packs themselves out of the population', () => {
+    // A pack file importing a sibling pack is a DEFINITION, never a reader.
+    for (const file of [...derived.nonTest, ...derived.test]) {
+      expect(file.startsWith('packages/i18n/'), `${file} is a locale-pack file and cannot be a reader of the packs`).toBe(false);
+    }
+  });
+
+  it('splits test importers out — only a non-test importer can keep a SHIPPED key alive', () => {
+    // Both spellings this repo uses, because a predicate that knew one of them
+    // would promote the other half into the set the bullets answer for.
+    for (const file of derived.nonTest) {
+      expect(/(^|\/)__tests__\//.test(file) || /\.test\.tsx?$/.test(file), `${file} is a test file and does not belong in the non-test set`).toBe(false);
+    }
+    expect(derived.test.some((f) => f.includes('/__tests__/'))).toBe(true);
+    expect(derived.test.some((f) => /\.test\.tsx?$/.test(f) && !f.includes('/__tests__/'))).toBe(true);
+  });
+
+  it('EVERY non-test importer in the live population is analysed in the header', () => {
+    const unanalysed = derived.nonTest.filter((f) => !ANALYSED_PACK_OBJECT_IMPORTERS.includes(f));
+    expect(
+      unanalysed,
+      'A pack-object importer with no bullet is a reader nobody has classified — the objectui#8752 ' +
+        'state exactly. Read the file, decide what its shape means for the property-chain leg (covered ' +
+        'by design / by luck / nothing at risk), write the bullet in the header section, and only then ' +
+        'add the path to ANALYSED_PACK_OBJECT_IMPORTERS. ⛔ Adding the path alone makes this test green ' +
+        'while reproducing the defect it exists to catch.',
+    ).toEqual([]);
+  });
+
+  it('EVERY analysed importer still exists in the live population', () => {
+    // The other direction, and it is not symmetry for its own sake: a bullet
+    // about a deleted file reads as coverage of a class that no longer has a
+    // member, which is how an enumeration starts describing a tree nobody has.
+    const vanished = ANALYSED_PACK_OBJECT_IMPORTERS.filter((f) => !derived.nonTest.includes(f));
+    expect(vanished, 'these paths are analysed in the header but no longer import a locale pack — delete the bullet with the entry').toEqual([]);
+  });
+
+  it('each analysed path is spelled in the header, so an entry cannot exist without its reading', () => {
+    // What stops the previous test from being satisfied by a paste. The
+    // constant is an INDEX of bullets; if the path is not in the header text,
+    // the bullet was never written and the reading does not exist.
+    const source = fs.readFileSync(scriptPath, 'utf8');
+    const header = source.slice(0, source.indexOf('\nimport ts from'));
+    for (const file of ANALYSED_PACK_OBJECT_IMPORTERS) {
+      expect(header.includes(file), `${file} is listed as analysed but the header carries no bullet for it`).toBe(true);
+    }
+  });
+
+  it('the header states no hand-written match count', () => {
+    // The regression this card is: a number in prose that nothing recomputes.
+    // The population is printed by the run now, so a total reappearing here is
+    // a step back to the shape that decayed three times.
+    const source = fs.readFileSync(scriptPath, 'utf8');
+    const header = source.slice(0, source.indexOf('\nimport ts from'));
+    const stated = header.match(/\d+\s+matches?\s+today/i);
+    expect(stated, `the enumeration must not state its own population in prose — it decayed through three values doing that; derivePackObjectImporters() reports it instead`).toBeNull();
+  });
+});
+
+/**
+ * objectui#8752 — the fifth importer's reading, MEASURED rather than asserted
+ * in a comment.
+ *
+ * Its bullet claims something specific and load-bearing: the file reads two
+ * TWO-SEGMENT keys off the pack by property access, both legs are blind to that
+ * read, and the keys stay out of the candidate tiers only because the same
+ * expression also spells them literally as the `t()` argument. If that stops
+ * being true — someone templates the key, or moves the default away from its
+ * call — the bullet becomes a false statement about a live blind spot. These
+ * cases are what turn red first.
+ */
+describe('the fifth importer is covered BY COINCIDENCE, not by the leg (objectui#8752)', () => {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+  /**
+   * Assembled from segments for the reason the objectui#6666 control block
+   * above gives: `textFootprint()` greps `scripts/` too, so a dotted key
+   * spelled contiguously here would make THIS FILE a hit for it and the
+   * measurements below would be measuring the test.
+   */
+  const ceilingKey = (leaf: string) => ['common', leaf].join('.');
+  const KEYS = [ceilingKey('rowCeilingNote'), ceilingKey('rowCeilingNoteUnknownTotal')];
+
+  it('the property-chain leg does not apply: both keys are two segments', () => {
+    for (const k of KEYS) {
+      expect(propertyChainProbe(k), `${k} has two segments; a one-word chain is not evidence`).toBeNull();
+    }
+  });
+
+  it('the full-key probe does NOT see a pack-object property read of these keys', () => {
+    // The measurement the bullet rests on, run on a fixture carrying ONLY the
+    // property read — the real file also spells the key literally, so measuring
+    // it there would answer a different question.
+    const root = repoWith({
+      'packages/x/src/reader.tsx': `import { en } from '${I18N_PKG}';\n` + KEYS.map((k) => `const v = en.${k};\n`).join(''),
+    });
+    const found = textFootprint(root, KEYS);
+    for (const k of KEYS) {
+      expect(found.get(k), `${k} read as a property off the pack is invisible to the full-key probe (a '.' on the left marks a longer key)`).toEqual([]);
+    }
+  });
+
+  it('and DID see it before the key boundary — so the blindness is a measured cost of that boundary', () => {
+    // The control that keeps the assertion above from passing for the wrong
+    // reason (a typo in the fixture, a probe that matches nothing at all).
+    const root = repoWith({
+      'packages/x/src/reader.tsx': `import { en } from '${I18N_PKG}';\n` + KEYS.map((k) => `const v = en.${k};\n`).join(''),
+    });
+    const found = textFootprint(root, KEYS, { keyBoundary: false });
+    for (const k of KEYS) expect(found.get(k)).toEqual(['packages/x/src/reader.tsx']);
+  });
+
+  it('what keeps them live is the LITERAL t() argument in the same expression', () => {
+    const source = fs.readFileSync(path.join(repoRoot, 'packages/react/src/utils/nonGridRowCeiling.tsx'), 'utf8');
+    for (const k of KEYS) {
+      expect(source.includes(`t('${k}'`), `${k} must stay spelled literally at its call site — the property read alone is invisible to every leg`).toBe(true);
+    }
   });
 });

--- a/scripts/check-i18n-dead-keys.mjs
+++ b/scripts/check-i18n-dead-keys.mjs
@@ -152,7 +152,7 @@
  *      for a property access instead of grepping the dotted key, finding
  *      nothing, and concluding the tool is broken.
  *
- * ## The pack-object importers, enumerated (objectui#6666)
+ * ## The pack-object importers, enumerated (objectui#6666, objectui#8752)
  *
  * The leg is only as good as the class it covers, so the class is written down
  * rather than left to memory. Re-derive it — the specifier is kept off the
@@ -164,8 +164,28 @@
  *     packages apps examples e2e \
  *     | grep "@object-ui/i18n" | grep -v '^packages/i18n/'
  *
- * NON-TEST importers — the ones that can keep a SHIPPED key alive (19 matches
- * today, of which these four):
+ * NO MATCH COUNT IS STATED IN THIS SECTION, and the absence is the fix rather
+ * than an omission (objectui#8752). It used to open with one — "19 matches
+ * today, of which these four" — written true and then decayed in place: 19 in
+ * the comment, 28 when the drift was filed, 31 when it was corrected. A stale
+ * total is worse here than no total, and worse for a reason specific to this
+ * section: it ships the command to re-derive itself, so a number a reader
+ * trusts is a re-derivation that never happens. The population is now DERIVED
+ * on every run by `derivePackObjectImporters()` below, which executes exactly
+ * the pipeline above and reports the split; the CLI prints it, so the only
+ * count anyone reads is one that cannot be older than the run.
+ *
+ * The BULLETS stay hand-written, and that is not a half-measure. Each says what
+ * its importer's SHAPE means for this leg — covered by design, covered by luck,
+ * nothing at risk — which is a reading, not a population, and no derivation can
+ * produce it. Derived and read are pinned TO EACH OTHER instead:
+ * `ANALYSED_PACK_OBJECT_IMPORTERS` below lists exactly the paths these bullets
+ * analyse, and `scripts/__tests__/check-i18n-dead-keys.test.ts` fails when the
+ * derived non-test set and that list disagree in either direction. A sixth
+ * importer therefore turns a test red instead of joining the silence, which is
+ * the failure this section had: not a wrong number, an UNCLASSIFIED READER.
+ *
+ * NON-TEST importers — the ones that can keep a SHIPPED key alive:
  *
  *   - `packages/app-shell/src/chrome/LoadingScreen.tsx` — the case this leg was
  *     built for. Bootstrap-critical UI: it must render BEFORE i18n loads, which
@@ -184,12 +204,34 @@
  *     `packages/plugin-grid/demo/bulk-actions.tsx` — whole-pack `resources`
  *     wiring only, no per-key property reads: nothing for the leg to see and
  *     nothing at risk.
+ *   - `packages/react/src/utils/nonGridRowCeiling.tsx` — the importer this
+ *     section was missing when objectui#8752 was filed, and the one worth
+ *     reading twice: it is the first instance in this tree of class 4 below.
+ *     It dereferences the pack at render to supply the `defaultValue` beside a
+ *     `t()` call, and BOTH keys it reads are TWO SEGMENTS. The property-chain
+ *     leg returns `null` below three segments by design, and with the key
+ *     boundary on (objectui#8701) the full-key probe refuses the property read
+ *     too, because a `.` on the left is exactly what marks a longer key.
+ *     Measured on a fixture carrying only the property-read line: no hit for
+ *     either key under today's boundary, a hit for both under the pre-boundary
+ *     substring behaviour. ⇒ BOTH LEGS ARE BLIND to this read.
+ *     Nothing is at risk today, and the reason is a property of this FILE
+ *     rather than of the leg: the same two keys are also spelled literally as
+ *     the first argument of the `t()` call each default sits inside, so the AST
+ *     pass reads them directly and neither is ever a candidate (measured: both
+ *     absent from CONFIRMED and from NEEDS-REVIEW). ⇒ read this bullet as
+ *     covered BY COINCIDENCE, the same tier as `outboundAgentText` above and
+ *     for an unrelated reason. Build either key from a template, or move the
+ *     default away from its call site, and both go dark to every leg while a
+ *     shipping component still renders them — and that edit would read as a
+ *     tidy-up.
  *
  * The rest of the matches are TEST-only importers, deliberately not listed one
  * by one. A key read only by a test is not a key a user can see, so a test
  * importer never establishes liveness — it only ever adds a textual footprint,
- * which the full-key probe already catches. The re-derivation returns both
- * sets; the split is the point, not the count.
+ * which the full-key probe already catches. The derivation returns both sets;
+ * the split is the point, and it is the split — never a total — that the
+ * bullets are answerable to.
  *
  * ## What CONFIRMED does NOT guarantee (objectui#7592)
  *
@@ -222,6 +264,15 @@
  *      is read by hand. Measured when the boundary became the default:
  *      re-deriving that list and reading every NON-TEST importer it returns,
  *      not one of them reads any of the keys the change re-tiered.
+ *      ⚠️ That measurement stands, but it was taken over a list of FOUR that
+ *      had already drifted to five (objectui#8752), so read it as "no wrong
+ *      verdict was found", never as "the population was complete". The fifth —
+ *      `nonGridRowCeiling.tsx`, bulleted above — is this class's first
+ *      instance in the tree: two-segment keys read off the pack by property
+ *      access, invisible to both legs, kept out of the tiers only by a literal
+ *      `t()` argument sitting in the same expression. The list's COMPLETENESS
+ *      is mechanical now (`derivePackObjectImporters()` plus its pin); what
+ *      stays hand-read is what each importer's shape means.
  *
  * The tier is therefore the one to READ FIRST, and each entry still needs a
  * human before deletion. The cost of reading it as bulk-deletable is measured:
@@ -251,7 +302,7 @@
 
 import ts from 'typescript';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -269,6 +320,18 @@ const TEXT_SWEEP_SKIP_DIRS = new Set([
   'node_modules', '.git', 'dist', 'build', 'coverage', '.next', '.turbo',
   '.changeset',
 ]);
+
+/**
+ * The workspace package the locale PACK OBJECTS come from — the import edge
+ * `derivePackObjectImporters()` filters its grep output down to.
+ *
+ * Held as a plain string rather than written into the header's grep recipe for
+ * the reason that recipe already gives: kept off a `from '...'` shape, this
+ * file is not itself read as an importer of it. A string literal is not an
+ * import edge to `workspaceImportSpecifiers()` either, so nothing here is
+ * concealment — it is one spelling for one specifier.
+ */
+const PACK_IMPORT_SPECIFIER = '@object-ui/i18n';
 
 /** The locale pack directory — every candidate's DEFINITION lives here, so a
  *  hit inside it is not evidence of a reference and must not count as one. */
@@ -486,6 +549,111 @@ export function textFootprint(root, keys, options = {}) {
     );
   }
   return result;
+}
+
+/**
+ * The directories the pack-object importer derivation searches, and the only
+ * ones it needs: a pack-object reader outside them cannot be built or shipped.
+ */
+const IMPORTER_SEARCH_DIRS = ['packages', 'apps', 'examples', 'e2e'];
+
+/**
+ * The importer paths the header section "The pack-object importers,
+ * enumerated" ANALYSES — one entry per bullet there, and nothing else.
+ *
+ * This is the hand-read half, deliberately: what a bullet says about its
+ * importer's shape (covered by design / by luck / nothing at risk) is a
+ * reading no derivation produces. What this constant buys is that the reading
+ * cannot go SILENTLY incomplete — `derivePackObjectImporters()` supplies the
+ * live population and this file's test suite fails when the two disagree in
+ * either direction, so a new importer arrives as a red test with a name rather
+ * than as an unclassified reader nobody noticed (objectui#8752, where the
+ * section had been carrying four bullets for a population of five).
+ *
+ * ⛔ Never satisfy that test by pasting a path in here. The entry is the
+ * INDEX of a bullet; adding one without writing the bullet reproduces exactly
+ * the state the pin exists to detect, and the test checks for the bullet too.
+ */
+export const ANALYSED_PACK_OBJECT_IMPORTERS = Object.freeze([
+  'packages/app-shell/src/chrome/LoadingScreen.tsx',
+  'packages/app-shell/src/console/ai/outboundAgentText.ts',
+  'packages/plugin-grid/demo/main.tsx',
+  'packages/plugin-grid/demo/bulk-actions.tsx',
+  'packages/react/src/utils/nonGridRowCeiling.tsx',
+]);
+
+/** A path is a TEST importer when it lives in a `__tests__` directory or is
+ *  itself a `.test.ts`/`.test.tsx` file — this repo spells test files both
+ *  ways, and a predicate that knew only one of them would quietly promote the
+ *  other half into the non-test set the bullets are answerable to. */
+function isTestImporter(relPath) {
+  return /(^|\/)__tests__\//.test(relPath) || /\.test\.tsx?$/.test(relPath);
+}
+
+/**
+ * Derive the pack-object importer population — the class the property-chain
+ * leg covers — by running the header section's own pipeline.
+ *
+ * This exists so that no COUNT has to be written into a comment. The section
+ * used to state one, it decayed through three values while nothing noticed,
+ * and objectui#8752 is that decay. A number the script computes on the run
+ * that prints it cannot be stale; the bullets, which are readings rather than
+ * counts, stay written out and are pinned against `nonTest` by this file's
+ * test suite.
+ *
+ * The regex and the `@object-ui/i18n` filter are the header's, character for
+ * character. Two things are added, and neither narrows the class: the search
+ * skips `TEXT_SWEEP_SKIP_DIRS` (a copy of a pack importer under `dist/` or
+ * `node_modules/` is a build artefact, not a reader), and a missing search
+ * directory is tolerated so a partial checkout degrades to a smaller list
+ * instead of throwing. Locale-pack files are excluded for the same reason a
+ * definition is not a reference.
+ *
+ * @param {string} root Repository root.
+ * @returns {{ nonTest: string[], test: string[] }} Repo-relative POSIX paths,
+ *   sorted. `nonTest` is the set the enumeration's bullets must cover;
+ *   `test` is the rest, which never establishes liveness (see the header).
+ */
+export function derivePackObjectImporters(root) {
+  const dirs = IMPORTER_SEARCH_DIRS.map((dir) => join(root, dir)).filter((dir) => existsSync(dir));
+  if (dirs.length === 0) return { nonTest: [], test: [] };
+
+  const args = [
+    '-rn',
+    '-I',
+    '--include=*.ts',
+    '--include=*.tsx',
+    ...[...TEXT_SWEEP_SKIP_DIRS].flatMap((dir) => ['--exclude-dir', dir]),
+    '-E',
+    String.raw`import \{[^}]*\b(en|zh|builtInLocales|ja|ko|de|fr|es|pt|ru|ar)\b[^}]*\}`,
+    '--',
+    ...dirs,
+  ];
+
+  let output = '';
+  try {
+    output = execFileSync('grep', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  } catch (error) {
+    // Exit 1 is grep's "no line matched" — a real empty population, not a
+    // failure. Anything else (2 = usage/IO) must surface: a derivation that
+    // swallowed an IO error would return an empty set, and an empty set reads
+    // as "no importers to classify", which is the most reassuring possible
+    // rendering of a broken tool.
+    if (error.status !== 1) throw error;
+  }
+
+  const nonTest = new Set();
+  const test = new Set();
+  for (const line of output.split('\n')) {
+    if (!line) continue;
+    if (!line.includes(PACK_IMPORT_SPECIFIER)) continue;
+    const firstColon = line.indexOf(':');
+    if (firstColon === -1) continue;
+    const relPath = relative(root, line.slice(0, firstColon)).split('\\').join('/');
+    if (relPath.startsWith(LOCALES_DIR) || relPath.startsWith('packages/i18n/')) continue;
+    (isTestImporter(relPath) ? test : nonTest).add(relPath);
+  }
+  return { nonTest: [...nonTest].sort(), test: [...test].sort() };
 }
 
 /** The namespace bucket a key reports under: two segments once the key is at
@@ -942,6 +1110,9 @@ if (invokedDirectly) {
   const asJson = process.argv.includes('--json');
   const result = sweep(root);
   const designer = sweepDesignerTable(root);
+  const importers = derivePackObjectImporters(root);
+  const unanalysedImporters = importers.nonTest.filter((f) => !ANALYSED_PACK_OBJECT_IMPORTERS.includes(f));
+  const vanishedImporters = ANALYSED_PACK_OBJECT_IMPORTERS.filter((f) => !importers.nonTest.includes(f));
 
   // Same collapse guard as the call-site gate's own CLI block: on the REAL
   // repo, an empty or near-empty comparison means the extractor or file walk
@@ -988,6 +1159,13 @@ if (invokedDirectly) {
           candidateCount: result.candidateCount,
           confirmed: result.confirmed,
           needsReview: result.needsReview,
+          packObjectImporters: {
+            nonTest: importers.nonTest,
+            testCount: importers.test.length,
+            analysed: [...ANALYSED_PACK_OBJECT_IMPORTERS],
+            unanalysed: unanalysedImporters,
+            vanished: vanishedImporters,
+          },
           designerTable: {
             file: DESIGNER_TABLE,
             tableSizes: Object.fromEntries(designer.tableSizes),
@@ -1043,6 +1221,37 @@ if (invokedDirectly) {
         for (const hit of hits.slice(0, 5)) console.log(`    ${hit}`);
         if (hits.length > 5) console.log(`    … and ${hits.length - 5} more`);
       }
+    }
+
+    // ── the pack-object importer population, DERIVED (objectui#8752) ────────
+    // Printed rather than written into the header, because the header's
+    // hand-written total decayed through three values while nothing noticed.
+    // A count computed on the run that prints it cannot be stale.
+    console.log(
+      `\npack-object importers of the locale packs, derived this run: ` +
+        `${importers.nonTest.length} non-test, ${importers.test.length} test-only. Only the non-test ` +
+        'ones can keep a SHIPPED key alive, and each is read by hand in the header of this script — a ' +
+        'reading of what its shape means for the property-chain leg, which no count replaces:',
+    );
+    for (const file of importers.nonTest) {
+      const mark = ANALYSED_PACK_OBJECT_IMPORTERS.includes(file) ? 'analysed  ' : 'UNANALYSED';
+      console.log(`  [${mark}]  ${file}`);
+    }
+    if (unanalysedImporters.length > 0) {
+      console.log(
+        `\n⛔ ${unanalysedImporters.length} non-test importer(s) above have no bullet in the header's ` +
+          'enumeration. That is the objectui#8752 state exactly: a pack-object reader nobody has ' +
+          'classified, and the next one lands in the same silence. Read the file, decide what its ' +
+          'shape means for the leg, write the bullet, then add the path to ' +
+          'ANALYSED_PACK_OBJECT_IMPORTERS — in that order.',
+      );
+    }
+    if (vanishedImporters.length > 0) {
+      console.log(
+        `\n⚠️ ${vanishedImporters.length} analysed importer(s) are no longer in the derived set: ` +
+          `${vanishedImporters.join(', ')}. Delete the bullet with the entry, so the enumeration does ` +
+          'not keep reasoning about a file that is gone.',
+      );
     }
 
     console.log(


### PR DESCRIPTION
Fixes #8752

## What was stale, re-measured on this branch

`scripts/check-i18n-dead-keys.mjs`'s header section "The pack-object importers, enumerated" ships the command to re-derive its own class and then stated the result in prose — *"19 matches today, of which these four"*.

I re-ran that command myself on `152f0a700` before writing anything. It returns **31 matches — 5 non-test, 26 test-only**. Every premise the order carried is confirmed at my base:

| premise | mine |
|---|---|
| header still says 19, "of which these four" | confirmed |
| the command's own result: 19 → 28 → 31 | confirmed, still **31** |
| the fifth importer is in the tree and the script names it nowhere | confirmed — 0 mentions, against a control of 1 for a name the file certainly contains |

The drift is the card's thesis demonstrating itself: written true, decayed in place, and the bullet list decayed with it, carrying four entries for a population of five.

## The count is deleted, not corrected

Per the ruling, and following objectui#8606 / objectui#8629 on `main`: the total is **removed** from the prose, the header says in place *why* no total is stated there, and a new `derivePackObjectImporters()` runs the header's own pipeline so the CLI prints the split on every run. The only population anyone reads is now computed by the run that prints it.

## …but the bullets stay, because a count cannot produce them

This surface differs from the two precedents in a way that matters: each bullet says what its importer's SHAPE means for the property-chain leg — covered by design, covered by luck, nothing at risk — which is a reading, not a population. So derived and read are pinned **to each other** instead:

- `ANALYSED_PACK_OBJECT_IMPORTERS` indexes the bullets;
- the test suite fails when it and the live population disagree **in either direction**;
- and a further assertion requires each listed path to be spelled in the header, so pasting a path in to make the test green — reproducing exactly the defect the pin exists to catch — fails too.

A sixth importer now turns a test red **by name** instead of joining the silence. The failure this section had was never a wrong number; it was an unclassified reader.

## The fifth importer's analysis — the real work on this card

`packages/react/src/utils/nonGridRowCeiling.tsx` dereferences the pack at render to supply a `defaultValue` beside a `t()` call, and **both keys it reads are two segments**. That makes it this tree's **first instance of class 4** of the header's "What CONFIRMED does NOT guarantee": the property-chain leg returns `null` below three segments by design, and with the key boundary on (objectui#8701) the full-key probe refuses the property read too, because a dot on the left is what marks a longer key.

Measured on a fixture carrying **only** the property-read line, through the script's own `textFootprint()`:

- under today's boundary: **no hit** for either key;
- with `keyBoundary: false` (the pre-boundary substring behaviour): **a hit** for both.

⇒ **both legs are blind to that read.** Nothing is at risk today, and the reason is a property of that FILE rather than of the leg: the same expression also spells each key literally as its `t()` argument, so the AST pass reads them directly and neither key is ever a candidate — verified against a real run, both absent from CONFIRMED and from NEEDS-REVIEW. Coverage **by coincidence**, and the header now says so rather than leaving a reader to infer it. Four tests pin that coincidence for this file, so templating a key or moving the default away from its call goes red instead of quietly going dark.

The class-4 note is annotated in the same spirit: its own measurement ("not one of them reads any of the keys the change re-tiered") stands, but it was taken over the four-item list, so it now reads as *no wrong verdict was found* rather than *the population was complete*.

## Boundaries respected

⛔ No i18n key deleted, retired or re-tiered. ⛔ objectui#8701's boundary predicate untouched — what the leg accepts is byte-identical. ⛔ No test skipped, disabled or quarantined. ⛔ `content/docs/releases/` untouched. The fifth importer establishes **no** liveness the leg cannot already see, so the order's stop-and-escalate condition did not fire.

## Verification

| check | result |
|---|---|
| `vitest run scripts/__tests__/check-i18n-dead-keys.test.ts` | **75 passed** (11 new) |
| `vitest run scripts/__tests__/` — the whole directory, the tightest correct scope for a `scripts/**` diff | **139 files passed, 4131 tests**, 2 skipped |
| `node scripts/check-i18n-dead-keys.mjs` | exit 0; new section prints `5 non-test, 26 test-only`, all five marked `analysed` |
| `type-check:scripts` | exit 0 |
| `lint:root` — run in **full**, not narrowed | exit 0, 0 errors (32 pre-existing warnings) |
| `check:control-bytes` | OK, 7239 tracked text files scanned |
| `check:new-line-citations` · `check:shell-escape-residue` · `check:esm-specifiers` · `check:entry-guard` · `check:unreferenced-sources` · `check:comment-mask-corpus` | all exit 0 |

Every exit code above was captured before any pipe.

**Changeset:** the repo's presence gate was run and printed — *"Compared the working tree with 152f0a700 (merge-base with origin/main): 2 file(s) changed, 0 of them published source of a package the release covers … No source or published contract of a released package changed in this range, so no changeset is owed."* ⇒ none added.

### Ablation — the pin is shown able to fail

Both legs mutated the committed file on disk, proved the mutation landed by blob hash and anchor grep counts, ran, then restored under a trap and proved the restore by blob-hash equality with `HEAD` plus an empty `git diff HEAD`.

1. **Drop the fifth entry from the pinned list, and put `19 matches today` back in the prose** → vitest exit 1, `2 failed | 73 passed`: *"EVERY non-test importer in the live population is analysed in the header"* and *"the header states no hand-written match count"*.
2. **Paste a path into the list with no bullet written for it** → vitest exit 1, `2 failed | 73 passed`: *"EVERY analysed importer still exists in the live population"* and *"each analysed path is spelled in the header, so an entry cannot exist without its reading"*.

Direction was **transition to red** in both, as predicted before running.

## Filed, not fixed here

`Refs:` objectui#9046 — observation-class, filed bare. Class 4 now has a live instance and this PR pins that one file against it, but the **class** has no detector: a future importer reading a two-segment key off a pack with no co-located literal arrives with nothing measuring it, and that reading looks derivable. Out of scope here, because it would change what the leg measures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_