### PR TITLE
fix(app-shell): rank the two remaining spec-declared lookup spellings first in resolveActionParams (objectui#7435)

### DIFF
--- a/.changeset/7435-remaining-declared-lookup-legs.md
+++ b/.changeset/7435-remaining-declared-lookup-legs.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Read the two remaining spec-declared lookup spellings `resolveActionParams` could not see
+(objectui#7435).
+
+`resolveActionParams`' picker group read the resolved object-schema field def in
+`snake_case` only for `lookupColumns` and `lookupPageSize`. That def is what
+`getObjectSchema` / `useMetadata()` serve, and it carries the spelling
+`@objectstack/spec`'s `FieldSchema` declares — so both values were dropped on the floor
+and a field-backed action param rendered its record picker with default columns and a
+default page size. Nothing warned, because the resolver was simply reading keys that were
+not there. Each key now has its declared spelling ranked FIRST, with the existing
+`snake_case` leg kept behind it in its existing order — the shape objectui#7155
+established and objectui#9121 applied to `displayField` / `descriptionField` /
+`lookupFilters` at this same site.
+
+Measured on the pin this tree resolves, `@objectstack/spec@17.4.0`: `FieldSchema.safeParse`
+over a minimal lookup def accepts both camelCase keys and refuses both snake twins with
+`unrecognized_keys`, with the minimal def accepted and a nonsense key refused as controls
+in the same run.
+
+The legacy legs are kept rather than retired. A producer sweep found no in-repo producer
+of either snake spelling and zero key-position occurrences in the producer repo (controls
+lit), but two producers lie outside what that sweep measures: a document stored before the
+key was tightened, since the serve path runs no parse, and a host `DataSource` that never
+passes through the adapter's key canonicalisation.
+
+`dependsOn` — the third declared key recorded on this card — deliberately keeps its
+snake-only read. The camel leg was built and rendered before being refused: a field-backed
+lookup param whose def declares the spec spelling then renders a permanently gated,
+disabled picker, because the action dialog supplies dependent values only to the cascade
+option widgets and `lookup` is not one of them. That would trade a config-loss bug for an
+unusable picker, so the disposition is left to objectui#8672, which owns the question.

--- a/packages/app-shell/src/utils/resolveActionParams.remainingLookupLegs-7435.test.ts
+++ b/packages/app-shell/src/utils/resolveActionParams.remainingLookupLegs-7435.test.ts
@@ -1,0 +1,204 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ⭐ THE REMAINING DECLARED LOOKUP LEGS REACH THE PICKER — objectui#7435,
+ * second slice (`lookupColumns`, `lookupPageSize`).
+ *
+ * ## The defect, stated as what the author saw
+ *
+ * `resolveActionParams`' picker group read the resolved object-schema field def
+ * in `snake_case` ONLY for these two keys. `field` there is a `getObjectSchema`
+ * / `useMetadata()` document, which serves the spelling `@objectstack/spec`
+ * declares — so a field declaring `lookupColumns` / `lookupPageSize` had both
+ * values silently dropped and the action param's record picker rendered with
+ * default columns and a default page size. Nothing warned: the resolver read
+ * keys that were not there. The first slice repaired `displayField` /
+ * `descriptionField` / `lookupFilters` the same way.
+ *
+ * ## What each case asserts, and why it is the resolved VALUE
+ *
+ * Two exits are read, never "the resolver ran":
+ *
+ *   1. `ActionParamDef` — what this resolver EMITS.
+ *   2. the field object `paramToField()` hands `ActionParamDialog`, which is
+ *      what `LookupField` actually consumes. A value that reaches (1) but is
+ *      dropped at (2) is not a fix, and only the second exit can say so.
+ *      ⚠️ That bag is objectui's RUNTIME field metadata, whose spelling for
+ *      these two members is `lookup_columns` / `lookup_page_size` — a different
+ *      contract from the authored one, and deliberately not touched here.
+ *
+ * Camel and snake fixtures carry DIFFERENT values on every key, so no assertion
+ * can be satisfied by the wrong leg.
+ *
+ * ## Measured, on the pin this tree resolves
+ *
+ * `@objectstack/spec@17.4.0`. `FieldSchema.safeParse` over a minimal lookup def
+ * ACCEPTS `lookupColumns` and `lookupPageSize` and REJECTS `lookup_columns` /
+ * `lookup_page_size` with `unrecognized_keys`. Controls lit in the same run:
+ * the minimal def ACCEPTED, `zzz_not_a_real_key` REJECTED. {@link contract}
+ * re-runs that reading here, so the claim is checkable rather than quoted.
+ *
+ * ## ⛔ Why `dependsOn` — the third declared key of this slice — is NOT here
+ *
+ * It keeps its snake-only read, and the reason is MEASURED, not contractual:
+ * `FieldSchema` does declare `dependsOn`. Adding the camel leg was built and
+ * rendered before being refused — a field-backed lookup param whose def carries
+ * the declared spelling then renders `lookup-trigger-gated` and DISABLED, where
+ * the same def renders an enabled trigger today, with an otherwise identical
+ * lookup enabled beside it in both runs. The gate never lifts, because
+ * `ActionParamDialog` supplies `dependentValues` only to
+ * `CASCADE_OPTION_WIDGET_TYPES` and `lookup` is not a member. So the declared
+ * leg would trade a config-loss bug for an unusable picker.
+ *
+ * ⛔ That absence is NOT re-pinned here — it is already pinned, with a keystroke
+ * witness, by `views/ActionParamDialog.lookupDependsOnReach-8672.test.tsx` (leg
+ * A for the permanent gate, leg C for the `undefined` this read produces). A
+ * second copy of a pin is how two pins drift. Which disposition applies is
+ * objectui#8672's ruling to make.
+ */
+import { describe, it, expect } from 'vitest';
+import { FieldSchema } from '@objectstack/spec/data';
+import {
+  resolveActionParams,
+  type ResolveActionParamsContext,
+  type RawActionParam,
+} from './resolveActionParams';
+import { paramToField } from './paramToField';
+
+/** The camel column list — kept by reference so identity is assertable. */
+const CAMEL_COLUMNS = [{ field: 'name' }, { field: 'email' }];
+/** The snake column list — a DIFFERENT array, so the wrong leg cannot pass. */
+const SNAKE_COLUMNS = [{ field: 'legacy_name' }];
+
+/** Page sizes differ between the two dialects for the same reason. */
+const CAMEL_PAGE_SIZE = 25;
+const SNAKE_PAGE_SIZE = 5;
+
+/**
+ * Three lookup fields on one object, each isolating one reading of the chain.
+ *
+ * Cast once, at the boundary: these fixtures are object-schema documents, not
+ * the `RuntimeField` view the resolver narrows them to.
+ */
+const OBJECTS = [
+  {
+    name: 'quality_dispatch',
+    fields: {
+      // Declared (camelCase) spellings only — the shape `getObjectSchema` serves.
+      camel: {
+        type: 'lookup',
+        label: 'Camel',
+        reference: 'sys_user',
+        lookupColumns: CAMEL_COLUMNS,
+        lookupPageSize: CAMEL_PAGE_SIZE,
+      },
+      // The recorded dialect only — a document stored before the key tightened.
+      snake: {
+        type: 'lookup',
+        label: 'Snake',
+        reference: 'sys_user',
+        lookup_columns: SNAKE_COLUMNS,
+        lookup_page_size: SNAKE_PAGE_SIZE,
+      },
+      // Both present — the ranking case.
+      both: {
+        type: 'lookup',
+        label: 'Both',
+        reference: 'sys_user',
+        lookupColumns: CAMEL_COLUMNS,
+        lookup_columns: SNAKE_COLUMNS,
+        lookupPageSize: CAMEL_PAGE_SIZE,
+        lookup_page_size: SNAKE_PAGE_SIZE,
+      },
+    },
+  },
+] as unknown as ResolveActionParamsContext['objects'];
+
+const ctx = (): ResolveActionParamsContext => ({
+  objectName: 'quality_dispatch',
+  objects: OBJECTS,
+  fieldLabel: (_o, _f, fallback) => fallback,
+});
+
+/** Exit 1 — what this resolver emits for a field-backed param. */
+const resolved = (fieldName: string) => {
+  const params: RawActionParam[] = [{ field: fieldName }];
+  return resolveActionParams(params, ctx())[0];
+};
+
+/** Exit 2 — the field object `ActionParamDialog` hands the widget. */
+const widgetField = (fieldName: string) =>
+  paramToField(resolved(fieldName)) as unknown as Record<string, unknown>;
+
+describe('contract — the spellings this change ranks first are the ones `FieldSchema` declares (objectui#7435)', () => {
+  /** The minimal lookup definition, built from `FieldSchema.shape`: `type` is
+   * the only required member, and the target's declared spelling is
+   * `reference` — ⛔ not `referenceTo`, which is what voided the first slice's
+   * opening probe run. */
+  const MINIMAL = { type: 'lookup', name: 'owner', label: 'Owner', reference: 'sys_user' };
+
+  it('CONTROLS — the minimal lookup def is ACCEPTED and a nonsense key is REJECTED', () => {
+    // Without both, an "accepted" below could be a schema that accepts anything
+    // and a "rejected" could be a fixture broken for an unrelated reason.
+    expect(FieldSchema.safeParse(MINIMAL).success).toBe(true);
+    const nonsense = FieldSchema.safeParse({ ...MINIMAL, zzz_not_a_real_key: 'x' });
+    expect(nonsense.success).toBe(false);
+    expect(nonsense.error?.issues.some((i) => i.code === 'unrecognized_keys')).toBe(true);
+  });
+
+  it('declares `lookupColumns` and `lookupPageSize`, and refuses both snake twins', () => {
+    expect(FieldSchema.safeParse({ ...MINIMAL, lookupColumns: CAMEL_COLUMNS }).success).toBe(true);
+    expect(FieldSchema.safeParse({ ...MINIMAL, lookupPageSize: CAMEL_PAGE_SIZE }).success).toBe(true);
+    expect(FieldSchema.safeParse({ ...MINIMAL, lookup_columns: SNAKE_COLUMNS }).success).toBe(false);
+    expect(FieldSchema.safeParse({ ...MINIMAL, lookup_page_size: SNAKE_PAGE_SIZE }).success).toBe(false);
+  });
+});
+
+describe('resolveActionParams lookup group — the remaining declared spellings reach the picker (objectui#7435)', () => {
+  it('a camel-authored `lookupColumns` REACHES the resolved param and the widget', () => {
+    // Asserted by identity: the value is carried across, not cloned or reshaped.
+    expect(resolved('camel').lookupColumns).toBe(CAMEL_COLUMNS);
+    // Exit 2 spells it `lookup_columns` — the runtime bag's own key, which
+    // `LookupField` reads. The VALUE is what this case is about.
+    expect(widgetField('camel').lookup_columns).toBe(CAMEL_COLUMNS);
+  });
+
+  it('a camel-authored `lookupPageSize` REACHES the resolved param and the widget', () => {
+    expect(resolved('camel').lookupPageSize).toBe(CAMEL_PAGE_SIZE);
+    expect(widgetField('camel').lookup_page_size).toBe(CAMEL_PAGE_SIZE);
+  });
+
+  it('camel WINS over snake on both keys when both spellings are present', () => {
+    // The ranking needs its own case: a chain that merely CONTAINS the declared
+    // leg — appended last — passes every case above and fails only here.
+    const def = resolved('both');
+    expect(def.lookupColumns).toBe(CAMEL_COLUMNS);
+    expect(def.lookupPageSize).toBe(CAMEL_PAGE_SIZE);
+    expect(widgetField('both').lookup_columns).toBe(CAMEL_COLUMNS);
+    expect(widgetField('both').lookup_page_size).toBe(CAMEL_PAGE_SIZE);
+  });
+});
+
+describe('resolveActionParams lookup group — the recorded dialect still resolves (objectui#7435)', () => {
+  // The snake legs are KEPT: a producer sweep found no in-repo producer and
+  // zero key-position occurrences in the producer repo (controls lit), but a
+  // sweep measures what is EMITTED TODAY, not what is ALREADY STORED — a
+  // document written before the key tightened (the serve path runs no parse)
+  // and a host `DataSource` that never reaches the adapter's normalisation are
+  // both invisible to it.
+  it('a `lookup_columns`-only def still reaches the picker', () => {
+    expect(resolved('snake').lookupColumns).toBe(SNAKE_COLUMNS);
+    expect(widgetField('snake').lookup_columns).toBe(SNAKE_COLUMNS);
+  });
+
+  it('a `lookup_page_size`-only def still reaches the picker', () => {
+    expect(resolved('snake').lookupPageSize).toBe(SNAKE_PAGE_SIZE);
+    expect(widgetField('snake').lookup_page_size).toBe(SNAKE_PAGE_SIZE);
+  });
+});

--- a/packages/app-shell/src/utils/resolveActionParams.ts
+++ b/packages/app-shell/src/utils/resolveActionParams.ts
@@ -310,6 +310,13 @@ interface RuntimeField {
   // `displayField` / `descriptionField` / `lookupFilters` and REFUSES every
   // snake twin below with `unrecognized_keys`, controls lit in the same run.
   //
+  // ⭐ objectui#7435 second slice — `lookupColumns` and `lookupPageSize` join
+  // them on the same measurement, re-taken on the pin this tree resolves:
+  // `FieldSchema.safeParse` ACCEPTS both camel spellings and REFUSES
+  // `lookup_columns` / `lookup_page_size` with `unrecognized_keys`, with the
+  // minimal lookup def ACCEPTED and `zzz_not_a_real_key` REJECTED as controls
+  // in the same run.
+  //
   // ⛔ `id_field` and `title_format` deliberately gain NO camel twin. Measured
   // on that same pin, `FieldSchema` refuses `idField` exactly as it refuses
   // `id_field` (the spec's only `idField` is on `InlineGridColumnSchema`, a
@@ -317,6 +324,10 @@ interface RuntimeField {
   // target carries an ADR-0079 deprecation toward `nameField`. Declaring either
   // camel spelling here would fossilise a spelling no contract declares —
   // the exact defect this family exists to stop. Routed to objectui#7650.
+  //
+  // ⛔ `depends_on` gains no camel twin either, and its reason is the opposite
+  // shape: `FieldSchema` DOES declare `dependsOn`, so the omission is not
+  // contractual but MEASURED. See the read site below.
   reference_to?: string;
   reference?: string;
   displayField?: string;
@@ -326,9 +337,11 @@ interface RuntimeField {
   descriptionField?: string;
   description_field?: string;
   title_format?: string;
+  lookupColumns?: unknown[];
   lookup_columns?: unknown[];
   lookupFilters?: unknown[];
   lookup_filters?: unknown[];
+  lookupPageSize?: number;
   lookup_page_size?: number;
   depends_on?: unknown[];
 }
@@ -562,7 +575,8 @@ export function resolveActionParam(
         // serve path runs no parse, so retiring a snake read deletes the only read
         // of an authorable key. (That census sentence used to add "and none of the
         // four reads below has a camel leg" — objectui#7435 made that half false for
-        // three of them; the KEEP verdict it supports is unchanged.)
+        // three of them, and its second slice for `lookup_columns` and
+        // `lookup_page_size` too; the KEEP verdict it supports is unchanged.)
         //
         // ⭐ objectui#7435 — the DECLARED spelling is ranked FIRST on the three
         // keys that have one. Every read here used to be snake-only, so the
@@ -575,22 +589,42 @@ export function resolveActionParam(
         // parse — objectui#7650) and a host adapter outside this repo. Dropping
         // a leg is a retirement with its own evidence, not a side effect here.
         //
+        // ⭐ objectui#7435 second slice — `lookupColumns` and `lookupPageSize`
+        // get the same treatment, on the same re-taken measurement. Both are
+        // pure picker CONFIG: the value they carry changes what the picker
+        // shows, never whether it can be opened.
+        //
         // ⛔ `idField` and `titleFormat` keep their snake-only reads on purpose
         // — see {@link RuntimeField}. Neither has a `FieldSchema` spelling to
         // rank first, so there is nothing to add that would not fossilise an
-        // undeclared key. `lookupColumns` / `lookupPageSize` / `dependsOn` ARE
-        // declared and DO still read snake-only; they are outside this card's
-        // three-key scope and stay recorded on objectui#7435 rather than being
-        // swept in silently.
+        // undeclared key.
+        //
+        // ⛔ `dependsOn` is the third declared key of that slice and it keeps
+        // its snake-only read for a MEASURED reason, not a contractual one.
+        // Adding `field.dependsOn ?? field.depends_on` was built and rendered
+        // before being refused: a field-backed lookup param whose def declares
+        // the spec spelling then renders `lookup-trigger-gated` and DISABLED,
+        // where the same def renders an enabled trigger today (control: an
+        // otherwise identical lookup without the key, enabled in both runs).
+        // The gate never lifts — this dialog supplies `dependentValues` only to
+        // `CASCADE_OPTION_WIDGET_TYPES`, which excludes `lookup`, so
+        // `LookupField`'s `dependenciesMissing` can never clear. That is pinned,
+        // with a keystroke witness, by leg A of
+        // `views/ActionParamDialog.lookupDependsOnReach-8672.test.tsx`, and leg
+        // C of the same file pins the `undefined` this read produces today.
+        // ⇒ ranking the declared spelling first here would trade a config-loss
+        // bug for an unusable picker on every spec-valid def that declares the
+        // cascade. Which of objectui#8672's three dispositions to take — wire
+        // it, refuse it, declare the limit — is that card's ruling to make.
         referenceTo: param.reference ?? field.reference,
         displayField:
           field.displayField ?? field.display_field ?? field.reference_field,
         idField: field.id_field,
         descriptionField: field.descriptionField ?? field.description_field,
         titleFormat: field.title_format,
-        lookupColumns: field.lookup_columns,
+        lookupColumns: field.lookupColumns ?? field.lookup_columns,
         lookupFilters: field.lookupFilters ?? field.lookup_filters,
-        lookupPageSize: field.lookup_page_size,
+        lookupPageSize: field.lookupPageSize ?? field.lookup_page_size,
         dependsOn: field.depends_on,
       }
     : {};


### PR DESCRIPTION
`resolveActionParams`' picker group still read the resolved object-schema field def in
`snake_case` ONLY for `lookupColumns` and `lookupPageSize`. That def is what `getObjectSchema` /
`useMetadata()` serve, and it carries the spelling `@objectstack/spec`'s `FieldSchema` declares —
so both values were dropped on the floor and a field-backed action param rendered its record
picker with default columns and a default page size. Nothing warned: the resolver was reading keys
that were not there.

Each key now has its declared spelling ranked FIRST, with the existing snake leg kept behind it in
its existing relative order — the shape objectui#7155 established and PR objectui#9121 applied to
`displayField` / `descriptionField` / `lookupFilters` at this same site, three lines away —
and `RuntimeField` gains the two camel twins.

```
lookupColumns:  field.lookupColumns  ?? field.lookup_columns
lookupPageSize: field.lookupPageSize ?? field.lookup_page_size
```

Part of #7435

## Measured on the pin this tree resolves, with both controls lit

`@objectstack/spec@17.4.0`. The fixture was built FROM `FieldSchema.shape` (74 keys), not from
memory — the target's declared spelling is `reference`, which is what voided the previous slice's
first probe run.

| reading | result |
| :-- | :-- |
| CONTROL — minimal lookup def | ACCEPTED |
| CONTROL — `zzz_not_a_real_key` | REJECTED `unrecognized_keys` |
| `lookupColumns` / `lookupPageSize` / `dependsOn` in `FieldSchema.shape` | all three present |
| camel `lookupColumns`, `lookupPageSize` | ACCEPTED |
| snake `lookup_columns`, `lookup_page_size`, `depends_on` | REJECTED `unrecognized_keys` |
| carve-outs `idField` / `titleFormat` (and their snake twins) | REJECTED `unrecognized_keys` |

The carve-out row is re-measured rather than quoted: on this pin `FieldSchema` still refuses
`idField` and `titleFormat` in both casings, so the fence those two sit behind is intact and this
change adds no read of either. Their absence pins in
`resolveActionParams.declaredLookupLegs-7435.test.ts` stay green.

## Producer sweep — and why the snake legs stay anyway

Key-position occurrences in the producer repo, `objectstack` `origin/main` `e03cb88`:

```
lookup_columns    0 files      control lookupColumns    6 files
lookup_page_size  0 files      control lookupPageSize   4 files
depends_on        1 file       control dependsOn       37 files
```

The single `depends_on` hit is a `docker-compose` service key in a scaffold template, not field
metadata. In objectui itself every occurrence of the two snake keys is a test fixture, this
resolver's own read, `paramToField`'s emit onto the widget bag, or a register entry — no producer.

The legs stay regardless. A producer sweep measures what is EMITTED TODAY, not what is ALREADY
STORED: a document written before the key tightened (the serve path runs no parse) and a host
`DataSource` that never reaches the adapter's normalisation are both invisible to it.

## The third key of this slice, `dependsOn`, is deliberately NOT repaired — and this is measured

The dispatch scoped three keys. `dependsOn` is `FieldSchema`-declared exactly as the other two are,
so the reason it keeps its snake-only read is not contractual. The camel leg was BUILT AND RENDERED
before being refused. Readings from one dialog render of a field-backed lookup param, with an
otherwise identical lookup as control in both runs:

| tree | resolved `dependsOn` | subject trigger | control trigger |
| :-- | :-- | :-- | :-- |
| as shipped here (`bef003c`) | `undefined` | normal, ENABLED | enabled |
| with `field.dependsOn ?? field.depends_on` | `['account_id']` | `lookup-trigger-gated`, DISABLED | enabled |

And the gate never lifts: `ActionParamDialog` supplies `dependentValues` only to
`CASCADE_OPTION_WIDGET_TYPES`, which has no `lookup` member, so `LookupField`'s
`dependenciesMissing` can never clear. That is already pinned, with a keystroke witness, by leg A of
`ActionParamDialog.lookupDependsOnReach-8672.test.tsx`; leg C of the same file pins the `undefined`
in the first row.

So ranking the declared spelling first on this key would trade a config-loss bug for an UNUSABLE
picker on every spec-valid def that declares the cascade — the harm the dispatch's second stop
condition names, reached from the camel side rather than the snake side. objectui#8672 owns that
question and states in its own docblock that none of its three dispositions (wire it, refuse it,
declare the limit) has been chosen; this PR does not choose one for it. The absence is NOT re-pinned
here either — a second copy of a pin is how two pins drift.

The mutation was reverted and the tree proven clean BY STATE: `git diff HEAD` empty and the file's
blob hash back to `HEAD`'s.

## Acceptance — the resolved VALUE at BOTH exits

`resolveActionParams.remainingLookupLegs-7435.test.ts`, 7 cases. Exit 1 is the `ActionParamDef` the
resolver emits; exit 2 is the field object `paramToField()` hands `ActionParamDialog`, which is what
`LookupField` consumes. A value that reaches the first and is dropped at the second is not a repair,
and only the second exit can say so.

Per key: a camel-authored value reaches both exits, a snake-only def still resolves at both, and
camel WINS when both spellings are present. Camel and snake fixtures carry different values on every
key, so no assertion can be satisfied by the wrong leg, and the column lists are asserted BY
IDENTITY. Exit 2 spells these two members `lookup_columns` / `lookup_page_size` because that is what
objectui's own widget contract (`LookupFieldMetadata`) declares — a different contract from the
authored one, deliberately untouched.

## Ablation — each new leg, with its two cases red

Each leg was removed in turn, the mutation proven on disk (anchor count before, mutated count after,
blob hash moved), the file re-run, then restored with `git checkout HEAD -- PATH` and proven clean by
state. No build step is involved: the test imports the module under test by relative path inside the
same package, so no `dist` sits between the mutation and the assertion.

```
lookupColumns  ablated -> 2 failed | 5 passed
               x a camel-authored `lookupColumns` REACHES the resolved param and the widget
               x camel WINS over snake on both keys when both spellings are present
lookupPageSize ablated -> 2 failed | 5 passed
               x a camel-authored `lookupPageSize` REACHES the resolved param and the widget
               x camel WINS over snake on both keys when both spellings are present
restored       -> git diff HEAD empty, blob 4686671 == HEAD's blob
```

## Gates and tests

Run at `4a59e69`, exit codes captured by redirect before any pipe:

```
check:control-bytes                      0   (7322 tracked text files)
check:installed-pin-claims               0   (69 claim sites, 11 at the pin)
check:new-line-citations                 0   (0 new citations)
check:changeset-presence                 0   (1 released-package source file, 1 changeset)
check:changeset-no-major                 0
check:changeset-claims                   0
check-governed-queue-guard --test        0   NOT GOVERNED (3 paths vs 5 surfaces)
pnpm --filter @object-ui/app-shell build-closure   0   (dependency closure, under the shared lock)
pnpm --filter @object-ui/app-shell run type-check  0   (`tsc --noEmit && tsc -p tsconfig.test.json`;
                                                        the new test file confirmed present in that
                                                        project's 4495-file list)
vitest 25 consumer test files            0   378 passed
```

The 25 files are every test in the tree that reads `resolveActionParams` or `paramToField`, derived
by `git grep -l`. That set is a DECLARED NARROWING of the full app-shell suite; CI runs the rest.
It includes the first slice's carve-out pins and all three legs of the objectui#8672 pin file, so
the fences are checked rather than assumed.

eslint: the two touched files report 0 errors and 0 warnings under `--no-inline-config`. A root
`eslint .` run over the whole population — 4803 files, the count read from eslint's own JSON output
— reports 95 pre-existing errors in 79 files (`react-hooks/static-components`, `no-console` and
friends), none of them in this diff; the repo's wired lint command is the per-package
`turbo run lint`, and no type-aware linting is configured, so this diff cannot move a verdict on any
file it does not touch.

## Acceptance notes

- `ObjectChart` has no read of any of these keys in either casing, so nothing was added there:
  writing a read for a value that renderer never consumed would fabricate a consumer. Unchanged from
  the previous slice's correction.
- `@objectstack/spec` untouched. objectui#7650's ingestion choke point is named, not worked — worth
  recording that its fold rule, being derived from `FieldSchema.shape` by alias probe, already folds
  `lookup_columns` and `lookup_page_size` onto the declared spelling for any def arriving through a
  choke point, so the camel leg added here is the populated one there and the snake legs behind it
  protect the host-adapter case alone.
- The repo's own advice to authors, `RESOLVED_ONLY_PARAM_KEYS.dependsOn` ("make the param
  field-backed to pick it up"), still does not hold for a spec-valid `dependsOn` after this PR. That
  is objectui#8672 leg C's recorded subject, not a new finding, and it is the thing that card's
  ruling will settle.
- `LookupField` reads `lookup_columns` / `lookup_page_size` ahead of their camel twins. Checked and
  NOT a defect of the same class: on the widget bag the declared contract is `LookupFieldMetadata` in
  `@object-ui/types`, which declares the snake spellings, so that reader already ranks its own
  contract first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_