### PR TITLE
fix(core): refuse an empty or non-string `icontains` comparand on the stored-view rule path, and give all three faces one refusal

### DIFF
--- a/.changeset/icontains-comparand-view-rule-9048.md
+++ b/.changeset/icontains-comparand-view-rule-9048.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/core': minor
+---
+
+Refuse an empty or non-string `icontains` comparand on the stored-view rule path, and give all three `@object-ui/core` faces one implementation of that refusal
+
+`@objectstack/spec`'s `FILTER_TEXT_CASES` declares two shapes refused for the case-insensitive contains operator — an empty comparand and a non-string one — each with `code: 'INVALID_FILTER'`. `ValueDataSource` has answered both since objectui#8748 and `convertFiltersToAST` since objectui#9001, but `viewFilterRuleToNode` (reached through the exported `toFilterNode`) lowered both onto the wire: a rule an author saved as `{ field, operator: 'icontains', value: '' }` became `['name','icontains','']`, which the in-memory matchers answer with zero rows while the published table states the wire answer is a predicate that constrains nothing. Same authored filter, two answers, chosen by which data source the view renders against.
+
+The refusal now throws `FilterOperatorError` (`INVALID_FILTER` / 400) from the lowering, naming the field and the operator spelling the view vocabulary actually uses. A valid comparand, the sibling positive operators (`contains` / `starts_with` / `ends_with`), objectui#8557's array-arity refusal and a rule carrying no comparand at all are all unchanged.
+
+The discrimination and the refusal text moved into one internal module that `ValueDataSource`, `convertFiltersToAST` and `viewFilterRuleToNode` all read, so the three faces cannot drift. Both already-shipped messages are byte-identical to what they were. No published export was added.

--- a/packages/core/src/adapters/ValueDataSource.ts
+++ b/packages/core/src/adapters/ValueDataSource.ts
@@ -24,6 +24,11 @@ import {
   RETIRED_FILTER_OPERATORS,
 } from '@objectstack/spec/data';
 import { emulateBatchTransaction } from './batchTransaction.js';
+import {
+  describeComparand,
+  isRefusedTextComparand,
+  textComparandRefusalReason,
+} from '../utils/text-comparand.js';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -192,51 +197,24 @@ function refuseArrayComparand(
  * the one outcome worse than the bug.
  */
 /**
- * A comparand as it appears INSIDE a refusal message.
+ * ⚠️ The DISCRIMINATION and the MESSAGE moved to `utils/text-comparand.ts`
+ * (objectui#9048). Nothing about this face's answer changed — the reason string
+ * is the same bytes it has been since objectui#8748, and the pins that drive
+ * both faces and compare their wording verify that without transcribing it.
  *
- * `JSON.stringify` alone is not safe here even though it is what the message
- * wants: it THROWS on a BigInt and on a cyclic object, and this is an
- * exclude-and-log face — a refusal that throws while explaining itself would
- * turn the one path that stays quiet about a bad filter into the one path that
- * takes the caller down. No JSON-sourced filter can carry either shape, so this
- * is about the in-memory callers who hand `find()` a literal.
- *
- * `?? String(target)` keeps `undefined` and a symbol readable — `JSON.stringify`
- * returns `undefined` for both — which is the idiom this file already used.
+ * What stayed here is the ENVELOPE, which is the half that does NOT transfer:
+ * this matcher is deciding about one ROW and HAS a row to exclude, so it
+ * excludes-and-logs (objectui#7349). Its two siblings each seat the same reason
+ * in their own envelope — `filter-converter` throws `FilterOperatorError`
+ * because it is a PRODUCER with no row to exclude.
  */
-function describeComparand(target: unknown): string {
-  try {
-    return JSON.stringify(target) ?? String(target);
-  } catch {
-    return String(target);
-  }
-}
-
 function refuseTextComparand(
   refusals: Set<string>,
   field: string,
   operator: string,
   target: unknown,
 ): false {
-  const declared =
-    `@objectstack/spec's FILTER_TEXT_CASES declares this shape refused `
-    + `(INVALID_FILTER); the declared comparand for '${operator}' is a NON-EMPTY STRING`;
-  if (target === '') {
-    return refuseFilterNode(
-      refusals,
-      `filter comparand for field '${field}' on operator '${operator}' is the EMPTY `
-      + `STRING. Every value contains the empty substring, so evaluating it is a `
-      + `predicate that constrains nothing. ${declared}. Drop the condition instead `
-      + `of sending an empty comparand`,
-    );
-  }
-  return refuseFilterNode(
-    refusals,
-    `filter comparand for field '${field}' on operator '${operator}' is `
-    + `${target === null ? 'null' : typeof target} (${describeComparand(target)}), `
-    + `not a string. Coercing it would answer a query nobody wrote. ${declared}. `
-    + `Write the comparand as a string`,
-  );
+  return refuseFilterNode(refusals, textComparandRefusalReason(field, operator, target));
 }
 
 /**
@@ -513,7 +491,7 @@ function matchesComparisonNode(
     // after a `String()` coercion nobody wrote. Both are refusals in
     // `FILTER_TEXT_CASES`; see {@link refuseTextComparand}.
     case 'icontains':
-      if (typeof target !== 'string' || target === '') {
+      if (isRefusedTextComparand(target)) {
         return refuseTextComparand(refusals, field, String(rawOperator), target);
       }
       return typeof value === 'string' && asciiCaseInsensitiveContains(value, target);
@@ -732,7 +710,7 @@ function matchesDollarOperator(
     // object, so a door on one side only is a result that changes with the
     // SHAPE of the filter rather than with its meaning (objectui#8447).
     case '$icontains':
-      if (typeof target !== 'string' || target === '') {
+      if (isRefusedTextComparand(target)) {
         return refuseTextComparand(refusals, field, operator, target);
       }
       return typeof value === 'string' && asciiCaseInsensitiveContains(value, target);

--- a/packages/core/src/utils/__tests__/filter-view-rule-text-comparand-9048.test.ts
+++ b/packages/core/src/utils/__tests__/filter-view-rule-text-comparand-9048.test.ts
@@ -1,0 +1,424 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `viewFilterRuleToNode` refuses the two `icontains` comparand shapes the
+ * published table declares REFUSED, and all three faces now read ONE
+ * implementation of that refusal (objectui#9048).
+ *
+ * ## The defect
+ *
+ * `@objectstack/spec`'s `FILTER_TEXT_CASES` carries two REJECTION rows for the
+ * case-insensitive contains operator — an empty comparand and a non-string one
+ * — each with `code: 'INVALID_FILTER'`. `ValueDataSource` has answered both
+ * since objectui#8748 and `convertFiltersToAST` since objectui#9001. The STORED
+ * VIEW rule vocabulary answered neither: measured on `origin/main` `6df26f025`
+ * with `@objectstack/spec` 17.4.0,
+ *
+ * ```
+ * toFilterNode([{ field:'name', operator:'icontains', value:'' }]) => [["name","icontains",""]]
+ * toFilterNode([{ field:'name', operator:'icontains', value:42 }]) => [["name","icontains",42]]
+ * convertFiltersToAST({ name: { $icontains: '' } })                => THROWS INVALID_FILTER / 400
+ * ```
+ *
+ * — one contract, refused when the author writes it in the `$` dialect and
+ * lowered onto the wire when the same author SAVES it as a view rule.
+ *
+ * ## What is asserted, and why in this shape
+ *
+ * The weak version of this file would be `expect(() => …).toThrow()`, satisfied
+ * by any throw including a bare `Error` from a converter that had simply
+ * broken. Four stronger claims are made instead, three of them inherited from
+ * `filter-text-comparand-9001.test.ts` because this card is the same contract
+ * one dialect over.
+ *
+ *   1. **The contract's own rows are DRIVEN, not transcribed.** The rejection
+ *      rows are read off the installed `FILTER_TEXT_CASES` at run time; each
+ *      row's comparand is re-seated as a view rule and pushed through
+ *      `toFilterNode`. A transcribed contract drifts from the contract.
+ *   2. **ONE refusal, three envelopes — checked by driving all three.** Triage
+ *      ruled "make the dialects share the one that works", so the matcher's
+ *      refusal text is captured live and BOTH producer faces must contain it
+ *      verbatim. A fourth copy pasted in later cannot satisfy this without
+ *      being byte-identical, and a drift in any one face reddens here.
+ *   3. **The two already-shipped faces are UNCHANGED.** This card consolidates
+ *      them; it must not move them. Pinned so "all three agree" cannot be
+ *      satisfied by having quietly edited the reference implementation.
+ *   4. **The refusal is not "refuse everything".** A valid comparand must still
+ *      lower byte for byte, the sibling positive operators must be untouched,
+ *      objectui#8557's ARRAY arm must still answer the ARRAY message for this
+ *      operator, and a rule with NO comparand must still lower to its 2-tuple.
+ *
+ * ⚠️ Deliberately NOT claimed: that the refusal reaches a real backend. What is
+ * provable in this tree is the lowering and the three faces' agreement.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { FILTER_TEXT_CASES } from '@objectstack/spec/data';
+import * as corePublicEntry from '../../index.js';
+import { toFilterNode, convertFiltersToAST, FilterOperatorError } from '../filter-converter';
+import { ValueDataSource } from '../../adapters/ValueDataSource';
+
+/**
+ * The `FILTER_TEXT_CASES` rejection rows that are about the case-insensitive
+ * contains COMPARAND, read off the installed spec rather than transcribed.
+ *
+ * Narrowed by the OPERATOR KEYS of the row's own filter, not by its
+ * `mustMention` list: the `$regex` rows also mention `$icontains` (they
+ * prescribe it as the repair), and re-seating those as view rules would assert
+ * something true for a different reason.
+ */
+type RejectionRow = { name: string; code: string; comparand: unknown };
+
+function icontainsComparandRejectionRows(): RejectionRow[] {
+  const rows: RejectionRow[] = [];
+  for (const row of FILTER_TEXT_CASES as readonly any[]) {
+    if (row.expectRejection !== true) continue;
+    const filter = row.filter as Record<string, any>;
+    const fields = Object.keys(filter);
+    if (fields.length !== 1) continue;
+    const operatorMap = filter[fields[0]];
+    if (!operatorMap || typeof operatorMap !== 'object' || Array.isArray(operatorMap)) continue;
+    const operators = Object.keys(operatorMap);
+    if (operators.length !== 1 || operators[0] !== '$icontains') continue;
+    rows.push({ name: row.name, code: row.code, comparand: operatorMap.$icontains });
+  }
+  return rows;
+}
+
+const REJECTION_ROWS = icontainsComparandRejectionRows();
+
+/** The view-rule spelling of the operator — no `$`, a `VIEW_FILTER_OPERATORS` member. */
+const VIEW_SPELLING = 'icontains';
+
+const ROWS = [
+  { id: 'a', name: 'ACME Corporation' },
+  { id: 'b', name: 'acme holdings' },
+  { id: 'c', name: 'Globex' },
+];
+
+/** The envelope `refuseFilterNode` wraps every `ValueDataSource` refusal in. */
+const MATCHER_PREFIX = '[ObjectUI] ValueDataSource: ';
+const MATCHER_SUFFIX = '. Rows are excluded rather than passed through.';
+
+function viewRule(value: unknown, operator: string = VIEW_SPELLING) {
+  return value === undefined
+    ? { field: 'name', operator }
+    : { field: 'name', operator, value };
+}
+
+async function matcherRefusals(filter: unknown): Promise<string[]> {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const ds = new ValueDataSource({ items: ROWS });
+  await ds.find('rows', { $filter: filter as any });
+  const refusals = warn.mock.calls.map((call) => String(call[0]));
+  warn.mockRestore();
+  return refusals;
+}
+
+/**
+ * The REASON `ValueDataSource` refused, with its face-specific envelope removed
+ * — the half of the message the CONTRACT owns, and so the half every producer
+ * has to repeat.
+ *
+ * Throws rather than returning `undefined` when the envelope no longer matches:
+ * a silently-unparsed refusal would make the mirror assertions below compare
+ * against an empty string, which every message contains.
+ */
+function matcherReason(refusal: string | undefined): string {
+  if (
+    refusal === undefined
+    || !refusal.startsWith(MATCHER_PREFIX)
+    || !refusal.endsWith(MATCHER_SUFFIX)
+  ) {
+    throw new Error(
+      `ValueDataSource's refusal envelope changed (objectui#9048 reads it to compare the three `
+      + `faces' wording). Re-point this reader at the new envelope; do NOT delete the check — `
+      + `the wording agreement IS what makes "one refusal, three envelopes" checkable. `
+      + `Got: ${String(refusal)}`,
+    );
+  }
+  return refusal.slice(MATCHER_PREFIX.length, refusal.length - MATCHER_SUFFIX.length);
+}
+
+/** `JSON.stringify` made total, so a diagnostic survives the values fed to it. */
+function show(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function viewRefusalFor(value: unknown): FilterOperatorError {
+  const rule = viewRule(value);
+  try {
+    const lowered = toFilterNode([rule]);
+    throw new Error(
+      `toFilterNode([${show(rule)}]) did NOT refuse — it lowered ${show(lowered)} onto the `
+      + `wire. That is objectui#9048.`,
+    );
+  } catch (error) {
+    if (error instanceof FilterOperatorError) return error;
+    throw error;
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// 0. Controls — the populations were really read, and can really fail
+// ---------------------------------------------------------------------------
+
+describe('objectui#9048 — controls', () => {
+  it('read BOTH icontains comparand rejection rows off the installed spec', () => {
+    // Guards the vacuous pass: a reader that matched nothing would make the
+    // `it.each` blocks below iterate zero rows and report success.
+    expect(
+      REJECTION_ROWS.length,
+      'FILTER_TEXT_CASES no longer carries the $icontains comparand rejection rows this card '
+        + 'exists to honour — the premise changed and this file must be re-read, not re-pointed',
+    ).toBeGreaterThanOrEqual(2);
+    expect(
+      REJECTION_ROWS.some((row) => row.comparand === ''),
+      'the EMPTY-comparand row must be among them',
+    ).toBe(true);
+    expect(
+      REJECTION_ROWS.some((row) => typeof row.comparand !== 'string'),
+      'the NON-STRING comparand row must be among them',
+    ).toBe(true);
+    expect(
+      REJECTION_ROWS.every((row) => row.code === 'INVALID_FILTER'),
+      'every row must declare the ADR-0112 code this converter carries',
+    ).toBe(true);
+  });
+
+  it('LIVE CONTROL: a valid comparand still lowers, on the very path this card edits', () => {
+    // Green before this card and after it. A red here is about the harness or
+    // about a guard that refuses too much, never about the comparand door.
+    expect(toFilterNode([viewRule('acme')])).toEqual([['name', VIEW_SPELLING, 'acme']]);
+  });
+
+  it('LIVE CONTROL: the matcher really runs on this fixture and stays quiet for a valid filter',
+    async () => {
+      const refusals = await matcherRefusals([['name', VIEW_SPELLING, 'acme']]);
+      expect(refusals, 'a working operator must not print a refusal').toEqual([]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 1. The contract's rejection rows, re-seated as STORED VIEW rules
+// ---------------------------------------------------------------------------
+
+describe('objectui#9048 — every FILTER_TEXT_CASES icontains comparand rejection is honoured '
+  + 'on the view-rule path', () => {
+  it.each(REJECTION_ROWS.map((row) => [row.name, row] as const))(
+    '%s',
+    (_name, row) => {
+      const error = viewRefusalFor(row.comparand);
+      // The envelope, not merely "it threw": `classifyLoadError` reads these,
+      // and a bare `Error` classifies as a NETWORK fault — the one thing a
+      // malformed filter definitely is not.
+      expect(error.code, 'the row declares the ADR-0112 code the refusal must carry').toBe(row.code);
+      expect(error.httpStatus, 'and its 400-class status').toBe(400);
+      expect(
+        error.message,
+        'the refusal must name the operator SPELLING THAT ARRIVED — a view rule has no `$`, '
+          + 'and prescribing one sends the author looking for a key their metadata cannot hold',
+      ).toContain(`'${VIEW_SPELLING}'`);
+      expect(
+        error.message,
+        'and it must still name the $-dialect spelling FILTER_TEXT_CASES uses, so an author '
+          + 'reading the published table can recognise their own condition in it',
+      ).toContain('$icontains');
+      expect(
+        error.message,
+        'and the FIELD, so an author can find the condition in their saved view',
+      ).toContain('name');
+    },
+  );
+
+  it('the refusal happens BEFORE the node exists, so nothing lowers', () => {
+    // The distinction the card is about: a node that reaches the wire is
+    // answered two layers later by a 400 the author cannot attribute to their
+    // view — or, on an in-memory data source, by an empty list and no error.
+    for (const row of REJECTION_ROWS) {
+      expect(() => toFilterNode([viewRule(row.comparand)])).toThrow(FilterOperatorError);
+    }
+  });
+
+  it('a mixed source refuses the rule without the surrounding AST nodes deciding the answer', () => {
+    // `ObjectView` concatenates a saved view's rules with `?filter[…]` URL
+    // triples into ONE array, so the refused rule really does arrive beside
+    // already-lowered nodes.
+    expect(() => toFilterNode([
+      ['stage', '=', 'won'],
+      viewRule(''),
+    ])).toThrow(FilterOperatorError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. ONE refusal, three envelopes — the consolidation, checked by driving it
+// ---------------------------------------------------------------------------
+
+describe('objectui#9048 — all three faces repeat the same refusal', () => {
+  it.each(REJECTION_ROWS.map((row) => [row.name, row] as const))(
+    '%s — same words in the matcher, the $ converter and the view rule',
+    async (_name, row) => {
+      // The matcher's AST arm, driven with the SAME operator spelling the view
+      // rule carries, so the reason strings are comparable without allowances.
+      const refusals = await matcherRefusals([['name', VIEW_SPELLING, row.comparand]]);
+      expect(
+        refusals,
+        'objectui#8748 refuses this shape in the matcher; if it does not, the reference '
+          + 'implementation moved and this consolidation must be re-derived rather than re-pinned',
+      ).toHaveLength(1);
+      const reason = matcherReason(refusals[0]);
+      expect(reason.length, 'a non-empty reason, or `toContain` below is vacuous').toBeGreaterThan(40);
+
+      expect(
+        viewRefusalFor(row.comparand).message,
+        'triage ruled "make the dialects share the one that works": a view refusal that no '
+          + 'longer contains the matcher\'s reason is a SECOND implementation, which is the one '
+          + 'thing this card exists to prevent',
+      ).toContain(reason);
+    },
+  );
+
+  it('the $ dialect keeps repeating it too — the consolidation did not move objectui#9001',
+    async () => {
+      for (const row of REJECTION_ROWS) {
+        const refusals = await matcherRefusals({ name: { $icontains: row.comparand } });
+        const reason = matcherReason(refusals[0]);
+        let converterMessage = '';
+        try {
+          convertFiltersToAST({ name: { $icontains: row.comparand } });
+        } catch (error) {
+          converterMessage = (error as Error).message;
+        }
+        expect(converterMessage, 'the $ dialect must still refuse').not.toBe('');
+        expect(converterMessage).toContain(reason);
+      }
+    });
+
+  it('each face keeps its OWN envelope — the half that does NOT transfer', async () => {
+    // `ValueDataSource` excludes-and-logs because it is deciding about one ROW;
+    // both converter faces are PRODUCERS deciding whether to send a query at
+    // all and have no row to exclude, so they throw. Pinned so "share the
+    // refusal" is not misread as "share the delivery".
+    const refusals = await matcherRefusals([['name', VIEW_SPELLING, '']]);
+    expect(refusals[0]).toContain('Rows are excluded rather than passed through');
+    expect(viewRefusalFor('').message).not.toContain(
+      'Rows are excluded rather than passed through',
+    );
+    // …and the two throwing faces are still distinguishable from each other:
+    // the view face says which vocabulary the author is writing in.
+    expect(viewRefusalFor('').message).toContain('STORED VIEW rule');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. The boundaries this card must not move
+// ---------------------------------------------------------------------------
+
+describe('objectui#9048 — what must NOT change', () => {
+  it('a valid comparand lowers byte for byte, on every shape that reaches this function', () => {
+    expect(toFilterNode([viewRule('acme')])).toEqual([['name', VIEW_SPELLING, 'acme']]);
+    expect(toFilterNode([viewRule('a')])).toEqual([['name', VIEW_SPELLING, 'a']]);
+    // A comparand that merely LOOKS empty is a real one and must survive.
+    expect(toFilterNode([viewRule(' ')])).toEqual([['name', VIEW_SPELLING, ' ']]);
+    expect(toFilterNode([viewRule('0')])).toEqual([['name', VIEW_SPELLING, '0']]);
+  });
+
+  it('the sibling positive operators are untouched — only the declared row is answered', () => {
+    // `$contains` / `$startsWith` / `$endsWith` have no rejection row in
+    // FILTER_TEXT_CASES, so widening by analogy would be this file inventing a
+    // contract the published table did not declare.
+    for (const operator of ['contains', 'starts_with', 'ends_with', 'not_contains', 'equals']) {
+      expect(
+        toFilterNode([viewRule('', operator)]),
+        `${operator} has no FILTER_TEXT_CASES rejection row and must keep lowering`,
+      ).toEqual([['name', operator, '']]);
+      expect(toFilterNode([viewRule(42, operator)])).toEqual([['name', operator, 42]]);
+    }
+  });
+
+  it("objectui#8557's ARRAY arm still answers FIRST for an array on this operator", () => {
+    // Ordering is load-bearing. An array comparand is not a "not a string"
+    // problem — it is a membership-spelling problem, and #8557's message
+    // prescribes `in` / `not_in` / `between`. A comparand door placed ahead of
+    // it would answer a true sentence with the wrong repair.
+    let message = '';
+    try {
+      toFilterNode([viewRule(['a'])]);
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message, 'an array on a single-value operator must still be refused').not.toBe('');
+    expect(message, "the ARRAY arm's message, not the comparand arm's").toContain('carries an ARRAY');
+    expect(message).toContain('objectui#8557');
+  });
+
+  it('a rule with NO comparand still lowers to its 2-tuple', () => {
+    // `isRefusedTextComparand(undefined)` is TRUE, so this is the carve-out the
+    // guard spells out rather than a happy accident. The view vocabulary HAS an
+    // "absent" the `$` dialect does not, the valueless operators depend on it,
+    // and `FILTER_TEXT_CASES` declares two rows — not three.
+    expect(toFilterNode([viewRule(undefined)])).toEqual([['name', VIEW_SPELLING]]);
+    expect(toFilterNode([{ field: 'name', operator: 'is_null' }])).toEqual([['name', 'is_null']]);
+  });
+
+  it('an operator the spec does not know is still passed through VERBATIM', () => {
+    // A misspelling must reach `isFilterAST` and be named by the server, not be
+    // coerced into a valid operator or answered with the wrong diagnosis. The
+    // `$`-prefixed spelling is not a member of this vocabulary either.
+    expect(toFilterNode([viewRule('', 'icontainz')])).toEqual([['name', 'icontainz', '']]);
+    expect(toFilterNode([viewRule('', '$icontains')])).toEqual([['name', '$icontains', '']]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. The consolidation stayed INSIDE the package
+// ---------------------------------------------------------------------------
+
+describe('objectui#9048 — the shared refusal is internal to @object-ui/core', () => {
+  it('is not re-exported from the package entry', () => {
+    // objectui#9048 fixed the two `@object-ui/core` producers by giving them ONE
+    // refusal to read. The third producer — `objectFilterEntryToAST` in
+    // `@object-ui/data-objectstack` — is in a SECOND published package, and
+    // `@object-ui/core`'s `exports` map has exactly one entry (`"."`), so it can
+    // only import what `src/index.ts` re-exports. Reaching the shared refusal
+    // from there is therefore a PUBLISHED-SURFACE addition, which this card
+    // deliberately did not make.
+    //
+    // ⚠️ This pin is not a ban. It is the place the decision gets recorded: if
+    // you are landing the cross-package half, change this assertion in the same
+    // commit and say so in the PR, so the addition is a decision rather than a
+    // side effect of an `export *` somewhere.
+    for (const name of ['isRefusedTextComparand', 'textComparandRefusalReason', 'describeComparand']) {
+      expect(
+        Object.prototype.hasOwnProperty.call(corePublicEntry, name),
+        `${name} reached @object-ui/core's published entry. objectui#9048 kept the shared `
+          + 'refusal internal on purpose; adding it is a published-surface change and a '
+          + "maintainer's call",
+      ).toBe(false);
+    }
+  });
+
+  it('…while both in-package faces do read it', async () => {
+    // The other half of the same claim: internal does not mean unused. Both
+    // producers and the matcher answer the same shape, which is only true
+    // because they share one implementation.
+    expect(() => toFilterNode([viewRule('')])).toThrow(FilterOperatorError);
+    expect(() => convertFiltersToAST({ name: { $icontains: '' } })).toThrow(FilterOperatorError);
+    expect(await matcherRefusals([['name', VIEW_SPELLING, '']])).toHaveLength(1);
+  });
+});

--- a/packages/core/src/utils/filter-converter.ts
+++ b/packages/core/src/utils/filter-converter.ts
@@ -1085,14 +1085,33 @@ function viewFilterRuleToNode(rule: ViewFilterRuleLike): FilterNode {
   // than assumed. The Console cannot author this rule: `foldFilterGroupToSpecRules`
   // (`@object-ui/app-shell`, objectui#4155) DROPS a condition whose value is
   // `null` / `''` / `[]` before it is persisted, precisely so an incomplete row
-  // never reaches storage. What remains is hand-authored metadata and views
-  // saved before that landed. And the throw is not a new blast radius: both
-  // sinks already catch a `FilterOperatorError` from this same function —
-  // `plugin-list`'s `buildEffectiveFilter` inside `ListView`'s load `try`,
-  // `plugin-view`'s `ObjectView` inside its own — and `classifyLoadError` reads
-  // this error's `INVALID_FILTER` / `400`, so the user sees the "filter is
-  // malformed" panel naming their field and operator, not a crashed page and
-  // not a network error.
+  // never reaches storage. And nothing in this tree authors the shape: over
+  // every tracked file, an `operator: 'icontains'` rule appears only in this
+  // card's own test, changeset and comment — lit control, 40 tracked files
+  // mention the operator at all.
+  //
+  // ## ⚠️ Where the throw LANDS is a second question, and it is NOT settled here
+  //
+  // Two of the sinks catch it: `plugin-list`'s `buildEffectiveFilter` runs
+  // inside `ListView`'s load `try` and `plugin-view`'s `ObjectView` inside its
+  // own, and `classifyLoadError` reads this error's `INVALID_FILTER` / `400`, so
+  // there the user sees the "filter is malformed" panel naming their field and
+  // operator. FOUR more entries do not: `plugin-grid`'s `ObjectGrid` (twice),
+  // `plugin-detail`'s `RelatedList` and `plugin-form`'s `LineItemsPanel` all
+  // call `toFilterNode` inside a RENDER-time `useMemo`, where a throw
+  // propagates as a render error with no `classifyLoadError` in the path.
+  // `ObjectGrid` feeds it `schema.filter`, which the spec declares as
+  // `z.array(ViewFilterRuleSchema)` — i.e. exactly the shape this arm judges.
+  //
+  // That is objectui#9050, an OPEN card on the DELIVERY axis, and this arm
+  // deliberately does not pre-empt it. It is not a class this card creates or
+  // even joins first: objectui#8557's array-arity refusal directly above throws
+  // from this same function through those same four entries and has shipped
+  // that way, and objectui#9050 counts eleven pre-existing throw sites reachable
+  // the same way. ⛔ The alternatives are worse in the direction this whole card
+  // family exists to close — dropping the rule widens the result set, lowering
+  // it keeps the two-answers split. So the refusal lands and WHERE it surfaces
+  // stays objectui#9050's decision to make for all thirteen at once.
   if (
     operator === 'icontains'
     && rule.value !== undefined

--- a/packages/core/src/utils/filter-converter.ts
+++ b/packages/core/src/utils/filter-converter.ts
@@ -20,6 +20,7 @@ import {
   VIEW_FILTER_PAIR_VALUE_OPERATORS,
 } from '@objectstack/spec/ui';
 import { isAcceptedFilterComparand, ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE } from '@objectstack/spec/data';
+import { isRefusedTextComparand, textComparandRefusalReason } from './text-comparand.js';
 
 /**
  * FilterNode AST type definition
@@ -310,34 +311,6 @@ function describeExoticComparand(value: object): string {
 }
 
 /**
- * A comparand as it appears INSIDE a refusal message.
- *
- * `JSON.stringify` alone is not safe here even though it is what the message
- * wants: it THROWS on a BigInt and on a cyclic object. On THIS face that is not
- * merely noisy, it would REPLACE the refusal — the call sits inside a
- * `throw new FilterOperatorError(...)` expression, so a `TypeError` raised while
- * the message is being built escapes in the refusal's place, and
- * `classifyLoadError` reads a bare `TypeError` as a network fault: the author
- * would be told to check their connection about a filter this layer had already
- * judged. Ported from `ValueDataSource`'s twin (objectui#8748), where the same
- * call is unsafe for the mirror-image reason — a refusal that throws while
- * explaining itself turns the one path that stays quiet into the one path that
- * takes the caller down.
- *
- * No JSON-sourced filter can carry either shape, so this is about the in-memory
- * callers who hand a literal to `convertFiltersToAST`. `?? String(target)` keeps
- * `undefined` and a symbol readable — `JSON.stringify` returns `undefined` for
- * both.
- */
-function describeComparand(target: unknown): string {
-  try {
-    return JSON.stringify(target) ?? String(target);
-  } catch {
-    return String(target);
-  }
-}
-
-/**
  * An `$icontains` comparand that is not a NON-EMPTY STRING —
  * `{ name: { $icontains: '' } }`, `{ name: { $icontains: 42 } }` (objectui#9001).
  *
@@ -376,13 +349,18 @@ function describeComparand(target: unknown): string {
  *
  * ## What transfers from the sibling, and what cannot
  *
- * The DISCRIMINATION (`typeof target !== 'string' || target === ''`) and the
- * MESSAGE transfer verbatim, and the message is load-bearing rather than
- * cosmetic: `mustMention: ['$icontains']` means a differently-worded refusal is
- * a different failure to honour the same contract, not a stylistic variant.
+ * The DISCRIMINATION and the MESSAGE transfer verbatim, and the message is
+ * load-bearing rather than cosmetic: `mustMention: ['$icontains']` means a
+ * differently-worded refusal is a different failure to honour the same
+ * contract, not a stylistic variant.
  * `filter-text-comparand-9001.test.ts` pins the two messages against each other
  * by DRIVING both faces and asserting this one contains the sibling's refusal
  * text, so the mirror cannot drift in silence.
+ *
+ * ⭐ Since objectui#9048 "transfer verbatim" is no longer a claim about two
+ * copies agreeing: both halves are ONE implementation in `text-comparand.ts`,
+ * and this function is the envelope that seats it. The pin above is kept, and
+ * is now a pin on the SEATING rather than on a transcription.
  *
  * The DELIVERY cannot transfer, and that is the card's own Q1 answered by the
  * two call sites rather than by a fresh ruling. `ValueDataSource`
@@ -405,25 +383,11 @@ function describeComparand(target: unknown): string {
  * oversight.
  */
 function refuseTextComparand(field: string, operator: string, target: unknown): never {
-  const declared =
-    `@objectstack/spec's FILTER_TEXT_CASES declares this shape refused `
-    + `(INVALID_FILTER); the declared comparand for '${operator}' is a NON-EMPTY STRING`;
   const ported =
     `It is refused here rather than lowered onto the wire (objectui#9001; ported from `
     + `ValueDataSource's refuseTextComparand, objectui#8748).`;
-  if (target === '') {
-    throw new FilterOperatorError(
-      `[ObjectUI] The filter comparand for field '${field}' on operator '${operator}' is the EMPTY `
-      + `STRING. Every value contains the empty substring, so evaluating it is a `
-      + `predicate that constrains nothing. ${declared}. Drop the condition instead `
-      + `of sending an empty comparand. ${ported}`
-    );
-  }
   throw new FilterOperatorError(
-    `[ObjectUI] The filter comparand for field '${field}' on operator '${operator}' is `
-    + `${target === null ? 'null' : typeof target} (${describeComparand(target)}), `
-    + `not a string. Coercing it would answer a query nobody wrote. ${declared}. `
-    + `Write the comparand as a string. ${ported}`
+    `[ObjectUI] The ${textComparandRefusalReason(field, operator, target)}. ${ported}`
   );
 }
 
@@ -731,7 +695,7 @@ export function convertFiltersToAST(
           // is keyed the same way. The `$` spelling the AUTHOR wrote is what
           // travels into the message, which is what `FILTER_TEXT_CASES`'
           // `mustMention: ['$icontains']` is about.
-          if (astOperator === 'icontains' && (typeof operatorValue !== 'string' || operatorValue === '')) {
+          if (astOperator === 'icontains' && isRefusedTextComparand(operatorValue)) {
             refuseTextComparand(field, operator, operatorValue);
           }
           conditions.push([field, astOperator, operatorValue]);
@@ -926,8 +890,16 @@ function isViewFilterRule(value: unknown): value is ViewFilterRuleLike {
  * single-value operator is refused rather than passed through. See the arm
  * itself for the reasoning and for why the refusal is a throw (objectui#8557).
  *
+ * Its COMPARAND is checked on one operator, `icontains`, whose two refused
+ * shapes `@objectstack/spec`'s `FILTER_TEXT_CASES` declares (objectui#9048).
+ * That arm reads the same shared refusal `convertFiltersToAST` and
+ * `ValueDataSource` read, and the arm itself carries the weighing for a SAVED
+ * view — which is a different input from objectui#8557's and was redone rather
+ * than inherited.
+ *
  * @throws {FilterOperatorError} If the rule carries an ARRAY on an operator the
- * spec declares single-valued.
+ * spec declares single-valued, or an empty / non-string comparand on
+ * `icontains`.
  */
 /**
  * The view-filter operators whose `value` is legitimately an ARRAY.
@@ -1047,6 +1019,106 @@ function viewFilterRuleToNode(rule: ViewFilterRuleLike): FilterNode {
       `'not_in', or a range as { operator: 'between', value: [min, max] } — the ` +
       `three operators the spec declares array-valued, which are untouched ` +
       `(objectui#8557; the same ruling objectui#8530 applied to the object arm).`
+    );
+  }
+
+  // The `icontains` COMPARAND door, on the STORED VIEW rule vocabulary —
+  // objectui#9048. Same two shapes `FILTER_TEXT_CASES` declares refused, same
+  // discrimination and same words as `convertFiltersToAST` and
+  // `ValueDataSource`, because all three now read ONE implementation
+  // (`text-comparand.ts`) rather than three copies of it. Triage ruled exactly
+  // that: "three implementations of one refusal, of which one is correct ⇒ the
+  // useful dispatch is not 'add a third guard' but 'make the dialects share the
+  // one that works'".
+  //
+  // ## Placed AFTER the arity arm, deliberately
+  //
+  // An ARRAY comparand on `icontains` is refused by objectui#8557 above, with
+  // its message about `in` / `not_in` / `between`. Running this door first would
+  // answer the same input with "not a string" — a true sentence that prescribes
+  // the wrong repair, and a silent change to a shipped ruling this card is
+  // fenced away from.
+  //
+  // ## An ABSENT comparand is left alone, and that is a boundary not an omission
+  //
+  // `isRefusedTextComparand(undefined)` is true, so the `!== undefined` test is
+  // load-bearing. The `$` dialect has no "absent" — `{ $icontains: undefined }`
+  // still HAS the key — but this vocabulary does, and the tail below already
+  // encodes it: a rule with no `value` lowers to the 2-tuple `[field, operator]`
+  // because the valueless operators (`is_null` and friends) take their direction
+  // from the operator NAME. Measured on today's tree, that 2-tuple is already
+  // refused downstream with THIS card's code: `parseFilterAST(['name',
+  // 'icontains'])` throws `INVALID_FILTER` / 400 naming
+  // `where.name.$icontains`. So the shape is loud already; moving WHERE it is
+  // refused is a separate argument nobody has made, and `FILTER_TEXT_CASES`
+  // declares two rows, not three.
+  //
+  // ## Why a THROW here, when it means a saved view fails at RENDER
+  //
+  // This is objectui#8557's weighing done again on a different input, not
+  // inherited from it — the card says so, and the inputs really do differ.
+  // Measured on `origin/main` `6df26f025` with `@objectstack/spec` 17.4.0, one
+  // authored view rule `{ field: 'name', operator: 'icontains', value: '' }`:
+  //
+  //   - it lowers to `['name','icontains','']`, which `isFilterAST` ACCEPTS, so
+  //     it is sent rather than stopped at any door;
+  //   - `parseFilterAST` reads it as `{ name: { $icontains: '' } }`;
+  //   - against the in-memory matchers that condition selects ZERO of the
+  //     spec's own nine `FILTER_TEXT_ROWS` (`@objectstack/formula`'s
+  //     `matchesFilterCondition`, and `ValueDataSource` since objectui#8748,
+  //     which also prints a refusal);
+  //   - and on the wire the published table states the other answer in its own
+  //     words — "Every row contains the empty substring, so evaluating it is a
+  //     predicate that constrains nothing".
+  //
+  // So the pre-fix answer is not one behaviour but TWO, chosen by which data
+  // source the saved view happens to render against: silently-empty on the
+  // in-memory faces, constrains-nothing on the wire. That is the acceptance-set
+  // split this card family exists to close, and neither half is "a view that
+  // renders correctly today". objectui#8557's conclusion (loud beats
+  // silently-empty) covers the first half unchanged; the second half is the
+  // WIDENING direction this file's own arity arm names as the one it exists to
+  // avoid — "a stored view's whole purpose can be to hide rows". Both halves
+  // point the same way, which is why the weighing survives the different input.
+  //
+  // The blast radius is also smaller than the shape suggests, measured rather
+  // than assumed. The Console cannot author this rule: `foldFilterGroupToSpecRules`
+  // (`@object-ui/app-shell`, objectui#4155) DROPS a condition whose value is
+  // `null` / `''` / `[]` before it is persisted, precisely so an incomplete row
+  // never reaches storage. What remains is hand-authored metadata and views
+  // saved before that landed. And the throw is not a new blast radius: both
+  // sinks already catch a `FilterOperatorError` from this same function —
+  // `plugin-list`'s `buildEffectiveFilter` inside `ListView`'s load `try`,
+  // `plugin-view`'s `ObjectView` inside its own — and `classifyLoadError` reads
+  // this error's `INVALID_FILTER` / `400`, so the user sees the "filter is
+  // malformed" panel naming their field and operator, not a crashed page and
+  // not a network error.
+  if (
+    operator === 'icontains'
+    && rule.value !== undefined
+    && isRefusedTextComparand(rule.value)
+  ) {
+    // The spelling that ARRIVED, never `$icontains` substituted for it. The
+    // published rows spell the operator `$icontains` because their filters are
+    // written in the `$` dialect; a view rule spells the same operator
+    // `icontains`, and `ValueDataSource` already answers this question the same
+    // way on today's tree — its `$` arm names `$icontains`, its AST arm names
+    // `icontains`, each from the node in hand. Prescribing a spelling this
+    // vocabulary does not have would send a view author looking for a `$` key
+    // their metadata cannot contain, so the `$` twin is NAMED in the tail below
+    // instead of substituted for what they wrote.
+    const arrived = typeof rule.operator === 'string' && rule.operator !== ''
+      ? rule.operator
+      : operator;
+    const tail =
+      `This is a STORED VIEW rule, so it is refused as the filter is BUILT rather `
+      + `than lowered onto the wire: the spelling @objectstack/spec's `
+      + `FILTER_TEXT_CASES uses for this operator is the $-dialect '$icontains', `
+      + `which this vocabulary spells '${arrived}'. Remove the condition from the `
+      + `view, or give it a non-empty string comparand (objectui#9048; the same `
+      + `refusal ValueDataSource and convertFiltersToAST already share).`;
+    throw new FilterOperatorError(
+      `[ObjectUI] The ${textComparandRefusalReason(rule.field, arrived, rule.value)}. ${tail}`
     );
   }
 

--- a/packages/core/src/utils/text-comparand.ts
+++ b/packages/core/src/utils/text-comparand.ts
@@ -1,0 +1,143 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The ONE `icontains` comparand ruling this package owns, in one place
+ * (objectui#9048).
+ *
+ * ## Why this module exists rather than a third copy
+ *
+ * `@objectstack/spec`'s `FILTER_TEXT_CASES` carries two REJECTION rows for the
+ * case-insensitive contains operator — an empty comparand and a non-string one
+ * — each with `code: 'INVALID_FILTER'` and `mustMention: ['$icontains']`.
+ * Before this module the SAME discrimination and the SAME message were written
+ * out twice inside this package: `ValueDataSource`'s `refuseTextComparand`
+ * (objectui#8748, the reference implementation) and `filter-converter`'s
+ * (objectui#9001, whose own docblock calls itself "a PORT of a shipped,
+ * reviewed implementation"). objectui#9048's triage ruled on that directly:
+ *
+ * > three implementations of one refusal, of which one is correct ⇒ the useful
+ * > dispatch is not "add a third guard" but "make the dialects share the one
+ * > that works"
+ *
+ * So the contract's half — WHICH comparands are refused, and WHAT the author is
+ * told — lives here once, and each face keeps only its own ENVELOPE. That split
+ * is not a tidy-up: it is the half that does and the half that does not
+ * transfer, and both docblocks already said so before this module existed.
+ * `ValueDataSource` excludes-and-logs because it is deciding about one ROW and
+ * HAS a row to exclude; `filter-converter` is a PRODUCER deciding whether to
+ * send a query at all and has none, so it throws `FilterOperatorError`
+ * (`INVALID_FILTER` / 400).
+ *
+ * ## Not exported from `@object-ui/core`'s entry, deliberately
+ *
+ * `src/index.ts` names its re-exports one file at a time and does NOT name this
+ * one, so nothing here reaches the published surface. The package's sibling
+ * `@object-ui/data-objectstack` carries the same defect on its own ARRAY-form
+ * producer and CANNOT reach this module — `@object-ui/core`'s `exports` map has
+ * exactly one entry (`"."`), so a second package can only import what
+ * `src/index.ts` re-exports. Closing that half is a published-surface addition
+ * and a maintainer's call, not this module's; see objectui#9048 for the exact
+ * export it would need.
+ *
+ * ## Scope
+ *
+ * Only the case-insensitive contains operator, because only that operator is
+ * what the published table declares. The sibling positive operators
+ * (`$contains` / `$startsWith` / `$endsWith`) have no such row and keep the
+ * answer they have always given on every face — widening by analogy is the
+ * table's decision, not this module's.
+ */
+
+/**
+ * A comparand as it appears INSIDE a refusal message.
+ *
+ * `JSON.stringify` alone is not safe here even though it is what the message
+ * wants: it THROWS on a BigInt and on a cyclic object. Both faces are hurt by
+ * that and in mirror-image ways, which is why the guard travels with the text
+ * rather than being re-derived per face. On the THROWING face the call sits
+ * inside a `throw new FilterOperatorError(...)` expression, so a `TypeError`
+ * raised while the message is being built escapes in the refusal's place, and
+ * `classifyLoadError` reads a bare `TypeError` as a network fault: the author
+ * would be told to check their connection about a filter this layer had already
+ * judged. On the EXCLUDE-AND-LOG face a refusal that throws while explaining
+ * itself turns the one path that stays quiet about a bad filter into the one
+ * path that takes the caller down.
+ *
+ * No JSON-sourced filter can carry either shape, so this is about the in-memory
+ * callers who hand a literal to a data source or to the converter.
+ * `?? String(target)` keeps `undefined` and a symbol readable — `JSON.stringify`
+ * returns `undefined` for both.
+ */
+export function describeComparand(target: unknown): string {
+  try {
+    return JSON.stringify(target) ?? String(target);
+  } catch {
+    return String(target);
+  }
+}
+
+/**
+ * Is this comparand one of the two shapes `FILTER_TEXT_CASES` declares REFUSED
+ * for the case-insensitive contains operator?
+ *
+ * The discrimination, not a re-reading of it: `typeof target !== 'string'`
+ * answers the "a non-string $icontains comparand is REFUSED" row and
+ * `target === ''` answers the "an empty $icontains comparand is REFUSED" row.
+ * It is written once so a face cannot drift into judging a slightly different
+ * set — the failure mode that produced this module's card, where the same
+ * authored filter was refused in one dialect and lowered onto the wire in
+ * another.
+ */
+export function isRefusedTextComparand(target: unknown): boolean {
+  return typeof target !== 'string' || target === '';
+}
+
+/**
+ * The REASON a case-insensitive-contains comparand is refused — the half of the
+ * message the CONTRACT owns, with no face's envelope on it.
+ *
+ * Returned without a leading capital and without a trailing period so each face
+ * can seat it in its own sentence: the matcher logs `…ValueDataSource: <reason>.
+ * Rows are excluded…`, the converter throws `[ObjectUI] The <reason>. <tail>`.
+ * Those two seatings are exactly what objectui#8748 and objectui#9001 already
+ * shipped, byte for byte — this function is where the shared bytes moved to, not
+ * a rewording of them. `mustMention` is what makes that load-bearing rather than
+ * stylistic: a differently-worded refusal is a different failure to honour the
+ * same row.
+ *
+ * `operator` is the spelling that ACTUALLY ARRIVED, never a canonical one
+ * substituted for it. That is `ValueDataSource`'s own answer to the question and
+ * it is measurable on today's tree: its `$` arm names `$icontains` and its AST
+ * arm names `icontains`, each from the node in hand. Telling an author about a
+ * spelling their dialect does not have is the same class of misdirection the
+ * `describeComparand` guard above exists to avoid.
+ */
+export function textComparandRefusalReason(
+  field: string,
+  operator: string,
+  target: unknown,
+): string {
+  const declared =
+    `@objectstack/spec's FILTER_TEXT_CASES declares this shape refused `
+    + `(INVALID_FILTER); the declared comparand for '${operator}' is a NON-EMPTY STRING`;
+  if (target === '') {
+    return (
+      `filter comparand for field '${field}' on operator '${operator}' is the EMPTY `
+      + `STRING. Every value contains the empty substring, so evaluating it is a `
+      + `predicate that constrains nothing. ${declared}. Drop the condition instead `
+      + `of sending an empty comparand`
+    );
+  }
+  return (
+    `filter comparand for field '${field}' on operator '${operator}' is `
+    + `${target === null ? 'null' : typeof target} (${describeComparand(target)}), `
+    + `not a string. Coercing it would answer a query nobody wrote. ${declared}. `
+    + `Write the comparand as a string`
+  );
+}


### PR DESCRIPTION
Part of #9048 — the `@object-ui/core` half only. The `@object-ui/data-objectstack` half of that card is **not** addressed here and stays open; see FORK B below for why and for the exact export it needs.

## What this changes

`@objectstack/spec`'s `FILTER_TEXT_CASES` declares two shapes refused for the case-insensitive contains operator — an empty comparand and a non-string one — each with `code: 'INVALID_FILTER'`. Three producers in this repo emit that node. Before this PR, one refused it (`ValueDataSource`, objectui#8748), a second refused it by carrying **a copy** of the first (`convertFiltersToAST`, objectui#9001), and two lowered it onto the wire.

Triage ruled the useful dispatch is not a third guard but *"make the dialects share the one that works"*. So:

1. The **discrimination** and the **refusal message** move into one internal module (`packages/core/src/utils/text-comparand.ts`). `ValueDataSource`, `convertFiltersToAST` and `viewFilterRuleToNode` all read it. Each keeps only its own **envelope**, which is the half that genuinely does not transfer — the matcher excludes-and-logs because it has a row to exclude, the two producers throw because they are deciding whether to send a query at all.
2. `viewFilterRuleToNode` (the STORED VIEW rule vocabulary, reached through the exported `toFilterNode`) now refuses both shapes instead of lowering them.

Two copies of `describeComparand`, two copies of the `declared` sentence and two copies of the reason text are deleted in the process. **No new published export.**

## FORK A — the weighing for a saved view, redone rather than inherited

**Measured on `origin/main` `6df26f025`, `@objectstack/spec` 17.4.0.** One authored view rule `{ field: 'name', operator: 'icontains', value: '' }`:

| step | measured |
| :-- | :-- |
| `toFilterNode([rule])` | `[["name","icontains",""]]` |
| `isFilterAST(node)` | `true` — nothing stops it at the wire gate |
| `parseFilterAST(node)` | `{"name":{"$icontains":""}}` |
| in-memory: `@objectstack/formula` `matchesFilterCondition` over the spec's own nine `FILTER_TEXT_ROWS` | **0 rows** |
| in-memory: `ValueDataSource` | **0 rows**, plus one printed refusal (objectui#8748) |
| on the wire | the published table states it in its own words: *"Every row contains the empty substring, so evaluating it is a predicate that constrains nothing"* |

⇒ **The pre-fix answer is not one behaviour but two**, chosen by which data source the saved view happens to render against: silently-empty on the in-memory faces, constrains-nothing on the wire. **Neither half is "a view that renders correctly today."**

That is why objectui#8557's conclusion survives the different input rather than needing to be reversed:

- for the in-memory half the pre-fix behaviour **is** "no rows", which is exactly the input objectui#8557 weighed and answered *loud beats silently-empty*;
- for the wire half the pre-fix behaviour is the **widening** direction the arity arm one screen above names as the one this file exists to avoid — *"a stored view's whole purpose can be to hide rows"*.

Both halves point the same way.

Exposure, measured rather than assumed:

- The Console **cannot author** this rule. `foldFilterGroupToSpecRules` (`@object-ui/app-shell`, objectui#4155) drops a condition whose value is `null` / `''` / `[]` before it is persisted.
- Nothing in this tree authors the shape: over every tracked file, an `operator: 'icontains'` rule appears only in this card's own test, changeset and comment. Lit control: 40 tracked files mention the operator at all, so the probe is live.

### ⚠️ Where the throw LANDS — read this before landing

This is the part the card did not name and I did not assume: **objectui#9050 is an open card on the DELIVERY axis, and it governs this arm.**

Two sinks catch a `FilterOperatorError` from this function — `plugin-list`'s `buildEffectiveFilter` inside `ListView`'s load `try`, `plugin-view`'s `ObjectView` inside its own — and `classifyLoadError` reads `INVALID_FILTER` / `400`, so there the user gets the "filter is malformed" panel naming their field and operator.

**Four more entries do not.** Verified on today's tree: `plugin-grid`'s `ObjectGrid` (two call sites), `plugin-detail`'s `RelatedList` and `plugin-form`'s `LineItemsPanel` each call `toFilterNode` inside a render-time `useMemo`. `ObjectGrid` feeds it `schema.filter`, which the spec declares `z.array(ViewFilterRuleSchema)` — **exactly the shape this arm judges**.

It is not a class this PR creates, or even joins first: **objectui#8557's array-arity refusal, directly above the new arm in the same function, already throws through those same four entries and has shipped that way**, and objectui#9050 counts eleven pre-existing throw sites reachable the same way. The alternatives are both worse in the direction this card family exists to close — dropping the rule widens the result set, lowering it keeps the two-answers split.

⇒ **I did not pre-empt objectui#9050.** The refusal lands; *where* it surfaces stays that card's decision, for all thirteen sites at once. ⚠️ A maintainer who wants objectui#9050 decided first has a legitimate reason to hold this PR — which is one reason it is a draft.

## FORK B — the cross-package half is NOT here

**Measured, not assumed.** `@object-ui/core`'s `package.json` declares exactly one `exports` entry, `"."`, mapping to `./dist/index.js`. `src/index.ts` names its re-exports one file at a time. So a second package can import **only** what `src/index.ts` re-exports, and the shared module is deliberately not among them.

⇒ `objectFilterEntryToAST` in `@object-ui/data-objectstack` **cannot** reach the shared refusal without a new name on `@object-ui/core`'s published entry. That is a published-surface addition, so it is not in this PR.

⚠️ Note the trap for whoever takes it: under vitest, `@object-ui/core` is **aliased to `packages/core/src`**, so a `data-objectstack` test that deep-imports the internal module would pass while the published build broke. The export has to be real.

**The exact export it would need**, if a maintainer decides that way:

```ts
// packages/core/src/index.ts
export * from './utils/text-comparand.js';
// adds: isRefusedTextComparand, textComparandRefusalReason, describeComparand
```

…after which `objectFilterEntryToAST` reads the same two functions and seats the reason in `MalformedFilterError`'s own envelope — a second changeset and a second review surface either way, as the card says. A pin in the new test file asserts those three names are **not** on the published entry today, with a message telling whoever lands the cross-package half to change that assertion in the same commit so the addition is a decision rather than a side effect.

## The message question

`FILTER_TEXT_CASES`'s rows spell the operator `$icontains` because their filters are written in the `$` dialect. A view rule spells the same operator `icontains`.

`ValueDataSource` already answers this, and it is measurable on today's tree rather than inferred: its `$` arm names `$icontains`, its AST arm names `icontains`, **each from the node in hand**. This PR does the same — and, because a view author reading the published table needs to recognise their own condition in it, the view face's tail **also names the `$` twin** instead of substituting it:

```
[ObjectUI] The filter comparand for field 'name' on operator 'icontains' is the EMPTY STRING.
Every value contains the empty substring, so evaluating it is a predicate that constrains
nothing. @objectstack/spec's FILTER_TEXT_CASES declares this shape refused (INVALID_FILTER);
the declared comparand for 'icontains' is a NON-EMPTY STRING. Drop the condition instead of
sending an empty comparand. This is a STORED VIEW rule, so it is refused as the filter is
BUILT rather than lowered onto the wire: the spelling @objectstack/spec's FILTER_TEXT_CASES
uses for this operator is the $-dialect '$icontains', which this vocabulary spells
'icontains'. Remove the condition from the view, or give it a non-empty string comparand
(objectui#9048; the same refusal ValueDataSource and convertFiltersToAST already share).
```

## The two shipped messages did not move — byte for byte

Both existing faces were driven before and after the consolidation, in one process each, and the captured output is **identical**: `sha256 be5b77338e92fe8a58d580718632e3e42dd17741cf7b703dd98b28095dbb728f` both times, over six messages (`convertFiltersToAST` × 2 shapes, `ValueDataSource` `$` arm × 2, `ValueDataSource` AST arm × 2). That is the claim "the consolidation is not a rewording", measured rather than asserted.

## What is unchanged — live control, same run

- A valid comparand still lowers byte for byte: `toFilterNode([{field:'name',operator:'icontains',value:'acme'}])` is `[["name","icontains","acme"]]`. This control **pre-exists** the change and is green on both sides of it.
- Sibling positive operators (`contains` / `starts_with` / `ends_with` / `not_contains` / `equals`) are untouched with the same comparands — they have no rejection row, and widening by analogy is the published table's call.
- objectui#8557's ARRAY arm still answers **first** for an array on this operator, with its own message about `in` / `not_in` / `between`. The new arm is placed after it on purpose: the reverse order answers a true sentence with the wrong repair.
- A rule carrying **no** comparand still lowers to its 2-tuple `["name","icontains"]`. `isRefusedTextComparand(undefined)` is `true`, so the carve-out is explicit. The view vocabulary has an "absent" the `$` dialect does not, and that shape is already refused downstream with this same code — `parseFilterAST(["name","icontains"])` throws `INVALID_FILTER` / 400 naming `where.name.$icontains`.
- An operator the spec does not know is still passed through verbatim.

## Ablation — three legs, each proven on disk in both directions

Each leg: mutate → prove the mutation reached disk (**exact substring occurrence count both ways, plus the blob hash moved**) → run → restore → prove the restore **by state** (`git hash-object` back to the HEAD blob **and** `git diff HEAD` empty for that path). ⛔ No exit code was read as evidence of restoration. The script carries a `trap ... EXIT INT TERM` with absolute paths, and `git checkout HEAD -- path` (never the bare form, which would restore the mutation from the index).

The subject resolves to **source**, not `dist` — the test imports the module by relative path and vitest aliases the package to `packages/core/src` — so no build staleness applies to these runs.

| leg | mutation | blob | result |
| :-- | :-- | :-- | :-- |
| A | the new arm's operator key made unreachable | `556ac36` → `badaf52` | **8 of 18 failed** |
| B | the arrived-spelling resolution replaced by a hard-coded `$` spelling | `556ac36` → `ffb1094` | **4 of 18 failed** — both the "name the spelling that arrived" pins and both mirror pins |
| C | the absent-comparand carve-out made unreachable | `556ac36` → `0aefaca` | **1 of 18 failed** — the 2-tuple boundary pin |

All three restored to `556ac36bc6f4da1e543b491c800ee3aa84a4fbcb` with an empty `git diff HEAD`.

## Tests and gates

Run from the repo root, the one canonical invocation.

| run | result |
| :-- | :-- |
| `pnpm exec vitest run packages/core/` | **148 files, 3141 tests passed** (exit 0) |
| `pnpm exec vitest run packages/data-objectstack/ packages/plugin-list/src/__tests__/filter-operator-ast-parity.test.ts packages/components/src/hooks/ packages/plugin-view/src/config/` | **67 files, 945 tests passed** — under the shared verify lock, `VERDICT command-exit 0` |
| `pnpm --filter @object-ui/core exec tsc --noEmit` | exit 0 |
| `pnpm --filter @object-ui/core build` | exit 0, dist completeness 202 files |
| `check:new-line-citations` · `check:control-bytes` · `check:self-import` · `check:phantom-deps` · `check:unused-deps` · `check:spec-symbols` · `check:entry-guard` · `check:lint-rule-coverage` · `check:side-effects-array` | all exit 0 |
| `node scripts/check-changeset-presence.mjs` · `node scripts/check-changeset-no-major.mjs` | exit 0 |

Control-byte self-scan over all five changed files, outside the gate: no match (`grep` exit 1).

### Lint narrowing, declared with all three pieces

- **Population, read from eslint's own config** — not guessed: `pnpm --filter @object-ui/core lint` is `eslint .` inside `packages/core`, resolving the repo-root flat config. The diff touches exactly one package, so that package's own run is the complete population for this diff; the other packages' runs belong to CI.
- **File count, read from `--format json`**: **250** files linted, **0 errors**, 542 warnings (all pre-existing `no-explicit-any`, none in the files this PR adds — `text-comparand.ts` reports 0/0).
- **Invariance for untouched files**: type-aware linting is **not enabled** — the root `eslint.config.js` extends `tseslint.configs.recommended` (not the type-checked variant) and its `languageOptions` carries only `ecmaVersion` and `globals`, with no `parserOptions.project` and no `projectService`. No rule reads the type graph, so this diff cannot move the verdict on any file it does not itself contain.

## Acceptance notes

Findings from this run that are **not** repaired here.

- **A THIRD unguarded producer the card does not name** — `convertFilterGroupToAST` / `mapOperator` in `plugin-list`'s `ListView` emits `[field, 'icontains', value]` triples directly, and `toFilterNode` returns an array of AST triples **verbatim** (its rule-object branch never runs), so neither comparand door sees them. The empty half is already shut there by `isFilterValueComplete`, which drops `''` / `null` / `[]`; the **non-string** half is not — that predicate accepts `0`, `false` and `42`. In scope? **No**: a fourth package, a third changeset, and the card's subject is the object-form dialects. Filed separately.
- `packages/core/src/index.ts` re-exports `./utils/filter-converter.js` with `export *`, so every exported name in that file is already on the published entry. Noted because it is what makes FORK B's measurement a one-line check rather than a guess — not a defect.

## 🤖 Provenance

Generated by Claude Code; the session reference for this run is `https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_