### PR TITLE
fix(components): judge a single-node `body` by the same page-header rule (objectui#8923)

### DIFF
--- a/.changeset/8923-page-header-single-node-delegation.md
+++ b/.changeset/8923-page-header-single-node-delegation.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/components': patch
+---
+
+Fix: a `page:header` authored as a SINGLE-NODE `body` (or `children`) no longer leaves
+the page drawing a duplicate `h1` (objectui#8923).
+
+`PageRenderer` delegates its implicit heading to an authored `page:header` so a document
+has exactly one `h1` (objectui#3434). The predicate that decides this,
+`containsTitledPageHeader`, opened with an early `return false` for anything that is not
+an array. `PageNodeSchema.body` and `.children` are declared `SchemaNode | SchemaNode[]`,
+so a page whose `body` is one bare node — the arity the root `README` flagship example
+authors — took that early return: the page emitted its own `h1` next to the one the
+header rendered. A screen reader announced the title twice and it was visibly duplicated.
+
+The hole was per recursion level, not only at the top: the walk feeds each node's nested
+`body` / `children` back into the same early return, so a bare-node hop anywhere in the
+chain ended the search. Measured, not read: before the change the top-level case rendered
+2 `h1` elements, as did a bare hop at depth 1, 2 and 6.
+
+The repair normalises the arity once, at the predicate's entry, the way `FlatContent` in
+the same file has always widened these two keys — so `regions[].components`, `body` and
+`children` are judged by one rule instead of three call sites each remembering
+`Array.isArray`. The `depth > 6` bound is unchanged: the widening happens inside the same
+invocation as the depth check, so it spends no budget.
+
+Deliberately unchanged: a `page:header` whose title renders no literal text (absent,
+empty, or `'{name}'` interpolating to nothing with no record in scope) still does NOT take
+the page's heading away — suppressing ours there would leave the page with zero `h1`.

--- a/packages/components/src/__tests__/page-header-single-node-delegation-8923.test.tsx
+++ b/packages/components/src/__tests__/page-header-single-node-delegation-8923.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * "One page, one h1" — the SINGLE-NODE arity (objectui#8923).
+ *
+ * `page-single-h1.test.tsx` pinned the rule for `regions[].components`, where
+ * the shape is declared `SchemaNode[]` and only ever a list. The delegation
+ * check `containsTitledPageHeader` opened with `if (!Array.isArray(nodes)) …
+ * return false`, so every channel whose declared arity is
+ * `SchemaNode | SchemaNode[]` — `PageNodeSchema.body`, `PageNodeSchema.children`
+ * and, through the recursion, every nested `body` / `children` — took that early
+ * return and answered "no titled header here". PageRenderer then drew its own
+ * `h1` next to the one the header renders: the exact broken document outline
+ * objectui#3434 closed, reopened for the arity the README flagship example
+ * actually authors (`body: { type: 'grid', … }`, a bare node).
+ *
+ * The single-node arity became a declared, first-class authored shape in
+ * objectui#8914 (card objectui#8310), which widened `PageNodeSchema.body` /
+ * `.children` to `SchemaNode | SchemaNode[]`; `FlatContent` in the same file has
+ * always normalised a bare node into a one-element list. This suite is the
+ * runtime reproduction the card asked the fixing seat to take first: assertions
+ * are written against the ACCESSIBLE TREE (`getAllByRole` with an explicit
+ * level), never against class names.
+ *
+ * Row taxonomy, so the evidence value of each row is readable without running
+ * the ablation:
+ *   - `DISCRIMINATING` — red before the normaliser, green after.
+ *   - `LIVE CONTROL`   — green on BOTH ablation legs. These are the rows that
+ *     say the fix did not cross a boundary: the list arity that already worked,
+ *     and the deliberately conservative "a header that renders no heading does
+ *     NOT take the page's h1 away" rule.
+ *   - `CANNOT DISCRIMINATE` — identical on both legs AND not a boundary the fix
+ *     could plausibly cross; pinned only so the depth budget cannot move
+ *     silently. Explicitly NOT evidence that the fix works.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ActionProvider, SchemaRenderer } from '@object-ui/react';
+// Module scope, not a hook: registers PageRenderer (`app`/`home`/`record`/…),
+// `page:header` and `card`. A cold `await import()` inside a hook is billed to
+// `hookTimeout` and races the assertions (AGENTS.md §测试纪律, objectui#3010).
+import '../renderers';
+
+const PAGE_LABEL = 'New Project + Tasks';
+const HEADER_TITLE = 'Authored header title';
+
+/** A titled `page:header` — the node that renders the page's real heading. */
+function titledHeader(props: Record<string, unknown> = { title: HEADER_TITLE }) {
+  return { type: 'page:header', properties: props } as any;
+}
+
+/**
+ * A region-less page. `body` / `children` are handed through verbatim so each
+ * row controls the ARITY under test — the whole point of the suite.
+ */
+function pageWith(extra: Record<string, unknown>) {
+  return {
+    type: 'app',
+    pageType: 'app',
+    name: 'single_node_body_page',
+    // Spec pages carry `label`; PageRenderer dual-reads it as the page title.
+    label: PAGE_LABEL,
+    template: 'default',
+    ...extra,
+  } as any;
+}
+
+function renderPage(schema: any) {
+  return render(
+    <ActionProvider>
+      <SchemaRenderer schema={schema} />
+    </ActionProvider>,
+  );
+}
+
+/**
+ * A chain of `cards` nested containers whose INNERMOST `body` is the bare
+ * header node and whose every outer `body` is a one-element list. The header is
+ * therefore examined at recursion depth `cards`, through the single-node hop —
+ * exactly the arity the budget must keep treating like the list arity.
+ */
+function chainToBareHeader(cards: number): any {
+  let node: any = { type: 'card', body: titledHeader() };
+  for (let i = 1; i < cards; i += 1) {
+    node = { type: 'card', body: [node] };
+  }
+  return node;
+}
+
+describe('PageRenderer — single-node `body`/`children` delegate the h1 too (objectui#8923)', () => {
+  // -------------------------------------------------------------------------
+  // A1 — the reproduction the card asked for, at the top level.
+  // -------------------------------------------------------------------------
+  it('DISCRIMINATING — `body` as a SINGLE titled `page:header` node renders exactly ONE h1', () => {
+    renderPage(pageWith({ body: titledHeader() }));
+
+    // Before the normaliser this read 2: the page's implicit `label` h1 plus
+    // the header's own. `getAllByRole` is the locator the live e2e depends on.
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe(HEADER_TITLE);
+    expect(screen.queryByText(PAGE_LABEL)).toBeNull();
+  });
+
+  it('DISCRIMINATING — `children` as a SINGLE titled `page:header` node renders exactly ONE h1', () => {
+    // `PageNodeSchema.children` carries the same `SchemaNode | SchemaNode[]`
+    // arity and is the second channel `pageHeaderOwnsTitle` reads.
+    renderPage(pageWith({ children: titledHeader() }));
+
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe(HEADER_TITLE);
+  });
+
+  // -------------------------------------------------------------------------
+  // A2 — the hole is per-RECURSION-LEVEL, not only at the top. The recursion
+  // feeds `n.body` / `n.children` back into the SAME early return.
+  // -------------------------------------------------------------------------
+  it('DISCRIMINATING — a nested container whose `body` is a SINGLE titled header still delegates', () => {
+    renderPage(pageWith({ body: [{ type: 'card', body: titledHeader() }] }));
+
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe(HEADER_TITLE);
+  });
+
+  it('DISCRIMINATING — a nested container whose `children` is a SINGLE titled header still delegates', () => {
+    renderPage(pageWith({ body: [{ type: 'card', children: titledHeader() }] }));
+
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe(HEADER_TITLE);
+  });
+
+  it('DISCRIMINATING — a bare node at EVERY level of the chain (single-node all the way down)', () => {
+    // Neither the outer `body` nor any inner one is a list. Before the fix the
+    // walk stopped at the very first hop.
+    renderPage(
+      pageWith({
+        body: { type: 'card', body: { type: 'card', body: titledHeader() } },
+      }),
+    );
+
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe(HEADER_TITLE);
+  });
+
+  // -------------------------------------------------------------------------
+  // LIVE CONTROLS — the list arity that already worked. Green on BOTH ablation
+  // legs; they are what says the normaliser did not cross a boundary.
+  // -------------------------------------------------------------------------
+  it('LIVE CONTROL — `body` as a one-element LIST still renders exactly ONE h1', () => {
+    renderPage(pageWith({ body: [titledHeader()] }));
+
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe(HEADER_TITLE);
+  });
+
+  it('LIVE CONTROL — a nested container whose `body` is a LIST still renders exactly ONE h1', () => {
+    renderPage(pageWith({ body: [{ type: 'card', body: [titledHeader()] }] }));
+
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe(HEADER_TITLE);
+  });
+
+  it('LIVE CONTROL — a page that authors NO `page:header` keeps its own implicit h1', () => {
+    renderPage(pageWith({ body: { type: 'element:text', properties: { text: 'body' } } }));
+
+    const h1s = screen.getAllByRole('heading', { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0].textContent).toBe(PAGE_LABEL);
+  });
+
+  // -------------------------------------------------------------------------
+  // LIVE CONTROLS — the conservatism `pageHeaderOwnsTitle` documents. A header
+  // that renders NO heading must NOT take the page's h1 away; the normaliser
+  // widens the arity, never the "counts as titled" test. Without these rows the
+  // repair could trade a duplicate h1 for a page with ZERO h1 — strictly worse.
+  // -------------------------------------------------------------------------
+  it('LIVE CONTROL — single-node `body` header with NO title leaves the page its own h1', () => {
+    // PageHeaderRenderer's bare branch renders `{explicitTitle && <h1>}`, so an
+    // untitled header contributes no heading at all.
+    renderPage(pageWith({ body: titledHeader({ subtitle: 'Just a subtitle' }) }));
+
+    const h1s = screen.getAllByRole('heading', { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0].textContent).toBe(PAGE_LABEL);
+  });
+
+  it('LIVE CONTROL — single-node `body` header whose title interpolates to nothing leaves the page its own h1', () => {
+    // `title: '{name}'` with no record in scope → `interpolate()` blanks it.
+    renderPage(pageWith({ body: titledHeader({ title: '{name}' }) }));
+
+    const h1s = screen.getAllByRole('heading', { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0].textContent).toBe(PAGE_LABEL);
+  });
+
+  it('DISCRIMINATING — delegating from a single-node `body` keeps the page `description`', () => {
+    renderPage(pageWith({ body: titledHeader(), description: 'Page-level prose.' }));
+
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+    expect(screen.getByText('Page-level prose.')).toBeTruthy();
+  });
+
+  // -------------------------------------------------------------------------
+  // Depth budget. The normaliser runs INSIDE the same invocation as the
+  // `depth > 6` check, so wrapping a bare node must not spend a level.
+  // -------------------------------------------------------------------------
+  describe('depth budget (`depth > 6`) — unchanged by the normaliser', () => {
+    it('DISCRIMINATING — a bare header at the LAST in-budget depth (6) still delegates', () => {
+      // Six containers; the header is reached through the innermost container's
+      // single-node `body`, so it is examined at depth 6 — the last value the
+      // guard admits. If normalising a bare node spent a depth level this row
+      // would fall out of budget and the page would draw a second h1.
+      renderPage(pageWith({ body: [chainToBareHeader(6)] }));
+
+      expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+      expect(screen.getByRole('heading', { level: 1 }).textContent).toBe(HEADER_TITLE);
+    });
+
+    it('CANNOT DISCRIMINATE — a header one level BEYOND the budget (7) is still not found', () => {
+      // ⚠️ NOT evidence that this fix works — identical on both ablation legs.
+      // It is here so the budget cannot silently WIDEN: the normaliser must not
+      // buy the walk an extra level. The duplicate h1 it asserts is the
+      // pre-existing outcome for headers buried deeper than the walk looks
+      // (objectui#3434's depth bound), and is out of scope for objectui#8923.
+      renderPage(pageWith({ body: [chainToBareHeader(7)] }));
+
+      expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(2);
+    });
+  });
+});

--- a/packages/components/src/renderers/layout/page.tsx
+++ b/packages/components/src/renderers/layout/page.tsx
@@ -120,10 +120,29 @@ function isTitledPageHeader(node: any): boolean {
   return literalTitleText(node?.title ?? node?.properties?.title) !== '';
 }
 
-/** Depth-bounded walk over the component shapes a page can nest. */
+/**
+ * Depth-bounded walk over the component shapes a page can nest.
+ *
+ * Takes ONE node or a LIST of them, and judges both by the same rule. `body`
+ * and `children` are declared `SchemaNode | SchemaNode[]` on `PageNodeSchema`
+ * and on `BaseSchema`, and `FlatContent` below has always rendered the bare-node
+ * form, so a single node is a first-class authored shape — at the top level and
+ * at every nested level the recursion re-enters (objectui#8923). This used to
+ * open with `if (!Array.isArray(nodes)) return false`, so every bare-node
+ * channel answered "no titled header here" and PageRenderer drew a second `h1`
+ * next to the authored one (the outline objectui#3434 closed).
+ *
+ * Normalising HERE rather than at the three call sites is deliberate: one
+ * normaliser at the entry beats four predicates each having to remember
+ * `Array.isArray`. It spends no depth budget — the widening happens inside the
+ * same invocation as the `depth > 6` check — so the bound still admits exactly
+ * the levels it admitted before. Spelled the way `FlatContent` already widens
+ * the same two keys.
+ */
 function containsTitledPageHeader(nodes: unknown, depth = 0): boolean {
-  if (!Array.isArray(nodes) || depth > 6) return false;
-  return nodes.some(
+  if (depth > 6) return false;
+  const list: unknown[] = Array.isArray(nodes) ? nodes : nodes ? [nodes] : [];
+  return list.some(
     (n: any) =>
       !!n &&
       typeof n === 'object' &&
@@ -157,8 +176,8 @@ function pageHeaderOwnsTitle(schema: PageNodeSchema): boolean {
   const regionNodes = (schema.regions ?? []).flatMap((r: any) => r?.components ?? []);
   return (
     containsTitledPageHeader(regionNodes) ||
-    containsTitledPageHeader((schema as any).body) ||
-    containsTitledPageHeader((schema as any).children)
+    containsTitledPageHeader(schema.body) ||
+    containsTitledPageHeader(schema.children)
   );
 }
 


### PR DESCRIPTION
Fixes #8923

## What changed

`containsTitledPageHeader` in `packages/components/src/renderers/layout/page.tsx` opened with an early `return false` for anything that is not an array. `PageNodeSchema.body` and `.children` are declared `SchemaNode | SchemaNode[]` (widened in objectui#8914, card objectui#8310), and the root `README` flagship example authors the bare-node form — so a page whose `body` is one titled `page:header` took that early return, `pageHeaderOwnsTitle` answered `false`, and `PageRenderer` drew its own `h1` next to the one the header rendered.

Two changes, both in that one file:

1. **Normalise the arity once, at the predicate's entry** — spelled the way `FlatContent` in the same file has always widened these two keys. `regions[].components`, `body` and `children` are now judged by one rule instead of three call sites each remembering `Array.isArray`.
2. **Drop the two `as any` casts** in `pageHeaderOwnsTitle`. The parameter is `unknown`, so neither bought anything; the `body` one was doubly redundant once the key was declared with the arity being asked about.

The `depth > 6` bound is **unchanged**: the widening runs inside the same invocation as the depth check, so it spends no budget. Pinned in both directions (see the depth-budget block in the new suite).

## Measured, not read

The card was read-derived and explicitly asked the fixing seat to reproduce first. The pin was written first and run against unmodified `origin/main` source (8e74b27fc):

```
AssertionError: expected [ h1 …(1), h1 …(1) ] to have a length of 1 but got 2
  packages/components/src/__tests__/page-header-single-node-delegation-8923.test.tsx:99
Tests  7 failed | 7 passed (14)
```

Two `h1` elements, exactly as the card predicted. After the repair, the new suite plus the pre-existing `page-single-h1.test.tsx`: `Tests 21 passed (21)`.

### The hole was per recursion level, not only at the top

A hypothesis neither the card nor triage stated, and it measured TRUE. The walk feeds each node's `n.body` / `n.children` back into the same early return, so a bare-node hop **anywhere** in the chain ended the search. Reproduced red at the top level, through `children`, at a nested container's `body`, at a nested container's `children`, with a bare node at every level of the chain, and at the last in-budget depth (6).

`regions[].components` is declared `SchemaNode[]` and had nothing to miss — and it is doubly safe, because `pageHeaderOwnsTitle` reaches it through `flatMap`, which keeps a non-array return as a single element rather than dropping it.

### The conservatism is intact

`pageHeaderOwnsTitle` is deliberately conservative: only a header whose title renders literal text counts, because suppressing ours against a header that renders no heading would leave the page with **zero** `h1`. Live-control rows pin that a single-node `body` header that is untitled, or whose title interpolates to nothing (`title: '{name}'` with no record in scope), still leaves the page its own heading. Both stayed green on both ablation legs.

## Ablation

The normaliser was reverted verbatim, with the mutation proven on disk before the run and the restore proven by state, never by an exit code:

```
HEAD_BLOB=6fdf1e8ddefb71b2932fb3c224e5648d18e2f614
BEFORE_HASH=6fdf1e8ddefb71b2932fb3c224e5648d18e2f614   (tree == HEAD before mutating)
anchor counts BEFORE:  fixed-line 1, original-line 0
anchor counts AFTER:   fixed-line 0, original-line 1
AFTER_HASH=ce06d7444cb2167b876d6eaad9455ef8e04c54e4    (!= HEAD blob: the edit reached disk)
RESTORED_HASH=6fdf1e8ddefb71b2932fb3c224e5648d18e2f614 (== HEAD blob)
git diff HEAD -- page.tsx  =>  0 bytes
anchor counts AFTER RESTORE: fixed-line 1, original-line 0
```

The ablated run failed **exactly** the rows labelled `DISCRIMINATING`, and nothing else:

```
Tests  7 failed | 14 passed (21)
  × DISCRIMINATING — `body` as a SINGLE titled `page:header` node renders exactly ONE h1
  × DISCRIMINATING — `children` as a SINGLE titled `page:header` node renders exactly ONE h1
  × DISCRIMINATING — a nested container whose `body` is a SINGLE titled header still delegates
  × DISCRIMINATING — a nested container whose `children` is a SINGLE titled header still delegates
  × DISCRIMINATING — a bare node at EVERY level of the chain (single-node all the way down)
  × DISCRIMINATING — delegating from a single-node `body` keeps the page `description`
  × DISCRIMINATING — a bare header at the LAST in-budget depth (6) still delegates
```

All five `LIVE CONTROL` rows, the one row labelled `CANNOT DISCRIMINATE` (the depth-budget upper bound, pinned only so the budget cannot silently widen — explicitly not evidence), and all eight rows of the pre-existing `page-single-h1.test.tsx` stayed green on both legs. The test file is loaded from source through the repo vitest aliases, so no build sits between the edit and the assertion; the red/green flip above is the proof of that.

## Verification

All at `44677d44d`, exit codes captured by redirection before any pipe:

| step | command | result |
|---|---|---|
| dependency closure | `pnpm --workspace-concurrency=2 --filter '@object-ui/components^...' build` | exit 0 |
| affected package suite | `pnpm exec vitest run packages/components/` | `Test Files 263 passed (263)`, `Tests 2399 passed (2399)`, exit 0 |
| type-check | `pnpm --filter @object-ui/components type-check` | exit 0 — the script is `tsc --noEmit && tsc -p tsconfig.test.json`, so the new suite is inside the checked set, not excluded |
| lint | `pnpm --filter @object-ui/components lint` | exit 0, `951 problems (0 errors, 951 warnings)` — every warning pre-existing, all in `src/ui/**` |
| changeset presence | `node scripts/check-changeset-presence.mjs` | exit 0, declares `.changeset/8923-page-header-single-node-delegation.md` |
| changeset no-major | `node scripts/check-changeset-no-major.mjs` | exit 0 |
| control bytes | `node scripts/check-control-bytes.mjs` | exit 0, 7366 tracked text files scanned |
| line citations | `node scripts/check-new-cross-file-line-citations.mjs` | exit 0, 0 new citations |
| unreferenced sources | `node scripts/check-unreferenced-sources.mjs` | exit 0 |
| governed surface | `node scripts/check-governed-queue-guard.mjs --test <the 3 paths>` | `NOT GOVERNED` — 3 paths, none matched |

**Declared narrowing.** Repo-wide `pnpm lint` is `turbo run lint`, one leg per package; only the affected package's leg was run locally. The other legs cannot move: the diff is confined to `packages/components/src`, and each leg lints only its own package's files. The full fan-out is CI's.

`check-changeset-claims.mjs` flags two pending changesets whose bodies name `page.tsx`. Both re-read, neither falsified: `7926-page-node-refuses-actions.md` rests on `git grep -ni action` over `page.tsx`, and that grep returns the **same four hits** at `8e74b27fc` and at `44677d44d` — this diff adds zero occurrences. `page-source-tailwind-prose-retraction-5469.md` concerns `html-elements.tsx`, `sdui-parser/src/types.ts`, a README, and the `kind === 'html'` dispatch-arm comment; none of them is touched here.

## Acceptance notes

Out of scope for this card, noted while measuring:

- **Filed as objectui#9174.** `interpolate`'s no-token fast path (`if (!template.includes('{')) return template;`) returns the template verbatim and so skips the `.replace(/\s+/g,' ').trim()` its own token path applies. A whitespace-only authored `page:header` title therefore stays truthy, renders a **blank `h1`**, and — because `literalTitleText` does trim and so declines to delegate — the page adds a second one. Measured on this branch through `regions[].components`, the array channel this PR does not touch: `title: '   '` gives 2 `h1` (`["PAGE LABEL", "   "]`) while `title: '{name} '` gives 1. Pre-existing, lands in `containers.tsx`, and the repair direction is a judgement call — so filed, not smuggled in.
- **Noted, not filed.** `Array.isArray` early-return census over `page.tsx`: the file holds exactly three boolean-returning functions (`isTitledPageHeader`, `containsTitledPageHeader`, `pageHeaderOwnsTitle`), and only `containsTitledPageHeader` carried an arity hole. No sibling predicate in the file has the same defect, so there is nothing to file. Successor for the note: the next seat editing this delegation block.

## Delivery posture

Draft. Per dispatch: **not** flipped to ready, **not** queued, no auto-merge. Clause-② is `no`, matching the claim comment — both edited functions are module-private (no `export`), so widening their parameters moves no published surface, and this PR carries no `needs:contract-review` label.

Generated by Claude Code, seat session `https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_


---
_Generated by [Claude Code](https://claude.ai/code)_