### PR TITLE
fix(fields): render a picklist option value when its label is blank

### DIFF
--- a/.changeset/9230-picklist-blank-option-label.md
+++ b/.changeset/9230-picklist-blank-option-label.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/core': minor
+'@object-ui/fields': minor
+---
+
+A picklist option with a blank label now renders its `value` instead of a blank row (objectui#9230).
+
+Adding a picklist option in App Builder and filling only the value box publishes
+`{ "value": "low", "label": "" }`, and the record form's select then offered three
+unclickable blank rows with nothing anywhere explaining why.
+
+**The producer was not the bug.** An empty label is a document the contract accepts —
+measured on `@objectstack/spec` 17.4.0, `SelectOptionSchema` accepts
+`{ value: 'low', label: '' }` and refuses `{ value: 'low' }` at `[label]` — so `''` is
+the only legal thing the designer can write for a cleared Label box, and it writes it
+deliberately (objectui#7014 Q2, pinned). What the contract does not state is what a
+renderer should DISPLAY for a legal-but-blank label, and objectui had already answered
+that on half its read sites: all four option widgets fell back to the value on their
+read-only path (`opt?.label || v`) and rendered `{opt.label}` raw on their interactive
+path. The same option read `low` in a read-only form and blank in an editable one.
+
+`optionDisplayLabel` in `@object-ui/core` is now that decision written once —
+label, or the value when the label is blank or whitespace-only — and all eight read
+sites across `SelectField`, `MultiSelectField`, `RadioField` and `CheckboxesField` call
+it, so the two halves cannot drift apart again. Radio and checkbox rows gain real
+`<label for>` text with it, which is hit area and an accessible name, not just glyphs.
+
+Minor rather than patch on the stored-data test: every option already published with an
+empty label renders differently after this change, without the document moving. It also
+adds one public export to `@object-ui/core`.
+
+This is display only. Nothing is rewritten, no metadata is migrated, and whether the
+contract should refuse blank labels outright stays a `packages/spec` question.

--- a/content/docs/fields/select.mdx
+++ b/content/docs/fields/select.mdx
@@ -116,6 +116,22 @@ const status: SelectFieldMetadata = {
 };
 ```
 
+### A blank `label` falls back to the `value`
+
+`label` is **required** on an option and an empty string is a legal value for it —
+`@objectstack/spec`'s `SelectOptionSchema` accepts `{ "value": "low", "label": "" }`
+and refuses an option with no `label` key at all. An option authored that way (the
+field designer writes it whenever you fill only the value box) is therefore a document
+the platform stores and serves, and every option widget — `select`, `multiselect`,
+`radio`, `checkboxes` — **displays its `value`** for it rather than an empty row, on
+both the editable and the read-only path
+([objectui#9230](https://github.com/objectstack-ai/objectui/issues/9230)). A label that
+is only whitespace is treated the same way.
+
+This is a display fallback, not a repair: the stored option keeps its empty `label`.
+Author a real label whenever the value is not something you want a person to read —
+`low` is a tolerable row, `acct_st_2` is not.
+
 Cascading option lists are driven by a sibling field's value, declared with
 `dependsOn` — a `BaseFieldMetadata` member every field type inherits
 ([objectui#6153](https://github.com/objectstack-ai/objectui/issues/6153)), in the

--- a/packages/core/src/evaluator/__tests__/optionRules.test.ts
+++ b/packages/core/src/evaluator/__tests__/optionRules.test.ts
@@ -16,6 +16,7 @@ import {
   resolveVisibleOptions,
   isValueStillOffered,
   resolveCascadingOptions,
+  optionDisplayLabel,
   type OptionLike,
 } from '../optionRules';
 
@@ -163,5 +164,44 @@ describe('resolveCascadingOptions — one-shot resolution', () => {
       current_user: { positions: ['admin'] },
     });
     expect(admin.options.map((o) => o.value)).toEqual(['standard', 'admin_only']);
+  });
+});
+
+
+describe('optionDisplayLabel — a blank label falls back to the value (objectui#9230)', () => {
+  it('returns the label when there is one', () => {
+    expect(optionDisplayLabel({ label: 'High', value: 'high' })).toBe('High');
+  });
+
+  it('falls back to the value when the label is the empty string', () => {
+    // The shape the field designer writes when the author fills only the
+    // value box. It is a LEGAL document (the spec requires the key and
+    // accepts ''), so the fallback is display, never a rewrite of metadata.
+    expect(optionDisplayLabel({ label: '', value: 'low' })).toBe('low');
+  });
+
+  it('falls back when the label is only whitespace — the same invisible row', () => {
+    expect(optionDisplayLabel({ label: '   ', value: 'low' })).toBe('low');
+    expect(optionDisplayLabel({ label: '\n\t', value: 'low' })).toBe('low');
+  });
+
+  it('keeps a label whose text merely has surrounding space', () => {
+    // Trim decides EMPTINESS only; it never edits the text that is shown.
+    expect(optionDisplayLabel({ label: ' High ', value: 'high' })).toBe(' High ');
+  });
+
+  it('stringifies a non-string value for the fallback (#3090-widened values)', () => {
+    expect(optionDisplayLabel({ label: '', value: 5 })).toBe('5');
+    expect(optionDisplayLabel({ label: '', value: true })).toBe('true');
+  });
+
+  it('falls back rather than throwing on unvalidated runtime metadata', () => {
+    // `label` is typed required, but renderers are handed raw metadata. The
+    // old `{opt.label}` rendered nothing here; a `.trim()` with no guard would
+    // throw and take the whole form down, which is strictly worse than blank.
+    const absent = { value: 'low' } as unknown as OptionLike;
+    expect(optionDisplayLabel(absent)).toBe('low');
+    const wrongType = { label: 5, value: 'low' } as unknown as OptionLike;
+    expect(optionDisplayLabel(wrongType)).toBe('low');
   });
 });

--- a/packages/core/src/evaluator/optionRules.ts
+++ b/packages/core/src/evaluator/optionRules.ts
@@ -110,6 +110,72 @@ export function resolveVisibleOptions<T extends OptionLike>(
 }
 
 /**
+ * The text an option widget SHOWS for one option: its `label`, or its `value`
+ * when the label is blank (objectui#9230).
+ *
+ * ## Why a blank label reaches a renderer at all — it is a LEGAL document
+ *
+ * This is deliberately NOT the lenient renderer fallback AGENTS.md #0.1
+ * forbids. That rule governs metadata the contract REFUSES ("if the metadata
+ * is off-spec, fix it at the producer"); an empty label is metadata the
+ * contract ACCEPTS. Measured on the installed `@objectstack/spec` 17.4.0,
+ * `SelectOptionSchema`:
+ *
+ *   { value: 'low', label: 'Low' } -> ACCEPT   (lit control)
+ *   { value: 'low', label: '' }    -> ACCEPT   <- the key reading
+ *   { value: 'low' }               -> REJECT invalid_type at [label]
+ *
+ * `@object-ui/types` mirrors that reading in prose on `SelectOptionBase`:
+ * "An empty string is a valid label; an ABSENT one is not." So the producer
+ * is right to emit `label: ''` — the field designer's `patchOptions` does,
+ * under the objectui#7014 Q2 ruling, and a pin
+ * (`ObjectFieldInspector.optionLabel.test.tsx`) fails if it ever invents
+ * content to fill the hole instead. A document every layer calls legal has to
+ * render as something a person can click.
+ *
+ * ## What the contract does NOT say, and who had already answered it
+ *
+ * The spec states no display default for a legal-but-blank label, so nothing
+ * upstream decides this. objectui had nevertheless already decided it — on
+ * HALF its read sites. Measured across the four option widgets before this
+ * helper existed, with `{ value: 'low', label: '' }` authored and
+ * `{ value: 'high', label: 'High' }` beside it as the lit control:
+ *
+ *   | widget      | readonly path      | interactive path |
+ *   | select      | "low"              | ""               |
+ *   | multiselect | "low"              | ""               |
+ *   | radio       | "low"              | ""               |
+ *   | checkboxes  | "low"              | ""               |
+ *
+ * Four summary paths spelled `opt?.label || value` and fell back; the four
+ * interactive paths spelled `{opt.label}` and rendered nothing. So the same
+ * option read "low" in a read-only form and blank in the editable one — the
+ * bug was never "tolerate or refuse", it was a widget family disagreeing with
+ * itself, and the blank half is the one a person has to click.
+ *
+ * This function is that decision written ONCE, the same "one definition, N
+ * surfaces" move as {@link CASCADE_OPTION_WIDGET_TYPES} below. All eight sites
+ * call it, so the two halves cannot drift apart again.
+ *
+ * ## Boundaries
+ *
+ * - Blank means TRIM-empty, so a whitespace-only label falls back too: it is
+ *   the same invisible row to the person looking at it, and it is the
+ *   spelling the producer's own reader already uses to call an authored
+ *   `value` blank (`classifyOption`, `o.value.trim() === ''`).
+ * - `label` is typed required, but this reads defensively because renderers
+ *   are handed unvalidated runtime metadata: a non-string label must fall back
+ *   rather than throw where `{opt.label}` merely rendered nothing.
+ * - This changes DISPLAY only. It writes nothing, and it is not a licence to
+ *   author blank labels — whether the contract should refuse them outright is
+ *   a `packages/spec` question, not a renderer one.
+ */
+export function optionDisplayLabel(option: OptionLike): string {
+  const { label } = option;
+  return typeof label === 'string' && label.trim() !== '' ? label : String(option.value);
+}
+
+/**
  * Whether a scalar field value is still valid given the currently-visible
  * options — used to decide a cascade clear (parent changed, child's old choice
  * no longer offered). An empty value is always "valid" (nothing to clear).

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -146,6 +146,10 @@ never drift). While a `dependsOn` parent is empty the control is gated; a parent
 change re-filters the list and clears a now-invalid value (scalar `select` /
 `radio` drop the value; multi-value `multiselect` / `checkboxes` prune just the
 offered-out entries).
+An option whose `label` is blank (the empty string is a legal label; an absent one is
+not) displays its `value` instead of an empty row, on the editable and the read-only
+path alike — all eight read sites across the four widgets share the one
+`optionDisplayLabel` helper in `@object-ui/core` (objectui#9230).
 Client-side hiding is UX only — gate authorization-sensitive values on the
 server too. See
 [`content/docs/fields/select.mdx`](../../content/docs/fields/select.mdx).

--- a/packages/fields/src/widgets/CheckboxesField.tsx
+++ b/packages/fields/src/widgets/CheckboxesField.tsx
@@ -1,6 +1,6 @@
 import React, { useId, useEffect } from 'react';
 import { Checkbox, Label, EmptyValue, Badge } from '@object-ui/components';
-import type { OptionLike } from '@object-ui/core';
+import { optionDisplayLabel, type OptionLike } from '@object-ui/core';
 import { FieldWidgetComponentProps } from './types.js';
 import { toDomProps } from './toDomProps.js';
 import { toHostGroupProps } from './toHostGroupProps.js';
@@ -90,7 +90,7 @@ export function CheckboxesField({
           // Label from the raw set so a stored value hidden by `visibleWhen`
           // still renders its label rather than a bare id.
           const opt = rawOptions.find((o) => o.value === v);
-          return <Badge key={v} variant="outline">{opt?.label || v}</Badge>;
+          return <Badge key={v} variant="outline">{opt ? optionDisplayLabel(opt) : v}</Badge>;
         })}
       </div>
     );
@@ -164,7 +164,7 @@ export function CheckboxesField({
               aria-invalid={!!error}
               data-testid={`checkboxes-option-${value}`}
             />
-            <Label htmlFor={id} className="font-normal">{opt.label}</Label>
+            <Label htmlFor={id} className="font-normal">{optionDisplayLabel(opt)}</Label>
           </div>
         );
       })}

--- a/packages/fields/src/widgets/MultiSelectField.tsx
+++ b/packages/fields/src/widgets/MultiSelectField.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { Badge, EmptyValue, cn } from '@object-ui/components';
-import type { OptionLike } from '@object-ui/core';
+import { optionDisplayLabel, type OptionLike } from '@object-ui/core';
 import { FieldWidgetComponentProps } from './types.js';
 import { toDomProps } from './toDomProps.js';
 import { toHostGroupProps } from './toHostGroupProps.js';
@@ -111,7 +111,7 @@ export function MultiSelectField({
           // Label from the raw set so a stored value hidden by `visibleWhen`
           // still renders its label rather than a bare id.
           const opt = rawOptions.find((o) => o.value === v);
-          return <Badge key={v} variant="outline">{opt?.label || v}</Badge>;
+          return <Badge key={v} variant="outline">{opt ? optionDisplayLabel(opt) : v}</Badge>;
         })}
       </div>
     );
@@ -191,7 +191,7 @@ export function MultiSelectField({
                 : 'border-input bg-background text-foreground hover:bg-accent',
             )}
           >
-            {opt.label}
+            {optionDisplayLabel(opt)}
           </button>
         );
       })}

--- a/packages/fields/src/widgets/RadioField.tsx
+++ b/packages/fields/src/widgets/RadioField.tsx
@@ -1,6 +1,6 @@
 import React, { useId, useEffect } from 'react';
 import { RadioGroup, RadioGroupItem, Label, EmptyValue } from '@object-ui/components';
-import { isValueStillOffered, type OptionLike } from '@object-ui/core';
+import { isValueStillOffered, optionDisplayLabel, type OptionLike } from '@object-ui/core';
 import { FieldWidgetComponentProps } from './types.js';
 import { toDomProps } from './toDomProps.js';
 import { toHostGroupProps } from './toHostGroupProps.js';
@@ -83,7 +83,7 @@ export function RadioField({
     // Label from the raw set so a stored value hidden by `visibleWhen` still
     // renders its label rather than a bare id.
     const opt = rawOptions.find((o) => o.value === value);
-    return <span {...hostGroupProps} className="text-sm">{opt?.label || String(value)}</span>;
+    return <span {...hostGroupProps} className="text-sm">{opt ? optionDisplayLabel(opt) : String(value)}</span>;
   }
 
   // No offered options is unfillable — surface a legible state instead of an
@@ -137,7 +137,7 @@ export function RadioField({
         return (
           <div key={value} className="flex items-center space-x-2">
             <RadioGroupItem value={value} id={id} data-testid={`radio-option-${value}`} />
-            <Label htmlFor={id} className="font-normal">{opt.label}</Label>
+            <Label htmlFor={id} className="font-normal">{optionDisplayLabel(opt)}</Label>
           </div>
         );
       })}

--- a/packages/fields/src/widgets/SelectField.tsx
+++ b/packages/fields/src/widgets/SelectField.tsx
@@ -7,7 +7,7 @@ import {
   SelectValue,
   EmptyValue,
 } from '@object-ui/components';
-import { isValueStillOffered } from '@object-ui/core';
+import { isValueStillOffered, optionDisplayLabel } from '@object-ui/core';
 import { SelectFieldMetadata } from '@object-ui/types';
 import { useFieldTranslation } from './useFieldTranslation.js';
 import { FieldWidgetComponentProps } from './types.js';
@@ -128,7 +128,7 @@ function SingleSelectField({
 
   if (readonly) {
     const option = rawOptions.find((o) => o.value === value);
-    const display = option?.label || value;
+    const display = option ? optionDisplayLabel(option) : value;
     return display ? <span className="text-sm">{display}</span> : <EmptyValue />;
   }
 
@@ -196,7 +196,7 @@ function SingleSelectField({
       <SelectContent position="popper">
         {options.map((option) => (
           <SelectItem key={option.value} value={option.value} data-testid={`select-option-${option.value}`}>
-            {option.label}
+            {optionDisplayLabel(option)}
           </SelectItem>
         ))}
       </SelectContent>

--- a/packages/fields/src/widgets/optionWidgets.emptyLabel.test.tsx
+++ b/packages/fields/src/widgets/optionWidgets.emptyLabel.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A picklist option with a BLANK label renders its `value`, on BOTH paths
+ * (objectui#9230).
+ *
+ * ## The document is legal, so the renderer owes it a visible row
+ *
+ * The field designer writes `label: ''` when the author fills only the value
+ * box, and that is the correct producer behaviour, not the bug: the contract
+ * accepts an empty label and REFUSES an absent one, so `''` is the only legal
+ * thing to write for a cleared Label box. That reading is pinned at the
+ * producer in `app-shell`'s `ObjectFieldInspector.optionLabel.test.tsx`
+ * (objectui#7014 Q2), whose fourth case also pins that the designer must NOT
+ * invent `value` into `label` behind the author's back. The control below
+ * re-derives the half this file depends on rather than trusting prose: if the
+ * spec ever starts refusing a blank label, it goes red and this fallback is
+ * the wrong shape.
+ *
+ * ## What was actually broken: the family disagreed with itself
+ *
+ * Measured on `origin/main` before the fix, one authored option
+ * `{ value: 'low', label: '' }` with `{ value: 'high', label: 'High' }` beside
+ * it as the lit control:
+ *
+ *   | widget      | readonly path | interactive path |
+ *   | select      | "low"         | ""   <- blank    |
+ *   | multiselect | "low"         | ""   <- blank    |
+ *   | radio       | "low"         | ""   <- blank    |
+ *   | checkboxes  | "low"         | ""   <- blank    |
+ *
+ * All four summary paths already fell back to the value (`opt?.label || v`);
+ * all four interactive paths rendered `{opt.label}` raw. Same option, same
+ * record: "low" when the form was read-only and an unclickable blank row when
+ * it was editable. `optionDisplayLabel` in `@object-ui/core` is now the single
+ * definition both halves call.
+ *
+ * So every widget below is asserted on BOTH paths, and the two are asserted to
+ * AGREE — a fix applied to only one half is exactly the state this file exists
+ * to keep from coming back.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SelectOptionSchema } from '@objectstack/spec/data';
+import { SelectField } from './SelectField';
+import { MultiSelectField } from './MultiSelectField';
+import { CheckboxesField } from './CheckboxesField';
+import { RadioField } from './RadioField';
+
+/**
+ * The authored list under test. `low` is the defect shape; `high` is the LIT
+ * CONTROL — it must keep rendering its own label, so a green assertion on
+ * `low` cannot come from a probe that sees no labels at all.
+ */
+const OPTIONS = [
+  { value: 'low', label: '' },
+  { value: 'high', label: 'High' },
+];
+
+const severityField = (type: string) =>
+  ({ name: 'sev', type, options: OPTIONS }) as unknown as Record<string, unknown>;
+
+/** The structural slice of a Zod schema this file needs -- no `any` (AGENTS.md #6). */
+type SpecSchema = { safeParse: (value: unknown) => { success: boolean } };
+const accepts = (schema: SpecSchema, doc: unknown): boolean => schema.safeParse(doc).success;
+
+describe('option widgets · a blank option label falls back to the value (objectui#9230)', () => {
+  it('the premise: the contract ACCEPTS a blank label and REFUSES an absent one', () => {
+    // Why the renderer, and not the designer, is the fix site: `label: ''` is
+    // a document every layer calls legal, so it reaches a widget by design.
+    expect(accepts(SelectOptionSchema, { value: 'low', label: '' })).toBe(true);
+    // Lit control — this schema does reject things, so the ACCEPT means something.
+    expect(accepts(SelectOptionSchema, { value: 'low' })).toBe(false);
+    expect(accepts(SelectOptionSchema, { value: 'low', label: 'Low' })).toBe(true);
+  });
+
+  it('SelectField shows the value in the OPEN dropdown, not a blank row', () => {
+    render(
+      <SelectField
+        value={undefined}
+        onChange={vi.fn()}
+        field={severityField('select')}
+        {...({ name: 'sev' } as Record<string, unknown>)}
+      />,
+    );
+    fireEvent.keyDown(screen.getByTestId('select-trigger-sev'), { key: 'Enter' });
+    expect(screen.getByTestId('select-option-low')).toHaveTextContent('low');
+    expect(screen.getByTestId('select-option-high')).toHaveTextContent('High');
+  });
+
+  it('SelectField read-only keeps showing the value (unchanged) — both paths agree', () => {
+    const { container } = render(
+      <SelectField
+        value="low"
+        onChange={vi.fn()}
+        readonly
+        field={severityField('select')}
+        {...({ name: 'sev' } as Record<string, unknown>)}
+      />,
+    );
+    expect(container).toHaveTextContent('low');
+  });
+
+  it('MultiSelectField shows the value on its toggle, not a blank chip', () => {
+    render(
+      <MultiSelectField
+        value={[]}
+        onChange={vi.fn()}
+        field={severityField('multiselect')}
+        {...({ name: 'sev' } as Record<string, unknown>)}
+      />,
+    );
+    expect(screen.getByTestId('multiselect-option-low')).toHaveTextContent('low');
+    expect(screen.getByTestId('multiselect-option-high')).toHaveTextContent('High');
+  });
+
+  it('MultiSelectField read-only keeps showing the value (unchanged) — both paths agree', () => {
+    const { container } = render(
+      <MultiSelectField
+        value={['low']}
+        onChange={vi.fn()}
+        readonly
+        field={severityField('multiselect')}
+        {...({ name: 'sev' } as Record<string, unknown>)}
+      />,
+    );
+    expect(container).toHaveTextContent('low');
+  });
+
+  it('RadioField labels the radio with the value, so the row is clickable copy', () => {
+    render(
+      <RadioField
+        value={undefined}
+        onChange={vi.fn()}
+        field={severityField('radio')}
+        {...({ name: 'sev' } as Record<string, unknown>)}
+      />,
+    );
+    // The <label for> must carry text: an empty one names nothing to a screen
+    // reader and gives a pointer user no hit area beyond the dot itself.
+    expect(screen.getByLabelText('low')).toBe(screen.getByTestId('radio-option-low'));
+    expect(screen.getByLabelText('High')).toBe(screen.getByTestId('radio-option-high'));
+  });
+
+  it('RadioField read-only keeps showing the value (unchanged) — both paths agree', () => {
+    const { container } = render(
+      <RadioField
+        value="low"
+        onChange={vi.fn()}
+        readonly
+        field={severityField('radio')}
+        {...({ name: 'sev' } as Record<string, unknown>)}
+      />,
+    );
+    expect(container).toHaveTextContent('low');
+  });
+
+  it('CheckboxesField labels the box with the value, so the row is clickable copy', () => {
+    render(
+      <CheckboxesField
+        value={[]}
+        onChange={vi.fn()}
+        field={severityField('checkboxes')}
+        {...({ name: 'sev' } as Record<string, unknown>)}
+      />,
+    );
+    expect(screen.getByLabelText('low')).toBe(screen.getByTestId('checkboxes-option-low'));
+    expect(screen.getByLabelText('High')).toBe(screen.getByTestId('checkboxes-option-high'));
+  });
+
+  it('CheckboxesField read-only keeps showing the value (unchanged) — both paths agree', () => {
+    const { container } = render(
+      <CheckboxesField
+        value={['low']}
+        onChange={vi.fn()}
+        readonly
+        field={severityField('checkboxes')}
+        {...({ name: 'sev' } as Record<string, unknown>)}
+      />,
+    );
+    expect(container).toHaveTextContent('low');
+  });
+
+  it('a whitespace-only label falls back too — it is the same invisible row', () => {
+    render(
+      <MultiSelectField
+        value={[]}
+        onChange={vi.fn()}
+        field={
+          {
+            name: 'sev',
+            type: 'multiselect',
+            options: [{ value: 'low', label: '   ' }],
+          } as unknown as Record<string, unknown>
+        }
+        {...({ name: 'sev' } as Record<string, unknown>)}
+      />,
+    );
+    expect(screen.getByTestId('multiselect-option-low')).toHaveTextContent('low');
+  });
+});

--- a/packages/fields/src/widgets/optionWidgets.emptyLabel.test.tsx
+++ b/packages/fields/src/widgets/optionWidgets.emptyLabel.test.tsx
@@ -51,6 +51,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { SelectOptionSchema } from '@objectstack/spec/data';
+import type { FieldMetadata } from '@object-ui/types';
 import { SelectField } from './SelectField';
 import { MultiSelectField } from './MultiSelectField';
 import { CheckboxesField } from './CheckboxesField';
@@ -66,8 +67,12 @@ const OPTIONS = [
   { value: 'high', label: 'High' },
 ];
 
+// `radio` and `checkboxes` are WIDGET keys with no member of their own in the
+// `FieldMetadata` union, so one documented cast stands in for a type that does
+// not exist. Deliberately `as unknown as`, never `as any` (AGENTS.md #6): every
+// assertion below stays type-checked.
 const severityField = (type: string) =>
-  ({ name: 'sev', type, options: OPTIONS }) as unknown as Record<string, unknown>;
+  ({ name: 'sev', type, options: OPTIONS }) as unknown as FieldMetadata;
 
 /** The structural slice of a Zod schema this file needs -- no `any` (AGENTS.md #6). */
 type SpecSchema = { safeParse: (value: unknown) => { success: boolean } };
@@ -89,7 +94,7 @@ describe('option widgets · a blank option label falls back to the value (object
         value={undefined}
         onChange={vi.fn()}
         field={severityField('select')}
-        {...({ name: 'sev' } as Record<string, unknown>)}
+        name="sev"
       />,
     );
     fireEvent.keyDown(screen.getByTestId('select-trigger-sev'), { key: 'Enter' });
@@ -104,7 +109,7 @@ describe('option widgets · a blank option label falls back to the value (object
         onChange={vi.fn()}
         readonly
         field={severityField('select')}
-        {...({ name: 'sev' } as Record<string, unknown>)}
+        name="sev"
       />,
     );
     expect(container).toHaveTextContent('low');
@@ -116,7 +121,7 @@ describe('option widgets · a blank option label falls back to the value (object
         value={[]}
         onChange={vi.fn()}
         field={severityField('multiselect')}
-        {...({ name: 'sev' } as Record<string, unknown>)}
+        name="sev"
       />,
     );
     expect(screen.getByTestId('multiselect-option-low')).toHaveTextContent('low');
@@ -130,7 +135,7 @@ describe('option widgets · a blank option label falls back to the value (object
         onChange={vi.fn()}
         readonly
         field={severityField('multiselect')}
-        {...({ name: 'sev' } as Record<string, unknown>)}
+        name="sev"
       />,
     );
     expect(container).toHaveTextContent('low');
@@ -139,10 +144,12 @@ describe('option widgets · a blank option label falls back to the value (object
   it('RadioField labels the radio with the value, so the row is clickable copy', () => {
     render(
       <RadioField
-        value={undefined}
+        // `RadioField` declares `value: string` (required), so the
+        // nothing-selected state is the empty string, not `undefined`.
+        value=""
         onChange={vi.fn()}
         field={severityField('radio')}
-        {...({ name: 'sev' } as Record<string, unknown>)}
+        name="sev"
       />,
     );
     // The <label for> must carry text: an empty one names nothing to a screen
@@ -158,7 +165,7 @@ describe('option widgets · a blank option label falls back to the value (object
         onChange={vi.fn()}
         readonly
         field={severityField('radio')}
-        {...({ name: 'sev' } as Record<string, unknown>)}
+        name="sev"
       />,
     );
     expect(container).toHaveTextContent('low');
@@ -170,7 +177,7 @@ describe('option widgets · a blank option label falls back to the value (object
         value={[]}
         onChange={vi.fn()}
         field={severityField('checkboxes')}
-        {...({ name: 'sev' } as Record<string, unknown>)}
+        name="sev"
       />,
     );
     expect(screen.getByLabelText('low')).toBe(screen.getByTestId('checkboxes-option-low'));
@@ -184,7 +191,7 @@ describe('option widgets · a blank option label falls back to the value (object
         onChange={vi.fn()}
         readonly
         field={severityField('checkboxes')}
-        {...({ name: 'sev' } as Record<string, unknown>)}
+        name="sev"
       />,
     );
     expect(container).toHaveTextContent('low');
@@ -200,9 +207,9 @@ describe('option widgets · a blank option label falls back to the value (object
             name: 'sev',
             type: 'multiselect',
             options: [{ value: 'low', label: '   ' }],
-          } as unknown as Record<string, unknown>
+          } as unknown as FieldMetadata
         }
-        {...({ name: 'sev' } as Record<string, unknown>)}
+        name="sev"
       />,
     );
     expect(screen.getByTestId('multiselect-option-low')).toHaveTextContent('low');


### PR DESCRIPTION
Part of #9230

Adding a picklist option in App Builder and filling only the value box publishes `{"value":"low","label":""}`, and the record form's select then offered unclickable blank rows with nothing anywhere explaining why.

## Which side to fix was a measurement

**1. The published contract, read first.** `@objectstack/spec` **17.4.0**, resolved from this worktree's `node_modules` after `pnpm install`, `SelectOptionSchema`:

| document | verdict |
|---|---|
| `{ value: 'low', label: 'Low' }` | ACCEPT (lit control) |
| `{ value: 'low', label: '' }` | **ACCEPT** |
| `{ value: 'low' }` | REJECT `invalid_type` at `[label]` |
| `{ value: 'low', label: '   ' }` | ACCEPT |

`label` is `z.ZodString` — required, no `.default()`, no `.min(1)`. `@object-ui/types` mirrors the same reading in prose on `SelectOptionBase`: *"An empty string is a valid label; an ABSENT one is not."*

**2. So the producer is not the bug.** `''` is the only legal thing the field designer can write for a cleared Label box, and it writes it deliberately — the objectui#7014 Q2 ruling, whose pin `ObjectFieldInspector.optionLabel.test.tsx` *also* forbids the producer-side repair: its first case asserts `option.value` is untouched precisely so a fix that stored `value` into `label` behind the author's back goes red. That route is closed by an existing gate, not by opinion.

**3. What the contract does NOT state** is what a renderer should DISPLAY for a legal-but-blank label. objectui had already answered it — on half its read sites. Measured on `origin/main` before the fix, one authored `{value:'low',label:''}` with `{value:'high',label:'High'}` beside it as the lit control:

| widget | read-only path | interactive path |
|---|---|---|
| select | `"low"` | `""` blank |
| multiselect | `"low"` | `""` blank |
| radio | `"low"` | `""` blank |
| checkboxes | `"low"` | `""` blank |

All four summary paths already spelled `opt?.label || v`; all four interactive paths spelled `{opt.label}` raw. **The same option read `low` in a read-only form and blank in an editable one.** The bug was never "tolerate or refuse" — it was a widget family disagreeing with itself, and the blank half is the one a person has to click.

This is also why AGENTS.md #0.1 does not bar it: that rule governs metadata the contract **refuses** ("if the metadata is off-spec, fix it at the producer"). This metadata is on-spec, measured. A document every layer calls legal has to render as something clickable.

## The change

`optionDisplayLabel` in `@object-ui/core` (beside `resolveCascadingOptions`, which the same four widgets already share) is that decision written once — label, or the value when the label is blank or whitespace-only. All **eight** read sites call it, so the halves cannot drift apart again. Radio and checkbox rows gain real text in their `label for` element: hit area and an accessible name, not just the glyph.

Display only. Nothing is rewritten, nothing stored is migrated.

## Stored population

Producer-only fixes leave already-published rows broken; this one repairs them on read. Swept for authored blank labels (each with a lit control proving the probe fires): JSON `"label": ""` — 1 hit, a `button` label in `examples/schema-catalog`, not an option (control: 720 non-empty). TS `label: ''` — 34 hits, all designer scaffolding, test fixtures or non-option surfaces (control: 9418). So no seeded picklist option ships with a blank label today; the affected population is whatever authors have published since objectui#7014 Q2, which is unmeasurable from here and is exactly the population a producer-only fix could not have reached.

## Verification

All figures below are from one tree: `78e0a21bf`, working tree clean, workspace built (`pnpm build` 43/43 successful) before anything that reads `dist`.

| run | result |
|---|---|
| `pnpm --filter @object-ui/core --filter @object-ui/fields run type-check` | exit 0 |
| `pnpm exec vitest run packages/core/` | 152 files / **3249** passed |
| `pnpm exec vitest run packages/fields/` | 160 files / **2768** passed |
| producer pins (`ObjectFieldInspector.optionLabel` + `.malformedOptions`) | 2 files / **32** passed — untouched, still green in the other direction |
| `pnpm lint` (turbo, whole repo) | 47/47 tasks successful, 0 cached, **0 errors** |

The script name is `type-check`, hyphenated, in both packages — `typecheck` would have matched no script and exited 0 having run nothing.

**Gates, all exit 0 on this HEAD against the built tree** (14): `control-bytes`, `changeset-claims`, `new-line-citations`, `installed-pin-claims`, `spec-symbols`, `readme-exports`, `test-path-roots`, `doc-fences`, `doc-example-ids`, `doc-snippets`, `doc-examples`, `doc-types`, `vi-mock-specifiers`, `unreferenced-sources`. `check:readme-exports` and the doc-type gates were **red before the build** with `run pnpm build first` and `the population COLLAPSED -- this run proves nothing`: a prerequisite failure, not a pass and not a defect, and they were re-read after building rather than waved through. `check-governed-queue-guard.mjs --test` on the 10 changed paths: NOT GOVERNED.

**Ablation.** `optionDisplayLabel`'s body replaced with `return label as string;` (the pre-fix behaviour), mutation proven on disk before the run — anchor text 1 occurrence to 0, replacement 0 to 1, blob `83b246c2…` to `1cbcfefb…`:

| leg | result |
|---|---|
| mutated | exit 1 — **13 failed** / 20 passed |
| restored | exit 0 — 33 passed |

Restore is `git checkout HEAD --` on an absolute path under an `EXIT`/`INT`/`TERM` trap, and is proven by the on-disk blob returning to `83b246c2…` with `git diff HEAD` empty — not by the restore command's exit code. No `dist` leg is owed here and none was faked: the root `vitest.config.mts` aliases `@object-ui/core` to `packages/core/src`, so the pins read the mutated source directly.

## Acceptance notes

Out of scope, noted and deliberately not filed:

- **Other option-rendering surfaces carry the same blank-label blindness** — `packages/components/src/renderers/form/select.tsx` (the SDUI form face, a different option vocabulary whose `value` is widened) and `packages/fields/src/widgets/GridField.tsx:938` (inline-grid select column, authored through `columns[].options`, a *different* producer than the picklist editor). Neither is this card's consumer and neither was measured here. Successor: the next PR touching the SDUI form select or inline-grid columns.
- **The contract states no display default at all**, and does not refuse a blank label. Whether it should (`label: z.string().min(1)`, or a publish-time warning) is the second half of this card's own "Expected" and belongs to `@objectstack/spec` — an `objectstack` `domain:spec` card with `Blocked-by:` back here, per this card's ⚠️ note. Reported to the PM rather than filed from a UI lane. **Not** needed for this PR: the fix stands whichever way that lands, and only becomes wrong if the spec starts *refusing* blank labels — which the contract control in the new test file makes go red the moment it does.

⛔ Left in draft deliberately, unqueued and with no auto-merge: the PM lands it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_


---
_Generated by [Claude Code](https://claude.ai/code)_