### PR TITLE
test(app-shell): characterize the failed-script-action toast chain end to end (objectui#9151)

### DIFF
--- a/.changeset/9151-failed-script-action-toast-characterization.md
+++ b/.changeset/9151-failed-script-action-toast-characterization.md
@@ -1,0 +1,12 @@
+---
+---
+
+Characterize the console's failed-script-action toast chain end to end (objectui#9151).
+
+Test only; no package is released by this change. The new pin drives a real
+`ActionRunner` through the real `createConsoleServerActionHandler` and asserts
+what the toast sink is handed for a refused `POST /api/v1/actions/...` — the
+question three separate readers answered from code rather than from a run.
+It also closes the preimage of "no toast at all" to exactly two shapes: an
+authored `toast: { showOnError: false }`, and a handler returning
+`{ success: false }` with no `error`.

--- a/packages/app-shell/src/utils/__tests__/consoleServerAction.errorToast.test.ts
+++ b/packages/app-shell/src/utils/__tests__/consoleServerAction.errorToast.test.ts
@@ -59,12 +59,11 @@
 
 import { describe, it, expect, vi } from 'vitest';
 
-vi.mock('sonner', () => {
-  const fn: any = vi.fn();
-  fn.error = vi.fn();
-  fn.success = vi.fn();
-  return { toast: fn };
-});
+// `consoleServerAction` imports sonner at module load for its popup-blocked
+// fallback. Nothing here asserts on it; the mock only keeps the import inert.
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() }),
+}));
 
 import { ActionRunner, type ActionDef, type ActionResult } from '@object-ui/core';
 import { createConsoleServerActionHandler } from '../consoleServerAction';

--- a/packages/app-shell/src/utils/__tests__/consoleServerAction.errorToast.test.ts
+++ b/packages/app-shell/src/utils/__tests__/consoleServerAction.errorToast.test.ts
@@ -1,0 +1,187 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9151 — "a failed script action renders no toast", characterized
+ * END TO END through the console's real failure chain.
+ *
+ * ## Why this file exists
+ *
+ * The question "does a server refusal on `POST /api/v1/actions/...` reach the
+ * user?" was re-derived from scratch by three separate readers, each by
+ * reading code rather than running it, and each answer was a theory. It is a
+ * measurable question, so it is measured here once and kept measured.
+ *
+ * The chain under test is the real one, with nothing stubbed between its ends:
+ *
+ *   ActionRunner.execute
+ *     -> the registered `script` handler
+ *        = createConsoleServerActionHandler   (this package)
+ *        -> createServerActionHandler         (@object-ui/core)
+ *           -> interpretActionResponse        (the /actions envelope rule)
+ *     -> ActionRunner.handlePostExecution     (the toast sink)
+ *
+ * Only the transport (`fetch`) and the toast SINK are test doubles. The sink
+ * double stands in for the console's `toastHandler`, which is one `switch` on
+ * `options.type` in `useConsoleActionRuntime` and a byte-identical copy in
+ * `RecordDetailView`; asserting on the payload handed to the sink pins the
+ * contract without copying that mapping into a third place.
+ *
+ * ## What the readings establish
+ *
+ * 1. A 500 carrying a business sentence produces exactly ONE toast, typed
+ *    `error`, carrying that sentence VERBATIM.
+ * 2. The identical body under 400 produces the identical toast. The path is
+ *    status-blind by construction (`!res.ok`), which is why moving a refusal
+ *    from 500 to 4xx — objectstack#17265 / PR objectstack#17679 — changes
+ *    nothing on this path, and why it must not be "fixed" by teaching the
+ *    console to branch on status.
+ * 3. An unreadable body still produces exactly one error toast, on the
+ *    `(HTTP nnn)` fallback. So `result.error` is never empty after a non-ok
+ *    response, and the zero-toast symptom cannot originate in this chain.
+ *
+ * ⇒ The preimage of "zero toast elements" is therefore CLOSED, and the last
+ * two cases below are the whole of it:
+ *
+ *   A. the action declares `toast: { showOnError: false }` — an authorable
+ *      per-action opt-out that the runner honours; or
+ *   B. a handler returns `{ success: false }` with NO `error` — the deliberate
+ *      "I already messaged the user" convention (`useObjectActions`'s bulk
+ *      delete, `useConsoleActionRuntime`'s entitlement dialog).
+ *
+ * Anything else that renders no toast is dispatching outside this chain.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('sonner', () => {
+  const fn: any = vi.fn();
+  fn.error = vi.fn();
+  fn.success = vi.fn();
+  return { toast: fn };
+});
+
+import { ActionRunner, type ActionDef, type ActionResult } from '@object-ui/core';
+import { createConsoleServerActionHandler } from '../consoleServerAction';
+
+/** The hook's written, user-facing refusal — the sentence that must survive. */
+const REFUSAL = 'Contract cannot be submitted without a version file.';
+
+/** A `Response`-shaped double: only `ok` / `status` / `json()` are read. */
+function respond(status: number, body: unknown | (() => never)) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => (typeof body === 'function' ? (body as () => never)() : body),
+  };
+}
+
+/**
+ * Mount the real chain. `script` is registered exactly as the console
+ * registers it (`handlers={{ script: … }}` on `<ActionProvider>`).
+ */
+function mountConsoleChain(response: ReturnType<typeof respond>) {
+  const toasts: Array<{ message: unknown; options?: { type?: string } }> = [];
+  const fetchDouble = vi.fn(async () => response as never);
+  const runner = new ActionRunner({});
+  runner.setToastHandler(((message: unknown, options?: { type?: string }) => {
+    toasts.push({ message, options });
+  }) as never);
+  runner.registerHandler('script', createConsoleServerActionHandler({
+    fetch: fetchDouble as never,
+    baseUrl: () => '',
+    resolveObject: () => 'clm_contract',
+    onRefresh: vi.fn(),
+  }) as never);
+  return { runner, toasts, fetchDouble };
+}
+
+/** The dispatch shape `DeclaredActionsBar` builds for a record-page action. */
+function submitContract(extra?: Record<string, unknown>): ActionDef {
+  return {
+    name: 'submit_contract',
+    type: 'script',
+    objectName: 'clm_contract',
+    params: { _rowRecord: { id: 'ctr_1' } },
+    ...(extra ?? {}),
+  } as ActionDef;
+}
+
+describe('objectui#9151 — a refused script action reaches the toast sink', () => {
+  it('500 carrying the business sentence: exactly one error toast, sentence verbatim', async () => {
+    const { runner, toasts, fetchDouble } = mountConsoleChain(
+      respond(500, { success: false, error: { code: 'INTERNAL_ERROR', message: REFUSAL } }),
+    );
+
+    const result = await runner.execute(submitContract());
+
+    // The POST really happened — this is the chain, not a short circuit.
+    expect(fetchDouble).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ success: false, error: REFUSAL });
+    expect(toasts).toEqual([{ message: REFUSAL, options: { type: 'error', duration: undefined } }]);
+  });
+
+  it('LIT CONTROL — 400 with the same body produces the same toast (the path never reads status)', async () => {
+    const { runner, toasts } = mountConsoleChain(
+      respond(400, { success: false, error: { code: 'VALIDATION_ERROR', message: REFUSAL } }),
+    );
+
+    await runner.execute(submitContract());
+
+    expect(toasts).toEqual([{ message: REFUSAL, options: { type: 'error', duration: undefined } }]);
+  });
+
+  it('LIT CONTROL — a 200 success toasts green, so an empty error list is never the sink being dead', async () => {
+    const { runner, toasts } = mountConsoleChain(respond(200, { success: true, data: { ok: 1 } }));
+
+    await runner.execute(submitContract({ successMessage: 'Submitted.' }));
+
+    expect(toasts).toEqual([
+      { message: 'Submitted.', options: { type: 'success', duration: undefined, undo: undefined } },
+    ]);
+  });
+
+  it('an unreadable 500 body still toasts — on the (HTTP nnn) fallback, never nothing', async () => {
+    const { runner, toasts } = mountConsoleChain(respond(500, () => { throw new SyntaxError('not JSON'); }));
+
+    const result = await runner.execute(submitContract());
+
+    expect(result.success).toBe(false);
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].options).toEqual({ type: 'error', duration: undefined });
+    expect(String(toasts[0].message)).toBe('Action "submit_contract" failed (HTTP 500)');
+  });
+});
+
+describe('objectui#9151 — the two shapes that legitimately render NO toast', () => {
+  it('A: the action declares toast.showOnError false — the refusal is swallowed BY THE AUTHOR', async () => {
+    const { runner, toasts } = mountConsoleChain(
+      respond(500, { success: false, error: { code: 'INTERNAL_ERROR', message: REFUSAL } }),
+    );
+
+    const result = await runner.execute(submitContract({ toast: { showOnError: false } }));
+
+    // The refusal reached the runner intact; only the SINK was opted out of.
+    expect(result).toEqual({ success: false, error: REFUSAL });
+    expect(toasts).toEqual([]);
+  });
+
+  it('B: a handler returning `{ success: false }` with no `error` is silent by convention', async () => {
+    const toasts: Array<unknown> = [];
+    const runner = new ActionRunner({});
+    runner.setToastHandler(((message: unknown) => { toasts.push(message); }) as never);
+    // The shape `useObjectActions`'s bulk delete and `useConsoleActionRuntime`'s
+    // entitlement dialog return on purpose: they already told the user.
+    runner.registerHandler('script', (async (): Promise<ActionResult> => ({ success: false })) as never);
+
+    const result = await runner.execute(submitContract());
+
+    expect(result).toEqual({ success: false });
+    expect(toasts).toEqual([]);
+  });
+});


### PR DESCRIPTION
Part of #9151 — the console half of objectstack#17265.

## What lands here

One new test file and one empty-frontmatter changeset. **No runtime code changes**, and the
measurement below is the reason rather than an omission.

| | |
|---|---|
| `packages/app-shell/src/utils/__tests__/consoleServerAction.errorToast.test.ts` | new — 6 readings |
| `.changeset/9151-failed-script-action-toast-characterization.md` | empty frontmatter — releases nothing |

## The finding: on today's `main`, the silence cannot originate in this repo's chain

The card asked why a `beforeUpdate` hook's business refusal on
`POST /api/v1/actions/clm_contract/submit_contract` produces **zero toast elements**. Three
readers had answered the underlying question — *does a server refusal on that route reach the
user?* — by reading code. Each answer was a theory. It is a measurable question, so this branch
measured it, driving the real chain with nothing stubbed between its ends:

```
ActionRunner.execute
  -> the registered `script` handler
     = createConsoleServerActionHandler           (packages/app-shell)
     -> createServerActionHandler                 (@object-ui/core)
        -> interpretActionResponse                (the /actions envelope rule)
  -> ActionRunner.handlePostExecution             (the toast sink)
```

Only the transport and the toast **sink** are doubles. The sink double stands in for the console's
`toastHandler`, which is one switch on the options `type` member in `useConsoleActionRuntime` and a
byte-identical copy in `RecordDetailView`; asserting on the payload handed to the sink pins the
contract without copying that mapping into a third place.

### Measured, on `main` at `2f073f153`

| response | result | toast calls |
|---|---|---|
| **500** `{success:false, error:{code:'INTERNAL_ERROR', message: SENTENCE}}` | `{success:false, error: SENTENCE}` | **1**, type `error`, message = SENTENCE verbatim |
| **400**, identical body (lit control) | same | **1**, identical |
| **200** `{success:true, …}` (lit control) | `{success:true, …}` | **1**, type `success` |
| **500**, body that will not parse | `{success:false, …}` | **1**, `Action "submit_contract" failed (HTTP 500)` |

Two consequences, both now pinned:

1. The path is **status-blind by construction** (`!res.ok`). That is exactly why moving the refusal
   from 500 to 4xx — objectstack#17265 / PR objectstack#17679 — changes nothing here, and why it
   must not be "repaired" by teaching the console to branch on status.
2. `result.error` is **never empty** after a non-ok response, because the non-inner arm of
   `interpretActionResponse` always carries the `(HTTP nnn)` fallback string.

### ⇒ "zero toast elements" has exactly two preimages, and that is all of them

Both are pinned in the same file:

- **A.** the action declares `toast: { showOnError: false }` — an authorable per-action opt-out
  (`SPEC_ACTION_KEYS`) that the runner honours. The refusal still reaches the runner intact; only
  the sink is opted out of.
- **B.** a handler returns `{ success: false }` with **no** `error` — the deliberate "I already
  messaged the user" convention that `useObjectActions`'s bulk delete and
  `useConsoleActionRuntime`'s entitlement-dialog branch already rely on.

Anything else that renders no toast is dispatching **outside this chain**.

## Ablation — the pins bite

A runtime assertion is enforced by vitest, so each leg is read through vitest. `vitest.config.mts`
aliases `@object-ui/core` to `packages/core/src`, so the mutated **source** is what the pin
executes and no `dist` rebuild stands between the mutation and the reading. Every leg proved the
mutation reached disk (marker count 0 then 1, plus an on-disk blob hash differing from the HEAD
blob) before its result was read, and every restore leg was proved by blob-hash equality **and** an
empty `git diff HEAD`, never by an exit code.

| leg | mutation in `ActionRunner.handlePostExecution` | vitest | failures |
|---|---|---|---|
| **M1** | the whole error arm short-circuited to `false` | exit 1 | **3 failed / 3 passed** — exactly the three error-toast readings; the success control and both zero-toast pins stayed green |
| **M2** | the `showOnError !== false` term dropped | exit 1 | **1 failed / 5 passed** — exactly the `showOnError:false` pin |
| restored | none | exit 0 | 6 passed; blob `65f74816` = HEAD blob |

M1's failure set is itself a reading: the mutation that kills error toasts leaves the two
"legitimately silent" pins green, which is what makes those two a *preimage* rather than a guess.

## Not a stale pin either — extended from one file to the whole chain

Triage had already ruled out the shipped-console-is-older hypothesis by comparing
`ActionRunner.ts` at the pinned `.objectui-sha` `53ded82b` against `main`. This branch extended
that comparison from one file to every file on the failure-to-toast path:

`git diff --stat 53ded82b HEAD` over `packages/core/src/actions/`, `consoleServerAction.ts`,
`useConsoleActionRuntime.tsx`, `RecordDetailView.tsx`, `ActionContext.tsx`, `useActionRunner.ts`
and `error-message.ts` reports **no change at all** to `consoleServerAction.ts`,
`serverActionHandler.ts`, `actionResponse.ts`, `actionErrorDetail.ts`, `ActionContext.tsx`,
`useActionRunner.ts` or `error-message.ts`. What did move: `ActionRunner.ts` by 3 lines (a
`ActionParamDef.visible` docblock), `actionKeys.ts` by 18 (two spec key-inventory entries plus
their justification comment), and `RecordDetailView.tsx` by 75 lines of which **zero** touch
`toast`, `onToast`, `serverActionHandler`, `script` or `ActionProvider`.

## What is left, and where it lives

With the chain measured correct end to end, the two surviving candidates are both **outside this
repo**, which is what triage's acceptance note 3 anticipated:

- **candidate 2** — the action is not dispatched through the console's registered `script` handler
  at all;
- **candidate 3** — the action's metadata carries `toast: { showOnError: false }` (shape **A**
  above, which reproduces "zero toast elements" with everything else correct).

Settling between them needs the `objectstack-ai/hotclm` action metadata and its wiring
(the dogfood pass is hotclm#45). That repository is **not reachable from this session** — a
repo-scoped REST read answers 403 and attaching it was refused — so this branch states the two
candidates and the reading that narrows to them, rather than guessing between them.

⛔ No `ActionRunner` change was made to have something to show. Per the triage acceptance note,
when the root cause is app-side configuration the deliverable is the diagnosis, and the durable
form of a diagnosis that three readers each re-derived is a test.

## Verification

All readings below were taken at `e9fc1e59d`, the branch head as pushed. Every exit code was
captured by redirect-then-capture, and each gate's own verdict line is what was read — never a
bare shell status through a pipe.

| what | reading |
|---|---|
| the new pin | **6 passed**, `Test Files 1 passed (1)` — collected as one file, not zero |
| ablation M1 / M2 / restored | as tabled above; re-run at this head, both restore legs proved by blob equality with the HEAD blob `65f74816` plus an empty `git diff HEAD` |
| `pnpm --filter @object-ui/app-shell test` | `VERDICT command-exit 0` — **687 files, 6644 passed, 1 skipped** |
| `pnpm --filter @object-ui/app-shell type-check` | `VERDICT command-exit 0` |
| the dependency closure | `turbo run type-check --filter=@object-ui/app-shell --concurrency=2`, **30 tasks successful** (the 29 `^build` tasks plus the type-check), so the test project read real `.d.ts` and not stale ones — `tsconfig.test.json` sets `paths: {}` on purpose, which makes that build load-bearing |
| is the new file actually type-checked? | yes — `tsc -p tsconfig.test.json --listFilesOnly` lists it, 1 of 4505 program files. Not a NOT-MEASURED green |

Gates run locally, every one exit 0: `check:control-bytes`, `check:vi-mock-specifiers`,
`check:vi-mock-inherit`, `check:vi-mock-override-shape`, `check:test-path-roots`,
`check:new-line-citations`, `check:action-ref-convention`, `check:changeset-claims`,
`check:unreferenced-sources`, `check:phantom-deps`, `check:unused-deps`,
`check-changeset-no-major.mjs`, `check-type-check-coverage.mjs`,
`check-changeset-presence.mjs` (which reads the empty frontmatter as the explicit exemption), and
`check-governed-queue-guard.mjs --test` (**NOT GOVERNED** — the normal review route applies).

`scripts/pm/check-half-states.mjs` is **NOT MEASURED**: it exits 3, `PREREQUISITE NOT MET`, because
this container's token is not a GitHub credential. Its own message states that nothing was swept,
so it is neither a clean board nor a dirty one. It is also a board sweep rather than a diff gate.

**Lint — a narrowed run, with the three readings that make the narrowing a measurement:**

1. *Population, read from the config rather than guessed:* `eslint.config.js` lints
   `**/*.{ts,tsx}` minus its own `ignores` list, which contains only build output
   (`dist`, `.next`, `node_modules`, `public`, `.source` and three literal generated paths, each
   chosen to be auditable against `git check-ignore` precisely so no source file leaves the
   population).
2. *Count, read from eslint:* `--format json` reports **1 file linted, 0 errors, 0 warnings**
   (it was 0 errors / 1 warning before the second commit removed the copied `any`).
3. *Invariance over untouched files:* the config enables **no type-aware linting** — no
   `projectService`, no `parserOptions.project`, no `tsconfigRootDir` anywhere in it — so there is
   no cross-file program and a file's verdict depends only on its own bytes plus the config.
   This branch changes neither for any untouched file. ⚠️ The one caveat, stated rather than
   hidden: two repo-local rules (`no-line-address-in-test-name`, `no-synthetic-event-trigger`) do
   read the filesystem, so the invariance claim is "no untouched file's verdict moves", not "no
   rule ever looks outward"; the added file is new, and it is in the narrowed run.

Repository-wide scans (`pnpm lint` across the farm and the remaining gates) are CI's run, not
this branch's.

Session for this work: `https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ`

## Acceptance notes

Observations from the sweep, recorded rather than filed — none is a reproducible defect, a declared
contract violated, or an authoring trap:

- noted, not filed: `{ success: false }` with no `error` is a **load-bearing silent-failure
  convention** on `ActionResult`, relied on by two call sites, and it is documented only in those
  call sites' comments — not on `ActionResult.error` itself, which is where a handler author reads.
  It is now pinned by shape **B**, so a rename or a semantic change reds a test. Carrier: the next
  PR that touches `ActionResult`'s declaration.
- noted, not filed: `handlePostExecution`'s success arm honours `result.silent` while the error arm
  does not. Deliberate on today's reading (the two silent-failure call sites use the missing-`error`
  channel instead), and no caller wants the other behaviour. Carrier: none.


---
_Generated by [Claude Code](https://claude.ai/code)_