### PR TITLE
docs(changeset): correct two now-false sentences in pending `@object-ui/types` changesets

### DIFF
--- a/.changeset/8913-object-kanban-columns-declared.md
+++ b/.changeset/8913-object-kanban-columns-declared.md
@@ -62,11 +62,20 @@ render is the same defect one layer up, so neither is blessed:
   in "Uncategorized") and a string-first mix is ignored whole. The protocol's "or"
   names two array shapes and no mixed example.
 
-**The bare-string array is admitted for parity and is inert on this block.** The
-renderer honours it only when a board has no `groupBy`, and `groupBy` is required
-on this face — so no document that passes this schema reaches it. It is declared
-because refusing an arm the protocol names would be a second narrowing; the
-requiredness is tracked as objectui#8990.
+**The bare-string array is admitted for parity, and on this block it is now
+REACHABLE.** The renderer honours it only when a board has no `groupBy` — the
+`effectiveColumns` memo takes the string branch under `if (!schema.groupBy)` — and
+`groupBy` was required on this face when this entry was written, so no document
+that passed this schema could reach it. objectui#8990 has since made `groupBy`
+optional on both twins (`groupBy?: string` in `objectql.ts`,
+`z.string().optional()` in the Zod mirror), and a lane-less board now does reach
+the arm: a board carrying only `objectName` and `columns: ['todo', 'doing', 'done']`
+parses green and satisfies every guard on that branch, drawing those lanes titled
+by the raw strings. It is declared because refusing an arm the protocol names would
+be a second narrowing — that reason is unchanged; what moved is that the arm is
+exercised rather than dormant. objectui#8990's own entry records the same
+reachability from its side, pinned with a firing control in
+`packages/plugin-kanban/src/__tests__/laneLessBoard-8990.test.tsx`.
 
 **What is deliberately NOT judged.** `cards` is not required (a swimlane does not
 carry its own cards), so an undeclared lane key such as the retired `items`

--- a/.changeset/8992-user-actions-collapse-and-docblock.md
+++ b/.changeset/8992-user-actions-collapse-and-docblock.md
@@ -58,7 +58,7 @@ both measured by rebuilding `packages/types/dist` on each side of the change:
    `description = undefined` after the strip, on both sides of this change, while
    `buttons` — the one member that never carried a default — keeps its description
    through it. So the three simply stop being an exception: before, the local extension
-   supplied descriptions the other ten defaulted keys did not have. Nothing in this
+   supplied descriptions the other seven defaulted keys did not have. Nothing in this
    repository reads them.
 2. In the emitted `objectql.zod.d.ts` the three move from `z.ZodOptional[z.ZodBoolean]`
    to `z.ZodDefault[z.ZodBoolean]` — the spec's own declaration, as the compiler sees it


### PR DESCRIPTION
Fixes #9042

Two **pending** changesets on `main` carry sentences that are false today and would ship
verbatim into `packages/types/CHANGELOG.md` at the next `@object-ui/types` publish. This
corrects both. Markdown only, both files under `.changeset/`; no source, no accept set.

## Site 1 — `8992-user-actions-collapse-and-docblock.md`, one word

`the other ten defaulted keys` to `the other **seven** defaulted keys`. One line.

The file contains **two** whole-word occurrences of "ten" and only one is wrong; the other
(`all ten defaulted keys read description = undefined after the strip`, line 57) is correct
and is **untouched** — verified after the edit, not just before.

Re-derived on this branch's base rather than taken from the card. Two independent
derivations of the resolved dependency, `@objectstack/spec@17.4.0`:

| derivation | members | defaulted | not defaulted | the three are defaulted | "the other" defaulted |
|---|---|---|---|---|---|
| published `json-schema/ui/ListView.json` | 11 | 10 | 1 (`buttons`) | yes | **7** |
| runtime, over the installed package's Zod shape | 11 | 10 | 1 (`buttons`, def type `optional`) | yes | **7** |

The seven are `sort, search, filter, refresh, rowHeight, addRecordForm, editInline` — exactly
the seven the file's own item 2 already enumerates, which is the self-contradiction the card
identified.

The post-strip reading behind the occurrence that must NOT move was also measured, through
`packages/types/dist` built on this branch:

```
POST-STRIP description===undefined count: 10 [addRecordForm, editInline, filter, group,
                                              hideFields, refresh, rowColor, rowHeight,
                                              search, sort]
POST-STRIP description KEPT count:        1 [buttons]
CONTROL descOf(spec.buttons) = "Custom action button IDs to show in the toolbar"
CONTROL descOf(spec.group)   = "Allow users to change record grouping fr..."
```

The two CONTROL lines are the live half: the reader returns real strings when a description
is present, so the ten `undefined` readings are a measurement rather than a broken accessor.

## Site 2 — `8913-object-kanban-columns-declared.md`, one paragraph

The paragraph was true when written and was invalidated when objectui#8990 landed. The
**headline sentence** is the wrong one, so deleting the trailing `objectui#8990` clause would
have left both false claims standing.

Re-derived on current `main`:

| claim in the old paragraph | measured now |
|---|---|
| "`groupBy` is **required** on this face" | **FALSE** — `groupBy?: string` in `packages/types/src/objectql.ts`; the Zod twin's node reports def type `optional` |
| "is **inert** … no document that passes this schema reaches it" | **FALSE** — a schema-valid lane-less board reaches the bare-string arm |
| "the requiredness is tracked as objectui#8990" | stale — that card is `closed` / `completed` |

The reachability is a real parse plus the renderer's own dispatch predicate, evaluated on the
**parsed** document rather than read off the source:

```
SUBJECT  lane-less + bare-string columns : success=true
CONTROL  no record source (must FAIL)     : success=false issues=["custom@"]
CONTROL  mixed columns array (must FAIL)  : success=false issues=["invalid_union@columns"]
CONTROL  numeric lane id (must FAIL)      : success=false issues=["invalid_union@columns"]
CONTROL  groupBy present, bare strings    : success=true

PARSED groupBy value: undefined
renderer guard  schema.columns && length>0 : true
renderer guard  typeof columns[0] === str  : true
renderer guard  !schema.groupBy            : true
=> BARE-STRING ARM REACHED BY A SCHEMA-VALID DOCUMENT: true
```

Three refusals with distinct issue codes and a second success: the instrument discriminates,
so `success=true` on the subject is a reading and not a schema that accepts everything.

The rewrite says the arm is now reachable and cites objectui#8990 as the change that made it
so rather than as pending work. It keeps the original reason the arm is declared (refusing an
arm the protocol names would be a second narrowing) — that reason did not move; what moved is
that the arm is exercised rather than dormant. It also points at
`packages/plugin-kanban/src/__tests__/laneLessBoard-8990.test.tsx`, whose existence was checked.
The sibling `8990-object-kanban-groupby-optional.md` already records the same reachability from
its own side, so after this change the two pending entries agree instead of contradicting.

## Both files are still PENDING — verified with live controls

- Present in `.changeset/` on `origin/main`: both, listed straight out of the `origin/main` tree.
- Absent from **all 42** tracked `CHANGELOG.md` files: 0 files for each of six distinctive
  sentences from the two changesets.
- Live control on that same sweep, so the 0s are a reading and not a dead query:
  `ObjectKanban` hits 20 files, `object-kanban` 17, `UserActionsConfigSchema` 5.
- `packages/types/CHANGELOG.md` is 4550 lines; controls `Minor Changes` (27) and
  `ListColumnSchema` (6) hit inside that file specifically.

Neither has been released, so the correction belongs here and not in a docs-only CHANGELOG PR.

## Does this PR owe a changeset of its own?

Answered by running `scripts/check-changeset-presence.mjs`, not by guessing:

```
Compared the working tree with 7f27bc543 (merge-base with origin/main): 2 file(s) changed,
0 of them published source of a package the release covers, 0 of them a manifest whose
published contract moved, 0 under a package changesets ignores, 0 changeset(s) added.
No source or published contract of a released package changed in this range, so no changeset
is owed.
```

Exit 0. The guarded population is a released package's published, executable source — its
`src/`, its `index.html`, files its `package.json` publishes verbatim — minus documentation.
`.changeset/` is under no package, so a markdown-only diff there is outside the population
entirely and owes nothing.

## Gates run locally

| gate | exit | note |
|---|---|---|
| `check-changeset-presence.mjs` | 0 | no changeset owed, quoted above |
| `check-changeset-no-major.mjs` | 0 | no `major` declared |
| `check-changeset-fixed.mjs` | 0 | all workspace packages classified |
| `check-changeset-overwrite.mjs` | 0 | report-only; see below |
| `check-governed-queue-guard.mjs --test` | 0 | NOT GOVERNED, 2 paths vs 5 surfaces; control `AGENTS.md` returns exit 3 GOVERNED |

`check-changeset-overwrite.mjs` **does report this PR**, expectedly and non-blockingly — it
reports any change that modifies a changeset it did not add:

```
0 changeset(s) added, 2 modified, 0 deleted.
   M  .changeset/8913-object-kanban-columns-declared.md
          declared at base: @object-ui/types: minor
          declares now:     @object-ui/types: minor
   M  .changeset/8992-user-actions-collapse-and-docblock.md
          declared at base: @object-ui/types: minor
          declares now:     @object-ui/types: minor
```

That gate's own header names this exact case as legitimate — "factual corrections to prose" —
and its narrower signal, a **lost** package declaration, does not fire: `declared at base` and
`declares now` are identical on both files, which is the 18-for-19 shape its history measured.

## Labels

⛔ `needs:contract-review` is deliberately **NOT** hung on this PR. The card carries
`Clause-②: no` and carries no such label; `h31ContractReviewCarrierSplit` in
`scripts/pm/check-half-states.mjs` returns a finding only when the two carriers **disagree**
(`cardGated && barePrs.length > 0`, or `!cardGated && gatedPrs.length > 0`) and returns `null`
when both are absent. Hanging it here would manufacture the second, more dangerous half of that
split. Verified by reading the function, and the card's labels were re-read immediately before
opening this PR.

The declaration holds against the diff: 2 paths changed, 0 outside `.changeset/`, 0 not
markdown — no accept set moves and no exported symbol changes.

## Sibling sweep

Fixed here: the two files named on the card. Nothing else is touched.

Reported, not fixed:

- **7 pending changesets carry a `tracked as #N` forward reference whose card is now
  `closed`/`completed`** (`#6011, #7170, #7188, #7708, #8166, #8983, #8990`). One of those is
  this PR's own site 2. The other six read as a citation whose *implication of pending work* is
  stale; ⛔ I did not verify whether each surrounding claim was actually falsified, and none of
  them carries a falsified headline claim of the kind site 2 had. They are a report, not a fix,
  and not this PR's one-line class.
- Checked and found **still true** on `main`: `9012-core-spec-floor.md` (core declares
  `@objectstack/spec: ^17.3.0`), `8604-record-details-columns-enum.md`
  (`columns?: '1' | '2' | '3' | '4'` in `record-components.ts`, while the dashboard `columns`
  one level away stays `number`), and `8990-object-kanban-groupby-optional.md`.
- No other pending changeset asserts `groupBy` requiredness or the inert/unreachable claim
  (1 match each, both this PR's file), against controls of 25 files mentioning `groupBy` and 67
  mentioning `inert`. No other pending changeset carries the miscount class (`the other ten`,
  `defaulted keys`, `eleven members`, `UserActionsSchema` — 1 file each, this PR's), against
  controls of 43 files containing `all ten` and 393 containing `keys`.

The PR body of #9017 carries the same "the other ten" sentence. It is merged, so its body is
cosmetic and reaches no CHANGELOG; ⛔ I did not edit it, and it is not required.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_