### PR TITLE
fix(plugin-gantt): honour filter, sort and the row ceiling on inline `value` data

### DIFF
--- a/.changeset/8769-gantt-inline-query-keys.md
+++ b/.changeset/8769-gantt-inline-query-keys.md
@@ -1,0 +1,48 @@
+---
+'@object-ui/plugin-gantt': minor
+---
+
+Honour `filter`, `sort` and the platform row ceiling on a gantt's inline
+(`provider: 'value'`) data (objectui#8769).
+
+**The defect was fail-open.** `ObjectGantt`'s `reload` short-circuited the
+inline provider — it set the authored rows and returned BEFORE the adapter
+query, which is the one site that lowers `schema.filter` to `$filter`,
+`schema.sort` to `$orderby` and the objectui#7210 ceiling to `$top`. So an
+inline gantt that declared a `filter` drew **every** authored row, with no
+diagnostic. The key that was dropped is the key that NARROWS, which is why this
+matters: the chart answered a wider question than the author asked. ⛔ Nothing
+was exposed that was not already in the authored schema — this is a
+correctness defect, not a data-access one.
+
+Measured two-sided before the repair: the same five rows and the same
+`status = open` filter drew 3 rows through a fetching data source and 5 rows
+inline, with the same matcher on both sides.
+
+**What changed.** The inline branch is gone; `provider: 'value'` now goes
+through `resolveDataSource`'s `ValueDataSource` like every other provider,
+which already implements `$filter` / `$orderby` / `$skip` / `$top` / `$select`
+over its own array. No filter combinator was written for this change.
+
+**Behaviour you may notice.**
+
+- An authored `filter` / `sort` now narrows and orders inline rows. Both
+  spellings reach it: `data: { provider: 'value', items }` and `staticData`.
+- The row ceiling now applies to inline rows: past 2,000 drawn rows the chart
+  draws 2,000 and shows the footnote naming both numbers, as it already did for
+  fetched rows. It is applied to the **filtered** set, so a large inline array
+  that a `filter` cuts below the ceiling draws every matching row and stays
+  quiet. Rows a host passes down through the `data` React prop are still never
+  capped — those are not ours to cap.
+- Inline rows now reach the chart as the adapter's own deep copy rather than as
+  the authored array's object identities. `ViewData.items` is serializable
+  metadata, so every value the contract admits survives that copy unchanged;
+  code comparing a row handed to `onTaskClick` against the authored array with
+  `===` would need `id` equality instead.
+- An inline gantt's own write-backs (drag, dependency edit, inline edit,
+  delete) now survive the reload that follows them, because the reload reads
+  the adapter that took the write instead of re-reading the authored array over
+  the top of it.
+- A filter comparand that `@object-ui/core`'s `convertFiltersToAST` refuses does
+  **not** throw at render on this path: the inline matcher is local and never
+  reaches that converter. The row is excluded and the reason is logged once.

--- a/content/docs/plugins/plugin-gantt.mdx
+++ b/content/docs/plugins/plugin-gantt.mdx
@@ -127,8 +127,17 @@ const schema: ObjectGanttSchema = {
   gantt?: GanttConfig,              // Gantt-specific configuration
   viewMode?: 'day' | 'week' | 'month' | 'quarter' | 'year',
   readOnly?: boolean                // disable every edit path
+  filter?: Array<any>,              // JSON-Rules query filter — applies on EVERY provider
+  sort?: Array<{ field, order }>,   // ordering — applies on EVERY provider
 }
 ```
+
+`filter` and `sort` are not object-only keys. They narrow and order inline rows
+(`staticData`, or `data: { provider: 'value' }`) exactly as they narrow and
+order fetched ones, and the platform row ceiling — 2,000 drawn rows with a
+footnote naming both numbers — applies to inline rows too. The ceiling is
+applied to the **filtered** set, so a large inline array that a `filter` cuts
+below the ceiling draws every matching row and shows no footnote.
 
 `onTaskClick` and `className` are **React props on `<ObjectGantt>`**, not schema
 keys — the renderer never reads them off the schema, and a function cannot

--- a/packages/plugin-gantt/README.md
+++ b/packages/plugin-gantt/README.md
@@ -243,6 +243,16 @@ const recordSource = {
 `{ provider: 'value', items }`, `{ provider: 'api', read, write }` or
 `{ provider: 'schema', schemaId }`.
 
+**The provider does not change which query keys apply.** An authored `filter`
+and `sort` narrow and order the rows on **every** provider, inline ones
+included, and the platform row ceiling (2,000 drawn rows, with a footnote
+naming both numbers) applies to all of them — inline rows cost the browser what
+fetched rows cost. Inline rows go through the same in-memory adapter the other
+providers go through, so `filter` is evaluated with the same matcher and the
+ceiling is applied to the **filtered** set, never to the raw one. Before
+objectui#8769 the inline provider skipped that query and drew every authored
+row with an authored `filter` silently dropped.
+
 **2. How the fields map — `getGanttConfig`.** Two spellings, checked in order.
 The **`gantt` block wins whenever it is present**, and it is taken WHOLE — the
 flat top-level keys are not merged into it. The flat spelling is read only when

--- a/packages/plugin-gantt/src/ObjectGantt.inlineQueryKeys-8769.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.inlineQueryKeys-8769.test.tsx
@@ -1,0 +1,272 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8769 — a `provider: 'value'` gantt honours the three query keys the
+ * fetching path honours: `filter`, `sort`, and the objectui#7210 row ceiling.
+ *
+ * ## What was wrong
+ *
+ * `reload` short-circuited the inline provider (`setData(dataItems)`; return)
+ * BEFORE `effectiveDataSource.find(...)`, which is the ONE site that lowers
+ * `schema.filter` to `$filter`, `schema.sort` to `$orderby` and the ceiling to
+ * `$top`. An authored `filter` therefore reached nothing and every inline row
+ * was charted — the fail-OPEN direction: the key that was ignored is the key
+ * that NARROWS, so the author saw MORE rows than declared, with no diagnostic.
+ *
+ * ⛔ Not a data-exposure boundary. The rows are already in the authored schema;
+ * what is wrong is that the chart answers a question nobody asked.
+ *
+ * ## The two-sided reading is the finding
+ *
+ * A one-sided reproduction cannot tell "the filter was ignored" from "the
+ * filter matched everything", so the first case renders the SAME rows and the
+ * SAME filter twice — once inline, once through a context adapter — and reads
+ * the DISAGREEMENT. The adapter is a `ValueDataSource` over the same rows, so
+ * the matcher is literally the same object on both sides and the only variable
+ * left is which branch of `reload` ran.
+ *
+ * ## ORDER: filter first, ceiling second (objectui#7210 ruling a′)
+ *
+ * The ceiling is applied to the FILTERED set, matching the fetching path
+ * exactly — there `$filter` and `$top` travel in one query and every backend
+ * filters before it limits. `ceilingOrder` pins it from the observable side: a
+ * set that is over the ceiling BEFORE filtering and under it after draws every
+ * matching row and shows NO footnote. A ceiling-then-filter implementation
+ * would draw at most 2,000 rows there and would still footnote.
+ *
+ * ## The `never capped by us` case this file replaces
+ *
+ * `ObjectGantt.rowCeiling-7210.test.tsx` asserted that an inline set is never
+ * capped and never footnoted. That case pinned the SHORT-CIRCUIT's behaviour,
+ * not ruling a′: the ruling's own budget is measured in DOM ELEMENTS PER
+ * RECORD (its table was measured over "real child views, inline `value`
+ * provider"), and an inline row costs the browser exactly what a fetched row
+ * costs. Nothing in the ruling text carves the provider out. So the exemption
+ * moves here, inverted, with the triage ruling on objectui#8769 as its
+ * authority — and `ceilingNote` below is what makes the cut loud rather than
+ * silent, which is the half ruling a′ actually protects.
+ *
+ * ## Live adjacency, measured (objectui#9001 / PR objectui#9049)
+ *
+ * That card makes core's `convertFiltersToAST` THROW `FilterOperatorError` for
+ * an `$icontains` comparand that is not a non-empty string. This repair does
+ * NOT inherit it: the inline provider resolves to `ValueDataSource`, whose
+ * matcher is local — it imports `@object-ui/types`, `@objectstack/spec/data`
+ * and `./batchTransaction.js`, and never the converter, which is reached only
+ * by `@object-ui/data-objectstack` on the wire path. `refusedComparandDoesNotThrow`
+ * pins the consequence from the outside: a render, not a throw.
+ *
+ * REVERSE VERIFICATION — direction predicted BEFORE running, from the committed
+ * fix, by restoring the short-circuit: `twoSidedFilter`, `inlineSort`,
+ * `staticDataSpelling`, `ceilingCap`, `ceilingNote` and `ceilingOrder` go RED;
+ * `control` and `refusedComparandDoesNotThrow` stay GREEN (the control draws
+ * the same rows in the same order either way, which is what makes it a
+ * control).
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NON_GRID_ROW_CEILING, NON_GRID_ROW_CEILING_TOP } from '@object-ui/react';
+import { ValueDataSource } from '@object-ui/core';
+import { ObjectGantt } from './ObjectGantt';
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }));
+
+// The bar canvas is irrelevant here — every assertion is about WHICH rows
+// reached the chart and in WHAT ORDER. Same stub the sibling ObjectGantt pins
+// use, widened by the id list because `sort` is unreadable from a count.
+vi.mock('./GanttView', () => ({
+  GanttView: ({ tasks }: any) => (
+    <div
+      data-testid="gantt-view"
+      data-task-count={String(tasks.length)}
+      data-task-ids={tasks.map((t: any) => String(t.id)).join(',')}
+    />
+  ),
+}));
+
+vi.mock('@object-ui/plugin-detail', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@object-ui/plugin-detail')>()),
+  RecordDetailDrawer: () => null,
+  deriveRecordPageHref: () => null,
+}));
+
+const ROWS = [
+  { id: '1', subject: 'Alpha', status: 'open', rank: 30, visible_from: '2026-01-01', due_date: '2026-01-31' },
+  { id: '2', subject: 'Bravo', status: 'closed', rank: 10, visible_from: '2026-02-01', due_date: '2026-02-28' },
+  { id: '3', subject: 'Charlie', status: 'open', rank: 40, visible_from: '2026-03-01', due_date: '2026-03-31' },
+  { id: '4', subject: 'Delta', status: 'closed', rank: 20, visible_from: '2026-04-01', due_date: '2026-04-30' },
+  { id: '5', subject: 'Echo', status: 'open', rank: 50, visible_from: '2026-05-01', due_date: '2026-05-31' },
+];
+
+/** The three rows an authored `status = open` filter declares. */
+const OPEN_IDS = '1,3,5';
+const OPEN_FILTER = [['status', '=', 'open']];
+
+const base: any = {
+  type: 'object-gantt',
+  gantt: {
+    titleField: 'subject',
+    startDateField: 'visible_from',
+    endDateField: 'due_date',
+  },
+};
+
+function drawn() {
+  const el = screen.getByTestId('gantt-view');
+  return {
+    count: el.getAttribute('data-task-count'),
+    ids: el.getAttribute('data-task-ids'),
+  };
+}
+
+function makeRows(n: number, status: (i: number) => string = () => 'open') {
+  return Array.from({ length: n }, (_, i) => ({
+    id: String(i + 1),
+    subject: `Task ${i + 1}`,
+    status: status(i),
+    visible_from: '2026-01-01',
+    due_date: '2026-12-31',
+  }));
+}
+
+describe('objectui#8769 — the inline `value` provider honours filter / sort / the row ceiling', () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warn.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it('twoSidedFilter: the inline path and the fetching path agree on the SAME rows and the SAME filter', async () => {
+    // One matcher, two branches of `reload`. Any disagreement here is the
+    // short-circuit and nothing else.
+    const dataSource = new ValueDataSource({ items: ROWS }) as any;
+
+    const { unmount } = render(
+      <ObjectGantt
+        schema={{ ...base, data: { provider: 'value', items: ROWS }, filter: OPEN_FILTER }}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('gantt-view')).toBeTruthy());
+    await waitFor(() => expect(drawn().count).toBe('3'));
+    const inline = drawn();
+    unmount();
+
+    render(
+      <ObjectGantt
+        schema={{ ...base, objectName: 'duly_task', filter: OPEN_FILTER }}
+        dataSource={dataSource}
+      />,
+    );
+    await waitFor(() => expect(drawn().count).toBe('3'));
+    const fetching = drawn();
+
+    expect(inline.ids).toBe(OPEN_IDS);
+    expect(fetching.ids).toBe(OPEN_IDS);
+    // The finding, stated as the two paths agreeing.
+    expect(inline.ids).toBe(fetching.ids);
+  });
+
+  it('inlineSort: an authored `sort` orders the inline rows', async () => {
+    render(
+      <ObjectGantt
+        schema={{
+          ...base,
+          data: { provider: 'value', items: ROWS },
+          sort: [{ field: 'rank', order: 'desc' }],
+        }}
+      />,
+    );
+    await waitFor(() => expect(drawn().count).toBe('5'));
+    // rank 50,40,30,20,10 → Echo, Charlie, Alpha, Delta, Bravo
+    expect(drawn().ids).toBe('5,3,1,4,2');
+  });
+
+  it('staticDataSpelling: the `staticData` rung reaches the same repair', async () => {
+    // The ruled three-rung ladder wraps `staticData` into
+    // `{ provider: 'value', items }`, so it lands on exactly this path. It is
+    // the second spelling an author can use and it needs its own row.
+    render(<ObjectGantt schema={{ ...base, staticData: ROWS, filter: OPEN_FILTER }} />);
+    await waitFor(() => expect(drawn().count).toBe('3'));
+    expect(drawn().ids).toBe(OPEN_IDS);
+  });
+
+  it('ceilingCap: an inline set past the ceiling draws exactly the ceiling', async () => {
+    render(
+      <ObjectGantt
+        schema={{
+          ...base,
+          data: { provider: 'value', items: makeRows(NON_GRID_ROW_CEILING_TOP + 500) },
+        }}
+      />,
+    );
+    await waitFor(() => expect(drawn().count).toBe(String(NON_GRID_ROW_CEILING)));
+  });
+
+  it('ceilingNote: the cut is LOUD — the footnote names both numbers', async () => {
+    const total = NON_GRID_ROW_CEILING_TOP + 500;
+    render(
+      <ObjectGantt schema={{ ...base, data: { provider: 'value', items: makeRows(total) } }} />,
+    );
+    await waitFor(() => expect(drawn().count).toBe(String(NON_GRID_ROW_CEILING)));
+
+    const note = await screen.findByRole('note');
+    expect(note.getAttribute('data-row-ceiling-note')).toBe('non-grid');
+    expect(note.textContent).toContain(String(NON_GRID_ROW_CEILING));
+    expect(note.textContent).toContain(String(total));
+  });
+
+  it('ceilingOrder: the ceiling is applied to the FILTERED set, not to the raw one', async () => {
+    // Over the ceiling before filtering, under it after: 2,400 rows of which
+    // only every third is `open` (800). Filter-then-ceiling draws all 800 and
+    // stays quiet; ceiling-then-filter could not.
+    const rows = makeRows(2400, (i) => (i % 3 === 0 ? 'open' : 'closed'));
+    render(
+      <ObjectGantt
+        schema={{ ...base, data: { provider: 'value', items: rows }, filter: OPEN_FILTER }}
+      />,
+    );
+    await waitFor(() => expect(drawn().count).toBe('800'));
+    expect(screen.queryByRole('note')).toBeNull();
+  });
+
+  it('control: an inline chart with NO filter, NO sort and under the ceiling is unchanged', async () => {
+    // ⭐ Green on BOTH ablation legs by construction. Without it a reviewer
+    // cannot tell this repair from "the inline path now drops rows".
+    render(<ObjectGantt schema={{ ...base, data: { provider: 'value', items: ROWS } }} />);
+    await waitFor(() => expect(drawn().count).toBe('5'));
+    expect(drawn().ids).toBe('1,2,3,4,5');
+    expect(screen.queryByRole('note')).toBeNull();
+  });
+
+  it('refusedComparandDoesNotThrow: a comparand core would refuse RENDERS, it does not throw', async () => {
+    // objectui#9001 / PR objectui#9049 makes `convertFiltersToAST` throw for
+    // this comparand. The inline path resolves to `ValueDataSource`, which
+    // never reaches that converter — it excludes the row and logs once.
+    render(
+      <ObjectGantt
+        schema={{
+          ...base,
+          data: { provider: 'value', items: ROWS },
+          filter: [['subject', 'icontains', '']],
+        }}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('gantt-view')).toBeTruthy());
+    await waitFor(() => expect(drawn().count).toBe('0'));
+    expect(
+      warn.mock.calls.some((c: unknown[]) => String(c[0]).includes('icontains')),
+    ).toBe(true);
+  });
+});

--- a/packages/plugin-gantt/src/ObjectGantt.rowCeiling-7210.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.rowCeiling-7210.test.tsx
@@ -29,7 +29,9 @@
  * REVERSE VERIFICATION — MEASURED, and corrected from what this docblock used
  * to predict (objectui#7507). Removing `$top: NON_GRID_ROW_CEILING_TOP` from
  * `ObjectGantt`'s reload turns the truncation case red at the **`$top`
- * assertion**, 1 failed / 2 passed; the below-ceiling case stays green.
+ * assertion**; the below-ceiling case stays green. ⚠️ The pass/fail TALLY that
+ * used to be quoted here is deliberately gone: objectui#8769 changed how many
+ * cases this file has, and a stale count reads as a measurement.
  *
  * ⚠️ It does NOT go red at the footnote. The prediction that it would — "no
  * probe row ⇒ `truncated` false ⇒ no note" — reads the mechanism backwards,
@@ -159,17 +161,53 @@ describe('objectui#7210 ruling a′ — the gantt draws at most the platform cei
     expect(screen.queryByRole('note')).toBeNull();
   });
 
-  it('an inline `value` data set is never capped by us, and never footnoted', async () => {
+  /**
+   * ⚠️ THIS CASE WAS INVERTED (objectui#8769). It used to read "an inline
+   * `value` data set is never capped by us, and never footnoted", and it was
+   * green because `reload` returned before the query — the same short-circuit
+   * that dropped an authored `filter` on that provider. It pinned the
+   * SHORT-CIRCUIT, not ruling a′: the ruling's budget is measured in DOM
+   * ELEMENTS PER RECORD, its own measurement table was taken over "real child
+   * views, inline `value` provider", and its text carves out no provider. An
+   * inline row costs the browser exactly what a fetched row costs.
+   *
+   * The inline provider's own three-key pin lives in
+   * `ObjectGantt.inlineQueryKeys-8769.test.tsx`; this one stays here so the
+   * ceiling's own file states the exemption boundary in one place.
+   */
+  it('an inline `value` data set IS capped, and says so', async () => {
+    const total = NON_GRID_ROW_CEILING_TOP + 500;
     const inline: any = {
       ...schema,
-      data: { provider: 'value', items: makeRows(NON_GRID_ROW_CEILING_TOP + 500) },
+      data: { provider: 'value', items: makeRows(total) },
     };
 
     render(<ObjectGantt schema={inline} />);
 
     await waitFor(() =>
       expect(screen.getByTestId('gantt-view').getAttribute('data-task-count')).toBe(
-        String(NON_GRID_ROW_CEILING_TOP + 500),
+        String(NON_GRID_ROW_CEILING),
+      ),
+    );
+    const note = await screen.findByRole('note');
+    expect(note.textContent).toContain(String(NON_GRID_ROW_CEILING));
+    expect(note.textContent).toContain(String(total));
+  });
+
+  /**
+   * The exemption that REMAINS, and the reason the case above is not a
+   * contradiction: rows a HOST component hands down through the `data` prop
+   * are not ours to cap — we did not issue the query that produced them and
+   * have no `total` to name in a footnote.
+   */
+  it('a host `data` prop is still never capped, and never footnoted', async () => {
+    const rows = makeRows(NON_GRID_ROW_CEILING_TOP + 500);
+
+    render(<ObjectGantt schema={schema} {...({ data: rows } as any)} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('gantt-view').getAttribute('data-task-count')).toBe(
+        String(rows.length),
       ),
     );
     expect(screen.queryByRole('note')).toBeNull();

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -547,8 +547,15 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
    * State rather than a value derived from `data.length`: once the rows are
    * capped, `data.length === NON_GRID_ROW_CEILING` is exactly what a result
    * set of exactly the ceiling ALSO looks like, so the fact has to be carried
-   * from the response that knew it. Every path that sets `data` sets this too
-   * — a host `data` prop and an inline `value` set are never truncated by us.
+   * from the response that knew it. Every path that sets `data` sets this too.
+   *
+   * ⚠️ The exempt path is now the HOST `data` prop and only it — rows a host
+   * component handed down are not ours to cap. An inline `value` set IS capped
+   * (objectui#8769): it goes through the same adapter query as every other
+   * provider, so the ceiling arrives with the same `$top` and the same
+   * footnote. Ruling a′'s budget is measured in DOM elements per record and
+   * its own table was measured over the inline provider, so an inline row
+   * costs what a fetched row costs and the ruling text carves out no provider.
    */
   const [rowCeiling, setRowCeiling] = useState<{ truncated: boolean; total?: number }>({
     truncated: false,
@@ -580,20 +587,27 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   const ganttConfig = getGanttConfig(schema);
   const dataProvider = dataConfig?.provider;
   const hasInlineData = dataProvider === 'value';
-  /**
-   * The one primitive field `reload` (below) reads off `dataConfig` beyond
-   * `dataProvider` — the inline-data payload for the `value` provider.
-   * `reload` used to key on `dataConfig` itself: `useMemo` carries no
-   * semantic guarantee (React may discard its cache and recompute), and a
-   * discard alone was enough to give `reload` a fresh identity and re-fire
-   * the mount effect below, refetching. `effectiveDataSource`'s own memo
-   * intentionally keeps `dataConfig` as a dependency (not just its
-   * `object`/`items` primitives): `resolveDataSource` reads a
-   * provider-shaped slice of it (the whole `read`/`write` request config
-   * on `api`), which cannot be flattened to a fixed primitive list the way
-   * the 'object'/'value' branches below can be (objectui#6592).
+  /*
+   * There is deliberately no `dataItems` binding here any more
+   * (objectui#8769). It existed because `reload` READ the inline payload
+   * directly, and it was in `reload`'s dependency list as the one primitive
+   * standing in for `dataConfig` — `reload` may not key on `dataConfig`
+   * itself, because `useMemo` carries no semantic guarantee (React may
+   * discard its cache and recompute) and a discard alone was enough to give
+   * `reload` a fresh identity and re-fire the mount effect below
+   * (objectui#6592).
+   *
+   * `reload` no longer reads the payload: the inline provider goes through
+   * `effectiveDataSource` like every other provider. That memo intentionally
+   * keeps `dataConfig` as a dependency (not just its `object`/`items`
+   * primitives), because `resolveDataSource` reads a provider-shaped slice of
+   * it — the whole `read`/`write` request config on `api` — which cannot be
+   * flattened to a fixed primitive list. Authored items therefore still reach
+   * `reload`: new items → new `dataConfig` (deep-compared above) → new
+   * adapter → new `reload`. The primitive is redundant, and a binding
+   * documented as "the field `reload` reads" that `reload` does not read is
+   * the kind of comment the next reader would trust.
    */
-  const dataItems = dataConfig?.provider === 'value' ? dataConfig.items : undefined;
 
   // Resolve the ViewData config into a concrete DataSource adapter:
   //   provider: 'object' → the context DataSource passed via props (unchanged)
@@ -672,14 +686,24 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
         return;
       }
 
-      if (hasInlineData && dataProvider === 'value') {
-        if (isCurrent()) {
-          setData(dataItems as any[]);
-          setRowCeiling({ truncated: false });
-        }
-        return;
-      }
-
+      // ⭐ THERE IS NO SECOND EXIT FOR THE INLINE PROVIDER (objectui#8769).
+      //
+      // `provider: 'value'` used to return here with `setData(dataItems)` —
+      // BEFORE the `find` below, which is the ONE site that lowers
+      // `schema.filter` to `$filter`, `schema.sort` to `$orderby` and the
+      // objectui#7210 ceiling to `$top`. So an authored `filter` reached
+      // nothing and the chart drew EVERY inline row: the fail-OPEN direction,
+      // because the key that was dropped is the key that NARROWS. Accepting a
+      // declared key one cannot honour is the defect; the adapter can honour
+      // all three, so it honours them.
+      //
+      // `resolveDataSource` already answers this provider with a
+      // `ValueDataSource`, which implements `$filter` / `$orderby` / `$skip` /
+      // `$top` / `$select` over its own array — so nothing below is
+      // provider-specific and no combinator had to be written here
+      // (objectui#8513 stays where it is). The matcher is LOCAL: it never
+      // reaches `convertFiltersToAST`, so a comparand that converter refuses
+      // is excluded-and-logged here rather than thrown at render.
       if (!effectiveDataSource || typeof effectiveDataSource.find !== 'function') {
         throw new Error('DataSource required for object/api providers');
       }
@@ -763,7 +787,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- (rest as any).data intentionally untracked, matching the original effect
-  }, [effectiveDataSource, resource, hasInlineData, dataProvider, dataItems, schema.filter, schema.sort, objectSchema, perms]);
+  }, [effectiveDataSource, resource, hasInlineData, dataProvider, schema.filter, schema.sort, objectSchema, perms]);
 
   /**
    * Does the query this effect is about to issue DERIVE anything from the

--- a/packages/plugin-gantt/src/index.tsx
+++ b/packages/plugin-gantt/src/index.tsx
@@ -65,14 +65,21 @@ export type {
  *
  * `columns` and a row cap are NOT mapped, because neither has a read site: a
  * gantt projects the fields its `gantt` config names (start/end/title/progress/
- * dependencies/…) rather than a column list, and its reload issues no `$top` at
- * all — it loads the whole bar set and lets `GanttView` window it. Writing a
- * view's field list or page size onto either key would hand the block a value it
- * ignores, which is the defect this wiring removes, one layer deeper.
+ * dependencies/…) rather than a column list, and the `$top` its reload does
+ * send is the platform ceiling — a named constant, ⛔ not authorable
+ * (objectui#7210, ruling a′). Writing a view's field list or page size onto
+ * either key would hand the block a value it ignores, which is the defect this
+ * wiring removes, one layer deeper. ⚠️ This paragraph used to say the reload
+ * "issues no `$top` at all"; that stopped being true at objectui#7210 and is
+ * corrected here because objectui#8769 puts the same `$top` on one more path.
  *
- * Inline data still wins, unchanged: `getDataConfig` prefers `schema.data` /
+ * Inline data still WINS: `getDataConfig` prefers `schema.data` /
  * `schema.staticData` over the object name, so a gantt authored with both a
- * binding and inline rows renders the inline rows exactly as it did before.
+ * binding and inline rows renders the inline rows. ⚠️ It no longer renders
+ * them UNPROCESSED — objectui#8769 routes the inline provider through the same
+ * adapter query as every other provider, so a `filter` / `sort` mapped here
+ * narrows and orders inline rows exactly as it does fetched ones, and the row
+ * ceiling applies to them too.
  */
 const OBJECT_GANTT_DATA_SOURCE: ElementDataSourceMapping = {
   filter: true,


### PR DESCRIPTION
Fixes #8769

Exit taken: the **preferred** one. Both exits were pre-authorised — apply the keys, or refuse the combination loudly — and the measurement chose the first: `resolveDataSource` already answers this provider with `ValueDataSource`, which implements `$filter`, `$orderby`, `$skip`, `$top` and `$select` over its own array, so there was no capability the inline path could not support and nothing to refuse. **No filter combinator was written here** — objectui#8513's work stays where it is.

## What was wrong

`ObjectGantt`'s `reload` short-circuited the inline provider: it set the authored rows and returned **before** `effectiveDataSource.find(...)`, which is the one site that lowers `schema.filter` onto `$filter`, `schema.sort` onto `$orderby` and the objectui#7210 ceiling onto `$top`. An authored `filter` therefore reached nothing and the chart drew every inline row.

The direction is **fail-open**: the dropped key is the key that NARROWS, so the author was shown more rows than declared, with no diagnostic. ⛔ Nothing was exposed — the rows are already in the authored schema. What was wrong is that the chart answered a wider question than the one asked.

## The two-sided reading is the finding

A one-sided reproduction cannot separate "the filter was ignored" from "the filter matched everything", so the same five rows and the same `status = open` filter were rendered twice, with **one `ValueDataSource` serving both sides** — the matcher is literally the same object, and the only remaining variable is which branch of `reload` ran.

| path | rows drawn | ids |
|---|---|---|
| fetching (`objectName` + context adapter) | 3 | `1,3,5` |
| inline (`provider: 'value'`) — before | **5** | `1,2,3,4,5` |
| inline (`provider: 'value'`) — after | 3 | `1,3,5` |

## What changed

The inline branch is deleted; `provider: 'value'` falls through to the same adapter query as every other provider. The now-dead `dataItems` binding goes with it — `reload` no longer reads the payload, and authored items still reach it through the deep-compared `dataConfig` that builds the adapter, so the objectui#6592 memo-identity reasoning is preserved and re-stated where the binding used to be.

## The assumptions, and how each resolved

**A — does the repair inherit objectui#9001 / PR objectui#9049's new `FilterOperatorError` throw? NO, measured.** `convertFiltersToAST` is reached only by `@object-ui/data-objectstack` on the wire path. `ValueDataSource` never imports it — its imports are `@object-ui/types`, `@objectstack/spec/data` and its own `batchTransaction` module — and it carries its own local refusal for that comparand, which excludes the row and logs once. So an inline chart whose filter carries such a comparand renders with zero rows and a console line, it does **not** throw at render. This was a deliberate decision, not an accident of routing: an in-memory matcher decides about one row at a time, while the converter is deciding whether to send a query at all, and that asymmetry is the adapter's own stated refusal shape. Pinned from the outside by `refusedComparandDoesNotThrow`.

**B — is `find(...)` really the only site applying the three? HELD.** Verified by symbol across the package: `applyNonGridRowCeiling` appears at exactly one call site, and `$filter` / `$orderby` at exactly one each, all inside `reload`.

**C — are the ceiling and filter/sort independent? NO, and the order is now asserted.** A ceiling computed before filtering is a different number from one computed after. **Filter first, ceiling second**, matching the fetching path exactly: there `$filter` and `$top` travel in one query and every backend filters before it limits, so any other order would have made the two paths disagree again in a subtler way. `ceilingOrder` pins it from the observable side — 2,400 inline rows of which 800 match draw all 800 with **no** footnote, which a ceiling-then-filter implementation could not produce.

**D — is `data: { provider: 'value' }` the only spelling? NO — there are TWO.** The ruled three-rung record-source ladder also wraps `staticData` into a `provider: 'value'` config, so an author lands on this path either way. `staticDataSpelling` covers the second one. (A bare `data: []` array does **not** reach here on the gantt — this renderer returns it verbatim rather than normalising it, so it falls through to the fallback adapter; and the host `data` React prop is a different branch, objectui#7333's.)

**E — are the card's `path:line` anchors stale? ASSUMED SO and not used.** Everything was re-derived by symbol, and there is no line citation anywhere in this diff.

**F — is today's behaviour silently wrong? HELD.** Nothing warned. The short-circuit set state and returned with no console line, so the card's "no diagnostic" framing is correct.

## A standing pin is INVERTED here, deliberately

`ObjectGantt.rowCeiling-7210.test.tsx` asserted "an inline `value` data set is never capped by us, and never footnoted", and `ObjectGantt.tsx` carried the matching comment. That case pinned the **short-circuit**, not objectui#7210 ruling a-prime:

- the ruling's own budget is measured in **DOM elements per record**, and its measurement table was taken over "real child views, **inline `value` provider**" — an inline row costs the browser exactly what a fetched row costs;
- the ruling text names no provider carve-out; what it forbids is a view crossing the ceiling **quietly**, which is why the footnote is the load-bearing half.

So the case is inverted in place with that reasoning recorded on it, and the exemption that genuinely remains — rows a **host** hands down through the `data` React prop, which we did not query and have no total for — gets its own case beside it. If a maintainer reads the exemption as ruled rather than incidental, this is the one hunk to revert; it is isolated.

## Behaviour a consumer can notice

- An authored `filter` / `sort` now narrows and orders inline rows.
- Past 2,000 drawn rows an inline chart draws 2,000 and shows the footnote naming both numbers.
- Inline rows now reach the chart as the adapter's own deep copy rather than as the authored array's object identities. `ViewData.items` is serializable metadata, so every value the contract admits survives that copy unchanged; only reference comparison against the authored array changes, and `id` equality is the replacement.
- An inline gantt's write-backs (drag, dependency edit, inline edit, delete) now survive the reload that follows them, because the reload reads the adapter that took the write instead of re-reading the authored array over the top of it. Reads and writes previously disagreed about which array was the source of truth; they now agree.

## Ablation — predicted before running, then measured

Prediction written down first: restoring the short-circuit turns 8 cases red and leaves 4 green (`control`, plus the above-ceiling, below-ceiling and host-`data`-prop ceiling cases).

Measured: **8 failed, 4 passed** — exactly the predicted split, no miscount.

On-disk proof, both directions: the injected marker went 0 to 1 and the removed marker 1 to 0 in the same file; blob `e6e1b46a` became `fba326a2`. Restore proved by hash equality back to `e6e1b46a` **and** by an empty `git diff HEAD`, from a trap with absolute paths. No `dist` is involved on this path — the pin imports the mutated module relatively, as source.

The `control` case is the one that makes the rest readable: an inline chart with no filter, no sort and under the ceiling draws the same five rows in the same order on **both** legs, which is what separates this repair from "the inline path now drops rows".

## Verification

All at `05d946890`, the final commit.

- `pnpm exec vitest run packages/plugin-gantt/` — **66 files, 514 tests passed**.
- `pnpm --filter @object-ui/plugin-gantt type-check` — clean. The new pin is **proven inside** the typechecked set rather than assumed into it: its first run failed with `TS7006` on line 269 of the new file, so `tsc -p tsconfig.test.json` demonstrably reads it.
- Dependency-closure build `pnpm --filter '@object-ui/plugin-gantt^...' build` — green (13 packages).
- Gates run green: control bytes, new cross-file line citations, the three vi-mock gates, element-data-source declaration, unreferenced sources, doc fences, shell-escape residue, comment-mask corpus, changeset presence, changeset-no-major.
- **Lint, narrowed and the narrowing declared.** eslint over the `plugin-gantt` subtree: **94 files** counted from `--format json`, **0 errors on every file this PR touches**. The narrowing is a measurement, not a skip: the linted population is read from `eslint.config.js`'s own top-level `ignores`, which excludes only build output (`dist`, `.next`, `node_modules`, `public`, `.source` and three named artefacts) and not one source file; and the config sets **no** `parserOptions.project` and no `projectService`, so linting is not type-aware and this diff cannot move the verdict on any file it did not touch. The 2 errors the run does report are in `packages/plugin-gantt/demo/main.tsx`, which this PR does not touch — pre-existing.
- **NOT MEASURED, with reasons:** `check:readme-exports` — the gate itself printed "the population COLLAPSED, this run proves nothing" because most packages have no `dist` in this worktree; after building `plugin-gantt` its own README is judged and reports zero complaints. `check:sdui-registration-pins` — exit 2, its own text says a run with no console build "has measured nothing". Both need a full-repo build, which is CI's run.

## Acceptance notes

- **filed as objectui#9061** — `ObjectCalendar` and `ObjectMap` carry the same inline short-circuit, hand-copied. Fenced out of this PR by the brief and filed rather than fixed. The dedup behind it was controlled: a repo-scoped REST listing over `state=all`, 400 rows, grepped locally, with objectui#8769 itself as the positive control proving the enumeration reached this neighbourhood.
- **noted, not filed** — `packages/plugin-gantt/demo/main.tsx` carries 2 eslint errors on `main` (`react-hooks/purity`, `no-console`). Whoever runs this package's own lint task hits them; not filed because the repo's actual wired lint invocation cannot be confirmed from here, so "this is red for everyone" would be a guess.
- **noted, not filed** — `ObjectGrid` and `ObjectTree` also branch on the inline provider, but their surrounding machinery is different and neither was measured here. objectui#9061 deliberately names only calendar and map, the two that are literal copies of this shape.
- Not touched in either direction: the contract-review label. The claim on this card declares Clause-2 yes and the carriers gate is expected to report C3; that is a disclosed, escalated governance question, and per the brief it is neither cleared nor hung by this seat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB)_