### PR TITLE
docs(types): the four objectql mirror docblocks say "not defaulted on parse" (objectui#8735)

### DIFF
--- a/.changeset/8735-objectql-mirror-docblocks-not-defaulted.md
+++ b/.changeset/8735-objectql-mirror-docblocks-not-defaulted.md
@@ -1,0 +1,14 @@
+---
+'@object-ui/types': patch
+---
+
+Correct four `zod/objectql.zod.ts` docblocks that described the behaviour objectui#8317
+removed. Since that change the zod mirrors strip imported `@objectstack/spec` defaults at
+this package's import boundary, but the docblocks on `HttpRequestSchema`, `ListColumnSchema`,
+`SelectionConfigSchema` and `PaginationConfigSchema` still said, in the present tense, that
+`method`, `prefix.type`, `type` and `pageSize` are defaulted on parse — the opposite of what
+each export does. Each now says the key is declared and accepted but NOT defaulted on parse.
+
+Comment-only: no default, no behaviour and no accept set moves. The corrected text is
+published — it is emitted verbatim into `dist/zod/objectql.zod.d.ts`, which is why it earns
+an entry rather than being an internal note.

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -95,7 +95,9 @@ export const HttpMethodSchema = stripImportedDefaults(SpecHttpMethodSubsetSchema
  * HTTP Request Schema — `@objectstack/spec/ui` schema re-exported by reference
  * (issue #2231; formerly a hand-written mirror). Differences vs the old mirror:
  * `body` is the spec's `z.unknown()` (a superset of the old record/string/FormData/
- * Blob union) and `method` now defaults to `'GET'` on parse.
+ * Blob union). `method` is declared and accepted but NOT defaulted on parse:
+ * the spec's `.default('GET')` is stripped at the import boundary above, so a
+ * request that omits `method` comes back without it.
  */
 export const HttpRequestSchema = stripImportedDefaults(SpecHttpRequestSchema);
 
@@ -118,22 +120,27 @@ export const ViewDataSchema = stripImportedDefaults(SpecViewDataSchema);
  * and `prefix` is the spec's `ColumnPrefixSchema`. With both upstream the
  * extension collapses to the plain re-export it always said it would become.
  *
- * One behavior change rides along: the spec's `prefix.type` defaults to `'text'`
- * on parse instead of staying `undefined`, so the renderer always gets a value.
+ * The spec declares `prefix.type` with a `.default('text')`. That default is
+ * stripped at the import boundary above, so the key is declared and accepted but
+ * NOT defaulted on parse: a column omitting `prefix.type` comes back without it,
+ * and a renderer reading it cannot assume a value is present.
  */
 export const ListColumnSchema = stripImportedDefaults(SpecListColumnSchema);
 
 /**
  * Selection Config Schema — `@objectstack/spec/ui` schema re-exported by reference
- * (issue #2231; formerly a hand-written mirror). `type` now defaults to `'none'`
- * on parse instead of staying undefined.
+ * (issue #2231; formerly a hand-written mirror). `type` is declared and accepted
+ * but NOT defaulted on parse: the spec's `.default('none')` is stripped at the
+ * import boundary above, so an omitted `type` stays omitted.
  */
 export const SelectionConfigSchema = stripImportedDefaults(SpecSelectionConfigSchema);
 
 /**
  * Pagination Config Schema — `@objectstack/spec/ui` schema re-exported by reference
- * (issue #2231; formerly a hand-written mirror). `pageSize` is now the spec's
- * positive-int with a default of 25 on parse.
+ * (issue #2231; formerly a hand-written mirror). `pageSize` is the spec's
+ * positive-int, declared and accepted but NOT defaulted on parse: the spec's
+ * `.default(25)` is stripped at the import boundary above, so an omitted
+ * `pageSize` stays omitted.
  */
 export const PaginationConfigSchema = stripImportedDefaults(SpecPaginationConfigSchema);
 


### PR DESCRIPTION
Fixes #8735

objectui#8317 made `@object-ui/types`' zod mirrors stop substituting imported `@objectstack/spec` defaults on parse, via `stripImportedDefaults`. Four docblocks in `packages/types/src/zod/objectql.zod.ts` still described the OLD behaviour in the present tense, so each stated the opposite of what its own export does. Each now says the key is **declared and accepted but NOT defaulted on parse**.

Comment-only. No default, no behaviour and no accept set moves.

## Premise re-derived on my own base

Re-measured on `c3a427378` (my clone's `origin/main`, not the card's numbers). All four survive; anchors are the end-of-sentence lines.

| key | anchor | the sentence that was false |
|---|---|---|
| `HttpRequestSchema.method` | `:98` | "`method` now defaults to `'GET'` on parse" |
| `ListColumnSchema.prefix.type` | `:121-122` | "defaults to `'text'` on parse ... so the renderer always gets a value" |
| `SelectionConfigSchema.type` | `:128-129` | "`type` now defaults to `'none'` on parse" |
| `PaginationConfigSchema.pageSize` | `:135-136` | "positive-int with a default of 25 on parse" |

⚠️ **The line-wrap trap is real and I reproduced it.** A line-scoped `grep -F` on these sentences returns a false 0 for three of the four, because they wrap across a line break — it reads exactly like "already fixed". Flattening the docblock line-prefix first gives `flattened_count=1` for all four:

```
A method-GET        flattened_count=1   line_scoped_count=1
B prefix.type-text  flattened_count=1   line_scoped_count=0   <- false 0
C selection-none    flattened_count=1   line_scoped_count=0   <- false 0
D pageSize-25       flattened_count=1   line_scoped_count=0   <- false 0
```

Live-query controls on that same corpus: "on parse" occurs 5 times, an absent sentinel 0 times.

## Each rewrite measured against the code, with a firing control

For every key: the spec leg still substitutes the default; the mirror leg does not; an authored value is preserved; an illegal value is refused. The **firing control** is a key whose value *does* survive the same parse, so an absent key is a real absence and not an empty probe.

```
A  HttpRequestSchema.method            [key: method]
  L1 spec   parse(omit method)   = {"url":"/x","method":"GET"}
  L2 mirror parse(omit method)   = {"url":"/x"}
  AC mirror parse(author method) = {"url":"/x","method":"POST"}
  FC control url on the omitted leg = "/x"
  RJ mirror safeParse(illegal method).success = false

B  ListColumnSchema.prefix.type        [key: prefix.type]
  L1 spec   parse(omit prefix.type)   = {"field":"f","prefix":{"field":"icon","type":"text"}}
  L2 mirror parse(omit prefix.type)   = {"field":"f","prefix":{"field":"icon"}}
  AC mirror parse(author prefix.type) = {"field":"f","prefix":{"field":"icon","type":"badge"}}
  FC control prefix.field on the omitted leg = "icon"
  RJ mirror safeParse(illegal prefix.type).success = false

C  SelectionConfigSchema.type          [key: type]
  L1 spec   parse(omit type)   = {"type":"none"}
  L2 mirror parse(omit type)   = {}
  AC mirror parse(author type) = {"type":"multiple"}
  FC control type on the authored leg = "multiple"
  RJ mirror safeParse(illegal type).success = false

D  PaginationConfigSchema.pageSize     [key: pageSize]
  L1 spec   parse(omit pageSize)   = {"pageSize":25,"pageSizeOptions":[10,20]}
  L2 mirror parse(omit pageSize)   = {"pageSizeOptions":[10,20]}
  AC mirror parse(author pageSize) = {"pageSize":50,"pageSizeOptions":[10,20]}
  FC control pageSizeOptions on the omitted leg = [10,20]
  RJ mirror safeParse(illegal pageSize).success = false
```

⚠️ **One asymmetry, stated rather than hidden.** `SelectionConfigSchema`'s shape has exactly one key, so no sibling can serve as its control; C's firing control is the authored leg of the same key. A/B/D use a genuine sibling key in the same parse output. My first attempt at C put the control on the omitted leg, where it could not fire — that run is discarded, not reported.

The probe was a scratch file. It is **not** in this diff.

## The changeset question, answered by reading the gate

`scripts/check-changeset-presence.mjs`, `isPublishedSource`:

```js
export function isPublishedSource(relative, pkg) {
  if (relative.startsWith('src/')) return true;
  ...
```

Clause (a) answers **first and unconditionally**, and the gate does no content-level inspection anywhere — it classifies by path. So a comment-only edit inside `packages/types/src/` is guarded exactly like any other source change, provided the package is in the `fixed` group. `@object-ui/types` is: `versioned: true, ignored: false` (read from the gate's own `discoverPackages`; control: `README.md` returns `false` from the same function).

⇒ **a changeset is owed.** The gate's own verdict lines, both directions:

```
with the changeset (rc=0)
  ✅  1 source file(s) of 1 released package(s) changed, and this change declares
      1 changeset(s): .changeset/8735-objectql-mirror-docblocks-not-defaulted.md.

ablated, changeset removed (rc=1)
  ❌  1 source file(s) of 1 released package(s) changed, and this change adds no changeset:
        @object-ui/types
            packages/types/src/zod/objectql.zod.ts
```

Restore leg: byte-identical (`git hash-object` matches before and after), `git diff HEAD` empty, gate back to rc=0.

Independently — and this is why the entry is a `patch` rather than an empty declaration — **the corrected text really ships**. Built `@object-ui/types` and matched the emitted declarations (flattened, since the emitted text wraps too):

```
dist/zod/objectql.zod.d.ts
  4  "declared and accepted but NOT defaulted on parse"     (new)
  1  "an omitted `pageSize` stays omitted"                  (new)
  0  "now defaults to `'GET'` on parse"                     (old, gone)
  0  "so the renderer always gets a value"                  (old, gone)
controls: "Selection Config Schema" 1, "HTTP Request Schema" 1, absent sentinel 0
```

`files` for this package is `["dist", ...]`, `private` unset, so those declarations are in the npm tarball. This matches the gate header's own recorded finding (objectui#5666) that comment text in `src` reaches a published `.d.ts`.

## Verification

| check | result |
|---|---|
| `pnpm --filter @object-ui/types test` | rc=0 — 173 files, 3401 tests passed |
| `pnpm --filter @object-ui/types run type-check` | rc=0 (script name echoed; 31s of real work) |
| `pnpm --filter @object-ui/types build` | rc=0 — 128 emitted files verified |
| `check:changeset-presence` | rc=0 ✅ (and rc=1 when ablated) |
| `check:spec-symbols` | rc=0 ✅ — 1372 files vs 5085 spec export names |
| `check:control-bytes` | rc=0 ✅ — 7264 tracked text files scanned |
| `check:comment-mask-corpus` | rc=0 — 4774 files, 1 disagree, at the objectui#7882 ceiling and not this file |
| `check:new-line-citations` | rc=0 — 0 new citations |
| governed-surface guard | NOT GOVERNED, 2 paths vs 5 surfaces (control: `AGENTS.md` matches) |

Every rc was captured to a file before any pipe, and each line quotes the gate's own verdict rather than a bare exit code.

**Lint, as a proven narrowing** (the repo-wide baseline is red on `main`, so a repo-wide run is not the measurement):
1. Population read from eslint's own resolution, not guessed: **243 files** in `packages/types`.
2. Counts read from `--format json`: package total **0 errors, 278 warnings** (pre-existing); **my file: 0 errors, 0 warnings**.
3. Invariance: `eslint.config.js` sets `languageOptions` to `ecmaVersion` + `globals` only — no `parserOptions.project`, no `projectService`, no type-checked preset (each queried and 0, against a file that exists; control term `rules` returns 12). Type-aware linting is off, so a comment-only edit in one file cannot move any untouched file's verdict.

## Scope

- ⛔ No default or behaviour was changed to match a docblock. The code is right; the prose was stale.
- ⛔ PR #8721's PASS verdict is not re-opened. These were explicitly non-blocking there.
- ⛔ Not widened. Card item ② (the seven repeated boundary blocks) is untouched, and every `stripImportedDefaults(...)` crossing is exactly as it was.
- `Clause-②: no` holds: the diff is comments only, mechanically checked — 14 added and 7 removed lines, **0 of them non-comment** (control: the classifier returns `false` for `export const X = 1;`). No accept set moves; `needs:contract-review` is correctly absent on both carriers.

## Note for the reviewer

`One behavior change rides along: prefix.type defaults to 'text' on parse` also appears in three `CHANGELOG.md` files (`packages/core`, `packages/react`, `packages/types`). Those are **left alone deliberately**: they are historical release records that were true when written, and `check-changeset-presence.mjs`'s header records a maintainer ruling (2026-08-24) that those compiled copies are never hand-edited.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_

---
_Generated by [Claude Code](https://claude.ai/code)_