### PR TITLE
test(scripts): judge the spawned-vitest child env by what it IS, not by whether the helper's name occurs in its text (objectui#9013)

### DIFF
--- a/.changeset/9013-ast-child-vitest-env-membership.md
+++ b/.changeset/9013-ast-child-vitest-env-membership.md
@@ -1,0 +1,22 @@
+---
+---
+
+Judge the spawned-vitest child environment by what it IS rather than by whether
+`childVitestEnv`'s name occurs in its text (objectui#9013).
+
+`scripts/__tests__/spawned-vitest-child-env-8616.test.ts` derived its population
+of vitest spawns by AST and then judged each one with `env.includes('childVitestEnv')`
+over the resolved `env:` text. A comment lives inside the declaration's span, so a
+call site somebody explained instead of fixing passed the gate. Measured with two
+probe files differing by one comment line and nothing else: without the helper's
+name the gate refused the spawn at `1 failed | 4 passed`; with
+`// childVitestEnv() would be the right thing to use here.` above the same
+hand-rolled `{ ...process.env, CI: 'true' }` it accepted it at `5 passed`.
+
+The `env:` expression is now classified on nodes — a call to `childVitestEnv()`, or
+an object literal spreading one, reached directly or through the name the spawn
+passes — so a comment about the helper resolves to nothing. The population walk,
+its pre-filter, the floor, the named member and the live `isAgent` probe are
+untouched; the population is still four spawns and all four still pass.
+
+Test only; no package is released by this change.

--- a/scripts/__tests__/spawned-vitest-child-env-8616.test.ts
+++ b/scripts/__tests__/spawned-vitest-child-env-8616.test.ts
@@ -51,7 +51,23 @@ import { childVitestEnv } from './helpers/child-vitest-env';
  *  3. Spawns are found by AST with identifiers RESOLVED to their declarations,
  *     because both halves of what is judged — which program is started, and
  *     which env it is given — are naturally written as named constants.
- *  4. ⭐ And the helper is MEASURED, not trusted: a real child process reports
+ *  4. ⭐ The environment is judged by what it IS, never by whether the
+ *     helper's NAME occurs in its text. Measured for objectui#9013, while the
+ *     judgement was `env.includes('childVitestEnv')`: two probe files differing
+ *     by one COMMENT line and nothing else — `// childVitestEnv() would be the
+ *     right thing to use here.` sitting above a hand-rolled
+ *     `{ ...process.env, CI: 'true' }` — split `1 failed | 4 passed` from
+ *     `5 passed`. A comment lives inside the declaration's span, so it was part
+ *     of the text being compared, and the accepted spelling was exactly the one
+ *     the sibling gate's header calls out as the thing to refuse: a call site
+ *     somebody EXPLAINED instead of fixing.
+ *     ⛔ Narrower than objectui#8712's hole one gate over, and ⛔ not the same
+ *     defect. There, presence was the wrong test in BOTH directions because the
+ *     goal was REMOVAL — a tree that SET the variable passed a gate that existed
+ *     to remove it, and the idiomatic scrub was refused. Here presence of the
+ *     helper IS the goal, so the only reachable hole is text that names it
+ *     without calling it. ⭐ It was reachable.
+ *  5. ⭐ And the helper is MEASURED, not trusted: a real child process reports
  *     `std-env`'s own `isAgent` back, once under the helper's env and once
  *     under an env the helper produced and a caller then re-marked. A helper
  *     that silently stopped scrubbing would pass every static check above.
@@ -129,11 +145,84 @@ function namesAVitest(node: ts.CallExpression, source: ts.SourceFile): boolean {
   return tokens.some((t) => /vitest/i.test(t.replace(/vitest[.\-\w]*config[.\w]*/gi, '')));
 }
 
+/** The one shared spelling of the child environment (`helpers/child-vitest-env.ts`). */
+const HELPER = 'childVitestEnv';
+
+/**
+ * What the `env:` an individual spawn passes IS — never what its text contains.
+ *
+ * `helper`  — it IS a call to `childVitestEnv()`, or an object literal that
+ *   SPREADS one (`{ ...childVitestEnv(), NO_COLOR: '1' }`), reached directly or
+ *   through the name the spawn hands the child.
+ * `foreign` — there is an `env:` and it is not that: a hand-rolled copy of
+ *   `process.env`, a scrub of some other key, or a comment ABOUT the helper.
+ *   All three hand the child this container's agent markers.
+ * `absent`  — no `env:` property at all, so the child inherits this worker's
+ *   environment outright, markers included.
+ */
+type EnvVerdict = 'helper' | 'foreign' | 'absent';
+
+/** `childVitestEnv(...)` — the helper, actually CALLED. */
+function callsHelper(node: ts.Node): boolean {
+  if (!ts.isCallExpression(node)) return false;
+  const callee = node.expression;
+  if (ts.isIdentifier(callee)) return callee.text === HELPER;
+  return ts.isPropertyAccessExpression(callee) && callee.name.text === HELPER;
+}
+
+/** The initializer of a `const`/`let` named `name` in this file, as a NODE. */
+function declarationInitializer(source: ts.SourceFile, name: string): ts.Expression | null {
+  let found: ts.Expression | null = null;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name &&
+      node.initializer !== undefined
+    ) {
+      found = node.initializer;
+    }
+    node.forEachChild(visit);
+  };
+  visit(source);
+  return found;
+}
+
+/**
+ * Where an `env:` expression's value COMES FROM.
+ *
+ * ⚠️ This is the judgement, and it is made on NODES. The text of the resolved
+ * declaration is never consulted, because a comment sitting inside that
+ * declaration's span is part of its text and answers "does this name the
+ * helper" exactly as well as a line calling it does (objectui#9013).
+ *
+ * ⛔ The resolution stays deliberately narrow — the declaration of the name the
+ * spawn passes, and the names spread into it, never the whole file. Anything
+ * wider answers "does this FILE mention `childVitestEnv`", which is the same
+ * question by a longer route.
+ */
+function envVerdict(value: ts.Expression, source: ts.SourceFile, seen: Set<string>): EnvVerdict {
+  if (ts.isIdentifier(value)) {
+    if (seen.has(value.text)) return 'foreign';
+    seen.add(value.text);
+    const initializer = declarationInitializer(source, value.text);
+    return initializer === null ? 'foreign' : envVerdict(initializer, source, seen);
+  }
+  if (callsHelper(value)) return 'helper';
+  if (ts.isObjectLiteralExpression(value)) {
+    for (const property of value.properties) {
+      if (!ts.isSpreadAssignment(property)) continue;
+      if (envVerdict(property.expression, source, seen) === 'helper') return 'helper';
+    }
+  }
+  return 'foreign';
+}
+
 interface VitestSpawn {
   readonly file: string;
   readonly line: number;
-  /** Text of the `env:` value passed in the options object, if any — IDENTIFIER resolved. */
-  readonly env: string | null;
+  /** What the `env:` this spawn passes IS — decided on the AST, never on text. */
+  readonly verdict: EnvVerdict;
 }
 
 /** Every call in `file` that starts a child vitest. */
@@ -155,23 +244,23 @@ function vitestSpawns(file: string): VitestSpawn[] {
           : '';
       if (SPAWNERS.has(callee) && namesAVitest(node, source)) {
         const options = node.arguments.find(ts.isObjectLiteralExpression.bind(ts));
-        let env: string | null = null;
+        let verdict: EnvVerdict = 'absent';
         if (options !== undefined) {
           for (const property of options.properties) {
             const key =
               property.name !== undefined && ts.isIdentifier(property.name) ? property.name.text : '';
             if (key !== 'env') continue;
             if (ts.isShorthandPropertyAssignment(property)) {
-              env = declarationText(source, property.name.text) ?? property.name.text;
+              verdict = envVerdict(property.name, source, new Set<string>());
             } else if (ts.isPropertyAssignment(property)) {
-              env = resolved(property.initializer, source);
+              verdict = envVerdict(property.initializer, source, new Set<string>());
             }
           }
         }
         found.push({
           file,
           line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
-          env,
+          verdict,
         });
       }
     }
@@ -200,8 +289,13 @@ describe(`objectui#8616 — ${SPAWNS.length} vitest spawn(s) in the test tree`, 
   });
 
   it('every one of them builds the child environment with childVitestEnv()', () => {
-    const leaking = SPAWNS.filter((s) => s.env === null || !s.env.includes('childVitestEnv')).map(
-      (s) => `${s.file}:${s.line}`,
+    const leaking = SPAWNS.filter((s) => s.verdict !== 'helper').map(
+      (s) =>
+        `${s.file}:${s.line} — ${
+          s.verdict === 'absent'
+            ? 'no `env:` at all'
+            : 'this `env:` is not `childVitestEnv()` and does not spread one'
+        }`,
     );
 
     expect(
@@ -213,7 +307,9 @@ describe(`objectui#8616 — ${SPAWNS.length} vitest spawn(s) in the test tree`, 
         'byte stream CI never produces, and the assertion is verified against the wrong ' +
         'thing forever (objectui#8616). ⛔ Imitating CI with `CI=true` does not expose ' +
         'it, and neither does `FORCE_COLOR=1`. Use `childVitestEnv()` from ' +
-        '`scripts/__tests__/helpers/child-vitest-env.ts`:\n  ' +
+        '`scripts/__tests__/helpers/child-vitest-env.ts`. ⚠️ NAMING the helper is not ' +
+        'using it — this is read off the AST, so a comment about `childVitestEnv()` ' +
+        'beside a hand-rolled environment resolves to nothing (objectui#9013):\n  ' +
         leaking.join('\n  '),
     ).toEqual([]);
   });


### PR DESCRIPTION
Fixes #9013

## The defect

`scripts/__tests__/spawned-vitest-child-env-8616.test.ts` derives its population of vitest spawns by **AST** — that half is real, and its own header explains why a substring census of this class is not a census. It then judged each spawn's environment with a **token-presence test over the resolved `env:` text**:

```js
const leaking = SPAWNS.filter((s) => s.env === null || !s.env.includes('childVitestEnv')).map(
```

`resolved()` hands that predicate `node.initializer.getText(source)`. `getText()` spans from the initializer's start to its end, so a comment sitting **inside** the declaration — between the braces of `{ ...process.env, CI: 'true' }` — is part of the text being compared. A spawn therefore passed by **naming** the helper. A child spawned that way inherits this container's agent markers, which is the entire defect objectui#8616 closed.

## ⛔ Not a duplicate of objectui#8712 — it is a NARROWER hole

Keeping the two apart is the point of the card, so it is stated here rather than collapsed:

| | objectui#8712, one gate over (`spawned-build-vitest-env-8598.test.ts`) | **objectui#9013, here** |
|:--|:--|:--|
| the goal | `VITEST` must be **REMOVED** from the child env | `childVitestEnv()` must be **PRESENT** as the child env |
| why presence was the wrong test | wrong in **both directions at once**: `env: { ...process.env, VITEST: 'true' }` — a tree that **SETS** the variable the gate exists to remove — passed, and the idiomatic rest-pattern scrub was **REFUSED** | presence of the helper genuinely **is** the property; the predicate was not wrong about what to look for |
| the reachable hole | a call site that does the opposite of the fix | **only** text that names the helper without calling it |

⇒ there, the question itself was wrong. Here the question is right and the *evidence* was text, so the single reachable hole is a comment. Narrower — and, as the card measured, reachable.

## The repair

The `env:` expression is now classified on **nodes**, the way objectui#8712's branch classifies its own env expression by what it *does* to the key:

- **`helper`** — it **is** a call to `childVitestEnv()`, or an object literal that **spreads** one (`{ ...childVitestEnv(), NO_COLOR: '1' }`), reached directly or through the name the spawn hands the child.
- **`foreign`** — there is an `env:` and it is not that.
- **`absent`** — no `env:` property at all.

The resolved declaration's **text is never consulted**, so a comment about the helper resolves to nothing. Resolution stays deliberately narrow — the declaration of the name the spawn passes, and the names spread into it, never the whole file; anything wider answers "does this FILE mention `childVitestEnv`", which is the same question by a longer route.

The failure message now names *which* of the two ways a spawn leaks, and says that naming the helper is not using it.

### ⛔ What was NOT touched

The fences held, and each is checkable in the diff:

- **The AST population walk** — untouched. In particular its cheap pre-filter `if (!text.includes('vitest')) return [];` is **not** the defect and was **not** "fixed for symmetry": it selects candidates for the AST pass, and every judgement is still made on the AST. `git diff` contains no `+`/`-` line matching `includes('vitest')`.
- **The floor and the named member** — `POPULATION_FLOOR = 1` and `NAMED_MEMBER` are byte-identical.
- **The live `isAgent` probe** and its control — byte-identical.
- **The four call sites** objectui#8616 protects — not edited at all. The population is still **4 spawns** and all four still pass, so no count over them moved down.

## ⭐ The acceptance probe: reproduced, then inverted

The card's probe, verbatim. The two files differ by **one comment line and nothing else** (`diff` reports `5c5`, one hunk). The probe was removed after **every** run and its absence verified with `ls` each time.

| probe | before (`1f4e02995a`) | after (`4c4551610d`) |
|:--|:--|:--|
| **control** — `// A plain comment that names nothing in particular.` | **exit 1**, `1 failed \| 4 passed`, naming `scripts/__tests__/probe-9013.test.ts:10` | **exit 1**, `1 failed \| 4 passed`, same spawn, now with a reason |
| **hole** — `// childVitestEnv() would be the right thing to use here.` | ⛔ **exit 0**, `5 passed` | ✅ **exit 1**, `1 failed \| 4 passed` |
| **accept** (added here) — `{ ...childVitestEnv(), CI: 'true' }` | — | ✅ **exit 0**, `5 passed`, describe title reads `5 vitest spawn(s)` |

⭐ The **control** is load-bearing: it proves the probe really is in this gate's population and really is refused when the helper is absent, so the green in row two was **the predicate accepting it**, not the walk failing to see it. After the fix the control is unchanged — the walk still sees the probe.

⭐ The **accept** row is the other half, and it is why the "after" column is not just a gate that reds at everything: with the helper actually spread, the same probe is admitted to the population (`5 vitest spawn(s)` in the describe title) **and passes**.

Verdict lines, quoted from the runs:

```
before/hole:    Test Files  1 passed (1)   /   Tests  5 passed (5)          exit 0
after/hole:     FAIL ... > every one of them builds the child environment with childVitestEnv()
                scripts/__tests__/probe-9013.test.ts:10 — this `env:` is not `childVitestEnv()` and does not spread one
                Test Files  1 failed (1)   /   Tests  1 failed | 4 passed (5)   exit 1
```

## Two-sided ablation

Ran from the committed tree, under `trap … EXIT INT TERM`.

- **Mutation**: `return 'helper'; // MUTANT-9013` inserted as the first statement of `envVerdict`, making the new judgement incapable of refusing anything.
- **Landed on disk**: anchor `MUTANT-9013` grepped back at line 205 (matched line printed, not counted); blob moved `72aac35ee17a576f0bf026a5bd8d53160793a771` → `11e33585c6385d9cd022f007c6c605969c7e156c`. An empty hash was coded as FAILURE.
- **Direction**: with the **control** probe present — the one the fixed gate must refuse — the mutant went **green**, `5 passed`, population `5 vitest spawn(s)`. ⇒ the refusal in both probe rows comes from `envVerdict` and from nothing else.
- **Restored**: `git checkout HEAD -- ABSOLUTE_PATH`, then blob equality back to `72aac35e…` **and** an empty `git diff HEAD`. Probe file absence re-verified.

## Gates run locally

Exit codes captured by redirect-then-capture, never through a pipe.

| command | verdict line |
|:--|:--|
| `pnpm exec vitest run scripts/__tests__/spawned-vitest-child-env-8616.test.ts` | `Test Files 1 passed (1)` · `Tests 5 passed (5)` · exit 0 |
| 7 neighbouring gate test files (incl. the objectui#8598 sibling, `scripts-type-check`, `tsconfig-test-parity-census`, `check-changeset-presence`, `check-control-bytes`, `zero-test-member-exclusion-9106`) | `Test Files 7 passed (7)` · `Tests 138 passed (138)` · exit 0 |
| `pnpm type-check:scripts` | exit 0; `tsc -p tsconfig.scripts.json --listFiles` lists the edited file at line 879, so this is a measurement and not an exclusion |
| `pnpm lint:root` | `✖ 32 problems (0 errors, 32 warnings)` · exit 0; **0** of them in the edited file. ⚠️ `pnpm lint` here is `turbo run lint`, ⛔ not `eslint . --no-inline-config` |
| `pnpm check:control-bytes` | `✅ check-control-bytes: OK (scanned 7401 tracked text file(s); skipped 85 binary).` |
| `pnpm check:new-line-citations` | `VERDICT new-cross-file-line-citations: 0 new citation(s), enforcement report-only -> exit 0` |
| `pnpm check:test-path-roots` | `✅ check-test-path-roots: OK` |
| `node scripts/check-changeset-presence.mjs` | `✅ No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `check-changeset-fixed` / `-no-major` / `-overwrite` / `check:changeset-claims` | all `✅`, exit 0 |

The changeset carries **empty frontmatter**: test-only, no package is released.

CI's required contexts — `Test (shard N/4)`, `Type Check`, `Lint`, `Changeset Declaration`, `Control Byte Scan` — are left to CI; their verdict lines are not quoted here because they had not reported when this was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_