### PR TITLE
fix(form): a whole-row field spans the whole row at EVERY breakpoint tier

### DIFF
--- a/.changeset/span-full-tier-ladder-9244.md
+++ b/.changeset/span-full-tier-ladder-9244.md
@@ -1,0 +1,23 @@
+---
+"@object-ui/components": patch
+"@object-ui/plugin-form": patch
+---
+
+fix(form): a whole-row field now spans the whole row at **every** breakpoint tier, not only the widest
+
+The form's column count is resolved per tier by container queries
+(`grid-cols-1 @md:grid-cols-2 @2xl:grid-cols-3` is three column counts on one
+screen), but the renderer emitted a single col-span class for the widest tier
+that reached the target. A field authored `span: 'full'` — the spelling
+`@objectstack/spec` declares as «whole row at any column count» and tells
+authors to prefer — therefore took 1 of 2 cells at the middle tier, rendering
+pixel-identical to authoring nothing at all (measured in Chromium at 285px of
+a 586px grid). It now emits one class per multi-column tier, each clamped to
+that tier's column count: `@md:col-span-2 @2xl:col-span-3`.
+
+⚠️ **Existing forms will look different at intermediate container widths** —
+that is the fix. A field that was silently narrow in a modal or drawer now
+occupies the full row there, as its metadata always asked. Narrowest and
+widest tiers are unchanged, and a `colSpan` smaller than the grid is
+unchanged. Layouts hand-tuned around the old behaviour should be re-checked at
+modal width.

--- a/packages/components/src/renderers/form/__tests__/form-span-tier-ladder-9244.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-span-tier-ladder-9244.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9244 — the col-span ladder the form renderer emits for a field that
+ * must occupy the whole row.
+ *
+ * ⭐ WHICH LAYER THIS PINS, said out loud because the blind spot this card
+ * closes is a pin one layer too high. `plugin-form`'s `resolveColSpan` already
+ * had a green pin named «span: 'full' spans the whole row at any grid width»,
+ * and it is honest: that function DOES return the full grid count. It never
+ * observes the class that reaches the DOM. The class is picked HERE, and until
+ * this file existed nothing asserted it. So every assertion below reads a
+ * rendered `className`, never a resolver's return value.
+ *
+ * The contract, from the published declaration rather than from the helper's
+ * behaviour — `@objectstack/spec` 17.4.0, `FormField.span`'s `.describe()`:
+ *
+ *   'full': whole row at any column count. Prefer this over the absolute
+ *   `colSpan`.
+ *
+ * «at any column count» is the load-bearing half. The form's column count is
+ * resolved by CONTAINER QUERIES, so one authored field passes through several
+ * column counts on one screen (`grid-cols-1 @md:grid-cols-2 @2xl:grid-cols-3`
+ * is three of them). A single class for the widest tier satisfies the sentence
+ * at the top tier only; at the middle tier the field renders identically to
+ * authoring nothing at all — measured in Chromium at 285px of a 586px grid by
+ * objectstack#17328, and reproduced here as an emitted-class reading.
+ *
+ * ⚠️ `span: 'full'` never reaches this renderer as `span`. `plugin-form`'s
+ * `resolveColSpan` collapses it to a NUMBER (the grid's column count) before
+ * the schema is handed down, which is why `span: 'full'` and a clamped
+ * `colSpan: 4` are byte-identical here — objectstack#17328's measurement #4.
+ * The cross-layer leg, from an authored `span: 'full'` all the way to the DOM,
+ * lives in `plugin-form/src/__tests__/spanFullTierLadder-9244.test.tsx`; this
+ * file pins the emission itself, with the container classes `plugin-form`'s
+ * `CONTAINER_GRID_COLS` actually produces written out as literals (components
+ * must not depend on plugin-form, and a literal is what Tailwind's scanner
+ * sees anyway).
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import '../../../renderers';
+
+afterEach(() => cleanup());
+
+/**
+ * The three container classes `plugin-form`'s `CONTAINER_GRID_COLS` emits,
+ * verbatim. Kept as literals rather than imported: `@object-ui/components` is
+ * downstream of nothing in `plugin-form`, and a drift between the two is
+ * caught by `containerGridColsLiteralsAgree` in the plugin-form sibling file.
+ */
+const CONTAINER = {
+  2: 'grid gap-4 grid-cols-1 @md:grid-cols-2',
+  3: 'grid gap-4 grid-cols-1 @md:grid-cols-2 @2xl:grid-cols-3',
+  4: 'grid gap-4 grid-cols-1 @md:grid-cols-2 @2xl:grid-cols-3 @4xl:grid-cols-4',
+} as const;
+
+/** The viewport-prefixed family the renderer falls back to with no override. */
+const VIEWPORT = {
+  2: 'grid gap-4 md:grid-cols-2',
+  3: 'grid gap-4 md:grid-cols-2 lg:grid-cols-3',
+  4: 'grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
+} as const;
+
+/**
+ * Render one field at `colSpan` inside `fieldContainerClass` and return the
+ * class tokens the renderer put on its grid cell.
+ */
+function spanTokens(colSpan: number | undefined, fieldContainerClass: string): string[] {
+  // ⚠️ Unmount first. The read below is a `document.body` query, so a second
+  // render inside one `it` would be read through the FIRST render's cell and
+  // silently answer the previous question — which is how the four-tier leg
+  // first came back short by one tier with the implementation already correct.
+  cleanup();
+  const Form = ComponentRegistry.get('form')!;
+  render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: false,
+        showCancel: false,
+        fieldContainerClass,
+        fields: [
+          { name: 'notes', label: 'Notes', type: 'input', ...(colSpan ? { colSpan } : {}) },
+          { name: 'other', label: 'Other', type: 'input' },
+        ],
+      }}
+    />,
+  );
+  const cell = document.body.querySelector('[data-field="notes"]');
+  if (!cell) throw new Error('field not rendered: notes');
+  return (cell.getAttribute('class') || '').split(/\s+/).filter(Boolean);
+}
+
+const spanClasses = (tokens: string[]) => tokens.filter((t) => /(^|:)col-span-/.test(t));
+
+describe("objectui#9244 — a whole-row field spans the whole row at EVERY tier", () => {
+  it('3-column container: 2 of 2 at the middle tier, 3 of 3 at the top', () => {
+    const emitted = spanClasses(spanTokens(3, CONTAINER[3]));
+
+    // Acceptance 1. The middle tier is the defect: without `@md:col-span-2`
+    // the field occupies 1 of 2 there — pixel-identical to authoring nothing.
+    expect(emitted).toEqual(['@md:col-span-2', '@2xl:col-span-3']);
+  });
+
+  it('4-column container: one class per tier, each clamped to that tier', () => {
+    const emitted = spanClasses(spanTokens(4, CONTAINER[4]));
+
+    expect(emitted).toEqual(['@md:col-span-2', '@2xl:col-span-3', '@4xl:col-span-4']);
+  });
+
+  it('2-column container: the single tier that exists', () => {
+    const emitted = spanClasses(spanTokens(2, CONTAINER[2]));
+
+    expect(emitted).toEqual(['@md:col-span-2']);
+  });
+
+  it('viewport-prefixed family: the same ladder, viewport prefixes', () => {
+    // ⭐ This is the string `plugin-detail`'s `getResponsiveSpanClass` has
+    // always returned for the same input — two renderers, one concept, and
+    // after this card one answer. `pickSpanClass` derives its tiers from the
+    // container class rather than hard-coding the ladder, so it also handles
+    // the container-query family above, which `getResponsiveSpanClass` cannot.
+    expect(spanClasses(spanTokens(3, VIEWPORT[3]))).toEqual(['md:col-span-2', 'lg:col-span-3']);
+    expect(spanClasses(spanTokens(4, VIEWPORT[4]))).toEqual([
+      'md:col-span-2',
+      'lg:col-span-3',
+      'xl:col-span-4',
+    ]);
+  });
+});
+
+describe('objectui#9244 — the negative controls the prefixing exists for', () => {
+  it('⭐ never emits a BARE col-span on a container whose base tier is 1 column', () => {
+    // Acceptance 2. A bare `col-span-2` on `grid-cols-1` makes CSS grid
+    // synthesize an implicit second track and distorts every column width —
+    // the distortion the prefixing was introduced to prevent. Asserted as a
+    // token check, not a substring check: `@md:col-span-2` CONTAINS the text
+    // `col-span-2`, so `toContain` would pass on the broken output.
+    for (const container of [CONTAINER[2], CONTAINER[3], CONTAINER[4], VIEWPORT[3]]) {
+      for (const colSpan of [2, 3, 4]) {
+        const bare = spanTokens(colSpan, container).filter((t) => /^col-span-\d+$/.test(t));
+        expect(bare, `bare span leaked for colSpan ${colSpan} in "${container}"`).toEqual([]);
+      }
+    }
+  });
+
+  it('emits no span class at all for a 1-cell field', () => {
+    expect(spanClasses(spanTokens(1, CONTAINER[3]))).toEqual([]);
+    expect(spanClasses(spanTokens(undefined, CONTAINER[3]))).toEqual([]);
+  });
+
+  it('does not repeat a tier whose span is unchanged from the tier below', () => {
+    // A `colSpan: 2` field in a 3-column container is 2 of 2 at `@md` and
+    // still 2 of 3 at `@2xl`. Tailwind's prefixes are min-width, so the `@md`
+    // class is already in force at `@2xl`; a second `@2xl:col-span-2` would be
+    // dead weight in the class attribute and in the generated CSS.
+    expect(spanClasses(spanTokens(2, CONTAINER[3]))).toEqual(['@md:col-span-2']);
+  });
+
+  it('a container with no responsive grid information still gets a bare class', () => {
+    // Unchanged behaviour, pinned so the ladder cannot swallow it: with no
+    // tier to mirror, the grid is multi-column at every width and the bare
+    // class is the correct — and only — answer.
+    expect(spanClasses(spanTokens(2, 'grid gap-4 grid-cols-2'))).toEqual(['col-span-2']);
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -116,6 +116,121 @@ function unclaimedFields(
 const panePercent = (size: number | undefined): string | undefined =>
   typeof size === 'number' && Number.isFinite(size) ? String(size) : undefined;
 
+/**
+ * Breakpoint ladder, narrowest first. Shared by the container-query family
+ * (`@md:`) and the viewport family (`md:`) — the two never appear in the same
+ * container class, but ordering both off one list keeps the walk in
+ * {@link spanLadderFor} deterministic regardless of the order the prefixes
+ * happen to be written in.
+ */
+const SPAN_BREAKPOINTS = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl', '6xl', '7xl'] as const;
+
+/**
+ * Every col-span class {@link spanLadderFor} can emit, written out as a
+ * literal. ⛔ Never build one with a template string: Tailwind's scanner reads
+ * source text, so a computed class is scanned out and the utility silently
+ * does not exist in the built CSS.
+ *
+ * Keyed `<prefix>:<span>`, exhaustive over the prefixes the tier regex matches
+ * × the spans a form field can take (2-4). Exhaustive on purpose: the previous
+ * table was partial, and its `||` fallback answered an unmapped key with a
+ * BARE `col-span-N` — the one answer that must never be given under a
+ * single-column base tier, because CSS grid then synthesizes an implicit
+ * track. A missing key now yields no class at all, which under-spans (visibly
+ * wrong, recoverable) instead of distorting every column width.
+ */
+const SPAN_CLASS: Record<string, string> = {
+  '@sm:2': '@sm:col-span-2', '@sm:3': '@sm:col-span-3', '@sm:4': '@sm:col-span-4',
+  '@md:2': '@md:col-span-2', '@md:3': '@md:col-span-3', '@md:4': '@md:col-span-4',
+  '@lg:2': '@lg:col-span-2', '@lg:3': '@lg:col-span-3', '@lg:4': '@lg:col-span-4',
+  '@xl:2': '@xl:col-span-2', '@xl:3': '@xl:col-span-3', '@xl:4': '@xl:col-span-4',
+  '@2xl:2': '@2xl:col-span-2', '@2xl:3': '@2xl:col-span-3', '@2xl:4': '@2xl:col-span-4',
+  '@3xl:2': '@3xl:col-span-2', '@3xl:3': '@3xl:col-span-3', '@3xl:4': '@3xl:col-span-4',
+  '@4xl:2': '@4xl:col-span-2', '@4xl:3': '@4xl:col-span-3', '@4xl:4': '@4xl:col-span-4',
+  '@5xl:2': '@5xl:col-span-2', '@5xl:3': '@5xl:col-span-3', '@5xl:4': '@5xl:col-span-4',
+  '@6xl:2': '@6xl:col-span-2', '@6xl:3': '@6xl:col-span-3', '@6xl:4': '@6xl:col-span-4',
+  '@7xl:2': '@7xl:col-span-2', '@7xl:3': '@7xl:col-span-3', '@7xl:4': '@7xl:col-span-4',
+  'sm:2': 'sm:col-span-2', 'sm:3': 'sm:col-span-3', 'sm:4': 'sm:col-span-4',
+  'md:2': 'md:col-span-2', 'md:3': 'md:col-span-3', 'md:4': 'md:col-span-4',
+  'lg:2': 'lg:col-span-2', 'lg:3': 'lg:col-span-3', 'lg:4': 'lg:col-span-4',
+  'xl:2': 'xl:col-span-2', 'xl:3': 'xl:col-span-3', 'xl:4': 'xl:col-span-4',
+  '2xl:2': '2xl:col-span-2', '2xl:3': '2xl:col-span-3', '2xl:4': '2xl:col-span-4',
+  '3xl:2': '3xl:col-span-2', '3xl:3': '3xl:col-span-3', '3xl:4': '3xl:col-span-4',
+  '4xl:2': '4xl:col-span-2', '4xl:3': '4xl:col-span-3', '4xl:4': '4xl:col-span-4',
+  '5xl:2': '5xl:col-span-2', '5xl:3': '5xl:col-span-3', '5xl:4': '5xl:col-span-4',
+  '6xl:2': '6xl:col-span-2', '6xl:3': '6xl:col-span-3', '6xl:4': '6xl:col-span-4',
+  '7xl:2': '7xl:col-span-2', '7xl:3': '7xl:col-span-3', '7xl:4': '7xl:col-span-4',
+};
+
+/** Bare (unprefixed) col-span, for a container that is multi-column at every width. */
+const BARE_SPAN_CLASS: Record<number, string> = {
+  2: 'col-span-2',
+  3: 'col-span-3',
+  4: 'col-span-4',
+};
+
+/**
+ * The col-span classes a field must carry to occupy `targetCols` cells of
+ * `containerClass` — ONE CLASS PER TIER, not one class for the widest tier
+ * (objectui#9244).
+ *
+ * The form's column count is resolved per tier, by container queries on the
+ * field container (`grid-cols-1 @md:grid-cols-2 @2xl:grid-cols-3` is three
+ * different column counts on one screen). `@objectstack/spec`'s `FormField.
+ * span` declares `'full'` as «whole row at ANY column count», so a whole-row
+ * field needs a span at every tier where the grid is multi-column. Emitting
+ * only the widest tier's class satisfies the declaration at the widest tier
+ * and nowhere else: at `@md` the field takes 1 of 2 cells, which is
+ * pixel-identical to authoring nothing at all (measured in Chromium at 285px
+ * of a 586px grid — objectstack#17328).
+ *
+ * ⚠️ The prefixing itself is deliberate and stays. A bare `col-span-2` while
+ * the grid is still `grid-cols-1` makes CSS grid synthesize an implicit second
+ * track and distorts every column width, so a tier only gets a class once that
+ * tier actually has the columns to give.
+ *
+ * The walk: tiers narrowest-first, each wanting `min(tierCols, targetCols)`
+ * cells, skipping any tier whose want is not an INCREASE. Tailwind prefixes
+ * are min-width, so a class emitted at `@md` is still in force at `@2xl`;
+ * re-emitting the same span there would be dead weight in the class attribute
+ * and in the generated CSS. That skip is also what keeps `colSpan: 2` in a
+ * 3-column container at exactly `@md:col-span-2`, unchanged by this card.
+ *
+ * ⭐ `plugin-detail`'s `getResponsiveSpanClass` has always returned this ladder
+ * for the viewport family (`md:col-span-2 lg:col-span-3 xl:col-span-4`); it
+ * hard-codes that ladder, while this derives the tiers from the container
+ * class and therefore also covers the container-query family.
+ */
+function spanLadderFor(containerClass: string, targetCols: number): string {
+  const re = /(@)?(sm|md|lg|xl|2xl|3xl|4xl|5xl|6xl|7xl):grid-cols-(\d+)/g;
+  const tiers = Array.from(containerClass.matchAll(re))
+    .map((m) => ({ at: m[1] || '', bp: m[2], cols: Number(m[3]) }))
+    .sort(
+      (a, b) =>
+        SPAN_BREAKPOINTS.indexOf(a.bp as (typeof SPAN_BREAKPOINTS)[number]) -
+        SPAN_BREAKPOINTS.indexOf(b.bp as (typeof SPAN_BREAKPOINTS)[number]),
+    );
+  if (!tiers.length) {
+    // No responsive/container prefix found — the bare class is safe because
+    // the grid is already multi-column at all widths.
+    return BARE_SPAN_CLASS[Math.min(Math.max(targetCols, 2), 4)];
+  }
+  const ladder: string[] = [];
+  // The base tier of every container this renderer builds is one column, so a
+  // tier only earns a class once it can give MORE than the one cell the field
+  // already occupies.
+  let spanned = 1;
+  for (const tier of tiers) {
+    const want = Math.min(tier.cols, targetCols);
+    if (want <= spanned) continue;
+    const cls = SPAN_CLASS[`${tier.at}${tier.bp}:${want}`];
+    if (!cls) continue;
+    ladder.push(cls);
+    spanned = want;
+  }
+  return ladder.join(' ');
+}
+
 const useSafeFormTranslation = createSafeTranslation(
   {
     'common.selectOption': 'Select an option',
@@ -2663,59 +2778,12 @@ ComponentRegistry.register('form',
       // `fieldContainerClass` (overrides, typically container-query based)
       // or the locally-computed `gridClass` (viewport-based).
       const containerClass = schema.fieldContainerClass || gridClass;
-      // Match both container-query (`@md:`) and viewport (`md:`) prefixes.
-      // Return an explicit, statically-detectable class so Tailwind JIT
-      // can scan and include it.
-      const pickSpanClass = (targetCols: number): string => {
-        const re = /(@)?(sm|md|lg|xl|2xl|3xl|4xl|5xl|6xl|7xl):grid-cols-(\d+)/g;
-        const matches = Array.from(containerClass.matchAll(re)).map(m => ({
-          at: m[1] || '',
-          bp: m[2],
-          cols: Number(m[3]),
-        }));
-        if (!matches.length) {
-          // No responsive/container prefix found — bare class is safe
-          // because the grid is already multi-column at all widths.
-          if (targetCols === 2) return 'col-span-2';
-          if (targetCols === 3) return 'col-span-3';
-          return 'col-span-4';
-        }
-        const hit = matches.find(m => m.cols >= targetCols) || matches[matches.length - 1];
-        const key = `${hit.at}${hit.bp}:${targetCols}`;
-        // Explicit literal map so Tailwind JIT discovers these classes.
-        const table: Record<string, string> = {
-          '@sm:2':  '@sm:col-span-2',
-          '@md:2':  '@md:col-span-2',
-          '@lg:2':  '@lg:col-span-2',
-          '@xl:2':  '@xl:col-span-2',
-          '@2xl:2': '@2xl:col-span-2',
-          '@sm:3':  '@sm:col-span-3',
-          '@md:3':  '@md:col-span-3',
-          '@lg:3':  '@lg:col-span-3',
-          '@xl:3':  '@xl:col-span-3',
-          '@2xl:3': '@2xl:col-span-3',
-          '@4xl:3': '@4xl:col-span-3',
-          '@sm:4':  '@sm:col-span-4',
-          '@md:4':  '@md:col-span-4',
-          '@lg:4':  '@lg:col-span-4',
-          '@xl:4':  '@xl:col-span-4',
-          '@2xl:4': '@2xl:col-span-4',
-          '@4xl:4': '@4xl:col-span-4',
-          'sm:2':   'sm:col-span-2',
-          'md:2':   'md:col-span-2',
-          'lg:2':   'lg:col-span-2',
-          'xl:2':   'xl:col-span-2',
-          'sm:3':   'sm:col-span-3',
-          'md:3':   'md:col-span-3',
-          'lg:3':   'lg:col-span-3',
-          'xl:3':   'xl:col-span-3',
-          'sm:4':   'sm:col-span-4',
-          'md:4':   'md:col-span-4',
-          'lg:4':   'lg:col-span-4',
-          'xl:4':   'xl:col-span-4',
-        };
-        return table[key] || (targetCols === 2 ? 'col-span-2' : targetCols === 3 ? 'col-span-3' : 'col-span-4');
-      };
+      // One class PER TIER, derived from the container class — see
+      // {@link spanLadderFor} for why a single widest-tier class under-spans
+      // every intermediate width (objectui#9244), and for why the tier
+      // prefixes are load-bearing rather than decoration.
+      const pickSpanClass = (targetCols: number): string =>
+        spanLadderFor(containerClass, targetCols);
 
       const colSpanClass = colSpan && colSpan > 1
         ? colSpan === 2 ? pickSpanClass(2)

--- a/packages/plugin-form/src/__tests__/spanFullTierLadder-9244.test.tsx
+++ b/packages/plugin-form/src/__tests__/spanFullTierLadder-9244.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9244, the cross-layer leg: an AUTHORED `span: 'full'` all the way
+ * to the class on the grid cell.
+ *
+ * ⭐ WHY THIS FILE EXISTS SEPARATELY FROM `autoLayout.test.ts`. That suite
+ * already carries, verbatim:
+ *
+ *   it("span: 'full' spans the whole row at any grid width")
+ *
+ * and it passes — honestly, because `resolveColSpan` really does return the
+ * full grid count. It is the layer BELOW the claim its name makes. The claim
+ * is about what renders, `resolveColSpan` only produces a number, and until
+ * objectui#9244 nothing joined the two. So this file asserts nothing about
+ * return values: it runs the real layout helper, hands the result to the real
+ * form renderer, and reads the rendered `className`.
+ *
+ * The narrow pin on the emission itself is
+ * `components/src/renderers/form/__tests__/form-span-tier-ladder-9244.test.tsx`.
+ * This one covers what that one structurally cannot: that the number
+ * `resolveColSpan` chooses and the container class `containerGridColsFor`
+ * chooses still describe the same grid by the time they meet.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import type { FormField } from '@object-ui/types';
+import '@object-ui/components';
+import { CONTAINER_GRID_COLS, sectionFormLayout } from '../autoLayout';
+
+afterEach(() => cleanup());
+
+/**
+ * Author one `span: 'full'` field beside plain ones in a `columns`-wide
+ * section, run it through the layout helper the section variants all use, and
+ * return the span classes the renderer put on that field's grid cell.
+ */
+function renderAuthoredSection(columns: number): string[] {
+  cleanup();
+  const fields = [
+    { name: 'summary', label: 'Summary', type: 'input', span: 'full' },
+    { name: 'owner', label: 'Owner', type: 'input' },
+    { name: 'stage', label: 'Stage', type: 'input' },
+    { name: 'amount', label: 'Amount', type: 'input' },
+  ] as unknown as FormField[];
+
+  const laidOut = sectionFormLayout(fields, columns);
+  const Form = ComponentRegistry.get('form')!;
+  render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: false,
+        showCancel: false,
+        fields: laidOut.fields,
+        columns: laidOut.columns,
+        ...(laidOut.fieldContainerClass
+          ? { fieldContainerClass: laidOut.fieldContainerClass }
+          : {}),
+      }}
+    />,
+  );
+  const cell = document.body.querySelector('[data-field="summary"]');
+  if (!cell) throw new Error('field not rendered: summary');
+  return (cell.getAttribute('class') || '')
+    .split(/\s+/)
+    .filter((t) => /(^|:)col-span-/.test(t));
+}
+
+describe("objectui#9244 — an authored `span: 'full'` reaches the DOM as a whole ladder", () => {
+  it('3-column section: full row at the middle tier as well as the top', () => {
+    // The middle tier is the whole card: `@md:grid-cols-2` is where the field
+    // used to take 1 of 2 cells while the author had written `span: 'full'`.
+    expect(renderAuthoredSection(3)).toEqual(['@md:col-span-2', '@2xl:col-span-3']);
+  });
+
+  it('4-column section: a class for each of the three multi-column tiers', () => {
+    expect(renderAuthoredSection(4)).toEqual([
+      '@md:col-span-2',
+      '@2xl:col-span-3',
+      '@4xl:col-span-4',
+    ]);
+  });
+
+  it('2-column section: the one tier that exists', () => {
+    expect(renderAuthoredSection(2)).toEqual(['@md:col-span-2']);
+  });
+
+  it('1-column section: no grid, and therefore no span class', () => {
+    // `CONTAINER_GRID_COLS[1]` is `undefined` by design — the renderer falls
+    // back to its `space-y-4` stack, where every field is already the row.
+    expect(CONTAINER_GRID_COLS[1]).toBeUndefined();
+    expect(renderAuthoredSection(1)).toEqual([]);
+  });
+
+  it('the tier ladder covers every tier the container class declares', () => {
+    // The drift guard between the two halves of this card: the renderer
+    // derives its tiers by parsing the container class, so a tier added to
+    // `CONTAINER_GRID_COLS` and not to the renderer's literal class table
+    // would silently emit nothing for that tier. Read the tiers out of the
+    // container class itself and require one emitted class per INCREASE.
+    for (const columns of [2, 3, 4]) {
+      const container = CONTAINER_GRID_COLS[columns]!;
+      const tiers = Array.from(container.matchAll(/@(\w+):grid-cols-(\d+)/g)).map((m) => ({
+        bp: m[1],
+        cols: Number(m[2]),
+      }));
+      const expected = tiers.map((t) => `@${t.bp}:col-span-${Math.min(t.cols, columns)}`);
+      expect(renderAuthoredSection(columns), `columns=${columns}`).toEqual(expected);
+    }
+  });
+});

--- a/packages/plugin-form/src/autoLayout.ts
+++ b/packages/plugin-form/src/autoLayout.ts
@@ -134,6 +134,15 @@ function clampGrid(n: number | undefined): number {
  * the robust field-width primitive is the relative `span`, NOT an absolute
  * colSpan. Precedence:
  *   1. `span: 'full'`     → whole row (grid cells).
+ *
+ * ⚠️ «Whole row» is a claim about what RENDERS, and this function only returns
+ * a number. It is kept by the form renderer's `spanLadderFor`, which turns
+ * that number into one col-span class per container-query tier. Until
+ * objectui#9244 the renderer emitted a single class for the widest tier only,
+ * so this sentence was true of the return value and false on screen at every
+ * intermediate width. ⛔ A pin under this function cannot observe that — see
+ * `__tests__/spanFullTierLadder-9244.test.tsx` for the leg that can.
+ *
  *   2. legacy `colSpan`   → honoured but CLAMPED to the grid (never overflows).
  *   3. wide widget type   → whole row (textarea/markdown/… — the `span:'auto'` default).
  *   4. section density    → grid / sectionColumns, so `sectionColumns` fields fill a row.


### PR DESCRIPTION
Part of #9244

## What changed

`pickSpanClass` in `packages/components/src/renderers/form/form.tsx` emitted **one** col-span class — for the first tier that reached the target span — and the form's column count is resolved **per tier** by container queries. So a field that must occupy the whole row got a class at the widest tier and nowhere else.

It now delegates to a module-scope `spanLadderFor`, which walks the tiers narrowest-first and emits a class for every tier that can give **more** cells than the tier below, each clamped to that tier's own column count.

| container (3-column section) | before | after |
|:--|:--|:--|
| base `grid-cols-1` | (no class) — 1 of 1 ✅ | (no class) — 1 of 1 ✅ |
| `@md:grid-cols-2` | **(no class) — 1 of 2** ⛔ | `@md:col-span-2` — 2 of 2 ✅ |
| `@2xl:grid-cols-3` | `@2xl:col-span-3` — 3 of 3 ✅ | `@2xl:col-span-3` — 3 of 3 ✅ |

## What I measured on `origin/main` (`2f073f153`), rather than inherited

The card carries two readings: a browser measurement from objectstack#17328 and a mechanism reading from the triage seat. Both were re-derived here as emitted-class readings, by a new pin run against the **unmodified** tree:

```
AssertionError: expected [ '@2xl:col-span-3' ] to deeply equal [ '@md:col-span-2', '@2xl:col-span-3' ]
AssertionError: expected [ '@4xl:col-span-4' ] to deeply equal [ '@md:col-span-2', …(2) ]
AssertionError: expected [ 'lg:col-span-3' ]   to deeply equal [ 'md:col-span-2', 'lg:col-span-3' ]
Tests  3 failed | 5 passed (8)
```

⇒ the mechanism reading is confirmed, and it is **narrower than "gated at the top breakpoint"**: the class is gated at the first tier that REACHES the target, which for a whole-row field happens to be the top tier. The five that already passed are the negative controls — the prefixing behaviour that must not regress, and which does not.

## The contract, taken from a published declaration

Not from the helper's behaviour. `@objectstack/spec` **17.4.0**, read from `node_modules` in this worktree — the `.describe()` on `FormField.span`:

> Relative field width. … `'full'`: whole row at any column count. Prefer this over the absolute `colSpan`.

«at any column count» is the load-bearing half, and a form passes through several column counts on one screen. The declaration is unambiguous, so this is a renderer bug and is fixed in the renderer — no fallback, no alias, no loosening of the declaration (Commandment #0.1).

⇒ **Consequence for objectstack#17670, which is queued to correct 12 carriers of that sentence on the grounds that it is false.** Once this lands the sentence is TRUE, and the `span: 'full'` half of that correction becomes wrong. The `colSpan` half is untouched by this PR and still needs whatever objectstack#17328 concluded. That card is not addressed here and stays open; I will say so on it.

## Convergence with `plugin-detail`

`getResponsiveSpanClass` has always returned `md:col-span-2 lg:col-span-3 xl:col-span-4` for the same question. `spanLadderFor` now returns exactly that string for the viewport family, and additionally handles the container-query family, which the hard-coded ladder cannot. The two renderers now agree; ⛔ the hard-coded ladder was **not** copied over, per the card.

## Two behaviours deliberately preserved, both pinned

1. **No bare col-span under a one-column base tier** (the card's negative control). A bare `col-span-2` on `grid-cols-1` makes CSS grid synthesize an implicit second track and distorts every column width. Asserted as a **token** check, not a substring check — `@md:col-span-2` contains the text `col-span-2`, so a `toContain` assertion would pass on the broken output.
2. **A container with no responsive grid information still gets the bare class** — with no tier to mirror, the grid is multi-column at every width.

Also unchanged: a `colSpan` smaller than the grid. `colSpan: 2` in a 3-column container is still exactly `@md:col-span-2`; the ladder skips a tier whose span is not an increase, because Tailwind prefixes are min-width and the lower tier's class is still in force there.

## The literal class table is now exhaustive

It was partial, and its `||` fallback answered an unmapped key with a **bare** class — the one answer that must never be given. `2xl:grid-cols-N` (viewport) was one such unmapped key. A missing key now yields no class at all: under-spanning is visible and recoverable, a distorted grid is neither.

⛔ Still literals, never a template string: Tailwind's scanner reads source text, so a computed class is scanned out and the utility silently does not exist.

## Verification

Commands and their own verdict lines; exit codes captured by redirect-then-capture, never through a pipe. All heavy runs through the shared verify lock.

| what | command | result |
|:--|:--|:--|
| new pins, RED arm | `vitest run …form-span-tier-ladder-9244.test.tsx` **on unmodified tree** | `Tests 3 failed \| 5 passed (8)` |
| new pins, GREEN arm | same, after the fix | `Tests 8 passed (8)` |
| cross-layer pin | `vitest run …spanFullTierLadder-9244.test.tsx` | `Tests 5 passed (5)` |
| affected packages | `pnpm exec vitest run packages/components/ packages/plugin-form/` | `Test Files 356 passed (356)` · `Tests 3326 passed \| 1 skipped (3327)` |
| types | `pnpm --filter @object-ui/components --filter @object-ui/plugin-form run type-check` | `Done` / `Done`, `0` lines matching `error TS` |
| dependency closure | `pnpm --filter '@object-ui/components^...' --filter '@object-ui/plugin-form^...' run build` | exit 0 |

`type-check` is `tsc --noEmit && tsc -p tsconfig.test.json` in both packages, so the two new test files are typechecked rather than merely run.

### Acceptance 4 — the classes exist in the built CSS, not merely in the JSX

Compiled `apps/console/src/index.css` through `@tailwindcss/postcss` 4.3.3 (the console's own postcss config) and read the selectors out of the 446,831-byte result:

```
.\@md\:col-span-2   .\@md\:col-span-3   .\@md\:col-span-4
.\@2xl\:col-span-2  .\@2xl\:col-span-3  .\@2xl\:col-span-4
.\@4xl\:col-span-2  .\@4xl\:col-span-3  .\@4xl\:col-span-4
.md\:col-span-2     .lg\:col-span-3     .xl\:col-span-4     .\32 xl\:col-span-2
```

Every class the ladder can emit for a container `CONTAINER_GRID_COLS` produces is present. Negative control, so the grep can fail: `@md:col-span-9` → **0** hits.

⚠️ One honest bound: the viewport spellings `3xl:` … `7xl:` are in the tier regex and therefore in the table, but Tailwind v4 defines no such viewport breakpoint, so they generate no CSS (measured: 0 hits each). A container written with one would get **no** class — under-spanning, not a distorted grid, which is the direction chosen above. No in-repo container uses them.

### Ablation — read through the gate that enforces the claim

This claim is enforced by **vitest**, not by `tsc`: the ladder is a runtime string, and both new files assert a rendered `className`. There is no compile-time pin here for `tsc` to be the arbiter of, so vitest is the right arm — stated because it is the wrong answer for a type-level pin, which vitest erases before it runs.

One line mutated in `spanLadderFor`, turning the ladder back into "the widest tier only" — the exact defect:

```
-    if (want <= spanned) continue;
+    if (want < targetCols) continue; // ABLATION objectui#9244: widest tier only
```

Mutation proven ON DISK before the run, not inferred from the editor's exit code:

```
pre-mutation   removed-text hits: 1   injected-text hits: 0
post-mutation  removed-text hits: 0   injected-text hits: 1
HEAD blob a8b587354baf3f13f239defce96bcf397db60e32 -> mutated blob f89c30d93ab652693a16cd21595ec9240b650be7
```

| arm | result |
|:--|:--|
| **RED** (mutated) | `Test Files 2 failed (2)` · `Tests 7 failed \| 6 passed (13)` |
| **GREEN** (restored) | `Test Files 2 passed (2)` · `Tests 13 passed (13)` |

The 6 that survive the mutation are the discrimination profile, not slack: the negative controls, the 1-cell cases, and the 2-column container — where a one-tier ladder and a full ladder are the same string by construction.

Restore proven by blob hash, not by an exit code: `git checkout HEAD -- …` then `git diff HEAD` empty, blob back to `a8b5873…`, injected text 0 hits. The script carried `trap restore EXIT INT TERM` with absolute paths throughout.

⚠️ **The first attempt of this ablation is reported as void, not quietly re-run.** Its anchor string carried the wrong indentation, so the replacement matched nothing, the tree was never mutated, and the "RED" arm came back `13 passed` — a well-formed reading of nothing. The pre-mutation hit count is what caught it, which is why it is printed above rather than assumed.

### Gates

Derived from the diff's shape against `.github/workflows/**`, not from a hand list of what the content "looks like" it needs.

| gate | verdict |
|:--|:--|
| `check:changeset-presence` | `✅ 2 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)` |
| `check:control-bytes` | `✅ OK (scanned 7443 tracked text file(s))` |
| `check:test-path-roots` | `✅ OK` |
| `check:vi-mock-specifiers` / `-inherit` / `-override-shape` | `✅ OK` (the new tests carry no mock) |
| `check:new-line-citations` | `0 new citation(s)` — symbols cited, never line numbers |
| `check:unreferenced-sources`, `check:side-effects-array`, `check:changeset-claims` | exit 0 |
| `check:eager-closure` (ratchet, reads the built console) | exit 0 — `ui-components` **386.1 KB measured / 389.6 KB ceiling**, 3.6 KB headroom ⚠️ tight |
| `check:eager-locale-catalogues` | `✅ Exactly one locale catalogue is eager` |
| `check:sdui-registration-pins` | `✅ All 16 registration(s) … present in the built console (528 chunks weighed)` |
| `pnpm --filter @object-ui/components --filter @object-ui/plugin-form run lint` | exit 0 — `0 errors` in both; the two new files raise **no** finding of any kind |
| `check-governed-queue-guard --test` on the 5 changed paths | `✅ NOT GOVERNED — 5 path(s) checked against 5 governed surface(s); none matched` |

Those three read `apps/console/dist`, so they were run against a real build (`pnpm --filter '@object-ui/console^...' build` then `pnpm --filter @object-ui/console build`, both exit 0) rather than reported off an unbuilt tree — an unbuilt run exits 2 with PREREQUISITE NOT MET, which is not a pass. ⚠️ The `ui-components` ceiling has 3.6 KB of headroom and this change adds module-scope constants to an eagerly-loaded module, so it was worth measuring rather than assuming.

All gate and test figures above were taken at `f524a441`, the branch head as pushed.

Not applicable by shape, stated so they are not read as skipped: no `scripts/` entry point added (`check:entry-guard`), no README fence edited (`check:doc-snippets` / `check:doc-examples`), no new pin reading markdown (`scripts/markdown-test-inputs.mjs`), no `skills/**` path, no `packages/spec` path (this repo has none), and `packages/components/src/ui/**` — the No-Touch zone — is untouched: the defect lives in `src/renderers/form/`, so no `src/custom/` wrapper was needed.

## Bump level: `patch`, and why not `minor`

The runtime test says a changeset is owed: stored metadata demonstrably renders differently, because an authored `span` now compiles to more classes. The **level** is a separate question, and `patch` is the honest one — no export moved, no signature changed, nothing new is offered. The renderer begins honouring a sentence `@objectstack/spec` 17.4.0 already publishes verbatim; making published behaviour match a published declaration is the definition of a fix. A `minor` would signal a new capability that does not exist here, and all 41 packages share one `fixed` group, so it would move every package's minor line for a renderer bug.

⚠️ The visibility concern that argues for `minor` is real and is handled in the changeset body instead, where it reaches the CHANGELOG: **existing forms will look different at intermediate container widths.** A field that was silently narrow in a modal or drawer now fills the row, as its metadata always asked. Layouts hand-tuned around the old behaviour should be re-checked at modal width.

## Acceptance notes

- **Acceptance 5** — `autoLayout.ts`'s «`span: 'full'` → whole row (grid cells)» needed no correction: after this change it is true at every tier. It gained a note saying where the promise is actually kept and why a pin under `resolveColSpan` structurally cannot observe it.
- **Why the existing pin was green.** `autoLayout.test.ts`'s `it("span: 'full' spans the whole row at any grid width")` is honest about `resolveColSpan`, which really does return the full grid count — it is one layer below the claim its own name makes. Both new files therefore read a rendered `className` and never a return value.
- **Observation, not filed — the unprefixed base tier.** `spanLadderFor` seeds its walk at one cell, so a container whose *unprefixed* `grid-cols-N` is already multi-column (say `grid-cols-2 @2xl:grid-cols-3`) gets no class for that base tier and under-spans there — the same shape as this card, one tier lower. ⛔ Not fixed here and ⛔ not filed: no producer in this repo emits such a container (`CONTAINER_GRID_COLS` and the renderer's own `gridClass` both start at one column), so it is reachable only by hand-writing `fieldContainerClass`. Named successor: none — there is no queued work on this file. Recorded here so the next reader of `spanLadderFor` does not have to re-derive it.

## Notes for the reviewer

- `needs:contract-review` is on this PR: Clause-② was declared `yes` at dispatch under "not sure ⇒ yes", and the measurement confirms it — what an authored `span` compiles to really does change.
- ⛔ Not enqueued and auto-merge not armed, per the dispatch. The PM lands it.

Authored by the os-dev seat in Claude Code; the originating session is `https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_


---
_Generated by [Claude Code](https://claude.ai/code)_