### PR TITLE
fix(plugin-detail): the percent summary chip states the percentage it draws

### DIFF
--- a/.changeset/percent-summary-chip-one-rule.md
+++ b/.changeset/percent-summary-chip-one-rule.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+fix(plugin-detail): the `percent` summary chip beside the record H1 stated one percentage in its text and drew another in its bar — a stored `0.123` read `0.123%` next to a bar filled to 12.3%. Both halves now scale the stored value by the same rule (the bar's existing one), so the chip states the percentage it draws. Values already in percentage points, such as `12.3` or `250`, render exactly as before.

--- a/packages/plugin-detail/src/DetailView.tsx
+++ b/packages/plugin-detail/src/DetailView.tsx
@@ -53,6 +53,7 @@ import { getCellRenderer, resolveCellRendererType, coerceToSafeValue } from '@ob
 import { hasCellValue } from './emptiness';
 import { enrichDetailField } from './fieldEnrichment';
 import { chipTakesCellRenderer } from './summaryChipRenderers';
+import { summaryChipPercentPoints } from './summaryChipPercent';
 
 
 /** Stable empty draft so the section `data`-merge identity is preserved when
@@ -1085,11 +1086,16 @@ export const DetailView: React.FC<DetailViewProps> = ({
                     } else if (ftype === 'percent') {
                       const num = Number(val);
                       if (!Number.isNaN(num)) {
-                        display = `${num}%`;
-                        // Normalize to 0..100 for the bar; values <=1 are
-                        // treated as ratios (0.6 → 60%), otherwise capped.
-                        const normalized = num <= 1 ? num * 100 : num;
-                        percentValue = Math.max(0, Math.min(100, normalized));
+                        // ONE number, read by both halves of this chip: the
+                        // text states it, the bar below draws it clamped to
+                        // its track. They used to scale `num` by two different
+                        // rules, so a stored `0.123` said `0.123%` beside a bar
+                        // at 12.3% (objectui#8728). Which rule survived, and
+                        // why it is not the repo-wide one, is in
+                        // `./summaryChipPercent`.
+                        const points = summaryChipPercentPoints(num);
+                        display = `${points}%`;
+                        percentValue = Math.max(0, Math.min(100, points));
                       }
                     } else if (ftype === 'select' || ftype === 'status' || ftype === 'multiselect') {
                       // Resolve raw option label from field metadata as

--- a/packages/plugin-detail/src/__tests__/summaryChip.objectValue-8464.test.tsx
+++ b/packages/plugin-detail/src/__tests__/summaryChip.objectValue-8464.test.tsx
@@ -404,6 +404,16 @@ describe('objectui#8464 — an object-valued summary chip beside the H1', () => 
       },
     );
 
+    /**
+     * ⚠️ The expected text moved from `0.123%` to `12.3%` in objectui#8728, and
+     * the pin is still doing its job. Its subject is ROUTING — that a percent
+     * keeps the chip's own text path and its own single bar instead of being
+     * handed to a cell renderer — and the routing is unchanged. What that card
+     * found is that this chip's two halves scaled the same stored number by two
+     * different rules, so the `0.123%` this line used to require was the text
+     * disagreeing with the bar drawn beside it. The agreement itself is pinned
+     * in `summaryChip.percentOneRule-8728.test.tsx`.
+     */
     it('PERCENT — keeps its own text AND its single decorative bar', () => {
       const { container } = renderPage({
         summaryFields: ['ratio'] as any,
@@ -412,14 +422,14 @@ describe('objectui#8464 — an object-valued summary chip beside the H1', () => 
       });
 
       const chip = requireChip(container, 'ratio');
-      expect(textOf(chip), 'the percent chip keeps its own text').toBe('0.123%');
+      expect(textOf(chip), 'the percent chip keeps its own text').toBe('12.3%');
       // The chip's OWN bar is two `rounded-full` spans — track and fill. A cell
       // renderer routed in here would add its own, so the exact count is the pin.
       expect(nestedPills(chip).length, 'exactly the chip\'s own two-span bar, no renderer bar').toBe(2);
       expect(
         chip.getAttribute('aria-label'),
-        'and the accessible name is unchanged',
-      ).toBe('ratio: 0.123%');
+        'and the accessible name still comes from that same string',
+      ).toBe('ratio: 12.3%');
     });
   });
 

--- a/packages/plugin-detail/src/__tests__/summaryChip.percentOneRule-8728.test.tsx
+++ b/packages/plugin-detail/src/__tests__/summaryChip.percentOneRule-8728.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The `summaryFields` chip beside the record H1 states ONE percentage
+ * (objectui#8728).
+ *
+ * ## The defect, reproduced two-sided
+ *
+ * The chip draws a `percent` twice — as text and as a bar — and the two halves
+ * scaled the same stored number by two different rules:
+ *
+ *     display = `${num}%`;                            // the text: no scaling
+ *     const normalized = num <= 1 ? num * 100 : num;  // the bar: ratio, scaled
+ *
+ * Measured on `7f27bc543`, before the fix, with `fields: [{ name: 'ratio',
+ * type: 'percent' }]`:
+ *
+ * | stored  | chip text | bar fill  | agree? |
+ * |---------|-----------|-----------|--------|
+ * | `0.123` | `0.123%`  | `12.3%`   | NO     |
+ * | `12.3`  | `12.3%`   | `12.3%`   | yes    |
+ *
+ * Two-sided is the point: a one-sided reproduction cannot tell "this chip
+ * contradicts itself" apart from "percent formatting is odd here". The second
+ * row is also the CONTROL — it must read exactly as it does today, before and
+ * after, and on both legs of the ablation.
+ *
+ * ## What is asserted, and why it is a RELATION
+ *
+ * Every row asserts that the bar draws the number the text states, clamped to
+ * the track — not that a particular string appeared. A per-half assertion
+ * ("text is `12.3%`", "bar is 12.3%") would go green on a repair that made both
+ * halves wrong in a new matching way, which is precisely the failure this card
+ * is about. The expected strings are pinned as well, because a relation alone
+ * would go green on a chip that printed `0%` beside an empty bar for
+ * everything.
+ *
+ * ## The boundary rows
+ *
+ * `EXACTLY 1` is the fork triage named: is a stored `1` one percent or one
+ * hundred? This chip answers 100%, because that is what its bar already drew
+ * and the ruling was that the text follows the bar. ⚠️ That answer is this
+ * chip's alone — `percentDisplayValue` in `@object-ui/core`, and so the list
+ * cell, the dashboard measure and the grid column summary, all render a stored
+ * `1` as `1%`. The census and the three routes out are objectui#9071; the row
+ * below exists so the answer is PINNED rather than incidental, and so that
+ * card's PR has to state which way it is moving.
+ *
+ * ## Instruments
+ *
+ * - The chip is navigated by `[data-summary-chip="ratio"]`, never by
+ *   `queryByText`: every summary value also renders in the body grid, and
+ *   `queryByText` throws on multiple matches as well as on none.
+ * - The bar's fill is read from the inline `width` — the one place the drawn
+ *   percentage exists in the DOM. It is an author-declared, data-driven length,
+ *   the carve-out the styling rule already grants this bar.
+ * - The accessible name is asserted only for its PERCENTAGE — that it ends with
+ *   the same text the chip shows. How the chip NAMES the field is objectui#8729,
+ *   the serial card on this same render, and pinning that here would hand it a
+ *   pin to fight for no reason.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import * as React from 'react';
+import { DetailView } from '../DetailView';
+import type { DetailViewSchema } from '@object-ui/types';
+
+/**
+ * `useRecordEditable` falls back to the GLOBAL fetch with no
+ * `SchemaRendererProvider` in the tree; under happy-dom that is a real request.
+ * Served from a double so no case here depends on the network.
+ */
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true, json: async () => ({ record: { visible: true } }) })),
+  );
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+});
+
+const renderChip = (stored: unknown) =>
+  render(
+    <DetailView
+      schema={
+        {
+          type: 'record:details',
+          objectName: 'account',
+          summaryFields: ['ratio'],
+          fields: [{ name: 'ratio', label: 'Ratio', type: 'percent' }],
+          data: { id: 'A9', name: 'Acme', ratio: stored },
+        } as unknown as DetailViewSchema
+      }
+    />,
+  ).container;
+
+const requireChip = (c: HTMLElement): HTMLElement => {
+  const chip = c.querySelector<HTMLElement>('[data-summary-chip="ratio"]');
+  expect(chip, 'a summary chip for "ratio" is beside the H1').not.toBeNull();
+  return chip!;
+};
+
+const textOf = (el: HTMLElement) => (el.textContent ?? '').replace(/\s+/g, ' ').trim();
+
+/** The percentage the chip SAYS, read back out of its own text. */
+const spokenPercent = (chip: HTMLElement): number => {
+  const text = textOf(chip);
+  expect(text, 'the chip states a percentage').toMatch(/^-?\d+(\.\d+)?%$/);
+  return Number(text.slice(0, -1));
+};
+
+/** The percentage the chip DRAWS, read off the bar fill's own width. */
+const drawnPercent = (chip: HTMLElement): number => {
+  const track = chip.querySelector<HTMLElement>('[aria-hidden]');
+  expect(track, 'the chip draws its own bar track').not.toBeNull();
+  const fill = track!.querySelector<HTMLElement>('span[style]');
+  expect(fill, 'the track carries a fill span with a width').not.toBeNull();
+  const width = fill!.style.width;
+  expect(width, 'the fill width is a percentage').toMatch(/%$/);
+  return Number(width.slice(0, -1));
+};
+
+/** The bar cannot draw outside its track, so agreement is stated modulo this. */
+const onTrack = (p: number) => Math.max(0, Math.min(100, p));
+
+interface Row {
+  what: string;
+  stored: number;
+  text: string;
+}
+
+const ROWS: Row[] = [
+  // The card's own reproduction. Before the fix: text `0.123%`, bar 12.3%.
+  { what: 'a stored ratio — the card\'s reproduction', stored: 0.123, text: '12.3%' },
+  // CONTROL. Already percentage points, so nothing about it may move.
+  { what: 'CONTROL — a value already in points is untouched', stored: 12.3, text: '12.3%' },
+  { what: 'zero', stored: 0, text: '0%' },
+  // THE FORK. See the header: this chip's answer, pinned, and objectui#9071's
+  // to move.
+  { what: 'EXACTLY 1 — this chip reads it as a ratio', stored: 1, text: '100%' },
+  { what: 'just above 1 — the other side of the same boundary', stored: 1.5, text: '1.5%' },
+  // Agreement has to survive the clamp: the text keeps the real number, the
+  // bar saturates. A row that only ever tested unclamped values would let a
+  // repair that clamped the TEXT too pass.
+  { what: 'a large value — the bar saturates, the text does not', stored: 250, text: '250%' },
+  // The residue row. `0.07 * 100` is `7.000000000000001` in binary floating
+  // point — invisible as a CSS width, unreadable as a label.
+  { what: 'a ratio whose scaling carries float residue', stored: 0.07, text: '7%' },
+  // The drift, now visible on both halves instead of one. Before the fix the
+  // text read `-5%` here while the bar drew an empty track; the bar's rule
+  // scales it, and the ruling was that the text follows the bar. Recorded on
+  // objectui#9071 with the census that names it.
+  { what: 'a negative at or below -1 — moves with the bar\'s rule', stored: -5, text: '-500%' },
+];
+
+describe('summary chip percent — one stored number, one percentage (objectui#8728)', () => {
+  it.each(ROWS)('$what: a stored $stored states $text', ({ stored, text }) => {
+    const chip = requireChip(renderChip(stored));
+
+    expect(textOf(chip), 'the chip states this percentage').toBe(text);
+    expect(
+      drawnPercent(chip),
+      'THE PIN: the bar draws the number the text states, clamped to its track',
+    ).toBe(onTrack(spokenPercent(chip)));
+  });
+
+  /**
+   * The same relation, stated once over the whole table rather than row by
+   * row — a repair that fixed one row and broke another is red here even if
+   * someone edited that row's expected string to match.
+   */
+  it('never states one percentage and draws another, for any row above', () => {
+    const disagreements = ROWS.filter(({ stored }) => {
+      const chip = requireChip(renderChip(stored));
+      const disagrees = drawnPercent(chip) !== onTrack(spokenPercent(chip));
+      cleanup();
+      return disagrees;
+    });
+    expect(disagreements.map((r) => r.stored), 'every row agrees with itself').toEqual([]);
+  });
+
+  /**
+   * The accessible name carries no percent formatting of its own — it is built
+   * from the very string the chip shows — so the repair reaches it without
+   * touching it. Asserted as a suffix on purpose: WHICH name the chip gives the
+   * field is objectui#8729's subject, not this card's.
+   */
+  it('says the same percentage to a screen reader as it shows on screen', () => {
+    const chip = requireChip(renderChip(0.123));
+    const label = chip.getAttribute('aria-label') ?? '';
+    expect(label, 'the chip has an accessible name').not.toBe('');
+    expect(
+      label.endsWith(textOf(chip)),
+      `the accessible name ends with the percentage on screen (got "${label}")`,
+    ).toBe(true);
+  });
+
+  /**
+   * A value the branch cannot read as a number never reaches the bar at all —
+   * it falls through to the plain string chip. Pinned because the repair moved
+   * the text onto the scaled number, and a coercion that started admitting
+   * these would put a `NaN%` beside the H1.
+   */
+  it('leaves a non-numeric percent value on the plain string path', () => {
+    const chip = requireChip(renderChip('n/a' as unknown as number));
+    expect(textOf(chip), 'the raw string, not a scaled number').toBe('n/a');
+    expect(chip.querySelector('[aria-hidden]'), 'and no bar to disagree with').toBeNull();
+  });
+});

--- a/packages/plugin-detail/src/summaryChipPercent.ts
+++ b/packages/plugin-detail/src/summaryChipPercent.ts
@@ -1,0 +1,75 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The ONE rule the `summaryFields` chip scales a stored `percent` by
+ * (objectui#8728).
+ *
+ * ## The defect this function exists to make impossible
+ *
+ * The chip beside the record H1 draws a percent TWICE — as its text and as a
+ * small bar — and the two halves scaled the same stored number by two
+ * different rules:
+ *
+ *     display = `${num}%`;                            // the text: no scaling
+ *     const normalized = num <= 1 ? num * 100 : num;  // the bar: ratio, scaled
+ *
+ * so a stored `0.123` labelled itself `0.123%` beside a bar filled to 12.3%.
+ * One control, two percentages, and neither half told the reader which one was
+ * right. Both halves now read this function — which is why it is a named
+ * function and not the same ternary written twice. The next reader cannot
+ * re-desynchronise them without deleting a call site.
+ *
+ * ## Which of the two rules survived, and why it is the BAR's
+ *
+ * Triage's ruling on objectui#8728: the text follows the bar, ⛔ never the
+ * reverse, and ⛔ never a third rule invented for the occasion. So every bar
+ * this chip has ever drawn is preserved here — a stored `12.3` still reads
+ * `12.3%` beside a bar at 12.3%, a stored `250` still reads `250%` beside a
+ * full one. What moved is the text, which now states the number the bar was
+ * already drawing.
+ *
+ * ## ⚠️ This is NOT the repo's percent rule — measured, and filed
+ *
+ * The census that ruling asked for says the bar's `num <= 1` is the only
+ * spelling of its kind in the tree. `percentDisplayValue` in `@object-ui/core`
+ * — whose doc comment calls itself the single source of truth for percent
+ * display scaling, and requires any third surface to take BOTH halves from it,
+ * the scaling AND the convention — uses the symmetric `value > -1 && value < 1`,
+ * and the list cell (`formatPercent`), the dashboard measure and the grid
+ * column summary all reach it. Two consequences, both RECORDED on
+ * objectui#9071 rather than decided here:
+ *
+ *  - exactly `1` scales to `100` here and renders `1%` in every other band.
+ *    objectui#5607 pinned that boundary in words for `plugin-dashboard` — 1 is
+ *    percentage points, the convention `PercentScale` spells as `whole` — when
+ *    it removed this same drift shape one package over;
+ *  - a stored value at or below -1 now reads `-500%` for a stored `-5`, where
+ *    the text alone used to read `-5%`. The bar is unchanged either way (any
+ *    negative clamps to an empty track), so this is the drift becoming visible
+ *    on the half that had been accidentally right.
+ *
+ * Converging the chip onto `percentDisplayValue` — or onto the field's declared
+ * scale, which is what the edit widget `PercentField` reads instead of guessing
+ * from magnitude — is objectui#9071's decision to make, not this one's.
+ */
+export function summaryChipPercentPoints(raw: number): number {
+  // Already in percentage points: passed through untouched, so every value the
+  // chip renders correctly today is byte-identical after the repair.
+  if (raw > 1) return raw;
+
+  // A ratio, scaled to points. The `toPrecision` is load-bearing, not
+  // defensive: `raw * 100` is binary floating-point multiplication, and it is
+  // now the TEXT that reads the result. 246 of the 999 three-decimal ratios
+  // (0.001 through 0.999) carry residue when multiplied by 100 — a stored
+  // `0.07` is `7.000000000000001`, a stored `0.29` is `28.999999999999996` —
+  // which a CSS bar width absorbs invisibly and a label cannot. 12 significant
+  // digits is far wider than any percent a human authored, and far narrower
+  // than the residue.
+  return Number((raw * 100).toPrecision(12));
+}


### PR DESCRIPTION
Fixes #8728

## The defect

The `summaryFields` chip beside the record H1 draws a `percent` twice — as its text and as a small bar — and the two halves scaled the same stored number by two different rules:

```
display = `${num}%`;                            // the text: no scaling
const normalized = num <= 1 ? num * 100 : num;  // the bar: a ratio, scaled
```

Reproduced two-sided on `7f27bc543`, both chips rendered together — which is what tells "this chip contradicts itself" apart from "percent formatting is odd here":

| stored | chip text | bar fill | agree? |
|---|---|---|---|
| `0.123` | `0.123%` | `12.3%` | NO |
| `12.3` | `12.3%` | `12.3%` | yes |

## The fix

One named function — `packages/plugin-detail/src/summaryChipPercent.ts` — read by both halves. A function rather than the ternary written twice, so the next reader cannot re-desynchronise them without deleting a call site. The rule that survived is the BAR's, per triage's ruling: every bar this chip has ever drawn is preserved, and the text is what moved.

The scaling arm carries a `toPrecision(12)` guard, load-bearing rather than defensive: it is now the TEXT that reads the product of `num * 100`, and 246 of the 999 three-decimal ratios carry binary-float residue when multiplied — a stored `0.07` is `7.000000000000001` — which a CSS width absorbs invisibly and a label cannot.

## ⚠️ The census: the bar's rule is this file's, not the repo's

The assumption under test was that `num <= 1 ? num * 100 : num` is already the repo's interpretation of a stored `percent`. It is not. Every site that turns a stored percent into a display magnitude, measured on `7f27bc543`:

| site | rule | a stored `1` | a stored `-5` |
|---|---|---|---|
| `core/src/utils/dataset-format.ts` — `percentDisplayValue`, the declared single source of truth | `value > -1 && value < 1` | `1%` | `-5%` |
| `fields/src/index.tsx` — `formatPercent`, so `PercentCellRenderer` and the list cell | via `percentDisplayValue` | `1%` | `-5%` |
| `plugin-dashboard/src/recordFields.tsx` | via `percentDisplayValue` since objectui#5607 | `1%` | `-5%` |
| `plugin-grid/src/useColumnSummary.ts` | inline copy, same boundary | `1%` | `-5%` |
| **this chip** | `num <= 1 ? num * 100 : num` | `100%` | `-500%` |

⇒ this PR closes a two-way disagreement that sits inside a three-way one, and it does not close the three-way one: the ruling was that the text follows the bar and the bar does not move. The census, the contract it breaks (`percentDisplayValue`'s doc comment requires any third surface to take BOTH halves from it, the scaling and the convention), the third convention — the one the WRITER uses, since `PercentField` reads the field's declared `max` instead of guessing from magnitude — and three routes out are filed as objectui#9071.

## The fork at exactly `1`

Triage named it: is a stored `1` one percent or one hundred? Answered here as `100%` — not by preference, but because that is what this chip's bar already drew and the text follows the bar. It is PINNED as its own row rather than left incidental, so objectui#9071 has to state which way it moves it.

⚠️ That answer is this chip's alone. Everywhere else in this repo a stored `1` renders `1%`, and objectui#5607 already settled that boundary in words for `plugin-dashboard` — 1 is percentage points, the convention `PercentScale` spells as `whole` — when it removed this same drift shape one package over.

## One consequence, stated rather than buried

A stored value at or below -1 now reads `-500%` for a stored `-5`, where the text alone used to read `-5%`. The bar is unchanged for those inputs — any negative clamps to an empty track either way — so this is the drift becoming visible on the half that had been accidentally right. Pinned as a row here; it is the same asymmetry objectui#9071 is about.

## The dispatch's assumptions, as measured

- **A — FALSIFIED.** The bar's rule is local, not repo-wide. Census above; `num <= 1` is the only spelling of its kind in `packages/*/src` and `apps/*/src`.
- **B — held, with an addition.** The chip's `aria-label` carries no percent formatting of its own; it is built from the same `display` string, so the repair reaches it without a second rule. objectui#8729's subject (which NAME the chip gives the field) is untouched, and the new test asserts only the percentage half of the accessible name so that card keeps a free hand over the other half.
- **C — held.** `num` is `Number(val)` behind a `Number.isNaN` guard: a string `'0.123'` coerces and scales, `'n/a'` falls through to the plain string chip (now pinned), and `hasCellValue` one step above keeps null, undefined and whitespace out of the branch entirely. The repair inherits neither degradation.
- **D — held (assume stale).** Re-derived by symbol: the branch is inside `effectiveSummaryFields.map` in `DetailView.tsx`. No line number cited anywhere in this PR or its comments.
- **E — FALSIFIED.** A pin did require the contradictory text: `summaryChip.objectValue-8464.test.tsx` asserted `0.123%` and `ratio: 0.123%`. UPDATED, not routed around, with a note recording that its real subject is ROUTING — a percent keeps the chip's own text path and its own single bar rather than being handed to a cell renderer — and that subject is unchanged.
- **F — held.** Presentational only. `display` and `percentValue` are consumed by exactly three things: the Badge's text, its `aria-label`, and the bar fill's width. No query, no sort key, no export or wire path reads them.

## Verification

Run from the repo root, paths relative to it, nothing after a `--`:

- `pnpm exec vitest run packages/plugin-detail/src/__tests__/summaryChip.percentOneRule-8728.test.tsx packages/plugin-detail/src/__tests__/summaryChip.objectValue-8464.test.tsx` — `Test Files 2 passed (2)`, `Tests 32 passed (32)`, exit 0.
- **Declared narrowing.** `pnpm exec vitest run` over the 17 files in `plugin-detail` that mount `DetailView` or exercise a percent value — `Test Files 17 passed (17)`, `Tests 234 passed (234)`, exit 0. The full 118-file package suite is NOT MEASURED locally: the container's shared heavy-verify lock has been held by another agent's `packages/app-shell/` run for 21+ minutes across three acquisition attempts (`exit 99`, queue place kept). CI runs the whole farm.
- `pnpm --filter @object-ui/plugin-detail lint` — exit 0 (985 pre-existing warnings, 0 errors).
- `node scripts/check-changeset-presence.mjs` — exit 0: `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`. The gate's own verdict, not an assumption: a test file under `packages/*/src` counts as published source, and the chip's rendered text moves for stored values at or below 1, so this is a real `patch`, not a `skip-changeset`.
- `pnpm run check:control-bytes` — OK (7256 tracked text files). `check:new-line-citations` — 0 new citations. `check:unreferenced-sources` — every shipped source file reachable, which is the gate that sees the new module.
- **NOT MEASURED:** `pnpm --filter @object-ui/plugin-detail type-check`, because it needs `pnpm --filter '@object-ui/plugin-detail^...' build` first — the fresh worktree has no `dist/*.d.ts` for the workspace peers, and that closure build is exactly what the held lock serialises. Reason recorded rather than papered over; CI type-checks.

## Ablation — predicted in writing, then run

Mutation: the committed one-rule branch in `DetailView.tsx` replaced on disk by the pre-fix two-rule form; helper and both test files left as committed. The tests import `../DetailView`, a relative specifier inside the same package, so the mutated SOURCE is what ran — no `dist`, no package `exports`, no vitest alias between them, so no missing build could hide it.

Mutation proven on disk before the run, restore proven after, by blob hash rather than by an exit code:

```
HEAD blob:      9f918f8a94b19c388eacb5d5827629c86717afec
on-disk before: 9f918f8a94b19c388eacb5d5827629c86717afec   (equal: tree was at HEAD)
on-disk after:  e24d61c54aca14e202cc49a61fa634db1bf04989   (differs: the mutation landed)
injected text present: 1     removed text present: 0
after restore:  9f918f8a94b19c388eacb5d5827629c86717afec   (equal again, `git diff HEAD` empty)
```

Predicted red: the `0.123`, exactly-`1`, `0.07` and `-5` rows, the whole-table agreement test, and the updated pin in `summaryChip.objectValue-8464.test.tsx` — six. Predicted green on both legs: the `12.3` CONTROL, `0`, `1.5`, `250`, the non-numeric string row, and the accessible-name test (both of its halves read `display`, so it cannot see this defect — which is why it is not the pin).

Measured: `Tests 6 failed | 26 passed (32)`, and the six were exactly the six predicted. Restored leg re-run: `Tests 32 passed (32)`.

## What the new test pins, and why it is a RELATION

Every row asserts that the bar draws the number the text states, clamped to the track — not that a particular string appeared. A per-half assertion would go green on a repair that made both halves wrong in a new matching way, which is the failure mode this card is about. The expected strings are pinned alongside it, because a relation alone would go green on a chip that printed `0%` beside an empty bar for everything.

## Acceptance notes

- **objectui#8729 is not addressed here** and remains open. It touches this same `effectiveSummaryFields.map` render (the chip's accessible name); triage ruled the two serial, not folded. Nothing in this diff touches how the chip names its field, and the new test deliberately asserts only the percentage half of the accessible name.
- Noted, not filed: `Number(true)` is `1`, so a `percent` field storing a boolean lands on exactly the ambiguous input. Carrier if anyone hits it: objectui#9071, which is about which authority this branch reads. No authored `percent` field in this tree stores a boolean, and this PR changes none of the guards in front of it.
- Noted, not filed: `packages/plugin-grid/src/useColumnSummary.ts` spells core's boundary inline rather than calling `percentDisplayValue`. It is not drifted — same boundary, same answers — so it is a duplicate, not a defect. Carrier if the convergence lands: objectui#9071, which already names it in its census table.

---

Provenance in prose, so it survives an edit to this body: written by the `os-dev` seat in session `session_01MPaVWWMuWeT5LgB1qoXjVB`, worktree `objectui-issue-8728`, branch `claude/issue-8728-percent-chip-one-rule`, base `7f27bc543`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPaVWWMuWeT5LgB1qoXjVB)_