### PR TITLE
fix(core): drill the empty bucket by is-null, not by a bare null the converter drops

### DIFF
--- a/.changeset/empty-bucket-drill-is-null-9085.md
+++ b/.changeset/empty-bucket-drill-is-null-9085.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/core': minor
+---
+
+fix(core): an empty-bucket drill filters on "this dimension is empty" instead of writing a spelling the converter drops
+
+`buildDatasetDrillFilter` wrote a bare `null` for a bucket whose dimension value
+is empty. `convertFiltersToAST` SKIPS a key whose value is `null` / `undefined`
+— its oldest pinned behaviour — so the constraint never reached the wire and
+drilling into the empty bucket answered with a SUPERSET: every row, silently,
+with nothing thrown and nothing logged. Measured on three shapes (two drill
+dimensions with one empty; one drill dimension plus a runtime filter; one drill
+dimension with no runtime filter), all three were wrong.
+
+The empty bucket now lowers to `{ [field]: { $null: true } }`, which the
+converter carries end to end as `[field, 'is_null', true]`. That spelling means
+"this dimension has no value" — the rows the aggregate actually counted into
+the bucket — where an equality test against `null` would have meant "this
+dimension holds the literal value null" and dropped every row whose field is
+absent. All three empty authorings (`''`, `null`, `undefined`) reach the one
+spelling; `null` is included because JSON cannot carry `undefined`, so a SQL
+NULL grouped value arrives over the wire as `null`.
+
+BREAKING for a direct consumer of the exported `buildDatasetDrillFilter`: the
+value written for an empty bucket changes shape. Marked `minor` per this repo's
+version-alignment rule, which reserves `major` for following `@objectstack`.
+
+The drill "escape hatch" (the host's `openRecordList`, which serializes a drill
+filter into `filter[...]` URL params) is unchanged and still returns a superset
+for the empty bucket: that URL dialect has no is-null operator, so it drops the
+new spelling exactly as it dropped the bare `null`, byte for byte. Closing that
+needs a URL-dialect operator on both the write and the read side.

--- a/packages/app-shell/src/views/drillEmptyBucketNavHost-9085.test.ts
+++ b/packages/app-shell/src/views/drillEmptyBucketNavHost-9085.test.ts
@@ -1,0 +1,95 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The drill "escape hatch" and the empty bucket — the THIRD consumer of
+ * `buildDatasetDrillFilter`, measured for objectui#9085.
+ *
+ * `buildDatasetDrillFilter`'s output has three consumers. Two of them
+ * (`ObjectDataTable`, and the report drill's `SchemaRenderer` path, which wraps
+ * the filter in an `$and`) lower it through `convertFiltersToAST`, where
+ * objectui#9085's `{ $null: true }` becomes `['field','is_null',true]` and the
+ * empty bucket selects its own rows. This is the third: the host's
+ * `openRecordList`, which does NOT go through that converter — it serializes
+ * the same object into `filter[...]` URL params for the bare data surface.
+ *
+ * ## The measured boundary, recorded rather than closed
+ *
+ * ⚠️ This dialect has NO spelling for is-null. Its whole operator vocabulary is
+ * equality plus four range bounds (`URL_FILTER_OPS` / `RANGE_OP_PARAM` name
+ * them), so there is no param shape that carries "this dimension is empty" and
+ * no suffix `parseUrlFilterTriples` would read back as one. An empty-bucket
+ * drill escalated to the list page has therefore ALWAYS landed on a superset,
+ * and it still does.
+ *
+ * ⇒ objectui#9085 changes NOTHING here, and that is the claim these assertions
+ * exist to hold: the new spelling produces the byte-identical query string the
+ * bare `null` produced, so the escape hatch neither improves nor regresses.
+ * Closing it needs a URL-dialect operator on BOTH the write and the read side
+ * (plus a chip rendering for it), which is a separate card — ⛔ not folded in
+ * here, where it would be an unpinned new URL contract riding along with a
+ * one-expression producer fix.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildDatasetDrillFilter } from '@object-ui/core';
+import {
+  serializeDrillFilterParams,
+  parseUrlFilterTriples,
+  URL_FILTER_OPS,
+  RANGE_OP_PARAM,
+} from './drillUrlFilters';
+
+const DIMENSION_FIELDS = { stage: 'stage', owner: 'owner' };
+
+/** What the producer wrote BEFORE objectui#9085 — the shape being replaced. */
+const PREVIOUS_EMPTY_SPELLING = null;
+
+describe('drill escape hatch vs the empty bucket (objectui#9085)', () => {
+  it('the URL dialect has no is-null operator at all', () => {
+    // Stated as the two exported maps rather than as prose, so the day someone
+    // adds one, this assertion is where the claim above stops being true.
+    expect(Object.keys(URL_FILTER_OPS)).toEqual(['gte', 'lte', 'gt', 'lt']);
+    expect(Object.keys(RANGE_OP_PARAM)).toEqual(['$gte', '$lte', '$gt', '$lt']);
+  });
+
+  it('the new spelling serializes byte-identically to the bare null it replaced', () => {
+    const now = buildDatasetDrillFilter({ stage: 'won', owner: '' }, ['stage', 'owner'], DIMENSION_FIELDS);
+    const before = { stage: 'won', owner: PREVIOUS_EMPTY_SPELLING };
+
+    expect(now).toEqual({ stage: 'won', owner: { $null: true } });
+    expect(serializeDrillFilterParams(now).toString())
+      .toBe(serializeDrillFilterParams(before).toString());
+    // And the surviving condition is the NON-empty one, which is what makes
+    // this a superset rather than an empty list.
+    expect(parseUrlFilterTriples(new URLSearchParams(serializeDrillFilterParams(now).toString())))
+      .toEqual([['stage', '=', 'won']]);
+  });
+
+  it('an empty-bucket-only drill serializes to nothing, before and after', () => {
+    const now = buildDatasetDrillFilter({ owner: '' }, ['owner'], DIMENSION_FIELDS);
+    expect(serializeDrillFilterParams(now).toString()).toBe('');
+    expect(serializeDrillFilterParams({ owner: PREVIOUS_EMPTY_SPELLING }).toString()).toBe('');
+  });
+
+  it('CONTROL: a NON-empty drill still reaches the URL, so an empty result set above is the boundary and not a broken serializer', () => {
+    const composed = buildDatasetDrillFilter({ owner: 'alice' }, ['owner'], DIMENSION_FIELDS);
+    expect(serializeDrillFilterParams(composed).toString()).toBe('filter%5Bowner%5D=alice');
+  });
+
+  it('CONTROL: a date-bucket RANGE drill still reaches the URL', () => {
+    const composed = buildDatasetDrillFilter({}, [], {}, undefined, {
+      closed: { field: 'closed_at', gte: '2026-01-01', lt: '2026-04-01' },
+    });
+    expect(parseUrlFilterTriples(new URLSearchParams(serializeDrillFilterParams(composed).toString())))
+      .toEqual([
+        ['closed_at', '>=', '2026-01-01'],
+        ['closed_at', '<', '2026-04-01'],
+      ]);
+  });
+});

--- a/packages/core/src/utils/__tests__/dataset-drill-empty-bucket-9085.test.ts
+++ b/packages/core/src/utils/__tests__/dataset-drill-empty-bucket-9085.test.ts
@@ -1,0 +1,193 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The empty-bucket drill returns the empty bucket's ROWS — objectui#9085.
+ *
+ * ## What was wrong
+ *
+ * `buildDatasetDrillFilter` wrote a bare `null` for a bucket whose dimension
+ * value is empty. `convertFiltersToAST` SKIPS a key whose value is `null` /
+ * `undefined` — its oldest pinned behaviour, pinned by name as "should skip
+ * null and undefined values" — so the constraint never reached the wire and the
+ * drill answered with a SUPERSET: every row, silently, nothing thrown and
+ * nothing logged.
+ *
+ * The repair is at the PRODUCER. ⛔ The converter is NOT touched: other
+ * producers rely on that skip, and objectui#9020 ruled it stays.
+ *
+ * ## Why these assertions are ROW SETS and not composed-object shapes
+ *
+ * The defect is invisible in the composed object — `{ owner: null }` looks like
+ * a filter. It only becomes wrong one layer down, where the key is dropped. A
+ * shape assertion therefore cannot fail for the reason this card exists, so
+ * every case below lowers the composed filter through the real sink
+ * (`toFilterNode`) and asks a real matcher (`ValueDataSource`) which rows come
+ * back.
+ *
+ * ## The fixture answers the semantic question the spelling had to settle
+ *
+ * `MISSING` has no `owner` KEY AT ALL; `EXPLICIT_NULL` has `owner: null`. The
+ * two are told apart by exactly one thing — which spelling the producer emits:
+ *
+ *   - `['owner','is_null',true]`  selects BOTH  (what `{ $null: true }` lowers to)
+ *   - equality against `null`      selects only EXPLICIT_NULL
+ *
+ * The aggregate counted both into the one empty bucket, so the drill has to
+ * return both, and the third case below is that choice pinned as a row set
+ * rather than asserted as a preference.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildDatasetDrillFilter } from '../dataset-format';
+import { toFilterNode } from '../filter-converter';
+import { ValueDataSource } from '../../adapters/ValueDataSource';
+
+/**
+ * Deals across two stages and three authorings of "no owner". `MISSING` is a
+ * row object with NO `owner` key — written as a separate literal rather than
+ * `owner: undefined`, because the source goes through a `JSON` round trip that
+ * would erase the key either way and the distinction has to be the fixture's,
+ * not the clone's.
+ */
+const WON_ALICE = { id: 'won-alice', stage: 'won', owner: 'alice' };
+const WON_EXPLICIT_NULL = { id: 'won-null', stage: 'won', owner: null };
+const WON_MISSING = { id: 'won-missing', stage: 'won' };
+const LOST_EXPLICIT_NULL = { id: 'lost-null', stage: 'lost', owner: null };
+const LOST_BOB = { id: 'lost-bob', stage: 'lost', owner: 'bob' };
+
+const ROWS = [WON_ALICE, WON_EXPLICIT_NULL, WON_MISSING, LOST_EXPLICIT_NULL, LOST_BOB];
+const ALL_IDS = ROWS.map((r) => r.id);
+
+/** Dimension NAME -> object FIELD, as the server sends it beside the rows. */
+const DIMENSION_FIELDS = { stage: 'stage', owner: 'owner' };
+
+/** Lower a composed drill filter through the real sink and select real rows. */
+async function drilledIds(composed: Record<string, unknown>): Promise<string[]> {
+  const node = toFilterNode(composed);
+  const ds = new ValueDataSource({ items: ROWS as never });
+  const result = await ds.find('deal', (node === undefined ? {} : { $filter: node }) as never);
+  return (result.data as Array<{ id: string }>).map((r) => String(r.id));
+}
+
+describe('empty-bucket drill (objectui#9085)', () => {
+  /**
+   * The three shapes the card names, each re-measured as the rows a user would
+   * see in the drill drawer. Before the producer fix these answered
+   * `[WON_ALICE, WON_EXPLICIT_NULL, WON_MISSING]`, the same two ways, and
+   * `ALL_IDS` the third way — supersets in every case.
+   */
+  it('two drill dimensions, one of them empty, selects only the empty bucket', async () => {
+    const composed = buildDatasetDrillFilter(
+      { stage: 'won', owner: '' },
+      ['stage', 'owner'],
+      DIMENSION_FIELDS,
+    );
+    expect(await drilledIds(composed)).toEqual([WON_EXPLICIT_NULL.id, WON_MISSING.id]);
+  });
+
+  it('one drill dimension plus a runtime filter keeps BOTH constraints', async () => {
+    const composed = buildDatasetDrillFilter(
+      { owner: '' },
+      ['owner'],
+      DIMENSION_FIELDS,
+      { stage: 'won' },
+    );
+    // Both halves are load-bearing: the empty-bucket condition survives (the
+    // `lost` rows are gone) AND the runtime filter still scopes the list (the
+    // owned `won` row is gone).
+    expect(await drilledIds(composed)).toEqual([WON_EXPLICIT_NULL.id, WON_MISSING.id]);
+  });
+
+  it('one drill dimension with no runtime filter still constrains', async () => {
+    const composed = buildDatasetDrillFilter({ owner: '' }, ['owner'], DIMENSION_FIELDS);
+    expect(await drilledIds(composed)).toEqual([
+      WON_EXPLICIT_NULL.id,
+      WON_MISSING.id,
+      LOST_EXPLICIT_NULL.id,
+    ]);
+    // ⚠️ The control that makes the assertion above mean something. This shape
+    // is the one that degraded to EVERY ROW, so a fixture where the answer
+    // happened to be every row would pass either way.
+    expect(await drilledIds(composed)).not.toEqual(ALL_IDS);
+  });
+
+  /**
+   * The row the spelling decision is about. `MISSING` carries no `owner` key,
+   * and it is in the answer above — which is what an equality test against
+   * `null` would NOT have produced.
+   */
+  it('the empty bucket includes the row whose dimension key is absent, not only an explicit null', async () => {
+    const composed = buildDatasetDrillFilter({ owner: '' }, ['owner'], DIMENSION_FIELDS);
+    expect(await drilledIds(composed)).toContain(WON_MISSING.id);
+    // The rejected spelling, run side by side so the difference is visible here
+    // rather than asserted in prose: equality against `null` drops the
+    // missing-key row. This is the fork objectui#9085 had to settle.
+    const ds = new ValueDataSource({ items: ROWS as never });
+    const equality = await ds.find('deal', { $filter: ['owner', '=', null] } as never);
+    expect((equality.data as Array<{ id: string }>).map((r) => r.id)).toEqual([
+      WON_EXPLICIT_NULL.id,
+      LOST_EXPLICIT_NULL.id,
+    ]);
+  });
+
+  /**
+   * All three empty authorings reach ONE spelling. `null` is in this set because
+   * JSON cannot carry `undefined`: a SQL NULL grouped value arrives over the
+   * wire AS `null`, so it is the empty bucket's most common shape and a fix
+   * that skipped it would leave the common case broken.
+   */
+  it.each([
+    ['empty string', { owner: '' }],
+    ['explicit null', { owner: null }],
+    ['absent key', {}],
+    ['absent raw row', undefined],
+  ])('%s all become one is-empty spelling', async (_name, rawRow) => {
+    const composed = buildDatasetDrillFilter(
+      rawRow as Record<string, unknown> | undefined,
+      ['owner'],
+      DIMENSION_FIELDS,
+    );
+    expect(composed).toEqual({ owner: { $null: true } });
+    expect(toFilterNode(composed)).toEqual(['owner', 'is_null', true]);
+  });
+
+  // ── LIVE CONTROLS — pre-existing behaviour this change must not move ──────
+  //
+  // Same KIND as the subject (a drill composed by the same producer and lowered
+  // through the same sink), pre-existing, and untouched by the change: neither
+  // reaches the empty-value branch at all.
+
+  it('CONTROL: a non-empty bucket drill is unchanged', async () => {
+    const composed = buildDatasetDrillFilter({ owner: 'alice' }, ['owner'], DIMENSION_FIELDS);
+    expect(composed).toEqual({ owner: 'alice' });
+    expect(await drilledIds(composed)).toEqual([WON_ALICE.id]);
+  });
+
+  it('CONTROL: a non-empty bucket drill still carries its runtime filter', async () => {
+    const composed = buildDatasetDrillFilter(
+      { owner: 'bob' },
+      ['owner'],
+      DIMENSION_FIELDS,
+      { stage: 'lost' },
+    );
+    expect(composed).toEqual({ stage: 'lost', owner: 'bob' });
+    expect(await drilledIds(composed)).toEqual([LOST_BOB.id]);
+    // …and the runtime filter is a real constraint here, not decoration: drop
+    // it and a second row would qualify on the drill condition alone.
+    const withoutRuntime = buildDatasetDrillFilter({ stage: 'lost' }, ['stage'], DIMENSION_FIELDS);
+    expect(await drilledIds(withoutRuntime)).toEqual([LOST_EXPLICIT_NULL.id, LOST_BOB.id]);
+  });
+
+  it('CONTROL: a date-bucket RANGE drill is unchanged', async () => {
+    const composed = buildDatasetDrillFilter({}, [], {}, undefined, {
+      closed: { field: 'closed_at', gte: '2026-01-01', lt: '2026-04-01' },
+    });
+    expect(composed).toEqual({ closed_at: { $gte: '2026-01-01', $lt: '2026-04-01' } });
+  });
+});

--- a/packages/core/src/utils/dataset-format.ts
+++ b/packages/core/src/utils/dataset-format.ts
@@ -520,9 +520,49 @@ export interface DatasetDrillRange {
  * Each drillable dimension maps to its underlying object field, filtered by the
  * dimension's RAW grouped value (from the server's parallel `drillRawRows`, NOT
  * the visible row which carries the display LABEL — a select/lookup label would
- * mis-filter). An empty/undefined raw value normalizes to `null` (an explicit
- * "is empty" filter). The render-time `runtimeFilter` is ANDed in so the drilled
- * list stays within the same slice the aggregate was computed over.
+ * mis-filter). The render-time `runtimeFilter` is ANDed in so the drilled list
+ * stays within the same slice the aggregate was computed over.
+ *
+ * ## What the EMPTY bucket means, and why it is spelled `{ $null: true }`
+ *
+ * A drill must return exactly the rows the clicked bucket COUNTED. The empty
+ * bucket is the one the aggregate grouped rows with NO VALUE for that dimension
+ * into, so the drill means "this dimension has no value" — NOT "this dimension
+ * holds the literal value null". Those are different row sets, and the
+ * difference is measurable rather than theoretical: against `ValueDataSource`'s
+ * matcher over rows `{owner:'alice'}` / `{owner:null}` / `{}` (no `owner` key),
+ * `['owner','is_null',true]` selects the explicit-null row AND the missing-key
+ * row, while an equality test against `null` selects only the explicit-null one
+ * and drops the row that has no `owner` at all. The bucket counted both, so
+ * is-null is the one that agrees with the number the user clicked.
+ *
+ * ⇒ every empty authoring — `''`, `null` and `undefined` alike — becomes ONE
+ * spelling, `{ [field]: { $null: true } }`, which `convertFiltersToAST` lowers
+ * to `[field, 'is_null', true]`. The three are not told apart because the
+ * server already merged them into the single bucket the user clicked; there is
+ * no second bucket here for a second spelling to address.
+ *
+ * ⚠️ This value used to be a bare `null`, and that is the defect objectui#9085
+ * records: `convertFiltersToAST`'s OLDEST pinned behaviour is to SKIP a key
+ * whose value is `null` / `undefined` (pinned as "should skip null and
+ * undefined values"), so the constraint was dropped on the way to the wire and
+ * the empty-bucket drill answered with a SUPERSET — every row, silently. The
+ * repair is here at the PRODUCER and ⛔ not at that converter: the skip is
+ * relied on by other producers, and changing it would move every caller's
+ * meaning at once (objectui#9020 ruled it stays). `$null` is not a new
+ * vocabulary either — it is a declared spec operator this dialect already
+ * lowers, and the one spelling that says the same thing on BOTH of
+ * `ValueDataSource`'s routes, where a bare `null` said "only an explicit null"
+ * on the plain-object route and "no constraint at all" on the AST route.
+ *
+ * ⚠️ Known BOUNDARY, unchanged by this and deliberately not widened: the drill
+ * "escape hatch" (the host's `openRecordList`, which serializes a drill filter
+ * into `filter[...]` URL params) has NO spelling for is-null — its operator
+ * vocabulary is equality plus four range bounds — so it drops this condition
+ * exactly as it already dropped the bare `null`, byte-for-byte the same query
+ * string. That surface is a superset today and stays one; closing it needs a
+ * URL-dialect operator on both the write and the read side, which is its own
+ * card.
  *
  * A time-bucketed date dimension (#1752) drills by RANGE, not equality — a
  * humanized bucket ("2026-Q2") can't be exact-matched, so the server sends a
@@ -544,7 +584,12 @@ export function buildDatasetDrillFilter(
   const drillFilter: Record<string, unknown> = {};
   for (const d of drillDims) {
     const raw = rawRow?.[d];
-    drillFilter[dimensionFields[d]] = raw === '' || raw === undefined ? null : raw;
+    // `null` is in this test, not only `''` / `undefined`: JSON cannot carry
+    // `undefined`, so a SQL NULL grouped value arrives over the wire AS `null`
+    // — it is the empty bucket's most common shape, and leaving it out would
+    // fix the defect for the spellings the wire rarely uses.
+    drillFilter[dimensionFields[d]] =
+      raw === '' || raw === null || raw === undefined ? { $null: true } : raw;
   }
   if (rawRanges) {
     for (const r of Object.values(rawRanges)) {

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.chartBucketIdentity.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.chartBucketIdentity.test.tsx
@@ -210,7 +210,10 @@ describe('DatasetWidget — a bucket drills to ITS OWN rows (objectui#4508)', ()
     expect(chartRows()[1]).toEqual({ owner_name: NULL_CATEGORY_LABEL, deals: 3 });
 
     clickBar(1);
-    await waitFor(() => expect(lastFilter()).toEqual({ owner_id: null }));
+    // objectui#9085: the empty bucket's is-empty predicate, not a bare `null`
+    // the converter would drop. What this BOUNDARY case pins is unchanged —
+    // that the null bucket drills by the OWNER FIELD at all.
+    await waitFor(() => expect(lastFilter()).toEqual({ owner_id: { $null: true } }));
   });
 
   it('BOUNDARY — an ordinary category drills by its stored id, rows untouched', async () => {
@@ -252,6 +255,7 @@ describe('DatasetWidget — a bucket drills to ITS OWN rows (objectui#4508)', ()
 
     await waitFor(() => expect(chartRows().length).toBe(2));
     capturedChartProps.onSegmentClick({ category: NULL_CATEGORY_LABEL });
-    await waitFor(() => expect(lastFilter()).toEqual({ owner_id: null }));
+    // objectui#9085 spelling; the identity-free fallback path itself is unchanged.
+    await waitFor(() => expect(lastFilter()).toEqual({ owner_id: { $null: true } }));
   });
 });

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.drillTitleLabel.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.drillTitleLabel.test.tsx
@@ -193,7 +193,10 @@ describe('DatasetWidget — the drill title reads the series LABEL (objectui#468
     await waitFor(() => expect(drawerProps.length).toBeGreaterThan(0));
     // The KEY did the lookup — the right records, which is what objectui#4673
     // already guaranteed and what must not move…
-    expect(lastDrawer().filter).toEqual({ status_id: 'st-backlog', priority_id: null });
+    // objectui#9085: the empty `priority` dimension carries the is-empty
+    // predicate; the identity-keyed `status` half is untouched, which is what
+    // this test is about.
+    expect(lastDrawer().filter).toEqual({ status_id: 'st-backlog', priority_id: { $null: true } });
     // …and the TITLE reads the label. Pre-fix: 'Backlog / [null]'.
     expect(lastDrawer().title).toBe(`Backlog / ${NULL_CATEGORY_LABEL}`);
     expect(lastDrawer().title).not.toContain('[null]');

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.nullCategoryI18n.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.nullCategoryI18n.test.tsx
@@ -190,7 +190,9 @@ describe('DatasetWidget — the null-category bucket reads the locale bundle (ob
     await waitFor(() => expect(drillFilters.length).toBeGreaterThan(0));
     // Index 1 of `drillRawRows`: an explicit "is empty" filter on the OBJECT
     // field, never the display label and never Ada's row.
-    expect(drillFilters[drillFilters.length - 1]).toEqual({ owner_id: null });
+    // objectui#9085 spelling. The PAIRING this test measures — that the
+    // localized bucket bar drills to ITS row — is unchanged.
+    expect(drillFilters[drillFilters.length - 1]).toEqual({ owner_id: { $null: true } });
   });
 
   it('BOUNDARY — the non-null group is byte-identical', async () => {

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.tablePolish.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.tablePolish.test.tsx
@@ -219,7 +219,8 @@ describe('objectui#5827 — the empty dimension bucket sorts last', () => {
     // …and the blank bucket, now last, still drills to "is empty".
     fireEvent.click(bodyRows()[2]);
     await waitFor(() =>
-      expect(drillFilters[drillFilters.length - 1]).toEqual({ industry: null }),
+      // objectui#9085 spelling; the sorted-row identity this test pins is unchanged.
+      expect(drillFilters[drillFilters.length - 1]).toEqual({ industry: { $null: true } }),
     );
   });
 });

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.tableTotalsRow.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.tableTotalsRow.test.tsx
@@ -309,7 +309,8 @@ describe('objectui#5846 — the totals row is outside the sortable rows', () => 
     expect(drillFilters[drillFilters.length - 1]).toEqual({ industry: 'fin' });
 
     fireEvent.click(bodyRows()[2]);
-    await waitFor(() => expect(drillFilters[drillFilters.length - 1]).toEqual({ industry: null }));
+    // objectui#9085 spelling; the (row, index) pairing this test pins is unchanged.
+    await waitFor(() => expect(drillFilters[drillFilters.length - 1]).toEqual({ industry: { $null: true } }));
   });
 
   it('keeps the totals row OUT of the CSV, as the cross-tab already does', async () => {

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
@@ -444,9 +444,18 @@ describe('DatasetWidget', () => {
     ).toEqual({ archived: false, status: 'open', priority: 'high' });
   });
 
-  it('buildDrillFilter normalizes a missing/empty raw value to null', () => {
-    expect(buildDrillFilter({ status: '' }, ['status'], { status: 'status' })).toEqual({ status: null });
-    expect(buildDrillFilter(undefined, ['status'], { status: 'status' })).toEqual({ status: null });
+  // objectui#9085: an empty bucket used to normalize to a bare `null`, which
+  // `convertFiltersToAST` SKIPS — so the constraint never reached the wire and
+  // the drill answered with every row. The is-empty spelling the converter
+  // carries end to end is `{ $null: true }` -> `[field, 'is_null', true]`. The
+  // row-set consequence is pinned in `@object-ui/core`'s
+  // `dataset-drill-empty-bucket-9085.test.ts`; this is the producer's own shape.
+  it('buildDrillFilter normalizes a missing/empty raw value to an is-empty predicate', () => {
+    expect(buildDrillFilter({ status: '' }, ['status'], { status: 'status' })).toEqual({ status: { $null: true } });
+    expect(buildDrillFilter(undefined, ['status'], { status: 'status' })).toEqual({ status: { $null: true } });
+    // `null` is in the same class: JSON cannot carry `undefined`, so a SQL NULL
+    // grouped value arrives over the wire AS `null`.
+    expect(buildDrillFilter({ status: null }, ['status'], { status: 'status' })).toEqual({ status: { $null: true } });
   });
 
   // ── #1752 date-bucket RANGE drill ────────────────────────────────────────


### PR DESCRIPTION
Fixes #9085

Session `session_01UzHd6hDYatoDn17BuwKxnZ`, with Claude Code. Measured on `origin/main` `67917170d`.

## What the empty bucket MEANS — settled before a spelling was written

A drill must return exactly the rows the clicked bucket **counted**. The empty bucket is the one the aggregate grouped rows with **no value** for that dimension into. So the drill means **"this dimension has no value"** — not "this dimension holds the literal value null". Those are two different row sets, and the difference is measured, not asserted: against `ValueDataSource`'s matcher over rows `alice` / explicit-`null` / **key absent entirely**,

| spelling | rows selected |
|---|---|
| `[owner, is_null, true]` — what `{ $null: true }` lowers to | explicit-null **and** key-absent |
| equality against `null` | explicit-null only |

The bucket counted both, so is-null is the spelling that agrees with the number the user clicked. Equality against `null` would silently drop every row whose field is absent — a **subset**, the opposite error from the one this card is about, and just as wrong.

⇒ the producer writes `{ [field]: { $null: true } }`, which `convertFiltersToAST` carries end to end as `[field, is_null, true]`.

**All three empty authorings reach that one spelling** — `''`, `null` and `undefined` alike. `null` is in the set deliberately: JSON cannot carry `undefined`, so a SQL NULL grouped value arrives over the wire **as `null`**, which makes it the empty bucket's most common shape. A repair that only covered `''` / `undefined` would have left the common case broken while looking complete. The three are not told apart because the server already merged them into the single bucket the user clicked; there is no second bucket here for a second spelling to address.

⛔ `convertFiltersToAST` is **not touched**. Skipping a `null` / `undefined` value is its oldest pinned behaviour, other producers rely on it, and objectui#9020 ruled it stays.

## The three shapes, re-measured on today's tree as ROW SETS

Not as the composed object's shape: the defect is invisible there (`{ owner: null }` looks like a filter) and only becomes wrong one layer down. Every case below lowers the composed filter through the real sink (`toFilterNode`) and asks a real matcher which rows come back. Fixture: `won/alice`, `won/null`, `won/`(no owner key), `lost/null`, `lost/bob`.

| shape | before | after | correct answer |
|---|---|---|---|
| two drill dims, one empty | `won/alice`, `won/null`, `won/` | `won/null`, `won/` | `won/null`, `won/` |
| one drill dim + runtime filter | `won/alice`, `won/null`, `won/` | `won/null`, `won/` | `won/null`, `won/` |
| one drill dim, no runtime filter | **every row (all five)** | `won/null`, `won/`, `lost/null` | `won/null`, `won/`, `lost/null` |

**Live controls in the same run**, same KIND as the subject, pre-existing, and untouched by the change (neither reaches the empty-value branch):

- a **non-empty** bucket drill is unchanged — composes `{ owner: alice }` and selects `won/alice` only;
- a drill **with a runtime filter still carries it** — `{ stage: lost, owner: bob }` selects `lost/bob`, and dropping the runtime filter widens the answer to two rows, so the filter is a real constraint in that assertion and not decoration;
- a date-bucket **range** drill is unchanged.

## The dispatch's mechanism assumptions, re-derived rather than inherited

**1. objectui#9020 has landed — CONFIRMED, and it matters.** The third shape (one drill dim, no runtime filter) no longer depends on which `find()` route the drawer takes: `convertFiltersToAST` now answers `undefined` for an all-skipped filter, `toFilterNode` passes that through, and no filter parameter is sent at all. Measured before the repair: **every row**, deterministically. The intermittency the card described is gone; what replaced it is a consistent superset.

**2. The three consumers — PARTLY FALSIFIED, and this is the important one.** Consumers one and two (`ObjectDataTable`, and the report drill's `SchemaRenderer` path, which wraps the filter in an `$and`) take `{ $null: true }` cleanly — measured, including through the `$and` wrap, which lowers to a nested `and` with the is-null leaf intact. The **third**, the navigation host, was the one the card never measured, and it does **not** take it — but neither did it take the bare `null`:

The escape hatch (`openRecordList`, which serializes a drill filter into `filter[...]` URL params) has **no is-null operator in its dialect at all**. Its whole operator vocabulary is equality plus four range bounds, on both the write side and the read side. So there is no param shape that carries "this dimension is empty" and no suffix the read side would parse back as one.

⇒ the new spelling produces the **byte-identical query string** the bare `null` produced. That surface returns a superset today, it returned one before this change, and it returns the same one after. **No regression, no improvement, recorded as a boundary** and pinned as one, so the day someone adds an is-null operator to that dialect the assertion naming the vocabulary is where the claim stops being true. Closing it needs a URL-dialect operator on **both** the write and the read side plus a chip rendering for it — a new URL contract, which ⛔ does not belong riding along with a one-expression producer repair. Filed separately as objectui#9159.

**3. "14 assertions pin the bare-null spelling" — FALSIFIED. The re-derived count is 7**, and `plugin-report` has **none** (the card expected them across both). All seven are in `plugin-dashboard`. Enumerated by running the suites and reading the failures, not by grep:

- `DatasetWidget.test.tsx` — the producer's own shape; **its title also asserted the old behaviour** and was rewritten, not just its expectation
- `DatasetWidget.chartBucketIdentity.test.tsx` — two null-bucket drill assertions
- `DatasetWidget.drillTitleLabel.test.tsx`, `DatasetWidget.nullCategoryI18n.test.tsx`, `DatasetWidget.tableTotalsRow.test.tsx`, `DatasetWidget.tablePolish.test.tsx` — one each

Each moved because **what it says changed**, and each keeps saying what it was written to say: the identity-keyed half, the (row, index) pairing, the localized-bucket pairing and the sorted-row identity are all untouched — only the empty dimension's value moved. Every one of the seven is proven still able to fail below.

## Ablation — the pins can fail

Mutate the producer back to the bare `null`, **prove the mutation on disk before the run**, run, restore, **prove the restore by state**. Never by an exit code.

```
HEAD blob               = d81fc35e0001799d402a939ba5458060e3141f66
BEFORE    fixed text 1 / broken text 0   blob d81fc35e0001799d402a939ba5458060e3141f66
MUTATED   fixed text 0 / broken text 1   blob 0ec8df4bc421533400905938849771a18c9e8e52   (hash moved)
RUN       Test Files 8 failed (8) · Tests 15 failed | 103 passed (118)   exit 1
RESTORED  fixed text 1 / broken text 0   blob d81fc35e0001799d402a939ba5458060e3141f66 == HEAD blob
          git diff HEAD --stat = [] (empty)
```

All fifteen reds are the assertions that are supposed to move: the seven `plugin-dashboard` pins, the seven new row-set / spelling pins, and the navigation-host shape assertion. The run's exit code was captured **by redirect before any pipe**. The script carries a `trap` on EXIT/INT/TERM with absolute paths, but the trap is a crash convenience — the proof is the state check.

## Verification

Run at `358fe3123`, heavy runs serialized through the shared container verify lock.

| what | result |
|---|---|
| affected suites — `packages/core/`, `packages/plugin-dashboard/`, `packages/plugin-report/`, `queryDataset.test.ts`, the two nav-host test files | `Test Files 279 passed (279)` · `Tests 4374 passed (4374)` · lock VERDICT `command-exit 0` |
| `turbo run type-check` for `@object-ui/core`, `@object-ui/plugin-dashboard`, `@object-ui/app-shell` | `32 successful, 32 total` |
| `turbo run lint` for the same three | `4 successful, 4 total`, zero errors, zero findings on the changed files |
| `check-changeset-presence` | pass — 1 changeset declared |
| `check-changeset-no-major`, `check-control-bytes`, `check:new-line-citations` (0 new), `check:changeset-claims` | all exit 0 |
| `check-governed-queue-guard --test` on the five changed paths | `NOT GOVERNED` |

**Scope narrowing, declared.** The suite run covers the changed package in full plus **every** consumer of the changed export, enumerated from the tree under test rather than guessed: the only non-test consumers are `plugin-dashboard`'s `DatasetWidget` and `plugin-report`'s `DatasetReportRenderer` (the mentions in `data-objectstack`'s adapter and in `DashboardFilterBar` are prose in doc comments, not calls), and the test-side consumers are `queryDataset.test.ts`, two `plugin-dashboard` suites and the new `app-shell` file. `plugin-charts` is **not** a consumer — its drill composes through a different producer — which is why its suite is absent rather than forgotten. Repo-wide `pnpm test` and repo-wide `pnpm lint` are CI's runs.

## Acceptance notes

**Filed as objectui#9159** — the drill escape hatch's `filter[...]` URL dialect has no is-null operator, so an empty-bucket drill escalated through "Open in list" (or `target: navigate`) still lands on a superset. Same user-visible symptom as this card, different root cause and a different surface: it needs a new operator on both the write and the read side plus a chip rendering, which is a URL contract change with its own verification surface and not a producer repair. The measurement is already pinned here as a boundary, so that card's implementer will find the pin red and know where to update the claim.

**Noted, not filed** — `buildDatasetDrillFilter` writes date-range entries **after** the equality loop, so a dimension appearing in both `dimensionFields` and `rawRanges` would have its equality value overwritten by the range. Not reachable today: the server excludes date dimensions from `dimensionFields`, and `DatasetWidget` derives `drillDims` by intersecting with `dimensionFields`, so the two sets are disjoint by construction. An ordering observation, not a defect — no probe fails. Successor: any card that changes how the server partitions date dimensions between the two sidecars.

**Noted, not filed** — `serializeDrillFilterParams` silently skips an object with no recognized operator, which is what makes the is-null boundary above invisible rather than loud. Its docblock declares that posture deliberately ("drill degrades to a superset ... rather than stringified"), so this is a ruled trade-off, not a defect. Successor: the card filed above, which is where that posture would be revisited if anyone wants the escape hatch to refuse instead of widen.

## Delivery

Draft, per dispatch. ⛔ Not flipped ready, ⛔ no auto-merge, ⛔ not enqueued. `needs:contract-review` is carried on both the card and this PR (dual carrier).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_