### PR TITLE
docs(changeset): correct six pending changesets whose surrounding claims a later merge falsified (objectui#9065)

### DIFF
--- a/.changeset/5293-view-sort-order-spelling.md
+++ b/.changeset/5293-view-sort-order-spelling.md
@@ -32,15 +32,20 @@ was dropped at three independent readers rather than rejected at one. This renam
 take away a feature — it converts a silent wrong answer into a loud type error at the one
 place that can still be fixed cheaply.
 
-**Scope — one published export still accepts `direction`, and this release does not retire
-it.** `toSortItems` (`packages/plugin-view/src/config/view-config-utils.ts`, re-exported
-from the package root and listed in the README) folds `s.order || s.direction || 'asc'`.
-It serves a different surface — the studio inspector-draft that feeds `SortBuilder` — and
-it is not reachable from the `views` prop, so it neither affects nor is affected by this
-rename. If you migrate by searching for the old key, that is the other hit you will find:
-it is dormant (nothing in this repo calls it outside a test), and removing it would be a
-separate break on a separate public export, tracked as objectui#6011. It is not a partial
-retirement of this one.
+**Scope — at this change one other published export still accepted `direction`, and this
+release did not retire it.** `toSortItems` (`packages/plugin-view/src/config/view-config-utils.ts`,
+re-exported from the package root and listed in the README) folded
+`s.order || s.direction || 'asc'`. It serves a different surface — the studio
+inspector-draft that feeds `SortBuilder` — and it is not reachable from the `views` prop,
+so it neither affected nor was affected by this rename: dormant (nothing in this repo
+called it outside a test), and removing it would be a separate break on a separate public
+export, tracked as objectui#6011. It was not a partial retirement of this one.
+
+⚠️ **That second export has since been retired too — objectui#6011.** `toSortItems` now
+reads `order`, and only `order`: a draft entry still spelled `{ field, direction }` takes
+the `'asc'` default instead of the direction it asked for. So the migration search
+described above no longer finds a live `direction` read on this package's published sort
+path.
 
 `order` is the spelling every other sort surface already uses (`SortConfig`,
 `NamedListView.sort`, `ObjectGridSchema.sort` / `.defaultSort`, and the shared

--- a/.changeset/7165-grid-dependent-values.md
+++ b/.changeset/7165-grid-dependent-values.md
@@ -23,8 +23,15 @@ and the grid never got it. `renderCellEditor` now passes
 `dependentValues={ctx.row}`, supplying that missing input; no cascade is
 re-implemented.
 
-⚠️ Interim, and deliberately labelled as such in the code (#7165): `ctx.row` is
-the **saved** record, so a parent edited but not yet saved in the same row does
-not re-scope the child — it stays scoped by the persisted value. Matching the
-form's live-record semantics needs a new member on `renderCellEditor`'s
-published context type and is tracked as #7188.
+⚠️ Interim at this change, and deliberately labelled as such in the code
+(#7165): `ctx.row` is the **saved** record, so a parent edited but not yet saved
+in the same row did not re-scope the child — it stayed scoped by the persisted
+value. Matching the form's live-record semantics needed a new member on
+`renderCellEditor`'s published context type, tracked as #7188.
+
+✅ **#7188 has since landed, and that limitation is gone.** `renderCellEditor`'s
+context now carries the row twice — `row` is still the persisted record and
+`pendingRow` is that record with the row's staged, unsaved edits merged over it —
+and the grid passes `dependentValues={ctx.pendingRow ?? ctx.row}`. A parent
+picked but not yet saved re-scopes the child immediately, which is the form's
+semantics.

--- a/.changeset/7655-chatbot-registration-authoring-faces.md
+++ b/.changeset/7655-chatbot-registration-authoring-faces.md
@@ -38,11 +38,14 @@ per key on the PR's base (one `schema.KEY` read per registration body in
   plus `enableMarkdown`, `enableFileUpload`, `onClear`, and the two keys it
   declares alongside `ChatbotSchema` — `floatingConfig` (`FloatingChatbotConfig`)
   and `displayMode`. No `maxHeight`, `processVisibility` or `surface`: the
-  floating registration has no named read for any of them. (Its trailing raw
-  props spread does carry authored keys into the panel today — `processVisibility`,
-  `surface` and `showAvatars` are live there, measured through the real host;
-  that accidental channel is tracked as objectui#7708, and this face neither
-  declares nor promises it.)
+  floating registration has no named read for any of them. (At this change its
+  trailing raw props spread still carried authored keys into the panel —
+  `processVisibility`, `surface` and `showAvatars` were live there, measured
+  through the real host — and this face neither declared nor promised that
+  accidental channel, which was tracked as objectui#7708. That card has since
+  fenced the spread the way the two sibling registrations do, so those three keys
+  are dark on `chatbot-floating` now; no member this face declares depended on
+  the channel.)
 - Neither face declares `ChatbotSchema`'s six legacy members (`loading`,
   `showAvatars`, `userAvatar`, `assistantAvatar`, `markdown`, `height`) — no
   registration reads them by name — and neither redeclares `disabled`, which

--- a/.changeset/7727-conditional-formatting-record-scope.md
+++ b/.changeset/7727-conditional-formatting-record-scope.md
@@ -123,10 +123,17 @@ flattened.
 - **The `data.*` half.** Dropping `'data'` from `ROW_PREDICATE_ROOTS` stops
   *recommending* it; it does not stop the lint *accepting* it.
   `@objectstack/formula`'s `SCOPE_ROOTS` lists `data`, so `data.status == 'x'` still
-  lints clean at `scope:'record'` while resolving against the host's ambient `data`
-  rather than the row — constant-false, silently. Pinned here as a characterization
-  test, tracked as objectui#8166. This changeset closes the **bare-field** half of the
-  retirement only.
+  lints clean at `scope:'record'` — and at this change it also still RESOLVED, against
+  the host's ambient `data` rather than the row, constant-false and silently. Pinned
+  here as a characterization test, tracked as objectui#8166. This changeset closes the
+  **bare-field** half of the retirement only.
+
+  ⚠️ **objectui#8166 has since closed the half this repo owns.** `buildExpressionScope`
+  no longer binds an ambient `data` on record surfaces, so such a condition now FAULTS
+  with the engine's own `Unknown variable: data` instead of resolving constant-false.
+  The lint still accepts the spelling — narrowing `SCOPE_ROOTS` is the producer-side
+  half and lives in `@objectstack/formula` — so what moved is the silence, not the
+  accept set.
 
 ⛔ And this editor is **not** the last authoring site still on the flattened default —
 `ConditionBuilder` reaches it by passing no `scope` at all, which is why a grep for the

--- a/.changeset/8253-export-tree-view-config.md
+++ b/.changeset/8253-export-tree-view-config.md
@@ -35,15 +35,28 @@ re-writes.
   of the exported one and the resolver's own type is `Pick`ed off it. No runtime
   behaviour changes, and no key is added to or removed from what the renderer reads.
 
-**`titleField` is declared, not deleted — and that was a measurement.** The ruling put
+**`titleField` was declared, not deleted — and that was a measurement.** The ruling put
 this key to a test: declare it if the console writes it, else remove the read. The
 console's create-view dialog does **not** offer it (its `tree` slot collects
 `parentField` alone), but the console's own host composition reads it by name, so do
-the `ListView` and `ObjectView` tree branches, and the rung is pinned as live behaviour
-by objectui#6557 ("the tree's second view-declared rung … still answers"). Deleting the
-read would have reversed a recorded ruling and reddened its pin. Declaring it makes
-declared = enforced at all four read sites at once. `labelField` remains canonical and
-wins wherever both are present.
+the `ListView` and `ObjectView` tree branches, and that rung is pinned as live behaviour
+by objectui#6557 ("the tree's second view-declared rung … still answers"). Deleting that
+read would have reversed a recorded ruling and reddened that pin, so this change declared
+the key at all four read sites instead. `labelField` remains canonical and wins wherever
+both are present.
+
+⚠️ **Superseded — the declaration has since been removed.** objectui#8841 (PR
+objectui#9052) settled it against the protocol rather than against the reads:
+`@objectstack/spec@17.4.0`'s `TreeConfigSchema` is a `strictObject` and refuses
+`titleField` on `ListView.tree` by name, so declaring it here published a key an author
+following `@object-ui/types` was refused for at publish. `TreeViewConfig` is now derived
+from that protocol block and no longer carries the key, and `plugin-tree`'s
+`?? schema.titleField` rung — which read the flattened NODE, not this block — went with
+it. ⛔ What did NOT go is the view-declared read objectui#6557 pins: the
+`labelField || titleField` dual-reads in `plugin-view`, `plugin-list` and the console
+survive as undeclared tolerance, so stored view records keep resolving and that pin is
+still green. Read this entry for why the key was declared and objectui#8841's for why the
+declaration could not stand; the migration is to write `tree.labelField`.
 
 **Migration.** None required. Hosts that already compose a `tree` block keep working;
 hosts that annotate one against `TreeViewConfig` start getting a compile error for a

--- a/.changeset/8934-chatter-feed-affordance-only.md
+++ b/.changeset/8934-chatter-feed-affordance-only.md
@@ -29,11 +29,14 @@ now names the spec symbol it delegates to.
 **Defaults come with the shape, and two of them are visible.** This applies to
 an **authored `record:chatter` / `record:discussion` block**, and to every
 synthesized default page (which emits `record:discussion`) — those are the
-surfaces that render through `RecordChatterRenderer`. The panel the host
-auto-appends when a page omits a discussion block mounts `RecordChatterPanel`
-directly and does **not** run this pipeline, so it is unchanged and now renders
-a different feed from the authored block on the same record; that divergence is
-filed as objectui#8983. On the surfaces this change does reach:
+surfaces that render through `RecordChatterRenderer`. At this change the panel
+the host auto-appends when a page omits a discussion block mounted
+`RecordChatterPanel` directly and did **not** run this pipeline, so it was
+unchanged and rendered a different feed from the authored block on the same
+record; that divergence was filed as objectui#8983 and has since been closed —
+the fallback now mounts this renderer with no schema, so both chatter surfaces
+run the one pipeline and render the same feed. On the surfaces this change
+reaches:
 
 - `showCompleted` defaults to `false`, so **completed activities (feed type
   `task`) are no longer rendered** unless the block authors
@@ -49,8 +52,8 @@ no-filter.
 `enableMentions` are also members of the declared shape and are still unread on
 this path — `RecordActivityTimeline` takes `filterMode` as a component prop
 rather than off `config`, and the chatter path's mentions come from the host
-context. Tracked as objectui#8968. The host fallback panel described above is
-tracked as objectui#8983.
+context. Tracked as objectui#8968. The host fallback panel described above was
+tracked as objectui#8983, since closed — see the note above it.
 
 Marked `minor` rather than `patch`: this repository never declares `major` (the
 fixed release group would drag every package off `@objectstack`'s cadence), and


### PR DESCRIPTION
Fixes #9065

Seven pending `.changeset/*.md` bodies carried a claim that had expired or was never true. A pending changeset body publishes VERBATIM into a CHANGELOG at the next release, and this repository's Changesets release PR — objectui#5400, `chore: release packages`, branch `changeset-release/main` — has been standing **open since 2026-08-20**. So the deadline here is one maintainer click, not one release cycle.

Prose only. ⛔ No frontmatter moves: `scripts/check-changeset-overwrite.mjs` prints `declared at base` and `declares now` identically for all six edited files, and `0 changeset(s) added, 6 modified, 0 deleted`.

⚠️ **Six files are edited, not seven.** `.changeset/olive-pears-invent.md` is deliberately left alone as a **measured ruling** — see its row below.

---

## Site 7 — `.changeset/8253-export-tree-view-config.md`, taken first

The `domain:spec` seat routed this here as the strong class, and it is: the paragraph states the opposite of what the tree face now does.

### Half 1 — "`titleField` is declared, not deleted" is FALSE on `main`

Re-derived on `fac5acfa4`, three readings:

1. `packages/types/src/views.ts:147` — `TreeViewConfig` is now the protocol's own block: `NonNullable` of `SpecListView`'s `tree` member.
2. `packages/types/src/__tests__/tree-view-config-readers-8253.test.ts:123` — a compile-time assertion that `TreeViewConfig` is **not** structurally equal to that block intersected with an optional `titleField`. It is a FIRING CONTROL on the parity check next to it, so the parity check can say `false`.
3. Same file, `:304` — the console rung is asserted **not** to contain the cast-then-`titleField` read.

⇒ the declaration is gone. The paragraph is rewritten to past tense and gains a `⚠️ Superseded` note naming objectui#8841 / PR objectui#9052 and `@objectstack/spec@17.4.0`'s `strictObject` refusal, and keeps the historical reason the key was declared. ⛔ The paragraph is not deleted.

### Half 2 — "Deleting the read would have … reddened its pin" measured TRUE. ⭐ The card's table is wrong here.

The instruction to drop that clause was explicitly conditional on this measurement, and the condition fired. Measured at **`2f6b2bf1a^` = `c3a427378`**, in a dedicated detached worktree, with objectui#6557's pin **unedited** and each leg proven on disk (anchor counts before/after plus a blob-hash comparison against `HEAD`, restored to `git diff HEAD` empty after every leg):

| leg | what was deleted at `2f6b2bf1a^` | objectui#6557's pin |
|---|---|---|
| baseline | nothing | **8 passed (8)** |
| A | the console composition's `titleField` rung in `packages/app-shell/src/views/ObjectView.tsx` | **1 failed, 7 passed** — `expected 'name' to be 'v_tree_title'` |
| B | only `plugin-tree`'s `?? schema.titleField` node rung | **8 passed (8)** |
| C | all four tree `titleField` reads | **1 failed, 7 passed** |

⇒ under the sentence's own antecedent — the reads it has just enumerated, "all four read sites" — deleting the read **does** redden the pin. The clause is therefore **kept**, re-scoped, ⛔ not dropped.

Two premises behind the "it was never true" verdict do not survive measurement:

- **objectui#9052 did NOT edit the pin.** `packages/app-shell/src/views/ObjectView.titleFieldConvergence.test.tsx` has blob `04fd1e306` at `2f6b2bf1a^`, at `2f6b2bf1a` and at `fac5acfa4` — byte-identical. Control: `packages/types/src/views.ts` moves `544cb074e` to `29824e7eb` across the same merge. The two phrases attributed to objectui#9052 ("the seam count below dropped from seven to six", "the middle rung is gone") are already present at `2f6b2bf1a^` and belong to objectui#7029 and objectui#6557 respectively.
- **"32/32" is not a reading of this pin.** The pin file holds **8** tests; the three app-shell files citing objectui#6557 hold **37** between them. Neither is 32.

What objectui#9052 actually removed is leg B plus the declaration — which is exactly why it could ship without touching the pin, and its own changeset says so: "objectui#6557's pin on that rung stays green".

---

## The six — a per-changeset reading, with the closed card's outcome

⭐ Five of six turned out to be the objectui#9042 class, not the cosmetic one: the citation's **surrounding claim** was falsified when the card closed.

| pending changeset | what the closed card actually did | the surrounding claim | ruling |
|---|---|---|---|
| `5293-view-sort-order-spelling.md` | objectui#6011 closed by PR objectui#6234, which **retired** `direction` from the second published export | "one published export **still accepts** `direction`, and this release does not retire it" — `toSortItems` "folds `s.order or s.direction or 'asc'`" | **EDIT** — falsified. `view-config-utils.ts:326` now reads "Reads **`order`**, and only `order`", and the body is `(s.order or 'asc')` |
| `olive-pears-invent.md` | objectui#7170 closed **"option 1, leave it. Already done."** — a triage ruling with **no code change** | "it lands on `create`, tracked as objectui#7170" | **LEAVE ALONE** — still TRUE. `packages/data-objectstack/src/index.ts` still reads `(op?.action ?? 'create') === 'create' ? 'create' : 'update'`, and the comment above it still explains why. Two independent reasons, below. |
| `7165-grid-dependent-values.md` | objectui#7188 closed by PR objectui#7241, which carried the staged row across the seam | "⚠️ Interim … a parent edited but not yet saved **does not re-scope the child**" | **EDIT** — falsified. `pendingRow` is a published member of the `renderCellEditor` context, and `ObjectGrid.tsx:4324` passes `dependentValues={ctx.pendingRow ?? ctx.row}` |
| `7655-chatbot-registration-authoring-faces.md` | objectui#7708 closed by PR objectui#8077, "fence chatbot-floating's raw props spread" | "Its trailing raw props spread **does carry** authored keys into the panel **today** — `processVisibility`, `surface` and `showAvatars` **are live** there" | **EDIT** — falsified. `renderer.tsx:448` is now `toDomProps(props)` spread FIRST, and `renderer.authoring-faces-7655.test.tsx:231` pins those three keys as **dark** |
| `7727-conditional-formatting-record-scope.md` | objectui#8166 closed by PR objectui#8963, which unbound the ambient `data` root on record surfaces | "`data.status == 'x'` still lints clean … **while resolving against the host's ambient `data`** rather than the row — constant-false, silently" | **EDIT** — half falsified, and it is the material half. The lint still ACCEPTS the spelling (producer-side, `@objectstack/formula`'s `SCOPE_ROOTS`), but it no longer RESOLVES: it now faults with `Unknown variable: data`. The silence is gone |
| `8934-chatter-feed-affordance-only.md` | objectui#8983 closed by PR objectui#9011, "bind the host discussion fallback to the feed pipeline" | "The panel the host auto-appends … **does not** run this pipeline, so it is unchanged and **now renders a different feed**" | **EDIT** — falsified. `record-chatter.tsx:74` — "since objectui#8983 that fallback mounts THIS renderer with no schema"; `RecordDetailView.discussionFallbackPipeline-8983.test.tsx` pins that both surfaces render the same feed |

### ⭐ Why `olive-pears-invent.md` is a ruling and not an omission

Two independent measurements, either of which is sufficient:

1. **The surrounding claim is still true.** objectui#7170 was closed as a triage **ruling not to fix** (option 2 ruled out on contract-review allocation, option 3 on measurement). The fabrication is live on `main` today, so the sentence describing it is accurate.
2. **It cannot reach a reader through a CHANGELOG.** Its frontmatter is empty — the repo's explicit no-release declaration — so Changesets writes no entry for it at all. Re-run below with a firing control.

---

## Measurement method — every phrase read FLATTENED, every zero paired with a control

The card names a false zero that already cost one reading: a line-based `grep` returns **0** for a phrase spanning a line break. Every count below is taken after `tr '\n' ' ' | tr -s ' '`.

Sweep across all **42** `CHANGELOG.md` files, one instrument, one run, on each of the two heads:

| phrase | objectui#5400 head `e4ce4f42f` | `main` `fac5acfa4` |
|---|--:|--:|
| `tracked as objectui#6011` | **1** | 0 |
| `tracked as #7188` | **1** | 0 |
| `tracked as objectui#7708` | **2** | 0 |
| `tracked as objectui#8166` | 0 | 0 |
| `tracked as objectui#8983` | 0 | 0 |
| `is declared, not deleted` | 0 | 0 |
| `reddened its pin` | 0 | 0 |
| `UNATTRIBUTED_STRIP_OBJECT` | **0** | 0 |
| FIRING CONTROL: `Patch Changes` | **2938** | **2899** |

⇒ the instrument fires, and it fires differently on the two heads. `UNATTRIBUTED_STRIP_OBJECT` reading 0 in the same run where three siblings read 1 / 1 / 2 is a **real zero**, ⛔ not a dead query.

⚠️ **The three zeros in rows 4-6 are NOT safety.** objectui#5400's head was last refreshed 2026-09-07; those changesets landed on `main` after that. The action regenerates that head from `main` on the next push, so every pending changeset is one refresh away from being staged. A correction on `main` propagates into it. ⛔ objectui#5400 is not touched by this PR.

---

## Gates, by required-context name

| required context | the command CI runs | exit |
|---|---|--:|
| `Changeset Declaration` | `node scripts/check-changeset-presence.mjs` | **0** |
| `Lint` | `node scripts/check-lint-coverage.mjs` and the rest, behind lint.yml's `Decide whether this change needs a full run` | **0** locally; the job's own gate resolves `should_run=false` for a `.changeset/**`-only PR and still reports |
| `Type Check` | ci.yml, same `should_run` gate | same |
| `Test (shard 1/4 .. 4/4)` | ci.yml, same `should_run` gate | same |
| `Build & E2E` | ci.yml, same `should_run` gate | same |
| `Build Docs` | ci.yml, same `should_run` gate | same |

`Changeset Declaration` is the one required context with **no** path filter, so it evaluates this diff for real. Verbatim:

```
Compared the working tree with fac5acfa4 (merge-base with origin/main): 6 file(s) changed, 0 of them published source of a package the release covers, 0 of them a manifest whose published contract moved, 0 under a package changesets ignores, 0 changeset(s) added.
✅  No source or published contract of a released package changed in this range, so no changeset is owed.
```

⇒ no changeset is owed for this PR, and ⛔ no `skip-changeset` label is applied — in this repository that label is not the mechanism.

The four other gates that read `.changeset/`, plus two that read every tracked text file, all run and all exit 0:

| gate | exit | note |
|---|--:|---|
| `node scripts/check-changeset-claims.mjs` | 0 | `0 file(s) changed outside .changeset/` — nothing to re-read |
| `node scripts/check-changeset-overwrite.mjs` | 0 | REPORTS all six, which is its documented case 2, "You are CORRECTING a declaration on purpose". Report-only. Declarations identical before and after |
| `node scripts/check-changeset-no-major.mjs` | 0 | no `major` declared |
| `node scripts/check-changeset-fixed.mjs` | 0 | fixed group intact |
| `node scripts/check-control-bytes.mjs` | 0 | 7327 tracked text files scanned |
| `node scripts/check-new-cross-file-line-citations.mjs` | 0 | 0 new citations |

**No test pins any rewritten sentence.** No file outside `.changeset/` names any of the seven changesets; a `grep -rl` for each rewritten phrase returns nothing outside `.changeset/` (with a firing control on `applyFeedConfig`, which returns three files). `TURBO_SCM_BASE` against the base reports **`0 no packages`** affected. `scripts/__tests__` for the five changeset gates plus control-bytes: **157 passed (157)**.

---

## A two-sided probe for `origin/main` after merge

Both legs flattened; floors are **per file**. ⭐ Leg 2 is leg 1's FIRING CONTROL: same pipeline, same instrument, same run, same `.changeset/` files — it must return non-zero, so a leg 1 of all zeros cannot be a broken query. Verified on this branch: leg 1 = 0 six times, leg 2 = 1 six times.

```bash
# leg 1 — what must have CHANGED (each must print 0)
for pair in \
  "8253-export-tree-view-config.md|is declared, not deleted" \
  "5293-view-sort-order-spelling.md|still accepts \`direction\`" \
  "7165-grid-dependent-values.md|does not re-scope the child" \
  "7655-chatbot-registration-authoring-faces.md|are live there" \
  "7727-conditional-formatting-record-scope.md|while resolving against the host" \
  "8934-chatter-feed-affordance-only.md|so it is unchanged and now renders"; do
  f=".changeset/${pair%%|*}"; p="${pair#*|}"
  printf '%-52s %s\n' "$p" "$(cat "$f" | tr '\n' ' ' | tr -s ' ' | grep -o -F "$p" | wc -l)"
done

# leg 2 — what must have SURVIVED (each must print exactly 1)
for pair in \
  "8253-export-tree-view-config.md|reddened that pin" \
  "8253-export-tree-view-config.md|the tree's second view-declared rung" \
  "8253-export-tree-view-config.md|declare it if the console writes it, else remove the read" \
  "olive-pears-invent.md|it lands on \`create\`, tracked as objectui#7170" \
  "olive-pears-invent.md|UNATTRIBUTED_STRIP_OBJECT" \
  "7727-conditional-formatting-record-scope.md|tracked as objectui#8166"; do
  f=".changeset/${pair%%|*}"; p="${pair#*|}"
  printf '%-58s %s\n' "$p" "$(cat "$f" | tr '\n' ' ' | tr -s ' ' | grep -o -F "$p" | wc -l)"
done
```

Expected values come from reads taken on this branch, not from intent. Leg 2 is the one that matters for review: it asserts that site 7's **historical reasoning survived** — the ruling, the pin citation and the counterfactual clause — and that the one changeset ruled leave-alone was in fact left alone, byte for byte (`git diff fac5acfa4 -- .changeset/olive-pears-invent.md` must be empty).

---

## Things the card, the triage and the PM claim got wrong

1. ⭐ **objectui#9052 did not edit objectui#6557's pin.** The blob is identical across `2f6b2bf1a^`, `2f6b2bf1a` and `fac5acfa4`. The "the pin was rewritten to expect the removal" trap is real as a *class* but does not apply to this file.
2. ⭐ **"reddened its pin" was TRUE, not false.** Measured at the pre-merge base with the pin unedited: legs A and C red, leg B green. The `domain:spec` seat's row substitutes a narrower antecedent (the `plugin-tree` resolver rung) for the one the sentence actually names (all four read sites).
3. **"32/32" is not reproducible.** The pin holds 8 tests; the three objectui#6557-citing app-shell files hold 37.
4. **The card under-rated its own six.** It says only the citation's *implication* is stale and ranks this the objectui#9042-least-important clause. Five of the six surrounding claims are flatly false present-tense statements about shipped behaviour — the objectui#9042 class the card said it was probably not.
5. Triage's all-clear control (`Version Packages` PRs = 0) does not fire here, as the PM claim already recorded and objectui#9134 now tracks.

## Deliberately not done

- ⛔ objectui#5400 untouched; ⛔ not a rider on objectui#9052; ⛔ not folded into objectui#9064.
- ⛔ The two `the other eight` phrase-match neighbours are untouched — different objects, no miscount.
- ⛔ No published `CHANGELOG.md` is edited.
- ⛔ `7655`'s `displayMode` tripwire sentence is left alone on purpose. objectui#7654 has landed the `?: never` tombstone, but that sentence carries its own expiry in its own words ("until that PR flips it"), which is what separates it from the five corrected above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_