### PR TITLE
fix(dashboard): converge the metric tile percent branch onto the shared percent rule

### DIFF
--- a/.changeset/9165-metric-percent-converged.md
+++ b/.changeset/9165-metric-percent-converged.md
@@ -1,0 +1,57 @@
+---
+'@object-ui/plugin-dashboard': minor
+---
+
+Converge the metric tile's percent `format` branch onto the repo's single percent
+display rule (objectui#9165).
+
+`formatMetricValue` in `MetricWidget.tsx` held a **second, drifted copy** of the
+percent display rule. It was spelled inside out — a pass-through guarded by a
+greater-than-one test with the multiply in the else arm — so it scaled everything
+at or below `1` and passed through everything above, where the declared source
+(`percentDisplayValue` in `@object-ui/core`) is the symmetric
+`value > -1 && value < 1`. The negative half was unguarded and the boundary sat
+on the wrong side of `1`. Because of that spelling, objectui#9071's census could
+not see it: "the only `num <= 1` spelling in the repo" was true of the SPELLING
+and false of the DRIFT.
+
+The branch now hands the raw stored value to `formatPercent` — the identical call
+this package's own `renderFieldValue` already makes (objectui#5607) and the one
+the list-view percent cell makes — so it takes BOTH halves the shared helper's doc
+comment demands of a third surface: the SCALING and the locale's percent
+CONVENTION. The decimal count still comes from this surface's numeral pattern
+(`'0.00%'` renders two decimals), which is an author declaration on the widget
+rather than a guess about the value.
+
+**BREAKING — stored data renders differently on a KPI tile after this change.**
+Nothing about the stored value moves; what moves is how the tile prints it. On a
+`metric-card` with a percent pattern such as `'0%'`, measured against the
+list-cell path in the same run:
+
+| stored | before | after | why |
+|---|---|---|---|
+| `1` | `100%` | `1%` | exactly `1` is percentage points, not a fraction |
+| `-1` | `-100%` | `-1%` | the negative half was unguarded |
+| `-5` | `-500%` | `-5%` | same |
+| `1234.5` | `1235%` | `1,235%` | the locale's grouping (objectui#4553's move) |
+| `1234.5` (`de-DE`) | `1235%` | `1.235 %` | the locale's percent affix, no-break space included |
+| `0.25` | `25%` | `25%` | unchanged — a fraction, scaled as before |
+| `12.3` | `12%` | `12%` | unchanged — already percentage points |
+
+The first three rows are the defect: the same stored number read `100%` on a KPI
+tile and `1%` in the list cell beside it, which users report as a data bug rather
+than a formatting one. The next two are the convention half, which brings the tile
+in line with the list cell, the summary chip and the dataset measure formatter.
+
+**Level.** `minor`, not `major` and not `patch`. This repo keeps its major aligned
+with `@objectstack`'s (see AGENTS.md, "版本号策略") and ships breaking changes as
+`minor` with a written breaking note; `scripts/check-changeset-no-major.mjs`
+enforces that mechanically, and all packages sit in one `fixed` group so a split
+changeset could not produce split levels anyway. `patch` would be wrong because
+values that render correctly today (four-digit percents, every non-`en` session)
+render differently afterwards.
+
+**Migration.** If a dashboard stored whole-percent values in the `0`–`1` band and
+relied on the tile's old scaling to print them (a stored `1` shown as `100%`), it
+was already disagreeing with every other percent surface in the console; store the
+fraction (`0.01`) or the points (`1`) consistently and both surfaces now agree.

--- a/packages/plugin-dashboard/README.md
+++ b/packages/plugin-dashboard/README.md
@@ -170,6 +170,26 @@ const card: MetricCardNode = {
 `value` is the only required key. `title` and `description` take a plain string
 or the spec's inline per-locale map (`I18nLabel`).
 
+#### Percent `format` patterns (`'0%'`, `'0.00%'`)
+
+A numeral pattern ending in `%` is handed whole to `formatPercent`
+(`@object-ui/fields`), the same call the list-view percent cell and this
+package's own record-field renderer already make. Two consequences, both of
+them shared with every other percent surface in the console rather than decided
+by the tile:
+
+- **Magnitude** follows `percentDisplayValue` in `@object-ui/core` — a stored
+  value strictly between `-1` and `1` is a fraction and is scaled (`0.25` reads
+  `25%`); anything at or outside that band is already in percentage points and
+  passes through (`1` reads `1%`, `-5` reads `-5%`, `12.3` reads `12%`).
+- **The percent sign is the locale's**, not a literal `%`: a `de-DE` session
+  gets the no-break space German writes before the sign, and grouping follows
+  the locale (`1234.5` reads `1,235%` in `en`).
+
+The pattern's decimal count still belongs to the tile — `'0.00%'` renders two
+decimals — because that is an author declaration on the widget rather than a
+guess about the value.
+
 ## Examples
 
 ### Basic Dashboard

--- a/packages/plugin-dashboard/src/MetricWidget.tsx
+++ b/packages/plugin-dashboard/src/MetricWidget.tsx
@@ -1,6 +1,12 @@
 import React, { useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, getLazyIcon } from '@object-ui/components';
 import { cn } from '@object-ui/components';
+// The percent display path, read from the same package `renderFieldValue` in
+// this file's own package already reads it from (objectui#5607).
+// `@object-ui/fields` publishes one implementation, whose scaling half is
+// `percentDisplayValue` in `@object-ui/core` — so this adds no dependency edge,
+// and no second percent rule.
+import { formatPercent } from '@object-ui/fields';
 import {
   createSafeTranslation,
   useDisplayLocale,
@@ -61,7 +67,10 @@ function trendLabelKey(label: string): string | undefined {
  * Honors a numeral.js-style `format` pattern:
  * - `'0,0'` / `'0,0.00'` → thousands separators with explicit decimals
  * - leading `$/¥/€/£` or `currency` prop → currency formatting
- * - trailing `%` → percent (assumes already in 0-100 unless < 1)
+ * - trailing `%` → percent, handed WHOLE to `formatPercent`
+ *   (`@object-ui/fields`), which owns both the fraction-vs-points scaling and
+ *   the locale's percent convention. This function makes neither decision —
+ *   see the branch's own note (objectui#9165).
  *
  * When no format is given but the value is a finite number, defaults to
  * thousands separators with no decimals — that's what users expect for
@@ -119,8 +128,38 @@ function formatMetricValue(
   }
 
   if (isPercent) {
-    const v = (value as number) > 1 ? (value as number) : (value as number) * 100;
-    return `${v.toFixed(decimals)}%`;
+    // objectui#9165 — the percent decision is NOT made here any more.
+    //
+    // This branch held a SECOND copy of the repo's percent display rule,
+    // spelled inside out, which is why objectui#9071's census could not see it:
+    //
+    //   const v = value > 1 ? value : value * 100;
+    //   return `${v.toFixed(decimals)}%`;
+    //
+    // `percentDisplayValue` in `@object-ui/core` is the symmetric
+    // `value > -1 && value < 1`; written this way round it scaled everything at
+    // or BELOW 1 and passed through everything above, so the negative half was
+    // unguarded and the boundary sat on the wrong side of 1. Measured against
+    // the list cell in the same run: a stored `1` read `100%` on the tile and
+    // `1%` in the cell beside it, `-1` read `-100%`, `-5` read `-500%`. A user
+    // reports that as a data bug, not a formatting one.
+    //
+    // The raw stored value now goes to `formatPercent` — the identical call
+    // `renderFieldValue` in this same package already makes (objectui#5607),
+    // and the one the list-view percent cell makes (`PercentCellRenderer`).
+    // It carries BOTH halves `percentDisplayValue`'s doc comment demands of a
+    // third surface:
+    //  - the SCALING, so the fraction/points boundary has one home; and
+    //  - the CONVENTION, via `style: 'percentPoints'`, so the percent affix is
+    //    the LOCALE's and not a literal '%'. Taking only the first is the drift
+    //    objectui#4576 already paid for once: `1.234,5 %` in a German list cell
+    //    beside `1.234,5%` from a dashboard, the same number under two
+    //    conventions.
+    //
+    // `decimals` still comes from this surface's numeral PATTERN (`'0.00%'` →
+    // 2), which is the one percent decision that genuinely belongs here — it is
+    // an author declaration on the widget, not a magnitude heuristic.
+    return formatPercent(value as number, decimals, locale);
   }
 
   // MEASURED EXCEPTION to objectui#4033's ordinal no-grouping default, and the

--- a/packages/plugin-dashboard/src/__tests__/MetricWidget.percentConvergence-9165.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/MetricWidget.percentConvergence-9165.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9165 — the metric tile's percent branch stops holding a SECOND copy
+ * of the percent display rule.
+ *
+ * `formatMetricValue`'s trailing-`%` branch used to decide fraction-vs-points
+ * itself, spelled inside out:
+ *
+ *   const v = value > 1 ? value : value * 100;
+ *   return `${v.toFixed(decimals)}%`;
+ *
+ * That is `percentDisplayValue`'s rule written the other way round — a
+ * pass-through guarded by a greater-than-one test with the multiply in the else
+ * arm — so it scaled everything at or below 1 and passed through everything
+ * above. objectui#9071's census concluded the `plugin-detail` chip held the
+ * only copy in the tree ("the only `num <= 1` spelling in the repo"): true of
+ * the SPELLING, false of the DRIFT, because a literal `num <= 1` grep cannot
+ * see this one.
+ *
+ * ── What this file measures, and why it is two different assertions ──────
+ * The card's claim is AGREEMENT BETWEEN TWO SURFACES, so the primary case
+ * compares the tile's own rendered DOM text against the declared source
+ * (`formatPercent`, which applies `percentDisplayValue`) — never against a
+ * hand-written expected string. A hand-written string would restate one side
+ * and could not fail for the reason the card names.
+ *
+ * ⭐ But a two-surface comparison is blind to a JOINT move: if a repair
+ * overshot and dragged BOTH surfaces, the equality would still hold. That is
+ * what the two LIT CONTROLS are for, and it is the one place a literal is the
+ * correct instrument: `0.25 -> 25%` and `12.3 -> 12%` already agree today, so
+ * they are pinned to their exact bytes. If they move, the repair overshot and
+ * this file says so. The two assertions are not redundant — neither can fail
+ * for the other's reason.
+ *
+ * ── Directions, predicted in writing BEFORE the run ──────────────────────
+ *   1, -1, -5        RED before the repair (tile rendered 100% / -100% / -500%)
+ *   0.25, 12.3       GREEN on BOTH forms — they are the controls
+ *   convention pins  RED before the repair (bare '%' + toFixed, no locale affix)
+ */
+
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { LocalizationProvider } from '@object-ui/i18n';
+import { formatPercent } from '@object-ui/fields';
+import { percentDisplayValue } from '@object-ui/core';
+import { MetricWidget } from '../MetricWidget';
+
+const LOCALE = 'en';
+
+/**
+ * The tile's OWN rendered output, read off the DOM it produced.
+ *
+ * Deliberately NOT a call to `formatMetricValue` (it is private) and
+ * deliberately not a reconstruction: the card's measurement was "what a
+ * `MetricWidget` with `format: '0%'` shows", so that is what is read. The value
+ * lives in the single `.tabular-nums` node of the card body; no `trend` prop is
+ * passed, which is what keeps that selector unambiguous.
+ */
+function tileText(value: number, format = '0%', locale: string = LOCALE): string {
+  const { container, unmount } = render(
+    <LocalizationProvider value={{ locale }}>
+      <MetricWidget label="Ratio" value={value} format={format} />
+    </LocalizationProvider>,
+  );
+  const text = container.querySelector('.tabular-nums')?.textContent ?? '';
+  unmount();
+  return text;
+}
+
+describe('MetricWidget percent branch agrees with the declared source (objectui#9165)', () => {
+  /**
+   * The card's disagreement table, now asserted as an agreement table. The
+   * right-hand side is COMPUTED from the declared source in the same run — the
+   * list-cell path that reaches `percentDisplayValue` — so this case measures
+   * the two surfaces against each other rather than against a literal.
+   *
+   * Rows 1 / -1 / -5 are the three the card measured as disagreeing (the tile
+   * showed 100% / -100% / -500%); rows 0.25 / 12.3 already agreed.
+   */
+  it.each([[1], [-1], [-5], [0.25], [12.3]])(
+    'stored %p renders the same on the tile as at the declared source',
+    (stored) => {
+      expect(tileText(stored)).toBe(formatPercent(stored, 0, LOCALE));
+    },
+  );
+
+  /**
+   * ⭐ THE LIT CONTROLS — the only literals in this file, and they earn it.
+   *
+   * These two agree today and must still agree at the SAME bytes afterwards.
+   * The `it.each` above cannot see a joint move (both sides shifting together
+   * keeps the equality true), so overshoot is detectable only against an
+   * absolute. If either of these moves, the repair took something the card did
+   * not authorise and this case is the one that fails.
+   */
+  it.each([
+    [0.25, '25%'],
+    [12.3, '12%'],
+  ])('leaves the already-agreeing control %p at exactly %p', (stored, unmoved) => {
+    expect(tileText(stored)).toBe(unmoved);
+    // and it is still an agreement, not merely an unmoved byte string
+    expect(tileText(stored)).toBe(formatPercent(stored, 0, LOCALE));
+  });
+
+  /**
+   * The SCALING half, asserted against the owning function directly rather than
+   * through `formatPercent`, so the boundary decision has a pin that does not
+   * depend on the percent renderer's own behaviour.
+   *
+   * `percentDisplayValue` is the symmetric `value > -1 && value < 1`: exactly 1
+   * is points and passes through, and every value at or below -1 is points too.
+   * The retired local rule got both wrong.
+   */
+  it.each([[1], [-1], [-5], [0.25], [12.3]])(
+    'takes its magnitude for %p from percentDisplayValue, not from a local predicate',
+    (stored) => {
+      const numerals = tileText(stored).replace(/[^\d.-]/g, '');
+      expect(Number(numerals)).toBe(Number(percentDisplayValue(stored).toFixed(0)));
+    },
+  );
+});
+
+describe('MetricWidget percent branch takes the CONVENTION half too (objectui#9165)', () => {
+  /**
+   * `percentDisplayValue`'s doc comment is explicit that a third surface "takes
+   * BOTH halves from here — the scaling AND the convention — or this promise
+   * breaks again in the same place", and objectui#4576 is the round this repo
+   * already paid for taking only one of them.
+   *
+   * This case is what makes the convention half FALSIFIABLE: the five-row table
+   * above passes under a scaling-only repair too, because a bare `%` and the
+   * locale affix coincide in `en` below four digits. These two rows do not
+   * coincide — one on grouping, one on the affix itself — so they are the rows
+   * that can fail for the reason this half exists.
+   */
+  it('groups a four-digit percent the way the declared source does', () => {
+    // en moves from `1235%` to `1,235%` at four digits — objectui#4553 recorded
+    // that move as the fix, not as a regression.
+    expect(tileText(1234.5)).toBe(formatPercent(1234.5, 0, LOCALE));
+    expect(tileText(1234.5)).not.toBe(`${percentDisplayValue(1234.5).toFixed(0)}%`);
+  });
+
+  it("renders a non-en session under that locale's percent convention", () => {
+    // de writes a NO-BREAK SPACE before the sign; the retired local rule
+    // appended a bare ASCII '%' in every locale. Asserting against the declared
+    // source keeps the expectation out of this file, and the second line is the
+    // negative that names what was retired.
+    expect(tileText(1234.5, '0%', 'de-DE')).toBe(formatPercent(1234.5, 0, 'de-DE'));
+    expect(tileText(1234.5, '0%', 'de-DE')).not.toBe(
+      `${percentDisplayValue(1234.5).toFixed(0)}%`,
+    );
+  });
+
+  it('still honours the decimal count parsed off the numeral pattern', () => {
+    // `decimals` comes from the format PATTERN here, not from a field's
+    // declared scale — that is this surface's own contract and the repair does
+    // not move it.
+    expect(tileText(0.12345, '0.00%')).toBe(formatPercent(0.12345, 2, LOCALE));
+  });
+});


### PR DESCRIPTION
Fixes #9165

`formatMetricValue` in `packages/plugin-dashboard/src/MetricWidget.tsx` held a **second, drifted copy** of the percent display rule, spelled inside out — a pass-through guarded by a greater-than-one test with the multiply in the else arm. The declared single source of truth, `percentDisplayValue` in `@object-ui/core`, is the symmetric `value > -1 && value < 1`; written the other way round this copy scaled everything at or below 1 and passed through everything above, so the negative half was unguarded and the boundary sat on the wrong side of 1.

That spelling is why objectui#9071's census missed it: "the only `num LTE 1` spelling in the repo" was true of the SPELLING and false of the DRIFT. (Comparison operators written as words here — a literal angle bracket does not survive GitHub's body sanitizer.)

## The repair

The local predicate is **deleted**, not realigned. The raw stored value now goes to `formatPercent` — the identical call `renderFieldValue` in this same package already makes (objectui#5607) and the one the list-view percent cell makes (`PercentCellRenderer`). `@object-ui/fields` was already a dependency of this package, so no dependency edge is added.

## Measured — the card's disagreement table is now an agreement table

Tile rendered and the declared source computed **in the same run**, `format: '0%'`, read off the tile's own DOM:

| stored | before (tile) | after (tile) | declared source | agree now? |
|---|---|---|---|---|
| `1` | `100%` | `1%` | `1%` | yes |
| `-1` | `-100%` | `-1%` | `-1%` | yes |
| `-5` | `-500%` | `-5%` | `-5%` | yes |
| `0.25` | `25%` | `25%` | `25%` | yes — **lit control, unmoved** |
| `12.3` | `12%` | `12%` | `12%` | yes — **lit control, unmoved** |

Convention rows, added because the five rows above pass under a scaling-only repair too (a bare percent sign and the locale affix coincide in `en` below four digits), so they are the rows that can fail for the convention half's own reason:

| stored | locale | before | after | declared source |
|---|---|---|---|---|
| `1234.5` | `en` | `1235%` | `1,235%` | `1,235%` |
| `1234.5` | `de-DE` | `1235%` | `1.235 %` (no-break space) | `1.235 %` |

## How the test compares two surfaces rather than a string

`packages/plugin-dashboard/src/__tests__/MetricWidget.percentConvergence-9165.test.tsx` renders the widget and reads the value node off the produced DOM, then asserts it equals `formatPercent(stored, 0, 'en')` **computed in the same run**. No hand-written expected string is involved in the agreement cases — the card's claim is agreement between two surfaces, so that is what is measured.

The two lit controls are the one place a literal is the correct instrument, and they are not redundant with the above: a two-surface comparison is blind to a **joint** move, so `0.25` and `12.3` are additionally pinned to their exact bytes. If a repair overshot and dragged both surfaces together, the equality would still hold and only the control fails. Both assertions are present; neither can fail for the other's reason.

## The stale doc comment

`formatMetricValue`'s doc comment said the trailing-percent branch assumes the value is already in 0-100 "unless" it is *below* 1, while the code scaled at or *below* 1 — it already contradicted its own code. It is **replaced, not corrected**: the branch no longer decides anything, so the sentence now says where the decision lives instead of restating a boundary. No sentence describing the retired behaviour survives.

## ⚠️ Conflict between the triage comment and the R23 claim — flagging, not choosing silently

The two comments on the card disagree about the **convention** half:

- The triage comment (`os-musk`, 05:18Z) rules **scaling only**, and routes the convention half to objectui#9167, noting this file should join that card's file surface later.
- The R23 PM claim (`os-tesla`, 08:35Z, later, and named binding in the dispatch) says take **both halves — the scaling and the convention**.

This PR follows the R23 claim. Three things decided it, and all three are reversible if contract review rules the other way:

1. `renderFieldValue` in **this same package** — objectui#5607's already-converged sibling — calls `formatPercent(value, decimals, displayLocale)`, which carries both halves. A scaling-only repair would leave `formatMetricValue` the only percent surface in this package still holding a local convention rule: a new, narrower drift rather than the end of one.
2. Acceptance item 2 asks the test to compare the tile against `formatPercent`. Under a scaling-only repair that equality holds only by coincidence for the five probe values and is false at four digits and in every non-`en` session — which is the "two rules agreeing by coincidence" shape the card exists to end.
3. The measurement the triage asked for came back favourable: **the two lit controls do not move.** What moves is grouping at four digits and the locale's percent affix — the same move objectui#4553 recorded for the list cell, and objectui#4576 recorded for the dataset measure.

The precision question that makes objectui#9167 genuinely undecided does **not** arise here: this surface's decimal count comes from the numeral **pattern** (`'0.00%'`), an author declaration on the widget, and it is unchanged by this PR. objectui#9167's open question is the `plugin-detail` chip's precision authority. ⇒ If this lands as written, the metric tile no longer needs to be in objectui#9167's file surface; if contract review prefers scaling only, the revert is the one `return` line plus the convention pins in the test.

## Not widened

The three neighbours the card named as already correct are untouched: `recordFields` (objectui#5607), `formatMeasure` (reads the declared `percentScale` first), and the `plugin-detail` chip (objectui#9071). The diff is the numeral-pattern branch keyed on a `format` string ending in a percent sign, its doc comment, one test file, one README section and one changeset.

## Changeset

`minor`, with a written breaking note. `major` is unavailable — all packages sit in one `fixed` group and `scripts/check-changeset-no-major.mjs` enforces the repo's major-alignment convention — and `patch` would be wrong, because values that render correctly today (four-digit percents, every non-`en` session) render differently afterwards. The changeset body states plainly that stored data renders differently and carries the before/after table and a migration note.

## Verification

Run in this worktree at `350fae941`.

| check | command | result |
|---|---|---|
| ablation (mutation leg) | pre-repair `MetricWidget.tsx` restored from the pinned base, test re-run | exit 1 — `8 failed / 7 passed (15)` |
| ablation (restore leg) | `git checkout HEAD -- ...`, `git diff HEAD` empty, test re-run | exit 0 — `15 passed (15)` |
| package suite | `pnpm exec vitest run packages/plugin-dashboard/` | exit 0 — `Test Files 116 passed`, `Tests 1104 passed` |
| type-check | `pnpm --filter @object-ui/plugin-dashboard type-check` | exit 0 |
| lint | `pnpm --filter @object-ui/plugin-dashboard lint` | exit 0 — 0 errors; no finding on either changed file |
| build | `pnpm turbo run build --filter=!@object-ui/site --concurrency=2` | exit 0 — 43/43 |
| changeset presence | `node scripts/check-changeset-presence.mjs` | exit 0 |
| changeset level | `pnpm changeset:check` | exit 0 — "No changeset declares a `major` bump" |
| changeset claims | `pnpm check:changeset-claims` | exit 0 |
| control bytes | `pnpm check:control-bytes` | exit 0 |
| readme exports | `pnpm check:readme-exports` | exit 0 — "0 unbuilt" |
| eager closure | `pnpm check:eager-closure` | exit 0 |
| locale catalogues | `pnpm check:eager-locale-catalogues` | exit 0 |
| sdui registration pins | `pnpm check:sdui-registration-pins` | exit 0 |
| phantom deps | `pnpm check:phantom-deps` | exit 0 |
| test path roots | `pnpm check:test-path-roots` | exit 0 |
| line citations | `pnpm check:new-line-citations` | exit 0 — 0 new citations |
| doc fences | `pnpm check:doc-fences` | exit 0 |
| unreferenced sources | `pnpm check:unreferenced-sources` | exit 0 |
| comment mask corpus | `pnpm check:comment-mask-corpus` | exit 0 |
| vi.mock specifiers | `pnpm check:vi-mock-specifiers` | exit 0 |
| upstream port parity | `pnpm check:upstream-port-parity` | exit 0 |
| governed surface | `node scripts/check-governed-queue-guard.mjs --test` on all four paths | exit 0 — **NOT GOVERNED** |

Two readings that are **NOT MEASURED** rather than green, recorded so they are not mistaken for passes:

- `pnpm check:readme-exports` exited 1 on its **first** run with "36 unbuilt" and its own message naming "the packages were never built" as a cause. That was a prerequisite failure, not a red gate; it is exit 0 with "0 unbuilt" after the build, and the row above is that run.
- `node scripts/check-half-states.mjs` does not exist in this repo (`MODULE_NOT_FOUND`); `half-state-patrol.yml` runs `scripts/check-upstream-port-parity.mjs`, which is the row above.

Gates are derived by hand from `package.json` plus `.github/workflows/` — objectui has no `scripts/pm/dispatch-gates.mjs`. Repo-wide runs (`pnpm lint`, `pnpm test`, the full `type-check` fan-out) are left to CI.

Generated by Claude Code, session `session_01UzHd6hDYatoDn17BuwKxnZ`.


---
_Generated by [Claude Code](https://claude.ai/code)_