### PR TITLE
fix(components): action:button / action:icon keep their enablement verdict through SchemaRenderer

### DIFF
--- a/.changeset/9131-action-enablement-verdict-carrier.md
+++ b/.changeset/9131-action-enablement-verdict-carrier.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/components': minor
+---
+
+fix(components): `action:button` / `action:icon` keep their own enablement verdict through `SchemaRenderer` (objectui#9131)
+
+An action the author declared disabled was still clickable on the ordinary rendering
+path. Both renderers computed `disabled` from the schema and then spread
+`{...toFormControlDomProps(rest)}` after it; that helper forwards `disabled`
+deliberately (the host is a form control) and `pickDomProps` iterates `Object.keys`,
+so a `disabled` key PRESENT with the value `undefined` re-declared the computed value
+and won. `SchemaRenderer` always forwards exactly that shape —
+`disabled: __disabled || undefined`, the key unconditional and only the value
+conditional — so whenever the node gate had nothing to say, the renderer's own verdict
+was overwritten with `undefined` on the way to the DOM.
+
+The loss was total on the legacy non-spec `enabled` leg, because the node gate never
+consults `enabled`: measured, a plain literal `enabled: false` (no envelope, no CEL
+dialect, no config bag) was disabled on a direct mount and NOT disabled through
+`SchemaRenderer`, at node level and in the `properties` bag alike. The direction is
+fail-OPEN — the author wrote a gate and the control stayed pressable. The spec
+`disabled` / `disabledOn` leg lost nothing visible, because the node gate evaluates the
+same key and forwards the same answer.
+
+Both renderers now take the host verdict by name (`disabled: hostDisabled`) so it never
+reaches the DOM spread, and OR it into the one computed carrier. This is exactly the
+repair objectui#7238 made on `ui:button` and `form`; these two renderers were not among
+the seven it covered. `disabled` stays in the form-control pass-through list — the
+defect was the order plus "a present key wins", not the forwarding.
+
+**Minor rather than patch, on the stored-data test.** No document moves and no API is
+removed, but metadata already published renders differently: an `action:button` /
+`action:icon` carrying `enabled: false` (or an `enabled` predicate that evaluates
+false) becomes disabled where it used to be live. A host that passes `disabled={false}`
+to these two renderers directly no longer re-enables a control their own gate disabled,
+which is the same precedence change objectui#7238 shipped. Not carried as
+`**BREAKING**`: it makes an existing declaration true rather than redefining or
+retiring one.

--- a/packages/components/src/renderers/action/__tests__/action-enablement-verdict-carrier.test.tsx
+++ b/packages/components/src/renderers/action/__tests__/action-enablement-verdict-carrier.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9131 — one carrier for one question on `action:button` /
+ * `action:icon`: the renderer's OWN enablement verdict must survive the trip
+ * through `SchemaRenderer`.
+ *
+ * ## The mechanism (objectui#7238's, left behind in these two renderers)
+ *
+ * Both renderers compute `disabled` from the schema and then spread
+ * `{...toFormControlDomProps(rest)}` AFTER it. `toFormControlDomProps`
+ * forwards `disabled` deliberately (it is a form control), and `pickDomProps`
+ * iterates `Object.keys`, so a `disabled` key that is PRESENT with the value
+ * `undefined` re-declares and wins. `SchemaRenderer` always forwards exactly
+ * that shape — `disabled: __disabled || undefined`, the key unconditional and
+ * only the value conditional — so whenever the node gate had nothing to say,
+ * the renderer's own verdict was overwritten with `undefined` on the way to
+ * the DOM.
+ *
+ * The damage is confined to the legacy non-spec `enabled` leg, and there it is
+ * total: `SchemaRenderer` never consults `enabled`, so its forwarded verdict is
+ * always `undefined` for it. The direction is fail-OPEN — the author declared
+ * the control disabled and it stayed pressable on the ordinary rendering path.
+ * (`disabled` / `disabledOn` lost nothing visible: the node gate evaluates the
+ * same key and forwards the same answer.)
+ *
+ * ## What this file measures, and why it is shaped as a three-channel matrix
+ *
+ * The pre-existing pin (`action-disabled-declared-gate.test.tsx`) mounts the
+ * leaf DIRECTLY off the registry — the one channel that forwards no `disabled`
+ * prop, so it was green throughout. It is the lit control here rather than a
+ * casualty: it proves the renderer computes correctly on its own, and it is
+ * deliberately left untouched.
+ *
+ * Every shape below is therefore measured on all THREE channels and asserted as
+ * one object:
+ *
+ *   • `direct`      — `ComponentRegistry.get(type)`, the way `action:bar`
+ *                     mounts its members (no host `disabled` prop at all);
+ *   • `node`        — through the real `SchemaRenderer`, key at NODE level;
+ *   • `properties`  — through the real `SchemaRenderer`, key inside the
+ *                     `properties` bag, which is the spelling the server emits
+ *                     (it reaches the node through the `properties` hoist).
+ *
+ * Asserting the three as one object is what makes a disagreement legible: the
+ * card's whole finding is that two channels answered differently for the same
+ * authored schema, so a per-channel assertion would report "one row is wrong"
+ * where the defect is "the rows do not agree".
+ *
+ * ## What makes each case fail
+ *
+ *   • `enabled: false` — goes red on `node` and `properties` if the forwarded
+ *     `disabled: undefined` is ever allowed to re-declare the computed verdict
+ *     again (i.e. if the destructure that takes the host prop by name is
+ *     removed from either renderer). This is the card's decisive control: a
+ *     plain literal, no envelope, no CEL dialect, no config bag anywhere in it.
+ *   • `enabled: true` / no gate at all — go red on every channel if a repair
+ *     over-corrects into "always disabled"; they are what refuses that.
+ *   • the predicate pair — goes red if the legacy leg stops being EVALUATED
+ *     (both polarities on the same authored predicate, so "never disabled" and
+ *     "always disabled" each fail one row).
+ *   • `disabled: true` / `disabled: false` — the spec leg, which the node gate
+ *     also reaches. They go red if the host verdict stops being consumed at
+ *     all, which is the other way to make the channels agree and the wrong one.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer, PredicateScopeProvider } from '@object-ui/react';
+// Module-scope side-effect imports so the renderers are in the registry when
+// `ComponentRegistry.get` runs (the light `dom` project does not load the
+// `@object-ui/components` graph), per AGENTS.md §测试纪律 — the cost lands in
+// the import phase, not under a hook timeout.
+import '../action-button';
+import '../action-icon';
+
+type ActionType = 'action:button' | 'action:icon';
+
+/** No enablement key of any kind — each case adds exactly one. */
+const ACT = { name: 'act', label: 'Act', icon: 'check', actionType: 'script' } as const;
+
+/** The predicate scope both predicate rows resolve against. */
+const SCOPE = { features: { locked: true, unlocked: false } };
+
+const control = () => screen.getByRole('button') as HTMLButtonElement;
+
+/** Channel 1 — the leaf mounted DIRECTLY, the way `action:bar` mounts a member. */
+function direct(type: ActionType, gate: Record<string, unknown>): boolean {
+  const Renderer = ComponentRegistry.get(type);
+  if (!Renderer) throw new Error(`${type} is not registered`);
+  render(
+    <PredicateScopeProvider scope={SCOPE}>
+      <Renderer schema={{ ...ACT, ...gate, type }} />
+    </PredicateScopeProvider>,
+  );
+  const verdict = control().disabled;
+  cleanup();
+  return verdict;
+}
+
+/** Channel 2 — the ordinary SDUI path, key at NODE level. */
+function node(type: ActionType, gate: Record<string, unknown>): boolean {
+  render(
+    <PredicateScopeProvider scope={SCOPE}>
+      <SchemaRenderer schema={{ ...ACT, type, ...gate } as never} />
+    </PredicateScopeProvider>,
+  );
+  const verdict = control().disabled;
+  cleanup();
+  return verdict;
+}
+
+/** Channel 3 — the same path with the key inside the `properties` bag. */
+function properties(type: ActionType, gate: Record<string, unknown>): boolean {
+  render(
+    <PredicateScopeProvider scope={SCOPE}>
+      <SchemaRenderer schema={{ ...ACT, type, properties: { ...gate } } as never} />
+    </PredicateScopeProvider>,
+  );
+  const verdict = control().disabled;
+  cleanup();
+  return verdict;
+}
+
+/** The same authored gate on all three channels. */
+function everyChannel(type: ActionType, gate: Record<string, unknown>) {
+  return { direct: direct(type, gate), node: node(type, gate), properties: properties(type, gate) };
+}
+
+/** All three agreeing on one verdict — the card's only success criterion. */
+const all = (verdict: boolean) => ({ direct: verdict, node: verdict, properties: verdict });
+
+afterEach(cleanup);
+
+describe.each(['action:button', 'action:icon'] as const)(
+  '%s — the enablement verdict reaches the DOM on every mount channel (objectui#9131)',
+  (type) => {
+    it('a plain-literal `enabled: false` disables the control on all three channels', () => {
+      // THE case. Pre-fix this read `{ direct: true, node: false, properties: false }`.
+      expect(everyChannel(type, { enabled: false })).toEqual(all(true));
+    });
+
+    it('`enabled: true` leaves it clickable on all three channels', () => {
+      expect(everyChannel(type, { enabled: true })).toEqual(all(false));
+    });
+
+    it('no enablement key at all leaves it clickable on all three channels', () => {
+      expect(everyChannel(type, {})).toEqual(all(false));
+    });
+
+    it('a predicate `enabled` still decides, both ways, on all three channels', () => {
+      expect(everyChannel(type, { enabled: 'features.unlocked == true' })).toEqual(all(true));
+      expect(everyChannel(type, { enabled: 'features.locked == true' })).toEqual(all(false));
+    });
+
+    it('the spec `disabled` leg keeps its verdict on all three channels', () => {
+      expect(everyChannel(type, { disabled: true })).toEqual(all(true));
+      expect(everyChannel(type, { disabled: false })).toEqual(all(false));
+    });
+
+    it('a predicate `disabled` still decides, both ways, on all three channels', () => {
+      expect(everyChannel(type, { disabled: 'features.locked == true' })).toEqual(all(true));
+      expect(everyChannel(type, { disabled: 'features.unlocked == true' })).toEqual(all(false));
+    });
+
+    it('the control is really on screen in the disabled rows, so "disabled" is not "never rendered"', () => {
+      // `action:button` / `action:icon` have a `visible` gate that returns
+      // `null`; without this a missing element would read as a false verdict.
+      render(
+        <PredicateScopeProvider scope={SCOPE}>
+          <SchemaRenderer schema={{ ...ACT, type, enabled: false } as never} />
+        </PredicateScopeProvider>,
+      );
+      expect(control()).toBeInTheDocument();
+    });
+  },
+);

--- a/packages/components/src/renderers/action/action-button.tsx
+++ b/packages/components/src/renderers/action/action-button.tsx
@@ -49,6 +49,14 @@ export interface ActionButtonProps {
   className?: string;
   /** Override context for this specific action */
   context?: Record<string, any>;
+  /**
+   * The host-EVALUATED enablement verdict, declared rather than left to the
+   * index signature (objectui#9131). `SchemaRenderer` evaluates the node's
+   * `disabled` / `disabledOn` and forwards the answer under this name as
+   * `disabled: __disabled || undefined`. It is consumed by name below and
+   * therefore never reaches the DOM spread — see the destructure.
+   */
+  disabled?: boolean;
   [key: string]: any;
 }
 
@@ -72,6 +80,22 @@ const ActionButtonRenderer = forwardRef<
       'data-obj-type': dataObjType,
       style,
       data,
+      // The host's EVALUATED verdict, taken by name — and taking it OFF `rest`
+      // is the load-bearing half (objectui#9131, the repair objectui#7238 made
+      // on `ui:button` and `form`). `toFormControlDomProps` forwards `disabled`
+      // deliberately (this host IS a form control) and `pickDomProps` iterates
+      // `Object.keys`, so a `disabled` key PRESENT with the value `undefined`
+      // re-declares and wins. `SchemaRenderer` always hands down exactly that
+      // shape — `disabled: __disabled || undefined`, key unconditional, only
+      // the value conditional — so spread after the computed value it
+      // overwrote this renderer's own verdict with `undefined` on the way to
+      // the DOM. The legacy `enabled` leg took the whole loss: the node gate
+      // never consults `enabled`, so its forwarded value is `undefined` for
+      // every `enabled` shape, and a control the author declared disabled
+      // stayed pressable on the ordinary `SchemaRenderer` path — fail-OPEN.
+      // Destructuring it here removes that second writer; the gate below is now
+      // the only one, and it consumes this verdict instead of losing to it.
+      disabled: hostDisabled,
       ...rest
     } = props;
 
@@ -269,7 +293,13 @@ const ActionButtonRenderer = forwardRef<
         // shapes (derivation table in
         // `__tests__/action-disabled-declared-gate.test.tsx`) and keeps one
         // spelling of "declared" on both legs.
-        disabled={(
+        //
+        // `hostDisabled` leads the OR (objectui#9131): the host verdict is a
+        // reason to disable, never a reason to enable. `SchemaRenderer` emits
+        // `true` or `undefined` and never `false`, so OR-ing it is exactly
+        // "the node gate said disable, or this renderer's own gate did, or an
+        // execution is in flight" — one carrier, three sources, no re-declare.
+        disabled={hostDisabled || (
           hasDeclaredVisibilityGate((schema as any).disabled)
             ? isDisabled
             : hasDeclaredVisibilityGate(schema.enabled)

--- a/packages/components/src/renderers/action/action-icon.tsx
+++ b/packages/components/src/renderers/action/action-icon.tsx
@@ -41,6 +41,12 @@ export interface ActionIconProps {
   schema: UIActionSchema & { type: string; className?: string; actionType?: string };
   className?: string;
   context?: Record<string, any>;
+  /**
+   * The host-EVALUATED enablement verdict — see `ActionButtonProps` for the
+   * mechanism (objectui#9131). Declared rather than left to the index
+   * signature, consumed by name below, never re-spread onto the DOM.
+   */
+  disabled?: boolean;
   [key: string]: any;
 }
 
@@ -67,6 +73,16 @@ const ActionIconRenderer = forwardRef<
       // `record.` root), and it must not reach `...rest`, which is spread onto
       // the DOM button.
       data,
+      // The host's EVALUATED verdict, taken by name — same repair, same
+      // mechanism, same card as `action:button` (objectui#9131; the sanctioned
+      // fix is objectui#7238's on `ui:button` / `form`). `SchemaRenderer`
+      // forwards `disabled: __disabled || undefined` with the key
+      // unconditional, `toFormControlDomProps` forwards `disabled` by design,
+      // and `pickDomProps` iterates `Object.keys` — so spread after the
+      // computed value, a PRESENT `undefined` re-declared it and this
+      // renderer's verdict never reached the DOM. Taking it off `rest` removes
+      // that second writer; the gate below consumes it instead.
+      disabled: hostDisabled,
       ...rest
     } = props;
 
@@ -179,7 +195,11 @@ const ActionIconRenderer = forwardRef<
         // behaviour-preserving (derivation table in
         // `__tests__/action-disabled-declared-gate.test.tsx`) and leaves one
         // spelling of "declared" on both legs.
-        disabled={(
+        //
+        // `hostDisabled` leads the OR (objectui#9131): the host verdict is a
+        // reason to disable, never a reason to enable — `SchemaRenderer` emits
+        // `true` or `undefined`, never `false`. See `action:button`.
+        disabled={hostDisabled || (
           hasDeclaredVisibilityGate((schema as any).disabled)
             ? isDisabledPred
             : hasDeclaredVisibilityGate(schema.enabled)


### PR DESCRIPTION
Fixes #9131

## The defect

`action:button` and `action:icon` compute `disabled` from the schema and then spread `{...toFormControlDomProps(rest)}` **after** it. That helper forwards `disabled` deliberately (the host is a form control) and `pickDomProps` iterates `Object.keys`, so a `disabled` key **present with the value `undefined`** re-declares and wins. `SchemaRenderer` always forwards exactly that shape — `disabled: __disabled || undefined`, the key unconditional and only the value conditional — so whenever the node gate had nothing to say, the renderer's own verdict was overwritten with `undefined` on the way to the DOM.

The loss is total on the legacy non-spec `enabled` leg, because the node gate never consults `enabled`. Direction: **fail-OPEN** — the author declared the control disabled and it stayed pressable on the ordinary rendering path.

## How this follows objectui#7238

objectui#7238 repaired this same mechanism on `ui:button` and `form`: it takes the host's evaluated verdict **by name** (`disabled: hostDisabled`), which removes the key from the props that reach the DOM spread, and folds that verdict into the one computed carrier (`const isDisabled = hostDisabled || isLoading`). One carrier, one question, one writer.

This PR applies that repair to the two renderers that were not among its seven:

- each renderer destructures `disabled: hostDisabled` off its props, so `rest` — and therefore `toFormControlDomProps(rest)` — no longer carries a `disabled` key at all;
- the gate becomes `hostDisabled || (declared-gate chain) || loading`. `hostDisabled` leads the OR because the host verdict is a reason to disable and never a reason to enable: `SchemaRenderer` emits `true` or `undefined` and never `false`.

Differences from objectui#7238, stated rather than hidden: `ui:button` could drop its raw `schema.disabled` read entirely, because `SchemaRenderer` is its only mount path. These two renderers keep their declared-gate chain, because `action:bar` mounts its members directly and that chain is the only gate on that path — which is also why the existing direct-mount pins must keep passing.

`disabled` stays in `toFormControlDomProps`'s form-control pass-through list. The defect was the order plus "a present key wins", not the forwarding. As a side effect the helper's own docblock — which already claims "`action:button` ORs it with its declared-gate verdict" — becomes true.

`SchemaRenderer` is not touched. The round authorised changing its forwarding, but the sanctioned in-tree repair does not need it, and narrowing that unconditional key would move behaviour for every renderer objectui#7238 already repaired plus every other consumer of the props bag.

## The new pin: three channels, one object

`packages/components/src/renderers/action/__tests__/action-enablement-verdict-carrier.test.tsx` mounts through the **real `SchemaRenderer`** and measures every authored shape on three channels, asserting them as one object so that a *disagreement* is what goes red:

| channel | mount | position of the key |
|---|---|---|
| `direct` | `ComponentRegistry.get(type)` — the way `action:bar` mounts a member | on the schema |
| `node` | real `SchemaRenderer` | **node level** |
| `properties` | real `SchemaRenderer` | inside the **`properties` bag** (the spelling the server emits; it reaches the node through the `properties` hoist) |

Which case covers which position: every case covers **both** positions, because each one calls all three channels and asserts a single object. The cases are: plain-literal `enabled: false`; `enabled: true`; no enablement key at all; an `enabled` predicate in both polarities; literal `disabled: true` / `disabled: false`; a `disabled` predicate in both polarities; plus a presence check so a `false` verdict can never be a renderer that returned `null`. Both renderers run the whole matrix (`describe.each`).

What makes each assertion fail is written into the file's docblock: the `enabled: false` row goes red if the forwarded `undefined` is ever allowed to re-declare the computed verdict again; the `enabled: true` and no-gate rows refuse an over-correction into "always disabled"; the predicate pairs refuse "the leg is no longer evaluated"; the `disabled` rows refuse the other wrong way to make the channels agree, namely dropping the host verdict.

⛔ The existing direct-mount cases in `__tests__/action-disabled-declared-gate.test.tsx` are untouched — they are the lit control proving each renderer computes correctly on its own.

## Evidence

**Before the fix**, on this branch, with only the new pin added (`pnpm exec vitest run` on the new file, tree at `20b507aff`): 4 failed / 10 passed. Both renderers, identical reading —

```
AssertionError: expected { direct: true, node: false, ...(1) } to deeply equal { direct: true, node: true, ...(1) }
  {
    "direct": true,
-   "node": true,
-   "properties": true,
+   "node": false,
+   "properties": false,
  }
```

⇒ the card's plain-literal control reproduced exactly: `enabled: false` disabled on a direct mount, live through `SchemaRenderer`, at **both** positions. The `disabled` / `disabledOn` rows were already green, which is the polarity the card predicted (the node gate evaluates the same key and forwards the same answer).

**After the fix** — `pnpm exec vitest run packages/components/src/renderers/action/`: `Test Files 17 passed (17)`, `Tests 276 passed (276)`. Whole package, `pnpm exec vitest run packages/components/`: `Test Files 267 passed (267)`, `Tests 2452 passed (2452)`.

**Ablation (per-renderer, one leg at a time).** With the fix committed, `action-icon.tsx` alone was taken back to the pre-fix bytes (`git checkout BASE_SHA -- path`, restore via `git checkout HEAD -- path` in an `EXIT` trap), the mutation proved on disk (`hostDisabled` occurrences 3 to 0, blob hash differs from the `HEAD` blob), the pin re-run, then restored and proved restored (`git diff HEAD` empty, occurrences back to 3):

```
Tests  2 failed | 12 passed (14)
FAIL ... action:icon ... a plain-literal `enabled: false` disables the control on all three channels
FAIL ... action:icon ... a predicate `enabled` still decides, both ways, on all three channels
```

Exactly the two `action:icon` rows, with every `action:button` row still green ⇒ the pin discriminates per renderer; neither fix is carrying the other.

## Changeset

`.changeset/9131-action-enablement-verdict-carrier.md`, `@object-ui/components: minor`.

**Minor, not patch**, on the stored-data test: no document moves and no API is removed, but metadata already published renders differently — an action carrying `enabled: false` (or an `enabled` predicate evaluating false) becomes disabled where it used to be live, and a host passing `disabled={false}` to these two renderers directly no longer re-enables a control their own gate disabled (the same precedence change objectui#7238 shipped). **Not patch**, because a consumer upgrading inside a patch range should not find live controls becoming disabled. **Not major**, because `.changeset/config.json` puts all packages in one `fixed` group and this repo's version-alignment rule ships breaking changes as `minor`; `changeset:check` (the `check-changeset-no-major.mjs` gate) passes. Not carried as `**BREAKING**` either: this makes an existing declaration true rather than redefining or retiring one.

## Acceptance notes

- Hard acceptance 1 — the new pin mounts through `SchemaRenderer` and covers node level **and** `properties` level. ✅
- Hard acceptance 2 — the existing direct-mount cases are neither deleted nor weakened, and both channels now give the same answer for every shape in the matrix. ✅
- Hard acceptance 3 — the plain-literal `enabled: false` pair reads disabled `true` on both channels; the repair is in the shared gate, not in a CEL-envelope branch. ✅
- `disabled` was not removed from `toFormControlDomProps`'s pass-through list. ✅
- objectui#9107's declaration (`action-enablement-cel-envelope.test.tsx`, which deliberately does not pin the current bad value) was not touched; that file passes unchanged. ✅
- Out of scope, noted and not filed: `action:group` and `action:menu` run the same declared-gate chain, but they render their own controls without a trailing `toFormControlDomProps` spread over the computed value, so the mechanism has no second writer there. Carrier for this observation: this PR's own review — no other PR or file is pending on it.

Session: `session_01UzHd6hDYatoDn17BuwKxnZ`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_