### PR TITLE
fix(plugin-dashboard): one spelling for a field key across the drill chain

### DIFF
--- a/.changeset/field-key-spelling-outside-table-9055.md
+++ b/.changeset/field-key-spelling-outside-table-9055.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/plugin-dashboard': patch
+---
+
+One field key now renders under one spelling across a dashboard drill chain: the record drawer and the chart series label both derive their display string with `humanizeFieldKey`, the single home for the KEY convention (objectui#9055).
+
+**The record drawer, on the same click.** `RecordDetailDrawer` built its field label from a fourth inline spelling that upper-cased only the FIRST word. `ObjectDataTable`'s drill list is drill-to-record by default and the record it opens is this drawer, so one click moved from a column headed `Close Date` to a field labelled `Close date` — same key, same widget, one uninterrupted interaction. Measured on the rendered DOM of one chain, before the fix: headers `Close Date · Needs Analysis · Unit Price · Amount` against drawer labels `Close date · Needs analysis · Unit Price · Amount`. camelCase agreed under both spellings, which is why it went unnoticed.
+
+**The chart series label, on two of its three arms.** `resolveSeriesLabel` in `DashboardRenderer` handed back the RAW field key twice: as `fieldLabel`'s fallback on the object-bound arm, and outright on the arm every static-data chart takes. A chart grouped on `close_date` legended it `close_date` while the table widget beside it headed that column `Close Date`. The static-data arm is not named by the card; it is the same defect reached through the other call site, and it is fixed here rather than left for a follow-up. The synthetic-key arm — a count aggregation with no real field, which resolves an i18n'd aggregate name (Count / 计数) — is a different vocabulary and is deliberately untouched.
+
+The i18n wrapper is unchanged everywhere: a bundle entry still wins and the derived spelling is only its fallback, and the `objectName` guards are as they were. No published export, schema key or registry entry moves. The KEY prefixer stays distinct from `humanizeLabel`, the VALUE prefixer in `@object-ui/core` — converging those two is a separate decision its own docblock already reserves for its own card.

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -39,7 +39,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { isObjectProvider, deriveStaticTableColumns } from './utils';
+import { isObjectProvider, deriveStaticTableColumns, humanizeFieldKey } from './utils';
 import { classifyWidgetType, METRIC_LIKE_TYPES } from './widgetDispatch';
 import { LEGACY_RETIRED_WIDGET_SCHEMA, isLegacyRetiredWidget } from './legacyRetiredWidget';
 import { DatasetWidget } from './DatasetWidget';
@@ -318,16 +318,39 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
      * key like 'value' (used by count aggregations that have no real field),
      * fall back to an i18n'd aggregate name (Count / Sum / Average …) instead
      * of leaking the placeholder 'value' string into the legend / tooltip.
+     *
+     * ⭐ THREE ARMS, and only the last two derive a display string from a FIELD
+     * KEY (objectui#9055). The aggregate arm is a different vocabulary and is
+     * deliberately left alone — it is what a blind "humanize everything" here
+     * would eat, and it is pinned as a live control in
+     * `__tests__/fieldKeySpellingOutsideTable-9055.test.tsx`.
+     *
+     * The other two used to hand back the RAW key — `fieldLabel`'s fallback on
+     * the object-bound arm, and the bare `yField` on the arm a static-data
+     * chart takes — so a chart grouped on `close_date` legended it
+     * `close_date` while the table widget beside it on the same dashboard
+     * headed that column `Close Date`. That is the same fallback shape
+     * objectui#9000 removed from the table's whitelist branch, and the class
+     * objectui#5425 ruled out: one value, two spellings, one dashboard.
+     * `humanizeFieldKey` is the single home for the KEY convention
+     * (`./utils`); the i18n wrapper is untouched, a bundle entry still wins and
+     * this is only its fallback.
+     *
+     * It stays distinct from `humanizeLabel`, the VALUE prefixer in
+     * `@object-ui/core` — `utils/humanize-label.ts`'s docblock carries the
+     * per-input difference table and rules that converging the two "is a
+     * decision, not a refactor … it needs its own card".
      */
     const resolveSeriesLabel = useCallback((objectName: string | undefined, yField: string, aggFn: string | undefined) => {
       const isSynthetic = !yField || yField === 'value' || yField === 'count';
       if (aggFn && (isSynthetic || aggFn === 'count')) {
         return t(`report.aggregate.${aggFn}`, { defaultValue: aggFn });
       }
+      const humanized = humanizeFieldKey(yField);
       if (objectName) {
-        return fieldLabel(objectName, yField, yField);
+        return fieldLabel(objectName, yField, humanized);
       }
-      return yField;
+      return humanized;
     }, [t, fieldLabel]);
     const dashName = (schema as any).name as string | undefined;
 

--- a/packages/plugin-dashboard/src/RecordDetailDrawer.tsx
+++ b/packages/plugin-dashboard/src/RecordDetailDrawer.tsx
@@ -34,6 +34,7 @@ import {
   isSystemField,
   isNumericFieldMeta,
 } from './recordFields';
+import { humanizeFieldKey } from './utils';
 
 export interface RecordDetailDrawerProps {
   /** The record to display, or `null` when nothing is selected. */
@@ -102,7 +103,21 @@ export const RecordDetailDrawer: React.FC<RecordDetailDrawerProps> = ({
 
     return keys.map((key) => {
       const def = fieldsByName[key];
-      const humanized = key.charAt(0).toUpperCase() + key.slice(1).replace(/([A-Z])/g, ' $1').replace(/_/g, ' ');
+      // Same shape as `ObjectDataTable`'s `buildHeader` half, function for
+      // function: `humanizeFieldKey` derives the fallback and the i18n wrapper
+      // (bundle entry wins, this is only its fallback) and the `objectName`
+      // guard are unchanged. This line used to carry a FOURTH inline spelling
+      // that upper-cased only the first word, so one key rendered as
+      // `Close Date` in the column the user clicked and `Close date` in the
+      // field this drawer opened — one key, two spellings, one uninterrupted
+      // interaction (objectui#9055; the class objectui#5425 ruled out).
+      //
+      // The KEY prefixer stays distinct from `humanizeLabel`, the VALUE
+      // prefixer in `@object-ui/core` — see `utils/humanize-label.ts`, whose
+      // docblock gives the per-input difference table and rules that
+      // converging the two "is a decision, not a refactor … it needs its own
+      // card". This card adopts the KEY convention; it does not merge them.
+      const humanized = humanizeFieldKey(key);
       const label = objectName ? fieldLabel(objectName, key, humanized) : humanized;
       const fieldMeta = buildFieldMeta({ accessorKey: key, label, def, objectName, fieldOptionLabel });
       return {

--- a/packages/plugin-dashboard/src/__tests__/fieldKeySpellingOutsideTable-9055.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/fieldKeySpellingOutsideTable-9055.test.tsx
@@ -1,0 +1,310 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9055 — the field-key display spellings that survived OUTSIDE the
+ * `table` widget family, pinned on the surfaces that actually render them.
+ *
+ * ## The class, already ruled on
+ *
+ * objectui#5425 ruled that one value may not appear twice under two spellings
+ * on one dashboard, and `humanizeFieldKey` (`../utils`) names itself the single
+ * home for the KEY convention. objectui#9000 made the two header branches of
+ * `ObjectDataTable` agree with it. Two more producers of a field-key display
+ * string were left outside that diff on purpose — its scope was the surface it
+ * named — and this file is their pin.
+ *
+ * ## Instance 1 — the record drawer, measured ON ONE CLICK CHAIN
+ *
+ * `RecordDetailDrawer` built its label from an inline expression that
+ * upper-cased only the FIRST word, where `humanizeFieldKey` title-cases every
+ * word. The assertions below deliberately do NOT compare two pure functions:
+ * they render ONE `ObjectDataTable`, read its rendered headers, CLICK a row,
+ * and read the drawer that click opened. That is the card's severity argument
+ * — one uninterrupted interaction, one key, two spellings — and a
+ * pure-function comparison cannot carry it.
+ *
+ * ⚠️ `unitPrice` and `amount` render IDENTICALLY under both spellings, so they
+ * cannot tell the fixed world from the broken one. They are asserted under
+ * `KEYS_THAT_CANNOT_DISCRIMINATE` and are recorded, not evidence; the
+ * discriminating population is the snake_case pair.
+ *
+ * ## Instance 2 — the chart series label
+ *
+ * `resolveSeriesLabel` (`../DashboardRenderer`) has THREE arms, and the card
+ * names only one of them:
+ *
+ *   arm 1  synthetic y-field + an aggregate  -> an i18n'd aggregate name.
+ *          UNTOUCHED, and pinned below as a LIVE CONTROL rather than as a
+ *          comment: it is the arm a blind "humanize everything" would eat.
+ *   arm 2  a real object + a real field      -> `fieldLabel`'s fallback WAS the
+ *          raw key; it is the humanized key now. The bundle still wins over it.
+ *   arm 3  no object name at all             -> returned the raw key outright.
+ *          ⭐ objectui#9055 does not mention this arm. It is reached on every
+ *          static-data chart `DashboardRenderer` composes
+ *          (`resolveSeriesLabel(undefined, yField, undefined)`), so it is a
+ *          live third spelling of one decision, not dead code — which is why
+ *          it is fixed here rather than "noted".
+ *
+ * ## Why the composed node rather than a recharts legend
+ *
+ * The decision under test is which string the RELAY composes. `ChartRenderer`
+ * turns `series[].label` into `config[dataKey].label` (`s.label || s.dataKey`),
+ * which is the legend / tooltip text; recharts resolves inside `plugin-charts`
+ * and lays out no SVG in happy-dom. Same split objectui#8266 made for the
+ * sibling `dataKey` decision on this very callback.
+ *
+ * ## DIRECTIONS, written before the reverse verification was run
+ *
+ * Predicted RED on `origin/main` 8e74b27fc: the drill-chain PARITY assertions
+ * over `close_date` / `needs_analysis`, and the arm-2 / arm-3 series-label
+ * assertions. Predicted GREEN on both sides: every
+ * `KEYS_THAT_CANNOT_DISCRIMINATE` assertion, the arm-1 aggregate control, and
+ * both BUNDLE ENTRY controls. Measured results are recorded in the PR body.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+import { I18nProvider } from '@object-ui/i18n';
+import { SchemaRendererProvider } from '@object-ui/react';
+
+import { ObjectDataTable } from '../ObjectDataTable';
+import { DashboardRenderer } from '../DashboardRenderer';
+import { humanizeFieldKey } from '../utils';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '@object-ui/components';
+
+const OBJECT_NAME = 'crm_opportunity';
+
+/**
+ * One record. `id` is a system field on BOTH surfaces (the shared
+ * `isSystemField` denylist), so the key populations stay identical without
+ * either side being told what to hide.
+ */
+const ROW = {
+  id: 'opp-1',
+  close_date: '2026-01-01',
+  needs_analysis: 'Needs a call',
+  unitPrice: 3,
+  amount: 1500,
+};
+
+/** snake_case: the two spellings differ, so these tell the two worlds apart. */
+const DISCRIMINATING_KEYS = ['close_date', 'needs_analysis'];
+
+/**
+ * ⚠️ NOT EVIDENCE. The inline drawer expression and `humanizeFieldKey` return
+ * the same string for these, so they hold in the broken world too. Recorded so
+ * the fix is not misread as having moved them.
+ */
+const KEYS_THAT_CANNOT_DISCRIMINATE = ['unitPrice', 'amount'];
+
+/** Render order on both surfaces: the record's own key order, minus `id`. */
+const VISIBLE_KEYS = [...DISCRIMINATING_KEYS, ...KEYS_THAT_CANNOT_DISCRIMINATE];
+
+type Wrap = (node: React.ReactElement) => React.ReactElement;
+
+const zhWrap = (resources: Record<string, any> = {}): Wrap => (node) => (
+  <I18nProvider config={{ defaultLanguage: 'zh', detectBrowserLanguage: false, resources }}>
+    {node}
+  </I18nProvider>
+);
+
+/**
+ * ONE interaction: render the table, read its headers, click a row, read the
+ * drawer the click opened. Both readings come out of the same mounted tree.
+ */
+function drillChain(extra: Record<string, unknown> = {}, wrap?: Wrap) {
+  const node = (
+    <ObjectDataTable
+      schema={{
+        type: 'object-data-table',
+        objectName: OBJECT_NAME,
+        data: [ROW],
+        drillDown: { enabled: true },
+        ...extra,
+      } as any}
+    />
+  );
+  render(wrap ? wrap(node) : node);
+
+  const headers = Array.from(document.querySelectorAll('thead th')).map(
+    (th) => (th.textContent ?? '').trim(),
+  );
+
+  // The click the card's argument is about: a table cell, not a test hook.
+  fireEvent.click(screen.getByText('Needs a call'));
+  const body = screen.getByTestId('record-detail-body');
+  const labels = Array.from(body.querySelectorAll('dt')).map(
+    (dt) => (dt.textContent ?? '').trim(),
+  );
+
+  const byKey = (values: string[]) =>
+    Object.fromEntries(VISIBLE_KEYS.map((k, i) => [k, values[i]]));
+
+  return { headers, labels, headerByKey: byKey(headers), labelByKey: byKey(labels) };
+}
+
+/* ------------------------------------------------------------------ */
+/* Instance 2 harness — record what the relay composes.                */
+/* ------------------------------------------------------------------ */
+
+/** Every chart node `DashboardRenderer` handed the renderer, in order. */
+const composed: any[] = [];
+
+const recorder = (props: any) => {
+  composed.push(props.schema ?? props);
+  return null;
+};
+for (const type of ['object-chart', 'chart'] as const) {
+  ComponentRegistry.register(type, recorder as any, {
+    namespace: 'test',
+    label: 'recorder',
+    category: 'plugin',
+  } as any);
+}
+
+const chartDataSource = { aggregate: async () => [], find: async () => [] };
+
+async function composedSeriesLabel(widget: Record<string, unknown>, wrap?: Wrap) {
+  composed.length = 0;
+  const node = (
+    <SchemaRendererProvider dataSource={chartDataSource as any}>
+      <DashboardRenderer schema={{ widgets: [widget] } as any} />
+    </SchemaRendererProvider>
+  );
+  render(wrap ? wrap(node) : node);
+  await waitFor(() => expect(composed.length).toBeGreaterThan(0));
+  const label = composed[composed.length - 1]?.series?.[0]?.label;
+  cleanup();
+  return label;
+}
+
+const objectBoundChart = (aggregate: Record<string, unknown>) => ({
+  id: 'w-object',
+  type: 'bar',
+  title: 'By stage',
+  options: { xField: 'stage' },
+  data: { provider: 'object', object: OBJECT_NAME, aggregate },
+});
+
+const staticChart = (yField: string) => ({
+  id: 'w-static',
+  type: 'bar',
+  title: 'Inline rows',
+  options: { xField: 'name', yField },
+  data: [{ name: 'Acme', [yField]: 1 }],
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('objectui#9055 instance 1 — the record drawer agrees with the header the user just left', () => {
+  it('PARITY on one click chain, over the keys that can discriminate', () => {
+    const { headerByKey, labelByKey } = drillChain();
+
+    for (const key of DISCRIMINATING_KEYS) {
+      // Reported as a pair so a failure names the key, not just two strings.
+      expect([key, labelByKey[key]]).toEqual([key, headerByKey[key]]);
+    }
+    // The convention anchor, referenced rather than re-spelled: parity alone
+    // would also hold if BOTH surfaces moved to a new shared wrongness.
+    expect(DISCRIMINATING_KEYS.map((k) => labelByKey[k])).toEqual(
+      DISCRIMINATING_KEYS.map(humanizeFieldKey),
+    );
+  });
+
+  it('PARITY over the whole rendered chain, header list against label list', () => {
+    const { headers, labels } = drillChain();
+    expect(headers).toHaveLength(VISIBLE_KEYS.length);
+    expect(labels).toEqual(headers);
+  });
+
+  it('KEYS_THAT_CANNOT_DISCRIMINATE — recorded, NOT evidence (green in both worlds)', () => {
+    const { headerByKey, labelByKey } = drillChain();
+    for (const key of KEYS_THAT_CANNOT_DISCRIMINATE) {
+      expect([key, labelByKey[key]]).toEqual([key, headerByKey[key]]);
+    }
+  });
+
+  it('the `objectName` guard is intact — no object name, still one spelling', () => {
+    // Both surfaces skip the i18n lookup here and use the derived string
+    // directly. If the guard were dropped the render would throw or fall back
+    // to a raw key; it does neither.
+    const { headerByKey, labelByKey } = drillChain({ objectName: undefined });
+    for (const key of DISCRIMINATING_KEYS) {
+      expect([key, labelByKey[key]]).toEqual([key, humanizeFieldKey(key)]);
+      expect([key, headerByKey[key]]).toEqual([key, humanizeFieldKey(key)]);
+    }
+  });
+
+  it('BUNDLE ENTRY — a translation still wins over the derived spelling on BOTH surfaces', () => {
+    const resources = { zh: { crm: { fields: { [OBJECT_NAME]: { close_date: '结单日期' } } } } };
+    const { headerByKey, labelByKey } = drillChain({}, zhWrap(resources));
+
+    expect(headerByKey.close_date).toBe('结单日期');
+    expect(labelByKey.close_date).toBe('结单日期');
+    // The untranslated neighbour still shows the derived spelling, so the
+    // assertion above is about the bundle and not about the whole surface.
+    expect(labelByKey.needs_analysis).toBe(humanizeFieldKey('needs_analysis'));
+  });
+});
+
+describe('objectui#9055 instance 2 — the chart series label stops leaking the raw key', () => {
+  it('arm 2 — an object-bound measure legends under the humanized key, not the raw one', async () => {
+    const label = await composedSeriesLabel(
+      objectBoundChart({ function: 'max', field: 'close_date', groupBy: 'stage' }),
+    );
+    expect(label).toBe(humanizeFieldKey('close_date'));
+    expect(label).not.toBe('close_date');
+  });
+
+  it('arm 3 — a static-data chart legends under the humanized key (the arm the card missed)', async () => {
+    const label = await composedSeriesLabel(staticChart('unit_price'));
+    expect(label).toBe(humanizeFieldKey('unit_price'));
+    expect(label).not.toBe('unit_price');
+  });
+
+  it('arm 1 LIVE CONTROL — a synthetic key with an aggregate still gets the i18n aggregate name', async () => {
+    // Green before AND after. A blind humanize applied above this branch would
+    // render `Count` here and fail: the aggregate vocabulary would be gone.
+    const label = await composedSeriesLabel(
+      objectBoundChart({ function: 'count', groupBy: 'stage' }),
+      zhWrap(),
+    );
+    expect(label).toBe('计数');
+  });
+
+  it('arm 1 LIVE CONTROL — a fieldless count keeps the aggregate name in English too', async () => {
+    const label = await composedSeriesLabel(
+      objectBoundChart({ function: 'count', groupBy: 'stage' }),
+      (node) => (
+        <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false, resources: {} }}>
+          {node}
+        </I18nProvider>
+      ),
+    );
+    expect(label).toBe('Count');
+  });
+
+  it('BUNDLE ENTRY — a translated field label still wins over the humanized fallback', async () => {
+    const resources = { zh: { crm: { fields: { [OBJECT_NAME]: { close_date: '结单日期' } } } } };
+    const label = await composedSeriesLabel(
+      objectBoundChart({ function: 'max', field: 'close_date', groupBy: 'stage' }),
+      zhWrap(resources),
+    );
+    expect(label).toBe('结单日期');
+  });
+});


### PR DESCRIPTION
Fixes #9055

One field key now renders under one spelling across a dashboard drill chain. Two files, three arms, no published surface moves.

| site | before | after |
|---|---|---|
| `RecordDetailDrawer` field label | a fourth inline spelling (first word only) | `humanizeFieldKey(key)` |
| `resolveSeriesLabel` object-bound arm | `fieldLabel(objectName, yField, yField)` | `fieldLabel(objectName, yField, humanizeFieldKey(yField))` |
| `resolveSeriesLabel` no-object arm | `return yField` | `return humanizeFieldKey(yField)` |
| `resolveSeriesLabel` aggregate arm | i18n aggregate name | **unchanged**, pinned as a live control |

## The triage question, answered

⭐ *"Whoever takes any of them should say whether one helper should own it, rather than fixing a third call site to match the first two."*

**One helper already owns the KEY convention, and this card reconnects the two call sites that were never wired to it** — `humanizeFieldKey` (`packages/plugin-dashboard/src/utils.ts:27`) is the only definition of it in the tree, its own docstring names itself "the single home for this convention", and both sites here are inside that same package. Merging the KEY prefixer with `humanizeLabel`, the VALUE prefixer in `@object-ui/core`, is a different question and is already reserved: `packages/core/src/utils/humanize-label.ts` carries the per-input difference table (`unitPrice` / `BestCase` / `lost-to-competitor` diverge) and rules that "Converging them is a decision, not a refactor … it needs its own card". This PR does not touch that.

## Instance 1, measured as TWO RENDERED STRINGS ON ONE CLICK — not two function returns

The pin renders one `ObjectDataTable`, reads `thead th`, clicks a row, and reads the drawer that click opened. On `origin/main` `8e74b27fc` the run printed both lists side by side:

```
- Expected            (headers, thead th)
+ Received            (drawer labels, dt)

  [
-   "Close Date",
-   "Needs Analysis",
+   "Close date",
+   "Needs analysis",
    "Unit Price",
    "Amount",
  ]
```

`unitPrice` / `amount` are identical under both spellings, so they **cannot discriminate the two worlds**. They are asserted under `KEYS_THAT_CANNOT_DISCRIMINATE` and are recorded, not evidence — green before and after.

## The briefing's four mechanism assumptions, re-measured

**A1 — CONFIRMED.** The drawer's two lines and `ObjectDataTable`'s `buildHeader` (lines 817-820) are byte-for-byte the same shell; only the `humanized` expression differed. Argument order (`fieldLabel(objectName, key, humanized)`) and the `objectName` guard are identical and both are unchanged by this PR.

**A2 — CONFIRMED, and measured on the chain rather than copied.** The table above is the rendered output of one interaction, not a pure-function comparison. The root cause is as assumed: the inline expression upper-cases only the first character, `humanizeFieldKey` title-cases every word via `\b\w`.

**A3 — CONFIRMED, including the arm the card does not name.** Arm 3 IS reachable: `DashboardRenderer.tsx:677` calls `resolveSeriesLabel(undefined, yField, undefined)` on the static-inline-data branch of every series chart, and arm 1 cannot intercept it because that call passes no `aggFn`. Where it renders: `ChartRenderer` turns `series[].label` into `newConfig[s.dataKey] = { label: s.label || s.dataKey, … }`, which is the legend / tooltip text. So arm 3 is a live third spelling of one decision, and it is fixed here. Arm 1 is untouched and is pinned as a live control in two locales.

**A4 — CONFIRMED, with a lit control for the zero.** `grep -c humanizeFieldKey`, per file, before this PR:

```
packages/plugin-dashboard/src/RecordDetailDrawer.tsx         0
packages/plugin-dashboard/src/DashboardRenderer.tsx          0
packages/plugin-dashboard/src/ObjectDataTable.tsx            7   <- lit control, matches the briefing's 7
packages/plugin-dashboard/src/utils.ts                       2
```

The full repo-wide file list from the same command (13 files, none of them the two above) is in the dispatch report. `humanizeFieldKey` has exactly ONE definition in the tree (`packages/plugin-dashboard/src/utils.ts:27`) and is NOT re-exported from `packages/plugin-dashboard/src/index.tsx` — both re-measured, so Clause-② stands at `no`.

## Reverse verification — four legs, each proved ON DISK before it was read

Every leg: mutate → prove the bytes moved (fixed-text count 1→0, old-text count 0→1, blob hash shifted, HEAD blob untouched) → run → restore → prove restoration by STATE (`git diff HEAD` empty **and** blob back to the HEAD blob), never by an exit code. Restores use `git checkout HEAD -- path` (never a bare `git checkout -- path`, which would take the mutation back out of the polluted index). Each leg ran after the fix was committed, so the restore point is a real commit. The harness carries a `trap … EXIT INT TERM` with absolute paths as a crash-path convenience only.

| leg | mutation | predicted red | measured red |
|---|---|---|---|
| A | drawer back to the inline expression | the 4 instance-1 assertions | exactly those 4; all 6 others green |
| B | arm 2 back to `fieldLabel(objectName, yField, yField)` | `arm 2` only | `arm 2` only, 9 green |
| C | arm 3 back to `return yField` | `arm 3` only | `arm 3` only, 9 green |
| D | arm 1's return replaced by a blind `humanizeFieldKey(yField)` | the arm-1 live control | the zh live control, 9 green |

Leg D exists because a control that cannot fail is not a control. ⚠️ It also shows the two arm-1 controls are not equivalent: `humanizeFieldKey('count')` is `Count`, which **coincides** with the English pack, so the `en` control stayed green under leg D and only the `zh` control (`计数`) discriminated it. Recorded rather than tidied away.

Blob hashes from leg A, as an example of the proof shape: `2ead771df…` → `896d9f022…` on mutation, back to `2ead771df…` on restore, with the HEAD blob `2ead771df…` unmoved throughout.

## Verification

Read from each command's own verdict line, with the exit code captured by redirection **before** any pipe.

| check | command | verdict |
|---|---|---|
| new pins | `pnpm exec vitest run packages/plugin-dashboard/src/__tests__/fieldKeySpellingOutsideTable-9055.test.tsx` | `Tests 10 passed (10)`, exit 0 — and `6 failed / 4 passed` on the unmodified tree |
| affected package suite | `pnpm exec vitest run packages/plugin-dashboard/` (via the shared verify lock) | `Test Files 112 passed (112)` · `Tests 1005 passed (1005)`, exit 0 |
| dependency closure build | `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-dashboard^...' build` | exit 0 |
| type-check (both legs) | `tsc --noEmit` and `tsc -p tsconfig.test.json` | exit 0 each |
| lint (WHOLE repo, not narrowed) | `turbo run lint --concurrency=2` | `Tasks: 47 successful, 47 total`, exit 0 |
| changeset presence | `node scripts/check-changeset-presence.mjs` | exit 0 — 2 published source files, 1 changeset |
| governed surface | `node scripts/check-governed-queue-guard.mjs --test …` | `NOT GOVERNED — 4 path(s) checked against 5 governed surface(s)` |

⚠️ The first type-check run was RED with 12 `Cannot find module '@object-ui/*'` errors. That was an unbuilt dependency closure, not this diff: the same command is exit 0 after the closure build. Recorded because reading that red as a regression is exactly the trap.

Lint is reported as the full repo run, so no narrowing claim is being made. For the record, this config could not have moved an untouched file anyway: `eslint.config.js` extends `tseslint.configs.recommended` (not the type-checked variant) and sets no `parserOptions.project` / `projectService`, so no rule here reads a type graph.

## Acceptance notes — found while working, deliberately NOT in this diff

- **Filed as objectui#9172.** `DashboardGridLayout`, the sibling relay, composes `series: [{ dataKey }]` with **no `label` key at all** on both its branches, and `ChartRenderer` falls back to `s.label || s.dataKey` — so its legend renders the raw field key. Measured with a throwaway recorder probe (deleted in the same turn, never committed): `renderer object-bound label="Close Date"` / `grid object-bound label=undefined`, and the same pair for the static branch. ⚠️ Direction of the debt, stated plainly: before this PR the two relays AGREED (both raw); this PR moves one of them, so objectui#9172 is the other half of this family rather than a pre-existing divergence. It is filed instead of folded in because it is a different file and a different mechanism — repairing it ADDS a label to a surface that never had one, on a relay this card does not name, needing its own pins.
- **noted, not filed — `plugin-detail`'s `DetailSection` / `HeaderHighlight`.** The card asks that a one-spelling move confirm these are a different population, and they are: `DetailSection.tsx:416,451` and `HeaderHighlight.tsx:198` resolve `fieldLabel(objectName, field.name, field.label …)` — the object schema's own declared label, not a derived spelling. Correctly out of scope. One observation, unmeasured: `DetailSection`'s last-resort fallback is `field.label || field.name`, so a field def carrying no `label` would show the raw key; whether that is reachable with a real schema was not measured here because the dispatch rules this surface out of scope. Successor: whoever takes objectui#9172 is already in this family.
- **noted, not filed — other inline capitalizers.** `git grep 'charAt(0).toUpperCase()'` finds further first-letter capitalizers in `app-shell` / `apps/console` (nav segments, approval verbs, icon names). They are not field-key display spellings and do not meet a field on screen, so they are not this class. Successor: none.

## Delivery posture

Clause-② is **`no`**, unchanged from the claim comment and re-measured above: no published export, no schema key, no closed-set member, no registry entry moves. The guard prints `NOT GOVERNED`. Per the dispatch this PR stays a **draft** — not flipped to ready, not enqueued, no auto-merge — for the PM seat to land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_