### PR TITLE
test(app-shell): make the via_override pin discriminate its two failure causes

### DIFF
--- a/.changeset/via-override-pin-discriminates.md
+++ b/.changeset/via-override-pin-discriminates.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: the `RecordApprovalsPanel` `via_override` pin now settles on the timeline rows it asserts rather than on the panel shell, and its two failure causes ("the rows have not arrived" vs "the chip is no longer rendered") report as two different messages. No published behaviour changes — no file outside `packages/app-shell/src/views/RecordApprovalsPanel.viaOverrideMarker.test.tsx` was touched.

--- a/packages/app-shell/src/views/RecordApprovalsPanel.viaOverrideMarker.test.tsx
+++ b/packages/app-shell/src/views/RecordApprovalsPanel.viaOverrideMarker.test.tsx
@@ -20,6 +20,47 @@
  * So this pins the read: an override row says so, and — just as important — a
  * row that is NOT an override, and a row too old to know, both stay silent.
  * A marker that appears on ordinary approvals is worse than no marker.
+ *
+ * ## Why this file settles the way it does (objectui#9158)
+ *
+ * This pin previously awaited `findByTestId('record-approvals-panel')` — the
+ * panel SHELL — and then read the chips synchronously. The chips live on rows
+ * built from the stubbed `/actions` response, a SECOND async state that lands
+ * after the shell. So the pin settled on something that is ready EARLIER than
+ * the thing it asserts, and under load the assertion could run before the rows
+ * existed.
+ *
+ * The damage was not a wasted CI minute. Both of these produced the SAME
+ * failure text, measured on `865d34485`:
+ *
+ *   cause A — the chip stops rendering entirely (a real objectui#5178 regression)
+ *   cause B — the rows had not arrived yet (a timing reading about the harness)
+ *
+ *   both: `Unable to find an element by: [data-testid="via-override-chip"]`
+ *
+ * A pin whose two causes are indistinguishable from its output teaches the
+ * reader to re-run rather than to look, which is exactly how a real regression
+ * on this marker gets re-run to green. And the twist worth carrying forward:
+ * the `await` was not missing. It was present, and pointed at the wrong
+ * element — so a reviewer saw an `await` and stopped looking. The check is not
+ * "is there an await", it is "does the awaited element land in the same flush
+ * as the asserted one".
+ *
+ * Two rules therefore hold in this file, and `describe('the pin discriminates
+ * its two causes')` at the bottom keeps them honest:
+ *
+ *   1. Settle on the ROWS. {@link renderPanel} does not return until every row
+ *      the stub declared is in the DOM, and it fails with a TIMING message that
+ *      says so — never with a chip-shaped one.
+ *   2. Every absence assertion carries a LIVE POSITIVE CONTROL in the same DOM.
+ *      An absence is satisfied by a panel that renders nothing at all: with the
+ *      chip deleted outright, three of the assertions below used to pass. A
+ *      permanently-green absence is worse than an intermittently-red presence,
+ *      because nothing ever surfaces it.
+ *
+ * Note what is deliberately NOT done here: no timeout was raised and no
+ * `waitFor` wraps an assertion block. Waiting longer for `via-override-chip`
+ * would have kept both causes under one message and merely delayed the verdict.
  */
 
 import * as React from 'react';
@@ -49,13 +90,26 @@ const REQUEST: ApprovalRequestLite = {
   completed_at: '2026-08-03T08:00:00Z',
 };
 
+/** A row of the stubbed `GET /approvals/requests/:id/actions` payload. */
+interface StubAction {
+  id: string;
+  request_id: string;
+  action: string;
+  actor_id: string;
+  /** Every stub row names its actor, because the settle keys on these. */
+  actor_name: string;
+  created_at: string;
+  step_name?: string;
+  via_override?: boolean;
+}
+
 /**
  * One thread carrying all three states of the column at once, so the assertions
  * below are about the ROW and not about the panel happening to render a chip
  * somewhere. The two approvals are otherwise identical — same action, same
  * step — which is exactly the indistinguishability being fixed.
  */
-const ACTIONS = [
+const ACTIONS: StubAction[] = [
   {
     id: 'a1', request_id: 'req_1', action: 'submit',
     actor_id: 'u_submitter', actor_name: 'Zhou Ming', created_at: '2026-08-01T08:00:00Z',
@@ -77,11 +131,26 @@ const ACTIONS = [
   },
 ];
 
-function stubApi(rows: any[]) {
+/** The thread the override row has been taken out of — nobody earns a chip. */
+const ACTIONS_WITHOUT_OVERRIDE = ACTIONS.filter((a) => a.via_override !== true);
+
+const CHIP = 'via-override-chip';
+
+interface StubOptions {
+  /**
+   * Answer the `/actions` request with a promise that never settles, which is
+   * cause B — "the rows have not arrived" — made deterministic. Used only by
+   * the discrimination pin at the bottom of this file.
+   */
+  withholdActions?: boolean;
+}
+
+function stubApi(rows: StubAction[], opts: StubOptions = {}) {
   vi.stubGlobal(
     'fetch',
     vi.fn(async (url: string) => {
       if (/\/approvals\/requests\/[^/]+\/actions$/.test(String(url))) {
+        if (opts.withholdActions) return new Promise<never>(() => {});
         return { ok: true, json: async () => ({ data: rows }) } as any;
       }
       return { ok: false, status: 404, json: async () => ({}) } as any;
@@ -89,15 +158,78 @@ function stubApi(rows: any[]) {
   );
 }
 
-async function renderPanel(rows: any[] = ACTIONS) {
-  stubApi(rows);
+/** What the panel looks like right now, for a failure message to carry. */
+function panelSnapshot(): string {
+  const shell = screen.queryByTestId('record-approvals-panel');
+  if (!shell) return 'panel shell: ABSENT — the component rendered nothing testable';
+  const text = (shell.textContent ?? '').replace(/\s+/g, ' ').trim();
+  return `panel shell: present · list rows: ${shell.querySelectorAll('li').length}`
+    + ` · text: ${text.slice(0, 240)}`;
+}
+
+/** Cause B's message. It must never be confusable with a marker reading. */
+function timelineNeverArrived(expected: string[]): string {
+  const present = expected.filter((n) => screen.queryAllByText(n).length > 0);
+  const missing = expected.filter((n) => screen.queryAllByText(n).length === 0);
+  return [
+    'TIMELINE ROWS NEVER ARRIVED — a TIMING reading about this harness, NOT a statement',
+    'about the via_override marker (objectui#9158).',
+    `  rows expected (${expected.length}): ${expected.join(', ')}`,
+    `  rows present  (${present.length}): ${present.join(', ') || '(none)'}`,
+    `  rows missing  (${missing.length}): ${missing.join(', ') || '(none)'}`,
+    `  ${panelSnapshot()}`,
+    'The GET /approvals/requests/:id/actions flush had not landed when the settle window',
+    'closed, so whether the override chip still renders is UNTESTED by this run. Fix the',
+    'async path or the harness; re-running to green proves nothing about objectui#5178.',
+  ].join('\n');
+}
+
+/** Cause A's message. It asserts the rows were settled, so timing is excluded. */
+const MARKER_GONE = [
+  'VIA_OVERRIDE MARKER REGRESSION — the timeline rows are SETTLED (renderPanel awaited',
+  'every stubbed row before this assertion ran), so a missing chip is the marker no',
+  'longer rendering (objectui#5178), not a row that had not arrived. Re-running will not',
+  'change this reading.',
+].join('\n');
+
+const CONTROL_DEAD = [
+  'POSITIVE CONTROL DEAD — the override row (Sun Wei) carries no chip, so the absence',
+  'asserted in this test would also be satisfied by a panel that renders NO chip at all.',
+  'An absence is evidence only while the marker is demonstrably live in the same DOM.',
+].join('\n');
+
+const ZERO_CONTROL_DEAD = [
+  'POSITIVE CONTROL DEAD — with the override row put back, the same harness and the same',
+  'settle produced no chip. So the zero asserted above is not "nobody earned one", it is',
+  '"the marker never renders" (objectui#5178).',
+].join('\n');
+
+/**
+ * Settle on the rows the assertions are about.
+ *
+ * `findByText` is Testing Library's own await, one per stubbed row, so the
+ * window closes only once the `/actions` flush has produced the whole payload.
+ * On failure it is re-thrown as a TIMING message — the single reason this
+ * helper exists rather than a bare `await findByTestId(...)`.
+ */
+async function settleTimelineRows(rows: StubAction[]): Promise<void> {
+  const expected = rows.map((r) => r.actor_name);
+  try {
+    for (const name of expected) await screen.findByText(name);
+  } catch {
+    throw new Error(timelineNeverArrived(expected));
+  }
+}
+
+async function renderPanel(rows: StubAction[] = ACTIONS, opts: StubOptions = {}) {
+  stubApi(rows, opts);
   const view = render(
     <RecordApprovalsPanel
       approvals={{ available: true, requests: [REQUEST], pendingRequest: null }}
       currentUserId="u_viewer"
     />,
   );
-  await screen.findByTestId('record-approvals-panel');
+  await settleTimelineRows(rows);
   return view;
 }
 
@@ -107,6 +239,11 @@ function rowFor(actorName: string): HTMLElement {
   const li = cell.closest('li');
   if (!li) throw new Error(`no timeline row for ${actorName}`);
   return li as HTMLElement;
+}
+
+/** The live control every absence assertion in this file leans on. */
+function expectMarkerIsLive(): void {
+  expect(within(rowFor('Sun Wei')).queryByTestId(CHIP), CONTROL_DEAD).not.toBeNull();
 }
 
 beforeEach(() => {
@@ -122,20 +259,22 @@ describe('RecordApprovalsPanel — via_override marker (objectui#5178)', () => {
   it('marks the override row, and only the override row', async () => {
     await renderPanel();
     // Exactly one chip in the whole timeline, on the row that earned it.
-    expect(screen.getAllByTestId('via-override-chip')).toHaveLength(1);
-    expect(within(rowFor('Sun Wei')).getByTestId('via-override-chip')).toBeTruthy();
+    expect(screen.queryAllByTestId(CHIP), MARKER_GONE).toHaveLength(1);
+    expect(within(rowFor('Sun Wei')).queryByTestId(CHIP), MARKER_GONE).not.toBeNull();
   });
 
   it('leaves a checked-and-NOT-override approval unmarked', async () => {
     await renderPanel();
+    expectMarkerIsLive();
     // `via_override: false` is a positive statement that this was an ordinary
     // approval. Marking it would be a false accusation in an audit surface.
-    expect(within(rowFor('Qian Hua')).queryByTestId('via-override-chip')).toBeNull();
+    expect(within(rowFor('Qian Hua')).queryByTestId(CHIP)).toBeNull();
   });
 
   it('leaves a pre-column row unmarked — "not recorded" is not "not an override"', async () => {
     await renderPanel();
-    expect(within(rowFor('Old Row')).queryByTestId('via-override-chip')).toBeNull();
+    expectMarkerIsLive();
+    expect(within(rowFor('Old Row')).queryByTestId(CHIP)).toBeNull();
   });
 
   it('still reads as an approval — the marker annotates, it does not replace', async () => {
@@ -143,7 +282,7 @@ describe('RecordApprovalsPanel — via_override marker (objectui#5178)', () => {
     const row = rowFor('Sun Wei');
     expect(row.textContent).toContain('Approved');
     expect(row.textContent).toContain('Sun Wei');
-    expect(row.textContent).toContain('Admin override');
+    expect(row.textContent, MARKER_GONE).toContain('Admin override');
   });
 
   it('gives the override row a different timeline dot from an ordinary approval', async () => {
@@ -157,7 +296,52 @@ describe('RecordApprovalsPanel — via_override marker (objectui#5178)', () => {
   });
 
   it('renders no chip at all for a thread with no overrides', async () => {
-    await renderPanel(ACTIONS.filter((a) => a.via_override !== true));
-    expect(screen.queryAllByTestId('via-override-chip')).toHaveLength(0);
+    await renderPanel(ACTIONS_WITHOUT_OVERRIDE);
+    expect(screen.queryAllByTestId(CHIP)).toHaveLength(0);
+
+    // The control for that zero. This thread has no override row, so the live
+    // control has to be a second render: same harness, same settle, override
+    // row restored. Without it, the zero above is also what a deleted chip
+    // reads, and the two are indistinguishable again.
+    cleanup();
+    await renderPanel(ACTIONS);
+    expect(screen.queryAllByTestId(CHIP), ZERO_CONTROL_DEAD).toHaveLength(1);
+  });
+});
+
+/**
+ * The property objectui#9158 asks for, asserted rather than argued: the two
+ * ways this pin can fail read differently. Proving it once in a PR ablation
+ * leaves nothing behind; these two keep the property from eroding.
+ */
+describe('RecordApprovalsPanel — the pin discriminates its two causes (objectui#9158)', () => {
+  it('rows that never land fail as a TIMING reading, naming neither the chip nor a regression', async () => {
+    const err = await renderPanel(ACTIONS, { withholdActions: true }).then(
+      () => null,
+      (e: unknown) => e as Error,
+    );
+    expect(err, 'withholding the /actions flush must fail the pin, not pass it').not.toBeNull();
+    expect(err!.message).toContain('TIMELINE ROWS NEVER ARRIVED');
+    expect(err!.message).toContain('rows missing  (4)');
+    // The whole point: this cause must not borrow the marker's vocabulary.
+    expect(err!.message).not.toContain('MARKER REGRESSION');
+    expect(err!.message).not.toContain(CHIP);
+  });
+
+  it('a settled timeline with no chip fails as a MARKER reading, naming neither timing nor arrival', async () => {
+    // Rows present, nothing earning a chip — which is, from the harness's point
+    // of view, exactly what a chip deleted from the panel looks like.
+    await renderPanel(ACTIONS_WITHOUT_OVERRIDE);
+    const err = ((): Error | null => {
+      try {
+        expect(screen.queryAllByTestId(CHIP), MARKER_GONE).toHaveLength(1);
+        return null;
+      } catch (e: unknown) {
+        return e as Error;
+      }
+    })();
+    expect(err, 'a settled timeline missing its chip must fail').not.toBeNull();
+    expect(err!.message).toContain('VIA_OVERRIDE MARKER REGRESSION');
+    expect(err!.message).not.toContain('TIMELINE ROWS NEVER ARRIVED');
   });
 });


### PR DESCRIPTION
Part of #9158 — this PR does not end that card on merge; the PM lands it.

## The defect, restated

The `via_override` pin awaited `findByTestId('record-approvals-panel')` — the panel SHELL — and then read the chips synchronously. The chips live on timeline rows built from the stubbed `GET /approvals/requests/:id/actions` response, a SECOND async state that lands after the shell. So the pin settled on something that is ready EARLIER than the thing it asserts.

The harm is not a wasted CI minute. It is that the pin could no longer report the thing it guards.

## Baseline — the two causes, measured on `865d34485`

Both causes were constructed deliberately (a solo run of this file is green, so no red greets you). Each leg mutated one file on disk, was proven to have landed by a before/after occurrence count plus a blob-hash comparison, ran the pin, and was restored from `HEAD` with `git diff HEAD` proving the restore.

| leg | cause constructed | first assertion reported |
|---|---|---|
| A | the chip stops rendering entirely (`isViaOverrideRow(a) &&` becomes `false &&` in `RecordApprovalsPanel.tsx`) | `TestingLibraryElementError: Unable to find an element by: [data-testid="via-override-chip"]` |
| B | the rows are withheld past the assertion window (3000ms delay in the test's own `/actions` stub) | `TestingLibraryElementError: Unable to find an element by: [data-testid="via-override-chip"]` |

Byte-for-byte the same sentence. That is the card's claim, reproduced.

Leg A also exposed the worse half. With the chip deleted outright, the run was `Tests 2 failed | 4 passed (6)` — the three ABSENCE assertions all PASSED. An absence is satisfied by a panel that renders nothing, so a permanently green assertion sat there testing nothing, and unlike the intermittent red it would never have surfaced itself.

## What changed

Test-only. One file plus a no-release changeset declaration.

1. **Settle on the rows, not the shell.** `renderPanel` now awaits one `findByText` per stubbed actor, so it does not return until the whole `/actions` flush is in the DOM. On failure it re-throws a TIMING message naming which rows arrived, what the panel currently shows, and that the marker is UNTESTED by such a run.
2. **The chip assertions carry a MARKER message** that states the rows were already settled, so the reading is about objectui#5178 and not about timing. The two messages share no vocabulary.
3. **Every absence assertion carries a live positive control** in the same DOM — the override row must still be wearing its chip. The no-override thread has no override row to control against, so it gets a second render with the row restored.
4. **The discrimination is pinned, not merely argued.** Two new tests assert that a withheld flush reports the timing message and never the chip's, and that a settled timeline missing its chip reports the marker message and never the timing one. An ablation in a PR description leaves nothing behind; these do not erode.

Deliberately NOT done, per the card: no timeout was raised, no `waitFor` wraps an assertion block, and nothing was re-run until it went green. Waiting longer for `via-override-chip` would have kept both causes under one message and merely delayed the verdict — the same defect in a longer form.

No new marker or testid was needed. The settle keys on the actor names the stub already supplies, so **no published surface moved** and `packages/spec` is untouched. `packages/components/src/ui/**` was not touched either.

## Ablation after the change — the two causes now read differently

Same script, same on-disk proof and restore proof, run against the committed implementation.

| leg | run | message |
|---|---|---|
| A — chip removed | `Tests 5 failed \| 3 passed (8)` | `AssertionError: VIA_OVERRIDE MARKER REGRESSION — the timeline rows are SETTLED …` and `AssertionError: POSITIVE CONTROL DEAD — the override row (Sun Wei) carries no chip …` |
| B — rows withheld | `Tests 7 failed \| 1 passed (8)` | `Error: TIMELINE ROWS NEVER ARRIVED — a TIMING reading about this harness, NOT a statement about the via_override marker` |

Neither leg's output contains the other's vocabulary: leg A never prints `TIMELINE ROWS NEVER ARRIVED`, leg B never prints `MARKER REGRESSION`. Leg B's message also carries the live panel state, which reads `text: ApprovalsBudget ApprovalApprovedActivityLoading…` — the panel is visibly still loading, which is the diagnosis itself.

Note the second number in leg A: the three absence assertions that used to pass with the chip deleted now fail, with `POSITIVE CONTROL DEAD`.

## Which gate arbitrates, and why

These are runtime assertions about what a React tree rendered, so **vitest is the arbiter** — a type checker cannot observe whether a chip reached the DOM, and nothing here became a compile-time pin. `tsc` is run below only to show the edited file is in the type-check program at all, not as evidence about the behaviour.

## Verification

All heavy runs went through the shared verify lock; exit codes were captured by redirect-then-capture, never through a pipe.

- `pnpm exec vitest run packages/app-shell/src/views/RecordApprovalsPanel.viaOverrideMarker.test.tsx` — `Test Files 1 passed (1)` / `Tests 8 passed (8)`, wrapper exit 0.
- `pnpm --filter @object-ui/app-shell type-check` — exit 0. Coverage proven rather than assumed: `tsc -p tsconfig.test.json --listFiles` lists the edited file exactly once, so the green is a reading about it.
- `pnpm --filter @object-ui/app-shell lint` — exit 0, 0 errors. The edited file carries 2 `no-explicit-any` warnings, down from 4 before, because the stub rows are now typed.
- `pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build` — exit 0, 29 of 47 projects.
- Gates, each exit 0: `check-changeset-presence`, `check-changeset-no-major`, `check-changeset-fixed`, `check-changeset-overwrite`, `check-changeset-claims`, `check-test-path-roots`, `check-control-bytes`, `check-vi-mock-specifiers`, `check-vi-mock-inherit`, `check-vi-mock-override-shape`, `check-shell-escape-residue`, `check-new-cross-file-line-citations`.
- `check-entry-guard` and the two doc-snippet gates are not owed: this diff adds no `scripts/` entry point and edits no README fence.

### The changeset call

`check-changeset-presence` refused the first attempt verbatim: `1 source file(s) of 1 released package(s) changed, and this change adds no changeset` — a test file under `src/` of a released package counts as published source by that gate's own criterion, regardless of whether anything ships. The answer is the explicit no-release declaration, not an exemption: `.changeset/via-override-pin-discriminates.md` with an EMPTY frontmatter. The gate then reads `Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.` No version moves; all 41 packages stay where they are.

### The whole affected package, under the load the card's red was measured under

`pnpm exec vitest run packages/app-shell/` — **`Test Files 686 passed (686)` / `Tests 6667 passed | 1 skipped (6668)`**, wrapper exit 0, `Duration 736.86s`. That is a saturated run (the lock held 12m18s; `import 1543.77s` across workers), which is the condition the card's red was measured under, and the repaired pin is green in it.

Measured at `6a7bc1e9e`. The only later commit is `ecd352ce2`, which adds one `.changeset/*.md` and nothing else; `grep -rn '\.changeset' packages/app-shell/src` exits 1, so no app-shell test reads that directory and the suite reading does not move. The gate family below was re-run on `ecd352ce2` after that commit and is green there, and `pnpm exec vitest run packages/app-shell/src/views/RecordApprovalsPanel.viaOverrideMarker.test.tsx` was re-run on `ecd352ce2` as well: `Test Files 1 passed (1)` / `Tests 8 passed (8)`.

### Scope this PR does NOT claim

`pnpm lint` at the repository root (all 47 projects) and the four CI test shards are CI's runs, not this seat's. What is claimed locally is the affected package: its own suite, its own `type-check`, its own `lint`, plus the gates that fire on this diff's shape.

Clause-② was declared `yes` at dispatch and the label is on this PR; `check-clause2-carriers.mjs --pair 9259` exits 0 — "the clause-② declaration is readable in the fixed spelling and both carriers agree".

Attribution, written as prose because a footer block does not survive an edit: produced by a Claude Code seat, session `session_01UzHd6hDYatoDn17BuwKxnZ`.

## Acceptance notes

Out of scope, filed nowhere, recorded here because it is the question a reviewer will ask next: **does the same defect sit in the sibling pins of this family?** Audited, and no.

- `RecordApprovalsPanel.test.tsx` settles on the panel shell at two sites, but everything it then asserts — the waiting-on chips, the sign-off tally, the header, and the absence of the Send-reminder button — is derived from PROPS (`isSubmitter` comes from `isSubmitterOf(pendingRequest, currentUserId)`), so it lands in the shell's own first commit. Same flush, so the settle is correct. That is the rule this card produces, applied: the question is never "is there an await", it is "does the awaited element land in the same flush as the asserted one".
- `RecordApprovalsPanel.approverIdentity.test.tsx` already waits on the asserted content itself.
- `RecordApprovalsPanel.stepProgressVertical.test.tsx` has no async settle at all; its subject renders synchronously from props.

No card was opened for any of these, because there is nothing to open one about.


---
_Generated by [Claude Code](https://claude.ai/code)_