### PR TITLE
fix(plugin-report): resolve the report chart's own h3 title through pickLocalized (objectui#9150)

### DIFF
--- a/.changeset/9150-report-chart-title-locale-map.md
+++ b/.changeset/9150-report-chart-title-locale-map.md
@@ -1,0 +1,55 @@
+---
+'@object-ui/plugin-report': minor
+---
+
+A dataset-bound report whose `chart.title` is an inline locale map now draws its heading
+instead of drawing none (objectui#9150).
+
+`@objectstack/spec` types `ReportChartSchema.title` as `I18nLabel` — a plain string OR an
+inline locale map — so `{ "chart": { "type": "bar", "title": { "en": "Pricing", "zh-CN": "定价" } } }`
+is authored surface the contract accepts. `DatasetReportChart` paints the report chart's
+heading itself, as its own `h3`, and read the value back through
+`typeof chart.title === 'string'`. The map arm failed that test, the local `title` became
+`undefined`, and the `{title ? … : null}` guard skipped the element entirely: the report
+drew **no heading at all**, in every language, with no diagnostic.
+
+Note the shape, because it is the same one objectui#9038 described and not the sibling
+objectui#8943: the value was not resolved badly, it was not resolved at all. There was no
+heading to compare against a locale, so no locale-comparison check could see it, and an
+author who wrote spec-legal metadata saw a chart that looked as though it had simply been
+given no title.
+
+The read site now resolves through `pickLocalized`, this repo's one resolver for the
+union — the form already used a few lines above in the same file for an authored
+`series[].label`, against the same `useObjectTranslation().language`. Both branches that
+paint the heading (the series chart and the single-value metric) read one binding, so one
+change covers both, and both are pinned.
+
+Why this is `minor` and not `patch`. Every publishable package here sits in one `fixed`
+group, so `major` is unavailable by policy and this repo ships behaviour-visible changes
+as `minor`. This one is behaviour-visible on a **published** package: stored documents
+that render nothing today start rendering an `h3`, and an author who worked around the
+absence by authoring a separate heading of their own will now see two. That is a change
+to what the renderer paints for metadata it already accepted, not an internal repair. The
+direct sibling objectui#9038 — same union, same defect shape, same round — shipped
+`minor` for exactly this, and one release should not classify the two differently.
+
+What did **not** change:
+
+- A plain-string `title` renders byte-identically, in every language. It is the lit
+  control in the new pins, and if it had moved the repair would have overshot.
+- The chart component is still handed **no** `title`. This renderer drops it from the
+  lowered chrome on purpose, so the chart cannot draw a second heading inside its own
+  frame; that pin is kept and extended to the map arm.
+- The resolution policy is not re-decided here. `pickLocalized`'s documented chain (exact
+  tag, base language, region-qualified sibling, `default`, `en`, first entry) is what a
+  map with no limb for the active language falls back along, so it draws another limb
+  rather than vanishing — `default` outranks `en`, pinned, so the fallback is demonstrably
+  the resolver's chain and not an ad-hoc "else English". Only a map carrying no usable
+  string at all resolves to a miss, and that still draws no heading rather than an empty
+  one.
+
+The neighbouring read sites objectui#9038 ledgered by name are unchanged, and that ledger
+is updated to record this one as resolved. The remaining entry — a series `label` and an
+axis `title` still taking `labelText`'s first-string-wins pick (objectui#4020) — stays
+open on purpose.

--- a/packages/core/src/utils/chart-presentation.ts
+++ b/packages/core/src/utils/chart-presentation.ts
@@ -366,18 +366,22 @@ export function mergeAuthoredPresentation(
  * the renderer to resolve against the viewer's language. Read that helper for
  * why resolving cannot happen in this package.
  *
- * ⚠️ LEDGERED, by name, as still unresolved after objectui#9038 — neither is in
- * that card's scope and neither is reached by the change above:
+ * ⚠️ LEDGERED, by name, as still unresolved after objectui#9038 — not in
+ * that card's scope and not reached by the change above:
  *
  *  - **A series `label` and an axis `title`** still go through
  *    {@link labelText}'s first-string-wins pick, the design objectui#4020
  *    ledgered and a caller can override. Not reopened here.
- *  - **The report renderer's own heading.** `DatasetReportChart`
- *    (`@object-ui/plugin-report`) drops `title` from this result and paints its
- *    own `h3` from a plain-string narrowing of `chart.title`, so a locale-map
- *    title still draws no heading on the REPORT surface. That read site is the
- *    renderer's, not this whitelist's; `subtitle` and `description` do reach
- *    the chart there and are fixed by this change.
+ *
+ * ✓ CLEARED, objectui#9150 — **the report renderer's own heading.**
+ * `DatasetReportChart` (`@object-ui/plugin-report`) still drops `title` from
+ * this result and still paints its own `h3`, but that read site no longer
+ * narrows `chart.title` to a plain string: it resolves the union through
+ * `pickLocalized` against the viewer's language, like every other `I18nLabel`
+ * on that surface. Kept here rather than deleted because the ledger entry is
+ * what the fixing card was dispatched from, and because the FIRST half of it —
+ * that a caller painting the title itself must drop `title` from this result —
+ * is a live constraint on this whitelist, stated above.
  *
  * @param raw the authored chart config (anything, incl. absent)
  * @param fieldCategoryColors per-category colours resolved from the category

--- a/packages/plugin-report/src/DatasetReportRenderer.tsx
+++ b/packages/plugin-report/src/DatasetReportRenderer.tsx
@@ -924,7 +924,33 @@ function DatasetReportChart({
     };
   }, [dimensionMeta, fieldOptionLabel]);
 
-  const title = typeof chart.title === 'string' ? chart.title : undefined;
+  // objectui#9150 — the heading BOTH branches below paint, resolved through
+  // `pickLocalized`, this repo's one resolver for the `I18nLabel` union.
+  //
+  // `ReportChartSchema.title` is that union — a plain string OR an inline
+  // locale map — and the plain-string narrowing this replaced dropped the map
+  // arm silently: a title authored `{ en: 'Pricing', 'zh-CN': <the zh limb> }`
+  // is metadata the contract ACCEPTS, and the `h3` simply did not render, in
+  // every language, with no diagnostic. Not the wrong language — NO heading at
+  // all, which is why no "does the heading match the locale" check could see
+  // it. `subtitle` and `description` on this same surface were fixed by
+  // objectui#9038; `title` was not, because it is read HERE and not through
+  // that lowering.
+  //
+  // `language` is the UI language (`useObjectTranslation` above), deliberately
+  // not `displayLocale` — the same division `authoredSeriesLabel` makes, for
+  // the same reason. The `|| undefined` keeps the `{title ? … : null}` guards
+  // below meaningful: `pickLocalized` spells a miss `''`, and an empty heading
+  // element is not the absence those guards encode. The resolution order
+  // (exact tag -> base -> region-qualified sibling -> `default` -> `en` ->
+  // first entry) is the RESOLVER's and is not re-decided here, so a map with no
+  // limb for the active language falls back to another limb rather than
+  // vanishing, and only a map with no usable string at all draws nothing.
+  //
+  // ⚠️ `chart.title` is still DROPPED from the lowered chrome (see
+  // `_chartOwnTitle` below): the chart must not draw a SECOND heading inside
+  // its own frame.
+  const title = pickLocalized(chart.title, language) || undefined;
 
   // `table` / `pivot`: the grouped table rendered beneath this slot IS the
   // tabular presentation — a duplicate chart would say nothing new.

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.chartLocaleChrome-9038.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.chartLocaleChrome-9038.test.tsx
@@ -16,12 +16,18 @@
  *
  * This renderer paints the chart's title itself, as its own `h3` above the
  * plot, and therefore DROPS `title` from the lowered result so the chart does
- * not draw a second one — a decision the sibling file pins. Its `h3` reads
- * `chart.title` through a plain-string narrowing of its own, so a locale-map
- * title still draws no heading on this surface. That read site is the
- * renderer's own and is outside objectui#9038's subject (the shared lowering);
- * it is reported separately rather than pinned here, because pinning it would
- * record a live defect as an expectation.
+ * not draw a second one — a decision the sibling file pins, and one this file
+ * pins again below for the map arm.
+ *
+ * When this file was written its `h3` read `chart.title` through a plain-string
+ * narrowing of its own, so a locale-map title still drew no heading on this
+ * surface — a live defect this scope note reported rather than pinned, because
+ * pinning it would have recorded the defect as an expectation. That is
+ * objectui#9150, now fixed: the heading resolves through `pickLocalized`, and
+ * `DatasetReportRenderer.chartTitleLocale-9150.test.tsx` holds its pins, in two
+ * languages and on both branches that paint it. The division of labour is
+ * unchanged — this file is the LOWERING (`subtitle`/`description` reaching the
+ * chart), that one is the renderer's OWN heading.
  *
  * ## Where these assertions stop
  *

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.chartTitleLocale-9150.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.chartTitleLocale-9150.test.tsx
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#9150 — a report chart's own `h3` heading narrowed `chart.title` to a
+ * plain string, so a title authored as the spec's INLINE LOCALE MAP arm drew no
+ * heading at all.
+ *
+ * `ReportChartSchema.title` is `I18nLabel`: a plain string OR an inline locale
+ * map. `DatasetReportChart` paints the heading itself (it deliberately DROPS
+ * `title` from the lowered chrome so the chart cannot draw a second one inside
+ * its frame) and read it back through `typeof chart.title === 'string'`. The
+ * map arm failed that test, `title` became `undefined`, and the `h3` was not
+ * rendered — in EVERY language, with no diagnostic. Not the wrong language: no
+ * heading, which is why no "does the heading match the locale" check could see
+ * it.
+ *
+ * The repair converges this one read site onto the precedent already in the
+ * same file: `pickLocalized`, the repo's one resolver for this union, which
+ * `authoredSeriesLabel` a few lines above already uses.
+ *
+ * ## Scope
+ *
+ * The REPORT surface's own `h3`, both branches that paint it — the series chart
+ * (`dataset-report-chart`) and the single-value metric (`dataset-report-metric`)
+ * read ONE binding, and the triage note asked for that to be measured rather
+ * than assumed. The dashboard surface is objectui#9038's and is not touched
+ * here. The sibling `DatasetReportRenderer.chartLocaleChrome-9038.test.tsx`
+ * covers `subtitle`/`description` on this surface; its scope note names this
+ * gap as reported-not-pinned, and this file is what it was pointing at.
+ *
+ * ## Every case pins TWO languages, on purpose
+ *
+ * A single-language assertion cannot tell `pickLocalized` apart from "picked
+ * the first key in the map" — with `en` written FIRST in every fixture below, a
+ * first-key pick returns the English limb and a lone `en` assertion passes
+ * under a wrong repair. Two languages over one authored document must draw two
+ * DIFFERENT headings; that is the un-fakeable signal (objectui#8943's defect
+ * was exactly a first-string-wins pick).
+ *
+ * ## The missing-language case, decided rather than left to `|| undefined`
+ *
+ * `pickLocalized` resolves exact tag -> base language -> region-qualified
+ * sibling -> `default` -> `en` -> first entry, and spells a total miss `''`.
+ * The ruling pinned below is that this renderer does NOT re-decide any of that:
+ *
+ *  - a map with no limb for the active language FALLS BACK along that chain and
+ *    still draws a heading (a heading in another language is strictly better
+ *    than the silent nothing this card is about, and it is what every other
+ *    `I18nLabel` on this surface already does — a second policy here would make
+ *    the report the one surface that disagrees with the resolver);
+ *  - `default` outranks `en`, so the fallback is the resolver's documented
+ *    chain and not an ad-hoc "else English";
+ *  - only a map with NO usable string at all resolves to `''`, and the
+ *    `|| undefined` turns that into the absence the `{title ? … : null}` guards
+ *    encode — an empty `h3` would be a rendered element with nothing in it.
+ *
+ * PREDICTIONS, written before the run: every locale-map case RED before the fix
+ * (no `h3` at all, in either language); both plain-string controls GREEN on
+ * both sides; the "no second heading" pin GREEN on both sides.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { I18nProvider } from '@object-ui/i18n';
+import { DatasetReportRenderer } from '../DatasetReportRenderer';
+
+/** The schema the registered chart component was handed, or `null`. */
+let captured: { schema: Record<string, any> } | null = null;
+
+beforeEach(() => {
+  captured = null;
+  ComponentRegistry.register('chart', (props: any) => {
+    captured = props;
+    return null;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const RESULT = {
+  rows: [
+    { stage: 'Qualification', amount: 120 },
+    { stage: 'Negotiation', amount: 80 },
+  ],
+  fields: [
+    { name: 'stage', type: 'text', label: 'Stage' },
+    { name: 'amount', type: 'number', label: 'Amount' },
+  ],
+};
+
+const sourceOf = (result: unknown) => ({ queryDataset: vi.fn(async () => result) });
+
+const BASE = {
+  name: 'pipeline_by_stage',
+  type: 'tabular',
+  dataset: 'pipeline_metrics',
+  rows: ['stage'],
+  values: ['amount'],
+};
+
+const CHART = { type: 'bar', xAxis: 'stage', yAxis: 'amount' } as const;
+/** The single-value family, which paints the SAME `title` binding above its number. */
+const METRIC = { type: 'kpi', yAxis: 'amount' } as const;
+
+/**
+ * ⚠️ `en` FIRST in every map. A "first key wins" pick therefore returns the
+ * English limb, so a zh assertion below fails under that wrong repair instead
+ * of passing by coincidence.
+ */
+const TITLE = { en: 'Pricing', 'zh-CN': '定价' };
+/** `default` written AFTER `en`, so key order cannot be what selects it. */
+const TITLE_DEFAULTED = { en: 'Pricing', default: 'Tarification' };
+/** A map the contract admits that carries no usable string at all. */
+const TITLE_EMPTY: Record<string, string> = {};
+
+/** Render one authored report at one UI language. */
+function renderAt(language: string, chart: Record<string, unknown>) {
+  return render(
+    <I18nProvider
+      config={{ defaultLanguage: language, detectBrowserLanguage: false }}
+      persistLanguage={false}
+    >
+      <DatasetReportRenderer
+        report={{ ...BASE, chart } as never}
+        dataSource={sourceOf(RESULT) as never}
+      />
+    </I18nProvider>,
+  );
+}
+
+/** The text of the series chart's own heading, or `null` when none is drawn. */
+async function seriesHeading(language: string, chart: Record<string, unknown>) {
+  const { container } = renderAt(language, chart);
+  const slot = await screen.findByTestId('dataset-report-chart');
+  // The chart component is a registry stub that renders nothing, so the wait
+  // above is on the SLOT; the heading is a sibling of it inside the same box.
+  const h3 = slot.querySelector('h3');
+  return { text: h3 ? h3.textContent : null, container, slot };
+}
+
+/** The text of the single-value metric's heading, or `null` when none is drawn. */
+async function metricHeading(language: string, chart: Record<string, unknown>) {
+  renderAt(language, chart);
+  const slot = await screen.findByTestId('dataset-report-metric');
+  const h3 = slot.querySelector('h3');
+  return h3 ? h3.textContent : null;
+}
+
+describe('report chart heading — the inline-locale-map arm draws (objectui#9150)', () => {
+  it('draws the heading for a locale-map title, resolved for the active language', async () => {
+    // Before the fix there was no `h3` in this slot at all, in either language.
+    const { text } = await seriesHeading('en', { ...CHART, title: TITLE });
+    expect(text).toBe('Pricing');
+  });
+
+  it('the SAME authored document draws a DIFFERENT heading under another language', async () => {
+    // The falsifier for "picked the first key": `en` is first in TITLE, so a
+    // first-key pick prints 'Pricing' here and this fails.
+    const en = await seriesHeading('en', { ...CHART, title: TITLE });
+    cleanup();
+    const zh = await seriesHeading('zh', { ...CHART, title: TITLE });
+    expect(en.text).toBe('Pricing');
+    expect(zh.text).toBe('定价');
+    expect(zh.text).not.toBe(en.text);
+  });
+
+  it('leaves a plain-string title exactly where it was — the lit control', async () => {
+    // This case rendered correctly BEFORE the fix and must render identically
+    // after it. If it moves, the repair overshot.
+    const en = await seriesHeading('en', { ...CHART, title: 'Pricing' });
+    expect(en.text).toBe('Pricing');
+    cleanup();
+    const zh = await seriesHeading('zh', { ...CHART, title: 'Pricing' });
+    // A plain string is not translatable metadata: it must NOT move with the
+    // language. Same document, same bytes, both languages.
+    expect(zh.text).toBe('Pricing');
+  });
+
+  it('still hands the chart NO title, so no second heading is drawn in its frame', async () => {
+    // The most easily broken acceptance item: this renderer paints the heading,
+    // so `title` must stay dropped from the lowered chrome.
+    const { slot, container } = await seriesHeading('zh', { ...CHART, title: TITLE });
+    await waitFor(() => expect(captured?.schema?.data?.length).toBe(2));
+    expect(captured!.schema.title).toBeUndefined();
+    // And exactly ONE heading exists on the rendered surface.
+    expect(container.querySelectorAll('h3')).toHaveLength(1);
+    expect(slot.querySelectorAll('h3')).toHaveLength(1);
+  });
+});
+
+describe('report chart heading — the single-value branch reads the same binding', () => {
+  it('draws a locale-map title above the metric, in the active language', async () => {
+    // Measured, not assumed: the triage note asked for this branch to be shown
+    // covered by the one change rather than inferred from the series branch.
+    expect(await metricHeading('en', { ...METRIC, title: TITLE })).toBe('Pricing');
+    cleanup();
+    expect(await metricHeading('zh', { ...METRIC, title: TITLE })).toBe('定价');
+  });
+
+  it('leaves a plain-string metric title unchanged — the second lit control', async () => {
+    expect(await metricHeading('en', { ...METRIC, title: 'Pricing' })).toBe('Pricing');
+    cleanup();
+    expect(await metricHeading('zh', { ...METRIC, title: 'Pricing' })).toBe('Pricing');
+  });
+});
+
+describe('report chart heading — a map with no limb for the active language', () => {
+  it('falls back along the resolver chain and still draws a heading', async () => {
+    // `de` is in neither limb of TITLE. The ruling: fall back (here to `en`),
+    // do NOT draw nothing — a heading in another language beats the silent
+    // absence this card exists to remove, and it is what every other I18nLabel
+    // on this surface already does.
+    const { text } = await seriesHeading('de', { ...CHART, title: TITLE });
+    expect(text).toBe('Pricing');
+  });
+
+  it('takes `default` over `en`, so the fallback is the resolver chain and not "else English"', async () => {
+    // If this renderer had grown its own `?? title.en` fallback instead of
+    // deferring to `pickLocalized`, this would read 'Pricing'.
+    const { text } = await seriesHeading('de', { ...CHART, title: TITLE_DEFAULTED });
+    expect(text).toBe('Tarification');
+  });
+
+  it('draws NO heading when the map carries no usable string at all', async () => {
+    // `pickLocalized` spells a total miss `''`; `|| undefined` turns that into
+    // the absence the `{title ? … : null}` guard encodes, so the surface gets
+    // no empty `h3`.
+    const { text, slot } = await seriesHeading('en', { ...CHART, title: TITLE_EMPTY });
+    expect(text).toBeNull();
+    expect(slot.querySelectorAll('h3')).toHaveLength(0);
+  });
+
+  it('draws no heading when no title is authored at all — unchanged', async () => {
+    const { slot } = await seriesHeading('zh', { ...CHART });
+    expect(slot.querySelectorAll('h3')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Fixes #9150

## What was wrong

`@objectstack/spec` types `ReportChartSchema.title` as `I18nLabel` — a plain string **OR**
an inline locale map. `DatasetReportChart` paints the report chart's heading itself, as
its own `h3`, and read the value back through a narrowing of its own:

```ts
const title = typeof chart.title === 'string' ? chart.title : undefined;
```

The map arm failed that test, `title` became `undefined`, and the `{title ? … : null}`
guard skipped the element. A report authoring

```json
{ "chart": { "type": "bar", "xAxis": "stage", "yAxis": "amount", "title": { "en": "Pricing", "zh-CN": "定价" } } }
```

— metadata the contract **accepts** — drew **no heading at all**, in every language, with
no diagnostic. Not the wrong language: no heading, which is why no "does the heading match
the locale" check could see it.

## The repair

One read site, converged onto the precedent already in the same file:

```ts
const title = pickLocalized(chart.title, language) || undefined;
```

`pickLocalized` is this repo's one resolver for the union; the import was already present,
`language` (`useObjectTranslation()`) was already in scope for the authored series label a
few lines above, and the file already documented the convention. No mechanism was
introduced and no second narrowing or fallback was invented.

Both branches that paint the heading — the series chart (`dataset-report-chart`) and the
single-value metric (`dataset-report-metric`) — read that one binding, so one change
covers both. The triage note asked for that to be **measured** rather than assumed; it is
pinned on both branches.

## Acceptance, mapped to the pins

`packages/plugin-report/src/__tests__/DatasetReportRenderer.chartTitleLocale-9150.test.tsx`
(10 cases, all reading the heading out of the **DOM**, never a helper's return value):

1. **Locale-map title draws.** `en` renders `Pricing`; before the change there was no `h3`
   in the slot at all.
2. **Plain-string control stays lit.** A plain-string title renders `Pricing` under `en`
   **and** under `zh` — identical to today. It was correct before and had to stay
   byte-identical; if it had moved, the repair overshot.
3. **Language switch.** The same authored document draws `Pricing` under `en` and `定价`
   under `zh` — two different strings. **What would make it fail:** `en` is written FIRST
   in every fixture, so a "picked the first key in the map" implementation returns
   `Pricing` in both and the `zh` assertion fails. That is the case a single-language
   assertion cannot see.
4. **No second heading.** The chart component is still handed no `title` (pinned
   `undefined` on the captured schema) and exactly one `h3` exists on the rendered surface.
5. **Missing-language case, decided and pinned** — see below.

## The missing-language case

**Decision: fall back along `pickLocalized`'s chain and still draw a heading. Only a map
with no usable string at all draws nothing.**

Why: this card is about a heading that silently vanished. A heading in another language is
strictly better than that silence, and it is what every other `I18nLabel` on this surface
already does — a second policy here would make the report the one surface that disagrees
with the repo's single resolver, which is precisely what the triage note forbade. The
resolver's documented order is exact tag, base language, region-qualified sibling,
`default`, `en`, first entry.

Three cases pin it rather than leaving it to whatever `|| undefined` happens to produce:

- a `{ en, zh-CN }` title under `de` renders `Pricing` — it falls back, it does not vanish;
- a `{ en: 'Pricing', default: 'Tarification' }` title under `de` renders `Tarification` —
  `default` outranks `en`, with `default` written **after** `en` so key order cannot be
  what selects it. This is the pin that proves the fallback is the **resolver's chain**
  and not an ad-hoc "else English" grown at this read site;
- a map carrying no usable string resolves to a miss and draws **no** `h3` — the
  `|| undefined` keeps the guard meaningful, so the surface never gets an empty heading
  element.

## Ledger hygiene

Two places asserted this read site was still broken. Both are corrected, because the
change makes them false:

- `chartConfigPresentation`'s doc comment (`@object-ui/core`) ledgered it by name as
  unresolved after objectui#9038. Its entry is moved to a CLEARED note; the other ledgered
  entry (a series `label` and an axis `title` still taking `labelText`'s first-string-wins
  pick, objectui#4020) is untouched and stays open on purpose. The live constraint in the
  same comment — a caller that paints the title itself must drop `title` from the lowered
  result — is unchanged.
- `DatasetReportRenderer.chartLocaleChrome-9038.test.tsx`'s scope note said the gap was
  "reported rather than pinned, because pinning it would record a live defect as an
  expectation". It now points at the file that pins it.

## Scope held

The dashboard surface is not touched — objectui#9038 and PR objectui#9149 scoped `title`
to the dashboard and `subtitle`/`description` to both, deliberately, and this is the report
surface's own `h3`.

One further read site outside `DatasetReportRenderer.tsx` was found and is **filed, not
fixed here** — see `## Acceptance notes` below.

## Changeset level: `minor`

`.changeset/9150-report-chart-title-locale-map.md`, `'@object-ui/plugin-report': minor`.

All 41 packages sit in one `fixed` group, so a split changeset cannot produce split levels
and `major` is unavailable by policy (this repo ships breaking as `minor`). Within what is
available, `minor` and not `patch`, because this is behaviour-visible on a **published**
package: stored documents that render nothing today start rendering an `h3`, and an author
who worked around the absence by authoring a heading of their own will now see two. That is
a change to what the renderer paints for metadata it already accepted, not an internal
repair. The direct sibling objectui#9038 — same union, same defect shape, same round —
shipped `minor` for exactly this, and one release should not classify the two differently.

## Verification

Gate results are quoted from each gate's own verdict line, with the exit code captured
before any pipe.

| run | result |
|---|---|
| `pnpm --filter @object-ui/plugin-report test` (the whole package) | `Test Files 17 passed (17)` · `Tests 191 passed (191)` |
| `vitest` over `packages/core/src/utils/__tests__/chart-presentation*` | `Test Files 1 passed (1)` · `Tests 12 passed (12)` |
| `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-report^...' build` (dependency closure) | exit 0 |
| `pnpm --filter @object-ui/plugin-report run type-check` | exit 0 |
| `pnpm --filter @object-ui/core run type-check` | exit 0 |
| `pnpm --filter @object-ui/example-schema-catalog test` — the out-of-package census pins | `Test Files 31 passed (31)` · `Tests 2151 passed (2151)` |
| `eslint` on the four changed source files (repo spelling: package `lint` is `eslint .`) | 0 errors, 9 warnings, all pre-existing shapes matching the sibling test file |
| `node scripts/check-changeset-no-major.mjs` | `✅ No changeset declares a major bump.` exit 0 |
| `node scripts/check-changeset-fixed.mjs` | `✅ All workspace packages are in the changeset fixed group.` exit 0 |
| `node scripts/check-control-bytes.mjs` | `✅ check-control-bytes: OK (scanned 7455 tracked text file(s))` exit 0 |
| `node scripts/check-new-cross-file-line-citations.mjs` | `VERDICT new-cross-file-line-citations: 0 new citation(s)` exit 0 |
| `node scripts/check-governed-queue-guard.mjs --test` (the 5 changed paths) | `✅ NOT GOVERNED — 5 path(s) checked` exit 0 |
| `check-spec-symbol-derivation`, `check-action-forward-parity`, `check-designer-field-key-parity`, `check-handler-key-read-sites`, `check-element-data-source-declaration`, `check-i18n-en-drift`, `check-i18n-designer-table-parity`, `check-i18n-call-site-keys`, `check-i18n-dead-keys`, `check-unreferenced-sources`, `check-comment-mask-corpus`, `check-vi-mock-specifiers`, `check-vi-mock-inherit`, `check-vi-mock-override-shape`, `check-package-self-import`, `check-phantom-dependencies`, `check-shell-escape-residue` | all exit 0 |
| clause-② dual carrier, `check-clause2-carriers.mjs --pair 9272` against this board | exit 4 at first (card bare, PR labelled), then **exit 0** once both carriers were hung — `both carriers agree` |

Heavy runs went through the shared verify lock; figures are shared-box seconds.

### eslint narrowing, declared

`eslint` was run over the four changed files rather than the repo. Three readings, so the
narrowing is a measurement and not a skipped run: the population is the repo's own lint
spelling (root `lint` is `turbo run lint`, each package's is `eslint .` — **not**
`--no-inline-config`; run with that flag the file reports one error, and it is the
pre-existing `react-hooks/static-components` disable comment on the registry lookup, not
anything in this diff); the file count is 4, read from `--format json`; and type-aware
linting is not enabled in `eslint.config.js`, so this diff cannot move the verdict on any
file it did not touch. CI runs the full farm.

### Reverse verification

Measured. The repair was committed FIRST, then the one changed line was reverted to the
original narrowing under a restoring trap, the pins were re-run, and the tree was restored
and proved clean. Predicted in writing before the run: 6 red, 4 green.

| leg | result |
|---|---|
| mutation (the narrowing put back) | `Tests 6 failed \| 4 passed (10)` — **exactly the predicted split** |
| restore (`git checkout HEAD --` the file) | `Tests 10 passed (10)` |

The four survivors are the ones that cannot move and are named as such: both plain-string
controls, the empty-map case, and the no-title case. The six that went red are the
locale-map cases, both languages, both branches, plus the heading-count assertion — which
is the one that would catch a repair that drew the heading twice.

The mutation was proved to have reached disk before the run was believed: the replaced
text counted 0 occurrences and the injected text 1, and the mutated blob hash differed
from the `HEAD` blob hash. The restore was proved by BOTH readings, not by an exit code —
`git hash-object` on the file equals the `HEAD` blob (`0b52e039…`) and `git diff HEAD` is
empty. The test imports the subject by relative path inside its own package, so the
mutation reaches the run directly and no `dist` sits in that resolution path.

### What was not measured locally, and why

- `node scripts/check-readme-exports.mjs` exits 1 with `the population COLLAPSED -- this
  run proves nothing`: it needs every package built, and this worktree built only the
  dependency closure. A **prerequisite not met**, not a red gate — and this diff touches no
  README, so the gate's subject is untouched either way. CI builds first and judges it.
- `node scripts/check-sdui-registration-pins.mjs` exits 2 with `No console build to weigh at
  apps/console/dist/assets` — same class, and this diff registers nothing.
- `pnpm check:changeset-no-major` is not a script in this repo and exits 254
  `Command not found`. The gate is real and was run at its file path, and it also runs via
  `changeset:check`.

## Acceptance notes

**Filed, not fixed here** — `packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.tsx`
reads the same `chart.title` through the same plain-string narrowing, into a text input,
and commits with a shallow merge. That is a different and worse failure than this card's:
an author whose report has a locale-map title sees an EMPTY title box in Studio, and typing
into it writes a plain string over the whole map, destroying every other locale. It is
outside this card's stated scope (a different package, an authoring surface rather than a
rendering one, and a write path), so it is named and filed rather than repaired here:
**objectui#9274**. Deduplicated first against the 457 open issues on this board, read from
the repository-scoped REST list endpoint and grepped locally, carrying a known-hit control
so the empty result is a reading rather than a dead channel.

Generated with Claude Code; session reference `session_01UzHd6hDYatoDn17BuwKxnZ`.


---
_Generated by [Claude Code](https://claude.ai/code)_