### PR TITLE
fix(core): the retired-`sort` refusal no longer prescribes metadata the spec rejects

### DIFF
--- a/.changeset/9031-retired-sort-diagnostic-wording.md
+++ b/.changeset/9031-retired-sort-diagnostic-wording.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/core': patch
+---
+
+The retired-`sort` refusal no longer prescribes metadata the spec rejects (objectui#9031).
+
+`convertSortToQueryParams` refuses the retired string `sort` clause out loud, and the
+diagnostic it prints is the text an author reads at the moment they are ALREADY being
+corrected. It ended by telling them "`order` is optional and means `'asc'`". It is not
+optional: `SortConfig.order` is required on the interface, on its zod mirror, and on
+`@objectstack/spec`'s `SortItemSchema`, which refuses an entry without it. An author who
+followed the correction verbatim was refused a second time — at publish, by a different
+door, with no hint that the advice itself was wrong.
+
+The repair is not "delete the sentence". A missing `order` genuinely IS read as ascending
+by this renderer — a real runtime tolerance, documented as `normalizeSortEntries`' rule
+since objectui#8973, and true because types are erased and an entry that arrives without
+`order` still has to mean something. The message now keeps BOTH truths and stops stating
+the runtime tolerance as an authoring permission: it asks for both keys on every entry,
+names the three faces that require `order`, and says the tolerance is a runtime reading
+rather than permission to omit the key.
+
+**Wording only — no behaviour moved.** The same inputs are refused, on the same
+`console.error` channel, returning the same `undefined`; the array arm lowers unchanged.
+Pinned by reading the ACTUAL emitted message and feeding the entry it prescribes back
+through `SortItemSchema` from the installed `@objectstack/spec`, so the pin fails if
+somebody shortens the example the diagnostic quotes rather than only if somebody edits
+prose.

--- a/.changeset/9031-retired-sort-diagnostic-wording.md
+++ b/.changeset/9031-retired-sort-diagnostic-wording.md
@@ -7,7 +7,7 @@ The retired-`sort` refusal no longer prescribes metadata the spec rejects (objec
 `convertSortToQueryParams` refuses the retired string `sort` clause out loud, and the
 diagnostic it prints is the text an author reads at the moment they are ALREADY being
 corrected. It ended by telling them "`order` is optional and means `'asc'`". It is not
-optional: `SortConfig.order` is required on the interface, on its zod mirror, and on
+optional: `SortConfig.order` is required on the interface, on its zod counterpart, and on
 `@objectstack/spec`'s `SortItemSchema`, which refuses an entry without it. An author who
 followed the correction verbatim was refused a second time — at publish, by a different
 door, with no hint that the advice itself was wrong.

--- a/packages/core/src/utils/__tests__/sort-query.test.ts
+++ b/packages/core/src/utils/__tests__/sort-query.test.ts
@@ -17,7 +17,7 @@
  *
  * ⚠️ That first one is a RUNTIME tolerance, not an optional key. This header
  * used to call `SortConfig.order` "optional"; it is required on the interface,
- * on its zod mirror and on `@objectstack/spec`'s `SortItemSchema`. Corrected
+ * on its zod counterpart and on `@objectstack/spec`'s `SortItemSchema`. Corrected
  * under objectui#9031, whose subject is the third copy of that same sentence —
  * the one the refusal diagnostic printed at authors.
  *

--- a/packages/core/src/utils/__tests__/sort-query.test.ts
+++ b/packages/core/src/utils/__tests__/sort-query.test.ts
@@ -11,9 +11,15 @@
  * conversion `ObjectGantt` / `ObjectMap` / `ObjectCalendar` each inline.
  *
  * Two of the cases below pin the two places this function is deliberately MORE
- * faithful to the declared contract than those copies: `SortConfig.order` is
- * optional (an entry without it means ascending, not "drop this key"), and
- * nothing usable yields `undefined` rather than a truthy-but-empty `{}`.
+ * faithful to the declared contract than those copies: an entry with no `order`
+ * is READ as ascending rather than dropped, and nothing usable yields
+ * `undefined` rather than a truthy-but-empty `{}`.
+ *
+ * ⚠️ That first one is a RUNTIME tolerance, not an optional key. This header
+ * used to call `SortConfig.order` "optional"; it is required on the interface,
+ * on its zod mirror and on `@objectstack/spec`'s `SortItemSchema`. Corrected
+ * under objectui#9031, whose subject is the third copy of that same sentence —
+ * the one the refusal diagnostic printed at authors.
  *
  * The rest pin objectui#8221 (director ruling, decision batch #77, option B):
  * the legacy string clause is RETIRED, and — this is the load-bearing half —
@@ -27,6 +33,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+// The INSTALLED published artifact, not a local mirror of it — this is the judge
+// a publish actually uses, and objectui#9031 is about the diagnostic disagreeing
+// with it. No `resolve.alias` entry covers `@objectstack/*`, so this specifier
+// resolves to `node_modules`, which is the whole point of reading it here.
+import { SortItemSchema } from '@objectstack/spec/shared';
 import { convertSortToQueryParams, normalizeSortEntries, resetRetiredSortSpellingReports } from '../sort-query';
 
 /** The retired spelling, reached the only way it still can be: at runtime. */
@@ -151,6 +162,113 @@ describe('convertSortToQueryParams — the retired string clause (objectui#8221)
     // disconnected mock.
     expect(convertSortToQueryParams(asRuntimeValue('   '))).toBeUndefined();
     expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+/** Every `{ … }` entry the diagnostic quotes as the form the author must write. */
+function entriesPrescribedBy(message: string): Array<Record<string, string>> {
+  return (message.match(/\{[^{}]*\}/g) ?? []).map((literal) => {
+    const entry: Record<string, string> = {};
+    for (const [, key, value] of literal.matchAll(/(\w+)\s*:\s*'([^']*)'/g)) entry[key] = value;
+    return entry;
+  });
+}
+
+/**
+ * objectui#9031 — what the refusal PRESCRIBES has to survive a publish.
+ *
+ * This text is read at the moment the author is ALREADY being corrected. It used
+ * to end "`order` is optional and means `'asc'`" — a RUNTIME tolerance stated as
+ * an AUTHORING permission — so an author who followed the correction verbatim was
+ * refused a second time, at publish, by a different door, with no hint that the
+ * advice itself was wrong.
+ *
+ * The judge here is `SortItemSchema` from the INSTALLED `@objectstack/spec`, and
+ * it is fed the message's OWN prescription, parsed back out of the emitted
+ * string. Re-typing the example into the test would only pin the test's copy of
+ * it; the way this regresses is somebody shortening the example the diagnostic
+ * quotes, and only reading the real message catches that.
+ *
+ * Every leg runs against a live refusal produced in the same run. That control
+ * is not bookkeeping: without it, "the wrong sentence is gone" is satisfied just
+ * as well by a diagnostic that stopped firing.
+ */
+describe('the refusal prescribes metadata `@objectstack/spec` ACCEPTS (objectui#9031)', () => {
+  /** Drive one real refusal and hand back exactly what it printed. */
+  const captureRefusal = (spelling = 'name desc'): string => {
+    resetRetiredSortSpellingReports();
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(convertSortToQueryParams(asRuntimeValue(spelling))).toBeUndefined();
+      // LIVE CONTROL — the diagnostic FIRED, on this spy, in this run.
+      expect(spy).toHaveBeenCalledTimes(1);
+      return String(spy.mock.calls[0][0]);
+    } finally {
+      spy.mockRestore();
+    }
+  };
+
+  it('every entry it tells the author to write is ACCEPTED by the installed spec', () => {
+    const prescribed = entriesPrescribedBy(captureRefusal());
+    // Anti-vacuity: a message quoting no entry at all would otherwise pass.
+    expect(prescribed.length).toBeGreaterThan(0);
+    for (const entry of prescribed) {
+      const verdict = SortItemSchema.safeParse(entry);
+      expect(verdict.success, `prescribed entry rejected by SortItemSchema: ${JSON.stringify(entry)}`).toBe(true);
+    }
+  });
+
+  it('CONTROL — the judge can say no, and names the key it is judging', () => {
+    // `{ field: 'name' }` is precisely what "`order` is optional" told authors to
+    // write. The SAME schema refuses it, so the ACCEPT above is a reading and not
+    // a schema that says yes to whatever it is handed.
+    const noOrder = SortItemSchema.safeParse({ field: 'name' });
+    expect(noOrder.success).toBe(false);
+    expect(noOrder.error?.issues[0]?.path).toEqual(['order']);
+
+    // …and it names `field` when `field` is the missing one, so it judges keys
+    // rather than refusing every object.
+    const noField = SortItemSchema.safeParse({ order: 'desc' });
+    expect(noField.success).toBe(false);
+    expect(noField.error?.issues[0]?.path).toEqual(['field']);
+  });
+
+  it('states the tolerance as a tolerance, never as an authoring permission', () => {
+    const message = captureRefusal();
+    // The defect, spelled out. ("is not optional" does not contain this.)
+    expect(message).not.toContain('is optional');
+    expect(message).toMatch(/`order` is required/);
+    expect(message).toContain('SortItemSchema');
+
+    // …and the other truth still stands. "Delete the sentence" was rejected by
+    // name: a missing `order` really is read as ascending here, and a message
+    // that denies it sends the author hunting a key nothing ever dropped.
+    expect(message).toContain("`'asc'`");
+    expect(message).toMatch(/runtime tolerance/);
+  });
+
+  it('BEHAVIOUR — the rewording moved nothing: same inputs refused, same channel', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      for (const spelling of ['name desc', 'name asc', 'name', 'name DESC']) {
+        resetRetiredSortSpellingReports();
+        expect(convertSortToQueryParams(asRuntimeValue(spelling))).toBeUndefined();
+      }
+      // Same severity channel: `console.error`, never `console.warn`. A rewording
+      // that also downgraded the channel would pass every text assertion above.
+      expect(errorSpy).toHaveBeenCalledTimes(4);
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      // CONTROL — the arm that still works lowers unchanged, and silently, so
+      // the four refusals are a refusal of the string and not a dead sink.
+      expect(convertSortToQueryParams([{ field: 'name', order: 'desc' }])).toEqual({ name: 'desc' });
+      expect(convertSortToQueryParams([{ field: 'name' }])).toEqual({ name: 'asc' });
+      expect(errorSpy).toHaveBeenCalledTimes(4);
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/core/src/utils/sort-query.ts
+++ b/packages/core/src/utils/sort-query.ts
@@ -76,6 +76,13 @@ export interface QuerySortEntry {
 /**
  * The canonical spelling, quoted in the refusal diagnostic so the message
  * carries the fix and not just the complaint.
+ *
+ * ⚠️ BOTH keys, deliberately. `order` is REQUIRED on `SortConfig`, on its zod
+ * mirror and on `@objectstack/spec`'s `SortItemSchema`, so an example that
+ * omitted it would make this diagnostic prescribe metadata a publish refuses —
+ * objectui#9031. The pin feeds this very example back through `SortItemSchema`
+ * from the installed artifact rather than eyeballing it, because the way this
+ * regresses is somebody "simplifying" the example, not somebody editing prose.
  */
 const ARRAY_FORM_EXAMPLE = "[{ field: 'name', order: 'desc' }]";
 
@@ -112,6 +119,25 @@ export function resetRetiredSortSpellingReports(): void {
  * for. That is the same severity class as `reportRetiredFieldType`, which is
  * also unconditional, and the opposite of `warnOnUnknownActionKeys`, which only
  * reports keys nothing was ever going to read.
+ *
+ * ⚠️ This text is read at the moment the author is ALREADY being corrected, so
+ * it must not prescribe metadata the spec refuses (objectui#9031). It used to
+ * end "`order` is optional and means `'asc'`" — a RUNTIME tolerance stated as
+ * an AUTHORING permission. Both halves of that are load-bearing and both have to
+ * survive any rewording:
+ *
+ *  - the tolerance is REAL — a missing `order` is read as ascending here rather
+ *    than dropped (see {@link normalizeSortEntries}), because types are erased
+ *    and an entry that arrives without it still has to mean something;
+ *  - and it is NOT permission — `order` is required on `SortConfig`, on its zod
+ *    mirror and on `@objectstack/spec`'s `SortItemSchema`, which refuses an
+ *    entry without it.
+ *
+ * Stating only the first is what made an author who followed this correction
+ * verbatim get refused a second time, at publish, by a different door. Deleting
+ * the tolerance instead would be the opposite error: it is what this renderer
+ * actually does, and a diagnostic that denies it sends the author hunting for a
+ * dropped sort key that was never dropped.
  */
 function reportRetiredSortSpelling(sort: string): void {
   if (reportedRetiredSpellings.has(sort)) return;
@@ -120,7 +146,11 @@ function reportRetiredSortSpelling(sort: string): void {
     `[object-ui] convertSortToQueryParams: the legacy string \`sort\` clause is retired ` +
       `(objectui#8221) and was REFUSED — received ${JSON.stringify(sort)}, so this query ` +
       `carries no \`$orderby\`. Write the array form instead: ` +
-      `sort: ${ARRAY_FORM_EXAMPLE} (\`order\` is optional and means \`'asc'\`). ` +
+      `sort: ${ARRAY_FORM_EXAMPLE} — both keys, on every entry. \`order\` is required: on ` +
+      `\`SortConfig\`, on its zod mirror, and on \`@objectstack/spec\`'s \`SortItemSchema\`, ` +
+      `which refuses an entry without it. (A missing \`order\` is still read as \`'asc'\` ` +
+      `here — that is a runtime tolerance, not permission to omit the key: metadata ` +
+      `written that way is refused when it is published.) ` +
       `The array is the only spelling every \`sort\` input declares, and the only one ` +
       `\`@objectstack/spec\` accepts.`,
   );

--- a/packages/core/src/utils/sort-query.ts
+++ b/packages/core/src/utils/sort-query.ts
@@ -78,7 +78,7 @@ export interface QuerySortEntry {
  * carries the fix and not just the complaint.
  *
  * ⚠️ BOTH keys, deliberately. `order` is REQUIRED on `SortConfig`, on its zod
- * mirror and on `@objectstack/spec`'s `SortItemSchema`, so an example that
+ * counterpart and on `@objectstack/spec`'s `SortItemSchema`, so an example that
  * omitted it would make this diagnostic prescribe metadata a publish refuses —
  * objectui#9031. The pin feeds this very example back through `SortItemSchema`
  * from the installed artifact rather than eyeballing it, because the way this
@@ -130,7 +130,7 @@ export function resetRetiredSortSpellingReports(): void {
  *    than dropped (see {@link normalizeSortEntries}), because types are erased
  *    and an entry that arrives without it still has to mean something;
  *  - and it is NOT permission — `order` is required on `SortConfig`, on its zod
- *    mirror and on `@objectstack/spec`'s `SortItemSchema`, which refuses an
+ *    counterpart and on `@objectstack/spec`'s `SortItemSchema`, which refuses an
  *    entry without it.
  *
  * Stating only the first is what made an author who followed this correction
@@ -147,7 +147,7 @@ function reportRetiredSortSpelling(sort: string): void {
       `(objectui#8221) and was REFUSED — received ${JSON.stringify(sort)}, so this query ` +
       `carries no \`$orderby\`. Write the array form instead: ` +
       `sort: ${ARRAY_FORM_EXAMPLE} — both keys, on every entry. \`order\` is required: on ` +
-      `\`SortConfig\`, on its zod mirror, and on \`@objectstack/spec\`'s \`SortItemSchema\`, ` +
+      `\`SortConfig\`, on its zod counterpart, and on \`@objectstack/spec\`'s \`SortItemSchema\`, ` +
       `which refuses an entry without it. (A missing \`order\` is still read as \`'asc'\` ` +
       `here — that is a runtime tolerance, not permission to omit the key: metadata ` +
       `written that way is refused when it is published.) ` +


### PR DESCRIPTION
Fixes #9031

`reportRetiredSortSpelling` in `@object-ui/core`'s sort-query sink is the text an author reads at the moment they are **already being corrected** — it is what objectui#8221's retirement and objectui#8767's route-C refusal both print. It ended by telling them "`order` is optional and means `'asc'`". All three declared faces require the key, so an author who followed the correction verbatim was refused a second time, at publish, by a different door, with no hint that the advice itself was wrong.

## Re-derived at source, and one dispatch assumption falsified

The dispatch brief flagged that its probe matched `Write the array form instead:` but **not** the "`order` is optional" half, and asked whether the wording had already moved. It had not. The probe missed for a mechanical reason: inside the template literal the backticks are backslash-escaped, so the plain phrase does not exist on disk. Measured on `origin/main` `6df26f025`, in the file that declares `reportRetiredSortSpelling`:

- Searched for the sentence **as it is actually spelled on disk** — with a backslash before each backtick, because the string is a template literal — it is there **once**.
- Searched for the plain, unescaped spelling, it is there **zero** times. That zero is the whole of the dispatch's negative reading, and it is an artefact of the escaping, not of the wording.

So the card's quotation is accurate in content; only its `path:line` anchors were stale. Reported as a falsified mechanism assumption rather than quietly worked around.

## The three faces, each re-derived

- **`SortConfig`** (`@object-ui/types`, interface) — reads `order: 'asc' \| 'desc';` with no `?`. Required.
- **`SortConfigSchema`** (`@object-ui/types`, zod) — reads `order: z.enum(['asc', 'desc'])` with no `.optional()`. Required.
- **`SortItemSchema`** (`@objectstack/spec`) — measured against the **installed published artifact**, version `17.4.0`, resolved out of `node_modules` (no `resolve.alias` entry covers `@objectstack/*`, so this is the artifact a publish judges by). Required.

The third face was run with the card's own two control legs in the same instrument, so the reading is a reading and not a schema that refuses everything:

```
SUBJECT    { field: "name" }                 (order omitted)
  verdict: REFUSED, code invalid_value, path ["order"]
CONTROL-A  { field: "name", order: "desc" }
  verdict: ACCEPTED, data {"field":"name","order":"desc"}
CONTROL-B  { order: "desc" }                 (field omitted)
  verdict: REFUSED, code invalid_type, path ["field"]
```

CONTROL-A proves the instrument can say yes. CONTROL-B proves it names the key it is judging.

## The repair — both truths kept standing

The card ruled that the repair is not "delete the sentence", and that ruling is honoured. A missing `order` genuinely **is** read as ascending by this renderer — a real runtime tolerance, documented as `normalizeSortEntries`' rule since objectui#8973, and true because types are erased and an entry that arrives without `order` still has to mean something. The message now states the tolerance **as a tolerance** instead of as an authoring permission. It reads:

```
[object-ui] convertSortToQueryParams: the legacy string `sort` clause is retired
(objectui#8221) and was REFUSED — received "name desc", so this query carries no
`$orderby`. Write the array form instead: sort: [{ field: 'name', order: 'desc' }]
— both keys, on every entry. `order` is required: on `SortConfig`, on its zod
counterpart, and on `@objectstack/spec`'s `SortItemSchema`, which refuses an entry
without it. (A missing `order` is still read as `'asc'` here — that is a runtime
tolerance, not permission to omit the key: metadata written that way is refused
when it is published.) The array is the only spelling every `sort` input declares,
and the only one `@objectstack/spec` accepts.
```

## Behaviour is unchanged, with its own evidence

Separate from the wording pin, three readings:

1. **The diff itself.** The implementation file has exactly three hunks: two docblock additions and one replacement of a string literal **inside the argument to `console.error`**. No condition, no return, no signature and no channel moved. `git diff` on that file shows nothing else.
2. **A dedicated behaviour test** in the same run: all four retired spellings still refused, still on `console.error` and never `console.warn`, with the array arm still lowering silently as the live control.
3. **The pre-existing suites**, unmodified: the objectui#8221 refusal describe, the `normalizeSortEntries` describe, the literal-captured regression pin, and objectui#8767's route-C test in `@object-ui/plugin-grid`, which captures this same message from the other emit path.

Both emit paths were enumerated by content before editing: `normalizeSortEntries` is called from `convertSortToQueryParams` and from `@object-ui/plugin-grid`'s `toOrderByClause`. Both are "the author wrote a retired string `sort` clause and it was refused", so the new wording is correct on both. No third path exists, so the brief's stop condition did not trigger.

## The pin, and the ablation proving it can fail

The pin reads the **actual emitted message**, parses the `{ … }` entry the message quotes out of it, and feeds that entry back through `SortItemSchema` from the installed artifact. Re-typing the example into the test would only pin the test's copy of it; the way this regresses is somebody shortening the example the diagnostic quotes.

Three ablation legs, each: mutate on disk → prove the mutation reached disk (occurrence counts plus a moved blob hash) → run → restore → prove the restore **by state** (`git hash-object` back to the HEAD blob **and** `git diff HEAD` empty). Every leg carries `trap restore EXIT INT TERM` with absolute paths, and the restore is `git checkout HEAD -- path`, never a bare checkout. Run against HEAD blob `10d9e17d5bd86eae37b7931150f13309a977da13`:

| leg | mutation | occurrences | blob | result |
|:--|:--|:--|:--|:--|
| A | put the false sentence back | removed 1 → 0, injected 1 → 2 | `10d9e17d` → `82c86dcf` | 1 failed / 30 passed — `expected … not to contain 'is optional'` |
| B | shorten the quoted example to one key | removed 1 → 0, injected 0 → 1 | `10d9e17d` → `6195478a` | 2 failed / 29 passed — `prescribed entry rejected by SortItemSchema: {"field":"name"}` |
| C | make the diagnostic go silent | injected 0 → 1 | `10d9e17d` → `692bd0c9` | 7 failed / 24 passed — every objectui#9031 leg fails on its **live control**, not on its text assertion |

Leg C is the one the acceptance asked for by name: "the wrong sentence is gone" is **not** equally satisfied by a diagnostic that stopped firing. Leg C is an insertion, so only the injected count can move; the removed-text count stays 1 → 1 by construction and the moved blob hash carries the on-disk proof. Every restore leg reported `hash-object == HEAD blob : YES` and `git diff HEAD is empty : YES`.

## Verification

Run through the shared verify lock (`OS_VERIFY_LOCK_SLOT=objectui-9031`), reading each verdict line the wrapper printed rather than a bare exit code:

- `pnpm --filter "@object-ui/core^..." build` — `VERDICT command-exit 0`. Needed first: without it `type-check` answers `TS6305` (`packages/types/dist/index.d.ts` has not been built), which is prerequisite-not-met, not a red gate.
- `pnpm --filter @object-ui/core type-check && pnpm --filter @object-ui/core lint && pnpm exec vitest run packages/core/ packages/plugin-grid/` — `VERDICT command-exit 0`. Tests: **271 files, 4221 passed**. Lint: 0 errors, 539 pre-existing warnings, none in either edited file.
- `tsc -p tsconfig.test.json --listFiles` confirms the typecheck program really contains both edited files — measured, not assumed.
- Gates run locally: `check-changeset-presence` (declares this changeset), `check-changeset-no-major`, `check-changeset-fixed`, `check-changeset-overwrite`, `check-new-cross-file-line-citations`, `check-control-bytes`, `check-phantom-dependencies`, `check-spec-symbol-derivation`, `check-published-tsconfig-tooling-exclude`, `check-unreferenced-sources`, `check-vi-mock-specifiers`, `check-vi-mock-inherit`, `check-vi-mock-override-shape`, `check-shell-escape-residue`, `check-installed-spec-pin-claims`, `check-type-check-coverage` — all exit 0. The rest of the gate farm is CI's run.

One gate caught this change mid-flight and is worth naming: `check-spec-symbol-derivation` reads an alignment cue within 60 characters of `@objectstack/spec` in the same sentence as a spec-derivation claim on the declaration it sits on. The first draft's note said "on its zod mirror and on `@objectstack/spec`'s `SortItemSchema`", which reads as a claim that a deliberately hand-written display string is spec-derived. The claim was never intended, so the second commit changes the word rather than adding an allow-list entry.

## Acceptance notes

- **One bounded in-place correction, declared.** The test file's own header docblock called `SortConfig.order` "optional" — a fourth copy of the very sentence this card exists to remove, sitting in the file this change already edits. Corrected here: same defect class, mechanical, no other claim on the file, no new verification surface. objectui#8973 corrected two docblock copies; this change corrects the runtime one it deliberately left alone, plus this test header.
- **noted, not filed:** the other retired form, `sort: ['name desc']` (array of strings), still has no diagnostic. The card records as an observation that objectui#9028 moved that row from a loud failure to a silent one, and states that a diagnostic for it is objectui#8767's / objectui#8961's territory. Both are live and named, so there is a successor; deliberately not widened here, per the dispatch fence.
- **noted, not filed:** `SortUISchema` (a different component) declares its own `sort[].direction`, not `order`. Its documentation example matches its declaration, so nothing is wrong — recorded only so a future reader of "the platform has one sort spelling" does not mistake it for a second violation of that ruling.
- Nothing about which inputs are refused changed, `SortConfig.order` was not touched on any face, `normalizeSortEntries`' runtime tolerance was not touched in either direction, and objectui#8767's route-C refusal was not weakened or re-opened.

## Delivery

Draft on purpose — the PM reviews at source and lands it. The card declares `Clause-②: yes`, so `needs:contract-review` is hung on this PR as the second carrier of the dual-carrier rule (maintainer ruling 2026-08-22). No other label was touched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_