### PR TITLE
test(types): pin the filter-builder doc WIDENING, seeded from the doc itself (objectui#8774)

### DIFF
--- a/.changeset/8774-filter-builder-doc-widening-pin.md
+++ b/.changeset/8774-filter-builder-doc-widening-pin.md
@@ -1,0 +1,25 @@
+---
+---
+
+Test-only: `packages/types/src/__tests__/filter-builder-mirror-6939.test.ts`. It sits
+under `src/`, so the presence gate counts it, but nothing published moves — the
+package's build `tsconfig.json` excludes `**/__tests__/**` and its `files` list is
+`["dist", "README.md", "CHANGELOG.md", "LICENSE"]`, so the file never reaches a
+consumer. Declared as releasing nothing.
+
+objectui#8774: after objectui#7562 the published doc
+(`content/docs/components/complex/filter-builder.mdx`) is the AUTHORITY for the
+`filter-builder` authoring surface, but the pins bound the enum to a hard-coded
+`DOCUMENTED_FOURTEEN` constant and the doc-reading pin asserted only doc ⊇ fourteen.
+So the doc NARROWING reddened and the doc WIDENING reddened nothing — and widening is
+the direction objectui#7562 came from.
+
+The population is now taken FROM the doc (`documentedTypes()` parses the `type?:` union
+out of the doc's `interface FilterField` block) instead of copied beside it, so `the
+accept set is EXACTLY the published doc` compares the enum against the authority and
+fails in both directions. A doc-seeded pin can go vacuous the moment its reader stops
+matching, so every reader throws on absence, and a floor test drives both throws with
+the doc's own two-member `logic` union as its positive control.
+
+⛔ No accept set moves: doc and mirror were measured to agree on all fourteen members
+before and after (14 = 14, no divergence in either direction).

--- a/packages/types/src/__tests__/filter-builder-mirror-6939.test.ts
+++ b/packages/types/src/__tests__/filter-builder-mirror-6939.test.ts
@@ -73,6 +73,35 @@
  * closing line — which pinned that the mirror still required `type` — became
  * its opposite. That is the whole delta objectui#7562 lands here.
  *
+ * ## objectui#8774 — the doc-WIDENING direction, which nothing here caught
+ *
+ * objectui#7562 made the doc the authority, but the pins in this file bound the
+ * enum to a hard-coded `DOCUMENTED_FOURTEEN` constant, and the doc-reading pin
+ * asserted only doc ⊇ fourteen. So of the two ways the authority can move, one
+ * was guarded and one was not:
+ *
+ *   - doc NARROWS (a member removed) → the ⊇ pin reddens.
+ *   - doc WIDENS (a fifteenth member added) → nothing reddened. And widening is
+ *     the direction objectui#7562 CAME FROM: the doc published fourteen while
+ *     the mirror accepted seven, and no instrument said so.
+ *
+ * Measured, not reasoned. The ceiling reviewer's ablation Leg E added `'email'`
+ * to the DOC alone (hash-verified, restored) and every pin in this file stayed
+ * green; its control, Leg D — the same member added to BOTH code faces — did
+ * redden, so the file was live and the hole was directional.
+ *
+ * The fix is that the population is now TAKEN from the doc (`documentedTypes()`)
+ * instead of copied beside it, so `the accept set is EXACTLY the published doc`
+ * compares the enum against the authority rather than against a copy of it and
+ * fails in both directions. A doc-seeded pin has its own failure mode — a reader
+ * that silently matches nothing turns the pin vacuous in the same stroke — so
+ * every reader THROWS on absence and `the doc reader has a floor` drives that,
+ * with the doc's own two-member `logic` union as the positive control.
+ *
+ * ⛔ If this pin reddens because the DOC widened: the mirror follows, as its own
+ * reviewable change. ⛔ Never narrow the doc to match the mirror — under
+ * decision batch #88 a contract does not retract what it published to authors.
+ *
  * ## What this change does NOT reach, stated rather than left as an absence
  *
  * Two of the four census entries — `product-search` and `with-conditions`, plus
@@ -101,6 +130,17 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, '..', '..', '..', '..');
 const CATALOG = join(REPO_ROOT, 'examples/schema-catalog/src/schemas/components-complex-filter-builder');
 const READER = 'packages/components/src/custom/filter-builder.tsx';
+/**
+ * The published doc — a THIRD declaration of this authoring surface, and since
+ * decision batch #88 (objectui#7562) the AUTHORITY for it: *"a contract does
+ * not retract what it published to authors."* Both faces repaired in this file
+ * follow it; they do not define it.
+ */
+const DOC = 'content/docs/components/complex/filter-builder.mdx';
+
+function publishedDoc(): string {
+  return readFileSync(join(REPO_ROOT, DOC), 'utf8');
+}
 
 /** The four entries `node packages/cli/dist/cli.js check` counts for this row. */
 const CENSUS = ['empty-filter-builder', 'product-search', 'user-filters', 'with-conditions'] as const;
@@ -223,14 +263,66 @@ const DOC_ONLY_TYPES: ReadonlyArray<readonly [string, string]> = [
 /** The seven spellings above, for the places that only need the names. */
 const UNRULED_LIVE_TYPES = DOC_ONLY_TYPES.map(([type]) => type);
 
-/** Every member the published doc offers — the accept set after objectui#7562. */
-const DOCUMENTED_FOURTEEN = [
-  'text', 'number', 'currency', 'percent', 'rating',
-  'date', 'datetime', 'time',
-  'boolean',
-  'select', 'status',
-  'lookup', 'master_detail', 'user',
-] as const;
+/**
+ * One `interface <name> { … }` block out of the published doc's schema fence.
+ *
+ * Throws rather than returning an empty string, and the same goes for every
+ * reader below it. A doc-seeded pin has exactly one interesting failure mode —
+ * the reader quietly matches nothing, the population comes back empty, and
+ * every assertion built on it passes while checking nothing — so absence is
+ * LOUD here, and the floor test drives both throws.
+ */
+function docInterfaceBlock(doc: string, iface: string): string {
+  const open = doc.indexOf(`interface ${iface} {`);
+  if (open === -1) throw new Error(`${DOC}: no \`interface ${iface} {\` block`);
+  const close = doc.indexOf('\n}', open);
+  if (close === -1) throw new Error(`${DOC}: \`interface ${iface}\` is never closed`);
+  return doc.slice(open, close);
+}
+
+/**
+ * Every quoted member of the union `<iface>.<key>` declares, in the doc's own
+ * order. The union may span LINES — the doc lays `type?:` out over five rows —
+ * so the slice runs to the terminating `;`, not to the end of the line. Line
+ * comments are stripped first: `// Field type` sits inside that slice, and an
+ * apostrophe in some future one would otherwise mint a phantom member.
+ */
+function docUnionMembers(doc: string, iface: string, key: string): string[] {
+  const block = docInterfaceBlock(doc, iface);
+  const at = block.indexOf(`\n  ${key}:`);
+  if (at === -1) throw new Error(`${DOC}: \`${iface}\` no longer declares \`${key}\``);
+  const end = block.indexOf(';', at);
+  if (end === -1) throw new Error(`${DOC}: \`${iface}.${key}\` is unterminated`);
+  const body = block.slice(at, end).replace(/\/\/[^\n]*/g, '');
+  const members = [...body.matchAll(/'([^']*)'/g)].map((m) => m[1]);
+  if (members.length === 0) {
+    throw new Error(`${DOC}: \`${iface}.${key}\` parsed to ZERO members`);
+  }
+  return members;
+}
+
+/**
+ * The accept set, TAKEN from the authority rather than copied from it
+ * (objectui#8774).
+ *
+ * This used to be a hand-kept `DOCUMENTED_FOURTEEN` constant sitting beside the
+ * pin. A population maintained here can only ever confirm the mirror it was
+ * copied from, which is precisely the blindness objectui#7562 turned out to be:
+ * the doc had moved, both code faces agreed with each other, and no instrument
+ * said so. Measured before it was changed — the ceiling reviewer's ablation
+ * Leg E added a fifteenth member to the DOC alone and every pin in this file
+ * stayed green.
+ */
+function documentedTypes(): string[] {
+  return docUnionMembers(publishedDoc(), 'FilterField', 'type?');
+}
+
+/** The enum this mirror actually declares, behind `.optional()`. */
+function mirrorTypeMembers(): string[] {
+  return (FilterFieldSchema as unknown as {
+    shape: { type: { unwrap(): { options: string[] } } };
+  }).shape.type.unwrap().options;
+}
 
 describe('objectui#6939 — the type vocabulary', () => {
 
@@ -313,10 +405,76 @@ describe('objectui#6939 — the type vocabulary', () => {
     // The set equality, not fourteen individual accepts: an enum that had
     // gained a fifteenth member the doc never published would pass every
     // per-member assertion above and fail only here.
-    const declared = (FilterFieldSchema as unknown as {
-      shape: { type: { unwrap(): { options: string[] } } };
-    }).shape.type.unwrap().options;
-    expect([...declared].sort()).toEqual([...DOCUMENTED_FOURTEEN].sort());
+    //
+    // objectui#8774 — the expectation is now READ FROM the doc rather than
+    // copied into a constant beside it, which is what makes this fail in BOTH
+    // directions instead of one:
+    //
+    //   - the MIRROR grows a member the doc never published → the mirror
+    //     widened past the authority;
+    //   - the DOC grows a fifteenth member the mirror does not implement →
+    //     the divergence objectui#7562 WAS, in the direction that recreates it.
+    //
+    // The second one is the whole card: while this compared against a
+    // hard-coded list, a member added to the mdx reddened nothing here.
+    const declared = mirrorTypeMembers();
+    const documented = documentedTypes();
+    expect(
+      documented.filter((t) => !declared.includes(t)),
+      `the published doc offers \`type\` members this mirror refuses. Under decision ` +
+        `batch #88 the DOC is the authority and the MIRROR follows — widen ` +
+        `FilterFieldSchema.type and FilterField['type'] to match, as its own reviewable ` +
+        `change. ⛔ Do NOT narrow ${DOC} to match the mirror. The one exception to ` +
+        `"the mirror follows": a spelling a LATER ruling RETIRED from this doc — the ` +
+        `way objectui#4814 retired \`owner\` — reappearing in it is a doc REGRESSION, ` +
+        `not a widening, and the doc edit is what gets reverted.`,
+    ).toEqual([]);
+    expect(
+      declared.filter((t) => !documented.includes(t)),
+      `this mirror accepts \`type\` members ${DOC} never published — the mirror widened ` +
+        `past the authority.`,
+    ).toEqual([]);
+    expect([...declared].sort()).toEqual([...documented].sort());
+  });
+
+  it('every member the published doc offers, the mirror ACCEPTS', () => {
+    // The behavioural half of the equality above: `.options` is introspection
+    // of the enum, this is a parse. Seeded from the doc, so a member added to
+    // the mdx is asserted on the day it is added rather than on the day
+    // somebody remembers to copy it into a list in this file.
+    for (const type of documentedTypes()) {
+      expect(
+        FilterFieldSchema.safeParse({ value: 'a', label: 'A', type }).success,
+        `${DOC} offers \`type: '${type}'\`, which this mirror refuses`,
+      ).toBe(true);
+    }
+  });
+
+  it('the doc reader has a floor — its positive control is the doc\'s own `logic` union', () => {
+    // ⚠️ A doc-seeded pin fails the way this repository has failed before: the
+    // reader silently matches nothing, the population is empty, and every
+    // assertion built on it passes while checking nothing — turning the two
+    // tests above vacuous in the same stroke that made them doc-driven. Three
+    // legs, so an empty read cannot be mistaken for agreement.
+    const doc = publishedDoc();
+    // (1) CONTROL — the same reader, the same file, a DIFFERENT block whose
+    //     answer is fixed by the ruling at exactly two members. It can fire in
+    //     the region under test: a reader that matched nothing, matched the
+    //     wrong interface, or stopped at the first line of a multi-line union
+    //     returns something that is not `['and','or']`, and this reddens. And
+    //     it is independent of the `type?:` block it vouches for, so the thing
+    //     being measured cannot be what satisfies it.
+    expect(docUnionMembers(doc, 'FilterGroup', 'logic')).toEqual(['and', 'or']);
+    // (2) The population itself is non-empty and duplicate-free — a duplicated
+    //     member would make the sorted-equality above pass on unequal sets.
+    const documented = documentedTypes();
+    expect(documented.length).toBeGreaterThan(0);
+    expect([...new Set(documented)]).toEqual(documented);
+    // (3) A renamed block or a renamed key is a THROW, not an empty set. This
+    //     is the leg that keeps (2) from being all that stands between a doc
+    //     edit and a pin that has quietly stopped reading anything.
+    expect(() => docUnionMembers(doc, 'FilterField', 'nosuchkey?')).toThrow('no longer declares `nosuchkey?`');
+    expect(() => docUnionMembers(doc, 'NoSuchInterface', 'type?')).toThrow('no `interface NoSuchInterface {` block');
   });
 
   it('the gap is measured against the PUBLISHED doc, not against a private opinion', () => {
@@ -327,7 +485,7 @@ describe('objectui#6939 — the type vocabulary', () => {
     // member `type?` union. This assertion is what makes "the mirror is the odd
     // one out" a reading rather than a claim — and it turns red if someone
     // narrows the DOC to match the mirror, which is the wrong direction.
-    const doc = readFileSync(join(REPO_ROOT, 'content/docs/components/complex/filter-builder.mdx'), 'utf8');
+    const doc = publishedDoc();
     expect(doc).toContain("logic: 'and' | 'or';");
     expect(doc).toMatch(/value: string;\s+\/\/ Field identifier/);
     for (const type of [...RULED, 'select', ...UNRULED_LIVE_TYPES]) {


### PR DESCRIPTION
Fixes #8774

## The gap

Director ruling batch #88 (objectui#7562) made `content/docs/components/complex/filter-builder.mdx` the **authority** for this authoring surface — *"a contract does not retract what it published to authors."* PR #8766 aligned the zod mirror and the TS twin to its fourteen `type` members. But the pins bound the enum to a hard-coded `DOCUMENTED_FOURTEEN` constant, and the doc-reading pin asserted only doc ⊇ fourteen. Of the two ways the authority can move, one was guarded and one was not:

| the doc moves | before this PR | after this PR |
|---|---|---|
| doc **narrows** (a member removed) | ✅ the ⊇ pin reddens | unchanged |
| doc **widens** (a fifteenth member added) | ⛔ **nothing reddens** | ✅ reddens, naming the member and the remedy |

Widening is the direction objectui#7562 came from: the doc published fourteen while the mirror accepted seven, and no instrument said so.

## The change

One file — `packages/types/src/__tests__/filter-builder-mirror-6939.test.ts` — plus its changeset.

- **`documentedTypes()` parses the `type?:` union out of the doc's `interface FilterField` block.** The population is **taken from the authority**, never copied beside it. A list maintained in the pin file can only ever confirm the mirror it was copied from, which is the failure mode being fixed. The hard-coded `DOCUMENTED_FOURTEEN` is gone; the literal fourteen still exist in the file as `RULED` + `select` + `DOC_ONLY_TYPES`, which is the doc ⊇ pin's floor, and in the `expectType` annotation on the TS twin.
- **`the accept set is EXACTLY the published doc, member for member`** now compares the enum against that population and fails in **both** directions, each with its own message: the doc growing a member the mirror refuses says *the doc is the authority and the mirror follows, as its own reviewable change — do not narrow the doc*; the mirror growing a member the doc never published says *the mirror widened past the authority*.
- **`every member the published doc offers, the mirror ACCEPTS`** — the behavioural half. `.options` is introspection of the enum; this is a real `safeParse` per doc-published member.
- **`the doc reader has a floor`** — a doc-seeded pin has its own failure mode: the reader silently matches nothing and the two pins above go vacuous in the same stroke that made them doc-driven. Three legs: the doc's own two-member `logic` union as the positive control, a non-empty and duplicate-free population, and both "block renamed" / "key renamed" paths asserted to **throw** rather than return an empty set.

## Leg E, reproduced as the firing control

Run against the final head `db804c0c8`, doc mutated on disk and hash-verified, restored and the restore proved.

```
MUTATION           doc blob 0384d4e2511a4a0acd1b4b233c65f36120a367d5
                        -> efad77a7f231b16851a7bbfa9ee0df0ccad97c7d
                   occurrences: 'email' 0 -> 1 ; old anchor "| 'user';" 1 -> 0

NEGATIVE CONTROL   pre-change pin (blob 0be5ad6, == BASE 7f27bc543) vs the widened doc
                   -> RC=0, Tests 42 passed (42)          the hole, reproduced on my own base

FIRING CONTROL     this PR's pin (blob cca45a2, == HEAD db804c0c8) vs the same widened doc
                   -> RC=1, Tests 2 failed | 42 passed (44)
                   × the accept set is EXACTLY the published doc, member for member
                   × every member the published doc offers, the mirror ACCEPTS

RESTORE            doc blob back to 0384d4e2511a4a0acd1b4b233c65f36120a367d5
                   'email' occurrences 0 ; anchor restored to 1
                   git diff HEAD: 0 lines ; git status --porcelain: 0 lines
                   restored tree -> RC=0, Tests 44 passed (44)
```

The failure message the firing leg printed:

```
AssertionError: the published doc offers `type` members this mirror refuses. Under
decision batch #88 the DOC is the authority and the MIRROR follows — widen
FilterFieldSchema.type and FilterField['type'] to match, as its own reviewable change.
⛔ Do NOT narrow content/docs/components/complex/filter-builder.mdx to match the mirror.
[…]: expected [ 'email' ] to deeply equal []
```

**Why each control can fire in the region it tests.** The negative control is the *same* mutation against the *previous* instrument, so it measures the instrument and not the mutation — and it came back green, which is the hole. The firing control is a doc-only change in exactly the direction the new pin claims to catch. The floor's positive control is the same reader over a *different* block whose answer is fixed by the ruling at exactly two members, so a reader that matched nothing, matched the wrong interface, or stopped at the first line of a multi-line union returns something that is not `['and','or']`; it is independent of the `type?:` block it vouches for, so the thing being measured cannot be what satisfies it.

**Second ablation — the floor itself.** Renaming `interface FilterField` in the doc (blob `0384d4e` → `b339a04`, restored, `git diff HEAD` 0 lines) turned the run **red** with `Error: content/docs/…/filter-builder.mdx: no \`interface FilterField {\` block` — 3 failed | 41 passed. A vacuous reader would have left that green.

## The doc-vs-mirror reading, run for real

**No divergence today.** Doc 14, mirror 14, `doc \ mirror` empty and `mirror \ doc` empty. So the stop-and-report branch does not apply and nothing was widened, narrowed or edited on either face. The doc file is byte-identical at `BASE` and at `HEAD` (blob `0384d4e2511a4a0acd1b4b233c65f36120a367d5` both) — this PR does not touch it.

## Changeset level, from this repo's own precedent

`.changeset/8774-filter-builder-doc-widening-pin.md`, **empty frontmatter** — declared as releasing nothing.

Measured rather than assumed. Over the last 1200 commits touching `packages/*/src/__tests__/*`, **60 commits changed nothing but test files under a package `src/` plus their changeset. 60 of the 61 changesets they carried had empty frontmatter; exactly one declared a bump** — `.changeset/7344-handler-string-any-mirrors.md` (`@object-ui/types: minor`), whose own text says *"The accept set of published validators moves"*, i.e. its level was set by a published move, not by the test file. That discriminator is exactly what is absent here: no accept set moves.

The closest precedent by content is `.changeset/8458-parity-header-pairs-figure.md` — same package, same directory, same reasoning, quoted: *"It sits under `src/`, so the presence gate counts it, but nothing published moves: the package's build `tsconfig.json` excludes `**/__tests__/**` and its `files` list is `dist` only, so the file never reaches a consumer."* Both halves re-derived on my own base: `packages/types/tsconfig.json` `exclude` contains `**/__tests__/**`, and `files` is `["dist", "README.md", "CHANGELOG.md", "LICENSE"]`.

The gate agrees, in its own words: `✅ … Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.` The rule is also the gate's own header: *"No carve-out for test files under `src/`. A change confined to `src/__tests__/` is answered by the empty-frontmatter exemption, in one line."*

## Tests

| what | how | result |
|---|---|---|
| the pin file | `pnpm exec vitest run packages/types/src/__tests__/filter-builder-mirror-6939.test.ts` | RC=0 — 44 passed (44); the three new tests confirmed by name under `--reporter=verbose` |
| affected package, whole suite | `pnpm exec vitest run packages/types/` under `os-verify-lock.sh` | `VERDICT command-exit 0` — 171 files, 3370 passed |
| type-check | `pnpm --filter @object-ui/types run type-check` | RC=0. `tsc -p tsconfig.test.json --listFiles` names this file among 637 program files, so the green covers it |
| lint | `pnpm exec eslint --format json <the pin file>` | RC=0, `errorCount: 0`, `warningCount: 0` — counts read from the JSON report, not from grepped text |
| `check:control-bytes` | `node scripts/check-control-bytes.mjs` | RC=0 — 7256 tracked text files |
| control bytes, own sweep | `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` on both changed files | grep RC=1 (no match), 0 hit lines |
| `check:changeset-presence` | `node scripts/check-changeset-presence.mjs` | RC=0 |
| `check:changeset-no-major` | `node scripts/check-changeset-no-major.mjs` | RC=0 |
| `check:new-line-citations` | `node scripts/check-new-cross-file-line-citations.mjs` | RC=0 — 0 new citations |
| governed surface | `node scripts/check-governed-queue-guard.mjs --test` on both paths | RC=0 — **NOT GOVERNED**, none of the 5 surfaces matched |

Every `rc` above was captured to a file before any pipe. The repo-wide `pnpm lint` / full `pnpm test` are CI's runs, not narrowed away here.

## One boundary, stated rather than left as an absence

The remedy this pin prints — *the doc is the authority, so the mirror follows* — has exactly one exception, and it is written into the message: a spelling a **later** ruling retired from this doc (the way objectui#4814 retired `owner`) reappearing in it is a doc regression, not a widening, and the doc edit is what gets reverted. Worth knowing that `packages/types/src/__tests__/owner-retired-contract-twins.test.ts` names the three shrunk doc unions in prose only and reads no `.mdx` at runtime, so before this PR nothing pinned the doc half of that retirement for this page. It does now, as a side effect: `'owner'` returning to the doc reddens the new equality pin.

## Scope

⛔ Not re-litigating batch #88. ⛔ No accept set moves, neither face of the mirror was touched, and the doc was not edited. ⛔ The PR stays **draft** — landing is the seat's act. `needs:contract-review` is hung to match the card's carrier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_