### PR TITLE
feat(types)!: refuse both content channels on the 62 schemas whose renderer reads neither (objectui#9256, family D)

### DIFF
--- a/.changeset/9256-content-channel-family-d.md
+++ b/.changeset/9256-content-channel-family-d.md
@@ -1,0 +1,37 @@
+---
+'@object-ui/types': minor
+---
+
+Narrow 62 component schemas whose renderer reads NEITHER content channel: both `body`
+and `children` are now refused by name on both published faces (objectui#9256, family D
+of the objectui#8284 measured table).
+
+**BREAKING, deliberately.** A `body` or `children` authored on any of these node types
+is now a `tsc` error at the authoring site and an `invalid_type` refusal at the key's
+own path on the zod mirror. Nothing that RENDERED stops rendering: the measurement is
+that no renderer read consumes either key for these types, so an authored value drew an
+empty element before this change and draws the same empty element after it — it is
+merely refused first, instead of silently dropped. `minor` rather than `major` because
+this repo's version policy forbids `major` in any changeset (41 packages in one `fixed`
+group), and records `minor` plus an explicit breaking note as the spelling for a
+breaking change here.
+
+Executes the maintainer ruling recorded on objectui#8284 (summon #17, decision batch #2,
+2026-09-07, verbatim 「同意」): every component schema narrows to the channel its renderer
+actually reads and tombstones the other. PR objectui#9254 landed families A and B (the
+components that read exactly one channel); this is family D, the components that read
+neither.
+
+The verdict is a claim of ABSENCE, so it was measured with the TypeScript type checker
+across **46 programs** — every workspace package plus the apps and examples, 1,604 source
+files — not with grep and not over one package. The extended table is on objectui#9256.
+Held out and named there rather than guessed: the nine `type` names carried by two or
+more registrations with different declarations, `InputSchema` (an `Omit` of it is the
+shorthand face, whose registrations are `any`-typed), `AppComponentSchema` and
+`DetailViewSchema` (their own type literals are served by other registrations), and the
+`body` key of the three chatbot faces (the parity ledger records it as a naming
+collision awaiting a ruling — their `children` is narrowed).
+
+Four published documents in the schema catalog and three component reference pages were
+authoring `children` on `dialog`, `drawer`, `popover` and `collapsible`, all of which
+read `content`. They rendered empty boxes and are corrected here.

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -78,8 +78,8 @@ One row per declared member, in declaration order, so the list can be checked ag
 | `style` | `Record<string, string \| number>` | Inline CSS styles. Use sparingly — prefer `className`. |
 | `data` | `any` | Arbitrary data attached to the node. `any` because the shape is defined by the consuming component rather than by `BaseSchema`. |
 | `bind` | `string` | Data-scope path this node draws its rows or value from, resolved by `useDataScope()`. Honoured only by components that call it. |
-| `body` | `SchemaNode \| SchemaNode[]` | Child components rendered inside this component. |
-| `children` | `SchemaNode \| SchemaNode[]` | Alias for `body`. |
+| `body` | `SchemaNode \| SchemaNode[]` | Child components rendered inside this component — **as `BaseSchema` declares it**. Which of the two channels a given node type actually renders is per component; see the note below. |
+| `children` | `SchemaNode \| SchemaNode[]` | A second content channel `BaseSchema` declares beside `body`. ⚠️ **Not an alias** — nothing folds one into the other at runtime, and this row used to say it was. See the note below. |
 | `visible` | `boolean \| string \| { dialect?: string; source: string }` | Visibility control. Accepts a boolean, a predicate expression string, **or** the CEL envelope object (`{ dialect: 'cel', source }` — what `objectstack build` emits for every authored predicate) — the renderer evaluates this key rather than reading it as a boolean. The string-or-envelope half is `ExpressionWire`, the one wire type `visibleWhen` on form fields already carries. |
 | `visibleWhen` | `string` | Canonical conditional-visibility predicate (ADR-0089); the element is shown when it evaluates truthy. Evaluated **before** `visible` and `visibleOn`, and outranks both. |
 | `visibleOn` | `string` | Expression for conditional visibility. **Deprecated** (ADR-0089) — use `visibleWhen`. |
@@ -93,6 +93,7 @@ One row per declared member, in declaration order, so the list can be checked ag
 Two things the table cannot show in a cell:
 
 - **A concrete schema may narrow an inherited member, and its own declaration wins.** Many component schemas restate `label`, `description` or `disabled` more narrowly than `BaseSchema` declares them, so the unions above are what a node gets when its own schema does not restate the key. Check the component's own property table before writing a predicate string or a locale map into an inherited slot.
+- **⚠️ `body` and `children` are TWO channels, not one key with two spellings, and which one a node type renders is decided PER COMPONENT.** Each renderer reads one, the other, both, or neither, and `SchemaRenderer` strips both out of the props bag it spreads — so writing the channel a renderer does not read rendered an EMPTY element, with no error at authoring time, none at validation time and none at render time. That is the defect objectui#8284 named after seven cards had repaired one page of it each. It is being closed per component, by measurement: each schema narrows to the channel its renderer actually reads and **tombstones the other as `never`**, refused by name on both published faces (objectui#9254 for the components that read exactly one channel, objectui#9256 for the ones that read neither). ⇒ check the component's own section before writing either key; the types in this row are `BaseSchema`'s, and a concrete schema's own declaration wins.
 - **This list is exhaustive for *declared* members, not for *accepted* keys.** `BaseSchema` carries an index signature (`[key: string]: any`) and its Zod mirror is `.passthrough()`, so an undeclared key — a misspelling included — is still accepted by both halves. Absence from this table does not mean a key is rejected.
 
 ---

--- a/content/docs/components/overlay/dialog.mdx
+++ b/content/docs/components/overlay/dialog.mdx
@@ -15,7 +15,7 @@ interface DialogSchema {
   trigger: SchemaNode | SchemaNode[];
   title?: string;
   description?: string;
-  children: SchemaNode[];
+  content?: SchemaNode | SchemaNode[];
   footer?: SchemaNode[];
 }
 ```

--- a/content/docs/components/overlay/drawer.mdx
+++ b/content/docs/components/overlay/drawer.mdx
@@ -14,7 +14,7 @@ interface DrawerSchema {
   type: 'drawer';
   trigger: SchemaNode | SchemaNode[];
   title?: string;
-  children: SchemaNode[];
+  content?: SchemaNode | SchemaNode[];
   side?: 'left' | 'right' | 'top' | 'bottom';
 }
 ```

--- a/content/docs/components/overlay/popover.mdx
+++ b/content/docs/components/overlay/popover.mdx
@@ -13,7 +13,7 @@ description: "Floating content panel"
 interface PopoverSchema {
   type: 'popover';
   trigger: SchemaNode | SchemaNode[];
-  children: SchemaNode[];
+  content?: SchemaNode | SchemaNode[];
   side?: 'top' | 'right' | 'bottom' | 'left';
 }
 ```

--- a/examples/schema-catalog/src/schemas/components-disclosure-collapsible/basic-collapsible.json
+++ b/examples/schema-catalog/src/schemas/components-disclosure-collapsible/basic-collapsible.json
@@ -4,7 +4,7 @@
     "type": "button",
     "label": "Toggle"
   },
-  "children": [
+  "content": [
     {
       "type": "text",
       "content": "Hidden content"

--- a/examples/schema-catalog/src/schemas/components-overlay-dialog/dialog-trigger.json
+++ b/examples/schema-catalog/src/schemas/components-overlay-dialog/dialog-trigger.json
@@ -6,7 +6,7 @@
   },
   "title": "Dialog Title",
   "description": "Dialog description",
-  "children": [
+  "content": [
     {
       "type": "text",
       "content": "Dialog content goes here"

--- a/examples/schema-catalog/src/schemas/components-overlay-drawer/basic-drawer.json
+++ b/examples/schema-catalog/src/schemas/components-overlay-drawer/basic-drawer.json
@@ -5,7 +5,7 @@
     "label": "Open Drawer"
   },
   "title": "Drawer Title",
-  "children": [
+  "content": [
     {
       "type": "text",
       "content": "Drawer content"

--- a/examples/schema-catalog/src/schemas/components-overlay-popover/basic-popover.json
+++ b/examples/schema-catalog/src/schemas/components-overlay-popover/basic-popover.json
@@ -4,7 +4,7 @@
     "type": "button",
     "label": "Open Popover"
   },
-  "children": [
+  "content": [
     {
       "type": "text",
       "content": "Popover content"

--- a/examples/schema-catalog/test/overlay-trigger-mirror-6939.test.tsx
+++ b/examples/schema-catalog/test/overlay-trigger-mirror-6939.test.tsx
@@ -132,11 +132,33 @@ describe('objectui#6939 — `children` is no longer required on either member', 
       content: 'Helpful information',
       children: [{ type: 'button', label: 'Hover me' }],
     }).success).toBe(true);
-    expect(ContextMenuSchema.safeParse({
+    // ⚠️ `context-menu` is NO LONGER part of that widen-only half.
+    // objectui#9256 measured it into FAMILY D — its renderer reads `items`,
+    // `trigger`, `modal` and the two class-name keys, and NOTHING reads
+    // `children` — with the read-site sweep extended across all 24 registering
+    // packages plus the generic traversers, which is the measurement
+    // objectui#8284 named as the precondition for acting on a NEITHER verdict.
+    // So the spelling that used to parse here is now refused BY NAME.
+    const menuRefused = ContextMenuSchema.safeParse({
       type: 'context-menu',
       items: [{ label: 'Copy' }],
       children: { type: 'text', content: 'Right-click here' },
+    });
+    expect(menuRefused.success).toBe(false);
+    if (!menuRefused.success) {
+      expect(menuRefused.error.issues.map((i) => i.path.join('.'))).toEqual(['children']);
+      expect(menuRefused.error.issues[0]!.message).toContain('objectui#9256');
+    }
+
+    // CONTROL — the refusal is about the KEY, not about the mirror: the keys
+    // both renderers DO read still parse, so the two readings above are not a
+    // whole-schema regression.
+    expect(ContextMenuSchema.safeParse({
+      type: 'context-menu',
+      items: [{ label: 'Copy' }],
+      trigger: { type: 'text', content: 'Right-click here' },
     }).success).toBe(true);
+    expect(TooltipSchema.safeParse({ type: 'tooltip', content: 'Helpful information' }).success).toBe(true);
   });
 });
 

--- a/packages/plugin-calendar/README.md
+++ b/packages/plugin-calendar/README.md
@@ -149,11 +149,20 @@ ComponentRegistry.register('my-calendar', ObjectCalendarRenderer);
 ### CalendarView
 
 Display a calendar computed from the node's `data` records. This is the full
-authored surface: `CalendarViewSchema` in `@object-ui/types` declares 13 keys of
-its own, converged on what the registered `calendar-view` renderer actually
-reads (objectui#5667). Two of them — `data` and `className` — refine common
-`BaseSchema` keys; the rest of `BaseSchema` (`id`, `visible`, ...) applies as on
-any node.
+authored surface: `CalendarViewSchema` in `@object-ui/types` declares 15 keys of
+its own. **13 of them are authorable**, converged on what the registered
+`calendar-view` renderer actually reads (objectui#5667), and they are the ones
+listed below. Two of them — `data` and `className` — refine common `BaseSchema`
+keys; the rest of `BaseSchema` (`id`, `visible`, ...) applies as on any node.
+
+**The other two are REFUSALS, not keys you can write.** `body` and `children`
+are declared `never` (objectui#9256): a read-site sweep of every package that
+registers a component measured that no renderer read consumes either content
+channel for a `calendar-view` node — it renders events computed from `data`, not
+child nodes — so authoring one is now refused at `tsc` and at validation instead
+of silently rendering nothing. They are counted above because the interface
+declares them; they are absent from the listing below because the listing is the
+*authorable* surface.
 
 ```typescript
 import type { CalendarViewSchema, CalendarViewMode, CalendarEvent } from '@object-ui/types';

--- a/packages/types/src/__tests__/content-channel-family-d-9256.test.ts
+++ b/packages/types/src/__tests__/content-channel-family-d-9256.test.ts
@@ -397,7 +397,14 @@ describe('objectui#9256 — the TypeScript face refuses both channels at the AUT
   });
 
   it('CONTROL — `chatbot` still TYPE-CHECKS with `body`, the held-out key', () => {
-    const held = { type: 'chatbot', messages: [], body: { temperature: 0.2 } } satisfies ChatbotSchema;
+    // ⚠️ The VALUE differs from the mirror control above, and that difference
+    // IS the ledgered collision: the TypeScript face inherits `body` from
+    // `BaseSchema` as a content channel (`SchemaNode | SchemaNode[]`), while
+    // the mirror declares it as `Record` of unknown, "additional API body
+    // params". One key, two meanings, on the two published faces of one node —
+    // which is why objectui#9256 refuses to tombstone it on a measurement and
+    // leaves it for a ruling.
+    const held = { type: 'chatbot', messages: [], body: CONTENT } satisfies ChatbotSchema;
     expect(held.type).toBe('chatbot');
   });
 });

--- a/packages/types/src/__tests__/content-channel-family-d-9256.test.ts
+++ b/packages/types/src/__tests__/content-channel-family-d-9256.test.ts
@@ -1,0 +1,403 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9256 — FAMILY D of the measured table: the components whose renderer
+ * reads NEITHER content channel. Both `body` and `children` are tombstoned on
+ * both published faces, in the shape PR objectui#9254 established for families
+ * A and B (maintainer ruling, summon #17 decision batch #2, 2026-09-07,
+ * verbatim 「同意」: every component schema narrows to the channel its renderer
+ * actually reads and tombstones the other).
+ *
+ * ## Why a NEITHER verdict needed a bigger instrument than families A+B did
+ *
+ * objectui#9254 measured `packages/components` only. A verdict of ABSENCE is
+ * not sound over a subset: any of the other 23 registering packages, or a
+ * generic traverser that is not a component at all, could have been the reader.
+ * The sweep behind this file runs the same TypeScript type-checker instrument
+ * over 46 programs — every workspace package plus the apps and examples, 1,604
+ * source files — and files every `body` / `children` read under the TYPE of the
+ * object it is read from. The extended table is objectui#9256 comment
+ * 5644340762; the numbers moved (77 family-D registrations, not the card's ~60,
+ * and 20 of them outside `packages/components`).
+ *
+ * Two readers decide a NEITHER verdict and neither is a component:
+ *
+ *   - `SchemaRenderer` (`packages/react`) destructures `children` and `body`
+ *     OUT of the props bag it spreads, so the channels cannot reach a renderer
+ *     by any route except that renderer reading `schema.body` / `schema.children`
+ *     itself. That is what makes "reads neither" mean "renders nothing".
+ *   - `validateSchema` (`packages/core`) reads `schema.children` else
+ *     `schema.body` for EVERY node, but only to RECURSE into authored content
+ *     and validate it. It renders nothing, so it does not make a channel live.
+ *
+ * ## What is held OUT of this file, and why — each is a measurement, not appetite
+ *
+ *   - the nine `type` names carrying 2+ registrations with different
+ *     declarations (`accordion`, `tabs`, `text`, `image`, `icon`, `list`,
+ *     `calendar`, `timeline`, and the `UIActionSchema` arm of `button`):
+ *     `ComponentRegistry.register` writes a bare-name fallback LAST-ONE-WINS, so
+ *     which declaration governs an authored node depends on import order.
+ *   - `InputSchema`: `InputShorthandSchema` is declared as an `Omit` of it, so a
+ *     tombstone here would propagate onto the `email` / `password` shorthand
+ *     face, whose registrations are `any`-typed — family E, frozen.
+ *   - `AppComponentSchema`: it declares the `app` type literal, and `app` is
+ *     served by `PageNodeSchema`, which reads BOTH channels — family C, with the
+ *     maintainer.
+ *   - `DetailViewSchema`: its own literal is `detail-view`, and that name is
+ *     registered with an `any`-typed renderer whose reads are unattributable.
+ *   - the `body` channel of the three chatbot faces: the parity ledger already
+ *     records that key as "two different meanings of one key — a naming
+ *     collision to rule on". Their `children` channel is narrowed here, and the
+ *     LIVE CONTROL below proves `body` still parses there.
+ *
+ * ## ⚠️ Half of this file is a COMPILE-TIME assertion and vitest CANNOT read it
+ *
+ * `?: never` narrowings are erased before a test runs. The `@ts-expect-error`
+ * lines in the last block are read by `tsc -p tsconfig.test.json` (the
+ * `type-check` script), NOT by this runner: under vitest alone, deleting a
+ * tombstone from the TypeScript face leaves every case here GREEN. Both readers
+ * are the gate; either one alone reports NOT MEASURED.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { z } from 'zod';
+import {
+  SeparatorSchema as SeparatorMirror,
+  ResizableSchema as ResizableMirror,
+} from '../zod/layout.zod';
+import {
+  HtmlSchema as HtmlMirror,
+  AvatarSchema as AvatarMirror,
+  TreeViewSchema as TreeViewMirror,
+  StatisticSchema as StatisticMirror,
+  KbdSchema as KbdMirror,
+  TableSchema as TableMirror,
+  DataTableSchema as DataTableMirror,
+} from '../zod/data-display.zod';
+import {
+  ButtonGroupSchema as ButtonGroupMirror,
+  PaginationSchema as PaginationMirror,
+  NavigationMenuSchema as NavigationMenuMirror,
+  HeaderBarSchema as HeaderBarMirror,
+  BreadcrumbSchema as BreadcrumbMirror,
+} from '../zod/navigation.zod';
+import {
+  LabelSchema as LabelMirror,
+  TextareaSchema as TextareaMirror,
+  CheckboxSchema as CheckboxMirror,
+  SwitchSchema as SwitchMirror,
+  SelectSchema as SelectMirror,
+  RadioGroupSchema as RadioGroupMirror,
+  SliderSchema as SliderMirror,
+  InputOTPSchema as InputOTPMirror,
+  DatePickerSchema as DatePickerMirror,
+  FileUploadSchema as FileUploadMirror,
+  ComboboxSchema as ComboboxMirror,
+  CommandSchema as CommandMirror,
+} from '../zod/form.zod';
+import {
+  ProgressSchema as ProgressMirror,
+  SkeletonSchema as SkeletonMirror,
+  ToasterSchema as ToasterMirror,
+  LoadingSchema as LoadingMirror,
+  ToastSchema as ToastMirror,
+  SpinnerSchema as SpinnerMirror,
+  EmptySchema as EmptyMirror,
+  SonnerSchema as SonnerMirror,
+} from '../zod/feedback.zod';
+import {
+  DialogSchema as DialogMirror,
+  SheetSchema as SheetMirror,
+  PopoverSchema as PopoverMirror,
+  AlertDialogSchema as AlertDialogMirror,
+  DrawerSchema as DrawerMirror,
+  HoverCardSchema as HoverCardMirror,
+  DropdownMenuSchema as DropdownMenuMirror,
+  ContextMenuSchema as ContextMenuMirror,
+  MenubarSchema as MenubarMirror,
+} from '../zod/overlay.zod';
+import {
+  CollapsibleSchema as CollapsibleMirror,
+  ToggleGroupSchema as ToggleGroupMirror,
+} from '../zod/disclosure.zod';
+import {
+  CarouselSchema as CarouselMirror,
+  FilterBuilderSchema as FilterBuilderMirror,
+  CalendarViewSchema as CalendarViewMirror,
+  ChatbotSchema as ChatbotMirror,
+  ChatbotEnhancedSchema as ChatbotEnhancedMirror,
+  ChatbotFloatingSchema as ChatbotFloatingMirror,
+  DashboardComponentSchema as DashboardComponentMirror,
+} from '../zod/complex.zod';
+import {
+  ObjectDataTableSchema as ObjectDataTableMirror,
+  ObjectGallerySchema as ObjectGalleryMirror,
+} from '../zod/objectql.zod';
+import {
+  ReportViewerSchema as ReportViewerMirror,
+} from '../zod/reports.zod';
+import {
+  ViewSwitcherSchema as ViewSwitcherMirror,
+  FilterUISchema as FilterUIMirror,
+  SortUISchema as SortUIMirror,
+} from '../zod/views.zod';
+import { ChatbotSchema as ChatbotBodyControl } from '../zod/complex.zod';
+import { AnyComponentSchema } from '../zod/index.zod';
+import type { CollapsibleSchema } from '../disclosure';
+import type { DialogSchema } from '../overlay';
+import type { SeparatorSchema } from '../layout';
+import type { CheckboxSchema } from '../form';
+import type { KbdSchema, PivotTableSchema } from '../data-display';
+import type { SkeletonSchema } from '../feedback';
+import type { PaginationSchema } from '../navigation';
+import type { ObjectGallerySchema } from '../objectql';
+import type { CarouselSchema, ChatbotSchema } from '../complex';
+import type { ReportViewerSchema } from '../reports';
+import type { ViewSwitcherSchema } from '../views';
+import type { NLQuerySchema } from '../ai';
+
+type Mirror = {
+  safeParse: (v: unknown) => { success: boolean; error?: z.ZodError };
+  shape: Record<string, { description?: string } | undefined>;
+};
+
+/**
+ * One row of family D: the registered `type`, its mirror, the channels
+ * tombstoned on it, and the node's OTHER required members — `table` requires
+ * `columns` and `data`, so a bare `{ type: 'table' }` is refused for a reason
+ * that has nothing to do with this change and would read here as a false
+ * positive. Both channels are dead on every row except the three chatbot faces,
+ * whose `body` is held out (see the header).
+ */
+const ROWS: ReadonlyArray<readonly [
+  type: string, mirror: Mirror, dead: ReadonlyArray<'body' | 'children'>, required: Record<string, unknown>,
+]> = [
+  ['separator', SeparatorMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['html', HtmlMirror as unknown as Mirror, ['body', 'children'], {"html":"x"}],
+  ['button-group', ButtonGroupMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['pagination', PaginationMirror as unknown as Mirror, ['body', 'children'], {"totalPages":1}],
+  ['navigation-menu', NavigationMenuMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['label', LabelMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['textarea', TextareaMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['checkbox', CheckboxMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['switch', SwitchMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['select', SelectMirror as unknown as Mirror, ['body', 'children'], {"options":[]}],
+  ['radio-group', RadioGroupMirror as unknown as Mirror, ['body', 'children'], {"options":[]}],
+  ['slider', SliderMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['input-otp', InputOTPMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['date-picker', DatePickerMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['file-upload', FileUploadMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['combobox', ComboboxMirror as unknown as Mirror, ['body', 'children'], {"options":[]}],
+  ['command', CommandMirror as unknown as Mirror, ['body', 'children'], {"groups":[]}],
+  ['header-bar', HeaderBarMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['avatar', AvatarMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['tree-view', TreeViewMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['statistic', StatisticMirror as unknown as Mirror, ['body', 'children'], {"value":1}],
+  ['breadcrumb', BreadcrumbMirror as unknown as Mirror, ['body', 'children'], {"items":[]}],
+  ['kbd', KbdMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['progress', ProgressMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['skeleton', SkeletonMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['toaster', ToasterMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['loading', LoadingMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['toast', ToastMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['spinner', SpinnerMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['empty', EmptyMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['sonner', SonnerMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['dialog', DialogMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['sheet', SheetMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['popover', PopoverMirror as unknown as Mirror, ['body', 'children'], {"content":{"type":"text"},"trigger":{"type":"button"}}],
+  ['alert-dialog', AlertDialogMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['drawer', DrawerMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['hover-card', HoverCardMirror as unknown as Mirror, ['body', 'children'], {"content":{"type":"text"},"trigger":{"type":"button"}}],
+  ['dropdown-menu', DropdownMenuMirror as unknown as Mirror, ['body', 'children'], {"items":[],"trigger":{"type":"button"}}],
+  ['context-menu', ContextMenuMirror as unknown as Mirror, ['body', 'children'], {"items":[]}],
+  ['menubar', MenubarMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['collapsible', CollapsibleMirror as unknown as Mirror, ['body', 'children'], {"trigger":{"type":"button"},"content":{"type":"text"}}],
+  ['toggle-group', ToggleGroupMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['carousel', CarouselMirror as unknown as Mirror, ['body', 'children'], {"items":[]}],
+  ['filter-builder', FilterBuilderMirror as unknown as Mirror, ['body', 'children'], {"fields":[]}],
+  ['resizable', ResizableMirror as unknown as Mirror, ['body', 'children'], {"panels":[]}],
+  ['table', TableMirror as unknown as Mirror, ['body', 'children'], {"data":[],"columns":[]}],
+  ['data-table', DataTableMirror as unknown as Mirror, ['body', 'children'], {"data":[],"columns":[]}],
+  ['calendar-view', CalendarViewMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['chatbot', ChatbotMirror as unknown as Mirror, ['children'], {"messages":[]}],
+  ['chatbot-enhanced', ChatbotEnhancedMirror as unknown as Mirror, ['children'], {"messages":[]}],
+  ['chatbot-floating', ChatbotFloatingMirror as unknown as Mirror, ['children'], {"messages":[]}],
+  ['dashboard', DashboardComponentMirror as unknown as Mirror, ['body', 'children'], {"widgets":[]}],
+  ['object-data-table', ObjectDataTableMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['object-gallery', ObjectGalleryMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['report-viewer', ReportViewerMirror as unknown as Mirror, ['body', 'children'], {}],
+  ['view-switcher', ViewSwitcherMirror as unknown as Mirror, ['body', 'children'], {"views":[]}],
+  ['filter-ui', FilterUIMirror as unknown as Mirror, ['body', 'children'], {"filters":[]}],
+  ['sort-ui', SortUIMirror as unknown as Mirror, ['body', 'children'], {"fields":[]}],
+];
+
+const CONTENT = [{ type: 'text', content: 'measured' }];
+const issues = (m: Mirror, doc: unknown) => {
+  const r = m.safeParse(doc);
+  return r.success ? null : r.error!.issues.map((i) => ({ code: i.code, path: i.path.join('.'), message: i.message }));
+};
+const CASES = ROWS.flatMap(([type, mirror, dead, required]) =>
+  dead.map((key) => [`${type}.${key}`, mirror, key, required] as const));
+
+/* ── (a) the dead channels are REFUSED BY NAME, at the key's own path ─────── */
+
+describe('objectui#9256 — family D refuses the content channels its renderers never read', () => {
+  it('the population is the measured one — a row dropped from the table fails here', () => {
+    expect(ROWS).toHaveLength(58);
+    // 3 fewer than 2x: the chatbot faces carry `children` only.
+    expect(CASES).toHaveLength(58 * 2 - 3);
+  });
+
+  it.each(CASES)('%s is refused at that key\'s own path', (_label, mirror, key, required) => {
+    const found = issues(mirror, { ...required, type: ROWS.find((r) => r[1] === mirror)![0], [key]: CONTENT });
+    expect(found, `${_label} parsed green — the tombstone is not installed`).not.toBeNull();
+    expect(found!.some((i) => i.path === key && i.code === 'invalid_type')).toBe(true);
+  });
+
+  it.each(CASES)('%s — the message names the key and the card, so the author is told why', (_label, mirror, key, required) => {
+    const issue = issues(mirror, { ...required, type: ROWS.find((r) => r[1] === mirror)![0], [key]: CONTENT })!
+      .find((i) => i.path === key)!;
+    expect(issue.message).toContain(`\`${key}\``);
+    expect(issue.message).toContain('objectui#9256');
+    expect(issue.message).toContain('NEITHER content channel');
+  });
+
+  it.each(CASES)('%s — ONE string feeds both author-facing channels: the issue message IS the `.describe()` metadata', (_label, mirror, key, required) => {
+    const issue = issues(mirror, { ...required, type: ROWS.find((r) => r[1] === mirror)![0], [key]: CONTENT })!
+      .find((i) => i.path === key)!;
+    expect(mirror.shape[key]?.description).toBe(issue.message);
+  });
+
+  it.each(CASES)('%s — the refusal is about the KEY, not a value domain: every value is refused', (_label, mirror, key, required) => {
+    const type = ROWS.find((r) => r[1] === mirror)![0];
+    for (const value of [CONTENT, 'text', 42, null, {}, []]) {
+      expect(issues(mirror, { ...required, type, [key]: value })?.some((i) => i.path === key)).toBe(true);
+    }
+  });
+});
+
+/* ── (b) CONTROLS — nothing that rendered before stops parsing ────────────── */
+
+describe('objectui#9256 — CONTROLS: the node itself, and the held-out channel, are untouched', () => {
+  it.each(ROWS)('`%s` still parses with its own required members and a `className`', (type, mirror, _dead, required) => {
+    expect(issues(mirror, { ...required, type })).toBeNull();
+    expect(issues(mirror, { ...required, type, className: 'p-4' })).toBeNull();
+  });
+
+  it.each(CASES)('%s — the tombstone is a MEMBER of the mirror shape, so the parity ratchet\'s key sets stay equal', (_label, mirror, key) => {
+    expect(Object.keys(mirror.shape)).toContain(key);
+  });
+
+  it('LIVE CONTROL — `chatbot` still accepts `body`, the key held out of this card', () => {
+    // The parity ledger records `body` here as "two different meanings of one
+    // key — a naming collision to rule on": the mirror declares it as API
+    // request params, the declaration inherits the base's content channel.
+    // Refusing it would have been a guess, so it is untouched — and this line
+    // is what keeps the row above a reading about `children`.
+    const r = (ChatbotBodyControl as unknown as Mirror)
+      .safeParse({ type: 'chatbot', messages: [], body: { temperature: 0.2 } });
+    expect(r.success).toBe(true);
+  });
+
+  it('LIVE CONTROL — family C is NOT narrowed: a `div` still accepts both channels', () => {
+    // `div` reads `children || body` (a live fallback). Removing a live read is
+    // a behaviour change and is with the maintainer, so this line must stay
+    // green for this card to be a declaration repair rather than a behaviour
+    // change.
+    expect(AnyComponentSchema.safeParse({ type: 'div', children: CONTENT }).success).toBe(true);
+    expect(AnyComponentSchema.safeParse({ type: 'div', body: CONTENT }).success).toBe(true);
+  });
+});
+
+/* ── (c) the refusal reaches NESTED nodes, not only the root ──────────────── */
+
+describe('objectui#9256 — a nested family-D node is refused too', () => {
+  it('a `skeleton` authoring `children` INSIDE a `box`\'s `children` is REFUSED', () => {
+    const r = AnyComponentSchema.safeParse({
+      type: 'box',
+      children: [{ type: 'skeleton', children: CONTENT }],
+    });
+    expect(r.success).toBe(false);
+    // The child slot is a `z.union`, so what surfaces is ONE `invalid_union` at
+    // `children` carrying objectui#8344's capped message — the nested path and
+    // the remedy text are collapsed by that union, not by this change.
+    expect(r.error!.issues.map((i) => ({ code: i.code, path: i.path.join('.') })))
+      .toEqual([{ code: 'invalid_union', path: 'children' }]);
+  });
+
+  it('CONTROL — the same tree with a bare `skeleton` parses', () => {
+    expect(AnyComponentSchema.safeParse({
+      type: 'box',
+      children: [{ type: 'skeleton' }],
+    }).success).toBe(true);
+  });
+});
+
+/* ── (d) the TypeScript face — ⚠️ READ BY `tsc`, NOT BY VITEST ────────────── */
+
+describe('objectui#9256 — the TypeScript face refuses both channels at the AUTHORING site', () => {
+  it('the `@ts-expect-error` lines in this block are the assertion; vitest only proves they are reachable', () => {
+    // One pair per declaration FILE this card edits, so no edited file is
+    // covered by the runtime block alone.
+    // @ts-expect-error objectui#9256 — `separator` reads neither channel
+    const separatorBody: SeparatorSchema = { type: 'separator', body: CONTENT };
+    // @ts-expect-error objectui#9256 — `separator` reads neither channel
+    const separatorChildren: SeparatorSchema = { type: 'separator', children: CONTENT };
+    // @ts-expect-error objectui#9256 — `kbd` reads neither channel
+    const kbdBody: KbdSchema = { type: 'kbd', body: CONTENT };
+    // @ts-expect-error objectui#9256 — `skeleton` reads neither channel
+    const skeletonChildren: SkeletonSchema = { type: 'skeleton', children: CONTENT };
+    // @ts-expect-error objectui#9256 — `checkbox` reads neither channel
+    const checkboxBody: CheckboxSchema = { type: 'checkbox', body: CONTENT };
+    // @ts-expect-error objectui#9256 — `pagination` reads neither channel
+    const paginationChildren: PaginationSchema = { type: 'pagination', totalPages: 1, children: CONTENT };
+    // @ts-expect-error objectui#9256 — `dialog` reads `content`, never `children`
+    const dialogChildren: DialogSchema = { type: 'dialog', children: CONTENT };
+    // @ts-expect-error objectui#9256 — `collapsible` reads `trigger` + `content`
+    const collapsibleChildren: CollapsibleSchema = { type: 'collapsible', children: CONTENT };
+    // @ts-expect-error objectui#9256 — `carousel` reads neither channel
+    const carouselBody: CarouselSchema = { type: 'carousel', items: [], body: CONTENT };
+    // @ts-expect-error objectui#9256 — `object-gallery` reads neither channel
+    const galleryBody: ObjectGallerySchema = { type: 'object-gallery', body: CONTENT };
+    // @ts-expect-error objectui#9256 — `view-switcher` reads neither channel
+    const viewSwitcherChildren: ViewSwitcherSchema = { type: 'view-switcher', views: [], children: CONTENT };
+    // @ts-expect-error objectui#9256 — `report-viewer` reads neither channel
+    const reportBody: ReportViewerSchema = { type: 'report-viewer', body: CONTENT };
+    // @ts-expect-error objectui#9256 — `nl-query` reads neither channel (no zod mirror exists; this face is the only gate)
+    const nlQueryChildren: NLQuerySchema = { type: 'nl-query', children: CONTENT };
+    // @ts-expect-error objectui#9256 — `pivot` reads neither channel (no zod mirror exists; this face is the only gate)
+    const pivotBody: PivotTableSchema = { type: 'pivot', body: CONTENT };
+    // @ts-expect-error objectui#9256 — `chatbot` reads neither channel; `children` is narrowed, `body` is held out
+    const chatbotChildren: ChatbotSchema = { type: 'chatbot', messages: [], children: CONTENT };
+
+    expect([
+      separatorBody, separatorChildren, kbdBody, skeletonChildren, checkboxBody, paginationChildren,
+      dialogChildren, collapsibleChildren, carouselBody, galleryBody, viewSwitcherChildren, reportBody,
+      nlQueryChildren, pivotBody, chatbotChildren,
+    ]).toHaveLength(15);
+  });
+
+  it('CONTROL — the same nodes WITHOUT a content channel compile (no `@ts-expect-error` here, and `tsc` is the reader)', () => {
+    const ok = [
+      { type: 'separator' } satisfies SeparatorSchema,
+      { type: 'kbd' } satisfies KbdSchema,
+      { type: 'skeleton' } satisfies SkeletonSchema,
+      { type: 'checkbox' } satisfies CheckboxSchema,
+      { type: 'dialog', content: CONTENT } satisfies DialogSchema,
+      { type: 'collapsible', trigger: CONTENT, content: CONTENT } satisfies CollapsibleSchema,
+    ];
+    expect(ok).toHaveLength(6);
+  });
+
+  it('CONTROL — `chatbot` still TYPE-CHECKS with `body`, the held-out key', () => {
+    const held = { type: 'chatbot', messages: [], body: { temperature: 0.2 } } satisfies ChatbotSchema;
+    expect(held.type).toBe('chatbot');
+  });
+});

--- a/packages/types/src/__tests__/static-table-narrow-surface.test.ts
+++ b/packages/types/src/__tests__/static-table-narrow-surface.test.ts
@@ -465,8 +465,14 @@ describe('the split itself — narrow = rich key set, live = the measured read s
     expect(Object.keys(shapeOf(TableColumnSchema)).sort()).toEqual([...RICH_COLUMN_KEYS].sort());
   });
 
-  it('the static table zod tombstones exactly `hoverable` and `striped`', () => {
-    expect(tombstonedKeys(TableZod).sort()).toEqual(['hoverable', 'striped']);
+  it('the static table zod tombstones exactly its two retired keys plus the two content channels', () => {
+    // `hoverable` / `striped` are objectui#5474's retirements — keys the static
+    // renderer never read. `body` / `children` joined them in objectui#9256 for
+    // the SAME reason measured a second time: the compiler-API read-site sweep
+    // over all 24 registering packages files zero `body` / `children` reads
+    // under `TableSchema`, so both content channels were silent empty boxes
+    // here too. Four tombstones, one mechanism.
+    expect(tombstonedKeys(TableZod).sort()).toEqual(['body', 'children', 'hoverable', 'striped']);
   });
 });
 

--- a/packages/types/src/__tests__/undeclared-but-consumed-keys-6150.test.ts
+++ b/packages/types/src/__tests__/undeclared-but-consumed-keys-6150.test.ts
@@ -188,7 +188,12 @@ const TREE_CONTROL = { type: 'tree-view', nodes: [] };
 const CHECKBOX_CONTROL = { type: 'checkbox', label: 'Accept' };
 const UPLOAD_CONTROL = { type: 'file-upload', label: 'Attach' };
 const HOVER_CONTROL = { type: 'hover-card', content: NODE, trigger: NODE };
-const MENU_CONTROL = { type: 'context-menu', items: [], children: NODE };
+// ⚠️ NO `children` here (objectui#9256). This control carried one until the
+// family-D sweep measured `context-menu`: its renderer reads `items` and
+// `trigger`, and NOTHING reads `children` on it — the key was a silent empty
+// box, and is now a declared refusal. Authoring it made every case in this
+// block fail on a key the block is not about.
+const MENU_CONTROL = { type: 'context-menu', items: [] };
 
 const R = 'packages/components/src/renderers/';
 

--- a/packages/types/src/ai.ts
+++ b/packages/types/src/ai.ts
@@ -187,6 +187,54 @@ export interface AIFormAssistSchema extends BaseSchema {
    * Callback when a suggestion is rejected
    */
   onRejectSuggestion?: string;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `ai-form-assist` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. This renderer takes its configuration from
+   * the props bag `SchemaRenderer` spreads rather than from `schema.*`, and
+   * carries zero `body` / `children` reads either way.
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `ai-form-assist` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `ai-form-assist` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. This renderer takes its configuration from
+   * the props bag `SchemaRenderer` spreads rather than from `schema.*`, and
+   * carries zero `body` / `children` reads either way.
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `ai-form-assist` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -315,6 +363,54 @@ export interface AIRecommendationsSchema extends BaseSchema {
    * Message to display when no recommendations are available
    */
   emptyMessage?: string;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `ai-recommendations` reads
+   * NEITHER content channel: no renderer read consumes `body` or `children` for
+   * this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. This renderer takes its configuration from
+   * the props bag `SchemaRenderer` spreads rather than from `schema.*`, and
+   * carries zero `body` / `children` reads either way.
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `ai-recommendations` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `ai-recommendations` reads
+   * NEITHER content channel: no renderer read consumes `body` or `children` for
+   * this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. This renderer takes its configuration from
+   * the props bag `SchemaRenderer` spreads rather than from `schema.*`, and
+   * carries zero `body` / `children` reads either way.
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `ai-recommendations` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -432,6 +528,54 @@ export interface NLQuerySchema extends BaseSchema {
    * Callback when a query is submitted
    */
   onSubmit?: string;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `nl-query` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. This renderer takes its configuration from
+   * the props bag `SchemaRenderer` spreads rather than from `schema.*`, and
+   * carries zero `body` / `children` reads either way.
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `nl-query` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `nl-query` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. This renderer takes its configuration from
+   * the props bag `SchemaRenderer` spreads rather than from `schema.*`, and
+   * carries zero `body` / `children` reads either way.
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `nl-query` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -409,6 +409,56 @@ export interface CalendarViewSchema extends BaseSchema {
    * (function values only).
    */
   onViewChange?: (view: CalendarViewMode) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `calendar-view` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `allDayField`, `colorField`, `data`, `endDateField`, `startDateField`,
+   * `titleField` (in
+   * `packages/plugin-calendar/src/calendar-view-renderer.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `calendar-view` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `calendar-view` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `allDayField`, `colorField`, `data`, `endDateField`, `startDateField`,
+   * `titleField` (in
+   * `packages/plugin-calendar/src/calendar-view-renderer.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `calendar-view` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -550,6 +600,54 @@ export interface FilterBuilderSchema extends BaseSchema {
    * further in. Declared by objectui#6150.
    */
   wrapperClass?: string;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `filter-builder` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `fields`, `label`, `name`, `value`, `wrapperClass` (in
+   * `packages/components/src/renderers/complex/filter-builder.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `filter-builder` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `filter-builder` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `fields`, `label`, `name`, `value`, `wrapperClass` (in
+   * `packages/components/src/renderers/complex/filter-builder.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `filter-builder` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -702,6 +800,54 @@ export interface CarouselSchema extends BaseSchema {
    * @deprecated Not part of this contract — the value was inert.
    */
   onSlideChange?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `carousel` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `itemClassName`, `items`, `opts`, `orientation`, `showArrows` (in
+   * `packages/components/src/renderers/complex/carousel.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `carousel` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `carousel` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `itemClassName`, `items`, `opts`, `orientation`, `showArrows` (in
+   * `packages/components/src/renderers/complex/carousel.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `carousel` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -1294,6 +1440,33 @@ export interface ChatbotSchema extends BaseSchema {
    * read by `chatbot-floating` alone and forwarded to `<FloatingChatbot>`.
    */
   floatingConfig?: FloatingChatbotConfig;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `chatbot` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `api`, `assistantAvatarFallback`, `assistantAvatarUrl`, `autoResponse`,
+   * `autoResponseDelay`, `autoResponseText`, `conversationId`, `headers`,
+   * `maxHeight`, `maxToolRoundtrips`, `messages`, `model`, `onError`, `onSend`,
+   * `placeholder`, `requestBody`, `showTimestamp`, `streamingEnabled`,
+   * `systemPrompt`, `userAvatarFallback`, `userAvatarUrl` (in
+   * `packages/plugin-chatbot/src/renderer.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `chatbot` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -1414,6 +1587,35 @@ export interface ChatbotEnhancedSchema
    * `plugin-chatbot`'s `handleClear` invokes `schema.onClear?.()`.
    */
   onClear?: () => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `chatbot-enhanced` reads
+   * NEITHER content channel: no renderer read consumes `body` or `children` for
+   * this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `api`, `assistantAvatarFallback`, `assistantAvatarUrl`, `autoResponse`,
+   * `autoResponseDelay`, `autoResponseText`, `conversationId`,
+   * `enableFileUpload`, `enableMarkdown`, `headers`, `maxHeight`,
+   * `maxToolRoundtrips`, `messages`, `model`, `onClear`, `onError`, `onSend`,
+   * `placeholder`, `processVisibility`, `requestBody`, `showTimestamp`,
+   * `streamingEnabled`, `surface`, `systemPrompt`, `userAvatarFallback`,
+   * `userAvatarUrl` (in `packages/plugin-chatbot/src/renderer.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `chatbot-enhanced` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -1499,6 +1701,35 @@ export interface ChatbotFloatingSchema
    * read by `chatbot-floating` alone and forwarded to `<FloatingChatbot>`.
    */
   floatingConfig?: FloatingChatbotConfig;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `chatbot-floating` reads
+   * NEITHER content channel: no renderer read consumes `body` or `children` for
+   * this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `api`, `assistantAvatarFallback`, `assistantAvatarUrl`, `autoResponse`,
+   * `autoResponseDelay`, `autoResponseText`, `conversationId`,
+   * `enableFileUpload`, `enableMarkdown`, `floatingConfig`, `headers`,
+   * `maxToolRoundtrips`, `messages`, `model`, `onClear`, `onError`, `onSend`,
+   * `placeholder`, `requestBody`, `showTimestamp`, `streamingEnabled`,
+   * `systemPrompt`, `userAvatarFallback`, `userAvatarUrl` (in
+   * `packages/plugin-chatbot/src/renderer.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `chatbot-floating` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -1951,6 +2182,62 @@ export interface DashboardComponentSchema extends BaseSchema {
   // as `any` — this deletion removes the type-level suggestion and the false
   // parity claim, not a key that ever rendered. Pinned by
   // `__tests__/dashboard-aria-retired-contract-twins.test.ts`.
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `dashboard` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `columns`, `dateRange`, `description`, `gap`, `globalFilters`, `header`,
+   * `label`, `name`, `refreshIntervalSeconds`, `type`, `widgets` (in
+   * `packages/plugin-dashboard/src/DashboardGridLayout.tsx`,
+   * `packages/plugin-dashboard/src/DashboardRenderer.tsx`,
+   * `packages/plugin-dashboard/src/DashboardWithConfig.tsx`,
+   * `packages/plugin-designer/src/DashboardEditor.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `dashboard` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `dashboard` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `columns`, `dateRange`, `description`, `gap`, `globalFilters`, `header`,
+   * `label`, `name`, `refreshIntervalSeconds`, `type`, `widgets` (in
+   * `packages/plugin-dashboard/src/DashboardGridLayout.tsx`,
+   * `packages/plugin-dashboard/src/DashboardRenderer.tsx`,
+   * `packages/plugin-dashboard/src/DashboardWithConfig.tsx`,
+   * `packages/plugin-designer/src/DashboardEditor.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `dashboard` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -85,6 +85,54 @@ export interface StatisticSchema extends BaseSchema {
     * Optional icon name
     */
   icon?: string;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `statistic` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `description`, `icon`, `label`, `trend`, `value` (in
+   * `packages/components/src/renderers/data-display/statistic.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `statistic` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `statistic` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `description`, `icon`, `label`, `trend`, `value` (in
+   * `packages/components/src/renderers/data-display/statistic.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `statistic` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -138,6 +186,52 @@ export interface AvatarSchema extends BaseSchema {
    * @default 'circle'
    */
   shape?: 'circle' | 'square';
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `avatar` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `alt`, `fallback`, `src` (in
+   * `packages/components/src/renderers/data-display/avatar.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `avatar` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `avatar` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `alt`, `fallback`, `src` (in
+   * `packages/components/src/renderers/data-display/avatar.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `avatar` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -672,6 +766,52 @@ export interface TableSchema extends BaseSchema {
    * @deprecated Retired — style rows via `className`, or use `data-table`.
    */
   striped?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `table` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `caption`, `columns`, `data`, `footer` (in
+   * `packages/components/src/renderers/complex/table.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `table` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `table` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `caption`, `columns`, `data`, `footer` (in
+   * `packages/components/src/renderers/complex/table.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `table` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -1160,6 +1300,62 @@ export interface DataTableSchema extends BaseSchema {
    * Called when columns are reordered via drag-and-drop
    */
   onColumnReorder?: (newOrder: string[]) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `data-table` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `emptyAction`, `onAddRecord`, `onBatchSave`, `onCellChange`,
+   * `onColumnResize`, `onColumnsReorder`, `onRowActionDef`, `onRowClick`,
+   * `onRowDelete`, `onRowEdit`, `onRowSave`, `onSelectionChange`,
+   * `renderCellEditor`, `rowActionDefs`, `rowDeletePredicates`,
+   * `rowEditPredicates` (in
+   * `packages/components/src/renderers/complex/data-table.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `data-table` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `data-table` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `emptyAction`, `onAddRecord`, `onBatchSave`, `onCellChange`,
+   * `onColumnResize`, `onColumnsReorder`, `onRowActionDef`, `onRowClick`,
+   * `onRowDelete`, `onRowEdit`, `onRowSave`, `onSelectionChange`,
+   * `renderCellEditor`, `rowActionDefs`, `rowDeletePredicates`,
+   * `rowEditPredicates` (in
+   * `packages/components/src/renderers/complex/data-table.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `data-table` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -1384,6 +1580,54 @@ export interface TreeViewSchema extends BaseSchema {
    * `__tests__/zod-mirror-parity.test.ts`'s `RuntimeOnlyDeclared` instead.
    */
   onNodeClick?: (node: TreeNode) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `tree-view` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `bind`, `nodes`, `onNodeClick`, `title` (in
+   * `packages/components/src/renderers/data-display/tree-view.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `tree-view` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `tree-view` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `bind`, `nodes`, `onNodeClick`, `title` (in
+   * `packages/components/src/renderers/data-display/tree-view.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `tree-view` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -1868,6 +2112,52 @@ export interface PivotTableSchema extends BaseSchema {
    * row header / column header / total opens a filtered list view.
    */
   drillDown?: DrillDownConfig;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `pivot` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `bind`, `columnField`, `data`, `filter`, `objectName`, `rowField`, `title`
+   * (in `packages/plugin-dashboard/src/ObjectPivotTable.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `pivot` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `pivot` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `bind`, `columnField`, `data`, `filter`, `objectName`, `rowField`, `title`
+   * (in `packages/plugin-dashboard/src/ObjectPivotTable.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `pivot` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -2148,6 +2438,52 @@ export interface KbdSchema extends BaseSchema {
    * Key labels (multiple keys)
    */
   keys?: string | string[];
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `kbd` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `keys`, `label` (in
+   * `packages/components/src/renderers/data-display/kbd.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `kbd` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `kbd` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `keys`, `label` (in
+   * `packages/components/src/renderers/data-display/kbd.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `kbd` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -2237,4 +2573,48 @@ export interface HtmlSchema extends BaseSchema {
    * The HTML content string
    */
   html: string;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `html` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `html` (in `packages/components/src/renderers/basic/html.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `html` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `html` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `html` (in `packages/components/src/renderers/basic/html.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `html` reads — nothing renders it.
+   */
+  children?: never;
 }

--- a/packages/types/src/disclosure.ts
+++ b/packages/types/src/disclosure.ts
@@ -129,6 +129,54 @@ export interface CollapsibleSchema extends BaseSchema {
    * spread onto the Radix `Collapsible` root by the renderer's `{...props}`.
    */
   onOpenChange?: (open: boolean) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `collapsible` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `content`, `defaultOpen`, `trigger` (in
+   * `packages/components/src/renderers/disclosure/collapsible.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `collapsible` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `collapsible` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `content`, `defaultOpen`, `trigger` (in
+   * `packages/components/src/renderers/disclosure/collapsible.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `collapsible` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -195,6 +243,54 @@ export interface ToggleGroupSchema extends BaseSchema {
    * `{...toggleGroupProps}`.
    */
   onValueChange?: (value: string | string[]) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `toggle-group` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `items`, `selectionType`, `size`, `value`, `variant` (in
+   * `packages/components/src/renderers/disclosure/toggle-group.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `toggle-group` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `toggle-group` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `items`, `selectionType`, `size`, `value`, `variant` (in
+   * `packages/components/src/renderers/disclosure/toggle-group.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `toggle-group` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**

--- a/packages/types/src/feedback.ts
+++ b/packages/types/src/feedback.ts
@@ -41,6 +41,52 @@ export interface LoadingSchema extends BaseSchema {
    * @default false
    */
   fullscreen?: boolean;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `loading` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `fullscreen`, `size`, `text` (in
+   * `packages/components/src/renderers/feedback/loading.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `loading` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `loading` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `fullscreen`, `size`, `text` (in
+   * `packages/components/src/renderers/feedback/loading.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `loading` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -77,6 +123,52 @@ export interface ProgressSchema extends BaseSchema {
    * @default false
    */
   indeterminate?: boolean;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `progress` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `value` (in `packages/components/src/renderers/feedback/progress.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `progress` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `progress` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `value` (in `packages/components/src/renderers/feedback/progress.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `progress` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -107,6 +199,54 @@ export interface SkeletonSchema extends BaseSchema {
    * @default true
    */
   animate?: boolean;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `skeleton` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `height`, `width` (in
+   * `packages/components/src/renderers/feedback/skeleton.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `skeleton` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `skeleton` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `height`, `width` (in
+   * `packages/components/src/renderers/feedback/skeleton.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `skeleton` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -194,6 +334,54 @@ export interface ToastSchema extends BaseSchema {
    * `components/src/__tests__/toast-button-variant-parity.test.ts`.
    */
   buttonVariant?: 'default' | 'secondary' | 'destructive' | 'outline' | 'ghost' | 'link';
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `toast` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `buttonLabel`, `buttonVariant`, `className`, `description`, `duration`,
+   * `title`, `variant` (in
+   * `packages/components/src/renderers/feedback/toast.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `toast` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `toast` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `buttonLabel`, `buttonVariant`, `className`, `description`, `duration`,
+   * `title`, `variant` (in
+   * `packages/components/src/renderers/feedback/toast.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `toast` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -211,6 +399,52 @@ export interface ToasterSchema extends BaseSchema {
    * @default 5
    */
   limit?: number;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `toaster` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `limit`, `position` (in
+   * `packages/components/src/renderers/feedback/toaster.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `toaster` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `toaster` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `limit`, `position` (in
+   * `packages/components/src/renderers/feedback/toaster.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `toaster` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -223,6 +457,52 @@ export interface SpinnerSchema extends BaseSchema {
    * @default 'md'
    */
   size?: 'sm' | 'md' | 'lg' | 'xl';
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `spinner` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `size` (in
+   * `packages/components/src/renderers/feedback/spinner.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `spinner` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `spinner` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `size` (in
+   * `packages/components/src/renderers/feedback/spinner.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `spinner` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -281,6 +561,52 @@ export interface EmptySchema extends BaseSchema {
    * @example "Nothing here yet"
    */
   action?: SchemaNode;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `empty` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `action`, `className`, `description`, `title` (in
+   * `packages/components/src/renderers/feedback/empty.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `empty` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `empty` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `action`, `className`, `description`, `title` (in
+   * `packages/components/src/renderers/feedback/empty.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `empty` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -313,6 +639,54 @@ export interface SonnerSchema extends BaseSchema {
    * Button variant
    */
   buttonVariant?: 'default' | 'secondary' | 'destructive' | 'outline' | 'ghost' | 'link';
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `sonner` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `buttonLabel`, `buttonVariant`, `className`, `description`, `message`,
+   * `title`, `variant` (in
+   * `packages/components/src/renderers/feedback/sonner.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `sonner` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `sonner` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `buttonLabel`, `buttonVariant`, `className`, `description`, `message`,
+   * `title`, `variant` (in
+   * `packages/components/src/renderers/feedback/sonner.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `sonner` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -223,6 +223,56 @@ export interface TextareaSchema extends BaseSchema {
    * Maximum length
    */
   maxLength?: number;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `textarea` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `defaultValue`, `id`, `label`, `name`, `placeholder`, `readOnly`,
+   * `required`, `rows`, `value`, `wrapperClass` (in
+   * `packages/components/src/renderers/form/textarea.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `textarea` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `textarea` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `defaultValue`, `id`, `label`, `name`, `placeholder`, `readOnly`,
+   * `required`, `rows`, `value`, `wrapperClass` (in
+   * `packages/components/src/renderers/form/textarea.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `textarea` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -289,6 +339,54 @@ export interface SelectSchema extends BaseSchema {
    * after `SchemaRenderer` spreads it.
    */
   onChange?: (value: string | number | boolean) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `select` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `defaultValue`, `label`, `name`, `options`, `placeholder`, `required`,
+   * `value`, `wrapperClass` (in
+   * `packages/components/src/renderers/form/select.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `select` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `select` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `defaultValue`, `label`, `name`, `options`, `placeholder`, `required`,
+   * `value`, `wrapperClass` (in
+   * `packages/components/src/renderers/form/select.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `select` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -384,6 +482,54 @@ export interface CheckboxSchema extends BaseSchema {
    * `SchemaRenderer` spreads it.
    */
   onChange?: (checked: boolean) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `checkbox` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `checked`, `defaultChecked`, `id`, `label`, `name`, `required`,
+   * `wrapperClass` (in `packages/components/src/renderers/form/checkbox.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `checkbox` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `checkbox` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `checked`, `defaultChecked`, `id`, `label`, `name`, `required`,
+   * `wrapperClass` (in `packages/components/src/renderers/form/checkbox.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `checkbox` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -432,6 +578,54 @@ export interface RadioGroupSchema extends BaseSchema {
    * @deprecated Not part of this contract — the value was inert.
    */
   onChange?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `radio-group` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `defaultValue`, `id`, `options`, `orientation` (in
+   * `packages/components/src/renderers/form/radio-group.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `radio-group` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `radio-group` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `defaultValue`, `id`, `options`, `orientation` (in
+   * `packages/components/src/renderers/form/radio-group.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `radio-group` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -501,6 +695,52 @@ export interface SwitchSchema extends BaseSchema {
    * @deprecated Not part of this contract — the value was inert.
    */
   onChange?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `switch` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `id`, `label`, `wrapperClass` (in
+   * `packages/components/src/renderers/form/switch.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `switch` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `switch` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `id`, `label`, `wrapperClass` (in
+   * `packages/components/src/renderers/form/switch.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `switch` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -592,6 +832,52 @@ export interface SliderSchema extends BaseSchema {
    * @deprecated Not part of this contract — the value was inert.
    */
   onChange?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `slider` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `defaultValue`, `max`, `min`, `step` (in
+   * `packages/components/src/renderers/form/slider.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `slider` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `slider` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `defaultValue`, `max`, `min`, `step` (in
+   * `packages/components/src/renderers/form/slider.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `slider` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -658,6 +944,54 @@ export interface FileUploadSchema extends BaseSchema {
    * `SchemaRenderer` spreads it.
    */
   onChange?: (files: FileList | File[]) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `file-upload` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `accept`, `buttonText`, `id`, `label`, `multiple`, `wrapperClass` (in
+   * `packages/components/src/renderers/form/file-upload.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `file-upload` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `file-upload` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `accept`, `buttonText`, `id`, `label`, `multiple`, `wrapperClass` (in
+   * `packages/components/src/renderers/form/file-upload.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `file-upload` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -727,6 +1061,54 @@ export interface DatePickerSchema extends BaseSchema {
    * `SchemaRenderer` spreads it.
    */
   onChange?: (date: Date | undefined) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `date-picker` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `format`, `id`, `label`, `placeholder`, `wrapperClass` (in
+   * `packages/components/src/renderers/form/date-picker.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `date-picker` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `date-picker` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `format`, `id`, `label`, `placeholder`, `wrapperClass` (in
+   * `packages/components/src/renderers/form/date-picker.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `date-picker` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -818,6 +1200,54 @@ export interface InputOTPSchema extends BaseSchema {
    * @deprecated Not part of this contract — the value was inert.
    */
   onComplete?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `input-otp` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `maxLength`, `value` (in
+   * `packages/components/src/renderers/form/input-otp.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `input-otp` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `input-otp` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `maxLength`, `value` (in
+   * `packages/components/src/renderers/form/input-otp.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `input-otp` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -1401,6 +1831,52 @@ export interface LabelSchema extends BaseSchema {
    * HTML for attribute
    */
   htmlFor?: string;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `label` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `content`, `label`, `text` (in
+   * `packages/components/src/renderers/form/label.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `label` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `label` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `content`, `label`, `text` (in
+   * `packages/components/src/renderers/form/label.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `label` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -1502,6 +1978,54 @@ export interface ComboboxSchema extends BaseSchema {
    * @deprecated Not part of this contract — the value was inert.
    */
   onChange?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `combobox` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `description`, `options`, `placeholder`, `value` (in
+   * `packages/components/src/renderers/form/combobox.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `combobox` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `combobox` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `description`, `options`, `placeholder`, `value` (in
+   * `packages/components/src/renderers/form/combobox.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `combobox` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -1563,6 +2087,52 @@ export interface CommandSchema extends BaseSchema {
    * @deprecated Not part of this contract — the value was inert.
    */
   onChange?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `command` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `emptyText`, `groups`, `placeholder` (in
+   * `packages/components/src/renderers/form/command.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `command` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `command` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `emptyText`, `groups`, `placeholder` (in
+   * `packages/components/src/renderers/form/command.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `command` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**

--- a/packages/types/src/layout.ts
+++ b/packages/types/src/layout.ts
@@ -222,6 +222,52 @@ export interface SeparatorSchema extends BaseSchema {
    * Whether to add decorative content
    */
   decorative?: boolean;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `separator` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `orientation` (in `packages/components/src/renderers/basic/separator.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `separator` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `separator` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `orientation` (in `packages/components/src/renderers/basic/separator.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `separator` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -583,6 +629,54 @@ export interface ResizableSchema extends BaseSchema {
    * Resizable panels
    */
   panels: ResizablePanel[];
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `resizable` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `direction`, `minHeight`, `panels`, `withHandle` (in
+   * `packages/components/src/renderers/complex/resizable.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `resizable` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `resizable` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `direction`, `minHeight`, `panels`, `withHandle` (in
+   * `packages/components/src/renderers/complex/resizable.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `resizable` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**

--- a/packages/types/src/navigation.ts
+++ b/packages/types/src/navigation.ts
@@ -110,6 +110,54 @@ export interface HeaderBarSchema extends BaseSchema {
    * @default 'default'
    */
   variant?: 'default' | 'bordered' | 'floating';
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `header-bar` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `actions`, `crumbs`, `rightContent`, `search` (in
+   * `packages/components/src/renderers/navigation/header-bar.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `header-bar` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `header-bar` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `actions`, `crumbs`, `rightContent`, `search` (in
+   * `packages/components/src/renderers/navigation/header-bar.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `header-bar` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -225,6 +273,54 @@ export interface BreadcrumbSchema extends BaseSchema {
    * Maximum items to display before collapsing
    */
   maxItems?: number;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `breadcrumb` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `items`, `maxItems`, `separator` (in
+   * `packages/components/src/renderers/data-display/breadcrumb.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `breadcrumb` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `breadcrumb` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `items`, `maxItems`, `separator` (in
+   * `packages/components/src/renderers/data-display/breadcrumb.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `breadcrumb` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -269,6 +365,54 @@ export interface PaginationSchema extends BaseSchema {
    * `SchemaRenderer` spreads it.
    */
   onPageChange?: (page: number) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `pagination` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `currentPage`, `page`, `totalPages` (in
+   * `packages/components/src/renderers/basic/pagination.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `pagination` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `pagination` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `currentPage`, `page`, `totalPages` (in
+   * `packages/components/src/renderers/basic/pagination.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `pagination` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -311,6 +455,54 @@ export interface NavigationMenuSchema extends BaseSchema {
    * @default 'horizontal'
    */
   orientation?: 'horizontal' | 'vertical';
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `navigation-menu` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `items` (in
+   * `packages/components/src/renderers/basic/navigation-menu.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `navigation-menu` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `navigation-menu` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `items` (in
+   * `packages/components/src/renderers/basic/navigation-menu.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `navigation-menu` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -366,6 +558,54 @@ export interface ButtonGroupSchema extends BaseSchema {
    * @default 'default'
    */
   size?: 'default' | 'sm' | 'lg' | 'icon';
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `button-group` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `buttons`, `className`, `size`, `variant` (in
+   * `packages/components/src/renderers/basic/button-group.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `button-group` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `button-group` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `buttons`, `className`, `size`, `variant` (in
+   * `packages/components/src/renderers/basic/button-group.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `button-group` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -3676,6 +3676,56 @@ export interface ObjectGallerySchema extends BaseSchema {
   imageField?: string;
   /** @deprecated Use `gallery.titleField` instead */
   titleField?: string;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `object-gallery` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `bind`, `className`, `data`, `filter`, `gallery`, `grouping`, `imageField`,
+   * `navigation`, `objectName`, `titleField` (in
+   * `packages/plugin-list/src/ObjectGallery.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `object-gallery` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `object-gallery` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `bind`, `className`, `data`, `filter`, `gallery`, `grouping`, `imageField`,
+   * `navigation`, `objectName`, `titleField` (in
+   * `packages/plugin-list/src/ObjectGallery.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `object-gallery` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -3723,6 +3773,54 @@ export interface ObjectDataTableSchema extends BaseSchema {
    * refuses the key by name). When present it overrides drill-to-record.
    */
   onRowClick?: (row: any) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `object-data-table` reads
+   * NEITHER content channel: no renderer read consumes `body` or `children` for
+   * this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `bind`, `columns`, `data`, `drillDown`, `filter`, `objectName`,
+   * `onRowClick` (in `packages/plugin-dashboard/src/ObjectDataTable.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `object-data-table` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `object-data-table` reads
+   * NEITHER content channel: no renderer read consumes `body` or `children` for
+   * this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `bind`, `columns`, `data`, `drillDown`, `filter`, `objectName`,
+   * `onRowClick` (in `packages/plugin-dashboard/src/ObjectDataTable.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `object-data-table` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**

--- a/packages/types/src/overlay.ts
+++ b/packages/types/src/overlay.ts
@@ -81,6 +81,52 @@ export interface DialogSchema extends BaseSchema {
    * spread onto the Radix `Dialog` root by the renderer's `{...props}`.
    */
   onOpenChange?: (open: boolean) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `dialog` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `content`, `defaultOpen`, `description`, `footer`, `modal`, `title`,
+   * `trigger` (in `packages/components/src/renderers/overlay/dialog.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `dialog` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `dialog` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `content`, `defaultOpen`, `description`, `footer`, `modal`, `title`,
+   * `trigger` (in `packages/components/src/renderers/overlay/dialog.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `dialog` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -282,6 +328,56 @@ export interface AlertDialogSchema extends BaseSchema {
    * spread onto the Radix `AlertDialog` root by the renderer's `{...props}`.
    */
   onOpenChange?: (open: boolean) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `alert-dialog` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `actionText`, `actionVariant`, `cancelText`, `content`, `defaultOpen`,
+   * `description`, `onAction`, `title`, `trigger` (in
+   * `packages/components/src/renderers/overlay/alert-dialog.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `alert-dialog` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `alert-dialog` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `actionText`, `actionVariant`, `cancelText`, `content`, `defaultOpen`,
+   * `description`, `onAction`, `title`, `trigger` (in
+   * `packages/components/src/renderers/overlay/alert-dialog.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `alert-dialog` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -338,6 +434,54 @@ export interface SheetSchema extends BaseSchema {
    * spread onto the Radix `Sheet` (Dialog) root by the renderer's `{...props}`.
    */
   onOpenChange?: (open: boolean) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `sheet` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `content`, `defaultOpen`, `description`, `footer`, `modal`, `side`,
+   * `title`, `trigger` (in
+   * `packages/components/src/renderers/overlay/sheet.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `sheet` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `sheet` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `content`, `defaultOpen`, `description`, `footer`, `modal`, `side`,
+   * `title`, `trigger` (in
+   * `packages/components/src/renderers/overlay/sheet.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `sheet` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -390,6 +534,54 @@ export interface DrawerSchema extends BaseSchema {
    * spread onto the vaul `Drawer` root by the renderer's `{...props}`.
    */
   onOpenChange?: (open: boolean) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `drawer` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `content`, `defaultOpen`, `description`, `footer`, `shouldScaleBackground`,
+   * `showClose`, `title`, `trigger` (in
+   * `packages/components/src/renderers/overlay/drawer.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `drawer` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `drawer` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `content`, `defaultOpen`, `description`, `footer`, `shouldScaleBackground`,
+   * `showClose`, `title`, `trigger` (in
+   * `packages/components/src/renderers/overlay/drawer.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `drawer` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -439,6 +631,52 @@ export interface PopoverSchema extends BaseSchema {
    * spread onto the Radix `Popover` root by the renderer's `{...props}`.
    */
   onOpenChange?: (open: boolean) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `popover` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `align`, `content`, `defaultOpen`, `modal`, `side`, `trigger` (in
+   * `packages/components/src/renderers/overlay/popover.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `popover` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `popover` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `align`, `content`, `defaultOpen`, `modal`, `side`, `trigger` (in
+   * `packages/components/src/renderers/overlay/popover.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `popover` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -563,6 +801,54 @@ export interface HoverCardSchema extends BaseSchema {
    * spread onto the Radix `HoverCard` root by the renderer's `{...props}`.
    */
   onOpenChange?: (open: boolean) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `hover-card` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `align`, `closeDelay`, `content`, `openDelay`, `side`, `trigger` (in
+   * `packages/components/src/renderers/overlay/hover-card.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `hover-card` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `hover-card` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `align`, `closeDelay`, `content`, `openDelay`, `side`, `trigger` (in
+   * `packages/components/src/renderers/overlay/hover-card.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `hover-card` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -701,6 +987,54 @@ export interface DropdownMenuSchema extends BaseSchema {
    * spread onto the Radix `DropdownMenu` root by the renderer's `{...props}`.
    */
   onOpenChange?: (open: boolean) => void;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `dropdown-menu` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `align`, `defaultOpen`, `items`, `label`, `modal`, `side`, `trigger` (in
+   * `packages/components/src/renderers/overlay/dropdown-menu.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `dropdown-menu` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `dropdown-menu` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `align`, `defaultOpen`, `items`, `label`, `modal`, `side`, `trigger` (in
+   * `packages/components/src/renderers/overlay/dropdown-menu.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `dropdown-menu` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -756,6 +1090,56 @@ export interface ContextMenuSchema extends BaseSchema {
    * Undeclared until objectui#6939.
    */
   modal?: boolean;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `context-menu` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `contentClassName`, `items`, `modal`, `trigger`,
+   * `triggerClassName` (in
+   * `packages/components/src/renderers/overlay/context-menu.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `context-menu` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `context-menu` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `contentClassName`, `items`, `modal`, `trigger`,
+   * `triggerClassName` (in
+   * `packages/components/src/renderers/overlay/context-menu.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `context-menu` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -781,6 +1165,52 @@ export interface MenubarSchema extends BaseSchema {
    * Menubar menus
    */
   menus?: MenubarMenu[];
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `menubar` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `menus` (in
+   * `packages/components/src/renderers/overlay/menubar.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `menubar` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `menubar` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `className`, `menus` (in
+   * `packages/components/src/renderers/overlay/menubar.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `menubar` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**

--- a/packages/types/src/reports.ts
+++ b/packages/types/src/reports.ts
@@ -598,4 +598,52 @@ export interface ReportViewerSchema extends BaseSchema {
    * Loading state
    */
   loading?: boolean;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `report-viewer` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. This renderer takes its configuration from
+   * the props bag `SchemaRenderer` spreads rather than from `schema.*`, and
+   * carries zero `body` / `children` reads either way.
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `report-viewer` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `report-viewer` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. This renderer takes its configuration from
+   * the props bag `SchemaRenderer` spreads rather than from `schema.*`, and
+   * carries zero `body` / `children` reads either way.
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `report-viewer` reads — nothing renders it.
+   */
+  children?: never;
 }

--- a/packages/types/src/views.ts
+++ b/packages/types/src/views.ts
@@ -960,6 +960,56 @@ export interface ViewSwitcherSchema extends BaseSchema {
     type: 'share' | 'settings' | 'duplicate' | 'delete';
     icon?: string;
   }>;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `view-switcher` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `activeView`, `allowCreateView`, `defaultView`, `id`, `onViewChange`,
+   * `persistPreference`, `position`, `storageKey`, `variant`, `viewActions`,
+   * `views` (in `packages/plugin-view/src/ViewSwitcher.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `view-switcher` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `view-switcher` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `activeView`, `allowCreateView`, `defaultView`, `id`, `onViewChange`,
+   * `persistPreference`, `position`, `storageKey`, `variant`, `viewActions`,
+   * `views` (in `packages/plugin-view/src/ViewSwitcher.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `view-switcher` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -1020,6 +1070,54 @@ export interface FilterUISchema extends BaseSchema {
    * Filter layout
    */
   layout?: 'inline' | 'popover' | 'drawer';
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `filter-ui` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `filters`, `layout`, `onChange`, `showApply`, `showClear`, `values` (in
+   * `packages/plugin-view/src/FilterUI.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `filter-ui` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `filter-ui` reads NEITHER
+   * content channel: no renderer read consumes `body` or `children` for this
+   * node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `filters`, `layout`, `onChange`, `showApply`, `showClear`, `values` (in
+   * `packages/plugin-view/src/FilterUI.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `filter-ui` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**
@@ -1069,6 +1167,52 @@ export interface SortUISchema extends BaseSchema {
    * UI variant
    */
   variant?: 'dropdown' | 'buttons';
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `sort-ui` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `fields`, `multiple`, `onChange`, `sort`, `variant` (in
+   * `packages/plugin-view/src/SortUI.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `sort-ui` reads — nothing renders it.
+   */
+  body?: never;
+  /**
+   * REFUSED BY NAME (objectui#9256, ADR-0049) — `sort-ui` reads NEITHER content
+   * channel: no renderer read consumes `body` or `children` for this node.
+   *
+   * MEASURED with the TypeScript TYPE CHECKER and not with grep, across all 24
+   * packages that register components plus the generic traversers — a docblock
+   * mention is not a read, and `body: schema.requestBody` in
+   * `packages/plugin-chatbot/src/renderer.tsx` is the kind of prefix hit grep
+   * scores. Every read is filed under the TYPE of the object it is read from;
+   * this declaration carries none. What the renderer DOES read off this node:
+   * `fields`, `multiple`, `onChange`, `sort`, `variant` (in
+   * `packages/plugin-view/src/SortUI.tsx`).
+   *
+   * `body` and `children` are inherited-and-optional from {@link BaseSchema},
+   * whose own docblock admits "some components use `children` instead of
+   * `body`" without saying which — so authoring either here type-checked,
+   * parsed green through `.passthrough()`, and rendered NOTHING: no error, no
+   * warning, no element. `SchemaRenderer` strips both keys out of the props bag
+   * it spreads, so neither reaches the component by another route either.
+   *
+   * @deprecated Not a channel `sort-ui` reads — nothing renders it.
+   */
+  children?: never;
 }
 
 /**

--- a/packages/types/src/zod/complex.zod.ts
+++ b/packages/types/src/zod/complex.zod.ts
@@ -265,6 +265,22 @@ export const CalendarViewSchema = BaseSchema.extend({
   // `onViewChange` below.
   onEventClick: handlerKeyRefusal('onEventClick', 'runtime-slot', 'Host-only event click handler'),
   onViewChange: handlerKeyRefusal('onViewChange', 'runtime-slot', 'Host-only view change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `calendar-view` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `allDayField`, `colorField`, `data`, `endDateField`, `startDateField`, '
+    + '`titleField`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `calendar-view` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `allDayField`, `colorField`, `data`, `endDateField`, `startDateField`, '
+    + '`titleField`.',
+  ),
 });
 
 /**
@@ -482,6 +498,20 @@ export const FilterBuilderSchema = BaseSchema.extend({
   maxDepth: z.number().optional().describe('Maximum nesting depth'),
   // Applied at renderers/complex/filter-builder.tsx:37 as `className={schema.wrapperClass || ''}`.
   wrapperClass: z.string().optional().describe('Outer wrapper classes for the filter builder (objectui#6150)'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `filter-builder` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `fields`, `label`, `name`, `value`, `wrapperClass`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `filter-builder` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `fields`, `label`, `name`, `value`, `wrapperClass`.',
+  ),
 });
 
 /**
@@ -511,6 +541,20 @@ export const CarouselSchema = BaseSchema.extend({
   itemsPerView: z.number().optional().describe('Items per view'),
   gap: z.number().optional().describe('Gap between items'),
   onSlideChange: handlerKeyRefusal('onSlideChange', 'retired', 'Slide change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `carousel` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `itemClassName`, `items`, `opts`, `orientation`, `showArrows`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `carousel` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `itemClassName`, `items`, `opts`, `orientation`, `showArrows`.',
+  ),
 });
 
 /**
@@ -658,6 +702,16 @@ export const ChatbotSchema = BaseSchema.extend({
   autoResponseText: z.string().optional().describe('Text of the local auto-response'),
   autoResponseDelay: z.number().optional().describe('Delay in milliseconds before the local auto-response is sent'),
   onSend: handlerKeyRefusal('onSend', 'runtime-slot', 'Called after a message is sent, in both API and local auto-response mode'),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `chatbot` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `api`, `assistantAvatarFallback`, `assistantAvatarUrl`, `autoResponse`, '
+    + '`autoResponseDelay`, `autoResponseText`, `conversationId`, `headers`, `maxHeight`, '
+    + '`maxToolRoundtrips`, `messages`, `model`, `onError`, `onSend`, `placeholder`, `requestBody`, '
+    + '`showTimestamp`, `streamingEnabled`, `systemPrompt`, `userAvatarFallback`, `userAvatarUrl`.',
+  ),
 });
 
 /**
@@ -726,6 +780,17 @@ export const ChatbotEnhancedSchema = BaseSchema.extend({
   surface: z.enum(['card', 'plain']).optional()
     .describe("Visual chrome for the chat surface: 'card' bordered panel (default) or 'plain' frameless full-page workspace (objectui#6687)"),
   onClear: chatbotOnClearArm(),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `chatbot-enhanced` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `api`, `assistantAvatarFallback`, `assistantAvatarUrl`, `autoResponse`, '
+    + '`autoResponseDelay`, `autoResponseText`, `conversationId`, `enableFileUpload`, `enableMarkdown`, '
+    + '`headers`, `maxHeight`, `maxToolRoundtrips`, `messages`, `model`, `onClear`, `onError`, '
+    + '`onSend`, `placeholder`, `processVisibility`, `requestBody`, `showTimestamp`, '
+    + '`streamingEnabled`, `surface`, `systemPrompt`, `userAvatarFallback`, `userAvatarUrl`.',
+  ),
 });
 
 /**
@@ -760,6 +825,17 @@ export const ChatbotFloatingSchema = BaseSchema.extend({
   enableMarkdown: chatbotEnableMarkdownArm(),
   enableFileUpload: chatbotEnableFileUploadArm(),
   onClear: chatbotOnClearArm(),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `chatbot-floating` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `api`, `assistantAvatarFallback`, `assistantAvatarUrl`, `autoResponse`, '
+    + '`autoResponseDelay`, `autoResponseText`, `conversationId`, `enableFileUpload`, `enableMarkdown`, '
+    + '`floatingConfig`, `headers`, `maxToolRoundtrips`, `messages`, `model`, `onClear`, `onError`, '
+    + '`onSend`, `placeholder`, `requestBody`, `showTimestamp`, `streamingEnabled`, `systemPrompt`, '
+    + '`userAvatarFallback`, `userAvatarUrl`.',
+  ),
 });
 
 /**
@@ -1065,6 +1141,22 @@ export const DashboardComponentSchema = BaseSchema.extend(SpecDashboardFields.sh
     defaultRange: z.string().optional(),
     allowCustomRange: z.boolean().optional(),
   }).optional().describe('Built-in date range filter'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `dashboard` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `columns`, `dateRange`, `description`, `gap`, `globalFilters`, '
+    + '`header`, `label`, `name`, `refreshIntervalSeconds`, `type`, `widgets`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `dashboard` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `columns`, `dateRange`, `description`, `gap`, `globalFilters`, '
+    + '`header`, `label`, `name`, `refreshIntervalSeconds`, `type`, `widgets`.',
+  ),
 });
 
 /**

--- a/packages/types/src/zod/data-display.zod.ts
+++ b/packages/types/src/zod/data-display.zod.ts
@@ -78,6 +78,20 @@ export const StatisticSchema = BaseSchema.extend({
   trend: z.enum(['up', 'down', 'neutral']).optional().describe('Trend indicator'),
   description: z.string().optional().describe('Description text'),
   icon: z.string().optional().describe('Statistic icon'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `statistic` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `description`, `icon`, `label`, `trend`, `value`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `statistic` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `description`, `icon`, `label`, `trend`, `value`.',
+  ),
 });
 
 /**
@@ -101,6 +115,20 @@ export const AvatarSchema = BaseSchema.extend({
   fallback: z.string().optional().describe('Fallback text/initials'),
   size: z.enum(['sm', 'default', 'lg', 'xl']).optional().describe('Avatar size'),
   shape: z.enum(['circle', 'square']).optional().describe('Avatar shape'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `avatar` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `alt`, `fallback`, `src`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `avatar` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `alt`, `fallback`, `src`.',
+  ),
 });
 
 /**
@@ -276,6 +304,20 @@ export const TableSchema = BaseSchema.extend({
   footer: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional().describe('Table footer'),
   hoverable: retirementTombstone('RETIRED (objectui#5474) — the static table never implemented row hover; use data-table'),
   striped: retirementTombstone('RETIRED (objectui#5474) — the static table never implemented striping; style rows via className, or use data-table'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `table` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `caption`, `columns`, `data`, `footer`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `table` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `caption`, `columns`, `data`, `footer`.',
+  ),
 });
 
 /**
@@ -315,6 +357,26 @@ export const DataTableSchema = BaseSchema.extend({
   frozenColumns: z.number().optional().describe('Number of frozen columns'),
   showRowNumbers: z.boolean().optional().describe('Show row numbers'),
   emptyAction: SchemaNodeSchema.optional().describe('Optional schema node rendered inside the empty-state, e.g. an "Add record" button. Lets the empty state become an actionable invitation rather than a dead end.'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `data-table` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `emptyAction`, `onAddRecord`, `onBatchSave`, `onCellChange`, '
+    + '`onColumnResize`, `onColumnsReorder`, `onRowActionDef`, `onRowClick`, `onRowDelete`, '
+    + '`onRowEdit`, `onRowSave`, `onSelectionChange`, `renderCellEditor`, `rowActionDefs`, '
+    + '`rowDeletePredicates`, `rowEditPredicates`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `data-table` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `emptyAction`, `onAddRecord`, `onBatchSave`, `onCellChange`, '
+    + '`onColumnResize`, `onColumnsReorder`, `onRowActionDef`, `onRowClick`, `onRowDelete`, '
+    + '`onRowEdit`, `onRowSave`, `onSelectionChange`, `renderCellEditor`, `rowActionDefs`, '
+    + '`rowDeletePredicates`, `rowEditPredicates`.',
+  ),
 });
 
 /**
@@ -405,6 +467,20 @@ export const TreeViewSchema = BaseSchema.extend({
   showLines: z.boolean().optional().describe('Show connecting lines'),
   onSelectChange: handlerKeyRefusal('onSelectChange', 'retired', 'Selection change handler'),
   onExpandChange: handlerKeyRefusal('onExpandChange', 'retired', 'Expand change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `tree-view` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `bind`, `nodes`, `onNodeClick`, `title`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `tree-view` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `bind`, `nodes`, `onNodeClick`, `title`.',
+  ),
 });
 
 /**
@@ -850,6 +926,20 @@ export const KbdSchema = BaseSchema.extend({
   type: z.literal('kbd'),
   label: z.string().optional().describe('Key label'),
   keys: z.union([z.string(), z.array(z.string())]).optional().describe('Key(s) to display'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `kbd` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `keys`, `label`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `kbd` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `keys`, `label`.',
+  ),
 });
 
 /**
@@ -858,6 +948,20 @@ export const KbdSchema = BaseSchema.extend({
 export const HtmlSchema = BaseSchema.extend({
   type: z.literal('html'),
   html: z.string().describe('HTML content'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `html` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `html`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `html` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `html`.',
+  ),
 });
 
 /**

--- a/packages/types/src/zod/disclosure.zod.ts
+++ b/packages/types/src/zod/disclosure.zod.ts
@@ -17,7 +17,7 @@
  */
 
 import { z } from 'zod';
-import { handlerKeyRefusal } from './tombstone.zod.js';
+import { handlerKeyRefusal, retirementTombstone } from './tombstone.zod.js';
 import { BaseSchema, SchemaNodeSchema } from './base.zod.js';
 
 /**
@@ -54,6 +54,20 @@ export const CollapsibleSchema = BaseSchema.extend({
   defaultOpen: z.boolean().optional().describe('Default open state'),
   open: z.boolean().optional().describe('Controlled open state'),
   onOpenChange: handlerKeyRefusal('onOpenChange', 'runtime-slot', 'Open change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `collapsible` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `content`, `defaultOpen`, `trigger`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `collapsible` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `content`, `defaultOpen`, `trigger`.',
+  ),
 });
 
 /**
@@ -77,6 +91,20 @@ export const ToggleGroupSchema = BaseSchema.extend({
   defaultValue: z.union([z.string(), z.array(z.string())]).optional().describe('Default value(s)'),
   value: z.union([z.string(), z.array(z.string())]).optional().describe('Controlled value(s)'),
   onValueChange: handlerKeyRefusal('onValueChange', 'runtime-slot', 'Value change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `toggle-group` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `items`, `selectionType`, `size`, `value`, `variant`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `toggle-group` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `items`, `selectionType`, `size`, `value`, `variant`.',
+  ),
 });
 
 /**

--- a/packages/types/src/zod/feedback.zod.ts
+++ b/packages/types/src/zod/feedback.zod.ts
@@ -29,6 +29,20 @@ export const LoadingSchema = BaseSchema.extend({
   size: z.enum(['sm', 'default', 'lg']).optional().describe('Loading indicator size'),
   variant: z.enum(['spinner', 'dots', 'pulse']).optional().describe('Loading variant'),
   fullscreen: z.boolean().optional().describe('Whether to show fullscreen overlay'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `loading` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `fullscreen`, `size`, `text`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `loading` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `fullscreen`, `size`, `text`.',
+  ),
 });
 
 /**
@@ -42,6 +56,20 @@ export const ProgressSchema = BaseSchema.extend({
   showLabel: z.boolean().optional().describe('Show progress label'),
   size: z.enum(['sm', 'default', 'lg']).optional().describe('Progress bar size'),
   indeterminate: z.boolean().optional().describe('Indeterminate progress'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `progress` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `value`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `progress` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `value`.',
+  ),
 });
 
 /**
@@ -54,6 +82,20 @@ export const SkeletonSchema = BaseSchema.extend({
   height: z.union([z.string(), z.number()]).optional().describe('Skeleton height'),
   lines: z.number().optional().describe('Number of text lines'),
   animate: z.boolean().optional().describe('Enable animation'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `skeleton` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `height`, `width`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `skeleton` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `height`, `width`.',
+  ),
 });
 
 /**
@@ -110,6 +152,22 @@ export const ToastSchema = BaseSchema.extend({
     .enum(['default', 'secondary', 'destructive', 'outline', 'ghost', 'link'])
     .optional()
     .describe('Trigger button variant'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `toast` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `buttonLabel`, `buttonVariant`, `className`, `description`, `duration`, '
+    + '`title`, `variant`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `toast` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `buttonLabel`, `buttonVariant`, `className`, `description`, `duration`, '
+    + '`title`, `variant`.',
+  ),
 });
 
 /**
@@ -126,6 +184,20 @@ export const ToasterSchema = BaseSchema.extend({
     'bottom-right',
   ]).optional().describe('Toaster position'),
   limit: z.number().optional().describe('Maximum number of toasts'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `toaster` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `limit`, `position`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `toaster` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `limit`, `position`.',
+  ),
 });
 
 /**
@@ -134,6 +206,20 @@ export const ToasterSchema = BaseSchema.extend({
 export const SpinnerSchema = BaseSchema.extend({
   type: z.literal('spinner'),
   size: z.enum(['sm', 'md', 'lg', 'xl']).optional().describe('Spinner size'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `spinner` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `size`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `spinner` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `size`.',
+  ),
 });
 
 /**
@@ -155,6 +241,20 @@ export const EmptySchema = BaseSchema.extend({
   // is neither a node object with a `type` nor a primitive is refused, where
   // before it was admitted.
   action: SchemaNodeSchema.optional().describe('Call-to-action node rendered below the description'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `empty` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `action`, `className`, `description`, `title`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `empty` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `action`, `className`, `description`, `title`.',
+  ),
 });
 
 /**
@@ -180,6 +280,22 @@ export const SonnerSchema = BaseSchema.extend({
     .enum(['default', 'secondary', 'destructive', 'outline', 'ghost', 'link'])
     .optional()
     .describe('Action button variant'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `sonner` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `buttonLabel`, `buttonVariant`, `className`, `description`, `message`, '
+    + '`title`, `variant`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `sonner` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `buttonLabel`, `buttonVariant`, `className`, `description`, `message`, '
+    + '`title`, `variant`.',
+  ),
 });
 
 /**

--- a/packages/types/src/zod/form.zod.ts
+++ b/packages/types/src/zod/form.zod.ts
@@ -255,6 +255,22 @@ export const TextareaSchema = BaseSchema.extend({
     .describe('Classes on the wrapper div around the textarea and its label (objectui#7722)'),
   onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
   maxLength: z.number().optional().describe('Maximum length'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `textarea` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `defaultValue`, `id`, `label`, `name`, `placeholder`, `readOnly`, '
+    + '`required`, `rows`, `value`, `wrapperClass`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `textarea` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `defaultValue`, `id`, `label`, `name`, `placeholder`, `readOnly`, '
+    + '`required`, `rows`, `value`, `wrapperClass`.',
+  ),
 });
 
 /**
@@ -274,6 +290,22 @@ export const SelectSchema = BaseSchema.extend({
   wrapperClass: z.string().optional()
     .describe('Classes on the wrapper div around the trigger and its label (objectui#7722)'),
   onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `select` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `defaultValue`, `label`, `name`, `options`, `placeholder`, `required`, '
+    + '`value`, `wrapperClass`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `select` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `defaultValue`, `label`, `name`, `options`, `placeholder`, `required`, '
+    + '`value`, `wrapperClass`.',
+  ),
 });
 
 /**
@@ -292,6 +324,22 @@ export const CheckboxSchema = BaseSchema.extend({
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
   onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `checkbox` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `checked`, `defaultChecked`, `id`, `label`, `name`, `required`, '
+    + '`wrapperClass`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `checkbox` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `checked`, `defaultChecked`, `id`, `label`, `name`, `required`, '
+    + '`wrapperClass`.',
+  ),
 });
 
 /**
@@ -308,6 +356,20 @@ export const RadioGroupSchema = BaseSchema.extend({
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
   onChange: handlerKeyRefusal('onChange', 'retired', 'Change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `radio-group` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `defaultValue`, `id`, `options`, `orientation`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `radio-group` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `defaultValue`, `id`, `options`, `orientation`.',
+  ),
 });
 
 /**
@@ -323,6 +385,20 @@ export const SwitchSchema = BaseSchema.extend({
   wrapperClass: z.string().optional()
     .describe("Classes on the wrapper div around the switch and its label (objectui#7722)"),
   onChange: handlerKeyRefusal('onChange', 'retired', 'Change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `switch` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `id`, `label`, `wrapperClass`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `switch` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `id`, `label`, `wrapperClass`.',
+  ),
 });
 
 /**
@@ -353,6 +429,20 @@ export const SliderSchema = BaseSchema.extend({
   step: z.number().optional().describe('Step value'),
   description: z.string().optional().describe('Help text'),
   onChange: handlerKeyRefusal('onChange', 'retired', 'Change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `slider` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `defaultValue`, `max`, `min`, `step`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `slider` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `defaultValue`, `max`, `min`, `step`.',
+  ),
 });
 
 /**
@@ -373,6 +463,20 @@ export const FileUploadSchema = BaseSchema.extend({
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
   onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `file-upload` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `accept`, `buttonText`, `id`, `label`, `multiple`, `wrapperClass`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `file-upload` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `accept`, `buttonText`, `id`, `label`, `multiple`, `wrapperClass`.',
+  ),
 });
 
 /**
@@ -393,6 +497,20 @@ export const DatePickerSchema = BaseSchema.extend({
   wrapperClass: z.string().optional()
     .describe("Classes on the wrapper div around the popover trigger and its label (objectui#7722)"),
   onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `date-picker` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `format`, `id`, `label`, `placeholder`, `wrapperClass`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `date-picker` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `format`, `id`, `label`, `placeholder`, `wrapperClass`.',
+  ),
 });
 
 /**
@@ -422,6 +540,20 @@ export const InputOTPSchema = BaseSchema.extend({
   error: z.string().optional().describe('Error message'),
   onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
   onComplete: handlerKeyRefusal('onComplete', 'retired', 'Complete handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `input-otp` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `maxLength`, `value`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `input-otp` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `maxLength`, `value`.',
+  ),
 });
 
 /**
@@ -452,6 +584,20 @@ export const ComboboxSchema = BaseSchema.extend({
     ),
   error: z.string().optional().describe('Error message'),
   onChange: handlerKeyRefusal('onChange', 'retired', 'Change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `combobox` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `description`, `options`, `placeholder`, `value`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `combobox` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `description`, `options`, `placeholder`, `value`.',
+  ),
 });
 
 /**
@@ -462,6 +608,20 @@ export const LabelSchema = BaseSchema.extend({
   text: z.string().optional().describe('Label text'),
   label: z.string().optional().describe('Label text (alternative)'),
   htmlFor: z.string().optional().describe('Associated input ID'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `label` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `content`, `label`, `text`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `label` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `content`, `label`, `text`.',
+  ),
 });
 
 /**
@@ -473,6 +633,20 @@ export const CommandSchema = BaseSchema.extend({
   emptyText: z.string().optional().describe('Empty state text'),
   groups: z.array(CommandGroupSchema).describe('Command groups'),
   onChange: handlerKeyRefusal('onChange', 'retired', 'Change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `command` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `emptyText`, `groups`, `placeholder`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `command` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `emptyText`, `groups`, `placeholder`.',
+  ),
 });
 
 /**

--- a/packages/types/src/zod/layout.zod.ts
+++ b/packages/types/src/zod/layout.zod.ts
@@ -199,6 +199,20 @@ export const SeparatorSchema = BaseSchema.extend({
   type: z.literal('separator'),
   orientation: z.enum(['horizontal', 'vertical']).optional().describe('Separator orientation'),
   decorative: z.boolean().optional().describe('Whether decorative'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `separator` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `orientation`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `separator` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `orientation`.',
+  ),
 });
 
 /**
@@ -346,6 +360,20 @@ export const ResizableSchema = BaseSchema.extend({
   minHeight: z.union([z.string(), z.number()]).optional().describe('Minimum height'),
   withHandle: z.boolean().optional().describe('Show resize handle'),
   panels: z.array(ResizablePanelSchema).describe('Resizable panels'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `resizable` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `direction`, `minHeight`, `panels`, `withHandle`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `resizable` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `direction`, `minHeight`, `panels`, `withHandle`.',
+  ),
 });
 
 /**

--- a/packages/types/src/zod/navigation.zod.ts
+++ b/packages/types/src/zod/navigation.zod.ts
@@ -17,7 +17,7 @@
  */
 
 import { z } from 'zod';
-import { handlerKeyRefusal } from './tombstone.zod.js';
+import { handlerKeyRefusal, retirementTombstone } from './tombstone.zod.js';
 import { BaseSchema, SchemaNodeSchema } from './base.zod.js';
 import type { NavLink, NavigationMenuItem } from '../navigation.js';
 
@@ -79,6 +79,20 @@ export const HeaderBarSchema = BaseSchema.extend({
   sticky: z.boolean().optional().describe('Whether header is sticky'),
   height: z.union([z.string(), z.number()]).optional().describe('Header height'),
   variant: z.enum(['default', 'bordered', 'transparent']).optional().describe('Header variant'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `header-bar` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `actions`, `crumbs`, `rightContent`, `search`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `header-bar` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `actions`, `crumbs`, `rightContent`, `search`.',
+  ),
 });
 
 /**
@@ -108,6 +122,20 @@ export const BreadcrumbSchema = BaseSchema.extend({
   items: z.array(BreadcrumbItemSchema).describe('Breadcrumb items'),
   separator: z.string().optional().describe('Custom separator'),
   maxItems: z.number().optional().describe('Maximum items to display'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `breadcrumb` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `items`, `maxItems`, `separator`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `breadcrumb` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `items`, `maxItems`, `separator`.',
+  ),
 });
 
 /**
@@ -121,6 +149,20 @@ export const PaginationSchema = BaseSchema.extend({
   showFirstLast: z.boolean().optional().describe('Show first/last page buttons'),
   showPrevNext: z.boolean().optional().describe('Show previous/next buttons'),
   onPageChange: handlerKeyRefusal('onPageChange', 'runtime-slot', 'Page change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `pagination` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `currentPage`, `page`, `totalPages`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `pagination` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `currentPage`, `page`, `totalPages`.',
+  ),
 });
 
 /**
@@ -150,6 +192,20 @@ export const NavigationMenuSchema = BaseSchema.extend({
   type: z.literal('navigation-menu'),
   items: z.array(NavigationMenuItemSchema).optional().describe('Menu items'),
   orientation: z.enum(['horizontal', 'vertical']).optional().describe('Menu orientation'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `navigation-menu` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `items`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `navigation-menu` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `items`.',
+  ),
 });
 
 /**
@@ -172,6 +228,20 @@ export const ButtonGroupSchema = BaseSchema.extend({
   buttons: z.array(ButtonGroupButtonSchema).optional().describe('Group buttons'),
   variant: z.enum(['default', 'secondary', 'destructive', 'outline', 'ghost', 'link']).optional().describe('Button group variant'),
   size: z.enum(['default', 'sm', 'lg', 'icon']).optional().describe('Button group size'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `button-group` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `buttons`, `className`, `size`, `variant`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `button-group` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `buttons`, `className`, `size`, `variant`.',
+  ),
 });
 
 /**

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -1577,6 +1577,22 @@ export const ObjectGallerySchema = BaseSchema.extend({
   grouping: stripImportedDefaults(SpecGroupingConfigSchema).optional().describe('Grouping configuration for sectioned display'),
   imageField: z.string().optional().describe('DEPRECATED — use gallery.coverField'),
   titleField: z.string().optional().describe('DEPRECATED — use gallery.titleField'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `object-gallery` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `bind`, `className`, `data`, `filter`, `gallery`, `grouping`, '
+    + '`imageField`, `navigation`, `objectName`, `titleField`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `object-gallery` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `bind`, `className`, `data`, `filter`, `gallery`, `grouping`, '
+    + '`imageField`, `navigation`, `objectName`, `titleField`.',
+  ),
 });
 
 /**
@@ -1612,6 +1628,22 @@ export const ObjectDataTableSchema = BaseSchema.extend({
     'Drill-to-record: clicking a row opens that record in a detail drawer (DashboardRenderer defaults object-backed table widgets to { enabled: true, mode: record })',
   ),
   onRowClick: handlerKeyRefusal('onRowClick', 'runtime-slot', 'Row click handler (overrides drill-to-record)'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `object-data-table` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `bind`, `columns`, `data`, `drillDown`, `filter`, `objectName`, '
+    + '`onRowClick`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `object-data-table` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `bind`, `columns`, `data`, `drillDown`, `filter`, `objectName`, '
+    + '`onRowClick`.',
+  ),
 });
 
 /**

--- a/packages/types/src/zod/overlay.zod.ts
+++ b/packages/types/src/zod/overlay.zod.ts
@@ -35,6 +35,22 @@ export const DialogSchema = BaseSchema.extend({
   footer: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional().describe('Dialog footer'),
   modal: z.boolean().optional().describe('Whether dialog is modal'),
   onOpenChange: handlerKeyRefusal('onOpenChange', 'runtime-slot', 'Open change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `dialog` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `content`, `defaultOpen`, `description`, `footer`, `modal`, `title`, '
+    + '`trigger`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `dialog` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `content`, `defaultOpen`, `description`, `footer`, `modal`, `title`, '
+    + '`trigger`.',
+  ),
 });
 
 /**
@@ -179,6 +195,22 @@ export const AlertDialogSchema = BaseSchema.extend({
   onConfirm: handlerKeyRefusal('onConfirm', 'retired', 'Confirm handler'),
   onCancel: handlerKeyRefusal('onCancel', 'retired', 'Cancel handler'),
   onOpenChange: handlerKeyRefusal('onOpenChange', 'runtime-slot', 'Open change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `alert-dialog` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `actionText`, `actionVariant`, `cancelText`, `content`, `defaultOpen`, '
+    + '`description`, `onAction`, `title`, `trigger`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `alert-dialog` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `actionText`, `actionVariant`, `cancelText`, `content`, `defaultOpen`, '
+    + '`description`, `onAction`, `title`, `trigger`.',
+  ),
 });
 
 /**
@@ -195,6 +227,22 @@ export const SheetSchema = BaseSchema.extend({
   side: z.enum(['top', 'right', 'bottom', 'left']).optional().describe('Sheet position'),
   footer: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional().describe('Sheet footer'),
   onOpenChange: handlerKeyRefusal('onOpenChange', 'runtime-slot', 'Open change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `sheet` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `content`, `defaultOpen`, `description`, `footer`, `modal`, `side`, '
+    + '`title`, `trigger`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `sheet` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `content`, `defaultOpen`, `description`, `footer`, `modal`, `side`, '
+    + '`title`, `trigger`.',
+  ),
 });
 
 /**
@@ -210,6 +258,22 @@ export const DrawerSchema = BaseSchema.extend({
   open: z.boolean().optional().describe('Controlled open state'),
   direction: z.enum(['top', 'right', 'bottom', 'left']).optional().describe('Drawer direction'),
   onOpenChange: handlerKeyRefusal('onOpenChange', 'runtime-slot', 'Open change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `drawer` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `content`, `defaultOpen`, `description`, `footer`, '
+    + '`shouldScaleBackground`, `showClose`, `title`, `trigger`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `drawer` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `content`, `defaultOpen`, `description`, `footer`, '
+    + '`shouldScaleBackground`, `showClose`, `title`, `trigger`.',
+  ),
 });
 
 /**
@@ -224,6 +288,20 @@ export const PopoverSchema = BaseSchema.extend({
   side: z.enum(['top', 'right', 'bottom', 'left']).optional().describe('Popover side'),
   align: z.enum(['start', 'center', 'end']).optional().describe('Popover alignment'),
   onOpenChange: handlerKeyRefusal('onOpenChange', 'runtime-slot', 'Open change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `popover` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `align`, `content`, `defaultOpen`, `modal`, `side`, `trigger`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `popover` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `align`, `content`, `defaultOpen`, `modal`, `side`, `trigger`.',
+  ),
 });
 
 /**
@@ -279,6 +357,20 @@ export const HoverCardSchema = BaseSchema.extend({
   openDelay: z.number().optional().describe('Delay before opening (ms)'),
   closeDelay: z.number().optional().describe('Delay before closing (ms)'),
   onOpenChange: handlerKeyRefusal('onOpenChange', 'runtime-slot', 'Open change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `hover-card` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `align`, `closeDelay`, `content`, `openDelay`, `side`, `trigger`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `hover-card` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `align`, `closeDelay`, `content`, `openDelay`, `side`, `trigger`.',
+  ),
 });
 
 /**
@@ -339,6 +431,20 @@ export const DropdownMenuSchema = BaseSchema.extend({
   side: z.enum(['top', 'right', 'bottom', 'left']).optional().describe('Menu side'),
   align: z.enum(['start', 'center', 'end']).optional().describe('Menu alignment'),
   onOpenChange: handlerKeyRefusal('onOpenChange', 'runtime-slot', 'Open change handler'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `dropdown-menu` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `align`, `defaultOpen`, `items`, `label`, `modal`, `side`, `trigger`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `dropdown-menu` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `align`, `defaultOpen`, `items`, `label`, `modal`, `side`, `trigger`.',
+  ),
 });
 
 /**
@@ -366,6 +472,22 @@ export const ContextMenuSchema = BaseSchema.extend({
     .describe('Classes for the menu panel, applied to the underlying `ContextMenuContent` (objectui#6939)'),
   modal: z.boolean().optional()
     .describe('Forwarded to the Radix `ContextMenu` root as `modal` (objectui#6939)'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `context-menu` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `contentClassName`, `items`, `modal`, `trigger`, '
+    + '`triggerClassName`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `context-menu` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `contentClassName`, `items`, `modal`, `trigger`, '
+    + '`triggerClassName`.',
+  ),
 });
 
 /**
@@ -382,6 +504,20 @@ export const MenubarMenuSchema = z.object({
 export const MenubarSchema = BaseSchema.extend({
   type: z.literal('menubar'),
   menus: z.array(MenubarMenuSchema).optional().describe('Menubar menus'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `menubar` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `menus`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `menubar` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `className`, `menus`.',
+  ),
 });
 
 /**

--- a/packages/types/src/zod/reports.zod.ts
+++ b/packages/types/src/zod/reports.zod.ts
@@ -215,6 +215,20 @@ export const ReportViewerSchema = BaseSchema.extend({
   allowExport: z.boolean().optional().describe('Allow export'),
   allowPrint: z.boolean().optional().describe('Allow print'),
   loading: z.boolean().optional().describe('Loading state'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `report-viewer` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'It takes its configuration from the props bag `SchemaRenderer` spreads, not from `schema.*`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `report-viewer` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'It takes its configuration from the props bag `SchemaRenderer` spreads, not from `schema.*`.',
+  ),
 });
 
 /**

--- a/packages/types/src/zod/views.zod.ts
+++ b/packages/types/src/zod/views.zod.ts
@@ -241,6 +241,22 @@ export const ViewSwitcherSchema = BaseSchema.extend({
     type: z.enum(['share', 'settings', 'duplicate', 'delete']).describe('Action type'),
     icon: z.string().optional().describe('Action icon'),
   })).optional().describe('Per-view action icons'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `view-switcher` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `activeView`, `allowCreateView`, `defaultView`, `id`, `onViewChange`, '
+    + '`persistPreference`, `position`, `storageKey`, `variant`, `viewActions`, `views`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `view-switcher` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `activeView`, `allowCreateView`, `defaultView`, `id`, `onViewChange`, '
+    + '`persistPreference`, `position`, `storageKey`, `variant`, `viewActions`, `views`.',
+  ),
 });
 
 /**
@@ -262,6 +278,20 @@ export const FilterUISchema = BaseSchema.extend({
   showClear: z.boolean().optional().describe('Show clear button'),
   showApply: z.boolean().optional().describe('Show apply button'),
   layout: z.enum(['inline', 'popover', 'drawer']).optional().describe('Filter layout'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `filter-ui` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `filters`, `layout`, `onChange`, `showApply`, `showClear`, `values`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `filter-ui` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `filters`, `layout`, `onChange`, `showApply`, `showClear`, `values`.',
+  ),
 });
 
 /**
@@ -281,6 +311,20 @@ export const SortUISchema = BaseSchema.extend({
     .describe('Event name dispatched on window when the sort changes (detail: { sort }) — an event NAME, not a callback or a handler expression'),
   multiple: z.boolean().optional().describe('Allow multiple sort fields'),
   variant: z.enum(['dropdown', 'buttons']).optional().describe('UI variant'),
+  body: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `sort-ui` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `fields`, `multiple`, `onChange`, `sort`, `variant`.',
+  ),
+  children: retirementTombstone(
+    'REFUSED (objectui#9256, ADR-0049) — `sort-ui` reads NEITHER content channel: measured with the '
+    + 'TypeScript type checker across all 24 registering packages, no renderer read consumes `body` or '
+    + '`children` for this node, and `SchemaRenderer` strips both out of the props bag it spreads. An '
+    + 'authored value therefore rendered NOTHING — no error, no warning, no element. '
+    + 'What it renders instead: `fields`, `multiple`, `onChange`, `sort`, `variant`.',
+  ),
 });
 
 /**


### PR DESCRIPTION
Part of #9256 — deliberately not a closing keyword: this lands family D of the measured table, and the card stays open for the eleven registrations held out below.

Executes the ruling recorded on objectui#8284 (director seat, summon #17, decision batch #2, 2026-09-07; maintainer verbatim 「同意」): the `body` / `children` duality is resolved **per component, not by a second alias** — every component schema narrows to the channel its renderer actually reads and tombstones the other. PR objectui#9254 landed families A and B (read exactly one channel); this is family D — **reads neither**.

Ruling execution step (1), the measured table, is posted on the card BEFORE any declaration moved: objectui#9256 comment 5644340762.

Attribution for this work: session `session_01UzHd6hDYatoDn17BuwKxnZ` (written into the prose because a `PATCH` degrades the footer form).

## ⭐ The measurement came first, and it is bigger than objectui#9254's

A verdict of **absence** is not sound over a subset, so the compiler-API read-site instrument was extended from `packages/components` to **46 programs** — every workspace package plus `apps/console`, `apps/site` and the four examples, **1,604 source files**. Every `body` / `children` read is filed under the TYPE of the object it is read from, so a docblock cannot score.

**Two instrument defects were found while extending it, and both answered WRONG silently:**

1. **Attribution by bare type NAME pools unrelated types.** `__type` is the symbol name of every anonymous object type literal, `Record` of every mapped type. Bare-name filing put **20 registrations into "reads BOTH"** that read nothing. Identity is now the name plus the file and line of the type's own declaration.
2. **An unbuilt tree answers `any`, and `any` reads as NEITHER.** `@object-ui/types` resolves through `dist/*.d.ts`; before a build, `GridSchema` resolved to `any` and `grid` scored NEITHER — it reads `children`. The reading of record is on a fully built tree, with a module-resolution probe reporting 0 unresolved-module diagnostics.

**Lit controls, both directions.** Grep-hit / checker-non-hit, new in this family: `body: schema.requestBody` in `plugin-chatbot/src/renderer.tsx` (three times, in the very registrations this card narrows); `body:` inside the EXAMPLE schema literals in `carousel.tsx` and `resizable.tsx` registration metadata; a bare `{children}` React expression in `plugin-view/src/index.tsx` that can never receive the authored channel because `SchemaRenderer` strips it; four prose mentions in `layout/src/index.ts`. Positive control: 36 schema-attributed reads under the 18 published declarations of families A, B and C, two of which the one-package sweep could not see.

**The generic traversers were read directly, not inferred** — they are the readers no per-component sweep sees:

- `SchemaRenderer` destructures `children` and `body` OUT of the props bag it spreads ⇒ "reads neither" really does mean "renders nothing", by no other route.
- `validateSchema` reads `schema.children` else `schema.body` for every node, but only to RECURSE and validate; it renders nothing.
- the two DYNAMIC-tag factories (`semantic.tsx`, `html-elements.tsx`) DO read the channel — their 44 tag names were enumerated and intersected with the family-D names: **empty**.
- `containers.tsx` is the one that does collide (`accordion`, `tabs`), and both are held out.

## What this does

**219 registrations in 24 packages** (not 25: `apps/console` holds 21 `registerLazy` aliases and registers nothing directly). **77 are family D — not the card's ~60 — and 20 of them are outside `packages/components`**, in 11 other packages. 64 registrations over **62 published declarations** are narrowed here: `body` and `children` become `?: never` on the TypeScript face and a by-name `retirementTombstone` refusal on the zod mirror, kept a MEMBER so `zod-mirror-parity`'s key sets stay equal. Four declarations have no zod mirror at all (`AIFormAssistSchema`, `AIRecommendationsSchema`, `NLQuerySchema`, `PivotTableSchema`); for those the TypeScript face is the only gate, and the pin test says so.

Each tombstone's guidance names what the renderer DOES read, derived from the same instrument rather than written by hand — `collapsible` says "What it renders instead: `content`, `defaultOpen`, `trigger`".

## ⚠️ Held out — eleven registrations, each for a measurement, none for appetite

| held | why |
|---|---|
| `accordion`, `tabs`, `text`, `image`, `icon` (both arms), `list`, `calendar`, `timeline`, `button` (`UIActionSchema` arm) | the `type` name carries 2+ registrations with DIFFERENT declarations. `ComponentRegistry.register` writes the bare-name fallback LAST-ONE-WINS, so which declaration governs an authored node depends on import order — the same reason `sidebar` was held out of family B |
| `input` (`InputSchema`) | `InputShorthandSchema` is declared as an `Omit` of it, so a tombstone would propagate onto the `email` / `password` shorthand face, whose registrations are `any`-typed — family E, frozen |
| `app-schema-renderer` (`AppComponentSchema`) | that declaration's own type literal is `app`, and `app` is served by `PageNodeSchema` — family C, reads BOTH, with the maintainer |
| `detail` (`DetailViewSchema`) | its own literal is `detail-view`, which is registered with an `any`-typed renderer whose reads are unattributable |
| the `body` key of `chatbot` / `chatbot-enhanced` / `chatbot-floating` | `zod-mirror-parity`'s ledger already records it verbatim: "Two different meanings of one key — a naming collision to rule on, not a widening." Their `children` IS narrowed, and a LIVE CONTROL in the pin test proves `body` still parses |

⚠️ **The hazard is bigger than the card's nine: 19 `type` names carry 2+ registrations.** Eight are cross-PACKAGE collisions the one-package sweep could not see — `form`, `calendar`, `grid`, `list`, `alert`, `menu`, `chart`, `timeline`.

## ⚠️ Real authored usage of the refused channels — NON-ZERO, and it is the documentation's fault

A brace-matched object-literal census over **7,182 files** (positive control: **431** documents authoring the channel those renderers DO read) found 11 hits. **Seven are real documents, and every one renders an EMPTY element today:**

| document | node | authored | fixed here |
|---|---|---|---|
| `examples/schema-catalog/.../dialog-trigger.json` | `dialog` | `children` | → `content` |
| `examples/schema-catalog/.../basic-drawer.json` | `drawer` | `children` | → `content` |
| `examples/schema-catalog/.../basic-popover.json` | `popover` | `children` | → `content` |
| `examples/schema-catalog/.../basic-collapsible.json` | `collapsible` | `children` | → `content` |
| `content/docs/components/overlay/dialog.mdx` | `DialogSchema` | documents `children` | → `content` |
| `content/docs/components/overlay/drawer.mdx` | `DrawerSchema` | documents `children` | → `content` |
| `content/docs/components/overlay/popover.mdx` | `PopoverSchema` | documents `children` | → `content` |

⭐ The four catalog files are the **rendered demo gallery** and the three pages are the **published component reference**. They agree with each other and disagree with the renderer: the reference TEACHES the dead spelling, so this is not seven authors slipping — it is the documentation manufacturing the defect. `collapsible` is objectui#8197, found a third time. Reported rather than migrated in silence, per the card.

## ⚠️ This PR and PR objectui#9254 both edit one `it` block

`examples/schema-catalog/test/overlay-trigger-mirror-6939.test.tsx` — objectui#9254 rewrote the `tooltip` half of "the accept set only WIDENED" and left `context-menu` as its deliberate live control, saying in as many words that the control stands until "a cross-package sweep". **This is that sweep**, so this PR rewrites the `context-menu` half. Both edits live in the same hunk: expect a conflict on whichever lands second, and resolve it by keeping BOTH refusals plus the new key-scoped control.

## Fixture triage — three, none of them a batch rename

- `static-table-narrow-surface.test.ts` pinned the static `table` mirror's tombstones as exactly `hoverable` / `striped`. It now reads four, because `body` / `children` join for the same reason measured again.
- `undeclared-but-consumed-keys-6150.test.ts` had `children` in its `context-menu` control document. The control never needed it — the key was a silent empty box — and it made every case in that block fail on a key the block is not about.
- `overlay-trigger-mirror-6939.test.tsx` — above.

## Version level

`minor` with a **BREAKING** banner in the changeset. This narrows a published authoring type, but this repo's version policy forbids `major` in any changeset — 41 packages in one `fixed` group — and records `minor` plus an explicit breaking note as the spelling for a breaking change here. Split levels are impossible anyway.

## Verification

Run on `7bde46114`, the branch head, from the committed tree.

| reader | command | verdict |
|---|---|---|
| vitest | `pnpm exec vitest run packages/types/` | Test Files 180 passed (180) · Tests 4101 passed (4101) |
| vitest | `pnpm exec vitest run packages/components/ packages/types/` | Test Files 446 passed (446) · Tests 6539 passed (6539) |
| vitest | `pnpm exec vitest run examples/schema-catalog/` | Test Files 31 passed (31) · Tests 2151 passed (2151) |
| vitest | `pnpm exec vitest run examples/schema-catalog/ packages/core/ packages/react/` | 262 files · 6336 tests (the one failure it first reported was the objectui#9254 live control this PR supersedes; green after) |
| tsc | `turbo run type-check --filter='...@object-ui/types'` — the DOWNSTREAM consumer closure | **77 successful, 77 total** |
| build | `turbo run build --filter='!@object-ui/site'` | 43 successful, 43 total |
| gate | `check:doc-snippets` | exit 0 — every covered snippet compiles against the built types |
| gate | `check:doc-examples` | exit 0 — every covered `@example` compiles or fails as its ledger row declares |
| gate | `check:doc-types` | exit 0 — 188 docs, 1107 blocks, 897 `type` literals judged; every documented component type is registered |
| gate | `check:doc-fences` · `check:doc-example-ids` | exit 0 |
| gate | `check-changeset-presence.mjs` | exit 0 — 25 source files of 1 released package, 1 changeset |
| gate | `changeset:check` (fixed group + no-major) | exit 0 — no changeset declares `major` |
| gate | `check:control-bytes` | exit 0 — 7,449 tracked text files |
| gate | `check:new-line-citations` | 0 new cross-file line citations (every docblock cites a symbol or an expression, never a line address) |
| gate | `check:handler-key-reads` | exit 0 — 105 arms, 212 registrations, 59 reachable handler reads, 0 unjudged |
| gate | `check:spec-symbols` · `check:action-forward-parity` · `check:designer-field-key-parity` · `check:readme-exports` · `check:sdui-registration-pins` · `check:dist-completeness` | exit 0 |
| gate | `check-governed-queue-guard.mjs --test` | ✅ NOT GOVERNED — 35 paths, 0 matched |
| lint | `pnpm --filter @object-ui/types lint` | exit 0 — 280 problems, **0 errors** |
| lint | `eslint . --no-inline-config --format json` over the WHOLE population | **4,877 files selected by eslint's own config.** The 35 files this branch touches carry **0 errors** and 98 warnings, every one `no-explicit-any` and **none on a line this branch added** (checked against the diff's added-line set). Repo totals 95 errors / 13,008 warnings, all outside this diff. No narrowing argument needed — the full population was read. |

### Ablation — BOTH faces, BOTH readers, and leg 2 is why both are reported

Each leg prechecks the file's `git hash-object` against its HEAD blob, mutates, **proves the mutation on disk by counting the marker**, runs vitest AND tsc, and restores with `git checkout HEAD -- ABSOLUTE_PATH` proved by an empty `git diff HEAD` — never by an exit code. A `trap … EXIT INT TERM` carries the restore on every exit path.

| leg | mutation | on-disk proof | vitest | `tsc` (`@object-ui/types type-check`) |
|---|---|---|---|---|
| baseline | — | both files == HEAD blob | GREEN 631/631 | exit 0 |
| 1 — zod face | delete `DialogSchema`'s `children` refusal arm | refusal markers in the file 18 → 17; 8 lines removed | **RED — 4 failed / 627 passed** | **RED** — 2 errors, both `TS2322` in `zod-mirror-parity.test.ts`'s typed ledger |
| 2 — TS face | delete `DialogSchema`'s `children?: never` | `children?: never` in `overlay.ts` 9 → 8 | **GREEN — 631 passed (631)** | **RED** — `TS2578 Unused '@ts-expect-error' directive` plus a `TS2322` ledger error |
| restore | — | `git diff HEAD` empty for both files | GREEN 631/631 | exit 0 |

⭐ **Leg 2 is the whole reason both readers are reported** — the standard PR objectui#9254 set. The identical mutation is invisible to vitest (`?: never` is erased before a test runs) and loud under `tsc`. Read through vitest alone, "the pin test covers it" would have been recorded as measured when it was NOT MEASURED. Leg 1 lit a second independent reader as well: the parity ledger is a TYPED table, so deleting a mirror arm fails compilation, not just assertions.

### Cross-package reverse validation — the consumer reads the rebuilt `.d.ts`, not a cache

A temporary probe in `packages/components` authoring `{ type: 'dialog', children: [...] }` as a `DialogSchema` turned `pnpm --filter @object-ui/components type-check` **RED** with `TS2322: Type '{ type: string; content: string; }[]' is not assignable to type 'undefined'` — the narrowing arriving across a package boundary through the built types. Removing the probe returned **exit 0**, and `git status` is empty: the probe was never committed.

## ⚠️ Merged `origin/main` — the predicted conflict, and how it was resolved

`main` moved to `20b507aff0` while this branch was in flight (objectui#9254, objectui#9258, objectui#9259 landed). Merged, never rebased: `git merge origin/main`, merge commit `502660a19`. No history on this branch was rewritten and nothing was force-pushed.

**One conflict, and it is the one the section above predicted**: `examples/schema-catalog/test/overlay-trigger-mirror-6939.test.tsx`, where objectui#9254 rewrote the `tooltip` half of one `it` block and this PR rewrote the `context-menu` half. Resolved by keeping BOTH refusals, exactly as this body said to: objectui#9254's live control ended **on its own terms** — it said the control stands until "a cross-package sweep", and objectui#9256 is that sweep — so the reading about `tooltip` is now kept honest by the key-scoped control (the keys both renderers DO read still parse) rather than by `context-menu` staying permissive.

Nothing else conflicted. The two cards narrow **disjoint** declarations, so `packages/types`'s four shared files auto-merged, and the `tombstone.zod.ts` import lists merged into the union (`aliasKeyRefusal` from objectui#9254 beside `retirementTombstone` from this card). A duplicate-member scan over every edited interface reports **0** duplicated `body` / `children` declarations. `@object-ui/core`'s export surface (objectui#9258 added `optionDisplayLabel`) is untouched by this diff — this PR changes no file in `packages/core`. `pnpm-lock.yaml` is byte-identical across the merge (`git diff` over it is empty), so nothing generated needed regenerating; `pnpm install` re-ran clean anyway.

### Re-verified on the merge commit `502660a19`, from the committed tree

| reader | command | verdict |
|---|---|---|
| build | `turbo run build --filter='!@object-ui/site' --concurrency=2` | 43 successful, 43 total |
| tsc | `turbo run type-check --filter='...@object-ui/types'` — the downstream closure | **77 successful, 77 total**, 0 `error TS` lines |
| vitest | `pnpm exec vitest run packages/types/ packages/components/ examples/schema-catalog/` | Test Files 478 passed (478) · Tests 8778 passed (8778) |
| gates | `check:doc-snippets` · `check:doc-examples` · `check:doc-types` · `check:doc-fences` · `check:doc-example-ids` · `check:control-bytes` · `check:new-line-citations` · `check:handler-key-reads` · `check:spec-symbols` · `check-changeset-presence` · `changeset:check` | all exit 0 |
| gate | `check-governed-queue-guard.mjs --test` | ✅ NOT GOVERNED — 35 paths, 0 matched |
| lint | `eslint . --no-inline-config --format json` over the WHOLE population | 4,879 files selected by eslint's own config; the 35 files this branch touches carry **0 errors** and 98 warnings, all `no-explicit-any` and **none on a line this branch added**; repo totals 95 errors / 13,006 warnings, all outside this diff |

**The ablation was re-run in full**, because the merge touched both files its legs mutate. It reproduces identically, and the one number that moved is itself the proof the merge landed: the baseline count of `children?: never` in `packages/types/src/overlay.ts` is now **10, not 9** — objectui#9254's `TooltipSchema` tombstone is the tenth.

| leg | on-disk proof | vitest | `tsc` |
|---|---|---|---|
| baseline | both files == HEAD blob | GREEN 631/631 | exit 0 |
| 1 — zod face | refusal markers 18 → 17, 8 lines removed | **RED — 4 failed / 627 passed** | **RED** — 2× `TS2322` in the parity ledger |
| 2 — TS face | `children?: never` 10 → 9 | **GREEN — 631 passed** | **RED** — `TS2578` + a `TS2322` ledger error |
| restore | `git diff HEAD` empty for both | GREEN 631/631 | exit 0 |

### Declared to CI, deliberately not run here

The full `pnpm test`, `turbo run type-check` across all 41 packages (only the downstream closure of `@object-ui/types` ran here, 77 tasks), and the rest of the `lint.yml` gate farm. Every gate that fires on THIS diff's shape was run locally and is in the table.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code)_