### PR TITLE
fix(ci): read a locale-catalogue chunk whose content hash contains a hyphen

### DIFF
--- a/scripts/__tests__/check-eager-locale-catalogues.test.ts
+++ b/scripts/__tests__/check-eager-locale-catalogues.test.ts
@@ -81,6 +81,34 @@ describe('the population this gate looks for', () => {
     expect(catalogueCodeOfFileName(`assets/${CATALOGUE_CHUNK_PREFIX}zh-Bx9f1.js`)).toBe('zh');
   });
 
+  it('reads a hash that CONTAINS a hyphen — rolldown names chunks in base64url', () => {
+    // ⛔ Not invented fixtures. These three file names were emitted by one
+    // console build (objectui#9078's head) alongside seven siblings whose
+    // hashes drew no `-`, and the previous matcher read exactly these three as
+    // null — so the gate announced that zh, de and fr "were emitted under no
+    // `i18n-locale-<code>` chunk at all" while all three sat in `assets/`.
+    // Every fixture above this line is hyphen-free, which is why the defect
+    // shipped: the suite could not tell the two spellings apart.
+    expect(catalogueCodeOfFileName('assets/i18n-locale-de-cTrdGXD-.js')).toBe('de');
+    expect(catalogueCodeOfFileName('assets/i18n-locale-fr-CH3jagZ-.js')).toBe('fr');
+    expect(catalogueCodeOfFileName('assets/i18n-locale-zh-Ixe-DTac.js')).toBe('zh');
+    // An underscore is in the same alphabet and was never exercised either.
+    expect(catalogueCodeOfFileName('assets/i18n-locale-ja-Ab_c-1D2.js')).toBe('ja');
+  });
+
+  it('still refuses to read one code as another, which is what the old matcher bought', () => {
+    // The retired spelling constrained the hash in order to keep
+    // `i18n-locale-en-*.js` from being read as some other code's chunk. That
+    // ambiguity is about the CODE, not the hash, so it is answered by matching
+    // the declared codes longest-first — and it must keep being answered.
+    for (const code of BUILT_IN_LANGUAGE_CODES) {
+      expect(catalogueCodeOfFileName(`assets/${CATALOGUE_CHUNK_PREFIX}${code}-Ab-cD.js`)).toBe(code);
+    }
+    // A hash has to actually follow the code.
+    expect(catalogueCodeOfFileName(`assets/${CATALOGUE_CHUNK_PREFIX}zh.js`)).toBeNull();
+    expect(catalogueCodeOfFileName(`assets/${CATALOGUE_CHUNK_PREFIX}zh-.js`)).toBeNull();
+  });
+
   it('claims nothing it should not — the matcher must be able to say no', () => {
     // Without these the verdicts below are statements about a matcher that
     // matches everything, which agrees with every bundle.

--- a/scripts/check-eager-locale-catalogues.mjs
+++ b/scripts/check-eager-locale-catalogues.mjs
@@ -118,14 +118,41 @@ export function catalogueCodeOfChunkName(name) {
   return BUILT_IN_LANGUAGE_CODES.includes(code) ? code : null;
 }
 
-/** `assets/i18n-locale-zh-Bx9f1.js` -> `zh`; anything else -> `null`. */
+/**
+ * `assets/i18n-locale-zh-Bx9f1.js` -> `zh`; anything else -> `null`.
+ *
+ * ⛔ The hash segment is NOT constrained to hyphen-free text, and the premise
+ * that it could be was measured false. Rolldown names a chunk with a
+ * **base64url** content hash, whose alphabet includes `-` and `_`. Measured on
+ * one console build of objectui#9078: `i18n-locale-de-cTrdGXD-.js`,
+ * `i18n-locale-fr-CH3jagZ-.js` and `i18n-locale-zh-Ixe-DTac.js` were emitted
+ * alongside seven siblings whose hashes happened to draw no `-`. A matcher
+ * spelled `${code}-[^-]+\\.js$` read exactly those three as `null`, so the gate
+ * reported three catalogues "emitted under no `i18n-locale-<code>` chunk at
+ * all" while all three sat in `assets/`. Which codes fail is decided by the
+ * content hash, i.e. by chance, and it re-rolls whenever a pack's bytes change
+ * — so this gate went red on roughly a third of the packs in any build that
+ * touched one, and green in the next build for no reason it could name.
+ *
+ * ⭐ What the old spelling actually bought is kept, by a different means. Its
+ * comment gave the reason as "`i18n-locale-en-*.js` cannot be read as some
+ * other code's chunk" — a real ambiguity, but one about the CODE, not the
+ * hash: it appears only when one code is a prefix of another followed by `-`,
+ * e.g. a future regional `zh-CN` beside `zh`. So the remainder is matched
+ * against the declared code list LONGEST FIRST, which resolves that case
+ * correctly (`zh-CN-<hash>.js` reads as `zh-CN`) and is indifferent to what
+ * the hash contains.
+ */
 export function catalogueCodeOfFileName(fileName) {
   if (typeof fileName !== 'string') return null;
   const base = path.basename(fileName);
-  for (const code of BUILT_IN_LANGUAGE_CODES) {
-    // `-` then a rolldown hash then `.js`: the hash never contains a `-`, so
-    // `i18n-locale-en-*.js` cannot be read as some other code's chunk.
-    if (new RegExp(`^${CATALOGUE_CHUNK_PREFIX}${code}-[^-]+\\.js$`).test(base)) return code;
+  if (!base.startsWith(CATALOGUE_CHUNK_PREFIX) || !base.endsWith('.js')) return null;
+  const rest = base.slice(CATALOGUE_CHUNK_PREFIX.length, -'.js'.length);
+  // Longest first, so a code that is a prefix of another never wins over it.
+  const byLength = [...BUILT_IN_LANGUAGE_CODES].sort((a, b) => b.length - a.length);
+  for (const code of byLength) {
+    // A hash must actually follow: `i18n-locale-zh.js` names no chunk here.
+    if (rest.startsWith(`${code}-`) && rest.length > code.length + 1) return code;
   }
   return null;
 }


### PR DESCRIPTION
## The defect

`check-eager-locale-catalogues.mjs` reads a catalogue chunk's language code with

```js
new RegExp(`^${CATALOGUE_CHUNK_PREFIX}${code}-[^-]+\\.js$`)
```

on a premise its own comment states outright:

> `-` then a rolldown hash then `.js`: **the hash never contains a `-`**

⛔ The premise is false. Rolldown names a chunk with a **base64url** content hash, whose alphabet includes `-` and `_`.

## Measured, not argued

One console build — objectui#9078's head `d908ce70a` — emitted ten catalogues. Three of them drew a hash containing `-`:

| emitted file | old matcher reads | actually |
|---|---|---|
| `i18n-locale-de-cTrdGXD-.js` | `null` | `de` |
| `i18n-locale-fr-CH3jagZ-.js` | `null` | `fr` |
| `i18n-locale-zh-Ixe-DTac.js` | `null` | `zh` |
| `i18n-locale-ar-DdtRgb3e.js` + 6 more | their code | their code |

The gate then reported:

> ⚠️ counter-probe failed: 3 of 10 catalogues were emitted under no `i18n-locale-<code>` chunk at all — zh, de, fr. … Until that is fixed this gate is matching nothing, and matching nothing agrees with everything.

and exited **2**, which the `Check console performance budget` step turns into a failed `Bundle Analysis` check. All three files were sitting in `apps/console/dist/assets/` the whole time.

⭐ **Which codes fail is decided by the content hash — i.e. by chance — and it re-rolls whenever a pack's bytes change.** So the gate goes red on roughly a third of the packs in any build that touches a locale pack, and green again in the next build for no reason it can name. It is red on objectui#9078 right now and green on three sibling PRs carrying the same gate, which is the shape of a coin flip, not of a finding.

## What the old spelling bought, and how it is kept

Its comment gave the reason as *"`i18n-locale-en-*.js` cannot be read as some other code's chunk"*. That is a real ambiguity — but it is about the **code**, not the hash: it can only arise when one code is a prefix of another followed by `-`, e.g. a future regional `zh-CN` beside `zh`.

So the remainder is now matched against the declared code list **longest first**, which resolves that case correctly (`zh-CN-<hash>.js` → `zh-CN`) and is indifferent to what the hash contains. A hash must still actually follow the code, so `i18n-locale-zh.js` and `i18n-locale-zh-.js` still read as `null`.

## Verification

- **Unit:** `scripts/__tests__/check-eager-locale-catalogues.test.ts` → **12 passed**.
- **Ablation:** parser reverted to the retired matcher → **2 failed / 10 passed**, and the two failures are exactly the new pins. ⭐ The ten pre-existing tests stay green under the ablation — the old suite genuinely could not see this defect, because every fixture it had was hyphen-free (`Bx9f1`, `Hash1`). That is why it shipped, and the new pins use the **three real emitted file names** rather than invented ones.
- **End to end:** run against the same `apps/console/dist` that made CI red → **exit 0**, all ten catalogues reported, `405.7 KB gzipped is deferred — the 9 catalogue(s) a page load does not fetch.`
- `check-changeset-presence` → *"2 file(s) changed, 0 of them published source of a package the release covers"* ⇒ no changeset owed.
- `check-control-bytes` → OK (7408 tracked text files).

## Scope

Two files, both under `scripts/`. No published package source, no runtime behaviour, no bundle contents change — the gate reads the same build it always read, it just stops mis-parsing three of its file names.

Ref: objectui#9078 (the PR this is currently blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_