### PR TITLE
fix(core): the TRUE-identity fold counts only the keys the loop processed

### DIFF
--- a/.changeset/identity-fold-skipped-keys-9030.md
+++ b/.changeset/identity-fold-skipped-keys-9030.md
@@ -1,0 +1,55 @@
+---
+'@object-ui/core': patch
+---
+
+The TRUE-identity fold now counts only the keys the loop PROCESSED, so a filter
+that mixes an identity group with a skipped key folds too (objectui#9030).
+
+`convertFiltersToAST` folds a filter that is nothing but TRUE-identity
+combinators to `undefined` (objectui#8770), and folds a filter whose every key
+the loop SKIPPED for a `null` / `undefined` value to `undefined` too
+(objectui#9020). Each fold compared its own count with
+`Object.keys(filter).length`.
+
+But the loop's first statement skips the null/undefined keys without
+incrementing anything the identity fold counts, while that denominator counted
+them anyway. So a filter carrying one identity group beside one skipped key read
+`1 === 2`, the fold declined, and the caller's original object came back — even
+though each of its keys, taken alone, folds:
+
+```
+{ $and: [] }                ->  undefined         folded
+{ b: undefined }            ->  undefined         folded
+{ $and: [], b: undefined }  ->  { $and: [], … }   did NOT fold
+```
+
+Behaviour decided by a sibling, read the other way round: adding an always-TRUE
+`$and: []` to a filter that folded could stop it folding.
+
+What that cost, measured on both `find()` routes of `@object-ui/data-objectstack`
+rather than assumed. The plain route hands a non-AST object to
+`client.data.find`, whose else-branch spreads its entries as query parameters, so
+`{ $and: [], b: undefined }` left as `?$and=` with no `filter` parameter at all —
+the `400 UNSUPPORTED_QUERY_PARAM` objectui#8770 exists to end. The
+`$expand` / `$search` route JSON-serialises the same object into `filter=`, where
+`{ $and: [], a: null }` arrived carrying a real `a IS NULL` predicate the
+converter had already decided contributes nothing. One authored filter, two row
+sets, and neither matched the converter's own answer for either key alone.
+
+The denominator is now the count of keys the loop actually processed — every key
+minus the ones its own first statement skipped. Both skipped spellings come
+along, because the loop skips them with one statement and objectui#9020 already
+ruled what that skip means when it is all that is left.
+
+**Unchanged, and pinned as controls in the same run:** the null/undefined skip
+itself (`{ a: null, s: 1 }` still lowers to `['s', '=', 1]`); the FALSE identity
+`{ $or: [] }`, which still selects no row; an identity group beside a key that
+does lower (`{ $and: [], a: 'x' }` still lowers to `['a', '=', 'x']`); a plain
+filter's AST; and the object tail, which still serves `{}`, an empty operator map
+`{ a: {} }`, and an empty operator map beside a skipped key — a key the loop
+ENTERED and that produced no condition is neither an identity group nor a skipped
+key, so no arm claims it. The two counts stay apart; only one denominator moved.
+
+This supersedes one sentence in objectui#9020's own entry above, which named
+`{ $and: [], a: null }` as still returning the object and objectui#9030 as the
+open question about it.

--- a/packages/core/src/utils/__tests__/filter-all-skipped-9020.test.ts
+++ b/packages/core/src/utils/__tests__/filter-all-skipped-9020.test.ts
@@ -160,13 +160,28 @@ describe('objectui#9020 — the boundary that proves the two folds were told apa
   it.each([
     ['{ $and: [], a: null }', { $and: [], a: null }],
     ['{ $and: [], b: undefined }', { $and: [], b: undefined }],
-  ])('%s satisfies NEITHER guard and keeps the object', (_label, filter) => {
-    // ⭐ Each guard is keyed on "EVERY key was of MY kind". One identity group
-    // beside one skipped key satisfies neither — even though each key ALONE now
-    // folds. A single merged counter would swallow these, which is exactly the
-    // accidental merge this card was fenced against. Whether they should fold is
-    // objectui#9030's open question, and neither card answers it.
-    expect(convertFiltersToAST(filter)).toEqual(filter);
+  ])('%s folds — answered by objectui#9030, not by a merged counter', (_label, filter) => {
+    // ⚠️ UPDATED. These used to pin the object coming back: each guard was keyed
+    // on "EVERY key was of MY kind", so one identity group beside one skipped
+    // key satisfied neither — even though each key ALONE folds.
+    //
+    // objectui#9030 answered it, and NOT by merging the counters. The identity
+    // fold's denominator became the count of keys the loop actually PROCESSED,
+    // which is every key minus the ones its own first statement skipped; this
+    // card's guard still has its own count and its own arm. The control for
+    // "not merged" is the case below, where a PROCESSED key produced no
+    // condition and neither arm fires.
+    expect(convertFiltersToAST(filter)).toBeUndefined();
+  });
+
+  it('⭐ a PROCESSED key that produced nothing still satisfies neither guard', () => {
+    // Where the arms are still told apart. `{ a: {} }` is entered by the loop
+    // and pushes no condition; it is neither an identity group nor a skipped
+    // key, so it stays in the denominator and the object comes back. A repair
+    // that had keyed the fold on "no conditions were produced" would swallow
+    // these — which is the accidental merge this card was fenced against.
+    expect(convertFiltersToAST({ a: {}, b: undefined })).toEqual({ a: {}, b: undefined });
+    expect(convertFiltersToAST({ $and: [], a: {} })).toEqual({ $and: [], a: {} });
   });
 
   it('a nested all-skipped child was already handled and is unchanged', async () => {

--- a/packages/core/src/utils/__tests__/filter-identity-skipped-mix-9030.test.ts
+++ b/packages/core/src/utils/__tests__/filter-identity-skipped-mix-9030.test.ts
@@ -1,0 +1,268 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The TRUE-identity fold counts only the keys the loop PROCESSED — objectui#9030.
+ *
+ * ## What was wrong
+ *
+ * `convertFiltersToAST` folds a filter that is nothing but TRUE-identity
+ * combinators to `undefined` (objectui#8770), and folds a filter whose every key
+ * the loop SKIPPED for a `null` / `undefined` value to `undefined` too
+ * (objectui#9020). Each fold was keyed on its own count compared with
+ * `Object.keys(filter).length`.
+ *
+ * But the loop's first statement skips the null/undefined keys without
+ * incrementing anything the identity fold counts, while that denominator counted
+ * them anyway. So a filter carrying one identity group beside one skipped key
+ * read `1 === 2`, the fold declined, and the CALLER'S ORIGINAL OBJECT came back:
+ *
+ * ```
+ * { $and: [] }                =>  undefined            folds
+ * { b: undefined }            =>  undefined            folds
+ * { $and: [], b: undefined }  =>  { $and: [], … }      did NOT fold
+ * ```
+ *
+ * ⭐ Each key folds ALONE and the two together did not — behaviour decided by a
+ * sibling, the hazard objectui#8555 named on this same function. Read the other
+ * way round: adding an always-TRUE `$and: []` to a filter that folded could stop
+ * it folding.
+ *
+ * ## Why BOTH skipped classes come along, and why that is not a new ruling
+ *
+ * The loop skips `null` and `undefined` with ONE statement, and objectui#9020
+ * already ruled what that skip means when it is all that is left: the key
+ * contributes no condition, so the filter constrains nothing and says so. That
+ * ruling is what this card carries into the mixed case; it does not re-decide
+ * it, and it does not touch the skip — `{ a: null, s: 1 }` still lowers to
+ * `['s', '=', 1]`, pinned in the controls below.
+ *
+ * ⚠️ The card that filed this proposed admitting `undefined` while keeping
+ * `null` out, on the reasoning that a null-valued key rides the `$expand` route
+ * as a real `a IS NULL` predicate. That reasoning was measured before
+ * objectui#9020 landed and no longer holds: `{ a: null }` no longer reaches
+ * either route as a predicate. Keeping `null` out would ALSO have meant reading
+ * the two spellings apart for the first time anywhere in this file, and would
+ * have left `{ $and: [], a: null }` as the one member of the family that still
+ * 400s on the plain route — the very defect objectui#8770 exists to end. The
+ * two-route measurement is in
+ * `filter-identity-skipped-mix-two-routes-9030.test.ts`.
+ *
+ * ## Why the assertions are shaped the way they are
+ *
+ * Two halves, the shape taken from objectui#8770's own file, because either
+ * alone passes on something worse than the bug:
+ *
+ *   - a SHAPE assertion (`toBeUndefined`) alone passes on a converter that has
+ *     stopped emitting anything at all;
+ *   - a ROW-SET assertion alone cannot tell "honoured" from "dropped" — a filter
+ *     whose ruled answer is every row and an absent filter select the same rows.
+ *
+ * So §0 proves the fixture distinguishes every-row from a real subset before any
+ * of it is read that way, the shape half is asserted against the spec's own door
+ * (`isFilterAST`) rather than a literal, and the FALSE identity `{ $or: [] }` is
+ * carried as a control that must keep selecting NO rows.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isFilterAST } from '@objectstack/spec/data';
+import { convertFiltersToAST, toFilterNode, mergeFilterNodes } from '../filter-converter';
+import { ValueDataSource } from '../../adapters/ValueDataSource';
+
+const ROWS = [
+  { id: '1', a: 'x', s: 1 },
+  { id: '2', a: null, s: 1 },
+  { id: '3', a: 'y', s: 2 },
+  { id: '4', a: 'z', s: 2 },
+];
+const ALL_IDS = ['1', '2', '3', '4'];
+
+async function selectedIds(filter: unknown): Promise<string[]> {
+  const ds = new ValueDataSource({ items: ROWS as never });
+  const result = await ds.find('rows', (filter === undefined ? {} : { $filter: filter }) as never);
+  return (result.data as Array<{ id: string }>).map((r) => String(r.id));
+}
+
+/**
+ * The census, enumerated rather than exemplified — a repair aimed at the card's
+ * one literal would be re-touched immediately.
+ *
+ * The family is stated as a rule, not a list: a filter that produces NO
+ * condition and whose every key was either a TRUE-identity group or a key the
+ * loop skipped. The rows below walk that rule's degrees of freedom — which
+ * identity spelling, which skipped spelling, key ORDER, more than one of each,
+ * and an identity group that only becomes one because ITS child folded.
+ */
+const MIXED_FAMILY: ReadonlyArray<[string, Record<string, unknown>]> = [
+  ['{ $and: [], b: undefined }', { $and: [], b: undefined }],
+  ['{ $and: [], a: null }', { $and: [], a: null }],
+  ['{ $or: [{}], b: undefined }', { $or: [{}], b: undefined }],
+  ['{ $and: [{}], a: null }', { $and: [{}], a: null }],
+  ['{ b: undefined, $and: [] }', { b: undefined, $and: [] }],
+  [
+    '{ $and: [], $or: [{}], a: null, b: undefined }',
+    { $and: [], $or: [{}], a: null, b: undefined },
+  ],
+  ['{ $and: [{ a: null }], b: undefined }', { $and: [{ a: null }], b: undefined }],
+];
+
+// ---------------------------------------------------------------------------
+// 0. The harness has to be able to fail
+// ---------------------------------------------------------------------------
+
+describe('objectui#9030 — harness', () => {
+  it('every row, the `a = null` subset and a real predicate are three answers here', async () => {
+    expect(await selectedIds(undefined)).toEqual(ALL_IDS);
+    // The predicate the object became on one route. It is NOT "every row".
+    expect(await selectedIds({ a: null })).toEqual(['2']);
+    // A filter that really constrains lands strictly between the two, so "every
+    // row" below is a measurement and not this fixture's only answer.
+    expect(await selectedIds(['s', '=', 1])).toEqual(['1', '2']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 1. The family folds
+// ---------------------------------------------------------------------------
+
+describe('objectui#9030 — an identity group beside a skipped key folds', () => {
+  it.each(MIXED_FAMILY)('%s lowers to "no constraint"', (_label, filter) => {
+    expect(convertFiltersToAST(filter)).toBeUndefined();
+  });
+
+  it.each(MIXED_FAMILY)('%s is no longer the caller\'s own object', (_label, filter) => {
+    // Stated as identity rather than shape: what came back WAS the input, so a
+    // caller could not tell "lowered" from "handed back untouched".
+    expect(convertFiltersToAST(filter)).not.toBe(filter);
+  });
+
+  it('nothing unreadable is handed back', () => {
+    // The property objectui#8770 and objectui#9020 each stated for their own
+    // member: a value this function returns is either `undefined` — no filter —
+    // or something the spec's own door accepts. A plain object is neither.
+    for (const [, filter] of MIXED_FAMILY) {
+      const out = convertFiltersToAST(filter);
+      expect(out === undefined || isFilterAST(out)).toBe(true);
+    }
+  });
+
+  it('⭐ the property the counting broke — each key alone, and the two together', () => {
+    // The defect in one assertion, and the reason this is a counting fix rather
+    // than a new member: both halves already folded, so their conjunction had
+    // no third answer available to it.
+    expect(convertFiltersToAST({ $and: [] })).toBeUndefined();
+    expect(convertFiltersToAST({ b: undefined })).toBeUndefined();
+    expect(convertFiltersToAST({ $and: [], b: undefined })).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The sinks
+// ---------------------------------------------------------------------------
+
+describe('objectui#9030 — the sinks', () => {
+  it.each(MIXED_FAMILY)('%s is skipped outright by `toFilterNode`', (_label, filter) => {
+    expect(toFilterNode(filter)).toBeUndefined();
+  });
+
+  it.each(MIXED_FAMILY)('%s contributes nothing to the merged `and`', async (_label, filter) => {
+    // What `plugin-list`'s `buildEffectiveFilter` and `plugin-view`'s
+    // `ObjectView` build. Before the fix the object landed in AST CHILD
+    // position — `['and', { $and: [] }, ['s', '=', 1]]` — which `isFilterAST`
+    // refuses, so a list whose filter narrowed nothing failed to load outright.
+    const merged = mergeFilterNodes(filter, ['s', '=', 1]);
+    expect(merged).toEqual(['s', '=', 1]);
+    expect(isFilterAST(merged)).toBe(true);
+    expect(await selectedIds(merged)).toEqual(['1', '2']);
+  });
+
+  it.each(MIXED_FAMILY)('%s selects EVERY row through a real matcher', async (_label, filter) => {
+    expect(await selectedIds(toFilterNode(filter))).toEqual(ALL_IDS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Controls — everything that must NOT have moved
+// ---------------------------------------------------------------------------
+
+describe('objectui#9030 — controls', () => {
+  it('⭐ the skip pin itself is untouched', async () => {
+    // ⛔ The one repair this card was forbidden: making a null-valued key
+    // meaningful. If this reddens, every caller's row set moved.
+    const node = convertFiltersToAST({ a: null, s: 1 });
+    expect(node).toEqual(['s', '=', 1]);
+    expect(await selectedIds(node)).toEqual(['1', '2']);
+  });
+
+  it('⭐ a plain filter lowers to exactly the AST it always did', async () => {
+    expect(convertFiltersToAST({ a: 'x' })).toEqual(['a', '=', 'x']);
+    expect(convertFiltersToAST({ a: { $null: true } })).toEqual(['a', 'is_null', true]);
+    expect(convertFiltersToAST({ a: 'x', s: 1 })).toEqual([
+      'and',
+      ['a', '=', 'x'],
+      ['s', '=', 1],
+    ]);
+    expect(await selectedIds(convertFiltersToAST({ a: 'x' }))).toEqual(['1']);
+  });
+
+  it('⭐ an identity group beside a key that DOES lower still lets the sibling carry it', async () => {
+    // The fold must not start swallowing a live sibling now that its
+    // denominator is smaller.
+    const node = convertFiltersToAST({ $and: [], a: 'x' });
+    expect(node).toEqual(['a', '=', 'x']);
+    expect(await selectedIds(node)).toEqual(['1']);
+  });
+
+  it('⭐ the FALSE identity `{ $or: [] }` still selects NO row', async () => {
+    // FALSE is not "no constraint", and the AST has no contradiction literal, so
+    // the pre-existing leaf is still the emission. A fold that swept the
+    // identities together would take this control with it.
+    const node = convertFiltersToAST({ $or: [] });
+    expect(node).toEqual(['$or', '=', []]);
+    expect(await selectedIds(node)).toEqual([]);
+    // …and it survives a skipped key and a TRUE identity beside it.
+    expect(convertFiltersToAST({ $or: [], a: null })).toEqual(['$or', '=', []]);
+    expect(convertFiltersToAST({ $and: [], $or: [] })).toEqual(['$or', '=', []]);
+  });
+
+  it('⛔ an empty operator map still returns the original object', () => {
+    // NOT a member. Its key was PROCESSED — the loop entered it and the operator
+    // loop ran zero times — so it is counted in the denominator and no arm
+    // claims it. objectui#8770 measured this boundary and this card does not
+    // move it.
+    expect(convertFiltersToAST({ a: {} })).toEqual({ a: {} });
+  });
+
+  it('⛔ an empty operator map beside a SKIPPED key still returns the original object', () => {
+    // ⭐ The sharpest boundary case, and the one that says what "processed"
+    // means: subtracting the skipped key leaves one processed key that produced
+    // no condition and is not an identity group, so neither arm fires. A repair
+    // that had folded on "no conditions were produced" instead would swallow
+    // this.
+    const filter = { a: {}, b: undefined };
+    expect(convertFiltersToAST(filter)).toEqual(filter);
+    expect(convertFiltersToAST({ $and: [], a: {} })).toEqual({ $and: [], a: {} });
+  });
+
+  it('⛔ an empty filter still returns the original object', () => {
+    // `trueIdentityGroups > 0` and `skippedNullKeys > 0` both exclude it: there
+    // is no key of either kind. `toFilterNode` already folds `{}` one level up.
+    expect(convertFiltersToAST({})).toEqual({});
+  });
+
+  it('⭐ objectui#8770 and objectui#9020 keep their own answers', () => {
+    // The two pure members, restated where a reader of this file will see them:
+    // this card widened the denominator of one arm, it did not merge the arms.
+    expect(convertFiltersToAST({ $and: [] })).toBeUndefined();
+    expect(convertFiltersToAST({ $or: [{}] })).toBeUndefined();
+    expect(convertFiltersToAST({ $and: [{}] })).toBeUndefined();
+    expect(convertFiltersToAST({ a: null })).toBeUndefined();
+    expect(convertFiltersToAST({ b: undefined })).toBeUndefined();
+    expect(convertFiltersToAST({ a: null, b: undefined })).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/__tests__/filter-text-comparand-9001.test.ts
+++ b/packages/core/src/utils/__tests__/filter-text-comparand-9001.test.ts
@@ -386,14 +386,18 @@ describe('objectui#9001 — what the guard must NOT touch', () => {
     // adds no `continue` and skips no key, and the tail is unreachable from
     // it. Pinned rather than argued.
     //
-    // ⚠️ UPDATED by objectui#9020, which gave the all-skipped tail its own
-    // count and its own `undefined`. That is a SECOND guard beside this one,
-    // not a change to it: the two cases below that mix the kinds still satisfy
-    // neither guard, which is how this control keeps measuring what it was
-    // written to measure.
+    // ⚠️ UPDATED TWICE. objectui#9020 gave the all-skipped tail its own count
+    // and its own `undefined` — a SECOND guard beside this one. objectui#9030
+    // then narrowed THIS guard's denominator to the keys the loop actually
+    // PROCESSED, so a mixed filter folds too. Neither touched what this control
+    // measures: a refusal that THROWS adds no `continue`, skips no key, and so
+    // moves neither the numerator nor the denominator. The empty-operator-map
+    // case below is the one that still reaches the object tail, and it is what
+    // keeps this control able to see a perturbation at all.
     expect(convertFiltersToAST({ $and: [] })).toBeUndefined();
     expect(convertFiltersToAST({ $or: [{}] })).toBeUndefined();
-    expect(convertFiltersToAST({ $and: [], a: null })).toEqual({ $and: [], a: null });
+    expect(convertFiltersToAST({ $and: [], a: null })).toBeUndefined();
+    expect(convertFiltersToAST({ $and: [], a: {} })).toEqual({ $and: [], a: {} });
     expect(convertFiltersToAST({})).toEqual({});
     expect(convertFiltersToAST({ a: null })).toBeUndefined();
     expect(convertFiltersToAST({ $and: [], name: { $icontains: 'x' } })).toEqual([

--- a/packages/core/src/utils/__tests__/filter-true-identity-8770.test.ts
+++ b/packages/core/src/utils/__tests__/filter-true-identity-8770.test.ts
@@ -228,16 +228,35 @@ describe('objectui#8770 — the non-combinator tail is untouched', () => {
     expect(convertFiltersToAST({ a: {} })).toEqual({ a: {} });
   });
 
-  it('an identity group beside a NON-combinator key returns the original object', () => {
-    // ⭐ The control for "the two folds were told apart". Each guard is keyed on
-    // "EVERY key was of MY kind": one identity group and one skipped key
-    // satisfies neither, so this filter still keeps the answer it has always
-    // had — even though both of its keys, taken alone, now fold. A single
-    // merged counter would swallow this case, which is exactly the accident
-    // objectui#9020 was fenced against. Whether it SHOULD fold is
-    // objectui#9030's open question, deliberately not answered by either card.
-    expect(convertFiltersToAST({ $and: [], a: null })).toEqual({ $and: [], a: null });
-    expect(convertFiltersToAST({ $and: [], b: undefined })).toEqual({ $and: [], b: undefined });
+  it('an identity group beside a SKIPPED key folds — answered by objectui#9030', () => {
+    // ⚠️ UPDATED. This case used to pin the original object coming back, as the
+    // control for "the two folds were told apart": each guard was keyed on
+    // "EVERY key was of MY kind", so one identity group beside one skipped key
+    // satisfied neither — even though both keys, taken alone, fold.
+    //
+    // objectui#9030 measured what that cost and answered it: the loop SKIPS a
+    // null/undefined key without incrementing anything this fold counts, while
+    // the fold's denominator counted it anyway, so a filter whose every key
+    // folds ALONE did not fold TOGETHER — adding an always-TRUE `$and: []` to a
+    // folding filter could stop it folding. The repair narrowed the denominator
+    // to the keys the loop actually PROCESSED; it did not merge the counters.
+    //
+    // ⭐ The control moved rather than vanished: the case below is what now
+    // proves the arms were not merged, because its key was PROCESSED and still
+    // produced nothing.
+    expect(convertFiltersToAST({ $and: [], a: null })).toBeUndefined();
+    expect(convertFiltersToAST({ $and: [], b: undefined })).toBeUndefined();
+  });
+
+  it('⭐ an identity group beside an EMPTY OPERATOR MAP still returns the object', () => {
+    // The control for "the two folds were told apart", restated on the boundary
+    // objectui#9030 did not move. `{ a: {} }` is a key the loop ENTERED — the
+    // operator loop simply ran zero times — so it is neither an identity group
+    // nor a skipped key, it stays in the denominator, and no arm claims it. A
+    // repair that had folded on "no conditions were produced" would swallow
+    // this; the one that landed cannot.
+    expect(convertFiltersToAST({ $and: [], a: {} })).toEqual({ $and: [], a: {} });
+    expect(convertFiltersToAST({ a: {}, b: undefined })).toEqual({ a: {}, b: undefined });
   });
 
   it('an identity group beside a key that DOES lower is unchanged', async () => {

--- a/packages/core/src/utils/filter-converter.ts
+++ b/packages/core/src/utils/filter-converter.ts
@@ -450,6 +450,14 @@ function refuseTextComparand(field: string, operator: string, target: unknown): 
  * // when a sibling survives (objectui#9020). Callers skip the slot.
  * convertFiltersToAST({ a: null })
  * // => undefined
+ *
+ * @example
+ * // … and a filter that MIXES the two constrains nothing either, because the
+ * // identity fold counts only the keys the loop actually PROCESSED
+ * // (objectui#9030). A skipped key used to be counted against that fold, so a
+ * // filter whose every key folds alone did not fold together.
+ * convertFiltersToAST({ $and: [], b: undefined })
+ * // => undefined
  */
 export function convertFiltersToAST(
   filter: Record<string, any>,
@@ -686,9 +694,9 @@ export function convertFiltersToAST(
           // objectui#9001 — the comparand door, at the ONE place this function
           // reads a comparand. It runs before the push, so the refused node is
           // never built; there is no `continue` and no key is skipped, which is
-          // what keeps the TRUE-identity tail's `Object.keys(filter).length`
-          // comparison (objectui#8770, and the counting question objectui#9030
-          // is open on) reading exactly what it read before.
+          // what keeps the TRUE-identity tail's key-count comparison
+          // (objectui#8770, and the denominator objectui#9030 narrowed to the
+          // keys the loop processes) reading exactly what it read before.
           //
           // Keyed on the LOWERED operator rather than on the `$` spelling: the
           // rule belongs to `icontains` itself, and `ValueDataSource`'s AST arm
@@ -761,12 +769,31 @@ export function convertFiltersToAST(
     // site of this function already acts on it: `lowerLogicalGroup` above tests
     // `Array.isArray`, the other three test for `undefined` or falsiness.
     //
-    // ⛔ Scoped to a filter whose EVERY key is such a group, which is why the
-    // count above is compared with the key count instead of being a flag. The
+    // ⛔ Scoped to a filter whose every PROCESSED key is such a group, which is
+    // why the count above is compared with a count instead of being a flag. The
     // `return filter` below still serves inputs that are not combinators at all
-    // — `{}`, an empty operator map, and a MIXTURE of an identity group with a
-    // skipped key — and they are NOT this case.
-    if (trueIdentityGroups > 0 && trueIdentityGroups === Object.keys(filter).length) {
+    // — `{}` and an empty operator map — and they are NOT this case.
+    //
+    // ⭐ The denominator is the number of keys the LOOP ACTUALLY PROCESSED, not
+    // `Object.keys(filter).length` — objectui#9030. Those differ by exactly the
+    // keys the loop's own first statement skipped, and counting a skipped key
+    // against this fold made the fold's answer depend on a key that, by this
+    // function's oldest ruling, contributes nothing: `{ $and: [] }` folded and
+    // `{ $and: [], b: undefined }` did not, though `JSON.stringify` drops the
+    // second key entirely and the two reach either wire route as the same
+    // bytes. Both `null` and `undefined` are subtracted, because the loop skips
+    // them with one statement and the guard below already gives that whole
+    // class the same `undefined` when it is alone — leaving the MIXTURE out
+    // would mean adding an always-TRUE `$and: []` to a filter that folds could
+    // stop it folding, which is the sibling-dependence hazard objectui#8555
+    // named on this file.
+    //
+    // ⚠ Subtraction, not a merged counter. `trueIdentityGroups > 0` still
+    // gates this arm and the skipped count still has its own arm below, so the
+    // two states stay told apart — what changed is only which keys this one
+    // is measured against.
+    const keysTheLoopProcessed = Object.keys(filter).length - skippedNullKeys;
+    if (trueIdentityGroups > 0 && trueIdentityGroups === keysTheLoopProcessed) {
       return undefined;
     }
 
@@ -815,11 +842,16 @@ export function convertFiltersToAST(
     // one is this file's own tolerance made consistent with itself. They
     // coincide because "no constraint" has exactly ONE expressible spelling in
     // this dialect — the absence of the slot — not because the two inputs are
-    // the same kind of thing. Keeping the counts apart is also what keeps each
-    // fence readable: a filter that MIXES the two (`{ $and: [], a: null }`,
-    // `{ $and: [], b: undefined }`) satisfies neither guard and still returns the
-    // object, which is objectui#9030's open question and deliberately not
-    // answered here.
+    // the same kind of thing.
+    //
+    // A filter that MIXES the two kinds (`{ $and: [], a: null }`,
+    // `{ $and: [], b: undefined }`) is answered by the fold ABOVE, since
+    // subtracting the skipped keys leaves a filter whose every processed key is
+    // an identity group — objectui#9030. It used to satisfy neither guard and
+    // come back as the object, so a filter each of whose keys folds ALONE did
+    // not fold TOGETHER. That is why the counts staying apart is a statement
+    // about the two STATES and never about the two ARMS being unreachable from
+    // one input.
     //
     // ⛔ `{}` is not this case either — `skippedNullKeys > 0` excludes it. An
     // empty filter has no key to skip, `toFilterNode` already folds it one level

--- a/packages/data-objectstack/src/filter-all-skipped-two-routes-9020.test.ts
+++ b/packages/data-objectstack/src/filter-all-skipped-two-routes-9020.test.ts
@@ -251,17 +251,24 @@ describe('objectui#9020 — controls', () => {
 describe('objectui#9020 — the mixed filter is a different card', () => {
   beforeEach(() => clearSharedDiscoveryCache());
 
-  it('an identity group beside a skipped key is left exactly as it was', async () => {
-    // ⛔ Each guard in the tail is keyed on "EVERY key was of MY kind", so a
-    // filter that mixes the two kinds satisfies neither and keeps the object it
-    // has always returned — even though each of its keys, alone, now folds.
-    // Whether it SHOULD fold is objectui#9030's open question; answering it here
-    // by merging the two counts is the accident this card was fenced against.
+  it('an identity group beside a PROCESSED key that produced nothing is left as it was', async () => {
+    // ⚠️ UPDATED. This used to name `{ $and: [], a: null }` — a filter mixing an
+    // identity group with a SKIPPED key — as the case each guard declines
+    // because each is keyed on "EVERY key was of MY kind". objectui#9030
+    // answered that one: the identity fold now counts only the keys the loop
+    // actually PROCESSED, so the mixed filter folds and both routes agree on it
+    // (measured in `filter-identity-skipped-mix-two-routes-9030.test.ts`).
     //
-    // ⚠️ Asserted at the CONVERTER, not on the routes: the routes still disagree
-    // about this filter, and pinning that disagreement in a file whose subject
-    // is route agreement would read as a claim that it is settled. It is not.
+    // ⭐ The boundary this card was fenced against moving is still here, one
+    // shape over: `{ a: {} }` is a key the loop ENTERED that pushed no
+    // condition, so it is neither an identity group nor a skipped key and no arm
+    // claims it. That is what proves the two counts were not merged into "no
+    // conditions were produced".
+    //
+    // ⚠️ Asserted at the CONVERTER, not on the routes: this input still reaches
+    // both routes as the caller's object, and pinning that in a file whose
+    // subject is route agreement would read as a claim that it is settled.
     const { convertFiltersToAST } = await import('@object-ui/core');
-    expect(convertFiltersToAST({ $and: [], a: null })).toEqual({ $and: [], a: null });
+    expect(convertFiltersToAST({ $and: [], a: {} })).toEqual({ $and: [], a: {} });
   });
 });

--- a/packages/data-objectstack/src/filter-identity-skipped-mix-two-routes-9030.test.ts
+++ b/packages/data-objectstack/src/filter-identity-skipped-mix-two-routes-9030.test.ts
@@ -1,0 +1,255 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * An identity group beside a skipped key selects one row set on both routes —
+ * objectui#9030.
+ *
+ * ## Why this file exists beside the converter's own pins
+ *
+ * The card that filed this reasoned about the wire from `JSON.stringify`
+ * semantics and from objectui#8770's measurements, and said so: *"Whoever takes
+ * it should confirm, rather than inherit from here, that `undefined`-valued keys
+ * really do vanish on BOTH wire routes."* This file is that confirmation, driven
+ * rather than inherited.
+ *
+ * ## What was wrong, per route
+ *
+ * `find()` has two routes to the server and they read a plain OBJECT in the
+ * `$filter` slot differently — the split objectui#6948 recorded on this shape
+ * and objectui#9020 measured for the all-skipped filter. For a filter MIXING an
+ * identity group with a skipped key the converter used to hand back that object,
+ * so both routes were wrong and they were wrong differently:
+ *
+ * ```
+ * plain   client.data.find spreads a non-AST object's entries as query
+ *         parameters, so `{ $and: [], b: undefined }` left as `?$and=` with no
+ *         `filter` parameter at all — the `400 UNSUPPORTED_QUERY_PARAM`
+ *         objectui#8770 exists to end.
+ * expand  the same object is JSON-serialised into `filter=`, which the server
+ *         accepts as a `FilterCondition` — so `{ $and: [] }` arrived as the
+ *         ruled every-row answer, and `{ $and: [], a: null }` arrived carrying a
+ *         real `a IS NULL` predicate the converter had already dropped.
+ * ```
+ *
+ * ⭐ So the two members of the family failed in two different directions, and
+ * neither matched the converter's own answer for either of their keys alone.
+ *
+ * ## Why the assertions are shaped the way they are
+ *
+ * The oracle is the DISAGREEMENT between the routes, never a shape on either —
+ * objectui#9020's file argues this at length and the shape is taken from it: a
+ * test that drove one route and asserted a shape goes green on a repair that
+ * leaves the two disagreeing differently. So every case is driven down both
+ * routes and the two answers are compared with EACH OTHER before either is
+ * compared with a literal, and §0 proves the fixture can tell every-row from the
+ * `a = null` subset before any of it is read that way.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ValueDataSource } from '@object-ui/core';
+import { ObjectStackAdapter, clearSharedDiscoveryCache } from './index';
+
+const ROWS = [
+  { id: '1', a: 'x', s: 1 },
+  { id: '2', a: null, s: 1 },
+  { id: '3', a: 'y', s: 2 },
+  { id: '4', a: 'z', s: 2 },
+];
+const ALL_IDS = ['1', '2', '3', '4'];
+
+function makeAdapter() {
+  const calls: string[] = [];
+  const fetchImpl = vi.fn(async (url: unknown) => {
+    const u = String(url);
+    calls.push(u);
+    if (u.includes('/api/v1/discovery')) {
+      return {
+        ok: true, status: 200, statusText: 'OK',
+        json: async () => ({ success: true, data: { version: 'v1', routes: {} } }),
+      } as never;
+    }
+    return {
+      ok: true, status: 200, statusText: 'OK',
+      json: async () => ({ success: true, data: { object: 'account', records: [], total: 0 } }),
+    } as never;
+  });
+  const adapter = new ObjectStackAdapter({
+    baseUrl: 'http://localhost:3000', token: 't', autoReconnect: false, fetch: fetchImpl as never,
+  });
+  return { adapter, calls };
+}
+
+type Route = 'plain' | 'expand';
+
+/**
+ * What one route actually sent: the parsed `filter=` parameter, or `undefined`
+ * when no filter parameter was emitted at all.
+ */
+async function wireFilter($filter: unknown, route: Route): Promise<unknown> {
+  const { adapter, calls } = makeAdapter();
+  await adapter.find('account', {
+    $filter,
+    ...(route === 'expand' ? { $expand: ['owner'] } : {}),
+  } as never);
+  const dataCall = calls.filter((u) => u.includes('/data/account')).pop();
+  const raw = dataCall ? new URL(dataCall).searchParams.get('filter') : null;
+  return raw === null ? undefined : JSON.parse(raw);
+}
+
+/** Every query parameter one route put on the wire, so a `$`-prefixed leak is visible. */
+async function wireParams($filter: unknown, route: Route): Promise<string[]> {
+  const { adapter, calls } = makeAdapter();
+  await adapter.find('account', {
+    $filter,
+    ...(route === 'expand' ? { $expand: ['owner'] } : {}),
+  } as never);
+  const dataCall = calls.filter((u) => u.includes('/data/account')).pop();
+  return dataCall ? [...new URL(dataCall).searchParams.keys()].sort() : [];
+}
+
+/** The rows a wire value selects. No wire value means no filter: every row. */
+async function rowsFor(wire: unknown): Promise<string[]> {
+  const ds = new ValueDataSource({ items: ROWS as never });
+  const result = await ds.find('rows', (wire === undefined ? {} : { $filter: wire }) as never);
+  return (result.data as Array<{ id: string }>).map((r) => String(r.id));
+}
+
+async function bothRoutes($filter: unknown) {
+  const plain = await wireFilter($filter, 'plain');
+  const expand = await wireFilter($filter, 'expand');
+  return { plain, expand, plainRows: await rowsFor(plain), expandRows: await rowsFor(expand) };
+}
+
+const MIXED_FAMILY: ReadonlyArray<[string, Record<string, unknown>]> = [
+  ['{ $and: [], b: undefined }', { $and: [], b: undefined }],
+  ['{ $and: [], a: null }', { $and: [], a: null }],
+  ['{ $or: [{}], b: undefined }', { $or: [{}], b: undefined }],
+  ['{ $and: [{}], a: null }', { $and: [{}], a: null }],
+];
+
+// ---------------------------------------------------------------------------
+// 0. The harness has to be able to fail
+// ---------------------------------------------------------------------------
+
+describe('objectui#9030 — harness', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  it('every row, the `a = null` subset and a real predicate are three answers here', async () => {
+    expect(await rowsFor(undefined)).toEqual(ALL_IDS);
+    expect(await rowsFor({ a: null })).toEqual(['2']);
+    expect(await rowsFor(['s', '=', 1])).toEqual(['1', '2']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 1. The two routes must AGREE, and on the ruled answer
+// ---------------------------------------------------------------------------
+
+describe('objectui#9030 — a mixed filter selects one row set', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  it.each(MIXED_FAMILY)('%s — both routes agree, and on "no constraint"', async (_label, filter) => {
+    const { plain, expand, plainRows, expandRows } = await bothRoutes(filter);
+
+    // The oracle, compared with EACH OTHER first: a repair that left the two
+    // disagreeing differently fails here even if it satisfies every literal
+    // below.
+    expect(plainRows).toEqual(expandRows);
+    expect(plain).toEqual(expand);
+
+    // …and on objectstack#5322's ruled answer for the identity, which is also
+    // the answer the converter's own skip gives the other key.
+    expect(plain).toBeUndefined();
+    expect(plainRows).toEqual(ALL_IDS);
+  });
+
+  it.each(MIXED_FAMILY)('%s puts no `$`-prefixed parameter on the wire', async (_label, filter) => {
+    // ⭐ The half a `filter=` assertion cannot see. The plain route's failure was
+    // never a wrong `filter` value — it was an object spread into query
+    // parameters, so `$and` became a parameter NAME and the server refused the
+    // request outright. Naming the parameter keys is what pins that it is gone.
+    for (const route of ['plain', 'expand'] as const) {
+      const keys = await wireParams(filter, route);
+      expect(keys.filter((k) => k.startsWith('$'))).toEqual([]);
+      expect(keys).not.toContain('filter');
+    }
+  });
+
+  it('⭐ the card`s own literal, stated as the disagreement it was', async () => {
+    // `{ $and: [], b: undefined }`: `JSON.stringify` drops the undefined key, so
+    // the `$expand` route used to ship `filter={"$and":[]}` — the ruled answer —
+    // while the plain route shipped `?$and=` and 400'd. Same filter, one route
+    // right by accident.
+    const { plain, expand } = await bothRoutes({ $and: [], b: undefined });
+    expect(plain).toBeUndefined();
+    expect(expand).toBeUndefined();
+  });
+
+  it('⭐ and its `null` sibling, where the disagreement ran the other way', async () => {
+    // `{ $and: [], a: null }`: the `$expand` route shipped
+    // `filter={"$and":[],"a":null}`, so it carried a real `a IS NULL` predicate
+    // that the converter had already decided contributes nothing — the two
+    // routes selected two different row sets from one filter.
+    const { plain, expand, expandRows } = await bothRoutes({ $and: [], a: null });
+    expect(expand).not.toEqual({ $and: [], a: null });
+    expect(plain).toBeUndefined();
+    expect(expand).toBeUndefined();
+    expect(expandRows).toEqual(ALL_IDS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Controls — everything that must NOT have moved
+// ---------------------------------------------------------------------------
+
+describe('objectui#9030 — controls', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  it('⭐ a skipped key beside a LIVE one lowers exactly as it always has', async () => {
+    // The pin this card was forbidden to break. If this reddens, the repair made
+    // null-valued keys meaningful instead of narrowing a denominator.
+    const { plain, expand, plainRows, expandRows } = await bothRoutes({ a: null, s: 1 });
+    expect(plain).toEqual(['s', '=', 1]);
+    expect(expand).toEqual(['s', '=', 1]);
+    expect(plainRows).toEqual(['1', '2']);
+    expect(expandRows).toEqual(['1', '2']);
+  });
+
+  it('⭐ an identity group beside a LIVE key lets the sibling carry the filter', async () => {
+    const { plain, expand, plainRows, expandRows } = await bothRoutes({ $and: [], a: 'x' });
+    expect(plain).toEqual(['a', '=', 'x']);
+    expect(expand).toEqual(['a', '=', 'x']);
+    expect(plainRows).toEqual(['1']);
+    expect(expandRows).toEqual(['1']);
+  });
+
+  it('⭐ the FALSE identity `{ $or: [] }` still selects NO row on both routes', async () => {
+    const { plain, expand, plainRows, expandRows } = await bothRoutes({ $or: [] });
+    expect(plain).toEqual(['$or', '=', []]);
+    expect(expand).toEqual(['$or', '=', []]);
+    expect(plainRows).toEqual([]);
+    expect(expandRows).toEqual([]);
+  });
+
+  it('a real predicate is untouched on both routes', async () => {
+    const { plain, expand, plainRows, expandRows } = await bothRoutes({ a: 'x' });
+    expect(plain).toEqual(['a', '=', 'x']);
+    expect(expand).toEqual(['a', '=', 'x']);
+    expect(plainRows).toEqual(['1']);
+    expect(expandRows).toEqual(['1']);
+  });
+
+  it('an author who MEANT `a IS NULL` still gets it, on both routes', async () => {
+    const { plain, expand, plainRows, expandRows } = await bothRoutes({ a: { $null: true } });
+    expect(plain).toEqual(['a', 'is_null', true]);
+    expect(expand).toEqual(['a', 'is_null', true]);
+    expect(plainRows).toEqual(['2']);
+    expect(expandRows).toEqual(['2']);
+  });
+});


### PR DESCRIPTION
Fixes #9030

## What was wrong

`convertFiltersToAST` folds a filter that is nothing but TRUE-identity combinators to `undefined` (objectui#8770), and folds a filter whose every key the loop SKIPPED for a `null` / `undefined` value to `undefined` too (objectui#9020). Each fold compared its own count with `Object.keys(filter).length`.

But the loop's first statement skips the null/undefined keys **without incrementing anything the identity fold counts**, while that denominator counted them anyway. So one identity group beside one skipped key read `1 === 2`, the fold declined, and the caller's original object came back — even though each of those keys, taken **alone**, folds:

| filter | folded before | folded now |
|:--|:--|:--|
| `{ $and: [] }` | yes | yes |
| `{ b: undefined }` | yes | yes |
| `{ $and: [], b: undefined }` | **no** | yes |

Read the other way round: adding an always-TRUE `$and: []` to a filter that folded could stop it folding. That is behaviour decided by a sibling — the hazard objectui#8555 named on this same function.

## The repair

The identity fold's denominator is now the count of keys the loop actually **processed** — every key minus the ones its own first statement skipped. The skip is untouched, the two counts stay apart, and the second arm keeps its own count and its own guard. One denominator moved.

## The family census, measured on this branch

⭐ The dispatch asked for the family's boundary rather than the card's one literal. The family is stated as a rule, not a list: **a filter that produces no condition and whose every key was either a TRUE-identity group or a key the loop skipped.** The rows below walk that rule's degrees of freedom — which identity spelling, which skipped spelling, key ORDER, more than one of each, and an identity group that only becomes one because its child folded. Driven twice through the same harness, once per tree:

```
                                                    BEFORE            AFTER
{ $and: [] }                                        undefined         undefined
{ $or: [{}] }                                       undefined         undefined
{ $and: [{}] }                                      undefined         undefined
{ $and: [], $or: [{}] }                             undefined         undefined
{ $and: [{ $and: [] }] }                            undefined         undefined
{ $and: [{ a: null }] }                             undefined         undefined
{ a: null }                                         undefined         undefined
{ b: undefined }                                    undefined         undefined
{ a: null, b: undefined }                           undefined         undefined
{ a: null, c: null }                                undefined         undefined
{ $and: [], a: null }                               THE OBJECT        undefined   <- moved
{ $and: [], b: undefined }                          THE OBJECT        undefined   <- moved
{ $or: [{}], b: undefined }                         THE OBJECT        undefined   <- moved
{ $and: [{}], a: null }                             THE OBJECT        undefined   <- moved
{ b: undefined, $and: [] }                          THE OBJECT        undefined   <- moved
{ $and: [], $or: [{}], a: null, b: undefined }      THE OBJECT        undefined   <- moved
{ $and: [{ a: null }], b: undefined }               THE OBJECT        undefined   <- moved
{}                                                  THE OBJECT        THE OBJECT
{ a: {} }                                           THE OBJECT        THE OBJECT
{ a: {}, b: undefined }                             THE OBJECT        THE OBJECT
{ $and: [], a: {} }                                 THE OBJECT        THE OBJECT
{ $or: [] }            (FALSE identity)             ['$or','=',[]]    ['$or','=',[]]
{ $or: [], a: null }                                ['$or','=',[]]    ['$or','=',[]]
{ $and: [], $or: [] }                               ['$or','=',[]]    ['$or','=',[]]
{ $and: [], a: 'x' }                                ['a','=','x']     ['a','=','x']
{ a: null, s: 1 }                                   ['s','=',1]       ['s','=',1]
{ a: 'x' }                                          ['a','=','x']     ['a','=','x']
{ a: { $null: true } }                              ['a','is_null',true]  ['a','is_null',true]
```

**Exactly the seven mixed members moved. Every other row is byte-identical.** The lit control is the last block: a plain filter's AST, the FALSE identity, the skip pin, and the three object-tail shapes are all unchanged, and `{}` / `{ a: {} }` prove the fold did not become "no conditions were produced".

## ⚠️ Two mechanism assumptions from the card, re-measured — one falsified

1. **`{ $and: [], b: undefined }` is still not folded.** CONFIRMED on this tree (row above).
2. **`{ $and: [], a: null }` should stay excluded, because a null-valued key rides the `$expand` route as a real `a IS NULL` predicate.** ⛔ **FALSIFIED** — the card measured that before objectui#9020 (PR objectui#9080) landed. That card ruled the other way *without touching the skip*: the key contributes no condition, so a filter that is nothing but such keys says so, and `{ a: null }` no longer reaches either route as a predicate. Keeping `null` out would also have meant reading the two spellings apart for the first time anywhere in this file, and would have left `{ $and: [], a: null }` as the one member of the family still 400'ing on the plain route.

⭐ Both landed sibling test files named the two mixed cases **as one pair** and deferred both to this card in so many words — *"Whether it SHOULD fold is objectui#9030's open question, deliberately not answered by either card."* So this card answers the pair the code itself posed, and does not invent a new member.

## The wire, driven rather than inherited

The card asked for this explicitly: *"Whoever takes it should confirm, rather than inherit from here, that `undefined`-valued keys really do vanish on BOTH wire routes."* `filter-identity-skipped-mix-two-routes-9030.test.ts` drives every member down both `find()` routes through a mocked `fetch`, compares the two answers **with each other** before either is compared with a literal, and reads the selected rows back through `ValueDataSource`'s matcher. It also asserts the parameter KEYS, which is the half a `filter=` assertion cannot see: the plain route's failure was never a wrong `filter` value, it was an object spread into query parameters, so `$and` became a parameter NAME and the request was refused outright.

The two members failed in two different directions before this change, and that asymmetry is stated in the file rather than smoothed over: `{ $and: [], b: undefined }` had `JSON.stringify` drop its second key, so the `$expand` route shipped the ruled answer by accident while the plain route 400'd; `{ $and: [], a: null }` had the `$expand` route ship a real `a IS NULL` predicate the converter had already dropped.

## Ablation — the pins can fail

⛔ Never read by an exit code. Mutation and restore are each proven on disk, by state.

**The mutation** puts the old denominator back — `trueIdentityGroups === keysTheLoopProcessed` becomes `trueIdentityGroups === Object.keys(filter).length`. `Object.keys(filter).length` still legitimately appears twice elsewhere in the file (inside `keysTheLoopProcessed` itself, and in the all-skipped arm), so a bare grep for it proves nothing; the anchor is the whole comparison, counted **both ways**, and the mutated line is printed rather than counted:

```
HEAD blob for target            : 868ce24fee93cf165c64a3fb8ae9615a6629a78b
on-disk hash BEFORE mutation    : 868ce24fee93cf165c64a3fb8ae9615a6629a78b
--- occurrence counts BEFORE mutation
  'trueIdentityGroups === keysTheLoopProcessed' : 1
  'trueIdentityGroups === Object.keys(filter).length' : 0
--- occurrence counts AFTER mutation (both directions)
  'trueIdentityGroups === keysTheLoopProcessed' : 0   (must be 0)
  'trueIdentityGroups === Object.keys(filter).length' : 1   (must be 1)
--- the mutated line, printed:
796:    if (trueIdentityGroups > 0 && trueIdentityGroups === Object.keys(filter).length) {
on-disk hash AFTER mutation     : 01ac4381b944db3e73621ec3ced6692568d1b53d
```

**The run on the mutated tree — the pins CAN fail:**

```
ablation vitest exit            : 1
 Test Files  5 failed | 1 passed (6)
 Failed Tests 48
```

⚠️ The one file that stayed green is `filter-all-skipped-two-routes-9020.test.ts`, and that is by construction, not by luck: its mixed-filter control was **moved** in this PR onto `{ $and: [], a: {} }` — the boundary this card does not touch — precisely so that file keeps measuring what it was written to measure. Naming it rather than letting "5 of 6" read as a near miss.

Two readings the ablation produced that are the defect itself, taken from the failure output:

```
{ $and: [], a: null } — both routes agree
  AssertionError: expected [ '1', '2', '3', '4' ] to deeply equal [ '2' ]
      plain route selected every row; $expand route selected the a = null subset

{ $and: [], a: null } puts no $-prefixed parameter on the wire
  AssertionError: expected [ '$and' ] to deeply equal []
      GET …/data/account?%24and=      <- the field became a parameter NAME

{ $and: [], b: undefined } — both routes agree
  AssertionError: expected undefined to deeply equal { '$and': [] }
      plain route sent no filter at all; $expand route sent filter={"$and":[]}
```

**The restore, proven by state:**

```
on-disk hash AFTER restore      : 868ce24fee93cf165c64a3fb8ae9615a6629a78b   (= the HEAD blob)
git diff HEAD --stat            : ''                                          (empty = clean)
  'trueIdentityGroups === keysTheLoopProcessed' restored count : 1
=== CONTROL RUN (restored tree) — the same pins must go GREEN
restored vitest exit            : 0
 Test Files  6 passed (6)
```

The script carries a `trap` on EXIT, INT and TERM that calls its restore function, with an absolute `REPO_ROOT`; it restores with `git checkout HEAD -- PATH` naming the absolute path (never a bare `git checkout -- PATH`, which takes the mutation back out of the index), and it treats an empty `git hash-object` reading as FAILURE rather than as "nothing to compare".

## Tests

Every exit code below was captured by REDIRECT before any pipe. Heavy runs went through this container's shared verify lock; each printed `VERDICT command-exit 0`.

| what | command | result |
|:--|:--|:--|
| affected packages, full | `pnpm exec vitest run packages/core/ packages/data-objectstack/` | **213 files, 4061 tests, all passed** |
| the seven touched files | same runner, paths named | 7 files, 155 tests passed |
| type-check, core | `pnpm --filter @object-ui/core run type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`) |
| type-check, data-objectstack | `pnpm --filter @object-ui/data-objectstack run type-check` | exit 0 |
| changeset presence | `node scripts/check-changeset-presence.mjs` | exit 0 — *"5 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)"* |
| line citations | `node scripts/check-new-cross-file-line-citations.mjs` | exit 0 — *"0 new citation(s)"* |
| control bytes | `node scripts/check-control-bytes.mjs` | exit 0 — 7359 tracked text files scanned |
| vi.mock specifiers / inherit | `node scripts/check-vi-mock-specifiers.mjs`, `…-inherit.mjs` | exit 0, exit 0 |
| governed surface | `node scripts/check-governed-queue-guard.mjs --test …` | *"NOT GOVERNED — 4 path(s) checked against 5 governed surface(s); none matched"* |

⚠️ **Both type-checks first returned exit 2 with `TS6305` — a PREREQUISITE NOT MET, not a red gate.** `packages/types/dist` had not been built in this fresh worktree. Re-run after `pnpm --workspace-concurrency=2 --filter '@object-ui/core^...' --filter '@object-ui/data-objectstack^...' build`: both exit 0. Recorded rather than quietly re-run.

⭐ **The new test files really are type-checked**, verified rather than assumed: `tsc -p tsconfig.test.json --listFiles` in `packages/core` names `filter-identity-skipped-mix-9030.test.ts`, and `tsc --noEmit --listFiles` in `packages/data-objectstack` names `filter-identity-skipped-mix-two-routes-9030.test.ts`. A `typecheck` that excludes `**/*.test.ts` would have been NOT MEASURED, not green.

### Lint — narrowed, with all three pieces of evidence

Ran `eslint .` for the two affected packages only, not the repo-wide `pnpm lint` (`turbo run lint`). **Both exit 0.**

1. **The population, read from the repo's own config rather than guessed:** all 47 workspace packages define a `lint` script, so `turbo run lint` is a 47-package farm. This run covered 2 of them — the 2 that contain every file in this diff.
2. **The file counts, read from `--format json`:** `@object-ui/core` 252 files linted (0 errors), `@object-ui/data-objectstack` 70 files linted (0 errors). The seven files this PR touches report **0 errors and 0 new warnings**; the pre-existing `@typescript-eslint/no-explicit-any` warnings on `filter-converter.ts` (7), `filter-true-identity-8770.test.ts` (4) and `filter-text-comparand-9001.test.ts` (5) sit on lines this PR does not add or move, and the two new files carry 0 warnings.
3. **Invariance for the 45 packages not run:** this repo's `eslint.config.js` extends `tseslint.configs.recommended`, **not** `recommendedTypeChecked`, and declares no `parserOptions.project` and no `projectService`. Type-aware linting is therefore off, so a file's verdict depends only on its own bytes and on the shared config — neither of which this diff moves outside those two packages. The narrowing excludes nothing.

The full 47-package farm belongs to CI, which runs it on this branch.

## Acceptance notes

Found while measuring this card, not fixed here, and not silently dropped:

- ⭐ **Filed as objectui#9164** — `convertFiltersToAST` still hands an EMPTY OPERATOR MAP back as the caller's object. `{ a: {} }` reaches the plain route as `?a=[object+Object]` (the field name became a query-parameter NAME, no `filter` parameter at all) and the `$expand` route as `filter={"a":{}}`, the widening `@objectstack/spec` refuses. Driven through both routes with a mocked `fetch`, controls lit in the same run. It is the last member of this tail still violating objectui#8770's own stated invariant, it satisfies none of the three folds by construction, and its repair is a different shape — fold, refuse, or lower — which needs a ruling. ⛔ Deliberately not touched here: it is the live control that proves this PR's fold did not become "no conditions were produced".
- **noted, not filed:** `skippedNullKeys` counts `undefined`-valued keys too, and its own docblock says so. A naming nit on a landed identifier; renaming it would touch objectui#9020's freshly-landed lines for no behavioural reason. **Successor: objectui#9164**, whose repair edits this same tail.
- **noted, not filed:** `.changeset/all-skipped-filter-tail-9020.md` — still pending, so it ships in the same CHANGELOG entry as this one — contains the sentence *"(`{ $and: [], a: null }`) still returns the object — objectui#9030's open question"*, which this PR makes false. ⛔ Not edited: it is another PR's delivered artifact and rewriting it would restate history. This PR's own changeset names the superseded sentence instead, so the two read as a narrative rather than as a contradiction. **Successor: the next release's changelog assembly.**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_