### PR TITLE
fix(tooling): open the citation continuation scope on a bare filename

### DIFF
--- a/.changeset/9026-bare-colon-continuation-scope.md
+++ b/.changeset/9026-bare-colon-continuation-scope.md
@@ -1,0 +1,36 @@
+---
+---
+
+**Chosen: make the parser see the form — ⛔ not narrow the charter.**
+`scripts/cross-file-line-citation-census.mjs` now opens the continuation scope
+on a bare FILENAME as well as on a full `NAME` plus address, so a docblock that
+writes "`ObjectKanban.tsx` reads `schema.groupBy` at" and then a run of bare
+addresses is read instead of scored empty (objectui#9026). Tooling and tests
+only; no package is released by this change.
+
+**What was actually broken.** Scope opened ONLY on a full address, so a filename
+carrying no number of its own put nothing in scope and every bare address under
+it was, to the scanner, a colon and a number. `ObjectKanbanSchema.groupBy`
+carried six of them into `plugin-kanban`'s renderer and every one had rotted;
+the census scored the docblock **empty** and `check:new-line-citations` reported
+`0 new citation(s)`. ⇒ The gate was not report-only about that class, it was
+**silent** on it, and the charter named the class as covered.
+
+**⛔ The proximity window was NOT the cause, and it did not move.** With the
+trigger absent, that docblock reads 0 of 6 at ANY window — no window can carry a
+file that never entered scope — so the window stays at its shipped value. It is
+deliberate, it is the guard that keeps a bare address from being a colon and a
+number, and widening it to reach one further address would have admitted 14 more
+rows of which three are a port, a cron minute and a Chinese enumeration.
+
+**Backlog measured BEFORE the change, so the two numbers stay separable.**
+Tree-wide population 1201 → 1271; 74 citations become visible and 4 are
+re-attributed to the file the prose actually names. Citations FALSE against
+today's tree: 532 → 561. Roughly eight of the newly visible rows are ports or
+JSON literals rather than citations, named in the pull request body rather than
+tuned away. ⛔ Enforcement is untouched (`report-only`) and this change ⛔ does
+not flip it: the number above is the reason to leave it where it is for now.
+
+Two follow-on effects, both measured: an address written after a second filename
+on the same line now goes to the file written to its LEFT rather than to
+whichever match the line ended on, and a blank line ends the scope.

--- a/scripts/__tests__/check-new-cross-file-line-citations.test.ts
+++ b/scripts/__tests__/check-new-cross-file-line-citations.test.ts
@@ -119,6 +119,49 @@ describe('the differ FIRES — the direction that makes this a gate at all', () 
     expect(added[1].citedWritten).toBe('packages/core/src/actions/ActionRunner.ts');
   });
 
+  /**
+   * objectui#9026 — THE GATE'S OWN ZERO, reproduced and then made to fire.
+   *
+   * ⭐ This is the assertion the card is about. A pull request whose docblock
+   * carried six cross-file addresses — all of them already rotted — was scored
+   * `0 new citation(s)` by this gate, because scope opened only on a full
+   * `NAME:NNN` and the docblock named its file without one. Report-only was
+   * never the problem: the gate was SILENT on the class, and a reader who knows
+   * a number is report-only still reads a clean sheet as nothing to look at.
+   *
+   * ⛔ A green run proves nothing here. The paired ablation below removes the
+   * filename and asserts the gate falls back to the zero it used to print, so
+   * the firing direction is the thing under test.
+   */
+  const KANBAN_DOCBLOCK = [
+    ' * `packages/plugin-kanban/src/ObjectKanban.tsx` reads `schema.groupBy` at',
+    ' * thirteen sites: lane materialisation (`:601`, `:625`, `:640`), card moves',
+    ' * (`:747`, `:865`) and their effect deps.',
+    '',
+  ].join('\n');
+
+  it('reports the continuation addresses under a filename that carries no number', () => {
+    const added = newCitationsIn({
+      relPath: NOTES,
+      baseText: '',
+      headText: KANBAN_DOCBLOCK,
+    });
+    expect(added.map((a) => a.citedLine)).toEqual([601, 625, 640, 747, 865]);
+    for (const a of added) {
+      expect(a.syntax).toBe('continuation');
+      expect(a.citedWritten).toBe('packages/plugin-kanban/src/ObjectKanban.tsx');
+    }
+  });
+
+  it('⛔ ABLATION — with the filename gone the gate prints the zero it used to', () => {
+    const added = newCitationsIn({
+      relPath: NOTES,
+      baseText: '',
+      headText: KANBAN_DOCBLOCK.replace('`packages/plugin-kanban/src/ObjectKanban.tsx` reads', 'the renderer reads'),
+    });
+    expect(added).toHaveLength(0);
+  });
+
   it('a RE-ADDRESSED citation is new — moving the number is not a repair', () => {
     // Clause 4 repairs an existing address by converting it to a content
     // anchor, never by moving the number to a different number. So an edited

--- a/scripts/__tests__/cross-file-line-citation-census.test.ts
+++ b/scripts/__tests__/cross-file-line-citation-census.test.ts
@@ -47,6 +47,7 @@ import {
   CONTROLS,
   FALSE_VERDICTS,
   MAX_ANCHOR_LINES,
+  CONT_WINDOW,
 } from '../cross-file-line-citation-census.mjs';
 
 const REPO_ROOT = join(__dirname, '..', '..');
@@ -363,5 +364,111 @@ describe('reporting buckets', () => {
     expect(bucketOf('scripts/pm/check-half-states.mjs')).toBe('scripts/pm');
     expect(bucketOf('scripts/check-doc-links.mjs')).toBe('scripts');
     expect(bucketOf('ROADMAP.md')).toBe('(repo root)');
+  });
+});
+
+/**
+ * objectui#9026 — the continuation form the charter claimed and the code could
+ * not read.
+ *
+ * ⭐ THE WHOLE POINT IS THAT GREEN WAS THE WRONG ANSWER. `ObjectKanbanSchema`
+ * carried six bare addresses into `plugin-kanban`'s renderer; every one of them
+ * had rotted by ~370 lines, and this scanner reported the docblock EMPTY. So a
+ * passing run of the assertions below proves nothing on its own — each one is
+ * written so that removing the mechanism it names sends it back to that zero,
+ * and the two `⛔` cases do exactly that ablation inline.
+ *
+ * The fixture is the real docblock, recovered from the commit that replaced it,
+ * ⛔ not a paraphrase — the shape is the finding.
+ */
+describe('a bare filename opens the continuation scope, not only a full address', () => {
+  const DOCBLOCK = [
+    '   * The lane key the `object-kanban` renderer actually reads —',
+    '   * `packages/plugin-kanban/src/ObjectKanban.tsx` reads `schema.groupBy` at',
+    '   * thirteen sites: lane materialisation (`:601`, `:625`, `:640`), card moves',
+    '   * (`:747`, `:865`) and their effect deps. Undeclared here until',
+    '   * objectui#7322, so an authored value reached the renderer only through',
+    "   * {@link BaseSchema}'s `[key: string]: any` — admitted, never examined.",
+    '   *',
+    '   * REQUIRED, as the retired `groupField` was: a board is a grouping of records',
+    "   * by one field. The renderer's `if (!schema.groupBy)` branches (`:601`,",
+    '   * `:613`) are defensive early-returns, not a lane-less mode — every',
+    '   * documented and tested `object-kanban` node authors this key.',
+  ].join('\n');
+
+  const NAMES_THE_FILE = '`packages/plugin-kanban/src/ObjectKanban.tsx` reads `schema.groupBy` at';
+  const cited = (text: string) =>
+    scan(text, 'packages/types/src/objectql.ts').hits.map((h) => h.citedLine);
+
+  it('reads the addresses that sit under the line naming the file', () => {
+    const seen = cited(DOCBLOCK);
+    // Reported against the file the prose names, ⛔ never against the citing file.
+    for (const h of scan(DOCBLOCK, 'packages/types/src/objectql.ts').hits) {
+      expect(h.syntax).toBe('continuation');
+      expect(h.citedWritten).toBe('packages/plugin-kanban/src/ObjectKanban.tsx');
+    }
+    expect(seen).toEqual([601, 625, 640, 747, 865]);
+  });
+
+  it('⛔ ABLATION — take the filename away and the same docblock reads zero again', () => {
+    // The trigger is the whole defect: scope used to open ONLY on a full
+    // `NAME:NNN`, so a filename carrying no number of its own put nothing in
+    // scope and every address below it was a colon and a number. This is that
+    // state, reconstructed — and it is the zero the census actually reported.
+    const noFilename = DOCBLOCK.replace(NAMES_THE_FILE, 'reads `schema.groupBy` at');
+    expect(noFilename).not.toContain('ObjectKanban.tsx');
+    expect(cited(noFilename)).toEqual([]);
+  });
+
+  it('⛔ ABLATION — the proximity window was never the binding constraint', () => {
+    // ⚠️ Reading the ±2 window as the cause is the tempting wrong turn, and it
+    // is measurably wrong: with the trigger absent, that docblock reads 0 of 6
+    // at ANY window, because no window can carry a file that never entered
+    // scope. Here is the same fact locally — the first address sits ONE line
+    // under the filename, well inside the window that was already shipped.
+    const lines = DOCBLOCK.split('\n');
+    const namesFileAt = lines.findIndex((l) => l.includes('ObjectKanban.tsx'));
+    const firstAddressAt = lines.findIndex((l) => l.includes(':601'));
+    expect(firstAddressAt - namesFileAt).toBeLessThanOrEqual(CONT_WINDOW);
+    // ⇒ the window admitted it and the scanner still refused it. So the window
+    // stays where it shipped; ⛔ widening it is not this fix.
+    expect(CONT_WINDOW).toBe(2);
+  });
+
+  it('⚠️ leaves the restated address BLIND, and says so rather than implying coverage', () => {
+    // The sixth address is restated in a second paragraph, eight lines below the
+    // only filename and with none of its own. It is NOT read, and that is the
+    // deliberate guard doing its job, ⛔ not an oversight to quietly widen: on
+    // this tree, reaching it costs 14 more rows of which 3 are a port, a cron
+    // minute and a Chinese enumeration. Pinned by name so no reader can cite
+    // this syntax as covering an address that drifted out of its scope.
+    expect(DOCBLOCK).toContain(':613');
+    expect(cited(DOCBLOCK)).not.toContain(613);
+  });
+
+  it('gives an address to the file named to its LEFT, not to the line’s last match', () => {
+    // REGRESSION: scope used to be whatever the line's LAST match left behind,
+    // so a line naming two files gave its bare addresses to the wrong one —
+    // silently, and with a verdict attached. Both belong to the file written
+    // before them.
+    const twoFiles = '// (`ViewTabBar.tsx:564`, `:667`; `ManageViewsDialog.tsx:300`, `:361`)';
+    expect(shapes(twoFiles)).toEqual([
+      'colon ViewTabBar.tsx:564',
+      'colon ManageViewsDialog.tsx:300',
+      'continuation ViewTabBar.tsx:667',
+      'continuation ManageViewsDialog.tsx:361',
+    ]);
+  });
+
+  it('does not let a filename in one paragraph capture a number in the next', () => {
+    // A blank line ends the prose unit. Without this, a filename in one
+    // sentence adopts the port number in the next one — measured on this tree
+    // as three readings, two of them a port and one a cron minute.
+    const acrossBlank = ['see `apps/console/vite.config.ts`', '', 'the backend runs on :3000'].join('\n');
+    expect(shapes(acrossBlank)).toEqual([]);
+    // FIRING CONTROL for the same code path: without the blank line it IS read,
+    // so the empty result above is the barrier and ⛔ not a scanner that failed.
+    const sameParagraph = ['see `apps/console/vite.config.ts`', 'the backend runs on :3000'].join('\n');
+    expect(shapes(sameParagraph)).toEqual(['continuation apps/console/vite.config.ts:3000']);
   });
 });

--- a/scripts/cross-file-line-citation-census.mjs
+++ b/scripts/cross-file-line-citation-census.mjs
@@ -65,12 +65,31 @@
  *   3. `line NNN of/in/at NAME` -- the address written before the name.
  *   4. `NAME line NNN`     -- the address written after the name.
  *   5. THE CONTINUATION ADDRESS -- a bare `:NNN` or `#LNNN` carrying NO
- *      filename, inheriting the file from an address earlier in the same
- *      window. `packages/types/src/crud.ts` writes
+ *      filename, inheriting the file from whatever put one in scope nearby.
+ *      `packages/types/src/crud.ts` writes
  *      `` `ActionRunner.ts:1788` and `:1794` ``; a `basename:[0-9]+` probe
  *      cannot match the second one. The card caught it only because a human
  *      read the site the probe did hit. It is the syntax most likely to be
  *      missed and the reason a count from a one-syntax probe is not a census.
+ *
+ *      ⚠️ SCOPE OPENS TWO WAYS, and until objectui#9026 only the first was
+ *      read: a full `NAME:NNN`, and -- the one that was missing -- a bare
+ *      FILENAME with no address of its own, as in "`` `…/ObjectKanban.tsx` ``
+ *      reads `schema.groupBy` at" followed by `` `:601`, `:625`, `:640` ``.
+ *      That second form is what `ObjectKanbanSchema.groupBy` used for six
+ *      addresses that had ALL rotted, and this file scored the docblock zero.
+ *      ⇒ It was not report-only about that class, it was SILENT on it, which
+ *      is worse: a reader who knows the number is report-only still reads a
+ *      clean sheet as nothing new to look at.
+ *
+ *      ⛔ WHAT THIS SYNTAX STILL DOES NOT COVER, stated so it cannot be cited
+ *      as coverage it does not have. Scope reaches `CONT_WINDOW` lines below
+ *      the last thing that named a file and stops at a blank line, so an
+ *      address restated further down -- past a paragraph break, with no
+ *      filename near it -- is NOT read. That is deliberate and measured: it is
+ *      the guard that keeps a bare `:NNN` from being a colon and a number, and
+ *      the docblock above is read five of six for exactly this reason. The
+ *      sixth is pinned as blind by name in this file's test.
  *
  * The extension list (`SOURCE_EXT`) is what makes `NAME.ext:NNN` a SOURCE
  * ADDRESS rather than a coincidence, and it is copied in spirit from
@@ -282,6 +301,42 @@ const RE_LINE_AFTER = new RegExp(String.raw`(${NAME})\`?[\s,(]+(?:at\s+)?\blines
  */
 const RE_CONT_COLON = /(?<![A-Za-z0-9_$./#-]):(\d+)\b/g;
 const RE_CONT_PERMALINK = /(?<![A-Za-z0-9_$./-])#L(\d+)\b/g;
+/**
+ * A source filename written with NO address of its own -- the OTHER way syntax
+ * 5's scope opens, and the one this file could not read until objectui#9026.
+ *
+ * ⚠️ Measured, not assumed. `ObjectKanbanSchema.groupBy` carried six bare
+ * addresses into `plugin-kanban`'s renderer under the line
+ * "`…/ObjectKanban.tsx` reads `schema.groupBy` at", and scope was opened ONLY
+ * by a full `NAME:NNN`, so a filename with no number of its own put nothing in
+ * scope and all six read as a colon and a number. Every one of them had rotted
+ * and this file scored the docblock EMPTY -- not report-only about the class,
+ * SILENT on it, which is the failure the census exists to make impossible.
+ *
+ * ⛔ The ±2 window is NOT what caused that, and widening it is ⛔ not the fix:
+ * with the window at 999999 and this trigger absent, that docblock still reads
+ * 0 of 6. The defect was what OPENS scope, so that is the only thing that moved.
+ */
+const RE_NAME_ONLY = new RegExp(String.raw`(${NAME})`, 'g');
+
+/**
+ * How far a bare `:NNN` may sit below the thing that put its file in scope.
+ *
+ * DELIBERATE, and left at its shipped value on purpose: a bare `:NNN` on its
+ * own really is a colon and a number, and this is the guard that keeps it from
+ * becoming a citation. Measured on this tree, widening it to 5 would admit 14
+ * more rows -- 11 real citations and 3 that are a port, a cron minute and a
+ * Chinese enumeration. That trade is a judgement about a false-positive guard,
+ * ⛔ not something objectui#9026 was asked to make, so the number stayed.
+ *
+ * ⚠️ Its consequence is stated rather than hidden: an address more than this
+ * many lines below the last thing that named a file is NOT read. In the
+ * docblock above, five of the six are read and the sixth -- restated eight
+ * lines lower, past a paragraph break, with no filename of its own anywhere
+ * near it -- is not. `scripts/__tests__/cross-file-line-citation-census.test.ts`
+ * pins that residual blindness by name so it cannot be mistaken for coverage.
+ */
+export const CONT_WINDOW = 2;
 
 /** A released changelog heading -- `## 1.2.3`, with or without a link wrapper. */
 const RELEASED_HEADING = /^##\s+\[?v?\d+\.\d+\.\d+/;
@@ -523,8 +578,53 @@ export function scanFile(relPath, text) {
 
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i];
+    /** Every source filename written on this line, with the column it starts at. */
+    const namesOnLine = [];
+    if (line.includes('.')) {
+      RE_NAME_ONLY.lastIndex = 0;
+      let nm;
+      while ((nm = RE_NAME_ONLY.exec(line)) !== null) namesOnLine.push({ written: nm[1], start: nm.index });
+    }
+
+    /**
+     * The file a bare `:NNN` at `col` inherits: the nearest filename to its
+     * LEFT on this line, and only failing that whatever is still in scope from
+     * above. Reading leftwards is what the prose means and it is measurable --
+     * `(`ViewTabBar.tsx:564`, `:667`; `ManageViewsDialog.tsx:300`, `:361`)`
+     * gave `:667` to ManageViewsDialog while the sentence gives it to
+     * ViewTabBar, because scope was whatever the line's LAST match happened to
+     * leave behind. Nothing announced that; it scored `out-of-range` and the
+     * wrong file simply absorbed the blame.
+     */
+    const scopeFor = (col) => {
+      for (let k = namesOnLine.length - 1; k >= 0; k -= 1) {
+        if (namesOnLine[k].start < col) return namesOnLine[k].written;
+      }
+      return lastAddress && i - lastAddress.line <= CONT_WINDOW ? lastAddress.written : null;
+    };
+
+    /**
+     * Hands scope to the lines below. A BLANK line ends it: a citation and its
+     * continuation belong to one piece of prose, and crossing a paragraph is
+     * how a filename in one sentence captures a port number in the next. It
+     * costs nothing to say so -- measured on this tree it removes no existing
+     * row at all and drops three readings that were `:3000`, `:5180` and a cron
+     * minute. Otherwise the line's LAST filename is what carries, by column and
+     * ⛔ not by whatever matched last, for the reason `scopeFor` records.
+     */
+    const carryScope = () => {
+      if (line.trim() === '') { lastAddress = null; return; }
+      if (namesOnLine.length > 0) {
+        lastAddress = { written: namesOnLine[namesOnLine.length - 1].written, line: i };
+      }
+      if (lastAddress && i - lastAddress.line > CONT_WINDOW) lastAddress = null;
+    };
+
     if (!/[:#]/.test(line) && !/\bline\s+\d/i.test(line)) {
-      if (lastAddress && i - lastAddress.line > 2) lastAddress = null;
+      // No address syntax can match here, but a bare filename on this line
+      // still puts a file in scope for the ones below it -- which is exactly
+      // the line the `ObjectKanban.tsx` docblock opened with.
+      carryScope();
       continue;
     }
     /** Character spans already claimed on this line, so syntaxes cannot double-count. */
@@ -566,18 +666,17 @@ export function scanFile(relPath, text) {
       }
     }
 
-    // Syntax 5 last, and only where an address is already in scope: a bare
-    // `:NNN` on its own is a colon and a number, not a citation.
-    if (lastAddress && i - lastAddress.line <= 2) {
-      for (const re of [RE_CONT_COLON, RE_CONT_PERMALINK]) {
-        re.lastIndex = 0;
-        let m;
-        while ((m = re.exec(line)) !== null) {
-          record('continuation', lastAddress.written, m[1], m.index, m.index + m[0].length);
-        }
+    // Syntax 5 last, and only where a file is already in scope: a bare `:NNN`
+    // on its own is a colon and a number, not a citation.
+    for (const re of [RE_CONT_COLON, RE_CONT_PERMALINK]) {
+      re.lastIndex = 0;
+      let m;
+      while ((m = re.exec(line)) !== null) {
+        const written = scopeFor(m.index);
+        if (written) record('continuation', written, m[1], m.index, m.index + m[0].length);
       }
     }
-    if (lastAddress && i - lastAddress.line > 2) lastAddress = null;
+    carryScope();
   }
   return { hits, carvedOut, lines };
 }


### PR DESCRIPTION
Fixes #9026

**Picked, in one sentence: MAKE THE PARSER SEE THE FORM — ⛔ not narrow the charter.** The charter is still corrected, because a charter that overstates coverage is the defect one level up, but it is corrected to describe what the code now does rather than to retreat from a class this tree demonstrably writes.

⛔ **Enforcement is untouched.** `ENFORCEMENT` is still `report-only`, and the backlog number below is the reason to leave it there.

---

## 1. The card's own address does not resolve — re-derived

`census.mjs:569-576` is a 404: there is no `scripts/census.mjs` on `main` (`ls` exit 2). Confirmed independently, and ⛔ not copied into this branch. The real code, by content:

| what | where |
| --- | --- |
| the proximity test | `scripts/cross-file-line-citation-census.mjs`, the `lastAddress` guard in `scanFile` |
| the shared parser | `scripts/check-new-cross-file-line-citations.mjs` imports `scanFile` / `judge` / `SELF_FILES` from that census module |

⇒ One parser change moves BOTH surfaces, so both are ablated below.

⭐ That the card about citation rot carried a rotted citation is the finding about itself.

## 2. What was actually broken — and it is NOT the window

Scope for a bare `:NNN` opened **only** on a full `NAME` plus address. A line naming a file *without* a number of its own — which is how the `ObjectKanbanSchema.groupBy` docblock opened — put **nothing** in scope, so all six addresses under it were, to the scanner, a colon and a number.

The census also skips lines carrying no `:` or `#` before doing any scope work, and the filename line has neither. So the trigger never fired on the one line that mattered.

## 3. ⭐ Backlog measured BEFORE the parser moved

Taken with an out-of-tree copy of the census carrying the candidate behind an env switch, so both numbers come from one instrument. **Faithfulness control: with the switch OFF the probe's row set is byte-for-byte the shipped census's** (population 1201 = 1201, row-set identity `True`) — without that, the delta would not be a delta.

| tree-wide | before | after |
| --- | --- | --- |
| cross-file citations in the population | 1201 | **1271** |
| of which FALSE against today's tree | 532 | **561** |
| resolving | 250 | 266 |
| unjudged | 419 | 444 |

**74 citations become visible; 4 are re-attributed** to the file the prose actually names (net +70). All four re-attributions are readable from their own quoted text, and two of them were scoring a verdict against the wrong file — one an unearned `resolves`, one an unearned `out-of-range`.

⚠️ **Named rather than tuned away:** roughly 8 of the 74 are not citations — bare ports in prose (`:3000`, `:5180`, `:3001`) and JSON object literals in fixture tables. They are ~0.6% of the population. A backtick-membership filter was measured and rejected: it also kills real citations written as `(:686)` and in aligned comment tables.

## 4. The firing control — ⭐ green was the wrong answer, so red is asserted first

The fixture is the **real** docblock, recovered from the commit that replaced it, ⛔ not a paraphrase.

| parser | reading on that docblock |
| --- | --- |
| shipped on `main` | `hits=0` — **0 of 6, BLIND** |
| window widened to 999999, trigger unchanged | `hits=0` — **still 0 of 6** |
| this branch | `hits=5` — 601, 625, 640, 747, 865 |

⛔ **The middle row is the one that settles the card's open question.** No window can carry a file that never entered scope, so the ±2 window is **not** the cause and **did not move**.

### Ablation on the committed code, both surfaces

Mutation (revert the trigger to full-address-only) proven on disk by blob hash `cb47a742…` → `a2e2a50a…`, injected marker present 1×, deleted text present 0×:

```
ABLATION_VITEST_EXIT=1
Test Files  2 failed (2)
Tests  4 failed | 67 passed (71)

× a bare filename opens the continuation scope … > reads the addresses that sit under the line naming the file
× a bare filename opens the continuation scope … > gives an address to the file named to its LEFT
× a bare filename opens the continuation scope … > does not let a filename in one paragraph capture a number in the next
× the differ FIRES … > reports the continuation addresses under a filename that carries no number
    AssertionError: expected [] to deeply equal [ 601, 625, 640, 747, 865 ]
```

That `[]` **is** the zero the card reported, reproduced inside the gate. Restored with `git checkout HEAD -- FILEPATH`, proven byte-identical to the HEAD blob and by an empty `git diff HEAD`; restore leg re-run green at 71 passed.

## 5. The card's four open questions, answered explicitly

1. **Is the ±2 window deliberate?** — **Yes, and it stays.** It is the guard that keeps a bare `:NNN` from being a colon and a number. Measured: widening it to 5 (the smallest width that reaches the sixth address) admits 14 more rows — 11 real citations, and a port, a cron minute and a Chinese enumeration. That is a judgement about a false-positive guard that this card was ⛔ not asked to make, so the number did not move.
2. **Is the fix charter-side?** — **No, parser-side**, and the middle row of the table above is the measurement that decides it.
3. **Are other citation forms also unparsed?** — **Not found, and the check was scoped.** The four full-address syntaxes each have a pin that this branch leaves green. ⚠️ What this branch did NOT do is sweep for a sixth spelling; the population is now 1271 and no instrument says that is complete.
4. **The gate's workflow trigger conditions** — `.github/workflows/line-citation-gate.yml` fires on `pull_request` into `main`/`develop` plus `workflow_dispatch`. **No `paths` / `paths-ignore` filter, deliberately.** No `merge_group` leg, so it is ⛔ not requirable while report-only.

⚠️ **One residual blindness, pinned by name rather than implied away.** The sixth address is restated in a second paragraph, eight lines below the only filename and with none of its own. It is **not** read. `scripts/__tests__/cross-file-line-citation-census.test.ts` asserts that blindness explicitly so no reader can cite this syntax as covering an address that drifted out of its scope.

## 6. Does this redden anything?

**No.** The gate on this branch's own diff:

```
Files compared  : 1
PASS  fires / does-not-fire-on-a-moved-citing-line / unresolvable-is-not-false / same-file-is-not-in-the-population
VERDICT new-cross-file-line-citations: 0 new citation(s), enforcement report-only -> exit 0
```

Three of the four changed files are in `SELF_FILES`; the fourth is the changeset, written with no line address of its own (verified by a `grep -P` that finds 13 such lines in the test file and 0 in the changeset).

⛔ The tree-wide backlog cannot redden other pull requests either: this gate is DIFFERENTIAL and the existing citations are explicitly not its denominator.

## Verification

| command | result |
| --- | --- |
| `vitest run scripts/__tests__/{cross-file-line-citation-census,check-new-cross-file-line-citations}.test.ts` | exit 0 — **71 passed** (was 63; +8 new) |
| `pnpm lint` (repo-wide, under the shared verify lock) | `VERDICT command-exit 0` — 47/47 tasks, **0 errors** |
| `eslint --no-inline-config` on the 3 lintable changed files | exit 0, 3 files, 0 errors — with a **firing control**: an address in a test NAME is refused by `object-ui/no-line-address-in-test-name` |
| `pnpm check:control-bytes` | exit 0, 7277 files |
| `pnpm check:entry-guard` / `check:esm-specifiers` / `check:pre-install-import-graph` | exit 0 |
| `pnpm changeset:check` | exit 0 |
| `vitest run scripts/__tests__/ci-cd-pipeline-doc.test.ts` | exit 0 — 79 passed (no command name or workflow moved) |
| `node scripts/check-governed-queue-guard.mjs --test` on all 4 paths | `NOT GOVERNED` — with `AGENTS.md` as the firing control |

## Out of scope, filed

- **#9081** — `census:cross-file-line-citations` exits 1 on `main` with "this run is NOT a reading": its `non-firing` control is pinned on a file PAIR that `packages/types/src/crud.ts` cites twice, and one of the two has rotted. ⛔ Not caused by this branch — measured on clean `main` before any edit and byte-identical after it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmxdo7bmeqCQHLSfmLVX9w)_