### PR TITLE
fix(plugin-detail): fail closed when a record:details field entry has no resolvable identity

### DIFF
--- a/.changeset/9054-record-details-identity-fail-closed.md
+++ b/.changeset/9054-record-details-identity-fail-closed.md
@@ -1,0 +1,34 @@
+---
+"@object-ui/plugin-detail": minor
+---
+
+fix(plugin-detail): `record:details` field security now fails closed on an entry it cannot name
+
+`filterList` filters `fields` and `sections[].fields` against the allow-list
+built from `enforceFieldSecurity` / `redactFields`. Its else-branch KEPT any
+entry whose identity it could not resolve, and its identity reader is
+`columnIdentity` alone — so every entry that is not a bare string, `{ field }`,
+`{ name }` or `{ fieldName }` escaped BOTH controls. A field-security control
+defaulting to *permit* on the one input it could not understand is the worst
+available default for a control; the entry is now excluded instead.
+
+This is the same one-arm repair objectui#8793 made on `record:related_list`'s
+fold, deliberately identical: one defect on two paths gets one shape.
+
+**Measured, and narrower than its sibling.** No record VALUE was reaching the
+screen through the kept entry. `RelatedList` resolves a column as
+`accessorKey || columnIdentity(c)`, a second read point that could name what
+the fold could not — that is what made objectui#8793 a data leak.
+`DetailSection` renders from `field.name` only, so the kept entry painted a
+labelless "no value" placeholder row and never a value. What is closed here is
+the fail-open default, not a measured exposure.
+
+**Behaviour change, deliberately narrowing.** On a detail block that switches
+the filter on, an entry resolving to none of `field` / `name` / `fieldName`
+stops rendering — including one authored purely in the table library's
+`accessorKey` spelling, and including the case where the redacted or denied
+field is some other entry entirely. What disappears is the placeholder row that
+entry already rendered, never a value. Blocks that set neither key are
+untouched: the fold does not run there and the list is handed down by
+reference. The spec-declared spelling for these keys is a field-name string,
+which resolves and is unaffected.

--- a/packages/plugin-detail/src/renderers/__tests__/record-details.unresolvedIdentityFailClosed-9054.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.unresolvedIdentityFailClosed-9054.test.tsx
@@ -1,0 +1,309 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#9054 — `record:details`' field-security fold must fail CLOSED on an
+ * entry whose identity it cannot resolve.
+ *
+ * ## The defect, in one sentence
+ *
+ * `filterList` filtered `fields` / `sections[].fields` against the allow-list
+ * built from `enforceFieldSecurity` / `redactFields` with an else-branch that
+ * KEPT any entry it could not name. Its identity reader is `columnIdentity`
+ * alone, so every entry that is not a bare string, `{ field }`, `{ name }` or
+ * `{ fieldName }` took that branch and escaped both controls — a field-security
+ * control defaulting to *permit* on the one input it could not understand.
+ *
+ * ## ⭐ What this is NOT, measured rather than assumed
+ *
+ * The card left ONE question open and said so: the SHAPE was read at the
+ * source, the EXPOSURE was not. On `record:related_list` (objectui#8793) the
+ * kept column rendered its REAL VALUE, because `RelatedList` resolves a column
+ * as `accessorKey || columnIdentity(c)` — a second read point that could name
+ * what the fold could not. That second reader is what made #8793 a data leak.
+ *
+ * Driven here the way a record page drives it — a real `RecordContextProvider`,
+ * a real record, the real `DetailView` / `DetailSection` — the answer is
+ * **no value ever reaches the screen**. `DetailSection` renders from
+ * `field.name` and nothing else; an entry the fold cannot name has no `name`
+ * for it either, so `data?.[field.name]` is `data?.[undefined]`. The kept entry
+ * painted a labelless `—` "No value" placeholder row. Every escape hatch that
+ * could have supplied a second reader was probed and none did: five `render`
+ * sub-schema spellings all rendered their own literal or nothing.
+ *
+ * ⇒ this card is a fail-open DEFAULT on a security boundary, not objectui#8793
+ * in a second block. The case `THE EXPOSURE MEASUREMENT` below pins that, so
+ * that if anyone ever teaches this path a second identity reader the grade
+ * moves loudly instead of silently.
+ *
+ * ## The instrument, stated rather than smuggled
+ *
+ * `enforceFieldSecurity` / `redactFields` are read off the block's schema with
+ * `(schema as any)`. They are the ONLY switch that makes the fold run at all;
+ * using them here is not a claim that they are a declared authoring surface.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { RecordContextProvider } from '@object-ui/react';
+import { PermissionProvider } from '@object-ui/permissions';
+import type { ObjectPermissionConfig, RoleDefinition } from '@object-ui/types';
+import { RecordDetailsRenderer } from '../record-details';
+
+const employeeSchema = {
+  name: 'employee',
+  label: 'Employee',
+  // Declared so the title dedupe has an unambiguous target that is NOT one of
+  // the fields these cases read — `code` is never listed, so no assertion
+  // below can be satisfied or defeated by the H1 dedupe ladder.
+  nameField: 'code',
+  fields: {
+    code: { type: 'text', label: 'Code' },
+    subject: { type: 'text', label: 'Subject' },
+    status: { type: 'text', label: 'Status' },
+    salary: { type: 'text', label: 'Salary' },
+  },
+};
+
+const RECORD = { id: 'E1', code: 'EMP-1', subject: 'Fix the pump', status: 'open', salary: '90000' };
+
+const roles: RoleDefinition[] = [{ name: 'restricted', label: 'Restricted' }];
+
+/** `read` on `employee`, and `read` on every field EXCEPT the ones named. */
+function permsDenying(...deniedFields: string[]): ObjectPermissionConfig[] {
+  return [
+    {
+      object: 'employee',
+      roles: {
+        restricted: {
+          actions: ['read'],
+          fieldPermissions: deniedFields.map((field) => ({ field, read: false })),
+        },
+      },
+    },
+  ];
+}
+
+/** Mount the block over the REAL `DetailView` with the given schema. */
+function renderBlock(schema: Record<string, unknown>, wrap?: (n: React.ReactNode) => React.ReactElement) {
+  const node = (
+    <RecordContextProvider objectName="employee" recordId="E1" data={RECORD} objectSchema={employeeSchema}>
+      <RecordDetailsRenderer schema={schema as never} />
+    </RecordContextProvider>
+  );
+  return render(wrap ? wrap(node) : node);
+}
+
+/**
+ * The DOM handle for a rendered-but-unnameable row. `DetailSection` paints
+ * `data?.[field.name] ?? field.value` and, finding neither, emits the shared
+ * empty-value span — `aria-label="No value"`. Counting these is how "the entry
+ * was KEPT" is read off the DOM, since a kept-but-unnameable entry has no
+ * label and no value to match text on.
+ *
+ * Every fixture below gives its named fields a value on purpose, so a
+ * placeholder in these renders can only have come from a kept entry.
+ */
+const ghostRows = () => screen.queryAllByLabelText('No value');
+
+beforeEach(() => {
+  // `useRecordEditable` probes `POST /api/v1/security/explain` for the ROW-level
+  // verdict; happy-dom resolves that relative URL to a REAL socket, which the
+  // repo's network-escape guard fails the file for (objectui#6640). Serve it
+  // from a double — its answer is orthogonal to which entry the fold drops.
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ allowed: true }),
+    text: async () => '{"allowed":true}',
+  })) as never);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('objectui#9054 — an unresolvable field identity is EXCLUDED, not kept', () => {
+  it('THE REDACT LEG — an entry the fold cannot name is dropped', () => {
+    renderBlock({
+      fields: [{ field: 'subject' }, { accessorKey: 'salary', header: 'Salary' }],
+      redactFields: ['salary'],
+    });
+
+    // THE LIVE CONTROL, in the same render: an entry whose identity DOES
+    // resolve and IS allowed still renders its value. Without it, "the
+    // unnameable entry is gone" is equally satisfied by a fold that filtered
+    // everything out, and a reviewer could not tell the repair from a rout.
+    expect(screen.getByText('Fix the pump')).toBeInTheDocument();
+
+    // The repair: the entry the fold could not check no longer survives it.
+    expect(ghostRows()).toHaveLength(0);
+  });
+
+  it('THE FLS LEG — the same branch, driven through `enforceFieldSecurity`', () => {
+    // Pinned separately from the redact leg because they are the same branch in
+    // the block but arrive by different routes: one from the schema's own list,
+    // one from the mounted permission provider.
+    renderBlock(
+      {
+        fields: [{ field: 'subject' }, { accessorKey: 'salary', header: 'Salary' }],
+        enforceFieldSecurity: true,
+      },
+      (n) => (
+        <PermissionProvider roles={roles} permissions={permsDenying('salary')} userRoles={['restricted']}>
+          {n}
+        </PermissionProvider>
+      ),
+    );
+
+    expect(screen.getByText('Fix the pump')).toBeInTheDocument(); // LIVE CONTROL
+    expect(ghostRows()).toHaveLength(0);
+  });
+
+  it('THE SECTIONS LEG — the second consumer of the same fold behaves identically', () => {
+    // `filterList` has exactly two consumers: the top-level `fields` list and
+    // each `sections[].fields`. Both are pinned so a repair applied to one arm
+    // only cannot pass.
+    renderBlock({
+      sections: [{ label: 'Compensation', fields: [{ field: 'subject' }, { accessorKey: 'salary' }] }],
+      redactFields: ['salary'],
+    });
+
+    expect(screen.getByText('Fix the pump')).toBeInTheDocument(); // LIVE CONTROL
+    expect(ghostRows()).toHaveLength(0);
+  });
+
+  it('NON-REGRESSION — every resolvable, allowed spelling still renders under an ACTIVE fold', () => {
+    // The narrowing must cost nothing that the fold can name. All three
+    // spellings `DetailSection` can also render are listed, with the fold
+    // switched on and redacting something else entirely.
+    renderBlock({
+      fields: ['subject', { field: 'status' }, { name: 'salary' }],
+      redactFields: ['code'],
+    });
+
+    expect(screen.getByText('Fix the pump')).toBeInTheDocument();
+    expect(screen.getByText('open')).toBeInTheDocument();
+    expect(screen.getByText('90000')).toBeInTheDocument();
+    expect(ghostRows()).toHaveLength(0);
+  });
+
+  it('NON-REGRESSION — the legacy `{ fieldName }` spelling is resolvable and is NOT over-dropped', () => {
+    // `columnIdentity` accepts `fieldName`, so the fold resolves it and the fix
+    // must leave it in. It cannot be asserted by its VALUE: `normaliseField`
+    // only promotes `field` to `name`, so `DetailSection` renders this entry as
+    // a placeholder — a pre-existing gap between the two readers, untouched
+    // here. Survival is therefore read through the gate that follows:
+    // `schema.fields.length > 0` is what makes `DetailView` render a body at
+    // all, so a fix that wrongly dropped this entry would empty the array and
+    // this document would be blank.
+    const { container } = renderBlock({
+      fields: [{ fieldName: 'subject' }],
+      redactFields: ['salary'],
+    });
+
+    expect(ghostRows()).toHaveLength(1);
+    expect(container.textContent).not.toBe('');
+  });
+
+  it('COUNTER-PROBE — with neither key set the fold never runs and nothing moves', () => {
+    // The bound on the blast radius, measured rather than argued. With no
+    // `enforceFieldSecurity` and no `redactFields`, `filterList` returns the
+    // list by reference before reaching the branch this card changed, so an
+    // unnameable entry renders exactly as it did before — placeholder and all.
+    renderBlock({
+      fields: [{ field: 'subject' }, { accessorKey: 'salary', header: 'Salary' }],
+    });
+
+    expect(screen.getByText('Fix the pump')).toBeInTheDocument();
+    expect(ghostRows()).toHaveLength(1);
+  });
+
+  it('THE EXPOSURE MEASUREMENT — no record VALUE ever reached the screen through this entry', () => {
+    // ⭐ The card's own open question, pinned as the answer it turned out to
+    // have. The fold is OFF here, so the entry is KEPT exactly as it was on the
+    // unfixed tree — the worst case the defect could produce. `salary` is
+    // `'90000'` on the record and the entry names it in the table library's own
+    // key, yet nothing paints it: `DetailSection` reads `field.name` and this
+    // path has no `accessorKey ||` second reader of the kind that made
+    // objectui#8793 a data leak.
+    //
+    // This case is the severity, held checkable. Teaching this path a second
+    // identity reader would red it, which is exactly when someone needs to know
+    // that objectui#9054 just became objectui#8793.
+    renderBlock({
+      fields: [{ field: 'subject' }, { accessorKey: 'salary', header: 'Salary' }],
+    });
+
+    expect(screen.getByText('Fix the pump')).toBeInTheDocument(); // LIVE CONTROL
+    expect(screen.queryByText('90000')).not.toBeInTheDocument();
+  });
+
+  describe('⭐ what happens when this filter removes EVERYTHING', () => {
+    /**
+     * Lane fact ㊸, written by this exact defect family: a hard stop catches
+     * only what it names, and the inverse hazard is the one it misses. A
+     * fail-CLOSED fold can empty the list, and on `record:related_list` an
+     * emptied list is read as "nothing was authored" and falls through to
+     * heuristic auto-derivation that the block's redaction never reaches
+     * (objectui#9053) — which is why PR objectui#9058 is held in draft.
+     *
+     * On THIS surface it does not. Both consumers of `filteredFields` are plain
+     * JSX conditionals in `DetailView` — `{schema.fields && schema.fields.length
+     * > 0 && !schema.sections?.length && (…)}` — with no `else` and no
+     * derivation. Pinned here rather than inherited from prose, on both routes
+     * into emptiness.
+     */
+    it('ROUTE A (reachable before this change) — every entry resolvable and redacted', () => {
+      const { container } = renderBlock({
+        fields: [{ field: 'salary' }],
+        redactFields: ['salary'],
+      });
+
+      expect(container.textContent).toBe('');
+      expect(ghostRows()).toHaveLength(0);
+    });
+
+    it('ROUTE B (opened by this change) — the sole entry is one the fold cannot name', () => {
+      const { container } = renderBlock({
+        fields: [{ accessorKey: 'salary', header: 'Salary' }],
+        redactFields: ['salary'],
+      });
+
+      expect(container.textContent).toBe('');
+      expect(ghostRows()).toHaveLength(0);
+    });
+
+    it('LIT CONTROL for both routes — one survivor is enough to paint a body', () => {
+      // Without this, `textContent === ''` above is equally satisfied by a
+      // harness that renders nothing for any input.
+      const { container } = renderBlock({
+        fields: [{ field: 'subject' }, { accessorKey: 'salary' }],
+        redactFields: ['salary'],
+      });
+
+      expect(container.textContent).not.toBe('');
+      expect(screen.getByText('Fix the pump')).toBeInTheDocument();
+    });
+
+    it('SECTIONS — an emptied section is DROPPED, not replaced by a derived one', () => {
+      renderBlock({
+        sections: [
+          { label: 'Compensation', fields: [{ field: 'salary' }] },
+          { label: 'Main', fields: [{ field: 'subject' }] },
+        ],
+        redactFields: ['salary'],
+      });
+
+      expect(screen.queryByText('Compensation')).not.toBeInTheDocument();
+      expect(screen.getByText('Main')).toBeInTheDocument(); // LIVE CONTROL
+      expect(screen.getByText('Fix the pump')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/plugin-detail/src/renderers/record-details.tsx
+++ b/packages/plugin-detail/src/renderers/record-details.tsx
@@ -158,7 +158,33 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
     );
     return list.filter((e) => {
       const n = fieldName(e);
-      return n ? allowed.has(n) : true;
+      // Fail CLOSED on an entry this fold cannot NAME (objectui#9054). The
+      // else-branch used to KEEP such an entry, so anything that is not a bare
+      // string, `{ field }`, `{ name }` or `{ fieldName }` escaped BOTH
+      // `enforceFieldSecurity` and `redactFields` — a field-security control
+      // defaulting to *permit* on the one input it could not understand.
+      //
+      // The same one-arm repair objectui#8793 / PR objectui#9058 made on
+      // `record:related_list`'s fold, deliberately identical: one defect on two
+      // paths gets one shape. `record-highlights.tsx` expresses the same
+      // semantics by dropping unnamed entries BEFORE its allow-list; that is
+      // this line's meaning, not a third policy.
+      //
+      // ⚠️ What this does NOT claim. On the related list the kept entry
+      // rendered its REAL VALUE, because `RelatedList` resolves a column as
+      // `accessorKey || columnIdentity(c)` — a second read point that could
+      // name what the fold could not. This path has no such second reader:
+      // `DetailSection` renders from `field.name` only, and an entry the fold
+      // cannot name has no `name` for it either, so the kept entry painted a
+      // labelless `—` placeholder row and never a record value (measured on
+      // the real DOM in the pin beside this file). The defect closed here is
+      // therefore the fail-open DEFAULT on a security boundary, not a measured
+      // value leak.
+      //
+      // Scoped to the filtering path only: with neither key set this whole
+      // function returns `list` by reference above, so an ordinary detail
+      // block renders exactly what it always did.
+      return n ? allowed.has(n) : false;
     });
   };
 


### PR DESCRIPTION
Fixes #9054

`record:details`' field-security fold kept any entry whose identity it could
not resolve, so that entry escaped both `enforceFieldSecurity` and
`redactFields`. The else-branch now excludes it.

## The card's open question, answered first

The card said plainly that the SHAPE was measured and the EXPOSURE was not, and
that its own probe was inconclusive. That measurement was the first job here.

**Measured answer: NO value reaches the screen. This is NOT objectui#8793 in a
second block.**

Driven the way a record page drives it — a real `RecordContextProvider`, a real
record, the real `DetailView` / `DetailSection` — an entry authored
`{ accessorKey: 'salary' }` against a record carrying `salary: '90000'` paints a
labelless `—` "No value" placeholder row. The value never appears.

The reason is the one the card guessed at, confirmed at the source:

- `RelatedList` resolves a column as `accessorKey || columnIdentity(c)`. That
  SECOND read point could name what the fold could not, so the kept column
  rendered its real value — which is what made objectui#8793 a data leak.
- `DetailSection` has no second reader. It renders `data?.[field.name] ?? field.value`,
  and `normaliseField` only ever promotes `field` to `name`. An entry the fold
  cannot name has no `name` for the renderer either, so the lookup is
  `data?.[undefined]`.

Every escape hatch that could have supplied a second reader was probed and none
did. `field.render` hands `SchemaRenderer` the whole record, so it was the
candidate worth chasing: five sub-schema spellings were driven
(`text`/`content`, `text`/`value`, `text`/`text`, `field`, `html`) and each
rendered its own literal template or nothing at all.

**Why the card's probe was inconclusive and this one is not.** The card reports
that its probe "could not get an ordinary `{ field: 'x' }` entry to render
either" — a dark instrument, so its zero meant nothing. The harness here is the
one the neighbouring pins already use (`record-details.nameFieldDedupe-8175.test.tsx`),
and its first probe was the lit control the card's lacked: an ordinary
`{ field: 'subject' }` entry renders `Fix the pump`. Every zero below sits
beside a live positive in the same render.

⇒ what is closed here is a fail-open DEFAULT on a security boundary — a
field-security control defaulting to *permit* on the one input it could not
understand — not a measured value leak. The p1 `security` grade is triage's and
is not re-litigated here; this paragraph is the severity detail the card asked
the PR body to state, not a re-grading.

## The repair

Per the triage ruling — "Fix it the way #8793 was fixed. Do not invent a second
shape for one defect on two paths" — this is objectui#9058's shape, one site,
one arm:

```ts
-      return n ? allowed.has(n) : true;
+      return n ? allowed.has(n) : false;
```

with the reasoning recorded at the site, because the next reader will otherwise
read a `false` as timidity.

⛔ `columnIdentity` is untouched. It is out of file surface (exported from
`packages/core`, imported by 20 files, two of them the surface of the held PRs
objectui#9058 and objectui#9090), and the repair does not need it: the fold's
allow-list is built from the entries it CAN name, and an unnameable entry
contributed nothing to it before or after.

`record-highlights.tsx` reaches the same semantics differently — it drops every
entry without a non-empty string `name` BEFORE the allow-list. On this file that
would mean reordering `normaliseList` ahead of `filterList`, a structural change
to two call sites, to land the identical outcome. The ruling picked the one-arm
shape; the code comment names the highlights pattern as the same policy rather
than a third one.

## ⭐ What happens when this filter removes EVERYTHING

Lane fact ㊸ applies and was written by this exact family. On
`record:related_list` this same fail-closed flip empties the authored array, and
`RelatedList` reads an empty array as "nothing was authored" and falls through
to heuristic auto-derivation that the block's redaction never reaches — which
is why objectui#9058 is held in draft.

On this surface it does not, and that is now PINNED rather than inherited from
prose. Re-derived at source on `d2f0c10`: `filteredFields` reaches exactly two
gates in `DetailView.tsx`, both plain JSX conditionals
(`{schema.fields && schema.fields.length > 0 && !schema.sections?.length && (…)}`),
with no `else` and no derivation.

Three pins hold the answer, on BOTH routes into emptiness:

| route | reachable | pinned result |
|---|---|---|
| A — every entry resolvable and redacted | before this change | `container.textContent === ''` |
| B — the sole entry is one the fold cannot name | opened by this change | `container.textContent === ''` |
| LIT CONTROL — one survivor | always | body renders, `Fix the pump` on screen |

The sections leg is pinned too: an emptied section is DROPPED, and the sibling
section still renders (live control).

⚠️ **Line numbers.** The pre-measurement comment cited these gates at `:1653`
and `:1804`; they are at **`:1691` and `:1842`** on `d2f0c10`. Every number in
this PR was re-derived, not inherited: `filterList` `:151`, its fail-open arm
`:161` (pre-fix), `fieldName` `:29`, the two consumers `:355` and `:473`,
`fields: filteredFields` `:514` — all confirmed. No line number is cited inside
a source comment.

## Blast radius

**The rule.** An entry stops rendering when, and only when, both hold:

1. the block's schema sets `enforceFieldSecurity: true` or a non-empty
   `redactFields` — otherwise `filterList` returns the list by reference before
   reaching this branch; and
2. the entry resolves to none of `field` / `name` / `fieldName` (bare strings
   resolve too). `{ accessorKey: 'salary' }` is the canonical instance.

What disappears in that case is the placeholder row the entry already rendered.
Never a value — there was none.

**The sweep.** Population: all 7379 tracked files.

```bash
# 1. Who can even reach the fold?
git grep -l "enforceFieldSecurity\|redactFields" -- .
# -> 13 files: the three renderers that implement them, four test files,
#    five CHANGELOG/changeset entries, and apps/console/src/pages/shared-record-shape.ts
#    (an unrelated server-share wire key). ZERO authored metadata, fixtures or docs.

# 2. Does anything set a gate key on a `record:details` schema?
git grep -l "record:details" -- . | xargs grep -l "enforceFieldSecurity\|redactFields"
# -> 7 files: 4 CHANGELOGs, this PR's changeset, this PR's new test, and the
#    renderer itself. The console parity ledger row that matches is prose about
#    `RelatedList`, i.e. objectui#9058's surface, not this one.
```

Both terms are lit — `record:details` hits 111 files and `accessorKey` hits 149
— so the intersections above are readings, not a dark instrument.

⇒ **zero producers in this repository switch the fold on for `record:details`.
Zero fields stop rendering.** The "legitimately-visible columns are not lost"
bar is additionally held live in-test by the NON-REGRESSION case: with the fold
active and something else redacted, all three spellings `DetailSection` can
render (bare string, `{ field }`, `{ name }`) still paint their values.

## Tests

New pin `packages/plugin-detail/src/renderers/__tests__/record-details.unresolvedIdentityFailClosed-9054.test.tsx`
— 11 cases, driving the real block over the real `DetailView` and reading the
rendered DOM.

| case | reads |
|---|---|
| THE REDACT LEG | the unnameable entry is excluded; `Fix the pump` still renders (live control) |
| THE FLS LEG | same branch via `enforceFieldSecurity` + a real `PermissionProvider` |
| THE SECTIONS LEG | the fold's second consumer, so a one-arm repair cannot pass |
| NON-REGRESSION, spellings | bare string / `{ field }` / `{ name }` all still render under an ACTIVE fold |
| NON-REGRESSION, `{ fieldName }` | resolvable, so NOT over-dropped — read through the `length > 0` gate, since this spelling renders a placeholder either way (a pre-existing reader gap, untouched) |
| COUNTER-PROBE | with neither key set nothing moves: the placeholder row is still there |
| THE EXPOSURE MEASUREMENT | no record VALUE ever reached the screen through the entry — the severity, held checkable |
| EMPTY SET × 4 | routes A and B, the lit control, and the dropped section |

A kept-but-unnameable entry has no label and no value to match text on, so its
presence is read through `getAllByLabelText('No value')` — the shared
empty-value span. Every fixture gives its named fields a value on purpose, so a
placeholder in these renders can only have come from a kept entry.

**Ablation.** Fix committed first, then the one arm reverted on disk from
`HEAD`, proven to have landed (`allowed.has(n) : false` count 1 → 0, `: true`
count 0 → 1; blob `9b0fe946` → `f5e411e3`), suite re-run, then restored with
`git checkout HEAD -- PATH` and proven byte-identical (blob back to `9b0fe946`,
`git diff HEAD` empty). Direction: RED, as predicted.

```
4 failed | 7 passed (11)
  × THE REDACT LEG      × THE FLS LEG
  × THE SECTIONS LEG    × ROUTE B (opened by this change)
```

The 7 that stay green are the ones that pin behaviour this change does not
move — the counter-probe, the exposure measurement, route A, the controls —
which is the correct shape, not a gap.

## Acceptance notes

Out of scope, noted, not filed:

- **`DetailView.tsx:482`, `autoSummaryFields`.** The header summary-chip
  heuristic seeds `fieldDefMap` from `schema.fields` and then overwrites it with
  every entry of `objectSchema.fields`, so its candidate pool is the whole
  object regardless of what the fold left. It is not a fall-through this change
  opens — emptying `fields` cannot widen a pool that was already the full object
  schema — but whether a redacted field can reach a chip when an author sets
  `showHeader: true` is **NOT MEASURED**: the chip band would not light in this
  harness, and the lit control for that zero came back DARK too, so the reading
  is void rather than clean. ⛔ It is recorded as unmeasured, not as cleared.
  Successor: whoever next works `DetailView`'s header band — it is one package
  and one file away from this surface, and the PM comment on the card already
  cleared the adjacent `highlightFields` question at the same altitude.
- **`{ fieldName: 'x' }` resolves for the fold but renders a placeholder.**
  `columnIdentity` accepts it; `normaliseField` only promotes `field` to `name`,
  so `DetailSection` cannot render it. A pre-existing disagreement between the
  two readers on this path, unchanged here and pinned as current behaviour in
  the NON-REGRESSION case above. Not filed: no producer emits a column-level
  `fieldName` (the `column-identity.ts` docblock records the repo-wide scan
  behind objectui#3104 finding zero writers), so nothing reaches it.
- **An unnameable entry carrying a literal `value` renders that value.**
  `{ label: 'Salary', value: '90000' }` paints `90000` through
  `data?.[field.name] ?? field.value`, and did so past the fold before this
  change. It is author-supplied page metadata, not a record read, so it is not
  an FLS bypass — the author already had the string. Recorded because it is the
  one shape where "the fold kept it" and "something rendered" were both true.

## Gates

| command | exit |
|---|---|
| `pnpm exec vitest run packages/plugin-detail/` | 0 — 165 files, 1548 tests passed |
| `pnpm --filter @object-ui/plugin-detail type-check` | 0 |
| `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-detail^...' build` | 0 |
| `npx eslint . --format json` | 0 — full population 4787 files, 0 errors (12636 pre-existing warnings) |
| `node scripts/check-changeset-presence.mjs` | 0 |
| `node scripts/check-changeset-fixed.mjs` / `-no-major` / `-overwrite` | 0 / 0 / 0 |
| `node scripts/check-control-bytes.mjs` | 0 |
| `node scripts/check-new-cross-file-line-citations.mjs` | 0 |
| `node scripts/check-vi-mock-specifiers.mjs` | 0 |
| `node scripts/check-governed-queue-guard.mjs --test PATHS` | 0 — NOT GOVERNED |

The heavy three ran under the container's shared verify lock
(`OS_VERIFY_LOCK_SLOT=objectui-issue-9054`), `VERDICT command-exit 0`. eslint
linted the whole population rather than a narrowed set, so no narrowing claim is
being made. All readings are on final head `7959bc3`; `origin/main` had not
moved since the branch point, so the merge was a no-op and nothing needed
re-measuring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_