### PR TITLE
fix(fields): zero-option `field:select` keeps its label association

### DIFF
--- a/.changeset/select-empty-host-id-8803.md
+++ b/.changeset/select-empty-host-id-8803.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/fields': patch
+'@object-ui/components': patch
+---
+
+fix(fields): a zero-option `field:select` keeps its label association
+
+A registered `field:select` whose option list resolved empty rendered the
+shared `OptionsEmptyState` box and returned before its DOM pass-through, so the
+host's `…-form-item` id reached no element at all and the visible label's `for`
+DANGLED. Measured on a real form: `HTMLLabelElement.control` was `null`, the
+rendered `<FormDescription>` had zero consumers, and `getByLabelText` threw
+"however no form control was found associated to that label" — an error that
+reads like a broken renderer against a correctly rendered empty state.
+
+The widget declares `labelling: 'control'`, which the registry defines as "the
+component's outermost rendered element is a LABELABLE HTML element". That is
+true of the Radix `button[role="combobox"]` it renders with options and was
+false of the `div` it rendered without them. The zero-option box is now an
+`<output>` — labelable, and a role that claims no interactivity — carrying the
+host id and `aria-describedby`. The label's `for` resolves, the box is named by
+the label and described by the help text, and nothing on the host side moved.
+
+Landing the id on the `div` instead was measured and rejected: `for` may only
+reference a labelable element, so the pointer stopped dangling while the label
+stayed exactly as unusable. Declaring `select` as `labelling: 'group'` was also
+measured and rejected: it moved the LIVE path (a select WITH options lost its
+working `<label for>` to the combobox) and still left the zero-option branch
+with no association.
+
+Breaking-ness: none intended, and none published — the repaired surface is the
+rendered element of one widget state. Apps or tests selecting that box by its
+`data-testid` are unaffected; any that asserted the literal `div` tag name will
+see an `<output>`.

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -518,10 +518,10 @@ function resolvesToRegisteredFieldWidget(type: string): boolean {
  *
  * ## ⛔ Deliberately NOT extended to the registered-widget path
  *
- * `@object-ui/fields`' `OptionsEmptyState` is the same FAULT on the
- * `field:select` path (measured: the `for` dangles there instead, pointing at
- * an id no element carries) but it is NOT the same mechanism, so it is not
- * fixed by this predicate:
+ * `@object-ui/fields`' `OptionsEmptyState` was the same FAULT on the
+ * `field:select` path — measured there, the `for` dangled instead, pointing at
+ * an id no element carried — but it is NOT the same mechanism, so it was never
+ * fixable by this predicate:
  *
  *  - the branch belongs to a component `ComponentRegistry` resolves, not to
  *    this file. Any third party may register a `field:select` that renders a
@@ -533,6 +533,13 @@ function resolvesToRegisteredFieldWidget(type: string): boolean {
  *    — they publish the label's id and answer with `aria-labelledby`
  *    (objectui#3990 / #4005). Single `select` declares `labelling: 'control'`
  *    and has no such channel; giving it one is a ruling, not a mirror.
+ *
+ * That half was repaired in the WIDGET, by objectui#8803, and it did not need
+ * a ruling after all: `'control'` already promises "the outermost rendered
+ * element is a LABELABLE HTML element", and the zero-option branch simply was
+ * not keeping that promise. It now renders an `<output>` carrying the host id,
+ * so this file's `for` reaches it unchanged — nothing here was extended, and
+ * the host still makes no guess about what a registered widget renders.
  */
 function rendersBuiltinSelectEmptyState(
   type: string,

--- a/packages/fields/src/__tests__/composite-group-label-readonly-e2e.test.tsx
+++ b/packages/fields/src/__tests__/composite-group-label-readonly-e2e.test.tsx
@@ -673,10 +673,13 @@ describe('STANDALONE readonly widgets are unchanged (objectui#3990)', () => {
   });
 
   it('the shared options-empty box emits nothing for a widget that is not group-labelled', () => {
-    // The positive control for `OptionsEmptyState`'s new prop. The single
-    // `SelectField` is NOT in `FIELD_WIDGET_LABELLING` — its label keeps a
-    // plain, working `for` — so the shared box must stay attribute-for-attribute
-    // what it was: no `role`, no IDREF, no host id.
+    // The positive control for `OptionsEmptyState`'s group prop. The single
+    // `SelectField` is the one option widget `FIELD_WIDGET_LABELLING` declares
+    // `'control'` rather than `'group'` — its label keeps a plain `for`, which
+    // objectui#8803 made resolve by rendering the box as a labelable
+    // `<output>`. Either way the GROUP channel must stay off it, and standalone
+    // rendering hands down no host keys at all: no `role`, no IDREF, no host
+    // id, no description.
     render(
       <SelectField
         value={undefined}
@@ -689,5 +692,6 @@ describe('STANDALONE readonly widgets are unchanged (objectui#3990)', () => {
     expect(box).not.toHaveAttribute('role');
     expect(box).not.toHaveAttribute('aria-labelledby');
     expect(box).not.toHaveAttribute('id');
+    expect(box).not.toHaveAttribute('aria-describedby');
   });
 });

--- a/packages/fields/src/__tests__/select-empty-label-association-8803.test.tsx
+++ b/packages/fields/src/__tests__/select-empty-label-association-8803.test.tsx
@@ -1,0 +1,264 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The zero-option state of the REGISTERED `field:select` widget keeps the
+ * host's label association (objectui#8803).
+ *
+ * The other half of objectui#3991, measured there and split out because it is
+ * the same FAULT reached by a different MECHANISM. #3991 repaired the BUILT-IN
+ * `select` branch, which `form.tsx` owns and can therefore reason about. This
+ * branch belongs to `SelectField`, a component `ComponentRegistry` resolves, so
+ * the host cannot know what it renders and must not guess.
+ *
+ * ## What was broken
+ *
+ * Measured on `origin/main` at `50798f37d`, the real form renderer hosting one
+ * `{ name: 'wempty', label: 'WEmpty', type: 'field:select', options: [] }`:
+ *
+ * ```
+ * label for="_r_2_-form-item"   label.control = NULL        (id on NO element)
+ * div   data-testid="select-empty-wempty"                   (no id, no name)
+ * getByLabelText('WEmpty') -> throws "however no form control was found
+ *                             associated to that label"
+ * ```
+ *
+ * The widget's zero-option branch returns before its `toDomProps` spread, so
+ * not one host key reaches an element: the `…-form-item` id is on nothing and
+ * the label's `for` DANGLES.
+ *
+ * ## Why the repair is a LABELABLE element and not any of the alternatives
+ *
+ * Each alternative below was rendered and read, not argued. `label.control` is
+ * the HTML mechanism itself (`HTMLLabelElement.control`); `byLabelText` is
+ * Testing Library resolving the same association an assistive technology walks.
+ *
+ * ```
+ * shape                         label.control   byLabelText   accessible name
+ * div carrying the host id      NULL            THROWS        (empty)
+ * no `for` at all               NULL            THROWS        (empty)
+ * button[disabled]              button          RESOLVES      WEmpty
+ * output                        output          RESOLVES      WEmpty
+ * ```
+ *
+ *  - **the host id on the `div`** — the shape #3991 had just judged inert. The
+ *    dangling pointer disappears from the DOM and the label is exactly as
+ *    unusable: `for` may only reference a LABELABLE element, so pointing it at
+ *    a `div` leaves `HTMLLabelElement.control` null and contributes no
+ *    accessible name;
+ *  - **dropping the `for`** — #3991's remedy on the branch IT owns. It does not
+ *    transfer: a widget cannot drop an attribute the host emits, and the
+ *    reading above shows the label ends up no more usable than before;
+ *  - **declaring `select` as `labelling: 'group'`** — measured to move the LIVE
+ *    path: a select WITH options lost its working `<label for>` to the
+ *    `button[role="combobox"]` (objectui#3306's path) and still left the
+ *    zero-option branch with no association at all, because the branch consumes
+ *    no IDREF either. Two changes, and the defect survives both;
+ *  - **a synthetic control** (`button`) — reads the same as `output` here, and
+ *    is the "synthetic role for a thing that is not a control" #3991 refused.
+ *
+ * `<output>` is a labelable element whose implicit role (`status`) claims no
+ * interactivity: it is the result of a computation, which is literally what the
+ * box states. So `labelling: 'control'` — "the component's outermost rendered
+ * element is a LABELABLE HTML element" — becomes TRUE of this branch for the
+ * first time, and nothing on the host side, and no published declaration, has
+ * to move.
+ *
+ * The widgets are registered raw rather than through `registerAllFields()`,
+ * whose `React.lazy` loaders put an unbounded module load inside a bounded
+ * `findBy` window — this repo's known flake generator (AGENTS.md 测试纪律,
+ * objectui#3010).
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope: pulls in the form renderer's registration side effect.
+import '@object-ui/components';
+
+import { SelectField } from '../widgets/SelectField';
+import { RadioField } from '../widgets/RadioField';
+
+beforeAll(() => {
+  // `select` registers with NO `labelling` key — `'control'` spelled as absence,
+  // exactly as `registerField` does it. `radio` carries `labelling: 'group'`,
+  // the declaration objectui#3990 / #4005 answer.
+  ComponentRegistry.register('select', SelectField as any, {
+    namespace: 'field',
+    skipFallback: true,
+  });
+  ComponentRegistry.register('radio', RadioField as any, {
+    namespace: 'field',
+    skipFallback: true,
+    labelling: 'group',
+  });
+}, 30000);
+
+beforeEach(() => {
+  if (!(Element.prototype as any).scrollIntoView) {
+    (Element.prototype as any).scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderForm(fields: any[]) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: false,
+        showCancel: false,
+        defaultValues: {},
+        fields,
+      }}
+    />,
+  );
+}
+
+const item = (name: string): HTMLElement => {
+  const el = document.querySelector<HTMLElement>(`[data-field="${name}"]`);
+  if (!el) throw new Error(`no form item rendered for field "${name}"`);
+  return el;
+};
+
+const hostLabel = (name: string): HTMLLabelElement => {
+  const el = item(name).querySelector('label');
+  if (!el) throw new Error(`no host label rendered for field "${name}"`);
+  return el as HTMLLabelElement;
+};
+
+/** Elements whose `aria-describedby` NAMES `id`, resolved against the document. */
+const describedbyConsumers = (id: string): HTMLElement[] =>
+  Array.from(document.querySelectorAll<HTMLElement>('[aria-describedby]')).filter((el) =>
+    (el.getAttribute('aria-describedby') ?? '').split(/\s+/).includes(id),
+  );
+
+const EMPTY_SELECT = {
+  name: 'wempty',
+  label: 'WEmpty',
+  type: 'field:select',
+  options: [],
+  description: 'Some help',
+};
+
+describe('objectui#8803 — a zero-option `field:select` keeps its label association', () => {
+  it('the label `for` resolves to a LABELABLE element, not to nothing', () => {
+    renderForm([EMPTY_SELECT]);
+    const label = hostLabel('wempty');
+
+    // The reproduction line. `HTMLLabelElement.control` is the HTML mechanism,
+    // not a query helper's opinion: it is null both when `for` points at no
+    // element at all (the reported defect) and when it points at a
+    // non-labelable one (the div-carries-the-id shape that was rejected).
+    expect(label.getAttribute('for')).toBeTruthy();
+    expect(label.control, 'the host label names no labelable element').not.toBeNull();
+  });
+
+  it('the element it resolves to IS the empty-state box, carrying the host id', () => {
+    renderForm([EMPTY_SELECT]);
+    const label = hostLabel('wempty');
+    const box = screen.getByTestId('select-empty-wempty');
+
+    // Ownership, resolved against the document — the same discipline
+    // `readonly-host-plumbing-e2e` uses. A name query would answer "no match"
+    // for both "nobody carries the id" and "the id is on the wrong element".
+    expect(document.getElementById(label.getAttribute('for')!)).toBe(box);
+    expect(box.tagName.toLowerCase()).toBe('output');
+  });
+
+  it('`getByLabelText` resolves it, and the box is named by the visible label', () => {
+    renderForm([EMPTY_SELECT]);
+
+    // The author/test-side symptom the card names: this threw
+    // "Found a label with the text of: WEmpty, however no form control was
+    // found associated to that label".
+    expect(screen.getByLabelText('WEmpty')).toBe(screen.getByTestId('select-empty-wempty'));
+    expect(screen.getByTestId('select-empty-wempty')).toHaveAccessibleName('WEmpty');
+  });
+
+  it('the visible help text is described by the box that replaced the control', () => {
+    renderForm([EMPTY_SELECT]);
+    const descEl = item('wempty').querySelector<HTMLElement>('[id$="-form-item-description"]');
+    expect(descEl).not.toBeNull();
+
+    // The objectui#4005 half of the same early return: the field renders no
+    // input in this state, so this box is the only surface that can carry the
+    // description. Measured at 0 consumers before this fix.
+    expect(describedbyConsumers(descEl!.id)).toEqual([screen.getByTestId('select-empty-wempty')]);
+  });
+
+  it('the box carries no CONTROL-channel state — the objectui#3291 / #4005 line', () => {
+    renderForm([EMPTY_SELECT]);
+    const box = screen.getByTestId('select-empty-wempty');
+
+    // `aria-invalid` / `aria-required` report what a user's own editing may do
+    // wrong, to the element they would edit; `name` is the leak objectui#3291
+    // sweeps for. None of them belongs on a surface nobody can edit.
+    expect(box).not.toHaveAttribute('aria-invalid');
+    expect(box).not.toHaveAttribute('aria-required');
+    expect(box).not.toHaveAttribute('name');
+    // Named by `for`, so a second IDREF channel would be the double naming
+    // objectui#3978 removed.
+    expect(box).not.toHaveAttribute('aria-labelledby');
+  });
+
+  /* ── Live controls ─────────────────────────────────────────────────────── */
+
+  it('LIVE CONTROL — a `field:select` WITH options does not move (objectui#3306)', () => {
+    renderForm([
+      {
+        name: 'wfull',
+        label: 'WFull',
+        type: 'field:select',
+        options: [{ label: 'Alpha', value: 'a' }],
+        description: 'Some help',
+      },
+    ]);
+    const label = hostLabel('wfull');
+
+    // The path that was already correct: the `for` reaches Radix's
+    // `button[role="combobox"]`, which IS labelable.
+    expect(label.control?.tagName.toLowerCase()).toBe('button');
+    expect(label.control).toHaveAttribute('role', 'combobox');
+    expect(screen.getByLabelText('WFull')).toBe(label.control);
+  });
+
+  it('LIVE CONTROL — a zero-option `field:radio` keeps the group IDREF channel', () => {
+    renderForm([
+      { name: 'rempty', label: 'REmpty', type: 'field:radio', options: [], description: 'Some help' },
+    ]);
+    const label = hostLabel('rempty');
+    const box = screen.getByTestId('radio-empty-rempty');
+
+    // objectui#3990 / #4005: a group-labelled widget publishes the label id and
+    // answers by IDREF instead. Untouched by this card — and the reason the
+    // repair here could not simply reuse that channel.
+    expect(label.getAttribute('for')).toBeNull();
+    expect(label.id).toBeTruthy();
+    expect(box.getAttribute('aria-labelledby')?.split(/\s+/)).toContain(label.id);
+    expect(box).toHaveAttribute('role', 'group');
+    expect(screen.getByLabelText('REmpty')).toBe(box);
+  });
+
+  /* ── NOT evidence ──────────────────────────────────────────────────────── */
+
+  it('NOT EVIDENCE (reads the same before and after) — the box still states the empty copy', () => {
+    // Kept because a repair that changed the element must not change what the
+    // box SAYS, but it cannot distinguish the fixed tree from the broken one:
+    // the text was already correct. It is named here so no reader counts it.
+    renderForm([EMPTY_SELECT]);
+    expect(screen.getByTestId('select-empty-wempty')).toHaveTextContent(/no options available/i);
+  });
+});

--- a/packages/fields/src/widgets/OptionsEmptyState.tsx
+++ b/packages/fields/src/widgets/OptionsEmptyState.tsx
@@ -9,7 +9,7 @@
 import React from 'react';
 import { cn } from '@object-ui/components';
 import { useFieldTranslation } from './useFieldTranslation.js';
-import type { HostGroupProps } from './toHostGroupProps.js';
+import type { HostControlProps, HostGroupProps } from './toHostGroupProps.js';
 
 /**
  * The "this option list cannot be filled" state shared by every fixed-option
@@ -67,11 +67,35 @@ export interface OptionsEmptyStateProps {
    * `aria-describedby` and the `role` that makes them meaningful may reach this
    * element, and reopening a spread is what objectui#3291 exists to prevent —
    * `aria-invalid` / `aria-required` are control-channel state and stay off this
-   * surface. Absent for the single `SelectField` — it is not group-labelled, its
-   * label still uses a plain `for`, and it must keep emitting no such
-   * attributes.
+   * surface. Absent for the single `SelectField`, which is not group-labelled
+   * and fills {@link OptionsEmptyStateProps.hostControlProps} instead.
    */
   hostGroupProps?: HostGroupProps;
+  /**
+   * The host label's PLAIN-`for` plumbing, for the one caller that is NOT
+   * group-labelled — the single `SelectField` (objectui#8803).
+   *
+   * Supplying this switches the rendered element from a `div` to an `<output>`,
+   * and that is the entire repair. `select` declares `labelling: 'control'`,
+   * which the registry defines as "the component's outermost rendered element
+   * is a LABELABLE HTML element" — true of the Radix
+   * `button[role="combobox"]` it renders with options, and FALSE of the `div`
+   * this box used to be. So the host's `for` pointed at an id no element
+   * carried, and `HTMLLabelElement.control` was null. Landing the id on the
+   * `div` instead was measured and rejected: `for` may only reference a
+   * labelable element, so it stayed null and the label stayed unusable.
+   *
+   * `<output>` is labelable, and its implicit `status` role claims no
+   * interactivity — it is the result of a computation, which is what this box
+   * reports. Declaring `select` as `'group'` was the alternative and it
+   * measurably moved the LIVE path: a select WITH options lost the working
+   * `<label for>` to its combobox (objectui#3306).
+   *
+   * Mutually exclusive with `hostGroupProps` — one host, one naming channel
+   * (objectui#3978). A caller that supplies neither renders the box with no
+   * host plumbing at all, which is what standalone rendering has always done.
+   */
+  hostControlProps?: HostControlProps;
 }
 
 export function OptionsEmptyState({
@@ -81,6 +105,7 @@ export function OptionsEmptyState({
   testId,
   className,
   hostGroupProps,
+  hostControlProps,
 }: OptionsEmptyStateProps) {
   const { t } = useFieldTranslation();
   // The host's hint when it computed one; otherwise this widget's own copy,
@@ -97,15 +122,23 @@ export function OptionsEmptyState({
           fields: dependsOnFields.join(t('validation.formInvalidJoiner')),
         })
       : t('fields.options.empty'));
+  const boxClassName = cn(
+    'flex w-full items-center rounded-md border border-input bg-muted/30 px-3 py-2 text-sm text-muted-foreground',
+    className,
+  );
+  // The element kind IS the labelling contract, not a styling choice: a
+  // `labelling: 'control'` caller needs a LABELABLE element for the host's
+  // `for` to reach, a `'group'` caller needs a container it can put
+  // `role="group"` on. See `hostControlProps` above for the measurements.
+  if (hostControlProps) {
+    return (
+      <output {...hostControlProps} data-testid={testId} className={boxClassName}>
+        {hint}
+      </output>
+    );
+  }
   return (
-    <div
-      {...hostGroupProps}
-      data-testid={testId}
-      className={cn(
-        'flex w-full items-center rounded-md border border-input bg-muted/30 px-3 py-2 text-sm text-muted-foreground',
-        className,
-      )}
-    >
+    <div {...hostGroupProps} data-testid={testId} className={boxClassName}>
       {hint}
     </div>
   );

--- a/packages/fields/src/widgets/SelectField.tsx
+++ b/packages/fields/src/widgets/SelectField.tsx
@@ -14,6 +14,7 @@ import { FieldWidgetComponentProps } from './types.js';
 import { toDomProps } from './toDomProps.js';
 import { MultiSelectField } from './MultiSelectField.js';
 import { OptionsEmptyState } from './OptionsEmptyState.js';
+import { toHostControlProps } from './toHostGroupProps.js';
 import { useCascadingOptions } from './useCascadingOptions.js';
 
 /**
@@ -144,6 +145,14 @@ function SingleSelectField({
         dependsOnFields={dependsOnFields}
         testId={fieldName ? `select-empty-${fieldName}` : undefined}
         className="h-9"
+        // This widget declares `labelling: 'control'`, so the host emits a
+        // plain `<label for>` and expects a LABELABLE element to be there.
+        // Returning early used to answer that with nothing: the host id
+        // reached no element and the `for` dangled (objectui#8803, the
+        // registered-widget half of objectui#3991). Handing the box this bag
+        // makes it an `<output>` carrying that id — see `OptionsEmptyState`
+        // for the readings that ruled out the alternatives.
+        hostControlProps={toHostControlProps(props)}
       />
     );
   }

--- a/packages/fields/src/widgets/toHostGroupProps.ts
+++ b/packages/fields/src/widgets/toHostGroupProps.ts
@@ -207,3 +207,61 @@ export function toHostGroupProps(
     ...(labelledBy != null ? { role: 'group' as const } : null),
   };
 }
+
+/**
+ * The host keys a LABELABLE surface may consume — the `labelling: 'control'`
+ * counterpart of {@link HostGroupProps} (objectui#8803).
+ *
+ * ## Why a second, smaller bag instead of reusing the group one
+ *
+ * A widget declared `'control'` is told nothing by the host: its label emits a
+ * plain `for` and expects to reach a labelable element on its own. Every
+ * editable branch answers that by spreading `toDomProps` onto the control it
+ * renders. The branches that return EARLY answer it with nothing — and for the
+ * single `SelectField` that is the zero-option box, where the `…-form-item` id
+ * reached no element at all and the label's `for` DANGLED.
+ *
+ * What such a surface needs is therefore the exact complement of the group
+ * bag:
+ *
+ *  - `id` — yes. It is the id the `for` points at, and landing it is the whole
+ *    repair;
+ *  - `aria-describedby` — yes, for the objectui#4005 reason, unchanged by the
+ *    surface being labelable: the field renders no input in this state, so
+ *    this box is the only element the visible help text can be announced on;
+ *  - `aria-labelledby` — ⛔ NO. The `for` already names this element. Adding an
+ *    IDREF beside it is the second naming channel objectui#3978 removed;
+ *  - `role` — ⛔ NO. A labelable element's own semantics are what make the name
+ *    land; a synthetic role on top is the category error objectui#3991 named.
+ *
+ * `aria-invalid` / `aria-required` / `name` stay off for the reasons spelled
+ * out at length on {@link HostGroupProps}: control-channel state on a surface
+ * nobody can edit, and the DOM leak objectui#3291 sweeps for. A closed type,
+ * not an open props tail, for that same reason.
+ */
+export interface HostControlProps {
+  /** The host's control id — the id its label's `for` points at. */
+  id?: string;
+  /** IDREF of the host's visible help text. */
+  'aria-describedby'?: string;
+}
+
+/**
+ * Read the two whole-field keys a labelable replacement surface may carry. See
+ * {@link HostControlProps}.
+ *
+ * Routed through {@link toDomProps} for the same reason {@link toHostGroupProps}
+ * is: the keys keep ONE gate, and its compile-time assertions bind that
+ * whitelist to the props contract in both directions.
+ *
+ * Standalone rendering (the grid's inline cell editor, an action param dialog,
+ * a bare SDUI node) hands down neither key, so both values are `undefined`,
+ * React emits no attribute, and that markup stays byte-identical.
+ */
+export function toHostControlProps(props: {
+  id?: string;
+  'aria-describedby'?: string;
+}): HostControlProps {
+  const { id, 'aria-describedby': describedBy } = toDomProps(props);
+  return { id, 'aria-describedby': describedBy };
+}


### PR DESCRIPTION
Fixes #8803

The registered-widget half of the class objectui#3991 measured and split out. A
`field:select` whose option list resolves empty rendered the shared
`OptionsEmptyState` box and returned before its DOM pass-through, so the host's
`…-form-item` id reached no element at all.

## The reproduction, on `origin/main` @ `50798f37d`

Real form renderer, one `{ name: 'wempty', label: 'WEmpty', type: 'field:select', options: [] }`:

```
LABEL  for="_r_2_-form-item"   ->  owner element = NONE      (id on nothing)
DIV    data-testid="select-empty-wempty"                     (no id, no name)
P      id="_r_2_-form-item-description"  "Some help"          consumers = 0
getByLabelText('WEmpty') -> throws "Found a label with the text of: WEmpty,
                            however no form control was found associated to
                            that label"
```

## A1 — the card's arm 1 is INERT, measured, not argued

The dispatch asked for an accessibility reading rather than "the id now exists".
Each shape below was rendered and read. `label.control` is the HTML mechanism
itself (`HTMLLabelElement.control`); `byLabelText` is Testing Library resolving
the association assistive technology walks.

| shape | label.control | byLabelText | accessible name |
|---|---|---|---|
| baseline (id on no element) | NULL | THROWS "no form control was found" | (empty) |
| **arm 1** — host id on the DIV | **NULL** | **THROWS "non-labellable"** | **(empty)** |
| `for` removed entirely | NULL | THROWS "no form control was found" | (empty) |
| BUTTON with disabled | button | RESOLVES | WEmpty |
| **OUTPUT element** (shipped) | **output** | **RESOLVES** | **WEmpty** |

Arm 1 measured exactly as the card warned and as R1 forbids: the dangling
pointer disappears from the DOM and the label is **exactly as unusable**,
because `for` may only reference a LABELABLE element. Row 3 is the same
reading for R1's other banned shape — and it is also what objectui#3991's
landed builtin arm produces today (measured: builtin empty `select` renders a
label with no `for`, `byLabelText` throws). That is why #3991's remedy does not
transfer here, R2's "where it transfers" hedge doing its job.

## Arms 2 / 3 excluded by measurement, not by reasoning

Declaring `select` as `labelling: 'group'` and re-reading the same form:

```
SELECT-EMPTY  for=(absent)  labelId=set  byLabelText=THROWS "no form control"
SELECT-FULL   for=(absent)  labelId=set  aria-labelledby consumer = BUTTON role=combobox
```

Two readings, both disqualifying. The **live** path moved: a select WITH options
lost its working LABEL-FOR to the combobox — the objectui#3306 path the dispatch
named as a control that must not move. And the zero-option branch was **still**
unassociated, because it consumes no IDREF either. Two changes, defect survives
both.

## What shipped

`select` declares `labelling: 'control'`, which the registry defines as *"the
component's outermost rendered element is a LABELABLE HTML element"*. That is
true of the Radix combobox BUTTON it renders with options and was **false** of
the DIV it rendered without them — the widget was not keeping the promise its
own published declaration already made.

The zero-option box is now an OUTPUT element (labelable; implicit `status` role
claims no interactivity — it is the result of a computation, which is what the
box reports), carrying the host id and `aria-describedby` through a new closed
`HostControlProps` bag routed via `toDomProps`, the sibling of the existing
`HostGroupProps`. `aria-labelledby` and `role` stay off it: the `for` already
names it, and a second channel is what objectui#3978 removed.

**No host change, no published declaration moved, no new vocabulary.**
`FIELD_WIDGET_LABELLING` is untouched; `toHostControlProps` is internal to
`@object-ui/fields` (not in its barrel). The one `packages/components` edit is a
doc comment this change falsified.

## Clause-②

`yes`, per the claim comment — unchanged. `needs:contract-review` is on this PR.
The measurement came out such that no published declaration had to move, and
that outcome is itself the thing to review: the alternative that *would* have
moved one is the arm the readings above disqualify.

## Tests

`packages/fields/src/__tests__/select-empty-label-association-8803.test.tsx` —
8 cases. Red first on the unfixed tree, **4 failed / 4 passed**, the four
failing for the card's own sentence.

- reproduction: `for` resolves to a labelable element; the element it resolves
  to IS the box, carrying the host id; `getByLabelText` resolves and the box is
  named "WEmpty"; the help text is described by the box (0 consumers before).
- **live control** — `field:select` WITH options: `for` still reaches
  `button[role=combobox]` (objectui#3306). Green on both ablation legs.
- **live control** — zero-option `field:radio`: label publishes its id, drops
  `for`, box answers by IDREF with `role=group` (objectui#3990 / #4005). Green
  on both ablation legs.
- **boundary guard** — no `aria-invalid` / `aria-required` / `name` /
  `aria-labelledby` on the box. Passes before and after: it cannot show the
  defect, it catches an over-delivering fix.
- **NOT EVIDENCE**, named as such in the file: "the box still states the empty
  copy". Identical on both sides; it counts for nothing.

Full `packages/fields` suite: **158 files / 2736 tests passed**. Commands,
exit codes and the ablation legs are in the report on #8803.

## A3 — source-text pin census (the objectui#9045 / PR objectui#9169 class)

Run **before the first edit**, because a pin that reads another package's source
text appears in no import graph.

```
git grep -l "readFileSync" -- 'packages/**/__tests__/**' \
    'packages/**/*.test.ts' 'packages/**/*.test.tsx'        -> 222 files
```

Control, lit: the same query reaches
`packages/i18n/src/__tests__/residue-namespaces-3546.test.tsx`, and that file
names `packages/plugin-kanban/src/KanbanImpl.tsx` at line 161 — the pin that bit
objectui#9169. A dark control would have made the census a non-reading.

One real hit on a file this PR edits:
`packages/types/src/__tests__/field-metadata-depends-on-declared-6153.test.ts`
pins the literal line `const dependsOn = field?.dependsOn ?? dependsOnProp;` in
`SelectField.tsx` and forbids two cast-shaped reads. **Preserved verbatim**;
verified by count after the edit. `scripts/vite-ineffective-dynamic-imports.ts`
also names the file, but as a module-identity allowlist, not a text pin.

## Acceptance notes (out of scope, not filed)

- The **builtin** empty-`select` path (objectui#3991's landed arm) still leaves
  `getByLabelText` throwing — measured above. That is not a defect: #3991 ruled
  deliberately that "nothing is lost, because nothing was ever associated". The
  two paths now differ in outcome, which a maintainer may want to revisit; it is
  a landed ruling, so this PR neither reopens nor files it.
- `composite-group-label-readonly-e2e.test.tsx` carried a comment asserting
  `SelectField` "is NOT in `FIELD_WIDGET_LABELLING`" (it is, as `'control'`) and
  that "its label keeps a plain, working `for`" (it dangled). Corrected in place
  — this PR made the second half true — rather than filed.
- `OptionsEmptyState` still renders the DIV when a caller supplies neither host
  bag. A future option widget could inherit that default silently. Making the
  surface a required discriminator would force edits across three unrelated
  widgets and their pins; noted, not filed.

## Risk and rollback

One element name in one widget state. Every consumer test selects the box by
`data-testid`, which is unchanged; a consumer asserting the literal DIV tag name
would see OUTPUT. Rollback is the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_