### PR TITLE
fix(types): the filter-builder doc reader strips comments before it locates the terminator

### DIFF
--- a/.changeset/9073-doc-union-members-comment-order.md
+++ b/.changeset/9073-doc-union-members-comment-order.md
@@ -28,3 +28,12 @@ never in the surface it reads. One existing throw branch changes outcome — a u
 only `;` lives in a comment is now `is unterminated` (loud) rather than a silently
 truncated set; the throw's wording is unchanged and the two throws the floor test pins
 are unaffected.
+
+The card's other two items land in the same file. The floor test's `logic` control
+claimed to catch "a reader that stopped at the first line of a multi-line union"; it
+cannot, because `logic` is itself single-line — measured by mutating the reader into a
+line-bounded one, where that leg stays green and what actually reddens is the
+zero-members throw out of `documentedTypes()`. The docblock now names that mechanism.
+And the equality pin's message offered its exception as "a LATER ruling", citing
+objectui#4814 (2026-08-16/17), which PREDATES batch #88 (2026-09-02); it now reads
+"ANY ruling", which is what the exception meant.

--- a/.changeset/9073-doc-union-members-comment-order.md
+++ b/.changeset/9073-doc-union-members-comment-order.md
@@ -1,0 +1,30 @@
+---
+---
+
+Test-only: `packages/types/src/__tests__/filter-builder-mirror-6939.test.ts`. It sits
+under `src/`, so the presence gate counts it, but nothing published moves — the
+package's build `tsconfig.json` excludes `**/__tests__/**` and its `files` list is
+`["dist", "README.md", "CHANGELOG.md", "LICENSE"]`, so the file never reaches a
+consumer. Declared as releasing nothing.
+
+objectui#9073: the doc reader objectui#8774 introduced located the terminating `;` of a
+union in the RAW interface block and stripped line comments only afterwards. A `;`
+inside a comment on one of the union's own rows therefore ended the slice early — the
+published doc's FOURTEEN-member `type?:` union read as EIGHT — and the mirror/doc pin
+then rendered *this mirror accepts `type` members … never published — the mirror
+widened past the authority.* for six members the doc does publish.
+
+⭐ The defect is the FALSE POSITIVE, not the under-count: that verdict sends whoever
+reads it to look for a widening nobody made, and a checker that lies confidently is
+worse than one that stays quiet.
+
+Comments now come off BEFORE the key is located, and `at` is computed on the stripped
+block — stripping shortens it, so an index taken before the strip addresses a different
+place after it, and carrying one across drops the union's LEADING members instead. Both
+hazards are pinned, alongside a control that is green in both worlds.
+
+⛔ No accept set moves and the published doc is untouched: the defect was in the reader,
+never in the surface it reads. One existing throw branch changes outcome — a union whose
+only `;` lives in a comment is now `is unterminated` (loud) rather than a silently
+truncated set; the throw's wording is unchanged and the two throws the floor test pins
+are unaffected.

--- a/packages/types/src/__tests__/filter-builder-mirror-6939.test.ts
+++ b/packages/types/src/__tests__/filter-builder-mirror-6939.test.ts
@@ -450,11 +450,17 @@ describe('objectui#6939 — the type vocabulary', () => {
     const documented = documentedTypes();
     expect(
       documented.filter((t) => !declared.includes(t)),
+      // ⚠️ This message used to say "a LATER ruling", which is wrong about the
+      // example it cites and was corrected in objectui#9073: objectui#4814
+      // retired `owner` on 2026-08-16/17, and batch #88 is 2026-09-02 — so the
+      // retirement PREDATES the batch it was offered as an exception to. The
+      // exception does not depend on the order anyway: a spelling ANY ruling
+      // has retired does not come back through the doc.
       `the published doc offers \`type\` members this mirror refuses. Under decision ` +
         `batch #88 the DOC is the authority and the MIRROR follows — widen ` +
         `FilterFieldSchema.type and FilterField['type'] to match, as its own reviewable ` +
         `change. ⛔ Do NOT narrow ${DOC} to match the mirror. The one exception to ` +
-        `"the mirror follows": a spelling a LATER ruling RETIRED from this doc — the ` +
+        `"the mirror follows": a spelling ANY ruling RETIRED from this doc — the ` +
         `way objectui#4814 retired \`owner\` — reappearing in it is a doc REGRESSION, ` +
         `not a widening, and the doc edit is what gets reverted.`,
     ).toEqual([]);
@@ -484,11 +490,22 @@ describe('objectui#6939 — the type vocabulary', () => {
     const doc = publishedDoc();
     // (1) CONTROL — the same reader, the same file, a DIFFERENT block whose
     //     answer is fixed by the ruling at exactly two members. It can fire in
-    //     the region under test: a reader that matched nothing, matched the
-    //     wrong interface, or stopped at the first line of a multi-line union
-    //     returns something that is not `['and','or']`, and this reddens. And
-    //     it is independent of the `type?:` block it vouches for, so the thing
-    //     being measured cannot be what satisfies it.
+    //     the region under test: a reader that matched nothing, or matched the
+    //     wrong interface, returns something that is not `['and','or']`, and
+    //     this reddens. And it is independent of the `type?:` block it vouches
+    //     for, so the thing being measured cannot be what satisfies it.
+    //     ⛔ One mode this control does NOT cover, corrected in objectui#9073
+    //     after it was claimed here: a reader that stops at the FIRST LINE of a
+    //     multi-line union. `logic` is itself single-line, so such a reader
+    //     reads it correctly and this leg stays green.
+    //     That mode IS covered — measured, by mutating this reader into a
+    //     line-bounded one: `type?:` then parses to zero members, the
+    //     zero-members throw fires out of `documentedTypes()`, and six tests in
+    //     this file redden, this one among them at leg (2) rather than here.
+    //     So the guard exists; it is the THROW below plus the equality pin, not
+    //     this control. ⚠️ A control that names a mode it cannot catch is the
+    //     same class of defect as the reader objectui#9073 repaired: a
+    //     confident claim that sends the next reader to the wrong place.
     expect(docUnionMembers(doc, 'FilterGroup', 'logic')).toEqual(['and', 'or']);
     // (2) The population itself is non-empty and duplicate-free — a duplicated
     //     member would make the sorted-equality above pass on unequal sets.

--- a/packages/types/src/__tests__/filter-builder-mirror-6939.test.ts
+++ b/packages/types/src/__tests__/filter-builder-mirror-6939.test.ts
@@ -284,16 +284,28 @@ function docInterfaceBlock(doc: string, iface: string): string {
  * Every quoted member of the union `<iface>.<key>` declares, in the doc's own
  * order. The union may span LINES — the doc lays `type?:` out over five rows —
  * so the slice runs to the terminating `;`, not to the end of the line. Line
- * comments are stripped first: `// Field type` sits inside that slice, and an
- * apostrophe in some future one would otherwise mint a phantom member.
+ * comments are stripped first: `// Field type` sits inside that slice, an
+ * apostrophe in some future one would otherwise mint a phantom member, and a
+ * `;` in one would otherwise be mistaken for the terminator (objectui#9073).
  */
 function docUnionMembers(doc: string, iface: string, key: string): string[] {
-  const block = docInterfaceBlock(doc, iface);
+  // ⛔ Comments come off FIRST, and everything after this line addresses the
+  // stripped block only (objectui#9073). Locating the terminating `;` in the
+  // raw block and stripping afterwards let a `;` inside a union-row comment
+  // end the slice early: the fourteen-member union read as eight, and the
+  // mirror/doc pin then announced a widening that had not happened — a
+  // confident lie, which is worse than silence.
+  //
+  // ⚠️ And it is a two-sided fix, not a one-line one: stripping SHORTENS the
+  // block, so an index taken before the strip addresses a different place
+  // after it. `at` is therefore computed here, on the stripped block, and
+  // never carried across from the raw one.
+  const block = docInterfaceBlock(doc, iface).replace(/\/\/[^\n]*/g, '');
   const at = block.indexOf(`\n  ${key}:`);
   if (at === -1) throw new Error(`${DOC}: \`${iface}\` no longer declares \`${key}\``);
   const end = block.indexOf(';', at);
   if (end === -1) throw new Error(`${DOC}: \`${iface}.${key}\` is unterminated`);
-  const body = block.slice(at, end).replace(/\/\/[^\n]*/g, '');
+  const body = block.slice(at, end);
   const members = [...body.matchAll(/'([^']*)'/g)].map((m) => m[1]);
   if (members.length === 0) {
     throw new Error(`${DOC}: \`${iface}.${key}\` parsed to ZERO members`);
@@ -315,6 +327,23 @@ function docUnionMembers(doc: string, iface: string, key: string): string[] {
  */
 function documentedTypes(): string[] {
   return docUnionMembers(publishedDoc(), 'FilterField', 'type?');
+}
+
+/**
+ * The "the mirror widened past the authority" verdict, as a function and a
+ * sentence rather than an expression buried in one assertion (objectui#9073).
+ *
+ * It is lifted out because a controlled input has to be pushed through THE SAME
+ * comparison and THE SAME sentence the pin renders — a copy of either could
+ * drift away from the thing it is there to vouch for, and this diagnosis is
+ * exactly the one that was observed to fire falsely.
+ */
+const WIDENED_MESSAGE =
+  `this mirror accepts \`type\` members ${DOC} never published — the mirror widened ` +
+  `past the authority.`;
+
+function widenedPastTheDoc(documented: string[]): string[] {
+  return mirrorTypeMembers().filter((t) => !documented.includes(t));
 }
 
 /** The enum this mirror actually declares, behind `.optional()`. */
@@ -429,11 +458,7 @@ describe('objectui#6939 — the type vocabulary', () => {
         `way objectui#4814 retired \`owner\` — reappearing in it is a doc REGRESSION, ` +
         `not a widening, and the doc edit is what gets reverted.`,
     ).toEqual([]);
-    expect(
-      declared.filter((t) => !documented.includes(t)),
-      `this mirror accepts \`type\` members ${DOC} never published — the mirror widened ` +
-        `past the authority.`,
-    ).toEqual([]);
+    expect(widenedPastTheDoc(documented), WIDENED_MESSAGE).toEqual([]);
     expect([...declared].sort()).toEqual([...documented].sort());
   });
 
@@ -496,6 +521,116 @@ describe('objectui#6939 — the type vocabulary', () => {
     // required `type` reddens here as well — the wrong direction, both ways.
     expect(doc).toContain('type?:');
     expect(FilterFieldSchema.safeParse({ value: 'a', label: 'A' }).success).toBe(true);
+  });
+});
+
+/* ── objectui#9073 — the reader's comment/terminator ORDER ────────────────── */
+
+/**
+ * The fixtures below are CONTROLLED INPUTS, not declarations found in this
+ * tree, and that is the shape of the card: objectui#9073 is a defect in a
+ * test-embedded READER, so nothing in the shipped surface is wrong and there is
+ * nothing to find. No comment anywhere in the published doc carries a `;`
+ * today — a fixture claiming to have found one would be describing a tree that
+ * does not exist.
+ *
+ * So each one is the REAL doc with exactly one comment rewritten, anchored to a
+ * literal row rather than hand-written, so that the fixture cannot quietly
+ * become a straw man when the doc moves: a vanished anchor THROWS.
+ */
+const UNION_ROW = "    | 'date' | 'datetime' | 'time'\n";
+const EARLIER_ROW = "  value: string;                         // Field identifier\n";
+
+function docWith(anchor: string, replacement: string): string {
+  const doc = publishedDoc();
+  if (!doc.includes(anchor)) {
+    throw new Error(
+      `${DOC}: objectui#9073 fixture anchor ${JSON.stringify(anchor)} is gone — ` +
+        `the fixture no longer perturbs the doc it claims to perturb`,
+    );
+  }
+  // Function replacement: a literal `$&`/`$1` in the text would otherwise be a
+  // substitution pattern rather than the bytes written here.
+  return doc.replace(anchor, () => replacement);
+}
+
+describe('objectui#9073 — the doc reader strips comments BEFORE it locates the terminator', () => {
+  it('a `;` inside a union-row comment no longer truncates the union — nor reports a widening that never happened', () => {
+    // ⭐ What this card is about is the FALSE POSITIVE, not the under-count.
+    // The reader used to locate the terminating `;` in the RAW block and strip
+    // comments only afterwards, so the `;` in the comment injected below ended
+    // the slice EIGHT members in. The mirror's fourteen then read as six
+    // members the doc "never published", and the pin above rendered
+    // WIDENED_MESSAGE — announcing a widening nobody had made and sending
+    // whoever read it to look for a change that does not exist. A reader that
+    // under-counts a mirror does not stay quiet; it lies confidently.
+    const poisoned = docWith(
+      UNION_ROW,
+      "    | 'date' | 'datetime' | 'time'   // dates; and date-times\n",
+    );
+    const documented = docUnionMembers(poisoned, 'FilterField', 'type?');
+    // The DIAGNOSIS first, deliberately: through the same function and the
+    // same sentence the pin renders rather than a copy of either, so the red
+    // run prints the false verdict itself and not a symptom of it.
+    expect(widenedPastTheDoc(documented), WIDENED_MESSAGE).toEqual([]);
+    // …and the read underneath it, seeded from the authority rather than from
+    // a count kept here — the reason objectui#8774 deleted this file's
+    // hand-kept `DOCUMENTED_FOURTEEN`.
+    expect(documented).toEqual(documentedTypes());
+  });
+
+  it('a `;` in a comment BEFORE the key keeps the anchor in ONE coordinate system', () => {
+    // ⚠️ The trap in the one-line reading of this repair. Stripping comments
+    // SHORTENS the block, so an index computed on the raw block addresses a
+    // different place in the stripped one. An implementation that strips the
+    // comments but carries the old `at` across starts its slice INSIDE the
+    // union and silently drops the LEADING members — a second wrong answer
+    // reached from the same fix, and one the test above cannot see.
+    //
+    // The comment rewritten here sits BEFORE `type?:`, so it never enters the
+    // slice at all and cannot affect the terminator search either. It can only
+    // be caught by that coordinate shift, which is why it is a separate leg.
+    const shifted = docWith(
+      EARLIER_ROW,
+      "  value: string;                         // Field identifier; never the label\n",
+    );
+    expect(docUnionMembers(shifted, 'FilterField', 'type?')).toEqual(documentedTypes());
+  });
+
+  it('CONTROL — a doc with no `;` in any comment reads identically in both worlds', () => {
+    // ⚠️ Named a control because it CANNOT tell the two worlds apart: the
+    // published doc carries no `;` inside a comment, so this is green before
+    // the repair and green after it. It is here so the two legs above are
+    // readable as perturbations of a known-good answer — ⛔ it is not evidence
+    // that the repair works, and it must not be counted as any.
+    expect(docUnionMembers(publishedDoc(), 'FilterGroup', 'logic')).toEqual(['and', 'or']);
+    expect(widenedPastTheDoc(documentedTypes()), WIDENED_MESSAGE).toEqual([]);
+  });
+
+  it('a union whose only `;` is inside a comment is UNTERMINATED — loudly, not truncated silently', () => {
+    // The ONE existing branch this repair moves, recorded here rather than
+    // discovered by somebody later. Before: the comment's `;` was accepted as
+    // the terminator and the reader returned a truncated set in silence.
+    // After: the comment is gone before the search runs, the block genuinely
+    // has no terminator past the key, and `is unterminated` fires — the throw
+    // that was already here, wording untouched. Silent-and-wrong → loud is the
+    // direction this file already declares for its readers ("absence is LOUD
+    // here"); the two throws pinned in the floor test are not moved at all.
+    //
+    // Hand-written rather than doc-anchored, and it has to be: the real block
+    // carries further `;` after the union (`options?: Array<{ … }>;`), so no
+    // edit to a COMMENT can leave the real block unterminated.
+    const handWritten = [
+      'interface FilterField {',
+      '  type?:',
+      "    | 'text'",
+      "    | 'number'   // no terminator past here; only this comment has one",
+      '}',
+      '',
+    ].join('\n');
+    expect(() => docUnionMembers(handWritten, 'FilterField', 'type?')).toThrow(
+      '`FilterField.type?` is unterminated',
+    );
   });
 });
 


### PR DESCRIPTION
Fixes #9073

`Clause-②: no` — declared from this diff. No accept set moves: doc 14, mirror 14, before and after. The published doc is byte-identical at BASE and at HEAD; the defect was in the reader, never in the surface it reads.

Scope note on the placeholder spelling below: this repository has measured GitHub deleting tag-shaped fragments from a stored body, backticks and fences included, so every placeholder here is written as a WORD (KEY, IFACE) rather than in angle brackets.

## Item 1 — the false diagnosis

`docUnionMembers` located the terminating semicolon in the RAW interface block and stripped line comments only afterwards. A semicolon inside a comment on one of the union's own rows therefore ended the slice early.

Re-derived here rather than taken on trust, on today's bytes: `packages/types/src/__tests__/filter-builder-mirror-6939.test.ts` lines 290-302 at `4784bb34f` match the card, terminator search first, `.replace(/\/\/.../g, '')` second.

**The verbatim false diagnosis, measured before the fix** — one comment injected into the published doc's `type?:` union row, nothing else changed:

```
AssertionError: this mirror accepts `type` members content/docs/components/complex/filter-builder.mdx never published — the mirror widened past the authority.: expected [ 'boolean', 'select', 'status', …(3) ] to deeply equal []

+ [ "boolean", "select", "status", "lookup", "master_detail", "user" ]
```

and, underneath it, the member list at **8** instead of 14 (`text number currency percent rating date datetime time`). The mirror had not widened. The reader had under-read the doc, and then named the mirror.

⭐ That is the whole card: a checker whose purpose is to be believed announced a change nobody made. After the fix the same input reads 14 and the verdict is empty.

**The repair, and the trap inside it.** Comments come off FIRST and `at` is computed on the stripped block. Stripping SHORTENS the block, so an index taken before the strip addresses a different place after it; an implementation that strips but carries the old `at` across starts its slice inside the union and drops the LEADING members instead — a second wrong answer reached from the same one-line reading. Both halves are pinned.

**Controlled inputs, said plainly.** No declaration in this tree carries a semicolon inside a comment today, so the fixtures are the real doc with exactly one comment rewritten, anchored to a literal row so a doc that moves THROWS instead of quietly testing a straw man.

## Item 2 — the `logic` control named a mode it cannot catch

The floor test's docblock claimed the `logic` control guards against "a reader that stopped at the first line of a multi-line union". It cannot: `logic` is itself single-line, so a first-line-only reader reads it correctly.

Measured, not restated — the reader was mutated into a line-bounded one and the file re-run: **6 tests red, every one of them through the zero-members throw raised out of `documentedTypes()`**, and the `logic` leg itself stayed green (the floor test failed at leg (2), not leg (1)). The docblock now names that mechanism and says what the control does not cover.

## Item 3 — two wording corrections

- The equality pin offered its exception as "a spelling a **LATER** ruling RETIRED from this doc", citing objectui#4814. Measured via the API: #4814 is 2026-08-16/17, batch #88 is 2026-09-02 — the retirement **predates** the batch. It now reads "ANY ruling", which is what the exception meant; the dating correction sits in a comment beside it.
- The remaining half of item 3 lives in the body of merged PR objectui#9069, not in this diff — see "Owed, deliberately not patched" below.

⛔ No existing leg is weakened or deleted. The one expression that moved is the widening verdict, lifted into `widenedPastTheDoc()` plus a `WIDENED_MESSAGE` constant so the controlled input travels through the SAME comparison and the SAME sentence the pin renders, rather than a copy that could drift. The pin's assertion and its message are byte-identical in effect.

## Ablation — three legs, each with two-way on-disk proof

Every leg: mutate, prove it reached disk (marker counts 1 to 0 and 0 to 1, `git hash-object` moved, HEAD blob unmoved), run, restore, prove the restore by STATE (`git hash-object` back to the HEAD blob, `git diff HEAD` empty) rather than by an exit code. Each script carried `trap restore EXIT INT TERM` with absolute paths.

| leg | mutation | result |
|---|---|---|
| A — the fix itself | strip-first reverted to locate-first | **2 red**, exactly the two intended: the false-diagnosis pin (rendering WIDENED_MESSAGE verbatim) and the unterminated-union pin. Control green. |
| B — the coordinate trap | `at` taken on the raw block, used on the stripped one | **5 red**, including the "comment BEFORE the key" leg. ⚠️ Honest reading: that leg is not the sole detector — the pre-existing equality pin and floor test also redden. It is the only one whose comment sits before `at` by construction, and the only one that names the hazard. |
| C — first-line-only reader | union body cut at the first newline | **6 red**, all via the zero-members throw. This is the measurement behind item 2. |

Blobs: HEAD `40ff1031`, leg A `38ce70e8`, leg B `e32f224c`, leg C `45874497`; restored to `40ff1031` on every leg with `git diff HEAD` empty.

⚠️ The CONTROL test is named as a control because it cannot tell leg A's two worlds apart — green before and after. It is **not** counted as evidence. It does fire under legs B and C, so it is not inert.

## One branch whose outcome moves, recorded rather than left to be discovered

A union whose ONLY semicolon lives inside a comment now raises `is unterminated` (loud) where it previously returned a silently truncated set. The throw's wording is untouched, and the two throws the floor test pins at lines 476-477 (`no longer declares`, `no interface IFACE block`) are unaffected — both still pass. The other two branches are unchanged: `at` cannot be created or destroyed by stripping (a comment at that indentation begins with `//`, so it can never spell a `\n  KEY:` match), and `parsed to ZERO members` now fires strictly LESS often.

## Verification — all at final commit `54a2fb796`

| what | command | result |
|---|---|---|
| the pin file + its render half | `pnpm exec vitest run packages/types/ examples/schema-catalog/test/filter-builder-mirror-6939.test.tsx scripts/__tests__/markdown-test-inputs.test.ts` | exit 0 — **177 files, 3498 tests passed** (through `os-verify-lock.sh`, `VERDICT command-exit 0`) |
| types type-check | `pnpm --filter @object-ui/types type-check` | exit 0. It runs `tsconfig.test.json`, and `--listFiles` confirms the edited file is inside that project — so this is a measurement, not a NOT-MEASURED |
| lint | `eslint .` in `packages/types` (what `turbo run lint` invokes) | exit 0 — **245 files, 0 errors** |
| changeset presence | `node scripts/check-changeset-presence.mjs` | exit 0, empty-frontmatter declaration accepted |
| changeset no-major / claims | `check:changeset-no-major`, `check:changeset-claims` | exit 0 |
| control bytes | `pnpm check:control-bytes` | exit 0, 7372 files |
| comment-mask corpus | `pnpm check:comment-mask-corpus` | exit 0, within the objectui#7882 ceiling (1 file, pre-existing) |
| doc-example shared reader | `pnpm check:doc-example-readers` | exit 0 |
| new cross-file line citations | `pnpm check:new-line-citations` | exit 0, 0 new citations |
| unreferenced sources | `pnpm check:unreferenced-sources` | exit 0 |
| markdown-test-inputs registry | `node scripts/markdown-test-inputs.mjs --audit` | exit 0 before and after — the edited file is a declared reader of the filter-builder mdx and still reads exactly that |
| governed surface | `node scripts/check-governed-queue-guard.mjs --test ...` | NOT GOVERNED, 2 paths against 5 surfaces |

Every exit code above was captured by redirecting to a file first and reading `$?` on the next statement, never across a pipe.

**Declared narrowing.** Lint ran for `@object-ui/types` only, not all 39 packages. Three pieces of evidence, not two: (1) the population is eslint's own — `eslint .` inside the package, the exact script `turbo run lint` runs; (2) the count is read from `--format json`: 245 files; (3) invariance — `eslint.config.js` configures no type-aware linting (no `parserOptions.project`, no `projectService`), so a file's verdict is a function of that file plus the shared config, and this diff touches one file inside this package and no config. It therefore cannot move the verdict of any untouched file. The whole farm is CI's run.

## Acceptance notes

- Six sites in this tree hand-roll a private line-comment stripper (`/\/\/[^\n]*/g`), two of them also hand-rolling block-comment removal, while `scripts/js-comment-mask.mjs` declares itself "the ONE answer" to that question and names both hand-rolled families as having drifted with silent, opposite failure modes. Two package tests already import `maskComments` from it. This diff MOVES one of those six but does not convert it: converting is a different defect from the ordering one this card names, and it would add a cross-tree import to a package that has none. Filed separately — see the report.
- `eslint .` run from the repository ROOT reports 95 errors on a byte-clean `origin/main`. That is not a defect: `pnpm lint` is `turbo run lint`, which runs `eslint .` per package, and no one runs the root form. Noted so the next reader who tries it is not misled.

## Owed, deliberately not patched

Card item 2 and item 3 each have a half that lives in the body of **merged** PR objectui#9069, which this diff cannot reach:

- its line 56 repeats the same false claim about the `logic` control;
- its line 78 says "the three new tests" where the count went **21 to 23** — two new plus one rewritten. Reproduced exactly: `grep -c 'it('` gives 21 at that PR's base `7f27bc54` and 23 at its head `db804c0c`.

⛔ Not patched, and the reason is measured rather than preferential: AGENTS.md records that a body PATCH unconditionally appends a second attribution footer and downgrades the session-URL form. On a merged historical record that trades one wrong sentence for a visibly damaged artifact, and the repository's own guidance is that a rewrite destroys a correct card. Left for the maintainer to decide; both sentences are quoted above so no one has to re-derive them.

## 维护者速读(草稿)

**改了什么** —— 一个测试内嵌的文档读取器,先找分号、后剥注释,顺序反了。改成先剥注释再定位,并保证下标在同一坐标系里。另外修正该文件对自己的两处错误描述。

**为什么改** —— 这个缺陷的要害不是"数少了",而是**假阳**:联合体被注释里的一个分号截断成 8 个成员后,断言报的是"mirror 变宽了",而 mirror 一个字节都没动。一个专门用来被相信的检查器,自信地指错了人 —— 比它沉默更糟。

**风险与代价(含回滚)** —— 改动只在一个测试文件加一份空 frontmatter 的 changeset,不发布任何包,已发布的文档一个字节未动,接受集合前后都是 14 = 14。唯一行为变化:只有注释里带分号、块内再无分号的联合体,现在会响亮地抛 `is unterminated`,而不是静默返回一个被截断的集合 —— 方向是从"静默错"到"响亮错"。回滚即 revert 这两个 commit,无迁移、无数据、无下游。

**席位意见** —— (留空,待席位定稿)

**你要做的** —— 这是 draft,按仓库规矩等 CI;Clause-② 为 `no`,不需要 contract review。上面"Owed, deliberately not patched"一节有两句话住在已合并的 PR objectui#9069 正文里,是否要去改那份历史记录,请您定。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_