### PR TITLE
docs(plugin-calendar): re-derive the calendar config key set from the renderer, and pin it

### DIFF
--- a/.changeset/8830-calendar-doc-key-set.md
+++ b/.changeset/8830-calendar-doc-key-set.md
@@ -1,0 +1,12 @@
+---
+---
+
+Docs + test only, no published behaviour change.
+
+`content/docs/plugins/plugin-calendar.mdx` claimed `ObjectCalendar` reads exactly
+the spec's four `CalendarConfig` keys and that a fifth is rejected. Re-derived
+from the renderer: it reads five — the four plus objectui's own `allDayField`,
+load-bearing since objectui#8026 — and neither objectui authoring face rejects a
+fifth key in the `calendar` block. The page now separates the spec face from the
+renderer face, and `packages/types/src/__tests__/calendar-doc-key-set-8830.test.ts`
+derives both sets on every run so the enumeration cannot drift again.

--- a/content/docs/plugins/plugin-calendar.mdx
+++ b/content/docs/plugins/plugin-calendar.mdx
@@ -263,12 +263,30 @@ const schema: ObjectCalendarSchema = {
 }
 ```
 
-`CalendarConfig` is `@objectstack/spec`'s `CalendarConfigSchema`, and that schema
-is **strict**: these four are the whole of it, and a fifth key is rejected rather
-than ignored. `ObjectCalendar` destructures exactly
-`{ startDateField, endDateField, titleField, colorField }`
-(`ObjectCalendar.tsx`), so the list above is also the whole of what the renderer
-reads.
+`CalendarConfig` is a re-export of `@objectstack/spec`'s `CalendarConfigSchema`,
+and that schema is **strict**: the four keys above are the whole of *the spec
+type*, and it refuses a fifth by name with an `unrecognized_keys` diagnostic.
+That is a statement about the type — not about what this renderer reads, and not
+about what reaches it.
+
+`ObjectCalendar` (`ObjectCalendar.tsx`) reads **five** keys off the `calendar`
+block: the four above plus objectui's own `allDayField`, honoured since
+objectui#8026.
+
+`{ startDateField, endDateField, titleField, colorField, allDayField }`
+
+`allDayField` names the record field carrying the all-day flag. It is
+objectui-local by design — the spec refuses the name — and this renderer gives it
+**no** default field name, so a calendar that never declares it draws exactly as
+before, with the all-day flag inferred from the absence of an end date.
+
+Nor is a fifth key rejected on the way in. Neither published face of
+`ObjectCalendarSchema` declares the `calendar` container, so whatever you write
+inside it reaches the renderer unexamined; on the list-view path the container
+*is* declared — as objectui's own mirror of the spec schema, which keeps
+`.passthrough()` for exactly this. Annotating the block `CalendarConfig` is what
+narrows it to the spec's four: under that annotation `allDayField` does not
+compile.
 
 ## Configuration
 

--- a/packages/types/src/__tests__/calendar-doc-key-set-8830.test.ts
+++ b/packages/types/src/__tests__/calendar-doc-key-set-8830.test.ts
@@ -1,0 +1,186 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8830 — the calendar plugin page's "CalendarConfig" section states a
+ * KEY SET and a COUNT. Both are now derived from the two sources they describe,
+ * on every run, instead of being maintained by hand.
+ *
+ * ## The defect
+ *
+ * The section carried one sentence that fused two different faces into a single
+ * false claim: that `CalendarConfig` is the spec's strict four-key schema, that
+ * "a fifth key is rejected rather than ignored", and that `ObjectCalendar`
+ * "destructures exactly" those same four — "so the list above is also the whole
+ * of what the renderer reads".
+ *
+ * Measured on the dispatch base, `@objectstack/spec` 17.4.0 installed:
+ *
+ *   SPEC FACE      `CalendarConfigSchema` is a strict object of exactly
+ *                  `startDateField` / `endDateField` / `titleField` /
+ *                  `colorField`, and refuses `allDayField` BY NAME with an
+ *                  `unrecognized_keys` diagnostic. True, and the only half the
+ *                  old sentence got right.
+ *   RENDERER FACE  `ObjectCalendar` reads FIVE keys off the `calendar` block —
+ *                  those four plus objectui's own `allDayField`, load-bearing
+ *                  since objectui#8026.
+ *   AUTHORING FACE `a fifth key is rejected` is false on both objectui paths.
+ *                  Neither published face of `ObjectCalendarSchema` declares the
+ *                  `calendar` container at all, so the block rides
+ *                  `BaseSchema`'s passthrough unexamined; on the list-view path
+ *                  the container IS declared, as this package's own mirror of
+ *                  the spec schema, which keeps `.passthrough()` for exactly
+ *                  this. Both admit `allDayField`.
+ *
+ * ## ⛔ Why this file is a DERIVATION and not a corrected number
+ *
+ * The enumeration had already drifted once — `allDayField` became load-bearing
+ * in objectui#8026 and the page was never revisited — and the card that caught
+ * it measured only the one key it happened to notice. Adding that key to the
+ * list would reproduce the same hand-maintained enumeration with a fresher
+ * value in it. So nothing here is restated: the renderer's key set is parsed out
+ * of `ObjectCalendar.tsx` and the spec's out of `CalendarConfigSchema.shape`,
+ * and the page is compared against both. A red here always means "the page
+ * drifted from the renderer (or the spec)", never "update the test".
+ *
+ * ⚠️ The derivation FAILS LOUDLY rather than vacuously. A renamed resolver, a
+ * renamed local, or a moved section throws — an empty key set can never pass as
+ * agreement, which is the failure mode a hand-written list has by construction.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { CalendarConfigSchema } from '@objectstack/spec/ui';
+
+/** Walk up to the workspace root, so both sources are found by repo layout. */
+function repoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 10; i += 1) {
+    if (existsSync(join(dir, 'pnpm-workspace.yaml'))) return dir;
+    dir = resolve(dir, '..');
+  }
+  throw new Error('repo root (pnpm-workspace.yaml) not found from this test file');
+}
+
+const ROOT = repoRoot();
+const RENDERER = join(ROOT, 'packages/plugin-calendar/src/ObjectCalendar.tsx');
+const DOC_PAGE = join(ROOT, 'content/docs/plugins/plugin-calendar.mdx');
+const SECTION = '### CalendarConfig';
+
+/** Blank comments out but keep every newline, so nothing shifts under us. */
+function withoutComments(src: string): string {
+  const blank = (m: string) => m.replace(/[^\n]/g, ' ');
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, blank)
+    .replace(/(^|[^:])(\/\/.*)$/gm, (_m, before: string, comment: string) => before + blank(comment));
+}
+
+/**
+ * Every key `ObjectCalendar` reads off the resolved calendar config, from the
+ * three constructs that can read one: the resolver's own return arms, the
+ * destructures of the resolved config, and its member reads.
+ */
+function rendererConfigKeys(): Set<string> {
+  const code = withoutComments(readFileSync(RENDERER, 'utf8'));
+  const keys = new Set<string>();
+
+  const start = code.indexOf('function getCalendarConfig');
+  if (start < 0) throw new Error(`getCalendarConfig not found in ${RENDERER}`);
+  let depth = 0;
+  let end = -1;
+  for (let i = code.indexOf('{', start); i < code.length; i += 1) {
+    if (code[i] === '{') depth += 1;
+    else if (code[i] === '}') {
+      depth -= 1;
+      if (depth === 0) { end = i; break; }
+    }
+  }
+  if (end < 0) throw new Error(`unterminated getCalendarConfig in ${RENDERER}`);
+  const body = code.slice(start, end);
+
+  // 1. The arms that BUILD a config: `titleField: (schema as any).titleField,`
+  for (const m of body.matchAll(/^\s*([A-Za-z_$][\w$]*)\s*:\s*\(schema as any\)/gm)) keys.add(m[1]);
+  // 2. `const { a, b } = calendarConfig;`
+  for (const m of code.matchAll(/const\s*\{([^}]*)\}\s*=\s*calendarConfig\b/g)) {
+    for (const raw of m[1].split(',')) {
+      const name = raw.trim().split(':')[0].trim();
+      if (name) keys.add(name);
+    }
+  }
+  // 3. `calendarConfig.titleField` / `calendarConfig?.titleField`
+  for (const m of code.matchAll(/calendarConfig\??\.([A-Za-z_$][\w$]*)/g)) keys.add(m[1]);
+
+  if (keys.size === 0) throw new Error(`derived an EMPTY config key set from ${RENDERER}`);
+  return keys;
+}
+
+/** The `### CalendarConfig` section of the page, up to the next level-2 heading. */
+function docSection(): string {
+  const page = readFileSync(DOC_PAGE, 'utf8');
+  const from = page.indexOf(SECTION);
+  if (from < 0) throw new Error(`"${SECTION}" not found in ${DOC_PAGE}`);
+  const rest = page.slice(from + SECTION.length);
+  const to = rest.search(/^## /m);
+  return rest.slice(0, to < 0 ? undefined : to);
+}
+
+const NUMBER_WORDS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+
+describe('objectui#8830 — the page states the renderer\'s key set, derived on every run', () => {
+  it('the renderer reads the four spec keys plus objectui\'s own `allDayField`', () => {
+    // Not the assertion this file exists for — the control that proves the
+    // derivation above is reading the renderer and not producing noise.
+    expect([...rendererConfigKeys()].sort()).toEqual([
+      'allDayField', 'colorField', 'endDateField', 'startDateField', 'titleField',
+    ]);
+  });
+
+  it('the section\'s inline key list is exactly what the renderer reads', () => {
+    const section = docSection().replace(/```[\s\S]*?```/g, '');
+    const spans = [...section.matchAll(/`\{([^`{}]+)\}`/g)];
+    expect(spans, `${SECTION} states no inline key list`).toHaveLength(1);
+    const stated = spans[0][1].split(',').map((s) => s.trim()).filter(Boolean).sort();
+    expect(stated).toEqual([...rendererConfigKeys()].sort());
+  });
+
+  it('the count the section states is the count the renderer answers', () => {
+    const section = docSection();
+    const derived = rendererConfigKeys().size;
+    const word = NUMBER_WORDS[derived];
+    expect(word, `no English word for a set of ${derived}`).toBeDefined();
+    expect(section).toContain(`reads **${word}** keys`);
+    // The stale claim this card removed, pinned as absent: the renderer's read
+    // set is NOT the spec's accept set, and the page must never say it is.
+    expect(section).not.toContain('these four are the whole of it');
+  });
+
+  it('the section\'s `plaintext` fence still describes the SPEC type, not the renderer\'s set', () => {
+    // ⛔ The wrong repair for this drift is shoving `allDayField` into the fence:
+    // `CalendarConfig` is a re-export of the spec's schema and that key is
+    // refused there by name. The fence tracks the spec; the prose tracks the
+    // renderer; the two are different sets on purpose.
+    const fence = /```plaintext\n([\s\S]*?)```/.exec(docSection());
+    if (!fence) throw new Error(`${SECTION} has no plaintext fence`);
+    const listed = [...fence[1].matchAll(/^\s{2}([A-Za-z_$][\w$]*)\??\s*:/gm)].map((m) => m[1]).sort();
+    expect(listed).toEqual(Object.keys((CalendarConfigSchema as unknown as { shape: Record<string, unknown> }).shape).sort());
+  });
+
+  it('the spec schema really does refuse the fifth key BY NAME — the half the old sentence got right', () => {
+    const four = { startDateField: 's', endDateField: 'e', titleField: 't', colorField: 'c' };
+    expect(CalendarConfigSchema.safeParse(four).success).toBe(true);
+    const refused = CalendarConfigSchema.safeParse({ ...four, allDayField: 'isAllDay' });
+    expect(refused.success).toBe(false);
+    if (!refused.success) {
+      expect(refused.error.issues.map((i) => i.code)).toContain('unrecognized_keys');
+      expect(JSON.stringify(refused.error.issues)).toContain('allDayField');
+    }
+  });
+});

--- a/scripts/markdown-test-inputs.mjs
+++ b/scripts/markdown-test-inputs.mjs
@@ -296,6 +296,10 @@ export const ADJUDICATED = new Map([
     { reads: ['content/docs/components/basic/button-group.mdx'] },
   ],
   [
+    'packages/types/src/__tests__/calendar-doc-key-set-8830.test.ts',
+    { reads: ['content/docs/plugins/plugin-calendar.mdx'] },
+  ],
+  [
     'packages/types/src/__tests__/calendar-flat-color-allday-8466.test.ts',
     { reads: ['packages/plugin-calendar/README.md'] },
   ],


### PR DESCRIPTION
Fixes #8830

The page's "CalendarConfig" section fused two different faces into one sentence:
that `CalendarConfig` is the spec's strict four-key schema, that "a fifth key is
rejected rather than ignored", and that `ObjectCalendar` "destructures exactly"
those four — "so the list above is also the whole of what the renderer reads".

Per triage, the key set was **re-derived from the renderer** rather than patched
by adding the one key the card happened to notice.

## The count

**Five.** Derived mechanically from `packages/plugin-calendar/src/ObjectCalendar.tsx`
(comments blanked, newlines preserved, so the printed lines are the real ones):

```text
FILE: packages/plugin-calendar/src/ObjectCalendar.tsx
  L 194  resolver arm startDateField    | startDateField: (schema as any).startDateField || (schema as any).dateField,
  L 195  resolver arm endDateField      | endDateField: (schema as any).endDateField || (schema as any).endField,
  L 196  resolver arm titleField        | titleField: (schema as any).titleField,
  L 197  resolver arm colorField        | colorField: (schema as any).colorField,
  L 198  resolver arm allDayField       | allDayField: (schema as any).allDayField
  L 566  destructure  startDateField endDateField titleField colorField allDayField
  L 745  destructure  startDateField endDateField
  L 817  destructure  startDateField endDateField titleField
  L1079  member read  titleField        | const titleText = calendarConfig?.titleField
  L1080  member read  titleField        | ? String(rec[calendarConfig.titleField] ?? 'Event Details')
  COUNT = 5
  KEYS  = allDayField, colorField, endDateField, startDateField, titleField
  LIT   startDateField present: true      titleField present: true
  DARK  defaultView present: false        zzzNonsense present: false
```

`defaultView` being DARK is a measurement, not an omission: this renderer reads
it off the NODE, not off the `calendar` block, so it is not a key of this set.

## The two faces, measured separately

The card said the sentence was missing one key. It was also asserting the fifth
key would be **rejected**, and that half is false on every objectui path.

**Spec face** — `@objectstack/spec/ui`'s `CalendarConfigSchema`, installed 17.4.0:

```text
  shape keys: ["startDateField","endDateField","titleField","colorField"] (count=4)
  the four keys                               -> ACCEPTED
  four + allDayField                          -> REFUSED [{"code":"unrecognized_keys","keys":["allDayField"]}]
  four + defaultView                          -> REFUSED [{"code":"unrecognized_keys","keys":["defaultView"]}]
  four + zzzNonsense  [LIT CONTROL]           -> REFUSED [{"code":"unrecognized_keys","keys":["zzzNonsense"]}]
```

**objectui authoring face** — `@object-ui/types`' `ObjectCalendarSchema` and the
published `safeValidateSchema`, on a real `object-calendar` node:

```text
  calendar declared on ObjectCalendarSchema.shape? false
  four keys                                   -> ACCEPTED
  four + allDayField                          -> ACCEPTED
  four + zzzNonsense                          -> ACCEPTED
  calendar.startDateField = 5                 -> ACCEPTED
  [LIT CONTROL] no record source              -> REFUSED [{"code":"custom","path":[]}]
  [LIT CONTROL] objectName = 5                -> REFUSED [{"code":"invalid_type","path":["objectName"]}]
  safeValidateSchema, four + allDayField      -> ACCEPTED
  safeValidateSchema, no record source        -> REFUSED [{"code":"custom","path":[]}]
```

The two lit controls are what make the ACCEPTED rows readable: the parse really
runs and really can refuse, so `calendar.startDateField = 5` going green is the
block being unexamined, not the probe missing the schema.

**ObjectView / list-view face** — `ListViewSchema.shape.calendar`, which IS declared:

```text
  four keys                                   -> ACCEPTED
  four + allDayField                          -> ACCEPTED
  [LIT CONTROL] startDateField = 5            -> REFUSED [{"code":"invalid_type","path":["startDateField"]}]
```

Here the block IS examined — and `allDayField` still lands, because that mirror is
the spec's four `.partial().passthrough()`, which the mirror's own comment says is
kept for precisely this class of renderer-ahead-of-protocol key.

## What changed on the page

The corrected prose states each face as its own claim: the `plaintext` fence
keeps describing `CalendarConfig` (the spec's four, re-exported); the prose states
the renderer's five; and "nor is a fifth key rejected on the way in" replaces the
claim that it is. ⛔ `allDayField` was deliberately NOT added to the fence — under
the `CalendarConfig` annotation it does not compile, and shoving it in there is
the wrong repair for this drift.

## The measurement point

`packages/types/src/__tests__/calendar-doc-key-set-8830.test.ts` re-derives both
sets on every run and compares the page against both — the stated list, the stated
count word, the fence against `CalendarConfigSchema.shape`, and the spec's
by-name refusal. Nothing is restated in the test, so a red always means "the page
drifted from the renderer (or the spec)", never "update the test". The derivation
throws on a missing anchor rather than passing an empty set.

Registered in `scripts/markdown-test-inputs.mjs` so a markdown-only change to the
page cannot skip the shard that reads it; the ledger audit is green.

## Acceptance notes

- Whole-page scan for sibling enumeration claims, as triage asked: the
  click-to-create payload paragraph names `titleField` / `startDateField` /
  optional `endDateField` plus auto-defaults, and that is exactly what the
  payload builder writes — accurate, left alone. The `CalendarView` schema fence
  already lists `allDayField`. No second instance of the corrected claim on this
  page, and `packages/plugin-calendar/README.md` already teaches `allDayField`,
  so nothing is owed there either.
- Source-text pin census run before editing (triage's A4): one existing pin names
  this page, `packages/types/src/__tests__/object-calendar-record-source-7313.test.ts`,
  and it pins the two static-data annotations rather than the key set — green after
  this change. The census control lit as specified.
- `check:changeset-claims` flagged `.changeset/7313-object-calendar-record-source.md`
  as naming this page. Read: its paragraph claims the two static-data examples are
  annotated and compile. This change touches neither example, so the claim stands —
  body left alone.
- Noted, not filed — already tracked. Neither published face of
  `ObjectCalendarSchema` declares the `calendar` container, though
  `getCalendarConfig` reads it FIRST; it is admitted through `BaseSchema`, so
  nothing breaks. That read is already on the books as objectui#8651 class (a)
  ("four undeclared reads on the `ObjectGridSchema` union", `calendar` named),
  which is open and queued, so no second card was opened. Adjacent to
  objectui#8831, which is still undecided and deliberately untouched here.

## Verification

Ablation, both legs, each proved on disk before running and restored by state
(`git checkout HEAD -- PATH`, then `git diff HEAD` empty and the blob hash back
at its HEAD value). The pin reads both files as TEXT off disk, so the on-disk
mutation is the whole mechanism — no `dist` sits between the mutation and the
assertion.

```text
LEG A — renderer stops reading allDayField (resolver arm + destructure + the read)
  HEAD blob     = 5ede88b21fad6449272e5656f3f8e48d54badd08
  grep BEFORE: resolver arm = 1, five-key destructure = 1
  grep AFTER : resolver arm = 0, five-key destructure = 0
  after mutate  = ddeaa5b9088718a9c1f26be5b32f2c1566071fba   (moved)
  VERDICT mutated-renderer vitest-exit=1   Tests 3 failed | 2 passed (5)
      derived set, page key list, and `reads **four** keys` all red
  after restore = 5ede88b21fad6449272e5656f3f8e48d54badd08   RESTORE PROVEN

LEG B — page restates the old four-key list
  HEAD blob     = 1777606840980c171860acfe81f8bc233da1f6db
  grep BEFORE: five-key list = 1, four-key list = 0
  grep AFTER : five-key list = 0, four-key list = 1
  after mutate  = c360e9aa91610c1ab3253eb586bf190ceb65e5af   (moved)
  VERDICT mutated-doc vitest-exit=1        Tests 1 failed | 4 passed (5)
  after restore = 1777606840980c171860acfe81f8bc233da1f6db   RESTORE PROVEN
```

Green on the restored tree, at `b073fd87`:

```text
vitest  calendar-doc-key-set-8830 · object-calendar-record-source-7313 ·
        markdown-test-inputs · component-docs-retired-handler-keys-7340   32+ passed, 0 failed
type-check @object-ui/types (tsc --noEmit + examples + test projects)      exit 0
        --listFiles proves the new test IS in the program (1 of 643 files)
turbo build, doc-gate closure (35 tasks)                                   exit 0
check:doc-fences · doc-example-ids · doc-types · doc-snippets ·
      doc-examples · doc-example-readers · new-line-citations ·
      control-bytes · unreferenced-sources · lint:coverage ·
      docs-route-closure                                                   exit 0 each
check-doc-links.mjs · check-changeset-overwrite.mjs ·
      check-doc-expression-carriage.mjs (report-only)                      exit 0 each
check-changeset-presence.mjs   empty frontmatter accepted as the answer    exit 0
check-changeset-no-major.mjs                                               exit 0
check-governed-queue-guard.mjs --test (4 paths)   NOT GOVERNED             exit 0
markdown-test-inputs.mjs --audit   46 candidates, all adjudicated          exit 0
```

ESLint was narrowed to the changed paths, and the narrowing is measured rather
than asserted: every rule block in `eslint.config.js` is scoped to
`**/*.{ts,tsx}` (8 `files:` blocks, all of them), so of the four changed paths
only the new test is in eslint's universe at all — the `.mdx` and the changeset
come back as "File ignored because no matching configuration was supplied" and
the `.mjs` matches no block. `--format json` reported 4 files, 0 errors. No
type-aware linting is configured (zero hits for `parserOptions` / `project:` /
`projectService` in `eslint.config.js`), so nothing in this diff can move a
rule's verdict on a file it does not touch. `pnpm lint` across all 46 packages
is CI's run, not this one's; `lint:coverage` (46/46, 0 outstanding) is reported
above.

Session reference, as prose so it survives a body edit:
`https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ


---
_Generated by [Claude Code](https://claude.ai/code)_