### PR TITLE
fix(grid): withhold a row's Edit/Delete when the host refuses that record (objectui#8674)

### DIFF
--- a/.changeset/8674-objectgrid-row-operations.md
+++ b/.changeset/8674-objectgrid-row-operations.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/plugin-grid': minor
+'@object-ui/plugin-designer': patch
+---
+
+Per-row operation gating for `ObjectGrid`, and the Field Designer stops drawing a
+delete action it refuses to run (objectui#8674).
+
+**The defect.** `FieldDesigner`'s `handleDelete` returned early on `field.isSystem` —
+before the confirm dialog — while the affordance was wired at the GRID level
+(`onDelete={readOnly ? undefined : handleDelete}`). `ObjectGrid` takes one grid-level
+`onDelete` and derives `{ update: !!onEdit, delete: !!onDelete }`, so the row action
+was drawn for every row: clicking delete on a system field produced no dialog, no
+toast and no console message. `readOnly` was honest in the same component (the
+callback is withheld, so no button is drawn); `isSystem` drew the button and dropped
+the click. The two states differed in the code and did not differ on screen.
+
+**`@object-ui/plugin-grid` — new, additive, opt-in.** `ObjectGridComponentProps`
+gains `rowOperations?: (record) => { update?: boolean; delete?: boolean }`, with the
+new `ObjectGridRowOperations` type exported from the package root. It speaks the same
+`update` / `delete` vocabulary the authored `operations` block speaks, resolved for
+one row instead of for the grid, and it is an INTERSECTION like every layer around it
+(the ADR-0103 lifecycle bucket, the object's `userActions`, the server's effective API
+operations, the principal's own grant, the record-level explain verdict): `false`
+withholds, and nothing it returns can re-open what those closed. A caller that passes
+no predicate renders exactly what it rendered before — measured, not asserted: the
+rendered DOM of a no-predicate grid is byte-identical across this change, and every
+other `<ObjectGrid>` call site in the repository is such a caller.
+
+It is a function value, so no metadata document can hold it and none is invited to:
+like the nine `on*` callbacks it sits beside, it is a renderer prop and not an
+authorable key.
+
+**`@object-ui/plugin-designer` — the first caller, and the user-visible fix.** The
+Field Designer passes the predicate, so a system field's row no longer offers Delete
+at all. Edit is untouched: the drawer still opens for a system field, with `name` and
+`type` disabled exactly as before — `isSystem` has never meant "this row is
+untouchable". The guard inside `handleDelete` stays as a second line for direct
+callers of the prop value, but it is no longer the only refusal.

--- a/content/docs/plugins/plugin-grid.mdx
+++ b/content/docs/plugins/plugin-grid.mdx
@@ -485,6 +485,47 @@ The declarative alternative, which *is* metadata and survives a round trip
 through storage, is `navigation`: its `mode` decides what a row click does
 without any host code.
 
+### Withholding a row's Edit or Delete
+
+`operations` and the `onEdit` / `onDelete` wiring are GRID-level: they decide
+whether the generic Edit / Delete entries exist at all, identically for every
+row. When the refusal belongs to one RECORD — a system field a designer may not
+drop — use `rowOperations`, a component prop called with a row record that
+answers for that row alone:
+
+```tsx
+import { ObjectGrid } from '@object-ui/plugin-grid';
+import type { ObjectGridSchema } from '@object-ui/types';
+
+const schema: ObjectGridSchema = {
+  type: 'object-grid',
+  objectName: 'field_definition',
+  columns: ['name', 'label', 'type'],
+};
+
+export const FieldList = ({ isSystem }: { isSystem: (name: string) => boolean }) => (
+  <ObjectGrid
+    schema={schema}
+    onEdit={(record) => console.log('edit', record)}
+    onDelete={(record) => console.log('delete', record)}
+    rowOperations={(record) => ({ delete: !isSystem(String(record.name)) })}
+  />
+);
+```
+
+It speaks the same `update` / `delete` vocabulary as the authored `operations`
+block, and it is an **intersection**, never a union: `false` withholds the
+entry, while `true`, an omitted member, and a `null` / `undefined` return all
+leave the grid's own verdict alone. Nothing it returns can re-open what the
+object's lifecycle bucket, its `userActions`, the server's effective operations,
+the principal's grant or the record-level verdict already closed — and a grid
+that passes no `rowOperations` renders exactly as it did before the prop
+existed.
+
+Prefer this over refusing inside the callback. A refusal that runs after the
+click ships a button that is drawn as available and then does nothing, which is
+indistinguishable from a broken build (objectui#8674).
+
 ### Inline Editing
 
 Enable inline cell editing for quick data updates:

--- a/packages/plugin-designer/src/FieldDesigner.tsx
+++ b/packages/plugin-designer/src/FieldDesigner.tsx
@@ -183,8 +183,37 @@ export function FieldDesigner({
     }
   }, [fields]);
 
+  /**
+   * [objectui#8674] Which generic row operations THIS row may be offered.
+   *
+   * The delete refusal used to live only inside {@link handleDelete}, which
+   * runs after the click: `ObjectGrid` takes ONE grid-level `onDelete` and drew
+   * the row action for every row, so a system field showed a delete button that
+   * answered a click with nothing at all — no dialog, no toast, no console
+   * message. `readOnly` was already honest (the callback is withheld, so no
+   * button is drawn); `isSystem` was not. This is the same refusal, moved to
+   * where it can withhold the affordance instead of swallowing its click.
+   *
+   * `isSystem` is the spelling the drawer form already uses to disable `name`
+   * and `type` on a system field — the one concept, "this field's structure is
+   * not the designer's to change", not a second one.
+   *
+   * An unresolvable row is withheld too, for the same reason and not as a
+   * defensive flourish: `handleDelete` returns early when the lookup misses, so
+   * offering delete for such a row would reproduce the exact defect this card
+   * is about.
+   */
+  const rowOperations = useCallback((record: Record<string, unknown>) => {
+    const field = fields.find((f) => f.name === record.name);
+    return { delete: !!field && !field.isSystem };
+  }, [fields]);
+
   const handleDelete = useCallback(async (record: Record<string, unknown>) => {
     const field = fields.find((f) => f.name === record.name);
+    // Unreachable through the grid now that `rowOperations` withholds the
+    // action for exactly these two cases — kept because this callback is a
+    // published prop value and nothing stops a future caller invoking it
+    // directly. It must never become the ONLY refusal again.
     if (!field || field.isSystem) return;
     const confirmed = await confirmDialog.confirm(
       t('appDesigner.fieldDesigner.deleteConfirmTitle'),
@@ -416,6 +445,7 @@ export function FieldDesigner({
         dataSource={dataSource}
         onEdit={readOnly ? undefined : handleEdit}
         onDelete={readOnly ? undefined : handleDelete}
+        rowOperations={rowOperations}
         onAddRecord={readOnly ? undefined : handleAddField}
       />
 

--- a/packages/plugin-designer/src/__tests__/FieldDesigner.systemFieldDelete-8674.test.tsx
+++ b/packages/plugin-designer/src/__tests__/FieldDesigner.systemFieldDelete-8674.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8674 — the Field Designer offers no delete action on a system field.
+ *
+ * ## The card
+ *
+ * `handleDelete` returned early on `field.isSystem`, before the confirm dialog,
+ * while the affordance was wired at the GRID level
+ * (`onDelete={readOnly ? undefined : handleDelete}`). `ObjectGrid` derives
+ * `{ update: !!onEdit, delete: !!onDelete }` for the whole grid, so the row
+ * action was drawn for EVERY row: clicking delete on a system field produced no
+ * dialog, no toast and no console message. `readOnly` was already honest in the
+ * same component — the operation is withheld, so no button is drawn — and the
+ * card's sentence for why that difference is the defect is that the two states
+ * "differ in the code and do not differ on screen".
+ *
+ * ## Why this file renders the REAL `ObjectGrid`
+ *
+ * Its siblings here mock `@object-ui/plugin-grid` (`__mocks__/plugin-grid`),
+ * and that mock draws a delete button for every row whenever `onDelete` is
+ * wired — i.e. it reproduces the defect by construction and cannot see the fix.
+ * The claim under test is about what the GRID draws for a row, so the grid
+ * under test has to be the real one; a stub grid would make this file green
+ * against the defect and against the fix alike.
+ *
+ * ## Every absence is paired with a presence
+ *
+ * The system row's missing Delete is read next to its surviving Edit (the row
+ * still has a menu, and the designer still opens the drawer for system fields —
+ * where `name` and `type` are disabled and everything else is editable), and
+ * next to the ordinary row that keeps both. A lone `queryBy… === null` would be
+ * green if the grid never rendered or the menu never opened.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import type { DesignerFieldDefinition } from '@object-ui/types';
+import { ActionProvider } from '@object-ui/react';
+
+import { FieldDesigner } from '../FieldDesigner';
+// The REAL record-level explain double and cache reset the grid suites use —
+// imported rather than restated, so this file answers that probe the same way
+// `plugin-grid`'s own suites do instead of hitting the network under happy-dom.
+import { installExplainDouble } from '../../../plugin-grid/src/__tests__/explainDouble';
+import { __clearRecordCrudVerdictCache } from '../../../plugin-grid/src/hooks/useRecordCrudVerdicts';
+
+// No `registerAllFields()`: `@object-ui/fields` is not a dependency of this
+// package, and nothing here needs a field WIDGET — the assertions read row text
+// and the row kebab's entries, both of which the grid renders on its own.
+
+/** An ordinary, author-created field — the presence half of every pair. */
+const CUSTOM: DesignerFieldDefinition = {
+  id: 'fld_custom',
+  name: 'nickname',
+  label: 'Nickname',
+  type: 'text',
+  isSystem: false,
+};
+
+/** A system field: the designer may not drop it, and now does not offer to. */
+const SYSTEM: DesignerFieldDefinition = {
+  id: 'fld_system',
+  name: 'created_at',
+  label: 'Created At',
+  type: 'datetime',
+  isSystem: true,
+};
+
+const FIELDS = [CUSTOM, SYSTEM];
+
+function renderDesigner(props: Partial<React.ComponentProps<typeof FieldDesigner>> = {}) {
+  return render(
+    <ActionProvider>
+      <FieldDesigner objectName="contacts" fields={FIELDS} onFieldsChange={vi.fn()} {...props} />
+    </ActionProvider>,
+  );
+}
+
+/** What the kebab of the row displaying `label` surfaces. Located by ROW. */
+async function rowKebab(label: string): Promise<{ edit: boolean; delete: boolean; trigger: boolean }> {
+  const row = screen.getByText(label).closest('tr');
+  const trigger = row?.querySelector('[data-testid="row-action-trigger"]');
+  if (!trigger) return { edit: false, delete: false, trigger: false };
+  await userEvent.click(trigger);
+  const answer = {
+    edit: screen.queryAllByTestId('row-action-builtin-edit').length > 0,
+    delete: screen.queryAllByTestId('row-action-builtin-delete').length > 0,
+    trigger: true,
+  };
+  await userEvent.keyboard('{Escape}');
+  return answer;
+}
+
+async function settle() {
+  await waitFor(() => expect(screen.getByText(SYSTEM.name)).toBeInTheDocument());
+}
+
+beforeEach(() => {
+  __clearRecordCrudVerdictCache();
+  installExplainDouble();
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('objectui#8674 · the system field draws no delete action', () => {
+  it('withholds Delete on the system row and keeps it on the custom row', async () => {
+    // BOTH ARMS in one render. Pre-fix this read `delete: true` on BOTH rows
+    // and the system row's click did nothing at all.
+    renderDesigner();
+    await settle();
+
+    expect(await rowKebab(SYSTEM.name)).toEqual({ edit: true, delete: false, trigger: true });
+    expect(await rowKebab(CUSTOM.name)).toEqual({ edit: true, delete: true, trigger: true });
+  });
+
+  it('keeps the system row editable — the drawer still opens, it is only delete that is refused', async () => {
+    // The narrowing is `delete` only. `isSystem` disables `name` and `type`
+    // inside the drawer form; it has never meant "this row is untouchable", and
+    // a fix that withheld Edit too would be a capability regression wearing a
+    // bug fix's clothes.
+    renderDesigner();
+    await settle();
+
+    const row = screen.getByText(SYSTEM.name).closest('tr');
+    await userEvent.click(row!.querySelector('[data-testid="row-action-trigger"]')!);
+    await userEvent.click(screen.getAllByTestId('row-action-builtin-edit')[0]);
+
+    await waitFor(() => expect(screen.getByDisplayValue(SYSTEM.label)).toBeInTheDocument());
+  });
+
+  it('readOnly stays honest: no row actions at all, for either kind of field', async () => {
+    // The state the card called the honest one, unchanged by this fix.
+    renderDesigner({ readOnly: true });
+    await settle();
+
+    expect(await rowKebab(SYSTEM.name)).toEqual({ edit: false, delete: false, trigger: false });
+    expect(await rowKebab(CUSTOM.name)).toEqual({ edit: false, delete: false, trigger: false });
+  });
+});

--- a/packages/plugin-grid/README.md
+++ b/packages/plugin-grid/README.md
@@ -587,6 +587,47 @@ The declarative alternative, which *is* metadata and survives a round trip throu
 storage, is `navigation`: `{ mode: 'page' | 'drawer' | 'modal' | 'split' | 'none' }`
 decides what a row click does without any host code.
 
+### Withholding a row's Edit or Delete
+
+`operations` and the `onEdit` / `onDelete` wiring are GRID-level: they decide
+whether the generic Edit / Delete entries exist at all, identically for every
+row. When the refusal belongs to one RECORD — a system field a designer may not
+drop — use `rowOperations`, a component prop called with a row record that
+answers for that row alone:
+
+```tsx
+import { ObjectGrid } from '@object-ui/plugin-grid';
+import type { ObjectGridSchema } from '@object-ui/types';
+
+const schema: ObjectGridSchema = {
+  type: 'object-grid',
+  objectName: 'field_definition',
+  columns: ['name', 'label', 'type'],
+};
+
+export const FieldList = ({ isSystem }: { isSystem: (name: string) => boolean }) => (
+  <ObjectGrid
+    schema={schema}
+    onEdit={(record) => console.log('edit', record)}
+    onDelete={(record) => console.log('delete', record)}
+    rowOperations={(record) => ({ delete: !isSystem(String(record.name)) })}
+  />
+);
+```
+
+It speaks the same `update` / `delete` vocabulary as the authored `operations`
+block, and it is an **intersection**, never a union: `false` withholds the
+entry, while `true`, an omitted member, and a `null` / `undefined` return all
+leave the grid's own verdict alone. Nothing it returns can re-open what the
+object's lifecycle bucket, its `userActions`, the server's effective operations,
+the principal's grant or the record-level verdict already closed — and a grid
+that passes no `rowOperations` renders exactly as it did before the prop
+existed.
+
+Prefer this over refusing inside the callback. A refusal that runs after the
+click ships a button that is drawn as available and then does nothing, which is
+indistinguishable from a broken build (objectui#8674).
+
 ### Inline Editing
 
 Enable inline cell editing for quick updates:

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -453,10 +453,58 @@ export interface ObjectGridExternalPaginationProps
  * The barrel keeps `ObjectGridProps` as a deprecated alias of this type, so no
  * importer breaks. Tripwire: `__tests__/spec-symbol-4650.test.ts`.
  */
+/**
+ * The subset of the grid-level `operations` block that a row may answer for
+ * ITSELF — the vocabulary {@link ObjectGridComponentProps.rowOperations} speaks.
+ *
+ * `update` / `delete` are the two the row kebab renders, and they are spelled
+ * exactly as the authored `operations` block spells them, so one word means one
+ * thing whether it is declared for the whole grid or resolved for one row. The
+ * block's other members (`create`, `export`) are deliberately absent: neither
+ * is a row affordance, so a per-row answer for them would have nowhere to land.
+ */
+export interface ObjectGridRowOperations {
+  update?: boolean;
+  delete?: boolean;
+}
+
 export interface ObjectGridComponentProps extends ObjectGridExternalPaginationProps {
   schema: ObjectGridSchema;
   dataSource?: DataSource;
   className?: string;
+  /**
+   * [objectui#8674] Narrow ONE row's generic Edit / Delete entries — the layer
+   * that lets a host withhold an operation the record itself cannot accept.
+   *
+   * ## Why this exists
+   *
+   * `operations` and the `onEdit` / `onDelete` wiring are GRID-level: they say
+   * whether the affordance exists at all, identically for every row. A host
+   * whose refusal is per RECORD had nowhere to put it, so it put the refusal in
+   * the callback instead — `FieldDesigner`'s delete handler returned early on a
+   * system field, after the grid had already drawn the button. The two states
+   * it was distinguishing (`readOnly`, which withholds the callback, and
+   * `isSystem`, which swallowed the click) differed in the code and did not
+   * differ on screen: the author clicked a button drawn as available and got no
+   * dialog, no toast, no console message. The operation an affordance cannot
+   * perform is not offered.
+   *
+   * ## The contract
+   *
+   * Called with a row record; returns the overrides for THAT row. It is an
+   * INTERSECTION, like every layer around it (the ADR-0103 bucket, the object's
+   * `userActions`, the server's effective API operations, the principal's own
+   * grant and the record-level explain verdict): `false` WITHHOLDS, and nothing
+   * it returns can re-open what those closed. `true`, an omitted member, a
+   * `null` / `undefined` return, and an absent prop all leave the verdict
+   * exactly as the grid resolved it — so a caller that passes nothing renders
+   * what it rendered before this prop existed.
+   *
+   * Scope is the row's kebab. Bulk delete rides `onBulkDelete` and the object
+   * verdict behind the selection bar, which no per-row answer can speak for:
+   * one selected row's `false` must not silently drop the other rows' action.
+   */
+  rowOperations?: (record: any) => ObjectGridRowOperations | null | undefined;
   onRowClick?: (record: any) => void;
   onEdit?: (record: any) => void;
   onDelete?: (record: any) => void;
@@ -1041,6 +1089,7 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
   dataSource,
   onEdit,
   onDelete,
+  rowOperations,
   onBulkDelete,
   onRowSelect,
   onRowClick,
@@ -3425,61 +3474,76 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
       // extent and is hidden). Excluded from the frozen-column decision below so
       // this auto-pin doesn't cancel the default left-freeze of the first column.
       pinned: 'right',
-      cell: (_value: any, row: any) => (
-        <RowActionMenu
-          row={row}
-          rowActions={customRowActions}
-          rowActionDefs={resolvedRowActionDefs as any[]}
-          objectFields={objectSchema?.fields}
-          // NON-AUTHOR SURFACE — `maxInlineRowActions` is deliberately
-          // absent from `GRID_QUERY_INPUTS` (maintainer ruling, 2026-08-18,
-          // objectui#5091), so this cast read is deliberate, not missed. It is
-          // a host/internal switch for the inline-button budget before the
-          // rest fold into the "⋮" menu — an embedder's layout call, set from
-          // code (`apps/console/src/dev/DevRowActions.tsx:51`), never from a
-          // view document. `ComponentPropsMap['object-grid']` is a
-          // `strictObject` and rejects the key by name, so publishing it would
-          // advertise a key the save gate refuses. The `?? 1` default is the
-          // published behaviour and stays the one an author sees. Pinned by
-          // `__tests__/gridNonAuthorKeys.test.tsx`.
-          maxInlineActions={(schema as any).maxInlineRowActions ?? 1}
-          // [#4296] The object verdict ANDed with THIS row's record-level one.
-          // It rides the same per-row channel the #2614 predicates ride —
-          // `planRowActionMenu` conjoins `canEdit`/`canDelete` with
-          // `visibleWhen` in one expression, so the item and the "⋮" guard read
-          // one decision (#3562) and a hidden row grows no empty trigger. An
-          // unanswered row keeps the object verdict, i.e. today's rendering.
-          canEdit={resolveRowRecordCrudAffordance(canEdit, recordVerdict(rowRecordId(row), 'update'))}
-          canDelete={resolveRowRecordCrudAffordance(canDelete, recordVerdict(rowRecordId(row), 'delete'))}
-          editPredicates={editPredicates}
-          deletePredicates={deletePredicates}
-          onEdit={onEdit}
-          onDelete={onDelete}
-          onAction={(action, r) => {
-            void executeAction({ type: action, params: { record: r } }).then(res => {
-              // A successful row action typically mutated this record; refresh
-              // so the grid reflects the server state (same rationale as bulk).
-              if (res?.success) setRefreshKey(k => k + 1);
-            });
-          }}
-          onActionDef={(def, r) => {
-            // Dispatch schema-driven row action through the runner. We forward
-            // the full action def so type/target/recordIdParam/bodyShape/etc.
-            // route correctly, attach the row record under `_rowRecord` for the
-            // apiHandler row-id injection, and surface raw `params` as
-            // `actionParams` so the runner shows the param dialog when present.
-            const { params: rawParams, ...rest } = def;
-            const dispatch: any = { ...rest };
-            if (Array.isArray(rawParams) && rawParams.length > 0) {
-              dispatch.actionParams = rawParams;
-            }
-            dispatch.params = { _rowRecord: r };
-            void executeAction(dispatch).then(res => {
-              if (res?.success) setRefreshKey(k => k + 1);
-            });
-          }}
-        />
-      ),
+      cell: (_value: any, row: any) => {
+        // [objectui#8674] The CALLER's answer for this one row, resolved
+        // once per row and ANDed into the two verdicts below. A host whose
+        // refusal is per record (a system field the designer may not drop)
+        // has no other place to put it: `operations` and the `onEdit` /
+        // `onDelete` wiring are grid-level and identical for every row, so
+        // the refusal used to live in the callback and fire AFTER the button
+        // had been drawn and clicked. Narrowing only — see `rowOperations`.
+        const rowOps = rowOperations?.(row);
+        return (
+          <RowActionMenu
+            row={row}
+            rowActions={customRowActions}
+            rowActionDefs={resolvedRowActionDefs as any[]}
+            objectFields={objectSchema?.fields}
+            // NON-AUTHOR SURFACE — `maxInlineRowActions` is deliberately
+            // absent from `GRID_QUERY_INPUTS` (maintainer ruling, 2026-08-18,
+            // objectui#5091), so this cast read is deliberate, not missed. It is
+            // a host/internal switch for the inline-button budget before the
+            // rest fold into the "⋮" menu — an embedder's layout call, set from
+            // code (`apps/console/src/dev/DevRowActions.tsx:51`), never from a
+            // view document. `ComponentPropsMap['object-grid']` is a
+            // `strictObject` and rejects the key by name, so publishing it would
+            // advertise a key the save gate refuses. The `?? 1` default is the
+            // published behaviour and stays the one an author sees. Pinned by
+            // `__tests__/gridNonAuthorKeys.test.tsx`.
+            maxInlineActions={(schema as any).maxInlineRowActions ?? 1}
+            // [#4296] The object verdict ANDed with THIS row's record-level one.
+            // It rides the same per-row channel the #2614 predicates ride —
+            // `planRowActionMenu` conjoins `canEdit`/`canDelete` with
+            // `visibleWhen` in one expression, so the item and the "⋮" guard read
+            // one decision (#3562) and a hidden row grows no empty trigger. An
+            // unanswered row keeps the object verdict, i.e. today's rendering.
+            // [objectui#8674] `rowOps` is the third narrowing in this one
+            // expression, and an INTERSECTION like the two around it: only
+            // `false` removes, so a caller that passes no `rowOperations` —
+            // every caller but the field designer today — reads exactly the
+            // verdict this line carried before the prop existed.
+            canEdit={resolveRowRecordCrudAffordance(canEdit && rowOps?.update !== false, recordVerdict(rowRecordId(row), 'update'))}
+            canDelete={resolveRowRecordCrudAffordance(canDelete && rowOps?.delete !== false, recordVerdict(rowRecordId(row), 'delete'))}
+            editPredicates={editPredicates}
+            deletePredicates={deletePredicates}
+            onEdit={onEdit}
+            onDelete={onDelete}
+            onAction={(action, r) => {
+              void executeAction({ type: action, params: { record: r } }).then(res => {
+                // A successful row action typically mutated this record; refresh
+                // so the grid reflects the server state (same rationale as bulk).
+                if (res?.success) setRefreshKey(k => k + 1);
+              });
+            }}
+            onActionDef={(def, r) => {
+              // Dispatch schema-driven row action through the runner. We forward
+              // the full action def so type/target/recordIdParam/bodyShape/etc.
+              // route correctly, attach the row record under `_rowRecord` for the
+              // apiHandler row-id injection, and surface raw `params` as
+              // `actionParams` so the runner shows the param dialog when present.
+              const { params: rawParams, ...rest } = def;
+              const dispatch: any = { ...rest };
+              if (Array.isArray(rawParams) && rawParams.length > 0) {
+                dispatch.actionParams = rawParams;
+              }
+              dispatch.params = { _rowRecord: r };
+              void executeAction(dispatch).then(res => {
+                if (res?.success) setRefreshKey(k => k + 1);
+              });
+            }}
+          />
+        );
+      },
       sortable: false,
     },
   ] : persistedColumns;

--- a/packages/plugin-grid/src/__tests__/rowOperationsPerRow-8674.test.tsx
+++ b/packages/plugin-grid/src/__tests__/rowOperationsPerRow-8674.test.tsx
@@ -154,9 +154,17 @@ describe('objectui#8674 · the row a predicate refuses does not draw the action'
     // principal's grant, the record-level verdict). A prop that could widen
     // would be the one hole in that chain, and a host could hand a user an
     // affordance the object's own policy removed.
+    //
+    // The two members are set in OPPOSITE directions on purpose, so this reads
+    // the wiring rather than a vacuous truth: the grid opens `update` and the
+    // predicate closes it (Edit must go — an assertion that dies with the
+    // wiring), while the grid closes `delete` and the predicate says `true`
+    // (Delete must stay gone — the union claim itself). A test that only made
+    // the union claim would stay green with the whole mechanism deleted,
+    // because an unconsulted predicate cannot widen anything either.
     renderGrid({
-      operations: { update: false, delete: false },
-      rowOperations: () => ({ update: true, delete: true }),
+      operations: { update: true, delete: false },
+      rowOperations: () => ({ update: false, delete: true }),
     });
     await settle();
 

--- a/packages/plugin-grid/src/__tests__/rowOperationsPerRow-8674.test.tsx
+++ b/packages/plugin-grid/src/__tests__/rowOperationsPerRow-8674.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8674 — `rowOperations`, the per-row narrowing of the grid's generic
+ * Edit / Delete entries.
+ *
+ * ## What the card measured
+ *
+ * `ObjectGrid` takes ONE grid-level `onDelete` and derives
+ * `{ update: !!onEdit, delete: !!onDelete }`, so the row action was drawn for
+ * every row. A host whose refusal is per RECORD had nowhere to put it and put
+ * it in the callback instead: `FieldDesigner`'s delete handler returned early
+ * on a system field, AFTER the button had been drawn and clicked — no dialog,
+ * no toast, no console message. `readOnly` was honest in the same component
+ * (the callback is withheld, so no button is drawn); `isSystem` was not.
+ *
+ * ## Why every assertion here is a RENDERED-AFFORDANCE assertion
+ *
+ * "the predicate was called" and "the prop was passed" are both green against
+ * the defect: the old code called `handleDelete` too, and drew the button
+ * anyway. The only thing that distinguishes the fix is what the row OFFERS, so
+ * each test below opens a real kebab and reads the entries out of it.
+ *
+ * Each absence is paired with a presence in the SAME render — the withheld
+ * entry against the surviving one on that row, and against the neighbouring
+ * row that keeps both. An absence on its own is equally green when the grid
+ * never rendered, the row was addressed wrongly, or the menu never opened.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import type { ObjectGridRowOperations } from '../ObjectGrid';
+import { __clearRecordCrudVerdictCache } from '../hooks/useRecordCrudVerdicts';
+import { installExplainDouble } from './explainDouble';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+
+registerAllFields();
+
+/** The row the host has no objection to — the presence half of every pair. */
+const ORDINARY = { id: 'r_ordinary', name: 'Ordinary' };
+/** The row the host refuses to delete — the card's system field, generically. */
+const LOCKED = { id: 'r_locked', name: 'Locked' };
+const ROWS = [ORDINARY, LOCKED];
+
+interface Case {
+  /** Omitted entirely when absent — the control renders no such attribute. */
+  rowOperations?: (record: any) => ObjectGridRowOperations | null | undefined;
+  /** An explicit grid-level `operations` block, when the case needs one. */
+  operations?: Record<string, boolean>;
+}
+
+function renderGrid(c: Case = {}) {
+  const schema: any = {
+    type: 'object-grid',
+    objectName: 'test_object',
+    columns: [{ field: 'name', label: 'Name' }],
+    data: { provider: 'value', items: ROWS },
+    ...(c.operations ? { operations: c.operations } : {}),
+  };
+  return render(
+    <ActionProvider>
+      <ObjectGrid
+        schema={schema}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        {...(c.rowOperations ? { rowOperations: c.rowOperations } : {})}
+      />
+    </ActionProvider>,
+  );
+}
+
+/**
+ * What the kebab of the row displaying `label` surfaces.
+ *
+ * Located by ROW rather than by index: a row whose entries are all hidden grows
+ * no "⋮" trigger at all (#3562), so indexing into `queryAllByTestId` would
+ * silently address a different row as soon as the gating works.
+ */
+async function rowKebab(label: string): Promise<{ edit: boolean; delete: boolean; trigger: boolean }> {
+  const row = screen.getByText(label).closest('tr');
+  const trigger = row?.querySelector('[data-testid="row-action-trigger"]');
+  if (!trigger) return { edit: false, delete: false, trigger: false };
+  await userEvent.click(trigger);
+  const answer = {
+    edit: screen.queryAllByTestId('row-action-builtin-edit').length > 0,
+    delete: screen.queryAllByTestId('row-action-builtin-delete').length > 0,
+    trigger: true,
+  };
+  // Close the (portalled) menu so the next row's read sees only its own items.
+  await userEvent.keyboard('{Escape}');
+  return answer;
+}
+
+async function settle() {
+  await waitFor(() => expect(screen.getByText(LOCKED.name)).toBeInTheDocument());
+}
+
+beforeEach(() => {
+  __clearRecordCrudVerdictCache();
+  installExplainDouble();
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('objectui#8674 · the row a predicate refuses does not draw the action', () => {
+  it('withholds Delete on the refused row and keeps it on the row beside it', async () => {
+    // BOTH ARMS, one render. Pre-fix the refused row answered `delete: true`
+    // and the click did nothing — that is the whole card.
+    renderGrid({ rowOperations: (record) => ({ delete: record.name !== LOCKED.name }) });
+    await settle();
+
+    expect(await rowKebab(LOCKED.name)).toEqual({ edit: true, delete: false, trigger: true });
+    expect(await rowKebab(ORDINARY.name)).toEqual({ edit: true, delete: true, trigger: true });
+  });
+
+  it('gates update and delete independently, in the grid-level vocabulary', async () => {
+    renderGrid({ rowOperations: (record) => (record.name === LOCKED.name ? { update: false } : null) });
+    await settle();
+
+    expect(await rowKebab(LOCKED.name)).toEqual({ edit: false, delete: true, trigger: true });
+    expect(await rowKebab(ORDINARY.name)).toEqual({ edit: true, delete: true, trigger: true });
+  });
+
+  it('hides rather than disables — a row refused everything grows no "⋮" at all', async () => {
+    renderGrid({
+      rowOperations: (record) =>
+        record.name === LOCKED.name ? { update: false, delete: false } : undefined,
+    });
+    await settle();
+
+    expect(await rowKebab(LOCKED.name)).toEqual({ edit: false, delete: false, trigger: false });
+    // …while the untouched row on the same screen keeps its trigger, so the
+    // absence above is a verdict and not an empty grid.
+    expect(await rowKebab(ORDINARY.name)).toEqual({ edit: true, delete: true, trigger: true });
+  });
+
+  it('never a union: a row-level `true` cannot re-open what the grid closed', async () => {
+    // Every layer around this one is an intersection (the ADR-0103 bucket, the
+    // object's `userActions`, the server's effective operations, the
+    // principal's grant, the record-level verdict). A prop that could widen
+    // would be the one hole in that chain, and a host could hand a user an
+    // affordance the object's own policy removed.
+    renderGrid({
+      operations: { update: false, delete: false },
+      rowOperations: () => ({ update: true, delete: true }),
+    });
+    await settle();
+
+    expect(await rowKebab(ORDINARY.name)).toEqual({ edit: false, delete: false, trigger: false });
+  });
+});
+
+/**
+ * The CONTROL for the additive claim: a caller that passes no predicate must
+ * render what it rendered before the prop existed. Every other `<ObjectGrid>`
+ * in this repository is such a caller.
+ */
+describe('objectui#8674 · CONTROL — a grid with no predicate is unchanged', () => {
+  it('keeps Edit and Delete on every row when `rowOperations` is not passed', async () => {
+    renderGrid();
+    await settle();
+
+    expect(await rowKebab(ORDINARY.name)).toEqual({ edit: true, delete: true, trigger: true });
+    expect(await rowKebab(LOCKED.name)).toEqual({ edit: true, delete: true, trigger: true });
+  });
+
+  it('is equally unchanged when the predicate answers with nothing at all', async () => {
+    // `null`, `undefined` and an empty object are the three ways a host says
+    // "no opinion about this row"; none of them may remove anything.
+    for (const answer of [null, undefined, {}] as const) {
+      renderGrid({ rowOperations: () => answer });
+      await settle();
+      expect(await rowKebab(LOCKED.name)).toEqual({ edit: true, delete: true, trigger: true });
+      cleanup();
+    }
+  });
+});

--- a/packages/plugin-grid/src/index.tsx
+++ b/packages/plugin-grid/src/index.tsx
@@ -38,7 +38,7 @@ export { useGroupReorder } from './useGroupReorder';
 export { useColumnSummary } from './useColumnSummary';
 export { FormulaBar } from './FormulaBar';
 export { SplitPaneGrid } from './SplitPaneGrid';
-export type { ObjectGridComponentProps, ObjectGridExternalPaginationProps, ObjectGridColumnState } from './ObjectGrid';
+export type { ObjectGridComponentProps, ObjectGridExternalPaginationProps, ObjectGridColumnState, ObjectGridRowOperations } from './ObjectGrid';
 
 /**
  * @deprecated Use `ObjectGridComponentProps`. Renamed in objectui#4650 because


### PR DESCRIPTION
Fixes #8674

`ObjectGrid` takes one grid-level `onDelete` and derives `{ update: !!onEdit, delete: !!onDelete }`, so the row action is drawn for every row. A host whose refusal is per RECORD had nowhere to put it and put it in the callback instead: `FieldDesigner`'s `handleDelete` returned early on `field.isSystem`, after the button had been drawn and clicked — no dialog, no toast, no console message. `readOnly` was honest in the same component (the callback is withheld, so no button is drawn); `isSystem` was not.

This adds the per-row operation predicate triage ruled the real content of the card, with `FieldDesigner` as its first caller.

- `packages/plugin-grid` — `ObjectGridComponentProps` gains `rowOperations`, plus the exported `ObjectGridRowOperations` type. Additive, opt-in, narrowing-only.
- `packages/plugin-designer` — `FieldDesigner` passes it, so a system field's row draws no Delete. Edit is untouched.
- Changeset: `plugin-grid` minor (new published prop on a published block), `plugin-designer` patch (the user-visible fix). Judged on the stated test — no existing caller and no stored document renders differently; only the designer's own system rows change, which is the defect being fixed.

## M1 — the shape, measured against the derivation that already exists

The prop is

```ts
rowOperations?: (record: any) => ObjectGridRowOperations | null | undefined;
// ObjectGridRowOperations = { update?: boolean; delete?: boolean }
```

read once per row inside the actions cell and ANDed into the verdict expression that is already there:

```tsx
canDelete={resolveRowRecordCrudAffordance(canDelete && rowOps?.delete !== false, recordVerdict(rowRecordId(row), 'delete'))}
```

**What `ObjectGrid` already does**, which decided this: `resolveRowCrudAffordances` folds the ADR-0103 lifecycle bucket, the object's `userActions`, the server's effective API operations (#3720) and the principal's grant (#4096) into one object-level `{ canEdit, canDelete }`; the actions cell then narrows that per row twice already — the #2614 `visibleWhen` / `disabledWhen` predicates, and the #4296 record-level explain verdict through `resolveRowRecordCrudAffordance`. There was already a per-row seam; what was missing was a channel for the CALLER to speak into it. So this is one more factor in the same conjunction, in the same vocabulary, at the same site — not a parallel mechanism beside it. `false` withholds; `true`, an omitted member, a `null`/`undefined` return and an absent prop all leave the verdict untouched. Never a union: nothing it returns can re-open what the layers above closed, pinned by its own test.

**Against a per-row `operations` callback** (widening the existing key to accept a function): `operations` is an AUTHORED schema key — read as `'operations' in schema`, declared on `ObjectGridSchema`, and accepted by `ComponentPropsMap['object-grid']`, a `strictObject`. A function cannot be serialised into a view document, so the function form could only ever arrive from code while the same key arrives from JSON: two dialects for one key, one of which the save gate refuses (AGENTS.md #0 / #0.1). Rejected.

**Against a `disabledOperations` set**: two independent refusals. It renders the entry and declines the click, which is arm 2 in arm 1's clothes and is what the ruling excludes — the repo's own posture here is hide, not disable (#4296 pins "a fully denied row grows no trigger at all"). And a record-keyed set cannot address these rows: `FieldDesigner`'s own comment records that the grid's `$select` strips `id`, which is why it keys fields by `name`. A set keyed on record id would have gated nothing, silently. Rejected.

## M2 — blast radius, enumerated and then measured

Every `ObjectGrid` call site in the tree, non-test:

| call site | passes a predicate? |
|---|---|
| `packages/plugin-designer/src/FieldDesigner.tsx` | YES — the only one |
| `packages/plugin-designer/src/ObjectManager.tsx` | no |
| `packages/plugin-view/src/ObjectView.tsx` | no |
| `packages/plugin-grid/src/index.tsx` (the SDUI renderer) | no |
| `packages/plugin-grid/demo/bulk-actions.tsx` | no |
| `apps/console/src/dev/DevRowActions.tsx` | no |

(A seventh occurrence, in `packages/fields/src/widgets/RecordPickerDialog.tsx`, is inside a docblock, not a render.) The rest of the 125 occurrences of the string are tests and type-level pins.

**The control is measured, not asserted.** A throwaway harness rendered two no-predicate callers — the real, untouched `ObjectManager`, and a bare grid with `onEdit`/`onDelete` — and dumped every byte each produces: the container HTML plus `document.body` with each row's kebab actually open. It was run twice: once on this branch, once with the three changed source files checked out at the base commit `b775500af` (mutation proved on disk first — the `rowOperations` marker went 6→0 in `ObjectGrid.tsx` and 3→0 in `FieldDesigner.tsx` — and restored by blob hash afterwards).

```
92191 bytes both legs
80f5438a14681caa5760abe343ef540c91050dcecebb6778a84407e9c728c6bb  base.html
80f5438a14681caa5760abe343ef540c91050dcecebb6778a84407e9c728c6bb  head.html
cmp: identical
```

Lit control for the instrument: `row-action-builtin-delete` occurs 4 times in each dump (two callers, two rows each), so the capture really did contain the affordance the change is about, rather than agreeing about an empty page.

Behavioural half, same claim: `packages/plugin-view` — a real consumer — is green unchanged, 37 files / 316 tests.

## M3 — the card's anchors, re-measured on today's tree (located by text, never by line)

- `packages/plugin-designer/src/FieldDesigner.tsx` still carries `if (!field || field.isSystem) return;` as the FIRST statement pair of `handleDelete`, above the `confirmDialog.confirm` call — the card's quote is current.
- `packages/plugin-grid/src/ObjectGrid.tsx` still declares `onDelete?: (record: any) => void` on the renderer props, and still derives `{ update: !!onEdit, delete: !!onDelete }` when the schema declares no `operations`.
- R3 reproduced before building anything: `rowOperations|operationsFor|disabledOperations` across `packages/plugin-grid/src/` = **0**, with `ObjectGrid` at **578** across the same file set as a lit control. The zero was a probe that was looking.

## M4 — the neighbouring honest case

The drawer form's `isSystem` use is two inline reads — `disabled: readOnly || (editingField?.isSystem ?? false)` on the `name` and `type` controls. There is no reusable predicate there to reuse, so the concept's SPELLING is the reuse: this fix reads the same `field.isSystem` flag (the one objectui#6044 made read the spec's `system` key), and it stays scoped to `delete`. `isSystem` has never meant "this row is untouchable" — the drawer opens for a system field and everything but `name`/`type` is editable — so withholding Edit as well would have been a capability regression wearing a bug fix's clothes. Pinned in both directions.

## Ablation — the pins die with the wiring they name

Each leg: mutate, prove the mutation is on disk, run both pins, restore, prove the restore by blob hash against HEAD.

| leg | mutation | grid pin | designer pin |
|---|---|---|---|
| (none) | — | 6 passed | 3 passed |
| A | the two `rowOps?.… !== false` conjunctions deleted from `ObjectGrid` | **4 failed** / 2 passed | **1 failed** / 2 passed |
| B | `rowOperations={rowOperations}` deleted from `FieldDesigner` | 6 passed | **1 failed** / 2 passed |

Leg B leaving the grid pin green is the correct signature, not a gap: that pin passes its own predicate and does not go through the designer. The two grid tests that survive leg A are the no-predicate CONTROLS, which assert the behaviour the ablation restores — a control that reddened there would be the broken one.

Leg A's first run reddened only 3 of 6: the intersection test set both members the same way, so "a row-level `true` cannot re-open what the grid closed" was also satisfied with the mechanism deleted, an unconsulted predicate being unable to widen anything either. That leg is the second commit here — the members now point in opposite directions, so the same test reads the wiring and dies with it.

## Verification

Run at `8f6848e3e`, the head of this branch.

- `pnpm exec vitest run packages/plugin-grid/ packages/plugin-designer/ packages/plugin-view/` — **182 files, 1572 tests, 0 failed**.
- `pnpm --filter @object-ui/plugin-grid --filter @object-ui/plugin-designer type-check` — both `Done`, after building the dependency closure (the first attempt was a PRECONDITION failure on an unbuilt tree, not a red).
- lint, the repo's own invocation (`eslint .`, per each package's `lint` script), both affected packages in full: **217 files, 0 errors** (plugin-grid 162, plugin-designer 55). Narrowed to the two packages the diff touches; the narrowing is sound because this config is not type-aware — `projectService` / `parserOptions` / `project:` match 0 times in `eslint.config.js`, against 8 for the lit control `rules:` — so no untouched file's verdict can move. The other 45 workspace projects go to CI.
- Gates: `check-changeset-presence` OK (1 changeset for 2 released packages), `check-control-bytes` OK, `check-readme-exports` OK (535/535 self-imports real, this PR's new README import among them), `check-doc-snippet-types` OK (644/644 blocks compile against the BUILT `dist/*.d.ts` — which is also what proves the new prop reached the shipped types), `check-doc-fences` OK, `check-doc-example-ids` OK, `check-new-cross-file-line-citations` 0 new, `check-phantom-dependencies` OK, `check-vi-mock-specifiers` OK. `check-governed-queue-guard --test` over the 8 changed paths: NOT GOVERNED.
- NOT MEASURED locally, left to CI: the repo-wide `turbo run lint` / `type-check` farm, the full `pnpm test` shards, E2E, and `apps/console` (an `ObjectGrid` consumer whose suite was not run here).

## Acceptance notes

Found while working, deliberately not fixed here:

- **filed as #9219** — `ObjectManager` has this defect verbatim (`if (!obj || obj.isSystem) return;` under a grid-level `onDelete`, with system objects shown by default). The repair is now three lines, and it was still kept out of this PR for a measured reason: `ObjectManager` is one of the untouched call sites this PR uses as its byte-identical control, and fixing it here would have consumed the control.
- **filed as #9220** — `scripts/check-readme-exports.mjs --list` crashes with a TypeError on an unbuilt tree, i.e. exactly the state its own failure message tells you to inspect. Named repro in the card; the plain run on the same tree reports cleanly, which is the control.
- **noted, not filed** — `packages/plugin-designer/src/__tests__/__mocks__/plugin-grid.tsx` draws a delete button per row whenever `onDelete` is wired and knows nothing about `rowOperations`, so a pin written through that double cannot see this fix. Not filed separately because it has a named taker: it is written into #9219 as the hazard for whoever fixes `ObjectManager`, which is the next PR that will touch it. This PR's designer pin renders the REAL grid for that reason.

⛔ Left as a draft deliberately, not enqueued, no auto-merge — the dispatching seat arms it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_