### PR TITLE
test(plugin-designer): pin the blank-target refusal message on the second writer

### DIFF
--- a/.changeset/8925-designer-refusal-four-state-pin.md
+++ b/.changeset/8925-designer-refusal-four-state-pin.md
@@ -1,0 +1,7 @@
+---
+---
+
+Pin the blank-target refusal banner in the designer writer too, so the parity
+claim both `describeUnusableTarget` docblocks make is a reading rather than a
+restatement (objectui#8925). Tests and comments only; no package is released by
+this change, and no refusal text moved.

--- a/packages/app-shell/src/services/MetadataService.ts
+++ b/packages/app-shell/src/services/MetadataService.ts
@@ -304,6 +304,15 @@ function describeUnusableTarget(reference: unknown): string {
  * input types on different paths and neither owns the other's. Both are pinned,
  * and each pin asserts the same four states so the copies cannot drift.
  *
+ * ⭐ The two pins are named here so the sentence above can be re-run rather
+ * than believed: `objectui#7714 · the refusal message distinguishes the four
+ * states`, in `MetadataService.specKeyReference.test.ts` (this writer) and in
+ * `MetadataFieldsPage.specKeyReference.test.tsx` (the sibling). The naming is
+ * the repair objectui#8925 made: the designer-side pin did not exist, so that
+ * sentence was false on three of its four rows — its `absent`, `non-string`
+ * and `empty` branches could all be rewritten with the whole `plugin-designer`
+ * package still green — while three separate places went on restating it.
+ *
  * ## The `.trim()` MIRRORS the contract — it is no longer a local opinion
  *
  * The predicate is `typeof reference === 'string' && reference.trim() !== ''`.

--- a/packages/plugin-designer/src/MetadataFieldsPage.specKeyReference.test.tsx
+++ b/packages/plugin-designer/src/MetadataFieldsPage.specKeyReference.test.tsx
@@ -644,3 +644,116 @@ describe('objectui#8058 · a lookup whose target survives only as `referenceTo`'
     expect('referenceTo' in wire.moved_id).toBe(false);
   });
 });
+
+/**
+ * objectui#7714 - the refusal DIAGNOSES the state it found, on THIS writer too.
+ *
+ * The sibling block of the same name lives in
+ * `packages/app-shell/src/services/MetadataService.specKeyReference.test.ts`.
+ * The two assert the SAME four states deliberately: what both
+ * `describeUnusableTarget` docblocks claim is specifically PARITY, so a partial
+ * pin would leave that sentence false in a subtler way than no pin at all.
+ *
+ * ## Why this block exists - the measurement, not the intuition (objectui#8925)
+ *
+ * Both docblocks said the two copies "cannot drift" because each pin asserts
+ * the same four states. That had never been measured on this side. Replacing
+ * ONE branch of this page's `describeUnusableTarget` with a marker sentence and
+ * running the whole package, on `6214db63f`, gave:
+ *
+ *   absent           mutated -> 19 files / 149 tests passed   UNPINNED
+ *   non-string       mutated -> 19 files / 149 tests passed   UNPINNED
+ *   empty            mutated -> 19 files / 149 tests passed   UNPINNED
+ *   whitespace-only  mutated -> 1 failed                      pinned, but by
+ *       `MetadataFieldsPage.carriedThroughReference-8896.test.tsx` and only
+ *       through the words "whitespace names no object" - a card about a
+ *       different subject, which is why it covered one row and no other.
+ *
+ * The same four mutations on the sibling writer turned its pin red every time.
+ * So the parity sentence was false on three rows out of four while being read
+ * as a guarantee.
+ *
+ * ⛔ The lesson worth carrying, because it is what made this survive: the claim
+ * had been restated in THREE places - objectui#8897's card text, that card's
+ * triage comment, and both docblocks - and not one of the three was a reading.
+ * Repetition is not measurement. A parity claim is only worth its words when
+ * the files that would go red are named and can be re-run.
+ *
+ * ## Why the page, and not the function
+ *
+ * `describeUnusableTarget` is module-private, and pinning it directly would pin
+ * a string builder instead of what an author is shown. These cases drive the
+ * page the way the author does - through the fire-and-forget `onFieldsChange`
+ * the designer calls - and read the text back out of the page's error surface,
+ * so a correct sentence that never reaches the banner cannot pass here.
+ */
+describe('objectui#7714 · the refusal message distinguishes the four states', () => {
+  /**
+   * Drive one unusable target through the page and hand back what the author
+   * reads. Re-entrant on purpose: the non-string row takes two probes inside
+   * one case, and a second `render` without `cleanup` would leave two error
+   * surfaces in the document for `getByTestId` to choose between.
+   */
+  const refusalFor = async (reference: unknown): Promise<string> => {
+    cleanup();
+    designerProps = null;
+    puts = [];
+    await renderPage();
+    const next = [
+      ...designerProps!.fields,
+      { id: 'fld_x', name: 'x_id', label: 'X', type: 'lookup', referenceTo: reference },
+    ] as DesignerFieldDefinition[];
+    await act(async () => {
+      designerProps!.onFieldsChange!(next);
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('metadata-fields-page-error').textContent,
+        `reference=${JSON.stringify(reference)} should be refused`,
+      ).toMatch(/needs a `reference` naming the object it links to/),
+    );
+    // A diagnosed message is only worth anything if it also stopped the write.
+    expect(puts, `reference=${JSON.stringify(reference)} must issue no PUT`).toEqual([]);
+    return screen.getByTestId('metadata-fields-page-error').textContent ?? '';
+  };
+
+  it('absent → "has none", and names the 422 consequence', async () => {
+    const m = await refusalFor(undefined);
+    expect(m).toMatch(/has none/);
+    expect(m).toMatch(/blocks EVERY later save of this object/);
+  });
+
+  it('empty string → "is empty", not "has none"', async () => {
+    const m = await refusalFor('');
+    expect(m).toMatch(/is empty/);
+    expect(m).not.toMatch(/has none/);
+  });
+
+  it('non-string → names the KIND and `invalid_type`, and does not prescribe "supply a target"', async () => {
+    const m = await refusalFor(42);
+    expect(m).toMatch(/holds a number instead of an object name/);
+    expect(m).toMatch(/invalid_type/);
+    expect(m).not.toMatch(/has none/);
+    // `null` is typeof 'object'; spelling it as "null" is the accurate word.
+    expect(await refusalFor(null)).toMatch(/holds null instead of an object name/);
+  });
+
+  it('whitespace-only → names the TRIM the contract applies, and is not the "is empty" sentence', async () => {
+    const m = await refusalFor('   ');
+    expect(m).toMatch(/is blank/);
+    // What replaced "the spec ACCEPTS this value": since 17.4.0 the contract
+    // applies its non-empty test to the trimmed value, so this writer can now
+    // promise the 422 it used to have to withhold here.
+    expect(m).toMatch(/TRIMMED value/);
+    expect(m).toMatch(/422/);
+    expect(m).toMatch(/objectstack#16920/);
+    // Falsification, and the reason the four-state split survives the merge of
+    // the two refusals: blank must still not be rendered as either of the
+    // states that carry a different repair.
+    expect(m).not.toMatch(/is empty/);
+    expect(m).not.toMatch(/has none/);
+    // The retired claim must be GONE, not merely out-ranked by a new match.
+    expect(m).not.toMatch(/ACCEPTS this value/);
+    expect(m).not.toMatch(/would succeed/);
+  });
+});

--- a/packages/plugin-designer/src/MetadataFieldsPage.tsx
+++ b/packages/plugin-designer/src/MetadataFieldsPage.tsx
@@ -505,6 +505,23 @@ const RELATIONSHIP_TYPES_REQUIRING_REFERENCE = ['lookup', 'master_detail'];
  * `MetadataService.ts` is word-for-word the same, and both pins assert all four
  * states so the copies cannot drift silently.
  *
+ * ⭐ THAT SENTENCE IS CHECKABLE NOW, AND IT WAS NOT WHEN IT WAS WRITTEN. The
+ * two pins are the `objectui#7714 · the refusal message distinguishes the four
+ * states` blocks in `MetadataFieldsPage.specKeyReference.test.tsx` (this
+ * writer) and `MetadataService.specKeyReference.test.ts` (the sibling). Before
+ * objectui#8925 only the sibling had one: mutating this function's `absent`,
+ * `non-string` or `empty` branch left the whole `plugin-designer` package
+ * green, so three of the four states here were free to drift while this
+ * paragraph read as a guarantee. The `whitespace-only` row was the lone
+ * exception, and only incidentally — pinned by
+ * `MetadataFieldsPage.carriedThroughReference-8896.test.tsx`, a card about a
+ * different subject.
+ *
+ * ⛔ Do not restate this parity claim anywhere without naming the files that
+ * would go red. It had been restated three times — objectui#8897's card text,
+ * that card's triage comment, and both docblocks — and not one of the three
+ * was a reading. Repetition is what kept it alive while it was false.
+ *
  * Measured for objectui#7714 on `@objectstack/spec` 17.3.0, at field level and
  * again through `ObjectSchema`, which agree on every row:
  *


### PR DESCRIPTION
Fixes #8925

`app-shell`'s `describeUnusableTarget` docblock said the two copies of the
blank-target refusal "cannot drift" because **each pin asserts the same four
states**. The designer side had no such pin. This adds it, and both docblocks
now name the two files that would go red, so the sentence can be re-run instead
of believed.

## The claim was restated three times and measured none of them

This is the part worth carrying out of this card. The same unmeasured assertion
appears in **four** places, and every one of them is a restatement of the one
before it:

1. objectui#8897's card text — the message "is asserted verbatim by pins in
   **both** writers' test files".
2. objectui#8897's triage comment — same sentence.
3. `MetadataService.ts`'s `describeUnusableTarget` docblock — "Both are pinned,
   and each pin asserts the same four states so the copies cannot drift."
4. `MetadataFieldsPage.tsx`'s `describeUnusableTarget` docblock — "both pins
   assert all four states so the copies cannot drift silently."

Nothing in that chain was a reading. Repetition is not measurement. Both
docblocks now carry an explicit instruction not to restate the parity claim
without naming the files that make it falsifiable.

## What was measured — per-branch ablation, both writers, before and after

Method, per row: replace exactly one branch of that writer's
`describeUnusableTarget` with a marker sentence, prove the edit reached disk
(anchor count down by one, marker count 0 to 1, worktree blob moved, HEAD blob
unmoved), run the tests, then restore and prove the restore by **state**
(`git diff HEAD` empty, worktree blob back to the HEAD blob) rather than by an
exit code. Harness ran under `trap ... EXIT INT TERM` with absolute paths.

Measured on `6214db63f` (before) and `5143af2b6` (after).

| branch mutated | app-shell BEFORE | designer BEFORE | app-shell AFTER | designer AFTER |
|---|---|---|---|---|
| `absent` | RED | **GREEN** | RED | RED |
| `non-string` | RED | **GREEN** | RED | RED |
| `empty` | RED | **GREEN** | RED | RED |
| `whitespace-only` | RED | RED | RED | RED |

- app-shell runs: `pnpm exec vitest run packages/app-shell/src/services/MetadataService.specKeyReference.test.ts`
- designer runs: `pnpm exec vitest run packages/plugin-designer/` (whole package)

The three GREEN cells are the finding, and they are readings rather than
counts: the same mutation on the sibling writer turned its pin red every time,
so the instrument was lit on every row. Each green designer run reported
`Test Files 19 passed (19) / Tests 149 passed (149)` with a branch of a
user-visible refusal replaced by a marker string.

The `whitespace-only` row was **already** red before this change, which
narrows the card's own premise: the designer side was not wholly unpinned. That
row is covered by `MetadataFieldsPage.carriedThroughReference-8896.test.tsx`,
through the words "whitespace names no object" — a card about a different
subject, which is why it caught one row and no other. So the docblock sentence
was false on three rows of four, not four of four.

Why the card read four of four: its ablation ran on the objectui#8897 branch
and reported `18 files, 142 tests` for the designer package. `main` carries
`19 files, 149 tests` — the extra file is exactly
`MetadataFieldsPage.carriedThroughReference-8896.test.tsx`, landed by PR #8918
at `2026-09-10T01:16:15Z`, **45 minutes before** this card was filed at
`2026-09-10T02:01:14Z`. The card's reading was true of the branch it was taken
on and already one file stale against `main` when it was written. Both
timestamps sit inside this checkout's history window (its boundary is
`2026-09-08T21:17:21Z`), so they are readings rather than shallow-clone
artifacts.

After the pin, every AFTER cell names the new block by test title, e.g.
`MetadataFieldsPage.specKeyReference.test.tsx > objectui#7714 · the refusal
message distinguishes the four states > empty string ...`. The
`whitespace-only` AFTER run reports **two** failing files: the new pin and the
8896 test.

## Are the two writers word-for-word the same today?

Yes — measured, not assumed. Both functions were extracted and **executed**
against five probes (`undefined`, `''`, `42`, `null`, `'   '`); all five
outputs are byte-identical between the two writers (214 / 229 / 290 / 286 / 427
chars). A control leg that perturbs one word in the designer copy makes the
comparator report `DIVERGED`, so the `IDENTICAL` reading is a real one. No
divergence was fossilised by this pin.

## The existing designer parity gate does not read message text

`scripts/check-designer-field-key-parity.mjs` compares **key sets** between
statically declared payload shapes and the installed spec schema. Its own
"NOT COVERED" section states it: *"This gate is a check on key NAMES only."*
Greps over that file: `describeUnusableTarget` 0 hits, "refusal banner" 0 hits,
against lit controls in the same file (`FieldSchema` 27, `PAYLOAD_SHAPES` 7).
Prose parity is out of its reach, and nothing here tries to put it there.

## Why the page and not the function

`describeUnusableTarget` is module-private on both sides. The new cases drive
the page the way an author does — through the fire-and-forget `onFieldsChange`
the designer calls — and read the text back out of the page's error surface, so
a correct sentence that never reaches the banner cannot pass. Each case also
asserts `puts` stayed empty: a diagnosed message is only worth something if it
also stopped the write.

## Verification

- `pnpm exec vitest run packages/plugin-designer/` — **19 files / 153 tests
  passed**, exit 0 (was 149; the four new cases are the delta).
- `pnpm exec vitest run packages/app-shell/src/services/MetadataService.specKeyReference.test.ts`
  — 18 tests passed, exit 0.
- `pnpm --filter @object-ui/plugin-designer --filter @object-ui/app-shell run type-check`
  — exit 0, after `pnpm --filter '@object-ui/plugin-designer^...' --filter '@object-ui/app-shell^...' build`.
  `tsc -p tsconfig.test.json --listFiles` confirms the new test file is in the
  program (1 hit; control: an app-shell source file, 0 hits).
- `pnpm --filter @object-ui/plugin-designer --filter @object-ui/app-shell run lint`
  — exit 0 (warnings only, pre-existing baseline: 65 and 2966).
- Gates, all exit 0: `check:changeset-presence` (declares the empty-frontmatter
  changeset), `check:control-bytes`, `check:new-line-citations`,
  `check:designer-field-key-parity`, `check:installed-pin-claims`,
  `check:changeset-claims`, `changeset:check`, `check:comment-mask-corpus`,
  `check:vi-mock-specifiers`, `check:unreferenced-sources`,
  `check:spec-symbols`.
- `node scripts/check-governed-queue-guard.mjs --test` on all three edited
  paths: **NOT GOVERNED**. This PR is still left as a draft, per its dispatch.

### Declared narrowing — the app-shell suite

The full `packages/app-shell/` run exceeds this environment's foreground
ceiling, so 1 of its 684 collected test files was run rather than all of them.
Three readings, not an assertion:

1. **Population** — 684 distinct app-shell test files, read from
   `pnpm exec vitest list --filesOnly packages/app-shell/`, i.e. from vitest's
   own project config, not from a guess.
2. **Ran** — 1 of those 684, the only app-shell file that greps for any
   per-state fragment of this message. The reader enumeration was done over the
   tree (`whitespace names no object`, `instead of an object name`,
   `TRIMMED value`, `holds a number instead`, `holds null instead`,
   `naming the object it links to`) across `packages/`, `apps/` and `scripts/`.
3. **Invariance** — the app-shell edit is comment-only, proven at the
   emitted-code level rather than by reading the diff: transpiling the base and
   head versions of `MetadataService.ts` with comments removed gives
   byte-identical output (sha `03878c4dc6e5e230` both sides), and the same for
   `MetadataFieldsPage.tsx` (`f0dd45f85e86f5c6`). A lit control — the test file,
   which really did change — reads `CHANGED`. Since no app-shell runtime byte
   moved, no untouched app-shell test can change verdict because of this diff.

`plugin-designer` was **not** narrowed: the whole package ran, 19 of 19 files.
CI runs the full farm for both.

### Changeset

`.changeset/8925-designer-refusal-four-state-pin.md`, empty frontmatter — the
repo's first-class "releases nothing" declaration. Tests and comments only; no
refusal text moved, and the emitted-code proof above is the evidence for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_