### PR TITLE
test(plugin-grid): give #8920's case-P pin a wait of its own

### DIFF
--- a/.changeset/9035-hinted-column-waitfor.md
+++ b/.changeset/9035-hinted-column-waitfor.md
@@ -1,0 +1,9 @@
+---
+---
+
+Give objectui#8920's case-P pin a wait of its own before it reads the hinted
+column's `tel:` anchor (objectui#9035). The two assertions preceding it settle on
+the inline rows; the anchor needs the `format` hint that only arrives with the
+async object-schema fetch, so reading it bare sampled an unsettled render and
+intermittently reddened PRs that cannot reach the code under test. Test only; no
+package is released by this change.

--- a/packages/plugin-grid/src/__tests__/formatHintedColumnRenderer-8920.test.tsx
+++ b/packages/plugin-grid/src/__tests__/formatHintedColumnRenderer-8920.test.tsx
@@ -258,7 +258,31 @@ describe('objectui#8920 — every ObjectGrid path honours a `format` hint', () =
     // The badge renderer translates the option value to its label; a plain
     // text prefix would print the raw `new`.
     await waitFor(() => expect(container.textContent).toContain('New'));
-    // …and the hinted column in the same grid is still promoted.
-    expect(telHrefs(container)).toContain(`tel:${HINTED_PHONE}`);
+    // …and the hinted column in the same grid is still promoted — which needs
+    // a wait of its OWN, because it is the only fact in this case that the two
+    // assertions above do not imply (objectui#9035).
+    //
+    // `Alice` is a raw row value, and the badge label `New` is
+    // `humanizeLabel('new')`: the prefix renderer is handed a FIXED-key field
+    // descriptor (`{ name, type: BADGE_PREFIX_RENDERER_KEY }`, ObjectGrid.tsx)
+    // carrying no `options`, so `SelectCellRenderer` finds no option to
+    // translate and humanizes the stored code. ⇒ both settle on the first
+    // commit that carries the inline rows, and NEITHER touches the object
+    // schema.
+    //
+    // The `tel:` anchor does. `format: 'phone'` is declared only in
+    // `CONTACT_SCHEMA`, which reaches the grid through the async
+    // `dataSource.getObjectSchema()` fetch, so the promotion lands in a
+    // STRICTLY LATER commit than the two waits above settle on. Read bare, this
+    // assertion sampled whatever tick it happened to run on and intermittently
+    // saw `[]` — reddening PRs that cannot reach the code under test.
+    //
+    // ⛔ The wait is the only thing that changed: the assertion is byte-identical
+    // and still fails if the hinted column stops being promoted (it retries the
+    // same `toContain`, and `telHrefs` re-queries the DOM on every attempt).
+    // Note the shape the file's own `expectHintHonoured` already uses: wait on
+    // the LATEST-arriving fact, then assert the earlier ones. This case had it
+    // inverted.
+    await waitFor(() => expect(telHrefs(container)).toContain(`tel:${HINTED_PHONE}`));
   });
 });


### PR DESCRIPTION
Fixes #9035

## What changed

One assertion in `packages/plugin-grid/src/__tests__/formatHintedColumnRenderer-8920.test.tsx` — case P's last line — gained a wait of its own:

```ts
await waitFor(() => expect(telHrefs(container)).toContain(`tel:${HINTED_PHONE}`));
```

The assertion text is byte-identical to what was there. Only the wait is new, and `waitFor` retries the same `toContain`, so the pin still fails if the hinted column stops being promoted — demonstrated by ablation below, not asserted. Plus an empty-frontmatter changeset declaring that this releases nothing.

⛔ No `packages/plugin-grid` source is touched. Nothing was deleted, skipped, loosened, slept on, or wrapped in try/catch.

## The real content of this card: what the hinted column waits on that the two preceding assertions do not

Case P's block was:

```ts
await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
await waitFor(() => expect(container.textContent).toContain('New'));
expect(telHrefs(container)).toContain(`tel:${HINTED_PHONE}`);   // no wait
```

Both waits settle on facts derivable from the **inline rows alone**:

1. **`Alice`** is a raw row value — `ROWS[0].name`, handed to the grid as `data: { provider: 'value', items: ROWS }`. No fetch stands between it and the first commit.
2. **`New`** looks schema-derived and is not. The badge prefix is this file's one deliberately *fixed-key* site: `ObjectGrid.tsx` renders it with a hard-coded field descriptor — name plus `type: BADGE_PREFIX_RENDERER_KEY` — carrying **no `options`**. So `SelectCellRenderer` finds no declared option to translate `'new'` with, and falls through to `humanizeLabel(String('new'))`, which returns `'New'` by capitalisation. `'new'` is itself a raw row value. ⇒ `New` also needs nothing beyond the inline rows.

The third line is the only fact in the case that does need more:

3. **The `tel:` anchor** exists only if `work_phone` resolves to `PhoneCellRenderer` rather than `TextCellRenderer`, and that promotion is driven by `format: 'phone'`. That hint is declared **only** in `CONTACT_SCHEMA`, which reaches the grid through `dataSource.getObjectSchema()` — an async fetch whose result lands in `useState` and drives a **strictly later commit** than the one carrying the rows (`ObjectGrid.tsx`, the effect commented "Inline data: still fetch objectSchema for type-aware rendering"; the renderer is then picked from `objectSchema?.fields?.[col.field]`).

⇒ The two waits certify commit N. The bare `expect` asserted a fact that only exists at commit N+1, sampling whatever tick it happened to run on. When the schema promise resolved a tick late, `telHrefs(container)` was `[]` — exactly the reported failure value, and exactly what a promotion that has not happened **yet** looks like.

⭐ The file's own shared helper already encodes the correct discipline: `expectHintHonoured` waits on the **latest-arriving** fact (the `tel:` anchor) and only then asserts the earlier ones. Case P had that order inverted — it waited on two early facts and then asserted the late one. That inversion, not the renderer, is the defect.

## PM assumptions — all five checked

| | assumption | verdict |
|:--|:--|:--|
| **A** | genuinely racy, not deterministically order-dependent | **held — and reproduced** |
| **B** | `telHrefs` reads the DOM at call time | **held** |
| **C** | the two preceding waits do not guarantee settlement | **held**, mechanism above |
| **D** | case P is the only un-awaited assertion in the file | **held** |
| **E** | no fake timers interact with `waitFor` polling | **held** |

**A — reproduced, two independent ways.**

1. **Spontaneously, at the original shape.** An exact behavioural replica of pre-fix case P (immediate async data source, bare assertion) was run in **6 fresh vitest processes, the file alone, no shard-mates: 1 red in 6.** The red is byte-identical to the CI signature:

   ```
   AssertionError: expected [] to include 'tel:+15551234567'
         Tests  1 failed | 3 skipped (4)
   ```

   ⇒ It is a genuine race, not an ordering artefact and not a shared-module leak: it failed in an isolated process with a single test selected, no neighbouring file loaded, nothing to leak in. The box was shared with other seats' locked runs, which is the contention that makes it visible; a quiet box may well go 6/6 green, so the 1-in-6 rate is a lower bound on a loaded shard, not a stable frequency.

2. **Deterministically, by forcing the ordering.** A temporary probe with `getObjectSchema` resolving one macrotask after the rows produced, in one run:
   - bare assertion (today's shape) — **RED**, same signature: `expected [] to include 'tel:+15551234567'`;
   - the identical assertion **awaited** (this repair) — **GREEN**, on identical ordering;
   - a third case with **no `getObjectSchema` at all** — `Alice` and `New` both render and `telHrefs` stays `[]` forever. That is the direct proof of the C mechanism: the two preceding assertions are satisfiable with zero object schema.

   The probe was temporary and is not part of this diff.

**B.** `telHrefs` is `Array.from(root.querySelectorAll('a[href^="tel:"]')).map(...)`, evaluated in the function body on every call; `container` is a stable node that `querySelectorAll` re-queries live. Nothing is snapshotted. Proven empirically by probe leg 2: the awaited form passes on the exact ordering that fails the bare form, which could not happen if the collection were captured earlier.

**D — the census.** After this change the file holds exactly two remaining un-awaited `expect`s, both inside `expectHintHonoured`. Neither is the same shape: both are ordered **after** that helper's `waitFor` on the hinted anchor — i.e. after the latest-arriving fact in the block — so they read a DOM that already implies the schema landed. Case P was the only assertion in the file whose wait was **weaker than its own subject**. Nothing else here needed changing, and no sibling file was touched (the card's scope fence).

**E.** No `vi.useFakeTimers` / `advanceTimersByTime` / `useRealTimers` in the file, and none in any root `vitest.setup.*`. `waitFor` polls on real timers; there is no hang-to-timeout hazard.

## The ablation that matters — does the pin still bite?

Not "it passes now", but "it still fails when it should".

`resolveCellRendererType` in `packages/fields/src/index.tsx` — the promotion itself — was mutated on disk so a `format` hint can never promote a textual base type. On-disk landing was verified in both directions before running: original anchor count 1 to 0, injected marker count 1.

**Result: all six cases RED, case P included.**

```
× ... > P: compound-cell prefix badge still draws the select renderer (must-not-change pin) 1050ms
  → expected [] to include 'tel:+15551234567'
 Test Files  1 failed (1)
      Tests  6 failed (6)
```

P failed at **1050ms** — the new `waitFor` retried to its timeout and then failed, which is precisely the behaviour a masking wait would not have. ⇒ the repair did not weaken the pin.

**Resolution path, so the RED cannot be a stale artefact:** `vitest.config.mts` aliases `@object-ui/fields` to `packages/fields/src`, so the mutation reaches the test through **source**, not `dist`. No rebuild sat between the edit and the run.

**Restore, proven by hash rather than by an exit code:**

- HEAD blob `41327228e8924c70f459ed702c3f533405b8be43`; blob after restore `41327228e8924c70f459ed702c3f533405b8be43` — byte-identical.
- `git diff HEAD --stat` after restore: empty.
- Restored-tree re-run of the real file: `Test Files 1 passed (1) / Tests 6 passed (6)`.

## Verification

All runs from the repo ROOT, serialized through the shared verify lock (`os-verify-lock.sh`, slot `objectui-9035`; verdicts `command-exit 0`).

| what | command | result |
|:--|:--|:--|
| the fixed file | `pnpm exec vitest run packages/plugin-grid/src/__tests__/formatHintedColumnRenderer-8920.test.tsx` | **6 passed (6)** |
| dependency-closure build (13 pkgs) | `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-grid^...' build` | exit **0** |
| type-check leg 1 (shipped source) | `pnpm exec tsc -p packages/plugin-grid/tsconfig.json --noEmit` | exit **0** |
| type-check leg 2 (tests) | `pnpm exec tsc -p packages/plugin-grid/tsconfig.test.json --listFiles` | exit **0** |
| lint, narrowed | `pnpm exec eslint --no-inline-config --format json` on the edited file | exit **0**, 0 errors |

**The type-check really did read this test.** `tsconfig.test.json` includes `src/**/*.test.tsx`, and `--listFiles` shows the edited file among the program's 1672 inputs (1 hit) — so leg 2's green is a green about this file, not a green that skipped it.

**Lint narrowing, declared.** The repo-wide `pnpm lint` is CI's run and is not claimed here. The narrowed run linted **1 file** (count read from `--format json`, not estimated) — the only file in this diff eslint's config covers; the changeset is a `.changeset/*.md` doc. The narrowing excludes nothing, because `eslint.config.js` declares **no** `parserOptions.project` and no `projectService` (0 occurrences) ⇒ type-aware linting is off ⇒ no rule's verdict on an untouched file can move because of this diff. The 3 remaining `no-explicit-any` warnings are pre-existing: the same 3 rule/line/column triples appear when the **base** version of the file (7f27bc543) is piped through the same command.

**Gates**

- `node scripts/check-changeset-presence.mjs` — **before**: exit 1, `1 source file(s) of 1 released package(s) changed, and this change adds no changeset`. ⇒ the "test-only needs no changeset" assumption is **false in form**: this gate counts a test file under `packages/plugin-grid/src` as published source of a released package. Its own text names the exemption — an EMPTY frontmatter changeset. **After** adding one, exit 0, its verdict line: `1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/9035-hinted-column-waitfor.md.` / `Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.` ⇒ true in substance: nothing is released.
- `pnpm changeset:check` — exit 0: `All workspace packages are in the changeset fixed group.` / `No changeset declares a 'major' bump.`
- `pnpm check:control-bytes` — exit 0: `check-control-bytes: OK (scanned 7257 tracked text file(s); skipped 85 binary).`
- `pnpm check:new-line-citations` — exit 0.

Repo-wide suites and the full shard remain CI's.

## Out of scope, noted not filed

The same un-awaited shape was **not** found elsewhere in this file (census above). No sibling file was surveyed — the card fences that to a successor card, and none was warranted from anything seen here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB