### PR TITLE
fix(react): page assignment resolves by declaration order — drop the unreachable `priority` read

### DIFF
--- a/.changeset/7298-page-assignment-priority-read.md
+++ b/.changeset/7298-page-assignment-priority-read.md
@@ -1,0 +1,24 @@
+---
+---
+
+Remove the unreachable `priority` read from `usePageAssignment`, so the hook's
+behaviour and its declared contract agree (objectui#7298, half ①).
+
+The hook sorted its record-page candidates on a `priority` key read off the
+page. `PageSchema` is a `strictObject` and does not declare `priority`, so no
+author could ever set one: writing it is a hard parse error, and omitting it
+left every candidate at `0`. Re-measured against the resolved pin
+`@objectstack/spec` 17.4.0 — still strict, and `priority` is refused with
+`unrecognized_keys`, the same way a nonsense key is, with a declared key
+(`isDefault`, `icon`) accepted as the positive control.
+
+No package is released by this change. Selection was already decided by
+declaration order in every reachable case — `Array.prototype.sort` is stable
+and the comparator returned `0` for every pair — and that is now pinned with a
+multi-candidate set asserting which page is returned, including the collision
+every stock install has (`@objectstack/platform-objects` ships
+`sys_user_detail` for `sys_user`, so any app authoring its own `sys_user`
+record page has exactly two candidates).
+
+The file's own header comment already recorded that the ordering was not live;
+it now tells the same story as the code.

--- a/packages/react/src/hooks/__tests__/usePageAssignment.declarationOrder-7298.test.tsx
+++ b/packages/react/src/hooks/__tests__/usePageAssignment.declarationOrder-7298.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * ObjectUI — usePageAssignment: page assignment resolves by DECLARATION ORDER
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#7298 (half ①). `usePageAssignment` used to sort its candidates on a
+ * `priority` key read off the page:
+ *
+ *     candidates.sort((a, b) => (b?.priority ?? 0) - (a?.priority ?? 0));
+ *
+ * `PageSchema` is a `strictObject` and does not declare `priority`, so no
+ * author could ever set it — writing it is a hard parse error, and omitting it
+ * left every candidate at `0`. The sort was decided by list position in every
+ * reachable case, and the read documented an affordance the schema refuses.
+ *
+ * These pins assert WHICH PAGE is returned, not that the hook ran, so the
+ * ordering rule is nailed down rather than implied — and the last block pins
+ * the CONTRACT the removal rests on, so that if `priority` is ever declared
+ * upstream (route A on that card) this file reds and points back here.
+ */
+
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { PageSchema } from '@objectstack/spec/ui';
+import { MetadataCtx } from '../../context/AppShellContext';
+import { usePageAssignment } from '../usePageAssignment';
+
+/** A metadata context carrying exactly the `pages` list under test. */
+function wrapperFor(pages: any[]) {
+  const ctx: any = {
+    apps: [],
+    objects: [],
+    dashboards: [],
+    reports: [],
+    pages,
+    loading: false,
+    error: null,
+    refresh: async () => {},
+    invalidate: () => {},
+    ensureType: async () => pages,
+    getItem: async () => null,
+    getItemsByType: () => [],
+    getTypeStatus: () => 'ready' as const,
+  };
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <MetadataCtx.Provider value={ctx}>{children}</MetadataCtx.Provider>;
+  };
+}
+
+async function assign(pages: any[], objectName: string) {
+  const { result } = renderHook(() => usePageAssignment(objectName), {
+    wrapper: wrapperFor(pages),
+  });
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  return result;
+}
+
+/** An app-authored full record page. */
+const full = (name: string, object: string, extra: Record<string, unknown> = {}) => ({
+  name,
+  label: name,
+  type: 'record',
+  object,
+  ...extra,
+});
+
+/**
+ * The platform's page, as `@objectstack/platform-objects` actually ships it:
+ * `packages/platform-objects/src/pages/sys-user.page.ts` — `type: 'record'`,
+ * `object: 'sys_user'`, `isDefault: true`, and `kind: 'slotted'`.
+ */
+const SYS_USER_DETAIL = {
+  name: 'sys_user_detail',
+  label: 'User',
+  type: 'record',
+  object: 'sys_user',
+  template: 'default',
+  kind: 'slotted',
+  isDefault: true,
+  regions: [],
+  slots: { discussion: [] },
+};
+
+describe('usePageAssignment — selection is by declaration order', () => {
+  it('returns the FIRST matching candidate, naming it', async () => {
+    const result = await assign(
+      [full('first_page', 'sys_user'), full('second_page', 'sys_user'), full('third_page', 'sys_user')],
+      'sys_user',
+    );
+    expect(result.current.page?.name).toBe('first_page');
+  });
+
+  it('reversing the declaration order reverses the winner — position is the whole rule', async () => {
+    const a = full('alpha', 'sys_user');
+    const b = full('beta', 'sys_user');
+
+    expect((await assign([a, b], 'sys_user')).current.page?.name).toBe('alpha');
+    expect((await assign([b, a], 'sys_user')).current.page?.name).toBe('beta');
+  });
+
+  it('`isDefault` on a later candidate does NOT promote it', async () => {
+    const result = await assign(
+      [full('authored', 'sys_user'), full('marked_default', 'sys_user', { isDefault: true })],
+      'sys_user',
+    );
+    // Declared and writable, but this decision never reads it: inert while
+    // looking decisive. Pinned so a future reader does not mistake the flag
+    // for the thing that picks the page.
+    expect(result.current.page?.name).toBe('authored');
+  });
+
+  it('skips pages for other objects and other page types while ordering the rest', async () => {
+    const result = await assign(
+      [
+        full('other_object', 'sys_organization'),
+        { ...full('designer_page', 'sys_user'), pageType: 'record_detail' },
+        full('the_winner', 'sys_user'),
+        full('the_runner_up', 'sys_user'),
+      ],
+      'sys_user',
+    );
+    expect(result.current.page?.name).toBe('the_winner');
+  });
+});
+
+describe('usePageAssignment — the collision every stock install has (objectui#7298)', () => {
+  // `@objectstack/platform-objects` ships `sys_user_detail`, so ANY app that
+  // authors its own `sys_user` record page has exactly two candidates.
+
+  it('the app page wins when it is declared first', async () => {
+    const result = await assign(
+      [full('app_user_detail', 'sys_user'), SYS_USER_DETAIL],
+      'sys_user',
+    );
+    expect(result.current.page?.name).toBe('app_user_detail');
+    // The app page is `kind: 'full'`, so it populates `page`, never `slots`.
+    expect(result.current.slots).toBeNull();
+  });
+
+  it('the platform page wins when IT is declared first — nothing authored breaks the tie', async () => {
+    const result = await assign(
+      [SYS_USER_DETAIL, full('app_user_detail', 'sys_user')],
+      'sys_user',
+    );
+    // `sys_user_detail` is `kind: 'slotted'`, so the win shows up as populated
+    // `slots` and a null `page` — an unmistakable discriminator between the two.
+    expect(result.current.page).toBeNull();
+    expect(result.current.slots).toEqual({ discussion: [] });
+  });
+
+  it('`isDefault: true` on the platform page does not make it win from second place', async () => {
+    const result = await assign(
+      [full('app_user_detail', 'sys_user'), SYS_USER_DETAIL],
+      'sys_user',
+    );
+    expect(SYS_USER_DETAIL.isDefault).toBe(true);
+    expect(result.current.page?.name).toBe('app_user_detail');
+  });
+});
+
+describe('PageSchema refuses `priority` — the contract the removal rests on', () => {
+  // Measured by PARSING, not by grepping: a bare grep for the key name
+  // false-positives on `priority` appearing as a VALUE, and on the several
+  // same-spelling keys of a DIFFERENT kind in this repo (validation rules,
+  // hooks, action-handler registration, and a plain data field on business
+  // objects). Parsing cannot be fooled by any of them.
+  const base = { name: 'x_user_detail', label: 'User', type: 'record', object: 'sys_user' };
+
+  it('is strict: a nonsense key is refused (negative control)', () => {
+    const r = PageSchema.safeParse({ ...base, zzzNotAKey: 1 });
+    expect(r.success).toBe(false);
+    expect(r.error!.issues.some(i => i.code === 'unrecognized_keys')).toBe(true);
+  });
+
+  it('accepts the keys it DOES declare (positive control)', () => {
+    // Without this leg the refusals below would also be produced by a schema
+    // that rejects everything, and would say nothing about `priority`.
+    expect(PageSchema.safeParse(base).success).toBe(true);
+    expect(PageSchema.safeParse({ ...base, isDefault: true }).success).toBe(true);
+    expect(PageSchema.safeParse({ ...base, icon: 'user' }).success).toBe(true);
+  });
+
+  it('refuses `priority` the same way it refuses a nonsense key — it is undeclared, not mistyped', () => {
+    for (const value of [10, 0]) {
+      const r = PageSchema.safeParse({ ...base, priority: value });
+      expect(r.success).toBe(false);
+      const unrecognized = r.error!.issues.filter(i => i.code === 'unrecognized_keys');
+      expect(unrecognized).toHaveLength(1);
+      expect((unrecognized[0] as any).keys).toEqual(['priority']);
+    }
+  });
+});

--- a/packages/react/src/hooks/usePageAssignment.ts
+++ b/packages/react/src/hooks/usePageAssignment.ts
@@ -18,10 +18,13 @@
  *     `buildDefaultPageSchema(objectDef, { slots })` so omitted slots
  *     fall through to synthesized defaults.
  *
- * Future work (deferred): recordType / profile / app / formFactor filtering
- * and priority-based selection. For now we return the first match so that
- * callers can deterministically fall back to the auto-generated DetailView
- * when no record Page is authored.
+ * Selection is by DECLARATION ORDER: the first matching page wins, so callers
+ * can deterministically fall back to the auto-generated DetailView when no
+ * record Page is authored.
+ *
+ * Future work (deferred): recordType / profile / app / formFactor filtering.
+ * Any author-driven ordering would have to be DECLARED on `PageSchema` in
+ * `@objectstack/spec` first — see the note on the selection itself below.
  */
 
 import { useEffect, useMemo, useState } from 'react';
@@ -134,9 +137,21 @@ export function usePageAssignment(
 
     if (!candidates.length) return null;
 
-    // Stable ordering: respect explicit `priority` if present (higher wins),
-    // otherwise fall back to declaration order.
-    candidates.sort((a, b) => (b?.priority ?? 0) - (a?.priority ?? 0));
+    // Declaration order decides: the first match wins.
+    //
+    // This used to sort on a `priority` key read off the candidate. No author
+    // could ever set it: `PageSchema` is a `strictObject` and does not declare
+    // `priority`, so a page carrying one is a HARD PARSE ERROR, not a page that
+    // sorts first. Every candidate therefore read `0`, the comparator returned
+    // `0` for every pair, and a stable sort left declaration order untouched —
+    // the sort documented an affordance the schema refuses (objectui#7298).
+    //
+    // `isDefault` is not consulted here either. It IS declared on `PageSchema`,
+    // so unlike `priority` it is writable — but nothing in this decision reads
+    // it, which makes the flag on a shipped page (e.g. the platform's
+    // `sys_user_detail`) inert while looking decisive. Reading it would be new
+    // behaviour, not a repair; it is recorded here so the next reader does not
+    // mistake the flag for the thing that picks the page.
     return candidates[0];
   }, [meta.pages, objectName, opts.pageName, opts.recordType, opts.profile, opts.app, opts.formFactor]);
 


### PR DESCRIPTION
Part of #7298 — **half ① only**. That card names two page keys the renderer reads and `PageSchema` does not declare. This PR does `priority` and nothing else. `disableDiscussion` is untouched and the card stays open for it.

## Why the card is split, and why this half is safe to delete

Triage handed the split decision to this seat and gave the criterion: the card's merge rationale — *same defect class, same fix shape on both sides* — holds for ① and fails for ②.

| half | route | why |
|---|---|---|
| ① `priority` | **B — delete the renderer read** | restores declared = enforced; nothing is lost, because nothing was reachable |
| ② `disableDiscussion` | A — declare upstream | ⛔ **not this PR.** Deleting that read turns *"the author cannot write the exit"* into *"there is no exit"*, and for a record page over a `protection: { lock: 'full' }` platform object such as `sys_user` the object-side `enable.feeds` switch is unreachable too. That page would get a comment box, reactions and threaded replies with no way at all to decline. ② would get worse, not better. |

## What changed

`packages/react/src/hooks/usePageAssignment.ts` sorted its record-page candidates on a `priority` key read off the page:

```js
// Stable ordering: respect explicit `priority` if present (higher wins),
// otherwise fall back to declaration order.
candidates.sort((a, b) => (b?.priority ?? 0) - (a?.priority ?? 0));
```

`PageSchema` is a `strictObject` and does not declare `priority`, so no author could ever set one: writing it is a hard parse error, and omitting it left every candidate at `0`. The sort was decided by list position in every reachable case, while the code documented an affordance the schema refuses.

The same file's header comment already recorded that the ordering was not live — *"and priority-based selection. For now we return the first match so that…"*. Code and comment now tell the same true story: selection is by declaration order, and any author-driven ordering would have to be DECLARED on `PageSchema` upstream first.

## Stop condition 1, re-measured: is `priority` reachable?

The card measured `@objectstack/spec` **17.2.0**; the resolved pin here is **17.4.0**. Re-measured by **parsing**, not grepping — a bare grep for the key name false-positives on `priority` appearing as a VALUE, and on the several same-spelling keys of a **different kind** in this repo (validation rules, hooks, action-handler registration, and a plain data field on business objects such as `showcase_task.priority`).

```
spec version: 17.4.0
PageSchema zod type   : object
PageSchema catchall   : never      ("never" === strictObject)
declared key count    : 24         (priority is NOT among them; isDefault IS)

--- LIT CONTROL: a key PageSchema DOES declare must be ACCEPTED ---
base + isDefault:true              success=true   issues=(none)
base + icon:"user"                 success=true   issues=(none)

--- LIT CONTROL: a nonsense key must be REFUSED ---
base + zzzNotAKey:1                success=false  issues=unrecognized_keys:zzzNotAKey

--- SUBJECT ---
base + priority:10                 success=false  issues=unrecognized_keys:priority
base + priority:0                  success=false  issues=unrecognized_keys:priority
```

`priority` is refused the **same way a nonsense key is** — `unrecognized_keys`, i.e. undeclared rather than mistyped. Premise holds on the new pin. Both controls are pinned in the test file so a future upstream declaration of `priority` reds here and points back at this change.

Corroborating, in-repo: the only `.priority` property read on a page object anywhere in this repository was this one line; the metadata designer's page inspectors never author it; and no page-shaped literal in this repo or in `@objectstack/platform-objects` carries it.

## Stop condition 2, proved rather than assumed: does the winner change?

Differential run of the OLD selection against the NEW one over ten candidate sets — single, the card's two-candidate collision in both orders, three, ten, `isDefault` in several positions, slotted mixed with full, duplicate names, and a null hole:

```
mismatches: 0          (winners compared by IDENTITY, not deep equality)

NEGATIVE CONTROL (a candidate hand-built carrying priority:10):
  old=second  new=first  ->  DIFF (the harness CAN detect a change)

sort() with an all-zero comparator preserves order over 50 elements: true
```

The negative control is the load-bearing half: it shows the comparison is a real measurement and not a tautology. `Array.prototype.sort` is stable and the comparator returned `0` for every pair, so declaration order already decided the winner. `candidates` is a fresh array from `.filter()`, so the removed in-place sort had no other observable effect either.

## `isDefault` — stated, deliberately not acted on

`isDefault` is **not consulted** in this decision. Verified independently rather than repeated from the card: after this change the only occurrence of `isDefault` anywhere in the assignment path (`usePageAssignment`, `AppShellContext`, `MetadataProvider`, `RecordDetailView`) is the explanatory comment this PR adds.

Unlike `priority`, `isDefault` **is** declared on `PageSchema`, so it is writable — which is what makes it worse to read about than to read: the flag on the platform's shipped `sys_user_detail` is **inert while looking decisive**. ⛔ This PR does **not** start reading it. That would be new behaviour, not a repair. It is recorded in a comment so the next reader does not mistake the flag for the thing that picks the page.

## Ablation — the direction is unusual here, and that is the point

**Predicted before running**, because for dead code the usual reading is inverted:

- **Leg A — put the deleted sort back. Predicted GREEN.** If the removed code was truly dead, restoring it must change nothing. A RED here would have *falsified the premise* and meant the code was live.
- **Leg B — power control, `candidates[0]` becomes the last candidate. Predicted RED.** Leg A being green cannot on its own distinguish *"the code was dead"* from *"the pins assert nothing"*, so this leg proves the pins can detect a change in which page wins.

Measured, both as predicted:

```
LEG A  sort restored        vitest exit: 0    Test Files 1 passed (1)   Tests 10 passed (10)
LEG B  first -> last        vitest exit: 1    Test Files 1 failed (1)   Tests 7 failed | 3 passed (10)
```

Leg B's three survivors are exactly the three `PageSchema` contract pins, which do not touch the hook — the seven that red are every declaration-order and collision pin.

Each leg proved the mutation reached disk before the run (marker counts in both directions, plus a blob hash differing from HEAD's), and restoration was proved **by state**, never by an exit code:

```
restore proof: blob=da9a80db1bc946a54d3ced315f216651927d6e12  HEAD=da9a80db1bc946a54d3ced315f216651927d6e12  match=YES
restore proof: 'git diff HEAD' for this path -> [EMPTY]   (the brackets held nothing; spelled as a word because GitHub's body sanitizer eats angle-bracket-shaped tokens, backticks and code fences included)
git status --porcelain:        (empty)
```

## Tests and gates

New pins in `packages/react/src/hooks/__tests__/usePageAssignment.declarationOrder-7298.test.tsx` — all assert **which page is returned**, never that the hook ran:

- declaration order: the first matching candidate wins, by name; reversing the list reverses the winner
- `isDefault` on a later candidate does not promote it
- non-matching objects and the designer-side `record_detail` page type are skipped while the rest stay ordered
- **the collision every stock install has**: `@objectstack/platform-objects` ships `sys_user_detail` (`type: 'record'`, `object: 'sys_user'`, `isDefault: true`, `kind: 'slotted'`), so any app authoring its own `sys_user` record page has exactly two candidates. Pinned in both orders — and because the platform page is `kind: 'slotted'`, its win shows up as a populated `slots` with a null `page`, an unmistakable discriminator between the two.
- the `PageSchema` contract the removal rests on, with both controls

Run locally from the repository root:

| gate | result |
|---|---|
| `pnpm exec vitest run packages/react/` | **78 files, 928 tests passed** (`VERDICT command-exit 0`, under the shared verify lock) |
| `packages/react` `type-check` (`tsc --noEmit` + `tsconfig.test.json`) | **exit 0**, after building the dependency closure first |
| `pnpm exec eslint .` — the whole repository, not a narrowing | **exit 0**; 4799 files judged, **0 errors** |
| `node scripts/check-changeset-presence.mjs` | exit 0 |
| `pnpm check:changeset-claims` | exit 0 |
| `pnpm check:control-bytes` | exit 0 |
| `pnpm lint:coverage` | exit 0 — 46/46 packages, 0 outstanding errors |
| `pnpm check:new-line-citations` | exit 0 |
| `node scripts/check-governed-queue-guard.mjs --test …` | **NOT GOVERNED** — 3 paths checked against 5 governed surfaces, none matched |

Every exit code above was captured before any pipe, and each gate's own verdict line is quoted rather than a bare shell status.

Type-check coverage was **measured, not assumed**: `tsc --noEmit --listFiles` excludes test files (count 0 for the new test) while `tsconfig.test.json --listFiles` includes it (count 1), and the hook source appears in the main project (count 1) as the positive control — so the package's `type-check` script covers both halves of this diff.

Changeset: `.changeset/7298-page-assignment-priority-read.md`, **empty frontmatter** — an explicit declaration that this releases nothing, which the presence gate names as the complete answer. Behaviour is provably identical for every reachable input, so a version bump would be noise in the platform's release notes.

## Acceptance notes

Noted while working here, **not filed and not fixed** — none is a reproducible defect, a declared-contract breach, or an author-facing metadata trap:

- `PageAssignmentOptions` declares four filter fields (`recordType`, `profile`, `app`, `formFactor`) that nothing reads; `matchesAssignment()` is a placeholder returning `true`. The hook's only caller, `RecordDetailView.tsx:376`, passes no options at all, so all four are dead across the repository. These are **hook arguments, not authorable metadata** — an author cannot reach them and cannot be misled by them — so they are not the same defect class as `priority`. They are dead code, left alone. Carrier: the deferred future-work line in this file's own header, which this PR keeps and makes accurate.
- `usePageAssignment.ts` carries pre-existing lint warnings (`react-hooks/set-state-in-effect` in the `ensureType` effect, `react-hooks/exhaustive-deps` on the `useMemo`). Untouched by this diff and outside its scope. Carrier: none.

⛔ Fences honoured: `RecordDetailView`'s `disableDiscussion` read is untouched; `@objectstack/spec` is untouched; and the gate the card suggests (walking renderer page-key reads against `PageSchema`'s declared keys) is **not** added here — triage is explicit that it is independent `domain:devx` work and must not ride along.

Clause-② remains **no**: no declared type, registration input, exported symbol, authorable key or accept-set moves. One read is deleted and one comment is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_