### PR TITLE
fix(plugin-detail): give the record header's title column a definite cross size below sm

### DIFF
--- a/.changeset/9119-detail-header-cross-axis.md
+++ b/.changeset/9119-detail-header-cross-axis.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+`DetailView`'s record header no longer sizes its title column to the record
+name below the `sm` breakpoint (objectui#9119).
+
+Below `sm` that header row is a **column** flex container, so the title
+column's width is its **cross** size — and `items-start` sizes a cross axis to
+fit-content. The column therefore took the h1's max-content width whatever the
+viewport was, the h1's `truncate` never fired because its containing block had
+been sized to the text, and the record page overflowed by the difference. The
+threshold was low: roughly 12.5px per character, so on a 375px phone any record
+name past about thirty characters was enough.
+
+None of the three utilities already on that element could have stopped it, which
+is why it survived two neighbouring fixes: `min-w-0` is a **floor, not a
+ceiling**; `flex-1` acts on the **main** axis, which in a column container is
+**height**; and `truncate` cannot fire inside a containing block that was sized
+to its own text. The repair is a definite cross size — `w-full sm:w-auto`, the
+same pair the action tail one level down already carries for the same reason.
+
+Measured in Chromium with a 98-character record title, before and after:
+
+| viewport | title column | h1 rect | ellipsis? | document overflow X |
+| --- | --- | --- | --- | --- |
+| 320px | 1045.59px -> **320px** | 997.59px -> **272px** | no -> **yes** | 726px -> **0px** |
+| 375px | 1045.59px -> **375px** | 997.59px -> **327px** | no -> **yes** | 671px -> **0px** |
+| 639px | 1045.59px -> **639px** | 997.59px -> **591px** | no -> **yes** | 407px -> **0px** |
+| 799px | 799px -> 799px | 747px -> 747px | yes -> yes | 0px -> 0px |
+
+`sm:w-auto` is what keeps that fourth row identical: at and above `sm` the row
+is a row again and the title/action arbitration objectui#7281 fixed is reached
+unchanged. It is the lit control for this change, and it did not move.
+
+What a user actually saw is a **clip, not a page scroll** — the half
+objectui#9119 filed as unmeasured. In the console the header renders inside
+`AppShell`'s content `main`, which `ConsoleLayout` styles `overflow-x-hidden`
+(computed: `overflow-x: hidden`, `overflow-y: auto`); at 375px that pane held
+1046px of header in 375px of width, so 671px of the title was clipped away with
+no scrollbar — and, because the h1's own `truncate` never fired, with no
+ellipsis either. The document itself never scrolled.

--- a/e2e/record-header-title-width.spec.ts
+++ b/e2e/record-header-title-width.spec.ts
@@ -310,8 +310,210 @@ const ROOMY = 1440;
 
 let css = '';
 test.beforeAll(async () => {
-  css = await tailwindFor(ALL_CANDIDATES);
+  // `CONSOLE_MAIN` is declared further down (it needs `classByPattern`), but
+  // this callback runs long after module evaluation, so its utilities are
+  // resolvable here — and they MUST be compiled, or the console pane below
+  // would be an unstyled block and its reading meaningless.
+  css = await tailwindFor([...ALL_CANDIDATES, ...CONSOLE_MAIN.split(' ')]);
 });
+
+/* ════════════════════════════════════════════════════════════════════════════
+ * objectui#9119 — the SAME header BELOW the `sm` breakpoint.
+ *
+ * Everything above this line is about the arbitration between the title column
+ * and the action tail at and ABOVE `sm`, where the row is a ROW. Below `sm`
+ * that row is `flex-col`, and a different thing goes wrong in it:
+ *
+ *   a child's WIDTH is its CROSS size in a column container, and
+ *   `items-start` sizes a cross axis to fit-content
+ *
+ * so the title column took the h1's max-content width — measured 1201.22px
+ * inside a 320px row — and the page gained that much horizontal overflow. The
+ * three utilities that look like they should have stopped it cannot: `min-w-0`
+ * is a floor rather than a ceiling, `flex-1` acts on the main axis (height
+ * here), and the h1's `truncate` never fires because its containing block had
+ * been sized to the text.
+ *
+ * ⚠️ WHY THIS IS HERE AND NOT IN A VITEST FILE — the same reason the header
+ * above is: this is a LAYOUT fact. jsdom and happy-dom have no layout engine,
+ * so an assertion on these widths there would be vacuous and green. And a
+ * CLASS-SHAPE pin would be worse than useless on this particular defect: the
+ * broken element already carries two plausible-looking utilities that do
+ * nothing here, so "the class is present" is exactly the evidence that misled
+ * everyone. Only the geometry can tell a floor that works from one that does
+ * not.
+ * ════════════════════════════════════════════════════════════════════════════ */
+
+/**
+ * The 98-character record title objectui#9119 measured with. Long enough to
+ * overflow the widest sub-`sm` viewport under test (639px), which is what
+ * makes `h1Clipped` a real reading at all three rather than a tautology at the
+ * narrow two.
+ */
+const LONG_TITLE =
+  'Specimen — Full · Northwind Traders Consolidated Quarterly Revenue Reconciliation Worksheet (EMEA)';
+
+/** The three sub-`sm` viewports objectui#9119 measured. */
+const BELOW_SM = [320, 375, 639];
+
+const LONG_TITLE_FIXTURE = box(
+  DETAIL.row,
+  box(
+    DETAIL.titleColumn,
+    `<button class="${DETAIL.backButton} ${ICON_BUTTON}"></button>` +
+      box(DETAIL.innerColumn, box(DETAIL.titleRow, `<h1 class="${DETAIL.h1}">${LONG_TITLE}</h1>`)),
+  ) +
+    box(DETAIL.tail, Array.from({ length: 4 }, () => box(DETAIL_TAIL_BOX)).join('')),
+);
+
+test.describe('record header below the sm breakpoint (objectui#9119)', () => {
+  for (const width of BELOW_SM) {
+    test(`DetailView: the title column cannot outgrow its row at ${width}px`, async ({ page }) => {
+      const r = await readGeometry(page, LONG_TITLE_FIXTURE, css, width);
+
+      // THE assertion — the cross-axis fact itself. Unmodified, this column
+      // measures 1045.59px here whatever the viewport is (1201.22px in the
+      // console's font metrics), because it is sized to the TEXT and not to
+      // the row.
+      expect(
+        r.titleColumnWidth,
+        `title column ${r.titleColumnWidth}px inside a ${r.rowWidth}px row — it was sized to the ` +
+          'title, not to the row, so no `min-w-0` and no `truncate` below it can bind',
+      ).toBeLessThanOrEqual(r.rowWidth + 0.5);
+
+      // The user-visible half of the same fact.
+      expect(r.documentOverflowX, 'the record header pushed the page sideways').toBe(0);
+
+      // …and the repair has to make `truncate` actually FIRE, not merely stop
+      // the overflow: a title cut off with no ellipsis is the other half of
+      // this defect, not a fix for it.
+      expect(
+        r.h1Clipped,
+        `h1 is ${r.h1Width}px wide for a ${r.h1ScrollWidth}px title but reports no clipping`,
+      ).toBe(true);
+    });
+  }
+});
+
+/* ── The open half objectui#9119 left unmeasured: clip, or page scroll? ──────
+ *
+ * The card's readings were taken with the header in an UNCONSTRAINED
+ * container, which isolates the header's own behaviour but does not say what a
+ * user sees. In the real console the header renders inside `AppShell`'s
+ * content `<main>`, and `ConsoleLayout` styles that element with
+ * `overflow-x-hidden` — so the page does NOT scroll sideways; the overflow is
+ * CLIPPED, and because the h1's own `truncate` never fires, it is clipped with
+ * no ellipsis.
+ *
+ * This reproduces that ancestor from the two real sources and measures the
+ * header inside it.
+ */
+const SHELL_FILE = 'packages/layout/src/AppShell.tsx';
+const CONSOLE_LAYOUT_FILE = 'packages/app-shell/src/layout/ConsoleLayout.tsx';
+
+/** Pull a class string out of a source with a regex, asserting a token so a drift throws. */
+function classByPattern(source: string, file: string, re: RegExp, mustContain: string[]): string {
+  const m = source.match(re);
+  if (!m) throw new Error(`${file}: no class string matched ${re}`);
+  const cls = m[1].replace(/\s+/g, ' ').trim();
+  for (const token of mustContain) {
+    if (!cls.split(' ').includes(token)) {
+      throw new Error(
+        `${file}: matched "${cls}", which does not carry "${token}" — the extraction walked onto ` +
+          'the wrong element, so this measurement would be meaningless.',
+      );
+    }
+  }
+  return cls;
+}
+
+const shellSrc = read(SHELL_FILE);
+const consoleLayoutSrc = read(CONSOLE_LAYOUT_FILE);
+
+/**
+ * `AppShell`'s content `<main>` as the console actually renders it: the base
+ * string the component writes, then the override `ConsoleLayout` passes in —
+ * in the order the real `cn()` receives them.
+ *
+ * ⚠️ The real `cn()` is `twMerge(clsx(...))`, and it COLLAPSES the pair: the
+ * base `overflow-auto` loses its x axis to the later `overflow-x-hidden`. That
+ * collapse is not re-run here (`tailwind-merge` is a `@object-ui/components`
+ * dependency and is not resolvable from the repo root, where this spec runs);
+ * instead the two strings are handed to the browser in that same order and the
+ * resulting boundary is READ back below. Measured identical either way:
+ * `overflow-x: hidden`, `overflow-y: auto`, padding 0.
+ */
+const CONSOLE_MAIN = [
+  classByPattern(shellSrc, SHELL_FILE, /<main className=\{cn\("([^"]+)"/, [
+    'flex-1',
+    'min-w-0',
+    'overflow-auto',
+  ]),
+  classByPattern(consoleLayoutSrc, CONSOLE_LAYOUT_FILE, /<AppShell[\s\S]*?className="([^"]+)"/, [
+    'overflow-x-hidden',
+  ]),
+].join(' ');
+
+test.describe("the console's own content pane (objectui#9119, the open half)", () => {
+  test('the header does not overflow the pane that clips it, at 375px', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.setContent(
+      `<style>html,body{margin:0}${css}</style>` +
+        `<main id="pane" class="${CONSOLE_MAIN}">${LONG_TITLE_FIXTURE}</main>`,
+      { waitUntil: 'load' },
+    );
+    await page.waitForFunction(
+      () => {
+        const h1 = document.querySelector('h1');
+        const pane = document.getElementById('pane');
+        if (!h1 || !pane || pane.getBoundingClientRect().width <= 0) return false;
+        const w = h1.getBoundingClientRect().width;
+        const prev = (window as unknown as { __w?: number }).__w;
+        (window as unknown as { __w?: number }).__w = w;
+        return prev !== undefined && Math.abs(prev - w) < 0.01;
+      },
+      null,
+      { polling: 'raf', timeout: 10_000 },
+    );
+    await page.evaluate(() => document.fonts?.ready);
+    const r = await page.evaluate(() => {
+      const pane = document.getElementById('pane')!;
+      const h1 = document.querySelector('h1')!;
+      return {
+        paneClientWidth: pane.clientWidth,
+        paneScrollWidth: pane.scrollWidth,
+        paneOverflowX: getComputedStyle(pane).overflowX,
+        h1Width: Math.round(h1.getBoundingClientRect().width * 100) / 100,
+        h1ScrollWidth: h1.scrollWidth,
+      };
+    });
+
+    // Premise guard, read from the browser rather than assumed: this test is
+    // only ABOUT a clip while the pane actually clips. If the shell ever
+    // switches to `overflow-x: auto`, the user-visible symptom changes from
+    // "cut off with no ellipsis" into "the content pane scrolls sideways" and
+    // the open half of objectui#9119 needs re-reading — so say so loudly
+    // instead of measuring on.
+    expect(
+      r.paneOverflowX,
+      'the console content pane no longer clips — re-read objectui#9119, the symptom has changed',
+    ).toBe('hidden');
+
+    // Unmodified, this pane reports scrollWidth 1046 against clientWidth 375 —
+    // 671px of header the reader can never reach, because `overflow-x: hidden`
+    // clips it and offers no scrollbar.
+    expect(
+      r.paneScrollWidth,
+      `content pane (overflow-x: ${r.paneOverflowX}) is ${r.paneClientWidth}px wide but holds ` +
+        `${r.paneScrollWidth}px of header — ${r.paneScrollWidth - r.paneClientWidth}px of it is ` +
+        'clipped away with no scrollbar and no ellipsis',
+    ).toBeLessThanOrEqual(r.paneClientWidth);
+
+    // And what the reader gets instead of the cut-off text is the ellipsis.
+    expect(r.h1ScrollWidth).toBeGreaterThan(Math.ceil(r.h1Width));
+  });
+});
+
 
 test.describe('record header title width arbitration (objectui#7281)', () => {
   for (const [name, fixture] of [

--- a/packages/plugin-detail/src/DetailView.tsx
+++ b/packages/plugin-detail/src/DetailView.tsx
@@ -1027,7 +1027,35 @@ export const DetailView: React.FC<DetailViewProps> = ({
             under a Lightning-style page) to avoid a duplicate title chip. */}
         {schema.showHeader !== false && (
         <div className="flex flex-col sm:flex-row sm:flex-wrap items-start justify-between gap-3 sm:gap-4 pb-4 border-b">
-          <div className="flex items-start gap-2 sm:gap-3 flex-1 min-w-0 sm:min-w-64">
+          {/* ── Why this column carries `w-full sm:w-auto` (objectui#9119) ──
+
+              Below `sm` this row is a COLUMN flex container, so a child's
+              WIDTH is its CROSS size — and `items-start` on the row sizes a
+              cross axis to fit-content. This column therefore took the h1's
+              max-content width whatever the viewport was (1201.22px inside a
+              320px row in the console; 1045.59px for the same 98-character
+              title under the headless font metrics the e2e pin reads). The
+              `truncate` below never fired, because its containing block had
+              been sized to the text, and the header overran its row by the
+              difference on every phone-width record whose name runs past
+              roughly thirty characters. What the reader got depended on the
+              host: the console's content pane computes `overflow-x: hidden`,
+              so there the title was cut off mid-word with no ellipsis and no
+              scrollbar; a host that does not clip got a sideways page scroll
+              instead. Both are this one defect.
+
+              ⛔ Neither utility already on this line can fix that, and a
+              third one of the same kind cannot either: `min-w-0` is a FLOOR,
+              not a ceiling, and `flex-1` acts on the MAIN axis — which in a
+              column container is HEIGHT. Only a definite cross size does it.
+              (objectui#3466 / objectui#2493 were a MISSING `min-w-0` on other
+              surfaces; this is not that one.)
+
+              `sm:w-auto` hands the row straight back to the `sm:flex-row`
+              title/action arbitration objectui#7281 fixed, unchanged — the
+              action tail below spells the same pair for the same reason, and
+              the 799px row of the pin is the lit control proving it. */}
+          <div className="flex items-start gap-2 sm:gap-3 flex-1 min-w-0 sm:min-w-64 w-full sm:w-auto">
             {(schema.showBack ?? true) && (
               <Tooltip>
                 <TooltipTrigger asChild>


### PR DESCRIPTION
Fixes #9119

Below the `sm` breakpoint `DetailView`'s record header row is a **column** flex container, so the title column's width is its **cross** size, and `items-start` sizes a cross axis to fit-content. The column therefore took the h1's max-content width whatever the viewport was; the h1's `truncate` never fired, because its containing block had been sized to the text.

The card's diagnosis was confirmed on this branch, not re-derived. One line changes:

```
- flex items-start gap-2 sm:gap-3 flex-1 min-w-0 sm:min-w-64
+ flex items-start gap-2 sm:gap-3 flex-1 min-w-0 sm:min-w-64 w-full sm:w-auto
```

None of the utilities already on that element could have stopped this, which is why it outlived two neighbouring repairs of the same header: `min-w-0` is a **floor, not a ceiling**; `flex-1` acts on the **main** axis, which in a column container is **height**; and `truncate` cannot fire inside a containing block sized to its own text. Only a definite cross size does it — and `w-full sm:w-auto` is the pair the action tail one level down already spells, for the same reason. ⛔ Deliberately NOT another `min-w-0`: objectui#3466 / objectui#2493 were a *missing* `min-w-0` on other surfaces and are a different defect.

## Before / after — measured in Chromium, 98-character record title

| viewport | header row | title column | h1 rect | h1 scrollWidth | ellipsis? | document overflow X |
| --- | --- | --- | --- | --- | --- | --- |
| 320px | 320px | 1045.59px → **320px** | 997.59px → **272px** | 998 → 998 | no → **yes** | 726px → **0px** |
| 375px | 375px | 1045.59px → **375px** | 997.59px → **327px** | 998 → 998 | no → **yes** | 671px → **0px** |
| 639px | 639px | 1045.59px → **639px** | 997.59px → **591px** | 998 → 998 | no → **yes** | 407px → **0px** |
| **799px (control)** | 799px | 799px → 799px | 747px → 747px | 1197 → 1197 | yes → yes | 0px → 0px |

⭐ **The 799px row did not move.** That is the state objectui#7281 left behind, and it is the lit control that the arbitration at and above `sm` was not regressed — `sm:w-auto` hands the row straight back to it. The four pre-existing pins in the same spec (DetailView and PageHeader, at 799px and 1440px) stay green throughout.

Absolute pixels differ from the card's table (1201.22px there) only by font metrics: the card measured against the console dev server, this pin against headless Chromium with the same 98-character string. The 799px row matches the card **to the pixel** (799 / 747 / clipped / 0), which is the calibration.

## Instrument: a real-browser pin, not a structural one

Added to `e2e/record-header-title-width.spec.ts` — the existing Playwright pin for this same header, which already reads the real class strings out of `DetailView.tsx` at run time and compiles real Tailwind for them. It runs in CI via `pnpm test:e2e --project=chromium`.

Why not a vitest pin: **jsdom and happy-dom have no layout engine** — every rect there is 0x0 — so an assertion on a 1045px column inside a 320px row would be vacuous and green. Why not a class-shape pin either, and this is the sharper half: the broken element **already carried two plausible-looking utilities that do nothing here**, so "the class is present" is precisely the evidence that let this survive two passes over the same header. Only geometry can tell a floor that works from one that does not.

## The assertion fails on unmodified code

Ablation from the committed state: the two utilities were removed from the class string, the removal was proven on disk in both directions (`sm:min-w-64 w-full sm:w-auto` 1 → 0, `sm:min-w-64"` 0 → 1, blob hash moved off the HEAD blob), the spec was re-run, and the tree was restored under an `EXIT` trap and verified by state (`git diff HEAD` empty, hash back to the HEAD blob).

```
✘ DetailView: the title column cannot outgrow its row at 320px
    title column 1045.59px inside a 320px row ... Expected: <= 320.5  Received: 1045.59
✘ ... at 375px      Expected: <= 375.5  Received: 1045.59
✘ ... at 639px      Expected: <= 639.5  Received: 1045.59
✘ the header does not overflow the pane that clips it, at 375px
    content pane (overflow-x: hidden) is 375px wide but holds 1046px of header
    Expected: <= 375   Received: 1046
4 failed, 5 passed
```

The 5 that passed are the objectui#7281 pins — so the red is specific to the sub-`sm` defect and does not implicate the arbitration above it.

## The open half: it is a CLIP, not a page scroll

The card flagged one thing as **not measured** — whether an ancestor in the real console clips this instead of scrolling. Measured now, in Chromium, with the shell's real class strings:

**The named ancestor is `AppShell`'s content `main`** (`packages/layout/src/AppShell.tsx`), the element `ConsoleLayout` styles by passing `className="!p-0 overflow-y-auto overflow-x-hidden bg-muted/5"` into it (`packages/app-shell/src/layout/ConsoleLayout.tsx`). `cn()` is `twMerge(clsx(...))`, so the component's own base `overflow-auto` loses its x axis to that later `overflow-x-hidden`.

Computed style read back from the browser:

| ancestor | element | computed overflow-x | computed overflow-y | clientWidth | scrollWidth |
| --- | --- | --- | --- | --- | --- |
| SidebarProvider wrapper | `div` (`h-svh overflow-hidden`) | `hidden` | `hidden` | 375 | 375 |
| lower section | `div` | `visible` | `visible` | 375 | 375 |
| SidebarInset | `main` | `visible` | `visible` | 375 | 375 |
| **AppShell content pane** | **`main`** | **`hidden`** | `auto` | **375** | **1046** |

So at 375px, before this change: `document.documentElement.scrollWidth - clientWidth` = **0** — the page never scrolled sideways — while the content pane held **671px of header the reader could never reach**, clipped with no scrollbar. And because the h1's own `truncate` never fired, there was no ellipsis either.

⇒ **What a user actually saw is the record title cut off mid-word, with no ellipsis** — the second of the two branches the card set out. Per the triage comment, that branch is the one on which `priority:p2` stands and no re-triage is called for. ⛔ No label was changed for that; the reading is reported on the card for the triage seat to act on.

The `@media print` block in `packages/app-shell/src/styles.css` forces `overflow: visible` on these elements, but it is print-only and does not touch the screen reading.

## Changeset

`.changeset/9119-detail-header-cross-axis.md`, `'@object-ui/plugin-detail': patch`.

Justification. `major` is unavailable by construction — all 41 packages sit in one `fixed` group, so any `major` drags the whole group off `@objectstack`'s major and `scripts/check-changeset-no-major.mjs` refuses it. That leaves `minor` and `patch`, and the repo reserves `minor` + a `**BREAKING**` carrier for breaking semantics. Nothing here breaks: no prop, schema, export or published contract field moves — the only change is two Tailwind tokens in one class string, restoring the `truncate` the h1 already declared and never got to use. The direct precedent is the sibling card on this same header: objectui#7281 made a comparable published layout change to `DetailView` plus `PageHeader` and shipped `'@object-ui/plugin-detail': patch` / `'@object-ui/layout': patch`. `pnpm changeset:check` and `node scripts/check-changeset-presence.mjs` are both green (note: `pnpm check:changeset-no-major` is not a script in this repo and exits 254 — NOT MEASURED, not a red gate; `changeset:check` is the real spelling).

## Local verification

| check | result |
| --- | --- |
| `pnpm exec playwright test --project=chromium e2e/record-header-title-width.spec.ts` | **9 passed** at `ae6809ecf` |
| ablation of the same spec on the unmodified class string | **4 failed / 5 passed**, as quoted above |
| `pnpm exec vitest run packages/plugin-detail/` | **173 files / 1602 tests passed** |
| `pnpm --filter @object-ui/plugin-detail type-check` | exit 0 |
| `pnpm type-check:e2e` | exit 0 |
| `pnpm turbo run build --filter=@object-ui/plugin-detail^...` | 11/11 successful |
| `pnpm exec eslint` on both changed files | exit 0 (0 errors; 45 pre-existing `any` warnings in untouched code) |
| `pnpm check:control-bytes` | OK, 7454 files |
| `pnpm check:new-line-citations` | 0 new citations, exit 0 |
| `node scripts/check-changeset-presence.mjs` | 1 published source file, 1 changeset |
| `pnpm changeset:check` | no `major`, fixed group intact |

Heavy runs went through `../objectstack/scripts/pm/os-verify-lock.sh`. Two local-only deviations, declared: the container ships Chromium build 1194 while this repo's `@playwright/test` wants 1234, so the local runs pointed `launchOptions.executablePath` at `/opt/pw-browsers/chromium` through a scratchpad config that otherwise imports this repo's own `playwright.config.ts` (⛔ `playwright install` was not run); and a stand-in static server satisfied the config's `webServer` readiness probe on :4173 instead of rebuilding the console, which this spec never navigates to — it uses `page.setContent` exclusively. CI runs both for real.

`packages/components/src/ui/**` was not touched. No test was skipped, disabled or quarantined; nothing was force-pushed.

Session: `https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_