### PR TITLE
fix(plugin-dashboard): compose the pivot drill filter instead of spreading it

### DIFF
--- a/.changeset/9024-pivot-drill-filter-composition.md
+++ b/.changeset/9024-pivot-drill-filter-composition.md
@@ -9,8 +9,10 @@ filter survives into the drilled query for BOTH dialects it reads (objectui#9024
 the first into an object literal — the identical statement objectui#8944 removed from
 `ObjectChart` one block over. Spreading an array yields index keys, so a pivot scoped by
 `[['region','=','emea']]` drilled as `{ '0': ['region','=','emea'], stage: 'won', source: 'web' }`
-— the pivot's conditions replaced by a key the query layer ignores. Nothing errored; the drawer
-opened and looked right, scoped by the clicked cell alone.
+— the pivot's conditions replaced by a stray index key. Nothing errored; the drawer opened and
+looked right. Measured at the two sinks: the URL writer skips a bare array comparand, so the list
+landed scoped by the clicked cell ALONE (the superset), and the in-memory matcher refuses that
+comparand and returns nothing at all. Neither carries the pivot's own conditions.
 
 **Direction of the failure.** The pivot's filter is what narrows. Dropping it made the drilled
 list a **superset** — it showed records the pivot itself was scoped to exclude.

--- a/.changeset/9024-pivot-drill-filter-composition.md
+++ b/.changeset/9024-pivot-drill-filter-composition.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/plugin-dashboard': patch
+---
+
+Compose an `ObjectPivotTable` drill-down filter instead of spreading it, so the pivot's own
+filter survives into the drilled query for BOTH dialects it reads (objectui#9024).
+
+**The defect.** The drill seam composed the pivot's filter with the click context by spreading
+the first into an object literal — the identical statement objectui#8944 removed from
+`ObjectChart` one block over. Spreading an array yields index keys, so a pivot scoped by
+`[['region','=','emea']]` drilled as `{ '0': ['region','=','emea'], stage: 'won', source: 'web' }`
+— the pivot's conditions replaced by a key the query layer ignores. Nothing errored; the drawer
+opened and looked right, scoped by the clicked cell alone.
+
+**Direction of the failure.** The pivot's filter is what narrows. Dropping it made the drilled
+list a **superset** — it showed records the pivot itself was scoped to exclude.
+
+**Why the array arm is reachable here.** `PivotTableSchema` declares no `filter` at all (the
+type that admits the value is a local props-intersection `filter?: any`), so nothing refuses the
+array form — and it is not only a hand author who can produce it. `object-pivot`'s registry entry
+advertises `{ name: 'filter', type: 'array' }` in its designer inputs, and `ElementDataSourceGate`
+writes the array arm mechanically: binding a pivot the way the spec documents
+(`dataSource: { object, view }`) sets `schema.filter` to `mergeFilterNodes(schema.filter,
+view.filter)`, an ObjectQL AST node, for every saved view that carries a filter. So the pre-fix
+drill dropped the scope of every view-bound pivot, not just of a pivot whose author happened to
+pick the array spelling.
+
+**The fix.** `composeDrillFilter` (`@object-ui/core`, added by objectui#8944) already names and
+applies the rule — `widget.filter` conjoined with `drill.filter`, via the repo's single filter
+sink `mergeFilterNodes` — and lowers the result back to the object dialect both of this widget's
+drill sinks take. Routing this site through it replaces the local spread with the shared answer
+rather than deriving a second one.
+
+**Compatibility.** The drilled ROW SET is unchanged wherever it was already correct, which is the
+oracle this change is measured by. The composed VALUE can change shape: a pivot cell click derives
+two conditions (row field and column field), which are themselves a conjunction, so a pivot with no
+filter of its own now drills by `{ $and: [{ stage: 'won' }, { source: 'web' }] }` where the spread
+produced one flat object. Every sink accepts both — `$filter` takes `$and`, and
+`serializeDrillFilterParams` flattens nested `$and` into the same `filter[...]` params it always
+wrote (pinned since objectui#8944). When neither source carries anything the seam now answers
+`undefined` rather than `{}`; `DrillDownDrawer.filter` is optional, so the drilled list is unscoped
+either way.

--- a/packages/plugin-dashboard/src/ObjectPivotTable.tsx
+++ b/packages/plugin-dashboard/src/ObjectPivotTable.tsx
@@ -9,7 +9,7 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { useDataScope, SchemaRendererContext, useFilterScope } from '@object-ui/react';
 import { useSafeFieldLabel } from '@object-ui/i18n';
-import { extractRecords, computeDrillFilter, isDrillEnabled, resolveDrillTitle, type DrillEvent } from '@object-ui/core';
+import { extractRecords, computeDrillFilter, composeDrillFilter, isDrillEnabled, resolveDrillTitle, type DrillEvent } from '@object-ui/core';
 import { Skeleton, cn } from '@object-ui/components';
 import { PivotTable } from './PivotTable';
 import { DrillDownDrawer } from './DrillDownDrawer';
@@ -46,6 +46,34 @@ export interface ObjectPivotTableProps {
     // local member grown because no schema shape declared it — the
     // second-declaration class objectui#6357 measured. `PivotTableSchema
     // extends BaseSchema`, which now declares it once, same spelling.
+
+    // ⚠️ `filter` STAYS a local member, and that is a decision rather than an
+    // oversight (objectui#9024). It is read twice below — the fetch leg's
+    // `$filter` and the drill seam — and `object-pivot`'s registry `inputs`
+    // advertise it, so the key is live. What it is NOT is a member of the
+    // schema type above: `PivotTableSchema` is `type: 'pivot'`, the plain
+    // cross-tab, and `PivotTable` reads no `filter` at all — declaring it there
+    // would put an `object-pivot`-only key on the one node type that never
+    // reads it, and STILL leave `object-pivot` (which does) undeclared, since
+    // an `object-pivot` node is not assignable to that `type` literal. It is
+    // the same reason `objectName` is passed to `PivotTable` as a PROP instead
+    // of read off `finalSchema` (see the comment at the render below).
+    //
+    // The sibling widgets each declare `filter` on their OWN `Object*Schema`:
+    // measured on this tree, NINE of the eleven `Object*Schema` interfaces in
+    // `@object-ui/types` declare it — six array-only (`ObjectGridSchema`,
+    // `ObjectViewSchema`, `ObjectMapSchema`, `ObjectGanttSchema`,
+    // `ObjectCalendarSchema`, `ObjectKanbanSchema`), plus `ObjectChartSchema`'s
+    // two-armed union, `ObjectGallerySchema`'s `unknown` and
+    // `ObjectDataTableSchema`'s `any`. `object-pivot` has no such interface at
+    // all, so the consistent fix is to give it one carrying all three members
+    // grown here — `objectName`, `dataProvider`, `filter`. That widens a
+    // published authorable surface and wants its own card and ruling, rather
+    // than a one-member edit smuggled into a composition fix.
+    //
+    // ⭐ The composition below does NOT depend on this: `composeDrillFilter`
+    // takes `unknown` and routes every shape through the repo's single filter
+    // sink, so the drill is correct for both arms whatever this key is typed.
     filter?: any;
   };
   dataSource?: any;
@@ -266,7 +294,30 @@ export const ObjectPivotTable: React.FC<ObjectPivotTableProps> = ({ schema, data
       rowField: schema.rowField,
       columnField: schema.columnField,
     });
-    const merged = { ...(schema.filter || {}), ...baseFilter };
+    // ⛔ Composed through `composeDrillFilter`, NOT by spreading this pivot's
+    // own filter into an object literal. `schema.filter` reaches this component
+    // in BOTH dialects and a spread is only correct for the second:
+    //
+    //   - the ObjectQL `$filter` OBJECT (`{ region: 'emea' }`), and
+    //   - a spec `FilterArray` / ObjectQL AST node (`[['region','=','emea']]`).
+    //
+    // The array arm is not hypothetical here, and it is not only what a hand
+    // author may write: `object-pivot`'s registry `inputs` advertise
+    // `{ name: 'filter', type: 'array' }` (see `index.tsx`), and
+    // `ElementDataSourceGate` WRITES the array arm mechanically — binding a
+    // pivot the spec way (`dataSource: { object, view }`) sets this key to
+    // `mergeFilterNodes(schema.filter, view.filter)`, an AST node, for every
+    // saved view that carries a filter. Spreading THAT yields index keys
+    // (`{ '0': ['region','=','emea'] }`), so the pivot's own conditions were
+    // replaced by a key the query layer ignores and the drilled list showed
+    // rows this pivot is scoped to exclude (objectui#9024).
+    //
+    // ⚠️ Direction: the widget filter is what NARROWS, so losing it widened the
+    // drill to a SUPERSET — silently, since nothing errors. The seam's docblock
+    // names the composition rule (`widget.filter ∧ drill.filter`, via the
+    // repo's single filter sink `mergeFilterNodes`); it is not decided here.
+    // `ObjectChart` was routed through the same seam by objectui#8944.
+    const merged = composeDrillFilter(schema.filter, baseFilter);
     const title = resolveDrillTitle(drillDown, drillEvent, schema.title || 'Details');
     return (
       <DrillDownDrawer

--- a/packages/plugin-dashboard/src/__tests__/ObjectPivotTable.drillFilterComposition-9024.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectPivotTable.drillFilterComposition-9024.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9024 — the pivot's OWN filter survives into the drill-down query,
+ * for BOTH dialects `ObjectPivotTable` reads at `schema.filter`.
+ *
+ * ## The defect
+ *
+ * The drill seam composed the pivot's filter with the click context by
+ * SPREADING the first into an object literal:
+ *
+ *     { ...(schema.filter || {}), ...computeDrillFilter(…) }
+ *
+ * Spreading an ARRAY yields index keys, so an authored `[['region','=','emea']]`
+ * drilled as `{ '0': ['region','=','emea'], stage: 'won', source: 'web' }` — the
+ * pivot's conditions replaced by a key the query layer ignores. Nothing errored;
+ * the drawer opened and looked right, scoped by the clicked cell ALONE. The same
+ * statement objectui#8944 removed from `ObjectChart` one block over.
+ *
+ * ⚠️ The direction matters: the pivot's filter is what NARROWS. Dropping it
+ * makes the drilled list a SUPERSET — it shows records the pivot itself was
+ * scoped to exclude.
+ *
+ * ## Why the array arm is reachable here, measured rather than assumed
+ *
+ * `PivotTableSchema` declares no `filter` at all (the type that admits the value
+ * is a local props-intersection `filter?: any`, which is strictly MORE
+ * permissive than the chart's union), so nothing refuses the array form. And it
+ * is not only a hand author who can produce it:
+ *
+ *   - `object-pivot`'s registry entry advertises `{ name: 'filter', type:
+ *     'array' }` in its designer `inputs` (`plugin-dashboard/src/index.tsx`);
+ *   - `ElementDataSourceGate` WRITES the array arm mechanically. Binding a pivot
+ *     the way the spec documents (`dataSource: { object, view }`) sets
+ *     `schema.filter` to `mergeFilterNodes(schema.filter, view.filter)` — an
+ *     ObjectQL AST node — for every saved view that carries a filter
+ *     (`ObjectPivot.elementDataSource.test.tsx` pins that binding).
+ *
+ * So the pre-fix drill dropped the scope of every view-bound pivot, not just of
+ * a pivot whose author happened to pick the array spelling.
+ *
+ * ## What these cases assert, and why not the index keys
+ *
+ * Asserting that `'0'` is absent from the composed object would pin the SYMPTOM.
+ * These cases assert the SEMANTICS instead — the composed filter is run through
+ * `ValueDataSource`, a real matcher for the `$filter` dialect, over a fixture
+ * built so the three possible outcomes are three different row sets:
+ *
+ *   pivot filter alone  (`region = emea`)           → a, c
+ *   click context alone (`stage = won, source = web`) → a, b   ← the pre-fix superset
+ *   both, conjoined                                  → a       ← the only correct answer
+ *
+ * The pivot's filter is deliberately on a field that is NEITHER axis, so losing
+ * it changes the row set; a filter on `rowField`/`columnField` would be
+ * re-stated by the click context and could not discriminate. The two
+ * single-source answers are asserted as live controls, so the fixture cannot go
+ * vacuous without saying so.
+ *
+ * ## Why the observation point is `openRecordList`
+ *
+ * `DrillDownDrawer`'s `target: 'navigate'` hands the composed filter to the host
+ * verbatim — one spy, no DOM archaeology over a drilled table. The in-place
+ * drawer arm is pinned through the same spy via its "Open in list" escape hatch,
+ * which passes the drawer's own `filter` prop; the last case proves the two
+ * agree rather than assuming it.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
+import { DrillNavigationProvider } from '@object-ui/react';
+import { ValueDataSource } from '@object-ui/core';
+
+import { ObjectPivotTable } from '../ObjectPivotTable';
+
+const OBJECT = 'crm_opportunity';
+
+/**
+ * Three rows chosen so each source excludes a DIFFERENT one: `b` survives only
+ * if the pivot's filter is lost, `c` only if the click context is lost.
+ */
+const ROWS = [
+  { id: 'a', stage: 'won', source: 'web', region: 'emea', amount: 10 },
+  { id: 'b', stage: 'won', source: 'web', region: 'apac', amount: 20 },
+  { id: 'c', stage: 'lost', source: 'web', region: 'emea', amount: 30 },
+];
+
+/** Run a composed filter through a real matcher and project the ids it selects. */
+async function selectedIds(filter: unknown): Promise<string[]> {
+  const ds = new ValueDataSource({ items: ROWS });
+  const result = await ds.find(OBJECT, { $filter: filter as any });
+  return result.data.map((r: any) => r.id as string);
+}
+
+/** A data source the drawer can hold without reaching the network. */
+const inertDataSource = () => ({ find: vi.fn(async () => ({ data: [] })) });
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({}) })));
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+});
+
+function renderPivot(filter: unknown, drillDown: Record<string, unknown>) {
+  const openRecordList = vi.fn();
+  const utils = render(
+    <DrillNavigationProvider value={{ openRecordList }}>
+      <ObjectPivotTable
+        schema={{
+          type: 'pivot',
+          objectName: OBJECT,
+          rowField: 'stage',
+          columnField: 'source',
+          valueField: 'amount',
+          aggregation: 'sum',
+          showRowTotals: true,
+          showColumnTotals: true,
+          data: ROWS,
+          filter,
+          drillDown,
+        } as any}
+        dataSource={inertDataSource()}
+      />
+    </DrillNavigationProvider>,
+  );
+  return { openRecordList, ...utils };
+}
+
+/** Click the `won x web` cell through the navigate arm; hand back the composed filter. */
+async function drillCellViaNavigate(filter: unknown): Promise<unknown> {
+  const { openRecordList } = renderPivot(filter, { enabled: true, target: 'navigate' });
+  fireEvent.click(screen.getByLabelText('Drill into stage=won, source=web'));
+  await waitFor(() => expect(openRecordList).toHaveBeenCalled());
+  const [objectName, composed] = openRecordList.mock.calls[0];
+  expect(objectName).toBe(OBJECT);
+  return composed;
+}
+
+describe('objectui#9024 — the fixture discriminates (live controls)', () => {
+  it('each source alone selects a DIFFERENT row set, so a dropped source is visible', async () => {
+    // Green before and after the fix. Its job is to prove the rows and the
+    // matcher work, so a red below is about the composition rather than the
+    // harness — and to name the pre-fix superset explicitly.
+    expect(await selectedIds({ region: 'emea' })).toEqual(['a', 'c']);
+    expect(await selectedIds({ stage: 'won', source: 'web' })).toEqual(['a', 'b']);
+    expect(await selectedIds(undefined)).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('objectui#9024 — the ARRAY arm survives the drill', () => {
+  it('conjoins a spec FilterArray with the click context, and the result still CONSTRAINS', async () => {
+    const composed = await drillCellViaNavigate([['region', '=', 'emea']]);
+
+    // The semantics: only the intersection. `['a','b']` here would be the
+    // pre-fix answer — the pivot's filter dropped, the list widened to the
+    // clicked cell alone.
+    expect(await selectedIds(composed)).toEqual(['a']);
+
+    // The spelling the repo's single filter sink produces. The click context's
+    // own two conditions (rowField AND columnField) are a conjunction in their
+    // own right, so they lower to a NESTED `$and` rather than to one flat
+    // object — the sink states each source as its OWN child, at every level.
+    // `serializeDrillFilterParams` walks that nesting (pinned in
+    // `app-shell/src/views/drillUrlFilters.test.ts`), and the row set above is
+    // the assertion that matters.
+    expect(composed).toEqual({
+      $and: [{ region: 'emea' }, { $and: [{ stage: 'won' }, { source: 'web' }] }],
+    });
+  });
+
+  it('carries EVERY condition of a multi-condition FilterArray, not just the first', async () => {
+    // A second condition the click context does not mention: if the array arm
+    // were being lowered one-condition-deep, `c` would come back.
+    const composed = await drillCellViaNavigate([
+      ['region', '=', 'emea'],
+      ['stage', '!=', 'lost'],
+    ]);
+    expect(await selectedIds(composed)).toEqual(['a']);
+  });
+
+  it('survives a ROW-header drill too — the scope narrows, the pivot filter stays', async () => {
+    const { openRecordList } = renderPivot([['region', '=', 'emea']], { enabled: true, target: 'navigate' });
+    fireEvent.click(screen.getByLabelText('Drill into stage: won'));
+    await waitFor(() => expect(openRecordList).toHaveBeenCalled());
+    const composed = openRecordList.mock.calls[0][1];
+
+    expect(await selectedIds(composed)).toEqual(['a']);
+    expect(composed).toEqual({ $and: [{ region: 'emea' }, { stage: 'won' }] });
+  });
+});
+
+describe('objectui#9024 — the OBJECT arm still composes (no regression)', () => {
+  it('conjoins the ObjectQL $filter object with the click context', async () => {
+    const composed = await drillCellViaNavigate({ region: 'emea' });
+    expect(await selectedIds(composed)).toEqual(['a']);
+    expect(composed).toEqual({
+      $and: [{ region: 'emea' }, { $and: [{ stage: 'won' }, { source: 'web' }] }],
+    });
+  });
+
+  it('a pivot with NO filter of its own drills the SAME ROWS as it did before', async () => {
+    // ⚠️ Measured, not assumed, and NOT byte-identical: a pivot cell click
+    // derives TWO conditions (rowField and columnField), which are themselves a
+    // conjunction, so the lone surviving source lowers to `$and` where the
+    // spread produced one flat object. `ObjectChart`'s equivalent case stayed
+    // flat only because its click context is a single `groupByField` key.
+    //
+    // The difference is inert at every sink, and that is asserted rather than
+    // asserted-about: the same matcher selects the same rows from the nested
+    // form and from the exact object the pre-fix spread produced.
+    const composed = await drillCellViaNavigate(undefined);
+    expect(composed).toEqual({ $and: [{ stage: 'won' }, { source: 'web' }] });
+
+    const preFixSpread = { stage: 'won', source: 'web' };
+    expect(await selectedIds(composed)).toEqual(await selectedIds(preFixSpread));
+    expect(await selectedIds(composed)).toEqual(['a', 'b']);
+  });
+});
+
+describe('objectui#9024 — a TOTAL drill, where the click context is empty', () => {
+  it('keeps the pivot filter when the click contributes nothing', async () => {
+    // `scope: 'total'` is drill-through to the whole set, so `computeDrillFilter`
+    // answers `{}`. The pivot's own scope must still apply — this is the case the
+    // old spread got right for the object arm and silently wrong for the array
+    // one, and the reason it is asserted for the ARRAY arm here.
+    const { openRecordList, container } = renderPivot([['region', '=', 'emea']], {
+      enabled: true,
+      target: 'navigate',
+    });
+    fireEvent.click(container.querySelector('tfoot tr td:last-child') as Element);
+    await waitFor(() => expect(openRecordList).toHaveBeenCalled());
+    const composed = openRecordList.mock.calls[0][1];
+
+    expect(await selectedIds(composed)).toEqual(['a', 'c']);
+    expect(composed).toEqual({ region: 'emea' });
+  });
+
+  it('sends NO filter when neither source carries anything', async () => {
+    // Both sources empty: the seam answers `undefined` so the caller can omit
+    // the key, where the spread answered `{}`. Same unscoped row set, and
+    // `DrillDownDrawer.filter` is optional, so the two are interchangeable at
+    // every sink — recorded here rather than left to be rediscovered.
+    const { openRecordList, container } = renderPivot(undefined, {
+      enabled: true,
+      target: 'navigate',
+    });
+    fireEvent.click(container.querySelector('tfoot tr td:last-child') as Element);
+    await waitFor(() => expect(openRecordList).toHaveBeenCalled());
+    const composed = openRecordList.mock.calls[0][1];
+
+    expect(composed).toBeUndefined();
+    expect(await selectedIds(composed)).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('objectui#9024 — the in-place drawer drills by the SAME composed filter', () => {
+  it("the drawer's 'Open in list' hands the host what the navigate arm hands it", async () => {
+    // Both arms read the one `merged` value this component computes. Pinning the
+    // drawer through the escape hatch keeps the assertion on the composed VALUE
+    // rather than on rows rendered by a table this file does not own.
+    const { openRecordList } = renderPivot([['region', '=', 'emea']], { enabled: true });
+    fireEvent.click(screen.getByLabelText('Drill into stage=won, source=web'));
+
+    await waitFor(() => expect(screen.getByTestId('drill-open-in-list')).toBeTruthy());
+    fireEvent.click(screen.getByTestId('drill-open-in-list'));
+
+    await waitFor(() => expect(openRecordList).toHaveBeenCalled());
+    const composed = openRecordList.mock.calls[0][1];
+    expect(await selectedIds(composed)).toEqual(['a']);
+    expect(composed).toEqual({
+      $and: [{ region: 'emea' }, { $and: [{ stage: 'won' }, { source: 'web' }] }],
+    });
+  });
+});

--- a/packages/plugin-dashboard/src/__tests__/ObjectPivotTable.drillFilterComposition-9024.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectPivotTable.drillFilterComposition-9024.test.tsx
@@ -52,15 +52,36 @@
  * `ValueDataSource`, a real matcher for the `$filter` dialect, over a fixture
  * built so the three possible outcomes are three different row sets:
  *
- *   pivot filter alone  (`region = emea`)           → a, c
- *   click context alone (`stage = won, source = web`) → a, b   ← the pre-fix superset
- *   both, conjoined                                  → a       ← the only correct answer
+ *   pivot filter alone  (`region = emea`)             → a, c
+ *   click context alone (`stage = won, source = web`) → a, b
+ *   both, conjoined                                   → a      ← the only correct answer
  *
  * The pivot's filter is deliberately on a field that is NEITHER axis, so losing
  * it changes the row set; a filter on `rowField`/`columnField` would be
  * re-stated by the click context and could not discriminate. The two
  * single-source answers are asserted as live controls, so the fixture cannot go
  * vacuous without saying so.
+ *
+ * ## What the pre-fix value did at each sink — measured, not assumed
+ *
+ * The spread produced `{ '0': ['region','=','emea'], stage: 'won', source:
+ * 'web' }`. The pivot's conditions are not absent in ONE way; each sink resolves
+ * the stray index key differently and both answers are wrong:
+ *
+ *   - this repo's in-memory matcher — `ValueDataSource`, the one these cases run
+ *     the composed filter through — REFUSES an array comparand outside
+ *     `$in`/`$nin`/`$between` and excludes every row. Ablating the routing turns
+ *     the array cases below into `[]`, with that diagnostic on stderr.
+ *   - the URL sink drops it silently: `serializeDrillFilterParams` skips a bare
+ *     array comparand rather than stringifying it (its own pin in
+ *     `app-shell/src/views/drillUrlFilters.test.ts`), so no `filter[0]` is ever
+ *     written and the list lands scoped by the clicked cell ALONE — the SUPERSET
+ *     this defect is named for, and the `a, b` row above.
+ *
+ * Either way the pivot's own conditions never reach the drilled query. These
+ * cases assert the conjunction, so a red names the drop whichever sink resolved
+ * it — rather than depending on one sink's treatment of a key nobody meant to
+ * send.
  *
  * ## Why the observation point is `openRecordList`
  *
@@ -198,6 +219,10 @@ describe('objectui#9024 — the ARRAY arm survives the drill', () => {
 
 describe('objectui#9024 — the OBJECT arm still composes (no regression)', () => {
   it('conjoins the ObjectQL $filter object with the click context', async () => {
+    // ⭐ The regression guard. Ablating the routing leaves THIS row-set assertion
+    // GREEN — measured — and reds only the shape assertion below it: spreading is
+    // already correct for the object arm, so routing through the seam changes the
+    // composed value's SHAPE here and not the rows it selects.
     const composed = await drillCellViaNavigate({ region: 'emea' });
     expect(await selectedIds(composed)).toEqual(['a']);
     expect(composed).toEqual({


### PR DESCRIPTION
Fixes #9024

`ObjectPivotTable` composed its drill filter by spreading its own filter into an object literal — the identical statement objectui#8944 removed from `ObjectChart` one block over, landed as PR objectui#9016. Spreading an ARRAY yields index keys, so a pivot scoped by `[['region','=','emea']]` drilled as `{ '0': ['region','=','emea'], stage: 'won', source: 'web' }`: the pivot's own conditions replaced by a stray index key. Nothing errors, and the direction is the bad one — the widget filter is what NARROWS, so losing it widens the drilled list to a SUPERSET of what the pivot itself was scoped to.

Routed through `composeDrillFilter` (`@object-ui/core`), which already names the rule (widget filter AND drill filter, via the repo's single filter sink `mergeFilterNodes`) and lowers the result back to the object dialect both of this widget's drill sinks take. No second local repair, and no second shape for the same defect.

## The seam drops in — the pivot's sinks confirmed, not assumed

The card asked for this before assuming the seam fits. `ObjectPivotTable` has one sink component, `DrillDownDrawer`, whose `filter` prop is declared `Record` of string to unknown — the object dialect — and it fans out to three consumers, all of which take that dialect:

- `openRecordList(objectName, filter)` (the `target: 'navigate'` arm and the drawer's "Open in list" escape hatch) — app-shell's `useOpenRecordList` serializes it with `serializeDrillFilterParams`, which since objectui#8944 flattens a top-level `$and` **and walks nesting**, with its own pin;
- `ObjectDataTable`, which forwards the value as `$filter`;
- the report arm, which conjoins it with the report's own filter under `$and`.

`composeDrillFilter` returns `Record` of string to unknown, or `undefined`. Same dialect, drop-in.

## Why the array arm is reachable here — the reach the card left unmeasured

The card measured that nothing DECLARES the array arm away (`PivotTableSchema` declares no `filter` at all; the type that admits the value is a local props-intersection `filter?: any`, strictly more permissive than the chart's union), and flagged that it had NOT measured whether anything in the corpus authors it. Measured here, and the answer is stronger than "an author might":

- `object-pivot`'s registry entry advertises `{ name: 'filter', type: 'array' }` in its designer `inputs` — the array arm is what the designer offers;
- `ElementDataSourceGate` **writes** the array arm mechanically. Binding a pivot the way the spec documents (`dataSource: { object, view }`, objectstack#7121) sets `schema.filter` to `mergeFilterNodes(schema.filter, view.filter)` — an ObjectQL AST node — for every saved view carrying a filter. `ObjectPivot.elementDataSource.test.tsx` pins exactly that binding, and it also authors the array form directly on a pivot with no `dataSource` at all;
- census of the in-repo corpus: 43 pivot nodes, 5 of them near a `filter` key, and **every one is the array arm or a gate-composed view filter**. Not one authors the object form. That is the OPPOSITE of the chart's corpus, whose docblock records the object form as what live charts write.

So the pre-fix drill dropped the scope of every view-bound pivot, not only of a pivot whose author happened to pick the array spelling.

## The declaration decision the card asked to be taken together

⚠️ Named rather than left silent, and the answer is **no declaration in this PR** — documented at the declaration site itself.

`filter?: any` stays a local props member. `PivotTableSchema` is `type: 'pivot'` — the plain cross-tab — and `PivotTable` reads no `filter` at all. Declaring `filter` there would put an `object-pivot`-only key on the one node type that never reads it, and would STILL leave `object-pivot` undeclared, because an `object-pivot` node is not assignable to that `type` literal. It is the same reason `objectName` is already passed to `PivotTable` as a prop rather than read off `finalSchema`, which the file says in so many words.

Measured on this tree: nine of the eleven `Object*Schema` interfaces in `@object-ui/types` declare `filter` on their OWN interface — six array-only, plus the chart's two-armed union, an `unknown` and an `any`. `object-pivot` has no such interface at all. The consistent repair is to give it one carrying all three members grown on this intersection (`objectName`, `dataProvider`, `filter`), which widens a published authorable surface and wants its own card and ruling rather than a one-member edit smuggled into a composition change.

⭐ And the composition does not depend on it: `composeDrillFilter` takes `unknown` and routes every shape through the single filter sink, so the drill is correct for both arms whatever this key is typed. The card's hypothesis that a declaration might not be needed holds.

On the stop condition: declaring the chart's union here WOULD narrow, because `BaseSchema` carries an index signature and `filter: 42` type-checks as `any` today. It would refuse only shapes that are already inert at runtime — but it is still a narrowing, and it belongs to the ruling above rather than to this PR.

## Verification

The oracle is the composed filter's ROW SET, not the composed object's shape — reusing PR objectui#9016's pin shape. The fixture is built so each source excludes a different row: the pivot filter alone selects `a, c`, the click context alone `a, b`, the conjunction `a`. The pivot's filter is deliberately on a field that is NEITHER axis, so losing it changes the row set (a filter on the row or column field would be re-stated by the click context and could not discriminate).

New pin: `packages/plugin-dashboard/src/__tests__/ObjectPivotTable.drillFilterComposition-9024.test.tsx` — 9 cases, including live fixture controls, both arms, a row-header drill, a total-scope drill, and the drawer and navigate arms agreeing.

```
pnpm exec vitest run packages/plugin-dashboard/src/__tests__/ObjectPivotTable.drillFilterComposition-9024.test.tsx
  EXIT=0 — Test Files 1 passed (1), Tests 9 passed (9)

pnpm exec vitest run packages/plugin-dashboard/            (under the shared verify lock)
  EXIT=0 — Test Files 110 passed (110), Tests 991 passed (991)

pnpm --filter @object-ui/plugin-dashboard type-check       (under the shared verify lock)
  EXIT=0 — tsc --noEmit AND tsc -p tsconfig.test.json, so the new pin is inside the typed program

pnpm exec turbo run build --filter="@object-ui/plugin-dashboard^..." --concurrency=2
  EXIT=0 — 12 tasks successful (the dependency closure the type-check reads)

cross-package readers of this file or of the composed shape
  EXIT=0 — 5 files / 245 tests (base-bind-declared, drill-down-config-declared-keys,
           skill-guide-data-table-binding, widget-dom-leak-sweep, drillUrlFilters)
  EXIT=0 — 2 files / 35 tests (console public-contract, public-block-binding-reach)

node scripts/check-changeset-presence.mjs                  EXIT=0
check:control-bytes · check:new-line-citations · check:changeset-claims ·
check:vi-mock-specifiers · check:vi-mock-inherit · check:vi-mock-override-shape ·
check:element-data-source-declaration · check:comment-mask-corpus ·
check:shell-escape-residue                                 EXIT=0 each
```

Every exit code above was captured by REDIRECT to a file, never after a pipe.

**Lint, narrowed and the narrowing proven.** `pnpm --filter @object-ui/plugin-dashboard lint` (which is exactly the unit `turbo run lint` runs for the one package this diff touches) EXIT=0 — 140 files linted per `--format json`, 0 errors, 450 warnings, all of them the pre-existing `no-explicit-any` warn. The invariance that makes this a measurement rather than a skipped run: `eslint.config.js` declares no `projectService` and no `parserOptions.project`, so type-aware linting is off and this diff cannot move the verdict of any file it does not contain. The diff contains three files, all in this package plus one changeset.

**NOT MEASURED:** `check:sdui-registration-pins` exits 2 with `No console build to weigh` — a prerequisite, not a red, and this diff adds no registration. Left to CI.

## Ablation

Committed the change first, then put the spread back, ran the pin, restored, and proved the tree clean BY STATE.

- mutation proven on disk before the run, anchored both ways: injected-spread hits 1 (want 1), routed-call hits 0 (want 0);
- ablated run EXIT=1 — **8 of 9 cases red**. The one that stayed green is the live-control case, by design: it proves the fixture and the matcher work, so the reds are about the composition and not the harness;
- restore: `git diff HEAD` for the path = **0 bytes**, `git diff HEAD` for the whole tree = **0 bytes**, and `git hash-object` back to HEAD's blob `f22f72460b12dd9f4cc83e887482e15229557314`. An EXIT trap was present for the crash path; the proof is the byte and hash comparison, never an exit code.

⭐ Two readings the ablation produced that are worth the words, because both correct a plausible assumption:

1. **The object arm's ROW SET is unchanged.** Under ablation the object-arm case's row-set assertion stays GREEN and only its shape assertion reds. That is the first stop condition, measured rather than argued: routing through the seam does not change the drilled rows for the shape a corpus would author in the object form.
2. **The pre-fix value fails differently at each sink.** The in-memory matcher this pin uses (`ValueDataSource`) REFUSES an array comparand outside `$in`/`$nin`/`$between` and excludes every row, so the ablated array cases read `[]`, not the superset. The superset is what the OTHER sink produces: `serializeDrillFilterParams` skips a bare array comparand, so no `filter[0]` is written and the list lands scoped by the clicked cell alone. Both readings are recorded in the pin's docblock, and the assertions stay on the conjunction so a red names the drop whichever sink resolved it.

## Compatibility

The drilled row set is unchanged wherever it was already correct. The composed VALUE can change shape: a pivot cell click derives two conditions (row field and column field), which are themselves a conjunction, so a pivot with no filter of its own now drills by `{ $and: [{ stage: 'won' }, { source: 'web' }] }` where the spread produced one flat object. `ObjectChart`'s equivalent case stayed flat only because its click context is a single key. Every sink accepts both, and the pin asserts the two select the same rows through the same matcher. When neither source carries anything the seam answers `undefined` rather than `{}`; `DrillDownDrawer.filter` is optional, so the drilled list is unscoped either way — pinned.

## Acceptance notes

Out of scope for this PR, reported rather than acted on:

- **`ObjectMetricWidget` — checked properly, and it is NOT a third copy of this defect.** The PM probed one spelling and asked for a real check. It composes nothing: it passes its own `resolvedFilter` straight to `DrillDownDrawer` as a single source, and the block states in a comment that `drillDown.filter` is deliberately not forwarded. There is no second filter source at that seam and therefore no merge to get wrong. It calls neither `computeDrillFilter` nor `composeDrillFilter` — which is correct for a KPI whose whole tile is the slice, not an omission.
- **A THIRD site of this exact class does exist, in a different widget: `buildDatasetDrillFilter`** (`packages/core/src/utils/dataset-format.ts`) ends `return runtimeFilter ? { ...runtimeFilter, ...drillFilter } : drillFilter;`. Its `runtimeFilter` parameter is declared as an object, but `DatasetWidget` reaches it from `widget: any`, and the guard that feeds it is `typeof rawFilter === 'object' && Object.keys(rawFilter).length > 0` — which an ARRAY passes. So an array-armed dataset widget filter would spread to index keys the same way. Not measured end to end and not touched here; reported for triage rather than filed, since filing is the PM's call this round and a third site is explicitly fenced out of this PR.
- **Placeholders are not resolved on the navigate arm.** Both this widget and `ObjectChart` pass the RAW `schema.filter` into the composition, so `{current_user_id}` and date macros are expanded by `ObjectDataTable` on the drawer arm but travel to the URL literally on the navigate arm. Pre-existing, identical on both widgets, unchanged by this PR, and out of its scope.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_