### PR TITLE
feat(app-shell): warn at typing time on a record-scope `data.*` predicate

### DIFF
--- a/.changeset/8972-cel-authoring-data-root-advisory.md
+++ b/.changeset/8972-cel-authoring-data-root-advisory.md
@@ -1,0 +1,19 @@
+---
+'@object-ui/app-shell': minor
+---
+
+Warn at typing time when a record-scope CEL predicate is rooted on `data`.
+
+`@objectstack/formula`'s scope vocabulary still accepts `data`, so a
+`visibleWhen` / `readonlyWhen` / `requiredWhen`, a formula `expression` or a
+conditional-formatting `condition` written as `data.status == 'x'` used to lint
+green and then fault at runtime with `Unknown variable: data`, because the row
+is bound as `record.*` and nothing else (objectui#5741, objectui#8166). The
+metadata editors now surface `@object-ui/core`'s `detectNonCanonicalRowSpelling`
+as an inline warning naming `record` as the fix.
+
+The accepted set is unchanged: this is advisory only, so it does not block save
+and does not mark the field invalid. It applies to `scope: 'record'` authoring
+sites only — flattened RLS `USING` / `CHECK` predicates, where a bare field
+reference is the correct spelling, are untouched, as is the metadata-editing
+layer where `data` is canonical.

--- a/packages/app-shell/src/views/metadata-admin/ConditionalFormattingEditor.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ConditionalFormattingEditor.test.tsx
@@ -177,23 +177,33 @@ describe('ConditionalFormattingEditor · CEL authoring scope (#2571 follow-up)',
     expect(await screen.findByText('perm.cel.valid', {}, { timeout: 3000 })).toBeTruthy();
   });
 
-  it('KNOWN GAP — a `data.*` condition still lints CLEAN although the row is not bound under it', async () => {
-    // NOT desired behaviour, and it is the half of the retirement this card
-    // does NOT close. Dropping `'data'` from ROW_PREDICATE_ROOTS stops
-    // RECOMMENDING it; it does not stop the lint ACCEPTING it, because
-    // `@objectstack/formula`'s `SCOPE_ROOTS` lists `data` and so the
-    // record-scope bare-reference check waves it through. `rowPredicateCanon.ts`
-    // already records exactly this for the server oracle: `data.status` is
-    // "⚠️ silently accepted" while the runtime faults on it.
+  it('a `data.*` condition is ACCEPTED but no longer SILENT — the author gets a warning (objectui#8972)', async () => {
+    // This pin used to assert an unbroken silence, and said it would redden
+    // "when the acceptance is fixed". Read that literally: the acceptance is
+    // NOT fixed here. `@objectstack/formula`'s `SCOPE_ROOTS` still lists
+    // `data`, so the engine still waves this through with zero findings, and
+    // narrowing that set remains the producer-side half (objectui#8166's
+    // ruling). What objectui#8972 changed is the other half of the defect —
+    // the ABSENCE of any diagnostic — by wiring `@object-ui/core`'s
+    // `detectNonCanonicalRowSpelling` into `celAuthoring` as a WARNING.
     //
-    // The runtime half is pinned in the contract suite below, where the same
-    // predicate against the same host bag evaluates to FALSE. Green here plus
-    // false there IS the defect. This test REDDENS when the acceptance is
-    // fixed, at which point objectui#8166 can be closed.
+    // So the two halves are now asserted separately, and the split is the
+    // point: the accept set is untouched (no error, `aria-invalid` unset, the
+    // editor's own error count unchanged, save open), while the author is told
+    // at typing time instead of at misbehaviour time. The runtime half is
+    // pinned in the contract suite below, where the same predicate against the
+    // same host bag evaluates to FALSE.
     render(<Harness initial={[{ condition: "data.status == 'overdue'", style: {} }]} />);
-    expect(await screen.findByText('perm.cel.valid', {}, { timeout: 3000 })).toBeTruthy();
+    expect(
+      await screen.findByText(/Re-root the reference on/, {}, { timeout: 3000 }),
+    ).toBeTruthy();
+    // ACCEPT SET UNCHANGED — the falsifiable half. Promoting the advisory to
+    // an error reddens both of these.
     const ta = document.getElementById('cf-condition-0') as HTMLTextAreaElement;
     expect(ta.getAttribute('aria-invalid')).not.toBe('true');
+    // `border-destructive` is applied from the same `errors.length > 0` the
+    // Save gate counts, so its absence is the editor's own "no blocking issue".
+    expect(ta.className).not.toMatch(/border-destructive/);
   });
 
   it('ALIGNED (objectui#8155) — `app` is neither advertised nor bound, and the lint refuses it', async () => {

--- a/packages/app-shell/src/views/metadata-admin/celAuthoring.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/celAuthoring.test.ts
@@ -110,11 +110,13 @@ describe('celAuthoring · the wrong-layer `data.*` advisory (objectui#8972)', ()
 
   it('LIVE CONTROL — the ACCEPT SET is not narrowed: the same predicate raises no error', async () => {
     // Every save gate on this tier counts `severity === 'error'` and nothing
-    // else, so "zero errors" IS "still accepted". This is the falsifiable form
-    // of WARN-not-REFUSE: promote the advisory to `error` and this reddens.
+    // else, so "zero errors" IS "still accepted". Deliberately asserts ONLY
+    // that: it is green with the advisory and green without it, and reddens on
+    // exactly one change — promoting the advisory to `error`. That is the
+    // falsifiable form of WARN-not-REFUSE, and mixing the presence of the
+    // warning into it would turn the control into a second true-positive pin.
     const issues = await lintCelPredicate("data.status == 'x'", RULE_HINT);
     expect(issues.filter((i) => i.severity === 'error')).toEqual([]);
-    expect(issues.some((i) => i.severity === 'warning')).toBe(true);
   });
 
   it('LIVE CONTROL — the canonical spelling stays completely clean', async () => {

--- a/packages/app-shell/src/views/metadata-admin/celAuthoring.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/celAuthoring.test.ts
@@ -83,6 +83,65 @@ describe('celAuthoring · lintCelPredicate in record scope (field conditional ru
   });
 });
 
+/**
+ * objectui#8972 — the wrong-layer `data.*` advisory.
+ *
+ * The engine's own `SCOPE_ROOTS` carries `data`, so every assertion in here
+ * that a finding EXISTS is an assertion about this module, not about
+ * `@objectstack/formula`: measured on `@objectstack/formula@17.4.0`,
+ * `validateExpression('predicate', "data.status == 'x'", { scope: 'record' })`
+ * answers `{ ok: true, errors: [], warnings: [] }`.
+ *
+ * Three of the five pins below are LIVE CONTROLS rather than true-positive
+ * pins, and they are the reason this is a WARNING and not an error. Each one
+ * describes a world the advisory must NOT create, so each one stays green
+ * across both legs of the ablation.
+ */
+describe('celAuthoring · the wrong-layer `data.*` advisory (objectui#8972)', () => {
+  const RULE_HINT = { ...HINT, scope: 'record' as const };
+
+  it('TRUE POSITIVE — a record-scope `data.*` predicate now warns, naming `record` as the fix', async () => {
+    const issues = await lintCelPredicate("data.status == 'x'", RULE_HINT);
+    const advisory = issues.filter((i) => /\bdata\b/.test(i.message) && /Re-root/.test(i.message));
+    expect(advisory).toHaveLength(1);
+    expect(advisory[0].severity).toBe('warning');
+    expect(advisory[0].message).toMatch(/`record`/);
+  });
+
+  it('LIVE CONTROL — the ACCEPT SET is not narrowed: the same predicate raises no error', async () => {
+    // Every save gate on this tier counts `severity === 'error'` and nothing
+    // else, so "zero errors" IS "still accepted". This is the falsifiable form
+    // of WARN-not-REFUSE: promote the advisory to `error` and this reddens.
+    const issues = await lintCelPredicate("data.status == 'x'", RULE_HINT);
+    expect(issues.filter((i) => i.severity === 'error')).toEqual([]);
+    expect(issues.some((i) => i.severity === 'warning')).toBe(true);
+  });
+
+  it('LIVE CONTROL — the canonical spelling stays completely clean', async () => {
+    // `rowPredicateCanon.test.ts` pins the detector returning null for this;
+    // this pins that the wiring does not turn it into a finding anyway.
+    expect(await lintCelPredicate("record.status == 'x'", RULE_HINT)).toEqual([]);
+  });
+
+  it('LIVE CONTROL — a FLATTENED (RLS) predicate is untouched, bare identifiers included', async () => {
+    // The detector's other arm would fire on all three genuine RLS predicates
+    // in this repo. The advisory is gated on `scope: 'record'` and passes
+    // `row = null`, so neither arm can reach this tier.
+    expect(await lintCelPredicate('organization_id == current_user.organization_id', HINT)).toEqual([]);
+    expect(await lintCelPredicate("data.status == 'x'", HINT)).toEqual([]);
+  });
+
+  it('adds nothing on top of a parse error, and stands down on a non-CEL dialect', async () => {
+    const broken = await lintCelPredicate('data.status ==', RULE_HINT);
+    expect(broken.some((i) => i.severity === 'error')).toBe(true);
+    expect(broken.some((i) => /Re-root/.test(i.message))).toBe(false);
+    // A legacy `${…}` string is not CEL; the detector stands down and so must
+    // this — classifying it belongs to its own dialect's rules.
+    const legacy = await lintCelPredicate('${data.status}', RULE_HINT);
+    expect(legacy.some((i) => /Re-root/.test(i.message))).toBe(false);
+  });
+});
+
 describe('celAuthoring · lintCelPredicate role "value" (formula expressions, #1582 follow-up)', () => {
   const FORMULA_HINT = { ...HINT, scope: 'record' as const, role: 'value' as const };
 

--- a/packages/app-shell/src/views/metadata-admin/celAuthoring.ts
+++ b/packages/app-shell/src/views/metadata-admin/celAuthoring.ts
@@ -181,6 +181,110 @@ const PUSHDOWN_FIELD_ROOTS = ['record', ''] as const;
 /** Roots resolved as scope VALUES for pushdown analysis. */
 const PUSHDOWN_VARIABLE_ROOTS = ['current_user', 'user'] as const;
 
+/* ── Lazy row-canon detector (objectui#8972) ─────────────────────────── */
+
+/** The shape of `@object-ui/core`'s offline row-spelling instrument. */
+interface RowCanonModule {
+  detectNonCanonicalRowSpelling?: (
+    source: string,
+    row: Record<string, unknown> | null | undefined,
+    dataNamesRow: boolean,
+  ) => { kind: string; identifier: string; canonical: string } | null;
+}
+
+let rowCanonCached: Promise<RowCanonModule | null> | null = null;
+
+/**
+ * Load `@object-ui/core`'s row-spelling detector the same way the engine is
+ * loaded: lazily, feature-detected, swallowing every failure. The detector
+ * imports `@objectstack/formula` at module scope, so a STATIC import here
+ * would drag the CEL parser into whatever chunk holds this module and undo the
+ * bundle split the header describes.
+ */
+function loadRowCanon(): Promise<RowCanonModule | null> {
+  if (!rowCanonCached) {
+    rowCanonCached = import('@object-ui/core')
+      .then((m) => m as unknown as RowCanonModule)
+      .catch(() => null);
+  }
+  return rowCanonCached;
+}
+
+/**
+ * The wrong-layer `data.*` advisory — why it is wired HERE, and why it is only
+ * an advisory (objectui#8972).
+ *
+ * ## What it closes
+ *
+ * `@objectstack/formula`'s `SCOPE_ROOTS` carries `data`, so at `scope: 'record'`
+ * the engine lint ACCEPTS `data.status == 'x'` with zero findings (measured on
+ * `@objectstack/formula@17.4.0`). objectui#5741 retired that spelling on runtime
+ * record surfaces and objectui#8166 stopped this tier binding an ambient `data`,
+ * so the predicate now faults at runtime with `Unknown variable: data` — but the
+ * author still gets a GREEN lint while typing it. That gap is the whole card:
+ * the diagnostic arrives at misbehaviour time instead of at typing time.
+ *
+ * ## Why this is not a re-run of the warning objectui#5741 deleted
+ *
+ * That ruling removed the Phase-1 warning from the runtime hot path and kept
+ * the export, in its own words, "as the offline instrument". `listConditional.ts`
+ * records the same split: the detector "stays exported for OFFLINE sweeps of
+ * authored metadata, not for this hot path". This call site is neither the hot
+ * path nor a render — it is the editor bridge, classifying authored text as the
+ * author types it, which is the sweep case one document at a time. Nothing is
+ * added back to `evalRowPredicate` / `listConditional.ts`.
+ *
+ * ## Why WARNING and never ERROR
+ *
+ * An `error` here would narrow the accepted set: every save gate on this tier
+ * counts `severity === 'error'` (`ConditionalFormattingEditor`,
+ * `ObjectFieldInspector`, `ConditionBuilder`, `PermissionAdvancedFacets`,
+ * `clientValidation.validateObjectFieldRules`), so promoting this would refuse
+ * predicates already stored in customer metadata. A `warning` leaves
+ * `aria-invalid` unset and every gate open. Narrowing the ACCEPT SET is the
+ * producer-side half and lives in `@objectstack/formula` (objectui#8166's
+ * ruling); adding an advisory the engine never had is not that change.
+ *
+ * ## Why only ONE of the detector's two arms is consulted
+ *
+ * The detector also reports the bare shorthand, and that arm is deliberately
+ * disabled here by passing `row = null` (the arm requires an own key of the
+ * row). Measured, both directions:
+ *
+ *  - at `scope: 'record'` the engine ALREADY errors on a bare identifier and
+ *    names the `record.<field>` fix, so the arm can only duplicate it;
+ *  - at `scope: 'flattened'` — RLS `USING` / `CHECK` — a bare identifier is the
+ *    CORRECT spelling (`organization_id == current_user.organization_id` is the
+ *    editor's own placeholder). All three genuine RLS predicates in this repo
+ *    fire that arm, i.e. it is a 100% false positive rate on that tier.
+ *
+ * `dataNamesRow` is passed `true` because what that guard actually decides — in
+ * its own words, "a surface whose `data` is the host scope's own … is a
+ * legitimate `data.*` site and is left alone" — is whether `data` is legitimate
+ * here. On a record-scope authoring site it is not: `ROW_PREDICATE_ROOTS`,
+ * `FIELD_RULE_ROOTS` and `FORMULA_ROOTS` all exclude it and `buildExpressionScope`
+ * binds nothing under it. The metadata-editing layer where `data` IS canonical
+ * (ADR-0089 D3) is `views/metadata-admin/SchemaForm.tsx`, which evaluates through
+ * `views/metadata-admin/predicate.ts` and never reaches this function — which is
+ * why the gate below is `scope === 'record'` and not a source pattern.
+ */
+function rowCanonAdvisory(finding: {
+  kind: string;
+  identifier: string;
+  canonical: string;
+}): CelLintIssue | null {
+  if (finding.kind !== 'metadata-layer-root') return null;
+  return {
+    severity: 'warning',
+    message:
+      `\`${finding.identifier}\` is not the row on this surface: a row predicate binds the ` +
+      `record as \`${finding.canonical}\` and nothing else (objectui#5741). The CEL scope ` +
+      `vocabulary still accepts \`${finding.identifier}\`, so nothing here blocks the save, but ` +
+      `at runtime the expression faults with \`Unknown variable: ${finding.identifier}\` and the ` +
+      `rule never fires. Re-root the reference on \`${finding.canonical}\`.`,
+  };
+}
+
 /* ── 1. Lint ─────────────────────────────────────────────────────────── */
 
 /**
@@ -197,6 +301,10 @@ const PUSHDOWN_VARIABLE_ROOTS = ['current_user', 'user'] as const;
  * With `hint.role: 'value'` the same checks run for a formula-style value
  * expression (usually paired with `scope: 'record'`, where a bare field ref IS
  * a hard error — it silently evaluates to null at runtime).
+ *
+ * At `scope: 'record'` one finding comes from outside the engine: the
+ * wrong-layer `data.*` advisory described on {@link rowCanonAdvisory}. It is
+ * always a `warning`, so it never narrows what this surface accepts.
  *
  * Empty input is always clean.
  */
@@ -240,6 +348,18 @@ export async function lintCelPredicate(
               `pushdown-able predicate (field vs. value or scope variable).`,
           });
         }
+      } catch {
+        /* advisory only — never let it break the lint */
+      }
+    }
+    // Wrong-layer `data.*` advisory (objectui#8972) — see `rowCanonAdvisory`.
+    // Only in `record` scope, only once the predicate parses, only a WARNING.
+    if (issues.every((i) => i.severity !== 'error') && hint.scope === 'record') {
+      try {
+        const canon = await loadRowCanon();
+        const finding = canon?.detectNonCanonicalRowSpelling?.(source, null, true);
+        const advisory = finding ? rowCanonAdvisory(finding) : null;
+        if (advisory) issues.push(advisory);
       } catch {
         /* advisory only — never let it break the lint */
       }


### PR DESCRIPTION
Fixes #8972

Wires `@object-ui/core`'s already-exported `detectNonCanonicalRowSpelling` into
`celAuthoring.lintCelPredicate` as a **WARNING**, gated on `scope === 'record'`.

Placeholders below are spelled as CAPITAL WORDS (`record.FIELD`) rather than
with angle brackets, because tag-shaped fragments are deleted from stored issue
and PR bodies — a before/after table written with them renders as "nothing
changed".

## The gap this closes, measured

`@objectstack/formula@17.4.0`'s `SCOPE_ROOTS` carries `data`, so at
`scope: 'record'` the authoring lint accepts the retired spelling with **zero
findings**. Measured directly against the installed engine:

| spelling | `validateExpression('predicate', …, {scope:'record'})` |
|---|---|
| `record.status == 'x'` | `{ ok: true, errors: [], warnings: [] }` |
| `status == 'x'` | `ok: false` — error naming the `record.status` fix |
| `data.status == 'x'` | `{ ok: true, errors: [], warnings: [] }` |

objectui#5741 retired `data.*` on runtime record surfaces and objectui#8166
stopped this tier binding an ambient `data`, so that third row now faults at
runtime with `Unknown variable: data` while the author still sees a green lint.
The diagnostic arrives at misbehaviour time instead of at typing time.

## A1 — this AGREES with objectui#5741; it does not reopen it

The ruling (director seat, 2026-09-02, maintainer verbatim `5741 B 治理审计 y`)
says, in the same sentence that removes the runtime half:

> `detectNonCanonicalRowSpelling` stays exported as the offline instrument; its
> runtime warning call goes.

`packages/core/src/evaluator/listConditional.ts:317-322` records the same split
in the tree:

> No spelling detector runs here (objectui#5741 removed the Phase-1 warning with
> the bindings) … `detectNonCanonicalRowSpelling` stays exported for OFFLINE
> sweeps of authored metadata, not for this hot path.

What that ruling removed is a **render-time** warning on the **runtime hot
path**. This call site is neither: it is the editor bridge classifying authored
text as the author types it, which is the sweep case one document at a time.
`evalRowPredicate` and `listConditional.ts` are untouched by this PR — the hot
path still has no detector. The rationale is left as a docblock at the wiring
point so the next reader does not re-derive it.

objectui#8166's two refusals are also respected. It refused *de-advertising* a
root and it refused *filtering* a diagnostic in `celAuthoring.ts` — "there is no
diagnostic to filter, the absence of one is the defect". This adds the absent
diagnostic. It does **not** narrow the accept set, which that ruling assigns to
`@objectstack/formula`.

## A2 — cross-package dependency: no new edge

`@object-ui/app-shell`'s manifest already carries `"@object-ui/core":
"workspace:*"`, and 48 non-test files under `packages/app-shell/src` import it
statically. Nothing was added to any manifest.

The import here is nonetheless **dynamic**, mirroring the engine loader:
`rowPredicateCanon.ts` imports `@objectstack/formula` at module scope, so a
static import would drag the CEL parser into whatever chunk holds this module
and undo the split the file header describes.

## A3 — the detector is correct for THIS seam, and only one of its arms is

The detector had never run on a hot path, so its true/false-positive rate was
unmeasured. It was run over the tree before anything was wired.

**Corpus**: every `git ls-files` path, JSON parsed structurally and TS/TSX/MD
scanned for the keys a `celAuthoring` editor writes (`visibleWhen`,
`readonlyWhen`, `requiredWhen`, `condition`, `expression`, `using`, `check`,
plus the runtime row-predicate keys `visible` / `disabled` / `enabled`).
**612 distinct predicate strings**, 473 of them parseable as CEL.

**Instrument control (lit).** The same instrument, in the same run, on the two
true positives pinned at `packages/core/src/evaluator/__tests__/rowPredicateCanon.test.ts:56`
and `:64`:

```
CONTROL pinned :56 bare | "status == 'in_review'"      => {"kind":"bare-shorthand","identifier":"status","canonical":"record.status"}
CONTROL pinned :64 data | "data.status == 'in_review'" => {"kind":"metadata-layer-root","identifier":"data","canonical":"record"}
WIRING CALL   data (row=null) => {"kind":"metadata-layer-root","identifier":"data","canonical":"record"}
WIRING CALL   bare (row=null) => null
WIRING CALL   canonical      => null
WIRING CALL   unparseable    => null
WIRING CALL   rls flattened  => null
```

A second positive control: 250 of the 612 strings are rooted at `record`, so
the sweep demonstrably reached predicates rather than reporting a clean zero
from never having parsed anything.

**Seam population** — the 29 predicates in the tree that sit at a record-scope
`celAuthoring` mount (`ConditionalFormattingEditor`, `ObjectFieldInspector`
field rules and formula, `clientValidation.validateObjectFieldRules`, the
`celGate` suites):

* **1 firing**, and it is a **true positive**:
  `ConditionalFormattingEditor.test.tsx` `condition: "data.status == 'overdue'"`
  — the fixture whose own comment called it a KNOWN GAP.
* **0 false positives.** `record.*`, `app.name` (the objectui#8155 case),
  `record.statu` (typo), bare identifiers and malformed sources all return
  `null` from the detector.

**The bare-shorthand arm is deliberately NOT wired**, and the sweep is why.
Passing `row = null` disables it:

* at `scope: 'record'` the engine already errors on a bare identifier and names
  the `record.FIELD` fix, so the arm could only duplicate an existing error;
* at `scope: 'flattened'` a bare identifier is the **correct** RLS spelling —
  `organization_id == current_user.organization_id` is the editor's own
  placeholder. All **3** genuine RLS predicates in this repo fire that arm:
  a 100% false-positive rate on that tier.

**The layer trap, measured rather than assumed.** 8 of the sweep's `data.*` hits
are `SchemaForm.visibleWhen.test.tsx` / `SchemaForm.optionVisibleWhen.test.tsx`
— the metadata-editing layer where `data` IS canonical (ADR-0089 D3). Those are
exactly the false positives this must not produce, and it cannot: `SchemaForm`
evaluates through `views/metadata-admin/predicate.ts` and never reaches
`lintCelPredicate`. That is why the gate is `scope === 'record'` and not a
source pattern.

**Honest limit on the corpus.** This repo holds no customer-authored metadata;
the population above is in-repo fixtures and example-app documents. Sizing the
stored population needs the export objectui#5741 was blocked on, and this PR
makes no claim about it. It does not need to: the advisory is non-blocking, so
a stored `data.*` predicate keeps saving exactly as it does today.

## A4 — source-text pin census

```
git grep -l "readFileSync" -- 'packages/**/__tests__/**' 'packages/**/*.test.ts' 'packages/**/*.test.tsx'
```

222 files. **Zero** name `rowPredicateCanon.ts`, `listConditional.ts`,
`celAuthoring.ts`, `CelPredicateField.tsx` or `ConditionalFormattingEditor.tsx`.
Control lit in the same run: the query returns
`packages/i18n/src/__tests__/residue-namespaces-3546.test.tsx`, which does name
`packages/plugin-kanban/src/KanbanImpl.tsx` at its line 161 — so the zero is a
reading, not a broken query.
`rowPredicateCanon.schemaCatalog.test.ts` reads the `examples/schema-catalog`
JSON corpus, not this PR's files, and is unaffected.

## WARN, not REFUSE — in falsifiable form

Every save gate on this tier counts `severity === 'error'` and nothing else
(`ConditionalFormattingEditor.tsx:268`, `PermissionAdvancedFacets.tsx:222`,
`ObjectFieldInspector.tsx:470`, `ConditionBuilder.tsx:342`,
`clientValidation.ts:815,830`), and `CelPredicateField` sets `aria-invalid` from
the same count. So "zero errors" is "still accepted", and two live controls pin
it: one asserts the record-scope `data.*` predicate raises no error, one asserts
the editor leaves `aria-invalid` unset and applies no `border-destructive`.
Both redden on exactly one change — promoting the advisory to `error`.

A third live control pins that flattened RLS predicates, bare identifiers
included, come back with no findings at all.

## Ablation

The wiring block was deleted literally, proved on disk, run, and restored from
`HEAD` with the restore proved by state rather than by an exit code.

```
HEAD_BLOB   = 94d8e4d6ac2a68b4915bcb0fbd48605dea9c9f93
BEFORE_HASH = 94d8e4d6ac2a68b4915bcb0fbd48605dea9c9f93
BEFORE  call-site occurrences: 1        AFTER  call-site occurrences: 0
BEFORE  gate occurrences:      1        AFTER  gate occurrences:      0
AFTER_HASH  = ee781176845e000909d1ba1e7e96aefdc62c15dd     (hash moved)
 packages/app-shell/src/views/metadata-admin/celAuthoring.ts | 12 ------------

=== ABLATED RUN ===
 × TRUE POSITIVE — a record-scope `data.*` predicate now warns, naming `record` as the fix
 × a `data.*` condition is ACCEPTED but no longer SILENT — the author gets a warning (objectui#8972)
 Test Files  2 failed (2)
      Tests  2 failed | 62 passed (64)

RESTORED_HASH = 94d8e4d6ac2a68b4915bcb0fbd48605dea9c9f93   (== HEAD blob)
git diff HEAD -- celAuthoring.ts  ->  empty
```

Exactly the two true-positive pins redden; all three live controls stay green on
the ablated leg, which is what makes them controls rather than a second copy of
the true-positive pin. (An earlier attempt mixed "the warning exists" into the
accept-set control; commit 2 splits it back out, for that reason.)

## Verification

* `pnpm exec vitest run packages/app-shell/src/views/metadata-admin/celAuthoring.test.ts packages/app-shell/src/views/metadata-admin/ConditionalFormattingEditor.test.tsx` — `Test Files 2 passed (2) · Tests 64 passed (64)`
* `node scripts/check-changeset-presence.mjs` — `exit 0`, `declares 1 changeset(s)`
* `node scripts/check-changeset-no-major.mjs` — `exit 0`, `No changeset declares a major bump`
* `pnpm check:control-bytes` — `exit 0`, `scanned 7375 tracked text file(s)`
* `node scripts/check-governed-queue-guard.mjs --test …` — `NOT GOVERNED`
* Full `packages/app-shell/` suite, `type-check` and the narrowed `lint` reading
  are added below as they land; see the report on objectui#8972 for anything
  still open at report time.

Every exit code above was captured by redirecting to a file first, never read
through a pipe.

## Acceptance notes

Out of scope, noted, not filed:

* `detectNonCanonicalRowSpelling`'s `dataNamesRow` parameter is named for the
  Phase-1 world where `data` was bound to the row. Since objectui#5741 nothing
  binds it on a record surface, so the name no longer describes any live
  binding; what the guard actually decides — per its own rationale — is whether
  `data` is a legitimate root on the calling surface. The behaviour is correct
  and pinned; only the name is vintage. Naming alone, so not filed. Carrier if
  one is ever wanted: the next PR that touches that signature.
* The `roots` override lists (`ROW_PREDICATE_ROOTS`, `FIELD_RULE_ROOTS`,
  `FORMULA_ROOTS`) each restate a subset of the engine's vocabulary in a
  different file. Observation only, no measured defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_