### PR TITLE
fix(react): carry the CEL predicate envelope through the ENABLEMENT keys too

### DIFF
--- a/.changeset/9107-enablement-cel-envelope-config-bag.md
+++ b/.changeset/9107-enablement-cel-envelope-config-bag.md
@@ -1,0 +1,31 @@
+---
+'@object-ui/react': minor
+---
+
+fix(react): keep the CEL predicate envelope intact on the ENABLEMENT keys too
+
+`SchemaRenderer`'s two per-value config-bag loops (`properties` — the spec
+spelling — and its legacy `props` alias) flattened a `{ dialect: 'cel', source }`
+predicate envelope on `disabled` / `disabledOn` / `enabled` down to its bare
+`source` string, exactly as objectui#9100 measured for the visibility chain. The
+envelope is the only thing that routes `evaluateCondition` to the canonical
+`@objectstack/formula` engine, so the flattened predicate took the legacy JS
+path, where a CEL stdlib call such as `has()` is not a function.
+
+objectui#9104 repaired this for the six visibility legs only. The enablement
+keys are not visibility legs — they route through the node's enablement gate and
+through the action renderers' own predicate call — so they were left flattened,
+and the resulting fail-soft `true` landed in OPPOSITE directions on the two
+halves of the chain:
+
+- `disabled` / `disabledOn` are not negated, so a CEL-authored gate greyed its
+  control out on every row and no predicate the author could write re-enabled
+  it — measured through `action:button` and `action:icon`;
+- the legacy `enabled` alias IS negated by those renderers, so the same `true`
+  arrived as "not disabled" and a control the author had disabled stayed
+  pressable.
+
+The guard now consults the union of the file's two closed predicate-chain
+declarations instead of the visibility one alone. `template` and dialect-less
+envelopes, non-predicate bag keys and predicates nested inside arrays keep their
+behaviour byte for byte.

--- a/packages/components/src/renderers/action/__tests__/action-enablement-cel-envelope.test.tsx
+++ b/packages/components/src/renderers/action/__tests__/action-enablement-cel-envelope.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9107 — the RENDER-LEVEL half: what a user could actually do.
+ *
+ * `packages/react/src/__tests__/SchemaRenderer.enablementEnvelopeConfigBag.test.tsx`
+ * pins the fix site itself. This file mounts the two renderers objectui#9107
+ * names as the carriers — `action:button` and `action:icon`, the only renderers
+ * declaring more than one of the three enablement keys — through the REAL
+ * `SchemaRenderer`, with the predicate authored at `properties` TOP LEVEL,
+ * which is the spelling the server emits and the one channel that runs through
+ * the per-value config-bag loops.
+ *
+ * ## What was measured on the pre-fix tree
+ *
+ * A CEL envelope in the bag was flattened to its bare `source` before either
+ * consumer saw it, so `has(…)` — which the legacy JS engine has no such
+ * function for — threw, and `evaluateCondition` fell soft to `true`. That
+ * `true` is UN-negated on this chain, so the button came out DISABLED whether
+ * the predicate held or failed: a control the author gated on a condition was
+ * dead on every row, and no predicate the author could write would re-enable
+ * it. Equal verdicts either way is the signature of a gate never consulted,
+ * which is why each case below asserts the PAIR and not one row.
+ *
+ * ## ⚠️ Why the legacy `enabled` leg is pinned one package over, not here
+ *
+ * `action:button` / `action:icon` compute `disabled` from `schema.enabled`
+ * (`toPredicateInput` -> `useCondition` -> `!isEnabled`) BEFORE
+ * `{...toFormControlDomProps(rest)}`, and `SchemaRenderer` always forwards a
+ * `disabled` key — `__disabled || undefined` — which that spread re-declares
+ * over the computed value. So the renderer's own verdict never reaches the DOM
+ * on this mount path. Measured, and PRE-EXISTING: a plain literal
+ * `enabled: false` with no envelope, no CEL and no config bag anywhere in it is
+ * disabled on a direct mount and NOT disabled through `SchemaRenderer`. That is
+ * objectui#7238's mechanism, left behind in these two renderers when it was
+ * repaired for `ui:button`; it is a different defect from this card and is
+ * filed separately, ⛔ not repaired here and ⛔ not pinned here either, because
+ * pinning a defect's current value makes its repair look like a regression.
+ * The `enabled` leg's own verdict is pinned in the react package, off a probe
+ * that reads the key exactly as these two do and does not re-spread a stale
+ * `disabled` over its own answer.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { SchemaRenderer, SchemaRendererProvider, PredicateScopeProvider } from '@object-ui/react';
+// Module-scope side-effect imports so the renderers are in the registry when
+// `ComponentRegistry.get` runs (the light `dom` project does not load the
+// `@object-ui/components` graph), per AGENTS.md §测试纪律 — the cost lands in
+// the import phase, not under a hook timeout.
+import '../action-button';
+import '../action-icon';
+
+const DATA = { status: 'draft' };
+
+/** CEL stdlib call + a comparison. `has` does not exist on the legacy engine. */
+const HOLDS = { dialect: 'cel', source: 'has(data.status) && data.status == "draft"' };
+const FAILS = { dialect: 'cel', source: 'has(data.status) && data.status == "published"' };
+
+function mountAction(type: 'action:button' | 'action:icon', properties: Record<string, unknown>) {
+  return render(
+    <SchemaRendererProvider dataSource={DATA}>
+      <PredicateScopeProvider scope={{ data: DATA }}>
+        <SchemaRenderer
+          schema={
+            {
+              type,
+              name: 'act',
+              label: 'Act',
+              icon: 'check',
+              actionType: 'script',
+              properties,
+            } as never
+          }
+        />
+      </PredicateScopeProvider>
+    </SchemaRendererProvider>,
+  );
+}
+
+const control = () => screen.getByRole('button') as HTMLButtonElement;
+
+/** Mount one key twice — holding and failing — and report whether the control was disabled. */
+function pair(type: 'action:button' | 'action:icon', key: string) {
+  const holds = (() => {
+    mountAction(type, { [key]: HOLDS });
+    const r = control().disabled;
+    cleanup();
+    return r;
+  })();
+  const fails = (() => {
+    mountAction(type, { [key]: FAILS });
+    const r = control().disabled;
+    cleanup();
+    return r;
+  })();
+  return { holds, fails };
+}
+
+afterEach(cleanup);
+
+describe.each(['action:button', 'action:icon'] as const)(
+  '%s — a CEL envelope authored in the `properties` bag actually gates the control',
+  (type) => {
+    // The `fails: false` half is what a flattened envelope could not produce:
+    // on the broken tree BOTH rows came out disabled.
+    it.each(['disabled', 'disabledOn'])(
+      'properties.%s: the holding row is disabled, the failing row is usable',
+      (key) => {
+        expect(pair(type, key)).toEqual({ holds: true, fails: false });
+      },
+    );
+
+    it('the control is really on screen in both rows, so "disabled" is not "never rendered"', () => {
+      // Without this, a `false` verdict would be indistinguishable from a
+      // renderer that returned `null` — `action:button` has a `visible` gate
+      // that does exactly that.
+      mountAction(type, { disabled: HOLDS });
+      expect(control()).toBeInTheDocument();
+      cleanup();
+      mountAction(type, { disabled: FAILS });
+      expect(control()).toBeInTheDocument();
+    });
+
+    it('a TEMPLATE envelope on the same key keeps its legacy `${…}` behaviour', () => {
+      // The guard matches the `cel` dialect alone; this is the no-op arm at
+      // render level rather than at the fix site.
+      mountAction(type, { disabled: { dialect: 'template', source: '${data.status === "draft"}' } });
+      expect(control().disabled).toBe(true);
+      cleanup();
+      mountAction(type, { disabled: { dialect: 'template', source: '${data.status === "published"}' } });
+      expect(control().disabled).toBe(false);
+    });
+  },
+);

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -257,10 +257,77 @@ type VisibilityChainKey =
  * The same six legs as a lookup, so the config-bag evaluation loops below can
  * ask "is this key a visibility predicate?" off the SAME declaration the chain
  * is built from rather than a second list that can drift from it.
+ *
+ * Since objectui#9107 those loops ask {@link PREDICATE_CHAIN_KEYS} — this set
+ * unioned with the enablement chain's — so this one is the VISIBILITY HALF of
+ * that union rather than the whole of it. Each chain still has exactly one
+ * declaration, which is the property this constant was added for.
  */
 const VISIBILITY_CHAIN_KEYS: ReadonlySet<string> = new Set<string>([
   ...VISIBILITY_SHOW_KEYS,
   ...VISIBILITY_HIDE_KEYS,
+]);
+
+/**
+ * The ENABLEMENT-chain keys — the SECOND predicate chain this file carries, and
+ * deliberately not a seventh leg of the visibility chain above (objectui#9107).
+ *
+ * Split the way this file actually consults them, which is not a polarity split:
+ *
+ *   * {@link ENABLEMENT_NODE_GATE_KEYS} are the two legs
+ *     {@link evaluateEnablementPredicate} consults HERE, in this precedence
+ *     order, as one early-return chain — the enablement counterpart of
+ *     `shouldHide`. Their `true` means DISABLED, un-negated.
+ *   * {@link ENABLEMENT_RENDERER_KEYS} is the legacy, non-spec `enabled` alias.
+ *     This component never evaluates it: the node gate does not consult it at
+ *     all, and the action renderers (`action:button`, `action:icon`) read it one
+ *     layer down off the schema and NEGATE it (`disabled = !isEnabled`). It is
+ *     declared here because the config-bag loops below flatten it exactly like
+ *     the other two — which is the whole defect — not because anything in this
+ *     file decides with it.
+ *
+ * ## Why a second declaration instead of widening the visibility chain
+ *
+ * {@link VisibilityChainKey} exists "so a seventh cannot be added to the chain
+ * without also being classified below", and {@link visibilityGateKind} is that
+ * classification — it hands each leg the consequence copy for ITS polarity.
+ * These three keys have neither property: they route through
+ * {@link evaluateEnablementPredicate}, which states `'enablement'` at its own
+ * call site, and `enabled` is not consulted here at all. Adding them to
+ * {@link VISIBILITY_SHOW_KEYS} / {@link VISIBILITY_HIDE_KEYS} to reach the
+ * guard would make that closed type assert something false about them, and
+ * would silently enrol them in `shouldHide`'s early-return chain and in the
+ * visibility consequence copy as a side effect of a config-bag repair.
+ *
+ * So the two chains stay two declarations, and the GUARD takes their union
+ * ({@link PREDICATE_CHAIN_KEYS}) — one lookup, derived, declared nowhere twice.
+ * The alternative shape (one flat predicate-chain set that both chains derive
+ * FROM) was rejected for the opposite reason: the chains do not share an order,
+ * a declared-test or a consequence, so the thing they genuinely share is only
+ * the guard's question, and that is exactly what a derived union expresses.
+ */
+const ENABLEMENT_NODE_GATE_KEYS = ['disabled', 'disabledOn'] as const;
+const ENABLEMENT_RENDERER_KEYS = ['enabled'] as const;
+
+/**
+ * The two legs the node gate itself consults, as ONE closed type — the
+ * enablement counterpart of {@link VisibilityChainKey}, load-bearing for the
+ * same reason: a third node-gate leg cannot be handed to
+ * {@link evaluateEnablementPredicate} without being declared above, which is
+ * the same edit that puts it into the config-bag guard below.
+ */
+type EnablementNodeGateKey = (typeof ENABLEMENT_NODE_GATE_KEYS)[number];
+
+/**
+ * Every key either predicate chain owns, as ONE lookup for the config-bag
+ * evaluation loops. DERIVED from the four declarations above and declared
+ * nowhere else, so a leg added to either chain is covered by the guard in the
+ * same edit that adds it.
+ */
+const PREDICATE_CHAIN_KEYS: ReadonlySet<string> = new Set<string>([
+  ...VISIBILITY_CHAIN_KEYS,
+  ...ENABLEMENT_NODE_GATE_KEYS,
+  ...ENABLEMENT_RENDERER_KEYS,
 ]);
 
 /**
@@ -333,20 +400,54 @@ const isCelEnvelope = (value: unknown): boolean =>
  * `record:alert` `properties.visible` is a TOP-LEVEL bag key and is hit
  * head-on. Same normalizer, different depth.
  *
+ * ## The enablement chain carries the identical defect (objectui#9107)
+ *
+ * `disabled` / `disabledOn` / `enabled` sit in the same two bags and are
+ * flattened by the same two loops, but they are NOT visibility legs — they
+ * route through {@link evaluateEnablementPredicate} and the action renderers'
+ * own `useCondition` call. Measured on the pre-fix tree through this component,
+ * with a CEL stdlib predicate authored at `properties` top level, and the two
+ * halves fail in OPPOSITE directions just as the visibility polarities do:
+ *
+ *   * `disabled` / `disabledOn` — BOTH a holding and a failing predicate left
+ *     the control DISABLED. The flattened source faults on the legacy engine
+ *     and `evaluateCondition`'s fail-soft `true` is un-negated here, so every
+ *     CEL-authored enablement gate greyed its control out on every row, with
+ *     no predicate an author could write to re-enable it.
+ *   * `enabled` — BOTH left the control ENABLED, because the renderers negate
+ *     that leg (`disabled = !isEnabled`), so the same fail-soft `true` lands on
+ *     "not disabled": a control the author disabled stayed pressable.
+ *
+ * ⇒ neither polarity alone detects this. A disabled-only suite is green on the
+ * broken `disabled` legs; an enabled-only suite is green on the broken
+ * `enabled` leg. Both are pinned, per key, in
+ * `__tests__/SchemaRenderer.enablementEnvelopeConfigBag.test.tsx`.
+ *
  * ## Scope
  *
- * Restricted to {@link VISIBILITY_CHAIN_KEYS} — the closed set this file
- * already declares and `shouldHide` / {@link winningVisibilityKey} already
- * consult. Every consumer of those six keys takes the envelope by contract
- * (`evaluateCondition`, `toPredicateInput`), and the metadata destructure near
- * `createElement` strips all six, so no object value can reach the DOM through
- * this. A non-predicate key keeps the flattening it has always had.
+ * Restricted to {@link PREDICATE_CHAIN_KEYS} — the union of the two closed
+ * chain declarations this file already carries, which `shouldHide` /
+ * {@link winningVisibilityKey} and {@link evaluateEnablementPredicate} already
+ * consult. Every consumer of those nine keys takes the envelope by contract
+ * (`evaluateCondition`, `toPredicateInput`). A non-predicate key keeps the
+ * flattening it has always had.
+ *
+ * Eight of the nine are stripped by the metadata destructure near
+ * `createElement`, so no object value can reach the DOM through them. The
+ * ninth, the legacy `enabled` alias, is not stripped — the action renderers
+ * read it off the schema, not off React props. Measured on a renderer that
+ * spreads what it is handed onto a DOM node: that attribute already carried the
+ * raw CEL SOURCE TEXT before this change and carries `[object Object]` after
+ * it, which is the same inert shape the `properties` bag itself already puts on
+ * every such node, with no React warning in either direction. Both spellings
+ * are meaningless to the DOM; the leak is pre-existing and is deliberately NOT
+ * repaired here.
  */
 const preservePredicateEnvelope = (
   key: string,
   value: unknown,
   evaluate: (v: unknown) => unknown,
-): unknown => (VISIBILITY_CHAIN_KEYS.has(key) && isCelEnvelope(value) ? value : evaluate(value));
+): unknown => (PREDICATE_CHAIN_KEYS.has(key) && isCelEnvelope(value) ? value : evaluate(value));
 
 /**
  * Which CONSEQUENCE the diagnostic should print for a faulting predicate on
@@ -935,6 +1036,15 @@ export const SchemaRenderer: ForwardRefExoticComponent<
      * that copy, and it carries the same #5330 dissolution pointer #5687's
      * entry does: both legs retire together when that window closes.
      *
+     * ## The `key` parameter is CLOSED (objectui#9107)
+     *
+     * Typed {@link EnablementNodeGateKey} rather than `string`, mirroring what
+     * {@link VisibilityChainKey} does for the sibling chain: the two legs this
+     * function serves are declared in ONE place, and the config-bag guard
+     * ({@link preservePredicateEnvelope}) reads that same declaration, so a
+     * third leg cannot arrive here without the same edit also carrying its CEL
+     * envelope through the bag loops.
+     *
      * Reachable only on the branch where the predicate evaluated CLEANLY —
      * `faulted` mirrors {@link evaluateVisibilityPredicate}'s try/catch split
      * without paying for a second (`throwOnError`) engine call: `onFault` is
@@ -943,7 +1053,7 @@ export const SchemaRenderer: ForwardRefExoticComponent<
      * re-deriving it. A predicate that faults is the OTHER reporter's case,
      * immediately above, in the same way it already is on the visibility leg.
      */
-    const evaluateEnablementPredicate = (raw: VisibilityPredicate, key: string): boolean => {
+    const evaluateEnablementPredicate = (raw: VisibilityPredicate, key: EnablementNodeGateKey): boolean => {
       let faulted = false;
       const verdict = evaluator.evaluateCondition(raw, {
         onFault: (reason) => {

--- a/packages/react/src/__tests__/SchemaRenderer.enablementEnvelopeConfigBag.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.enablementEnvelopeConfigBag.test.tsx
@@ -1,0 +1,322 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9107 — the ENABLEMENT keys carry objectui#9100's defect, and this is
+ * the sibling of `SchemaRenderer.predicateEnvelopeConfigBag.test.tsx`.
+ *
+ * ## The same two loops, a different chain
+ *
+ * `disabled` / `disabledOn` / `enabled` sit in the same per-value `properties` /
+ * `props` loops objectui#9100 measured, and were handed to
+ * `ExpressionEvaluator.evaluate`, whose FIRST action unwraps any
+ * `{ source: string }` object down to its bare `source`. The envelope is the
+ * only thing that routes `evaluateCondition` to the canonical
+ * `@objectstack/formula` engine, so the flattened predicate took the legacy JS
+ * path, where a CEL stdlib call is not a function.
+ *
+ * They are NOT a seventh visibility leg: they route through
+ * `evaluateEnablementPredicate` (the node gate) and through the action
+ * renderers' own `useCondition` call (the legacy `enabled` alias), which is why
+ * objectui#9104's guard — restricted to the six visibility legs — did not cover
+ * them.
+ *
+ * ## Both polarities, and this chain's are the OPPOSITE way round to the card's
+ *
+ * MEASURED on the pre-fix tree, through this component, `properties` top level:
+ *
+ *   | key          | predicate HOLDS | predicate FAILS | reading                |
+ *   |--------------|-----------------|-----------------|------------------------|
+ *   | `disabled`   | DISABLED        | DISABLED        | fail-CLOSED, never gated |
+ *   | `disabledOn` | DISABLED        | DISABLED        | fail-CLOSED, never gated |
+ *   | `enabled`    | enabled         | enabled         | fail-OPEN, never gated   |
+ *
+ * A pair of EQUAL verdicts is the signature of a gate that was never consulted,
+ * whichever way it landed. The two halves land in opposite directions because
+ * `evaluateCondition`'s fail-soft answer is `true` on every internal path, and
+ * the renderers NEGATE the `enabled` leg (`disabled = !isEnabled`) while the
+ * node gate does not negate `disabled` / `disabledOn`.
+ *
+ * ⇒ ⚠️ neither polarity alone detects this. A suite asserting only the DISABLED
+ * case is green on the two broken `disabled` legs; a suite asserting only the
+ * ENABLED case is green on the broken `enabled` leg. Every key below is pinned
+ * in BOTH directions for that reason.
+ *
+ * ## Why the predicate carries a CEL stdlib call
+ *
+ * `has(…)` is the discriminator, not decoration: a predicate both engines can
+ * evaluate cannot detect the routing, and a suite written with one would have
+ * been green on the broken tree.
+ *
+ * ## Why every mount writes the key in the BAG, never on the node
+ *
+ * `SchemaRenderer.predicateEnvelopeDeclared.test.tsx` (objectui#7530) pins this
+ * same envelope on `disabled` at NODE level and was green throughout
+ * objectui#9100's entire lifetime — nothing runs over a node-level key, so that
+ * channel could never observe this. The `properties` spelling is what a
+ * published artifact and both `/api/v1/meta/*` endpoints emit. The node-level
+ * mount appears below exactly once, labelled as a CONTROL: it is green on the
+ * broken tree and on the fixed one, which is what isolates the defect to the
+ * config-bag channel rather than to the predicate or the harness.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import React from 'react';
+import { ComponentRegistry, ExpressionEvaluator } from '@object-ui/core';
+import { SchemaRenderer } from '../SchemaRenderer';
+import { SchemaRendererContext } from '../context/SchemaRendererContext';
+import { useCondition, toPredicateInput } from '../hooks/useExpression';
+
+const DATA = { status: 'draft' };
+
+/** CEL stdlib call + a comparison. `has` does not exist on the legacy engine. */
+const HOLDS = { dialect: 'cel', source: 'has(data.status) && data.status == "draft"' };
+const FAILS = { dialect: 'cel', source: 'has(data.status) && data.status == "published"' };
+/** Not evaluable on EITHER engine — the fault direction, measured rather than assumed. */
+const FAULTS = { dialect: 'cel', source: 'nope(((' };
+
+/**
+ * A control, in both senses of the word: a real `<button disabled>` whose
+ * disabled state is reached by the two channels the three keys actually use.
+ *
+ *   * `disabled` / `disabledOn` — the node gate's verdict, which this component
+ *     forwards as a real `disabled` React prop (`_disabled`).
+ *   * `enabled` — read off the schema and NEGATED, which is byte-for-byte what
+ *     `action:button` / `action:icon` do one layer down
+ *     (`toPredicateInput(schema.enabled)` -> `useCondition` -> `!isEnabled`).
+ *     The node gate never consults this key, so the renderer leg is the only
+ *     place its verdict can be observed at all.
+ *
+ * ⚠️ This probe does NOT re-spread the `disabled` prop it is handed over its own
+ * answer, and the two real renderers do — they compute `disabled` before
+ * `{...toFormControlDomProps(rest)}`, and `SchemaRenderer` always forwards a
+ * `disabled` key (`__disabled || undefined`), so the legacy leg's verdict is
+ * overwritten before it reaches the DOM on that mount path. Measured, and
+ * PRE-EXISTING: a plain literal `enabled: false` — no envelope, no CEL, no
+ * config bag — is disabled on a direct mount and NOT disabled through
+ * `SchemaRenderer`. That is objectui#7238's mechanism left behind in the two
+ * action renderers, a different defect from this card, filed separately and ⛔
+ * not repaired here. The probe deliberately reads the key the way those
+ * renderers read it and stops there, so this file measures the envelope's
+ * survival rather than that unrelated seam.
+ */
+const Probe = (props: { schema?: Record<string, unknown>; disabled?: boolean }) => {
+  const schema = props.schema ?? {};
+  const isEnabled = useCondition(toPredicateInput(schema.enabled) as never, { data: DATA });
+  const gatedByLegacyLeg = schema.enabled !== undefined && !isEnabled;
+  return (
+    <button
+      data-testid="probe"
+      // What the `props`-bag value still IS by the time a renderer reads it.
+      // `@object-ui/components`' `readProps` merges `{ ...schema.props,
+      // ...schema.properties }`, so that bag is a real consumer surface even
+      // though the node gate never consults it (objectui#9108, not repaired
+      // here).
+      data-props-kind={JSON.stringify(
+        Object.fromEntries(
+          Object.entries((schema.props ?? {}) as Record<string, unknown>).map(([k, v]) => [
+            k,
+            v && typeof v === 'object' ? `envelope:${String((v as { dialect?: unknown }).dialect)}` : typeof v,
+          ]),
+        ),
+      )}
+      disabled={Boolean(props.disabled) || gatedByLegacyLeg}
+    />
+  );
+};
+
+function mount(schema: unknown) {
+  return render(
+    <SchemaRendererContext.Provider value={{ dataSource: DATA } as never}>
+      <SchemaRenderer schema={schema as never} />
+    </SchemaRendererContext.Provider>,
+  );
+}
+
+/** Is the rendered control disabled? Throws rather than answering for a control that never rendered. */
+function isDisabled(): boolean {
+  return (screen.getByTestId('probe') as HTMLButtonElement).disabled;
+}
+
+/** Mount one bag twice — holding and failing — and report the pair. */
+function pair(key: string, bag: 'properties' | 'props' = 'properties') {
+  const holds = (() => {
+    mount({ type: 'probe-9107', [bag]: { [key]: HOLDS } });
+    const r = isDisabled();
+    cleanup();
+    return r;
+  })();
+  const fails = (() => {
+    mount({ type: 'probe-9107', [bag]: { [key]: FAILS } });
+    const r = isDisabled();
+    cleanup();
+    return r;
+  })();
+  return { holds, fails };
+}
+
+function useProbe() {
+  beforeEach(() => {
+    ComponentRegistry.register('probe-9107', Probe as never);
+  });
+  afterEach(() => {
+    cleanup();
+    ComponentRegistry.unregister?.('probe-9107');
+  });
+}
+
+describe('#9107 — a CEL envelope on an enablement key reaches the CEL engine', () => {
+  useProbe();
+
+  // The node-gate legs. `true` means DISABLED and is NOT negated, so the
+  // pre-fix fail-soft `true` left BOTH rows disabled: the `fails: false` half
+  // of this assertion is the one that was red on the broken tree.
+  it.each(['disabled', 'disabledOn'])(
+    'properties.%s (node gate): holds disables, fails leaves the control usable',
+    (key) => {
+      expect(pair(key)).toEqual({ holds: true, fails: false });
+    },
+  );
+
+  // The legacy renderer leg. It is NEGATED, so the pre-fix fail-soft `true`
+  // left BOTH rows ENABLED: here the `fails: true` half is the one that was red
+  // on the broken tree — the user pressing a button the author disabled.
+  it('properties.enabled (legacy renderer leg): holds leaves it usable, fails disables', () => {
+    expect(pair('enabled')).toEqual({ holds: false, fails: true });
+  });
+
+  /**
+   * CONTROL — ⛔ not a detector. This is the one channel objectui#7530 measured
+   * and the reason this card exists: it is green on the broken tree AND on the
+   * fixed one. Its job is to prove the predicates, the engines and this harness
+   * are right, so a red row above can only mean the config-bag channel.
+   */
+  it.each(['disabled', 'enabled'])(
+    'CONTROL — the same envelope written at NODE level already decided, before and after',
+    (key) => {
+      mount({ type: 'probe-9107', [key]: HOLDS });
+      const holds = isDisabled();
+      cleanup();
+      mount({ type: 'probe-9107', [key]: FAILS });
+      const fails = isDisabled();
+      // `disabled` holds -> disabled; `enabled` holds -> usable. Both gate.
+      expect({ holds, fails }).toEqual(key === 'disabled' ? { holds: true, fails: false } : { holds: false, fails: true });
+    },
+  );
+
+  /**
+   * The `props` alias gets the SAME guard, and it has to: objectui#5123 ruled
+   * "one answer per key, whichever channel reads it". What that bag CANNOT do
+   * is drive the node gate — the hoist copies `properties` onto the node and
+   * nothing copies `props` (objectui#9108, filed separately, ⛔ not repaired
+   * here) — so the assertion is on the value a renderer receives, not on a
+   * verdict.
+   */
+  it.each(['disabled', 'disabledOn', 'enabled'])(
+    'props.%s keeps its envelope for the renderer that reads that bag',
+    (key) => {
+      mount({ type: 'probe-9107', props: { [key]: HOLDS } });
+      expect(JSON.parse(screen.getByTestId('probe').getAttribute('data-props-kind') as string)).toEqual({
+        [key]: 'envelope:cel',
+      });
+    },
+  );
+});
+
+/**
+ * objectui#9107's ⭐ stop condition, measured rather than assumed: can a
+ * repaired gate leave a control permanently unreachable with no authored
+ * recourse?
+ *
+ * ⇒ No, and the direction of travel is the opposite of the one feared. The
+ * fault VERDICT is byte-for-byte unchanged by this card — `evaluateCondition`
+ * still fails soft to `true` — so what moves is only WHICH predicates fault.
+ * Before this change EVERY CEL-authored `disabled` gate faulted (the flattened
+ * source is not evaluable on the legacy engine), so it disabled its control on
+ * every row and no predicate the author could write would re-enable it. After
+ * it, only a genuinely unevaluable CEL source does, and a well-formed one
+ * decides — which is authored recourse where there was none.
+ */
+describe('#9107 — what a FAULTING enablement predicate does after the fix', () => {
+  useProbe();
+
+  it('a faulting predicate still fails soft, in each leg\'s own direction', () => {
+    mount({ type: 'probe-9107', properties: { disabled: FAULTS } });
+    // Un-negated leg: fail-soft `true` disables. Unchanged by this card.
+    expect(isDisabled()).toBe(true);
+    cleanup();
+    mount({ type: 'probe-9107', properties: { enabled: FAULTS } });
+    // Negated leg: the same `true` arrives as "not disabled". Unchanged too.
+    expect(isDisabled()).toBe(false);
+  });
+
+  it('and the recourse is real: a well-formed predicate re-enables the control', () => {
+    mount({ type: 'probe-9107', properties: { disabled: FAULTS } });
+    expect(isDisabled()).toBe(true);
+    cleanup();
+    // The same key, the same channel, a predicate the CEL engine can answer.
+    mount({ type: 'probe-9107', properties: { disabled: FAILS } });
+    expect(isDisabled()).toBe(false);
+  });
+});
+
+describe('#9107 — what the widened guard deliberately does NOT change', () => {
+  useProbe();
+
+  it('a TEMPLATE envelope on an enablement key still interpolates on the legacy path', () => {
+    // Only the `cel` dialect is held back. Widening this to "any envelope"
+    // would silently retire the template spelling.
+    mount({ type: 'probe-9107', properties: { disabled: { dialect: 'template', source: '${data.status === "draft"}' } } });
+    expect(isDisabled()).toBe(true);
+    cleanup();
+    mount({ type: 'probe-9107', properties: { disabled: { dialect: 'template', source: '${data.status === "published"}' } } });
+    expect(isDisabled()).toBe(false);
+  });
+
+  it('a NON-predicate bag key still has its envelope flattened as before', () => {
+    // The guard is keyed on the two predicate chains, not on the envelope
+    // alone, so `content` / `title` / … keep the behaviour they have always had.
+    const ev = new ExpressionEvaluator({ data: DATA });
+    expect(ev.evaluate({ dialect: 'cel', source: 'data.status' } as never)).toBe('data.status');
+  });
+
+  it('the loops are SHALLOW, so an enablement envelope nested in an array is passed through', () => {
+    // An action's own `disabled` sits inside `actions[]`, one level down.
+    // `evaluate` returns a non-string untouched and nothing walks into it,
+    // which is why the action path never carried this defect.
+    const ev = new ExpressionEvaluator({ data: DATA });
+    const nested = [{ name: 'a', disabled: HOLDS, enabled: HOLDS }];
+    expect(ev.evaluate(nested as never)).toEqual(nested);
+  });
+
+  /**
+   * The ONE stated consequence, pinned so it cannot drift silently.
+   *
+   * Eight of the nine guarded keys are stripped by the metadata destructure
+   * before `createElement`. The legacy `enabled` alias is not — the action
+   * renderers read it off the schema, not off React props — so on a renderer
+   * that spreads what it is handed onto a DOM node the attribute changes
+   * spelling: raw CEL source text before, `[object Object]` after. Both are
+   * inert, neither warns, and the same `[object Object]` is already what the
+   * `properties` bag itself puts on such a node. Pre-existing leak, ⛔ not
+   * repaired here.
+   */
+  it('the unstripped `enabled` alias reaches a spreading renderer as the envelope', () => {
+    const Spreader = ({ schema: _schema, ...rest }: Record<string, unknown>) => (
+      <div data-testid="spread" {...(rest as Record<string, never>)} />
+    );
+    ComponentRegistry.register('probe-9107-spread', Spreader as never);
+    try {
+      mount({ type: 'probe-9107-spread', properties: { enabled: HOLDS } });
+      expect(screen.getByTestId('spread').getAttribute('enabled')).toBe('[object Object]');
+    } finally {
+      ComponentRegistry.unregister?.('probe-9107-spread');
+    }
+  });
+});


### PR DESCRIPTION
Fixes #9107

Extends objectui#9104's config-bag guard from the six visibility legs to the three enablement keys. All measurements below are in-process through the real `SchemaRenderer`, on this branch, at `3cbe0e5`.

## ⭐ The card's mechanism holds. Its POLARITY does not — and the acceptance criterion built on it is half backwards.

The card and the dispatch both state: "fail-soft here means a control that should be DISABLED stays ENABLED … every assertion must be on the DISABLED case; a suite that only checks the enabled case is blind to this defect."

Measured on the pre-fix tree, `properties` top level, one CEL stdlib predicate mounted twice — once so it HOLDS, once so it FAILS:

| key | predicate HOLDS | predicate FAILS | reading |
|:--|:--|:--|:--|
| `properties.disabled` | DISABLED | **DISABLED** | fail-CLOSED |
| `properties.disabledOn` | DISABLED | **DISABLED** | fail-CLOSED |
| `properties.enabled` | enabled | **enabled** | fail-OPEN |

⇒ the stated polarity is true for **one** of the three keys. `evaluateCondition`'s fail-soft answer is `true` on every internal path; the node gate does **not** negate `disabled` / `disabledOn`, and the action renderers **do** negate `enabled` (`disabled = !isEnabled`). So the same `true` lands in opposite directions — exactly the SHOW/HIDE split objectui#9104 found on the visibility chain, one chain over.

**The consequence for the acceptance criterion is not cosmetic.** On the broken tree a `disabled` control is what BOTH rows produce, so a disabled-only suite is **green on the two `disabled` legs** — it is blind to two thirds of this defect, which is the property the criterion was written to prevent. The correct rule is the one objectui#9104 arrived at: pin the PAIR on every key, because a pair of EQUAL verdicts is the signature of a gate that was never consulted, whichever way it landed. Every case here asserts the pair.

⚠️ And it inverts the sharp stop condition — see the ⭐ section below.

## The shape decision, and why

`VISIBILITY_CHAIN_KEYS` is built from a closed type whose docblock exists "so a seventh cannot be added to the chain without also being classified below", and `visibilityGateKind` is that classification: it hands each leg the console consequence copy for ITS polarity. The enablement keys have neither property — they route through `evaluateEnablementPredicate`, which states `'enablement'` at its own call site, and `enabled` is not consulted by this component at all. Widening the visibility declaration to reach the guard would make that closed type assert something false and would silently enrol three keys in `shouldHide`'s early-return chain and in the visibility consequence copy, as a side effect of a config-bag repair.

**Chosen: two closed chain declarations, and the guard consults their DERIVED UNION.**

```
ENABLEMENT_NODE_GATE_KEYS  = ['disabled', 'disabledOn']   // the node gate's own chain
ENABLEMENT_RENDERER_KEYS   = ['enabled']                  // the legacy alias, renderer-only
PREDICATE_CHAIN_KEYS       = VISIBILITY_CHAIN_KEYS + both of the above
```

- The enablement split is **not** a polarity split, because that is not how this file consults them: `disabled` / `disabledOn` are the two legs `evaluateEnablementPredicate` runs as one early-return chain; `enabled` is never evaluated here at all. Splitting them the way they are actually read is what lets the first array become the closed PARAMETER TYPE of `evaluateEnablementPredicate` (`key: EnablementNodeGateKey`, was `string`) — so a third node-gate leg cannot arrive there without the same edit also carrying its envelope through the bag loops. That closes the enablement chain the way `VisibilityChainKey` closes the visibility one, rather than leaving a dead type behind.
- **The rejected alternative** — one flat predicate-chain set that both chains derive FROM — was rejected for the mirror-image reason: the two chains share no order, no declared-test and no consequence copy, so the only thing they genuinely share is the guard's question. A derived union says exactly that and nothing more; a shared parent would claim they are one chain.
- Nothing is declared twice: a leg added to either chain reaches the guard in the same edit that adds it.

## The fix

One line moves. `preservePredicateEnvelope` asks `PREDICATE_CHAIN_KEYS.has(key)` instead of `VISIBILITY_CHAIN_KEYS.has(key)`; everything else is the declarations above and their docblocks.

- ⛔ `ExpressionEvaluator.evaluate` is **not** touched. Its `{ source }` unwrap is what makes a `template` envelope interpolate; the fence objectui#9104 set holds, and the repair needed nothing from it.
- ⛔ `VisibilityChainKey` / `VISIBILITY_SHOW_KEYS` / `VISIBILITY_HIDE_KEYS` are **not** widened.
- ⛔ objectui#9108's defect (the `props` bag never driving the node gate) is **not** touched.
- `isCelEnvelope` still matches the `cel` dialect only, so `template` and dialect-less envelopes keep their `${…}` behaviour byte for byte.

### One stated consequence, on the ninth key

Eight of the nine guarded keys are stripped by the metadata destructure before `createElement`, so no object value can reach the DOM through them. The legacy `enabled` alias is **not** stripped — the action renderers read it off the schema, not off React props. Measured on a renderer that spreads what it is handed onto a DOM node:

| | attribute emitted |
|:--|:--|
| before | `enabled="has(data.status) && data.status == …"` (the raw CEL source text) |
| after | `enabled="[object Object]"` |

Neither warns; both are inert; the same `[object Object]` is already what the `properties` bag itself puts on such a node today. The leak is pre-existing and deliberately not repaired here. Pinned so it cannot drift silently.

## ⭐ ZONE 3's sharp stop condition, measured rather than assumed — and it points the other way

> Stop if a repaired enablement gate can leave a control permanently unreachable with no authored recourse. Today these predicates fail SOFT (control stays enabled); after your fix a FAULTING predicate could disable a control the author cannot re-enable.

**No stop, and the premise is inverted on the two keys it is about.** Two measurements:

1. **The fault VERDICT is byte-for-byte unchanged.** A genuinely unevaluable CEL source, post-fix: `disabled` -> disabled (un-negated fail-soft `true`), `enabled` -> not disabled (negated). Identical to the pre-fix readings. This card moves only WHICH predicates fault, never what a fault decides.
2. **The permanent-unreachability harm already exists on `main`, categorically, and this PR is what removes it.** Pre-fix, EVERY CEL-authored `disabled` / `disabledOn` gate faults — the flattened source is not evaluable on the legacy engine — so it greys its control out on every row, and no predicate the author can write re-enables it. That is a control permanently unreachable with no authored recourse, today, for the whole dialect. Post-fix a well-formed predicate decides; pinned as its own case ("the recourse is real"), which goes red under ablation.

⇒ the fix strictly INCREASES authored recourse on the two keys the stop condition names. On `enabled` the direction was fail-open and remains fail-open on a fault, so no control becomes unreachable there either.

## Acceptance

`packages/react/src/__tests__/SchemaRenderer.enablementEnvelopeConfigBag.test.tsx` — 14 cases at the fix site, every mount writing the key in a BAG:

- each of the three keys, at `properties` top level, both directions, with `has(…)` as the discriminator — a predicate both engines can evaluate cannot detect the routing at all;
- the matching row that must stay usable, so "disabled" is never satisfied by a control that failed to render (`getByTestId` throws rather than answering for an absent node);
- each of the three keys in the `props` bag, asserting the renderer receives `envelope:cel`;
- the three objectui#9104 no-op cases on this chain: template envelope unchanged, non-predicate key still flattened, shallow-array pass-through unchanged;
- the fault-direction pair and the recourse case (above);
- the `enabled` DOM-attribute consequence (above);
- one **CONTROL**, labelled as such: the same envelope at NODE level. It is green on the broken tree and on the fixed one — that is its job. It isolates a red row above to the config-bag channel rather than to the predicate, the engines or the harness. ⛔ It is not a detector, and it is the only node-level mount in the file: objectui#7530's pin was green through objectui#9100's entire lifetime precisely because every one of ITS mounts was node-level.

`packages/components/src/renderers/action/__tests__/action-enablement-cel-envelope.test.tsx` — 8 cases at render level, the two renderers the card names (`action:button`, `action:icon`), mounted through the real `SchemaRenderer` with the key at `properties` top level: the `disabled` / `disabledOn` pairs, the "really on screen" control, and the template no-op arm.

### ⚠️ Why the `enabled` leg is pinned one package over and NOT at render level

Because the assertion could not be made honestly, and the reason is a second, independent defect — **filed as objectui#9131, not repaired here.** Those two renderers compute `disabled` BEFORE `{...toFormControlDomProps(rest)}`, and `SchemaRenderer` always forwards a `disabled` KEY (`__disabled || undefined`); the spread re-declares it and wins, so the renderer's own verdict never reaches the DOM on that mount path. The control that makes it independent of this card: a plain literal `enabled: false` — no envelope, no CEL, no config bag — is disabled on a direct mount and NOT disabled through `SchemaRenderer`. That is objectui#7238's mechanism, left behind in these two renderers when it was repaired for `ui:button`. ⛔ The current (broken) value is deliberately NOT pinned, so that repairing objectui#9131 does not read as a regression here. The `enabled` verdict is instead pinned in the react package off a probe that reads the key exactly as those renderers do and does not re-spread a stale `disabled` over its own answer.

## Ablation — the guard is load-bearing

Mutated on disk at `3cbe0e5` (the guard's lookup reverted to objectui#9104's visibility-only set — the precise ablation of THIS card), proven landed, run, then restored. These suites resolve through vitest's source aliases, so no `dist/` leg is involved.

```
HEAD blob 67a602af   marker PREDICATE_CHAIN_KEYS.has(key)  1 -> 0
MUT  blob 21a343c7   marker VISIBILITY_CHAIN_KEYS.has(key) 0 -> 1
ABLATED:  Tests 12 failed | 20 passed (32)   Test Files 2 failed | 1 passed (3)
RESTORED: blob 67a602af == HEAD blob, `git diff HEAD` EMPTY
```

Restored **by state**, not by an exit code: the on-disk blob hash is back to HEAD's and `git diff HEAD --quiet` is clean.

The 12 red are exactly the detectors: all three `properties.KEY` pairs, all three `props.KEY` envelope-survival cases, both renderers x `disabled` / `disabledOn` at render level, the recourse case, and the DOM-attribute case. Green throughout, correctly: the node-level CONTROL, the fault-direction case (its verdict does not depend on the guard — it documents, it does not detect, and this is the run that proves which), all three no-op cases, and the whole of objectui#9104's own `SchemaRenderer.predicateEnvelopeConfigBag.test.tsx` — the mutation restores its guard exactly, so its staying green is the check that the ablation hit only what this card added.

## Gates

All at `3cbe0e5`, exit codes captured before any pipe (redirected to a file, then read).

| command | exit |
|:--|:--|
| `pnpm exec vitest run packages/react/src/ packages/components/src/` | **0** — 341 files, 3328 tests passed |
| `pnpm --filter "@object-ui/react^..." --filter "@object-ui/components^..." build` | **0** |
| `pnpm --filter @object-ui/react --filter @object-ui/components type-check` | **0** (`tsc --noEmit` + `tsc -p tsconfig.test.json`, so both new test files are covered) |
| `node scripts/check-changeset-presence.mjs` | **0** |
| `node scripts/check-changeset-fixed.mjs` | **0** |
| `node scripts/check-changeset-no-major.mjs` | **0** |
| `node scripts/check-changeset-claims.mjs` | **0** (report-only) |
| `node scripts/check-control-bytes.mjs` | **0** (7325 tracked text files) |
| `node scripts/check-new-cross-file-line-citations.mjs` | **0** (0 new citations) |
| `node scripts/check-governed-queue-guard.mjs --test …` | **0** — NOT GOVERNED, all 4 paths |
| `eslint` on the 3 changed source files, `--format json` | **0** — 0 errors, 16 warnings, **all pre-existing**: every warning line in `SchemaRenderer.tsx` falls outside this diff's hunks (hunks at 260/271/403/428/450/1039/1056; warnings at 57…1649), and both new files are 0/0 |

⚠️ The first `type-check` run exited 2 with 26 `TS2307 Cannot find module` errors — a stale dependency closure, not a finding. It is 0 after the closure build above; stated because a reader hitting that exit code should build first, not investigate.

**Declared narrowing.** The behaviour change is observable only by metadata carrying a `{dialect:'cel'}` envelope on one of three enablement keys at the TOP LEVEL of a `properties` / `props` bag. Every other shape is a no-op by construction, pinned by the three no-op cases. The repo-wide `pnpm lint` and the full-farm run are CI's, not measured here.

## Out-of-scope findings (⛔ not fixed here)

1. **Filed as objectui#9131** — `SchemaRenderer`'s forwarded `disabled` prop overwrites `action:button` / `action:icon`'s own computed verdict, so their legacy `enabled` leg has never gated through `SchemaRenderer` for ANY predicate shape. objectui#7238's class; independent of this card, proven by a literal-`false` control.
2. Noted, not filed: the unstripped `enabled` alias reaches a spreading renderer's DOM as an attribute (raw CEL source before, `[object Object]` after). Inert in both spellings and structurally identical to the `properties="[object Object]"` attribute already emitted on every such node. Carrier: objectui#9108 is queued on this same file and destructure region and would touch it naturally; filing it alone would be a cosmetic card with no user-visible harm behind it.

## Collision with objectui#9108 — EASIER, not harder

objectui#9108 makes the `props` bag drive the node gate. This PR touches neither the gate nor the hoist: its diff is a declaration block near line 260 and a single token on the guard line. The textual overlap with objectui#9108's expected hunks (the hoist and the `isDisabled` / `shouldHide` blocks) is nil. Semantically it is strictly helpful: once `props` drives the node gate, a `cel` envelope written in THAT bag will already survive to it, because the guard covers both loops — without this PR, objectui#9108 would newly expose the flattened enablement predicate through a second channel and would have had to fix this first.

## 维护者速读(草稿)

**改了什么** — `SchemaRenderer` 逐值求值节点 `properties` / `props` 时,除了六个可见性键之外,现在也不再把 `{ dialect: 'cel', source }` 断言信封拍平成裸字符串;新增的三个键是 `disabled` / `disabledOn` / `enabled`。守卫查的是两条断言链声明的**并集**,而不是把新键塞进可见性那条封闭类型里。

**为什么改** — 这是一个**静默失效**的启用/禁用门禁,而且两半方向相反。作者写 CEL 断言控制按钮是否可点:`disabled` / `disabledOn` 这两个键在修复前**恒为禁用**(拍平后落到遗留引擎,`has()` 不存在 ⇒ 抛错 ⇒ fail-soft `true` ⇒ 灰掉),作者写任何断言都救不回来;`enabled` 这个遗留别名被渲染器取反,于是恒为**可点**——作者明明禁用了的按钮,用户照样能按。两种都与「作者本意如此」在屏幕上完全同形。

**风险与代价(含回滚)** — 这是**行为变更**:此前从不生效的 CEL 信封启用门禁现在真的生效了。范围经实测收窄:只有把 `cel` 信封写在这三个键之一、且位于 `properties` / `props` **顶层**的元数据会变;`template` 信封、无 dialect 信封、非断言键、数组里嵌套的断言全部逐字节不变,各自钉住。⚠️ 一处已声明的连带:遗留 `enabled` 别名不在元数据剥离清单里,会以 `[object Object]` 出现在「把收到的 props 全摊到 DOM 上」那类渲染器的属性里——修复前那里是原始 CEL 源文本,两者同样无意义、都不报警,且同一个节点上本来就有一个 `properties="[object Object]"`。回滚成本低:守卫行一个词加一段声明,`git revert` 即可。

**席位意见** — (待填)

**你要做的** — 有两点需要裁定:① 上面那条「行为变更」是否接受(以前不咬人的门禁现在会咬);② 卡片与派发词声明的失效极性**实测被证伪**——三个键里只有一个符合「该禁用却仍可点」的描述,另外两个恰恰相反、是**恒禁用且作者无法解除**,复核请按实测的极性读,不要按卡片叙述读。另外 objectui#9131 是本轮顺带实测出来的独立缺陷(同两个渲染器,不同机制),已单独立卡、本 PR 未修。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_