### PR TITLE
fix(plugin-detail): an authored `detail-section` node renders its declared inputs

### DIFF
--- a/.changeset/8626-detail-section-authored-node.md
+++ b/.changeset/8626-detail-section-authored-node.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+An authored `detail-section` node now renders. It used to draw an error banner.
+
+The registration declares eight FLAT inputs — `title`, `description`, `fields`,
+`collapsible`, `defaultCollapsed`, `columns`, `showBorder`, `headerColor` —
+while `DetailSection` declares a single `section` OBJECT prop and reads
+`section.*` only. `SchemaRenderer` spreads a node's non-metadata keys as React
+props, so an authored node arrived as `title` / `fields` / … and `section`
+arrived `undefined`.
+
+Not merely inert. `DetailSection`'s first statement is
+`React.useState(section.defaultCollapsed ?? false)`, so the render THREW and
+`SchemaErrorBoundary` put its orange banner on the page in place of the block —
+measured end to end through the real `SchemaRenderer` and the real registry:
+
+```
+Component "detail-section" failed to render
+Cannot read properties of undefined (reading 'defaultCollapsed')
+```
+
+The tag is now registered against a seam adapter that folds those eight
+declared inputs into the `section` object the component reads — the same shape
+of repair this package already uses for `field:permission-facet-link`
+(`withFieldCarrier`, objectui#3307).
+
+**The authoring surface did not move, deliberately.** The other available
+repair — re-declaring the eight as a nested `section` input — would have
+changed what authors may write, and the flat shape is both published and
+authored: a manifest built the way `PageRenderer` builds the JSX-page
+compiler's gives the flat eight ZERO diagnostics and REFUSES `section`
+(`unknown-prop`, plus `missing-required-prop "fields"`), this package's README
+documents a flat `detail-section` node inside `tabs[].content`, and
+objectui#6955's landed pin asserts that same flat surface. Folding at the seam
+invalidates none of them.
+
+`DetailSection` itself is byte-identical: every in-repo caller passes
+`section={…}` as a direct JSX child and is untouched.

--- a/packages/plugin-detail/src/DetailSectionNode.tsx
+++ b/packages/plugin-detail/src/DetailSectionNode.tsx
@@ -1,0 +1,146 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The component the `detail-section` TAG is registered against — the seam that
+ * makes the block's eight declared `inputs` true (objectui#8626).
+ *
+ * ## The defect this closes
+ *
+ * `ComponentRegistry.register('detail-section', …)` declares eight FLAT inputs
+ * — `title`, `description`, `fields`, `collapsible`, `defaultCollapsed`,
+ * `columns`, `showBorder`, `headerColor`. `DetailSection` declares no such
+ * props: it takes a single `section` object and reads `section.title`,
+ * `section.fields`, `section.defaultCollapsed` and the rest off it. The two
+ * are joined by `SchemaRenderer`, which spreads a node's non-metadata keys as
+ * React props — so an authored node arrived as `title` / `fields` / … and
+ * `section` arrived as `undefined`.
+ *
+ * That is not "every input inert". MEASURED on `b775500af` by rendering an
+ * authored node through the real `SchemaRenderer` and the real registry:
+ * `DetailSection`'s first statement is `React.useState(section.defaultCollapsed
+ * ?? false)`, so the render THREW, `SchemaErrorBoundary` caught it, and the
+ * author's page showed an orange banner reading
+ * `Component "detail-section" failed to render — Cannot read properties of
+ * undefined (reading 'defaultCollapsed')`. Every authored key was lost AND the
+ * block became a visible hole.
+ *
+ * ## Why the fold, and not a re-declaration
+ *
+ * The two repairs objectui#8626 names are not symmetric, and the measurement
+ * decides between them rather than taste:
+ *
+ *  - The flat eight are the PUBLISHED surface, and the platform enforces them.
+ *    `packages/components/src/renderers/layout/page.tsx` builds the JSX-page
+ *    compiler's manifest from `getKnownTypes()` plus these `inputs`, and
+ *    `sdui-parser`'s `validateTree` judges an authored page against it.
+ *    Measured against that live manifest: the flat eight draw ZERO
+ *    diagnostics, while `section` draws `unknown-prop` AND
+ *    `missing-required-prop "fields"`. The validator does not merely permit
+ *    the flat shape — it REFUSES the nested one.
+ *  - The flat shape is authored: `packages/plugin-detail/README.md` documents
+ *    a `detail-section` node inside `tabs[].content` (which `DetailTabs`
+ *    renders through `SchemaRenderer`), and
+ *    `__tests__/detailSectionHeaderColorEnum-6955.test.ts` pins the flat
+ *    `fields` + `headerColor` surface against that same validator.
+ *
+ * Re-declaring the registration as a nested `section` object would therefore
+ * invalidate both, and would delete the surface objectui#6955 had just
+ * narrowed. Folding at the seam invalidates nothing: every authored node keeps
+ * validating and starts rendering.
+ *
+ * ## Why HERE and not inside `DetailSection`
+ *
+ * `DetailSection` is a published export with five in-repo callers
+ * (`DetailView`, `SectionGroup` and their tests), every one of which passes
+ * `section={…}` as a direct JSX child — none goes through the registry. Teaching
+ * the component two prop shapes would put a second dialect in front of all of
+ * them (AGENTS.md #0.1). The registration seam is where the translation
+ * belongs, and this package already does exactly that for
+ * `field:permission-facet-link` via `withFieldCarrier` (objectui#3307).
+ *
+ * ⇒ this adapter accepts the DECLARED surface and nothing else. It does not
+ * take a `section` prop: a node carrying one is refused by the platform
+ * validator, so honouring it here would create the second de-facto contract
+ * #0.1 exists to prevent.
+ */
+
+import * as React from 'react';
+import type { DetailViewSection } from '@object-ui/types';
+import { DetailSection, type DetailSectionProps } from './DetailSection';
+
+/**
+ * The section members an authored `detail-section` node carries as FLAT props,
+ * i.e. exactly the names the registration declares as `inputs`.
+ *
+ * Single source for the fold. `detailSectionAuthoredNode-8626.test.tsx` pins
+ * this list against the registration's own declared input names in BOTH
+ * directions, so a ninth input declared without a fold — the shape of the
+ * original defect — reds rather than arriving silently inert.
+ */
+export const DETAIL_SECTION_NODE_INPUTS = [
+  'title',
+  'description',
+  'fields',
+  'collapsible',
+  'defaultCollapsed',
+  'columns',
+  'showBorder',
+  'headerColor',
+] as const;
+
+type DetailSectionNodeInput = (typeof DETAIL_SECTION_NODE_INPUTS)[number];
+
+/**
+ * What an author may write on a `detail-section` node: the eight declared
+ * inputs, flat, plus the render-context props a host supplies.
+ */
+export type DetailSectionNodeProps = Omit<DetailSectionProps, 'section'> &
+  Partial<Pick<DetailViewSection, DetailSectionNodeInput>>;
+
+export const DetailSectionNode: React.FC<DetailSectionNodeProps> = ({
+  title,
+  description,
+  fields,
+  collapsible,
+  defaultCollapsed,
+  columns,
+  showBorder,
+  headerColor,
+  ...rest
+}) => {
+  /**
+   * The fold. `fields` is `required: true` on the registration, so an absent
+   * one is already an ERROR from `validateTree`; it is NOT defaulted to `[]`
+   * here — a lenient default would make the required declaration untrue in the
+   * other direction.
+   *
+   * Undefined members are left undefined rather than stripped: every read site
+   * in `DetailSection` tests the VALUE (`section.title &&`,
+   * `section.showBorder === false`, `section.defaultCollapsed ?? false`), never
+   * key presence, so an unauthored key and an absent key are the same section.
+   */
+  const section = React.useMemo(
+    () =>
+      ({
+        title,
+        description,
+        fields,
+        collapsible,
+        defaultCollapsed,
+        columns,
+        showBorder,
+        headerColor,
+      }) as DetailViewSection,
+    [title, description, fields, collapsible, defaultCollapsed, columns, showBorder, headerColor],
+  );
+
+  return <DetailSection {...rest} section={section} />;
+};
+
+DetailSectionNode.displayName = 'DetailSectionNode(DetailSection)';

--- a/packages/plugin-detail/src/DetailSectionNode.tsx
+++ b/packages/plugin-detail/src/DetailSectionNode.tsx
@@ -78,10 +78,14 @@ import { DetailSection, type DetailSectionProps } from './DetailSection';
  * The section members an authored `detail-section` node carries as FLAT props,
  * i.e. exactly the names the registration declares as `inputs`.
  *
- * Single source for the fold. `detailSectionAuthoredNode-8626.test.tsx` pins
- * this list against the registration's own declared input names in BOTH
- * directions, so a ninth input declared without a fold — the shape of the
- * original defect — reds rather than arriving silently inert.
+ * THE single source for the fold, and load-bearing rather than descriptive:
+ * the component below folds by iterating THIS list, so a name removed from it
+ * is a name that stops reaching `DetailSection` — which is how the ablation
+ * for objectui#8626 reddens a per-input row.
+ * `detailSectionAuthoredNode-8626.test.tsx` additionally pins the list against
+ * the registration's own declared input names in BOTH directions, so a ninth
+ * input declared without a fold — the shape of the original defect — reds
+ * rather than arriving silently inert.
  */
 export const DETAIL_SECTION_NODE_INPUTS = [
   'title',
@@ -103,44 +107,42 @@ type DetailSectionNodeInput = (typeof DETAIL_SECTION_NODE_INPUTS)[number];
 export type DetailSectionNodeProps = Omit<DetailSectionProps, 'section'> &
   Partial<Pick<DetailViewSection, DetailSectionNodeInput>>;
 
-export const DetailSectionNode: React.FC<DetailSectionNodeProps> = ({
-  title,
-  description,
-  fields,
-  collapsible,
-  defaultCollapsed,
-  columns,
-  showBorder,
-  headerColor,
-  ...rest
-}) => {
-  /**
-   * The fold. `fields` is `required: true` on the registration, so an absent
-   * one is already an ERROR from `validateTree`; it is NOT defaulted to `[]`
-   * here — a lenient default would make the required declaration untrue in the
-   * other direction.
-   *
-   * Undefined members are left undefined rather than stripped: every read site
-   * in `DetailSection` tests the VALUE (`section.title &&`,
-   * `section.showBorder === false`, `section.defaultCollapsed ?? false`), never
-   * key presence, so an unauthored key and an absent key are the same section.
-   */
-  const section = React.useMemo(
-    () =>
-      ({
-        title,
-        description,
-        fields,
-        collapsible,
-        defaultCollapsed,
-        columns,
-        showBorder,
-        headerColor,
-      }) as DetailViewSection,
-    [title, description, fields, collapsible, defaultCollapsed, columns, showBorder, headerColor],
-  );
+const FOLDED = new Set<string>(DETAIL_SECTION_NODE_INPUTS);
 
-  return <DetailSection {...rest} section={section} />;
+export const DetailSectionNode: React.FC<DetailSectionNodeProps> = (props) => {
+  /**
+   * The fold, driven by `DETAIL_SECTION_NODE_INPUTS` rather than by a second
+   * hand-written destructure — a copy of the list is a copy that can drift out
+   * of the declaration, which is the defect this file exists to close.
+   *
+   * `fields` is `required: true` on the registration, so an absent one is
+   * already an ERROR from `validateTree`; it is NOT defaulted to `[]` here — a
+   * lenient default would make the required declaration untrue in the other
+   * direction.
+   *
+   * A key the author omitted stays omitted, and an authored `undefined` stays
+   * `undefined`: every read site in `DetailSection` tests the VALUE
+   * (`section.title &&`, `section.showBorder === false`,
+   * `section.defaultCollapsed ?? false`), never key presence, so the two are
+   * the same section.
+   *
+   * Rebuilt per render on purpose — no memo. `DetailSection` keys its own
+   * memos off section MEMBERS (`[section.fields, …]`), never off the object,
+   * so a stable identity would buy nothing and a stale one would cost
+   * correctness.
+   */
+  const section: Record<string, unknown> = {};
+  const hostProps: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(props)) {
+    (FOLDED.has(key) ? section : hostProps)[key] = value;
+  }
+
+  return (
+    <DetailSection
+      {...(hostProps as Omit<DetailSectionProps, 'section'>)}
+      section={section as unknown as DetailViewSection}
+    />
+  );
 };
 
 DetailSectionNode.displayName = 'DetailSectionNode(DetailSection)';

--- a/packages/plugin-detail/src/__tests__/detailSectionAuthoredNode-8626.test.tsx
+++ b/packages/plugin-detail/src/__tests__/detailSectionAuthoredNode-8626.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8626 — an authored `detail-section` node RENDERS the eight inputs
+ * its registration declares.
+ *
+ * ## What was broken, measured rather than read
+ *
+ * The registration declares eight FLAT inputs; `DetailSection` declares a
+ * single `section` OBJECT prop and reads `section.*` only. `SchemaRenderer`
+ * spreads a node's non-metadata keys as React props, so `section` arrived
+ * `undefined`.
+ *
+ * Rendering an authored node through the real `SchemaRenderer` and the real
+ * registry on `b775500af` produced, verbatim:
+ *
+ *   Component "detail-section" failed to render
+ *   Cannot read properties of undefined (reading 'defaultCollapsed')
+ *
+ * i.e. `SchemaErrorBoundary`'s banner in place of the block — worse than
+ * inert, and the half the card flagged as "a reading and not an execution".
+ * `errorBannerAbsent()` below is that exact face, asserted absent.
+ *
+ * ## Why each row is a RENDERING verdict
+ *
+ * Every declared input is measured by a consequence in the DOM — the text an
+ * author sees, the column track the grid gets, the tint class the header
+ * carries. Deliberately NOT "the prop was passed" and NOT "the registration
+ * declares eight inputs": both pass on a component that reads none of them,
+ * which is precisely the defect. Each class-shaped row carries its own
+ * negative (`grid-cols-1` without `md:grid-cols-2`, `bg-muted` without
+ * `bg-accent`) so it is a verdict and not a substring that was always there.
+ *
+ * ## The two guards beside the rendering rows
+ *
+ * - FOLD PARITY. The fold set and the registration's declared input names are
+ *   compared in BOTH directions. A ninth input declared without a fold is the
+ *   original defect in miniature — inert, silent — and reds here instead.
+ * - THE DECLARED SURFACE DID NOT MOVE. The flat eight still draw ZERO
+ *   diagnostics from a manifest built the way `page.tsx` builds the JSX-page
+ *   compiler's, and the nested `section` shape is still REFUSED by it. That is
+ *   the control on the repair NOT taken: this card folds at the seam, and does
+ *   not re-declare the surface authors already write.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '@object-ui/react';
+import { manifestFromConfigs, validateTree } from '@object-ui/sdui-parser';
+import { DETAIL_SECTION_NODE_INPUTS } from '../DetailSectionNode';
+
+// Module scope, not a hook (AGENTS.md 测试纪律): importing the package index
+// executes its registration side-effects, so the entry under test is the very
+// one production resolves.
+import '../index';
+
+const TAG = 'detail-section';
+const NAMESPACE = 'plugin-detail';
+
+/** The node an author writes, carrying all eight declared inputs, flat. */
+const authoredNode = (overrides: Record<string, unknown> = {}) =>
+  ({
+    type: TAG,
+    title: 'Billing Address',
+    description: 'Where invoices go',
+    collapsible: true,
+    defaultCollapsed: false,
+    columns: 2,
+    showBorder: true,
+    headerColor: 'muted',
+    fields: [
+      { name: 'street', label: 'Street' },
+      { name: 'city', label: 'City' },
+    ],
+    ...overrides,
+  }) as never;
+
+const RECORD = { street: '1 Market St', city: 'San Francisco' };
+
+const renderAuthored = (overrides: Record<string, unknown> = {}) =>
+  render(<SchemaRenderer schema={authoredNode(overrides)} data={RECORD} />);
+
+/**
+ * `SchemaErrorBoundary`'s face, asserted absent. Its copy is
+ * `Component "<type>" failed to render`, so a future refactor that reintroduces
+ * the throw lands here rather than on a subtler row.
+ */
+const errorBannerAbsent = () => {
+  expect(screen.queryByRole('alert')).toBeNull();
+  expect(screen.queryByText(/failed to render/i)).toBeNull();
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('objectui#8626 — an authored detail-section node renders its declared inputs', () => {
+  it('renders its authored TITLE, DESCRIPTION and FIELDS instead of an error banner', () => {
+    const { container } = renderAuthored();
+
+    errorBannerAbsent();
+    expect(screen.getByText('Billing Address')).toBeInTheDocument();
+    expect(screen.getByText('Where invoices go')).toBeInTheDocument();
+    // `fields` — both labels AND both values off the bound record, so the
+    // array reached the component as a section rather than as a lost prop.
+    expect(screen.getByText('Street')).toBeInTheDocument();
+    expect(screen.getByText('City')).toBeInTheDocument();
+    expect(screen.getByText('1 Market St')).toBeInTheDocument();
+    expect(screen.getByText('San Francisco')).toBeInTheDocument();
+    // Non-vacuity: the block rendered real chrome, not an empty container.
+    expect(container.innerHTML.length).toBeGreaterThan(500);
+  });
+
+  it('honours `columns` as the grid track count', () => {
+    const { container } = renderAuthored({ columns: 2 });
+    const grid = container.querySelector('.grid');
+    expect(grid).not.toBeNull();
+    expect(grid!.className).toContain('md:grid-cols-2');
+    // Control: a one-column authoring of the SAME node does not carry it.
+    cleanup();
+    const single = renderAuthored({ columns: 1 }).container.querySelector('.grid');
+    expect(single).not.toBeNull();
+    expect(single!.className).not.toContain('md:grid-cols-2');
+  });
+
+  it('honours `headerColor` as the header tint class', () => {
+    const { container } = renderAuthored({ headerColor: 'muted' });
+    const header = container.querySelector('.bg-muted');
+    expect(header).not.toBeNull();
+    // Control: the tint is the authored one, not any tint the chrome happens
+    // to carry.
+    expect(container.querySelector('.bg-accent')).toBeNull();
+    cleanup();
+    const accent = renderAuthored({ headerColor: 'accent' }).container;
+    expect(accent.querySelector('.bg-accent')).not.toBeNull();
+  });
+
+  /**
+   * ⚠️ Authored `collapsible: false` ON PURPOSE, and the reason is a defect
+   * this card did NOT fix: `DetailSection`'s collapsible branch renders a bare
+   * `<Card>` and never reads `section.showBorder`, so the key is honoured only
+   * on the non-collapsible branch. That is a separate, pre-existing bug inside
+   * `DetailSection` — the component this card deliberately leaves
+   * byte-identical — filed rather than repaired here. Pinning `showBorder`
+   * against the branch that DOES read it keeps this row a reading about the
+   * fold, not about that bug.
+   */
+  it('honours `showBorder: false` by dropping the card border', () => {
+    const bordered = renderAuthored({ collapsible: false, showBorder: true }).container;
+    expect(bordered.querySelector('.border-none')).toBeNull();
+    cleanup();
+    const borderless = renderAuthored({ collapsible: false, showBorder: false }).container;
+    expect(borderless.querySelector('.border-none')).not.toBeNull();
+  });
+
+  it('honours `collapsible` + `defaultCollapsed` as the initial disclosure state', () => {
+    const open = renderAuthored({ collapsible: true, defaultCollapsed: false }).container;
+    expect(open.querySelector('[aria-expanded="true"]')).not.toBeNull();
+    cleanup();
+    const collapsed = renderAuthored({ collapsible: true, defaultCollapsed: true }).container;
+    expect(collapsed.querySelector('[aria-expanded="false"]')).not.toBeNull();
+    // The value rows are not on screen while collapsed — the read that used to
+    // THROW is now the one deciding this.
+    expect(screen.queryByText('1 Market St')).toBeNull();
+  });
+
+  /**
+   * DRIFT GUARD, not the pin. The rows above are the pin; this one keeps a
+   * ninth declared input from arriving inert the way all eight once did.
+   */
+  it('folds exactly the inputs the registration declares, in both directions', () => {
+    const declared = (
+      (ComponentRegistry.getConfig(TAG, NAMESPACE) as unknown as {
+        inputs?: Array<{ name: string }>;
+      })?.inputs ?? []
+    ).map((i) => i.name);
+    // Non-vacuity: an empty read (wrong tag/namespace) must fail here.
+    expect(declared.length).toBeGreaterThan(0);
+    expect([...declared].sort()).toEqual([...DETAIL_SECTION_NODE_INPUTS].sort());
+  });
+
+  /**
+   * CONTROL on the repair NOT taken. Built the way
+   * `packages/components/src/renderers/layout/page.tsx` builds the JSX-page
+   * compiler's manifest — from the live registry — so these are the verdicts a
+   * real author gets.
+   */
+  it('leaves the published authoring surface where authors already write it', () => {
+    const manifest = manifestFromConfigs(
+      ComponentRegistry.getKnownTypes().map((type) => {
+        const meta = ComponentRegistry.getMeta(type);
+        return {
+          type,
+          namespace: meta?.namespace,
+          isContainer: meta?.isContainer,
+          inputs: meta?.inputs,
+        };
+      }) as unknown as Parameters<typeof manifestFromConfigs>[0],
+    );
+
+    // The flat eight: clean.
+    expect(validateTree(authoredNode(), manifest).diagnostics).toEqual([]);
+
+    // The nested shape: still refused, so this repair did not quietly open a
+    // second dialect for the same block.
+    const nested = validateTree(
+      { type: TAG, section: { title: 'x', fields: [{ name: 'street' }] } } as never,
+      manifest,
+    ).diagnostics;
+    expect(nested.map((d) => d.code).sort()).toEqual(['missing-required-prop', 'unknown-prop']);
+  });
+});

--- a/packages/plugin-detail/src/index.tsx
+++ b/packages/plugin-detail/src/index.tsx
@@ -16,6 +16,7 @@ import {
 import { withFieldCarrier } from '@object-ui/fields';
 import { DetailView } from './DetailView';
 import { DetailSection } from './DetailSection';
+import { DetailSectionNode } from './DetailSectionNode';
 import { headerColorVocabulary } from './headerColor';
 import { DetailTabs } from './DetailTabs';
 import { RelatedList } from './RelatedList';
@@ -319,8 +320,21 @@ ComponentRegistry.register('detail-view', DetailViewRenderer, {
   }
 });
 
-// Register DetailSection component
-ComponentRegistry.register('detail-section', DetailSection, {
+// Register DetailSection component.
+//
+// ⚠️ Against `DetailSectionNode`, NOT `DetailSection` — and that is what makes
+// the `inputs` below true (objectui#8626). `SchemaRenderer` spreads a node's
+// non-metadata keys as React props, so an authored node arrives as `title` /
+// `fields` / … while `DetailSection` reads a single `section` OBJECT prop. Bound
+// directly, `section` arrived `undefined` and the very first
+// `section.defaultCollapsed` read THREW — measured end to end, the author's page
+// showed `SchemaErrorBoundary`'s orange "failed to render" banner in place of the
+// block. `DetailSectionNode` folds the eight declared inputs into the `section`
+// object the component reads; see that file for why the fold sits at this seam
+// rather than in `DetailSection` (which every in-repo caller uses directly), and
+// why re-declaring these eight as a nested `section` input was the repair NOT
+// taken.
+ComponentRegistry.register('detail-section', DetailSectionNode, {
   namespace: 'plugin-detail',
   label: 'Detail Section',
   category: 'Detail Components',


### PR DESCRIPTION
Part of #8626

⚠️ **`Part of`, not `Fixes`, and that is the stop condition firing — see "The measurement came before the choice" below.** The card reserves ONE question for the maintainer (is `detail-section` meant to be authorable as a flat SDUI block at all, or should the registration be re-declared around the nested `section` shape). This PR takes the repair that invalidates nothing and leaves that question open rather than closing it by merge.

---

## The measurement came before the choice

The triage's stop condition, verbatim:

> Two repairs exist and they are not equivalent — name the one you take in the PR: teach the component to read the flat props, or change the registration to declare the nested `section` shape it actually reads. The second changes what authors may write; if the flat inputs have ever been authored anywhere, that is a compatibility question rather than a free choice. ⇒ **check for authored usages first** and say what you found; if any exist, stop and report rather than invalidating them.

**The sweep is POSITIVE. The flat surface is authored, twice.**

The complete universe is the 17 lines `git grep detail-section` returns on `b775500af`, hand-classified. Two of them are authored nodes:

| # | Site | What it writes | Reached how |
|---|---|---|---|
| 1 | `packages/plugin-detail/README.md:158` | `content: { type: 'detail-section', fields: [...] }` inside a `detail-view` `tabs[]` | `DetailTabs` renders `tab.content` through `SchemaRenderer` — a live authored node, and one this package documents |
| 2 | `packages/plugin-detail/src/__tests__/detailSectionHeaderColorEnum-6955.test.ts` | `validateTree({ type: TAG, fields: [{ name: 'amount' }], ...props })` with `TAG = 'detail-section'`, plus `expect(inputs.map(i => i.name)).toContain('fields')` | objectui#6955's landed contract pin, ON the flat surface |

The other 15 are prose (`ROADMAP.md`, four `CHANGELOG.md`s, the #6955 changeset), a comment in `LookupField.tsx`, the CLI's known-type list (`packages/cli/src/utils/known-schema-types.ts:111,324`), and the registration itself.

**Lit controls, in the same command.** The sweep counts `type: 'TAG'` literals, and is run at the merge-base and at HEAD so each control is individually checked as unmoved:

```
                   authored-node literals      all mentions
                   merge-base -> HEAD          merge-base -> HEAD
detail-section          1  ->  1                  13 -> 26   (subject; the +13 is this PR's own files)
detail-view            67  -> 67                 158 -> 158  (CONTROL — lit, unmoved)
activity-timeline       1  ->  1                   3 ->   3  (CONTROL — lit, unmoved)
```

Two candidate controls were tried and **discarded** rather than reported: `related-list` reads **0 on both sides** (a zero is not a control), and `grid` **moved** 6660 -> 6668 (this PR's own `grid-cols` text), so it cannot witness anything.

⇒ re-declaring the registration around a nested `section` would invalidate both authored sites, and would delete the very surface objectui#6955 had just narrowed. That is the branch the stop condition forbids.

## The repair taken, and what the other would have cost

**TAKEN — adapt at the seam.** `detail-section` is now registered against `DetailSectionNode`, which folds the eight declared inputs into the `section` object `DetailSection` reads. Same shape of repair this package already uses for `field:permission-facet-link` (`withFieldCarrier`, objectui#3307). The declared `inputs` array is byte-identical; every authored node keeps validating and starts rendering.

**NOT TAKEN — declare the nested shape.** It would have cost, concretely:

- the README example above, silently (it would still parse, and still render nothing an author asked for);
- objectui#6955's pin, which asserts the flat `fields` input exists and diagnoses a flat `headerColor` — the card the filing seat correctly kept separate (#8626's own out-of-scope note);
- every authored page already written against the manifest, since the platform currently REFUSES the nested shape (measured below);
- a migration this card has no mandate to design.

It would have BOUGHT a registration that describes `DetailSection`'s props literally. That is the cheaper declaration, not the truer contract: `inputs` publishes what an AUTHOR may write, and the author has never been able to write a `section` object here.

## M2 — the card's second half, EXECUTED (not restated)

The card flagged "a reading and not an execution". Executed, through the real `SchemaRenderer` and the real registry on `b775500af`, rendering a node authored exactly as the registration prescribes (`type: 'detail-section'` with `title` and `fields`):

It does **throw** — and the throw does not escape. `SchemaErrorBoundary` catches it and paints the block's slot orange:

```
role="alert"
  Component "detail-section" failed to render
  Cannot read properties of undefined (reading 'defaultCollapsed')
  [Retry]
```

⇒ the severity is **worse than the card's "inert"** and **milder than "breaks the page"**: every authored key is lost AND the author is shown a raw JavaScript message where their section should be. `errorBannerAbsent()` in the pin asserts that exact face is gone.

## M3 — the reach, verified rather than trusted

`packages/components/src/renderers/layout/page.tsx` (the `_jsxManifest` memo) builds the JSX-page compiler's manifest from `ComponentRegistry.getKnownTypes()` plus each entry's `inputs`, and `sdui-parser`'s `validateTree` judges an authored page against it — the same reach `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` records for `element:record_picker`, likewise outside `PUBLIC_BLOCKS`.

Driven against a manifest built that same way, from the live registry:

| Authored shape | Verdict |
|---|---|
| the flat eight | `[]` — **zero diagnostics** |
| `{ section: { title, fields } }` | `error missing-required-prop "fields"` + `warning unknown-prop "section"` |

⇒ the platform does not merely permit the flat shape; it **refuses** the nested one. That is the reading that decides between the two repairs, and it is pinned as this PR's control row.

## Ablation matrix — three legs, every row covered

Each leg: mutate, prove the mutation reached disk (anchor count + `git hash-object` before/after), run, restore via `git checkout HEAD -- PATH`, prove restoration by blob-hash equality and an empty `git diff HEAD`. Restoration ran from a `trap … EXIT INT TERM` with absolute paths. No build step is involved: the pin imports the mutated `../index` by relative path, so there is no `dist` between the mutation and the assertion.

| Leg | Mutation | Rows that redden |
|---|---|---|
| **A** | register the tag against `DetailSection` again (undo the repair) | all 5 rendering rows, each with `TypeError: Cannot read properties of undefined (reading 'defaultCollapsed')` |
| **B** | drop `'headerColor'` from `DETAIL_SECTION_NODE_INPUTS` | `honours headerColor as the header tint class` + `folds exactly the inputs the registration declares` |
| **C** | rename the declared input `fields` to `items` | `folds exactly the inputs…` + `leaves the published authoring surface where authors already write it` |

Every one of the 7 rows reddens under at least one leg — no assertion survives deletion of the thing it names. The two rows that survive leg A survive it correctly: they name the DECLARATION, not the binding, and legs B and C are the mutations of what they do name.

The fold list was made load-bearing for leg B: `DETAIL_SECTION_NODE_INPUTS` was a list the pin merely compared against the registration while a hand-written destructure did the folding. Two copies, so the list could keep agreeing with the declaration while the fold drifted away from both. The component now folds by iterating that list.

## CONTROL — what did not move, proven

```
packages/plugin-detail/src/DetailSection.tsx
  merge-base blob  ef5b7859084a73537a55140ab5303861d9fac8bc
  HEAD blob        ef5b7859084a73537a55140ab5303861d9fac8bc
  worktree         ef5b7859084a73537a55140ab5303861d9fac8bc   -> IDENTICAL
```

The registration's `inputs` array: `git diff MERGE_BASE..HEAD -- packages/plugin-detail/src/index.tsx` contains **no line inside it**. `@object-ui/types` is untouched. Five in-repo `DetailSection` call sites (`DetailView` x4, `SectionGroup`) pass `section={…}` as direct JSX children and go nowhere near the registry, so none of them is on this diff.

## Verification

Diffed against `git merge-base origin/main HEAD` = `b775500af` (4 files, +424/-2).

| What | Command | Result |
|---|---|---|
| the new pin | `pnpm exec vitest run packages/plugin-detail/src/__tests__/detailSectionAuthoredNode-8626.test.tsx` | `Test Files 1 passed`, `Tests 7 passed` |
| affected package | `pnpm exec vitest run packages/plugin-detail/` | `Test Files 173 passed (173)`, `Tests 1602 passed (1602)` |
| types | `pnpm --filter @object-ui/plugin-detail type-check` | exit 0 — and `tsc -p tsconfig.test.json --listFiles` lists BOTH new files, so the test leg really covers them |
| dependency closure | `pnpm --filter '@object-ui/plugin-detail^...' build` | exit 0 |
| changeset | `node scripts/check-changeset-presence.mjs` | `✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| control bytes | `pnpm check:control-bytes` | `✅ OK (scanned 7411 tracked text file(s))` |
| line citations | `pnpm check:new-line-citations` | `VERDICT new-cross-file-line-citations: 0 new citation(s) -> exit 0` |
| documented types | `pnpm check:doc-types` | `✅ Every documented component type is registered.` |

**Lint is narrowed, and the narrowing is declared.** `eslint --format json` over the three touched source files: **3 files linted, 0 errors, 32 warnings**, all `react-refresh/only-export-components` (31 pre-existing in `index.tsx`, 1 new for the exported fold list). The narrowing is safe to read as a measurement because **type-aware linting is not enabled** — `eslint.config.js` declares no `parserOptions.project` and no `projectService` anywhere — so this diff cannot move the verdict on any file it does not contain. The repo-wide run (`turbo run lint`, which sets no `--max-warnings` by deliberate policy) is CI's.

## Acceptance notes

- **Filed: #9218** — `DetailSection`'s collapsible branch never reads `section.showBorder`, so a declared `showBorder: false` keeps its border. Found as a failing assertion while writing this pin. NOT fixed here: it lives inside `DetailSection`, which is this PR's declared CONTROL, and it is a different defect class. The pin's `showBorder` row authors `collapsible: false` for exactly that reason and says so in place.
- **Noted, not filed** — the registration declares 8 of the 11 members `DetailViewSection` carries. `name`, `icon` and `visible` are undeclared, and `section.icon` IS read by the component, so an SDUI author cannot reach an affordance the renderer honours. Not filed: the validator WARNS on those keys rather than dropping them silently, so it is a decision to WIDEN the authoring surface (a product question), not a defect. Whoever picks up #8626's reserved question will be standing on this exact file.
- **Out of scope, untouched** — objectui#6955's input value-vocabulary question, per the card.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_