### PR TITLE
fix(core): conjoin the widget filter into a dataset drill instead of spreading it

### DIFF
--- a/.changeset/9137-dataset-drill-conjoin-widget-filter.md
+++ b/.changeset/9137-dataset-drill-conjoin-widget-filter.md
@@ -1,0 +1,47 @@
+---
+'@object-ui/core': minor
+---
+
+Conjoin the widget filter into a dataset drill instead of SPREADING it
+(objectui#9137) — the third and last site of the mis-composition objectui#8944
+removed from `ObjectChart` and objectui#9024 removed from `ObjectPivotTable`.
+
+`buildDatasetDrillFilter` ended in `{ ...runtimeFilter, ...drillFilter }`.
+Spreading is correct only for the object-dialect arm, and this site's declared
+producer sends the other one: `DashboardWidgetSchema.filter` says so in as many
+words — "objectui passes an ObjectQL FilterNode array here, not the spec's
+`FilterCondition` envelope" — and `DatasetWidget`'s guard admits an array
+(`typeof [] === 'object'` is true and `Object.keys(['x']).length` is 1). So the
+arm the type's own docblock names as the one objectui sends reached the spread,
+where `[['region','=','emea']]` became the index key `{ '0': [...] }`.
+
+**Breaking, deliberately** — the level is `minor` because every package in this
+repo sits in one `fixed` group and `major` would drag the whole group off the
+`@objectstack` major it tracks. What changes for a caller: when a widget filter
+IS present, the composed drill filter is now `{ $and: [<widget>, <drill>] }`
+rather than one flat object, and a field named by BOTH sources now applies both
+conditions instead of letting the clicked bucket overwrite the widget's. That is
+the repair — a drill may narrow the widget's scope and may never widen it. The
+result is produced by `composeDrillFilter`, the seam objectui#8944 added, which
+routes both arms through this repo's single filter confluence `mergeFilterNodes`
+and lowers the answer back to the object dialect; no local composition is
+derived here. The `runtimeFilter` parameter widens from
+`Record<string, unknown>` to `unknown` so the arm the declaration names is
+admitted without a cast — a widening, so no call site has to change, and
+neither consumer's own type was touched.
+
+**Unchanged on purpose.** With no widget filter there is nothing to conjoin, so
+that leg still returns the drill filter verbatim, byte for byte. Routing it
+through the sink anyway was measured and rejected: a lone source of two or more
+conditions also lowers to `$and`, which would have re-shaped every
+multi-condition dataset drill — including paths pinned by objectui#9085,
+objectui#4056, objectstack#5473 and #1752 — for no change in the rows selected
+or the `filter[...]` params emitted.
+
+**The failure direction, corrected by measurement.** This was filed and graded
+as a silent fail-OPEN superset, on the premise that an index key is one "nothing
+reads as a condition". It is not: a bare array is not a legal equality comparand
+in this dialect (objectui#8530 / objectui#8514), so `convertFiltersToAST`
+THROWS, the in-memory matcher selects nothing, and `driver-sql` answers
+`400 INVALID_FILTER`. The drilled list was dead, not wide. Pinned as row sets in
+`dataset-drill-array-arm-9137.test.ts`.

--- a/packages/core/src/utils/__tests__/dataset-drill-array-arm-9137.test.ts
+++ b/packages/core/src/utils/__tests__/dataset-drill-array-arm-9137.test.ts
@@ -1,0 +1,165 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `buildDatasetDrillFilter` and the ARRAY arm of the widget filter —
+ * objectui#9137, the THIRD site of the mis-composition objectui#8944 removed
+ * from `ObjectChart` and objectui#9024 removed from `ObjectPivotTable`.
+ *
+ * ## Why this site is the one that mattered most
+ *
+ * On the chart the array arm was what the corpus happened to author; on the
+ * pivot nothing declared `filter` at all. Here the declaration exists, it is
+ * reached, and it names the array arm as the one objectui sends —
+ * `DashboardWidgetSchema.filter`, verbatim: "objectui passes an ObjectQL
+ * FilterNode array here, not the spec's `FilterCondition` envelope". And
+ * `DatasetWidget`'s guard admits it: an array passes all three of
+ * `rawFilter &&`, `typeof rawFilter === 'object'` and
+ * `Object.keys(rawFilter).length > 0`.
+ *
+ * ## ⚠️ The failure direction, MEASURED — it is NOT the silent superset
+ *
+ * The card and its triage both graded this fail-OPEN, reasoning that the index
+ * key a spread array produces (`{ '0': ['region','=','emea'] }`) is "a key
+ * nothing reads as a condition", so the widget's own narrowing is dropped and
+ * the list widens to the clicked bucket. That premise does not hold on this
+ * tree, and §"the wire refuses it" below is the measurement: a bare array is
+ * not a legal equality comparand anywhere in this dialect (objectui#8530 /
+ * objectui#8514), so the index key is neither honoured nor dropped — it is
+ * REFUSED. `convertFiltersToAST` throws `FilterOperatorError`; the in-memory
+ * matcher selects nothing; `driver-sql` answers `400 INVALID_FILTER`.
+ *
+ * ⇒ the drilled list was not a superset, it was DEAD. Recorded here rather
+ * than argued, because it is the kind of claim a later reader will want the
+ * row counts for. The repair is the same either way, and it is the ruled one:
+ * conjoin through `composeDrillFilter`, the repo's single filter confluence.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildDatasetDrillFilter } from '../dataset-format';
+import { convertFiltersToAST, toFilterNode } from '../filter-converter';
+import { ValueDataSource } from '../../adapters/ValueDataSource';
+
+const EMEA_WON = { id: 'emea-won', region: 'emea', stage: 'won', closed_at: '2026-05-02' };
+const EMEA_LOST = { id: 'emea-lost', region: 'emea', stage: 'lost', closed_at: '2026-05-03' };
+const APAC_WON = { id: 'apac-won', region: 'apac', stage: 'won', closed_at: '2026-05-04' };
+const EMEA_WON_LATE = { id: 'emea-won-late', region: 'emea', stage: 'won', closed_at: '2026-08-02' };
+
+const ROWS = [EMEA_WON, EMEA_LOST, APAC_WON, EMEA_WON_LATE];
+const DIMENSION_FIELDS = { stage: 'stage' };
+
+/**
+ * The ARRAY arm, spelled exactly as `DashboardWidgetSchema.filter`'s docblock
+ * says objectui sends it: an ObjectQL FilterNode array, not the spec's
+ * `FilterCondition` object envelope.
+ */
+const WIDGET_FILTER_ARRAY = [['region', '=', 'emea']];
+
+/** Lower a composed drill filter through the real sink and select real rows. */
+async function drilledIds(composed: Record<string, unknown> | undefined): Promise<string[]> {
+  const node = toFilterNode(composed);
+  const ds = new ValueDataSource({ items: ROWS as never });
+  const result = await ds.find('deal', (node === undefined ? {} : { $filter: node }) as never);
+  return (result.data as Array<{ id: string }>).map((r) => String(r.id));
+}
+
+describe('dataset drill vs the widget filter ARRAY arm (objectui#9137)', () => {
+  it('conjoins the array arm instead of spreading it into index keys', async () => {
+    const composed = buildDatasetDrillFilter(
+      { stage: 'won' },
+      ['stage'],
+      DIMENSION_FIELDS,
+      WIDGET_FILTER_ARRAY,
+    );
+    expect(composed).toEqual({ $and: [{ region: 'emea' }, { stage: 'won' }] });
+    // The row set is the claim; the shape above is only how it is reached.
+    expect(await drilledIds(composed)).toEqual([EMEA_WON.id, EMEA_WON_LATE.id]);
+  });
+
+  it('the widget filter is a REAL constraint here, not decoration', async () => {
+    // The control that makes the assertion above mean something: drop the
+    // widget filter and an apac row qualifies on the drill condition alone, so
+    // a fixture whose answer happened to be the same either way cannot pass.
+    const bucketOnly = buildDatasetDrillFilter({ stage: 'won' }, ['stage'], DIMENSION_FIELDS);
+    expect(await drilledIds(bucketOnly)).toEqual([EMEA_WON.id, APAC_WON.id, EMEA_WON_LATE.id]);
+  });
+
+  it('pins the defect ABSENT: no index key from a spread array', () => {
+    const composed = buildDatasetDrillFilter(
+      { stage: 'won' },
+      ['stage'],
+      DIMENSION_FIELDS,
+      WIDGET_FILTER_ARRAY,
+    );
+    expect(Object.keys(composed)).not.toContain('0');
+  });
+
+  /**
+   * The measurement behind the docblock's "not a superset" correction, kept as
+   * an assertion so the claim cannot rot into prose. The shape the spread
+   * produced is built here directly — nothing in the tree produces it any more.
+   */
+  it('the wire REFUSES the spread product, so the old drill was dead rather than wide', async () => {
+    const spreadProduct = { ...WIDGET_FILTER_ARRAY, stage: 'won' } as Record<string, unknown>;
+    expect(Object.keys(spreadProduct)).toContain('0');
+    // Leg 1 — the lowering every `$filter` consumer goes through.
+    expect(() => convertFiltersToAST(spreadProduct)).toThrow(/bare ARRAY as its equality comparand/);
+    // Leg 2 — the in-memory matcher, which selects NOTHING rather than widening.
+    const ds = new ValueDataSource({ items: ROWS as never });
+    const result = await ds.find('deal', { $filter: spreadProduct } as never);
+    expect((result.data as unknown[]).length).toBe(0);
+  });
+
+  /**
+   * Precondition 2 of the card: a time-bucketed dimension contributes ObjectQL
+   * range operator objects, and the composition has to PRESERVE them.
+   */
+  it('preserves a half-open date range through the composition', async () => {
+    const composed = buildDatasetDrillFilter({}, [], {}, WIDGET_FILTER_ARRAY, {
+      closed: { field: 'closed_at', gte: '2026-04-01', lt: '2026-07-01' },
+    });
+    // Re-spelled as two `$and` children on one field — `convertFiltersToAST`
+    // emits one node per bound and `parseFilterAST` cannot fold two nodes back
+    // onto a single key. Both bounds survive, which is what the rows show.
+    expect(composed).toEqual({
+      $and: [
+        { region: 'emea' },
+        { $and: [{ closed_at: { $gte: '2026-04-01' } }, { closed_at: { $lt: '2026-07-01' } }] },
+      ],
+    });
+    // Scoped by BOTH bounds and by the widget: the late emea row and the apac
+    // row are each excluded, by a different half of the conjunction.
+    expect(await drilledIds(composed)).toEqual([EMEA_WON.id, EMEA_LOST.id]);
+  });
+
+  /**
+   * Precondition 1 of the card: the return type is a NON-optional
+   * `Record<string, unknown>` and callers do not expect `undefined`, while
+   * `composeDrillFilter` answers `undefined` when both sources are empty.
+   */
+  it('answers an empty OBJECT, never undefined, when both sources are empty', () => {
+    expect(buildDatasetDrillFilter(undefined, [], {}, {})).toEqual({});
+    expect(buildDatasetDrillFilter(undefined, [], {}, undefined)).toEqual({});
+  });
+
+  /**
+   * Precondition 3 of the card: two consumers hand this parameter different
+   * types — `any` from `DatasetWidget`, `Record<string, unknown>` from
+   * `DatasetReportRenderer`. The parameter is declared `unknown` so both arms
+   * are admitted without a cast; ⛔ neither consumer's own type was changed.
+   */
+  it('admits the OBJECT arm the report renderer sends, unchanged', async () => {
+    const composed = buildDatasetDrillFilter(
+      { stage: 'won' },
+      ['stage'],
+      DIMENSION_FIELDS,
+      { region: 'emea' },
+    );
+    expect(await drilledIds(composed)).toEqual([EMEA_WON.id, EMEA_WON_LATE.id]);
+  });
+});

--- a/packages/core/src/utils/__tests__/dataset-drill-empty-bucket-9085.test.ts
+++ b/packages/core/src/utils/__tests__/dataset-drill-empty-bucket-9085.test.ts
@@ -176,7 +176,12 @@ describe('empty-bucket drill (objectui#9085)', () => {
       DIMENSION_FIELDS,
       { stage: 'lost' },
     );
-    expect(composed).toEqual({ stage: 'lost', owner: 'bob' });
+    // objectui#9137 re-spelled the COMPOSITION (the widget filter is conjoined
+    // through `composeDrillFilter` instead of spread into the drill filter), so
+    // the shape moved while the row set below — this test's actual claim — did
+    // not. Only the composing leg moved: the no-runtime-filter control below is
+    // byte-identical to what objectui#9085 pinned.
+    expect(composed).toEqual({ $and: [{ stage: 'lost' }, { owner: 'bob' }] });
     expect(await drilledIds(composed)).toEqual([LOST_BOB.id]);
     // …and the runtime filter is a real constraint here, not decoration: drop
     // it and a second row would qualify on the drill condition alone.

--- a/packages/core/src/utils/dataset-format.ts
+++ b/packages/core/src/utils/dataset-format.ts
@@ -23,6 +23,7 @@ import type { PercentScale } from '@objectstack/spec/data';
 import { formatDisplayNumber, type DisplayNumberFormatOptions } from './number-display.js';
 import { formatDate, formatDateTime, formatRelativeDate } from './date-display.js';
 import { resolveMeasureLabel, type BuiltinAggregateLabels } from './chart-series.js';
+import { composeDrillFilter } from './drill-down.js';
 
 /**
  * Column metadata the analytics server returns alongside the rows — the spec's
@@ -571,6 +572,75 @@ export interface DatasetDrillRange {
  * scopes the list to the clicked time bucket instead of every bucket (which the
  * old date-dim skip degraded to — a superset).
  *
+ * ## The widget filter is CONJOINED, not spread (objectui#9137)
+ *
+ * ⛔ `runtimeFilter` is composed through {@link composeDrillFilter}, never by
+ * spreading it into the object literal below. Spreading is correct only for the
+ * OBJECT arm; this parameter's declared producer sends the ARRAY arm. The
+ * dashboard's `DashboardWidgetSchema.filter` docblock states it outright —
+ * "objectui passes an ObjectQL FilterNode array here, not the spec's
+ * `FilterCondition` envelope" — and `DatasetWidget`'s guard admits it
+ * (`typeof [] === 'object'` and `Object.keys(['x']).length === 1` are both
+ * true), so the array arm reached this line unfiltered. Spreading an ARRAY
+ * yields INDEX keys: `[['region','=','emea']]` became
+ * `{ '0': ['region','=','emea'] }`, which is not a condition anyone can honour.
+ *
+ * ⚠️ MEASURED, and it is NOT the silent superset the sibling sites had. An
+ * index key is not dropped on the way to the wire — every sink in circulation
+ * refuses it LOUDLY, because a bare array is not a legal equality comparand
+ * (objectui#8530 / objectui#8514): `convertFiltersToAST` THROWS
+ * `FilterOperatorError`, `driver-sql` answers `400 INVALID_FILTER`, and
+ * `ValueDataSource`'s matcher selects NOTHING. Against rows scoped
+ * `region = 'emea'`, drilling the `stage = 'won'` bucket returned `(none)`
+ * where the widget alone returned three rows and the conjunction returns the
+ * right two. So the widget's conditions were not merely lost — the drill was
+ * dead in the array arm. The failure is fail-CLOSED here, and this is the third
+ * site of the class objectui#8944 (chart) and objectui#9024 (pivot) removed.
+ *
+ * Three properties of THIS site, each confirmed rather than assumed — it is not
+ * a copy-paste of the other two:
+ *
+ * 1. The return stays a NON-optional `Record<string, unknown>`, because callers
+ *    do not expect `undefined`. `composeDrillFilter` answers `undefined` when
+ *    both sources are empty, so that one case is spelled `?? {}` — the same
+ *    empty object this function already returned for a bucket with no dims.
+ * 2. Range operators SURVIVE. A time-bucketed dim contributes
+ *    `{ $gte, $lt }`, and the composition re-spells it as two `$and` children
+ *    on the same field (`[{d:{$gte}},{d:{$lt}}]`) rather than losing a bound;
+ *    the selected rows are identical, and `serializeDrillFilterParams` walks
+ *    `$and` (objectui#8944) so both bounds still reach `filter[d][gte|lt]`.
+ * 3. `runtimeFilter` is declared `unknown`, which is what the two consumers
+ *    actually hand it — `any` from the dashboard, `Record<string, unknown>`
+ *    from `DatasetReportRenderer`. Widening the PARAMETER is what admits both
+ *    without a cast; ⛔ neither consumer's own type is changed by this.
+ *
+ * ⚠️ Conjunction changes one behaviour deliberately: a field named by BOTH the
+ * widget filter and the clicked bucket used to be overwritten by the bucket,
+ * and now both conditions apply. That is the point — a drill may narrow the
+ * widget's scope and may never widen it — and it is the posture the chart and
+ * pivot sites already ship.
+ *
+ * ## ⭐ Only the COMPOSING leg moves; the identity leg is left byte-identical
+ *
+ * The sink is asked only when there IS a second source. That is this site's
+ * one departure from `ObjectChart` / `ObjectPivotTable`, which call it
+ * unconditionally, and it is deliberate rather than a shortcut: the spread
+ * this replaces only ever ran when `runtimeFilter` was present, so the
+ * no-widget-filter path carries no defect to repair.
+ *
+ * ⚠️ Routing it anyway was MEASURED and rejected. `composeDrillFilter`'s own
+ * note — "a lone surviving source lowers back to exactly the flat object the
+ * spread produced" — holds only for a source of ONE condition; with two it
+ * lowers to `$and`, because `convertFiltersToAST` emits one node per condition
+ * and `parseFilterAST` cannot fold two nodes back onto one key. A `{ $gte,
+ * $lt }` range is two conditions on its own, so even a single date bucket
+ * re-spells. Sending the identity leg through the sink therefore re-shaped
+ * every multi-condition dataset drill — including the controls objectui#9085,
+ * objectui#4056, objectstack#5473 and #1752 pin on paths this card does not
+ * touch — for ZERO change in the rows selected or the `filter[...]` params
+ * emitted. ⛔ Do not "simplify" this to an unconditional call without redoing
+ * that measurement.
+ *
  * Shared by the dashboard `DatasetWidget` and the report renderer so a drill
  * filters identically (and correctly, including lookups) on both surfaces.
  */
@@ -578,7 +648,7 @@ export function buildDatasetDrillFilter(
   rawRow: Record<string, unknown> | undefined,
   drillDims: string[],
   dimensionFields: Record<string, string>,
-  runtimeFilter?: Record<string, unknown>,
+  runtimeFilter?: unknown,
   rawRanges?: Record<string, DatasetDrillRange>,
 ): Record<string, unknown> {
   const drillFilter: Record<string, unknown> = {};
@@ -596,5 +666,8 @@ export function buildDatasetDrillFilter(
       if (r && r.field) drillFilter[r.field] = { $gte: r.gte, $lt: r.lt };
     }
   }
-  return runtimeFilter ? { ...runtimeFilter, ...drillFilter } : drillFilter;
+  // ⛔ The composition is `composeDrillFilter`'s, never a spread. The identity
+  // leg is deliberately left alone — see "only the composing leg moves" above.
+  // `?? {}` is property 1: the empty/empty answer stays an empty object.
+  return runtimeFilter ? composeDrillFilter(runtimeFilter, drillFilter) ?? {} : drillFilter;
 }

--- a/packages/data-objectstack/src/queryDataset.test.ts
+++ b/packages/data-objectstack/src/queryDataset.test.ts
@@ -708,10 +708,23 @@ describe('queryDataset passes the server drillRanges sidecar through (#1752)', (
     // Both halves in one filter. Without the range the drill was a SUPERSET —
     // clicking June's bar opened every month for that region.
     expect(buildDatasetDrillFilter(result.drillRawRows?.[0], drillDims, result.dimensionFields ?? {}, { stage: 'won' }, result.drillRanges?.[0]))
+      // objectui#9137 re-spelled the COMPOSITION: the runtime filter is now
+      // conjoined through `composeDrillFilter` rather than spread into the
+      // drill filter, and the half-open range arrives as two `$and` children
+      // on one field (`convertFiltersToAST` emits a node per bound). Both
+      // halves are still here, which is this test's claim — without the range
+      // the drill was a superset.
       .toEqual({
-        stage: 'won',
-        'account.region': 'NA',
-        close_date: { $gte: '2026-06-01', $lt: '2026-07-01' },
+        $and: [
+          { stage: 'won' },
+          {
+            $and: [
+              { 'account.region': 'NA' },
+              { close_date: { $gte: '2026-06-01' } },
+              { close_date: { $lt: '2026-07-01' } },
+            ],
+          },
+        ],
       });
   });
 

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
@@ -438,10 +438,31 @@ describe('DatasetWidget', () => {
     expect(buildDrillFilter({ account: 'acc_123' }, ['account'], { account: 'account_id' })).toEqual({ account_id: 'acc_123' });
   });
 
+  // objectui#9137 — this test's NAME became true here. The widget filter used
+  // to be SPREAD into the drill filter, which is an AND only for the object
+  // arm; `DashboardWidgetSchema.filter` declares the ARRAY arm, and spreading
+  // an array yields index keys. It is now conjoined through
+  // `composeDrillFilter`, the repo's single filter confluence, so the result is
+  // a real `$and` of the two sources rather than one object overwriting the
+  // other. The nested `$and` is the drill filter's own two conditions.
   it('buildDrillFilter ANDs the widget runtime filter in', () => {
     expect(
       buildDrillFilter({ status: 'open', priority: 'high' }, ['status', 'priority'], { status: 'status', priority: 'priority' }, { archived: false }),
-    ).toEqual({ archived: false, status: 'open', priority: 'high' });
+    ).toEqual({ $and: [{ archived: false }, { $and: [{ status: 'open' }, { priority: 'high' }] }] });
+  });
+
+  // objectui#9137 — the arm the declaration names. `widget.filter` reaches
+  // `buildDrillFilter` as an ObjectQL FilterNode ARRAY (the `DatasetWidget`
+  // guard admits it: `typeof [] === 'object'` and `Object.keys(['x']).length`
+  // is 1), and spreading it produced the index key `{ '0': [...] }` — which no
+  // sink treats as a condition: `convertFiltersToAST` THROWS on a bare-array
+  // comparand, so the drill was DEAD, not merely unscoped.
+  it('buildDrillFilter conjoins the ARRAY arm of the widget filter instead of spreading it to index keys', () => {
+    const composed = buildDrillFilter({ status: 'open' }, ['status'], { status: 'status' }, [['region', '=', 'emea']]);
+    expect(composed).toEqual({ $and: [{ region: 'emea' }, { status: 'open' }] });
+    // The defect's exact signature, pinned as ABSENT: an index key from a
+    // spread array. `'0' in composed` is what failed before this card.
+    expect(Object.keys(composed)).not.toContain('0');
   });
 
   // objectui#9085: an empty bucket used to normalize to a bare `null`, which
@@ -476,10 +497,22 @@ describe('DatasetWidget', () => {
         { archived: false },
         { close_date: { field: 'close_date', gte: '2026-06-01', lt: '2026-07-01' } },
       ),
+    // objectui#9137 — conjoined, not spread. The half-open range SURVIVES the
+    // composition: `convertFiltersToAST` emits one node per bound, so the pair
+    // arrives as two `$and` children on the same field rather than one key with
+    // two operators. Same rows, and `serializeDrillFilterParams` still writes
+    // both `filter[close_date][gte]` and `[lt]`.
     ).toEqual({
-      archived: false,
-      stage: 'qualification',
-      close_date: { $gte: '2026-06-01', $lt: '2026-07-01' },
+      $and: [
+        { archived: false },
+        {
+          $and: [
+            { stage: 'qualification' },
+            { close_date: { $gte: '2026-06-01' } },
+            { close_date: { $lt: '2026-07-01' } },
+          ],
+        },
+      ],
     });
   });
 

--- a/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
+++ b/packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx
@@ -646,8 +646,12 @@ describe('DatasetReportRenderer', () => {
       dataset: 'task_metrics',
       object: 'task',
       groupKey: { status: 'In Progress' },
-      // raw stored value, mapped to the underlying object field, ANDed with scope
-      objectFilter: { owner: 'me', status: 'in_progress' },
+      // raw stored value, mapped to the underlying object field, ANDed with
+      // scope — a real `$and` since objectui#9137, where the report scope
+      // stopped being SPREAD into the drill filter and became a conjunction
+      // through `composeDrillFilter`. This renderer is the second consumer of
+      // that helper; its own `runtimeFilter` type is unchanged.
+      objectFilter: { $and: [{ owner: 'me' }, { status: 'in_progress' }] },
     }));
   });
 


### PR DESCRIPTION
Fixes #9137

Third and last site of the mis-composition objectui#8944 removed from `ObjectChart` and objectui#9024 removed from `ObjectPivotTable`. Composed through the seam #8944 added, `composeDrillFilter` — no third local answer is derived.

## The defect

`packages/core/src/utils/dataset-format.ts`, last line of `buildDatasetDrillFilter`:

```ts
return runtimeFilter ? { ...runtimeFilter, ...drillFilter } : drillFilter;
```

Spreading a filter SOURCE into an object literal is correct only for the object-dialect arm. This site's declared producer sends the other one. `DashboardWidgetSchema.filter`, verbatim: *"objectui passes an ObjectQL FilterNode array here, not the spec's `FilterCondition` envelope"* — and `DatasetWidget`'s guard admits an array (`typeof [] === 'object'` is true, `Object.keys(['x']).length` is 1). So `[['region','=','emea']]` reached the spread and became the index key `{ '0': ['region','=','emea'] }`.

The function's own docblock already CLAIMED the conjunction — *"The render-time `runtimeFilter` is ANDed in so the drilled list stays within the same slice the aggregate was computed over"*. The code did not do it.

## MEASURED FIRST, as triage asked — and it corrects the grading

Triage asked for (a) does the server accept it, and (b) are the drilled rows a superset, before the repair. Both are written back on the card.

**(a) The server does NOT refuse. The re-grade trigger does not fire.** Three legs, each measured:

| leg | reading |
|---|---|
| spec contract | `FilterConditionSchema.safeParse([['region','=','emea']])` REFUSES. The array arm is off-contract for both `DashboardWidget.filter` (platform `spec/src/ui/dashboard.zod.ts` declares `FilterConditionSchema.optional()`) and `DatasetSelection.runtimeFilter`. |
| the door | `packages/rest/src/analytics-selection-door.ts` deliberately PROJECTS `runtimeFilter` away before parsing. Its own TSDoc: *"Those four therefore still have no door."* No refusal. |
| the executor | `combineFilters(compiled.filter, selection.runtimeFilter)` wraps into `$and` with no validation. No refusal. |

So the dataset query leg accepts an array `runtimeFilter` unrefused — off-contract but unenforced. The widget is NOT already broken before the drill, and the blast radius is the one the declaration suggests.

**(b) ⚠️ The drilled rows are NOT a superset. They are EMPTY.** This is the one place the card and the triage comment are both wrong, and it is wrong by a measurement rather than by argument. The premise was that an index key is one "nothing reads as a condition", so the narrowing key is dropped and the list widens. A bare array is not a legal equality comparand anywhere in this dialect (objectui#8530 / objectui#8514), so the index key is neither honoured nor dropped — it is **refused, loudly**:

- `convertFiltersToAST` THROWS `FilterOperatorError` ("carries a bare ARRAY as its equality comparand");
- `ValueDataSource`'s matcher selects nothing;
- the error's own text names the third sink: `driver-sql` answers `400 INVALID_FILTER`.

Row counts over rows scoped `region = 'emea'`, drilling the `stage = 'won'` bucket:

| | rows |
|---|---|
| widget filter alone | 3 |
| **drill, before this PR** | **0 — dead, not wide** |
| drill, after this PR | 2 |
| intended (widget AND bucket) | 2 |
| what a superset would have looked like | 3, a different set |

⇒ the direction is fail-CLOSED. ⛔ I have not touched any label; re-grading is triage's. The repair is unchanged either way, and so is the ruling.

## The three preconditions

1. **Non-optional return.** `composeDrillFilter` answers `undefined` when both sources are empty; callers do not expect that. Spelled `?? {}` — the same empty object this function already returned for a bucket with no dims. Pinned.
2. **Range operators are PRESERVED.** A time-bucketed dim contributes `$gte` / `$lt`. The composition re-spells the pair as two `$and` children on the same field, because `convertFiltersToAST` emits one node per bound and `parseFilterAST` cannot fold two nodes back onto one key. Same rows, and `serializeDrillFilterParams` walks `$and` (#8944) so both bounds still reach `filter[close_date][gte]` and `[lt]`. Pinned as a row set, not as a shape alone.
3. **Two consumers, two `runtimeFilter` types.** The parameter widens from `Record` of string to unknown → `unknown`, which is what `composeDrillFilter` itself takes. A widening, so no call site changes. ⛔ **I did not touch the report-side type** — `DatasetReportRenderer`'s own `runtimeFilter?: Record` of string to unknown is untouched, and so is the dashboard's `any`. Saying so explicitly because the dispatch required it.

## ⭐ Only the composing leg moves — a deliberate departure from the sibling sites

`ObjectChart` and `ObjectPivotTable` call the seam unconditionally. Here it is asked only when a second source exists. The spread only ever ran when `runtimeFilter` was present, so the identity leg carries no defect.

Routing it anyway was measured and rejected. `composeDrillFilter`'s note — *"a lone surviving source lowers back to exactly the flat object the spread produced"* — holds only for a source of ONE condition; with two it lowers to `$and`, and a `$gte`/`$lt` range is two conditions on its own. Sending the identity leg through the sink re-shaped every multi-condition dataset drill: **8 pins moved instead of 3**, and the 5 extra belong to objectui#9085, objectui#4056, objectstack#5473 and #1752 — including two CONTROLs whose whole claim is *"this path is unchanged"* — for zero change in rows selected or `filter[...]` params emitted. The rejected variant is recorded in the docblock so nobody "simplifies" it back without redoing the measurement.

## Behaviour change, stated plainly

When a widget filter is present the composed value is `$and` of the two sources rather than one flat object, and a field named by BOTH now applies both conditions instead of the clicked bucket overwriting the widget's. That is the repair: a drill may narrow the widget's scope and may never widen it.

## Tests

- NEW `packages/core/src/utils/__tests__/dataset-drill-array-arm-9137.test.ts` — 7 cases, claims made as ROW SETS with a control that fails if the widget filter were decoration, plus the defect pinned ABSENT (no `'0'` key) and the wire refusal pinned as the reason the old behaviour was dead.
- 3 existing shape pins updated to the composed shape; each keeps its question, only the expected value moves, and each carries an inline note saying why.
- The 5 no-widget-filter pins are untouched and still green — that is the evidence for the paragraph above.

## Verification — all readings at `cb5df7acf`

**Gates** (objectui has no `scripts/pm/dispatch-gates.mjs`; family derived by hand from root `package.json` + `git ls-tree origin/main .github/workflows/`). Each cites the gate's own verdict line, never a bare `$?`:

- `changeset:check` exit 0 — *"No changeset declares a `major` bump."* ⚠️ `check:changeset-no-major` is not an npm script here; `changeset:check` is the real gate.
- `check-changeset-presence.mjs` exit 0 — *"3 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)"*.
- `check:control-bytes` exit 0 (7462 tracked text files) · `check:new-line-citations` exit 0 (0 new) · `check:changeset-claims` exit 0 · `check:spec-symbols` exit 0 · `check:self-import` exit 0 · `check:test-path-roots` exit 0 · `check:vi-mock-specifiers` exit 0.

**Tests**

- `packages/app-shell/` — **688 files, 6679 passed**, 1 skipped. `VERDICT command-exit 0`.
- `examples/schema-catalog/` — **31 files, 2151 passed**. Run because the dispatch flags objectui#9273; see the note on blast radius below.
- `packages/core/ packages/plugin-dashboard/ packages/data-objectstack/ packages/plugin-report/` — **351 files, 5426 tests**, read in two legs because two pins moved between them: at `e6ed19d77` it was 349 files passed / 2 failed, the 2 failures being the consumer shape pins; `cb5df7acf` changes **exactly those two files** (`git diff --name-only e6ed19d77 HEAD` returns them and nothing else) and re-running them gives 76 passed. ⚠️ Stated as a composite rather than as one clean run: the lock was held by a full-repo `pnpm test` from a sibling seat.

**Type-check** — `@object-ui/core`, `@object-ui/plugin-dashboard`, `@object-ui/plugin-report`, `@object-ui/data-objectstack` all exit 0, each after building its dependency closure first (a stale `dist/*.d.ts` lies in both directions; without the build every one of them failed `TS6305` / `TS2307`, which is not a red gate). Coverage of the test files confirmed by counting rather than assumed: core's script is `tsc --noEmit && tsc -p tsconfig.test.json`, and `--listFiles` on that project contains both `dataset-format.ts` and the new `dataset-drill-array-arm-9137.test.ts`; data-objectstack's bare `tsc --noEmit` contains `queryDataset.test.ts`.

**Lint — a narrowed run, declared, with the three readings that make it a measurement rather than a skipped gate**

1. Universe read from eslint's own config, not guessed: `eslint . --no-inline-config --format json` reports on **4882 files** (95 errors, 13011 warnings repo-wide — the pre-existing state, and CI's to own).
2. Narrowed run over exactly the 6 `.ts`/`.tsx` files this PR changes: **exit 0, 0 errors**. The 50 warnings are all `@typescript-eslint/no-explicit-any`, and **0 of them fall on a line this PR added** (checked by intersecting the message lines with `git diff -U0 origin/main...HEAD`).
3. Invariance over untouched files: type-aware linting is **not** enabled (`eslint.config.js` declares no `projectService` and no `parserOptions.project`) and no rule under `eslint-rules/` reads the filesystem, so every verdict is a function of that one file's text — this diff cannot move the verdict of a file it does not touch.

⚠️ **Narrowings declared:** the repo-wide `pnpm lint` / `turbo run lint` and the full `pnpm test` are CI's runs, not attempted here; the four consumer type-checks ran sequentially per package instead of as one `turbo` fan-out, and `examples/schema-catalog/` ran outside the shared lock, because the lock returned `exit 99` (queue-timeout, NOT MEASURED) twice across ~18 minutes of waiting.

**Blast radius (objectui#9273).** No call site moved, no rendered node changed, no declaration key added. `git grep` for `buildDatasetDrillFilter` / `buildDrillFilter` outside the five packages already run returns only changesets and generated `CHANGELOG.md` files — no census figure and no README prose pin names the symbol.

## Acceptance notes

- noted, not filed: `composeDrillFilter`'s docblock claim that "a lone surviving source lowers back to exactly the flat object the spread produced" is accurate only for a single-condition source. Measured false for two conditions and for any `$gte`/`$lt` range. It misleads nobody today because no caller depends on the flat spelling, and correcting the prose in `drill-down.ts` is outside this card's file surface. Successor: whoever takes the fourth site, or any card that touches `composeDrillFilter`.
- noted, not filed: objectui#9085's repair is already on `main` in this same function (the `$null: true` spelling and its tests), so the "same file, run an in-flight check" boundary resolved to no overlap — no open PR touches `dataset-format.ts` or `drill-down.ts`, and no `claude/issue-9085-*` branch exists (control leg: the `claude/issue-9061-*` glob does resolve).

Clause-②: yes — `needs:contract-review` hung on both this PR and the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_

---
_Generated by [Claude Code](https://claude.ai/code)_