### PR TITLE
fix(fields): honour the authored `dueLike` key on a datetime cell (objectui#8958)

### DIFF
--- a/.changeset/datetime-cell-duelike-affordance-8958.md
+++ b/.changeset/datetime-cell-duelike-affordance-8958.md
@@ -1,0 +1,49 @@
+---
+'@object-ui/fields': minor
+'@object-ui/types': minor
+---
+
+A `datetime` cell now honours the authored `dueLike` key its `date` sibling already honoured (objectui#8958).
+
+`DetailViewFieldSchema.dueLike` declares itself, in the `describe` text an author reads,
+as marking "a date/datetime field as due/deadline-semantic, gating the relative
+'Overdue Nd' wording". Both types. `DateTimeCellRenderer` never read the key, so an
+author who marked a `datetime` column `dueLike` published successfully and the
+affordance silently did not appear. Measured before anything was changed — clock pinned
+to `2026-09-09T12:00:00.000Z`, `TZ=UTC`, `en-US`, value `2026-09-06T09:30:00.000Z`:
+
+    date     dueLike: true  ->  "Overdue 3d"   tabular-nums text-red-600
+    datetime dueLike: true  ->  "3 days ago"   tabular-nums text-sm whitespace-nowrap
+    datetime  no key        ->  "3 days ago"   tabular-nums text-sm whitespace-nowrap
+
+The last two rows were byte-identical: the authored key changed nothing, and the cell
+still looked like a legitimate relative date, so the drop was invisible to a reader.
+After this change the `datetime` row reads `"Overdue 3d"` with the red styling, matching
+its `date` sibling on the same instant.
+
+Both halves of the affordance travel, because the affordance is both: the "Overdue Nd"
+wording (which also reaches the i18n translate fn, so a zh session no longer reads
+`Overdue 3d` beside a translated date cell) and the red styling, which is applied
+whichever display face the cell paints — gating it on the relative face alone would
+leave `compact`, this cell's default face, still disagreeing with its `date` sibling.
+
+Two populations change appearance, and the second is the larger one:
+
+- `datetime` fields with `dueLike: true` authored explicitly;
+- `datetime` fields whose NAME matches the due/deadline convention (`due_*`, `deadline`,
+  `expires_at`, `expiry`, `expected_close`, `target_close`, `sla*`, `return_by`,
+  `renewal*`, `next_action*`) with no key authored at all. That heuristic was already
+  live on `date` columns; it now answers the same on `datetime` columns, which is the
+  parity being restored.
+
+`DateTimeFieldMetadata` gains `dueLike?: boolean`, which `DateFieldMetadata` already
+carried. Nothing narrows and no accepted input is rejected: the key was already accepted
+by the view schema for both types, and leaving it off the datetime interface would have
+kept the declared-vs-enforced mismatch alive with the sign flipped — a key the renderer
+honours but the authoring type rejects.
+
+The affordance is day-granular on both cells, inherited from the shared relative-time
+path rather than re-decided here: the wording gates on whole calendar days, so a
+datetime a few hours past its deadline still reads "Today" and is not red, and
+"Overdue 0d" is not a string this codebase can produce. Sub-day precision is a separate
+call and was not taken.

--- a/content/docs/fields/date.mdx
+++ b/content/docs/fields/date.mdx
@@ -35,7 +35,9 @@ const closeDate: DateFieldMetadata = {
 ```
 
 The range bounds are `min_date` and `max_date` — the same spelling the datetime field
-uses. `datetime` is its own type with its own metadata (`DateTimeFieldMetadata`); see
+uses, and so is `dueLike`: it marks the field as due/deadline-semantic, gating the
+relative "Overdue Nd" wording and the red styling. `datetime` is its own type with its
+own metadata (`DateTimeFieldMetadata`) and honours `dueLike` identically; see
 [DateTime Field](/docs/fields/datetime).
 
 The value being edited, and the `className` / `disabled` a host supplies, are **not**

--- a/content/docs/fields/datetime.mdx
+++ b/content/docs/fields/datetime.mdx
@@ -39,8 +39,29 @@ const startsAt: DateTimeFieldMetadata = {
   format: 'yyyy-MM-dd HH:mm',
   min_date: '2024-01-01T00:00:00Z',
   max_date: '2030-12-31T23:59:59Z',
+  dueLike: true,
 };
 ```
+
+## Overdue Affordance
+
+`dueLike` marks the field as due/deadline-semantic. It is the same key, with the
+same meaning, that the [Date Field](/docs/fields/date) uses — a past `starts_at`
+or `created_at` is not a missed deadline, so only a field that says so gets the
+affordance:
+
+- the relative face reads **"Overdue Nd"** instead of the neutral "N days ago";
+- the cell is styled red, whichever display face it is painting.
+
+The key is optional. When it is omitted, common due/deadline field-name
+conventions (`due_at`, `deadline`, `expires_at`, `sla_at`, `renewal_at`,
+`next_action_at`, …) turn the affordance on by themselves; set `dueLike: false`
+is not required to opt out, but authoring a neutral name is.
+
+The affordance is **day-granular**. It compares calendar days, so a datetime a
+few hours past its deadline still reads "Today" and is not red — the same answer
+the date field gives for a deadline falling today. The shortest overdue phrase
+is "Overdue 2d".
 
 The value being edited, and the `className` / `disabled` a host supplies, are **not**
 metadata keys — they are runtime widget props. See [Field Widget Props](/docs/fields/widget-props).

--- a/packages/fields/src/__tests__/datetimeCell.dueLikeAffordance-8958.test.tsx
+++ b/packages/fields/src/__tests__/datetimeCell.dueLikeAffordance-8958.test.tsx
@@ -1,0 +1,299 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8958 — ONE authored `dueLike`, one overdue affordance, across the
+ * two neighbouring date cell renderers.
+ *
+ * ## The declared contract
+ *
+ * `DetailViewFieldSchema.dueLike` (`@object-ui/types`' zod views) says, in the
+ * `describe` text an author reads: "Marks a date/datetime field as
+ * due/deadline-semantic, gating the relative 'Overdue Nd' wording (vs. neutral
+ * 'Nd ago' for start/end/created dates)". Both types. `DateTimeCellRenderer`
+ * never read the key.
+ *
+ * ## What was measured, before anything was changed
+ *
+ * Clock pinned to `2026-09-09T12:00:00.000Z`, `TZ=UTC` (root vitest config),
+ * `en-US`, value `2026-09-06T09:30:00.000Z` (3 days past, inside the ±7-day
+ * relative window), through the two cell renderers:
+ *
+ *   date     `dueLike: true` -> "Overdue 3d"  `tabular-nums text-red-600`
+ *   datetime `dueLike: true` -> "3 days ago"  `tabular-nums text-sm whitespace-nowrap`
+ *   datetime  no key at all  -> "3 days ago"  `tabular-nums text-sm whitespace-nowrap`
+ *
+ * Rows 2 and 3 were BYTE-IDENTICAL: the authored key changed nothing. That is
+ * the silent-drop signature — the runtime accepts the key, parses it, drops
+ * it, and renders something that still looks like a legitimate relative date,
+ * so a reader cannot tell an honoured `dueLike` from a dropped one by looking
+ * at the cell. A green suite therefore proves nothing by itself, and every
+ * case below asserts a rendered FACE.
+ *
+ * ## The oracle is AGREEMENT, not a string
+ *
+ * The finding is the DISAGREEMENT between the two types, so the assertion is
+ * `datetimeFace === dateFace` — anchored to the literal face as well, so a
+ * redesign that moved both sides together cannot pass. A one-sided
+ * reproduction could not distinguish "datetime drops it" from "nothing paints
+ * overdue anywhere".
+ *
+ * ## Controls, and why each one is here
+ *
+ * - **A `datetime` WITHOUT `dueLike` renders exactly as before** — the
+ *   population that must not move. Without it, "every datetime now says
+ *   Overdue" passes every other case in this file.
+ * - **A `dueLike` datetime that is NOT overdue** (future, and today) paints no
+ *   affordance and stays byte-identical to the no-key face. Same reason.
+ * - **The `date` cell, same run, same instant** — it already honoured the key,
+ *   so it is what "honoured" looks like; without it an assertion here could be
+ *   measuring a broken clock or a dead locale channel.
+ *
+ * ## The granularity is INHERITED, and is pinned as such
+ *
+ * `formatRelativeDate` compares calendar-day boundaries and gates its wording
+ * on `diffDays < -1`, so **"Overdue 0d" is not a string this codebase can
+ * produce** — the shortest overdue phrase is "Overdue 2d". Measured, because
+ * it is the whole reason honouring the declaration is coherent at datetime
+ * precision rather than nonsense: a datetime two hours past its deadline reads
+ * "Today", exactly as the `date` cell has always answered for a deadline
+ * falling today. Sub-day precision is a separate call and was not taken here.
+ *
+ * ## Directions
+ *
+ * Reverting the `dueLike` read in `DateTimeCellRenderer` turns the repro, the
+ * styling cases, the heuristic case and the i18n case RED, and leaves every
+ * control GREEN — the controls measure surfaces this change does not touch,
+ * which is exactly why they can vouch for the run. Gating the red styling on
+ * the relative branch alone turns the compact-face case RED. Making the cell
+ * time-of-day aware turns the day-granularity cases RED.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { I18nProvider, LocalizationProvider } from '@object-ui/i18n';
+import { DateCellRenderer, DateTimeCellRenderer, formatRelativeDate } from '../index';
+
+/** The pinned clock. `TZ=UTC` comes from the root vitest config. */
+const CLOCK = '2026-09-09T12:00:00.000Z';
+
+/** 3 days past — inside the ±7-day window, so the relative face is a PHRASE. */
+const OVERDUE_3D = '2026-09-06T09:30:00.000Z';
+/** 2.5 hours past, SAME calendar day — the sub-day case. */
+const PAST_TODAY = '2026-09-09T09:30:00.000Z';
+/** Yesterday late — one calendar day back: red, but not yet "Overdue Nd". */
+const YESTERDAY_LATE = '2026-09-08T23:00:00.000Z';
+/** Future, inside the window. */
+const FUTURE_2D = '2026-09-11T09:30:00.000Z';
+/** Beyond the window, where the relative face collapses onto the absolute one. */
+const OUT_OF_WINDOW = '2026-08-31T09:30:00.000Z';
+
+type Face = { text: string; cls: string; red: boolean };
+
+/**
+ * Same session harness as `datetimeCell.formatVocabulary-8853.test.tsx`: the
+ * tag is the TENANT locale because that is the channel objectui#4468 made
+ * every date branch read, and `persistLanguage={false}` keeps each case on its
+ * own language instead of inheriting the previous one's.
+ */
+function renderSession(locale: string, language: string, node: React.ReactElement) {
+  return render(
+    <I18nProvider
+      config={{ defaultLanguage: language, detectBrowserLanguage: false }}
+      persistLanguage={false}
+    >
+      <LocalizationProvider value={{ locale }}>{node}</LocalizationProvider>
+    </I18nProvider>,
+  );
+}
+
+/** Render one cell at the pinned clock; text and class, nothing retained. */
+function faceOf(node: React.ReactElement, locale = 'en-US', language = 'en'): Face {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(CLOCK));
+  try {
+    const { container } = renderSession(locale, language, node);
+    const cls = container.querySelector('span')?.getAttribute('class') ?? '';
+    return { text: container.textContent ?? '', cls, red: cls.includes('text-red-600') };
+  } finally {
+    cleanup();
+    vi.useRealTimers();
+  }
+}
+
+const dateCell = (value: string, field: Record<string, unknown>) => (
+  <DateCellRenderer value={value} field={{ type: 'date', ...field } as any} />
+);
+
+const dateTimeCell = (value: string, field: Record<string, unknown>) => (
+  <DateTimeCellRenderer value={value} field={{ type: 'datetime', ...field } as any} />
+);
+
+/** The authored pair: one due-semantic field of each type, same relative face. */
+const DUE_DATE = { name: 'due_on', dueLike: true, format: 'relative' };
+const DUE_DATETIME = { name: 'due_at', dueLike: true, format: 'relative' };
+/** The same datetime field with the key withheld — the control population. */
+const PLAIN_DATETIME = { name: 'follow_up_at', format: 'relative' };
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('THE REPRO — one authored `dueLike`, one affordance, both cells (#8958)', () => {
+  it('a datetime cell honours `dueLike`, and paints what its date sibling paints', () => {
+    const date = faceOf(dateCell(OVERDUE_3D, DUE_DATE));
+    const dateTime = faceOf(dateTimeCell(OVERDUE_3D, DUE_DATETIME));
+
+    // The anchor, so a redesign that moved both sides together cannot pass.
+    expect(date.text).toBe('Overdue 3d');
+    expect(dateTime.text).toBe('Overdue 3d');
+
+    // The claim itself: ONE authored key, ONE meaning, across the two cells —
+    // in the wording AND in the styling, because the affordance is both.
+    expect(dateTime.text).toBe(date.text);
+    expect(dateTime.red).toBe(true);
+    expect(date.red).toBe(true);
+    expect(dateTime.red).toBe(date.red);
+
+    // And what it used to be, named — not merely "something else".
+    expect(dateTime.text).not.toBe('3 days ago');
+  });
+
+  it('the authored key is no longer byte-identical to withholding it', () => {
+    const withKey = faceOf(dateTimeCell(OVERDUE_3D, DUE_DATETIME));
+    const withoutKey = faceOf(dateTimeCell(OVERDUE_3D, PLAIN_DATETIME));
+
+    // Before this change these two were identical in BOTH halves — that
+    // identity IS the defect, so it is asserted away rather than merely
+    // asserted around.
+    expect(withKey.text).not.toBe(withoutKey.text);
+    expect(withKey.cls).not.toBe(withoutKey.cls);
+    expect(withoutKey.text).toBe('3 days ago');
+  });
+});
+
+describe('CONTROLS — the populations that must NOT move', () => {
+  it('a datetime WITHOUT `dueLike` renders exactly as it does today', () => {
+    const face = faceOf(dateTimeCell(OVERDUE_3D, PLAIN_DATETIME));
+    expect(face.text).toBe('3 days ago');
+    // The full class list, verbatim: no red, and nothing else added either.
+    expect(face.cls).toBe('tabular-nums text-sm whitespace-nowrap');
+  });
+
+  it('a `dueLike` datetime that is NOT overdue paints no affordance', () => {
+    for (const value of [FUTURE_2D, PAST_TODAY]) {
+      const withKey = faceOf(dateTimeCell(value, DUE_DATETIME));
+      const withoutKey = faceOf(dateTimeCell(value, PLAIN_DATETIME));
+      // Byte-identical here is CORRECT: the key is authored, the instant is
+      // not overdue, so the affordance must stay away.
+      expect(withKey.text).toBe(withoutKey.text);
+      expect(withKey.cls).toBe(withoutKey.cls);
+      expect(withKey.red).toBe(false);
+    }
+    expect(faceOf(dateTimeCell(FUTURE_2D, DUE_DATETIME)).text).toBe('In 2 days');
+  });
+});
+
+describe('DAY GRANULARITY — inherited from the shared relative path, not re-decided', () => {
+  it('"Overdue 0d" is not a string this codebase can produce', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(CLOCK));
+    try {
+      // The wording gate is `diffDays < -1` on calendar-day boundaries, so
+      // the sub-day and one-day cases never reach the overdue branch and the
+      // SHORTEST overdue phrase is "Overdue 2d". This is the measurement that
+      // makes honouring the declaration coherent at datetime precision.
+      expect(formatRelativeDate(PAST_TODAY, { dueLike: true, locale: 'en-US' })).toBe('Today');
+      expect(formatRelativeDate(YESTERDAY_LATE, { dueLike: true, locale: 'en-US' })).toBe('Yesterday');
+      expect(formatRelativeDate('2026-09-07T09:30:00.000Z', { dueLike: true, locale: 'en-US' })).toBe('Overdue 2d');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a datetime hours past its deadline reads "Today", exactly as its date sibling does', () => {
+    const dateTime = faceOf(dateTimeCell(PAST_TODAY, DUE_DATETIME));
+    const date = faceOf(dateCell(PAST_TODAY, DUE_DATE));
+    expect(dateTime.text).toBe('Today');
+    expect(dateTime.text).toBe(date.text);
+    expect(dateTime.red).toBe(false);
+    expect(dateTime.red).toBe(date.red);
+  });
+
+  it('one calendar day back is red on both cells, and worded the same on both', () => {
+    // The two halves have different thresholds — the wording needs
+    // `diffDays < -1`, the styling only needs an earlier calendar day — and
+    // that asymmetry is the `date` cell's own, inherited here rather than
+    // re-decided, so the columns still agree with each other.
+    const dateTime = faceOf(dateTimeCell(YESTERDAY_LATE, DUE_DATETIME));
+    const date = faceOf(dateCell(YESTERDAY_LATE, DUE_DATE));
+    expect(dateTime.text).toBe('Yesterday');
+    expect(dateTime.text).toBe(date.text);
+    expect(dateTime.red).toBe(true);
+    expect(dateTime.red).toBe(date.red);
+  });
+});
+
+describe('THE OTHER SURFACES the one key reaches', () => {
+  it('the field-name heuristic answers the same on both cells, with no key authored', () => {
+    // `due_at` matches the due/deadline name convention, so the affordance
+    // appears with nothing authored at all. This is the larger population the
+    // change moves, and it is pinned rather than left implicit.
+    const dateTime = faceOf(dateTimeCell(OVERDUE_3D, { name: 'due_at', format: 'relative' }));
+    const date = faceOf(dateCell(OVERDUE_3D, { name: 'due_at', format: 'relative' }));
+    expect(dateTime.text).toBe('Overdue 3d');
+    expect(dateTime.text).toBe(date.text);
+    expect(dateTime.red).toBe(date.red);
+
+    // A neutral name on the same instant stays neutral — the heuristic is a
+    // name test, not "every past datetime".
+    const neutral = faceOf(dateTimeCell(OVERDUE_3D, { name: 'created_at', format: 'relative' }));
+    expect(neutral.text).toBe('3 days ago');
+    expect(neutral.red).toBe(false);
+  });
+
+  it('the red styling is style-INDEPENDENT, on the compact face both cells default to', () => {
+    // `'compact'` is this cell's DEFAULT face, so gating red on the relative
+    // branch alone would leave the default population unchanged — the defect
+    // narrowed rather than closed. The two faces differ in text (a datetime
+    // keeps its time of day), so the agreement asserted here is the
+    // affordance, which is what the authored key gates.
+    const dateTime = faceOf(dateTimeCell(OVERDUE_3D, { name: 'due_at', dueLike: true }));
+    const date = faceOf(dateCell(OVERDUE_3D, { name: 'due_on', dueLike: true, format: 'compact' }));
+    expect(dateTime.red).toBe(true);
+    expect(dateTime.red).toBe(date.red);
+    // Still the compact face, not the relative one — reading the key must not
+    // drag a different face along with it.
+    expect(dateTime.text).not.toBe('Overdue 3d');
+
+    const control = faceOf(dateTimeCell(OVERDUE_3D, { name: 'follow_up_at' }));
+    expect(control.red).toBe(false);
+    expect(control.text).toBe(dateTime.text);
+  });
+
+  it('beyond the ±7-day window both cells fall back to the absolute face, still red', () => {
+    const dateTime = faceOf(dateTimeCell(OUT_OF_WINDOW, DUE_DATETIME));
+    const date = faceOf(dateCell(OUT_OF_WINDOW, DUE_DATE));
+    expect(dateTime.text).toBe('Aug 31');
+    expect(dateTime.text).toBe(date.text);
+    expect(dateTime.red).toBe(true);
+    expect(dateTime.red).toBe(date.red);
+  });
+
+  it('the overdue phrase resolves through `t` on the datetime cell too', () => {
+    // `formatRelativeDate` reaches `t` only through `dueLike`, which is why
+    // objectui#8853 left it off this branch. It travels with the key now, so
+    // a zh session does not read `Overdue 3d` beside a translated date cell.
+    const dateTime = faceOf(dateTimeCell(OVERDUE_3D, DUE_DATETIME), 'zh', 'zh');
+    const date = faceOf(dateCell(OVERDUE_3D, DUE_DATE), 'zh', 'zh');
+    expect(dateTime.text).toBe('逾期 3 天');
+    expect(dateTime.text).toBe(date.text);
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -957,12 +957,14 @@ const DUE_LIKE_FIELD_NAME =
  * one function down already follows: `as any` would also silence a typo in
  * the property name, this does not. The name spellings stay on a loose record
  * read because `accessorKey` / `key` are grid-column spellings that no field
- * interface carries.
+ * interface carries — and that read goes through `unknown`, because
+ * `FieldMetadata` is a closed union whose members carry no index signature,
+ * so a direct assertion is `TS2352` (measured, not assumed).
  */
 function resolveDueLike(field: CellRendererProps['field']): boolean {
   const declared = (field as DateFieldMetadata | DateTimeFieldMetadata | undefined)?.dueLike;
   if (declared === true) return true;
-  const named = field as Record<string, unknown> | undefined;
+  const named = field as unknown as Record<string, unknown> | undefined;
   const fieldName = String(named?.name || named?.accessorKey || named?.key || '').toLowerCase();
   return DUE_LIKE_FIELD_NAME.test(fieldName);
 }

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import type { DateTimeFieldMetadata, FieldMetadata, SelectOptionMetadata } from '@object-ui/types';
+import type { DateFieldMetadata, DateTimeFieldMetadata, FieldMetadata, SelectOptionMetadata } from '@object-ui/types';
 import { ComponentRegistry, percentDisplayValue, getRecordDisplayName, humanizeLabel, isEmptyValue, isMissingForRequired, formatDate, formatDateTime, formatDateTimeCompactParts, formatRelativeDate, extractRecords, type ComponentMeta, type DateDisplayOptions } from '@object-ui/core';
 // The platform's own value-shape contract, asked rather than restated
 // (objectui#6744). See `locationStoredValueSchemaFor` below for why this is a
@@ -915,6 +915,80 @@ export function BooleanCellRenderer({ value, field }: CellRendererProps): React.
 }
 
 /**
+ * The overdue affordance — ONE home for both date-family cell renderers
+ * (objectui#8958).
+ *
+ * `dueLike` is declared for BOTH types: `DetailViewFieldSchema.dueLike`
+ * (`@object-ui/types`' zod views) says, in the `describe` text an author
+ * reads, "Marks a date/datetime field as due/deadline-semantic, gating the
+ * relative 'Overdue Nd' wording". `DateCellRenderer` honoured it;
+ * `DateTimeCellRenderer` never read it, so an author who marked a `datetime`
+ * column `dueLike` published successfully and the affordance simply did not
+ * appear — accepted, parsed, dropped, and rendered as a legitimate-looking
+ * relative date. Measured before the change, one instant
+ * (`2026-09-06T09:30:00.000Z`), clock `2026-09-09T12:00:00.000Z`, `en-US`:
+ *
+ *   date     `dueLike: true` -> "Overdue 3d"  + `text-red-600`
+ *   datetime `dueLike: true` -> "3 days ago"  + no red
+ *   datetime no key at all   -> "3 days ago"  + no red   <- byte-identical
+ *
+ * These two functions exist so the repair is a SHARED read rather than a
+ * second copy. The regex and the midnight predicate below were inline in
+ * `DateCellRenderer`; copying either into the sibling is objectui#4576
+ * exactly — the shape this package already paid for when one convention was
+ * duplicated across a boundary and the two copies drifted while both stayed
+ * "correct". The wording half was already shared (both cells reach the same
+ * `formatRelativeDate`, which reads `options.dueLike`); these cover the two
+ * halves that were not.
+ */
+const DUE_LIKE_FIELD_NAME =
+  /(^|_)(due|deadline|expires?|expiry|expiration|expected_close|target_close|sla|return_by|renewal|next_action)(_|$)/;
+
+/**
+ * Whether a field is due/deadline-semantic: the authored key first, then the
+ * field-name convention.
+ *
+ * A date is only *semantically* a due/deadline when the field says so — a
+ * plain "start_date" or "created_at" in the past is neither overdue text nor
+ * red, even though it renders in the same relative-time style.
+ *
+ * `dueLike` is read through the two interfaces that DECLARE it rather than
+ * through `as any`, which is the objectui#7747 discipline the `format` read
+ * one function down already follows: `as any` would also silence a typo in
+ * the property name, this does not. The name spellings stay on a loose record
+ * read because `accessorKey` / `key` are grid-column spellings that no field
+ * interface carries.
+ */
+function resolveDueLike(field: CellRendererProps['field']): boolean {
+  const declared = (field as DateFieldMetadata | DateTimeFieldMetadata | undefined)?.dueLike;
+  if (declared === true) return true;
+  const named = field as Record<string, unknown> | undefined;
+  const fieldName = String(named?.name || named?.accessorKey || named?.key || '').toLowerCase();
+  return DUE_LIKE_FIELD_NAME.test(fieldName);
+}
+
+/**
+ * Whether a due/deadline instant has passed, at DAY granularity.
+ *
+ * ⚠️ The granularity is inherited, not re-decided here. `formatRelativeDate`
+ * compares calendar-day boundaries and gates its wording on `diffDays < -1`,
+ * so "Overdue 0d" is not a string this codebase can produce — the shortest
+ * overdue phrase is "Overdue 2d". This predicate is the same calendar-day
+ * question asked of the styling half, so a `datetime` two hours past its
+ * deadline reads "Today" and is not red, exactly as the `date` cell has
+ * always answered for a deadline falling today. Making the `datetime` cell
+ * time-of-day aware would put a SECOND convention in this file and make the
+ * two columns unequal again, which is the defect being closed; sub-day
+ * precision is a separate call, deliberately not taken here.
+ */
+function isOverdueInstant(date: Date, dueLike: boolean): boolean {
+  if (!dueLike) return false;
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+  return date < startOfToday;
+}
+
+/**
  * Date field cell renderer
  */
 export function DateCellRenderer({ value, field }: CellRendererProps): React.ReactElement {
@@ -968,18 +1042,12 @@ export function DateCellRenderer({ value, field }: CellRendererProps): React.Rea
   const dateField = field as any;
   const style = dateField.format || 'relative';
 
-  // A date is only *semantically* a due/deadline when the field says so — a
-  // plain "start_date" or "created_at" in the past is neither overdue text
-  // nor red, even though it renders in the same relative-time style.
-  const fieldName = String(dateField?.name || dateField?.accessorKey || dateField?.key || '').toLowerCase();
-  const dueLike =
-    dateField?.dueLike === true ||
-    /(^|_)(due|deadline|expires?|expiry|expiration|expected_close|target_close|sla|return_by|renewal|next_action)(_|$)/.test(fieldName);
+  // Both halves of the affordance come from the shared reads above, so the
+  // `datetime` sibling one function down answers this question identically
+  // instead of carrying a second copy (objectui#8958).
+  const dueLike = resolveDueLike(field);
   const formatted = formatDate(safe as string | Date, style, { dueLike, locale, t });
-
-  const startOfToday = new Date();
-  startOfToday.setHours(0, 0, 0, 0);
-  const isOverdue = dueLike && date < startOfToday;
+  const isOverdue = isOverdueInstant(date, dueLike);
 
   return (
     <span
@@ -1068,21 +1136,37 @@ export function DateTimeCellRenderer({ value, field }: CellRendererProps): React
   // ignored the word outright before, so it starts honouring a request whose
   // granularity is days.
   //
-  // ⚠️ `dueLike` is deliberately NOT threaded, and this is a bounded gap
-  // rather than an oversight. The `date` cell's overdue affordance — the
-  // "Overdue Nd" wording AND the red styling — is gated by a DIFFERENT
-  // authored key plus a field-name heuristic, and this renderer has never read
-  // either. Honouring `format` must not silently acquire a second key's
-  // behaviour; whether a `datetime` cell should paint overdue is its own call,
-  // filed rather than guessed (objectui#8958). `t` stays on the
-  // `formatDateTime` call below exactly as before, and is left off this branch
-  // because `formatRelativeDate` reads it only through `dueLike`.
+  // ── The overdue affordance is read HERE (objectui#8958) ────────────────
+  // `dueLike` used to be deliberately not threaded: objectui#8853 mapped
+  // `format` and refused to acquire a second key's behaviour in the same
+  // change, filing the call rather than guessing it. The call came back
+  // "honour the declaration" — `DetailViewFieldSchema.dueLike` says
+  // "date/datetime" in the `describe` text an author reads, and this renderer
+  // never read it, so the affordance silently did not appear on a `datetime`
+  // column that asked for it.
+  //
+  // Both halves are honoured, because the affordance IS both: the "Overdue
+  // Nd" wording (`formatRelativeDate` reads `options.dueLike`, and `t`
+  // travels with it — that function reaches `t` only through this key, which
+  // is why #8853 left it off) and the red styling, applied to the span below.
+  //
+  // ⚠️ The styling is deliberately style-INDEPENDENT, matching the sibling.
+  // `DateCellRenderer` reddens its span whatever face it painted, so gating
+  // red on the relative branch alone would leave a `compact` datetime and a
+  // `compact` date disagreeing about the same authored key — the defect
+  // narrowed rather than closed. Since `'compact'` is THIS cell's default
+  // face, that is also where the visible population is.
   const style = authoredFormat === 'short' ? 'compact' : authoredFormat;
+  const dueLike = resolveDueLike(field);
+  const isOverdue = isOverdueInstant(date, dueLike);
+  // Spelled as the sibling spells it, one function up, for the same reason
+  // every other guard in these two renderers is: one shape, one reading.
+  const cellClass = `tabular-nums text-sm whitespace-nowrap${isOverdue ? ' text-red-600' : ''}`;
 
   if (style === 'relative') {
     return (
-      <span className="tabular-nums text-sm whitespace-nowrap">
-        {formatRelativeDate(date, { locale })}
+      <span className={cellClass}>
+        {formatRelativeDate(date, { dueLike, locale, t })}
       </span>
     );
   }
@@ -1099,7 +1183,7 @@ export function DateTimeCellRenderer({ value, field }: CellRendererProps): React
     const parts = formatDateTimeCompactParts(date, { locale });
     if (parts) {
       return (
-        <span className="tabular-nums text-sm whitespace-nowrap">
+        <span className={cellClass}>
           <span>{parts.date}</span>
           <span className="ml-2 text-muted-foreground">{parts.time}</span>
         </span>
@@ -1108,7 +1192,7 @@ export function DateTimeCellRenderer({ value, field }: CellRendererProps): React
   }
 
   return (
-    <span className="tabular-nums text-sm whitespace-nowrap">
+    <span className={cellClass}>
       {formatDateTime(date, { style, locale, t })}
     </span>
   );

--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -448,6 +448,22 @@ export interface DateTimeFieldMetadata extends BaseFieldMetadata {
   format?: string;
   min_date?: string | Date;
   max_date?: string | Date;
+  /**
+   * Marks this field as due/deadline-semantic — the same key, with the same
+   * meaning, as {@link DateFieldMetadata.dueLike} one interface up.
+   *
+   * It is declared here because the runtime honours it here (objectui#8958).
+   * `DetailViewFieldSchema.dueLike` has always described itself as marking "a
+   * date/datetime field", and `DateTimeCellRenderer` now reads it; leaving it
+   * off this interface would keep the mismatch alive with the sign flipped —
+   * a key the renderer honours but the authoring type rejects.
+   *
+   * ⚠️ Day granularity, inherited from the shared relative-time path: the
+   * overdue wording gates on whole calendar days, so a datetime a few hours
+   * past its deadline is not yet overdue. Sub-day precision is a separate
+   * call and was not taken.
+   */
+  dueLike?: boolean;
 }
 
 /**


### PR DESCRIPTION
Fixes #8958

`DetailViewFieldSchema.dueLike` declares itself, in the `describe` text an author reads, as marking "a date/datetime field as due/deadline-semantic, gating the relative 'Overdue Nd' wording". Both types. `DateTimeCellRenderer` never read the key, so an author who marked a `datetime` column `dueLike` published successfully and the affordance silently did not appear.

## The reproduction, two-sided

The finding is the **disagreement between the two types**, so the repro renders the same instant through both cell renderers side by side. A one-sided repro cannot distinguish "datetime drops it" from "nothing paints overdue anywhere".

Clock pinned to `2026-09-09T12:00:00.000Z`, `TZ=UTC` (root vitest config), `en-US`, value `2026-09-06T09:30:00.000Z` — 3 days past, inside the plus-or-minus 7-day relative window.

| field | before | after |
|:--|:--|:--|
| `date`, `dueLike: true` | `Overdue 3d` · `tabular-nums text-red-600` | unchanged |
| `datetime`, `dueLike: true` | `3 days ago` · `tabular-nums text-sm whitespace-nowrap` | `Overdue 3d` · `tabular-nums text-sm whitespace-nowrap text-red-600` |
| `datetime`, no key at all | `3 days ago` · `tabular-nums text-sm whitespace-nowrap` | unchanged |

Rows 2 and 3 were **byte-identical before**: the authored key changed nothing, and the cell still looked like a legitimate relative date, so a reader could not tell an honoured `dueLike` from a dropped one by looking at it.

## The shape of the repair

Both cells already reach the same `formatRelativeDate`, which reads `options.dueLike` — the wording half was shared all along, and this renderer was simply not passing the key. The two halves that were **not** shared were inline in `DateCellRenderer`: the due/deadline field-name regex, and the midnight predicate behind the red styling. Copying either into the sibling is the objectui#4576 shape this package has already paid for, so they move into two module-local helpers both renderers call. The wording, the styling and the name heuristic now have one home each.

`t` travels with the key, because `formatRelativeDate` reaches `t` only through `dueLike` — that is exactly why objectui#8853 left it off this branch. Without it a zh session would read `Overdue 3d` beside a translated date cell.

The red styling is deliberately **style-independent**, matching the sibling: `DateCellRenderer` reddens its span whatever face it painted. Gating red on the relative branch alone would leave `compact` — this cell's default face — still disagreeing with its `date` sibling about the same authored key. That is the defect narrowed, not closed.

`DateTimeFieldMetadata` gains the `dueLike?: boolean` that `DateFieldMetadata` already carried. Nothing narrows and no accepted input is rejected: the view schema already accepted the key for both types. Leaving it off would have kept the declared-versus-enforced mismatch alive with the sign flipped — a key the renderer honours but the authoring type rejects.

## The stop-and-report fork did NOT fire, and here is the measurement

The card, triage and the dispatch all reserved a stop: if the relative wording turned out to be **incoherent at datetime precision**, this goes to the decision box for the narrowing instead. The specific worry named was `Overdue 0d` for a datetime a couple of hours past its deadline.

Measured: **`Overdue 0d` is not a string this codebase can produce.** `formatRelativeDate` compares *calendar-day* boundaries and gates the overdue wording on `diffDays` strictly below minus one, so the shortest overdue phrase is `Overdue 2d`. Sub-day and one-day deltas never reach that branch at all:

| delta from the pinned clock | `dueLike: true` renders |
|:--|:--|
| 2.5 hours past, same calendar day | `Today` |
| yesterday 23:00 | `Yesterday` |
| 2 days past | `Overdue 2d` |
| 3 days past | `Overdue 3d` |

So the phrase is day-granular by construction and produces the same string for a `date` and a `datetime` at the same instant. Honouring the declaration is coherent, and it is a strict improvement over "the key does nothing, ever". A datetime a few hours past its deadline reading `Today` is exactly what the `date` cell has always answered for a deadline falling today — inherited, not re-decided here. Making this cell time-of-day aware would put a second convention in the file and make the two columns unequal again, which is the defect being closed.

## Populations that change appearance

Two, and the second is the larger one — stated because a reviewer should not have to discover it:

- `datetime` fields with `dueLike: true` authored explicitly;
- `datetime` fields whose **name** matches the due/deadline convention (`due_*`, `deadline`, `expires_at`, `expiry`, `expected_close`, `target_close`, `sla*`, `return_by`, `renewal*`, `next_action*`) with no key authored at all. That heuristic was already live on `date` columns; it now answers the same on `datetime` columns, which is the parity being restored.

## Verification

Ablation ran **from the committed fix**, with the predicted split written down first. Mutation: the `dueLike` read in `DateTimeCellRenderer` forced to `false`. Proven on disk before the run — blob `577ceb81dc8771ab9900b0dbb26561812827fe74` to `c69f71982a9d7bcbe13759116fe44bed693a4144`, injected-text count 0 to 1, removed-text count 2 to 1 — and proven restored after: blob back to `577ceb81`, `git diff HEAD` empty, both counts back. A trap on EXIT/INT/TERM guarded the restore with absolute paths.

**Predicted 7 red / 4 green. Observed 7 red / 4 green, the same seven tests. No miscount.** The four that stayed green are the controls and the day-granularity cases, which measure surfaces the mutation does not touch — which is why they can vouch for the run. `DateCellRenderer.test.tsx` and `datetimeCell.formatVocabulary-8853.test.tsx` stayed fully green alongside.

Reverse validation on the type change, two legs: a `DateTimeFieldMetadata` literal carrying `dueLike: true` compiles, while the same literal carrying a one-letter typo of that key is rejected `TS2353`. The discriminating pair proves the compiler both sees the new member and is genuinely excess-property-checking. Probe removed; it is not in the diff.

Runs, all from the repo root:

- `pnpm --filter '@object-ui/fields^...' build` — clean, under the shared verify lock, `VERDICT command-exit 0`.
- `pnpm --filter @object-ui/fields --filter @object-ui/types type-check` then `lint` — under the lock, `VERDICT command-exit 0`; lint reports **0 errors** (994 and 277 pre-existing warnings; `lint.yml` deliberately sets no max-warnings). The two warnings my new test adds are `no-explicit-any` on the same field-literal construct its sibling 8853 test already uses.
- The new pin is proven **inside** the typechecked set rather than assumed: `tsc -p packages/fields/tsconfig.test.json --listFiles` lists it, with the sibling 8853 test as a positive control, among 1595 files.
- Targeted suite, **25 files / 367 tests, all passing**, covering this package and its dependents: `packages/fields`, `packages/core`, `packages/components`, `packages/plugin-grid`, `packages/plugin-detail`, `packages/plugin-list`, `packages/plugin-timeline`, `packages/app-shell`, `apps/console`.

That last set is a **declared narrowing** of "run the dependents' suites", and how it was chosen matters: every test file that names either cell renderer, `formatRelativeDate`, `Overdue`, `days ago` or `text-red-600`, **plus** every test file carrying a `datetime` field whose name matches the due/deadline heuristic. That second half is what found `packages/plugin-list`'s `ListView.speculativeFls-7216` test, which fixtures a `due_date` column typed `datetime` — precisely the dependent pin a renderer change is warned to check. It passes. The full dependent suites are CI's.

`NOT MEASURED: check:doc-snippets and check:doc-examples`, reason: both exited 2 with `PRECONDITION NOT MET` — they type-check documentation against built `dist/`, and they need 34 packages built. That is "could not run", not a failure, and no line in their output is a verdict about any document. The specific risk my diff carries into them was checked directly instead: the doc snippet I added declares `dueLike: true` on a `DateTimeFieldMetadata`, and the rebuilt `packages/types/dist/field-types.d.ts` carries that member.

Green gates: `check:changeset-presence`, `check:new-line-citations`, `check:control-bytes`, `check:doc-types`, `check:doc-fences`, `check:doc-example-ids`, `check:docs-route-closure`, `check:i18n-keys`, `check:unreferenced-sources`.

## Acceptance notes

Out of scope, observed and deliberately not filed:

- **The red styling and the wording have different thresholds, on both cells.** Red fires for any instant before local midnight today; the `Overdue Nd` wording needs two calendar days. So a `dueLike` cell one day back reads `Yesterday` in red. That asymmetry is pre-existing on the `date` cell and is inherited here rather than introduced, so the two columns still agree with each other — which is what this card asks for. Not filed: it is an observation about a deliberate pre-existing design, not a reproducible defect, and no declared contract contradicts it. Whoever picks up the next card on the overdue affordance is the one who would meet it.
- **`ENRICHED_FIELD_METADATA_KEYS` in `plugin-detail` already forwarded `dueLike`** from object metadata onto detail-view fields, key-by-key and type-agnostically. So the key was already reaching `datetime` detail fields before this change; it simply was not read at the end of the pipe. Not filed: it was correct all along, and this change is what makes it pay off.
- **`DetailViewFieldSchema` does not condition `dueLike` on the field's `type`** — a `text` field may carry it and nothing reads it. Not filed, and deliberately so: the schema is not type-discriminated for *any* of its keys (`currency` on a boolean, `reference_to` on a text, `options` on a date are all equally accepted), so this is a whole-schema property rather than anything specific to `dueLike`, and the key's own `describe` text already names the types it works on, so an author is not misled. Filing it against `dueLike` would misattribute it. The carrier is the next card that touches `DetailViewFieldSchema` itself.

## Notes for the reviewing seat

No line citations anywhere in the diff — `DateTimeCellRenderer` moved when objectui#8853 landed, so everything here was re-derived by symbol on today's `main`.

Left alone on purpose: objectui#8853's `field.format` vocabulary split, which the filing seat kept separate. It is not addressed here.

The `needs:contract-review` label is **not** touched in either direction. The claim declares `Clause-②: yes`, so `check-clause2-carriers` is expected to report C3 on this pair; that is the disclosed, escalated governance question on objectui#8568 and is not this seat's to resolve.

Generated by Claude Code in session `session_01MPaVWWMuWeT5LgB1qoXjVB`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB)_