### PR TITLE
fix(app-shell): filter the picklist preview before slicing it (objectui#9074)

### DIFF
--- a/.changeset/9074-fieldstub-picklist-filter-before-slice.md
+++ b/.changeset/9074-fieldstub-picklist-filter-before-slice.md
@@ -1,0 +1,24 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Fix the form-designer canvas picklist preview: `FieldStub` now filters the
+options before slicing them, so a well-formed option is no longer hidden by
+malformed ones in front of it and the `+N` overflow counter stops overcounting
+(objectui#9074).
+
+The preview took the first one (single-value) or three (multi-value) authored
+options and *then* dropped the ones with neither a value nor a label. Entries
+that render as nothing therefore consumed the display budget, and the counter —
+computed against the whole authored list — reported a number no badge on the
+card accounted for. With the authored list `['draft', 'open', 'closed',
+{ value: 'real', label: 'Real' }]`, which `ObjectFormCanvas` projects to three
+`{ value: '', label: undefined }` entries followed by one good one, the
+multi-value card showed its empty-state placeholder plus `+4` and zero badges,
+and the single-value card read as a field with no options at all — with `Real`
+on neither.
+
+Both now render `Real`, and `+N` counts only options that survived filtering and
+did not fit. A picklist with no malformed options previews and counts exactly as
+it did before: when every entry survives the filter, filtering first and slicing
+first compute the same result.

--- a/packages/app-shell/src/views/metadata-admin/previews/FieldStub.picklistSliceOrder-9074.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FieldStub.picklistSliceOrder-9074.test.tsx
@@ -13,9 +13,12 @@
  *   2. the overflow counter, `opts.length - visible.length`, counts the
  *      malformed entries too, so `+N` promises badges no surface can show.
  *
- * Both are pinned here, each by an assertion that can fail on its own: a
- * repair that fixes only the counter (the louder of the two) still leaves
- * `Real` off the screen, and this file says so.
+ * Both are pinned here, in two families that fail INDEPENDENTLY — no assertion
+ * does double duty, because the plausible wrong repair is the one that gets the
+ * counter right and leaves the option missing. Measured, by mutating each half
+ * of the repair on its own: reverting only the counter's population reds the
+ * counter family alone, and the caricature that keeps the slice-first order
+ * while computing an honest-looking `+N` reds the rendering family alone.
  *
  * ## The fixtures are the projection, not the authored list
  *
@@ -130,6 +133,16 @@ describe('FieldStub picklist preview — a well-formed option behind malformed o
     expect(screen.queryByText('Select…')).toBeNull();
   });
 
+  it('spends the whole budget on surviving options, not on malformed ones', () => {
+    render(<FieldStub type="multiselect" options={TWO_MALFORMED_THEN_FIVE} />);
+    // All three multi-value slots go to options that can actually render.
+    expect(screen.getByText('Willow')).toBeTruthy();
+    expect(screen.getByText('Walnut')).toBeTruthy();
+    expect(screen.getByText('Wisteria')).toBeTruthy();
+    // The budget is three, so the fourth survivor stays off the card.
+    expect(screen.queryByText('Wattle')).toBeNull();
+  });
+
   it('positional contrast: the same option with the malformed entries LAST always rendered', () => {
     render(<FieldStub type="multiselect" options={MALFORMED_LAST} />);
     expect(screen.getByText('Real')).toBeTruthy();
@@ -139,12 +152,7 @@ describe('FieldStub picklist preview — a well-formed option behind malformed o
 describe('FieldStub picklist preview — the +N overflow counter', () => {
   it('counts the options that survived filtering and were not rendered', () => {
     render(<FieldStub type="multiselect" options={TWO_MALFORMED_THEN_FIVE} />);
-
-    // Three renderable options fit the budget.
-    expect(screen.getByText('Willow')).toBeTruthy();
-    expect(screen.getByText('Walnut')).toBeTruthy();
-    expect(screen.getByText('Wisteria')).toBeTruthy();
-    // Two renderable options are hidden, so the counter says two.
+    // Five options survive the filter and three fit, so the counter says two.
     expect(screen.getByText('+2')).toBeTruthy();
     // Not `+6`: that is what the slice-first order claimed, counting the two
     // malformed entries and the four options it never reached.
@@ -153,7 +161,9 @@ describe('FieldStub picklist preview — the +N overflow counter', () => {
 
   it('drops the counter entirely when every surviving option is on screen', () => {
     render(<FieldStub type="multiselect" options={MALFORMED_FIRST} />);
-    expect(screen.getByText('Real')).toBeTruthy();
+    // Reported as `+4` before the repair: four authored entries, nothing on
+    // screen. Deliberately asserts nothing about `Real` — that belongs to the
+    // other half, and mixing them would stop either from failing on its own.
     expect(screen.queryByText(ANY_OVERFLOW)).toBeNull();
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/previews/FieldStub.picklistSliceOrder-9074.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FieldStub.picklistSliceOrder-9074.test.tsx
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `PicklistStub` inside `FieldStub` used to compute its preview as
+ *
+ *     const visible = opts.slice(0, single ? 1 : 3).filter((o) => o.value || o.label);
+ *
+ * — the slice runs BEFORE the filter, so entries the filter drops still
+ * consume the display budget (objectui#9074). One cause, two symptoms:
+ *
+ *   1. a well-formed option sitting BEHIND malformed ones never renders,
+ *      because the malformed ones ate the whole budget; and
+ *   2. the overflow counter, `opts.length - visible.length`, counts the
+ *      malformed entries too, so `+N` promises badges no surface can show.
+ *
+ * Both are pinned here, each by an assertion that can fail on its own: a
+ * repair that fixes only the counter (the louder of the two) still leaves
+ * `Real` off the screen, and this file says so.
+ *
+ * ## The fixtures are the projection, not the authored list
+ *
+ * `ObjectFormCanvas` is the only consumer of `FieldStub`, and it projects the
+ * authored `options` through
+ *
+ *     value: String(o.value ?? ''), label: typeof o.label === 'string' ? o.label : undefined
+ *
+ * so a bare string, a `null`, a number, or an option with no `value` all
+ * arrive here as `{ value: '', label: undefined }`. That shape — not the
+ * author's original entry — is what the stub filters on, so it is what these
+ * fixtures carry.
+ *
+ * ## Order is load-bearing in the fixtures
+ *
+ * ⚠️ Malformed entries must come FIRST. With them last the slice never
+ * reaches them, the defect cannot reproduce, and the pin would pass against
+ * the unrepaired component — decorative, not discriminating. The
+ * malformed-LAST case is kept below as a positional contrast: it renders
+ * `Real` on both sides of the repair, which is what identifies the
+ * slice/filter ORDERING as the cause rather than the filter itself.
+ *
+ * ## Control
+ *
+ * A picklist with NO malformed options is the same KIND of subject (same
+ * component, same branch, same code path), pre-exists this change and is
+ * untouched by it: when every entry survives the filter, `filter`-then-`slice`
+ * and `slice`-then-`filter` compute the same `visible` and the same `+N`.
+ * It is asserted in the same run so a repair that quietly changes how ordinary
+ * picklists preview fails here.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { FieldStub } from './FieldStub';
+
+afterEach(cleanup);
+
+type Opt = { value: string; label?: string };
+
+/** What `ObjectFormCanvas` hands us for a malformed authored option. */
+function malformed(): Opt {
+  return { value: '', label: undefined };
+}
+
+function wellFormed(value: string, label: string): Opt {
+  return { value, label };
+}
+
+/**
+ * The card's own repro: authored `['draft', 'open', 'closed', { value: 'real',
+ * label: 'Real' }]` — three malformed entries, then one well-formed one.
+ */
+const MALFORMED_FIRST: Opt[] = [
+  malformed(),
+  malformed(),
+  malformed(),
+  wellFormed('real', 'Real'),
+];
+
+/** Same entries, malformed ones last: the slice never reaches them. */
+const MALFORMED_LAST: Opt[] = [
+  wellFormed('real', 'Real'),
+  malformed(),
+  malformed(),
+  malformed(),
+];
+
+/**
+ * Two malformed entries then five well-formed ones. Chosen so BOTH counters
+ * are non-zero and they disagree: slicing first renders one badge and claims
+ * `+6`; filtering first renders three and claims `+2`. An assertion on `+2`
+ * therefore discriminates instead of merely observing an absence.
+ */
+const TWO_MALFORMED_THEN_FIVE: Opt[] = [
+  malformed(),
+  malformed(),
+  wellFormed('w1', 'Willow'),
+  wellFormed('w2', 'Walnut'),
+  wellFormed('w3', 'Wisteria'),
+  wellFormed('w4', 'Wattle'),
+  wellFormed('w5', 'Wormwood'),
+];
+
+/** No malformed entries at all — the control population. */
+const ALL_WELL_FORMED: Opt[] = [
+  wellFormed('a', 'Alder'),
+  wellFormed('b', 'Birch'),
+  wellFormed('c', 'Cedar'),
+  wellFormed('d', 'Dogwood'),
+  wellFormed('e', 'Elm'),
+  wellFormed('f', 'Fir'),
+];
+
+/** Fewer entries than the multi-value slice budget of three. */
+const SHORTER_THAN_BUDGET: Opt[] = [wellFormed('a', 'Alder'), wellFormed('b', 'Birch')];
+
+/** Any `+N` the overflow counter may have rendered, whatever the number. */
+const ANY_OVERFLOW = /^\+\d+$/;
+
+describe('FieldStub picklist preview — a well-formed option behind malformed ones', () => {
+  it('renders the well-formed option in the multi-value card', () => {
+    render(<FieldStub type="multiselect" options={MALFORMED_FIRST} />);
+    expect(screen.getByText('Real')).toBeTruthy();
+    // The empty-state placeholder is what the card reported seeing instead.
+    expect(screen.queryByText('Pick one or more…')).toBeNull();
+  });
+
+  it('renders the well-formed option in the single-value card', () => {
+    render(<FieldStub type="select" options={MALFORMED_FIRST} />);
+    expect(screen.getByText('Real')).toBeTruthy();
+    expect(screen.queryByText('Select…')).toBeNull();
+  });
+
+  it('positional contrast: the same option with the malformed entries LAST always rendered', () => {
+    render(<FieldStub type="multiselect" options={MALFORMED_LAST} />);
+    expect(screen.getByText('Real')).toBeTruthy();
+  });
+});
+
+describe('FieldStub picklist preview — the +N overflow counter', () => {
+  it('counts the options that survived filtering and were not rendered', () => {
+    render(<FieldStub type="multiselect" options={TWO_MALFORMED_THEN_FIVE} />);
+
+    // Three renderable options fit the budget.
+    expect(screen.getByText('Willow')).toBeTruthy();
+    expect(screen.getByText('Walnut')).toBeTruthy();
+    expect(screen.getByText('Wisteria')).toBeTruthy();
+    // Two renderable options are hidden, so the counter says two.
+    expect(screen.getByText('+2')).toBeTruthy();
+    // Not `+6`: that is what the slice-first order claimed, counting the two
+    // malformed entries and the four options it never reached.
+    expect(screen.queryByText('+6')).toBeNull();
+  });
+
+  it('drops the counter entirely when every surviving option is on screen', () => {
+    render(<FieldStub type="multiselect" options={MALFORMED_FIRST} />);
+    expect(screen.getByText('Real')).toBeTruthy();
+    expect(screen.queryByText(ANY_OVERFLOW)).toBeNull();
+  });
+});
+
+describe('FieldStub picklist preview — control: no malformed options', () => {
+  it('renders and counts a well-formed multi-value picklist exactly as before', () => {
+    render(<FieldStub type="multiselect" options={ALL_WELL_FORMED} />);
+    expect(screen.getByText('Alder')).toBeTruthy();
+    expect(screen.getByText('Birch')).toBeTruthy();
+    expect(screen.getByText('Cedar')).toBeTruthy();
+    expect(screen.queryByText('Dogwood')).toBeNull();
+    expect(screen.getByText('+3')).toBeTruthy();
+  });
+
+  it('renders a well-formed single-value picklist exactly as before', () => {
+    render(<FieldStub type="select" options={ALL_WELL_FORMED} />);
+    expect(screen.getByText('Alder')).toBeTruthy();
+    expect(screen.queryByText('Birch')).toBeNull();
+  });
+
+  it('shows no +N at all when the picklist is shorter than the slice budget', () => {
+    render(<FieldStub type="multiselect" options={SHORTER_THAN_BUDGET} />);
+    expect(screen.getByText('Alder')).toBeTruthy();
+    expect(screen.getByText('Birch')).toBeTruthy();
+    expect(screen.queryByText(ANY_OVERFLOW)).toBeNull();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/FieldStub.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/FieldStub.tsx
@@ -190,7 +190,13 @@ function TextareaStub({ placeholder, mono }: FieldStubProps & { mono?: boolean }
 
 function PicklistStub({ options, placeholder, single, locale }: FieldStubProps & { single: boolean }) {
   const opts = options ?? [];
-  const visible = opts.slice(0, single ? 1 : 3).filter((o) => o.value || o.label);
+  // Filter BEFORE slicing. An entry with neither a value nor a label renders
+  // as nothing, so letting it consume the display budget hid a well-formed
+  // option sitting behind it, and made the overflow counter below promise
+  // badges no wider card could ever show (objectui#9074). `renderable` is the
+  // population for both: what fits is rendered, what does not is counted.
+  const renderable = opts.filter((o) => o.value || o.label);
+  const visible = renderable.slice(0, single ? 1 : 3);
   if (single) {
     return (
       <div className="h-8 px-2 flex items-center justify-between text-sm border rounded bg-background text-muted-foreground">
@@ -208,8 +214,8 @@ function PicklistStub({ options, placeholder, single, locale }: FieldStubProps &
           <Badge key={i} variant="secondary" className="text-[10px]">{o.label || o.value}</Badge>
         ))
       )}
-      {opts.length > visible.length && (
-        <span className="text-[10px] text-muted-foreground">+{opts.length - visible.length}</span>
+      {renderable.length > visible.length && (
+        <span className="text-[10px] text-muted-foreground">+{renderable.length - visible.length}</span>
       )}
     </div>
   );


### PR DESCRIPTION
Fixes #9074

## What changed

`PicklistStub` inside `FieldStub` — the field-card preview on the form-designer canvas — computed its visible options as a slice followed by a filter:

```ts
const visible = opts.slice(0, single ? 1 : 3).filter((o) => o.value || o.label);
```

An entry with neither a value nor a label renders as nothing, but the slice had already spent the display budget on it. One cause, two symptoms:

1. **The missing option.** A well-formed option sitting BEHIND malformed ones never reached the card.
2. **The counter.** The overflow counter, `opts.length - visible.length`, counted those same entries, so `+N` promised badges no wider card could ever show.

The repair filters first and slices second, and counts `+N` against the filtered population:

```ts
const renderable = opts.filter((o) => o.value || o.label);
const visible = renderable.slice(0, single ? 1 : 3);
```

`ObjectFormCanvas` is the only consumer of `FieldStub`, and it is also what produces the shape the filter drops: it projects every authored option through `String(o.value ?? '')` with a non-string label mapped to `undefined`, so a bare string, a `null`, a number, or an option with no `value` all arrive as `{ value: '', label: undefined }`.

## Mechanism, measured on this tree rather than inherited

Triage's causal chain was confirmed by content before anything was edited, and its "two lines" estimate held:

- The slice/filter composition and the counter expression sit in **one module-local function**, `PicklistStub`, in one file. Not split across functions.
- **No second consumer.** `PicklistStub` is not exported; `FieldStub` is exported from its module but is absent from `previews/index.ts` and from the package's public surface, and `git grep FieldStub` over `packages`, `apps` and `examples` returns its own definition plus exactly one call site, in `ObjectFormCanvas`. Nothing depends on the pre-filter slice.
- The counter and the render read the **same** population today (`opts`) and the same one after (`renderable`), so fixing one without the other was never structurally forced — which is precisely why the acceptance pins them separately.

Then measured, by checking out the unrepaired file from this branch's base commit verbatim (blob `94d9c3175`, byte-identical to `HEAD:…/FieldStub.tsx` at the branch point) and running the new pins against it. The card's own fixture — authored `['draft', 'open', 'closed', { value: 'real', label: 'Real' }]` — reproduced exactly what the card reported: the multi-value card rendered the `Pick one or more…` placeholder and a counter span reading `+4`, the single-value card rendered `Select…`, and `Real` was on neither.

## No pre-existing preview renders differently

When every authored entry survives the filter, `filter`-then-`slice` and `slice`-then-`filter` compute the same `visible` and the same `+N` — the filter is a no-op on that population. A picklist shorter than the budget shows no `+N` on either side, for the same reason. The only previews that move are the malformed-options case this card is about.

That is asserted, not argued: the three control cases are in the same file as the subject, and they **passed against the unrepaired file** in the run above (4 passed there, and those four are the three controls plus the malformed-LAST positional contrast).

## Verification

Runs were serialised through the shared verify lock; each verdict below is the line the run printed for itself.

| run | command | result |
| --- | --- | --- |
| pins, repaired tree | `pnpm exec vitest run …/FieldStub.picklistSliceOrder-9074.test.tsx` | exit 0 — `Test Files 1 passed (1)`, `Tests 9 passed (9)` |
| pins, unrepaired file from the base commit | same, with the base blob checked out | exit 1 — `Tests 5 failed | 4 passed (9)`; the 5 are every subject pin, the 4 are the three controls and the positional contrast |
| previews regression | `pnpm exec vitest run packages/app-shell/src/views/metadata-admin/previews/` | exit 0 — `Test Files 57 passed (57)`, `Tests 655 passed (655)`, 91.56s |
| typecheck | `pnpm --filter @object-ui/app-shell run type-check` | exit 0, after building the dependency closure |
| lint | `pnpm --filter @object-ui/app-shell run lint` | exit 0 — `2966 problems (0 errors, 2966 warnings)`, all pre-existing; neither changed file is named |
| changeset presence | `node scripts/check-changeset-presence.mjs` | exit 0 — 1 published source file changed, 1 changeset declared |
| no-major / claims / citations / control-bytes | `check-changeset-no-major`, `check:changeset-claims`, `check:new-line-citations`, `check:control-bytes` | all exit 0 |

Two notes on what those numbers do and do not say:

- The first `type-check` attempt exited **2** with `TS2307: Cannot find module '@object-ui/fields'` and four siblings. That is the prerequisite-not-met shape — unbuilt workspace dependencies, not a red. It was re-run after `pnpm --filter '@object-ui/app-shell^...' run build` and exits 0. The typecheck does reach the new pin file: `tsc -p tsconfig.test.json --listFiles` emits 4498 files and both changed files are among them.
- `pnpm lint` at the repo root is `turbo run lint` across every package. It is CI's run, not this branch's: the diff touches one package, so the package's own `eslint .` is the scope, and it is green. (An exploratory run with `--no-inline-config` added reports 13 files with errors; that flag is not in this repo's lint command, the 13 are all pre-existing files carrying inline disables, and neither changed file is among them.)

## Ablation — two legs, one per half

The acceptance asks that each half be able to fail on its own, so each half was mutated on its own. Every mutation was proven on disk before its run (occurrence counts in both directions plus a moved `git hash-object` blob), and every restore was proven **by state** — `git diff HEAD` empty AND the blob back to the HEAD blob `c66683ab8` — never by an exit code. Both legs ran under a `trap … EXIT INT TERM`.

**Leg 1 — revert only the counter's population** (`renderable.length` back to `opts.length` in both the guard and the number; `renderable.length > visible.length` occurrences 1 → 0, `opts.length > visible.length` 0 → 1, blob `c66683ab8` → `e480417f6`):

```
Tests  2 failed | 7 passed (9)
  × counts the options that survived filtering and were not rendered
  × drops the counter entirely when every surviving option is on screen
```

Exactly the counter family. The rendering family and all three controls stayed green — the counter assertions are load-bearing in their own right, not a side effect of the reorder.

**Leg 2 — the caricature triage warned about**: keep the slice-first order, but compute an honest-looking `+N` from the filtered population (`renderable.slice(` 1 → 0, `opts.slice(0, single ? 1 : 3).filter` 0 → 1, `hiddenCount` 0 → 3, blob → `d72ef8cdc`):

```
Tests  3 failed | 6 passed (9)
  × renders the well-formed option in the multi-value card
  × renders the well-formed option in the single-value card
  × spends the whole budget on surviving options, not on malformed ones
```

Exactly the rendering family, with both counter assertions green. This is the shape the ruling exists to refuse — a `+N` that reads correct while `Real` is still off the screen — and this branch fails on it.

No build step is involved in either leg: the pin imports `./FieldStub` by relative path, so it resolves to the source file the mutation edits, not to any `dist`.

## Clause-②: `no` — and it held

The claim declared `Clause-②: no`, with a hard stop attached: any new exported symbol, any schema narrowing or widening, any published-payload change would mean the `no` was judged wrong. None was needed. The repair is two statements and one expression inside a function local to its module. The changed-file list, which a `no` owes in place of contract review:

| file | change |
| --- | --- |
| `packages/app-shell/src/views/metadata-admin/previews/FieldStub.tsx` | `PicklistStub` filters before slicing; `+N` counts the filtered population |
| `packages/app-shell/src/views/metadata-admin/previews/FieldStub.picklistSliceOrder-9074.test.tsx` | new — pins both halves independently, plus the unchanged-control population |
| `.changeset/9074-fieldstub-picklist-filter-before-slice.md` | `@object-ui/app-shell` patch |

## Acceptance notes

- **A picklist whose options are ALL malformed now previews silent.** Before this change it showed the empty-state placeholder plus a `+N` equal to the authored count; now it shows the placeholder and no counter. That is the chosen repair's own consequence and it is deliberate: the old number pointed at nothing, and the scope note on the card leaves "should the canvas show a malformed option at all" to the inspector, which reports the same malformed option loudly on the same screen. Worth a maintainer's eye if the preferred signal is the opposite one.
- Observed and deliberately **not** changed: `LookupStub`, in the same file, computes `const meta = referenceTo ? FIELD_TYPE_META.lookup : null;` and then renders `{meta && null}` under a comment reading "swallow unused import warning" — a value computed and discarded to keep an import alive. Cosmetic, no defect, out of this card's scope.

Draft on purpose: the dispatching PM reviews at source and lands it. Not flipped ready, no auto-merge, not enqueued.

Generated by Claude Code, session `session_01UzHd6hDYatoDn17BuwKxnZ`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ