### PR TITLE
fix(prompts): rule each key-teaching section, and widen check:prompt-keys to read them

### DIFF
--- a/.github/prompts/component.prompt.md
+++ b/.github/prompts/component.prompt.md
@@ -33,6 +33,22 @@
 
 You will be asked to build components in these 3 standard slots. Refer to `packages/spec` for the complete Zod definitions.
 
+> ⚠️ **Read the LABEL before you copy a token out of this file — the labels below are three different
+> vocabularies, and only two of them are things you may write as a `type`.** objectui#9098 landed the
+> ruling per section, and `pnpm check:prompt-keys` enforces it:
+>
+> - **`Keys:` and `Standard Components Library:` and `Required Components:`** — REGISTRY KEYS a real
+>   renderer answers. Safe to write as a `type`. Gated: the check reds if one of them stops rendering.
+> - **`Protocol Placeholders:`** — keys registered ONLY by the opt-in placeholder module. They
+>   validate and then paint a blank/OBJUI-001 panel. Gated the other way round: the check reds if one
+>   of them gains a real renderer, or loses its registration.
+> - **`Required Types (Ref: ...):`** — spec `type` VALUES inside a config object, ⛔ not registry
+>   keys, and ⛔ deliberately outside the check. See the note in §B for why the two vocabularies
+>   diverged.
+>
+> Anything in prose, in a blockquote, or in trailing text on a bullet is NOT a vocabulary — including
+> every ⛔ tombstone in this file, which names a key precisely so you do not write it.
+
 ### A. Field Widgets (`field:*`)
 Responsible for **Input** (Edit Mode) and **Display** (Read Mode) of a specific data type.
 *   **Contract:** Two layers with the same shape and DIFFERENT names — do not mix them up.
@@ -51,7 +67,8 @@ Responsible for **Input** (Edit Mode) and **Display** (Read Mode) of a specific 
     }
     ```
     The type is **closed**: a key it does not declare is a compile error, not a silent `any`.
-*   **Required Types (Ref: `src/data/field.zod.ts`):**
+*   **Required Types (Ref: `src/data/field.zod.ts`):** — spec `type` VALUES, ⛔ not registry keys;
+    outside `pnpm check:prompt-keys` by design (see §B).
     *   **Textual:** `text` (Input), `textarea` (Multi-line), `password`, `email`, `url`, `phone`.
     *   **Rich Content:** `markdown` (Editor), `html` (WYSIWYG), `code` (Monaco/Ace).
     *   **Numeric:** `number` (Int/Float), `currency` (Money), `percent` (Progress), `slider` (Range).
@@ -120,14 +137,26 @@ Reusable UI blocks for the Drag-and-Drop Page Builder.
       };
     }
     ```
-*   **Standard Components Library:**
+*   **Standard Components Library:** — a REGISTRY VOCABULARY. Every key here is answered by a real
+    renderer, and `pnpm check:prompt-keys` holds it to that.
     *   **Structure:** `page:header`, `page:footer`, `page:sidebar`, `page:tabs`, `page:accordion`, `page:card`.
-    *   **Record Context:** 
+    *   **Record Context:**
         *   `record:details` (The form), `record:highlights` (Key fields header).
         *   `record:related_list` (Sub-grid), `record:activity` (Timeline).
         *   `record:chatter` (Feed), `record:path` (Status Steps).
-    *   **Navigation:** `app:launcher`, `nav:menu`, `nav:breadcrumb`.
-    *   **Utility:** `global:search`, `global:notifications`, `user:profile`.
+    *   **Navigation:** `app:launcher`, `nav:menu`.
+    *   **Utility:** `global:search`, `global:notifications`.
+*   **Protocol Placeholders:** — registered, but ONLY by the opt-in placeholder module. These are
+    protocol surface, ⛔ not a library to reach for: a page schema naming one passes `objectui check`
+    and then paints the dashed placeholder panel in `apps/console`, or the OBJUI-001 "Unknown
+    component type" panel in every other host. The same gate holds this list to being placeholders.
+    *   `nav:breadcrumb` (no renderer ships yet).
+
+> ⛔ **Retired — do not write it, and never suggest it.** `user:profile` was dropped from
+> `PageComponentType` in `@objectstack/spec` 17.3.0 and removed across all three sites by
+> objectui#7122 (the placeholder module, the Studio palette ledger, and the CLI's known-type list).
+> It is no longer a page block any author can legitimately write, under any reading of this file.
+> The shell's own profile affordance is a React slot, not a page block type.
 
 ### E. Dashboard Widgets (`widget:*`)
 Standalone cards placed on a dashboard grid.
@@ -140,22 +169,32 @@ Standalone cards placed on a dashboard grid.
       height: number;
     }
     ```
-*   **Required Types (Ref: `src/ui/dashboard.zod.ts`):**
+*   **Required Types (Ref: `src/ui/dashboard.zod.ts`):** — spec `type` VALUES, ⛔ not registry keys;
+    outside `pnpm check:prompt-keys` by design (see §B).
     *   **KPI:** `metric` (Big Number with Trend).
     *   **Charts:** `bar`, `line`, `pie`, `funnel`, `radar`, `scatter`, `heatmap`.
     *   **Analysis:** `pivot` (Cross-Tab Table).
     *   **Content:** `table` (List), `text` (Note), `image`, `frame` (Embed).
 
-### F. Primitive Atoms (`atom:*`)
+### F. Primitive Atoms — IMPORTED, never authored
 The fundamental building blocks used by all other widgets.
 *   **Contract:** Pure UI components (No metadata dependencies).
-*   **Required Library:**
-    *   `atom:icon` (Lucide Wrapper).
-    *   `atom:button` (Standard Actions).
-    *   `atom:spinner` (Loading State).
-    *   `atom:empty` (No Data Placeholder).
-    *   `atom:error` (Error Boundary/Message).
-    *   `atom:badge` (Status Indicators).
+
+> ⛔ **`atom:` is a grouping label in this document, NOT a registry namespace — and this section is
+> NOT a vocabulary.** Measured against the shared registry derivation (`deriveRegistryKeys`):
+> **nothing in this repository registers any `atom:` key**, so `{ "type": "atom:button" }` in
+> metadata draws the OBJUI-001 "Unknown component type" panel, in every host. ⇒ this is not a
+> roadmap either — the primitives below already exist; what does not exist, and is not planned, is
+> a `type` string for them. They are React components you **import** from `@object-ui/components`.
+> Because the section teaches no keys, it is deliberately OUTSIDE `pnpm check:prompt-keys`.
+
+*   **Primitives (import from `@object-ui/components`; ⛔ never a `type` value):**
+    *   Icon (Lucide wrapper).
+    *   Button (Standard Actions).
+    *   Spinner (Loading State).
+    *   Empty (No Data Placeholder).
+    *   Error state (Error Boundary/Message).
+    *   Badge (Status Indicators).
 
 ### G. Smart Actions (`action:*`)
 Executable elements bound to the Action Protocol. They handle permissions, loading states, and confirmation dialogs automatically.
@@ -167,19 +206,32 @@ Executable elements bound to the Action Protocol. They handle permissions, loadi
       onExecute: () => Promise<void>;
     }
     ```
-*   **Required Components:**
+*   **Required Components:** — a REGISTRY VOCABULARY, and the one that was already correct. All four
+    are registered by a real renderer under `packages/components/src/renderers/action/`, and
+    `pnpm check:prompt-keys` now holds them there.
     *   `action:button`: Standalone smart button.
     *   `action:group`: Toolbar or Button Group.
     *   `action:menu`: Dropdown menu for overflow actions.
     *   `action:icon`: Icon-only trigger (for dense lists).
 
 ### H. AI Interface (`ai:*`)
-Conversational and Generative UI components.
-*   **Required Components:**
-    *   `ai:chat_window`: Standard conversational interface.
+Conversational and Generative UI components. ⚠️ This section is PROTOCOL PLACEHOLDER surface, ⛔ not
+an available component library — read the label before you write any of it.
+*   **Protocol Placeholders:** — registered, but ONLY by the opt-in placeholder module, so each one
+    validates and then paints the dashed placeholder panel in `apps/console` or the OBJUI-001
+    "Unknown component type" panel everywhere else. Name one only when a host you control calls
+    `registerPlaceholders()` and a blank panel is the outcome you want. `pnpm check:prompt-keys`
+    holds this list to being placeholders — it reds if one of them gains a real renderer (the claim
+    below would then understate the platform) and it reds if one of them loses its registration.
     *   `ai:input`: Prompt input with auto-complete/context.
     *   `ai:suggestion`: "Next Best Action" cards.
     *   `ai:feedback`: Thumbs up/down + reasoning capture.
+
+> ⛔ **`ai:chat_window` is DELIBERATELY unregistered — do not "fix" it by registering it.** The
+> placeholder module records the omission in its own comment: the floating chat overlay
+> (`plugin-chatbot`) is the canonical entry point, and inline page-level chat windows are not part of
+> the supported surface. A page schema naming it draws the loud OBJUI-001 panel **by design**, so the
+> misconfiguration gets fixed at the source instead of hiding behind a grey box.
 
 ---
 

--- a/.github/prompts/engine.prompt.md
+++ b/.github/prompts/engine.prompt.md
@@ -144,7 +144,8 @@ Scenario: User sees the record but lacks permission to view 'Salary' field.
 
 ### E. Theme Injection
 Scenario: App branding (`branding.primaryColor`) must apply to all Buttons.
-*   **Solution:** Convert `App.branding` values into CSS Variables (`--os-primary: #ff0000`) injected at the root `<LayoutProvider>`. All atoms (`atom:button`) consume these variables.
+*   **Solution:** Convert `App.branding` values into CSS Variables (`--os-primary: #ff0000`) injected at the root `<LayoutProvider>`. All atom-level primitives (the `Button` component imported from `@object-ui/components`) consume these variables.
+    *   ⛔ `atom:` is a grouping label, NOT a registry namespace: nothing registers an `atom:` key, so it is never a `type` an author writes. See §F of `component.prompt.md` (objectui#9098).
 
 ---
 

--- a/scripts/__tests__/check-prompt-component-keys.test.ts
+++ b/scripts/__tests__/check-prompt-component-keys.test.ts
@@ -437,6 +437,19 @@ describe('a gated label opens a block, and only the block is judged', () => {
     expect(findings).toEqual([]);
   });
 
+  it('never judges a backticked span with a space in it — that is a command, not a key', () => {
+    // The label lines in the live file end in prose that backticks
+    // `pnpm check:prompt-keys`. No key the derivation produces has whitespace in
+    // it (650 of 650 measured), so this skips nothing a bad key could hide in.
+    const { findings, counters } = run([
+      '*   **Required Components:** — held to this by `pnpm check:prompt-keys`, see `objectui check`.',
+      '    *   `view:grid`: the only key taught here.',
+    ]);
+
+    expect(counters.blockKeys).toBe(1);
+    expect(findings).toEqual([]);
+  });
+
   it('never judges trailing text on a sub-bullet unless it is backticked', () => {
     const { findings, counters } = run([
       '*   **Required Components:**',

--- a/scripts/__tests__/check-prompt-component-keys.test.ts
+++ b/scripts/__tests__/check-prompt-component-keys.test.ts
@@ -343,3 +343,242 @@ describe('wiring', () => {
     expect(external, `the gate's import graph reaches a package, so it needs an install: ${external}`).toEqual([]);
   });
 });
+
+// ── 5. the LABELLED BLOCK reading model (objectui#9098) ──────────────────────
+
+/**
+ * The `Keys:` model above reads ONE line. The prompt teaches keys in four more
+ * places shaped the other way round — a bolded label with nothing after it, and
+ * the keys one per SUB-BULLET with trailing prose. So the card's "add a label to
+ * the set it scans is a one-line change" is false, and the case below that
+ * matters most is the CONTROL: the same sub-bullets under an ungated label are
+ * read as nothing at all.
+ */
+describe('a gated label opens a block, and only the block is judged', () => {
+  /** One authorable key, one placeholder-only key — enough for every verdict. */
+  const registryTree = (write: (rel: string, contents: string) => void) => {
+    write(PLACEHOLDER_SITE, placeholderModule(['view:kanban', 'ai:input']));
+    write('packages/plugin-grid/src/index.tsx', "ComponentRegistry.register('grid', G, { namespace: 'view' });");
+  };
+  const KEYS_LINE = '*   **Keys:** `view:grid`, etc.';
+  const prompt = (...body: string[]) => [KEYS_LINE, ...body].join('\n');
+
+  const run = (body: string[]) =>
+    withTree((write) => {
+      registryTree(write);
+      write(`${PROMPT_DIR}/component.prompt.md`, prompt(...body));
+    }, analyzeFixture);
+
+  it('reads one key per sub-bullet — the shape the Keys model cannot see', () => {
+    const { findings, counters } = run([
+      '*   **Required Components:**',
+      '    *   `view:grid`: a real renderer answers this one.',
+      '    *   `view:kanban` (placeholder only).',
+    ]);
+
+    expect(counters.blockKeys).toBe(2);
+    expect(findings.map((f) => [f.key, f.reason])).toEqual([['view:kanban', 'placeholder-only-key']]);
+  });
+
+  it('reads NOTHING under an ungated label — the control that makes the case above mean something', () => {
+    // Byte-identical sub-bullets, one word changed on the label line. Without
+    // this leg the case above would also pass against a gate that judged every
+    // backticked token in the file, which is the failure triage warned about.
+    const { findings, counters } = run([
+      '*   **Required Library:**',
+      '    *   `view:grid`: a real renderer answers this one.',
+      '    *   `view:kanban` (placeholder only).',
+    ]);
+
+    expect(counters.blocks).toBe(0);
+    expect(counters.blockKeys).toBe(0);
+    expect(findings).toEqual([]);
+  });
+
+  it('leaves `Required Types:` alone — it is a spec `type` vocabulary, not a registry one', () => {
+    // objectui#8929 landed that distinction in the prompt itself. A registry-key
+    // gate reaching into it would red on `grid` / `kanban` / `gantt`, which are
+    // spec-valid by design, so the label must stay OUT of the gated set.
+    const { findings, counters } = run([
+      '*   **Required Types (Ref: `src/ui/view.zod.ts`):** `grid`, `kanban`, `gantt`.',
+      '*   **Required Types (Ref: `src/data/field.zod.ts`):**',
+      '    *   **Textual:** `text`, `textarea`.',
+    ]);
+
+    expect(counters.blocks).toBe(0);
+    expect(findings).toEqual([]);
+  });
+
+  it('never judges a tombstone in prose OUTSIDE the block — the whole point of scoping', () => {
+    // The live file names `view:kanban`, `view:gantt`, `user:profile` and
+    // `ai:chat_window` precisely so an author does NOT write them. Every one is
+    // a key this gate rejects when it reads it, so "do not write this" prose has
+    // to stay unread or the file cannot say it.
+    const { findings } = run([
+      '*   **Required Components:**',
+      '    *   `view:grid`: the only key taught here.',
+      '',
+      '> ⛔ Retired — do not write it: `view:kanban` no longer renders.',
+      '',
+      'And a plain paragraph naming `view:kanban` again.',
+    ]);
+
+    expect(findings).toEqual([]);
+  });
+
+  it('never judges a continuation line inside the block that is not a list item', () => {
+    const { findings, counters } = run([
+      '*   **Required Components:**',
+      '    this line sits IN the block and names `view:kanban`, but it is prose, not a list item.',
+      '    *   `view:grid`: the only key taught here.',
+    ]);
+
+    expect(counters.blockKeys).toBe(1);
+    expect(findings).toEqual([]);
+  });
+
+  it('never judges trailing text on a sub-bullet unless it is backticked', () => {
+    const { findings, counters } = run([
+      '*   **Required Components:**',
+      '    *   `view:grid`: a Standalone smart button, the view:kanban spelling is dead, see notes.',
+    ]);
+
+    expect(counters.blockKeys).toBe(1);
+    expect(findings).toEqual([]);
+  });
+
+  it('ends the block at a sibling bullet indented at the label`s own level', () => {
+    const { findings, counters } = run([
+      '*   **Required Components:**',
+      '    *   `view:grid`',
+      '*   **Contract:** the retired `view:kanban` is discussed on an ungated sibling bullet.',
+    ]);
+
+    expect(counters.blockKeys).toBe(1);
+    expect(findings).toEqual([]);
+  });
+
+  it('skips fenced code, so a document EXPLAINING the convention is not judged by it', () => {
+    const { findings, counters } = run([
+      '',
+      '```markdown',
+      '*   **Required Components:**',
+      '    *   `view:kanban`',
+      '```',
+    ]);
+
+    expect(counters.blocks).toBe(0);
+    expect(findings).toEqual([]);
+  });
+
+  it('refuses to run when a gated label opens a block that teaches no key', () => {
+    // The block model's equivalent of the `bullets === 0` collapse: the label is
+    // still there, the keys moved out from under it, and a gate that reads
+    // nothing under a live label would print a pass it did not earn.
+    expect(() =>
+      run([
+        '*   **Required Components:**',
+        '    *   see the table below for the current list.',
+      ]),
+    ).toThrow(/taught no key at all/);
+  });
+});
+
+// ── 6. the INVERTED leg: a placeholder list is a factual claim too ───────────
+
+describe('`Protocol Placeholders:` is judged the other way round', () => {
+  const run = (body: string[], placeholderKeys: string[] = ['view:kanban', 'ai:input']) =>
+    withTree((write) => {
+      write(PLACEHOLDER_SITE, placeholderModule(placeholderKeys));
+      write('packages/plugin-grid/src/index.tsx', "ComponentRegistry.register('grid', G, { namespace: 'view' });");
+      write(`${PROMPT_DIR}/component.prompt.md`, ['*   **Keys:** `view:grid`, etc.', ...body].join('\n'));
+    }, analyzeFixture);
+
+  const BLOCK = ['*   **Protocol Placeholders:**', '    *   `ai:input`: prompt input.'];
+
+  it('accepts a key the placeholder module alone registers', () => {
+    const { findings, counters } = run(BLOCK);
+    expect(counters.placeholderClaims).toBe(1);
+    expect(findings).toEqual([]);
+  });
+
+  it('rejects a key a REAL renderer answers — the section would understate the platform', () => {
+    // Same block, and the only change is that `ai:input` now has a real
+    // renderer. Without this leg, "move the placeholder-only keys into a
+    // placeholder section" would have moved the drift instead of fixing it.
+    const { findings } = withTree((write) => {
+      write(PLACEHOLDER_SITE, placeholderModule(['view:kanban', 'ai:input']));
+      write(
+        'packages/plugin-grid/src/index.tsx',
+        [
+          "ComponentRegistry.register('grid', G, { namespace: 'view' });",
+          "ComponentRegistry.register('input', AiInput, { namespace: 'ai' });",
+        ].join('\n'),
+      );
+      write(`${PROMPT_DIR}/component.prompt.md`, ['*   **Keys:** `view:grid`, etc.', ...BLOCK].join('\n'));
+    }, analyzeFixture);
+
+    expect(findings.map((f) => [f.key, f.reason])).toEqual([['ai:input', 'not-a-placeholder-key']]);
+  });
+
+  it('rejects a key the placeholder module has stopped registering', () => {
+    const { findings } = run(BLOCK, ['view:kanban']);
+    expect(findings.map((f) => [f.key, f.reason])).toEqual([['ai:input', 'unregistered-key']]);
+  });
+});
+
+// ── 7. the live tree, under the widened model ────────────────────────────────
+
+describe('the prompt surface this gate now reads', () => {
+  const scan = () => scanPromptKeys(repoRoot) as {
+    sites: { key: string; label: string; expect: string; scope: string }[];
+    bullets: number;
+    blocks: number;
+    emptyBlocks: string[];
+  };
+
+  it('really does reach the labelled blocks — floors, so a reformat cannot quietly empty them', () => {
+    const { blocks, sites, emptyBlocks } = scan();
+    expect(emptyBlocks).toEqual([]);
+    expect(blocks, 'gated label blocks on the live prompt surface').toBeGreaterThanOrEqual(4);
+    expect(sites.filter((s) => s.scope === 'block').length, 'keys read from blocks').toBeGreaterThanOrEqual(24);
+    expect(
+      sites.filter((s) => s.expect === 'placeholder-only').length,
+      'keys claimed as protocol placeholders',
+    ).toBeGreaterThanOrEqual(4);
+  });
+
+  it('still reads objectui#8929`s two `Keys:` bullets, and reads them the old way', () => {
+    // The widening must not have moved them: they are correct and already gated,
+    // and their sub-bullet prose (the `formType` values) must stay unjudged.
+    const { bullets, sites } = scan();
+    expect(bullets).toBe(2);
+    expect(sites.filter((s) => s.scope === 'keys-line').map((s) => s.key)).toEqual([
+      'view:grid',
+      'object-kanban',
+      'view:map',
+      'view:calendar',
+      'object-gantt',
+      'view:simple',
+      'view:form',
+      'view:detail',
+    ]);
+  });
+
+  it('teaches no key at all under a `Required Types` label', () => {
+    expect(scan().sites.filter((s) => /^Required Types/.test(s.label))).toEqual([]);
+  });
+
+  it('names the retired and deliberately-unregistered keys ONLY in prose', () => {
+    // Each of these appears in the file, and each would be a finding if the gate
+    // read it. That they are absent from the scan IS the prose-safety proof.
+    const taught = new Set(scan().sites.map((s) => s.key));
+    for (const tombstone of ['user:profile', 'ai:chat_window', 'view:kanban', 'view:gantt']) {
+      expect(taught.has(tombstone), `${tombstone} must stay in prose, never in a judged list`).toBe(false);
+    }
+    const prompt = fs.readFileSync(path.join(repoRoot, PROMPT_DIR, 'component.prompt.md'), 'utf8');
+    for (const tombstone of ['user:profile', 'ai:chat_window', 'view:kanban']) {
+      expect(prompt, `${tombstone} tombstone must still be written down`).toContain(`\`${tombstone}\``);
+    }
+  });
+});

--- a/scripts/check-prompt-component-keys.mjs
+++ b/scripts/check-prompt-component-keys.mjs
@@ -82,11 +82,11 @@
  *   BLOCK: the contiguous run of lines indented strictly MORE than the label's
  *   own bullet, ending at the first non-blank line indented at or below it (or
  *   at end of file). Inside that block only LIST-ITEM lines are read, and from
- *   each, every single-backticked token is taken as a key. Fenced code is
- *   skipped everywhere.
+ *   each, every single-backticked token WITHOUT whitespace in it is taken as a
+ *   key. Fenced code is skipped everywhere.
  *
- * Everything else is prose and is never judged. That is three escape hatches,
- * and the prompt surface uses all three today:
+ * Everything else is prose and is never judged. That is four escape hatches, and
+ * the prompt surface uses all four today:
  *
  *   OUTSIDE THE BLOCK    a blockquote or paragraph at the section's own level
  *                        is not in the label's sub-tree. This is where the
@@ -98,6 +98,10 @@
  *                        "do not write this" example has to stay unjudged.
  *   NOT A LIST ITEM      a continuation paragraph indented under the label is
  *                        skipped even though it IS in the block.
+ *   BACKTICKED PROSE     a backticked span with a space in it is a command or a
+ *                        phrase, never a key: `pnpm check:prompt-keys`,
+ *                        `objectui check`. Not one of the 650 derived keys has
+ *                        whitespace in it, so nothing real is skipped here.
  *   NOT BACKTICKED       trailing prose on a sub-bullet — `(Lucide Wrapper)`,
  *                        `: Standalone smart button.`, `(Sub-grid)` — carries no
  *                        backticks and so contributes nothing. An author who
@@ -252,12 +256,22 @@ export function promptFiles(root) {
     .map((name) => join(dir, name));
 }
 
-/** Every single-backticked token in `text`, pushed as taught keys. */
+/**
+ * Every single-backticked token in `text` that could be a registry key.
+ *
+ * A backticked span containing WHITESPACE is not one: the derivation produces
+ * 650 keys on this tree and not one of them has a space in it, while the prose
+ * around a vocabulary list is full of backticked commands and phrases —
+ * `pnpm check:prompt-keys`, `objectui check`. Skipping them is not a hole a bad
+ * key can hide in: a token with a space resolves to nothing under ANY spelling,
+ * so there is no registration for it to be judged against either way.
+ */
 function harvest(sites, text, { file, line, label, expect, scope }) {
   BACKTICKED.lastIndex = 0;
   let token;
   let found = 0;
   while ((token = BACKTICKED.exec(text))) {
+    if (/\s/.test(token[1])) continue;
     found++;
     sites.push({ file, key: token[1], text: line.trim(), label, expect, scope });
   }

--- a/scripts/check-prompt-component-keys.mjs
+++ b/scripts/check-prompt-component-keys.mjs
@@ -67,6 +67,59 @@
  * prompt names must exist and must render. The other direction (a new renderer
  * lands, the prompt does not mention it) leaves the prompt incomplete, never
  * WRONG, and gating it would red on every plugin that ships.
+ *
+ * ## The second reading model: LABELLED BLOCKS (objectui#9098)
+ *
+ * A `Keys:` bullet puts every key on ONE line, which is why the rule above is
+ * "the Keys LINE only". The prompt teaches component keys in four more places
+ * that are shaped differently — `Standard Components Library:` and two
+ * `Required Components:` bullets whose keys live in SUB-BULLETS, each followed
+ * by trailing prose. Widening the label set alone would have read nothing:
+ * those label lines carry no keys at all. So this gate carries a second reading
+ * model, and the token-selection rule it states is:
+ *
+ *   A GATED LABEL is a bolded bullet label drawn from a fixed set. It opens a
+ *   BLOCK: the contiguous run of lines indented strictly MORE than the label's
+ *   own bullet, ending at the first non-blank line indented at or below it (or
+ *   at end of file). Inside that block only LIST-ITEM lines are read, and from
+ *   each, every single-backticked token is taken as a key. Fenced code is
+ *   skipped everywhere.
+ *
+ * Everything else is prose and is never judged. That is three escape hatches,
+ * and the prompt surface uses all three today:
+ *
+ *   OUTSIDE THE BLOCK    a blockquote or paragraph at the section's own level
+ *                        is not in the label's sub-tree. This is where the
+ *                        tombstones live — the note naming `view:kanban` and
+ *                        `view:gantt` as retired, the one naming `user:profile`,
+ *                        the one naming `ai:chat_window` as deliberately
+ *                        unregistered. Every one of those is a key this gate
+ *                        would reject if it read it, which is precisely why a
+ *                        "do not write this" example has to stay unjudged.
+ *   NOT A LIST ITEM      a continuation paragraph indented under the label is
+ *                        skipped even though it IS in the block.
+ *   NOT BACKTICKED       trailing prose on a sub-bullet — `(Lucide Wrapper)`,
+ *                        `: Standalone smart button.`, `(Sub-grid)` — carries no
+ *                        backticks and so contributes nothing. An author who
+ *                        needs to name a NON-key in that prose writes it without
+ *                        backticks, or moves the note out of the block.
+ *
+ * ## Two verdicts, because a placeholder list is a claim too
+ *
+ * `Protocol Placeholders:` is gated with the partition INVERTED: every key under
+ * it must be placeholder-only. A list of protocol placeholders is as much a
+ * factual claim as a list of components, and it drifts the same way — if
+ * `ai:input` gains a real renderer the section is stale, and if it loses its
+ * registration entirely the section names nothing at all. Without the inverted
+ * leg, "move the placeholder-only keys to a placeholder section" would have
+ * moved the drift rather than fixed it.
+ *
+ * ## Why a block that opens and reads nothing is a failure
+ *
+ * `bullets === 0` catches the `Keys:` surface disappearing. The block model's
+ * equivalent is narrower and stronger: a gated label that matches but whose
+ * block yields no keys means the section was reformatted so the keys moved out
+ * from under it — the gate would then judge nothing while printing a pass.
  */
 
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
@@ -102,8 +155,73 @@ const KEYS_BULLET = /^\s*[*-]\s+\*\*Keys:\*\*\s*(.*)$/;
  *  the file it reads: a Keys bullet's keys live on the Keys line. */
 const BACKTICKED = /`([^`]+)`/g;
 
+/**
+ * Any bolded bullet label, e.g. `*   **Required Components:**`. Matching every
+ * label and filtering afterwards (rather than building one regex out of the
+ * gated names) keeps the gated set readable as DATA — the thing a future
+ * retirement has to edit — instead of as regex alternation.
+ */
+const LABEL_BULLET = /^(\s*)[*+-]\s+\*\*([^*]+?):\*\*\s*(.*)$/;
+
+/** A list item at any depth — the only kind of line a gated block reads. */
+const LIST_ITEM = /^\s*(?:[*+-]|\d+\.)\s+/;
+
+/** A fenced-code delimiter. A `**Keys:**` line inside a fence is an EXAMPLE of
+ *  a bullet, not a bullet, and judging it would red on a document explaining
+ *  the convention. */
+const FENCE = /^\s*(?:```|~~~)/;
+
+/**
+ * Bullet labels whose sub-bullet BLOCK teaches keys an author may write, and
+ * whose every key must therefore be authorable.
+ *
+ * ⛔ NOT a list of key names — that is the drift this gate exists about. This is
+ * a list of LABELS: the four claims the prompt surface makes about the registry.
+ * `Required Types:` is deliberately absent and must stay absent — objectui#8929
+ * landed the reason in the prompt itself: a `Required Types` entry is a spec
+ * `type` VALUE, not a registry key, so `grid` / `kanban` / `gantt` are correct
+ * there and a registry-key gate would red on correct text. `Keys:` is absent
+ * because it has its own, narrower reading model above.
+ */
+export const AUTHORABLE_BLOCK_LABELS = ['Standard Components Library', 'Required Components'];
+
+/**
+ * Bullet labels whose block lists PROTOCOL PLACEHOLDERS. The partition is read
+ * the other way round here: every key must be answered by the placeholder
+ * module and by nothing else.
+ */
+export const PLACEHOLDER_BLOCK_LABELS = ['Protocol Placeholders'];
+
+/** What the partition must say about a key, given the label that taught it. */
+export function expectationFor(label) {
+  if (AUTHORABLE_BLOCK_LABELS.includes(label)) return 'authorable';
+  if (PLACEHOLDER_BLOCK_LABELS.includes(label)) return 'placeholder-only';
+  return null;
+}
+
 /** Files the prompt surface is made of. */
 const PROMPT_EXTENSIONS = ['.md'];
+
+/** Leading width of a line, tabs counted as four columns. */
+function indentOf(line) {
+  const expanded = line.replace(/\t/g, '    ');
+  return expanded.length - expanded.trimStart().length;
+}
+
+/** Mark every line that sits inside a fenced code block. */
+function fenceMask(lines) {
+  const mask = new Array(lines.length).fill(false);
+  let open = false;
+  for (let i = 0; i < lines.length; i++) {
+    if (FENCE.test(lines[i])) {
+      mask[i] = true;
+      open = !open;
+      continue;
+    }
+    mask[i] = open;
+  }
+  return mask;
+}
 
 /** Which registration sites belong to the opt-in protocol placeholder. */
 export function placeholderSites(indirect = INDIRECT_REGISTRATIONS) {
@@ -134,25 +252,85 @@ export function promptFiles(root) {
     .map((name) => join(dir, name));
 }
 
-/** Every key taught on a `Keys:` bullet, with the file and bullet text. */
+/** Every single-backticked token in `text`, pushed as taught keys. */
+function harvest(sites, text, { file, line, label, expect, scope }) {
+  BACKTICKED.lastIndex = 0;
+  let token;
+  let found = 0;
+  while ((token = BACKTICKED.exec(text))) {
+    found++;
+    sites.push({ file, key: token[1], text: line.trim(), label, expect, scope });
+  }
+  return found;
+}
+
+/**
+ * Every key the prompt surface teaches, under both reading models.
+ *
+ * `bullets` counts `**Keys:**` lines (the objectui#8929 model, LINE only) and
+ * `blocks` counts gated labelled blocks (the objectui#9098 model). `emptyBlocks`
+ * records a gated label whose block yielded nothing — see the header: that is a
+ * reformatted section, not an empty one, and it must not read as a pass.
+ */
 export function scanPromptKeys(root) {
   const sites = [];
   let bullets = 0;
+  let blocks = 0;
+  const emptyBlocks = [];
+
   for (const abs of promptFiles(root)) {
     const rel = relative(root, abs).split(sep).join('/');
     const lines = readFileSync(abs, 'utf8').split('\n');
-    for (const line of lines) {
+    const fenced = fenceMask(lines);
+
+    for (let i = 0; i < lines.length; i++) {
+      if (fenced[i]) continue;
+      const line = lines[i];
+
       const bullet = KEYS_BULLET.exec(line);
-      if (!bullet) continue;
-      bullets++;
-      BACKTICKED.lastIndex = 0;
-      let token;
-      while ((token = BACKTICKED.exec(bullet[1]))) {
-        sites.push({ file: rel, key: token[1], text: line.trim() });
+      if (bullet) {
+        bullets++;
+        harvest(sites, bullet[1], {
+          file: rel,
+          line,
+          label: 'Keys',
+          expect: 'authorable',
+          scope: 'keys-line',
+        });
+        continue;
       }
+
+      const labelled = LABEL_BULLET.exec(line);
+      if (!labelled) continue;
+      const [, lead, label, trailing] = labelled;
+      const expect = expectationFor(label);
+      if (!expect) continue;
+
+      blocks++;
+      const indent = indentOf(lead + '*');
+      const site = { file: rel, line, label, expect, scope: 'block' };
+      // The label line itself is read too. Today every gated label ends at its
+      // colon, but reading the trailing text costs nothing and fails SAFE: a
+      // future author who puts keys on the label line gets them judged rather
+      // than silently skipped.
+      let found = harvest(sites, trailing, site);
+
+      let j = i + 1;
+      for (; j < lines.length; j++) {
+        const body = lines[j];
+        if (body.trim() === '') continue;
+        if (indentOf(body) <= indent) break;
+        if (fenced[j]) continue;
+        if (!LIST_ITEM.test(body)) continue;
+        found += harvest(sites, body, { ...site, line: body });
+      }
+
+      if (found === 0) emptyBlocks.push(`${rel}: \`${label}:\``);
+      i = j - 1;
     }
   }
-  return { sites, bullets };
+
+  return { sites, bullets, blocks, emptyBlocks };
 }
 
 /**
@@ -190,21 +368,33 @@ export function analyze(root, options = {}) {
     throw new Error('the derivation produced no authorable keys — refusing to judge against an empty set.');
   }
 
-  const { sites: taught, bullets } = scanPromptKeys(root);
+  const { sites: taught, bullets, blocks, emptyBlocks } = scanPromptKeys(root);
   if (bullets === 0) {
     throw new Error(
       `no \`**Keys:**\` bullet was found under ${PROMPT_DIR}. The surface this gate reads is gone or ` +
         'has been reformatted, and a run that reads nothing passes while asserting nothing.',
     );
   }
+  if (emptyBlocks.length > 0) {
+    throw new Error(
+      `${emptyBlocks.length} gated label(s) opened a block that taught no key at all:\n` +
+        emptyBlocks.map((b) => `  ${b}`).join('\n') +
+        '\nA label whose keys have moved out from under it is a REFORMATTED section, not an empty one, ' +
+        'and judging\nnothing under it would report a pass this gate did not earn.',
+    );
+  }
 
   const findings = [];
   for (const site of taught) {
-    if (authorable.has(site.key)) continue;
-    findings.push({
-      ...site,
-      reason: placeholderOnly.has(site.key) ? 'placeholder-only-key' : 'unregistered-key',
-    });
+    const isAuthorable = authorable.has(site.key);
+    const isPlaceholder = placeholderOnly.has(site.key);
+    if (site.expect === 'placeholder-only') {
+      if (isPlaceholder) continue;
+      findings.push({ ...site, reason: isAuthorable ? 'not-a-placeholder-key' : 'unregistered-key' });
+      continue;
+    }
+    if (isAuthorable) continue;
+    findings.push({ ...site, reason: isPlaceholder ? 'placeholder-only-key' : 'unregistered-key' });
   }
 
   return {
@@ -212,7 +402,10 @@ export function analyze(root, options = {}) {
     counters: {
       promptFiles: promptFiles(root).length,
       bullets,
+      blocks,
       keys: taught.length,
+      blockKeys: taught.filter((s) => s.scope === 'block').length,
+      placeholderClaims: taught.filter((s) => s.expect === 'placeholder-only').length,
       registryKeys: registry.keys.size,
       authorable: authorable.size,
       placeholderOnly: placeholderOnly.size,
@@ -230,6 +423,12 @@ const HINTS = {
   'unregistered-key':
     'Nothing in this repository registers this key, so it resolves to the OBJUI-001 "Unknown ' +
     'component type" panel everywhere. Teach a registered key.',
+  'not-a-placeholder-key':
+    'This key is taught under a `Protocol Placeholders:` label, but a REAL renderer answers it — so ' +
+    'the section understates what the platform ships and steers an author away from a component that ' +
+    'works. Move it to the components list. (The same label rejects a key nothing registers at all, ' +
+    'under `unregistered-key`: a placeholder list that names a key the placeholder module dropped is ' +
+    'as wrong as a component list that names a retired one.)',
 };
 
 if (isEntrypoint(import.meta.url)) {
@@ -254,13 +453,18 @@ if (isEntrypoint(import.meta.url)) {
   const { findings, counters } = result;
   console.log(
     `Scanned ${counters.promptFiles} prompt file(s) under ${PROMPT_DIR}, ` +
-      `${counters.bullets} \`Keys:\` bullet(s), ${counters.keys} taught key(s) against ` +
+      `${counters.bullets} \`Keys:\` bullet(s) and ${counters.blocks} gated label block(s), ` +
+      `${counters.keys} taught key(s) (${counters.blockKeys} of them from blocks, ` +
+      `${counters.placeholderClaims} claimed as placeholders) against ` +
       `${counters.authorable} authorable key(s) — the ${counters.registryKeys} registered key(s) less ` +
       `the ${counters.placeholderOnly} answered only by the ${PLACEHOLDER_NAMESPACE} registration.`,
   );
 
   if (findings.length === 0) {
-    console.log('OK  Every key taught on a `Keys:` bullet is answered by a real renderer.');
+    console.log(
+      'OK  Every key taught as available is answered by a real renderer, and every key taught as a ' +
+        'protocol placeholder is answered only by the placeholder.',
+    );
     process.exit(0);
   }
 


### PR DESCRIPTION
Fixes #9098

`.github/prompts/component.prompt.md` taught component keys in four labelled sections outside the two `**Keys:**` bullets objectui#8929 gated. Every section now carries **its own ruling, in the file**, and the gate reads the ones that are registry vocabularies — because a text-only pass buys nothing durable: the same drift returns on the next retirement.

## 1. Per-section ruling, and the measurement that decided it

Every verdict re-derived here from `deriveRegistryKeys`, partitioned into *some non-placeholder site registers it* vs *only `PROTOCOL_COMPONENTS` registers it*. Universe on `1e0e46af9`: **650 keys = 536 authorable + 114 placeholder-only**, derivation findings **0**.

| § | label | ruling | measurement | action |
|---|---|---|---|---|
| **D** | `Standard Components Library:` | **VOCABULARY** → gated | 16 of 18 authorable; `nav:breadcrumb` placeholder-only; `user:profile` registered by nothing | `user:profile` removed to a tombstone; `nav:breadcrumb` moved to a `Protocol Placeholders:` list |
| **F** | `Required Library:` | **NOT a vocabulary — and not a roadmap either** → stays outside the gate, and the section now says so | 0 of 6 `atom:*` registered; `atom:` appears in **no** registration site anywhere in the repo | the six become plain React imports; the `atom:` key spelling is gone from the file |
| **G** | `Required Components:` (`action:*`) | **VOCABULARY** → gated | **4 of 4 authorable**, each with a real renderer under `packages/components/src/renderers/action/` | unchanged text; now gated, and it is where the widening gets its non-vacuity |
| **H** | `Required Components:` (`ai:*`) | **PROTOCOL PLACEHOLDER surface** → gated, with the partition **inverted** | `ai:input` / `ai:suggestion` / `ai:feedback` placeholder-only; `ai:chat_window` registered by nothing | relabelled `Protocol Placeholders:`; `ai:chat_window` removed to a tombstone |
| **A, B, E** | `Required Types (Ref: ...):` | **spec `type` vocabulary** → ⛔ deliberately outside the gate | see §3 | markers added in §A and §E so the §B note reaches them |

The four verdict classes are kept apart, as triage required. `atom:*` (nothing registers it) is stated plainly as unavailable; `ai:chat_window` (deliberately unregistered) is recorded as a **designed** loud OBJUI-001 panel and ⛔ explicitly not to be "fixed" by registering it; `user:profile` (retired) is removed and marked never-suggest; the placeholder-only set is labelled as protocol surface rather than deleted.

## 2. Section G was the section the card missed — and it is clean

There are **two** `Required Components:` sections. The card measures only `ai:*`. Section G's `action:button` / `action:group` / `action:menu` / `action:icon` were unflagged and unmeasured, and a label-based widening pulls them in. Partitioned through `deriveRegistryKeys`:

```
action:button   AUTHORABLE   packages/components/src/renderers/action/action-button.tsx:293
action:group    AUTHORABLE   packages/components/src/renderers/action/action-group.tsx:367
action:menu     AUTHORABLE   packages/components/src/renderers/action/action-menu.tsx:351
action:icon     AUTHORABLE   packages/components/src/renderers/action/action-icon.tsx:224
```

⇒ **clean**, and a free non-vacuity datum: the widened gate reads four keys it passes for a reason, not because it read nothing. Corroborated at the source — `placeholders.tsx` carries the four commented out under `// 14. Smart Actions (implemented in ./action/)`.

## 3. ⛔ `Required Types` stays out, and that exclusion is load-bearing

objectui#8929 landed the answer in the file: **a `Keys` entry is a REGISTRY key; a `Required Types` entry is a spec `type` value.** Pulling those sections into a registry-key gate would red on values that are spec-valid by design. Not asserted — measured, by ablating the exclusion (temporarily treating any `Required Types` label as a gated vocabulary):

```
anchor count BEFORE: 0   AFTER: 1     blob 4dc39ba3 -> 548be1ce
VERDICT exit=1 — 23 problem(s), all [unregistered-key], including
  `kanban`  `gantt`  `spreadsheet`  `gallery`  `simple`  `tabbed`  `wizard`  `split`  `modal`
  `bar` `line` `pie` `funnel` `radar` `scatter` `heatmap` `frame` `json` `video` `audio` `duration`
restore -> blob 4dc39ba3, git diff HEAD EMPTY, VERDICT exit=0
```

⇒ 23 correct lines would have gone red. The card's label list invites exactly that mistake; the label set in the gate names `Required Types` in a comment as the label that must stay absent.

## 4. The token-selection rule, stated

The card says widening is "a one-line change to the label set". It is not, and the reason is structural: a `Keys:` bullet puts every key on **one LINE**, and the landed gate reads that line only, "never from the bullet's continuation or its sub-bullets". These sections put **one key per SUB-BULLET with trailing prose**, and their label lines carry no keys at all — a label added to the old anchor would have read **zero** tokens. So this is a second **reading model**:

> A **gated label** is a bolded bullet label drawn from a fixed set. It opens a **BLOCK**: the contiguous run of lines indented strictly **more** than the label's own bullet, ending at the first non-blank line indented at or below it, or at end of file. Inside that block only **list-item** lines are read, and from each, every single-backticked token **without whitespace in it** is taken as a key. Fenced code is skipped everywhere.

**What happens to the trailing prose:** it is judged only through its backticks. `(Lucide Wrapper)`, `: Standalone smart button.`, `(Sub-grid)` carry none, so they contribute nothing. An author naming a NON-key in that prose writes it unbackticked, or moves the note out of the block.

**Why it does not fire on prose — four escape hatches, all four in use today:**

1. **Outside the block.** A blockquote or paragraph at the section's own level is not in the label's sub-tree. This is where every tombstone lives — and each tombstone names a key the gate *would* reject: `user:profile`, `ai:chat_window`, and objectui#8929's own note naming `view:kanban` / `view:gantt`. The file can only say "do not write this" because this hatch exists. That makes the non-firing leg **load-bearing**, not a contrived fixture.
2. **Not a list item.** A continuation paragraph indented under the label is skipped even though it is in the block.
3. **Not backticked.** Trailing prose contributes nothing.
4. **Whitespace in the span.** `pnpm check:prompt-keys`, `objectui check` are commands, not keys. Measured: **0 of 650** derived keys contain whitespace, so this skips nothing a bad key could hide in.

**A block that opens and reads nothing is a FAILURE.** `bullets === 0` catches the `Keys:` surface disappearing; a gated label whose block yields no key means the section was reformatted so the keys moved out from under it, and the run throws rather than printing a pass.

## 5. Two verdicts, because a placeholder list is a claim too

`Protocol Placeholders:` is gated with the partition **inverted**: every key under it must be answered by the placeholder module and by nothing else. Without that leg, "move the placeholder-only keys into a placeholder section" would have **moved the drift rather than fixed it** — the section would go stale in both directions unwatched. New reason `not-a-placeholder-key` fires when a listed key gains a real renderer; `unregistered-key` fires when one loses its registration.

## 6. The ablation — two-sided, with anchor counts

All legs run from a **committed** tree, each mutation proved to land on disk (anchor count and `git hash-object` before/after), each restore proved by `git diff HEAD` empty **and** a blob-hash match, under a `trap ... EXIT INT TERM`.

**Must FIRE — an unregistered key in a NEWLY-scanned section (§G's block):**

```
anchor count BEFORE mutation: 0   AFTER: 1
blob f42bcecd -> f7e78b79
VERDICT exit=1
  component.prompt.md  [unregistered-key]  `action:teleport`
restore -> git diff HEAD EMPTY, blob f42bcecd
```

**Must FIRE — the inverted leg, an authorable key inside `Protocol Placeholders:`:**

```
anchor count BEFORE: 0   AFTER: 1
VERDICT exit=1
  component.prompt.md  [not-a-placeholder-key]  `action:button`
restore -> git diff HEAD EMPTY
```

**Must NOT fire — the same two bad keys, in PROSE:**

```
anchor count BEFORE: 0   AFTER: 1     blob f42bcecd -> 5d9d599e
injected: a blockquote naming `action:teleport` (registers nowhere) and `view:kanban` (placeholder-only)
VERDICT exit=0 — still green
restore -> git diff HEAD EMPTY
```

**Must NOT fire — the `Required Types` sections** (§3 above shows what the gate *would* have said had the exclusion not held: 23 red lines).

Final state: on-disk blob equals the HEAD blob, `git status --porcelain` empty, gate exit 0.

## 7. Gate verdicts, by required-context name

| required context | command CI runs | exit | evidence |
|---|---|---|---|
| `Lint` | `pnpm lint` (farm → CI); locally `eslint` over the root set as `lint:root` configures it | **0** | 328 files, **0 errors**, 32 warnings (all pre-existing), at `4cd3d5fcf`. Changed-file leg under the stricter `--no-inline-config`: 2 files, 0/0. Also green: `check-lint-coverage.mjs` (46/46), `check-entry-guard.mjs --self-test` (63 cases) and `check-entry-guard.mjs` (89 files) |
| `Type Check` | `pnpm type-check:scripts` | **0** | plus `pnpm check:esm-specifiers` 0, `pnpm check:doc-example-readers` 0 |
| `Test (shard 1..4/4)` | `vitest run` over `scripts/__tests__/check-prompt-component-keys.test.ts` | **0** | **34 passed** (17 before this PR) |
| `Changeset Declaration` | `node scripts/check-changeset-presence.mjs` | **0** | verbatim below |
| `Build & E2E`, `Build Docs` | not run locally | — | no package source, no docs content, and no build input in this diff; declared to CI |
| (`Doc Component Type Check`, the gate's own home — not a required context) | `node scripts/check-prompt-component-keys.mjs` | **0** | see §6 |

The narrowing on `Lint` is a measurement, not a skip: the universe is read from eslint's own flat config (which targets `**/*.{ts,tsx}` plus default JS — **no `.md` file is linted by anything in the lint pipeline**, 0 of 328 in the JSON output); the file count is read from `--format json`; and **no type-aware linting is configured** (no `project`, `projectService` or `parserOptions.project` in `eslint.config.js`), so this diff cannot move a verdict on any file it does not touch.

## 8. Changeset — quoted verbatim

```
Compared the working tree with 1e0e46af9 (merge-base with origin/main): 4 file(s) changed, 0 of them published source of a package the release covers, 0 of them a manifest whose published contract moved, 0 under a package changesets ignores, 0 changeset(s) added.
✅  No source or published contract of a released package changed in this range, so no changeset is owed.
```

⇒ exit 0, none owed, none added.

## 9. ⚠️ One bounded in-place fix, declared

`.github/prompts/engine.prompt.md:147` read "All atoms (`atom:button`) consume these variables" — the **same** unregistered `atom:` key spelling, in the **same** prompt surface the **same** gate reads, and it would have contradicted this PR's own measurement thirty lines away. One sentence changed; it now names the `Button` component and records that `atom:` is not a registry namespace. Measured after: **0** backticked `atom:` spellings remain anywhere under `.github/prompts/`.

## 10. What the card, triage and the PM claim got wrong

1. ✅ **The claim's premise (a) confirmed** — widening is a reading-model change, not a label-set change. Measured: the four sections' label lines carry **0** backticked tokens, so a label added to the `Keys:` anchor reads nothing. The test `reads NOTHING under an ungated label` pins the control.
2. ✅ **The claim's premise (b) confirmed, and now quantified** — gating `Required Types` reds on **23** spec-valid values (§3).
3. ⚠️ **The claim's count of `Required Types` sections is wrong: 3 vs the measured 4.** They are `component.prompt.md` lines 54 (§A field), 91 (§B list), 107 (§B form), 143 (§E dashboard) on `1e0e46af9`. The likely cause is that the claim greps `Required Types:` with the colon adjacent, while the file spells them with the ref and its closing paren between the words and the colon — that literal matches **0**. The consequence is benign (all four stay out of the gate) but the miss is real: the **§A** section sits *above* objectui#8929's disambiguating note, so a reader meets it undisambiguated. Markers added to §A and §E.
4. ⚠️ **The claim's shape description fits three of the four sections, not all four.** §F, §G and §H are one-key-per-sub-bullet with trailing prose, as stated. **§D is not**: it is grouped sub-bullets carrying *several* keys each, plus a nested sub-sub-bullet level with two keys and parenthetical prose per line. A reading model built only for "first token per sub-bullet" would have read 6 of §D's 18 keys and passed. The rule shipped here takes **every** qualifying token in the block for that reason.
5. ⚠️ **The card's roadmap-vs-vocabulary binary does not fit §F, and measuring is what shows it.** The card offers "read as a ROADMAP, `atom:*` is correct and nothing needs fixing". It is not a roadmap: the primitives are not aspirational, they **already exist** as React components in `@object-ui/components`; what never existed is a `type` string for them, and the section's own contract already said so — "Pure UI components (No metadata dependencies)". ⇒ the honest third answer, now written into the section.
6. ⚠️ **The card says "five more places"; the measured count of label-bearing sections that name registry keys is four** (`Standard Components Library:` ×1, `Required Library:` ×1, `Required Components:` ×2). The card's five are table *rows*, which collapse into three *sections* once §G is added.
7. ℹ️ **The gate's own workflow job is not a required context.** `node scripts/check-prompt-component-keys.mjs` runs in `Doc Component Type Check` (`doc-component-types.yml`), which is not in this round's required-context list. What actually blocks a merge is the live-tree case in the test file, inside `Test (shard N/4)`. Recorded, not acted on — ruleset configuration is not readable from the repository, and changing it is the maintainer's call.

## Where the non-vacuity lives

`analyze()` keeps objectui#8929's `bullets === 0` throw untouched and adds the empty-block throw. The **floors** are pinned in the test file, which is the half that runs inside a required context: ≥4 gated blocks, ≥24 block-scoped keys, ≥4 placeholder claims, the two `Keys:` bullets still read the old way with their exact 8 keys, **0** keys judged under any `Required Types` label, and each of the four tombstones present in the file yet absent from the scan.

## Fences honoured

- ⛔ Nothing registered. This PR moves documentation and one gate only.
- ⛔ objectui#8929's two `Keys:` bullets and its `Required Types` note are byte-for-byte untouched — pinned by a sha256 + count survival leg in the post-merge probe, and by a test.
- ⛔ Nothing under `.claude/**`, `docs/adr/**`, `skills/**`, `AGENTS.md` or `CLAUDE.md`.
- ⛔ `scripts/markdown-test-inputs.mjs` and `.github/workflows/ci.yml` untouched (objectui#9096 is concurrent there). Verified: nothing outside this gate reads `.github/prompts/**`.
- ℹ️ objectstack#17595 covers the same retired `user:profile` on the lint side in the other repo. Not a coupling, not a blocker, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_