### PR TITLE
fix(sdui-parser): refuse an authored `type` attribute on the html tier (port of objectstack#13957)

### DIFF
--- a/.changeset/7235-html-tier-discriminator-attr.md
+++ b/.changeset/7235-html-tier-discriminator-attr.md
@@ -1,0 +1,36 @@
+---
+'@object-ui/sdui-parser': minor
+---
+
+Refuse an authored `type=` attribute on the `kind:'html'` tier (objectui#7235 — the
+port of objectstack#13957, maintainer ruling 2026-09-01, recorded as an append-only
+amendment on ADR-0080).
+
+**Breaking, deliberately, and the direction is a narrowing.** On this tier the tag
+name *is* the node's `type`, so an authored `type=` attribute is a name collision
+with the envelope's own discriminator. It is now one `forbidden-attr` error naming
+both the tag and the attribute, and the node is composed as `{ ...props, type: tag }`
+so the tag always wins the slot.
+
+Two outcomes it replaces, the first of which produced no diagnostic at all:
+
+- the value named another **registered** type (`<flex type="grid">`) — the tree
+  carried `type:'grid'`, the manifest resolved it, every check passed, and a grid
+  rendered where the author wrote a flex. Zero diagnostics.
+- the value named **nothing registered** (`<object-chart type="bar">`) — loud, but
+  `unknown-component` naming `"bar"` read as a missing plugin rather than as an
+  attribute that should not be there.
+
+The existing `forbidden-attr` code is reused rather than a new one minted: the two
+copies of this parser (this one, which the renderer and the console's live edit
+preview run, and objectstack's, which the save gate runs) are held to one diagnostic
+vocabulary by `check:sdui-lockstep`, and a code minted on one side only is the dialect
+split that gate exists to catch.
+
+⚠️ Not carried over: the react tier's `specType` rescue (objectui#2880). The ruling
+declined it by name; that rescue stays where it lives.
+
+One visible non-behavioural consequence of the reversed spread: a compiled node's
+`type` key is now **last** rather than first in insertion order, so `JSON.stringify`
+of a parsed tree emits the same pairs in a different order. The key set, every value,
+the children and the html-tier provenance marker are unchanged.

--- a/packages/components/src/renderers/action/__tests__/action-type-input-html-tier.test.tsx
+++ b/packages/components/src/renderers/action/__tests__/action-type-input-html-tier.test.tsx
@@ -14,13 +14,20 @@
  * ## Why this row exists on the html tier specifically
  *
  * The old input name was unauthorable HERE and only here it is provable in one
- * hop. `parse.ts` composes a node as `{ type: tag, ...props }` — props spread
- * LAST — so an authored `type="api"` did not set an input, it REPLACED the
- * component discriminator and the node stopped resolving to a component at all.
- * `validate.ts` cannot report that either: `type` is in `BASE_PROPS`, so it is
- * skipped before the declared-input check ever runs. Two mechanisms, one
- * outcome, no diagnostic — which is the whole reason the collision was removed
- * at the source instead of being special-cased per tier.
+ * hop. `parse.ts` used to compose a node as `{ type: tag, ...props }` — props
+ * spread LAST — so an authored `type="api"` did not set an input, it REPLACED
+ * the component discriminator and the node stopped resolving to a component at
+ * all. `validate.ts` could not report that either: `type` is in `BASE_PROPS`,
+ * so it is skipped before the declared-input check ever runs. Two mechanisms,
+ * one outcome, no diagnostic — which is the whole reason the collision was
+ * removed at the source instead of being special-cased per tier.
+ *
+ * ⚠️ UPDATED by objectui#7235: the parser now REFUSES a `type` attribute on
+ * this tier outright (`forbidden-attr`, one diagnostic naming both the tag and
+ * the attribute) and composes `{ ...props, type: tag }`. Row 3 below still
+ * fails to compile and still renders no button, but for the ruled reason
+ * instead of the accidental one, and it now asserts WHICH diagnostic — without
+ * that it would go on passing while measuring nothing.
  *
  * The renamed input has no such problem: `actionType` is an ordinary declared
  * prop, so it survives the spread, validates against the manifest built from
@@ -36,10 +43,11 @@
  *    the handler being the only one registered; with it, the value is pinned to
  *    the authored prop.
  * 3. NO ALIAS — the pre-rename spelling `type="api"` does not resurrect the old
- *    behaviour. It is the discriminator: the node's type becomes `api`, which is
- *    not a component, so the page reports `unknown-component` and no button is
- *    rendered. It states the cost the ruling accepted by name (no alias, no
- *    transition window — the standing 不渐进 rule).
+ *    behaviour. Since objectui#7235 the attribute is REFUSED at parse, so the
+ *    page reports `forbidden-attr` naming the attribute and no button is
+ *    rendered. (Before that port it was the discriminator, and the page
+ *    reported `unknown-component` naming the VALUE.) Either way it states the
+ *    cost the ruling accepted by name: no alias, no transition window.
  * 4. THE DECLARATION — rows 1-3 are about the RENDERER, and every one of them
  *    was green before this change too: the renderer already read `actionType`
  *    first (`action:bar`'s member spread has always used it), and an undeclared
@@ -155,9 +163,14 @@ describe('objectui#7415 — action:button authors its execution type on the html
   it('no alias — the pre-rename `type` spelling is still the discriminator, not an input', async () => {
     renderHtmlPage(`<action:button label="Mark done" type="api" target="${TARGET}" />`);
 
-    // `{ type: tag, ...props }` — the authored `type` wins the slot, so the node
-    // is `<api>`, which no registry entry claims.
+    // objectui#7235: the attribute is refused at parse, so the panel names the
+    // ATTRIBUTE rather than the value. Asserting the panel alone would keep
+    // passing on the old `unknown-component` reading too, which is exactly the
+    // misdirection that port removed — so the message is read, not just the
+    // fact that compilation failed.
     expect(await screen.findByText(/failed to compile/i)).toBeInTheDocument();
+    expect(screen.getByText(/Attribute "type" is not allowed on <action:button>/)).toBeInTheDocument();
+    expect(screen.queryByText(/unknown component/i)).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Mark done' })).not.toBeInTheDocument();
     expect(api).not.toHaveBeenCalled();
   });

--- a/packages/sdui-parser/src/__tests__/provenance.test.ts
+++ b/packages/sdui-parser/src/__tests__/provenance.test.ts
@@ -51,15 +51,46 @@ describe('html-tier provenance (#4000)', () => {
     const root = tree as SchemaElement;
 
     expect(JSON.parse(JSON.stringify(root))).toEqual({ type: 'div', className: 'a' });
-    expect(Object.keys(root)).toEqual(['type', 'className']);
+    // ⚠️ Key ORDER, not key SET: `type` moved from first to last when the
+    // discriminator collision was closed (objectui#7235) and the node became
+    // `{ ...props, type: tag }`. The set, the values and the round-trip are
+    // unchanged — this line is the one visible consequence of that reversal,
+    // and it is here rather than adjusted away because an order pin that
+    // silently follows the implementation pins nothing.
+    expect(Object.keys(root)).toEqual(['className', 'type']);
     const seen: string[] = [];
     for (const k in root) seen.push(k);
-    expect(seen).toEqual(['type', 'className']);
+    expect(seen).toEqual(['className', 'type']);
 
     // The round-trip is the anti-forgery pin: a persisted tree comes back
     // unmarked, so a saved (or AI-generated) document cannot carry the
     // exemption back in with it.
     expect(isHtmlTierNode(JSON.parse(JSON.stringify(root)))).toBe(false);
+  });
+
+  it('survives the reversed spread — the marking is applied AFTER every key', () => {
+    // objectui#7235 reversed `markHtmlTierNode({ type: tag, ...props })` into
+    // `markHtmlTierNode({ ...props, type: tag })`. The wrapper is objectui-only
+    // (objectstack's copy of this parser builds a bare object), so the reversal
+    // is the one edit in that port where the stamp could have been dropped —
+    // e.g. by moving the call inside the literal, or by spreading a marked
+    // object into a fresh unmarked one. Pinned at every depth and for the
+    // shapes the reversal actually moves: props present, props absent, and a
+    // container whose children were attached after the stamp.
+    const { tree } = parseJsx('<flex direction="col" gap={4}><grid columns={2} /><div /></flex>');
+    const root = tree as SchemaElement;
+
+    expect(isHtmlTierNode(root)).toBe(true);
+    expect(root.type).toBe('flex');
+    // `children` is assigned after `markHtmlTierNode` returns; the stamp is on
+    // the same object, so it must still read true once they are attached.
+    expect(root.children).toHaveLength(2);
+    for (const child of root.children as SchemaElement[]) {
+      expect(isHtmlTierNode(child)).toBe(true);
+    }
+    // The propless element — `{ ...{}, type: tag }` — is the degenerate case
+    // of the reversal and has its own way of going wrong.
+    expect(isHtmlTierNode((root.children as SchemaElement[])[1])).toBe(true);
   });
 
   it('does not mark JSON smuggled in through a braced attribute', () => {

--- a/packages/sdui-parser/src/__tests__/type-attribute-collision-7235.test.ts
+++ b/packages/sdui-parser/src/__tests__/type-attribute-collision-7235.test.ts
@@ -1,0 +1,168 @@
+/**
+ * html tier: an authored `type=` attribute collides with the envelope's own
+ * discriminator, and is REFUSED at parse time (objectui#7235 — the port of
+ * objectstack#13957, maintainer ruling 2026-09-01, ADR-0080 amendment).
+ *
+ * The two outcomes this replaces are pinned side by side on purpose, because
+ * they are the reason the refusal is at parse rather than at the warning layer:
+ * one of them produced NO diagnostic at all, and the other produced a loud one
+ * pointing somewhere else. A test that only asserted "an error is raised" would
+ * pass on the second case before this change.
+ *
+ * ⚠️ This copy is the RENDERER's (and the console's live edit preview); the
+ * save gate runs objectstack's. Until this landed the two differed in accepted
+ * grammar, so an author got no diagnostic while typing and a refusal on save.
+ */
+import { describe, expect, it } from 'vitest';
+import { compile, manifestFromConfigs } from '../index.js';
+import { parseJsx } from '../parse.js';
+import { isHtmlTierNode } from '../provenance.js';
+import type { SchemaElement } from '../types.js';
+
+const manifest = manifestFromConfigs([
+  { type: 'flex', namespace: 'ui', isContainer: true, inputs: [
+    { name: 'direction', type: 'enum', enum: ['row', 'col'] },
+    { name: 'gap', type: 'number' },
+  ] },
+  { type: 'grid', namespace: 'ui', isContainer: true, inputs: [{ name: 'columns', type: 'number' }] },
+  { type: 'object-chart', namespace: 'plugin-charts', isContainer: false, inputs: [
+    { name: 'objectName', type: 'string', binding: 'object' },
+  ] },
+]);
+
+/** The refusal, as the author sees it: one diagnostic naming BOTH names. */
+const refusals = (source: string) =>
+  compile(source, manifest).diagnostics.filter((d) => d.code === 'forbidden-attr');
+
+describe('an authored `type` attribute is refused (the discriminator collision)', () => {
+  it('refuses when the value names ANOTHER REGISTERED type — the previously SILENT case', () => {
+    const r = compile('<flex type="grid" gap={4} />', manifest);
+
+    // Before this change: `grid` resolved in the manifest, every check passed,
+    // and the page rendered a grid where the author wrote a flex — zero
+    // diagnostics of any severity.
+    expect(r.ok).toBe(false);
+    expect(r.diagnostics).toContainEqual(
+      expect.objectContaining({ severity: 'error', code: 'forbidden-attr', tag: 'flex' }),
+    );
+
+    // ONE diagnostic, naming BOTH the tag and the attribute (the ruled shape).
+    const [only, ...rest] = refusals('<flex type="grid" gap={4} />');
+    expect(rest).toEqual([]);
+    expect(only.message).toContain('"type"');
+    expect(only.message).toContain('<flex>');
+
+    // …AND the tree still builds as the tag the author wrote. Asserting only
+    // the diagnostic would leave the other half of this defect in place: the
+    // silent redirect is the node carrying `grid` as its discriminator, and a
+    // loud diagnostic beside a redirected node is still a redirected node.
+    expect(r.tree?.type).toBe('flex');
+    expect(r.tree).not.toHaveProperty('type', 'grid');
+  });
+
+  it('refuses when the value names NOTHING registered — the previously MISDIRECTED case', () => {
+    // `<object-chart type="bar">` is the shape a react-tier author carries
+    // across: on that tier `type` is the chart family. Before this change the
+    // only diagnostic was `unknown-component` naming `"bar"`, which reads as a
+    // missing plugin rather than as an attribute that should not be there.
+    const source = '<object-chart objectName="invoice" type="bar" />';
+    const r = compile(source, manifest);
+
+    expect(r.ok).toBe(false);
+    expect(refusals(source)).toHaveLength(1);
+    expect(r.diagnostics.map((d) => d.code)).not.toContain('unknown-component');
+    // The diagnostic names the ATTRIBUTE, never the value the author gave it.
+    expect(refusals(source)[0].message).toContain('"type"');
+    expect(refusals(source)[0].message).not.toContain('"bar"');
+    expect(r.tree?.type).toBe('object-chart');
+  });
+
+  it('refuses a BARE `type` attribute too — the check is on the name, not the value', () => {
+    expect(refusals('<flex type />')).toHaveLength(1);
+    expect(refusals('<flex type={{"a":1}} />')).toHaveLength(1);
+  });
+
+  it('refuses it on a NESTED element, not only on the root', () => {
+    const found = refusals('<flex><grid type="flex" columns={2} /></flex>');
+    expect(found).toHaveLength(1);
+    expect(found[0].tag).toBe('grid');
+    expect(found[0].message).toContain('<grid>');
+  });
+
+  it('leaves a clean element alone — no regression', () => {
+    const r = compile('<flex direction="row" gap={4}><grid columns={2} /></flex>', manifest);
+    expect(r.ok).toBe(true);
+    expect(r.diagnostics).toEqual([]);
+    expect(r.tree).toMatchObject({ type: 'flex', direction: 'row', gap: 4 });
+  });
+
+  it('a node with NO `type` attribute keeps the same keys, values and provenance', () => {
+    // The regression guard, stated as what was actually measured. ⚠️ It is NOT
+    // byte-identical to the pre-change output: reversing the spread moves
+    // `type` from FIRST key to LAST, so `JSON.stringify` emits the same pairs
+    // in a different order. The key SET, every value, the children and the
+    // html-tier marker are unchanged, and that is the whole of the difference —
+    // `provenance.test.ts` carries the order pin itself.
+    const { tree, diagnostics } = parseJsx('<flex direction="col" gap={8} wrap><grid columns={3} /></flex>');
+    const root = tree as SchemaElement;
+
+    expect(diagnostics).toEqual([]);
+    expect(root).toMatchObject({
+      type: 'flex',
+      direction: 'col',
+      gap: 8,
+      wrap: true,
+      children: [{ type: 'grid', columns: 3 }],
+    });
+    expect(Object.keys(root).sort()).toEqual(['children', 'direction', 'gap', 'type', 'wrap']);
+    expect(isHtmlTierNode(root)).toBe(true);
+    expect(isHtmlTierNode(root.children![0])).toBe(true);
+  });
+});
+
+/**
+ * ⚠️ Read this before trusting the block below as coverage of the spread order.
+ *
+ * The order fix is DEFENSE IN DEPTH, which means the refusal makes it
+ * unobservable through the public API: measured by ablation on the committed
+ * tree, restoring `{ type: tag, ...props }` while LEAVING the refusal in place
+ * keeps every test in this file GREEN, because the refused attribute never
+ * reaches `props` to be spread. What turns them red is removing the refusal.
+ *
+ * So these tests pin the discriminator's identity, not the statement that
+ * produces it. That is not a gap to paper over with a stronger-sounding
+ * assertion — it is the ruled relationship between the two halves («拒绝使覆盖
+ * 不可达，顺序修复是防御纵深»), and it is stated here so the next author does
+ * not read a green suite as proof the order is load-bearing on its own.
+ */
+describe('spread order — defense in depth behind the refusal', () => {
+  it('keeps the TAG as the discriminator even when a `type` attribute was authored', () => {
+    // Parser-level, with no manifest: the refusal is a diagnostic, and the tree
+    // is still built. What must never happen is the tree carrying the AUTHOR's
+    // value as its discriminator — that is the silent redirect itself.
+    const { tree, diagnostics } = parseJsx('<flex type="grid" gap={4} />');
+
+    expect(tree?.type).toBe('flex');
+    expect(diagnostics.map((d) => d.code)).toContain('forbidden-attr');
+  });
+
+  it('and does not let the refused value land under its own name either', () => {
+    const { tree } = parseJsx('<flex type="grid" />');
+    expect(Object.values(tree ?? {})).not.toContain('grid');
+    // Nor under the `__forbidden_<name>` sentinel the OTHER refusals park in
+    // `props` — that sentinel draws an `unknown-prop` naming a key nobody
+    // wrote, which is the second diagnostic the ruled shape refuses to emit.
+    expect(Object.keys(tree ?? {})).not.toContain('__forbidden_type');
+  });
+
+  it('every other prop still survives the reordered spread', () => {
+    const { tree } = parseJsx('<flex direction="col" gap={8} wrap><grid columns={3} /></flex>');
+    expect(tree).toMatchObject({
+      type: 'flex',
+      direction: 'col',
+      gap: 8,
+      wrap: true,
+      children: [{ type: 'grid', columns: 3 }],
+    });
+  });
+});

--- a/packages/sdui-parser/src/parse.ts
+++ b/packages/sdui-parser/src/parse.ts
@@ -21,6 +21,48 @@ import { markHtmlTierNode } from './provenance.js';
 const EVENT_ATTR = /^on[A-Z]/;
 const FORBIDDEN_ATTRS = new Set(['dangerouslySetInnerHTML', 'ref', 'key']);
 
+/**
+ * The envelope's own discriminator, which on THIS tier the tag name sets.
+ *
+ * An authored `type=` attribute is a NAME COLLISION with it, and the parser
+ * refuses it at parse time (maintainer ruling 2026-09-01, recorded as an
+ * append-only amendment on ADR-0080 — 「响亮拒绝」, quoted verbatim there;
+ * objectui#7235 ports it to this copy, objectstack#13957 landed the other).
+ * One diagnostic naming BOTH the tag and the attribute replaces two bad
+ * outcomes:
+ *
+ *  - the value named another REGISTERED type (`<flex type="grid">`) — the tree
+ *    carried `type:'grid'`, `validateTree` found `grid` in the manifest, every
+ *    check passed, and the page rendered a grid where the author wrote a flex.
+ *    ZERO diagnostics. On the one tier whose whole premise is that unreviewed
+ *    and AI-authored source is safe to accept.
+ *  - the value named NOTHING registered (`<object-chart type="bar">`, the shape
+ *    a react-tier author carries across) — loud, but `unknown-component`
+ *    naming `"bar"` reads as a missing plugin, never as a bad prop.
+ *
+ * ⛔ NOT rescued as `specType` the way the react tier rescues it (objectui#2880):
+ * that is consumer-side tolerance, and it would spread an alias concept to a
+ * second tier. ⛔ NOT a warning grace period either — the same ruling declined
+ * a staged rollout. ⛔ And NOT fixable at the warning layer: `type` is in
+ * `validate.ts`'s `BASE_PROPS` deliberately (it is correct for every other
+ * member), so removing it there would make every legitimate node warn. The
+ * refusal belongs here, at parse.
+ *
+ * ⚠️ The code is the EXISTING `forbidden-attr`, not a new one, and that is
+ * load-bearing rather than lazy: objectstack's `scripts/check-sdui-lockstep.mjs`
+ * holds ITS copy's diagnostic-code set equal to THIS one's at the pinned
+ * revision, so a code minted on one side only IS the dialect split that gate
+ * exists to catch (objectstack#12719). `forbidden-attr` already carries this
+ * shape — an attribute this tier refuses, named beside its element — and both
+ * copies stamp it.
+ *
+ * ⚠️ This copy is the RENDERER's (and the console's live edit preview); the
+ * save gate runs objectstack's. Until this landed the two differed in accepted
+ * grammar: a page objectstack refused still compiled silently while its author
+ * was typing.
+ */
+const DISCRIMINATOR_ATTR = 'type';
+
 export function parseJsx(source: string, options: ParseOptions = {}): ParseResult {
   return new Parser(source, options).parseDocument();
 }
@@ -70,7 +112,15 @@ class Parser {
       if (c === '' || c === '>' || c === '/') break;
       const attr = this.parseAttr(start, tag);
       if (!attr) break;
-      props[attr.name] = attr.value;
+      // `drop` is set only for the refused discriminator attribute, and only so
+      // that ONE diagnostic is what the author gets. The `__forbidden_<name>`
+      // sentinel the other refusals park in `props` reaches `validateTree`,
+      // which knows no such prop and adds `unknown-prop` naming a key nobody
+      // wrote — loud, and pointing at the wrong thing, which is the species of
+      // diagnostic this whole change exists to remove. The existing sentinel
+      // behaviour is left exactly as it was for the attributes that already had
+      // it (`ref`, `key`, `dangerouslySetInnerHTML`, `on*`).
+      if (!attr.drop) props[attr.name] = attr.value;
     }
 
     this.skipWs();
@@ -91,12 +141,27 @@ class Parser {
     // JSON, to the DOM, and to anything an authored document could forge — see
     // provenance.ts. Values reached through a braced attribute are NOT marked:
     // that JSON was written by hand, and the JSON surface's advice does apply.
-    const node: SchemaElement = markHtmlTierNode({ type: tag, ...props });
+    // DEFENSE IN DEPTH (ruled together with the refusal above). `props` used to
+    // be spread AFTER `type: tag`, so an authored `type` attribute overwrote the
+    // discriminator the tag established and nothing downstream restored it —
+    // `compile()` returns this tree as-is and `validateTree` then looks up
+    // `manifest.components[node.type]`, i.e. the value the author wrote, not the
+    // tag they wrote. The refusal makes that overwrite unreachable; the order
+    // here makes it impossible. ⚠️ Reversing the order ALONE would have been a
+    // regression of its own — the authored value would then be dropped in
+    // silence, trading one silence for another. It is correct only BECAUSE the
+    // attribute is refused loudly one function up.
+    //
+    // ⚠️ The `markHtmlTierNode` wrapper is objectui-only and survives the
+    // reversal: it stamps the object the spread produced, so the marker is
+    // applied after every key is in place regardless of their order. Pinned in
+    // provenance.test.ts, because this is the one edit that could drop it.
+    const node: SchemaElement = markHtmlTierNode({ ...props, type: tag });
     if (children && children.length) node.children = children;
     return node;
   }
 
-  private parseAttr(elStart: number, tag: string): { name: string; value: unknown } | null {
+  private parseAttr(elStart: number, tag: string): { name: string; value: unknown; drop?: boolean } | null {
     const name = this.readName();
     if (!name) {
       this.error('bad-attr', `Malformed attribute on <${tag}>`, this.pos, tag);
@@ -109,6 +174,19 @@ class Parser {
     if (this.eat('=')) {
       this.skipWs();
       value = this.parseAttrValue(tag);
+    }
+    if (name === DISCRIMINATOR_ATTR) {
+      // ONE diagnostic naming both the tag and the attribute — see
+      // DISCRIMINATOR_ATTR above for why it replaces both prior outcomes.
+      this.error(
+        'forbidden-attr',
+        `Attribute "${DISCRIMINATOR_ATTR}" is not allowed on <${tag}> — on this tier the tag name IS the `
+        + `component, so <${tag}> already means type "${tag}". Delete the attribute, or write the tag of the `
+        + 'component you meant.',
+        elStart,
+        tag,
+      );
+      return { name, value: undefined, drop: true };
     }
     if (EVENT_ATTR.test(name) || FORBIDDEN_ATTRS.has(name)) {
       this.error('forbidden-attr', `Attribute "${name}" is not allowed on <${tag}>`, elStart, tag);


### PR DESCRIPTION
Fixes #7235

Port of objectstack#13957 (maintainer ruling 2026-09-01, recorded as an append-only amendment on objectstack's ADR-0080) into **this repo's copy** of `sdui-parser` — the copy the renderer and the console's live edit preview run. objectstack runs the save gate and has been the stricter of the two since that landed; this removes the grammar gap.

Session (durable reference, as a code span so it survives a body rewrite): `https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ`

## The four ruled steps

1. **`parseAttr` refuses a `type` attribute** with the **existing** `forbidden-attr` code — one diagnostic naming both the tag and the attribute. ⛔ No new code minted: `check:sdui-lockstep` holds the two copies' diagnostic-code sets equal, so a code on one side only IS the dialect split that gate exists to catch.
2. **Spread reversed inside the existing wrapper:** `markHtmlTierNode({ ...props, type: tag })`. ⚠️ Defense in depth, correct only *because* of (1).
3. ⛔ The react tier's `specType` rescue (#2880) is **not** carried here — the ruling declined it by name.
4. ⛔ Not in this PR: objectstack re-records its side with `gen:sdui-lockstep` when the `.objectui-sha` pin moves.

⚠️ The `markHtmlTierNode` wrapper is objectui-only (objectstack builds a bare object). It is kept; the spread is reversed **inside** the call.

## What the defect actually was — measured, both halves

Behavioural probe, run on four trees in one lock hold. Written without literal angle brackets because GitHub eats tag-shaped fragments; read `FLEX-TYPE-GRID` as a `flex` element carrying `type="grid"`.

| tree | node `type` | diagnostics | reading |
|---|---|---|---|
| this PR (refusal + reversed spread) | `flex` | `["forbidden-attr"]` | loud, and the tag wins |
| ablation A — **step 2 alone** (refusal removed) | `flex` | `[]` | **silent DISCARD** — the authored value vanishes with no diagnostic |
| ablation B — **step 1 alone** (old spread order restored) | `flex` | `["forbidden-attr"]` | indistinguishable from this PR through the public API |
| ablation C — **both removed** (`origin/main`) | **`grid`** | `[]` | **silent OVERWRITE** — a grid renders where the author wrote a flex |

Verbatim, for `FLEX-TYPE-GRID`:

```
this PR      type=flex json={"gap":4,"type":"flex"}  codes=["forbidden-attr"]
ablation A   type=flex json={"type":"flex","gap":4}  codes=[]
ablation B   type=flex json={"type":"flex","gap":4}  codes=["forbidden-attr"]
ablation C   type=grid json={"type":"grid","gap":4}  codes=[]
```

⇒ the card's claim is confirmed as stated: **step 2 alone trades a silent overwrite for a silent discard.** Ablation B is the reason the order fix is documented as defense in depth rather than as the fix: with the refusal in place the attribute never reaches `props`, so restoring the old order changes nothing observable (its only red was the key-order pin, below).

Red/green matrix over the three affected test files (17 tests):

| leg | vitest exit | red |
|---|---|---|
| this PR | 0 | — |
| A (refusal removed) | 1 | 5 red |
| B (order restored) | 1 | 1 red (the key-order pin only) |
| C (both removed) | 1 | 7 red |

Each leg proved on disk before it was read (anchor occurrence counts plus the blob id), and each restore proved **by state** — `git diff HEAD` empty and `git hash-object` back to HEAD's `834bf3b0484c` — never by an exit code. No probe file is left in the tree.

## ⚠️ One PM acceptance criterion is falsified, deliberately not papered over

The brief asked that a node with no `type` attribute be **byte-identical** to today. It is not, and cannot be: reversing the spread moves `type` from **first** key to **last**, so `JSON.stringify` of a parsed tree emits the same pairs in a different order. `provenance.test.ts` pinned that order, and it went red:

```
AssertionError: expected [ 'className', 'type' ] to deeply equal [ 'type', 'className' ]
```

The key **set**, every value, the children and the html-tier provenance marker are unchanged — measured. The pin is updated to the new order with the reason written beside it, rather than relaxed to a sorted or set-wise comparison: an order pin that silently follows the implementation pins nothing. Called out in the changeset too, since a consumer diffing serialized trees will see it.

## Provenance survives the reversal

`markHtmlTierNode` is exactly where the reversal could have dropped the stamp. A new pin covers it at every depth and for the shapes the reversal moves — props present, props absent, and a container whose `children` are attached *after* the stamp.

## Sweep — does refusing `type` reject anything this repo authors today?

**No.** Population = every file referencing `kind:'html'`, `parseJsx`, or `@object-ui/sdui-parser` (65 files), plus `examples/**`, `content/docs/**`, `skills/**` and `e2e/**`.

- **1** html-tier document in the repo authors a `type` attribute: `action-type-input-html-tier.test.tsx` row 3, a deliberate **negative control** asserting the spelling does *not* work. It still fails to compile and still renders no button — so the harm the stop condition names (a narrowing that breaks existing authored content) is untouched. Its prose said the reason was `unknown-component` on the overwritten discriminator; that is now false, so the prose is corrected and the row asserts **which** diagnostic, otherwise it would go on passing while measuring nothing.
- `examples/**`: 8 `type=` hits, **0** in html-tier source (all `data-obj-type` DOM assertions and a `script type="module"` in an `index.html`). The schema catalog is the JSON tier, where `type` is the legitimate discriminator and nothing here touches it.
- `content/docs/**`: 6 hits, all react-tier `Block type=...` or MDX callouts — neither goes through this parser.
- `apps/console/src/sdui-tiers-preview.tsx`, the repo's own html-tier authoring example whose test asserts zero error diagnostics: **0** hits.

The sweep regex is not vacuous: it found the negative control, which pre-exists this change.

## `check:sdui-lockstep` — green, measured, in both directions

`check:sdui-lockstep` lives in objectstack and needs an install this reference checkout does not have, so it was run from a faithful scratch copy of that tree with a resolvable `typescript`:

```
--self-test exit=0
gate       exit=0
  OK — byte-identical to objectui@53ded82bf7a4 over 214 grammar line(s)
  [blob 0131f27cf86d] and agrees on all 24 diagnostic code(s)
```

And the half that gate structurally cannot see — objectui moving after the record — measured with **its own** `fingerprintOf` on this branch versus `origin/main`:

- grammar region blob: `0131f27cf86d` **before and after**, byte-identical, and equal to the recorded value. All hunks land at lines 24–190; the region delimiter is at line 392.
- diagnostic codes: identical before and after. This PR adds **none**.

⚠️ That same measurement surfaced a **pre-existing** divergence this PR did not cause and does not touch: objectui `origin/main` already carries **26** codes to objectstack's **24** (`inert-quick-add`, `member-type-mismatch`, plus the file `kanban-quick-add.ts`), all landed after the record was taken on 2026-09-05. Filed as objectstack#17645 with the measurement and the pre-existing control. It is latent today and will surface at the next `.objectui-sha` bump, with or without this PR.

## Verification

| what | how | result |
|---|---|---|
| `packages/sdui-parser` tests | `pnpm exec vitest run packages/sdui-parser/` | 15 files, **204 passed** |
| affected components test | `pnpm exec vitest run …/action-type-input-html-tier.test.tsx` | 4 passed |
| every html-tier consumer test in the repo | the 39 test files referencing `kind:'html'`, `parseJsx` or `@object-ui/sdui-parser` outside the parser package itself | 39 files, **744 passed** |
| `@object-ui/sdui-parser` type-check | `tsc --noEmit && tsc -p tsconfig.test.json` | exit 0 |
| `@object-ui/components` type-check | same, after building its dependency closure | exit 0 |
| dependency-closure builds | `pnpm --filter '@object-ui/sdui-parser^...' build`, same for components | exit 0 |
| `check:control-bytes` | repo gate | exit 0, 7313 files scanned |
| `check:new-line-citations` | repo gate | exit 0, 0 new citations |
| `check:upstream-port-parity` | repo gate | exit 0, 3 ported files match |
| `check:vi-mock-specifiers` | repo gate | exit 0 |
| `check-changeset-presence` | repo gate | exit 0, 1 changeset declared |
| eslint | 4 changed files, `--no-inline-config --format json` | exit 0, 0 problems |

Every exit code above was captured by **redirect** before any pipe.

**eslint narrowing, declared.** Population read from eslint's own config (`isPathIgnored` over `git ls-files`): **4799** lintable files. Files actually linted, read from `--format json`: **4**. Invariance: `eslint.config.js` declares no `projectService` and no `parserOptions.project` (0 occurrences), so linting is not type-aware and this diff cannot move the verdict on any file it does not contain. The narrowing is therefore a measurement, not a skip; CI runs the full farm.

**NOT MEASURED:** `check:sdui-registration-pins` exits **2** (`PREREQUISITE NOT MET` — no `apps/console/dist/assets` to weigh). It pins bundle-time registrations; this diff adds and removes none. Left to CI rather than run against nothing.

## Acceptance notes

Noted, not filed:

- `packages/components/src/renderers/action/__tests__/action-type-input-html-tier.test.tsx` carries a Chinese phrase in a code comment, which AGENTS.md commandment #-1 (English-only codebase) forbids. It pre-exists this change and is one of **743** files under `packages/**` that do — so it is a repo-wide convention gap, not a defect, and not this PR's to open. Successor: none; it would need a ruling on whether #-1 still describes the tree.
- The two copies of `parse.ts` differ in two further places beyond the spread order, the refusal and the objectui-only provenance wrapper — both **comment-only**, no behavioural difference: the whitespace-collapse rationale is worded differently on each side, and objectstack's `interpretBrace` carries a `LOCKSTEP:` banner this copy lacks. Reported per the brief's "report, don't stop" clause; no third behavioural difference exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ


---
_Generated by [Claude Code](https://claude.ai/code)_