### PR TITLE
fix(gate): make an unrecognised half status LOUD in the eager-closure exit-code fold

### DIFF
--- a/scripts/__tests__/check-eager-closure-budget.test.ts
+++ b/scripts/__tests__/check-eager-closure-budget.test.ts
@@ -29,6 +29,8 @@ import {
   evaluateHeadroomSensitivity,
   evaluatePerChunkBudgets,
   extractCeilingDeclarations,
+  RECOGNISED_HALF_STATUSES,
+  foldHalfStatuses,
   main,
   measureChunksByName,
   renderTopChunks,
@@ -1284,6 +1286,139 @@ describe('main', () => {
     // number here would render as a verdict about a bundle nobody weighed.
     expect(outputs.closure_gzip_kb).toBe('');
     expect(outputs.closure_chunks).toBe('');
+  });
+
+  /**
+   * objectui#9006 — the fold used to enumerate only the statuses that FAIL:
+   *
+   *     if (statuses.includes('error')) return 2;
+   *     return statuses.includes('fail') ? 1 : 0;
+   *
+   * so a status NEITHER test names fell through to `0` — while the printer,
+   * which asks a different question (`status === 'pass'`), rendered that same
+   * value as ❌. A run could print a red cross and exit 0, which is quieter
+   * than either half of the rule this file argues for: a check that passes by
+   * measuring nothing must be LOUDER than one that fails by measuring
+   * something, never quieter.
+   *
+   * ⚠️ These cases live HERE, and not only in the gate's own workflows, on
+   * purpose. `docs-route-eager-closure.yml` and `performance-budget.yml` are
+   * not among this repo's required merge-queue contexts, so a regression in
+   * the fold would not block a merge through the gate's own job. This file
+   * runs inside `Test (shard N/4)`, which is required (objectui#9098 landed
+   * the same reasoning one card earlier).
+   */
+  describe('the fold recognises exactly the statuses the halves declare (objectui#9006)', () => {
+    const checker = fs.readFileSync(checkerPath, 'utf8');
+
+    /** Both places this file states a half's status: the assignments, and the JSDoc unions. */
+    function declaredStatuses(source: string) {
+      const found = new Set<string>();
+      for (const m of source.matchAll(/\bstatus: '([a-z-]+)',/g)) found.add(m[1]);
+      for (const m of source.matchAll(/@returns \{\{ status: ([^,]+),/g)) {
+        for (const q of m[1].matchAll(/'([a-z-]+)'/g)) found.add(q[1]);
+      }
+      return found;
+    }
+
+    /**
+     * ⛔ The fence, and it is the half that is easy to get wrong: this card is
+     * a DISTINCTION, not a tightening. Every status that exists today keeps the
+     * code it has — `not-applicable` above all, which is inert BY DESIGN ("the
+     * absence of a question, not the answer `pass`") and must stay inert.
+     */
+    it.each([
+      ['every half passing', { closure: 'pass', perChunk: 'pass', sensitivity: 'pass', freshness: 'pass' }, 0],
+      ['freshness not-applicable, the rest passing', { closure: 'pass', perChunk: 'pass', sensitivity: 'pass', freshness: 'not-applicable' }, 0],
+      ['one half failing', { closure: 'fail', perChunk: 'pass', sensitivity: 'pass', freshness: 'not-applicable' }, 1],
+      ['one half erroring', { closure: 'pass', perChunk: 'pass', sensitivity: 'error', freshness: 'not-applicable' }, 2],
+      ['error outranking fail', { closure: 'fail', perChunk: 'pass', sensitivity: 'error', freshness: 'pass' }, 2],
+    ])('leaves %s at its existing exit code', (_label, halves, expected) => {
+      const { code, unrecognised } = foldHalfStatuses(halves as Record<string, string>);
+      expect(code).toBe(expected);
+      expect(unrecognised).toEqual([]);
+    });
+
+    it('is LOUD about a status no half declares, instead of folding it into 0', () => {
+      // 'errror' rather than an obviously-fake token: the realistic arrival of
+      // this class is a typo or a fifth status added to one half without
+      // editing the fold, not a hostile input.
+      const { code, unrecognised } = foldHalfStatuses({
+        closure: 'errror',
+        perChunk: 'pass',
+        sensitivity: 'pass',
+        freshness: 'not-applicable',
+      });
+      // 2, not 1 and not a throw: an unrecognised status is a check that
+      // measured nothing, which is this file's exit 2. An uncaught throw would
+      // exit Node with 1 — the "over budget" code — labelling a broken gauge
+      // as a size regression, the one collapse `main`'s own comment refuses.
+      expect(code).toBe(2);
+      expect(unrecognised).toEqual([{ half: 'closure', status: 'errror' }]);
+    });
+
+    it('names the offending half even when a sibling half independently errors', () => {
+      // Both paths return 2, so this is not about the exit code: it is about
+      // the run that could reveal a status nobody enumerated not being the run
+      // that hides it behind an unrelated error.
+      const { code, unrecognised } = foldHalfStatuses({
+        closure: 'error',
+        perChunk: 'pass',
+        sensitivity: 'wobbly',
+        freshness: 'not-applicable',
+      });
+      expect(code).toBe(2);
+      expect(unrecognised).toEqual([{ half: 'sensitivity', status: 'wobbly' }]);
+    });
+
+    it('keeps `not-applicable` inert in the very run an unrecognised status is loud', () => {
+      // The control of known direction. One run, two classes that both fall
+      // through today: only ONE of them moves.
+      const { unrecognised } = foldHalfStatuses({
+        closure: 'pass',
+        perChunk: 'pass',
+        sensitivity: 'nearly-pass',
+        freshness: 'not-applicable',
+      });
+      expect(unrecognised.map((u) => u.half)).toEqual(['sensitivity']);
+      expect(unrecognised.map((u) => u.status)).not.toContain('not-applicable');
+      // And alone, it is still worth 0 — unchanged from before this card.
+      expect(
+        foldHalfStatuses({ closure: 'pass', perChunk: 'pass', sensitivity: 'pass', freshness: 'not-applicable' }).code,
+      ).toBe(0);
+    });
+
+    /**
+     * The tripwire for the case the card is actually about: a half gaining a
+     * FIFTH status. `RECOGNISED_HALF_STATUSES` is a written-down list, so
+     * AGENTS.md #9 requires an instrument that re-derives it — this is that
+     * instrument, reading the checker's own text rather than a copy.
+     */
+    it('recognises exactly the statuses this file declares, re-derived from its source', () => {
+      expect([...declaredStatuses(checker)].sort()).toEqual([...RECOGNISED_HALF_STATUSES].sort());
+    });
+
+    it('extracts statuses at all — a matcher that matches nothing agrees with everything', () => {
+      // Without this control the assertion above passes for the wrong reason
+      // the moment the shape it reads changes.
+      expect([...declaredStatuses(checker)].length).toBe(RECOGNISED_HALF_STATUSES.length);
+      expect([...declaredStatuses("      status: 'wobbly',")]).toEqual(['wobbly']);
+      expect([...declaredStatuses(" * @returns {{ status: 'pass' | 'wobbly', message: string,")].sort()).toEqual(
+        ['pass', 'wobbly'],
+      );
+    });
+
+    /**
+     * The floor above is only a floor while `main` actually routes through the
+     * function it tests. Re-inlining the two membership tests would leave these
+     * cases green against a function nothing calls.
+     */
+    it('is the fold `main` itself uses, not a parallel copy', () => {
+      const mainBody = checker.slice(checker.indexOf('export function main('));
+      expect(mainBody).toContain('evaluateCeilingFreshness({');
+      expect(mainBody).toContain('foldHalfStatuses({');
+      expect(mainBody).not.toMatch(/statuses\.includes\(/);
+    });
   });
 });
 

--- a/scripts/check-eager-closure-budget.mjs
+++ b/scripts/check-eager-closure-budget.mjs
@@ -2228,6 +2228,84 @@ export function readReport(reportPath) {
   }
 }
 
+/**
+ * Every status the four halves are declared to produce, and the only ones
+ * {@link foldHalfStatuses} knows how to weigh.
+ *
+ * DERIVED, not invented: it is the union of the four `@returns` unions above —
+ * {@link evaluateClosureBudget} and {@link evaluatePerChunkBudgets}
+ * (`pass | fail | error`), {@link evaluateHeadroomSensitivity}
+ * (`pass | error`), and {@link evaluateCeilingFreshness}
+ * (`pass | error | not-applicable`). `scripts/__tests__/` re-derives that union
+ * from this file's own text and reds when the two disagree, so a half that
+ * gains a FIFTH status cannot gain it without also being given a code here.
+ * That test is the reason this list may be written down at all (AGENTS.md #9):
+ * an instrument re-derives it.
+ */
+export const RECOGNISED_HALF_STATUSES = Object.freeze([
+  'pass',
+  'fail',
+  'error',
+  'not-applicable',
+]);
+
+/**
+ * Folds the halves' verdicts into one exit code, and names every half whose
+ * status this file does not recognise.
+ *
+ * objectui#9006 — the fold this replaces enumerated only the statuses that
+ * FAIL (`includes('error')`, then `includes('fail')`) and returned `0` for
+ * everything else. `pass` and `not-applicable` were meant to land there; a
+ * status NOBODY enumerated landed there too, while the printer above — which
+ * asks a different question, `status === 'pass'` — rendered that same value as
+ * ❌. A run could print a red cross and exit 0.
+ *
+ * ⛔ The repair is a DISTINCTION, not a tightening. Nothing that exists today
+ * moves: `pass` → 0, `fail` → 1, `error` → 2, and `not-applicable` stays
+ * exactly as INERT as the paragraph below says it must be — it is the absence
+ * of a question, not the answer `pass`, and it still contributes nothing.
+ * Only the unrecognised class changes, from silence to 2.
+ *
+ * WHY 2, AND WHY NOT A `throw`. Both were on the table (objectui#9006 lists
+ * four candidate shapes); the measurement that decides between them is what
+ * Node does with an uncaught exception:
+ *
+ *   - An uncaught `throw` exits Node with **1** — this file's "over budget"
+ *     code. A gauge that produced nothing would then be reported as a size
+ *     regression, which is the exact collapse the paragraph below refuses. A
+ *     `throw` is not louder; in the only unit a workflow reads, it is
+ *     MIS-LABELLED. It would also break `main`'s contract of RETURNING a code,
+ *     which both this file's entrypoint (`process.exit(main())`) and every
+ *     caller in the test file depend on.
+ *   - `2` is this file's own "no trustworthy verdict" code, and an
+ *     unrecognised status is precisely a check that measured nothing. The rule
+ *     stated below — a check that passes by measuring nothing must be LOUDER
+ *     than one that fails by measuring something, never quieter — is satisfied
+ *     by the ordering that already exists, rather than by inventing a rank
+ *     outside it.
+ *
+ * @param {Record<string, string>} halves  half name -> the status it declared
+ * @returns {{ code: number, unrecognised: { half: string, status: string }[] }}
+ *          `code` is 0, 1 or 2; `unrecognised` is empty on every run whose
+ *          halves all declared a recognised status.
+ */
+export function foldHalfStatuses(halves) {
+  const entries = Object.entries(halves);
+  const unrecognised = entries
+    .filter(([, status]) => !RECOGNISED_HALF_STATUSES.includes(status))
+    .map(([half, status]) => ({ half, status }));
+
+  // Ahead of the `error` test on purpose. Both return 2, so the ORDER cannot
+  // change an exit code — what it changes is whether the caller is told. A
+  // sibling half erroring in the same run must not be allowed to absorb the
+  // one signal that a status nobody enumerated exists at all.
+  if (unrecognised.length > 0) return { code: 2, unrecognised };
+
+  const statuses = entries.map(([, status]) => status);
+  if (statuses.includes('error')) return { code: 2, unrecognised };
+  return { code: statuses.includes('fail') ? 1 : 0, unrecognised };
+}
+
 /** Appends `name=value` lines to $GITHUB_OUTPUT when running in Actions. */
 function writeGithubOutput(entries, outputPath = process.env.GITHUB_OUTPUT) {
   if (!outputPath) return;
@@ -2339,9 +2417,30 @@ export function main(argv = process.argv.slice(2), env = process.env) {
   // added the third and objectui#6245 the fourth, each under the same rule
   // rather than taking a code of its own. `not-applicable` is inert in the
   // fold: it is the absence of a question, not the answer `pass`.
-  const statuses = [result.status, perChunk.status, sensitivity.status, freshness.status];
-  if (statuses.includes('error')) return 2;
-  return statuses.includes('fail') ? 1 : 0;
+  //
+  // objectui#9006 — the fold itself lives in {@link foldHalfStatuses}, which
+  // recognises those four statuses BY NAME and refuses to weigh any other. The
+  // halves are passed as a NAMED map rather than an array so the refusal can
+  // say which half produced the status nobody enumerated.
+  const { code, unrecognised } = foldHalfStatuses({
+    closure: result.status,
+    'per-chunk': perChunk.status,
+    sensitivity: sensitivity.status,
+    freshness: freshness.status,
+  });
+  for (const { half, status } of unrecognised) {
+    // A ❌, matching what the printer above already rendered for this value:
+    // the two predicates now agree, which is the whole of objectui#9006.
+    console.error(
+      `❌ The \`${half}\` half declared an UNRECOGNISED status ${JSON.stringify(status)}, ` +
+        `so this run has no verdict to give and exits 2 rather than 0.\n` +
+        `Recognised statuses are ` +
+        `${RECOGNISED_HALF_STATUSES.map((s) => `\`${s}\``).join(', ')}. A half that gained a ` +
+        `fifth one must be given a code in RECOGNISED_HALF_STATUSES and in foldHalfStatuses — ` +
+        `until it is, this gate refuses to read its silence as a pass.`,
+    );
+  }
+  return code;
 }
 
 if (isEntrypoint(import.meta.url)) {


### PR DESCRIPTION
Fixes #9006

## The defect, reproduced rather than asserted

The fold in `scripts/check-eager-closure-budget.mjs` enumerated only the statuses that FAIL:

```js
const statuses = [result.status, perChunk.status, sensitivity.status, freshness.status];
if (statuses.includes('error')) return 2;
return statuses.includes('fail') ? 1 : 0;
```

`pass` and `not-applicable` were meant to fall through to `0`. So did any status neither test names — while the printer, which asks a **different** question (`status === 'pass'`), rendered that same value as ❌.

Measured on `06973aa7e`, by mutating one half's `status: 'pass'` literal to `status: 'errror'` and running `main()` on a healthy report:

```
A status=pass            code=0 crosses=1
B status=not-applicable  code=0 crosses=1
```

One red cross on stderr, exit code 0. That is quieter than a `fail` (1) and quieter than an `error` (2), against a file whose own comment says a check that passes by measuring nothing must be LOUDER than one that fails by measuring something, never quieter.

## A DISTINCTION, not a tightening

Only the unrecognised class moves. Every status that exists today keeps its code, `not-applicable` above all — it is inert **by design** ("the absence of a question, not the answer `pass`") and stays inert.

| class | before | after |
|---|---|---|
| `pass` | 0 | 0 |
| `not-applicable` | 0 | 0 |
| `fail` | 1 | 1 |
| `error` | 2 | 2 |
| anything else | 0, silently, under a printed ❌ | 2, naming the half |

Before/after, from actual `main()` runs on the same four fixtures — byte-identical:

```
BEFORE (06973aa7e)          AFTER (e7b2f5aa1)
A pass            code=0    A pass            code=0
B not-applicable  code=0    B not-applicable  code=0
C fail            code=1    C fail            code=1
D error           code=2    D error           code=2
```

Under the identical mutation, only the unrecognised class moved: `A` and `B` went `0 -> 2` and gained the diagnostic. `B` is the control of known direction — one run in which `freshness` is `not-applicable` (still printed `ℹ️`, still contributing nothing) while the unrecognised status is loud, and the diagnostic names `closure` alone.

## Why exit 2, and why not a `throw`

objectui#9006 left four candidate shapes on the table (exhaustive switch · default that throws · union assertion · nothing at all) and said choosing was not its job. The measurement that decides:

- **A `throw` is not louder; it is MIS-LABELLED.** An uncaught exception exits Node with **1** — measured: `node -e 'throw new Error("x")'` → `1` — which is this file's "over budget, a real verdict about the bundle" code. A gauge that produced nothing would be reported as a size regression, the exact collapse `main`'s own comment refuses. It also breaks `main`'s contract of RETURNING a code, which both `process.exit(main())` and every caller in the test file depend on.
- **A union assertion cannot fail at the moment in question.** All four halves are already exhaustively typed in JSDoc, and `pnpm type-check:scripts` passes on `origin/main` **with the defect present**. A fifth status arrives with its own JSDoc updated in the same edit; the type layer stays green while the fold stays silent.
- **"Nothing at all" is indefensible against the file's own sentence.** An unrecognised status is precisely a check that measured nothing, and today it is quieter than both other outcomes. The fold has also gained a half three times (objectui#5490 two, objectui#5924 the third, objectui#6245 the fourth), so "a half gains a status" is a measured trend rather than a hypothetical.
- **Exit 2 is the file's own "no trustworthy verdict" code**, and satisfies the LOUDER-never-quieter rule through the ordering that already exists instead of inventing a rank outside it.

Shape: the four statuses are enumerated by name in `RECOGNISED_HALF_STATUSES` and the fold moves into `foldHalfStatuses`, which returns `{ code, unrecognised }`. A `switch` was rejected for one reason only — it would have to re-derive the `error` > `fail` precedence that two membership tests already express, and re-deriving it puts the four unchanged verdicts at risk for no behavioural gain.

## Where the floor lives, and a correction to the premise behind it

The assertions go in `scripts/__tests__/check-eager-closure-budget.test.ts`, which runs inside `Test (shard N/4)` — required under every reading. That conclusion holds, but the stated reason for it does not survive re-derivation, and the corrected facts make it stronger:

- **`docs-route-eager-closure.yml` does not run this gate at all.** It runs `pnpm check:docs-route-closure` (`scripts/check-docs-route-eager-closure.mjs`); its header's first line says so, citing objectui#6316. The only workflow that runs this file is `performance-budget.yml` / `Bundle Analysis`.
- **`Bundle Analysis` has no `merge_group` leg.** Its `on:` block is `push` + `pull_request`; the only two `merge_group` strings in the file sit inside a comment that measured the same thing ("300 sampled runs contain zero `merge_group` runs").
- `scripts/dependabot-merge-gate.mjs` lists it in `OPTIONAL_CONTEXTS`, and its `REQUIRED_CONTEXTS` holds 26 entries, not nine.

So a regression in this fold could not be caught by the gate's own job on a queue build, and the six prose sites in this tree that call `Bundle Analysis` a required context disagree with the classifier beside them — recorded separately as objectui#9155, which this PR does not address.

## Tests

11 new cases in the existing `describe('main')` suite (127 → 138 in that file; the file already held 127, not the 107 the dispatch quoted):

- the four existing statuses keep their exit codes, as a table — the fence, pinned where a required context runs it
- an unrecognised status folds to 2 and names its half
- it is named even when a sibling half independently errors (both paths return 2, so this is about being told, not about the code)
- `not-applicable` stays inert in the very run an unrecognised status is loud
- `RECOGNISED_HALF_STATUSES` equals the union re-derived from this file's own text — the tripwire for the fifth status, with a matcher-matches-nothing control beside it
- `main` routes through the exported fold and carries no second inline copy

Re-derived premises: the four declared unions are `pass|fail|error` (closure), `pass|fail|error` (per-chunk), `pass|error` (sensitivity), `pass|error|not-applicable` (freshness); 21 runtime `status:` literals across the file resolve to exactly those four values, all string literals, none computed. No fifth status exists anywhere.

## Verification

| command | exit | note |
|---|---|---|
| `pnpm exec vitest run scripts/__tests__/check-eager-closure-budget.test.ts` | 0 | `Test Files 1 passed`, `Tests 138 passed (138)` |
| `pnpm exec vitest run scripts/` | 0 | `Test Files 146 passed \| 2 skipped`, `Tests 4342 passed` — the whole `scripts/` slice |
| `pnpm type-check:scripts` | 0 | the `Type Check` gate, by name |
| `pnpm lint:root` | 0 | `32 problems (0 errors, 32 warnings)`, all pre-existing |
| `node scripts/check-changeset-presence.mjs` | 0 | "No source or published contract of a released package changed in this range, so no changeset is owed." |
| `node scripts/check-eager-closure-budget.mjs` | 2 | the gate itself, unbuilt tree: three halves `❌` broken gauge, freshness `ℹ️` not applicable — unchanged |
| `pnpm check:control-bytes` / `check:new-line-citations` / `check:shell-escape-residue` / `check:comment-mask-corpus` / `check:unreferenced-sources` / `check:esm-specifiers` | 0 | |

Declared narrowing: `pnpm test --shard=N/4` was not run locally. `vitest list --filesOnly` ignores `--shard`, so the shard holding this file cannot be identified without running quarters of the suite; the whole `scripts/` slice was run instead and CI owns the shard assignment.

Ablation restore proved by `git diff HEAD` being empty, with anchor counts on both sides (`status: 'pass',` 4 → 3, `status: 'errror',` 0 → 1, and back), under a `trap ... EXIT INT TERM`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_