### PR TITLE
fix(core): carry an authored locale-map chart heading through chartConfigPresentation

### DIFF
--- a/.changeset/chart-config-locale-heading-9038.md
+++ b/.changeset/chart-config-locale-heading-9038.md
@@ -1,0 +1,51 @@
+---
+'@object-ui/core': minor
+---
+
+A dataset-bound chart authored with an inline-locale-map `title` / `subtitle` /
+`description` now draws its heading instead of drawing none (objectui#9038).
+
+`@objectstack/spec` types `ChartConfigSchema.title` / `.subtitle` / `.description` as
+`I18nLabel` — a plain string OR an inline locale map — so
+`{ "chartConfig": { "title": { "zh-CN": "定价", "en": "Pricing" } } }` is authored
+surface, not an accident. `chartConfigPresentation` lowered all three through a local
+limb that admitted only a plain string, so the map arm returned `undefined`, the
+`if (title)` guard skipped the assignment, and the key never reached the result. The
+chart then drew **no heading at all**, in every language, with no diagnostic.
+
+Note the shape of it, because it is not the sibling defect objectui#8943: the value was
+not resolved badly, it was not resolved at all. There was no heading to compare against a
+locale, so no locale-comparison check could see it, and an author who wrote spec-legal
+metadata saw a chart that looked as though it had simply been given no title.
+
+The three keys are now carried through **unresolved**, as the union the spec declares,
+and resolved where the viewer is known:
+
+- `normalizeChartSchema` (`@object-ui/plugin-charts`) already resolves exactly these
+  three slots through `pickLocalized` against the language `ChartRenderer` reads from
+  `useObjectTranslation()` (objectui#8943), and `ObjectChart` reads `schema.title`
+  through the same resolver for its drill heading. Forwarding is what lets that
+  resolver see the value; `pickLocalized` remains the one answer for the union.
+- Resolving inside `@object-ui/core` was measured and is unavailable, not merely
+  undesirable: `pickLocalized` lives in `@object-ui/i18n`, which DEPENDS on this
+  package. Declaring the reverse edge makes the build graph cyclic — `turbo run build
+  --filter=@object-ui/core` refuses with `Cyclic dependency detected` — and that
+  package's entry point is a React provider plus hooks, which this package does not
+  admit.
+- No signature changed. `chartConfigPresentation(raw, fieldCategoryColors?)` takes the
+  same two arguments, every existing caller compiles, and every key other than those
+  three is byte-for-byte unchanged.
+- The admission test did not widen. A plain string, or a record carrying at least one
+  usable string entry — the same "is there anything here" question the old truthiness
+  guard asked, extended to the map arm. A number, a boolean, an array, `''`, `{}` and a
+  record with no string value are all still refused rather than stringified, because
+  broadening what the renderer accepts belongs in the spec and not in a renderer-side
+  coercion (AGENTS.md #0.1).
+
+Two neighbouring cases stay unresolved on purpose and are now ledgered by name in the
+source: a series `label` and an axis `title` still take `labelText`'s first-string-wins
+pick (objectui#4020 — a locale-unaware choice a caller can override, which is a different
+question from an erasure); and `plugin-report`'s `DatasetReportChart` paints the report
+chart's own `h3` from a plain-string narrowing of `chart.title` of its own, so a
+locale-map title still draws no heading on that surface. `subtitle` and `description` do
+reach the chart there and are fixed by this change.

--- a/packages/core/src/utils/__tests__/chart-presentation.i18nLabel-9038.test.ts
+++ b/packages/core/src/utils/__tests__/chart-presentation.i18nLabel-9038.test.ts
@@ -1,0 +1,116 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9038 — `chartConfigPresentation` DROPPED an inline-locale-map
+ * `title` / `subtitle` / `description`, so a chart authored in the spec's own
+ * `I18nLabel` union drew **no heading at all**.
+ *
+ * The old limb was `typeof v === 'string' && v ? v : undefined`. It did not
+ * pick the wrong locale — it erased the value, the `if (title)` guard then
+ * skipped the assignment, and the key never reached the result. That failure
+ * mode is invisible to any check that asks "does the heading match the locale",
+ * because there is no heading to compare; the assertions below therefore pin
+ * the key's PRESENCE and its identity with the authored value, not a string.
+ *
+ * ## What this file pins, and what it deliberately does not
+ *
+ * This half pins the SEAM: the authored union survives the lowering. It cannot
+ * pin that a viewer sees the right limb — resolution happens downstream, in
+ * `normalizeChartSchema`'s `label()` against the language `ChartRenderer`
+ * reads. The rendered half is
+ * `ChartRenderer.presentationLocaleHeading-9038.test.tsx` in
+ * `@object-ui/plugin-charts`, which draws the same map at two languages.
+ *
+ * A green run here over a renderer that had not yet learned the union would be
+ * a correct seam feeding a resolver that never sees it — which is exactly why
+ * neither half stands alone.
+ *
+ * ## The key-order control
+ *
+ * Every locale map below is written **`en` first**. The sibling defect
+ * objectui#8943 was a first-string-in-key-order pick, so a map written
+ * `zh-CN` first would be satisfied by that defect too; writing `en` first keeps
+ * these fixtures able to fail for the reason they exist.
+ *
+ * PREDICTIONS, written before the run: the `title`/`subtitle`/`description` map
+ * cases are RED before the fix (the key is absent) and the plain-string,
+ * refusal and untouched-key cases are GREEN on both sides — they pin decisions
+ * that must NOT move. The mutation legs are recorded in the pull request.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { axisPresentation, chartConfigPresentation, seriesPresentation } from '../chart-presentation.js';
+
+/** `en` FIRST — see the key-order control above. */
+const MAP = { en: 'Pricing', 'zh-CN': '定价' };
+
+const CHROME_KEYS = ['title', 'subtitle', 'description'] as const;
+
+describe('chartConfigPresentation — an inline-locale-map heading survives the lowering (objectui#9038)', () => {
+  it.each(CHROME_KEYS)('forwards a locale-map `%s` verbatim, for the renderer to resolve', (key) => {
+    const out = chartConfigPresentation({ [key]: MAP });
+    // Identity, not equality: the authored value travels untouched, so no
+    // renderer-side coercion can have happened on the way through.
+    expect(out[key]).toBe(MAP);
+  });
+
+  it.each(CHROME_KEYS)('leaves a plain-string `%s` exactly as it was — the live control', (key) => {
+    // The string arm of `I18nLabel` is the arm that already worked. It is in
+    // this run so that "the map arm now travels" cannot be bought by changing
+    // what a string does.
+    expect(chartConfigPresentation({ [key]: 'Quarterly revenue' })[key]).toBe('Quarterly revenue');
+  });
+
+  it.each(CHROME_KEYS)('still refuses every value the union does not admit, for `%s`', (key) => {
+    for (const value of [42, true, ['Pricing'], '', {}, { en: '' }, { en: 42 }, null, undefined]) {
+      const out = chartConfigPresentation({ [key]: value });
+      expect(Object.prototype.hasOwnProperty.call(out, key)).toBe(false);
+    }
+  });
+
+  it('admits a map on the strength of one usable entry and carries the rest as authored', () => {
+    // `InlineLocaleMapSchema` is `z.record(<tag>, z.string())`; enforcing that
+    // is the parse's job, not this whitelist's. The mixed map is admitted
+    // whole — `pickLocalized` skips the unusable entry the same way it skips an
+    // absent one.
+    const mixed = { en: 'Pricing', 'zh-CN': 7 };
+    expect(chartConfigPresentation({ title: mixed }).title).toBe(mixed);
+  });
+
+  it('changes no other key for the same input', () => {
+    // The harm this must not cause: a key other than the three moving value.
+    const config = {
+      showLegend: false,
+      showDataLabels: true,
+      height: 320,
+      annotations: [{ y: 10 }],
+      interaction: { tooltip: false },
+      colors: ['#111', '#222'],
+      title: MAP,
+    };
+    const withMap = chartConfigPresentation(config);
+    const withString = chartConfigPresentation({ ...config, title: 'Pricing' });
+    for (const [k, v] of Object.entries(withString)) {
+      if (k === 'title') continue;
+      expect(withMap[k]).toEqual(v);
+    }
+    expect(Object.keys(withMap).sort()).toEqual(Object.keys(withString).sort());
+  });
+
+  it('leaves the ledgered neighbours picked, not forwarded', () => {
+    // objectui#4020's first-string-wins pick for a series `label` and an axis
+    // `title` is a DIFFERENT question — a locale-unaware CHOICE a caller can
+    // override, not an erasure — and is out of this card's scope. Pinned here
+    // so a later edit cannot quietly fold them in under this card's banner, and
+    // so the asymmetry is visible rather than inferred: these two resolve to a
+    // string HERE, the three chrome keys resolve at the renderer.
+    expect(seriesPresentation({ name: 'total', label: MAP }).label).toBe('Pricing');
+    expect(axisPresentation({ field: 'total', title: MAP }).title).toBe('Pricing');
+  });
+});

--- a/packages/core/src/utils/chart-presentation.ts
+++ b/packages/core/src/utils/chart-presentation.ts
@@ -59,6 +59,8 @@
  *    the code that reads it.
  */
 
+import type { I18nLabel } from '@objectstack/spec/ui';
+
 import type { ChartSeriesBinding } from './chart-series.js';
 
 /** Authored spec `ChartSeries` presentation, in the renderer's internal spelling. */
@@ -97,6 +99,66 @@ function labelText(v: unknown): string | undefined {
   if (isRecord(v)) {
     const first = Object.values(v).find((x) => typeof x === 'string' && x);
     return first as string | undefined;
+  }
+  return undefined;
+}
+
+/**
+ * An authored `I18nLabel` that travels to the renderer **unresolved** — the
+ * chart's own `title` / `subtitle` / `description` (objectui#9038).
+ *
+ * ## Why this does not resolve, and why that is not {@link labelText}'s answer
+ *
+ * These three keys are lowered onto a chart SCHEMA slot that already declares
+ * the union: `normalizeChartSchema` (`@object-ui/plugin-charts`) resolves
+ * `title`/`subtitle`/`description` through `pickLocalized` with the viewer's
+ * language, which `ChartRenderer` reads from `useObjectTranslation` and hands
+ * down (objectui#8943), and `ObjectChart` reads `schema.title` through the same
+ * resolver for its drill heading. So the value's one resolution point is
+ * already downstream of here, holding the one thing this package does not have
+ * — the viewer. Forwarding is what lets that resolver see the value at all.
+ *
+ * Resolving here is not merely unnecessary, it is unavailable: `pickLocalized`
+ * lives in `@object-ui/i18n`, which DEPENDS on this package. Declaring the
+ * reverse edge makes the build graph cyclic (measured: `turbo run build
+ * --filter=@object-ui/core` refuses with `Cyclic dependency detected`), and
+ * that package's entry point is a React provider plus hooks — the layering
+ * this file's header states, arrived at from the other side.
+ *
+ * ⛔ Do NOT "fix" this by reusing {@link labelText}. The two answer different
+ * questions and only one of them is a choice:
+ *
+ *  - `labelText` is a locale-unaware PICK for a slot whose consumer takes a
+ *    plain string. It is wrong for a zh console and is ledgered as such
+ *    (objectui#4020) because a caller that CAN resolve the language overrides
+ *    the merged label — the mitigation depends on the value still existing.
+ *  - The guard this replaced (`typeof v === 'string' && v ? v : undefined`)
+ *    offered no such route: it ERASED the map arm, the `if (title)` guard then
+ *    skipped the assignment, and the chart drew **no heading at all**, in every
+ *    language, with no diagnostic. Nothing downstream could override a key that
+ *    never arrived.
+ *
+ * ## The admission test, and what it deliberately does not decide
+ *
+ * A plain string, or a record carrying at least one usable string entry. That
+ * is the same "is there anything here" question the `if (title)` truthiness
+ * guard always asked, extended to the map arm — it does NOT decide which limb
+ * wins, which stays `pickLocalized`'s alone. Everything else (a number, a
+ * boolean, an array, `''`, `{}`, a record with no string value) is refused
+ * exactly as before, so no key reaches the caller that cannot render, and the
+ * `@returns` contract below — only keys that resolved — still holds.
+ *
+ * The map is forwarded VERBATIM: `InlineLocaleMapSchema` is
+ * `z.record(<tag>, z.string())` and enforcing that belongs at the parse, not in
+ * a renderer-side coercion (AGENTS.md #0.1). A non-string entry falls through
+ * `pickLocalized`'s limbs exactly as an absent one does, which is why admitting
+ * the record on the strength of one usable entry cannot paint `[object
+ * Object]`.
+ */
+function forwardedI18nLabel(v: unknown): I18nLabel | undefined {
+  if (typeof v === 'string') return v || undefined;
+  if (isRecord(v) && Object.values(v).some((x) => typeof x === 'string' && x)) {
+    return v as I18nLabel;
   }
   return undefined;
 }
@@ -296,6 +358,27 @@ export function mergeAuthoredPresentation(
  * renderer's own `h3` above the chart) must drop it from the result, or the
  * chart draws a second one.
  *
+ * ## `title` / `subtitle` / `description` are `I18nLabel`, and travel as such
+ *
+ * `ChartConfigSchema` types all three as the spec's `I18nLabel` union — a plain
+ * string OR an inline locale map — so all three are lowered by
+ * {@link forwardedI18nLabel}, which hands the authored value on untouched for
+ * the renderer to resolve against the viewer's language. Read that helper for
+ * why resolving cannot happen in this package.
+ *
+ * ⚠️ LEDGERED, by name, as still unresolved after objectui#9038 — neither is in
+ * that card's scope and neither is reached by the change above:
+ *
+ *  - **A series `label` and an axis `title`** still go through
+ *    {@link labelText}'s first-string-wins pick, the design objectui#4020
+ *    ledgered and a caller can override. Not reopened here.
+ *  - **The report renderer's own heading.** `DatasetReportChart`
+ *    (`@object-ui/plugin-report`) drops `title` from this result and paints its
+ *    own `h3` from a plain-string narrowing of `chart.title`, so a locale-map
+ *    title still draws no heading on the REPORT surface. That read site is the
+ *    renderer's, not this whitelist's; `subtitle` and `description` do reach
+ *    the chart there and are fixed by this change.
+ *
  * @param raw the authored chart config (anything, incl. absent)
  * @param fieldCategoryColors per-category colours resolved from the category
  *   dimension's own select/lookup option colours, merged UNDER an explicit
@@ -310,15 +393,16 @@ export function chartConfigPresentation(
   const config: Record<string, unknown> = isRecord(raw) ? raw : {};
   const out: Record<string, unknown> = {};
 
-  const text = (v: unknown): string | undefined => (typeof v === 'string' && v ? v : undefined);
-
   if (typeof config.showLegend === 'boolean') out.showLegend = config.showLegend;
   if (typeof config.showDataLabels === 'boolean') out.showDataLabels = config.showDataLabels;
-  const title = text(config.title);
+  // The three `I18nLabel` slots, carried through unresolved — see
+  // {@link forwardedI18nLabel} for why this package forwards rather than picks,
+  // and for what is still ledgered as unresolved on purpose.
+  const title = forwardedI18nLabel(config.title);
   if (title) out.title = title;
-  const subtitle = text(config.subtitle);
+  const subtitle = forwardedI18nLabel(config.subtitle);
   if (subtitle) out.subtitle = subtitle;
-  const description = text(config.description);
+  const description = forwardedI18nLabel(config.description);
   if (description) out.description = description;
   // A non-positive height would collapse the plot; the container default is the
   // more honest answer than an invisible chart.

--- a/packages/plugin-charts/src/ChartRenderer.presentationLocaleHeading-9038.test.tsx
+++ b/packages/plugin-charts/src/ChartRenderer.presentationLocaleHeading-9038.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9038 — the card's acceptance at runtime: a chart config authored
+ * with an inline-locale-map `title` / `subtitle` / `description` draws those
+ * headings **in the viewer's language, at two languages**, on the path a
+ * dataset-bound surface actually takes.
+ *
+ * The seam half lives in `@object-ui/core`
+ * (`chart-presentation.i18nLabel-9038.test.ts`) and pins that the authored
+ * union survives the lowering. It cannot pin what a viewer sees. This file
+ * pins that, and it is the half the defect made unreachable: before the fix
+ * the lowering ERASED the map arm, so the key never reached a schema and the
+ * chart drew no heading in any language — which is why no locale-comparison
+ * check could ever have caught it.
+ *
+ * ## The schema is BUILT by the real lowering, not restated
+ *
+ * `chartConfigPresentation` is imported from `@object-ui/core` and its output
+ * is spread onto the schema exactly as `DatasetWidget` spreads it. So what is
+ * rendered here is the product of the two halves joined — the whitelist's
+ * result feeding the renderer's resolver — rather than a hand-written schema
+ * that merely resembles one. Restating the lowered shape would pass with the
+ * lowering still broken.
+ *
+ * `ChartRenderer` is rendered rather than `AdvancedChartImpl`: it is what the
+ * ComponentRegistry resolves `type: 'chart'` to, and it is the component that
+ * holds the `useObjectTranslation` hook the resolver needs.
+ *
+ * ## The key-order control
+ *
+ * Every map below is written **`en` first**. The sibling defect objectui#8943
+ * was a first-string-in-key-order pick, so a map written `zh-CN` first would be
+ * satisfied by that defect as well; `en` first keeps the `zh-CN` cases able to
+ * fail. The plain-string case is the live control that must not move.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, screen, waitFor } from '@testing-library/react';
+
+// Recharts' ResponsiveContainer measures via ResizeObserver, which reports 0×0
+// under the headless DOM, so nothing paints. Fix its size — the same double the
+// sibling `ChartRenderer.localeHeading-8943.test.tsx` installs, for the same
+// reason (recharts resolves inside THIS package alone).
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: 480, height: 320 }),
+  };
+});
+
+// `ChartRenderer` renders its implementation behind
+// `React.lazy(() => import('./AdvancedChartImpl'))`. Importing it here — with the
+// SAME specifier, so the ESM cache satisfies the lazy factory — pays the recharts
+// graph in the import phase, which no test timeout applies to (AGENTS.md §测试纪律).
+import './AdvancedChartImpl';
+import { chartConfigPresentation } from '@object-ui/core';
+import { I18nProvider } from '@object-ui/i18n';
+import { ChartRenderer } from './ChartRenderer';
+
+afterEach(cleanup);
+
+/** ⚠️ `en` FIRST — see the key-order control above. */
+const TITLE = { en: 'Pricing', 'zh-CN': '定价' };
+const SUBTITLE = { en: 'By stage', 'zh-CN': '按阶段' };
+const DESCRIPTION = { en: 'Bar chart of pricing by stage', 'zh-CN': '按阶段的价格柱状图' };
+
+/** Stable config objects — `I18nProvider` rebuilds its instance when `config` changes identity. */
+const ZH = { defaultLanguage: 'zh-CN', detectBrowserLanguage: false };
+const EN = { defaultLanguage: 'en', detectBrowserLanguage: false };
+
+/** The dataset-derived half, which this card does not touch. */
+const derived = {
+  type: 'chart',
+  chartType: 'bar' as const,
+  data: [
+    { status: 'open', total: 120 },
+    { status: 'paid', total: 80 },
+  ],
+  xAxisKey: 'status',
+  series: [{ dataKey: 'total', label: 'Total' }],
+  isAnimationActive: false,
+};
+
+/**
+ * Mount the authored config at one language, through the REAL lowering, and
+ * wait for the plot rather than the lazy skeleton.
+ */
+async function renderAuthored(chartConfig: Record<string, unknown>, config: Record<string, unknown>) {
+  const schema = { ...derived, ...chartConfigPresentation(chartConfig, null) };
+  const { container } = render(
+    <I18nProvider persistLanguage={false} config={config}>
+      <ChartRenderer schema={schema as any} />
+    </I18nProvider>,
+  );
+  await waitFor(() => expect(container.querySelector('.recharts-surface')).toBeTruthy());
+  return container;
+}
+
+describe('an authored locale-map chart heading reaches the DOM in the viewer language (objectui#9038)', () => {
+  it('draws the zh-CN title, subtitle and accessible description to a zh-CN viewer', async () => {
+    const container = await renderAuthored(
+      { title: TITLE, subtitle: SUBTITLE, description: DESCRIPTION },
+      ZH,
+    );
+    expect(screen.getByText('定价')).toBeTruthy();
+    expect(screen.getByText('按阶段')).toBeTruthy();
+    // `description` is the container's `role="img"` + `aria-label`, not a text node.
+    expect(container.querySelector('[role="img"]')?.getAttribute('aria-label')).toBe(
+      '按阶段的价格柱状图',
+    );
+    // The `en` entries — written FIRST in every map — must not be on screen.
+    expect(screen.queryByText('Pricing')).toBeNull();
+    expect(screen.queryByText('By stage')).toBeNull();
+  });
+
+  it('draws the en entries to an en viewer — the same maps, the other headings', async () => {
+    const container = await renderAuthored(
+      { title: TITLE, subtitle: SUBTITLE, description: DESCRIPTION },
+      EN,
+    );
+    expect(screen.getByText('Pricing')).toBeTruthy();
+    expect(screen.getByText('By stage')).toBeTruthy();
+    expect(container.querySelector('[role="img"]')?.getAttribute('aria-label')).toBe(
+      'Bar chart of pricing by stage',
+    );
+    expect(screen.queryByText('定价')).toBeNull();
+  });
+
+  it('a plain-string title is unchanged by either language — the live control', async () => {
+    for (const config of [ZH, EN]) {
+      await renderAuthored({ title: 'Quarterly revenue' }, config);
+      expect(screen.getByText('Quarterly revenue')).toBeTruthy();
+      cleanup();
+    }
+  });
+});

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.chartConfigLocaleHeading-9038.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.chartConfigLocaleHeading-9038.test.tsx
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#9038 — a dashboard widget whose `chartConfig.title` is an inline
+ * locale map reached the renderer with NO heading at all.
+ *
+ * `chartConfigPresentation` lowered the widget's chrome through a limb that
+ * admitted only a plain string, so the spec-legal map arm of `I18nLabel` was
+ * erased before the schema was built: not the wrong language, no language —
+ * and therefore invisible to any check comparing a heading against a locale.
+ *
+ * ## Where these assertions stop, and why
+ *
+ * One step past the seam, as the sibling `DatasetWidget.comboPresentation`
+ * file does and for the same mechanical reason: counting what is DRAWN needs
+ * `ResponsiveContainer` mocked to a measured box, and `recharts` resolves
+ * inside `plugin-charts` alone, so a `vi.mock('recharts')` in THIS package
+ * cannot even resolve the specifier. So the widget's emitted schema is run
+ * through `normalizeChartSchema` — the ONE translation `ChartRenderer` puts
+ * between the schema and `AdvancedChartImpl` — at the two languages a viewer
+ * could be in.
+ *
+ * The DRAWN half is pinned where recharts lives:
+ * `ChartRenderer.presentationLocaleHeading-9038.test.tsx` renders the same
+ * authored maps through `ChartRenderer` at both languages and reads the
+ * headings out of the DOM.
+ *
+ * ⚠️ `normalizeChartSchema` is called here with an EXPLICIT language, which is
+ * what `ChartRenderer` does with `useObjectTranslation().language`
+ * (objectui#8943). Omitting it is not neutral — `pickLocalized` reads an absent
+ * language as `en` — so a two-language assertion that passed no language would
+ * print the same heading twice and prove nothing.
+ *
+ * PREDICTIONS, written before the run: every locale-map case is RED before the
+ * fix, and red in the defect's own shape — the key is `undefined`, i.e. absent,
+ * i.e. no heading. The plain-string case is GREEN on both sides.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+// The renderer's own translation layer, imported read-only through its
+// PUBLISHED root entry — the same module `ChartRenderer` calls, reached the way
+// any consumer outside this repo would reach it (objectui#4529).
+import { normalizeChartSchema } from '@object-ui/plugin-charts';
+
+let lastChartSchema: any = null;
+
+vi.mock('@object-ui/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  SchemaRenderer: (props: any) => {
+    lastChartSchema = props.schema;
+    return null;
+  },
+}));
+
+import { DatasetWidget } from '../DatasetWidget';
+
+afterEach(() => {
+  cleanup();
+  lastChartSchema = null;
+});
+
+const rows = [
+  { stage: 'open', amount: 120 },
+  { stage: 'paid', amount: 80 },
+];
+
+const fields = [
+  { name: 'stage', label: 'Stage' },
+  { name: 'amount', label: 'Amount' },
+];
+
+/** ⚠️ `en` FIRST. objectui#8943's defect was a first-string-in-key-order pick,
+ *  so a map written `zh-CN` first would satisfy that defect too. */
+const TITLE = { en: 'Pricing', 'zh-CN': '定价' };
+const SUBTITLE = { en: 'By stage', 'zh-CN': '按阶段' };
+const DESCRIPTION = { en: 'Bar chart of pricing by stage', 'zh-CN': '按阶段的价格柱状图' };
+
+const renderWidget = async (chartConfig: Record<string, unknown>) => {
+  const src = { queryDataset: vi.fn(async () => ({ rows, fields })) };
+  render(
+    <DatasetWidget
+      widget={{
+        type: 'bar',
+        dataset: 'deals',
+        dimensions: ['stage'],
+        values: ['amount'],
+        chartConfig,
+      }}
+      dataSource={src}
+    />,
+  );
+  await waitFor(() => expect(lastChartSchema).not.toBeNull());
+  return lastChartSchema;
+};
+
+describe('DatasetWidget — an authored locale-map heading survives to the renderer (objectui#9038)', () => {
+  it('carries the authored union onto the emitted schema instead of erasing it', async () => {
+    const schema = await renderWidget({ title: TITLE, subtitle: SUBTITLE, description: DESCRIPTION });
+    // The failure this replaces was ABSENCE, so the first thing to pin is that
+    // the keys are there at all — and that what arrived is the author's value,
+    // not something coerced on the way.
+    expect(schema.title).toEqual(TITLE);
+    expect(schema.subtitle).toEqual(SUBTITLE);
+    expect(schema.description).toEqual(DESCRIPTION);
+  });
+
+  it('resolves to the zh-CN entries for a zh-CN viewer', async () => {
+    const schema = await renderWidget({ title: TITLE, subtitle: SUBTITLE, description: DESCRIPTION });
+    const zh = normalizeChartSchema(schema, 'zh-CN');
+    expect(zh.title).toBe('定价');
+    expect(zh.subtitle).toBe('按阶段');
+    expect(zh.description).toBe('按阶段的价格柱状图');
+  });
+
+  it('resolves to the en entries for an en viewer — the same maps, the other headings', async () => {
+    const schema = await renderWidget({ title: TITLE, subtitle: SUBTITLE, description: DESCRIPTION });
+    const en = normalizeChartSchema(schema, 'en');
+    expect(en.title).toBe('Pricing');
+    expect(en.subtitle).toBe('By stage');
+    expect(en.description).toBe('Bar chart of pricing by stage');
+  });
+
+  it('leaves a plain-string title alone in either language — the live control', async () => {
+    const schema = await renderWidget({ title: 'Quarterly revenue' });
+    expect(schema.title).toBe('Quarterly revenue');
+    expect(normalizeChartSchema(schema, 'zh-CN').title).toBe('Quarterly revenue');
+    expect(normalizeChartSchema(schema, 'en').title).toBe('Quarterly revenue');
+  });
+});

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.chartLocaleChrome-9038.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.chartLocaleChrome-9038.test.tsx
@@ -38,7 +38,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, waitFor } from '@testing-library/react';
 import { ComponentRegistry } from '@object-ui/core';
-import { normalizeChartSchema } from '@object-ui/plugin-charts';
+// The repository's ONE resolver for the `I18nLabel` union, and already a
+// dependency of this package — `DatasetReportRenderer` itself resolves measure
+// labels through it. Used below only to show that what ARRIVES at the chart
+// component is a usable two-language value; see the scope note above for which
+// half of the claim that is and where the other half lives.
+import { pickLocalized } from '@object-ui/i18n';
 import { DatasetReportRenderer } from '../DatasetReportRenderer';
 
 let captured: { schema: Record<string, any> } | null = null;
@@ -103,17 +108,22 @@ describe('report chart chrome — the locale-map arm travels too (objectui#9038)
     expect(schema.description).toEqual(DESCRIPTION);
   });
 
-  it('resolves to either language once the renderer supplies the viewer', async () => {
-    // ⚠️ An EXPLICIT language on both calls: `pickLocalized` reads an absent one
-    // as `en`, so a two-language claim made without it would print the same
+  it('what arrives is a usable two-language value, not merely a non-empty one', async () => {
+    // ⚠️ An EXPLICIT language on every call: `pickLocalized` reads an absent one
+    // as `en`, so a two-language claim made without one would print the same
     // string twice and prove nothing (objectui#8943).
+    //
+    // This restates the RESOLVER, deliberately and with its limit stated: it
+    // shows the arriving value resolves both ways, NOT that the renderer feeds
+    // it the viewer's language. That second half needs the real chart component
+    // and therefore recharts, which resolves in `@object-ui/plugin-charts`
+    // alone — `ChartRenderer.presentationLocaleHeading-9038.test.tsx` renders
+    // these same maps there and reads the headings out of the DOM.
     const schema = await chartSchema({ ...CHART, subtitle: SUBTITLE, description: DESCRIPTION });
-    const zh = normalizeChartSchema(schema, 'zh-CN');
-    expect(zh.subtitle).toBe('仅未结管道');
-    expect(zh.description).toBe('按阶段的金额');
-    const en = normalizeChartSchema(schema, 'en');
-    expect(en.subtitle).toBe('Open pipeline only');
-    expect(en.description).toBe('Amount by stage');
+    expect(pickLocalized(schema.subtitle, 'zh-CN')).toBe('仅未结管道');
+    expect(pickLocalized(schema.subtitle, 'en')).toBe('Open pipeline only');
+    expect(pickLocalized(schema.description, 'zh-CN')).toBe('按阶段的金额');
+    expect(pickLocalized(schema.description, 'en')).toBe('Amount by stage');
   });
 
   it('still drops `title` from the lowered chrome — this renderer paints its own', async () => {

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.chartLocaleChrome-9038.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.chartLocaleChrome-9038.test.tsx
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#9038, report surface — a report chart authoring `subtitle` /
+ * `description` as the spec's inline-locale-map arm of `I18nLabel` got neither
+ * key at all, so the chart drew no sub-heading and carried no accessible
+ * description, in every language.
+ *
+ * The lowering these two keys travel through is `chartConfigPresentation`
+ * (`@object-ui/core`), shared with the dashboard; its string-only limb erased
+ * the map arm before the schema was built. The sibling
+ * `DatasetReportRenderer.chartChrome.test.tsx` already pins that both keys
+ * travel — with a plain STRING. This file is the other arm of the same union.
+ *
+ * ## Scope: `subtitle` and `description`, and why `title` is not here
+ *
+ * This renderer paints the chart's title itself, as its own `h3` above the
+ * plot, and therefore DROPS `title` from the lowered result so the chart does
+ * not draw a second one — a decision the sibling file pins. Its `h3` reads
+ * `chart.title` through a plain-string narrowing of its own, so a locale-map
+ * title still draws no heading on this surface. That read site is the
+ * renderer's own and is outside objectui#9038's subject (the shared lowering);
+ * it is reported separately rather than pinned here, because pinning it would
+ * record a live defect as an expectation.
+ *
+ * ## Where these assertions stop
+ *
+ * At the schema the registered chart component is handed — the same seam the
+ * sibling file stops at. What that component then DRAWS from the union is
+ * pinned where recharts resolves:
+ * `ChartRenderer.presentationLocaleHeading-9038.test.tsx` in
+ * `@object-ui/plugin-charts` renders the same maps at two languages.
+ *
+ * PREDICTIONS, written before the run: both locale-map cases RED before the fix
+ * (the key is absent), the plain-string control GREEN on both sides.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { normalizeChartSchema } from '@object-ui/plugin-charts';
+import { DatasetReportRenderer } from '../DatasetReportRenderer';
+
+let captured: { schema: Record<string, any> } | null = null;
+
+beforeEach(() => {
+  captured = null;
+  ComponentRegistry.register('chart', (props: any) => {
+    captured = props;
+    return null;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const RESULT = {
+  rows: [
+    { stage: 'Qualification', amount: 120 },
+    { stage: 'Negotiation', amount: 80 },
+  ],
+  fields: [
+    { name: 'stage', type: 'text', label: 'Stage' },
+    { name: 'amount', type: 'number', label: 'Amount' },
+  ],
+};
+
+const sourceOf = (result: unknown) => ({ queryDataset: vi.fn(async () => result) });
+
+const BASE = {
+  name: 'pipeline_by_stage',
+  type: 'tabular',
+  dataset: 'pipeline_metrics',
+  rows: ['stage'],
+  values: ['amount'],
+};
+
+const CHART = { type: 'bar', xAxis: 'stage', yAxis: 'amount' } as const;
+
+/** ⚠️ `en` FIRST — objectui#8943's defect was a first-string-in-key-order pick. */
+const SUBTITLE = { en: 'Open pipeline only', 'zh-CN': '仅未结管道' };
+const DESCRIPTION = { en: 'Amount by stage', 'zh-CN': '按阶段的金额' };
+
+/** The schema the registered chart component was handed for this `chart` block. */
+async function chartSchema(chart: Record<string, unknown>) {
+  render(
+    <DatasetReportRenderer
+      report={{ ...BASE, chart } as never}
+      dataSource={sourceOf(RESULT) as never}
+    />,
+  );
+  await waitFor(() => expect(captured?.schema?.data?.length).toBe(2));
+  return captured!.schema;
+}
+
+describe('report chart chrome — the locale-map arm travels too (objectui#9038)', () => {
+  it('carries an authored locale-map `subtitle` and `description` onto the schema', async () => {
+    const schema = await chartSchema({ ...CHART, subtitle: SUBTITLE, description: DESCRIPTION });
+    // The failure this replaces was ABSENCE, so presence is the first pin.
+    expect(schema.subtitle).toEqual(SUBTITLE);
+    expect(schema.description).toEqual(DESCRIPTION);
+  });
+
+  it('resolves to either language once the renderer supplies the viewer', async () => {
+    // ⚠️ An EXPLICIT language on both calls: `pickLocalized` reads an absent one
+    // as `en`, so a two-language claim made without it would print the same
+    // string twice and prove nothing (objectui#8943).
+    const schema = await chartSchema({ ...CHART, subtitle: SUBTITLE, description: DESCRIPTION });
+    const zh = normalizeChartSchema(schema, 'zh-CN');
+    expect(zh.subtitle).toBe('仅未结管道');
+    expect(zh.description).toBe('按阶段的金额');
+    const en = normalizeChartSchema(schema, 'en');
+    expect(en.subtitle).toBe('Open pipeline only');
+    expect(en.description).toBe('Amount by stage');
+  });
+
+  it('still drops `title` from the lowered chrome — this renderer paints its own', async () => {
+    // Not a heading claim: the pin is that the chart is NOT handed a title, so
+    // it cannot draw a second one beside the `h3`. It held for the string arm
+    // and must keep holding for the map arm.
+    const schema = await chartSchema({ ...CHART, title: { en: 'Pricing', 'zh-CN': '定价' } });
+    expect(schema.title).toBeUndefined();
+  });
+
+  it('leaves plain-string chrome exactly as it was — the live control', async () => {
+    const schema = await chartSchema({
+      ...CHART,
+      subtitle: 'Open pipeline only',
+      description: 'Amount by stage for the current quarter',
+    });
+    expect(schema.subtitle).toBe('Open pipeline only');
+    expect(schema.description).toBe('Amount by stage for the current quarter');
+  });
+});


### PR DESCRIPTION
Fixes #9038

`chartConfigPresentation` lowered a chart config's `title` / `subtitle` / `description` through a local limb that admitted only a plain string, so the inline-locale-map arm of the spec's `I18nLabel` union returned undefined, the `if (title)` guard skipped the assignment, and the key never reached the result. The chart drew **no heading at all**, in every language, with no diagnostic.

That shape matters: this is not the sibling defect #8943. The value was not resolved badly, it was **not resolved at all** — so there was no heading to compare against a locale, and no locale-comparison check could ever have seen it.

---

## ⚠️ Route change, with the measurement that forced it — read this first

The dispatch settled the direction as route 2 of the card (give `chartConfigPresentation` an optional `language` parameter and resolve through `pickLocalized`), on the landed precedent of `normalizeChartSchema`. **Measurement falsifies that precedent for this function**, for a reason that is about the package rather than the call sites, and the falsification clause is why this PR takes the card's route 1 instead. It does not invent a third route.

**`@object-ui/core` cannot reach `pickLocalized`.** The resolver lives in `@object-ui/i18n`, which DEPENDS on `@object-ui/core` (`"@object-ui/core": "workspace:*"` in its `dependencies`) and peers React; its entry point re-exports `I18nProvider` and `useObjectTranslation`. The precedent lives in `@object-ui/plugin-charts`, which sits ABOVE i18n and may import it — a layering difference the dispatch's reasoning did not weigh.

Measured mechanically, mutation proven on disk before the run and the restore proven by state:

```
BEFORE  occurrences of '@object-ui/i18n' in packages/core/package.json: 0   blob 54cca7cc
AFTER   occurrences: 1                                                     blob b6584770
$ pnpm exec turbo run build --filter=@object-ui/core --dry
  WARNING  Circular package dependency detected: @object-ui/core, @object-ui/i18n
  x Cyclic dependency detected:
  |     @object-ui/i18n#build, @object-ui/core#build
  TURBO EXIT=1
RESTORE blob 54cca7cc (back to the HEAD blob) · git diff HEAD --name-only = 0 lines
```

The repo already states the same edge from the other side: the `@object-ui/i18n` test that pins the dashboard range-preset labels says it lives there rather than in core because i18n "depends on `@object-ui/core`, so it can reach both; core cannot reach the packs without inverting that edge."

**Route 1 is not a workaround here — the render-site resolver route 1 needs already landed with #8943.** `ChartRenderer` reads `useObjectTranslation().language` and calls `normalizeChartSchema(schema, language)`, whose `label()` resolves exactly these three slots through `pickLocalized`; `ObjectChart` reads `schema.title` through the same resolver for its drill heading and its comment already states that the slot is the union, not a plain string. So the chart schema slot these keys land in **already declares the union**, and `chartConfigPresentation` was narrowing it one layer below the only layer that knows the viewer. Forwarding is what lets the single resolver see the value at all.

So: `pickLocalized` stays the one resolver, `@object-ui/core` stays React-free, **and the function signature does not change** — which makes this a strictly smaller contract move than the one the Clause-② declaration was raised for. `needs:contract-review` is on the card and on this PR; the reviewer's decision is the route, not just the diff.

## What changed

One production edit, in `packages/core/src/utils/chart-presentation.ts`: the three chrome limbs stop calling the string-only local helper and call a new module-private `forwardedI18nLabel`, which carries the authored value through unresolved.

- **No signature change.** `chartConfigPresentation(raw, fieldCategoryColors?)` takes the same two arguments. Every existing caller compiles; no caller has to learn a language.
- **The admission test did not widen.** A plain string, or a record carrying at least one usable string entry — the same "is there anything here" question the old truthiness guard asked, extended to the map arm. A number, a boolean, an array, the empty string, the empty object and a record with no string value are all still refused, so the documented `@returns` contract ("only the keys that resolved") still holds and no key can arrive that renders nothing.
- **The map travels verbatim.** The spec's inline-locale-map arm is a record of language tag to string, and enforcing that belongs at the parse, not in a renderer-side coercion (AGENTS.md #0.1). A non-string entry falls through `pickLocalized`'s limbs exactly as an absent one does.
- `I18nLabel` is IMPORTED from `@objectstack/spec/ui`, not re-declared.

## `text()` is not `labelText()`, and `labelText()` is untouched

`labelText` — the first-string-wins pick for a series `label` and an axis `title` — is a documented, ledgered design (#4020): this package is React-free, holds no i18n provider, and **a caller that CAN resolve the language overrides the merged label**. That mitigation is real and this card does not reopen it; not one character of `labelText` moved, and a pin in the new core test asserts both of its call paths still return the picked string.

The limb this PR replaced offered no such route. It did not make a locale-unaware PICK that a caller could override — it **erased the value**, so nothing survived for any caller to re-resolve. The override route `labelText`'s ledger depends on was unavailable by construction. That is the whole distinction, and it is why one of them is a ledgered design and the other was a defect.

## Ledgered by name, as the card asked

Written into the source docblock, not only here:

1. **A series `label` and an axis `title`** still take `labelText`'s pick (#4020). Out of scope, deliberately, and now visibly asymmetric with the three chrome keys rather than silently so.
2. **The report renderer's own heading.** `DatasetReportChart` drops `title` from this result (it paints its own heading above the plot, or the chart would draw a second one) and reads `chart.title` through a plain-string narrowing of its own — so a locale-map **title** still draws no heading on the report surface. `subtitle` and `description` do reach the chart there and are fixed here. That read site is the renderer's own, outside this card's subject; filed separately rather than widened into this PR, and deliberately NOT pinned as an expectation, since pinning it would record a live defect as intended behaviour.

## Tests

Four files, layered so no half can carry the claim alone.

| Where | What it pins |
|---|---|
| `@object-ui/core` — `chart-presentation.i18nLabel-9038.test.ts` | the SEAM: the authored union survives the lowering; string arm unchanged; every non-admitted value still refused; no other key moves; `labelText`'s neighbours still picked |
| `@object-ui/plugin-charts` — `ChartRenderer.presentationLocaleHeading-9038.test.tsx` | the RENDERED acceptance: a schema built by the REAL `chartConfigPresentation` renders `定价` / `按阶段` to a zh-CN viewer and `Pricing` / `By stage` to an en viewer, with `description` read off the container's `aria-label`, plus a plain-string control |
| `@object-ui/plugin-dashboard` — `DatasetWidget.chartConfigLocaleHeading-9038.test.tsx` | the dashboard surface: the widget's emitted schema carries the union, and resolves to either language one step past the seam |
| `@object-ui/plugin-report` — `DatasetReportRenderer.chartLocaleChrome-9038.test.tsx` | the report surface: `subtitle` / `description` arrive as a usable two-language value; `title` is still withheld from the chart |

Every locale map in every fixture is written **`en` first**, on purpose: #8943's defect was a first-string-in-key-order pick, so a map written `zh-CN` first would be satisfied by that defect too. Every two-language assertion passes an EXPLICIT language — `pickLocalized` reads an absent one as `en`, so a two-language claim made without one would print the same string twice and prove nothing.

The report file uses `pickLocalized` rather than `normalizeChartSchema`, with the limit stated in the test: `@object-ui/plugin-charts` is not a dependency of `@object-ui/plugin-report` (importing it failed `type-check` with TS2307), and recharts resolves in plugin-charts alone, so the renderer-path half of the claim is pinned there.

## Ablation — the pins can fail

Mutation: the record arm of `forwardedI18nLabel` returns undefined again (the pre-fix behaviour), applied to the committed tree.

```
BEFORE  'return v as I18nLabel;' x1 · 'ABLATION-9038' x0 · blob 48a0d0ee
AFTER   'return v as I18nLabel;' x0 · 'ABLATION-9038' x1 · blob 1d037fd6
RUN     Test Files 4 failed (4) · Tests 12 failed | 11 passed (23) · exit 1
RESTORE blob 48a0d0ee (HEAD blob) · 'return v as I18nLabel;' x1 · 'ABLATION-9038' x0
        git diff HEAD --name-only = 0 lines
RE-RUN  Test Files 4 passed (4) · Tests 23 passed (23) · exit 0
```

The 11 that stayed GREEN under the mutation are the controls that must not move — the plain-string cases, the refusal cases, the `labelText` ledger pin and the report's withheld `title`. The 12 that went RED are every locale-map case, and they went red in the defect's own shape: the key is absent, i.e. no heading. `@object-ui/core` is aliased to its `src` in the root vitest config, so the mutated source is what the runner read; the red run is itself the proof it arrived.

## Verification

Run at `a40f0371`, all heavy runs serialized through the shared container verify lock.

- `pnpm exec vitest run packages/core/ packages/plugin-report/` — **164 files / 3316 tests passed**, `VERDICT command-exit 0`
- `pnpm exec vitest run packages/plugin-charts/` — **59 files / 532 tests passed**, `VERDICT command-exit 0`
- `pnpm exec vitest run packages/plugin-dashboard/` — **110 files / 986 tests passed**, `VERDICT command-exit 0`
- `turbo run type-check` over the four affected packages — **17 successful, 17 total**, `VERDICT command-exit 0`. `check-type-check-coverage` reports `43/43 packages compile their tests`, so this measured the new test files too — that is how the TS2307 above was caught.
- Gates: `check-new-line-citations` `0 new citation(s)` · `check-control-bytes` OK over 7337 files · `check-changeset-presence` OK (5 source files of 4 released packages, 1 changeset) · `check-changeset-no-major` OK · `check-changeset-claims` OK · `check-phantom-dependencies` OK · `check-unused-dependencies` OK · `check-package-self-import` OK · `check-vi-mock-specifiers` OK · `check-vi-mock-inherit` OK · `check-vi-mock-override-shape` OK · `check-unreferenced-sources` OK · `check-type-check-coverage` OK
- **NOT MEASURED — `check-readme-exports`**, by its own printed reason: `379 self-import(s) could not be judged … type entry ./dist/index.d.ts is not on disk — run pnpm build first`. It is a prerequisite miss over READMEs this diff does not touch, not a red gate. CI builds first and will judge it.
- **Lint, narrowed to the changed files, declared:** population read from eslint's OWN resolution — a repo-root `eslint .` enumerates **4813** files; count read from `--format json` — **5** files linted, **0 errors**, 7 warnings (`no-explicit-any` in the new test files, the same shape as their sibling test files), exit 0. Invariance: the resolved config for the changed file has EMPTY `parserOptions` and no `project` / `projectService`, so type-aware linting is off and this diff cannot move the verdict on any file it does not contain.

## Acceptance notes

Found and deliberately not fixed here (reported, not widened into this PR):

- **`DatasetReportChart`'s own `h3` narrows `chart.title` to a plain string**, so a locale-map title draws no heading on the report surface even after this change. Same defect class as this card, different read site, different package — filed separately, and ledgered by name in the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_