### PR TITLE
test(types): pin every AnyComponentSchema arm to a named zod export (objectui#8784)

### DIFF
--- a/.changeset/8784-arm-named-export-pin.md
+++ b/.changeset/8784-arm-named-export-pin.md
@@ -25,8 +25,9 @@ union's own top-level option count.
 
 Red on arrival, reported rather than declared away: `507b61bf7` (PR #8763, objectui#8499)
 armed `SemanticElementSchema`, `HtmlElementSchema`, `InputShorthandSchema` and
-`UiCalendarSchema` in `layout.zod.ts` and `form.zod.ts` and touched no barrel — 48 minutes
-after objectui#8784 was filed on a census reading 107 arms / 107 named / 0 unnamed. The
+`UiCalendarSchema` in `layout.zod.ts` and `form.zod.ts` and touched no barrel deliberately
+(PR #8763 merged 2026-09-09T08:11:20Z; the omission and its reason are declared in
+`.changeset/8499-node-slot-registered-arms.md`). The
 current reading is 111 arms / 154 `type` literals / 106 named / 5 unnamed. Four of the five
 carry ledger rows against objectui#9067, which holds the ruling, because exporting them mints
 new names on a published surface. The fifth, `RetiredKanbanNodeSchema`, is a refusal arm the

--- a/.changeset/8784-arm-named-export-pin.md
+++ b/.changeset/8784-arm-named-export-pin.md
@@ -17,7 +17,9 @@ wired into no `package.json` script and no workflow.
 The pin derives the arm list on every run — flatten the union recursively through nested
 unions and `z.lazy`, then match each leaf arm to a named export **by identity**. Both
 properties are load-bearing and both are controls in the file rather than claims in a comment:
-a walk that stops at the top-level sub-unions scores exactly `options.length` arms, and a
+a walk that stops at the 13 top-level members — 12 sub-unions plus one object arm
+(`AppComponentSchema`, an arm at depth 1), not 13 sub-unions — scores exactly
+`options.length` arms, and a
 name-based match is satisfied by `export { NavigationSchema as BreadcrumbSchema }` — the
 parent sub-union under the arm's name, which passes every behavioural leg of #8777's pin. No
 count is hard-coded; the only bound asserted against the real union is a floor read off that

--- a/.changeset/8784-arm-named-export-pin.md
+++ b/.changeset/8784-arm-named-export-pin.md
@@ -1,0 +1,34 @@
+---
+---
+
+Test-only: pin that every `AnyComponentSchema` arm is a NAMED export of `@object-ui/types/zod`,
+or is ledgered with the reason it is not (objectui#8784). No published source changes, so no
+package is released by this change.
+
+objectui#7917 found two arms with no named export on the barrel — `breadcrumb` and
+`object-tree` were maintained, were applied by the union, and could not be validated on their
+own. PR #8777 repaired both and nothing kept it repaired: `zod-mirror-parity.test.ts` builds
+its export population with `/^export const NAME/m`, which matches a DECLARATION and can never
+match `export { NAME } from './x.js'`, so it is structurally blind to a missing re-export; no
+test pinned a list or a count on `index.zod.ts`; and the one script that does compute the
+census, `scripts/measure-strict-authoring-face.mjs`, is a self-described MEASUREMENT THROWAWAY
+wired into no `package.json` script and no workflow.
+
+The pin derives the arm list on every run — flatten the union recursively through nested
+unions and `z.lazy`, then match each leaf arm to a named export **by identity**. Both
+properties are load-bearing and both are controls in the file rather than claims in a comment:
+a walk that stops at the top-level sub-unions scores exactly `options.length` arms, and a
+name-based match is satisfied by `export { NavigationSchema as BreadcrumbSchema }` — the
+parent sub-union under the arm's name, which passes every behavioural leg of #8777's pin. No
+count is hard-coded; the only bound asserted against the real union is a floor read off that
+union's own top-level option count.
+
+Red on arrival, reported rather than declared away: `507b61bf7` (PR #8763, objectui#8499)
+armed `SemanticElementSchema`, `HtmlElementSchema`, `InputShorthandSchema` and
+`UiCalendarSchema` in `layout.zod.ts` and `form.zod.ts` and touched no barrel — 48 minutes
+after objectui#8784 was filed on a census reading 107 arms / 107 named / 0 unnamed. The
+current reading is 111 arms / 154 `type` literals / 106 named / 5 unnamed. Four of the five
+carry ledger rows against objectui#9067, which holds the ruling, because exporting them mints
+new names on a published surface. The fifth, `RetiredKanbanNodeSchema`, is a refusal arm the
+barrel already declares deliberately internal (objectui#8802). A stale-row leg deletes any
+ledger row the moment its arm is exported or stops existing.

--- a/packages/types/src/__tests__/arm-named-export-8784.test.ts
+++ b/packages/types/src/__tests__/arm-named-export-8784.test.ts
@@ -1,0 +1,416 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Every `AnyComponentSchema` arm is a NAMED export of `./zod` — or it is
+ * ledgered below with the reason it is not (objectui#8784).
+ *
+ * ## The defect this closes
+ *
+ * objectui#7917 found that 2 of the union's arms had no named export from
+ * `@object-ui/types/zod`, so `breadcrumb` and `object-tree` could not be
+ * validated on their own: the schemas existed, were maintained, and were
+ * applied by the union, while no consumer could name them. PR #8777 repaired
+ * both. Nothing kept it repaired.
+ *
+ * `./zod` is this package's ONLY zod subpath (`packages/types/package.json`
+ * maps it to `dist/zod/index.zod.js`) and `index.zod.ts` carries no star
+ * re-export — every name on that barrel is written out by hand. So an arm added
+ * to a category module and not to the barrel is declared-and-unreachable, and
+ * BOTH of the ways that has happened were silent:
+ *
+ *  - `BreadcrumbSchema` was on the barrel at creation and was dropped by
+ *    `d908a82f4`, a "Fix schema duplication" dedup, as COLLATERAL — no
+ *    decision, no diagnostic — and stayed gone for 41 commits while this
+ *    directory's `README.md` kept advertising it;
+ *  - `ObjectTreeSchema` was never added at all: PR #1892's file list omits the
+ *    barrel.
+ *
+ * ⚠️ Neither failure mode was hypothetical when this pin was written, and one
+ * of them was LIVE: `507b61bf7` (PR #8763, objectui#8499) armed four new arms
+ * in `layout.zod.ts` and `form.zod.ts` and touched no barrel, 48 minutes after
+ * objectui#8784 was filed on a census that read 107 arms / 107 named / 0
+ * unnamed. Those four are the `ABSENT_PENDING_RULING` rows below.
+ *
+ * ## Why the existing checks could not see it
+ *
+ *  - `zod-mirror-parity.test.ts` reads its export population with
+ *    `/^export const NAME/m` over `src/zod/*.zod.ts`. That pattern matches a
+ *    DECLARATION; a barrel line is `export { NAME } from './x.js'`, which it
+ *    cannot match — so the census is structurally blind to a missing
+ *    re-export even though `index.zod.ts` is one of the files it reads.
+ *  - No test pinned an export list or a count on `index.zod.ts`. The per-name
+ *    presence assertions that exist (`crud-retirement-5373.test.ts`,
+ *    `block-family-retired-4895.test.ts`, `breadcrumb-object-tree-nameable-7917.test.ts`)
+ *    each pin the names their own card was about, which is one arm at a time.
+ *  - `scripts/measure-strict-authoring-face.mjs` does compute it, and is
+ *    self-described `MEASUREMENT THROWAWAY`: no `package.json` script and no
+ *    workflow runs it.
+ *
+ * ## The two properties this pin is built on
+ *
+ * 1. ⭐ **It reads the BARREL, not the modules.** The population is
+ *    `Object.entries` of the `../zod/index.zod.js` module namespace — the
+ *    runtime export surface itself, so a re-export counts and a declaration
+ *    that never reached the barrel does not. A pin that read `^export const`
+ *    from the same files as the parity census would have rebuilt the blind spot
+ *    under a new filename. (The category modules ARE imported below, but only
+ *    to turn a failing arm into a name a reader can act on; they never decide
+ *    the verdict. `namesOn` is given ONE namespace and the real reading passes
+ *    it the barrel.)
+ *
+ * 2. ⭐ **It matches by IDENTITY, not by name.** Adversarial probing of #8777's
+ *    pin found that `export { NavigationSchema as BreadcrumbSchema }` — the
+ *    PARENT sub-union re-exported under the arm's name — satisfies a name-based
+ *    check and every behavioural leg of that pin. Only identity catches it, and
+ *    the arm's identity chain deliberately starts at the union OPTION, so no
+ *    containing union is ever a candidate. `the parent union under the arm's
+ *    name is still unnamed` below is that property as a control.
+ *
+ * ⛔ The arm list is DERIVED on every run and no count is hard-coded: arms land
+ * (four did, mid-card), and a number stated in a comment that nothing checks is
+ * objectui#8606. The only bound asserted against the real union is a floor read
+ * off that union's own top-level option count, which is what proves the walk
+ * recursed rather than stopping at the 13 sub-unions — the reviewer's first
+ * census stopped there and reported a plausible, fully-populated, entirely
+ * wrong "13 arms / 2 literals".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+
+// The population under test: the published barrel's own module namespace.
+import * as barrel from '../zod/index.zod.js';
+
+// Diagnostics only — see property 1 above. These give a failing arm a name.
+import * as appZod from '../zod/app.zod.js';
+import * as complexZod from '../zod/complex.zod.js';
+import * as crudZod from '../zod/crud.zod.js';
+import * as dataDisplayZod from '../zod/data-display.zod.js';
+import * as disclosureZod from '../zod/disclosure.zod.js';
+import * as feedbackZod from '../zod/feedback.zod.js';
+import * as formZod from '../zod/form.zod.js';
+import * as layoutZod from '../zod/layout.zod.js';
+import * as navigationZod from '../zod/navigation.zod.js';
+import * as objectqlZod from '../zod/objectql.zod.js';
+import * as overlayZod from '../zod/overlay.zod.js';
+import * as reportsZod from '../zod/reports.zod.js';
+import * as viewsZod from '../zod/views.zod.js';
+
+/* ── The ledger ──────────────────────────────────────────────────────────────
+ *
+ * ⛔ NOT a claim that every arm must be exported — only that the answer is
+ * DECLARED rather than accidental. A row is keyed by ONE `type` literal of the
+ * arm, because an arm with no barrel export has, by definition, no barrel name
+ * to key on; `every ledger row still names an arm` below fails if that literal
+ * stops existing, so the key cannot rot into a comment.
+ */
+
+/** Arms whose absence from the barrel is a decision someone took, with its reason. */
+const ABSENT_BY_DECISION: Readonly<Record<string, string>> = {
+  kanban:
+    'complex.zod.ts#RetiredKanbanNodeSchema — an ADR-0049 refusal arm rather than a mirror. '
+    + 'The decision is written on the barrel itself, beside the `complex.zod.js` block: '
+    + '"it is deliberately NOT exported — nothing outside this package parses against a '
+    + 'refusal arm" (objectui#8802, maintainer ruling 2026-09-09).',
+};
+
+/**
+ * Arms absent from the barrel with the answer still OWED.
+ *
+ * ⚠️ These are NOT exemptions. All four were armed by `507b61bf7`
+ * (objectui#8499) without a barrel line, all four are registered as first-class
+ * mirror pairs by `zod-mirror-parity.test.ts` with a TypeScript counterpart,
+ * and none carries any of this directory's "Deliberately NOT exported" markers
+ * — the same evidence objectui#7917 used to conclude its two omissions were
+ * accidental. Exporting them mints new names on a published surface, so the
+ * reading was reported and the ruling is objectui#9067's. The rows exist so the
+ * state is visible and so a NEW omission cannot hide behind them.
+ */
+const ABSENT_PENDING_RULING: Readonly<Record<string, string>> = {
+  aside: 'layout.zod.ts#SemanticElementSchema — ruling owed, objectui#9067',
+  h1: 'layout.zod.ts#HtmlElementSchema — ruling owed, objectui#9067',
+  email: 'form.zod.ts#InputShorthandSchema — ruling owed, objectui#9067',
+  'ui:calendar': 'form.zod.ts#UiCalendarSchema — ruling owed, objectui#9067',
+};
+
+const LEDGER: Readonly<Record<string, string>> = { ...ABSENT_BY_DECISION, ...ABSENT_PENDING_RULING };
+
+/* ── The census ──────────────────────────────────────────────────────────────*/
+
+interface ZodDef {
+  readonly type: string;
+  readonly options?: readonly unknown[];
+  readonly getter?: () => unknown;
+  readonly shape?: Readonly<Record<string, unknown>>;
+  readonly values?: readonly unknown[];
+  readonly entries?: Readonly<Record<string, unknown>>;
+}
+
+/** Zod 4 keeps a schema's definition on `_zod`; nothing public exposes it. */
+function defOf(schema: unknown): ZodDef | undefined {
+  return (schema as { _zod?: { def?: ZodDef } } | null | undefined)?._zod?.def;
+}
+
+/** The `type` literals a member declares, or `[]` when it declares none. */
+function typeLiterals(schema: unknown): string[] {
+  const def = defOf(schema);
+  if (!def) return [];
+  if (def.type === 'literal') return (def.values ?? []).filter((v): v is string => typeof v === 'string');
+  if (def.type === 'enum') return Object.values(def.entries ?? {}).filter((v): v is string => typeof v === 'string');
+  if (def.type === 'union') return (def.options ?? []).flatMap((option) => typeLiterals(option));
+  return [];
+}
+
+interface Arm {
+  /**
+   * Every schema object this arm is reachable AS: the union option, then each
+   * `z.lazy` unwrapped along the way. ⛔ A containing union is never a member —
+   * that is what makes a name on the parent union not a name on the arm.
+   */
+  readonly chain: readonly unknown[];
+  readonly literals: readonly string[];
+}
+
+interface Census {
+  readonly arms: readonly Arm[];
+  /** Members that are neither union, `z.lazy` nor object — a finding, ⛔ never a silent skip. */
+  readonly unresolved: readonly string[];
+}
+
+/**
+ * Flatten a component union to its leaf object arms, recursively, through
+ * nested unions and `z.lazy`.
+ */
+function censusOf(union: unknown): Census {
+  const arms: Arm[] = [];
+  const unresolved: string[] = [];
+  const seen = new Set<unknown>();
+
+  const walk = (schema: unknown, chain: readonly unknown[]): void => {
+    const def = defOf(schema);
+    if (!def || seen.has(schema)) return;
+    seen.add(schema);
+    if (def.type === 'union') {
+      // A union is a CONTAINER, so each option starts its own chain.
+      for (const option of def.options ?? []) walk(option, [option]);
+      return;
+    }
+    if (def.type === 'lazy') {
+      const inner = def.getter?.();
+      if (inner === undefined) {
+        unresolved.push('lazy (getter returned nothing)');
+        return;
+      }
+      walk(inner, [...chain, inner]);
+      return;
+    }
+    if (def.type === 'object') {
+      arms.push({ chain, literals: typeLiterals(def.shape?.type) });
+      return;
+    }
+    unresolved.push(def.type);
+  };
+
+  walk(union, []);
+  return { arms, unresolved };
+}
+
+/** Named exports of `namespace` whose VALUE is one of the schemas this arm is reachable as. */
+function namesOn(namespace: Readonly<Record<string, unknown>>, arm: Arm): string[] {
+  const reachableAs = new Set(arm.chain);
+  return Object.entries(namespace)
+    .filter(([, value]) => reachableAs.has(value))
+    .map(([name]) => name);
+}
+
+/* ── The real reading ────────────────────────────────────────────────────────*/
+
+const CENSUS = censusOf(barrel.AnyComponentSchema);
+const BARREL = barrel as unknown as Readonly<Record<string, unknown>>;
+
+/** `file#name` for every schema declared by a category module — diagnostics only. */
+const MODULE_NAMES = new Map<unknown, string>();
+for (const [file, namespace] of Object.entries({
+  'app.zod.ts': appZod,
+  'complex.zod.ts': complexZod,
+  'crud.zod.ts': crudZod,
+  'data-display.zod.ts': dataDisplayZod,
+  'disclosure.zod.ts': disclosureZod,
+  'feedback.zod.ts': feedbackZod,
+  'form.zod.ts': formZod,
+  'layout.zod.ts': layoutZod,
+  'navigation.zod.ts': navigationZod,
+  'objectql.zod.ts': objectqlZod,
+  'overlay.zod.ts': overlayZod,
+  'reports.zod.ts': reportsZod,
+  'views.zod.ts': viewsZod,
+} as Readonly<Record<string, Readonly<Record<string, unknown>>>>)) {
+  for (const [name, value] of Object.entries(namespace)) {
+    if (value !== null && typeof value === 'object' && !MODULE_NAMES.has(value)) {
+      MODULE_NAMES.set(value, `${file}#${name}`);
+    }
+  }
+}
+
+/** What a failure prints: the declaring name, then the literals it owns. */
+function describeArm(arm: Arm): string {
+  const declared = arm.chain.map((schema) => MODULE_NAMES.get(schema)).find((name) => name !== undefined);
+  const shown = arm.literals.slice(0, 6).join(', ');
+  const rest = arm.literals.length > 6 ? `, and ${arm.literals.length - 6} more` : '';
+  return `${declared ?? '(arm declared by no exported const)'} [type: ${shown}${rest}]`;
+}
+
+const UNNAMED = CENSUS.arms.filter((arm) => namesOn(BARREL, arm).length === 0);
+
+describe('every AnyComponentSchema arm is nameable on `./zod` (objectui#8784)', () => {
+  it('no arm is missing from the barrel without a ledger row saying why', () => {
+    const undeclared = UNNAMED.filter((arm) => !arm.literals.some((literal) => literal in LEDGER));
+    expect(
+      undeclared.map(describeArm),
+      'These `AnyComponentSchema` arms have no named export on `./zod`, so no consumer can '
+      + 'validate one of these node types on its own — `AnyComponentSchema` only answers "is '
+      + 'this SOME valid node". Re-export each from packages/types/src/zod/index.zod.ts, or, '
+      + 'if it is deliberately internal, add a row to ABSENT_BY_DECISION in this file with the '
+      + 'reason (the way RetiredKanbanNodeSchema carries one).',
+    ).toEqual([]);
+  });
+
+  it.each(Object.keys(LEDGER))('ledger row `%s` still names a live, still-absent arm', (literal) => {
+    const arm = CENSUS.arms.find((candidate) => candidate.literals.includes(literal));
+    expect(
+      arm,
+      `No arm of AnyComponentSchema declares type '${literal}' any more. The ledger row in this `
+      + 'file outlived its arm — delete it, or key it on a literal the arm still declares.',
+    ).toBeDefined();
+    if (arm === undefined) return;
+    expect(
+      namesOn(BARREL, arm),
+      `The arm declaring type '${literal}' IS exported by index.zod.ts now, so its ledger row is `
+      + 'stale — delete the row. A ledger that keeps rows after their reason is gone stops being read.',
+    ).toEqual([]);
+  });
+
+  it('states each absence once — the two ledgers do not overlap', () => {
+    const both = Object.keys(ABSENT_BY_DECISION).filter((key) => key in ABSENT_PENDING_RULING);
+    expect(both, 'A row cannot be both a decision taken and a ruling owed.').toEqual([]);
+  });
+});
+
+describe('the census reads the real union, and reads all of it', () => {
+  it('recurses BELOW the top-level arms', () => {
+    // Derived floor, ⛔ not a count: the reviewer's first census stopped at the
+    // top-level sub-unions and reported one "arm" per union. Anything that does
+    // that scores exactly `options.length` here.
+    const topLevel = defOf(barrel.AnyComponentSchema)?.options ?? [];
+    expect(topLevel.length).toBeGreaterThan(0);
+    expect(CENSUS.arms.length).toBeGreaterThan(topLevel.length);
+  });
+
+  it('leaves no member unresolved', () => {
+    // A member that is neither union, `z.lazy` nor object is a shape this walk
+    // does not understand — it must be reported, never dropped, or the arm it
+    // hides is invisible to the assertion above.
+    expect(CENSUS.unresolved).toEqual([]);
+  });
+
+  it('every arm declares at least one `type` literal', () => {
+    // An arm contributing zero literals would satisfy the ledger check
+    // vacuously — `literals.some(...)` is false for an empty list, so it would
+    // read as "undeclared" rather than sneak through; this states the stronger
+    // property the discriminated union already rests on.
+    expect(CENSUS.arms.filter((arm) => arm.literals.length === 0).map(describeArm)).toEqual([]);
+  });
+
+  it('resolves an arm reached through `z.lazy`', () => {
+    // `crud.zod.ts`'s `ActionSchema` reaches its literal through a `z.lazy`. If
+    // the unwrap silently failed, this arm would simply not be in the census
+    // and the whole pin would go quiet by shrinking its population.
+    const action = CENSUS.arms.find((arm) => arm.literals.includes('action'));
+    expect(action).toBeDefined();
+    if (action === undefined) return;
+    expect(namesOn(BARREL, action)).not.toEqual([]);
+  });
+
+  it('matches a known arm to its barrel name BY IDENTITY', () => {
+    const button = CENSUS.arms.find((arm) => arm.literals.includes('button'));
+    expect(button).toBeDefined();
+    if (button === undefined) return;
+    expect(namesOn(BARREL, button)).toContain('ButtonSchema');
+  });
+});
+
+describe('the census fires — controls', () => {
+  // Every control below is built on schemas the census has never seen, so each
+  // one is free to be red: the arm under test is absent from the namespace it
+  // is judged against, which is precisely the state the real reading must
+  // detect. A census that reported nothing would leave all four green only if
+  // it reported nothing for the real union too, and the `recurses BELOW` and
+  // `matches a known arm` legs above already refuse that.
+  const armA = z.object({ type: z.literal('probe-a') });
+  const armB = z.object({ type: z.literal('probe-b') });
+  const armC = z.object({ type: z.literal('probe-c') });
+  const pair = z.discriminatedUnion('type', [armA, armB]);
+
+  it('reports an arm whose re-export was dropped', () => {
+    // The historical break, in miniature: `d908a82f4` deleted one line from the
+    // barrel and left the module untouched.
+    const census = censusOf(pair);
+    const unnamed = census.arms.filter((arm) => namesOn({ ProbeASchema: armA }, arm).length === 0);
+    expect(unnamed.flatMap((arm) => [...arm.literals])).toEqual(['probe-b']);
+  });
+
+  it('reports nothing when every arm is on the namespace', () => {
+    // The other direction, so the control above is not just "this always fails".
+    const census = censusOf(pair);
+    const unnamed = census.arms.filter(
+      (arm) => namesOn({ ProbeASchema: armA, ProbeBSchema: armB }, arm).length === 0,
+    );
+    expect(unnamed).toEqual([]);
+  });
+
+  it('still reports the arm when the PARENT union carries the arm name', () => {
+    // ⭐ `export { NavigationSchema as BreadcrumbSchema }` passes a name-based
+    // check and every behavioural leg of #8777's pin. The namespace below is
+    // that write: the name is present and it is bound to the union, not to the
+    // arm.
+    const namespace = { ProbeASchema: armA, ProbeBSchema: pair };
+    expect('ProbeBSchema' in namespace).toBe(true);
+    const census = censusOf(pair);
+    const unnamed = census.arms.filter((arm) => namesOn(namespace, arm).length === 0);
+    expect(unnamed.flatMap((arm) => [...arm.literals])).toEqual(['probe-b']);
+  });
+
+  it('counts the arms of a NESTED union, not the nested union', () => {
+    // The "13 arms / 2 literals" failure. A walk that stops at the outer
+    // options sees two members here and two literals; this one sees three arms.
+    const nested = z.discriminatedUnion('type', [pair, armC]);
+    const census = censusOf(nested);
+    expect(census.arms.length).toBe(3);
+    expect(census.arms.flatMap((arm) => [...arm.literals]).sort()).toEqual([
+      'probe-a',
+      'probe-b',
+      'probe-c',
+    ]);
+  });
+
+  it('accepts either side of a `z.lazy` as the arm name, and neither is still unnamed', () => {
+    // `z.union` rather than a discriminated one: a bare `z.lazy` member
+    // computes no `propValues`, which zod 4 refuses as a discriminated option
+    // (`any-component-union-fanout.test.ts` measures that refusal). The real
+    // tree reaches its lazy arm through an annotated member; what matters here
+    // is only which objects count as the arm's identity.
+    const lazyArm = z.lazy(() => armC);
+    const lazyUnion = z.union([lazyArm]);
+    const unnamedAgainst = (namespace: Readonly<Record<string, unknown>>) =>
+      censusOf(lazyUnion).arms.filter((arm) => namesOn(namespace, arm).length === 0).length;
+    expect(unnamedAgainst({ LazyProbeSchema: lazyArm })).toBe(0);
+    expect(unnamedAgainst({ ProbeCSchema: armC })).toBe(0);
+    expect(unnamedAgainst({ SomethingElseSchema: armA })).toBe(1);
+  });
+});

--- a/packages/types/src/__tests__/arm-named-export-8784.test.ts
+++ b/packages/types/src/__tests__/arm-named-export-8784.test.ts
@@ -22,7 +22,7 @@
  * maps it to `dist/zod/index.zod.js`) and `index.zod.ts` carries no star
  * re-export — every name on that barrel is written out by hand. So an arm added
  * to a category module and not to the barrel is declared-and-unreachable, and
- * BOTH of the ways that has happened were silent:
+ * TWO of the three ways that has happened were silent:
  *
  *  - `BreadcrumbSchema` was on the barrel at creation and was dropped by
  *    `d908a82f4`, a "Fix schema duplication" dedup, as COLLATERAL — no
@@ -31,11 +31,31 @@
  *  - `ObjectTreeSchema` was never added at all: PR #1892's file list omits the
  *    barrel.
  *
- * ⚠️ Neither failure mode was hypothetical when this pin was written, and one
- * of them was LIVE: `507b61bf7` (PR #8763, objectui#8499) armed four new arms
- * in `layout.zod.ts` and `form.zod.ts` and touched no barrel, 48 minutes after
- * objectui#8784 was filed on a census that read 107 arms / 107 named / 0
- * unnamed. Those four are the `ABSENT_PENDING_RULING` rows below.
+ * ⭐ The third way is neither of those, and it is the one live on this tree:
+ * a DECLARED deferral. `507b61bf7` (PR #8763, objectui#8499, merged
+ * 2026-09-09T08:11:20Z) armed four new arms in `layout.zod.ts` and
+ * `form.zod.ts` and left the barrel alone ON PURPOSE. Its own changeset,
+ * `.changeset/8499-node-slot-registered-arms.md`, declares the omission, the
+ * metric it moves, and the reason: exporting a `SemanticElementSchema` /
+ * `HtmlElementSchema` pair "would publish a NAMED authoring surface (`z.enum`
+ * families, not per-tag schemas) that this card's ruling does not cover", so
+ * "the metric is left to move and said out loud instead" and "whoever wants
+ * the number back down should treat naming these families as its own
+ * decision". objectui#8499's ceiling review raised the omission as blocking
+ * F1 (`5597569641`), a delta commit carrying the eight barrel lines was
+ * prepared, and the review then PASSed the deferral "on the surface-widening
+ * reason alone" (`5598263402`). ⛔ So this is NOT `d908a82f4` recurring: no
+ * one forgot, and the four rows below say "a decision is owed", not "someone
+ * slipped".
+ *
+ * ⚠️ It is still exactly what this pin is for, and the reason is where the
+ * declaration LIVES. A `.changeset/*.md` is consumed and deleted at release —
+ * measured, e.g. `59f61cfb8` "chore: release packages (#4655)" removes the
+ * batch it versioned. The absence outlives its own explanation, and once the
+ * explanation is gone a deferred non-export and a collateral drop are the same
+ * two lines of nothing in `index.zod.ts`. The rows below move that reason into
+ * the tree, where it is re-read on every run and deleted only when it stops
+ * being true.
  *
  * ## Why the existing checks could not see it
  *
@@ -76,9 +96,12 @@
  * (four did, mid-card), and a number stated in a comment that nothing checks is
  * objectui#8606. The only bound asserted against the real union is a floor read
  * off that union's own top-level option count, which is what proves the walk
- * recursed rather than stopping at the 13 sub-unions — the reviewer's first
- * census stopped there and reported a plausible, fully-populated, entirely
- * wrong "13 arms / 2 literals".
+ * recursed rather than stopping at those top-level members — the reviewer's
+ * first census stopped there and reported a plausible, fully-populated,
+ * entirely wrong "13 arms / 2 literals". ⚠️ Those 13 are 12 sub-unions plus one
+ * object arm (`AppComponentSchema`, an arm at depth 1), not 13 sub-unions; the
+ * floor holds either way, and the count is read off the union rather than
+ * written down here.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -105,7 +128,9 @@ import * as viewsZod from '../zod/views.zod.js';
 /* ── The ledger ──────────────────────────────────────────────────────────────
  *
  * ⛔ NOT a claim that every arm must be exported — only that the answer is
- * DECLARED rather than accidental. A row is keyed by ONE `type` literal of the
+ * DECLARED, in the tree, where it is re-read on every run. Neither row below
+ * records a slip: one is a decision taken and four are a decision deferred with
+ * its reason on the record. A row is keyed by ONE `type` literal of the
  * arm, because an arm with no barrel export has, by definition, no barrel name
  * to key on; `every ledger row still names an arm` below fails if that literal
  * stops existing, so the key cannot rot into a comment.
@@ -121,25 +146,54 @@ const ABSENT_BY_DECISION: Readonly<Record<string, string>> = {
 };
 
 /**
- * Arms absent from the barrel with the answer still OWED.
+ * Arms whose absence from the barrel was DEFERRED, with the decision still owed.
  *
- * ⚠️ These are NOT exemptions. All four were armed by `507b61bf7`
- * (objectui#8499) without a barrel line, all four are registered as first-class
- * mirror pairs by `zod-mirror-parity.test.ts` with a TypeScript counterpart,
- * and none carries any of this directory's "Deliberately NOT exported" markers
- * — the same evidence objectui#7917 used to conclude its two omissions were
- * accidental. Exporting them mints new names on a published surface, so the
- * reading was reported and the ruling is objectui#9067's. The rows exist so the
- * state is visible and so a NEW omission cannot hide behind them.
+ * ⛔ These are not oversights, and reading them as oversights is the mistake
+ * this comment exists to prevent. All four were armed by `507b61bf7`
+ * (objectui#8499), which left the barrel alone deliberately: its changeset,
+ * `.changeset/8499-node-slot-registered-arms.md`, declares the omission, states
+ * that exporting a `SemanticElementSchema` / `HtmlElementSchema` pair "would
+ * publish a NAMED authoring surface (`z.enum` families, not per-tag schemas)
+ * that this card's ruling does not cover", and closes by saying "whoever wants
+ * the number back down should treat naming these families as its own decision".
+ * The objectui#8499 ceiling review raised the omission as blocking F1
+ * (`5597569641`) and then PASSed the deferral "on the surface-widening reason
+ * alone" (`5598263402`).
+ *
+ * ⇒ The state is "a decision is owed", which is what these rows record, and the
+ * argument AGAINST naming them is on the record too. objectui#9067 carries the
+ * decision; anyone acting on it should read the changeset passage first, not
+ * only the case for exporting.
+ *
+ * ⚠️ They are ledgered anyway rather than left to that changeset, because a
+ * `.changeset/*.md` is consumed and deleted at release (measured: `59f61cfb8`
+ * "chore: release packages (#4655)" removes the batch it versioned). The rows
+ * keep the reason next to the state it explains.
  */
-const ABSENT_PENDING_RULING: Readonly<Record<string, string>> = {
-  aside: 'layout.zod.ts#SemanticElementSchema — ruling owed, objectui#9067',
-  h1: 'layout.zod.ts#HtmlElementSchema — ruling owed, objectui#9067',
-  email: 'form.zod.ts#InputShorthandSchema — ruling owed, objectui#9067',
-  'ui:calendar': 'form.zod.ts#UiCalendarSchema — ruling owed, objectui#9067',
+const ABSENT_PENDING_DECISION: Readonly<Record<string, string>> = {
+  aside: 'layout.zod.ts#SemanticElementSchema — deferred by objectui#8499, decision owed on objectui#9067',
+  h1: 'layout.zod.ts#HtmlElementSchema — deferred by objectui#8499, decision owed on objectui#9067',
+  email: 'form.zod.ts#InputShorthandSchema — deferred by objectui#8499, decision owed on objectui#9067',
+  'ui:calendar': 'form.zod.ts#UiCalendarSchema — deferred by objectui#8499, decision owed on objectui#9067',
 };
 
-const LEDGER: Readonly<Record<string, string>> = { ...ABSENT_BY_DECISION, ...ABSENT_PENDING_RULING };
+const LEDGER: Readonly<Record<string, string>> = { ...ABSENT_BY_DECISION, ...ABSENT_PENDING_DECISION };
+
+/**
+ * Own-key test. ⛔ Not `key in ledger`: these are plain object literals, so `in`
+ * answers `true` for every `Object.prototype` key and an arm declaring
+ * `type: 'constructor'` or `'toString'` would ledger itself.
+ *
+ * `Object.hasOwn` is the modern spelling and does not compile here — measured:
+ * `packages/types/tsconfig.json` sets `"lib": ["ES2020", "DOM"]`, and tsc says
+ * `TS2550: Property 'hasOwn' does not exist on type 'ObjectConstructor'. …Try
+ * changing the 'lib' compiler option to 'es2022' or later`. A lib bump is a
+ * build-config change this pin does not own, so the `.call` form stands.
+ * ⛔ Do not "modernise" it back without moving the lib first.
+ */
+function hasRow(ledger: Readonly<Record<string, string>>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(ledger, key);
+}
 
 /* ── The census ──────────────────────────────────────────────────────────────*/
 
@@ -193,9 +247,15 @@ function censusOf(union: unknown): Census {
   const seen = new Set<unknown>();
 
   const walk = (schema: unknown, chain: readonly unknown[]): void => {
-    const def = defOf(schema);
-    if (!def || seen.has(schema)) return;
+    if (seen.has(schema)) return;
     seen.add(schema);
+    const def = defOf(schema);
+    if (def === undefined) {
+      // ⛔ Not a silent `return`: a member with no `_zod` is a shape this walk
+      // does not understand, and dropping it would hide whatever arm it holds.
+      unresolved.push('(member carries no zod definition)');
+      return;
+    }
     if (def.type === 'union') {
       // A union is a CONTAINER, so each option starts its own chain.
       for (const option of def.options ?? []) walk(option, [option]);
@@ -270,14 +330,18 @@ const UNNAMED = CENSUS.arms.filter((arm) => namesOn(BARREL, arm).length === 0);
 
 describe('every AnyComponentSchema arm is nameable on `./zod` (objectui#8784)', () => {
   it('no arm is missing from the barrel without a ledger row saying why', () => {
-    const undeclared = UNNAMED.filter((arm) => !arm.literals.some((literal) => literal in LEDGER));
+    // `hasRow`, ⛔ not `in` — see its docblock for why, and why not `Object.hasOwn`.
+    const undeclared = UNNAMED.filter((arm) => !arm.literals.some((literal) => hasRow(LEDGER, literal)));
     expect(
       undeclared.map(describeArm),
       'These `AnyComponentSchema` arms have no named export on `./zod`, so no consumer can '
       + 'validate one of these node types on its own — `AnyComponentSchema` only answers "is '
-      + 'this SOME valid node". Re-export each from packages/types/src/zod/index.zod.ts, or, '
-      + 'if it is deliberately internal, add a row to ABSENT_BY_DECISION in this file with the '
-      + 'reason (the way RetiredKanbanNodeSchema carries one).',
+      + 'this SOME valid node". Three answers are acceptable and a fourth is not. Re-export '
+      + 'each from packages/types/src/zod/index.zod.ts; or, if it is deliberately internal, '
+      + 'add a row to ABSENT_BY_DECISION with the reason (the way RetiredKanbanNodeSchema '
+      + 'carries one); or, if naming it is a decision your card does not cover, add a row to '
+      + 'ABSENT_PENDING_DECISION naming the card that holds it. What is not acceptable is '
+      + 'leaving the answer to be inferred from an absence.',
     ).toEqual([]);
   });
 
@@ -297,8 +361,8 @@ describe('every AnyComponentSchema arm is nameable on `./zod` (objectui#8784)', 
   });
 
   it('states each absence once — the two ledgers do not overlap', () => {
-    const both = Object.keys(ABSENT_BY_DECISION).filter((key) => key in ABSENT_PENDING_RULING);
-    expect(both, 'A row cannot be both a decision taken and a ruling owed.').toEqual([]);
+    const both = Object.keys(ABSENT_BY_DECISION).filter((key) => hasRow(ABSENT_PENDING_DECISION, key));
+    expect(both, 'A row cannot be both a decision taken and a decision owed.').toEqual([]);
   });
 });
 


### PR DESCRIPTION
Fixes #8784

Adds `packages/types/src/__tests__/arm-named-export-8784.test.ts`: every `AnyComponentSchema` arm is a NAMED export of `@object-ui/types/zod`, or carries a ledger row saying why it is not. Test-only; the changeset declares an empty frontmatter.

## What the pin does

Derive the arm list on every run — flatten `AnyComponentSchema` recursively through nested unions and `z.lazy` — then match each leaf arm to a named export of the barrel **by identity**. Two properties are load-bearing, and both are controls inside the file rather than claims in a comment:

- **It reads the BARREL.** The population is `Object.entries` of the `../zod/index.zod.js` module namespace, i.e. the runtime export surface itself, so a re-export counts and a declaration that never reached the barrel does not.
- **It matches by IDENTITY.** An arm's identity chain starts at the union OPTION, so a containing union is never a candidate for the arm's name.

⛔ No count is hard-coded. The only bound asserted against the real union is a floor read off that union's own top-level option count, which is what proves the walk recursed instead of stopping at those 13 top-level members (12 sub-unions plus `AppComponentSchema`, an object arm at depth 1).

The category modules are imported too, but only to turn a failing arm into a name a reader can act on — `namesOn` takes ONE namespace and the real reading passes it the barrel.

## Round 2 — what the contract review corrected, and what it did not

Round 1 (`fc1ab897c`) came back **FAIL on a factual point, mechanism passing**. Round 2 is prose plus two hardening nits; the census, the identity matching, the ledger rows, the derived floor and both firing controls are unchanged, and the firing controls were re-run on the patched head to prove it (same mutation hashes, same output).

**What was wrong.** Round 1's docblock filed `507b61bf7` (PR #8763, objectui#8499) under the barrel's SILENT failure modes, next to `d908a82f4`'s collateral drop, and argued the four omissions were accidental. They were not. Three records say so, re-derived here rather than taken on trust:

1. `.changeset/8499-node-slot-registered-arms.md`, present in this very tree (blob `c055695d1` on `origin/main`), declares the omission and its reason: exporting a `SemanticElementSchema` / `HtmlElementSchema` pair *"would publish a NAMED authoring surface (`z.enum` families, not per-tag schemas) that this card's ruling does not cover: the ruling is 'arm the registered renderers', not 'add public exports to `@object-ui/types`'. So the metric is left to move and said out loud instead. ⇒ … whoever wants the number back down should treat naming these families as its own decision."* It also declares the movement it caused — `unexportedNodeSchemas` from `[breadcrumb, object-tree]` to 49 node types, *"Measured at this branch's head, not estimated."*
2. objectui#8499's ceiling review raised exactly this as **blocking F1** (`5597569641`): the four *"are published by the union but unreachable by name from any published entry"*, with the eight barrel lines named as the remedy.
3. That review then **PASSed the deferral** *"on the surface-widening reason alone"* (`5598263402`).

⇒ A deferral with a written reason, reviewed twice. Withdrawn accordingly: round 1's claim that this was the objectui#7917 defect recurring silently, and its reading of the stale census as the card's thesis arriving as evidence. objectui#8784's thesis — that the invariant has no keeper — stands on its own and does not need this commit.

**What survives, and is now the docblock's argument.** The pin still earns its place against a *declared* deferral, for a reason about where the declaration lives: a `.changeset/*.md` is consumed and deleted at release — measured, `59f61cfb8` "chore: release packages (#4655)" removes the batch it versioned — so the absence outlives its own explanation, and once the explanation is gone a deferred non-export and a collateral drop are the same two lines of nothing in `index.zod.ts`. The ledger moves that reason into the tree, where it is re-read on every run and deleted only when it stops being true. The classification is unchanged and was independently confirmed: the #8499 changeset itself leaves naming to "its own decision", so "a decision is owed" is the right state for those four rows.

`ABSENT_PENDING_RULING` is renamed `ABSENT_PENDING_DECISION` and its comment now carries the recorded argument AGAINST naming these families, not only the case for it — so a reader who meets the rows meets the counter-argument too.

**Hardening, both nits the review raised.** `hasRow` replaces `key in LEDGER`, so an arm declaring `type: 'constructor'` cannot ledger itself off `Object.prototype`; `Object.hasOwn` is the modern spelling and does not compile under this package's `"lib": ["ES2020", "DOM"]` (measured: tsc `TS2550`, "Try changing the 'lib' compiler option to 'es2022' or later"), so the `.call` form stands with that measurement recorded beside it — a lib bump is a build-config change this pin does not own. And the walk's `if (!def || seen.has(schema)) return` is split, so a member carrying no zod definition is pushed to `unresolved` instead of dropped, which is what the docblock already promised. Neither moved a reading: the types suite is identical at 172 files / 3385 tests, and `unresolved` is still empty on the real union.

## The census on this base

Base `7f27bc54343e6193f11ec3f58927fb9afb1bc635`. The card reads 107 arms / 107 literals / 107 named / 0 unnamed. This base reads **111 arms / 154 `type` literals / 106 named / 5 unnamed**, derived as described above. The review reproduced the same four numbers with two instruments of its own, and reproduced `107 / 107 / 107 / 0` at `ee4d19f6c`, the parent of `507b61bf7` — so the card's census was correct when it was taken.

Sequence, by `merged_at` rather than committer date: card filed 2026-09-09T07:05:02Z → PR #8777 merged 07:20:02Z (the objectui#7917 repair, census 107/107/0) → PR #8763 merged **2026-09-09T08:11:20Z**, arming four arms in `layout.zod.ts` and `form.zod.ts` with the barrel deliberately untouched. (`07:53:59Z`, which round 1 used, is `507b61bf7`'s committer date, not its merge time.)

The four are NOT exported here: a new exported symbol is the `Clause-2` branch and the dispatch said stop and report. objectui#9067 carries the decision and its framing has been corrected there by the seat. The fifth unnamed arm, `RetiredKanbanNodeSchema`, is a refusal arm the barrel already declares deliberately internal in as many words (objectui#8802) and is ledgered as a decision taken. A stale-row leg deletes any row the moment its arm is exported or stops existing, so the ledger cannot outlive its cause — and Legs A and B below show any arm outside those five rows still reddens.

Cross-check between the two instruments: the five unnamed arms carry 7 + 37 + 2 + 1 + 1 = 48 `type` literals, which is the #8499 changeset's `unexportedNodeSchemas` metric after PR #8777 landed (its own conditional, "If PR #8777 lands first, the same movement reads `0` to `47`") plus `kanban` from objectui#8802.

## Firing controls — run for real, on the committed tree, both restored, re-run on the patched head

Both legs mutate ONLY `packages/types/src/zod/index.zod.ts`, which is the shape of both historical breaks. Each leg proves the mutation reached disk by counting the anchor line before and after and by comparing `git hash-object` against the `HEAD` blob; each restore is proved by hash equality plus an empty `git diff HEAD`.

**Leg A — the dropped re-export.** Delete the barrel's `BreadcrumbSchema,` line, module untouched. This is `d908a82f4` in miniature. It can fire because `breadcrumb` is a live arm that IS named on the barrel today (PR #8777 put it back) and carries no ledger row, so the mutation moves it from named to unnamed — the exact transition the pin claims to detect, on a symbol this PR did not introduce.

    before: exact anchor lines = 1
    after : exact anchor lines = 0
    after : file hash = 0dd47171df8382efc4df9f29630cf9a1d2b8745d  (HEAD blob 2307622df6e3dce011c9a483cb72ae8a27a85c54)
     packages/types/src/zod/index.zod.ts | 1 -
    LEG A : vitest exit 1
      Tests  1 failed | 16 passed (17)

The failure names the arm:

    AssertionError: These `AnyComponentSchema` arms have no named export on `./zod` … : expected [ Array(1) ] to deeply equal []
    + [
    +   "navigation.zod.ts#BreadcrumbSchema [type: breadcrumb]",
    + ]

**Leg B — the parent union under the arm's name.** Replace that line with `NavigationSchema as BreadcrumbSchema,`. The NAME is present and bound to the parent sub-union. It can fire for the same reason as leg A, and it is the sharper control because a name-based census goes green on it:

    after : BreadcrumbSchema declaration lines = 0
    after : aliased lines = 1
    after : file hash = 6def775ec20a5b2b0902358c5e1b06b743d1e386  (HEAD blob 2307622df6e3dce011c9a483cb72ae8a27a85c54)
    LEG B : vitest exit 1
      Tests  1 failed | 16 passed (17)
    + [
    +   "navigation.zod.ts#BreadcrumbSchema [type: breadcrumb]",
    + ]

On the SAME mutation, `breadcrumb-object-tree-nameable-7917.test.ts` is fully green — `vitest exit 0`, `Tests 9 passed (9)`. That reproduces the ceiling reviewer's adversarial finding on this base: the accept leg succeeds, the near-miss refusal is byte-identical, another node type is still refused. Only identity catches it.

**Restore.** After both legs: `RESTORED: hash matches HEAD blob and git diff HEAD is empty`, then `RESTORED : vitest exit 0`, `Tests 17 passed (17)`, `git status --porcelain` empty. Both legs were re-run after the round-2 hardening and produced byte-identical mutation hashes and identical output, which is how "the walk did not change" is a reading rather than an assurance.

Four further controls live in the file permanently rather than as one-off runs — a dropped re-export, the parent-union alias, a NESTED union whose arms must be counted instead of the union (the "13 arms / 2 literals" failure), and a `z.lazy` arm named through either side of the wrapper.

## Verification

All commands run from the repository root, on the patched head. Exit codes captured to a file before any pipe; heavy runs serialised through the shared verify lock.

- `pnpm exec vitest run packages/types/` — `Test Files 172 passed (172)`, `Tests 3385 passed (3385)`, exit 0. 172 = 171 tracked test files plus this one, so the new file is in the run rather than assumed to be.
- `pnpm --filter @object-ui/types type-check` — exit 0 (`tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`). ⚠️ A green type-check does not by itself prove it read the new file: `tsc -p tsconfig.test.json --listFiles` was grepped and returns the file, 1 hit.
- `pnpm exec eslint --format json` on the changed file in `packages/types` — 0 errors, 0 warnings, counts read from the JSON. The package baseline measured in round 1 was 242 files, 0 errors, 278 warnings; the repo-wide baseline is red on `main`.
- `node scripts/check-changeset-presence.mjs` — exit 0: "Every one of them has an EMPTY frontmatter — declared as releasing nothing".
- `node scripts/check-control-bytes.mjs` — exit 0, 7258 tracked text files scanned. The changed file was also scanned directly with `grep -naP`; grep exited 1 with no output lines, which is a reading on that file and not a general claim about the tree.
- `node scripts/check-new-cross-file-line-citations.mjs` — exit 0, 0 new citations.
- `node scripts/check-vi-mock-override-shape.mjs` — exit 0.

Not run locally and left to CI: the repo-wide lint and type-check farms, the CLI self-check, and every gate outside the families above.

## Changeset level, from this repository's own precedent

Empty frontmatter, unchanged in round 2. `scripts/check-changeset-presence.mjs`'s header is the authority and states it in as many words: "**No carve-out for test files under `src/`.** A change confined to `src/__tests__/` is answered by the empty-frontmatter exemption, in one line." Read by content, the nearest precedent is `.changeset/4971-declared-arm-subset-gate.md` — the same shape of change (a test-only gate over a declared surface, carrying reasoned, issue-backed exemptions and a stale-exemption leg), declared as releasing nothing. Nothing in `packages/types/package.json`'s `files` list moves and no published contract field moves, so no package is released by this change.

⚠️ Round 3, one clause, on the seat's ruling. Round 2 flagged rather than acted on a conflict: `.changeset/8784-arm-named-export-pin.md` still carried round 1's "48 minutes after objectui#8784 was filed" — the same arithmetic corrected everywhere else, off the committer date — while the patch instruction listed the changeset among the files not to touch. The seat ruled to correct it. ⚠️ The ground the seat and I both gave for that ruling — that the changeset is release-note input consumed into `packages/types/CHANGELOG.md`, so it outlives the PR body — is FALSE for this changeset, and the contract review on `19f8ab48d` measured both sides of it: in release commit `59f61cfb8`, 0 of the 62 deleted changesets with EMPTY frontmatter reach any CHANGELOG hunk, against a control of 40/40 for the non-empty ones. This file has empty frontmatter, so it is deleted at release and published nowhere. My own earlier evidence (`git log --diff-filter=D` showing the release commit deleting the batch) measured the DELETION and never the COPYING, and publication was inferred from deletion — ⛔ "X is deleted at release" does not establish "X is published at release". The edit stands on its own merit instead: a knowingly wrong figure in a file this PR ships is worth one clause whether or not anyone downstream reads it. That clause now reads "and touched no barrel deliberately (PR #8763 merged 2026-09-09T08:11:20Z; the omission and its reason are declared in `.changeset/8499-node-slot-registered-arms.md`)". ⛔ The interval is not restated as its true value of 66.3 minutes: what made an interval meaningful was the accident premise, and that premise is withdrawn. Nothing else moved in that round.

⚠️ Round 4, one further clause, also on the seat's ruling. Round 2 corrected the top-level-member fact in the pin's docblock and did not carry it into the changeset, so this PR was shipping two faces that disagreed about the same fact. ⚠️ That, and only that, is the reason it earned a clause — ⛔ NOT the "published into `packages/types/CHANGELOG.md`" rationale given at the time, which the contract review falsified for empty-frontmatter changesets (see the round-3 note above). That clause now reads: a walk that stops at the 13 top-level members — 12 sub-unions plus one object arm (`AppComponentSchema`, an arm at depth 1), not 13 sub-unions — scores exactly `options.length` arms. The wording is taken from the docblock rather than paraphrased, and the match is measured rather than eyeballed: with jsdoc leaders stripped and whitespace collapsed, that phrase occurs exactly once in each file. The claim itself is unchanged. ⛔ The paragraph's opening clause, "Red on arrival, reported rather than declared away", stays byte-unchanged — it asserts nothing false and is a borrowed repo idiom (`.changeset/4971-declared-arm-subset-gate.md`), so rewording it would be editing voice rather than fact.

## Scope

⛔ No arm added or renamed. ⛔ No existing parity check weakened — `zod-mirror-parity.test.ts` is untouched, and this pin asks a question that census is structurally unable to ask rather than taking over any part of it. ⛔ No export added: that is objectui#9067's decision to take, not this PR's.

The diff touches no governed surface. It stays `draft` regardless: landing is the seat's act.

Carries `needs:contract-review` to match the card's carrier, per the dual-carrier rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_


---
_Generated by [Claude Code](https://claude.ai/code)_