### PR TITLE
fix(detail,layout): give both record headers a measured title-width floor

### DIFF
--- a/.changeset/7281-record-header-title-width-floor.md
+++ b/.changeset/7281-record-header-title-width-floor.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/plugin-detail': patch
+'@object-ui/layout': patch
+---
+
+Record headers: give the title column a width floor so a wide action tail can no
+longer starve it.
+
+Two headers repeated the title/action width arbitration objectui#7244 fixed on
+`page:header`. Both were measured in Chromium at a 799px viewport with three
+labelled `record_header` actions, before and after:
+
+| header | before | after |
+| --- | --- | --- |
+| `DetailView` (`type: 'detail'`, the header that renders when the host supplies no `page:header`) | h1 6.17px of a 218px title | 218.39px, tail wrapped to its own line |
+| `PageHeader` (`@object-ui/layout`) | h1 170.59px of a 265px title | 751.00px, tail wrapped to its own line |
+
+`DetailView` gets the precedent's two utilities, both `sm:`-scoped so the
+sub-640px column layout is untouched: `sm:flex-wrap` on the row and
+`sm:min-w-64` on the title column. The floor is one step above the precedent's
+`sm:min-w-48` because this title column carries the 40px back button and a 12px
+gap inside it, so 256px is what leaves the h1 the same ~192px readable floor.
+
+`PageHeader`'s row already wrapped, so it needed only the floor — and that floor
+is unconditional rather than `sm:`-scoped, because this row has no
+breakpoint-scoped direction change and the squeeze measures worse just below
+`sm` (639px: h1 10.59px of a 212px title). `min-w-48` replaces `min-w-0` rather
+than joining it: an explicit min-width overrides a flex item's automatic
+min-content minimum exactly as `min-w-0` did, so long titles still ellipsise
+(measured at 799px: 751px rendered of a 1682px title, no horizontal overflow).
+
+Wide viewports are unchanged: at 1440px both headers keep the tail on the
+title's line with the title unclipped, before and after alike.

--- a/e2e/record-header-title-width.spec.ts
+++ b/e2e/record-header-title-width.spec.ts
@@ -1,0 +1,322 @@
+import { test, expect, type Page } from '@playwright/test';
+import { compile } from 'tailwindcss';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+/**
+ * GEOMETRY pin for the record-header title/action width arbitration on the two
+ * headers objectui#7281 covers — `packages/plugin-detail/src/DetailView.tsx`
+ * and `packages/layout/src/PageHeader.tsx`. Sibling of
+ * `packages/components/src/__tests__/page-header-title-width.test.tsx`, which
+ * pins objectui#7244's fix on `page:header`.
+ *
+ * ⚠️ WHY THIS FILE IS A PLAYWRIGHT SPEC AND NOT A VITEST TEST. jsdom and
+ * happy-dom have no layout engine — every `getBoundingClientRect()` there is
+ * 0x0 and `clientWidth` is 0 — so the sibling pin had to settle for
+ * CLASS-SHAPE assertions, and a class-shape assertion passes against a floor
+ * that does nothing. This file asserts the widths themselves, in Chromium,
+ * which is the only place the arbitration actually happens.
+ *
+ * ## What is real here and what is a fixture
+ *
+ * REAL, read out of the source files at run time: the header row's class
+ * string, the title column's class string, the action tail's class string and
+ * the h1's class string, for both headers — plus real Tailwind, compiled from
+ * the installed `tailwindcss` for exactly those candidates. Delete
+ * `sm:min-w-64` from DetailView or `min-w-48` from PageHeader and the string
+ * this file measures changes with it.
+ *
+ * FIXTURE: the action tail's CONTENT is three or four fixed-width boxes rather
+ * than real `<Button>`s, so the tail's width is a constant instead of a
+ * font-metric. The element tree around them is transcribed from the two
+ * sources.
+ *
+ * ## Calibration against the running app (Chromium, console dev server,
+ * `type: 'detail'` and `<PageHeader actions={…}>`, three labelled
+ * `record_header` actions, viewport 799px, objectui#7281):
+ *
+ *   DetailView  before: h1  6.17px of a 218px scrollWidth, tail 724.83px
+ *               after:  h1 218.39px, tail wrapped to its own line
+ *   PageHeader  before: h1 170.59px of a 265px scrollWidth, tail 564.41px
+ *               after:  h1 751.00px, tail wrapped to its own line
+ *
+ * The fixture tails below (722px / 592px) are sized to that measured
+ * neighbourhood, so the geometry this file reproduces is the geometry the app
+ * produces, not a worst case invented to make a floor look necessary.
+ */
+
+const REPO_ROOT = (() => {
+  // Rooted on this file, never on `process.cwd()` — AGENTS.md's
+  // "tests read the filesystem relative to their own file" rule. Bare
+  // `import.meta.url`, walked up; never `new URL(<relative>, import.meta.url)`.
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 10; i++) {
+    try {
+      readFileSync(path.join(dir, 'pnpm-workspace.yaml'), 'utf8');
+      return dir;
+    } catch {
+      dir = path.dirname(dir);
+    }
+  }
+  throw new Error('could not locate the repo root from ' + import.meta.url);
+})();
+
+const read = (rel: string) => readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+
+/**
+ * Pull a literal `className="…"` out of a source file, anchored on a nearby
+ * landmark so the walk cannot silently drift onto a neighbouring element.
+ * `mustContain` is a token the extracted string has to carry that is NOT the
+ * floor under test, so a drifted walk throws instead of measuring the wrong
+ * element and passing.
+ */
+function classAt(
+  source: string,
+  file: string,
+  anchor: string,
+  nth: number,
+  mustContain: string[],
+): string {
+  const at = source.indexOf(anchor);
+  if (at < 0) throw new Error(`${file}: anchor not found: ${anchor}`);
+  const re = /className="([^"]+)"/g;
+  re.lastIndex = at;
+  let hit: RegExpExecArray | null = null;
+  for (let i = 0; i < nth; i++) {
+    hit = re.exec(source);
+    if (!hit) throw new Error(`${file}: only ${i} className literals after ${anchor}`);
+  }
+  const cls = hit![1];
+  for (const token of mustContain) {
+    if (!cls.split(/\s+/).includes(token)) {
+      throw new Error(
+        `${file}: className #${nth} after "${anchor}" is "${cls}", which does not carry "${token}" — ` +
+          'the extraction walked onto the wrong element, so this measurement would be meaningless.',
+      );
+    }
+  }
+  return cls;
+}
+
+/** Same, but the last literal BEFORE the anchor. */
+function classBefore(source: string, file: string, anchor: string, mustContain: string[]): string {
+  const at = source.indexOf(anchor);
+  if (at < 0) throw new Error(`${file}: anchor not found: ${anchor}`);
+  const head = source.slice(0, at);
+  const all = [...head.matchAll(/className="([^"]+)"/g)];
+  if (all.length === 0) throw new Error(`${file}: no className literal before ${anchor}`);
+  const cls = all[all.length - 1][1];
+  for (const token of mustContain) {
+    if (!cls.split(/\s+/).includes(token)) {
+      throw new Error(
+        `${file}: last className before "${anchor}" is "${cls}", which does not carry "${token}".`,
+      );
+    }
+  }
+  return cls;
+}
+
+const DETAIL_FILE = 'packages/plugin-detail/src/DetailView.tsx';
+const PAGE_FILE = 'packages/layout/src/PageHeader.tsx';
+
+const detailSrc = read(DETAIL_FILE);
+const pageSrc = read(PAGE_FILE);
+
+const DETAIL = {
+  // `{schema.showHeader !== false && (` opens the header this card is about —
+  // the one that renders when the host does NOT supply a `page:header`.
+  row: classAt(detailSrc, DETAIL_FILE, '{schema.showHeader !== false && (', 1, ['border-b', 'justify-between']),
+  titleColumn: classAt(detailSrc, DETAIL_FILE, '{schema.showHeader !== false && (', 2, ['flex-1', 'min-w-0']),
+  backButton: classAt(detailSrc, DETAIL_FILE, '{schema.showHeader !== false && (', 3, ['shrink-0']),
+  // #4 is the back button's own `<ArrowLeft className="h-4 w-4" />`.
+  innerColumn: classAt(detailSrc, DETAIL_FILE, '{schema.showHeader !== false && (', 5, ['flex-1', 'min-w-0']),
+  titleRow: classAt(detailSrc, DETAIL_FILE, '{schema.showHeader !== false && (', 6, ['flex-wrap']),
+  h1: classAt(detailSrc, DETAIL_FILE, '{schema.showHeader !== false && (', 7, ['truncate']),
+  // The action tail opens immediately before this comment.
+  tail: classBefore(detailSrc, DETAIL_FILE, '{/* Prev/Next Record Navigation */}', ['shrink-0']),
+};
+
+const PAGE = {
+  row: classBefore(pageSrc, PAGE_FILE, 'aria-label="Back to list"', ['flex-wrap', 'items-center']),
+  backButton: classAt(pageSrc, PAGE_FILE, 'aria-label="Back to list"', 1, ['flex-shrink-0']),
+  titleColumn: classBefore(pageSrc, PAGE_FILE, '{resolvedTitle ? (', ['flex-1', 'flex-col']),
+  h1: classAt(pageSrc, PAGE_FILE, '{resolvedTitle ? (', 1, ['truncate']),
+  slot: classAt(pageSrc, PAGE_FILE, '{slot && <div className=', 1, ['ml-auto']),
+};
+
+/** The measured render size of `<Button size="icon">` in both headers. */
+const ICON_BUTTON = 'h-10 w-10 shrink-0';
+/** A tail box wide enough to reproduce the measured app tails (see header). */
+const TAIL_BOX = 'h-9 w-44 shrink-0';
+
+const TITLE = 'Specimen — Full';
+
+async function tailwindFor(candidates: string[]): Promise<string> {
+  const twEntry = fileURLToPath(import.meta.resolve('tailwindcss/index.css'));
+  const twBase = path.dirname(twEntry);
+  const compiler = await compile('@import "tailwindcss";', {
+    base: twBase,
+    loadStylesheet: async (id: string, base: string) => {
+      const file = id === 'tailwindcss' ? twEntry : path.resolve(base, id);
+      return { path: file, base: path.dirname(file), content: readFileSync(file, 'utf8') };
+    },
+  });
+  const css = compiler.build(candidates);
+  if (!css.includes('@media')) {
+    throw new Error('Tailwind produced no media queries — the responsive variants under test would be inert.');
+  }
+  return css;
+}
+
+/** `<div class="…">` nested left-to-right, innermost last. */
+const box = (cls: string, inner = '') => `<div class="${cls}">${inner}</div>`;
+
+const DETAIL_FIXTURE = box(
+  DETAIL.row,
+  box(
+    DETAIL.titleColumn,
+    `<button class="${DETAIL.backButton} ${ICON_BUTTON}"></button>` +
+      box(DETAIL.innerColumn, box(DETAIL.titleRow, `<h1 class="${DETAIL.h1}">${TITLE}</h1>`)),
+  ) +
+    box(DETAIL.tail, Array.from({ length: 4 }, () => box(TAIL_BOX)).join('')),
+);
+
+const PAGE_FIXTURE = box(
+  PAGE.row,
+  `<button class="${PAGE.backButton} ${ICON_BUTTON}"></button>` +
+    box(PAGE.titleColumn, `<h1 class="${PAGE.h1}">${TITLE}</h1>`) +
+    box(PAGE.slot, Array.from({ length: 3 }, () => box(TAIL_BOX)).join('')),
+);
+
+const ALL_CANDIDATES = [
+  ...Object.values(DETAIL),
+  ...Object.values(PAGE),
+  ICON_BUTTON,
+  TAIL_BOX,
+]
+  .join(' ')
+  .split(/\s+/)
+  .filter(Boolean);
+
+type Reading = {
+  h1Width: number;
+  h1ScrollWidth: number;
+  h1Clipped: boolean;
+  rowWidth: number;
+  rowRight: number;
+  titleColumnWidth: number;
+  tailWidth: number;
+  tailWithinRow: boolean;
+  tailOnOwnLine: boolean;
+  documentOverflowX: number;
+};
+
+async function readGeometry(page: Page, fixture: string, css: string, width: number): Promise<Reading> {
+  await page.setViewportSize({ width, height: 900 });
+  await page.setContent(`<style>${css}</style><div id="host">${fixture}</div>`, {
+    waitUntil: 'load',
+  });
+  // ⛔ Not asserted immediately: a rect read in the same task as `setContent`
+  // can precede the first layout+paint. Wait for the h1 rect to be identical
+  // across two animation frames, then for fonts, then read.
+  await page.waitForFunction(
+    () => {
+      const h1 = document.querySelector('h1');
+      if (!h1) return false;
+      const w = h1.getBoundingClientRect().width;
+      const prev = (window as unknown as { __w?: number }).__w;
+      (window as unknown as { __w?: number }).__w = w;
+      return prev !== undefined && Math.abs(prev - w) < 0.01 && w > 0;
+    },
+    null,
+    { polling: 'raf', timeout: 10_000 },
+  );
+  await page.evaluate(() => document.fonts?.ready);
+  return page.evaluate(() => {
+    const round = (n: number) => Math.round(n * 100) / 100;
+    const h1 = document.querySelector('h1')!;
+    const row = document.querySelector('#host > div')!;
+    const kids = Array.from(row.children);
+    const titleIdx = kids.findIndex((k) => k.contains(h1));
+    const titleColumn = kids[titleIdx] as HTMLElement;
+    const tail = kids.slice(titleIdx + 1) as HTMLElement[];
+    const rowRect = row.getBoundingClientRect();
+    const h1Rect = h1.getBoundingClientRect();
+    return {
+      h1Width: round(h1Rect.width),
+      h1ScrollWidth: h1.scrollWidth,
+      h1Clipped: h1.scrollWidth > Math.ceil(h1Rect.width),
+      rowWidth: round(rowRect.width),
+      rowRight: round(rowRect.right),
+      titleColumnWidth: round(titleColumn.getBoundingClientRect().width),
+      tailWidth: round(tail.reduce((sum, t) => sum + t.getBoundingClientRect().width, 0)),
+      tailWithinRow: tail.every((t) => {
+        const r = t.getBoundingClientRect();
+        return r.left >= rowRect.left - 0.5 && r.right <= rowRect.right + 0.5;
+      }),
+      tailOnOwnLine:
+        tail.length > 0 &&
+        Math.round(tail[0].getBoundingClientRect().top) >
+          Math.round(titleColumn.getBoundingClientRect().top),
+      documentOverflowX: round(
+        document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      ),
+    };
+  });
+}
+
+/**
+ * The readable floor objectui#7244 established for the h1 itself. DetailView's
+ * column floor is larger than this because the back button and its gap live
+ * INSIDE that column; PageHeader's is this value exactly.
+ */
+const READABLE_H1_FLOOR = 192;
+/** The reproducing viewport from objectui#7244 and from this card's readings. */
+const CROWDED = 799;
+/** Wide enough that the tail was never in contention — the regression guard. */
+const ROOMY = 1440;
+
+let css = '';
+test.beforeAll(async () => {
+  css = await tailwindFor(ALL_CANDIDATES);
+});
+
+test.describe('record header title width arbitration (objectui#7281)', () => {
+  for (const [name, fixture] of [
+    ['DetailView (plugin-detail)', () => DETAIL_FIXTURE],
+    ['PageHeader (layout)', () => PAGE_FIXTURE],
+  ] as const) {
+    test(`${name}: the title keeps a readable width at ${CROWDED}px`, async ({ page }) => {
+      const r = await readGeometry(page, fixture(), css, CROWDED);
+      // THE assertion. Not `toHaveClass('sm:min-w-48')` — a floor that does
+      // nothing would pass that and fail this.
+      expect(
+        r.h1Width,
+        `h1 is ${r.h1Width}px of a ${r.h1ScrollWidth}px title; title column ${r.titleColumnWidth}px, tail ${r.tailWidth}px`,
+      ).toBeGreaterThanOrEqual(READABLE_H1_FLOOR);
+      // …and the floor must not have bought that width by pushing a button
+      // out of reach: a squeezed title truncates visibly, an action tail
+      // hanging off the header edge does not.
+      expect(r.tailWithinRow, `tail escaped the header box (row right ${r.rowRight})`).toBe(true);
+      expect(r.documentOverflowX, 'the header overflowed the document horizontally').toBe(0);
+    });
+
+    test(`${name}: the roomy viewport is unchanged at ${ROOMY}px`, async ({ page }) => {
+      const r = await readGeometry(page, fixture(), css, ROOMY);
+      // Regression guard: a header whose tail already fits must keep the tail
+      // on the title's line and the title unclipped, exactly as before the
+      // floor existed.
+      expect(r.tailOnOwnLine, 'the tail wrapped at a viewport where it used to fit').toBe(false);
+      expect(r.h1Clipped, `h1 ${r.h1Width}px vs scrollWidth ${r.h1ScrollWidth}px`).toBe(false);
+      expect(r.tailWithinRow).toBe(true);
+      expect(r.documentOverflowX).toBe(0);
+    });
+  }
+
+  test('the tail stays unshrinkable — squeezing the buttons is not the fix', async () => {
+    // Kept as a class-shape check on purpose: it states WHY the title needed a
+    // floor, and it is not what the geometry assertions above rest on.
+    expect(DETAIL.tail.split(/\s+/)).toContain('shrink-0');
+  });
+});

--- a/e2e/record-header-title-width.spec.ts
+++ b/e2e/record-header-title-width.spec.ts
@@ -230,11 +230,16 @@ async function readGeometry(page: Page, fixture: string, css: string, width: num
   await page.waitForFunction(
     () => {
       const h1 = document.querySelector('h1');
-      if (!h1) return false;
+      const row = document.querySelector('#host > div');
+      // The ROW is what proves layout has run — it always fills the viewport.
+      // ⛔ Deliberately NOT `h1 width > 0`: an ablated floor can drive the h1
+      // to exactly 0, and that reading is the finding, not a reason to hang
+      // until the wait times out and hides it behind a TimeoutError.
+      if (!h1 || !row || row.getBoundingClientRect().width <= 0) return false;
       const w = h1.getBoundingClientRect().width;
       const prev = (window as unknown as { __w?: number }).__w;
       (window as unknown as { __w?: number }).__w = w;
-      return prev !== undefined && Math.abs(prev - w) < 0.01 && w > 0;
+      return prev !== undefined && Math.abs(prev - w) < 0.01;
     },
     null,
     { polling: 'raf', timeout: 10_000 },

--- a/e2e/record-header-title-width.spec.ts
+++ b/e2e/record-header-title-width.spec.ts
@@ -147,8 +147,26 @@ const PAGE = {
 
 /** The measured render size of `<Button size="icon">` in both headers. */
 const ICON_BUTTON = 'h-10 w-10 shrink-0';
-/** A tail box wide enough to reproduce the measured app tails (see header). */
-const TAIL_BOX = 'h-9 w-48 shrink-0';
+/**
+ * Tail boxes sized so each fixture tail lands in the band where the hazard
+ * lives — and the band is narrow in BOTH directions, which is the part worth
+ * writing down.
+ *
+ * A tail has to FIT on the row to starve the title: `tail + gap <= viewport`.
+ * Push it wider than that and the row's own wrap drops it to a second line all
+ * by itself, the title gets the whole row back, and the floor looks
+ * unnecessary — measured: a 786px DetailView tail at 799px passes this spec
+ * with the floor deleted. Make it much narrower and there is no deficit to
+ * arbitrate at all.
+ *
+ * So these two match what the running app actually produced with three
+ * labelled `record_header` actions at 799px (DetailView 724.83px,
+ * PageHeader 564.41px), not a width chosen to make a floor look needed:
+ *   DetailView  4 x 176px + 3 x 6px (`gap-1.5`) = 722px
+ *   PageHeader  3 x 192px + 2 x 8px (`gap-2`)   = 592px
+ */
+const DETAIL_TAIL_BOX = 'h-9 w-44 shrink-0';
+const PAGE_TAIL_BOX = 'h-9 w-48 shrink-0';
 
 /**
  * Long enough that the h1's own text is never the binding constraint at the
@@ -186,21 +204,22 @@ const DETAIL_FIXTURE = box(
     `<button class="${DETAIL.backButton} ${ICON_BUTTON}"></button>` +
       box(DETAIL.innerColumn, box(DETAIL.titleRow, `<h1 class="${DETAIL.h1}">${TITLE}</h1>`)),
   ) +
-    box(DETAIL.tail, Array.from({ length: 4 }, () => box(TAIL_BOX)).join('')),
+    box(DETAIL.tail, Array.from({ length: 4 }, () => box(DETAIL_TAIL_BOX)).join('')),
 );
 
 const PAGE_FIXTURE = box(
   PAGE.row,
   `<button class="${PAGE.backButton} ${ICON_BUTTON}"></button>` +
     box(PAGE.titleColumn, `<h1 class="${PAGE.h1}">${TITLE}</h1>`) +
-    box(PAGE.slot, Array.from({ length: 3 }, () => box(TAIL_BOX)).join('')),
+    box(PAGE.slot, Array.from({ length: 3 }, () => box(PAGE_TAIL_BOX)).join('')),
 );
 
 const ALL_CANDIDATES = [
   ...Object.values(DETAIL),
   ...Object.values(PAGE),
   ICON_BUTTON,
-  TAIL_BOX,
+  DETAIL_TAIL_BOX,
+  PAGE_TAIL_BOX,
 ]
   .join(' ')
   .split(/\s+/)

--- a/e2e/record-header-title-width.spec.ts
+++ b/e2e/record-header-title-width.spec.ts
@@ -148,9 +148,16 @@ const PAGE = {
 /** The measured render size of `<Button size="icon">` in both headers. */
 const ICON_BUTTON = 'h-10 w-10 shrink-0';
 /** A tail box wide enough to reproduce the measured app tails (see header). */
-const TAIL_BOX = 'h-9 w-44 shrink-0';
+const TAIL_BOX = 'h-9 w-48 shrink-0';
 
-const TITLE = 'Specimen — Full';
+/**
+ * Long enough that the h1's own text is never the binding constraint at the
+ * crowded viewport — what is being measured is the width the arbitration
+ * LEAVES the title, not how long this particular string happens to be — and
+ * still short enough to fit unclipped at the roomy viewport, which is what the
+ * regression guard reads.
+ */
+const TITLE = 'Specimen — Full Assembly Record';
 
 async function tailwindFor(candidates: string[]): Promise<string> {
   const twEntry = fileURLToPath(import.meta.resolve('tailwindcss/index.css'));

--- a/packages/layout/src/PageHeader.tsx
+++ b/packages/layout/src/PageHeader.tsx
@@ -233,7 +233,7 @@ export function PageHeader({
                         {typeof icon === 'string' ? <LazyIcon name={icon} className="size-5" /> : icon}
                     </div>
                 )}
-                <div className="flex flex-col min-w-0 flex-1">
+                <div className="flex flex-col min-w-48 flex-1">
                     {resolvedTitle ? (
                         <h1 className="text-2xl font-bold tracking-tight md:text-3xl truncate">{resolvedTitle}</h1>
                     ) : null}

--- a/packages/plugin-detail/src/DetailView.tsx
+++ b/packages/plugin-detail/src/DetailView.tsx
@@ -1026,8 +1026,8 @@ export const DetailView: React.FC<DetailViewProps> = ({
             renders its own `page:header` (e.g. record:details embedded
             under a Lightning-style page) to avoid a duplicate title chip. */}
         {schema.showHeader !== false && (
-        <div className="flex flex-col sm:flex-row items-start justify-between gap-3 sm:gap-4 pb-4 border-b">
-          <div className="flex items-start gap-2 sm:gap-3 flex-1 min-w-0">
+        <div className="flex flex-col sm:flex-row sm:flex-wrap items-start justify-between gap-3 sm:gap-4 pb-4 border-b">
+          <div className="flex items-start gap-2 sm:gap-3 flex-1 min-w-0 sm:min-w-64">
             {(schema.showBack ?? true) && (
               <Tooltip>
                 <TooltipTrigger asChild>


### PR DESCRIPTION
Fixes #7281

Two headers repeated the title/action width arbitration that objectui#7244 fixed on `page:header`. The card was explicit that it had been identified **statically and never measured**, so the measurement — not the class change — is the deliverable here. Everything below is Chromium, the console dev server, three labelled `record_header` actions, layout allowed to settle before each read. ⚠️ jsdom and happy-dom report `clientWidth` 0, so no assertion in the vitest suites could have produced any of these numbers.

Re-derived locations (the card's `:919` / `:236` were from 2026-09-02): the DetailView header is `packages/plugin-detail/src/DetailView.tsx:1028-1030`, the PageHeader row `packages/layout/src/PageHeader.tsx:218/236`.

## The readings, before and after

Viewport 799px, the viewport objectui#7244 was measured at.

| header | | title column | h1 rect | h1 scrollWidth | action tail |
| --- | --- | --- | --- | --- | --- |
| **DetailView** | before | 58.17px | **6.17px** | 218px | 724.83px, same line |
| | after | 799px | **218.39px** | 218px | 724.83px, own line |
| **PageHeader** | before | 170.59px | **170.59px** | 265px | 564.41px, same line |
| | after | 751px | **751px** | 751px | 564.41px, own line |

The DetailView reading is worse than the sibling's: `58.17 = 40px back button + 12px gap + 6.17px`, so the h1 rendered as an ellipsis and nothing else. objectui#7244's sibling was left 29.5px.

Both hazards reproduce, so neither stop condition fired. The other stop condition — a floor that clips or overflows the action tail — was checked at 320px, 375px, 639px and 1440px: the tail is fully inside the header box and horizontal document overflow is 0 at every one of them.

## Two different floors, and why

**DetailView** takes objectui#7244's two utilities, both `sm:`-scoped so the sub-640px column layout is byte-for-byte what it was: `sm:flex-wrap` on the row so the deficit has somewhere to go, and `sm:min-w-64` on the title column. The floor is one step above the precedent's `sm:min-w-48` because **this** title column carries the back button and its gap INSIDE it — the 52px the table above accounts for — so 256px is what leaves the h1 the same ~192px readable floor objectui#7244 established.

**PageHeader**'s row already wrapped, so it needed only the floor. That floor is **unconditional**, not `sm:`-scoped, because this row has no breakpoint-scoped direction change and the squeeze measures WORSE just below `sm`:

| PageHeader @ 639px | title column | h1 rect | h1 scrollWidth |
| --- | --- | --- | --- |
| before | 10.59px | **10.59px** | 212px |
| after | 591px | **591px** | 591px |

An `sm:`-scoped floor copied from the precedent would have left that reading exactly as it is. Below about 620px the tail no longer fits on the row, wraps on its own, and the title is fine again — which is why the hazard band is bounded on both sides.

`min-w-48` REPLACES `min-w-0` rather than joining it: an explicit min-width overrides a flex item's automatic min-content minimum exactly as `min-w-0` did, so `truncate` keeps clipping. Measured, since that is the thing a reader will doubt — a 92-character title at 799px: h1 rect 751px of a 1682px scrollWidth, row still 799px, document overflow 0.

## Regression guard — the roomy viewport is untouched

| @ 1440px | title column | h1 | tail |
| --- | --- | --- | --- |
| DetailView before / after | 699.17 / 699.17 | 218.39 / 218.39, unclipped | same line, both |
| PageHeader before / after | 811.59 / 811.59 | 811.59 / 811.59, unclipped | same line, both |

Below `sm` the DetailView readings are identical before and after at 320px, 375px and 639px (`sm:`-scoped classes, computed `min-width` still `0px`).

## The pin

`e2e/record-header-title-width.spec.ts` — a browser pin per header asserting the **geometry**: at 799px the h1's `getBoundingClientRect().width` must clear the 192px readable floor and the action tail must stay inside the header's box. `toHaveClass('sm:min-w-48')` was ruled out as acceptance because it passes against a floor that does nothing.

What is real in it: the row, title column, action tail and h1 class strings are read out of the two source files at run time and compiled with the installed Tailwind, so deleting either floor changes the string the spec measures. Each extraction is anchored and validated against a token that is NOT the floor under test, so a walk that drifts onto a neighbouring element throws rather than measuring the wrong box — that guard fired for real during development and is why `innerColumn` is ordinal 5 and not 4.

What is fixture: the tail's CONTENT is fixed-width boxes, so the tail width is a constant rather than a font metric. Sized to the app's own measured tails (722px / 592px against 724.83px / 564.41px) — and that sizing matters: a 786px DetailView tail is wider than the 799px row can hold, so the row's wrap drops it unaided and the spec then passes with the floor deleted. The reasoning is written into the file.

The default `playwright.config.ts` picks all five tests up (`playwright test --list --project=chromium`: 42 tests in 8 files, 5 of them this file), so this runs on CI's `pnpm test:e2e --project=chromium` leg.

## Ablation

Each: mutate, prove the mutation reached disk by counting the removed text, run, restore, prove the tree clean by state — `git diff HEAD` empty AND the blob hash back to HEAD's, never by an exit code.

| removed | on-disk proof | verdict |
| --- | --- | --- |
| `sm:min-w-64` (DetailView floor) | 1 to 0 | red — `h1 is 9px of a 402px title; title column 61px, tail 722px`, expected >= 192 |
| `sm:flex-wrap` (DetailView row) | 1 to 0 | red — `tail escaped the header box (row right 799)` |
| `min-w-48` (PageHeader floor) | 1 to 0 | red — `h1 is 143px of a 479px title; title column 143px, tail 592px`, expected >= 192 |

Each ablation reds exactly one test and leaves the other four green, including the roomy-viewport guard — so the pin isolates the floor rather than the fixture. Restore verified after each: `git diff HEAD` empty, DetailView blob back to `30f5650`, PageHeader blob back to `1e7f086`.

One earlier ablation ran void and is reported as such rather than quietly re-run: a mis-written guard skipped the restore, so the next ablation ran on a doubly-mutated file and died as a wait timeout instead of a geometry assertion. Both were redone from a clean tree; the table above is the clean set. The settle-wait was also changed as a result, because a 10s TimeoutError hides the very reading a collapsed floor produces.

## Gates, on `f96f4f5`

| | |
| --- | --- |
| `vitest run packages/plugin-detail/` | 167 files, 1562 tests passed |
| `vitest run packages/layout/` | 21 files, 217 tests passed |
| `vitest run packages/components/src/__tests__/page-header-title-width.test.tsx` | 6 passed — objectui#7244's sibling pin, unchanged |
| `turbo run type-check --filter=@object-ui/plugin-detail --filter=@object-ui/layout` | 14/14 tasks |
| `pnpm type-check:e2e` | pass; `tsc --listFiles` confirms the new spec is IN the project, not excluded from it |
| `eslint` on the three changed files | 0 errors (49 pre-existing warnings, none in the new file) |
| `check-changeset-presence` / `-fixed` / `-no-major` | pass |
| `check-control-bytes` + a direct `grep -naP` control-byte scan of the four files | pass, 0 hits |
| `check-governed-queue-guard --test` | NOT GOVERNED — 4 paths, none matched |
| `check-unreferenced-sources`, `check-vi-mock-specifiers`, `check-type-check-coverage`, `check-new-cross-file-line-citations` | pass |

Every exit code was captured before any pipe (`cmd greater-than file 2 greater-than ampersand 1; EXIT=$?`), never read through `| tail`.

## Found and deliberately NOT fixed here

Filed as objectui#9119 — the same header sizes its title column to the full title text below the `sm` breakpoint, so a long record name pushes the page sideways (measured at 375px: title column 1201.22px inside a 375px row, 826px of horizontal document overflow). A different failure of the same element — a cross-axis size in a column flex container, where `min-w-0` is a floor and not a ceiling — and outside this card's fences. Measured twice, once on `d8b4739` and once with this branch applied: identical to the pixel, so it is pre-existing and this change neither causes nor fixes it.

Noted, not filed: `packages/components/src/__tests__/page-header-title-width.test.tsx` is class-shape only and says so in its own docblock; now that a browser geometry lane exists in `e2e/`, its assertions could be upgraded the same way. Not touched — that file is objectui#7244's surface.

## Acceptance notes

- No DOM was restructured. The whole change is three class strings.
- Clause-② stays **no**: no declared type, registration input, exported symbol, authorable key or accept-set moves. The diff is Tailwind utilities plus one new e2e spec plus one changeset.
- `packages/plugin-detail` also hosts the held PR objectui#9058; it touches `RelatedList.tsx` and `renderers/record-related-list.tsx`, neither of which appears in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_