### PR TITLE
fix(app-shell): resolve drill filter placeholders before the escape hatch builds a URL

### DIFF
--- a/.changeset/9022-drill-navigate-placeholder-scope.md
+++ b/.changeset/9022-drill-navigate-placeholder-scope.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/react': patch
+---
+
+Resolve filter placeholders on the drill "escape hatch", so one drill has one scope
+whatever `drillDown.target` says (objectui#9022).
+
+Every widget composes its drill filter from the RAW authored filter, so
+`{current_user_id}`, `{current_org_id}` and the relative-date macros were still
+literals when they reached the host's `openRecordList`. The in-place drawer arm never
+had the defect — the `object-data-table` it renders resolves the filter in its own
+fetch — so only the navigate arm, and the "Open in list →" button in the drawer header,
+wrote the placeholder into the URL. `filter[close_date][gte]={current_quarter_start}`
+parses back on the read side as an ordinary string comparand, so the destination list
+matched nothing, silently, and in disagreement with the chart bar the user had just
+clicked (that chart scopes its own bars by the RESOLVED value).
+
+`useOpenRecordList` now expands both placeholder vocabularies against the session scope
+it already sits inside, immediately before serialization. It is the single host handler
+every escape hatch funnels through — the chart's navigate arm and its own header
+button, `DrillDownDrawer`'s navigate arm, and `OpenInListButton` — so both widget
+families are covered by one resolution rather than N widget seams. A drill carrying no
+placeholder produces a byte-identical URL: both vocabularies substitute whole-string
+`{token}` values only.
+
+The `DrillNavigationValue.openRecordList` contract now states that resolving is the
+host implementation's job, since an out-of-repo host wiring the same context would
+otherwise reproduce the split.

--- a/packages/app-shell/src/views/drillPlaceholderParity-9022.test.tsx
+++ b/packages/app-shell/src/views/drillPlaceholderParity-9022.test.tsx
@@ -65,12 +65,20 @@ const LITERAL_FILTER = {
   close_date: { $gte: '2026-04-01' },
 };
 
-let location = { pathname: '', search: '' };
+/**
+ * Where the router currently is, rendered rather than captured into a module
+ * variable: a render-phase write to an outer binding is a lint error here, and
+ * an effect-based capture would need its own settling window on top of the one
+ * `waitFor` already gives us.
+ */
+function LocationProbe() {
+  const { pathname, search } = useLocation();
+  return <span data-testid="router-location">{`${pathname}${search}`}</span>;
+}
 
-function LocationSpy() {
-  const l = useLocation();
-  location = { pathname: l.pathname, search: l.search };
-  return null;
+/** The probe's current reading, or the empty string before anything mounted. */
+function currentLocation(): string {
+  return screen.queryByTestId('router-location')?.textContent ?? '';
 }
 
 /** The host wiring `DashboardView` and `ReportView` both use, verbatim. */
@@ -95,7 +103,6 @@ function mount(
   ds: ReturnType<typeof makeDataSource>,
 ) {
   cleanup();
-  location = { pathname: '', search: '' };
   return render(
     <MemoryRouter initialEntries={['/apps/crm/dashboard/pipeline']}>
       <FilterScopeProvider currentUserId={SCOPE.currentUserId} currentOrgId={SCOPE.currentOrgId}>
@@ -104,7 +111,7 @@ function mount(
             path="/apps/:appName/*"
             element={
               <Host>
-                <LocationSpy />
+                <LocationProbe />
                 <DrillDownDrawer
                   open
                   onClose={vi.fn()}
@@ -138,8 +145,8 @@ async function drawerScope(filter: Record<string, unknown>): Promise<FilterTripl
 async function navigateScope(filter: Record<string, unknown>): Promise<FilterTriple[]> {
   const ds = makeDataSource();
   mount('navigate', filter, ds);
-  await waitFor(() => expect(location.pathname).toBe('/apps/crm/opportunity/data'));
-  return parseUrlFilterTriples(new URLSearchParams(location.search));
+  await waitFor(() => expect(currentLocation()).toMatch(/^\/apps\/crm\/opportunity\/data/));
+  return parseUrlFilterTriples(new URLSearchParams(currentLocation().split('?')[1] ?? ''));
 }
 
 /** The scope the drawer's own header button lands on (`OpenInListButton`). */
@@ -147,8 +154,8 @@ async function openInListScope(filter: Record<string, unknown>): Promise<FilterT
   const ds = makeDataSource();
   mount('drawer', filter, ds);
   fireEvent.click(await screen.findByTestId('drill-open-in-list'));
-  await waitFor(() => expect(location.pathname).toBe('/apps/crm/opportunity/data'));
-  return parseUrlFilterTriples(new URLSearchParams(location.search));
+  await waitFor(() => expect(currentLocation()).toMatch(/^\/apps\/crm\/opportunity\/data/));
+  return parseUrlFilterTriples(new URLSearchParams(currentLocation().split('?')[1] ?? ''));
 }
 
 afterEach(cleanup);

--- a/packages/app-shell/src/views/drillPlaceholderParity-9022.test.tsx
+++ b/packages/app-shell/src/views/drillPlaceholderParity-9022.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9022 — drawer / navigate PARITY: one drill, one scope.
+ *
+ * The card's discriminator is that the two arms of the SAME drill disagreed.
+ * The drawer arm renders `object-data-table`, whose fetch resolves the filter
+ * placeholders itself, so it has always queried the RESOLVED scope. The
+ * navigate arm — and the "Open in list →" button in the drawer's own header —
+ * went through the host's `openRecordList`, which wrote the authored literal
+ * into the URL. So `{current_user_id}` meant "my records" in the drawer and
+ * meant a string nobody owns on the list page, decided only by
+ * `drillDown.target`.
+ *
+ * These mount the REAL `DrillDownDrawer` (plugin-dashboard) over the REAL
+ * `useOpenRecordList`, wired the way `DashboardView` / `ReportView` wire them,
+ * and compare the two arms' DESTINATION SCOPES:
+ *
+ *   - drawer   → the `$filter` handed to `dataSource.find`;
+ *   - navigate → the triples the bare data surface reads back out of the URL;
+ *   - header   → the same, via `OpenInListButton`.
+ *
+ * ## Why the comparison runs through the URL codec
+ *
+ * The two arms speak different dialects — an ObjectQL filter object and
+ * `filter[...]` params. They are compared by pushing the drawer arm's object
+ * through the repo's OWN encoder/parser pair, which is the dialect the
+ * destination already speaks and is pinned separately in `drillUrlFilters.test.ts`.
+ *
+ * ⚠️ Equality alone would also hold if BOTH arms carried the literal, which is
+ * exactly the state before the fix. So every parity case additionally asserts
+ * the resolved value is present — the two assertions are not redundant, they
+ * fail in different worlds.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { DrillNavigationProvider, FilterScopeProvider } from '@object-ui/react';
+import { DrillDownDrawer } from '@object-ui/plugin-dashboard';
+// Registers the renderers at module scope, NOT inside a hook — a cold dynamic
+// transform billed to `hookTimeout` is this repo's standing flake cause.
+import '@object-ui/components';
+import { parseUrlFilterTriples, serializeDrillFilterParams, type FilterTriple } from './drillUrlFilters';
+import { useOpenRecordList } from './useOpenRecordList';
+
+const SCOPE = { currentUserId: 'usr_42', currentOrgId: 'org_7' };
+
+/** A drill whose scope is a QUESTION about the session, not a constant. */
+const PLACEHOLDER_FILTER = {
+  owner_id: '{current_user_id}',
+  close_date: { $gte: '{current_quarter_start}' },
+};
+
+/** The same drill with every value already a constant — the live control. */
+const LITERAL_FILTER = {
+  owner_id: 'usr_42',
+  close_date: { $gte: '2026-04-01' },
+};
+
+let location = { pathname: '', search: '' };
+
+function LocationSpy() {
+  const l = useLocation();
+  location = { pathname: l.pathname, search: l.search };
+  return null;
+}
+
+/** The host wiring `DashboardView` and `ReportView` both use, verbatim. */
+function Host({ children }: { children: React.ReactNode }) {
+  const openRecordList = useOpenRecordList();
+  return <DrillNavigationProvider value={{ openRecordList }}>{children}</DrillNavigationProvider>;
+}
+
+function makeDataSource() {
+  const find = vi.fn(async () => ({ data: [] }));
+  return { find, getObjectSchema: async () => ({ fields: {} }) };
+}
+
+/**
+ * One arm, mounted alone. Each helper below calls this, so the previous arm is
+ * torn down first: two live drawers would put two `drill-open-in-list` buttons
+ * in the same document and the header case could not address either.
+ */
+function mount(
+  target: 'drawer' | 'navigate',
+  filter: Record<string, unknown>,
+  ds: ReturnType<typeof makeDataSource>,
+) {
+  cleanup();
+  location = { pathname: '', search: '' };
+  return render(
+    <MemoryRouter initialEntries={['/apps/crm/dashboard/pipeline']}>
+      <FilterScopeProvider currentUserId={SCOPE.currentUserId} currentOrgId={SCOPE.currentOrgId}>
+        <Routes>
+          <Route
+            path="/apps/:appName/*"
+            element={
+              <Host>
+                <LocationSpy />
+                <DrillDownDrawer
+                  open
+                  onClose={vi.fn()}
+                  title="Won × Web"
+                  target={target}
+                  objectName="opportunity"
+                  filter={filter}
+                  dataSource={ds}
+                />
+              </Host>
+            }
+          />
+        </Routes>
+      </FilterScopeProvider>
+    </MemoryRouter>,
+  );
+}
+
+/** The scope the DRAWER arm queries: what the table actually asked the source for. */
+async function drawerScope(filter: Record<string, unknown>): Promise<FilterTriple[]> {
+  const ds = makeDataSource();
+  mount('drawer', filter, ds);
+  await waitFor(() => expect(ds.find).toHaveBeenCalled());
+  const queried = (ds.find.mock.calls[0] as unknown as [string, { $filter: Record<string, unknown> }])[1].$filter;
+  // Expressed in the dialect the destination list speaks, so the two arms are
+  // comparable at all. The codec itself is pinned in `drillUrlFilters.test.ts`.
+  return parseUrlFilterTriples(serializeDrillFilterParams(queried));
+}
+
+/** The scope the NAVIGATE arm lands on: what the list page will read back. */
+async function navigateScope(filter: Record<string, unknown>): Promise<FilterTriple[]> {
+  const ds = makeDataSource();
+  mount('navigate', filter, ds);
+  await waitFor(() => expect(location.pathname).toBe('/apps/crm/opportunity/data'));
+  return parseUrlFilterTriples(new URLSearchParams(location.search));
+}
+
+/** The scope the drawer's own header button lands on (`OpenInListButton`). */
+async function openInListScope(filter: Record<string, unknown>): Promise<FilterTriple[]> {
+  const ds = makeDataSource();
+  mount('drawer', filter, ds);
+  fireEvent.click(await screen.findByTestId('drill-open-in-list'));
+  await waitFor(() => expect(location.pathname).toBe('/apps/crm/opportunity/data'));
+  return parseUrlFilterTriples(new URLSearchParams(location.search));
+}
+
+afterEach(cleanup);
+
+describe('drill parity — the navigate arm lands where the drawer arm queries (objectui#9022)', () => {
+  it('navigate lands on the same scope the drawer queries, with the session token expanded', async () => {
+    const viaDrawer = await drawerScope(PLACEHOLDER_FILTER);
+    const viaNavigate = await navigateScope(PLACEHOLDER_FILTER);
+
+    // Both arms agree…
+    expect(viaNavigate).toEqual(viaDrawer);
+    // …and they agree on the RESOLVED value, not on the literal they used to
+    // share in the other direction.
+    expect(viaNavigate).toContainEqual(['owner_id', '=', 'usr_42']);
+    expect(JSON.stringify(viaNavigate)).not.toContain('current_user_id');
+  });
+
+  it('the date macro lands as a real date on both arms', async () => {
+    const viaDrawer = await drawerScope(PLACEHOLDER_FILTER);
+    const viaNavigate = await navigateScope(PLACEHOLDER_FILTER);
+
+    const bound = (triples: FilterTriple[]) =>
+      String(triples.find(([field, op]) => field === 'close_date' && op === '>=')?.[2]);
+
+    expect(bound(viaNavigate)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(bound(viaNavigate)).toBe(bound(viaDrawer));
+  });
+
+  it('the drawer header escape hatch lands on that same scope', async () => {
+    const viaDrawer = await drawerScope(PLACEHOLDER_FILTER);
+    const viaButton = await openInListScope(PLACEHOLDER_FILTER);
+
+    expect(viaButton).toEqual(viaDrawer);
+    expect(viaButton).toContainEqual(['owner_id', '=', 'usr_42']);
+  });
+
+  it('CONTROL — a placeholder-free drill is unchanged on every arm', async () => {
+    const expected: FilterTriple[] = [
+      ['owner_id', '=', 'usr_42'],
+      ['close_date', '>=', '2026-04-01'],
+    ];
+
+    expect(await drawerScope(LITERAL_FILTER)).toEqual(expected);
+    expect(await navigateScope(LITERAL_FILTER)).toEqual(expected);
+    expect(await openInListScope(LITERAL_FILTER)).toEqual(expected);
+  });
+});

--- a/packages/app-shell/src/views/useOpenRecordList.placeholderScope-9022.test.tsx
+++ b/packages/app-shell/src/views/useOpenRecordList.placeholderScope-9022.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9022 — the drill escape hatch resolves filter placeholders, so ONE
+ * drill has ONE scope whatever `drillDown.target` says.
+ *
+ * Every widget composes its drill filter from the RAW authored `schema.filter`
+ * (`ObjectChart`'s `drillFilter` memo; `DrillDownDrawer`'s `filter` prop), so
+ * `{current_user_id}` and the relative-date macros are still literals when they
+ * reach the host handler. The drawer arm never had the defect — the
+ * `object-data-table` it renders resolves `schema.filter` in its own fetch — so
+ * the navigate arm was the only one writing a placeholder into the URL, where
+ * the READ side parses it back as an ordinary string comparand and the list
+ * matches nothing.
+ *
+ * ## What these assert, and why it is the URL rather than the helper
+ *
+ * The defect's whole signature is that every layer looked fine: the widget
+ * rendered, the navigation happened, the list page loaded, and only the
+ * comparand was wrong. So the observation point is the DESTINATION SCOPE — the
+ * filter triples the bare data surface will read back out of the URL, via the
+ * repo's own `parseUrlFilterTriples` — not the return value of any helper.
+ *
+ * The composed shape under test is built with the real `composeDrillFilter`,
+ * which is what `ObjectChart` hands the handler (pinned on the chart's side of
+ * the seam by its own drill-navigate and drill-composition tests). Feeding the
+ * handler a hand-written literal would pin a shape no caller actually produces.
+ *
+ * ## The controls
+ *
+ * A placeholder-free drill must be unchanged, and it is asserted as the exact
+ * URL string rather than "no placeholder remains" — an assertion that a
+ * resolver rewriting values in some other way would still pass. The same-kind
+ * pre-existing control is `drillUrlFilters.test.ts`, which pins the encoder
+ * this hook delegates to and is untouched by this change.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { composeDrillFilter } from '@object-ui/core';
+import { FilterScopeProvider } from '@object-ui/react';
+import { parseUrlFilterTriples } from './drillUrlFilters';
+import { useOpenRecordList } from './useOpenRecordList';
+
+/**
+ * Noon UTC in the middle of Q2 2026, so the quarter-start macro has ONE right
+ * answer and it can be pinned as a literal. Only `Date` is faked — the RTL
+ * timers this file's `act` relies on stay real (the convention already used in
+ * `plugin-timeline` / `plugin-map` / `dataset-format.date`), and the suite pins
+ * `TZ=UTC`, so a `Z` instant and the local calendar day cannot disagree.
+ */
+const NOW = new Date('2026-05-15T12:00:00Z');
+const QUARTER_START = '2026-04-01';
+
+beforeAll(() => {
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(NOW);
+});
+afterAll(() => vi.useRealTimers());
+
+function wrapperFor(scope: { currentUserId?: string | null; currentOrgId?: string | null }) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <MemoryRouter initialEntries={['/apps/crm/dashboard/pipeline']}>
+        <FilterScopeProvider currentUserId={scope.currentUserId} currentOrgId={scope.currentOrgId}>
+          <Routes>
+            <Route path="/apps/:appName/*" element={<>{children}</>} />
+          </Routes>
+        </FilterScopeProvider>
+      </MemoryRouter>
+    );
+  };
+}
+
+/** The handler under test, plus wherever it took the browser. */
+function useHarness() {
+  const openRecordList = useOpenRecordList();
+  const { pathname, search } = useLocation();
+  return { openRecordList, pathname, search };
+}
+
+function drillTo(
+  scope: { currentUserId?: string | null; currentOrgId?: string | null },
+  objectName: string,
+  filter?: Record<string, unknown>,
+) {
+  const { result } = renderHook(useHarness, { wrapper: wrapperFor(scope) });
+  act(() => result.current.openRecordList(objectName, filter));
+  return result;
+}
+
+/** The scope the destination list will actually run under. */
+function destinationScope(search: string) {
+  return parseUrlFilterTriples(new URLSearchParams(search));
+}
+
+describe('useOpenRecordList — the drilled URL carries the RESOLVED scope (objectui#9022)', () => {
+  it('resolves {current_user_id} inside the filter the chart composes', () => {
+    // Exactly what ObjectChart hands over: widget filter ∧ click context.
+    const composed = composeDrillFilter({ owner_id: '{current_user_id}' }, { stage: 'won' });
+    const result = drillTo({ currentUserId: 'usr_42', currentOrgId: 'org_7' }, 'opportunity', composed);
+
+    expect(result.current.pathname).toBe('/apps/crm/opportunity/data');
+    expect(destinationScope(result.current.search)).toEqual([
+      ['owner_id', '=', 'usr_42'],
+      ['stage', '=', 'won'],
+    ]);
+    // The literal is what shipped, and it is what a list page matches nothing on.
+    expect(result.current.search).not.toContain('current_user_id');
+  });
+
+  it('resolves a relative-date macro in a range bound to a real ISO date', () => {
+    const result = drillTo({ currentUserId: 'usr_42' }, 'opportunity', {
+      close_date: { $gte: '{current_quarter_start}' },
+    });
+
+    expect(destinationScope(result.current.search)).toEqual([
+      ['close_date', '>=', QUARTER_START],
+    ]);
+  });
+
+  it('resolves both vocabularies in one drill, and {current_org_id} too', () => {
+    const result = drillTo({ currentUserId: 'usr_42', currentOrgId: 'org_7' }, 'opportunity', {
+      owner_id: '{current_user_id}',
+      org_id: '{current_org_id}',
+      close_date: { $gte: '{current_quarter_start}' },
+    });
+
+    expect(destinationScope(result.current.search)).toEqual([
+      ['owner_id', '=', 'usr_42'],
+      ['org_id', '=', 'org_7'],
+      ['close_date', '>=', QUARTER_START],
+    ]);
+  });
+
+  it('CONTROL — a placeholder-free drill produces the same URL it always did', () => {
+    const result = drillTo({ currentUserId: 'usr_42', currentOrgId: 'org_7' }, 'opportunity', {
+      stage: 'won',
+      close_date: { $gte: '2026-04-01', $lt: '2026-07-01' },
+    });
+
+    // Pinned as the whole string, not as "no token survives": a resolver that
+    // rewrote ordinary comparands would pass the weaker assertion.
+    expect(`${result.current.pathname}${result.current.search}`).toBe(
+      '/apps/crm/opportunity/data?filter%5Bstage%5D=won&filter%5Bclose_date%5D%5Bgte%5D=2026-04-01&filter%5Bclose_date%5D%5Blt%5D=2026-07-01',
+    );
+  });
+
+  it('CONTROL — a drill with no filter at all still navigates bare', () => {
+    const { result } = renderHook(useHarness, {
+      wrapper: wrapperFor({ currentUserId: 'usr_42' }),
+    });
+    act(() => result.current.openRecordList('opportunity'));
+
+    expect(`${result.current.pathname}${result.current.search}`).toBe('/apps/crm/opportunity/data');
+  });
+
+  it('leaves a token it cannot resolve as a literal — narrowing, never widening', () => {
+    // Signed out: the resolver deliberately keeps the token rather than dropping
+    // the clause, because an empty result is far safer than a widened one.
+    const result = drillTo({ currentUserId: null, currentOrgId: null }, 'opportunity', {
+      owner_id: '{current_user_id}',
+    });
+
+    expect(destinationScope(result.current.search)).toEqual([
+      ['owner_id', '=', '{current_user_id}'],
+    ]);
+  });
+});

--- a/packages/app-shell/src/views/useOpenRecordList.ts
+++ b/packages/app-shell/src/views/useOpenRecordList.ts
@@ -8,6 +8,8 @@
 
 import { useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { resolveFilterPlaceholders } from '@object-ui/core';
+import { useFilterScope } from '@object-ui/react';
 import { serializeDrillFilterParams } from './drillUrlFilters.js';
 
 /**
@@ -20,17 +22,64 @@ import { serializeDrillFilterParams } from './drillUrlFilters.js';
  * range serializes to `filter[field][gte]=…&filter[field][lt]=…` (#1752). Wire it
  * into a `DrillNavigationProvider` so the dashboard/report drill drawers can offer
  * "Open in list →" and honor `drillDown.target: 'navigate'`.
+ *
+ * ## Placeholders are resolved HERE, because this is where the scope is
+ * (objectui#9022)
+ *
+ * Every widget composes its drill filter from the RAW authored `schema.filter`
+ * — `ObjectChart`'s `drillFilter` memo and `DrillDownDrawer`'s `filter` prop
+ * both do — so the value arriving here still carries whatever placeholders the
+ * author wrote: `{current_user_id}`, `{current_org_id}`, and the relative-date
+ * macros. Resolving it before serialization is what makes ONE drill mean ONE
+ * scope regardless of `drillDown.target`:
+ *
+ *   - `target: 'drawer'` renders `object-data-table`, whose own fetch calls
+ *     `resolveFilterPlaceholders(schema.filter, filterScope)` — so the drawer
+ *     arm has always been scoped by the RESOLVED value;
+ *   - `target: 'navigate'` (and the "Open in list →" button on either widget
+ *     family) comes through here, and used to write the placeholder into the
+ *     URL verbatim. `filter[close_date][gte]={current_quarter_start}` parses
+ *     back on the READ side as an ordinary string comparand, so the list
+ *     matched nothing — silently, and in disagreement with the chart bar the
+ *     user had just clicked, which `ObjectChart` scopes by the resolved value.
+ *
+ * ⛔ Deliberately NOT inside `serializeDrillFilterParams`: that function is a
+ * pure URL encoder which writes faithfully what it is handed, and the scope is
+ * a React context read, so putting the resolution there would make a pure
+ * function scope-dependent while leaving the callers holding the scope anyway.
+ *
+ * ⛔ And deliberately NOT at each widget's drill seam: `openRecordList` is the
+ * single host-provided handler every drill escape hatch funnels through
+ * (`ObjectChart`'s navigate arm and its own header button, `DrillDownDrawer`'s
+ * navigate arm, and `OpenInListButton`), so resolving once here covers both
+ * widget families and every future caller, instead of N seams the next
+ * hand-rolled drill panel would forget.
+ *
+ * Resolution cannot change a filter that carries no placeholder: both
+ * vocabularies substitute whole-string `{token}` values only and pass
+ * everything else through untouched, so a placeholder-free drill produces a
+ * byte-identical URL.
  */
 export function useOpenRecordList(): (objectName: string, filter?: Record<string, unknown>) => void {
   const navigate = useNavigate();
   const { appName } = useParams<{ appName?: string }>();
+  // Session scope for `{current_user_id}` / `{current_org_id}`. Read at hook
+  // level — the returned handler is a callback, and hooks cannot be called from
+  // inside it. `FilterScopeProvider` memoizes its value on the two ids, so this
+  // does not churn the callback identity on unrelated renders.
+  const filterScope = useFilterScope();
 
   return useCallback(
     (objectName: string, filter?: Record<string, unknown>) => {
+      // Expand EVERY placeholder vocabulary in one call — date macros and
+      // session tokens. Calling only one of the two is the defect this helper
+      // exists to prevent (framework #3574): `{today}` would work and
+      // `{current_user_id}` would silently not.
+      const runtimeFilter = resolveFilterPlaceholders(filter, filterScope);
       // A date-bucket drill carries an ObjectQL range operator object
       // (`{ $gte, $lt }`); the shared serializer emits it as `filter[field][gte|lt]`
       // (never "[object Object]"). Equality dims stay `filter[field]=value` (#1752).
-      const qs = serializeDrillFilterParams(filter).toString();
+      const qs = serializeDrillFilterParams(runtimeFilter).toString();
       const base = appName ? `/apps/${appName}` : '';
       // ADR-0055 bare data surface (`/:object/data`): "the URL is the view" — no
       // saved-view filter is baked in, so the drill scope is exactly these
@@ -38,6 +87,6 @@ export function useOpenRecordList(): (objectName: string, filter?: Record<string
       // view's own filter, which can silently over-narrow a drill.)
       navigate(`${base}/${objectName}/data${qs ? `?${qs}` : ''}`);
     },
-    [navigate, appName],
+    [navigate, appName, filterScope],
   );
 }

--- a/packages/react/src/context/DrillNavigationContext.tsx
+++ b/packages/react/src/context/DrillNavigationContext.tsx
@@ -30,6 +30,19 @@ export interface DrillNavigationValue {
    * Open the full list page for `objectName`, scoped by `filter` (an object
    * FIELD name → raw stored value map). Implemented by the app shell as a
    * SPA navigation to the object's list route. Absent when no host wired it.
+   *
+   * ⚠️ `filter` is the widget's AUTHORED filter composed with the click
+   * context, so it may still carry unresolved placeholders — `{current_user_id}`,
+   * `{current_org_id}`, and the relative-date macros. **Resolving them is the
+   * host implementation's job**: call `resolveFilterPlaceholders(filter, scope)`
+   * from `@object-ui/core` with the session scope the host holds
+   * (`useFilterScope`), exactly once, before the value reaches a query or a URL.
+   *
+   * A host that skips it gives ONE drill TWO scopes: the in-place drawer arm is
+   * already scoped by the resolved value, because the `object-data-table` it
+   * renders resolves `schema.filter` in its own fetch, so only the navigate arm
+   * would carry the literal — and a literal placeholder matches no record
+   * (objectui#9022).
    */
   openRecordList?: (objectName: string, filter?: Record<string, unknown>) => void;
 }


### PR DESCRIPTION
Fixes #9022

## What was wrong

Every widget composes its drill filter from the **raw authored** `schema.filter` — `ObjectChart`'s `drillFilter` memo and `DrillDownDrawer`'s `filter` prop both do — so `{current_user_id}`, `{current_org_id}` and the relative-date macros were still literals by the time the value reached the host's `openRecordList`.

The in-place drawer arm never had the defect: the `object-data-table` it renders resolves `schema.filter` in its own fetch. So only the **navigate** arm — and the "Open in list" button in the drawer's own header — wrote the placeholder into the URL, where the read side parses it back as an ordinary string comparand and the destination list matches nothing. One drill, two scopes, decided only by `drillDown.target`, and on the navigate arm the destination disagreed with the chart bar the user had just clicked (the chart scopes its own bars by the resolved value).

## Which call site owns the scope

**`useOpenRecordList` in `@object-ui/app-shell`.** Measured on this tree, not inherited:

- It is the **only** in-repo implementation of `DrillNavigationContext.openRecordList`. Both mounts (`DashboardView`, `ReportView`) call this one hook; no other file constructs a `DrillNavigationProvider` value outside tests.
- The scope is in hand there: `AppContent` mounts `FilterScopeProvider` around `ConsoleLayout`, and the `dashboard/:dashboardName` and `report/:reportName` routes are inside it, so `useFilterScope()` reads real session values at that hook.
- Every escape hatch funnels through it: `ObjectChart`'s navigate effect and its own header button, `DrillDownDrawer`'s navigate effect, and `OpenInListButton`. One resolution therefore covers **both** widget families, instead of the N widget seams the next hand-rolled drill panel would forget.

Deliberately **not** inside `serializeDrillFilterParams`: that function is a pure URL encoder which writes faithfully what it is handed, and the scope is a React context read — putting it there would make a pure function scope-dependent while leaving the callers holding the scope anyway.

`DrillNavigationValue.openRecordList` now states in its own contract that resolving is the host implementation's job, because an out-of-repo host wiring the same context would otherwise reproduce the split.

## Mechanism assumptions, re-measured — one is FALSIFIED

1. ⚠️ **FALSIFIED as stated.** The dispatch said the two consumers "pass it straight to `serializeDrillFilterParams`". Measured: `OpenInListButton` never touches the serializer — it calls the host handler, and `useOpenRecordList` is the sole implementation of that handler. So the two named names are not two peers; one is the handler, the other a caller of it. **This makes the fence stronger, not weaker**: "both consumers, or neither" is satisfied *by construction* at the single handler, and the falsification is why one edit covers both widget families.
2. ✅ **Confirmed.** The drawer path does not have the defect: `ObjectDataTable`'s fetch builds its params as a `$filter` of `resolveFilterPlaceholders(schema.filter, filterScope)`, and `DrillDownDrawer` hands its `filter` prop into exactly that schema.
3. ✅ **Confirmed.** The scope is available at the chosen site (see above).
4. ✅ **Confirmed.** `ObjectChart` composes `drillFilter` from `schema.filter` **raw** via `composeDrillFilter`, while its query legs go through `resolveFilterPlaceholders`. Same reading the objectui#9024 seat reported from the pivot path. Refs: objectui#9024, objectui#9135.

None of the STOP conditions tripped. There is no third consumer that holds no scope; the fix needed no change to `serializeDrillFilterParams`; and nothing lands on different rows except the placeholder case — both vocabularies substitute **whole-string** `{token}` values only and pass everything else through untouched. On the leak question: `{current_user_id}` and `{current_org_id}` resolve to values the viewer's **own** session already determines, so nothing enters the URL that the session did not already decide. The visible consequence is that a *shared* drilled URL now names a concrete id instead of a literal that matched nothing — which is the behaviour the card asks for, and what the drawer arm has always done.

## Pins

`packages/app-shell/src/views/useOpenRecordList.placeholderScope-9022.test.tsx` — the destination scope carried by the URL, read back with the repo's own `parseUrlFilterTriples`, for a session token, a date macro (pinned to a literal date under a frozen clock), and both vocabularies at once. The composed shape is built with the real `composeDrillFilter`, i.e. what `ObjectChart` actually hands over.

`packages/app-shell/src/views/drillPlaceholderParity-9022.test.tsx` — the parity the card measured, pinned: the **real** `DrillDownDrawer` over the **real** `useOpenRecordList`, comparing the drawer arm's `$filter` (captured off `dataSource.find`) against the navigate arm's URL and against the header button's URL. Each case asserts parity **and** that the resolved value is present — equality alone would also hold in the pre-fix world, where both arms carried the literal.

Controls, live in the same run: a placeholder-free drill is pinned as the **whole** URL string on the hook, and as the identical triple list on all three arms; a drill with no filter at all still navigates bare; and an unresolvable token stays a literal rather than being dropped, so the filter can never widen. The same-kind pre-existing control is `drillUrlFilters.test.ts`, which pins the encoder this hook delegates to and is untouched by this change.

## Ablation — the pins can fail

The resolution line was replaced on disk with a pass-through, at the branch head `7ac092df8`. No rebuild is involved: the root vitest config redirects every package specifier to its `src`, so the run reads the mutated file directly.

```
HEAD blob for packages/app-shell/src/views/useOpenRecordList.ts = 20a7fa10e579cb23605a8053a7f5a688eba051be
--- BEFORE mutation (on-disk occurrence counts) ---
fixed-line count   : 1
ablated-line count : 0
on-disk hash       : 20a7fa10e579cb23605a8053a7f5a688eba051be
--- AFTER mutation (on-disk occurrence counts) ---
fixed-line count   : 0
ablated-line count : 1
on-disk hash       : b80f993d6e7d39c1a65a997ac67b68d97a255fe6
VERDICT ablation-run exit = 1
 Test Files  2 failed (2)
      Tests  6 failed | 4 passed (10)
--- RESTORE ---
on-disk hash after restore : 20a7fa10e579cb23605a8053a7f5a688eba051be
fixed-line count           : 1
ablated-line count         : 0
git diff HEAD --name-only : []
RESTORE PROVEN BY STATE: hash back to HEAD blob and git diff HEAD empty
```

The six that reddened are exactly the six placeholder/parity cases. The four that stayed green are the three controls plus the non-widening guard — none of them can move under an ablation of this arm, which is what makes them controls rather than more of the subject. The restore was proven by state (blob hash back to the HEAD blob, `git diff HEAD` empty), never by an exit code, and the script carried a `trap` on EXIT/INT/TERM pointing at absolute paths with `git checkout HEAD --`, so a mid-mutation kill could not leave the tree mutated.

## Verification run

Measured at `7ac092df8`, on a shared box (other agents' unlocked work runs on the same cores), with every exit code captured by redirect before any pipe.

| what | command | verdict |
| --- | --- | --- |
| dependency closure | `turbo run build --filter="@object-ui/app-shell^..." --concurrency=2` | `28 successful, 28 total`, wrapper exit 0 |
| type-check | `pnpm --filter @object-ui/app-shell --filter @object-ui/react run type-check` | both `Done`, exit 0 |
| the new pins | `pnpm exec vitest run` on the two files | `Test Files 2 passed (2)`, `Tests 10 passed (10)`, exit 0 |
| affected packages | `pnpm exec vitest run packages/app-shell/ packages/react/` | `761` files, `7544 passed, 1 failed`, exit 1 — see below |
| lint | `pnpm --filter @object-ui/app-shell --filter @object-ui/react run lint` | exit 0 (2966 pre-existing warnings, 0 errors) |
| changeset presence | `node scripts/check-changeset-presence.mjs` | exit 0, declaration found |
| citation gate | `node scripts/check-new-cross-file-line-citations.mjs` | `0 new citation(s)`, exit 0 |
| control bytes | `grep -naP` over the five touched files | no match |

The type-check reading is a real one and not a silent skip: `tsc -p tsconfig.test.json --listFiles` lists both new test files in the program.

⚠️ **The one failure is not this change.** `RecordApprovalsPanel.viaOverrideMarker.test.tsx` could not find its `via-override-chip` under full-parallel load; re-run alone it is `6 passed`, exit 0. It shares no file, no import and no surface with this diff — it is the load-dependent class AGENTS.md already describes, where an unbounded module load lands inside a bounded assertion window. Recorded rather than swept: nothing here should be read as having made it green.

Heavy runs went through `scripts/pm/os-verify-lock.sh` in the sibling checkout, as this repo's AGENTS.md requires.

## Acceptance notes — found, and deliberately left alone

- `ObjectChart` hand-rolls its own "Open in list" button (same `data-testid`, same label) instead of rendering the shared `OpenInListButton`. Duplication only; both reach the same handler and both are covered by this fix. Noted, not filed — no card and no PR is heading for that file.
- `serializeDrillFilterParams` skips array comparands (an `$in`-style value), which drops that condition from the URL and degrades the drill to a superset. Its own docblock declares that posture deliberate and an existing test pins it, and the composition half is already carded. Noted, not filed. Refs: objectui#9024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_