### PR TITLE
docs(data-objectstack): the cache README describes the coalescing it actually does

### DIFF
--- a/.changeset/8927-metadata-cache-readme-coalescing.md
+++ b/.changeset/8927-metadata-cache-readme-coalescing.md
@@ -1,0 +1,8 @@
+---
+---
+
+Docs/test-comment only: `packages/data-objectstack/README.md`'s cache bullet said concurrent
+requests for the same uncached key "may result in multiple fetcher calls", which is the opposite
+of what `MetadataCache.get` does — it coalesces them onto one in-flight promise and counts the
+saving in `coalesced`. Corrected the bullet and the one stale test comment that repeated the same
+claim. No published behaviour changes; `MetadataCache.ts` is untouched (objectui#8927).

--- a/packages/data-objectstack/README.md
+++ b/packages/data-objectstack/README.md
@@ -386,6 +386,7 @@ const dataSource = createObjectStackAdapter({ baseUrl: 'https://api.example.com'
 const stats = dataSource.getCacheStats();
 console.log(`Cache hit rate: ${stats.hitRate * 100}%`);
 console.log(`Cache size: ${stats.size}/${stats.maxSize}`);
+console.log(`Fetches coalesced onto an in-flight request: ${stats.coalesced}`);
 
 // Manually invalidate cache entries
 dataSource.invalidateCache('users'); // Invalidate specific schema
@@ -401,7 +402,13 @@ dataSource.clearCache();
 - **TTL Expiration**: Entries expire after the configured time-to-live from creation (default: 5 minutes)
   - Note: TTL is fixed from creation time, not sliding based on access
 - **Memory Limits**: Configurable maximum cache size (default: 100 entries)
-- **Concurrent Access**: Handles async operations safely. Note that concurrent requests for the same uncached key may result in multiple fetcher calls.
+- **Request Coalescing**: Concurrent `get` calls for the same uncached key share a single
+  fetch. The first caller invokes the fetcher; every caller that arrives while that promise
+  is still in flight is handed the same promise instead of starting a second request, and
+  each one increments the `coalesced` counter in `getCacheStats()` — so the saving is
+  something you can read off the adapter, not just a claim in this page.
+  - The in-flight slot is released in a `finally`, so a rejected fetch is not cached and
+    does not poison the key: the next call starts a fresh fetch.
 
 ## Connection State Monitoring
 

--- a/packages/data-objectstack/src/cache/MetadataCache.test.ts
+++ b/packages/data-objectstack/src/cache/MetadataCache.test.ts
@@ -221,10 +221,11 @@ describe('MetadataCache', () => {
         cache.get('test', fetcher),
       ]);
       
-      // All should return the same data
-      // Note: Due to async nature, the first call will fetch and others might also fetch
-      // if they check before the first one completes. This is acceptable behavior.
-      // But at least one should be cached if they complete after the first one.
+      // All three are served. They also share ONE fetcher call — `get` coalesces
+      // concurrent misses for the same key onto a single in-flight promise — but
+      // that is pinned by "should coalesce concurrent fetches for the same key"
+      // below, which asserts the call count and the `coalesced` stat. This case
+      // asserts only that every caller gets a value.
       expect(results[0]).toBeDefined();
       expect(results[1]).toBeDefined();
       expect(results[2]).toBeDefined();


### PR DESCRIPTION
Fixes #8927

## The wrong half was the page, not the cache

`packages/data-objectstack/README.md:404` said:

> **Concurrent Access**: Handles async operations safely. Note that concurrent requests for the same uncached key may result in multiple fetcher calls.

`MetadataCache.get` does the opposite. On a miss it consults an in-flight map before it ever calls the fetcher. Source, `packages/data-objectstack/src/cache/MetadataCache.ts` — generic parameters are spelled out in WORDS here because GitHub strips tag-shaped fragments from stored bodies, code fences included:

```
 76:  private inflight: Map keyed by string, holding Promise-of-unknown;
...
138:    // Cache miss - dedupe concurrent fetches for the same key
139:    const existing = this.inflight.get(key);
140:    if (existing) {
141:      this.stats.coalesced++;
142:      return existing as Promise-of-T;
143:    }
144:
145:    this.stats.misses++;
146:    const promise = (async () => {
147:      try {
148:        const data = await fetcher();
149:        this.set(key, data);
150:        return data;
151:      } finally {
152:        this.inflight.delete(key);
153:      }
154:    })();
155:    this.inflight.set(key, promise as Promise-of-unknown);
```

One fetcher call per key; a `coalesced` counter incremented for every caller that joined the in-flight promise; a `finally` that frees the slot, so a rejected fetch is not cached and does not poison the key.

Per the card's adjudication, `MetadataCache.ts` is **untouched** — the behaviour is correct and pinned, only the prose was wrong.

## Before / after

**Before** (one line):

> - **Concurrent Access**: Handles async operations safely. Note that concurrent requests for the same uncached key may result in multiple fetcher calls.

**After**:

> - **Request Coalescing**: Concurrent `get` calls for the same uncached key share a single fetch. The first caller invokes the fetcher; every caller that arrives while that promise is still in flight is handed the same promise instead of starting a second request, and each one increments the `coalesced` counter in `getCacheStats()` — so the saving is something you can read off the adapter, not just a claim in this page.
>   - The in-flight slot is released in a `finally`, so a rejected fetch is not cached and does not poison the key: the next call starts a fresh fetch.

The worked example in the same section now prints the counter too, so "observable" is demonstrated rather than asserted:

```
console.log(`Fetches coalesced onto an in-flight request: ${stats.coalesced}`);
```

`ObjectStackAdapter.getCacheStats()` returns `this.metadataCache.getStats()` verbatim (`src/index.ts:6339-6341`), and `getStats()` includes `coalesced` (`MetadataCache.ts:247`), so the counter really is reachable from the documented entry point.

## Which side does a test pin?

The card title says "a test pins the opposite". Measured: the test pins the **code** side, and nothing pins the README's side.

- `MetadataCache.test.ts:413` "should coalesce concurrent fetches for the same key" asserts `expect(fetcher).toHaveBeenCalledTimes(1)` and `expect(stats.coalesced).toBe(2)` — the coalescing.
- `MetadataCache.test.ts:441` "should clear inflight slot after fetch rejection so retries are possible" — the `finally`.
- Nothing in the tree asserts multiple fetcher calls. `git grep "multiple fetcher"` returns exactly one hit repo-wide, and it was the README line this changes.

So "the opposite" means opposite-of-the-README, and the card's premise holds.

## Surveys run before editing

**Source-text pins on this README** (the objectui#8861 class — a test that reads a markdown file as data):

`git grep -l "readFileSync"` over the test globs returns 222 files. Control, deliberately chosen to be able to fail: the same query must reach `packages/i18n/src/__tests__/residue-namespaces-3546.test.tsx`, which names `packages/plugin-kanban/src/KanbanImpl.tsx` at its line 161. Both hit — the survey is a reading, not a silent zero.

Result: `packages/data-objectstack/README.md` **is** source-text pinned, by `packages/data-objectstack/src/readme-filter-operator-table.test.ts` (`README_PATH` at its line 137). That pin reads only the three filter-operator tables, under the headings "Supported Filter Operators", "Logical combinators" and "Refused at lowering time" — the Cache Configuration bullets are not in its window, and the edited section is nowhere near those headings. Nothing else in the tree reads this file: the whole-repo reference list is `.changeset/8558-…`, `.changeset/8568-…`, `content/docs/guide/data-source.md:206`, `packages/core/src/adapters/README.md:9,220` (all links), `scripts/__tests__/check-doc-links.test.ts` (a synthetic fixture tree, not this file), `scripts/dollar-dialect-alias-census.mjs:177` (a `$`-spelling census; this change adds no `$` token), `scripts/check-doc-component-types.mjs:289` (prose only — that gate deliberately does not walk package READMEs) and `scripts/markdown-test-inputs.mjs:210`.

That last one matters for CI: the file is on the markdown-test-input ledger, so `node scripts/markdown-test-inputs.mjs --changed packages/data-objectstack/README.md` echoes it back and `ci.yml` will not take the markdown fast path.

I considered adding a Cache-Configuration assertion to `readme-filter-operator-table.test.ts` and decided against it: that file's subject is one table held to `convertFiltersToAST`, and a coalescing assertion has no business there. The prose is instead backed by the pin that already exists, and the ablation below shows that pin can fail.

**Duplicate wrong prose** (file list, not a count). Swept `multiple fetcher`, `stampede`, `concurrent`, `coalesc`, `in-flight` across the tree:

- `multiple fetcher` — 1 hit repo-wide, `packages/data-objectstack/README.md:404`. Corrected.
- `stampede` — 0 hits repo-wide.
- `packages/data-objectstack/src/cache/MetadataCache.test.ts:224-226` — **a same-package duplicate of the same false claim**, in a comment: "the first call will fetch and others might also fetch … This is acceptable behavior." Corrected (comment only, no assertion changed). Leaving it would have left the retired claim written down three files from the page this corrects, phrased as a deliberate decision — the next reader would re-derive the old wording from it.
- Already correct, left alone: `MetadataCache.ts:27` ("coalesces concurrent fetches onto one in-flight promise"), `:37`, `:52`, `:138`; `src/index.ts:2880`, `:2979`; `ROADMAP.md:1057`.
- Nothing in `content/docs/**` documents this cache at all (`content/docs/guide/data-source.md` has zero `cach` hits).
- No hit in any other package, so nothing to hand off.

## Verification

All commands from the repo root of a dedicated worktree at `4784bb34f`; heavy steps serialized through `../objectstack/scripts/pm/os-verify-lock.sh` (`VERDICT command-exit 0 · held the lock 59s`). Exit codes captured by redirecting first, never across a pipe.

| Command | Exit | Result |
|---|---|---|
| `pnpm --workspace-concurrency=2 --filter '@object-ui/data-objectstack...' build` | 0 | dependency closure built |
| `pnpm exec vitest run packages/data-objectstack/` | 0 | `Test Files 63 passed (63)`, `Tests 856 passed (856)` |
| `pnpm --filter @object-ui/data-objectstack type-check` | 0 | clean |
| `pnpm --filter @object-ui/data-objectstack lint` | 0 | `445 problems (0 errors, 445 warnings)` — all pre-existing `no-explicit-any` warnings |
| `node scripts/check-changeset-presence.mjs` | 0 | see below |
| `node scripts/check-changeset-no-major.mjs` | 0 | `No changeset declares a major bump` |
| `pnpm check:control-bytes` | 0 | `scanned 7372 tracked text file(s)` |
| `pnpm check:doc-types` | 0 | `Every documented component type is registered` |
| `pnpm check:doc-fences` | 0 | clean |
| `pnpm check:new-line-citations` | 0 | `0 new citation(s)` |
| `pnpm check:changeset-claims` | 0 | report-only, no finding against this diff |
| `pnpm check:readme-exports` | 1 | **prerequisite not met, not a red** — see below |

The existing pin, green (`--reporter=verbose`, 22 passed):

```
✓ MetadataCache > Edge Cases > should coalesce concurrent fetches for the same key
✓ MetadataCache > Edge Cases > should clear inflight slot after fetch rejection so retries are possible
```

`check:readme-exports` wants every package's `dist/index.d.ts` on disk and a fresh worktree has none, so its first run reported `534 self-import(s) could not be judged` with `run pnpm build first` on every line. After building the data-objectstack closure it re-ran at `465 … could not be judged`, **zero of them in `packages/data-objectstack/README.md`** (`grep -c 'data-objectstack/README.md'` on the log = 0), and its census flipped that package's self-imports to `69 real, 0 wrong-path, 0 fabricated`. The remaining 465 belong to the other 33 unbuilt packages and are untouched by this diff; CI builds everything.

### Ablation — the pin behind the new prose can fail

A one-off proof, not a committed test: the new prose is only worth what its pin is worth, so I deleted the coalescing branch (lines 138-143) from `MetadataCache.ts` on disk, ran the file, and restored.

Predicted direction before running: the coalescing test turns red; the rejection/retry test stays green (without an in-flight map, a retry trivially works). Both held.

```
PRE  anchor 'this.stats.coalesced++' count = 1
POST anchor 'this.stats.coalesced++' count = 0      ← mutation proven on disk
ABLATED_EXIT=1
 × MetadataCache > Edge Cases > should coalesce concurrent fetches for the same key
   AssertionError: expected "vi.fn()" to be called 1 times, but got 3 times
     at packages/data-objectstack/src/cache/MetadataCache.test.ts:428
 ✓ MetadataCache > Edge Cases > should clear inflight slot after fetch rejection so retries are possible
 Tests  1 failed | 21 passed (22)
```

Restore verified by bytes, not by an exit code: on-disk `git hash-object` back to `79807051a7d34dab6960d32c9b05b2198b9a4dd8` = the `HEAD` blob, and `git diff HEAD -- packages/data-objectstack/src/cache/MetadataCache.ts` empty. The script carried a `trap … EXIT INT TERM` restoring via an absolute path. `MetadataCache.ts` is byte-identical to `main` in the delivered diff.

The same run also settled the A1 question by measurement: `Concurrent Access > should handle concurrent requests for the same key` **passed under the ablation**, so it pins neither side — which is exactly why its comment had drifted into blessing the wrong one.

## Changeset

Decided by the gate's actual output, not by feel. The README alone is not guarded (`1 of 2 file(s) … published source`: only the `src/` test file counts). With the test-comment edit the gate went to exit 1, so `.changeset/8927-metadata-cache-readme-coalescing.md` declares **empty frontmatter** — nothing releases:

```
✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s).
    Every one of them has an EMPTY frontmatter — declared as releasing nothing, which
    is the explicit exemption and a complete answer to this gate.
```

## Acceptance notes

- Not a governed surface: `node scripts/check-governed-queue-guard.mjs --test` over all three paths prints `NOT GOVERNED — 3 path(s) checked against 5 governed surface(s); none matched`. This stays a **draft** anyway — the dispatch for this card asks for draft, no ready flip, no queue.
- Clause-②: **no**, matching the claim comment. Zero code change, so no export, schema or payload moves; no `needs:contract-review`.
- *Noted, not filed* — `Concurrent Access > should handle concurrent requests for the same key` (`MetadataCache.test.ts:209`) asserts only `toBeDefined()` on its three results, so it cannot fail on the question its own name asks; the ablation above shows it green while the behaviour is gone. Not filed as a card: the question is already pinned by its sibling at line 413, so nothing is actually unprotected, and strengthening it is pin work this S-graded prose card should not grow into. Whoever next edits this file will see the corrected comment pointing at the real pin.
- Line numbers in this description are as of `4784bb34f` plus this branch's commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_