### PR TITLE
fix(gate): the expression-carriage blind-spot leg reads the JS object-literal dialect

### DIFF
--- a/scripts/__tests__/check-doc-expression-carriage.test.ts
+++ b/scripts/__tests__/check-doc-expression-carriage.test.ts
@@ -17,12 +17,14 @@ import {
   listDocuments,
   loadCarriage,
   parseFence,
+  parseFenceDialect,
   RENDERER_SOURCE,
   ROOT_PAGES,
   runControls,
   sanitizeFence,
   splitTopLevel,
   SURFACE_LABEL,
+  toJsonDialect,
 } from '../check-doc-expression-carriage.mjs';
 import {
   APP_DOCS as TYPES_APP_DOCS,
@@ -142,6 +144,49 @@ describe('check-doc-expression-carriage: the controls can see, and can fail', ()
     expect(CONTROL_FIXTURES.positive).toContain('"type": "badge"');
     expect(CONTROL_FIXTURES.positive).toContain('"text"');
   });
+
+  /**
+   * objectui#8334 — the DIALECT controls, both directions.
+   *
+   * The positive proves the leg can see a node tree spelled as a JS object
+   * literal. The negative proves it still refuses a TS `interface` body, which is
+   * what the great majority of these pages' ```plaintext fences hold: a leg that
+   * accepted those would flood the coverage line with type DECLARATIONS and be
+   * useless in the opposite direction.
+   */
+  it('sees the object-literal fixture and stays silent on a TS interface body', async () => {
+    const controls = runControls({ channels: deriveChannels(ROOT), carriage: await loadCarriage() });
+    expect(controls.failures).toEqual([]);
+    expect(controls.dialectPositive).toEqual(['filter-ui', 'text']);
+    expect(controls.dialectNegative).toEqual([]);
+  });
+
+  /**
+   * ⭐ The regression itself, pinned as a DIFFERENCE rather than described: run
+   * the OLD predicate — a strict `parseFence` — over the very fixture the corpus
+   * supplied, and it sees nothing. That silent nothing is what the summary used
+   * to print `✅ Dialect blind spot: none` on top of.
+   */
+  it('is a leg that CAN fail: the pre-objectui#8334 predicate is blind to this fixture', () => {
+    const before = parseFence(CONTROL_FIXTURES.dialectPositive);
+    expect(before.ok, 'the object-literal fixture must NOT parse as strict JSON').toBe(false);
+    expect(before.values.flatMap((value: unknown) => collectNodes(value))).toEqual([]);
+
+    const after = parseFenceDialect(CONTROL_FIXTURES.dialectPositive);
+    expect(after.ok).toBe(true);
+    expect(after.values.flatMap((value: unknown) => collectNodes(value)).map((n: { type: string }) => n.type)).toEqual([
+      'filter-ui',
+      'text',
+    ]);
+  });
+
+  it('keeps the dialect fixtures the shapes the corpus actually uses', () => {
+    // Unquoted key + single-quoted value: the spelling the five measured pages use.
+    expect(CONTROL_FIXTURES.dialectPositive).toContain("type: 'filter-ui'");
+    // ...and the negative must stay a TS declaration, or it stops excluding anything.
+    expect(CONTROL_FIXTURES.dialectNegative).toContain('interface');
+    expect(CONTROL_FIXTURES.dialectNegative).toContain('type: ');
+  });
 });
 
 describe('check-doc-expression-carriage: the parse surface', () => {
@@ -200,6 +245,44 @@ describe('check-doc-expression-carriage: the parse surface', () => {
   it('finds a node wherever it sits, including inside a bag', () => {
     const nodes = collectNodes({ type: 'page', properties: { child: { type: 'badge' } } });
     expect(nodes.map((n) => n.type)).toEqual(['page', 'badge']);
+  });
+
+  /**
+   * objectui#8334 — `toJsonDialect`, the object-literal normalization. It is a
+   * REMOVAL of dialect and ⛔ must never be able to invent a member: the
+   * blind-spot list it feeds is read as a coverage figure, and an invented key
+   * would inflate it with fences that hold no node at all.
+   */
+  it('quotes a bare key and re-spells a single-quoted string, inventing nothing', () => {
+    const parsed = JSON.parse(toJsonDialect("{ type: 'badge', label: 'a', variant: 'x' }"));
+    expect(Object.keys(parsed)).toEqual(['type', 'label', 'variant']);
+    expect(parsed).toEqual({ type: 'badge', label: 'a', variant: 'x' });
+  });
+
+  it('quotes an identifier only in a MEMBER position, so `type: string` stays unparseable', () => {
+    // A TS interface body: `string` is a value-position identifier and must NOT
+    // be quoted, or every type declaration in the corpus becomes a "node".
+    expect(parseFenceDialect('interface P {\n  type: string;\n}').ok).toBe(false);
+    expect(parseFenceDialect("{ kind: 'a', mode: 'b' }").ok).toBe(true);
+  });
+
+  it('survives an apostrophe inside a comment, which would otherwise open a string', () => {
+    const parsed = parseFenceDialect("{\n  // don't let this open a string\n  type: 'badge'\n}");
+    expect(parsed.ok).toBe(true);
+    expect(parsed.values).toEqual([{ type: 'badge' }]);
+  });
+
+  it('keeps a `//` and a quote that are DATA inside a string', () => {
+    // A raw `"` inside a single-quoted string, and a `//` that is a URL. The
+    // normalization must escape the first and leave the second alone.
+    const parsed = parseFenceDialect(`{ type: 'link', href: 'https://a.example', note: 'he said "hi"' }`);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.values).toEqual([{ type: 'link', href: 'https://a.example', note: 'he said "hi"' }]);
+  });
+
+  it('leaves a strict-JSON body byte-identical — the normalization is a no-op on JSON', () => {
+    const body = '{ "type": "badge", "label": "a//b" }';
+    expect(toJsonDialect(body)).toBe(body);
   });
 });
 
@@ -446,16 +529,84 @@ describe('check-doc-expression-carriage: the real tree, and the posture', () => 
     expect(page.every((fence: { lang: string; ok: boolean }) => fence.lang === 'jsonc' && fence.ok)).toBe(true);
   });
 
-  it('measures the DIALECT blind spot instead of asserting there is none', async () => {
+  /**
+   * objectui#8334. ⚠️ This pin used to read `expect(census.unscannedJsonLike).toEqual([])`
+   * — and it PASSED, for the worst possible reason: the leg it pinned required a
+   * strict JSON parse, so an entire dialect was invisible to it and the empty
+   * list was a blindness rather than a clean corpus.
+   *
+   * ⛔ Its failure message was worse than the pin. It instructed the next reader
+   * to "Widen `JSON_FENCE_LANGUAGES` deliberately" — the one fix PR objectui#8324
+   * REJECTED by content, because `plaintext` is not a JSON dialect and admitting
+   * it lets every future JSON-in-plaintext block through unjudged. A defect
+   * reasoned from written prose reproduces itself while the prose stands, so the
+   * prose is corrected here and not only in the gate.
+   *
+   * What replaces it is the opposite shape: a FLOOR proving the measurement can
+   * see the class, ⛔ per file rather than one summed total — a summed floor
+   * cannot tell "every page still measured" from "one page the matcher quietly
+   * stopped matching, and another that grew two blocks".
+   */
+  it('SEES the JS object-literal dialect the coverage line used to lie about', async () => {
+    const census = analyze(ROOT, { channels: deriveChannels(ROOT), carriage: await loadCarriage() });
+    const literals = census.unscannedJsonLike.filter(
+      (fence: { dialect: string }) => fence.dialect === 'object-literal',
+    );
+    // ⛔ Per file. Each of the five the card measured must still be SEEN; a zero
+    // on any one of them is the blindness this card exists to remove, and the
+    // summary would print `none` over it again.
+    for (const file of [
+      `${DOCS_ROOT}/components/complex/filter-ui.mdx`,
+      `${DOCS_ROOT}/components/complex/sort-ui.mdx`,
+      `${DOCS_ROOT}/components/complex/view-switcher.mdx`,
+      `${DOCS_ROOT}/components/feedback/toaster.mdx`,
+      `${DOCS_ROOT}/components/navigation/header-bar.mdx`,
+    ]) {
+      expect(
+        literals.filter((fence: { file: string }) => fence.file === file).length,
+        `${file} authors a node tree as a JS object literal in an unscanned fence. The blind-spot ` +
+          'measurement must REPORT it. If this page was legitimately retagged ```json, it has moved ' +
+          'into the judged population — drop it from this list; do NOT delete the list.',
+      ).toBeGreaterThan(0);
+    }
+    // ⛔ NOT an equality on the total: that number moves with every docs page and
+    // pinning it would make a report-only gate blocking through the back door.
+    // A floor is what distinguishes a measurement from a snapshot.
+    expect(
+      literals.length,
+      'the object-literal leg reported nothing at all on a corpus that demonstrably holds this ' +
+        'dialect — the leg has stopped matching and its zero is not readable.',
+    ).toBeGreaterThanOrEqual(5);
+  });
+
+  /**
+   * Triage's binding fence on objectui#8334, pinned mechanically rather than
+   * trusted: ⛔ "Do not fix this by widening the census." The blind-spot leg is a
+   * MEASUREMENT; if it ever starts feeding the judged population, this goes red.
+   */
+  it('judges exactly what it judged before the dialect leg existed', async () => {
     const census = analyze(ROOT, { channels: deriveChannels(ROOT), carriage: await loadCarriage() });
     expect(
-      census.unscannedJsonLike,
-      'a fence OUTSIDE ' +
-        JSON_FENCE_LANGUAGES.join('/') +
-        ' parses as a JSON document holding a typed node, so the census is missing a dialect. Widen ' +
-        '`JSON_FENCE_LANGUAGES` deliberately — the alternative is a human finding it by reading the ' +
-        'page, which is the detection mechanism objectui#7851 exists to replace.',
-    ).toEqual([]);
+      JSON_FENCE_LANGUAGES,
+      '⛔ `plaintext` is not a JSON dialect. Admitting it lets every future JSON-in-plaintext block ' +
+        'through UNJUDGED — rejected by content on PR objectui#8324, and the exact blind spot this ' +
+        'gate exists to close.',
+    ).not.toContain('plaintext');
+    // Every fence the census counted is in a scanned language, and every fence in
+    // the blind-spot list is NOT. The two sets are disjoint by construction, and
+    // that disjointness is the whole of triage's fence.
+    const judged = new Set(census.fences.map((fence: { lang: string }) => fence.lang));
+    expect([...judged].sort()).toEqual([...JSON_FENCE_LANGUAGES].sort());
+    for (const fence of census.unscannedJsonLike) {
+      expect(JSON_FENCE_LANGUAGES).not.toContain(fence.lang);
+    }
+  });
+
+  it('reports the strict-JSON and object-literal spellings as distinguishable dialects', async () => {
+    const census = analyze(ROOT, { channels: deriveChannels(ROOT), carriage: await loadCarriage() });
+    for (const fence of census.unscannedJsonLike) {
+      expect(['json', 'object-literal']).toContain(fence.dialect);
+    }
   });
 
   /**

--- a/scripts/check-doc-expression-carriage.mjs
+++ b/scripts/check-doc-expression-carriage.mjs
@@ -118,6 +118,18 @@
  * an object (`"dependencies": { … }`, a package.json excerpt) is retried
  * wrapped in braces.
  *
+ * And one normalization that is NOT on the judged path at all — `toJsonDialect`,
+ * which de-dialects a JS object literal (unquoted keys, single-quoted strings)
+ * so the BLIND-SPOT measurement can ask its question of that spelling too
+ * (objectui#8334). ⛔ It never runs on a judged fence: `analyze` reaches it only
+ * from the `!fence.scanned` branch, so the judged population is byte-for-byte
+ * what it was before that card. ⛔ And it is emphatically NOT a step toward
+ * adding `plaintext` to `JSON_FENCE_LANGUAGES` — that was considered and
+ * REJECTED by content on PR objectui#8324, because `plaintext` is not a JSON
+ * dialect and admitting it lets every future JSON-in-plaintext block through
+ * unjudged. The fix for a blind measurement is to make it see, not to make the
+ * census swallow what it cannot judge.
+ *
  * ## What it does not see, stated so nobody mistakes it for coverage
  *
  *   - A `${…}` inside an ARRAY on a node key (`"items": ["${a}"]`). Only string
@@ -130,8 +142,13 @@
  *     it; ⛔ this file changes no other gate's population. The LANGUAGE SET is its
  *     own blind spot and is measured rather than asserted: every run prints the
  *     per-language counts, and every fence in a language this gate does not scan
- *     is still parsed, purely to report whether it would have been a JSON
- *     document holding a typed node.
+ *     is still read, purely to report whether it holds a typed node.
+ *     ⚠️ objectui#8334: "read" used to mean `JSON.parse`, and that made the
+ *     measurement blind to the JS OBJECT-LITERAL spelling — a fence authoring a
+ *     real node tree with unquoted keys landed in NEITHER the judged population
+ *     nor the blind-spot list, and the summary printed `none` over it. Both
+ *     spellings are asked now; see `toJsonDialect`. ⛔ This did not widen the
+ *     census: the judged population is still `json` / `jsonc` and nothing else.
  *   - The repository-root `docs/` tree, and therefore `docs/ARCHITECTURE.md` —
  *     objectui#7838's site. ⚠️ objectui#7878 was filed expecting this widening to
  *     reach that file; it does not, and the card's premise was corrected before
@@ -541,6 +558,115 @@ export function parseFence(body) {
   return wrapped.ok ? { ...wrapped, wrapped: true } : first;
 }
 
+/**
+ * The JS OBJECT-LITERAL dialect, normalized to JSON — for the BLIND-SPOT
+ * MEASUREMENT ONLY (objectui#8334). ⛔ Never on the judged path: `analyze` still
+ * judges `fence.scanned` fences and nothing else, and this function is not
+ * reachable from that branch.
+ *
+ * The blind-spot leg asks one question — *does this unscanned fence hold a typed
+ * node?* — and before this existed it could only ask it of a body that survived
+ * `JSON.parse`. A page authoring a real node tree the way JavaScript spells it
+ * (unquoted keys, single-quoted strings) answered NOTHING, was counted in neither
+ * the judged population nor the blind-spot list, and the summary then printed
+ * `Dialect blind spot: none` over a class it could not see. That is the worst
+ * shape a detector takes: full coverage reported precisely where there is none.
+ *
+ * Two REMOVALS of dialect, nothing else — like the four tolerances above, ⛔
+ * neither can invent a key:
+ *
+ *   1. Single-quoted strings become double-quoted, with any interior `"`
+ *      escaped. A quote character is re-spelled; no member is added or dropped.
+ *   2. A bare identifier in a MEMBER position — immediately after `{` or `,` and
+ *      followed by `:` — is quoted. The position is what makes it a key, which is
+ *      the same predicate `dropElisionStrings` uses; an identifier anywhere else
+ *      (a bare `string` in `type: string;`) is left alone and goes on failing to
+ *      parse, which is how a TS `interface` body stays OUT of this measurement.
+ *
+ * The pass is comment-aware for the same reason `sanitizeFence` is: an
+ * apostrophe inside `// don't` would otherwise open a string and corrupt the rest
+ * of the body. Comments are dropped here rather than deferred, so the text handed
+ * on is already free of them.
+ */
+export function toJsonDialect(source) {
+  let out = '';
+  let quote = null;
+  let escaped = false;
+  // The last significant character outside a string, which is what makes an
+  // identifier a KEY rather than a value: only `{` and `,` introduce a member.
+  let prev = '';
+  for (let i = 0; i < source.length; i++) {
+    const ch = source[i];
+    if (quote) {
+      if (escaped) {
+        out += ch;
+        escaped = false;
+        continue;
+      }
+      if (ch === '\\') {
+        out += ch;
+        escaped = true;
+        continue;
+      }
+      if (ch === quote) {
+        out += '"';
+        quote = null;
+        continue;
+      }
+      // A `"` inside a single-quoted string is data; re-spelling the delimiter
+      // would otherwise end the string early and change what the body says.
+      if (quote === "'" && ch === '"') {
+        out += '\\"';
+        continue;
+      }
+      out += ch;
+      continue;
+    }
+    if (ch === '/' && source[i + 1] === '/') {
+      while (i < source.length && source[i] !== '\n') i++;
+      out += '\n';
+      continue;
+    }
+    if (ch === '/' && source[i + 1] === '*') {
+      i += 2;
+      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) i++;
+      i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      out += '"';
+      prev = '"';
+      continue;
+    }
+    if (/[A-Za-z_$]/.test(ch) && (prev === '{' || prev === ',')) {
+      let j = i;
+      while (j < source.length && /[A-Za-z0-9_$]/.test(source[j])) j++;
+      let k = j;
+      while (k < source.length && /\s/.test(source[k])) k++;
+      if (source[k] === ':') {
+        out += `"${source.slice(i, j)}"`;
+        i = j - 1;
+        prev = 'x';
+        continue;
+      }
+    }
+    out += ch;
+    if (!/\s/.test(ch)) prev = ch;
+  }
+  return out;
+}
+
+/**
+ * `parseFence`, asked of the object-literal dialect. Same parser, same
+ * tolerances, same "a fence that is an object BODY" retry — the ONE difference is
+ * that the body is de-dialected first, so the blind-spot leg asks its question of
+ * both spellings instead of only the one that happens to be JSON.
+ */
+export function parseFenceDialect(body) {
+  return parseFence(toJsonDialect(body));
+}
+
 /** Every `json` / `jsonc` fence on the scan surface, parsed or not. */
 export function scanFences(root) {
   const files = listDocuments(root);
@@ -657,18 +783,30 @@ export function analyze(root, { channels, carriage }) {
   const unparsed = [];
   const inventory = [];
   /**
-   * The DIALECT blind spot: a fence outside the scanned languages whose body is
-   * a JSON document holding a typed node. Counted, never judged — a `jsonc`
-   * spelling was invisible to an earlier draft of this gate, and the way that
-   * was found was a human reading a page, which is the detection mechanism this
-   * whole card exists to replace.
+   * The DIALECT blind spot: a fence outside the scanned languages whose body
+   * holds a typed node. Counted, never judged — a `jsonc` spelling was invisible
+   * to an earlier draft of this gate, and the way that was found was a human
+   * reading a page, which is the detection mechanism this whole card exists to
+   * replace.
+   *
+   * ⚠️ objectui#8334: this leg used to require `fence.ok` — a strict JSON parse —
+   * which made the measurement whose job is to report what the census cannot see
+   * blind to the JS OBJECT-LITERAL spelling. Such a fence was counted in neither
+   * the judged population nor here, and the summary printed `none` over it. Both
+   * spellings are asked the same question now; the DIALECT is recorded so the
+   * reader can tell the two apart.
    */
   const unscannedJsonLike = [];
 
   for (const fence of scan.fences) {
     if (!fence.scanned) {
-      if (fence.ok && fence.values.some((value) => collectNodes(value).length > 0)) {
-        unscannedJsonLike.push({ file: fence.file, line: fence.line, lang: fence.lang });
+      // ⛔ Measurement only. The judged population is `fence.scanned` and is not
+      // reached from this branch — widening the census is explicitly NOT the fix
+      // for objectui#8334, and ⛔ `plaintext` is still not a JSON dialect.
+      const dialect = fence.ok ? 'json' : 'object-literal';
+      const jsonLike = fence.ok ? fence : parseFenceDialect(fence.body.join('\n'));
+      if (jsonLike.ok && jsonLike.values.some((value) => collectNodes(value).length > 0)) {
+        unscannedJsonLike.push({ file: fence.file, line: fence.line, lang: fence.lang, dialect });
       }
       continue;
     }
@@ -743,6 +881,26 @@ export const CONTROL_FIXTURES = {
   "properties": { "className": "\${theme.card}" },
   "visibleOn": "\${item.active}"
 }`,
+  /**
+   * The DIALECT controls (objectui#8334). The positive fixture is the shape the
+   * corpus actually uses — `content/docs/components/complex/filter-ui.mdx:10`,
+   * trimmed — a real node tree spelled as a JS object literal. The negative is a
+   * TS `interface` BODY, which is what the great majority of these pages'
+   * ```plaintext fences hold and which must stay OUT of the measurement: it
+   * declares types, it does not author a node.
+   */
+  dialectPositive: `{
+  type: 'filter-ui',
+  layout: 'popover',
+  filters: [
+    { field: 'name', label: 'Name', type: 'text', placeholder: "Search name" }
+  ]
+}`,
+  dialectNegative: `interface FilterUIProps {
+  type: 'filter-ui';
+  layout?: 'popover' | 'inline';
+  showApply?: boolean;
+}`,
 };
 
 export function runControls({ channels, carriage }) {
@@ -778,7 +936,52 @@ export function runControls({ channels, carriage }) {
         'reporting carried channels as findings, which is a false-positive gate.',
     );
   }
-  return { positive: positive.found ?? [], negative: negative.found ?? [], failures };
+
+  /**
+   * The DIALECT leg's own two-sided control (objectui#8334), run on every run for
+   * the reason the whole file exists: `Dialect blind spot: none` is a sentence
+   * about coverage, and a measurement that has silently stopped matching prints
+   * that sentence and looks identical to a clean corpus. ⛔ Per counter, not one
+   * total — a leg that sees the object literal but has stopped rejecting
+   * interface bodies is broken in the direction that produces false findings, and
+   * the reverse is broken in the direction that produces a false green.
+   */
+  const dialectNodes = (source) => {
+    const parsed = parseFenceDialect(source);
+    if (!parsed.ok) return { ok: false, reason: parsed.reason, nodes: [] };
+    return { ok: true, reason: null, nodes: parsed.values.flatMap((value) => collectNodes(value)) };
+  };
+  const dialectPositive = dialectNodes(CONTROL_FIXTURES.dialectPositive);
+  const dialectNegative = dialectNodes(CONTROL_FIXTURES.dialectNegative);
+  const dialectTypes = dialectPositive.nodes.map((node) => node.type).sort();
+  if (!dialectPositive.ok) {
+    failures.push(
+      `dialect positive control: the object-literal fixture did not normalize (${dialectPositive.reason}). ` +
+        'The blind-spot leg cannot see the class objectui#8334 filed, and this run would have printed ' +
+        '"Dialect blind spot: none" over it.',
+    );
+  } else if (dialectTypes.join(',') !== 'filter-ui,text') {
+    failures.push(
+      `dialect positive control: expected the two typed nodes [filter-ui, text], got ` +
+        `[${dialectTypes.join(', ')}]. The object-literal measurement has stopped matching the shape the ` +
+        'corpus actually uses, so its zero would be a blindness, not a clean corpus.',
+    );
+  }
+  if (dialectNegative.ok && dialectNegative.nodes.length > 0) {
+    failures.push(
+      `dialect negative control: a TS \`interface\` body reported ` +
+        `[${dialectNegative.nodes.map((node) => node.type).join(', ')}] as typed node(s). The dialect leg is ` +
+        'reading type DECLARATIONS as authored nodes, which floods the blind-spot list with false entries.',
+    );
+  }
+
+  return {
+    positive: positive.found ?? [],
+    negative: negative.found ?? [],
+    dialectPositive: dialectTypes,
+    dialectNegative: dialectNegative.ok ? dialectNegative.nodes.map((node) => node.type) : [],
+    failures,
+  };
 }
 
 // ── CLI ──────────────────────────────────────────────────────────────────────
@@ -818,6 +1021,12 @@ if (isEntrypoint(import.meta.url)) {
       `negative fixture reported ${controls.negative.length === 0 ? 'nothing' : `[${controls.negative.join(', ')}]`} ` +
       '(expected nothing).',
   );
+  console.log(
+    `Dialect controls: the object-literal fixture yielded [${controls.dialectPositive.join(', ')}] ` +
+      '(expected filter-ui, text); the TS interface body yielded ' +
+      `${controls.dialectNegative.length === 0 ? 'nothing' : `[${controls.dialectNegative.join(', ')}]`} ` +
+      '(expected nothing).',
+  );
   if (controls.failures.length > 0) {
     console.error(`\n❌  The instrument failed its own controls:\n${controls.failures.map((f) => `      ${f}`).join('\n')}`);
     process.exit(1);
@@ -854,18 +1063,28 @@ if (isEntrypoint(import.meta.url)) {
       .map((row) => `${row.lang} ${row.fences} (${row.parsed} parsed, ${row.unparsed} unparsed)`)
       .join('; ')}`,
   );
+  // objectui#8334: BOTH spellings, counted separately. The `none` branch used to
+  // be reachable while an entire dialect was invisible to the measurement behind
+  // it, which is a detector reporting full coverage precisely where it has none.
+  const byDialect = (name) => unscannedJsonLike.filter((fence) => fence.dialect === name).length;
   if (unscannedJsonLike.length === 0) {
     console.log(
-      `✅  Dialect blind spot: none — no fence OUTSIDE ${JSON_FENCE_LANGUAGES.join('/')} parses as a JSON ` +
-        'document holding a typed node.',
+      `✅  Dialect blind spot: none — no fence OUTSIDE ${JSON_FENCE_LANGUAGES.join('/')} holds a typed node, ` +
+        'in EITHER the strict-JSON or the\n    JS object-literal spelling. Both were asked; the dialect ' +
+        'controls above are what make this line readable.',
     );
   } else {
     console.log(
-      `\n⚠️  ${unscannedJsonLike.length} fence(s) outside ${JSON_FENCE_LANGUAGES.join('/')} parse as a JSON ` +
-        'document holding a typed node. NOT judged — reported so the language set can be widened\n' +
-        '    deliberately rather than discovered by a human reading a page:',
+      `\n⚠️  ${unscannedJsonLike.length} fence(s) outside ${JSON_FENCE_LANGUAGES.join('/')} hold a typed node ` +
+        `(${byDialect('json')} as strict JSON, ${byDialect('object-literal')} as a JS object literal).\n` +
+        '    NOT judged, and ⛔ NOT a request to widen the census: `plaintext` is not a JSON dialect, and\n' +
+        '    admitting it would let every future JSON-in-plaintext block through UNJUDGED (rejected by\n' +
+        '    content on PR objectui#8324). This list is the coverage line telling the truth about what the\n' +
+        '    census does not read — repair a page by retagging it ```json, or leave it and know the number:',
     );
-    for (const fence of unscannedJsonLike) console.log(`      ${fence.file}:${fence.line}  (${fence.lang})`);
+    for (const fence of unscannedJsonLike) {
+      console.log(`      ${fence.file}:${fence.line}  (${fence.lang}, ${fence.dialect})`);
+    }
   }
 
   // The blind spot is printed on every run, in both directions. A census that


### PR DESCRIPTION
Fixes #8334

## The defect

`unscannedJsonLike` is the measurement whose whole job is to report what the census **cannot** see, and it only pushed a fence when `fence.ok` — i.e. only when the body parsed as strict JSON. A fence authoring a real node tree the way JavaScript spells it (unquoted keys, single-quoted strings) hit the `continue` and was counted in **neither** the judged population nor the blind-spot list, while the summary printed:

```
✅  Dialect blind spot: none
```

A detector reporting full coverage precisely where it is blind.

## Direction chosen: **A**, on measurement — and the measurement moved the card

Direction A (widen what counts as "JSON-like" **for the blind-spot measurement only**) is implemented. The measurement is what rules out B and C, not taste:

| | card's premise | measured today |
|:--|--:|--:|
| blocks in the class | **5** | **26** |
| …in `content/docs/components` | 5 | 5 |
| …in `content/docs/fields` | — | **18** |
| …in `content/docs/guide` | — | **3** |

The card's five was a `content/docs/components`-scoped reading; the instrument's surface is the whole doc tree (`content/docs`, `apps/*/docs`, `README.md`). **B** ("retag the five") and **C** ("a shrink-only exemption list naming the five") are both scoped to a population that does not exist — B becomes a 12-page teaching-content rewrite, C a 26-entry hand-maintained list that still leaves the instrument blind and merely asserts `none`. Only A scales to the 27th block, and only A makes the coverage line *derived* rather than *declared*.

⭐ **The class is not hypothetical.** `content/docs/guide/architecture.md:410` authors `content: 'Hello, ${user.name}!'` on a typed `text` node inside an unscanned `tsx` fence — an expression on a typed node, today, in a fence neither judged nor reported. (It happens to be carried, so it is not a *finding*; it is proof the shape is live.) The card's "the corpus is currently clean" was true of the five files and not of the class.

## What changed

`toJsonDialect` — two **removals** of dialect, nothing else:

1. single-quoted strings re-spelled double-quoted, any interior `"` escaped;
2. a bare identifier in a **member** position (immediately after `{` or `,`, followed by `:`) quoted — the same positional predicate `dropElisionStrings` already uses.

It is comment-aware, because an apostrophe inside `// don't` would otherwise open a string and corrupt the rest of the body. It can invent no member, and it is a **no-op on strict JSON** (pinned).

## ⛔ The fences, honoured mechanically rather than promised

- **`plaintext` is NOT added to `JSON_FENCE_LANGUAGES`** — rejected by content on #8324, and now pinned: `expect(JSON_FENCE_LANGUAGES).not.toContain('plaintext')`.
- **The judged population is not widened** (triage's binding fence). `toJsonDialect` is reachable only from `analyze`'s `!fence.scanned` branch. Proof, not assertion — the census output diffed against `main` from the findings section down is **byte-identical**: same 209 fences, 379 nodes, 68 sites, 65 carried, same 3 findings. A new pin asserts the judged-language set and the blind-spot language set are disjoint by construction.

## ⚠️ The pin that was passing for the worst possible reason

The existing `measures the DIALECT blind spot instead of asserting there is none` asserted `expect(census.unscannedJsonLike).toEqual([])` — and passed, because the leg it pinned was blind. Its failure message was worse than the pin: it instructed the next reader to *"Widen `JSON_FENCE_LANGUAGES` deliberately"* — the exact fix #8324 rejected. A defect reasoned from written prose reproduces itself while the prose stands, so the gate's header prose and this message are corrected alongside the code.

It is replaced by a stronger shape, not a weaker one: a **per-file floor** over the five pages the card measured (⛔ per file, never one summed total — a summed floor cannot tell "every page still measured" from "one page the matcher stopped matching and another that grew two blocks"), plus a `>= 5` non-vacuity floor. ⛔ No total is pinned as an equality — that would make a report-only gate blocking through the back door.

## Two-sided ablation

Both legs: anchor counts printed with the matched lines, blob hashes before/after (an empty hash coded to exit 9 as FAILURE), restored under `trap … EXIT INT TERM`, restore proved by blob equality **and** an empty `git diff HEAD` **and** zero marker residue.

**Leg 1 — revert the predicate** (`const jsonLike = fence`): anchor 1→0, marker 0→1, blob `cf846c55`→`99cf068e`. The gate prints `✅ Dialect blind spot: none` again — the defect reproduced verbatim — and exactly one pin goes red, the per-file floor, for the right reason.

**Leg 2 — neuter the normalizer** (`toJsonDialect` → passthrough): blob `cf846c55`→`7a0bd6b8`. The gate **exits 1**: `dialect positive control: the object-literal fixture did not normalize`. A run whose measurement has stopped matching **fails** rather than printing `none`.

⚠️ Worth stating: the dialect **controls still passed** under leg 1. They exercise `parseFenceDialect` directly, while leg 1 severs its wiring into `analyze`. The two guards are not redundant — the controls catch a broken normalizer, the per-file corpus floor catches a disconnected one.

## Gates

| required context | how run | verdict |
|:--|:--|:--|
| `Test (shard N/4)` | `pnpm exec vitest run scripts/__tests__/` | `147 passed \| 2 skipped (149)`, `4372 passed` — exit 0 |
| `Type Check` | `pnpm run type-check:scripts` (`tsc -p tsconfig.scripts.json`) | exit 0 |
| `Lint` | `lint:root`, the **whole** root population — `--format json` → **334 files**, 0 errors, 32 pre-existing warnings | exit 0 |
| `Changeset Declaration` | `node scripts/check-changeset-presence.mjs` | `✅ No source or published contract of a released package changed in this range, so no changeset is owed.` — exit 0 |
| `Build Docs` | its gate step, `node scripts/check-doc-expression-carriage.mjs` | exit 0 (report-only posture intact) |
| `Control Byte Scan` | `node scripts/check-control-bytes.mjs` | `OK (scanned 7385 tracked text file(s))` — exit 0 |

Every exit code captured by redirect-then-capture, never through a pipe. `Lint` is the full `lint:root` population rather than a narrowing, so no narrowing claim is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_