### PR TITLE
fix(plugin-detail): the summary chip reads the declared percent source instead of a drifted copy

### DIFF
--- a/.changeset/9071-summary-chip-percent-source.md
+++ b/.changeset/9071-summary-chip-percent-source.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+The `summaryFields` chip beside the record H1 reads the repo's percent authority
+instead of a drifted copy of it (objectui#9071).
+
+The chip scaled a stored `percent` by a rule of its own — a pass-through above 1,
+a scale-by-100 at or below it — while `percentDisplayValue` in `@object-ui/core`,
+the declared single source of truth that the list cell (`formatPercent` /
+`PercentCellRenderer`), the dashboard measure (`formatMeasure`) and the grid
+column summary all reach, uses the symmetric `value > -1 && value < 1`. The local
+predicate is deleted, not realigned.
+
+**Two values move, and only these two.** They are exactly where the two rules
+disagreed:
+
+- a stored `1` now reads `1%` beside a bar at 1%, where it read `100%` beside a
+  full bar — one percentage point, the answer every other surface already gave;
+- a stored value at or below `-1` is passed through: a stored `-5` now reads
+  `-5%` where it read `-500%`. The bar is unchanged for these inputs, since any
+  negative clamps to an empty track either way.
+
+Everything inside the band the two rules always agreed on is byte-identical: a
+stored `0.25` still reads `25%`, `0.123` still reads `12.3%`, `12.3` still reads
+`12.3%`, `250` still reads `250%`, and the float-residue trim that keeps `0.07`
+reading `7%` rather than `7.000000000000001%` is unchanged.

--- a/packages/plugin-detail/src/DetailView.tsx
+++ b/packages/plugin-detail/src/DetailView.tsx
@@ -1128,8 +1128,13 @@ export const DetailView: React.FC<DetailViewProps> = ({
                         // text states it, the bar below draws it clamped to
                         // its track. They used to scale `num` by two different
                         // rules, so a stored `0.123` said `0.123%` beside a bar
-                        // at 12.3% (objectui#8728). Which rule survived, and
-                        // why it is not the repo-wide one, is in
+                        // at 12.3% (objectui#8728). That number is now the
+                        // repo's — `percentDisplayValue` in `@object-ui/core`,
+                        // the same authority the list cell and the dashboard
+                        // measure read, so one record cannot state two
+                        // percentages in two places (objectui#9071). Which
+                        // predicate was deleted to get there, and which half of
+                        // that authority this chip still does not take, are in
                         // `./summaryChipPercent`.
                         const points = summaryChipPercentPoints(num);
                         display = `${points}%`;

--- a/packages/plugin-detail/src/__tests__/summaryChip.percentOneRule-8728.test.tsx
+++ b/packages/plugin-detail/src/__tests__/summaryChip.percentOneRule-8728.test.tsx
@@ -44,13 +44,23 @@
  * ## The boundary rows
  *
  * `EXACTLY 1` is the fork triage named: is a stored `1` one percent or one
- * hundred? This chip answers 100%, because that is what its bar already drew
- * and the ruling was that the text follows the bar. ⚠️ That answer is this
- * chip's alone — `percentDisplayValue` in `@object-ui/core`, and so the list
- * cell, the dashboard measure and the grid column summary, all render a stored
- * `1` as `1%`. The census and the three routes out are objectui#9071; the row
- * below exists so the answer is PINNED rather than incidental, and so that
- * card's PR has to state which way it is moving.
+ * hundred? This chip used to answer 100%, because that is what its bar already
+ * drew and the ruling here was that the text follows the bar — an answer that
+ * was this chip's alone, while `percentDisplayValue` in `@object-ui/core`, and
+ * so the list cell, the dashboard measure and the grid column summary, all
+ * rendered a stored `1` as `1%`.
+ *
+ * ⭐ objectui#9071 MOVED IT, and this is the row that recorded which way. That
+ * card took the census this one asked for, found the local predicate to be the
+ * only spelling of its kind on this side of the tree, and deleted it in favour
+ * of the declared source. A stored `1` now reads `1%` here as it always did
+ * everywhere else, and a stored `-5` reads `-5%` rather than `-500%`. The rows
+ * below carry the new answers; what did NOT move — every value inside the band
+ * the two rules always agreed on, the control among them — is the rest of this
+ * table, unchanged. The two-places pin is
+ * `summaryChip.percentSource-9071.test.tsx`; this file keeps stating the
+ * relation objectui#8728 is about, that the chip's two halves never disagree
+ * with EACH OTHER.
  *
  * ## Instruments
  *
@@ -144,9 +154,9 @@ const ROWS: Row[] = [
   // CONTROL. Already percentage points, so nothing about it may move.
   { what: 'CONTROL — a value already in points is untouched', stored: 12.3, text: '12.3%' },
   { what: 'zero', stored: 0, text: '0%' },
-  // THE FORK. See the header: this chip's answer, pinned, and objectui#9071's
-  // to move.
-  { what: 'EXACTLY 1 — this chip reads it as a ratio', stored: 1, text: '100%' },
+  // THE FORK, after objectui#9071 moved it. See the header: one percentage
+  // point, the answer every other band already gave.
+  { what: 'EXACTLY 1 — one percentage point, as everywhere else', stored: 1, text: '1%' },
   { what: 'just above 1 — the other side of the same boundary', stored: 1.5, text: '1.5%' },
   // Agreement has to survive the clamp: the text keeps the real number, the
   // bar saturates. A row that only ever tested unclamped values would let a
@@ -155,11 +165,13 @@ const ROWS: Row[] = [
   // The residue row. `0.07 * 100` is `7.000000000000001` in binary floating
   // point — invisible as a CSS width, unreadable as a label.
   { what: 'a ratio whose scaling carries float residue', stored: 0.07, text: '7%' },
-  // The drift, now visible on both halves instead of one. Before the fix the
-  // text read `-5%` here while the bar drew an empty track; the bar's rule
-  // scales it, and the ruling was that the text follows the bar. Recorded on
-  // objectui#9071 with the census that names it.
-  { what: 'a negative at or below -1 — moves with the bar\'s rule', stored: -5, text: '-500%' },
+  // The other end of the same boundary. objectui#8728 moved this text to
+  // `-500%` because the bar's rule scaled it and the ruling was that the text
+  // follows the bar; objectui#9071 then replaced that rule with the declared
+  // source, which passes a value at or below -1 straight through. The bar is
+  // unchanged across both cards — any negative clamps to an empty track — so
+  // this row only ever moved on the half that reads the number.
+  { what: 'a negative at or below -1 — passed through by the shared rule', stored: -5, text: '-5%' },
 ];
 
 describe('summary chip percent — one stored number, one percentage (objectui#8728)', () => {

--- a/packages/plugin-detail/src/__tests__/summaryChip.percentSource-9071.test.tsx
+++ b/packages/plugin-detail/src/__tests__/summaryChip.percentSource-9071.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ONE record, TWO places, ONE number (objectui#9071).
+ *
+ * ## What this pins, and why it is not "the chip's new number is right"
+ *
+ * The chip beside the record H1 scaled a stored `percent` by a rule of its
+ * own — a pass-through above 1, a scale-by-100 at or below it — while the
+ * declared single source of truth (`percentDisplayValue` in
+ * `@object-ui/core`, which the list cell reaches through `formatPercent`)
+ * uses the symmetric `value > -1 && value < 1`. The two rules disagree at
+ * EXACTLY 1 and at every value at or below -1.
+ *
+ * Triage's judgement is the acceptance, and it is about DISAGREEMENT, not
+ * about the chip:
+ *
+ *   "a stored `1` renders `100%` in the chip and `1%` everywhere else" — the
+ *   same record showing two different numbers in two places is the kind of
+ *   disagreement a user reports as a data bug rather than a formatting one.
+ *
+ * So every case here renders BOTH surfaces from the SAME stored value and the
+ * SAME field, and asserts they agree. A pin that only checked the chip could
+ * not fail for the reason this card exists: it would go green on a chip that
+ * had simply moved to a fourth rule of its own.
+ *
+ * ## Two instruments, because neither alone covers the disagreement set
+ *
+ * - **The stated text.** The only instrument that reaches a value at or below
+ *   -1: both bars clamp a negative to an empty track, so the bar cannot tell
+ *   `-5%` from `-500%`. ⚠️ Valid only where the two surfaces' CONVENTIONS
+ *   coincide — the chip appends a bare `%` to the full number, the cell renders
+ *   through the locale's percent affix at the field's precision (0 by default).
+ *   Every row asserted by text below scales to an integral count of percentage
+ *   points under four digits, where the two conventions are byte-identical.
+ *   The last case pins a value where they are NOT, so the half this card does
+ *   not fix is a recorded fact rather than a silence.
+ * - **The drawn bar.** Read off each surface's own fill width, before any
+ *   rounding, so it states agreement on the scaled MAGNITUDE independently of
+ *   how either side spells it.
+ *
+ * ## The live control
+ *
+ * `0.25` is inside the band where the two rules already agreed before this
+ * change. It renders identically in both places on both legs of the ablation —
+ * if it ever moves, the repair reached further than the boundary.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import * as React from 'react';
+import { I18nProvider, LocalizationProvider } from '@object-ui/i18n';
+import { PercentCellRenderer } from '@object-ui/fields';
+import { DetailView } from '../DetailView';
+import type { DetailViewSchema, FieldMetadata } from '@object-ui/types';
+
+/**
+ * `useRecordEditable` falls back to the GLOBAL fetch with no
+ * `SchemaRendererProvider` in the tree; under happy-dom that is a real request.
+ * Served from a double so no case here depends on the network.
+ */
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true, json: async () => ({ record: { visible: true } }) })),
+  );
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+});
+
+/**
+ * The field both surfaces are handed. `ratio` is deliberate: it does NOT match
+ * the cell renderer's whole-percent name pattern (`progress` / `completion`),
+ * so both surfaces are on the fraction-inferring path this card is about.
+ */
+const FIELD: FieldMetadata = { name: 'ratio', label: 'Ratio', type: 'percent' };
+
+interface Rendered {
+  /** What the surface SAYS, whitespace-collapsed. */
+  text: string;
+  /** What the surface DRAWS, read off its own fill width. */
+  bar: number;
+}
+
+/** Place one: the `summaryFields` chip beside the record H1. */
+function renderChip(stored: number): Rendered {
+  const container = render(
+    <DetailView
+      schema={
+        {
+          type: 'record:details',
+          objectName: 'account',
+          summaryFields: ['ratio'],
+          fields: [{ ...FIELD }],
+          data: { id: 'A9', name: 'Acme', ratio: stored },
+        } as unknown as DetailViewSchema
+      }
+    />,
+  ).container;
+  const chip = container.querySelector<HTMLElement>('[data-summary-chip="ratio"]');
+  expect(chip, 'a summary chip for "ratio" is beside the H1').not.toBeNull();
+  const fill = chip!.querySelector<HTMLElement>('[aria-hidden] span[style]');
+  expect(fill, 'the chip draws its own bar fill').not.toBeNull();
+  return { text: (chip!.textContent ?? '').replace(/\s+/g, ' ').trim(), bar: pct(fill!.style.width) };
+}
+
+/**
+ * Place two: the list cell — `PercentCellRenderer`, the surface that reaches
+ * `percentDisplayValue` through `formatPercent`. Mounted under an explicit
+ * `en` session so the comparison is a property of the SCALING and not of
+ * whatever locale the runner happens to carry.
+ */
+function renderCell(stored: number): Rendered {
+  const container = render(
+    <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false }} persistLanguage={false}>
+      <LocalizationProvider value={{ locale: 'en' }}>
+        <PercentCellRenderer value={stored} field={{ ...FIELD }} />
+      </LocalizationProvider>
+    </I18nProvider>,
+  ).container;
+  const bar = container.querySelector<HTMLElement>('[role="progressbar"] div[style]');
+  expect(bar, 'the cell draws its own bar fill').not.toBeNull();
+  const value = container.querySelector<HTMLElement>('span.tabular-nums');
+  expect(value, 'the cell states its own percentage').not.toBeNull();
+  return { text: (value!.textContent ?? '').replace(/\s+/g, ' ').trim(), bar: pct(bar!.style.width) };
+}
+
+function pct(width: string): number {
+  expect(width, 'the fill width is a percentage').toMatch(/%$/);
+  return Number(width.slice(0, -1));
+}
+
+interface Row {
+  what: string;
+  stored: number;
+  /** The one percentage BOTH surfaces state. */
+  text: string;
+  /** The one magnitude BOTH surfaces draw, after each clamps to its track. */
+  bar: number;
+}
+
+const ROWS: Row[] = [
+  // LIVE CONTROL — inside the band where the two rules already agreed. Green
+  // before this change and green after; it is the row that says the repair did
+  // not reach past the boundary.
+  { what: 'CONTROL — inside the band both rules already agreed on', stored: 0.25, text: '25%', bar: 25 },
+  // THE FORK objectui#8728 pinned and handed here. The chip read a stored 1 as
+  // a ratio and said `100%` beside a full bar; every other band reads it as one
+  // percentage point.
+  { what: 'EXACTLY 1 — one percentage point, not one hundred', stored: 1, text: '1%', bar: 1 },
+  // The far edge of the same boundary. `percentDisplayValue` passes -1 through;
+  // the chip's rule scaled it to -100.
+  { what: 'EXACTLY -1 — the symmetric edge the chip did not have', stored: -1, text: '-1%', bar: 0 },
+  // Below -1. Bars are useless here (both clamp to an empty track), which is
+  // why the text instrument exists.
+  { what: 'below -1 — the half the bar cannot see', stored: -5, text: '-5%', bar: 0 },
+];
+
+describe('the summary chip reads the declared percent source (objectui#9071)', () => {
+  it.each(ROWS)('$what: a stored $stored reads $text in BOTH places', ({ stored, text, bar }) => {
+    const chip = renderChip(stored);
+    cleanup();
+    const cell = renderCell(stored);
+
+    expect(
+      chip.text,
+      'THE PIN: the chip and the list cell state the same percentage for the same stored value',
+    ).toBe(cell.text);
+    expect(chip.text, 'and it is this percentage').toBe(text);
+    expect(chip.bar, 'the chip draws what the cell draws').toBe(cell.bar);
+    expect(chip.bar, 'and it is this magnitude').toBe(bar);
+  });
+
+  /**
+   * The relation stated once over the whole table rather than row by row, so a
+   * repair that fixed one row and broke another is red here even if someone
+   * edited that row's expected string to match.
+   */
+  it('never states one percentage in the chip and another in the cell', () => {
+    const disagreements = ROWS.filter(({ stored }) => {
+      const chip = renderChip(stored);
+      cleanup();
+      const cell = renderCell(stored);
+      cleanup();
+      return chip.text !== cell.text || chip.bar !== cell.bar;
+    });
+    expect(disagreements.map((r) => r.stored), 'every stored value reads the same in both places').toEqual([]);
+  });
+
+  /**
+   * ⚠️ THE HALF THIS CARD DOES NOT FIX, pinned so it cannot go quiet.
+   *
+   * `percentDisplayValue`'s doc comment requires a third surface to take BOTH
+   * halves — the scaling AND the convention. This card moves the SCALING only,
+   * because taking the convention half would change what the chip prints for
+   * values it renders correctly today: the cell rounds to the field's precision
+   * (0 by default) and groups through `Intl`, the chip states the full number
+   * with a bare `%`. So a stored `12.3` still reads `12.3%` on the chip and
+   * `12%` in the cell — DIFFERENT SPELLINGS OF THE SAME MAGNITUDE, which the
+   * bars prove by agreeing exactly.
+   */
+  it('agrees on the magnitude even where the two surfaces spell it differently', () => {
+    const chip = renderChip(12.3);
+    cleanup();
+    const cell = renderCell(12.3);
+
+    expect(chip.bar, 'the scaling agrees — this is what objectui#9071 repaired').toBe(cell.bar);
+    expect(chip.bar, 'both draw 12.3 points').toBe(12.3);
+    expect(chip.text, 'the chip states the full number with a bare percent sign').toBe('12.3%');
+    expect(cell.text, "the cell rounds to the field's precision and renders the locale's affix").toBe('12%');
+  });
+});

--- a/packages/plugin-detail/src/summaryChipPercent.ts
+++ b/packages/plugin-detail/src/summaryChipPercent.ts
@@ -6,11 +6,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { percentDisplayValue } from '@object-ui/core';
+
 /**
- * The ONE rule the `summaryFields` chip scales a stored `percent` by
- * (objectui#8728).
+ * The ONE rule the `summaryFields` chip scales a stored `percent` by — and it
+ * is the repo's, not this file's (objectui#9071).
  *
- * ## The defect this function exists to make impossible
+ * ## Why this function exists at all (objectui#8728)
  *
  * The chip beside the record H1 draws a percent TWICE — as its text and as a
  * small bar — and the two halves scaled the same stored number by two
@@ -21,55 +23,67 @@
  *
  * so a stored `0.123` labelled itself `0.123%` beside a bar filled to 12.3%.
  * One control, two percentages, and neither half told the reader which one was
- * right. Both halves now read this function — which is why it is a named
- * function and not the same ternary written twice. The next reader cannot
+ * right. Both halves read this function — which is why it is a named function
+ * and not the same ternary written twice. The next reader cannot
  * re-desynchronise them without deleting a call site.
  *
- * ## Which of the two rules survived, and why it is the BAR's
+ * ## What objectui#9071 DELETED, and why aligning it would not have done
  *
- * Triage's ruling on objectui#8728: the text follows the bar, ⛔ never the
- * reverse, and ⛔ never a third rule invented for the occasion. So every bar
- * this chip has ever drawn is preserved here — a stored `12.3` still reads
- * `12.3%` beside a bar at 12.3%, a stored `250` still reads `250%` beside a
- * full one. What moved is the text, which now states the number the bar was
- * already drawing.
+ * objectui#8728 converged the chip's two halves onto the BAR's rule and
+ * recorded, rather than decided, that the rule was the chip's own. The census
+ * it asked for answered the question: the predicate that stood here —
+ * a pass-through spelled `if (raw > 1) return raw;`, i.e. the bar's original
+ * `num <= 1` written the other way round — was the only spelling of its kind on
+ * this side of the tree, and it disagreed with the declared single source of
+ * truth at EXACTLY 1 and at every value AT OR BELOW -1:
  *
- * ## ⚠️ This is NOT the repo's percent rule — measured, and filed
+ * | stored | the deleted local rule | `percentDisplayValue`, and every other band |
+ * |--------|------------------------|---------------------------------------------|
+ * | `0.25` | `25%`                  | `25%`   (the band they always agreed on)     |
+ * | `1`    | `100%`                 | `1%`                                         |
+ * | `-1`   | `-100%`                | `-1%`                                        |
+ * | `-5`   | `-500%`                | `-5%`                                        |
  *
- * The census that ruling asked for says the bar's `num <= 1` is the only
- * spelling of its kind in the tree. `percentDisplayValue` in `@object-ui/core`
- * — whose doc comment calls itself the single source of truth for percent
- * display scaling, and requires any third surface to take BOTH halves from it,
- * the scaling AND the convention — uses the symmetric `value > -1 && value < 1`,
- * and the list cell (`formatPercent`), the dashboard measure and the grid
- * column summary all reach it. Two consequences, both RECORDED on
- * objectui#9071 rather than decided here:
+ * ⛔ The repair is NOT to move the local predicate's boundary onto the shared
+ * one. That would leave two rules agreeing by coincidence — the same shape
+ * objectui#5607 removed one package over, and the shape that produced this
+ * drift in the first place. The predicate is gone; the authority is
+ * {@link percentDisplayValue} in `@object-ui/core`, whose own doc comment
+ * requires exactly this of a third surface, and which the list cell
+ * (`formatPercent` / `PercentCellRenderer`), the dashboard measure
+ * (`formatMeasure`) and the grid column summary already read.
  *
- *  - exactly `1` scales to `100` here and renders `1%` in every other band.
- *    objectui#5607 pinned that boundary in words for `plugin-dashboard` — 1 is
- *    percentage points, the convention `PercentScale` spells as `whole` — when
- *    it removed this same drift shape one package over;
- *  - a stored value at or below -1 now reads `-500%` for a stored `-5`, where
- *    the text alone used to read `-5%`. The bar is unchanged either way (any
- *    negative clamps to an empty track), so this is the drift becoming visible
- *    on the half that had been accidentally right.
+ * ## ⚠️ The half objectui#9071 did NOT take, stated rather than left silent
  *
- * Converging the chip onto `percentDisplayValue` — or onto the field's declared
- * scale, which is what the edit widget `PercentField` reads instead of guessing
- * from magnitude — is objectui#9071's decision to make, not this one's.
+ * That doc comment asks a third surface for BOTH halves — the scaling AND the
+ * convention. Only the SCALING moved here. The chip states the full number with
+ * a bare `%`; the list cell renders through the locale's percent affix at the
+ * field's precision, which is `0` by default. So a stored `12.3` still reads
+ * `12.3%` on the chip and `12%` in the cell — two spellings of one magnitude,
+ * and the two bars prove the magnitude is one. Taking the convention half would
+ * move values the chip renders correctly today, which objectui#9071's
+ * acceptance forbids; it is pinned as a fact in
+ * `__tests__/summaryChip.percentSource-9071.test.tsx` so the next card inherits
+ * a measurement instead of a silence.
  */
 export function summaryChipPercentPoints(raw: number): number {
-  // Already in percentage points: passed through untouched, so every value the
-  // chip renders correctly today is byte-identical after the repair.
-  if (raw > 1) return raw;
+  const points = percentDisplayValue(raw);
 
-  // A ratio, scaled to points. The `toPrecision` is load-bearing, not
+  // Not a second rule, and not a boundary: this asks the SOURCE whether it
+  // scaled, by comparing its answer to its input, so it cannot drift away from
+  // whatever `percentDisplayValue` decides.
+  if (points === raw) return points;
+
+  // A ratio the source scaled to points. The `toPrecision` is load-bearing, not
   // defensive: `raw * 100` is binary floating-point multiplication, and it is
-  // now the TEXT that reads the result. 246 of the 999 three-decimal ratios
+  // the TEXT that reads the result. 246 of the 999 three-decimal ratios
   // (0.001 through 0.999) carry residue when multiplied by 100 — a stored
   // `0.07` is `7.000000000000001`, a stored `0.29` is `28.999999999999996` —
   // which a CSS bar width absorbs invisibly and a label cannot. 12 significant
   // digits is far wider than any percent a human authored, and far narrower
-  // than the residue.
-  return Number((raw * 100).toPrecision(12));
+  // than the residue. It rounds a MAGNITUDE the source already chose, so it is
+  // a rendering step on this chip's text path, not a percent convention: the
+  // guard above keeps it off every value the source passed through, where
+  // trimming to 12 digits would move numbers that render correctly today.
+  return Number(points.toPrecision(12));
 }


### PR DESCRIPTION
Fixes #9071

The `summaryFields` chip beside the record H1 scaled a stored `percent` by a rule of its own. The local predicate is **deleted**, not realigned — realigning it would leave two rules agreeing by coincidence, which triage named as the thing to avoid and which is the shape that produced the drift in the first place.

Executable change: **5 lines**, all in one function.

```
-  if (raw > 1) return raw;
+  const points = percentDisplayValue(raw);
+
+  if (points === raw) return points;
-  return Number((raw * 100).toPrecision(12));
+  return Number(points.toPrecision(12));
```

## Changed files (Clause-② is `no`, which owes this listing)

| file | what moved |
|---|---|
| `packages/plugin-detail/src/summaryChipPercent.ts` | the repair: the local predicate deleted, `percentDisplayValue` imported from the published `@object-ui/core` specifier |
| `packages/plugin-detail/src/DetailView.tsx` | **comment only** — no executable line changed; the call-site note now names the authority and points at the half not taken |
| `packages/plugin-detail/src/__tests__/summaryChip.percentSource-9071.test.tsx` | **new** — the two-places pin |
| `packages/plugin-detail/src/__tests__/summaryChip.percentOneRule-8728.test.tsx` | two boundary rows and the prose that handed this fork here |
| `.changeset/9071-summary-chip-percent-source.md` | **new** — `patch` on `@object-ui/plugin-detail` |

⛔ No new exported symbol, no schema change, and `packages/core/src/utils/dataset-format.ts` is **imported, never modified** — the same-file fence around in-flight objectui#9160 holds. Nothing outside `packages/plugin-detail` is touched.

## The census, re-derived on this branch's base rather than inherited

| site | rule | a stored `1` | a stored `-5` |
|---|---|---|---|
| `percentDisplayValue` in core — the declared source | `value > -1 && value < 1` | `1%` | `-5%` |
| `formatPercent` / `PercentCellRenderer`, the list cell | via `percentDisplayValue` | `1%` | `-5%` |
| `PercentCellRenderer`'s BAR value | inline copy, **same predicate** | `1%` | `-5%` |
| `useColumnSummary` in `plugin-grid` | inline copy, **same predicate** | `1%` | `-5%` |
| `recordFields` in `plugin-dashboard` | via `percentDisplayValue` | `1%` | `-5%` |
| `formatMeasure` in core | declared `percentScale` first, else `percentDisplayValue` | `1%` | `-5%` |
| **the summary chip** — before this PR | pass-through above 1 | **`100%`** | **`-500%`** |

⇒ disagreement set re-derived by hand and then confirmed by a failing run: **exactly `1`**, and **every value at or below `-1`**. The two inline copies are copies of the rule but **not drifted** — same predicate, same answers — so fixing the chip leaves no disagreement at either of them.

### ⚠️ Mechanism assumption 2 was FALSIFIED, and the finding is filed not widened

"Every other site routes through the declared source" is **not true today**. `formatMetricValue` in `packages/plugin-dashboard/src/MetricWidget.tsx` writes the same rule the other way round — a pass-through guarded by a greater-than-one test with the multiply in the else arm — so a literal `num <= 1` grep cannot see it, which is why objectui#9071's own census missed it. Measured, both surfaces in one run, a metric tile with `format: '0%'` against `formatPercent`:

| stored | MetricWidget | the declared source |
|---|---|---|
| `1` | `100%` | `1%` |
| `-1` | `-100%` | `-1%` |
| `-5` | `-500%` | `-5%` |
| `0.25` | `25%` | `25%` |

Identical disagreement set. It is **outside `plugin-detail`**, which this card's dispatch made a stop condition, so it is named and filed as objectui#9165 rather than pulled in here. Not addressed on this PR.

## The pin renders BOTH places, because a chip-only pin cannot fail for this card's reason

`summaryChip.percentSource-9071.test.tsx` renders the DetailView chip **and** `PercentCellRenderer` from the same stored value and the same field, then asserts they agree — on the stated text, and on the magnitude each one draws. Two instruments, because neither alone covers the disagreement set: bars clamp any negative to an empty track, so only the text reaches a value at or below `-1`.

- **Live control** `0.25`, inside the band the two rules always agreed on: identical in both places, green before the change and after, and green on **both** legs of the ablation.
- Both boundaries pinned: exactly `1`, and exactly `-1` as well as `-5`.

Run on the unrepaired tree first, and it failed for exactly the card's reason: `expected '100%' to be '1%'`, `expected '-100%' to be '-1%'`, `expected '-500%' to be '-5%'`, and the whole-table relation red with `[ 1, -1, -5 ]`.

## Ablation — the pins can fail, proved by state and never by an exit code

Direction predicted in writing before the run: reinstating the deleted predicate turns **both** pin files red at the boundary rows, and leaves the control and the already-agreeing rows green.

**Mutation proved on disk BEFORE the run.** HEAD blob `bd35a701aeb9a64bd8de9809defa27a590915741`, on disk before `bd35a701ae…` (equal, so the tree really was at HEAD). Occurrence counts both directions: repaired line 1 then 0, drifted line 0 then 1. Blob hash moved to `7cfbd5bc4e1180ac3f43eedae016ed66488ca598`. The mutated line printed from disk: `const points = raw > 1 ? raw : raw * 100;`. No build step is owed — the root vitest config aliases `@object-ui/core` and `@object-ui/fields` to their `src` trees, so the run reads the mutated source directly.

**Mutated run: `6 failed | 11 passed`** — the 8728 pin red at `1` and `-5`, the 9071 pin red at `1`, `-1`, `-5` plus the whole-table relation. The control `0.25` and the already-agreeing `12.3` case stayed green.

**Restore proved BY STATE.** `git hash-object` back to `bd35a701ae…` and equal to the HEAD blob; `git diff HEAD` empty; `git status --short` empty; the restored line printed from disk; occurrence counts back to 1 and 0. **Restored run: `17 passed`.** The mutation ran under a `trap … EXIT INT TERM` with absolute paths, and the restore points at `HEAD` explicitly rather than at the index.

## Verification, all on the final commit `7c620b228`

| what | result |
|---|---|
| `pnpm exec vitest run packages/plugin-detail/` (via the shared verify lock) | `VERDICT command-exit 0` — **170 files, 1581 tests passed** |
| `pnpm --filter @object-ui/plugin-detail type-check` | exit 0, after building the dependency closure (`pnpm --filter '@object-ui/plugin-detail^...' build`, `VERDICT command-exit 0`) — the script echoed `tsc --noEmit && tsc -p tsconfig.test.json`, so the new test file is covered too |
| eslint, **whole repo, not narrowed** | 4,827 files as eslint's own config selects them; 95 errors and 12,865 warnings, all pre-existing. My 4 linted files carry **0 errors and 0 warnings**; `DetailView.tsx`'s 45 warnings are unchanged in count, and the repo warning total is 2 **lower** than before this branch |
| `check:new-line-citations`, `check:control-bytes`, `check:changeset-claims`, `check:vi-mock-specifiers`, `check:unreferenced-sources` | exit 0 each |
| `node scripts/check-changeset-presence.mjs` | exit 0 — 3 published source files, 1 changeset |
| `node scripts/check-governed-queue-guard.mjs --test` on all 5 paths | `NOT GOVERNED — none matched` |

⚠️ First `type-check` attempt reported `TS2307: Cannot find module '@object-ui/core'` against my new import **and against every pre-existing one** — an unbuilt workspace, not a finding. Recorded because it reads like a real error. The reading above is from after the closure build.

## Acceptance notes

**What deliberately moved, and nothing else did.** A stored `1` now reads `1%` beside a 1% bar where it read `100%` beside a full bar; a stored value at or below `-1` is passed through, so `-5` reads `-5%` where it read `-500%` (the bar is unchanged there — any negative clamps to an empty track either way). Everything in the band the two rules always agreed on is byte-identical, including the float-residue trim that keeps `0.07` reading `7%` rather than `7.000000000000001%`.

**Why a trim survived at all, and why it is not a second rule.** The residue trim had to stay, or a value that renders correctly today would move — `percentDisplayValue(0.07)` is `7.000000000000001`, which `formatPercent` absorbs at its precision and this chip's bare `${points}%` cannot. It is guarded by `points === raw`, which asks the SOURCE whether it scaled by comparing its own answer to its own input, so it cannot drift away from whatever `percentDisplayValue` decides, and it never touches a value the source passed through. The scaling **predicate** is gone; its name survives only inside the comment that explains its removal.

**The half this PR does not take, filed rather than left silent.** `percentDisplayValue`'s doc comment asks a third surface for BOTH halves — the scaling AND the convention. Only the scaling moved, because taking the convention half moves values that render correctly today (`12.3` would become `12%`, `1234.5` would become `1,235%`), which this card's dispatch made a stop condition. That residue is pinned as a named case in the new test file and filed as objectui#9167, since this PR closes the card it would otherwise have lived on.

**Out-of-scope observations, noted and not filed.** The `PercentCellRenderer` bar value and `useColumnSummary` each hold a hand-written copy of the shared predicate; both agree with `percentDisplayValue` byte-for-byte today, so there is no disagreement to report and no defect — only a duplication that a future consolidation would pick up. Successor named: whoever takes objectui#9165, which has to touch this same family. Separately, `formatMetricValue`'s own doc comment describes its percent branch as scaling only **below** 1 while the code scales at or below it — recorded inside objectui#9165 rather than filed on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_