### PR TITLE
fix(plugin-dashboard): an authored drill `columns` whitelist no longer degrades its own headers

### DIFF
--- a/.changeset/9000-drill-columns-header-labels.md
+++ b/.changeset/9000-drill-columns-header-labels.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/plugin-dashboard': patch
+---
+
+An authored drill `columns` whitelist no longer degrades the headers of the table it
+narrows (objectui#9000).
+
+`ObjectDataTable` derives its column headers on two branches of one memo, and both call
+the same `fieldLabel` lookup. Only the fallback differed: the auto-derived branch fell
+back to the humanized field key, the explicit-whitelist branch fell back to whatever
+`header` the caller supplied. Both drill callers build `{ accessorKey: c, header: c }`
+out of a `drillDown.columns` string list, so that fallback was the raw field key — and
+with no bundle entry to resolve, which is the ordinary case in a drill, authoring
+`columns` rendered `close_date` where the same table without a whitelist rendered
+`Close Date`. The more deliberate configuration produced the less finished table.
+
+The whitelist branch now falls back to the same humanized key the auto-derived branch
+uses. **Visible change:** a drill-through list configured with `drillDown.columns` (the
+pivot, metric and chart drill surfaces) renders humanized headers where it previously
+rendered raw field names. Nothing else about the whitelist changes — it still narrows
+the table to exactly the listed columns, in the listed order.
+
+The fallback is **conditional**, and deliberately so: it fires only where the column
+carries no display text, or carries the raw field key itself. An author-written label —
+`{ accessorKey, header }` or the spec-canonical `{ field, label }`, both of which
+`normalizeColumns` resolves onto the same key, and both of which `DashboardRenderer`
+forwards here verbatim from an authored widget — is left exactly as authored. A
+translated bundle entry still wins over both, unchanged.

--- a/packages/plugin-dashboard/src/ObjectDataTable.tsx
+++ b/packages/plugin-dashboard/src/ObjectDataTable.tsx
@@ -887,11 +887,48 @@ export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSo
       return { ...col, name: fieldMeta.name, type: columnType, align: inferredAlign, cell };
     };
 
+    // The DECLARED half's header, and the FALLBACK it hands `fieldLabel`
+    // (objectui#9000). Both halves of this memo call the same lookup; only the
+    // fallback used to differ, and that difference was the whole defect: the
+    // auto-derived half fell back to `humanizeFieldKey(k)`, this half fell back
+    // to whatever `header` the caller put on the column. Both drill callers
+    // build `{ accessorKey: c, header: c }` out of a `drillDown.columns` string
+    // list, so `col.header` IS the raw field key — and with no bundle entry to
+    // resolve (the ordinary case in a drill) an authored whitelist rendered
+    // `close_date` where the same table without one rendered `Close Date`.
+    // Narrowing the table also stopped finishing it, which is backwards: the
+    // MORE deliberate configuration produced the LESS finished result.
+    //
+    // ⭐ The fallback is CONDITIONAL, and that is not caution — it is the whole
+    // correctness of the fix. This branch is not reached only by the two drill
+    // callers: `normalizeColumns` resolves the spec-canonical `{ field, label }`
+    // and the adapter-canonical `{ accessorKey, header }` into this same
+    // `col.header` (objectui#5351), and `DashboardRenderer` forwards an authored
+    // widget's `columns` here verbatim. So a genuine author-written label
+    // arrives on exactly the key an unconditional `humanizeFieldKey` would
+    // overwrite — trading this defect for a strictly worse one (a silently
+    // discarded label instead of an unpolished one). The fallback therefore
+    // fires only where the caller supplied NO display text, or supplied the raw
+    // field key itself, which is the drill callers' shape and carries no
+    // authorial intent to preserve. Pinned both ways in
+    // `ObjectDataTable.whitelistHeaderParity-9000.test.tsx`: PARITY for the
+    // derived case, AUTHORED LABEL for the case the condition protects.
     if (schema.columns && schema.columns.length > 0) {
       const normalized = normalizeColumns(schema.columns);
-      const withHeaders = !objectName
-        ? normalized
-        : normalized.map((col) => ({ ...col, header: fieldLabel(objectName, col.accessorKey, col.header) }));
+      const withHeaders = normalized.map((col) => {
+        // Nothing to key a lookup or a humanization on. `normalizeColumns`
+        // returns such an entry untouched and so does this.
+        if (!col?.accessorKey) return col;
+        const authoredHeader = col.header && col.header !== col.accessorKey ? col.header : undefined;
+        const fallback = authoredHeader ?? humanizeFieldKey(col.accessorKey);
+        // The i18n wrapper is unchanged: a bundle entry still wins, and this is
+        // only its fallback — the same shape `buildHeader` above already has,
+        // including its `objectName` guard.
+        const header = objectName ? fieldLabel(objectName, col.accessorKey, fallback) : fallback;
+        // Unchanged entries stay BY REFERENCE, the property objectui#4618 made
+        // load bearing for data-table's column-state re-seed.
+        return header === col.header ? col : { ...col, header };
+      });
       return withHeaders.map(enrich);
     }
     if (finalData.length === 0) return [];

--- a/packages/plugin-dashboard/src/__tests__/ObjectDataTable.whitelistHeaderParity-9000.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectDataTable.whitelistHeaderParity-9000.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9000 — an authored drill `columns` whitelist must not DEGRADE the
+ * headers of the table it narrows.
+ *
+ * ## The asymmetry
+ *
+ * `ObjectDataTable` derives headers on two branches of one `useMemo`, and both
+ * call the same `fieldLabel` lookup. Only the FALLBACK differed:
+ *
+ *   auto-derive branch   fieldLabel(objectName, k, humanizeFieldKey(k))
+ *   whitelist branch     fieldLabel(objectName, col.accessorKey, col.header)
+ *
+ * A column authored as a bare string is humanized by `normalizeColumns`, so the
+ * string shorthand always agreed. The OBJECT form did not: both drill callers
+ * build `{ accessorKey: c, header: c }` from a `drillDown.columns` string list,
+ * so `col.header` IS the raw field key, and the whitelist branch handed that
+ * raw key to `fieldLabel` as its fallback. When no bundle entry resolves — the
+ * ordinary case in a drill — the more deliberate configuration produced the
+ * less finished table.
+ *
+ * ## The oracle is PARITY, not a string
+ *
+ * The acceptance assertion below is "the two branches agree, key for key",
+ * taken over one render of each. A per-branch assertion (`expect(header).toBe
+ * ('Close Date')`) would go green on a repair that humanized both branches into
+ * a new shared wrongness; parity plus the shared `humanizeFieldKey` convention
+ * anchor cannot.
+ *
+ * ## The control that must stay green on BOTH ablation legs
+ *
+ * The fallback fires for EVERY caller of the whitelist branch, not only for the
+ * two drill callers that pass a raw key. `normalizeColumns` resolves the
+ * spec-canonical `{ field, label }` and the adapter-canonical
+ * `{ accessorKey, header }` into that same `col.header` (objectui#5351), and
+ * `DashboardRenderer` forwards an authored dashboard widget's `columns`
+ * verbatim into this widget. So a genuine author-written label reaches this
+ * branch too — and humanizing it UNCONDITIONALLY would clobber it, a worse
+ * defect than the one being fixed. `AUTHORED LABEL` below is that control: it
+ * is green before the fix and must stay green after it, and it is the
+ * assertion that fails if the fallback is ever made unconditional.
+ *
+ * ## DIRECTIONS, written before the reverse verification was run
+ *
+ * Predicted RED on `origin/main`: the two PARITY assertions (both the drawer's
+ * end-to-end pair and the widget-level pair) — they read `close_date` /
+ * `needs_analysis` where the auto-derived row reads `Close Date` /
+ * `Needs Analysis`. Predicted GREEN on both sides: every `AUTHORED LABEL`
+ * assertion and the i18n `BUNDLE ENTRY` assertions — the fix touches only the
+ * fallback handed to `fieldLabel`. Measured result recorded in the PR body.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { I18nProvider } from '@object-ui/i18n';
+
+import { DrillDownDrawer } from '../DrillDownDrawer';
+import { ObjectDataTable } from '../ObjectDataTable';
+import { humanizeFieldKey } from '../utils';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '@object-ui/components';
+
+/**
+ * Keys chosen so the humanized spelling is VISIBLY different from the raw key:
+ * a snake_case key is the case where the two disagree. `unitPrice` is the
+ * camelCase control — `humanizeFieldKey` and the raw key still differ there.
+ */
+const FIELD_ORDER = ['close_date', 'needs_analysis', 'unitPrice'];
+const WHITELIST = ['close_date', 'needs_analysis'];
+
+const OPPORTUNITY = {
+  name: 'crm_opportunity',
+  fields: {
+    close_date: { type: 'date' },
+    needs_analysis: { type: 'text' },
+    unitPrice: { type: 'number' },
+  },
+};
+
+const ROWS = [{ close_date: '2026-01-01', needs_analysis: 'x', unitPrice: 3 }];
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async () => ({ data: ROWS })),
+    getObjectSchema: vi.fn(async () => OPPORTUNITY),
+  };
+}
+
+const headers = (): string[] =>
+  Array.from(document.querySelectorAll('thead th')).map((th) => (th.textContent ?? '').trim());
+
+async function renderDrawer(columns?: string[]): Promise<string[]> {
+  render(
+    <DrillDownDrawer
+      open
+      onClose={vi.fn()}
+      title="Won x Web"
+      objectName="crm_opportunity"
+      filter={{ stage: 'won' }}
+      columns={columns}
+      dataSource={makeDataSource()}
+    />,
+  );
+  await waitFor(() => expect(headers().length).toBeGreaterThan(0));
+  return headers();
+}
+
+async function renderWidget(
+  columns: unknown[] | undefined,
+  wrap?: (node: React.ReactElement) => React.ReactElement,
+): Promise<string[]> {
+  const node = (
+    <ObjectDataTable
+      schema={{ type: 'object-data-table', objectName: 'crm_opportunity', columns } as any}
+      dataSource={makeDataSource()}
+    />
+  );
+  render(wrap ? wrap(node) : node);
+  await waitFor(() => expect(headers().length).toBeGreaterThan(0));
+  return headers();
+}
+
+/** The exact mapping both drill callers apply to `drillDown.columns`. */
+const asDrillColumns = (keys: string[]) => keys.map((c) => ({ accessorKey: c, header: c }));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('objectui#9000 — a `columns` whitelist narrows the table, it does not degrade it', () => {
+  it('PARITY, end to end through the drill drawer: whitelisted headers equal auto-derived headers', async () => {
+    // Both readings come from the same object schema, the same data source and
+    // the same locale; the whitelist is the only thing that differs.
+    const auto = await renderDrawer(undefined);
+    expect(auto).toHaveLength(FIELD_ORDER.length);
+    const autoByKey = Object.fromEntries(FIELD_ORDER.map((k, i) => [k, auto[i]]));
+    cleanup();
+
+    const declared = await renderDrawer(WHITELIST);
+
+    expect(declared).toEqual(WHITELIST.map((k) => autoByKey[k]));
+  });
+
+  it('PARITY at the widget seam, over the object column shape the drill callers build', async () => {
+    const auto = await renderWidget(undefined);
+    const autoByKey = Object.fromEntries(FIELD_ORDER.map((k, i) => [k, auto[i]]));
+    cleanup();
+
+    const declared = await renderWidget(asDrillColumns(WHITELIST));
+
+    expect(declared).toEqual(WHITELIST.map((k) => autoByKey[k]));
+    // The convention anchor, referenced rather than spelled: parity alone would
+    // also hold if BOTH branches moved to a new shared wrongness.
+    expect(declared).toEqual(WHITELIST.map(humanizeFieldKey));
+  });
+
+  it('PARITY holds for the string shorthand too (it always did — pinned so the fix is not misread)', async () => {
+    const auto = await renderWidget(undefined);
+    const autoByKey = Object.fromEntries(FIELD_ORDER.map((k, i) => [k, auto[i]]));
+    cleanup();
+
+    const declared = await renderWidget(WHITELIST);
+
+    expect(declared).toEqual(WHITELIST.map((k) => autoByKey[k]));
+  });
+
+  it('AUTHORED LABEL — an adapter-spelled `header` survives the fallback', async () => {
+    // Green before AND after. An unconditional humanize renders "Close Date"
+    // here and fails: the author's label would have been clobbered.
+    const declared = await renderWidget([{ accessorKey: 'close_date', header: 'Deal Close' }]);
+    expect(declared).toEqual(['Deal Close']);
+  });
+
+  it('AUTHORED LABEL — a spec-spelled `label` survives the fallback', async () => {
+    // The same control seen through the other authoring spelling
+    // (objectui#5351 resolves `{ field, label }` into the same `col.header`).
+    const declared = await renderWidget([{ field: 'close_date', label: 'Deal Close' }]);
+    expect(declared).toEqual(['Deal Close']);
+  });
+
+  it('AUTHORED LABEL — a label that happens to be the humanized spelling is still the author\'s', async () => {
+    // The boundary between "absent" and "authored": an author who writes the
+    // convention's own output must get it back unchanged.
+    const declared = await renderWidget([{ accessorKey: 'close_date', header: 'Close Date' }]);
+    expect(declared).toEqual(['Close Date']);
+  });
+
+  it('BUNDLE ENTRY — a translation still wins over the derived spelling in BOTH branches', async () => {
+    const resources = {
+      zh: { crm: { fields: { crm_opportunity: { close_date: '结单日期' } } } },
+    };
+    const wrap = (node: React.ReactElement) => (
+      <I18nProvider config={{ defaultLanguage: 'zh', detectBrowserLanguage: false, resources }}>
+        {node}
+      </I18nProvider>
+    );
+
+    const auto = await renderWidget(undefined, wrap);
+    expect(auto[0]).toBe('结单日期');
+    cleanup();
+
+    const declared = await renderWidget(asDrillColumns(['close_date']), wrap);
+    expect(declared).toEqual(['结单日期']);
+  });
+});


### PR DESCRIPTION
Fixes #9000

`ObjectDataTable` derives its column headers on two branches of one `useMemo`, and both call the same `fieldLabel` lookup. Only the FALLBACK differed:

| branch | fallback handed to `fieldLabel` |
| --- | --- |
| auto-derive (`buildHeader`) | `humanizeFieldKey(k)` |
| explicit whitelist (before) | whatever `header` the caller supplied |

Both drill callers build `{ accessorKey: c, header: c }` out of a `drillDown.columns` string list, so `col.header` IS the raw field key. With no bundle entry to resolve — the ordinary case in a drill — authoring `columns` rendered `close_date` where the same table without a whitelist rendered `Close Date`. Narrowing the table also stopped finishing it, which points the wrong way: the more deliberate configuration produced the less finished result.

The repair sits in the whitelist branch beside the asymmetry it has to match, **not** at the two call sites — those would leave it for the next caller to rediscover, and a third caller has already been written once.

---

## The one decision that shaped the diff: the fallback is CONDITIONAL

The dispatch asked whether a caller-supplied `header` is *always* the raw field name. It is not, and this is the finding that decides the shape of the fix.

The fallback fires for **every** caller of this branch, not only the two drill callers. Census of what reaches it:

- `DrillDownDrawer` and `ObjectChart` map `drillDown.columns` to `{ accessorKey: c, header: c }` — raw key, no authorial intent.
- `normalizeColumns` resolves the spec-canonical `{ field, label }` **and** the adapter-canonical `{ accessorKey, header }` onto that same `col.header` (objectui#5351) — a genuine author-written label, on the same key.
- `DashboardRenderer` forwards an authored widget's `columns` into this widget verbatim (its object-provider arm spreads `restOptions`), and always sets `objectName`, so an authored dashboard table reaches this branch with a real label.

So an unconditional humanize would **clobber a real label** — a silently discarded label instead of an unpolished one, which is strictly worse than the defect being fixed. The lit positive control for that population already exists in the tree: `ObjectDataTable.columnHeader.test.tsx` pins `{ label: 'Stage', accessorKey: 'stage' }` and `{ field: 'stage', label: 'Stage' }` rendering **Stage**.

⇒ The fallback fires only where the column carries **no display text**, or carries **the raw field key itself**. Ablation leg 2 below is the measurement that this condition is load-bearing rather than defensive.

## Blast radius — deliberate, and here it is

`drillDown.columns` reaches this branch from three widget surfaces today, not four:

| surface | passes a `columns` whitelist? | header before | header after |
| --- | --- | --- | --- |
| `ObjectPivotTable` drill list | yes (`columns={drillDown?.columns}`) | `close_date` | `Close Date` |
| `ObjectMetricWidget` drill list | yes (same prop) | `close_date` | `Close Date` |
| `ObjectChart` drill list | yes (builds the table schema itself) | `close_date` | `Close Date` |
| `DatasetWidget` drill list | **no** — renders the drawer without `columns` | `Close Date` | `Close Date` (unmoved) |
| `ReportView` drill drawer (app-shell) | **no** | `Close Date` | `Close Date` (unmoved) |

The filer's count of four counted `DatasetWidget`; measured, that widget never passes a `columns` prop, so its drill list has always taken the auto-derive branch. The real count of moving surfaces is **three**.

A fourth population does reach the branch — any authored `object-data-table` schema, including the dashboard widgets `DashboardRenderer` builds. Those headers move **only** where the authored column carries no display text or spells the raw key; an authored label is returned exactly as authored.

**What a user sees:** a drill-through list opened from a pivot cell, a metric card or a chart segment, configured with `drillDown.columns`, now heads its columns `Close Date` / `Needs Analysis` where it previously headed them `close_date` / `needs_analysis`. The whitelist still narrows the table to exactly the listed columns, in the listed order. A loaded translation still wins over both spellings, unchanged.

No snapshot or DOM assertion anywhere in the tree pinned a raw drill header: the full `plugin-dashboard` suite (108 files, 974 tests) and the full `plugin-charts` suite (55 files, 508 tests) are green with no pin edited.

## Reproduction, two-sided

Both readings come from one run of one file, so the object schema, the data source and the locale are held constant and the whitelist is the only difference. On `origin/main`, through the real `DrillDownDrawer`:

```
AssertionError: expected [ 'close_date', 'needs_analysis' ]
                to deeply equal [ 'Close Date', 'Needs Analysis' ]
```

A one-sided reading could not tell "headers are raw" apart from "labels are unavailable here"; the auto-derived row over the same three fields is what rules the second reading out.

## The pin, and why its oracle is PARITY

`packages/plugin-dashboard/src/__tests__/ObjectDataTable.whitelistHeaderParity-9000.test.tsx` — 7 assertions, in three groups:

- **PARITY** — the whitelisted header row equals the auto-derived header row, key for key, asserted end to end through `DrillDownDrawer` and again at the widget seam over the object column shape the drill callers build. A per-branch string assertion would go green on a repair that humanized *both* branches into a new shared wrongness; parity plus a convention anchor that references `humanizeFieldKey` rather than spelling its output cannot.
- **AUTHORED LABEL** (3) — an adapter-spelled `header`, a spec-spelled `label`, and the boundary case of a label that happens to equal the convention's own output. Green before the fix and after it; this is the group that fails on an over-eager fallback.
- **BUNDLE ENTRY** — a translation still wins over the derived spelling, in both branches.

## Ablation, from the committed fix

Predictions were written down before running (`ablation-predictions.txt`, quoted verbatim below). Both legs mutate the committed file on disk; each leg proves the mutation landed by blob hash and by counting the removed and injected text, runs the pin, restores, and proves the restore by blob hash against the `HEAD` blob plus an empty `git diff HEAD`.

`HEAD` blob of `ObjectDataTable.tsx`: `a8e8070b28c99d53256512d8dcb9677144781c0e`

| leg | mutation | blob after mutation | predicted | measured |
| --- | --- | --- | --- | --- |
| 1 | the pre-fix expression restored verbatim | `5caeffb5559c912cc57edf86fd65dcfad0150e2d` | RED: the 2 PARITY tests; GREEN: the other 5 | **exactly that** — `2 failed / 5 passed`, the two failures being the two PARITY tests |
| 2 | fallback made unconditional (`humanizeFieldKey` with no condition) | `338fa8da271ae80ae72f1767af0d6df8c0703d19` | RED: AUTHORED LABEL adapter-spelled and spec-spelled; GREEN: both PARITY, the string shorthand, the humanized-spelling boundary (green by coincidence, since `Close Date` IS the convention's output for that key), and BUNDLE ENTRY | **exactly that** — `2 failed / 5 passed`, the two failures being the two `Deal Close` assertions |

No miscount on either leg. Both restores verified: blob back to `a8e8070b28c99d53256512d8dcb9677144781c0e`, `git diff HEAD` empty.

Leg 2 is the one that earns the condition: it is a repair that satisfies the card as written and silently discards an author's label, and it is red only because the AUTHORED LABEL group exists.

## Verification

| check | result |
| --- | --- |
| `pnpm exec vitest run packages/plugin-dashboard/` | 108 files, 974 tests, all passed |
| `pnpm exec vitest run packages/plugin-charts/` (the other drill caller's package) | 55 files, 508 tests, all passed |
| `pnpm --filter '@object-ui/plugin-dashboard^...' build` (dependency closure) | exit 0 |
| `pnpm --filter @object-ui/plugin-dashboard type-check` | exit 0 (`tsc --noEmit` plus `tsc -p tsconfig.test.json`) |
| the new pin is inside the typechecked program | proved, not assumed: `tsc -p tsconfig.test.json --listFiles` emits 1805 files and both `src/ObjectDataTable.tsx` and the new pin are in it |
| `pnpm --filter @object-ui/plugin-dashboard lint` | exit 0, 0 errors (447 pre-existing `no-explicit-any` warnings, unchanged in kind) |
| `node scripts/check-changeset-presence.mjs` | exit 0 — 1 published source file changed, 1 changeset declared |
| `node scripts/check-changeset-no-major.mjs` | exit 0 |
| `pnpm check:control-bytes` | exit 0 |
| `pnpm check:new-line-citations` | exit 0 |
| `pnpm check:vi-mock-specifiers` / `check:vi-mock-inherit` / `check:vi-mock-override-shape` | exit 0 |
| `pnpm check:unreferenced-sources` / `check:published-tsconfig-exclude` | exit 0 |

Heavy runs were serialised through the container's shared verify lock; every verdict above is read from the gate's own printed line, never a bare shell status. Repo-wide `pnpm lint` and `pnpm test` are CI's runs, not narrowed local ones.

## Acceptance notes

- **`plugin-charts/src/ObjectChart.tsx` is not in this diff**, by both fences: the repair belongs beside the asymmetry, and that file is in the merge queue as part of PR objectui#9037. Its drill list picks the fix up for free, through the component it already renders. The `plugin-charts` suite is green against this branch.
- **The card's `path:line` anchors, re-derived by symbol.** `DrillDownDrawer.tsx:122` is still accurate on `origin/main`. `plugin-charts/src/ObjectChart.tsx:1388` is stale — that map is at 1399, eleven lines down. Nothing in this diff cites a line in another file; `check:new-line-citations` is green.
- **The whitelist branch was never uniformly broken, and that is worth knowing.** A column authored as a bare string is humanized by `normalizeColumns` on the way in, so `columns: ['close_date']` always rendered `Close Date`. Only the OBJECT form carried the raw key through — which is exactly the form both drill callers construct. Pinned as its own assertion so the fix is not misread as having changed the shorthand.
- **The same class survives on two non-table surfaces, and is filed rather than swept in** (objectui#9055): `RecordDetailDrawer` builds its field labels with a fourth inline spelling that upper-cases only the first word (`Close date` against this table's `Close Date`) and sits on the *same* drill chain one click later; and `resolveSeriesLabel` in `DashboardRenderer` still falls back to the raw y-field key for a chart series label. Both were ruled out of this diff on purpose — this card fixes the surface it names.
- noted, not filed: `DrillDownDrawerProps.columns` still takes a bare `string[]` and has each caller build the column objects, which is the duplication the card's closing note raises. It is now inert — both mappings produce a shape this branch normalises identically — so it is a shape question for whoever next touches the drawer's props, not a defect. Successor: none queued.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB)_