### PR TITLE
fix(plugin-detail): coerce record:details authored body width at the boundary

### DIFF
--- a/.changeset/9056-detail-body-columns-boundary-coercion.md
+++ b/.changeset/9056-detail-body-columns-boundary-coercion.md
@@ -1,0 +1,18 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+fix(plugin-detail): coerce `record:details`' authored body width at the boundary
+
+`@objectstack/spec` declares `RecordDetailsProps.columns` as a string enum,
+while `DetailViewSchema.columns`, `DetailViewSection.columns`,
+`applyDetailAutoLayout`'s `columns` parameter and the `DetailViewField.span`
+written from it are all `number`. `RecordDetailsRenderer` passed the authored
+value straight through, so those declared-`number` slots carried the string at
+runtime — invisible to `tsc` because the synthesized node is annotated `any`.
+
+The renderer now translates the contract's spelling into the internal node's
+spelling at the one place they meet. No rendered class, grid width or
+responsive behaviour changes: the output is byte-identical across every
+authored width. The published `@object-ui/types` declarations are untouched —
+neither the protocol nor the internal type is widened to meet the other.

--- a/packages/plugin-detail/src/renderers/__tests__/record-details.boundaryColumns-9056.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.boundaryColumns-9056.test.tsx
@@ -1,0 +1,292 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9056 — the protocol's body width is a STRING, and every slot it
+ * reaches inside this package is a NUMBER.
+ *
+ * `@objectstack/spec`'s `RecordDetailsProps.columns` is `z.enum(['1','2','3','4'])`.
+ * `RecordDetailsRenderer` used to hand that value straight into the detail node
+ * it synthesizes, and from there it reached — every one of these declared
+ * `number` in `@object-ui/types` or in this package:
+ *
+ *   `DetailViewSchema.columns` -> `DetailViewSection.columns`
+ *     -> `applyDetailAutoLayout(fields, columns)` -> `applyAutoSpan(fields, columns)`
+ *     -> `DetailViewField.span`
+ *
+ * Measured on the real render before the fix: `applyDetailAutoLayout` received
+ * `typeof 'string'`, and a wide field's `span` came out the string `'2'`.
+ * `tsc` could not see any of it, because the object the renderer builds is
+ * annotated `any` and that annotation launders the assignment (the identical
+ * write into a `DetailViewSchema` is `TS2322`, both from this renderer's own
+ * prop type and from a bare `RecordDetailsComponentProps`).
+ *
+ * ## ⚠️ WHY NOT ONE DOM ASSERTION IN THE VALUE LEGS
+ *
+ * The single consumer of `span` is `getResponsiveSpanClass`, and over the whole
+ * reachable set it emits BYTE-IDENTICAL classes for `'2'` and `2` — `span` is
+ * always the same value the width came from, so the strict-equality rungs that
+ * would have diverged (`span === 3` against a width of 4) are unreachable. A
+ * pin that asserted rendered output therefore COULD NOT GO RED on this change,
+ * and a green suite full of such rows is indistinguishable from no verification
+ * at all. Every leg below that pins the FIX reads the value itself — `typeof`
+ * and strict equality on what actually lands — captured from the real
+ * `applyDetailAutoLayout` / `applyAutoSpan` path driven by a real render.
+ *
+ * The one DOM leg here is labelled for what it is: the COMPATIBILITY claim
+ * ("no rendered class moves"), which needs its own instrument precisely because
+ * the value legs cannot speak to it. It carries a lit control so it is not a
+ * silent tautology.
+ *
+ * ## ⚠️ WHICH HALF OF THE FIXTURE IS HOST-COMPOSED, AND WHY
+ *
+ * A spec-validated `record:details` document declares `fields` as `string[]`
+ * (measured against the installed spec below, in both directions), so an
+ * authored entry cannot carry the `type` that `applyAutoSpan` tests for. The
+ * `span` legs therefore drive the OBJECT entry form — which this renderer
+ * documents and admits (`normaliseField` passes object entries through, and
+ * `RecordDetailsRendererProps.schema` is the props bag intersected with
+ * `Record<string, any>` for exactly that reason). The `columns` value on every
+ * fixture is the contract's own spelling and is parsed green here to prove it.
+ * ⛔ Do not read the `span` legs as "the flat body of a spec-only document
+ * produces spans" — it does not, and the leg that runs on a purely spec-valid
+ * document (THE CONTRACT LEG) is the one that pins the boundary without it.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import * as React from 'react';
+import { RecordDetailsProps } from '@objectstack/spec/ui';
+import { RecordContextProvider } from '@object-ui/react';
+import type { DetailViewField } from '@object-ui/types';
+
+/**
+ * Every `applyDetailAutoLayout` call the render below made — the argument that
+ * crossed the boundary and the fields that came back out of it.
+ *
+ * `vi.hoisted` because the factory runs before this module's own bindings are
+ * initialized.
+ */
+const recorder = vi.hoisted(() => ({
+  calls: [] as Array<{ columns: unknown; outColumns: unknown; fields: DetailViewField[] }>,
+}));
+
+vi.mock('../../autoLayout', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../autoLayout')>();
+  return {
+    ...actual,
+    // Same signature, same return value — the real function does the work and
+    // this wrapper only reads what passed through it. Nothing here decides an
+    // outcome, so a drifting stub cannot make a leg pass.
+    applyDetailAutoLayout: ((
+      fields: Parameters<typeof actual.applyDetailAutoLayout>[0],
+      columns: Parameters<typeof actual.applyDetailAutoLayout>[1],
+      containerWidth?: Parameters<typeof actual.applyDetailAutoLayout>[2],
+    ) => {
+      const out = actual.applyDetailAutoLayout(fields, columns, containerWidth);
+      recorder.calls.push({ columns, outColumns: out.columns, fields: out.fields });
+      return out;
+    }) as typeof actual.applyDetailAutoLayout,
+  };
+});
+
+import { RecordDetailsRenderer } from '../record-details';
+
+const objectSchema = {
+  fields: {
+    name: { type: 'text', label: 'Name' },
+    notes: { type: 'textarea', label: 'Notes' },
+    industry: { type: 'text', label: 'Industry' },
+    phone: { type: 'text', label: 'Phone' },
+    email: { type: 'text', label: 'Email' },
+  },
+};
+
+/** No name-ish VALUE, so the title-dedupe ladder hides no row it is asked about. */
+const data = { notes: 'A long note', industry: 'Manufacturing', phone: '555-0100', email: 'ops@acme.test' };
+
+/**
+ * The OBJECT entry form (see the header): `type` is what `applyAutoSpan` tests,
+ * and a bare-string entry cannot carry one.
+ */
+const TYPED_FIELDS = [
+  { name: 'notes', type: 'textarea' },
+  { name: 'industry' },
+  { name: 'phone' },
+  { name: 'email' },
+];
+
+/** The bare-string form a spec-validated document is limited to. */
+const BARE_FIELDS = ['notes', 'industry', 'phone', 'email'];
+
+beforeEach(() => {
+  recorder.calls.length = 0;
+  // The permission provider's `security/explain` probe would otherwise reach a
+  // real socket and trip the suite's network-escape guard.
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ allowed: true }),
+    text: async () => '{"allowed":true}',
+  })) as never);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+const renderDoc = (schema: Record<string, unknown>) =>
+  render(
+    <RecordContextProvider
+      objectName="crm_account"
+      recordId="A1"
+      data={data}
+      objectSchema={objectSchema}
+    >
+      <RecordDetailsRenderer schema={schema as never} />
+    </RecordContextProvider>,
+  );
+
+/** The one layout call the flat body makes, with a guard against reading a zero. */
+const soleCall = () => {
+  expect(recorder.calls.length, 'the render drove the real auto-layout path at least once').toBeGreaterThan(0);
+  return recorder.calls[0];
+};
+
+const fieldNamed = (fields: DetailViewField[], name: string) => {
+  const f = fields.find((x) => x.name === name);
+  expect(f, `the layout output still carries \`${name}\``).toBeDefined();
+  return f!;
+};
+
+describe('objectui#9056 — the protocol string is coerced at the boundary, not carried into `number` slots', () => {
+  it('THE CONTRACT LEG — a document the installed spec accepts hands the layout a NUMBER', () => {
+    const doc = { columns: '3', fields: BARE_FIELDS };
+
+    // The fixture IS the contract's spelling, on the installed artifact...
+    expect(RecordDetailsProps.safeParse(doc).success, 'the fixture is a spec-valid document').toBe(true);
+    // ...and the control that would have fired: the number is what the contract
+    // refuses at the top level, which is the whole reason this string exists.
+    expect(
+      RecordDetailsProps.safeParse({ ...doc, columns: 3 }).success,
+      'the control: the top-level key refuses the number, so the string is not a local invention',
+    ).toBe(false);
+
+    renderDoc(doc);
+
+    const call = soleCall();
+    expect(typeof call.columns, 'the value that crossed into `applyDetailAutoLayout`').toBe('number');
+    expect(call.columns).toBe(3);
+    // And what it returns into `DetailViewSection.columns` / `rawColumns`, which
+    // is declared `number` one frame further out.
+    expect(typeof call.outColumns).toBe('number');
+    expect(call.outColumns).toBe(3);
+  });
+
+  it('THE SPAN LEG — a wide field receives a NUMBER span, with both live controls in the same render', () => {
+    renderDoc({
+      columns: '2',
+      fields: [
+        ...TYPED_FIELDS,
+        // LIVE CONTROL B, authored into the same document: an explicit span.
+        { name: 'name', type: 'textarea', span: 1 },
+      ],
+    });
+
+    const { fields } = soleCall();
+
+    // THE REPAIR: the slot `@object-ui/types` declares `number` holds a number.
+    const wide = fieldNamed(fields, 'notes');
+    expect(typeof wide.span, '`DetailViewField.span` on a wide field').toBe('number');
+    expect(wide.span).toBe(2);
+
+    // LIVE CONTROL A — a non-wide field still gets no span at all. Without it,
+    // "span is a number" is equally satisfied by an `applyAutoSpan` that stopped
+    // writing spans, and a reviewer could not tell the repair from a rout.
+    expect(fieldNamed(fields, 'industry').span, 'a non-wide field is still untouched').toBeUndefined();
+    expect(fieldNamed(fields, 'phone').span).toBeUndefined();
+
+    // LIVE CONTROL B — an explicitly authored span still wins and is returned
+    // byte-for-byte, never overwritten by the coerced width.
+    const authored = fieldNamed(fields, 'name');
+    expect(authored.span, 'an authored span still takes priority').toBe(1);
+    expect(typeof authored.span).toBe('number');
+  });
+
+  it('THE EARLY-RETURN LEG — `columns: \'1\'` reaches the guard as the NUMBER 1 and still spans nothing', () => {
+    // Before the fix this branch was accidentally correct: `'1' <= 1` is also
+    // `true`. The assertion is therefore on the VALUE the guard compares, not on
+    // the outcome — the outcome never moved and cannot witness the change.
+    expect(RecordDetailsProps.safeParse({ columns: '1' }).success, 'the narrow width is in the contract\'s closed set').toBe(true);
+
+    renderDoc({ columns: '1', fields: TYPED_FIELDS });
+
+    const call = soleCall();
+    expect(typeof call.columns).toBe('number');
+    expect(call.columns).toBe(1);
+    // The behaviour half, unchanged in both directions.
+    for (const f of call.fields) {
+      expect(f.span, `\`${f.name}\` gets no span at a single-column width`).toBeUndefined();
+    }
+  });
+
+  it('THE UNAUTHORED LEG — an omitted width stays `undefined`, so inference still runs', () => {
+    // The load-bearing arm of the coercion. `Number(undefined)` is `NaN`, which
+    // is NOT `undefined`, so a bare `Number(...)` at the boundary would replace
+    // every unauthored body's inferred width with `NaN` — silently, and with no
+    // rendered class to notice it by.
+    renderDoc({ fields: TYPED_FIELDS });
+
+    const call = soleCall();
+    expect(call.columns, 'nothing was authored, so nothing is handed down').toBeUndefined();
+    expect(typeof call.outColumns, 'and the inference produced a real width').toBe('number');
+    expect(Number.isNaN(call.outColumns as number)).toBe(false);
+    expect(call.outColumns).toBe(2);
+  });
+
+  it('THE OTHER CALL SITE — `sections[].columns` is a NUMBER on the contract and passes through untouched', () => {
+    const doc = { columns: '4', sections: [{ label: 'Contact', columns: 2, fields: BARE_FIELDS }] };
+
+    // The inversion objectui#8604 pinned, restated here because this fix must
+    // not "unify" the two: a section takes the number and refuses the string.
+    expect(RecordDetailsProps.safeParse(doc).success).toBe(true);
+    expect(
+      RecordDetailsProps.safeParse({ sections: [{ fields: BARE_FIELDS, columns: '2' }] }).success,
+      'the control: one level down, the string is the refused spelling',
+    ).toBe(false);
+
+    renderDoc(doc);
+
+    const call = soleCall();
+    expect(typeof call.columns, 'a section width never passes through the body boundary').toBe('number');
+    expect(call.columns).toBe(2);
+  });
+
+  it('THE COMPATIBILITY LEG — no rendered class moves (⛔ this leg cannot witness the fix)', () => {
+    // ⛔ NOT evidence of the repair, and must never be cited as such: the string
+    // and the number emit byte-identical classes, so this comparison is green in
+    // both trees. It exists to guard the CLAIM the fix makes — that the DOM does
+    // not move — and it goes red the day a coercion changes a width.
+    const fields = TYPED_FIELDS;
+    const asProtocolString = renderDoc({ columns: '2', fields }).container.innerHTML;
+    cleanup();
+    const asNumber = renderDoc({ columns: 2, fields }).container.innerHTML;
+    cleanup();
+    expect(asProtocolString, 'the protocol string and the number render the same body').toBe(asNumber);
+
+    // THE LIT CONTROL, same instrument, same run: this comparison DOES see a
+    // difference, so the equality above is a measurement and not a tautology
+    // about an instrument that reads nothing.
+    const atFour = renderDoc({ columns: '4', fields }).container.innerHTML;
+    cleanup();
+    expect(atFour, 'the control: a different authored width really does move the DOM').not.toBe(asProtocolString);
+    expect(asProtocolString).toContain('md:col-span-2');
+    expect(atFour).toContain('xl:col-span-4');
+  });
+});

--- a/packages/plugin-detail/src/renderers/record-details.tsx
+++ b/packages/plugin-detail/src/renderers/record-details.tsx
@@ -28,6 +28,49 @@ import { deriveFieldGroupDetailSections } from '../synth/buildDefaultPageSchema'
 /** Normalize a field entry (string | {field} | {name}) to its machine name. */
 const fieldName = (entry: any): string | null => columnIdentity(entry) ?? null;
 
+/**
+ * The ONE boundary between `record:details`' authored body width and the
+ * internal detail node (objectui#9056).
+ *
+ * `@objectstack/spec`'s `RecordDetailsProps.columns` is a STRING enum
+ * (`z.enum(['1','2','3','4'])`, default `'2'`). Everything this renderer hands
+ * it to is a NUMBER: `DetailViewSchema.columns` and `DetailViewSection.columns`
+ * in `@object-ui/types`, the `columns` parameter of `applyDetailAutoLayout` /
+ * `applyAutoSpan`, and the `DetailViewField.span` that `applyAutoSpan` writes
+ * FROM it. Handing the authored value straight through left every one of those
+ * declared-`number` slots carrying the string `'2'` at runtime — measured, on
+ * the real render: `span` came out `typeof 'string'`.
+ *
+ * TypeScript could not see it because `synthesized` below is annotated `any`,
+ * which launders the assignment. (Measured three ways: the same value written
+ * into a `DetailViewSchema` directly is `TS2322`, from this renderer's own prop
+ * type AND from the bare `RecordDetailsComponentProps` — only the `any` hides
+ * it.)
+ *
+ * ⛔ The direction is contract-first (AGENTS.md #0.1): the protocol keeps its
+ * string enum, `@object-ui/types` keeps `number`, and neither is widened to
+ * meet the other. This function is the TRANSLATION between two declared types,
+ * not a tolerant reader — its parameter is spelled as the contract's own type
+ * so a protocol change arrives here as a compile error rather than as another
+ * silent string.
+ *
+ * ⚠️ NOT `sections[].columns`, one level down. That key is
+ * `z.number().int().min(1).max(4)` — already a number, and correct as one;
+ * objectui#8604 measured that copying either declaration onto the other is
+ * refused at publish. A section's width never passes through here.
+ *
+ * ⚠️ The `undefined` arm is load-bearing, not defensive. `applyDetailAutoLayout`
+ * treats `undefined` as "author said nothing" and infers the width from the
+ * field count; `Number(undefined)` is `NaN`, which is NOT `undefined`, so a
+ * bare `Number(...)` here would silently replace inference with a `NaN` width
+ * on every unauthored body.
+ */
+function detailBodyColumns(
+  columns: RecordDetailsComponentProps['columns'],
+): number | undefined {
+  return columns === undefined ? undefined : Number(columns);
+}
+
 const splitDesigner = (props: Record<string, any>) => {
   const { 'data-obj-id': id, 'data-obj-type': type, style, ...rest } = props || {};
   return { designer: { 'data-obj-id': id, 'data-obj-type': type, style }, rest };
@@ -535,7 +578,12 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
     // explicit groups, omitting it falls back to the object's highlightFields
     // (see `filteredSections` / `filteredFields` above). objectui#3818.
     layout: 'vertical',
-    columns: schema.columns,
+    // objectui#9056 — the protocol's STRING width becomes the internal node's
+    // NUMBER here, and only here. See `detailBodyColumns` above for why the
+    // coercion belongs on this side of the boundary rather than in
+    // `applyAutoSpan` (which would be a tolerant reader) or in the published
+    // `@object-ui/types` declaration (which would be a surface widening).
+    columns: detailBodyColumns(schema.columns),
     sections: filteredSections,
     fields: filteredFields,
     showBack: false,


### PR DESCRIPTION
Fixes #9056

## What was wrong

`@objectstack/spec` declares `RecordDetailsProps.columns` as a **string** enum,
`z.enum(['1','2','3','4'])`. Every slot that value reached inside this package is
a **number**:

`DetailViewSchema.columns` -> `DetailViewSection.columns` -> the `columns`
parameter of `applyDetailAutoLayout` -> `applyAutoSpan` -> `DetailViewField.span`

`RecordDetailsRenderer` handed the authored value straight into the node it
synthesizes, so those declared-`number` slots carried the string at runtime.

## The re-derivation this card required (the card was read before objectui#9041 merged)

objectui#9041 narrowed the published TypeScript face of the top-level
`record:details.columns` to the string enum. The question it raised — *can the
compiler see the violation today, or does the string still cross an untyped
boundary?* — was re-measured on today's tree with a three-leg `tsc` probe:

| leg | the assignment | verdict |
|---|---|---|
| A (the real shape) | the value into the `any`-annotated node the renderer builds | **no error** |
| B | the same value straight into a `DetailViewSchema`, from this renderer's own prop type | `TS2322` |
| C (control) | the same, from a bare `RecordDetailsComponentProps` | `TS2322` |

So the string still crosses an **untyped** boundary, and the untyped thing is the
`any` annotation on the synthesized node — nothing else. Legs B and C are the
control that `tsc` can see the violation at all when the boundary is typed.

## Consumer census for `field.span` — re-derived repo-wide

Population: all 7417 tracked files (`git ls-files`), swept for `.span` member
access, plus every `span` word hit under `packages/plugin-detail/src`, plus
bracket and destructuring forms across `packages/*/src` and `apps/*/src`.

- **Exactly one non-test consumer**: `DetailSection`'s
  `getResponsiveSpanClass(field.span, effectiveColumns)`.
- The only other read is the producer's own guard in `applyAutoSpan`
  (`field.span !== undefined`).
- **No consumer does arithmetic on `span`** — the STOP condition that would have
  made a boundary coercion insufficient does not fire.
- Lit control, pre-existing and in the same sweep: the same greps return hits in
  `autoLayout.ts` and in `plugin-form`'s unrelated `FormField.span` family, so a
  zero here is a measured zero.

## The fix — route 1, at the boundary

One translation function in `record-details.tsx`, applied at the single place the
protocol's spelling meets the internal node's spelling. Contract-first
(AGENTS.md #0.1): **the protocol keeps its string enum and `@object-ui/types`
keeps `number`** — neither is widened to meet the other, and no tolerant reader
is added downstream. Route 2 (widening `DetailViewField.span`) was fenced by
dispatch and is not taken.

The `undefined` arm is load-bearing, not defensive: `applyDetailAutoLayout` reads
`undefined` as "the author said nothing" and infers the width from the field
count, and `Number(undefined)` is `NaN`, which is not `undefined`.

`applyDetailAutoLayout`'s other call site takes `sections[].columns`, which the
contract declares `z.number().int().min(1).max(4)` — already a number, and
correct as one (objectui#8604). It does not pass through the boundary and is
pinned here as a non-regression leg.

## Evidence

### The value pin (6 legs, `record-details.boundaryColumns-9056.test.tsx`)

Every leg reads the **value itself** — `typeof` and strict equality on what
actually lands — captured from the real `applyDetailAutoLayout` / `applyAutoSpan`
path driven by a real render. No leg that pins the fix asserts DOM output, for the
reason the card names: the string and the number emit byte-identical classes over
the whole reachable set, so such a pin could never go red.

- **THE CONTRACT LEG** — a document the installed spec parses green (with the
  control that the number is refused at the top level) hands the layout a
  `number`.
- **THE SPAN LEG** — a wide field's `span` is `typeof 'number'` and strictly `2`.
  Two live controls in the same render: a non-wide field still gets no span, and
  an explicitly authored `span` still wins untouched.
- **THE EARLY-RETURN LEG** — `columns: '1'` reaches the guard as the number `1`
  and still spans nothing. (The outcome never moved — `'1' <= 1` was accidentally
  `true` — so the assertion is on the value the guard compares.)
- **THE UNAUTHORED LEG** — an omitted width stays `undefined`, so inference still
  runs and no body gets a `NaN` width.
- **THE OTHER CALL SITE** — `sections[].columns` is the number the contract
  declares and passes through untouched, with the objectui#8604 inversion
  re-pinned as its control.
- **THE COMPATIBILITY LEG** — labelled in the file as unable to witness the fix.

### Ablation — the pins can fail

The boundary coercion was reverted **on disk** and proven there before the run:

```
occurrences of the fixed spelling    1 -> 0
occurrences of the ablated spelling  0 -> 1
blob                                 a8b0a6743eb19c578363793c7b375b843c6deed1 -> 77e89f3b9830d503e763cebcda969e058c421c22
```

Result: `Tests 3 failed | 3 passed (6)`. The three that went red are THE CONTRACT
LEG, THE SPAN LEG and THE EARLY-RETURN LEG, each with the signature
`expected 'string' to be 'number'`. The three that stayed green are exactly the
non-regression and compatibility legs, which must not move.

Restore proven **by state**, not by an exit code: blob back to
`a8b0a6743eb19c578363793c7b375b843c6deed1` (identical to the `HEAD` blob),
`git diff HEAD` empty, `git status --short` empty, and both occurrence counts back.

### The compatibility claim — the DOM does not move

Measured before and after the change, not asserted: 19 documents (all four
authored widths across four document shapes, plus a host-number and a sections
control) rendered through the real renderer and dumped to disk.

```
dom-before.txt  150403 bytes  sha256 66f57b12acf519bc0efa7d43d5ca65ee1c8d656bf400d0f0fe7e701535fd5c82
dom-after.txt   150403 bytes  sha256 66f57b12acf519bc0efa7d43d5ca65ee1c8d656bf400d0f0fe7e701535fd5c82
diff            empty
```

Lit control of the same kind, from the same dump, so the zero is a measurement and
not a broken instrument: the `columns=1` and `columns=4` blocks are **not**
identical, and the dumps really do contain the span classes
(`md:col-span-2`, `lg:col-span-3`, `xl:col-span-4`) a change would have moved.

## Verification run

| check | result |
|---|---|
| `pnpm exec vitest run packages/plugin-detail/` | `Test Files 168 passed (168)` · `Tests 1568 passed (1568)` (verify-lock `VERDICT command-exit 0`) |
| `pnpm --filter @object-ui/plugin-detail run type-check` | exit 0 — and `tsc -p tsconfig.test.json --listFiles` confirms both changed files are in the program (1642 files), so this is not a NOT-MEASURED green |
| `eslint` over `@object-ui/plugin-detail` | exit 0 · 223 files · 0 errors · 994 warnings, all pre-existing |
| `check-vi-mock-specifiers` / `-inherit` / `-override-shape` | exit 0 each |
| `check-changeset-presence` / `-no-major` / `-fixed` | exit 0 each |
| `check-new-cross-file-line-citations` | exit 0 — 0 new citations |
| `check-control-bytes` | exit 0 — 7334 files scanned |
| `check-unreferenced-sources` | exit 0 |
| `check-governed-queue-guard --test` | `NOT GOVERNED` — 3 paths, 0 matched |
| `scripts/pm/check-half-states.mjs` | **NOT MEASURED**, exit 3: `PREREQUISITE NOT MET — the token in the environment is not a valid GitHub credential`. Nothing was swept |

**Lint narrowing, declared with all three pieces.** (1) Population comes from
eslint's own resolved config, not a guess: the `--format json` run over
`@object-ui/plugin-detail` returned **223** file entries. (2) Every lintable file
in this diff is inside that package — the third changed file is a
`.changeset/*.md`, which eslint's config does not match. (3) Type-aware linting is
**off** (`eslint.config.js` sets no `projectService`, no `parserOptions.project`),
so nothing in this diff can move the verdict on an untouched file. Same-file
before/after on the one edited source file: **40 warnings, 0 errors** on both the
base blob and `HEAD` — this change adds none.

## Acceptance notes (noted, not filed)

- **Reachability of the `span` leg specifically.** On a document
  `@objectstack/spec` validates, `record:details.fields` is an array of plain
  strings, so an authored entry cannot carry the `type` that `applyAutoSpan`
  tests — measured, both directions, against the installed 17.4.0 artifact. The
  string therefore reaches `applyDetailAutoLayout`'s `columns` parameter and
  `DetailViewSection.columns` on a purely spec-valid document (THE CONTRACT LEG),
  while the `span` slot itself needs the object entry form this renderer also
  admits (THE SPAN LEG). Both were reproduced live before the fix. This sharpens
  the card's "not currently observable" rather than contradicting it, and it
  changes nothing about where the coercion belongs.
- **`buildDefaultPageSchema` emits `columns` on sections only**, as the number
  the contract wants, and the authoring inspector offers only
  `sections[].columns` as a number field. Nothing else in the tree produces the
  top-level string. Observation, not a defect.

Card `objectui#9056` · session `session_01UzHd6hDYatoDn17BuwKxnZ`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_