### PR TITLE
fix(plugin-kanban): key both bucketing maps without Object.prototype

### DIFF
--- a/.changeset/9043-kanban-prototype-group-keys.md
+++ b/.changeset/9043-kanban-prototype-group-keys.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/plugin-kanban': patch
+---
+
+Fix the Kanban bucketer throwing (and mis-bucketing) when a record's `groupBy` value
+is a member name of `Object.prototype` (objectui#9043).
+
+`bucketCardsIntoColumns` built its label-to-lane map and its grouping accumulator as
+prototype-bearing object literals and then keyed both from **record data**, which no
+schema guards — `@objectstack/spec` narrows the lane `id` (objectui#8913), not the
+values stored in the grouped field. A stored value of `'toString'`, `'valueOf'` or
+`'hasOwnProperty'` therefore hit the inherited METHOD in the accumulator: it is truthy,
+so the array was never created and `.push` was called on a function, thrown during
+render — the user saw a blank board or an error boundary with nothing naming the
+offending record. `'constructor'` and `'__proto__'` took the other branch (they survive
+the `.toLowerCase()` on the label-map read) and were grouped under the stringified
+inherited member instead of their own value. A lane legitimately declared with one of
+these option values was worse still: writing `labelToColumnId['__proto__']` invoked the
+`__proto__` setter and was silently ignored, and the injection read `groups[col.id]`
+answered `Object.prototype`, which spreads as "not iterable".
+
+Both maps are now created with `Object.create(null)`, so every key is answered by what
+the function stored. A `hasOwnProperty` guard was not used: it closes the reads only,
+and the `'__proto__'` hazard is on the writes.
+
+Records that match no lane keep today's behaviour — they surface in the trailing
+"Uncategorized" lane (objectui#2792), never discarded. Bucketing for ordinary values is
+unchanged.

--- a/packages/plugin-kanban/src/__tests__/prototypeGroupKeys-9043.test.ts
+++ b/packages/plugin-kanban/src/__tests__/prototypeGroupKeys-9043.test.ts
@@ -1,0 +1,151 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9043 — `bucketCardsIntoColumns` built its two lookup maps as
+ * prototype-bearing object literals and then keyed them from RECORD DATA.
+ *
+ * ## The mechanism
+ *
+ * No schema guards these keys: `@objectstack/spec` narrows the lane `id`
+ * (objectui#8913), not the values stored in the grouped field. Imported legacy
+ * data, a free-text status field, or a picklist option whose stored value is a
+ * member name of `Object.prototype` all reach the maps, and a `{}` map answers
+ * such a key from the prototype instead of from what the function stored:
+ *
+ * - **The label map read** is `labelToColumnId[rawKey.toLowerCase()] ?? rawKey`.
+ *   `??` only falls back on null/undefined, so an INHERITED member is returned
+ *   as if it were a declared lane id, and the record is grouped under whatever
+ *   that member stringifies to.
+ * - **The label map write** is `labelToColumnId['__proto__'] = col.id`, which on
+ *   a prototype-bearing object invokes the `__proto__` setter and is silently
+ *   ignored for a string — a lane declared with that option value loses its
+ *   mapping entirely.
+ * - **The accumulator** does `if (!acc[key]) acc[key] = []; acc[key].push(...)`.
+ *   `acc['toString']` is the inherited METHOD, which is truthy, so the array is
+ *   never created and `.push` is called on a function. Thrown during render, so
+ *   the user sees a blank board or an error boundary with nothing naming the
+ *   offending record.
+ * - **The injection read** `groups[col.id] || []` is the same map a third time:
+ *   for a lane declared `{ id: '__proto__' }` it answers `Object.prototype`,
+ *   which is truthy and then spreads as "not iterable".
+ *
+ * Measured on `main` before the repair (`61afb87`), lanes `[{id:'a',title:'A'}]`,
+ * one record — the crash leg and the mis-bucket leg split on the `.toLowerCase()`
+ * in the label-map read, since `'toString'` lowercases to `'tostring'`, which is
+ * NOT an inherited member, while `'constructor'` and `'__proto__'` already are:
+ *
+ *     'ordinary_value' -> a:, __uncolumned__:r1            (clean — the control)
+ *     'toString'       -> THREW TypeError: acc[key].push is not a function
+ *     'valueOf'        -> THREW  (same)
+ *     'hasOwnProperty' -> THREW  (same)
+ *     'constructor'    -> a:, __uncolumned__:r1  — but grouped under the key
+ *                         "function Object() { [native code] }"
+ *     '__proto__'      -> a:, __uncolumned__:r1  — grouped under "[object Object]"
+ *
+ * ## What each row is for
+ *
+ * 1. CONTROLS — an ordinary value, matched by id, matched by label, and matched
+ *    by nothing. Green on BOTH sides of the repair. They are what make the rows
+ *    below statements about prototype member names rather than about bucketing
+ *    in general, and they are what separates a repair from a bucketer that
+ *    simply dropped everything: "nothing threw" is satisfied by both.
+ * 2. THE CRASH LEG — `toString` / `valueOf` / `hasOwnProperty`. Each asserts
+ *    WHICH LANE the record lands in, not merely that nothing threw.
+ * 3. THE MIS-BUCKET LEG — `constructor` / `__proto__`. ⚠️ These two were already
+ *    green at the LANE level before the repair (the table above): the label map
+ *    returned an inherited member, and the nonsense group key it produced still
+ *    matched no lane, so the record still fell into the trailing lane. They are
+ *    pinned because they are the reported readings; rows 4-6 are what make the
+ *    label map's defect observable in the return value.
+ * 4. DECLARED LANES — the picklist case, where the SAME option value produces
+ *    both the lane and the records. All three threw before the repair; each now
+ *    asserts the record reaches its declared lane, which is the reading the two
+ *    rows above cannot make.
+ * 5. NOTHING IS DROPPED (#2792) — the fence this repair must not trade away. A
+ *    board carrying every offending value at once renders each record exactly
+ *    once. Rows 2-4 would all pass if such records were discarded instead of
+ *    bucketed, and that would swap a visible crash for a silent loss.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bucketCardsIntoColumns, KANBAN_UNCOLUMNED_ID } from '../index';
+
+/** `id:card+card` per lane, in lane order — the whole board in one string. */
+const summarise = (lanes: Array<any>): string =>
+  lanes
+    .map((l: any) => `${String(l.id)}:${(l.cards || []).map((c: any) => c.id).join('+')}`)
+    .join(', ');
+
+const bucket = (columns: Array<any>, data: Array<any>): string =>
+  summarise(bucketCardsIntoColumns(columns, data, 'status', undefined, 'Uncategorized'));
+
+/** The card's reproduction: one lane, one record, the group value under test. */
+const oneRecord = (status: unknown, columns: Array<any> = [{ id: 'a', title: 'A' }]): string =>
+  bucket(columns, [{ id: 'r1', title: 'R1', status }]);
+
+/** Every card id the board renders, across every lane, duplicates included. */
+const renderedCardIds = (columns: Array<any>, data: Array<any>): string[] =>
+  bucketCardsIntoColumns(columns, data, 'status', undefined, 'Uncategorized').flatMap(
+    (l: any) => (l.cards || []).map((c: any) => c.id),
+  );
+
+/** Every member name of `Object.prototype` a record could carry as its value. */
+const PROTOTYPE_MEMBERS = Object.getOwnPropertyNames(Object.prototype);
+
+describe('bucketCardsIntoColumns — prototype member names as group values (objectui#9043)', () => {
+  it('row 1a — CONTROL: an ordinary unmatched value lands in the trailing lane', () => {
+    expect(oneRecord('ordinary_value')).toBe(`a:, ${KANBAN_UNCOLUMNED_ID}:r1`);
+  });
+
+  it('row 1b — CONTROL: an ordinary value matching a lane id lands in that lane', () => {
+    expect(oneRecord('a')).toBe('a:r1');
+  });
+
+  it('row 1c — CONTROL: an ordinary value matching a lane LABEL still maps to its id', () => {
+    expect(oneRecord('A')).toBe('a:r1');
+  });
+
+  it.each(['toString', 'valueOf', 'hasOwnProperty'])(
+    'row 2 — CRASH LEG: %s is bucketed instead of throwing, and lands in the trailing lane',
+    (status) => {
+      expect(oneRecord(status)).toBe(`a:, ${KANBAN_UNCOLUMNED_ID}:r1`);
+    },
+  );
+
+  it.each(['constructor', '__proto__'])(
+    'row 3 — MIS-BUCKET LEG: %s matches no lane, so it lands in the trailing lane',
+    (status) => {
+      expect(oneRecord(status)).toBe(`a:, ${KANBAN_UNCOLUMNED_ID}:r1`);
+    },
+  );
+
+  it('row 4a — DECLARED LANE `__proto__` receives its record (the label map WRITE)', () => {
+    expect(oneRecord('__proto__', [{ id: '__proto__', title: 'Proto' }, { id: 'a', title: 'A' }])).toBe(
+      '__proto__:r1, a:',
+    );
+  });
+
+  it('row 4b — DECLARED LANE `constructor` receives its record', () => {
+    expect(oneRecord('constructor', [{ id: 'constructor', title: 'Ctor' }, { id: 'a', title: 'A' }])).toBe(
+      'constructor:r1, a:',
+    );
+  });
+
+  it('row 4c — DECLARED LANE `toString` receives a record that reached it by LABEL', () => {
+    expect(oneRecord('Done', [{ id: 'toString', title: 'Done' }, { id: 'a', title: 'A' }])).toBe(
+      'toString:r1, a:',
+    );
+  });
+
+  it('row 5 — every prototype member name is bucketed exactly once, never dropped', () => {
+    const data = PROTOTYPE_MEMBERS.map((name, i) => ({ id: `r${i}`, title: name, status: name }));
+    const ids = renderedCardIds([{ id: 'a', title: 'A' }], data);
+    expect([...ids].sort()).toEqual(data.map((d) => d.id).sort());
+  });
+});

--- a/packages/plugin-kanban/src/index.tsx
+++ b/packages/plugin-kanban/src/index.tsx
@@ -67,20 +67,42 @@ export function bucketCardsIntoColumns(
 
   // Build label→id mapping so data values (labels like "In Progress") match
   // column IDs (option values like "in_progress").
-  const labelToColumnId: Record<string, string> = {};
+  // ⚠️ Null prototype, not `{}` (objectui#9043). This map and `groups` below are
+  // keyed by RECORD DATA, which no schema guards — `@objectstack/spec` narrows the
+  // lane `id` (objectui#8913), not the values stored in the grouped field — so a
+  // stored value like 'constructor' or '__proto__' would otherwise be answered by
+  // `Object.prototype` instead of by what this function actually put here:
+  //   - the READ below is `labelToColumnId[k] ?? rawKey`, and `??` only falls back
+  //     on null/undefined, so an INHERITED member is returned as if it were a
+  //     declared lane id;
+  //   - the WRITE `labelToColumnId['__proto__'] = col.id` on a prototype-bearing
+  //     object invokes the `__proto__` setter, which silently ignores a string —
+  //     so a lane legitimately declared with that option value loses its mapping.
+  // `Object.prototype.hasOwnProperty.call(...)` would close the READ only; the
+  // write hazard needs the null prototype, which is why both maps take that route.
+  const labelToColumnId: Record<string, string> = Object.create(null);
   columns.forEach((col: any) => {
     if (col.id) labelToColumnId[String(col.id).toLowerCase()] = col.id;
     if (col.title) labelToColumnId[String(col.title).toLowerCase()] = col.id;
   });
 
   // 1. Group data by key, normalizing via label→id mapping.
+  // ⚠️ Null prototype for the same reason (objectui#9043), and this is the leg that
+  // CRASHES: on a `{}` accumulator `acc['toString']` is the inherited METHOD, which
+  // is truthy, so the array is never created and the next line calls `.push` on a
+  // function — thrown during render, so the user sees a blank board with nothing
+  // naming the record. `acc['__proto__'] = []` would likewise hit the setter and be
+  // dropped, and step 2's `groups[col.id]` read would answer `Object.prototype` for
+  // a lane declared `{ id: '__proto__' }`, which spreads as "not iterable".
+  // ⚠️ The repair keeps every record: an offending one keeps its own value as its
+  // group key and still surfaces in the trailing lane, never discarded (#2792).
   const groups = data.reduce((acc, item) => {
     const rawKey = String(item[groupBy] ?? '');
     const key = labelToColumnId[rawKey.toLowerCase()] ?? rawKey;
     if (!acc[key]) acc[key] = [];
     acc[key].push(mapCoverImage(item));
     return acc;
-  }, {} as Record<string, any[]>);
+  }, Object.create(null) as Record<string, any[]>);
 
   // 2. Inject into declared columns.
   const mapped = columns.map((col: any) => ({


### PR DESCRIPTION
Fixes #9043

Note on spelling: type parameters are written with ROUND brackets — `Record(string, string)` — because the angle-bracket form is stripped from stored bodies, including inside backticks (AGENTS.md, "GitHub mutates body BYTES"). Session reference for this work: `session_01UzHd6hDYatoDn17BuwKxnZ`.

## The defect

`bucketCardsIntoColumns` (`packages/plugin-kanban/src/index.tsx`) built its two lookup maps as prototype-bearing object literals and then keyed both from **record data**, which no schema guards — `@objectstack/spec` narrows the lane `id` (objectui#8913), not the values stored in the grouped field. Four distinct reads/writes of those maps were answered by `Object.prototype` instead of by what the function had stored:

1. **label map READ** — `labelToColumnId[rawKey.toLowerCase()] ?? rawKey`. `??` only falls back on null/undefined, so an inherited member is returned as if it were a declared lane id.
2. **accumulator** — `if (!acc[key]) acc[key] = []; acc[key].push(...)`. `acc['toString']` is the inherited METHOD, truthy, so the array is never created and `.push` is called on a function. Thrown during render.
3. **label map WRITE** — `labelToColumnId['__proto__'] = col.id` invokes the `__proto__` setter and is silently ignored for a string, so a lane declared with that option value loses its mapping. (Not in the card; found while re-deriving the current shape.)
4. **injection READ** — `groups[col.id] || []` answers `Object.prototype` for a lane declared `{ id: '__proto__' }`, which is truthy and then spreads as "not iterable". (Also not in the card.)

The two symptom shapes split on the `.toLowerCase()` in read 1: `'toString'` lowercases to `'tostring'`, which is not an inherited member, so it survives the label map and dies in the accumulator; `'constructor'` and `'__proto__'` are already lowercase, hit the label map, and never reach the crash.

## Route: `Object.create(null)` for both maps — and why not `hasOwnProperty`

`Object.prototype.hasOwnProperty.call(...)` closes the two READS. It does nothing for hazard 3, which is a WRITE: on a prototype-bearing object the `__proto__` assignment is swallowed by the setter no matter how the map is later read. A null prototype makes `__proto__` an ordinary own key and closes all four at once. This is not an argument — it is ablation leg B below, where the accumulator is closed and the label map is left open: the record silently lands in the wrong lane.

## Measured — the card's reproduction, before and after

Lanes `[{id:'a',title:'A'}]`, one record, `groupBy: 'status'`; `lane:cards` per lane. Taken with the card's own reproduction shape (the exported function called directly, nothing mounted), at `61afb87` vs this branch:

| `status` value | before (`main`) | after |
|---|---|---|
| `ordinary_value` (CONTROL) | `a:, __uncolumned__:r1` | `a:, __uncolumned__:r1` |
| `a` (CONTROL, by lane id) | `a:r1` | `a:r1` |
| `A` (CONTROL, by lane label) | `a:r1` | `a:r1` |
| `toString` | THREW TypeError: acc[key].push is not a function | `a:, __uncolumned__:r1` |
| `valueOf` | THREW (same) | `a:, __uncolumned__:r1` |
| `hasOwnProperty` | THREW (same) | `a:, __uncolumned__:r1` |
| `constructor` | `a:, __uncolumned__:r1` (grouped under the stringified `Object` constructor) | `a:, __uncolumned__:r1` |
| `__proto__` | `a:, __uncolumned__:r1` (grouped under the stringified `Object.prototype`) | `a:, __uncolumned__:r1` |

Declared-lane rows — the picklist case, where the same option value produces both the lane and the records:

| board | before (`main`) | after |
|---|---|---|
| lane `{id:'__proto__'}`, record `'__proto__'` | THREW TypeError: (groups[col.id] or []) is not iterable | `__proto__:r1, a:` |
| lane `{id:'constructor'}`, record `'constructor'` | THREW TypeError: acc[key].push is not a function | `constructor:r1, a:` |
| lane `{id:'toString',title:'Done'}`, record `'Done'` | THREW TypeError: acc[key].push is not a function | `toString:r1, a:` |

The three CONTROL rows are unchanged in both directions — closing the maps does not move bucketing for an ordinary value.

Nothing is dropped: an offending record keeps its own value as its group key and still surfaces in the trailing "Uncategorized" lane (objectui#2792). Pinned as row 5 of the new test: a board carrying every one of the twelve `Object.prototype` member names renders each record exactly once.

## Ablation — each map's fix removed separately

Each leg mutates `packages/plugin-kanban/src/index.tsx` on disk from the committed fix, proves the mutation landed (anchor counts plus a `git hash-object` that differs from the HEAD blob), runs the new pin file, then restores with `git checkout HEAD -- PATH` and proves the tree clean **by state** — `git diff HEAD` empty (0 bytes) and the blob hash back to HEAD's `390ef594e314aaf9c7261f391505b2b3be3d06a0` — never by an exit code. A `trap ... EXIT INT TERM` holds the restore.

| leg | label map | accumulator | pin file | what still breaks |
|---|---|---|---|---|
| A (= `main` today) | open `{}` | open `{}` | 7 failed / 5 passed | all three crash values; all three declared-lane rows; the no-drop row |
| B | open `{}` | `Object.create(null)` | 1 failed / 11 passed | ONLY the declared `__proto__` lane — silently, no throw: `Expected "__proto__:r1, a:" / Received "__proto__:, a:, __uncolumned__:r1"` |
| C | `Object.create(null)` | open `{}` | 9 failed / 3 passed | the three crash values, both declared-lane crash rows — **and `constructor` / `__proto__`, which now THROW** `acc[key].push is not a function` where before they were silently mis-bucketed |

Leg C is the PM's "repairing one moves the failure" claim, measured: closing the label map alone converts the mis-bucket leg into a hard crash. Leg B is the same claim in the other direction, and it is weaker than the brief assumed — see Acceptance notes.

## Verification

Run from the repo root, exit codes captured by redirecting to a file before any pipe.

- `pnpm exec vitest run packages/plugin-kanban/` — **50 files, 305 tests passed**, `VERDICT command-exit 0` (through the shared verify lock, which held 84s after waiting 171s).
- `pnpm --filter @object-ui/plugin-kanban type-check` — exit 0. The first attempt exited 2 with `Cannot find module '@object-ui/core'`: stale workspace dist, NOT MEASURED, not a red. Re-run green after `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-kanban^...' build` (VERDICT command-exit 0). `tsc -p tsconfig.test.json --listFiles` confirms the new test file is inside the program (1 hit), so this typecheck really does cover it.
- `pnpm exec eslint --no-inline-config` on the two changed files — exit 0, `0 errors, 30 warnings`; every warning is a pre-existing `no-explicit-any` / `react-refresh` in untouched lines of this file.
- `node scripts/check-changeset-presence.mjs` — exit 0, names the added changeset.
- `pnpm check:control-bytes` exit 0; `pnpm check:changeset-claims` exit 0; `pnpm check:unreferenced-sources` exit 0; `node scripts/check-changeset-no-major.mjs` exit 0.
- `node scripts/check-governed-queue-guard.mjs --test` on all three changed paths — `NOT GOVERNED`.
- Repo-wide scans (`pnpm lint`, `pnpm test`, the rest of the `check:*` farm) are CI's run, not narrowed here.

Evidence above was taken at `57cec46`, the only commit on this branch.

## Acceptance notes

- **A refinement of the dispatch brief, stated because it was measured.** The brief says repairing one map "moves the failure rather than removing it". That is exactly right for the label map (leg C). It is weaker for the accumulator: with the accumulator alone closed (leg B), all five values the card measured behave correctly at the lane level, and the only reading that still fails is a lane *declared* with the `__proto__` option value. Both maps did need closing — but the evidence for the label map is the declared-lane row, not the card's five values, which is why that row exists. The card's `constructor` / `__proto__` rows are pinned as reported, and they were already green at the lane level before this repair; the test file says so in as many words so nobody later reads them as regression cover they are not.
- **Not touched, as instructed**: the objectui#8993 / objectui#9044 keying repair on the adjacent lines (the `knownIds` sweep is byte-identical); `effectiveColumns` in `ObjectKanban.tsx`; no schema widened — no declaration of any kind is in this diff.
- noted, not filed: the local annotation `const labelToColumnId: Record(string, string)` is inaccurate — the map stores raw lane ids, which `Array(any)` columns allow to be a number or a symbol (objectui#8993's comment relies on exactly that). It has no runtime effect, since every read path stringifies, and `tsc` cannot see it through `any`. Whoever next edits this function is the reader who would trip on it; nothing else touches it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_