### PR TITLE
refactor(core): import the spec's context-token map and predicate (objectui#7265)

### DIFF
--- a/.changeset/7265-core-context-token-mirrors.md
+++ b/.changeset/7265-core-context-token-mirrors.md
@@ -1,0 +1,16 @@
+---
+---
+
+Internal only, no release: `@object-ui/core`'s `filter-tokens.ts` stops carrying
+module-local copies of two `@objectstack/spec/data` exports —
+`CONTEXT_TOKEN_SUGGESTIONS` (the near-miss suggestion map) and `isContextToken`
+(the membership predicate) — and imports both instead (objectui#7265, the
+`@object-ui/core` slice of the DEBT ledger in
+`scripts/check-spec-symbol-derivation.mjs`).
+
+Neither symbol was ever exported from `@object-ui/core`, so no published surface
+moves. Behaviour is unchanged and was measured rather than assumed: the map
+matched the spec's on nine keys, in the same order, with the same values against
+the RESOLVED 17.4.0 pin (the seeding card had measured 17.2.0), and the resolver
+returned byte-identical results and byte-identical warning text across 248 cases
+(62 tokens x 2 placeholder spellings x 2 scopes) before and after the swap.

--- a/packages/core/src/utils/__tests__/filter-tokens.spec-derived-7265.test.ts
+++ b/packages/core/src/utils/__tests__/filter-tokens.spec-derived-7265.test.ts
@@ -1,0 +1,157 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { CONTEXT_TOKEN_SUGGESTIONS, CONTEXT_TOKENS } from '@objectstack/spec/data';
+
+import { resolveContextTokens } from '../filter-tokens';
+
+/**
+ * objectui#7265 — `filter-tokens.ts` carried module-local copies of two
+ * `@objectstack/spec/data` exports (`CONTEXT_TOKEN_SUGGESTIONS`, the near-miss
+ * map, and `isContextToken`, the membership predicate). Both are imports now.
+ *
+ * ## What this file pins, and why it is not a tautology
+ *
+ * The expectations below are a LITERAL TRANSCRIPTION of what the deleted local
+ * copies did, taken at 567f370 before the swap. They are deliberately NOT read
+ * back from the import that replaced them — an assertion shaped
+ * `expect(imported).toEqual(imported)` passes no matter what the spec does, and
+ * the whole risk of replacing a local definition with an imported one is that a
+ * later spec release moves it underneath us.
+ *
+ * The import is used for ONE thing: to widen the candidate pool the cases are
+ * driven over. That can only make this file stricter — a tenth near-miss
+ * spelling added upstream enters the pool, warns, and fails the exact-set
+ * assertion; a spelling dropped upstream stops warning and fails the same one.
+ *
+ * The surface under test is the resolver's OBSERVABLE behaviour (what comes
+ * back, and what it warns), because that is what the two deleted symbols were
+ * for. Neither was ever exported from `@object-ui/core`.
+ */
+
+/** Every near-miss spelling the deleted local map carried, with its target. */
+const NEAR_MISSES_AT_567f370 = [
+  ['current_user', 'current_user_id'],
+  ['current_user_email', 'current_user_id'],
+  ['user_id', 'current_user_id'],
+  ['userid', 'current_user_id'],
+  ['me', 'current_user_id'],
+  ['current_organization_id', 'current_org_id'],
+  ['org_id', 'current_org_id'],
+  ['organization_id', 'current_org_id'],
+  ['current_tenant_id', 'current_org_id'],
+] as const;
+
+/** Every token the deleted local predicate answered `true` for. */
+const CONTEXT_TOKENS_AT_567f370 = ['current_user_id', 'current_org_id'] as const;
+
+type Scope = { currentUserId?: string | null; currentOrgId?: string | null };
+
+const IN_SCOPE: Scope = { currentUserId: 'usr_42', currentOrgId: 'org_7' };
+
+/** Resolves one placeholder and reports both halves of the observable result. */
+function resolveOne(token: string, scope: Scope = IN_SCOPE) {
+  const warnings: string[] = [];
+  const out = resolveContextTokens(
+    { f: `{${token}}` },
+    { ...scope, onUnresolved: (m) => warnings.push(m) },
+  );
+  return { value: (out as { f: unknown }).f, warnings };
+}
+
+describe('objectui#7265 — the derived map and predicate behave as the local copies did', () => {
+  it('accepts and rejects exactly the tokens the local predicate did', () => {
+    // The predicate half, stated over the vocabulary rather than inferred from
+    // the map: a token that RESOLVES is one the predicate admitted.
+    const resolves = [
+      ...CONTEXT_TOKENS_AT_567f370,
+      ...NEAR_MISSES_AT_567f370.map(([spelling]) => spelling),
+      ...CONTEXT_TOKENS,
+      'today',
+      'this_month',
+      'nav_region_selector',
+      'unknown_thing',
+    ].filter((token) => resolveOne(token).value !== `{${token}}`);
+
+    expect([...new Set(resolves)].sort()).toEqual([...CONTEXT_TOKENS_AT_567f370].sort());
+  });
+
+  it('resolves each recognised token to its scope value, in both spellings', () => {
+    for (const token of CONTEXT_TOKENS_AT_567f370) {
+      const expected = token === 'current_user_id' ? 'usr_42' : 'org_7';
+      expect(resolveOne(token)).toEqual({ value: expected, warnings: [] });
+      // `${token}` is the second accepted spelling and must not diverge.
+      const warnings: string[] = [];
+      expect(
+        resolveContextTokens(
+          { f: `\${${token}}` },
+          { ...IN_SCOPE, onUnresolved: (m) => warnings.push(m) },
+        ),
+      ).toEqual({ f: expected });
+      expect(warnings).toEqual([]);
+    }
+  });
+
+  it('leaves a recognised token in place and warns when scope has no value', () => {
+    const signedOut = resolveOne('current_user_id', { currentUserId: null });
+    expect(signedOut.value).toBe('{current_user_id}');
+    expect(signedOut.warnings).toHaveLength(1);
+    expect(signedOut.warnings[0]).toContain('no signed-in user in scope');
+
+    const noOrg = resolveOne('current_org_id', { currentOrgId: undefined });
+    expect(noOrg.value).toBe('{current_org_id}');
+    expect(noOrg.warnings[0]).toContain('no active organization in scope');
+  });
+
+  it('warns with the same suggestion target for every near-miss spelling', () => {
+    for (const [spelling, target] of NEAR_MISSES_AT_567f370) {
+      const { value, warnings } = resolveOne(spelling);
+      expect(value).toBe(`{${spelling}}`); // never substituted — it is not a token
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain(`"{${spelling}}" is not a recognised token`);
+      expect(warnings[0]).toContain(`did you mean "{${target}}"?`);
+    }
+  });
+
+  it('warns for EXACTLY those spellings — nothing gained, nothing lost upstream', () => {
+    // The candidate pool unions the literal table with the imported map's keys,
+    // so an entry added or removed upstream lands in the pool either way; the
+    // EXPECTED set stays the literal transcription.
+    const pool = [
+      ...NEAR_MISSES_AT_567f370.map(([spelling]) => spelling),
+      ...Object.keys(CONTEXT_TOKEN_SUGGESTIONS),
+    ];
+    const warners = [...new Set(pool)].filter((s) => resolveOne(s).warnings.length > 0);
+
+    expect(warners.sort()).toEqual(
+      [...NEAR_MISSES_AT_567f370.map(([spelling]) => spelling)].sort(),
+    );
+  });
+
+  it('keeps the lookup case-folded, as the local copy did', () => {
+    const shouty = resolveOne('CURRENT_USER');
+    expect(shouty.value).toBe('{CURRENT_USER}');
+    expect(shouty.warnings[0]).toContain('did you mean "{current_user_id}"?');
+  });
+
+  it('still passes other vocabularies through in silence', () => {
+    // Date macros and nav-only context-selector ids are not this resolver's
+    // business; warning on them is the regression a widened predicate causes.
+    for (const token of ['today', 'this_quarter', 'nav_region_selector']) {
+      expect(resolveOne(token)).toEqual({ value: `{${token}}`, warnings: [] });
+    }
+  });
+
+  it('pins the token tuple itself, so a third token cannot arrive unnoticed', () => {
+    // `resolveContextTokens` builds its scope lookup with a `satisfies
+    // Record<ContextTokenName, …>` clause, so a third token reds the compile.
+    // This states the same ratchet at runtime, where the failure names itself.
+    expect([...CONTEXT_TOKENS]).toEqual([...CONTEXT_TOKENS_AT_567f370]);
+  });
+});

--- a/packages/core/src/utils/filter-tokens.ts
+++ b/packages/core/src/utils/filter-tokens.ts
@@ -6,7 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { CONTEXT_TOKENS } from '@objectstack/spec/data';
+import {
+  CONTEXT_TOKENS,
+  CONTEXT_TOKEN_SUGGESTIONS,
+  isContextToken,
+} from '@objectstack/spec/data';
 
 import { resolveDateMacros } from './date-macros.js';
 
@@ -57,37 +61,26 @@ import { resolveDateMacros } from './date-macros.js';
  * copy was byte-identical, so every value comparison and every behavioural
  * test passed while it sat here. Reference identity is the one check that
  * distinguishes a re-export from a fork (objectui#3003).
+ *
+ * The same argument retired the two module-local copies that sat beside it
+ * until objectui#7265 — the near-miss suggestion map and the membership
+ * predicate are imported from `@objectstack/spec/data` now, so neither can
+ * drift either. Both were re-measured against the RESOLVED pin (17.4.0; the
+ * card had measured 17.2.0) before the swap, because "byte-identical" is a
+ * statement about a version, not a property: the map matched on nine keys, in
+ * the same order, with the same values, and the two predicates agreed on every
+ * one of 61 real vocabulary members — the token tuple, both suggestion key
+ * sets, the date-macro tokens and their aliases, plus casing, whitespace and
+ * prototype-key spellings. Each comparison ran a lit control of the same kind
+ * through the same comparator (the spec's own token-description map, and its
+ * date-macro predicate), so "no difference" came from an instrument shown able
+ * to report one.
  */
 
 /** The complete set of session-scoped filter tokens (spec-owned, re-exported). */
 export { CONTEXT_TOKENS };
 
 export type ContextTokenName = (typeof CONTEXT_TOKENS)[number];
-
-/**
- * Near-miss spellings → the token the author meant.
- *
- * Every entry is a real authoring mistake, and each is a correct spelling
- * *somewhere else* in the platform, which is exactly why authors reach for it:
- * `current_user` is the RLS expression root, `{user_id}` is valid
- * `titleFormat` field interpolation, `organization_id` is a real column name.
- *
- * Mirrors `CONTEXT_TOKEN_SUGGESTIONS` in `@objectstack/spec`. Used only to
- * make the runtime warning actionable; the authoring-time gate
- * (`validateFilterTokens` in `@objectstack/lint`) is what actually prevents
- * these from shipping.
- */
-const CONTEXT_TOKEN_SUGGESTIONS: Record<string, ContextTokenName> = {
-  current_user: 'current_user_id',
-  current_user_email: 'current_user_id',
-  user_id: 'current_user_id',
-  userid: 'current_user_id',
-  me: 'current_user_id',
-  current_organization_id: 'current_org_id',
-  org_id: 'current_org_id',
-  organization_id: 'current_org_id',
-  current_tenant_id: 'current_org_id',
-};
 
 /** Session values a filter placeholder can resolve against. */
 export interface FilterTokenScope {
@@ -105,10 +98,6 @@ export interface FilterTokenScope {
 
 /** Whole-string placeholder: `{token}` or `${token}`, anchored. */
 const WHOLE_TOKEN_RE = /^\$?\{([a-zA-Z0-9_]+)\}$/;
-
-function isContextToken(token: string): token is ContextTokenName {
-  return (CONTEXT_TOKENS as readonly string[]).includes(token);
-}
 
 /**
  * Expand `{current_user_id}` / `{current_org_id}` inside a filter.
@@ -144,10 +133,16 @@ export function resolveContextTokens<T = any>(filter: T, scope: FilterTokenScope
           console.warn(`[object-ui] ${message}`);
         });
 
-  const values: Record<ContextTokenName, string | null | undefined> = {
+  // Annotated `Record<string, …>` because the spec's predicate returns a plain
+  // `boolean`, not the narrowing `token is ContextTokenName` the deleted local
+  // copy declared, so the narrowed branch below hands this lookup a `string`.
+  // The `satisfies` clause keeps the one thing that narrowing bought: a third
+  // context token in the spec reds this literal at compile time instead of
+  // resolving to `undefined` at runtime.
+  const values: Record<string, string | null | undefined> = {
     current_user_id: currentUserId,
     current_org_id: currentOrgId,
-  };
+  } satisfies Record<ContextTokenName, string | null | undefined>;
 
   const walk = (value: any): any => {
     if (value == null) return value;
@@ -171,6 +166,14 @@ export function resolveContextTokens<T = any>(filter: T, scope: FilterTokenScope
       // Not ours. Warn only for near-misses, which resolve in no vocabulary
       // at all and would otherwise fail silently; genuine date macros and
       // nav context-selector ids must pass through quietly.
+      //
+      // Every spelling in the imported map is a real authoring mistake, and
+      // each is a correct spelling *somewhere else* in the platform, which is
+      // exactly why authors reach for it: `current_user` is the RLS expression
+      // root, `{user_id}` is valid `titleFormat` field interpolation,
+      // `organization_id` is a real column name. The map only makes the runtime
+      // warning actionable; the authoring-time gate (`validateFilterTokens` in
+      // `@objectstack/lint`) is what actually prevents these from shipping.
       const suggestion = CONTEXT_TOKEN_SUGGESTIONS[token.toLowerCase()];
       if (suggestion) {
         warn(

--- a/scripts/__tests__/spec-symbol-ledger-core-7265.test.ts
+++ b/scripts/__tests__/spec-symbol-ledger-core-7265.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import * as specData from '@objectstack/spec/data';
+
+// Plain-JS CI helper. Its types are INFERRED from the .mjs source by
+// `tsconfig.scripts.json` (`allowJs`), so no `@ts-expect-error` here.
+import { scanFile, scanFileForClaims } from '../check-spec-symbol-derivation.mjs';
+
+/**
+ * objectui#7265, the `@object-ui/core` slice — 2 of the entries the DEBT block
+ * was seeded with at objectui#6291.
+ *
+ * `CONTEXT_TOKEN_SUGGESTIONS` and `isContextToken` were module-local copies of
+ * two `@objectstack/spec/data` exports living in `filter-tokens.ts`. They are
+ * imports now, so both left rule 1's DEBT block and the map's alignment claim
+ * left rule 2's CLAIM_DEBT block with the declaration that carried it — all
+ * three removals mechanical (`--ledger` / `--claim-ledger`), never hand-edited.
+ *
+ * Two different things are pinned here, and a ledger needs both:
+ *
+ *   1. THE SITE. The real scanner, run over the real file. This is the half
+ *      that reds if the local copies come back — deleting a name from a ledger
+ *      is not a burn-down unless the declaration went with it.
+ *   2. THE BLOCK. Shrink-only is the card's own invariant, so it is asserted,
+ *      not just respected: the two names are gone AND the block did not grow.
+ *      Stated as a ceiling rather than an equality so the next slice can shrink
+ *      it further without touching this file.
+ *
+ * ⚠️ The scanner is only evidence if it can fail, so each site assertion is
+ * paired with a fixture of the same kind that it MUST flag. A green scan with
+ * an empty `specNames` map, or over a path that does not exist, looks exactly
+ * like a green scan over a burned-down site.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const gateSource = path.join(repoRoot, 'scripts/check-spec-symbol-derivation.mjs');
+const site = path.join(repoRoot, 'packages/core/src/utils/filter-tokens.ts');
+
+const BURNED = ['CONTEXT_TOKEN_SUGGESTIONS', 'isContextToken'] as const;
+
+/**
+ * The names rule 1 matches on, built from the spec's own runtime exports rather
+ * than typed out here — a hand-written name list would keep asserting a
+ * collision after the spec stopped exporting the symbol.
+ */
+function specNamesFor(names: readonly string[]): Map<string, Set<string>> {
+  const out = new Map<string, Set<string>>();
+  for (const name of names) {
+    expect(
+      Object.prototype.hasOwnProperty.call(specData, name),
+      `@objectstack/spec/data must still export ${name} for this to be a collision at all`,
+    ).toBe(true);
+    out.set(name, new Set(['@objectstack/spec/data']));
+  }
+  return out;
+}
+
+/** Reads one `const NAME = { … };` block out of the gate's source text. */
+function ledgerBlock(name: string): string {
+  const text = fs.readFileSync(gateSource, 'utf8');
+  const start = text.indexOf(`const ${name} = {\n`);
+  expect(start, `${name} block not found in the gate source`).toBeGreaterThan(-1);
+  const end = text.indexOf('\n};\n', start);
+  expect(end, `${name} block is not terminated`).toBeGreaterThan(start);
+  return text.slice(start, end + 3);
+}
+
+const ledgerNames = (block: string) =>
+  [...block.matchAll(/^ {4}"([^"]+)",$/gm)].map((m) => m[1]);
+
+describe('the site: filter-tokens.ts declares neither symbol any more', () => {
+  it('rule 1 finds no local declaration under either spec name', () => {
+    const findings = scanFile(site, specNamesFor(BURNED));
+    expect(findings.map((f: { name: string }) => f.name)).toEqual([]);
+  });
+
+  it('rule 2 finds no spec-alignment claim left behind by the deleted map', () => {
+    const claims = scanFileForClaims(site, specNamesFor(BURNED));
+    expect(claims.map((c: { name: string }) => c.name)).toEqual([]);
+  });
+
+  it('the scanner can still see both shapes — the control for the two above', () => {
+    // Same kind as the subject: one module-local `const` under the spec's name
+    // carrying an alignment claim, one module-local `function` under the other.
+    // Written to a throwaway path so the control cannot be satisfied by
+    // anything already in the tree.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'spec-symbol-7265-'));
+    try {
+      const fixture = path.join(dir, 'relapse.ts');
+      fs.writeFileSync(
+        fixture,
+        [
+          "import { CONTEXT_TOKENS } from '@objectstack/spec/data';",
+          '',
+          '/** Mirrors `CONTEXT_TOKEN_SUGGESTIONS` in `@objectstack/spec`. */',
+          'const CONTEXT_TOKEN_SUGGESTIONS: Record<string, string> = { me: "current_user_id" };',
+          '',
+          'function isContextToken(token: string): boolean {',
+          '  return (CONTEXT_TOKENS as readonly string[]).includes(token);',
+          '}',
+          '',
+          'export const used = [CONTEXT_TOKEN_SUGGESTIONS, isContextToken];',
+          '',
+        ].join('\n'),
+      );
+
+      const names = specNamesFor(BURNED);
+      expect(scanFile(fixture, names).map((f: { name: string }) => f.name).sort()).toEqual(
+        [...BURNED].sort(),
+      );
+      expect(scanFileForClaims(fixture, names).map((c: { name: string }) => c.name)).toEqual([
+        'CONTEXT_TOKEN_SUGGESTIONS',
+      ]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('the block: shrink-only, and it shrank by exactly these entries', () => {
+  it('DEBT no longer lists either name', () => {
+    const block = ledgerBlock('DEBT');
+    for (const name of BURNED) expect(block).not.toContain(`"${name}"`);
+    expect(block).not.toContain('"@object-ui/core"'); // the whole group went
+  });
+
+  it('DEBT has not grown — 11 names is the ceiling this slice left', () => {
+    // The seeding card counted 14 names; `TreeConfig` (@object-ui/plugin-tree)
+    // had already gone before this slice, and this slice took two more. Any
+    // future measurement above this number is the ratchet failing, whatever the
+    // reason given for it.
+    expect(ledgerNames(ledgerBlock('DEBT')).length).toBeLessThanOrEqual(11);
+  });
+
+  it('CLAIM_DEBT lost that alignment claim and did not grow either', () => {
+    const block = ledgerBlock('CLAIM_DEBT');
+    expect(block).not.toContain('"CONTEXT_TOKEN_SUGGESTIONS"');
+    expect(ledgerNames(block).length).toBeLessThanOrEqual(18);
+  });
+});

--- a/scripts/check-spec-symbol-derivation.mjs
+++ b/scripts/check-spec-symbol-derivation.mjs
@@ -371,7 +371,9 @@
  *
  * The one that remains, `CONTEXT_TOKEN_SUGGESTIONS` (@object-ui/core), is a
  * real mirror and goes to CLAIM_DEBT — see the note there for why a
- * shrink-only block is allowed to grow on a jurisdiction widening. Zero
+ * shrink-only block is allowed to grow on a jurisdiction widening. (Burned
+ * down at objectui#7265; the figures in this paragraph are the #6291
+ * measurement and stay as measured.) Zero
  * legitimate-local fallout, zero CLAIM_ALLOW entries, and the named pin in
  * `scripts/__tests__/check-spec-symbol-derivation.test.ts` was REWRITTEN
  * rather than deleted: it now asserts that a module-local claim IS flagged,
@@ -841,8 +843,10 @@ const ALLOW = {
 // could not serve either, being the card its own PR closes. objectui#7265 is the
 // open burn-down card for the population seeded here.
 // ⚠️ `CLAIM_DEBT_ISSUE` a few screens down has the same defect — objectui#4592 is
-// closed while its 19-entry block is live — and is deliberately NOT changed here,
-// because rule 2's ledger is not what objectui#6291 widened.
+// closed while its 18-entry block is live — and is deliberately NOT changed here,
+// because rule 2's ledger is not what objectui#6291 widened. (Still deliberate at
+// objectui#7265, which burned two entries out of the block below and one out of
+// that one; only the COUNT above moved, never the dead anchor itself.)
 const DEBT_ISSUE = 7265;
 // Re-seeded at objectui#6291, mechanically (`--ledger`), when rule 1 stopped
 // skipping module-local declarations. ⚠️ The block is SHRINK-ONLY and this is the
@@ -850,12 +854,19 @@ const DEBT_ISSUE = 7265;
 // pre-existing mirrors it could not previously SEE, not forks anybody wrote. A
 // name may not be added here for any other reason.
 //
-// All 13 are real mirrors, classified by reading each site — the four
+// All 11 are real mirrors, classified by reading each site — the four
 // different-concept collisions the same widening surfaced went to ALLOW with
 // reasons instead, and the two carrying standalone defects beyond the mirroring
 // already have cards (objectui#6286, objectui#6287). Re-adding a name here still
 // means "collides, not yet triaged"; a name whose triage concluded "deliberate
 // divergence" belongs in ALLOW instead.
+//
+// Burned down so far, in slices, each by the route its own site allowed:
+// `TreeConfig` (@object-ui/plugin-tree), then the @object-ui/core pair
+// `CONTEXT_TOKEN_SUGGESTIONS` / `isContextToken` at objectui#7265 — both
+// imported from `@objectstack/spec/data` after the identity the seeding card
+// asserted against 17.2.0 was RE-MEASURED against the resolved 17.4.0 pin,
+// because "byte-identical" is a statement about a version, not a property.
 const DEBT = {
   "@object-ui/app-shell": [
     "AdminScope",
@@ -864,10 +875,6 @@ const DEBT = {
     "FlowRuntimeState",
     "ObjectLike",
     "RemoteTable",
-  ],
-  "@object-ui/core": [
-    "CONTEXT_TOKEN_SUGGESTIONS",
-    "isContextToken",
   ],
   "@object-ui/types": [
     "UserFilterFieldSchema",
@@ -987,7 +994,9 @@ export const CLAIM_ALLOW = {
 // re-export precisely because "the copy was byte-identical, so every value
 // comparison and every behavioural test passed while it sat here". Burning it
 // down is the same edit that fixed the neighbour; it is listed rather than
-// excused because nothing about it is deliberate. Widening a rule's
+// excused because nothing about it is deliberate. ⇒ DONE at objectui#7265: the
+// site imports the spec's map, the claim went with the declaration that carried
+// it, and the entry left this block by `--claim-ledger`. Widening a rule's
 // jurisdiction is the ONLY sanctioned way this block grows, and it must be
 // mechanically regenerated (`--claim-ledger`) in that same commit.
 //
@@ -1026,7 +1035,6 @@ const CLAIM_DEBT = {
     "SubmitBehavior",
   ],
   "@object-ui/core": [
-    "CONTEXT_TOKEN_SUGGESTIONS",
     "ResultDialogFieldSpec",
     "ViewDataConfig",
   ],


### PR DESCRIPTION
Part of #7265 — the `@object-ui/core` slice, 2 of the entries seeded into the `DEBT` block of `scripts/check-spec-symbol-derivation.mjs`. Twelve entries remain, so this does not close the anchor; the gate's stale-ledger message points at that card and it closes when the ledger is empty.

## What changed

`packages/core/src/utils/filter-tokens.ts` carried module-local copies of two `@objectstack/spec/data` exports:

- `CONTEXT_TOKEN_SUGGESTIONS` — the nine-entry near-miss suggestion map
- `isContextToken` — the membership predicate

Both are imports now. Neither was ever exported from `@object-ui/core`, so no published surface moves. The file already re-exports `CONTEXT_TOKENS` from the same module, and 25 lines above the deleted map it explains why: "the copy was byte-identical, so every value comparison and every behavioural test passed while it sat here". This applies that argument to its two neighbours.

Both ledger blocks were regenerated mechanically, never hand-edited:

| block | before | after | command |
|---|---|---|---|
| `DEBT` (rule 1) | 13 names | 11 names | `--ledger` |
| `CLAIM_DEBT` (rule 2) | 19 names | 18 names | `--claim-ledger` |

Neither block gained an entry. The `CLAIM_DEBT` removal is not a rider — it is forced: rule 2's entry existed because the deleted `const` carried the comment "Mirrors `CONTEXT_TOKEN_SUGGESTIONS` in `@objectstack/spec`", and ratchet 5 fails the gate on a claim-ledger entry whose declaration is gone. `CLAIM_DEBT_ISSUE = 4592`'s dead anchor is deliberately left alone, as the card asks; only the entry count quoted in the comment beside it moved (19 to 18).

## The measurement, re-taken on the resolved pin

The card asserted byte-identity against `@objectstack/spec@17.2.0`. The resolved pin is **17.4.0**, so it was re-measured before the swap — "byte-identical" is a statement about a version, not a property.

```
resolved @objectstack/spec = 17.4.0

SUBJECT  local CONTEXT_TOKEN_SUGGESTIONS (HEAD 567f370)  vs  spec CONTEXT_TOKEN_SUGGESTIONS
  keys(local)=9 keys(other)=9  keyOrder=true values=true json=true
  => IDENTICAL

CONTROL  local CONTEXT_TOKEN_SUGGESTIONS  vs  spec CONTEXT_TOKEN_DESCRIPTIONS (pre-existing, same kind)
  keys(local)=9 keys(other)=2  keyOrder=false values=false json=false
  => DIVERGENT
  control lit (comparator can report a difference): true

SUBJECT2 predicate equivalence over 61 real vocabulary members
  local.isContextToken vs spec.isContextToken disagreements: 0
CONTROL2 local.isContextToken vs spec.isDateMacroToken (pre-existing, same kind)
  disagreements: 38 — control lit: true
```

The local side is the HEAD bytes: `git show HEAD:packages/core/src/utils/filter-tokens.ts`, transpiled and imported, so nothing in this diff can supply the answer. Each control is **pre-existing** (a spec export that predates this branch) and of the **same kind** as its subject (a context-token string map; a `(token) to boolean` token predicate from the same subpath), run through the **same** comparator.

Whole-resolver A/B, because the stop condition is about what the predicate accepts and rejects, not about the map:

```
A/B over 62 tokens x 2 placeholder spellings x 2 scopes = 248 cases
divergences: 0
CONTROL (before vs a do-nothing resolver): divergences 72 — lit: true
```

Returned values **and** warning text are byte-identical in every case, signed-in and signed-out, in both the brace and dollar-brace spellings, including prototype-key spellings.

## One type-level difference, handled rather than papered over

The spec's predicate is `isContextToken(token: string): boolean`; the deleted local one was a narrowing `token is ContextTokenName`. The narrowed branch feeds a scope lookup, so the lookup is now annotated `Record<string, …>` with a `satisfies Record<ContextTokenName, …>` clause. That keeps the only thing the narrowing bought — a third context token in the spec reds this literal at compile time instead of resolving to `undefined` at runtime — with no unchecked assertion anywhere. A runtime pin states the same ratchet so the failure names itself.

The declared floor also holds: `@object-ui/core` declares `@objectstack/spec` `^17.3.0`, and both names are in the published export list of `dist/data/index.d.ts` at 17.3.0 and 17.2.0 (checked against the registry tarballs, with a negative control name that answered "not in the export list").

## Verification

- `pnpm exec vitest run` over the two site test files plus every `scripts/__tests__` file that names the edited gate script (`check-spec-symbol-derivation.test.ts`, `check-doc-component-types.test.ts`, `check-doc-example-shared-reader.test.ts`, `spec-symbol-ledger-core-7265.test.ts`) — **6 files, 177 tests passed**. Editing a gate script owes its own suite on top of the families it derives, and `git grep -l` over the test dirs is how that set was found rather than recalled.
- `pnpm --filter @object-ui/core type-check` — exit 0 (covers `tsconfig.test.json` too)
- `pnpm run type-check:scripts` — exit 0
- `check:spec-symbols` exit 0 — 13 untriaged collisions to **11**, 19 unbacked claims to **18**, stale-ledger message does not fire
- `check:control-bytes`, `check:installed-pin-claims`, `check:changeset-claims`, `check:new-line-citations`, `check:comment-mask-corpus`, `check:unreferenced-sources`, `check:phantom-deps`, `check:unused-deps` — all exit 0
- `check-changeset-presence` exit 0 — empty-frontmatter changeset, declared as releasing nothing
- `check:spec-floors` — **PREREQUISITE NOT MET on an unbuilt tree**, and narrowed rather than skipped. On the tree as checked out it reports 17 `no-artifact` findings across 17 packages ("produced no build output to judge"), `@object-ui/core` among them. After `pnpm --filter @object-ui/core build`, `@object-ui/core` **drops out of the finding list** (17 to 16) — it was judged, and judged clean; the artifact count it inspected went 128 to 328 and the (subpath, symbol) pairs judged went 135 to 170. The remaining 16 are unbuilt sibling packages, a whole-workspace-build precondition CI satisfies, not a verdict on this diff. The floor question it would answer was answered directly against the registry above.
- `pnpm lint` — **narrowed, declared.** Three readings, because a narrowing is only a measurement if all three are present: (i) the population comes from eslint's own resolved configuration, not a guess — `isPathIgnored` over the tracked tree says **4800 of 4801** lintable-extension files are in scope; (ii) the narrowed run covered **4** files, counted from `--format json` output, `exit 0`, 0 errors and 6 warnings; (iii) the invariance claim: this repo does **not** enable type-aware linting (no `parserOptions.project` and no `projectService` anywhere in `eslint.config.js`; it extends `tseslint.configs.recommended`, not the type-checked variant), so nothing in this diff can move the verdict on any untouched file. The 6 warnings are pre-existing `no-explicit-any` hits — the word `any` occurs 6 times in the file at 567f370 and 6 times at HEAD, and this diff adds and removes zero lines containing it. The full farm run stays with CI.

Every exit code above was captured by redirect before any pipe. All of them were taken on `f3891fa`, the head of this branch (`git rev-parse --short HEAD`), after the final commit.

## Ablation

Restore the two module-local declarations at the site, leave both ledgers as this branch left them:

```
grep -c 'const CONTEXT_TOKEN_SUGGESTIONS' = 1   (expect 1)
grep -c 'function isContextToken'         = 1   (expect 1)
HEAD blob    = f101d80df90b842125a046bf84247eeb89bd0165
mutated blob = c6f00d6fddf670761e2d5b8ddc2911ec0c9e3d84

spec-symbol-ledger-core-7265.test.ts:  Tests 2 failed | 4 passed (6)
GATE_EXIT_ON_ABLATED_TREE=1
  rule 1: @object-ui/core declares 2 spec-named symbols the spec already owns
  rule 2: @object-ui/core claims spec alignment on 1 declaration that references nothing from the spec
```

Restored and proven clean **by state**, not by an exit code — `git diff HEAD` empty, `git status --porcelain` empty, and the blob hash back to HEAD's `f101d80df90b842125a046bf84247eeb89bd0165`. The mutation ran under a shell `trap RESTORE EXIT INT TERM` with an absolute repo-root path.

## Acceptance notes

Noted while measuring, **not fixed here** and out of this slice's fence:

- The suggestion lookup is a plain-object index, so `{constructor}` and `{__proto__}` reach `Object.prototype` and warn with nonsense suggestion text (`did you mean "{function Object() { [native code] }}"` / `did you mean "{[object Object]}"`). Behaviour is **unchanged by this diff** — it is identical before and after, and the same pattern lives in the spec's own `classifyFilterToken` over the same map. Filed as #9129 rather than fixed here (the dedup search ran with two lit controls that both returned hits in the same minute, so the zero on the dedup query is a real negative).
- The `DEBT` block had already drifted from the card's census before this slice: the card lists 14 names including `TreeConfig` (`@object-ui/plugin-tree`), and the block held 13 on `origin/main` at 567f370. `--ledger` removed exactly this slice's two, no more and no fewer — the next slice should plan against 11, not 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ