### PR TITLE
fix(components): header-bar's rightContent slot stops leaking a falsy number

### DIFF
--- a/.changeset/9033-header-bar-right-content-numeric-falsy.md
+++ b/.changeset/9033-header-bar-right-content-numeric-falsy.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/components': patch
+---
+
+`ui:header-bar` no longer paints a stray `"0"` beside the header chrome when
+`rightContent` is authored as a falsy number (objectui#9033).
+
+`HeaderBarSchema.rightContent` is declared `SchemaNode` on both published faces — the
+interface in `@object-ui/types`, and its Zod mirror, whose node union carries a `z.number()`
+arm — so `0` is an authorable value for the slot. The renderer guarded it with an `&&` chain
+whose left operand is the raw slot value, and with `rightContent: 0` that chain evaluates to
+the **number** `0`, which React renders. Measured: `{ type: 'header-bar', title: 'H',
+rightContent: 0 }` painted `"Toggle Sidebar0"`.
+
+This is the numeric-falsy JSX trap objectui#8331 measured and closed one slot over on
+`DataTableSchema.emptyAction`, and the fix is that same shape rather than a second one: the
+`&&` chain becomes a ternary yielding `null`. The **truthiness** leg stays rather than
+becoming nullish. Both land on the same rendering today — since objectui#8908
+`toRenderableSchema` maps a falsy primitive onto nothing rather than onto its `String` form
+— so the choice is about which rule the slot states, and truthiness is the rule that keeps
+this slot's answer independent of the bridge. That independence is exactly what kept the
+sibling slot out of the defect while the bridge was wrong.
+
+Narrower than it may read, and stated precisely so the repair is not judged by the wrong
+row: only the falsy **numbers** leaked. `0` and `-0` painted the character `0`, `NaN` painted
+the three characters `NaN`. `false` and `''` were already correct — React ignores `false` as
+a child — and cannot discriminate the two worlds.
+
+Adjacent but **not** this defect: objectui#8908 repaired the bridge so a falsy primitive
+renders nothing. That repair does not reach this line and never could, because `&&`
+short-circuits and the chain produces the raw `0` before any bridge is called. Same symptom,
+different mechanism.
+
+The declaration is untouched — objectui#7105 ruled node slots relax the renderer rather than
+narrow the declaration, and a `typeof === 'object'` test here would silently drop a bare
+string the slot renders as its own text.
+
+Scored `patch`: no new capability, a slot that painted a character it was never asked to
+paint stops painting it.

--- a/packages/components/src/__tests__/header-bar-right-content-numeric-falsy.test.tsx
+++ b/packages/components/src/__tests__/header-bar-right-content-numeric-falsy.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ui:header-bar`'s `rightContent` slot no longer leaks a stray `"0"`
+ * (objectui#9033) — the numeric-falsy JSX trap objectui#8331 measured and
+ * closed one slot over on `DataTableSchema.emptyAction`.
+ *
+ * ## The mechanism, and why it is not objectui#8908
+ *
+ * `HeaderBarSchema.rightContent` is declared `SchemaNode` on BOTH published
+ * faces — the interface in `@object-ui/types`, and its zod mirror, whose node
+ * union carries a `z.number()` arm — so `0` is an authorable value for it.
+ * `theValidatorAcceptsZero` below asserts that from the published validator
+ * rather than asserting it in prose, because every row here is worthless if
+ * the value is unreachable.
+ *
+ * The renderer guarded the slot with an `&&` chain whose left operand is the
+ * raw slot value. With `rightContent: 0` that chain evaluates to the NUMBER
+ * `0`, and React renders numbers — so the header painted a stray `"0"`.
+ *
+ * objectui#8908 repaired `toRenderableSchema` so a falsy primitive becomes
+ * nothing rather than its `String` form. That repair does ⛔ NOT reach this
+ * line and never could: `&&` short-circuits, so the bridge is not called at
+ * all for a falsy value — the chain has already produced the raw `0` before
+ * any bridge runs. Same symptom from the user's seat, different mechanism,
+ * different fix. `theBridgeIsNotWhatFixesThis` pins that distinction directly
+ * so a future reader cannot conclude the bridge covers this slot.
+ *
+ * ## Why `false` and `''` are present but are ⛔ NOT evidence
+ *
+ * React ignores `false` as a child, and `''` contributes no characters. Both
+ * rows were GREEN before the repair and are green after it, so neither can
+ * discriminate the two worlds. They sit in `rowsThatCannotDiscriminate` under
+ * that name, kept only so a later reader does not "extend coverage" by adding
+ * them as if they proved something.
+ *
+ * The rows that DO discriminate are the falsy NUMBERS, and only they:
+ * `0` and `-0` (both of which React prints as the single character `0`) and
+ * `NaN` (which prints the three characters `NaN`).
+ *
+ * ## Why the assertions read whole text rather than query for a node
+ *
+ * The leak is a bare text node with no element of its own — there is nothing
+ * to `querySelector`. The instrument is therefore the header's entire
+ * `textContent`, compared against the baseline the same harness produces for
+ * `rightContent: undefined`. `theInstrumentSeesSlotText` is the lit control on
+ * that instrument: with `rightContent: 42` the text MUST grow by `42`, so a
+ * "no stray characters" row cannot pass because the instrument went blind.
+ *
+ * ## The `SidebarProvider` host
+ *
+ * `header-bar` renders `SidebarTrigger`, which calls `useSidebar()` and THROWS
+ * without a provider. A caught throw renders markup that reads as a clean pass
+ * for every row below, so `theHarnessRendersTheRealHeader` asserts the real
+ * header is mounted rather than assuming it.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Registered at module scope, NOT in a `beforeAll`: there the cold transform is
+// billed to `hookTimeout`, which is narrower than the timeout it replaces
+// (objectui#3010 / #3021, and `object-ui/no-dynamic-import-in-test-hook`).
+import '../renderers';
+import { SidebarProvider } from '../ui';
+import { toRenderableSchema } from '@object-ui/react';
+import { HeaderBarSchema as HeaderBarSchemaZod } from '@object-ui/types/zod';
+
+afterEach(() => cleanup());
+
+/** The header's own chrome text, contributed by `SidebarTrigger`'s sr-only label. */
+const CHROME = 'Toggle Sidebar';
+
+function renderRightContent(rightContent: unknown) {
+  const C = ComponentRegistry.get('header-bar') as React.ComponentType<any>;
+  const { container } = render(
+    <SidebarProvider>
+      <C schema={{ type: 'header-bar', title: 'H', rightContent }} />
+    </SidebarProvider>,
+  );
+  const header = container.querySelector('header');
+  if (!header) throw new Error('no <header> — the harness did not mount the real renderer');
+  return header.textContent ?? '';
+}
+
+/** `rightContent` omitted entirely: the chrome, and nothing else. */
+function renderBaseline() {
+  const C = ComponentRegistry.get('header-bar') as React.ComponentType<any>;
+  const { container } = render(
+    <SidebarProvider>
+      <C schema={{ type: 'header-bar', title: 'H' }} />
+    </SidebarProvider>,
+  );
+  const header = container.querySelector('header');
+  if (!header) throw new Error('no <header> — the harness did not mount the real renderer');
+  return header.textContent ?? '';
+}
+
+describe('ui:header-bar rightContent numeric-falsy leak (objectui#9033)', () => {
+  describe('harness controls', () => {
+    it('theHarnessRendersTheRealHeader — a real <header>, not error-boundary markup', () => {
+      // `useSidebar()` throws without `SidebarProvider`, and the caught throw is
+      // clean markup that would make every "no stray characters" row below pass
+      // for entirely the wrong reason.
+      expect(renderBaseline()).toContain(CHROME);
+    });
+
+    it('theBaselineIsTheChromeAlone', () => {
+      expect(renderBaseline()).toBe(CHROME);
+    });
+
+    it('theInstrumentSeesSlotText — LIT CONTROL: a truthy number DOES reach the text', () => {
+      // Green in both worlds BY DESIGN. Without it, a slot that rendered
+      // nothing at all — or a `textContent` read that stopped working — would
+      // make every leak row below green while measuring nothing.
+      expect(renderRightContent(42)).toBe(`${CHROME}42`);
+    });
+
+    it('theValidatorAcceptsZero — the leaked value is AUTHORABLE, not hypothetical', () => {
+      // The published zod face for this slot is `SchemaNodeSchema.optional()`,
+      // and that union carries a `z.number()` arm. If this row ever goes red the
+      // slot stopped admitting numbers and the rows below stopped being about
+      // anything — ⛔ that is a declaration change, not a licence to delete them
+      // (objectui#7105: node slots relax the RENDERER).
+      const parsed = HeaderBarSchemaZod.safeParse({ type: 'header-bar', title: 'H', rightContent: 0 });
+      expect(parsed.success).toBe(true);
+    });
+  });
+
+  describe('the falsy NUMBERS — the only rows that discriminate', () => {
+    it('rightContent: 0 renders the chrome and no stray "0"', () => {
+      // RED before the repair: `"Toggle Sidebar0"`.
+      expect(renderRightContent(0)).toBe(CHROME);
+    });
+
+    it('rightContent: -0 renders the chrome and no stray "0"', () => {
+      // React prints `-0` as the single character `0`, same as `0`.
+      expect(renderRightContent(-0)).toBe(CHROME);
+    });
+
+    it('rightContent: NaN renders the chrome and no stray "NaN"', () => {
+      // The loudest row of the three: `NaN` paints three characters, not one.
+      expect(renderRightContent(NaN)).toBe(CHROME);
+      expect(renderRightContent(NaN)).not.toContain('NaN');
+    });
+  });
+
+  describe('live controls — unchanged by the repair, asserted in the SAME run', () => {
+    it('rightContent: 42 still renders 42', () => {
+      expect(renderRightContent(42)).toBe(`${CHROME}42`);
+    });
+
+    it("rightContent: 'txt' still renders txt", () => {
+      expect(renderRightContent('txt')).toBe(`${CHROME}txt`);
+    });
+
+    it('rightContent: undefined renders the baseline chrome only', () => {
+      expect(renderRightContent(undefined)).toBe(CHROME);
+    });
+
+    it('an authored NODE still renders — the slot is still a node slot', () => {
+      // The repair must not have narrowed the slot to primitives-only.
+      expect(renderRightContent({ type: 'text', content: 'node' })).toContain('node');
+    });
+  });
+
+  describe('rowsThatCannotDiscriminate — ⛔ green before the repair too, kept only to say so', () => {
+    it('rightContent: false was ALREADY correct — React ignores `false` as a child', () => {
+      expect(renderRightContent(false)).toBe(CHROME);
+    });
+
+    it("rightContent: '' was ALREADY correct — an empty string contributes no characters", () => {
+      expect(renderRightContent('')).toBe(CHROME);
+    });
+  });
+
+  describe('the mechanism, pinned so it is not confused with objectui#8908', () => {
+    it('theBridgeIsNotWhatFixesThis — `toRenderableSchema` already mapped 0 onto nothing', () => {
+      // The bridge has been behaviour-preserving for falsy primitives since
+      // objectui#8908. It was ALREADY correct while this slot leaked, because
+      // `&&` short-circuits and never calls it for a falsy value. So a reader
+      // who finds the bridge correct must ⛔ not conclude this slot is covered:
+      // the guard shape is what covers it.
+      expect(toRenderableSchema(0)).toBeUndefined();
+      expect(toRenderableSchema(NaN)).toBeUndefined();
+      expect(toRenderableSchema(42)).toBe('42');
+    });
+  });
+});

--- a/packages/components/src/renderers/navigation/header-bar.tsx
+++ b/packages/components/src/renderers/navigation/header-bar.tsx
@@ -124,7 +124,41 @@ ComponentRegistry.register('header-bar',
         {schema.actions?.map((action, idx) => (
           <SchemaRenderer key={idx} schema={toRenderableSchema(action)} />
         ))}
-        {schema.rightContent && <SchemaRenderer schema={toRenderableSchema(schema.rightContent)} />}
+        {/* The numeric-falsy JSX trap. `HeaderBarSchema.rightContent` is
+            declared `SchemaNode` on both published faces — the interface in
+            `@object-ui/types` and its zod mirror, whose node union carries a
+            `z.number()` arm — so `0` is an AUTHORABLE value here. The `&&`
+            chain this replaced evaluated to the number `0` itself, and React
+            renders numbers, so `{ type: 'header-bar', rightContent: 0 }`
+            painted a stray "0" beside the header chrome. A ternary yields
+            `null` instead. Byte-for-byte the shape objectui#8331 measured and
+            settled one slot over on `DataTableSchema.emptyAction`; ⛔ not a
+            second shape for the same trap.
+
+            ⚠️ `false` and `''` were ALREADY correct — React ignores `false` as
+            a child and `''` paints nothing — so neither can tell the two
+            worlds apart. Only the falsy NUMBERS discriminate: `0`, `-0`, and
+            `NaN`, which painted the three characters "NaN".
+
+            The TRUTHINESS leg stays; ⛔ it is not swapped for a nullish one.
+            Both land on the same rendering today — since objectui#8908
+            `toRenderableSchema` maps a falsy primitive onto nothing rather
+            than onto its `String` form — so the choice is about which rule
+            this slot STATES, and truthiness is the rule that makes the slot's
+            answer independent of the bridge. That independence is exactly what
+            kept the sibling slot out of the defect while the bridge was wrong,
+            and objectui#8331 kept the leg for that reason rather than letting
+            it vanish as tidying.
+
+            ⛔ Do not narrow the declaration to close this: objectui#7105 ruled
+            node slots RELAX THE RENDERER. A `typeof === 'object'` test here
+            would silently drop a bare string, which this slot renders as its
+            own text.
+
+            Pinned in `header-bar-right-content-numeric-falsy.test.tsx`. */}
+        {schema.rightContent ? (
+          <SchemaRenderer schema={toRenderableSchema(schema.rightContent)} />
+        ) : null}
       </div>
     </header>
   ),


### PR DESCRIPTION
Fixes #9033

`{ type: 'header-bar', title: 'H', rightContent: 0 }` painted `"Toggle Sidebar0"`. It now paints `"Toggle Sidebar"`.

The slot was guarded by an `and-and` chain whose left operand is the raw slot value. `HeaderBarSchema.rightContent` is declared `SchemaNode` on both published faces, so `0` is authorable; the chain then evaluates to the **number** `0`, and React renders numbers. The chain becomes a ternary yielding `null` — byte-for-byte the shape objectui#8331 measured and settled one slot over on `DataTableSchema.emptyAction`, not a second shape for the same trap.

(This body spells JSX-guard operators as `and-and` in prose on purpose: the literal characters render as markup here.)

## The three mechanism assumptions, re-derived on today's tree

The tree moved after the card was written, so none of these is inherited.

**1. Is this still the only instance the card's grep finds?** Yes — `git grep -n '&& .*toRenderableSchema'` returns exactly one line, the `header-bar` `rightContent` line. Count unchanged at 1. ⚠️ But see the census below: that grep is scoped to the `toRenderableSchema` **spelling** of the right operand, and the trap does not depend on it. **Falsified as a statement about the trap**, confirmed as a statement about that grep.

**2. Does objectui#8908's bridge repair reach this line?** No, and it never could. `toRenderableSchema` already maps `0` and `NaN` onto `undefined` — asserted directly in this PR's pin, in the same run as the leak rows, under the name `theBridgeIsNotWhatFixesThis`. The bridge was **already correct while this slot leaked**, because `and-and` short-circuits and never calls it for a falsy value. Confirmed: two defects, one symptom, different mechanisms.

**3. Is the leak specific to falsy numbers?** Confirmed by ablation, which reproduces the card's table exactly on today's tree. Under the reverted guard, three rows and only three rows go red:

```
rightContent: 0     expected "Toggle Sidebar"  received "Toggle Sidebar0"
rightContent: -0    expected "Toggle Sidebar"  received "Toggle Sidebar0"
rightContent: NaN   expected "Toggle Sidebar"  received "Toggle SidebarNaN"
```

`false` and `''` stayed **green under the mutation**. They were correct before the change and cannot discriminate the two worlds, so they are pinned under the name `rowsThatCannotDiscriminate` and are ⛔ not counted as evidence — kept only so a later reader does not "extend coverage" by adding them as if they proved something.

## Which rule the slot states: truthiness, not nullish

The card named one genuinely open sub-question. **Truthiness stays.**

Both spellings land on the same rendering today — since objectui#8908 the bridge is behaviour-preserving for falsy primitives, so a nullish gate would also be correct, and a bare `''` renders nothing either way. So this is not a behaviour choice; it is a choice of which rule the slot **states**. Three reasons for truthiness:

1. The ruling is to port objectui#8331's shape, and that shape is a truthiness ternary. A nullish gate would be a second shape for one trap — the thing the ruling exists to prevent.
2. objectui#8331's own comment records why it kept the leg rather than letting it vanish as tidying: truthiness is what makes the slot's answer **independent of the bridge**, and that independence is exactly what kept the sibling slot out of the defect during the window when the bridge was wrong.
3. The slot that gates on nullish instead — the shipped `empty` renderer's `action` — is the one that printed a stray `0` through that window. The negative result is already on the record.

## ⭐ The census — and the answer is NOT "all `SchemaNode` slots are now guarded"

Triage asked for one of two sentences. Neither is available honestly, and the census is why.

**Instrument**: the TypeScript checker, not a grep. For every JSX guard `{X and-and …}`, ask `getTypeAtLocation(X)` whether the type admits `number`.

- **Population**: 816 non-test `.tsx` files under `packages/` and `apps/`, enumerated with `git ls-files`; **2396** JSX `and-and` guards in them; **2396** left operands across those guards (a chain contributes one operand per link).
- **Reported**: **66** operands whose checker type admits `number`. Of those, **14** are typed `SchemaNode` / `SchemaNode | SchemaNode[]`.
- **Control (must fire)**: `header-bar.tsx`'s `rightContent` — the one site already known to leak. **It fired.** A zero from an instrument with no lit control is not a reading.
- **Indeterminate, listed rather than counted clean**: **53** operands typed `any` / `unknown`. They carry no numeric type flag, so a flag-based census is blind to them; reporting them as clean would have been the census lying in the quiet direction. `overlay/drawer.tsx`'s `footer` sits in this bucket — and it leaks.

**Eleven of the other sites were then measured, not inferred**, through the real renderer stack, each row carrying its own lit control (the same slot given `42`, which must reach the text or the row reports NOT MEASURED):

```
renderer   slot      verdict
container  children  LEAK    baseline=[] with-0=[0]
flex       children  LEAK    baseline=[] with-0=[0]
grid       children  LEAK    baseline=[] with-0=[0]
stack      children  LEAK    baseline=[] with-0=[0]
card       header    LEAK    baseline=[] with-0=[0]
card       body      LEAK    baseline=[] with-0=[0]
card       children  clean   (control fired: with-42=[42])
card       footer    LEAK    baseline=[] with-0=[0]
dialog     footer    LEAK    baseline=[Close] with-0=[0Close]
sheet      footer    LEAK    baseline=[Close] with-0=[0Close]
drawer     footer    LEAK    baseline=[] with-0=[0]
table      footer    LEAK    baseline=[H] with-0=[H0]
```

⚠️ The instrument had to be repaired mid-census and the repair is worth recording: the first pass read the render container only, and Radix overlays **portal out of it**, so `dialog`, `sheet` and `drawer` all read "clean". Three real leaks presenting as a clean reading. The per-renderer lit control is what caught it.

⚠️ `card` `children` is the single clean row, and **it is clean by accident, not by a guard**: that site reads `(schema.children || schema.body)`, and `0 || undefined` is `undefined`. Author `body: 0` on the same renderer and the same chain evaluates to `0` — which is the `card body` row two lines above it.

⇒ **The census sentence is: eleven more `SchemaNode` slots carry this trap, they cannot be dismissed as unable to carry a numeric — the published zod node union has a `z.number()` arm, so every one of them accepts `0` — and they are not fixed here.** Filed as objectui#9162 with the full table, the population, the control, and the class-level question the count raises (eleven per-site ternaries, or one shared node-slot guard).

Not folded into this pull request on purpose: the dispatch named this exact outcome as a stop condition — report the list, fix the one line the card is about, do not silently widen. Eleven renderers across four files plus a remedy question is not a reviewable diff on a one-line card.

## Evidence

**Pin** — `pnpm exec vitest run packages/components/src/__tests__/header-bar-right-content-numeric-falsy.test.tsx` → `Test Files 1 passed (1) · Tests 14 passed (14)`, verify-lock `VERDICT command-exit 0`.

**Affected package** — `pnpm exec vitest run packages/components/` → `Test Files 263 passed (263) · Tests 2400 passed (2400)`, verify-lock `VERDICT command-exit 0`.

**Types** — `pnpm --filter @object-ui/components type-check` → exit 0. That script is `tsc --noEmit && tsc -p tsconfig.test.json`, and the test project globs `src/**/*.test.tsx`, so the new pin is compiled and not silently excluded.

**Dependency closure** — `pnpm --filter '@object-ui/components^...' build` → exit 0, 8 of 47 projects.

**Lint** — `pnpm --filter @object-ui/components lint` → exit 0 (`0 errors, 950 warnings`, all pre-existing `no-explicit-any` / `react-refresh` warnings; the two new ones on the pin are the `ComponentRegistry.get(…) as ComponentType` cast the sibling `header-bar` suite already uses). This is the whole affected package, ⛔ not a narrowed subset, so there is no narrowing to declare. The repo-wide `turbo run lint` across all 47 projects is CI's run.

**Gates** — `check:new-line-citations` printed `VERDICT new-cross-file-line-citations: 0 new citation(s)` (exit 0); `check:control-bytes` OK over 7358 tracked text files (exit 0); `check:changeset-claims` exit 0; `check:published-tsconfig-exclude` exit 0; `check-changeset-presence.mjs` exit 0 — `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`; `check-changeset-no-major.mjs` exit 0; `check-governed-queue-guard.mjs --test` → `NOT GOVERNED — 3 path(s) checked against 5 governed surface(s)`. Every exit code captured by redirect before any pipe.

**Ablation — the pins can fail.** Mutation: the ternary reverted to the `and-and` chain, byte-for-byte as it stood on the parent commit.

- *Proved on disk BEFORE the run, both directions plus the blob hash*: occurrences of the ternary `1 → 0`; occurrences of the `and-and` chain `0 → 1`; `git hash-object` moved `91059782…` → `2ab53120…` while the HEAD blob stayed `91059782…`. The script aborts if any of those three fails to move — the mutation's own exit code is ⛔ not the evidence.
- *Run under the mutation*: the three falsy-number rows went red with the exact strings quoted above. The live controls (`42`, `'txt'`, `undefined`, an authored node) and both `rowsThatCannotDiscriminate` rows stayed green, so the ablation also demonstrates that the repair moves nothing but the falsy-number case.
- *Restore proved by STATE, never by an exit code*: restored with `git checkout HEAD -- <absolute path>` from an `EXIT INT TERM` trap holding an absolute `git rev-parse --show-toplevel` path; then `git diff HEAD` empty for the whole tree, and `git hash-object` back to `91059782…`, byte-identical to the HEAD blob. An empty hash would have been read as FAILURE, not as "nothing to compare".

The temporary census probe is likewise gone: `git status --porcelain` empty, `git diff HEAD` empty.

## Clause-②: no — the changed-file listing that carries it

Three files, and none of them moves a published surface. ⛔ No new exported symbol, ⛔ no schema narrowing or widening, ⛔ no change to a published payload, and the `SchemaNode` declaration is untouched (objectui#7105 ruled node slots relax the renderer). The hard stop attached to the `no` was not reached.

| file | what changed |
|---|---|
| `packages/components/src/renderers/navigation/header-bar.tsx` | one JSX guard: `and-and` chain → ternary yielding `null`, plus the comment recording the trap and the truthiness choice |
| `packages/components/src/__tests__/header-bar-right-content-numeric-falsy.test.tsx` | new pin (14 rows: 4 harness controls, 3 falsy-number rows, 4 live controls, 2 non-discriminating rows, 1 mechanism row) |
| `.changeset/9033-header-bar-right-content-numeric-falsy.md` | `@object-ui/components: patch` |

No `needs:contract-review` label, per the `no` pair.

## Acceptance notes

- `{ type: 'header-bar', title: 'H', rightContent: 0 }` renders the chrome and no stray `"0"`, through the real renderer stack inside the `SidebarProvider` the renderer requires. Same for `-0` and `NaN`.
- Live controls asserted in the same run and unchanged: `42` renders `42`, `'txt'` renders `txt`, `undefined` renders the baseline chrome only, and an authored node still renders — so the repair did not narrow the slot to primitives-only.
- A validator row asserts the leaked value is **authorable**: the published zod face parses `rightContent: 0` successfully. Without it every other row is about a value nobody can reach.
- Out of scope, noted, not filed: the census's 53 `any` / `unknown` operands are a standing blind spot for any type-flag instrument in this tree, and three of them turned out to be real leaks. That is a property of the instrument, not a defect, and it is recorded inside objectui#9162 rather than as its own card.
- Out of scope, noted, not filed: `renderChildren`'s first leg already answers `null` for every falsy input, so at several census sites the `and-and` guard in front of it is doing nothing except creating the trap. Whether the guard should simply be deleted at those sites is part of the class-level question objectui#9162 raises; no opinion is executed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_