### PR TITLE
fix(app-shell): give the Studio create dialog's confirm control its own accessible name

### DIFF
--- a/.changeset/9231-create-app-accessible-name.md
+++ b/.changeset/9231-create-app-accessible-name.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/app-shell': minor
+---
+
+Studio: the create-draft dialog's confirm control no longer shares a name with the
+affordance that opens it (objectui#9231).
+
+**BREAKING** — a published, user-visible accessible name changes. The confirm control of
+the shared Studio create dialog (`engine.studio.createDraft`) reads `Save as draft`
+instead of `Create (save as draft)`, and `存为草稿` instead of `创建(存为草稿)`. It is the
+primary button of the app / object / automation create dialogs. Any automation, E2E
+selector or documentation that targets it by its old name must be updated; nothing about
+what the control DOES has changed.
+
+**Why the confirm side and not the opener.** The toolbar affordance is named `Create app`
+and the dialog it opens is titled after it — naming a dialog for the action that opened it
+is correct, and `Create app` is the name users, docs and automation already reach for. What
+was wrong is that the one control which actually creates the app offered `Create` as its
+only handle, and `Create` matched the three openers too (toolbar, Interfaces empty state,
+Interfaces rail). So no name could address the confirm control without also matching an
+opener — and while the dialog is open every opener is `aria-hidden` behind Radix's modal
+overlay, so a by-name click there dismisses the dialog with no error and nothing created.
+The user then meets `App not available … it may still be publishing` at the app's list
+route, which blames a publish that never started.
+
+**Why `minor` and not `patch`.** All 41 packages sit in one `fixed` group, so the release
+level is the max across pending changesets and a split changeset cannot produce split
+levels. This repo ships breaking changes as `minor` with a `**BREAKING**` carrier
+(`major` is reserved for tracking `@objectstack`'s major), and an accessible name is part
+of the observable surface a consumer can pin — `patch` would under-declare it.
+
+Pinned by `StudioDesignSurface.createAppAccessibleName.test.tsx`, which drives the real
+surface and the real dialog and asserts by accessible name only — never by `data-testid`,
+which would pin around the very name the defect was about.

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -1533,7 +1533,18 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.studio.cancel': 'Cancel',
   'engine.studio.create': 'Create',
   'engine.studio.creating': 'Creating…',
-  'engine.studio.createDraft': 'Create (save as draft)',
+  // objectui#9231 — this is the CONFIRM control of the shared create dialog.
+  // Never give it a name that shares a leading run with the affordance that
+  // OPENS that dialog (`engine.studio.app.create`, `Create app` — and the
+  // dialog itself is titled after it, which is correct). It used to read
+  // `Create (save as draft)`, so the only handle it offered a by-name caller
+  // was `Create`, which also matched all three openers (toolbar, Interfaces
+  // empty state, Interfaces rail): nothing could address THIS control, the one
+  // that actually creates. While the dialog is open every opener is
+  // `aria-hidden` behind Radix's modal overlay, so a by-name click there
+  // dismisses the dialog with no error and nothing created. Pinned by
+  // `studio-design/StudioDesignSurface.createAppAccessibleName.test.tsx`.
+  'engine.studio.createDraft': 'Save as draft',
   'engine.studio.saveDraft': 'Save draft',
   'engine.studio.more': 'More',
   'engine.studio.autoSaving': 'Saving…',
@@ -3483,7 +3494,9 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.studio.cancel': '取消',
   'engine.studio.create': '创建',
   'engine.studio.creating': '创建中…',
-  'engine.studio.createDraft': '创建(存为草稿)',
+  // objectui#9231 — see the English entry. This value must share no leading
+  // run with `engine.studio.app.create`, which opens the same dialog.
+  'engine.studio.createDraft': '存为草稿',
   'engine.studio.saveDraft': '保存草稿',
   'engine.studio.more': '更多',
   'engine.studio.autoSaving': '保存中…',

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.createAppAccessibleName.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.createAppAccessibleName.test.tsx
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Studio — the Create app dialog must be targetable BY ACCESSIBLE NAME
+ * (objectui#9231).
+ *
+ * ## The defect, as measured on `origin/main` before this fix
+ *
+ * The package workspace toolbar carries a button whose accessible name is
+ * `Create app`; it opens a dialog whose own accessible name is also
+ * `Create app` (its title — which is correct, a dialog is named after the
+ * action that opened it). The one control inside that dialog which actually
+ * creates the app was named `Create (save as draft)`.
+ *
+ * So every name a caller could write for "the control that creates the app"
+ * was ambiguous: `Create app` resolved ONLY to openers (three of them: the
+ * toolbar, the Interfaces empty state, the Interfaces rail), and the shorter
+ * `Create` — the only handle the confirm control offered — matched the openers
+ * too. There was no way to target the confirm control by name without also
+ * matching the toolbar button.
+ *
+ * The cost is not cosmetic. While the dialog is open Radix marks the rest of
+ * the tree `aria-hidden`, so a by-name click on `Create app` lands on the modal
+ * overlay and Radix dismisses the dialog — silently, with no error and nothing
+ * created. The failure only surfaces much later at the app's list route as
+ * `App not available … it may still be publishing`, which blames a publish that
+ * never started.
+ *
+ * ## What this suite pins
+ *
+ * Only accessible names, never `data-testid` — a testid would pin *around* the
+ * very name the defect is about and would stay green while the defect persists.
+ * Everything is asserted through the REAL `StudioDesignSurface` + the REAL
+ * `CreateItemDialog`, so the names under test are the ones a browser, a screen
+ * reader and an automation harness compute.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+let clientImpl: any;
+let saved: Array<[string, string, unknown, unknown]>;
+
+vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useMetadataClient: () => clientImpl,
+    useMetadataTypes: () => ({ loading: false, error: null, entries: [] }),
+  };
+});
+
+// The surface's writability gate — one writable package, so the toolbar's
+// create affordance is enabled rather than disabled.
+vi.mock('./packages-io', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    fetchPackages: vi.fn(async () => [
+      { id: 'app.a', name: 'App A', writable: true, namespace: 'a' },
+    ]),
+  };
+});
+
+// Docks irrelevant to the names under test — keep the render light.
+vi.mock('./StudioAiCopilot', () => ({ StudioChatDock: () => null }));
+vi.mock('../../preview/DraftChangesPanel', () => ({ DraftChangesPanel: () => null }));
+
+import { StudioDesignSurface } from './StudioDesignSurface';
+import { t } from '../metadata-admin/i18n';
+
+// jsdom has no matchMedia — useIsMobile / useIsWideViewport need a stub.
+window.matchMedia = ((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  addListener: () => {},
+  removeListener: () => {},
+  dispatchEvent: () => false,
+})) as any;
+
+// Radix Popover (PackageSwitcher) floats via floating-ui, which observes size.
+(globalThis as any).ResizeObserver =
+  (globalThis as any).ResizeObserver ??
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
+beforeEach(() => {
+  saved = [];
+  clientImpl = {
+    // No published app and no draft app, so the toolbar renders `Create app`
+    // rather than the pending badge or the open-app bridge.
+    list: async () => [],
+    listDrafts: async () => [],
+    layered: async () => ({ effective: null, code: null }),
+    getDraft: async () => null,
+    get: async () => null,
+    save: async (type: string, name: string, body: unknown, opts: unknown) => {
+      saved.push([type, name, body, opts]);
+      return body;
+    },
+  };
+  // The surface's pending-drafts counter polls over raw fetch — stub it flat.
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => [] })) as any);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+async function renderSurface() {
+  render(
+    <MemoryRouter initialEntries={['/studio/app.a/interfaces']}>
+      <Routes>
+        <Route path="/studio/:packageId/:tab" element={<StudioDesignSurface />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  // The header landmark is the toolbar under test; wait for its own create
+  // affordance rather than for a frame count.
+  const toolbar = await screen.findByRole('banner');
+  await waitFor(() =>
+    expect(within(toolbar).getByRole('button', { name: 'Create app' })).toBeInTheDocument(),
+  );
+  return toolbar;
+}
+
+/** Open the dialog from the toolbar CONTROL, by its accessible name. */
+async function openFromToolbar(): Promise<HTMLElement> {
+  const toolbar = await renderSurface();
+  fireEvent.click(within(toolbar).getByRole('button', { name: 'Create app' }));
+  return await screen.findByRole('dialog');
+}
+
+/** Every accessible name carried by a `button` inside `scope`. */
+function buttonNames(scope: HTMLElement): string[] {
+  const names: string[] = [];
+  within(scope).queryAllByRole('button', {
+    name: (n: string) => {
+      names.push(n);
+      return false;
+    },
+  });
+  return names;
+}
+
+/** Length of the longest common leading run of two strings. */
+function commonPrefixLength(a: string, b: string): number {
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i += 1;
+  return i;
+}
+
+describe('Studio create-app — accessible names (objectui#9231)', () => {
+  it('the toolbar CONTROL still answers to the accessible name "Create app"', async () => {
+    const toolbar = await renderSurface();
+    // As the CONTROL, not as text: a heading or a dialog title carrying the
+    // same string would not satisfy a caller trying to open the dialog.
+    const opener = within(toolbar).getByRole('button', { name: 'Create app' });
+    expect(opener).toHaveAccessibleName('Create app');
+    expect(opener.tagName).toBe('BUTTON');
+  });
+
+  it('the dialog it opens keeps that same name — the dialog, not a control', async () => {
+    const dialog = await openFromToolbar();
+    // Naming a dialog after the action that opened it is correct and stays.
+    // Pinned so a future "fix" cannot resolve the collision by renaming the
+    // dialog, which would only move the ambiguity somewhere less visible.
+    expect(dialog).toHaveAccessibleName('Create app');
+  });
+
+  it('NOTHING inside the dialog answers to the opener’s verb', async () => {
+    const dialog = await openFromToolbar();
+    // THE PIN. Before this fix the confirm control was `Create (save as
+    // draft)`, so this query returned it — i.e. a caller reaching for "the
+    // create control" could not tell the confirm from the three openers, and a
+    // by-name click outside the modal is silently swallowed by Radix's overlay.
+    expect(within(dialog).queryAllByRole('button', { name: /\bcreate\b/i })).toHaveLength(0);
+    expect(within(dialog).queryByRole('button', { name: 'Create app' })).toBeNull();
+  });
+
+  it('the confirm control is reachable BY ACCESSIBLE NAME and actually creates the app', async () => {
+    const dialog = await openFromToolbar();
+    // Found by name — no testid, no positional pick (DialogContent renders
+    // Radix's own sr-only Close AFTER the footer, so "the last button" is
+    // Close and a positional pick silently dismisses the dialog).
+    const confirm = within(dialog).getByRole('button', { name: 'Save as draft' });
+
+    const nameField = dialog.querySelectorAll('input')[0];
+    fireEvent.change(nameField, { target: { value: 'Field Service' } });
+    fireEvent.click(confirm);
+
+    // The claim is not "a button exists" — it is that THIS name creates the
+    // app. Anything else is the silent no-op the card is about.
+    await waitFor(() => expect(saved.length).toBe(1));
+    expect(saved[0][0]).toBe('app');
+    expect(saved[0][1]).toBe('field_service');
+    expect(saved[0][3]).toMatchObject({ mode: 'draft', packageId: 'app.a' });
+  });
+
+  it('opener and confirm share no name prefix — in BOTH Studio locales', async () => {
+    // The render-level pins above run in the catalogue's English face. The
+    // collision was present in the Chinese face too, so the rule is asserted
+    // on the catalogue directly, for both of the locales it carries.
+    //
+    // A caller writes a by-name query from the FRONT of a label, so a shared
+    // leading run is exactly what makes two controls indistinguishable — and
+    // unlike a word-boundary rule this one holds for a script with no spaces.
+    for (const locale of ['en-US', 'zh-CN'] as const) {
+      const opener = t('engine.studio.app.create', locale);
+      const confirm = t('engine.studio.createDraft', locale);
+      expect(commonPrefixLength(opener, confirm), `${locale}: ${opener} / ${confirm}`).toBe(0);
+      expect(confirm.includes(opener)).toBe(false);
+      expect(opener.includes(confirm)).toBe(false);
+    }
+  });
+
+  it('the open dialog exposes exactly three controls, all distinctly named', async () => {
+    const dialog = await openFromToolbar();
+    const names = buttonNames(dialog);
+    // Cancel, the confirm, and Radix's sr-only Close. Distinctness is the
+    // whole contract this suite defends, so assert the SET, not the count.
+    expect(new Set(names).size).toBe(names.length);
+    expect(names).toEqual(expect.arrayContaining(['Cancel', 'Save as draft', 'Close']));
+  });
+});


### PR DESCRIPTION
Part of #9231 — this delivers that card's **first** half only. Its second half was a measurement, and the measurement came back "shared": it is filed as objectui#9262 and is deliberately **not** repaired here. Do not close 9231 on this merge without reading both.

## The repair

`engine.studio.createDraft` — the confirm control of Studio's one shared create dialog — reads `Save as draft` instead of `Create (save as draft)` (and `存为草稿` instead of `创建(存为草稿)`). Nothing else moves.

**Which side, and why that one.** The toolbar affordance keeps `Create app`. It is an opener, `Create app` is the right name for an opener, the dialog it opens is titled after it (naming a dialog for the action that opened it is correct ARIA practice, not the defect), and it is the name users, docs and automation already reach for. What was wrong sat on the other side: the one control that actually creates the app offered `Create` as its only handle, and `Create` matched all **three** openers — the toolbar, the Interfaces empty state, the Interfaces rail. So no name could address the confirm control without also matching an opener, which is the card's sentence in its exact words.

## A measured correction to the card's stated mechanism

Worth reading before review, because the card attributes the collision to the wrong pair. Measured on `a08096a11` by mounting the real surface and dumping computed accessible names:

| | before this PR |
|---|---|
| buttons whose accessible name is exactly `Create app`, dialog closed | **3** (toolbar, Interfaces empty state, Interfaces rail) |
| accessible name of the dialog | `Create app` |
| accessible name of the confirm control | `Create (save as draft)` |
| buttons whose accessible name is exactly `Create app`, dialog **open** | **0** |

So the confirm control's name was never byte-identical to the toolbar's — the card's literal wording is off. The **defect it describes is real**, and the corrected mechanism is worse than the card's version, not better:

- nothing named `Create app` ever creates an app; all three matches are openers,
- the only handle the confirm offered was `Create`, which matched those openers too,
- and the last row is the silent part: while the dialog is open Radix marks the rest of the tree `aria-hidden`, so a by-name click on `Create app` does not hit a button at all — it lands on the modal overlay, and Radix dismisses the dialog. No error, nothing created. The author then meets `App not available … it may still be publishing` at the list route, which blames a publish that never started.

The premise therefore stands and the fix direction is unchanged; only the identity of the colliding pair is corrected.

## Tests

`packages/app-shell/src/views/studio-design/StudioDesignSurface.createAppAccessibleName.test.tsx` — six cases, driven through the **real** `StudioDesignSurface` and the **real** `CreateItemDialog`, asserting by accessible name only. ⛔ No `data-testid` anywhere in the suite: a testid would pin *around* the very name the defect is about and would stay green while the defect persisted.

- the toolbar **control** still answers to `Create app` (as a `button`, not as a heading or a dialog title),
- the dialog keeps that same name — pinned so a later "fix" cannot resolve this by renaming the dialog instead,
- **the pin:** nothing inside the dialog matches `/\bcreate\b/i`,
- the confirm control is reached **by accessible name** (`Save as draft`) and the click actually calls `save('app', 'field_service', …, { mode: 'draft', packageId })` — the claim is not "a button exists", it is that this name creates,
- opener and confirm share **no leading run**, asserted on the catalogue for both Studio locales (a shared leading run is what makes two controls indistinguishable to a by-name caller, and unlike a word-boundary rule it holds for a script with no spaces),
- the open dialog's control names are all distinct, asserted as a set.

**Reverse verification.** The suite was written and run first against unmodified `a08096a11`: `4 failed | 2 passed (6)`, the two survivors being the invariants (the toolbar keeps its name; the dialog keeps its title). After the one-line catalogue change: `6 passed (6)`.

### Commands run, in this worktree, at `34cf9447c`

| command | result |
|---|---|
| `pnpm --filter '@object-ui/app-shell^...' build` | exit 0 (dependency closure; the first typecheck failed on unbuilt `.d.ts` until this ran) |
| `pnpm --filter @object-ui/app-shell type-check` | exit 0 — `tsc --noEmit` **and** `tsc -p tsconfig.test.json`, so the new suite is typechecked |
| `pnpm exec vitest run packages/app-shell/src/views/studio-design/` | `58 files / 329 tests passed` |
| `pnpm exec vitest run packages/app-shell/src/views/metadata-admin/` | `252 files / 2654 passed, 1 skipped` |
| `pnpm --filter @object-ui/app-shell lint` | exit 0 — `0 errors, 2997 warnings` (the package's standing warning baseline; the new file contributes 5 `no-explicit-any`, matching the sibling mock recipe in `StudioDesignSurface.pillarNavGuard.test.tsx`) |
| `check:i18n-drift` | exit 0 — "1 en value(s) changed, 1 zh value(s) followed" |
| `check:i18n-designer-parity`, `check:i18n-keys`, `check:i18n-dead-keys` | exit 0 |
| `check:control-bytes`, `check:changeset-presence`, `check:changeset-no-major`, `check:changeset-claims` | exit 0 |
| `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:vi-mock-override-shape`, `check:test-path-roots`, `check:new-line-citations` | exit 0 |

Every heavy run went through `scripts/pm/os-verify-lock.sh` in the sibling `../objectstack` checkout, per AGENTS. Exit codes were captured before any pipe.

The ten-locale `@object-ui/i18n` catalogue is **untouched** — the string that moved lives in `packages/app-shell/src/views/metadata-admin/i18n.ts`, the Studio-local table, which carries exactly two locales and has its own parity gate (green above).

## Changeset level

`minor`, with a `**BREAKING**` carrier — not hand-picked. All 41 packages sit in one `fixed` group, so a split changeset cannot produce split levels and the release level is the max across pending changesets; `major` is reserved for tracking `@objectstack`'s major (`check:changeset-no-major` enforces it, green above). An accessible name is part of the observable surface a consumer can pin, so `patch` would under-declare a change that breaks any downstream selector targeting the old label. Migration is one string; nothing about what the control does has changed.

## The second half — measured, not repaired

The card asked for an **enumeration, not a count**, of how many causes reach `App not available … it may still be publishing`. Done, and filed as objectui#9262: exactly one render site (`AppContent.tsx:764-778`; every other hit of the key is a locale table or a test), and **seven read, reachable causes** behind it — never created, mistyped segment, unpublished draft, app gated by an absent optional service, a host DataSource with no `probeAppAccess`, any probe failure that is not a permission denial, and a genuine post-publish lag. Only the last is a publish. An eighth (`granted` falling through the `denied`-only branch) is listed there as structural, not observed, and counted separately. objectui#4252 already split one cause (`denied`) off the same screen; 9262 is the remainder of that split.

⇒ more than one cause ⇒ ⛔ not special-cased here, and this PR is not widened.

## Acceptance notes

Considered and deliberately **not** done, each with its reason:

- **A signal when the dialog is dismissed without creating.** The card raises it and the dispatch asked for a judgement. Declined: `Cancel`, `Esc` and an overlay click are all legitimate dismissals, so a toast on every one of them is noise, and the only non-noisy variant (signal only when the form is dirty) is a behaviour change with its own product decision behind it. The name repair removes the *cause* — a by-name click no longer lands on the overlay because the name no longer points at an opener when the author means the confirm. If maintainers want the signal anyway it deserves its own card rather than a rider on this one.
- **Three buttons share the accessible name `Create app`** (toolbar, Interfaces empty state, Interfaces rail). Noted, not filed: they are the same action with the same affordance in three contexts, which is ordinary UI and not a defect — it costs automation a strict-mode disambiguation, nothing more. Recorded here because it is the next thing a reader of this diff will notice.
- **`engine.studio.saveDraft` (`Save draft` / `保存草稿`) has no renderer** — its only reference in the tree is the locale sampler test. Noted, not filed: dead catalogue entries are `check:i18n-dead-keys`'s standing report, which already lists candidates for a human to read, and this is not that gate's verdict to pre-empt.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_