### PR TITLE
fix(components): close the numeric-falsy SchemaNode slot class — one guard, not eleven ternaries

### DIFF
--- a/.changeset/9162-node-slot-guard-class-closure.md
+++ b/.changeset/9162-node-slot-guard-class-closure.md
@@ -1,0 +1,54 @@
+---
+'@object-ui/components': minor
+'@object-ui/plugin-detail': minor
+'@object-ui/plugin-report': minor
+'@object-ui/plugin-timeline': minor
+---
+
+Close the numeric-falsy `SchemaNode` slot class: a slot may no longer guard itself
+(objectui#9162, triage ruling 2026-09-12).
+
+**What leaked.** `{schema.footer && <CardFooter>…</CardFooter>}` does not evaluate to
+`false` when the slot is falsy — it evaluates to the **slot**, and React renders
+numbers. A node slot's published zod face carries a `z.number()` arm
+(`nodeUnionOptions`, `packages/types/src/zod/base.zod.ts`), so `footer: 0` is **legal
+authored input**, and it painted a stray `0` into the DOM. `NaN` painted three
+characters. The `&&` also short-circuits, so `renderChildren`'s own
+`if (!children) return null` first leg was never reached — which is why the
+objectui#8908 bridge repair could not cover any of these sites.
+
+**Why a class fix and not N instance fixes.** This class was patched one instance at a
+time three times — objectui#8331 (`DataTableSchema.emptyAction`), objectui#9033
+(`header-bar`'s `rightContent`), and then objectui#9162's census found eleven more,
+because objectui#9033's grep was keyed on the spelling of the **right** operand while
+the trap depends only on the **left** one. Nineteen guards across eight files are
+repaired here, and the construct that permits them is now refused mechanically.
+
+**The one spelling, and the gate.** `renderChildren(slot)` is the guard for a bare
+slot; the new `renderNodeSlot(slot, render)` is the guard for a slot wrapped in chrome
+that must disappear with it. Both route through one exported predicate,
+`isEmptyNodeSlot`. The new lint rule `object-ui/no-bare-node-slot-guard` refuses the
+`&&` spelling, deriving its slot set per file from the file's own text — an expression
+is a node slot there if that file hands it to `renderChildren`, `renderNodeSlot`,
+`toRenderableSchema` or `<SchemaRenderer schema={…}>`. A twelfth slot is rendered
+through one of those, so it is covered the moment it is written, with no list to keep
+up to date.
+
+**Why `minor`.** Two reasons, and neither is a contract break.
+
+1. `@object-ui/components` gains public API: `renderNodeSlot` and `isEmptyNodeSlot` are
+   new exports. A new export is a `minor` on its own.
+2. Published renderers change what they emit for two authored inputs. A node slot
+   authored `0` / `-0` / `NaN` stops painting that character — that is the defect, and
+   no author asked for it. A node slot authored `[]` no longer renders its empty chrome
+   (an empty `CardHeader` / `CardContent` / `CardFooter` / `DialogFooter` /
+   `SheetFooter` / `DrawerFooter` / `TableFooter`, or `plugin-detail`'s wrapping
+   `div`); the chrome now appears and disappears with its content. Measured across
+   `examples/`, `content/` and `apps/`: **zero** authored node slots carry a numeric
+   value, and the single authored `"children": []` is on `div`, which never had the
+   `&&` guard and is unaffected.
+
+⛔ Deliberately **not** marked `**BREAKING**`: no authored input stops being accepted,
+no export is removed, no key stops being read, and objectui#7105 is respected — the
+declarations are untouched and node slots still relax the renderer. An author who
+genuinely wants the character `0` writes `"0"` or a `text` node, both unchanged.

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -11,6 +11,7 @@ import buttonHasType from './button-has-type.js';
 import noUnpairedBadgeColorClasses from './no-unpaired-badge-color-classes.js';
 import noUnusedImports from './no-unused-imports.js';
 import noLineAddressInTestName from './no-line-address-in-test-name.js';
+import noBareNodeSlotGuard from './no-bare-node-slot-guard.js';
 
 export default {
   rules: {
@@ -24,5 +25,6 @@ export default {
     'no-unpaired-badge-color-classes': noUnpairedBadgeColorClasses,
     'no-unused-imports': noUnusedImports,
     'no-line-address-in-test-name': noLineAddressInTestName,
+    'no-bare-node-slot-guard': noBareNodeSlotGuard,
   },
 };

--- a/eslint-rules/no-bare-node-slot-guard.js
+++ b/eslint-rules/no-bare-node-slot-guard.js
@@ -1,0 +1,237 @@
+/**
+ * ObjectUI ESLint rule: no-bare-node-slot-guard
+ *
+ * Forbids a bare `&&` whose left operand is a SchemaNode SLOT and whose value
+ * becomes a React child.
+ *
+ * ## The defect
+ *
+ * `{schema.footer && <CardFooter>{renderChildren(schema.footer)}</CardFooter>}`
+ * does not evaluate to `false` when the slot is falsy — it evaluates to the
+ * slot's own value. React ignores `false`, `null`, `undefined` and `''`, but it
+ * RENDERS numbers. A node slot's published zod face carries a `z.number()` arm
+ * (`nodeUnionOptions` in `packages/types/src/zod/base.zod.ts`), so `footer: 0`
+ * is legal authored input, and it paints a stray `0` into the DOM.
+ *
+ * The bridge does not save it. `toRenderableSchema` has mapped falsy primitives
+ * onto nothing since objectui#8908, and `renderChildren`'s own first leg is
+ * `if (!children) return null` — but `&&` SHORT-CIRCUITS, so neither of them is
+ * reached. The raw `0` has already been produced before any renderer runs.
+ *
+ * ## Why a rule and not eleven ternaries
+ *
+ * The class was patched one instance at a time three times — objectui#8331
+ * (`DataTableSchema.emptyAction`), objectui#9033 (`header-bar`'s
+ * `rightContent`), and then objectui#9162 found ELEVEN more sites that the
+ * second round's grep could not see, because that grep was keyed on the
+ * spelling of the RIGHT operand (`toRenderableSchema`) while the trap depends
+ * only on the LEFT one. Correcting eleven instances leaves the error-permitting
+ * construct in the tree and the twelfth slot gets written wrong. This rule
+ * deletes the construct instead: `renderChildren(value)` and
+ * `renderNodeSlot(value, wrap)` already answer every falsy input with `null`,
+ * so there is no shape left that needs an `&&`, and the `&&` is refused.
+ *
+ * ## What it keys on — the LEFT operand, derived, not listed
+ *
+ * A hard-coded list of slot names ("children", "footer", …) would be exactly
+ * the objectui#9033 mistake one level up: it would answer for today's names and
+ * go quiet on the twelfth. Instead the rule derives the slot set PER FILE from
+ * the file's own text: an expression is a node slot here if this file hands it
+ * to a node renderer — `renderChildren(x)`, `renderNodeSlot(x, …)`,
+ * `toRenderableSchema(x)`, or `<SchemaRenderer schema={x} />`. A twelfth slot is
+ * rendered through one of those (that is what rendering a node IS), so the rule
+ * sees it the moment it is written, with no list to update.
+ *
+ * `||`, `&&` and `??` chains are flattened on both sides, because
+ * `(schema.title || schema.description || schema.header) && <CardHeader>…`
+ * leaks through the `||` for exactly the same reason — `undefined || 0` is `0`.
+ *
+ * ## What it deliberately does NOT flag
+ *
+ * - `{schema.showClose && <DrawerClose/>}` — `showClose` is a declared boolean
+ *   and is never handed to a node renderer, so it is not in the derived set.
+ * - `{schema.title && <CardTitle>{schema.title}</CardTitle>}` — `title` is a
+ *   declared `string`; React renders `''` as no characters. Same reason.
+ * - `{items.length > 0 && …}` — the left operand is a comparison, already a
+ *   boolean.
+ * - An `&&` outside JSX child position (`const x = a && b`). The rule is about
+ *   what reaches React as a child; a value assigned first is reported at the
+ *   place it is actually rendered, if it is rendered bare at all.
+ *
+ * ## No autofixer, on purpose
+ *
+ * The two correct rewrites are not interchangeable. A slot rendered bare wants
+ * `{renderChildren(x)}`; a slot wrapped in chrome that must disappear with it
+ * wants `renderNodeSlot(x, (c) => <Chrome>{c}</Chrome>)`. Guessing wrong emits
+ * empty chrome — a visible, silent layout change — so the author picks.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+
+/** Calls whose argument is, by construction, a renderable node slot. */
+const NODE_RENDERER_CALLS = new Set([
+  'renderChildren',
+  'renderNodeSlot',
+  'toRenderableSchema',
+]);
+
+/** Components whose `schema` prop is, by construction, a renderable node slot. */
+const NODE_RENDERER_COMPONENTS = new Set(['SchemaRenderer']);
+
+/**
+ * Flatten a `&&` / `||` / `??` chain into its leaf operands. Every leaf of such
+ * a chain can be the chain's own value, so every leaf is a candidate leak.
+ */
+function flattenLogical(node, out) {
+  if (
+    node.type === 'LogicalExpression' &&
+    (node.operator === '&&' || node.operator === '||' || node.operator === '??')
+  ) {
+    flattenLogical(node.left, out);
+    flattenLogical(node.right, out);
+    return out;
+  }
+  out.push(node);
+  return out;
+}
+
+/** Strip the parentheses/`as`/`!` noise that would otherwise defeat text matching. */
+function unwrap(node) {
+  let n = node;
+  for (;;) {
+    if (n.type === 'TSAsExpression' || n.type === 'TSNonNullExpression') {
+      n = n.expression;
+      continue;
+    }
+    if (n.type === 'ChainExpression') {
+      n = n.expression;
+      continue;
+    }
+    return n;
+  }
+}
+
+/**
+ * True when this expression's value can reach React as a child — i.e. it is (or
+ * is the tail of) an expression inside a `{…}` container in element position,
+ * not in an attribute.
+ */
+function isInJsxChildPosition(node) {
+  let child = node;
+  let parent = node.parent;
+  while (parent) {
+    if (parent.type === 'JSXExpressionContainer') {
+      // An attribute value (`prop={x && y}`) is handed to the component, not to
+      // React's child reconciler, so the numeric-falsy leak does not apply.
+      return (
+        parent.parent &&
+        (parent.parent.type === 'JSXElement' || parent.parent.type === 'JSXFragment')
+      );
+    }
+    // Only keep climbing through positions whose value IS the enclosing value.
+    if (
+      (parent.type === 'LogicalExpression' && parent.right === child) ||
+      (parent.type === 'ConditionalExpression' &&
+        (parent.consequent === child || parent.alternate === child)) ||
+      parent.type === 'TSAsExpression' ||
+      parent.type === 'TSNonNullExpression' ||
+      parent.type === 'ChainExpression'
+    ) {
+      child = parent;
+      parent = parent.parent;
+      continue;
+    }
+    return false;
+  }
+  return false;
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Forbid a bare `&&` guard whose left operand is a SchemaNode slot — the guard renders the slot value itself, and a legal authored `0` leaks into the DOM (objectui#8331 / #9033 / #9162).',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      bareNodeSlotGuard:
+        'This `&&` guards a SchemaNode slot with the slot itself, so an authored `{{slot}}: 0` — which the published validator accepts — renders a stray "0" into the DOM (objectui#9162). `&&` short-circuits before `renderChildren`, so its `if (!children) return null` leg never runs. Render the slot through the guard instead: `{renderChildren({{slot}})}` when it is bare, or `renderNodeSlot({{slot}}, (c) => <Chrome>{c}</Chrome>)` when chrome must disappear with it.',
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    /** Source text of every expression this file hands to a node renderer. */
+    const slotTexts = new Set();
+    /** `&&` nodes in child position, collected in pass 1, judged in pass 2. */
+    const candidates = [];
+
+    function recordSlot(expr) {
+      if (!expr) return;
+      for (const leaf of flattenLogical(expr, [])) {
+        const u = unwrap(leaf);
+        if (u.type === 'MemberExpression' || u.type === 'Identifier') {
+          slotTexts.add(sourceCode.getText(u));
+        }
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        const callee = node.callee;
+        const name =
+          callee.type === 'Identifier'
+            ? callee.name
+            : callee.type === 'MemberExpression' && callee.property.type === 'Identifier'
+              ? callee.property.name
+              : null;
+        if (name && NODE_RENDERER_CALLS.has(name) && node.arguments.length > 0) {
+          recordSlot(node.arguments[0]);
+        }
+      },
+
+      JSXAttribute(node) {
+        if (node.name?.type !== 'JSXIdentifier' || node.name.name !== 'schema') return;
+        const owner = node.parent;
+        if (owner?.type !== 'JSXOpeningElement') return;
+        const tag = owner.name;
+        const tagName =
+          tag?.type === 'JSXIdentifier'
+            ? tag.name
+            : tag?.type === 'JSXMemberExpression' && tag.property?.type === 'JSXIdentifier'
+              ? tag.property.name
+              : null;
+        if (!tagName || !NODE_RENDERER_COMPONENTS.has(tagName)) return;
+        if (node.value?.type === 'JSXExpressionContainer') {
+          recordSlot(node.value.expression);
+        }
+      },
+
+      LogicalExpression(node) {
+        if (node.operator !== '&&') return;
+        if (!isInJsxChildPosition(node)) return;
+        candidates.push(node);
+      },
+
+      'Program:exit'() {
+        for (const node of candidates) {
+          // Every leaf of the LEFT side can be the `&&`'s value when the chain
+          // short-circuits, so each is a candidate leak.
+          for (const leaf of flattenLogical(node.left, [])) {
+            const u = unwrap(leaf);
+            if (u.type !== 'MemberExpression' && u.type !== 'Identifier') continue;
+            const text = sourceCode.getText(u);
+            if (!slotTexts.has(text)) continue;
+            context.report({
+              node: u,
+              messageId: 'bareNodeSlotGuard',
+              data: { slot: text },
+            });
+            break;
+          }
+        }
+      },
+    };
+  },
+};

--- a/eslint-rules/no-bare-node-slot-guard.test.js
+++ b/eslint-rules/no-bare-node-slot-guard.test.js
@@ -1,0 +1,284 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Unit test for the local ESLint rule that refuses a bare `&&` guard whose left
+ * operand is a SchemaNode slot (objectui#9162). Plain JS so it needs no package
+ * tsconfig.
+ *
+ * The `invalid` cases are transcribed from the live defect sites the card
+ * measured — `layout/container.tsx`, `layout/card.tsx` (all three guard
+ * shapes, including the compound `||` header guard and the `children || body`
+ * alias chain), `overlay/dialog.tsx`, `complex/table.tsx`,
+ * `plugin-detail/DetailView.tsx` and `layout/containers.tsx`'s `any`-typed
+ * `page:card` — so the rule is pinned against the shapes that actually
+ * occurred, not against shapes imagined for it.
+ *
+ * The `valid` cases carry the two halves the rule must NOT break:
+ *
+ *  - the REPAIRED spellings (`renderChildren(x)` bare, `renderNodeSlot(x, …)`
+ *    wrapped), and objectui#9033's ternary at `header-bar`, which is the
+ *    control the card used to separate fixed sites from unfixed ones. If the
+ *    rule flagged the ternary, the census could not tell those two apart.
+ *  - the guards that are NOT this class and must stay writable: a declared
+ *    boolean (`schema.showClose`), a declared string (`schema.title`), a
+ *    comparison, an array-length test, and an `&&` in an ATTRIBUTE position,
+ *    where the value is handed to a component rather than to React's child
+ *    reconciler.
+ */
+import { describe, it, afterAll } from 'vitest';
+import { RuleTester } from 'eslint';
+import rule from './no-bare-node-slot-guard.js';
+
+RuleTester.afterAll = afterAll;
+RuleTester.it = it;
+RuleTester.describe = describe;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: { ecmaFeatures: { jsx: true } },
+  },
+});
+
+ruleTester.run('no-bare-node-slot-guard', rule, {
+  valid: [
+    // The repaired bare spelling — `renderChildren` IS the guard
+    // (`layout/container.tsx`, `layout/flex.tsx`, `grid.tsx`, `stack.tsx`).
+    `
+      function Container({ schema }) {
+        return <div>{renderChildren(schema.children)}</div>;
+      }
+    `,
+    // The repaired wrapped spelling (`layout/card.tsx`, the overlays, `table`).
+    `
+      function Card({ schema }) {
+        return (
+          <div>
+            {renderNodeSlot(schema.footer, (footer) => (
+              <CardFooter>{renderChildren(footer)}</CardFooter>
+            ))}
+          </div>
+        );
+      }
+    `,
+    // objectui#9033's ternary at `header-bar`. ⛔ Must stay valid: it is the
+    // control that makes the census able to distinguish fixed from unfixed.
+    `
+      function HeaderBar({ schema }) {
+        return (
+          <header>
+            {schema.rightContent ? (
+              <SchemaRenderer schema={toRenderableSchema(schema.rightContent)} />
+            ) : null}
+          </header>
+        );
+      }
+    `,
+    // A declared BOOLEAN sibling, never handed to a node renderer
+    // (`overlay/drawer.tsx`'s `showClose`).
+    `
+      function Drawer({ schema }) {
+        return (
+          <DrawerFooter>
+            {renderChildren(schema.footer)}
+            {schema.showClose && <DrawerClose />}
+          </DrawerFooter>
+        );
+      }
+    `,
+    // Declared strings. `''` contributes no characters, and neither is ever
+    // handed to a node renderer, so neither is in the derived set.
+    `
+      function Card({ schema }) {
+        return (
+          <CardHeader>
+            {schema.title && <CardTitle>{schema.title}</CardTitle>}
+            {schema.description && <CardDescription>{schema.description}</CardDescription>}
+          </CardHeader>
+        );
+      }
+    `,
+    // A comparison is already a boolean, whatever it compares.
+    `
+      function List({ schema }) {
+        return <div>{schema.items.length > 0 && renderChildren(schema.items)}</div>;
+      }
+    `,
+    // The `header !== null` shape `layout/card.tsx` uses for its compound
+    // guard: the rendered result, not the slot.
+    `
+      function Card({ schema }) {
+        const header = renderChildren(schema.header);
+        return <div>{(schema.title || header !== null) && <CardHeader>{header}</CardHeader>}</div>;
+      }
+    `,
+    // ATTRIBUTE position: the value is handed to the component, not to React's
+    // child reconciler, so the numeric-falsy leak does not apply.
+    `
+      function Panel({ schema }) {
+        return <Slot content={schema.children && renderChildren(schema.children)} />;
+      }
+    `,
+    // No node renderer anywhere in the file ⇒ nothing is a slot here.
+    `
+      function Plain({ state }) {
+        return <div>{state.count && <span>n</span>}</div>;
+      }
+    `,
+  ],
+  invalid: [
+    {
+      // `layout/container.tsx:101`, verbatim shape.
+      code: `
+        function Container({ schema }) {
+          return <div>{schema.children && renderChildren(schema.children)}</div>;
+        }
+      `,
+      errors: [{ messageId: 'bareNodeSlotGuard' }],
+    },
+    {
+      // `layout/card.tsx:58` — the slot guarding its own chrome.
+      code: `
+        function Card({ schema }) {
+          return (
+            <Card>
+              {schema.footer && <CardFooter>{renderChildren(schema.footer)}</CardFooter>}
+            </Card>
+          );
+        }
+      `,
+      errors: [{ messageId: 'bareNodeSlotGuard' }],
+    },
+    {
+      // `layout/card.tsx:50` — the COMPOUND guard. `undefined || undefined || 0`
+      // is `0`, so the `||` leaks for exactly the same reason; the rule has to
+      // look through the chain rather than only at the immediate left operand.
+      code: `
+        function Card({ schema }) {
+          return (
+            <Card>
+              {(schema.title || schema.description || schema.header) && (
+                <CardHeader>{renderChildren(schema.header)}</CardHeader>
+              )}
+            </Card>
+          );
+        }
+      `,
+      errors: [{ messageId: 'bareNodeSlotGuard' }],
+    },
+    {
+      // `layout/card.tsx:57` — the alias chain used AS the guard. `children: 0`
+      // was converted away only by the accident of operand order, while
+      // `body: 0` went through `undefined || 0` and leaked.
+      code: `
+        function Card({ schema }) {
+          return (
+            <Card>
+              {(schema.children || schema.body) && (
+                <CardContent>{renderChildren(schema.children || schema.body)}</CardContent>
+              )}
+            </Card>
+          );
+        }
+      `,
+      errors: [{ messageId: 'bareNodeSlotGuard' }],
+    },
+    {
+      // `overlay/dialog.tsx:34` — multi-line wrapped shape.
+      code: `
+        function Dialog({ schema }) {
+          return (
+            <DialogContent>
+              {schema.footer && (
+                <DialogFooter>
+                  {renderChildren(schema.footer)}
+                </DialogFooter>
+              )}
+            </DialogContent>
+          );
+        }
+      `,
+      errors: [{ messageId: 'bareNodeSlotGuard' }],
+    },
+    {
+      // `complex/table.tsx:54` — the slot reaches the renderer only through a
+      // `typeof` ternary on the RIGHT, which is why objectui#9033's
+      // right-operand grep could not see this one.
+      code: `
+        function Table({ schema }) {
+          return (
+            <Table>
+              {schema.footer && (
+                <TableFooter>
+                  {typeof schema.footer === 'string' ? schema.footer : renderChildren(schema.footer)}
+                </TableFooter>
+              )}
+            </Table>
+          );
+        }
+      `,
+      errors: [{ messageId: 'bareNodeSlotGuard' }],
+    },
+    {
+      // `plugin-detail/DetailView.tsx:1440` — rendered through
+      // `<SchemaRenderer schema={…}>` rather than `renderChildren`, so the
+      // derived set has to cover that spelling too.
+      code: `
+        function DetailView({ schema, data }) {
+          return (
+            <div>
+              {schema.header && (
+                <div>
+                  <SchemaRenderer schema={toRenderableSchema(schema.header)} data={data} />
+                </div>
+              )}
+            </div>
+          );
+        }
+      `,
+      errors: [{ messageId: 'bareNodeSlotGuard' }],
+    },
+    {
+      // `layout/containers.tsx:939` — a plain IDENTIFIER, not a member
+      // expression, and the renderer's `schema` is `any`. The card's
+      // TypeScript census could not see this site; a syntactic derivation can.
+      code: `
+        function PageCard({ schema }) {
+          const body = schema?.body ?? schema?.children;
+          return <Card>{body && <CardContent>{renderChildren(body)}</CardContent>}</Card>;
+        }
+      `,
+      errors: [{ messageId: 'bareNodeSlotGuard' }],
+    },
+    {
+      // The TWELFTH slot: a name that exists nowhere in the repo today. A rule
+      // keyed on a list of slot names would let this through; this one does
+      // not, because the file itself declares the value to be a node by
+      // rendering it as one.
+      code: `
+        function Future({ schema }) {
+          return (
+            <div>
+              {schema.sidePanel && <aside>{renderChildren(schema.sidePanel)}</aside>}
+            </div>
+          );
+        }
+      `,
+      errors: [{ messageId: 'bareNodeSlotGuard' }],
+    },
+    {
+      // Two independent guards in one file are two reports, not one.
+      code: `
+        function Two({ schema }) {
+          return (
+            <div>
+              {schema.header && <header>{renderChildren(schema.header)}</header>}
+              {schema.footer && <footer>{renderChildren(schema.footer)}</footer>}
+            </div>
+          );
+        }
+      `,
+      errors: [{ messageId: 'bareNodeSlotGuard' }, { messageId: 'bareNodeSlotGuard' }],
+    },
+  ],
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -422,4 +422,50 @@ export default tseslint.config({
   rules: {
     'object-ui/no-unpaired-badge-color-classes': 'error',
   },
+}, {
+  // objectui#9162 ratchet — a `SchemaNode` slot may never guard itself.
+  //
+  // `{schema.footer && <CardFooter>…</CardFooter>}` does not evaluate to
+  // `false` when the slot is falsy: it evaluates to the SLOT, and React renders
+  // numbers. A node slot's published zod face carries a `z.number()` arm
+  // (`nodeUnionOptions`, `packages/types/src/zod/base.zod.ts`), so `footer: 0`
+  // is legal authored input that paints a stray "0" into the DOM. Worse, `&&`
+  // short-circuits, so `renderChildren`'s own `isEmptyNodeSlot` first leg is
+  // never reached — the objectui#8908 bridge repair cannot help either.
+  //
+  // Why it earns the ratchet: the class was patched ONE INSTANCE AT A TIME
+  // three times — objectui#8331 (`DataTableSchema.emptyAction`), objectui#9033
+  // (`header-bar`'s `rightContent`), and then objectui#9162's census found
+  // ELEVEN more, because objectui#9033's grep was keyed on the spelling of the
+  // RIGHT operand while the trap depends only on the LEFT one. Eleven ternaries
+  // would have left the error-permitting construct in the tree for the twelfth
+  // slot. Nothing else rejects it: it type-checks, it renders, and it is
+  // correct for every value except a falsy number.
+  //
+  // The rule derives its slot set PER FILE from the file's own text — an
+  // expression is a node slot here if this file hands it to `renderChildren`,
+  // `renderNodeSlot`, `toRenderableSchema` or `<SchemaRenderer schema={…}>`.
+  // ⛔ Deliberately NOT a list of slot names: a list would answer for today's
+  // names and go quiet on the twelfth, which is the objectui#9033 mistake one
+  // level up.
+  //
+  // `**/src/ui/**` is the upstream Shadcn zone, overwritten by the sync script
+  // and never hand-edited (AGENTS.md #7) — enforcing there would demand an edit
+  // the repo forbids. It reports zero today in any case. Tests are IN scope: a
+  // fixture that writes the construct is modelling the defect, and a deliberate
+  // reproduction can say so with a disable directive.
+  //
+  // Measured on 7d6439c4b: 19 reports across 8 files (the eleven sites
+  // objectui#9162 probed, plus `page:card`'s `body`/`footer`, `plugin-detail`'s
+  // `header`/`footer`, `plugin-report`'s `section.content` and
+  // `plugin-timeline`'s two `item.content`). `header-bar.tsx` — objectui#9033's
+  // ternary, already fixed — was NOT reported, which is the control that the
+  // instrument separates fixed from unfixed. All 19 are repaired in the same
+  // change, so this lints clean with no allowlist.
+  files: ['**/*.tsx'],
+  ignores: ['**/src/ui/**'],
+  plugins: { 'object-ui': objectUi },
+  rules: {
+    'object-ui/no-bare-node-slot-guard': 'error',
+  },
 });

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -37,7 +37,7 @@ import './renderers';
 
 // Export utils
 export { cn } from './lib/utils';
-export { renderChildren } from './lib/utils';
+export { renderChildren, renderNodeSlot, isEmptyNodeSlot } from './lib/utils';
 export { cva } from 'class-variance-authority';
 export { getLazyIcon, isLucideIconName, LazyIcon, toKebabIconName } from './lib/lazy-icon';
 

--- a/packages/components/src/lib/utils.tsx
+++ b/packages/components/src/lib/utils.tsx
@@ -15,13 +15,75 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+/**
+ * The ONE emptiness predicate for a `SchemaNode` slot (objectui#9162).
+ *
+ * A node slot's published zod face carries a `z.number()` arm
+ * (`nodeUnionOptions`, `packages/types/src/zod/base.zod.ts`), so `children: 0`
+ * is legal authored input — and React RENDERS numbers. Truthiness is therefore
+ * the rule a node slot states: every falsy value (`0`, `-0`, `NaN`, `''`,
+ * `false`, `null`, `undefined`) means "this slot has no content", plus the
+ * empty array, which has no content either.
+ *
+ * ⛔ Not a nullish test. `0` is not "absent"; it is present and renders
+ * nothing, which is the distinction objectui#8331 kept deliberately and
+ * objectui#9033 kept again: truthiness makes the slot's answer independent of
+ * `toRenderableSchema`, and that independence is what kept the sibling slot out
+ * of the defect while the bridge was wrong.
+ *
+ * ⛔ Not a `typeof === 'object'` test either. objectui#7105 ruled that node
+ * slots RELAX the renderer rather than narrow the declaration — a bare string
+ * is a legal node and renders as its own text.
+ */
+export function isEmptyNodeSlot(slot: unknown): boolean {
+  if (!slot) return true;
+  return Array.isArray(slot) && slot.length === 0;
+}
+
+/**
+ * Render a `SchemaNode` slot that lives inside chrome which must disappear
+ * along with it — `<CardFooter>`, `<DialogFooter>`, a wrapping `<div>`.
+ *
+ * This exists because the obvious spelling is a trap:
+ *
+ * ```tsx
+ * {schema.footer && <CardFooter>{renderChildren(schema.footer)}</CardFooter>}
+ * ```
+ *
+ * `&&` does not evaluate to `false` when the slot is falsy — it evaluates to
+ * the SLOT, and React paints `0`. Worse, `&&` short-circuits, so
+ * `renderChildren`'s own `if (isEmptyNodeSlot) return null` first leg is never
+ * reached and the bridge repair of objectui#8908 cannot help either. The class
+ * was patched one instance at a time three times (objectui#8331 →
+ * objectui#9033 → the eleven of objectui#9162) before it was closed here.
+ *
+ * `render` receives the slot itself, not a pre-rendered node, because some
+ * call sites render it with extra context (`<SchemaRenderer schema={…}
+ * data={data} />` in `plugin-detail`). It is invoked ONLY when the slot has
+ * content, so the chrome and the content appear and disappear together.
+ *
+ * A slot with NO chrome does not need this — call `renderChildren(slot)`
+ * directly, which is the same guard with nothing wrapped around it. The rule
+ * `object-ui/no-bare-node-slot-guard` refuses the `&&` spelling so that these
+ * two remain the only two.
+ */
+export function renderNodeSlot<T>(
+  slot: T,
+  render: (slot: NonNullable<T>) => React.ReactNode,
+): React.ReactNode {
+  if (isEmptyNodeSlot(slot)) return null;
+  return render(slot as NonNullable<T>);
+}
+
 export function renderChildren(children: any): React.ReactNode {
-  if (!children) return null;
+  // The guard — reachable now that no caller short-circuits ahead of it
+  // (objectui#9162). `0`, `-0`, `NaN`, `''`, `false` and `[]` all mean
+  // "no content", and none of them may reach the DOM.
+  if (isEmptyNodeSlot(children)) return null;
   if (typeof children === 'string' || typeof children === 'number') {
     return children;
   }
   if (Array.isArray(children)) {
-    if (children.length === 0) return null;
     // Unwrap single child to support Radix UI 'asChild' pattern which expects a single ReactElement, not an array
     if (children.length === 1) {
       return <SchemaRenderer schema={children[0]} />; 

--- a/packages/components/src/renderers/__tests__/node-slot-numeric-falsy.test.tsx
+++ b/packages/components/src/renderers/__tests__/node-slot-numeric-falsy.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Every `SchemaNode` slot in `@object-ui/components` refuses a numeric-falsy
+ * authored value instead of painting it into the DOM (objectui#9162).
+ *
+ * ## The defect, and why these values are authorable
+ *
+ * A slot guarded by a bare `&&` does not evaluate to `false` when the slot is
+ * falsy — it evaluates to the slot's own value, and React RENDERS numbers. The
+ * published zod face for a node slot carries a `z.number()` arm
+ * (`nodeUnionOptions`, `packages/types/src/zod/base.zod.ts`), so `children: 0`
+ * is legal authored input. `theValidatorAcceptsZero` asserts that from the
+ * published validator rather than in prose: every row below is worthless if the
+ * value cannot be authored.
+ *
+ * objectui#8908 repaired `toRenderableSchema`, and `renderChildren`'s own first
+ * leg is `if (!children) return null`. ⛔ NEITHER reaches these sites while the
+ * `&&` is there: `&&` short-circuits, so the chain produced the raw `0` before
+ * any renderer ran. That is why the repair is the guard SHAPE, not the bridge.
+ *
+ * ## The instrument, and the two ways it can lie
+ *
+ * 1. **Radix portals out of the render container.** `dialog`, `sheet` and
+ *    `drawer` mount their content on `document.body`, not inside the container
+ *    RTL returns — objectui#9162's own first probe read those three rows as
+ *    "clean" for exactly that reason. So every read here is
+ *    `document.body.textContent`, ⛔ never the container's.
+ * 2. **A row can go green because nothing rendered at all.** Each row therefore
+ *    carries its own LIT CONTROL: the SAME slot fed `42`, which must reach the
+ *    text. A leak row whose lit control does not fire is NOT MEASURED, not
+ *    clean — `it.each` runs the lit control as its own named row so a blind
+ *    instrument fails loudly instead of passing quietly.
+ *
+ * ## Which values discriminate
+ *
+ * Only the falsy NUMBERS. React ignores `false` and `''` contributes no
+ * characters, so those two rows were green before the repair and are green
+ * after it; they live in `rowsThatCannotDiscriminate` so a later reader does
+ * not mistake them for evidence. `0` and `-0` paint one character; `NaN` paints
+ * three.
+ *
+ * ## ⛔ Not a licence to narrow the declaration
+ *
+ * objectui#7105 ruled that node slots RELAX THE RENDERER rather than narrow the
+ * declaration. `anAuthoredNodeStillRenders` is the live control for that on
+ * every row: the repair must not have turned these into primitives-only or
+ * objects-only slots.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Registered at module scope, NOT in a `beforeAll`: there the cold transform is
+// billed to `hookTimeout`, which is narrower than the timeout it replaces
+// (objectui#3010 / #3021, and `object-ui/no-dynamic-import-in-test-hook`).
+import '../../renderers';
+import { SidebarProvider } from '../../ui';
+import {
+  CardSchema as CardSchemaZod,
+  ContainerSchema as ContainerSchemaZod,
+  DialogSchema as DialogSchemaZod,
+} from '@object-ui/types/zod';
+
+afterEach(() => cleanup());
+
+/** A sentinel distinct from every authorable value, including `undefined`. */
+const OMIT = Symbol('omit');
+
+interface Site {
+  /** Row label: `<registry key> <slot>`. */
+  readonly name: string;
+  /** Registry type. */
+  readonly type: string;
+  /** Registry namespace — `card` is registered twice (`ui:card`, `page:card`). */
+  readonly namespace: string;
+  /** The slot under test. */
+  readonly slot: string;
+  /** Sibling keys the renderer needs before it will mount its chrome at all. */
+  readonly base?: Record<string, unknown>;
+}
+
+/**
+ * The eleven leaking sites objectui#9162 measured, plus the three the same
+ * instrument reaches once the class is being closed rather than the instances:
+ * `ui:card` `children` (clean on `main` only by the accident of `||` operand
+ * order — see `cardChildrenWasCleanOnlyByAccident`), and `page:card`'s `body` /
+ * `footer`, which the card's TypeScript census could not see because that
+ * renderer's `schema` is `any`.
+ */
+const SITES: readonly Site[] = [
+  { name: 'container children', type: 'container', namespace: 'ui', slot: 'children' },
+  { name: 'flex children', type: 'flex', namespace: 'ui', slot: 'children' },
+  { name: 'grid children', type: 'grid', namespace: 'ui', slot: 'children' },
+  { name: 'stack children', type: 'stack', namespace: 'ui', slot: 'children' },
+  { name: 'ui:card header', type: 'card', namespace: 'ui', slot: 'header' },
+  { name: 'ui:card body', type: 'card', namespace: 'ui', slot: 'body' },
+  { name: 'ui:card children', type: 'card', namespace: 'ui', slot: 'children' },
+  { name: 'ui:card footer', type: 'card', namespace: 'ui', slot: 'footer' },
+  { name: 'page:card body', type: 'card', namespace: 'page', slot: 'body' },
+  { name: 'page:card footer', type: 'card', namespace: 'page', slot: 'footer' },
+  { name: 'dialog footer', type: 'dialog', namespace: 'ui', slot: 'footer', base: { defaultOpen: true } },
+  { name: 'sheet footer', type: 'sheet', namespace: 'ui', slot: 'footer', base: { defaultOpen: true } },
+  { name: 'drawer footer', type: 'drawer', namespace: 'ui', slot: 'footer', base: { defaultOpen: true } },
+  {
+    name: 'table footer',
+    type: 'table',
+    namespace: 'ui',
+    slot: 'footer',
+    // Without a column the footer cell's `colSpan` is `undefined` and the row
+    // still mounts, but a header column makes the baseline text non-empty,
+    // which is what proves the table itself rendered.
+    base: { columns: [{ header: 'H', accessorKey: 'a' }], data: [] },
+  },
+];
+
+/**
+ * Render one site and read the WHOLE document's text.
+ *
+ * ⛔ Not the RTL container: Radix overlays portal to `document.body`, and
+ * reading the container alone reported three of these rows as clean when they
+ * were leaking (objectui#9162).
+ */
+function renderSite(site: Site, value: unknown): string {
+  const C = ComponentRegistry.get(site.type, site.namespace) as React.ComponentType<any>;
+  if (!C) throw new Error(`no renderer registered for ${site.namespace}:${site.type}`);
+  const schema: Record<string, unknown> = { type: site.type, ...(site.base ?? {}) };
+  if (value !== OMIT) schema[site.slot] = value;
+  render(<C schema={schema} />);
+  return document.body.textContent ?? '';
+}
+
+describe('SchemaNode slots refuse numeric-falsy authored values (objectui#9162)', () => {
+  describe('authorability — the leaked value is legal input, not a hypothetical', () => {
+    it('theValidatorAcceptsZero — the published zod face admits a number in a node slot', () => {
+      // If these go red the slots stopped admitting numbers and every row below
+      // stopped being about anything. ⛔ That is a declaration change, not a
+      // licence to delete the rows (objectui#7105: node slots relax the
+      // RENDERER, they do not narrow the declaration).
+      expect(ContainerSchemaZod.safeParse({ type: 'container', children: 0 }).success).toBe(true);
+      expect(CardSchemaZod.safeParse({ type: 'card', footer: 0 }).success).toBe(true);
+      expect(CardSchemaZod.safeParse({ type: 'card', header: 0 }).success).toBe(true);
+      expect(CardSchemaZod.safeParse({ type: 'card', body: 0 }).success).toBe(true);
+      expect(DialogSchemaZod.safeParse({ type: 'dialog', footer: 0 }).success).toBe(true);
+    });
+  });
+
+  describe.each(SITES)('$name', (site) => {
+    it('LIT CONTROL — the instrument sees this slot: 42 reaches the text', () => {
+      // Green in BOTH worlds by design. Without it a slot that rendered nothing
+      // at all — or a `document.body.textContent` read that stopped reaching
+      // the portal — would make the leak rows below green while measuring
+      // nothing at all. A leak row whose lit control is red is NOT MEASURED.
+      const baseline = renderSite(site, OMIT);
+      cleanup();
+      const lit = renderSite(site, 42);
+      expect(lit).not.toBe(baseline);
+      expect(lit).toContain('42');
+    });
+
+    it('0 does not leak', () => {
+      // RED before the repair at eleven of these rows: the `&&` chain produced
+      // the raw `0` and React painted the character.
+      const baseline = renderSite(site, OMIT);
+      cleanup();
+      expect(renderSite(site, 0)).toBe(baseline);
+    });
+
+    it('-0 does not leak — React prints it as the single character "0"', () => {
+      const baseline = renderSite(site, OMIT);
+      cleanup();
+      expect(renderSite(site, -0)).toBe(baseline);
+    });
+
+    it('NaN does not leak — the loudest row, three characters not one', () => {
+      const baseline = renderSite(site, OMIT);
+      cleanup();
+      const withNaN = renderSite(site, NaN);
+      expect(withNaN).toBe(baseline);
+      expect(withNaN).not.toContain('NaN');
+    });
+
+    it('anAuthoredNodeStillRenders — LIVE CONTROL: the slot is still a node slot', () => {
+      // The repair must not have narrowed the slot. `''`/`0` render nothing;
+      // an authored NODE must still render its content.
+      expect(renderSite(site, { type: 'text', content: 'liveNode' })).toContain('liveNode');
+    });
+
+    it('anAuthoredStringStillRenders — LIVE CONTROL: primitives are still admitted', () => {
+      expect(renderSite(site, 'liveText')).toContain('liveText');
+    });
+
+    describe('rowsThatCannotDiscriminate — ⛔ green before the repair too', () => {
+      it("false was ALREADY correct — React ignores `false` as a child", () => {
+        const baseline = renderSite(site, OMIT);
+        cleanup();
+        expect(renderSite(site, false)).toBe(baseline);
+      });
+
+      it("'' was ALREADY correct — an empty string contributes no characters", () => {
+        const baseline = renderSite(site, OMIT);
+        cleanup();
+        expect(renderSite(site, '')).toBe(baseline);
+      });
+    });
+  });
+
+  describe('the one row that was clean on `main`, and why that was not protection', () => {
+    it('cardChildrenWasCleanOnlyByAccident — `body: 0` leaked through the SAME `||` chain', () => {
+      // `ui:card` read `(schema.children || schema.body)`, and `0 || undefined`
+      // is `undefined` — so `children: 0` was converted away by accident of
+      // OPERAND ORDER, not by any guard. The proof is the sibling key: with
+      // `children` absent, `undefined || 0` is `0`, and that row leaked. Both
+      // are asserted clean above; this row states WHY the pair had to be tested
+      // together, so a later reader does not re-derive "children is protected"
+      // from the `||`.
+      const site = SITES.find((s) => s.name === 'ui:card body')!;
+      const baseline = renderSite(site, OMIT);
+      cleanup();
+      expect(renderSite(site, 0)).toBe(baseline);
+    });
+  });
+
+  describe('the control that was ALREADY fixed — it must not move (objectui#9033)', () => {
+    // `ui:header-bar`'s `rightContent` took the ternary in objectui#9033 and is
+    // the negative control for this whole census: the instrument that finds the
+    // leaking sites above must find this one clean, and must still SEE it. Its
+    // own dedicated coverage is
+    // `__tests__/header-bar-right-content-numeric-falsy.test.tsx`; this pair
+    // exists so a run of THIS file cannot report a clean sweep while the
+    // control silently regressed, and reads through the same
+    // `document.body.textContent` instrument the rows above use.
+    //
+    // `header-bar` renders `SidebarTrigger`, which calls `useSidebar()` and
+    // THROWS without a provider — caught-throw markup would read as a clean
+    // pass — so the lit control below is what proves the real header mounted.
+    function renderHeaderBar(value: unknown): string {
+      const C = ComponentRegistry.get('header-bar', 'ui') as React.ComponentType<any>;
+      if (!C) throw new Error('no renderer registered for ui:header-bar');
+      const schema: Record<string, unknown> = { type: 'header-bar', title: 'H' };
+      if (value !== OMIT) schema.rightContent = value;
+      render(
+        <SidebarProvider>
+          <C schema={schema} />
+        </SidebarProvider>,
+      );
+      return document.body.textContent ?? '';
+    }
+
+    it('LIT CONTROL — the same instrument still sees header-bar rightContent', () => {
+      const baseline = renderHeaderBar(OMIT);
+      cleanup();
+      const lit = renderHeaderBar(42);
+      expect(lit).not.toBe(baseline);
+      expect(lit).toContain('42');
+    });
+
+    it('headerBarRightContentStaysClean — GREEN BEFORE AND AFTER this change', () => {
+      // ⛔ This row must not move. It was already green on `main`; if this
+      // change had turned it red, the repair would have broken the one site
+      // that was already correct.
+      const baseline = renderHeaderBar(OMIT);
+      cleanup();
+      expect(renderHeaderBar(0)).toBe(baseline);
+      cleanup();
+      expect(renderHeaderBar(NaN)).toBe(baseline);
+    });
+  });
+});

--- a/packages/components/src/renderers/complex/table.tsx
+++ b/packages/components/src/renderers/complex/table.tsx
@@ -14,7 +14,7 @@ import { ComponentRegistry } from '@object-ui/core';
 // key declared live there must be read here; the pairing is pinned by
 // `__tests__/table-declared-equals-enforced.test.tsx`.
 import type { StaticTableColumn, TableSchema } from '@object-ui/types';
-import { renderChildren } from '../../lib/utils';
+import { renderChildren, renderNodeSlot } from '../../lib/utils';
 import { 
   Table, 
   TableHeader, 
@@ -51,16 +51,22 @@ ComponentRegistry.register('table',
           </TableRow>
         ))}
       </TableBody>
-      {schema.footer && (
+      {/* ⛔ No `&&` guard on a node slot (objectui#9162): `&&` evaluates to
+          the slot, so a legal authored `footer: 0` painted "0" into the footer
+          cell. `renderNodeSlot` runs the wrapper only when the slot has
+          content, so the whole footer row disappears with it — which is what
+          the `&&` was there for. The `typeof === 'string'` branch is gone
+          because `renderChildren` already returns a string slot as its own
+          text; the branch was a second spelling of the same answer. */}
+      {renderNodeSlot(schema.footer, (footer) => (
           <TableFooter>
               <TableRow>
                    <TableCell colSpan={schema.columns?.length}>
-                     {/* Use renderChildren to handle SchemaNode potentially being an object */}
-                     {typeof schema.footer === 'string' ? schema.footer : renderChildren(schema.footer)}
+                     {renderChildren(footer)}
                    </TableCell>
               </TableRow>
           </TableFooter>
-      )}
+      ))}
     </Table>
   ),
   {

--- a/packages/components/src/renderers/layout/card.tsx
+++ b/packages/components/src/renderers/layout/card.tsx
@@ -8,7 +8,7 @@
 
 import { ComponentRegistry } from '@object-ui/core';
 import type { CardSchema } from '@object-ui/types';
-import { renderChildren, cn } from '../../lib/utils';
+import { renderChildren, renderNodeSlot, cn } from '../../lib/utils';
 import {
   Card,
   CardHeader,
@@ -35,6 +35,14 @@ const CardRenderer = forwardRef<HTMLDivElement, { schema: CardSchema; className?
     const isClickable = schema.clickable || !!props.onClick;
     const isHoverable = schema.hoverable || isClickable;
 
+    // Node slots are rendered THROUGH the guard, never guarded by themselves
+    // (objectui#9162). `&&` evaluates to the slot, not to `false`, and the
+    // published validator admits a number in a node slot — so
+    // `{schema.header && …}` painted a stray "0" for a legal authored
+    // `header: 0`. `renderChildren` returns `null` for every falsy slot, so
+    // `header !== null` is the honest "does this header have content" test;
+    // `title`/`description` are declared `string` and are not node slots.
+    const header = renderChildren(schema.header);
     return (
     <Card 
         ref={ref}
@@ -47,15 +55,26 @@ const CardRenderer = forwardRef<HTMLDivElement, { schema: CardSchema; className?
         // Apply designer props
         {...{ 'data-obj-id': dataObjId, 'data-obj-type': dataObjType, style }}
     >
-      {(schema.title || schema.description || schema.header) && (
+      {(schema.title || schema.description || header !== null) && (
         <CardHeader>
           {schema.title && <CardTitle>{schema.title}</CardTitle>}
           {schema.description && <CardDescription>{schema.description}</CardDescription>}
-          {schema.header && renderChildren(schema.header)}
+          {header}
         </CardHeader>
       )}
-      {(schema.children || schema.body) && <CardContent>{renderChildren(schema.children || schema.body)}</CardContent>}
-      {schema.footer && <CardFooter className="flex justify-between">{renderChildren(schema.footer)}</CardFooter>}
+      {/* `||` here is ALIAS RESOLUTION — `body` is the legacy spelling of
+          `children` — and ⛔ it is no longer the guard. That distinction is
+          the whole point: `children: 0` used to be converted away by the
+          accident of `0 || undefined === undefined`, which protected nothing,
+          because the sibling `body: 0` went through `undefined || 0 === 0`
+          and leaked. `renderNodeSlot` covers both; the alias order is
+          unchanged. */}
+      {renderNodeSlot(schema.children || schema.body, (body) => (
+        <CardContent>{renderChildren(body)}</CardContent>
+      ))}
+      {renderNodeSlot(schema.footer, (footer) => (
+        <CardFooter className="flex justify-between">{renderChildren(footer)}</CardFooter>
+      ))}
     </Card>
     );
   }

--- a/packages/components/src/renderers/layout/container.tsx
+++ b/packages/components/src/renderers/layout/container.tsx
@@ -98,7 +98,14 @@ const ContainerRenderer = forwardRef<HTMLDivElement, { schema: ContainerSchema; 
         className={containerClass} 
         style={style}
       >
-        {schema.children && renderChildren(schema.children)}
+        {/* ⛔ No `&&` guard: the slot IS the left operand, so a legal
+            authored `children: 0` would render the character (objectui#9162).
+            `renderChildren` is the guard — its `isEmptyNodeSlot` first leg
+            answers every falsy input with `null`, and it is reachable only
+            because nothing short-circuits ahead of it. Pinned in
+            `renderers/__tests__/node-slot-numeric-falsy.test.tsx`; the
+            spelling is held by `object-ui/no-bare-node-slot-guard`. */}
+        {renderChildren(schema.children)}
       </div>
     );
   }

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -24,7 +24,7 @@ import type { ComponentInput } from '@object-ui/core';
 import { actionRendersAt, resolveDeclaredActionIds } from '@object-ui/types';
 import type { DeclaredActionsRefusal } from '@object-ui/types';
 import { useRecordContext, useAction, useCapabilityGate, usePredicateScope, usePageVariables, useInlineEdit, useActionTextLocalizer, useMetadataItem, reportUnresolvableVisibilityPredicate } from '@object-ui/react';
-import { renderChildren, cn } from '../../lib/utils';
+import { renderChildren, renderNodeSlot, cn } from '../../lib/utils';
 import { LazyIcon } from '../../lib/lazy-icon';
 import { RelatedCountStore, useRelatedCountVersion } from '../../hooks/related-count-store';
 import { useIsMobile } from '../../hooks/use-mobile';
@@ -936,8 +936,18 @@ const PageCardRenderer: React.FC<any> = ({ schema, className, ...props }) => {
           <CardTitle>{title}</CardTitle>
         </CardHeader>
       )}
-      {body && <CardContent>{renderChildren(body)}</CardContent>}
-      {footer && <CardFooter className="flex justify-between">{renderChildren(footer)}</CardFooter>}
+      {/* ⛔ No `&&` guard on a node slot (objectui#9162): `&&` evaluates to
+          the slot itself, so a legal authored `body: 0` painted the character
+          "0" — and this renderer's `schema` is `any`, which is why the card's
+          TypeScript census could not see these two while the runtime probe
+          could. `renderNodeSlot` invokes the wrapper only when the slot has
+          content, so the chrome disappears with it. */}
+      {renderNodeSlot(body, (node) => (
+        <CardContent>{renderChildren(node)}</CardContent>
+      ))}
+      {renderNodeSlot(footer, (node) => (
+        <CardFooter className="flex justify-between">{renderChildren(node)}</CardFooter>
+      ))}
     </Card>
   );
 };

--- a/packages/components/src/renderers/layout/flex.tsx
+++ b/packages/components/src/renderers/layout/flex.tsx
@@ -90,7 +90,14 @@ ComponentRegistry.register('flex',
         className={flexClass} 
         style={style}
       >
-        {schema.children && renderChildren(schema.children)}
+        {/* ⛔ No `&&` guard: the slot IS the left operand, so a legal
+            authored `children: 0` would render the character (objectui#9162).
+            `renderChildren` is the guard — its `isEmptyNodeSlot` first leg
+            answers every falsy input with `null`, and it is reachable only
+            because nothing short-circuits ahead of it. Pinned in
+            `renderers/__tests__/node-slot-numeric-falsy.test.tsx`; the
+            spelling is held by `object-ui/no-bare-node-slot-guard`. */}
+        {renderChildren(schema.children)}
       </div>
     );
   },

--- a/packages/components/src/renderers/layout/grid.tsx
+++ b/packages/components/src/renderers/layout/grid.tsx
@@ -165,7 +165,14 @@ ComponentRegistry.register('grid',
         className={gridClass}
         style={style}
       >
-        {schema.children && renderChildren(schema.children)}
+        {/* ⛔ No `&&` guard: the slot IS the left operand, so a legal
+            authored `children: 0` would render the character (objectui#9162).
+            `renderChildren` is the guard — its `isEmptyNodeSlot` first leg
+            answers every falsy input with `null`, and it is reachable only
+            because nothing short-circuits ahead of it. Pinned in
+            `renderers/__tests__/node-slot-numeric-falsy.test.tsx`; the
+            spelling is held by `object-ui/no-bare-node-slot-guard`. */}
+        {renderChildren(schema.children)}
       </div>
     );
   },

--- a/packages/components/src/renderers/layout/stack.tsx
+++ b/packages/components/src/renderers/layout/stack.tsx
@@ -96,7 +96,14 @@ const StackRenderer = forwardRef<HTMLDivElement, { schema: StackSchema; classNam
         className={stackClass} 
         style={style}
       >
-        {schema.children && renderChildren(schema.children)}
+        {/* ⛔ No `&&` guard: the slot IS the left operand, so a legal
+            authored `children: 0` would render the character (objectui#9162).
+            `renderChildren` is the guard — its `isEmptyNodeSlot` first leg
+            answers every falsy input with `null`, and it is reachable only
+            because nothing short-circuits ahead of it. Pinned in
+            `renderers/__tests__/node-slot-numeric-falsy.test.tsx`; the
+            spelling is held by `object-ui/no-bare-node-slot-guard`. */}
+        {renderChildren(schema.children)}
       </div>
     );
   }

--- a/packages/components/src/renderers/overlay/dialog.tsx
+++ b/packages/components/src/renderers/overlay/dialog.tsx
@@ -17,7 +17,7 @@ import {
   DialogTitle, 
   DialogDescription
 } from '../../ui';
-import { renderChildren } from '../../lib/utils';
+import { renderChildren, renderNodeSlot } from '../../lib/utils';
 
 ComponentRegistry.register('dialog', 
   ({ schema, className, ...props }: { schema: DialogSchema; className?: string; [key: string]: any }) => (
@@ -31,11 +31,16 @@ ComponentRegistry.register('dialog',
           {schema.description && <DialogDescription>{schema.description}</DialogDescription>}
         </DialogHeader>
         {renderChildren(schema.content)}
-        {schema.footer && (
+{/* ⛔ No `&&` guard on a node slot (objectui#9162): `&&` evaluates to the
+            slot, so a legal authored `footer: 0` painted the character "0" —
+            and it short-circuits, so `renderChildren`'s own falsy leg never
+            ran. `renderNodeSlot` runs the wrapper only when the slot has
+            content, so the chrome disappears with it. */}
+        {renderNodeSlot(schema.footer, (footer) => (
           <DialogFooter>
-            {renderChildren(schema.footer)}
+            {renderChildren(footer)}
           </DialogFooter>
-        )}
+        ))}
       </DialogContent>
     </Dialog>
   ),

--- a/packages/components/src/renderers/overlay/drawer.tsx
+++ b/packages/components/src/renderers/overlay/drawer.tsx
@@ -18,7 +18,7 @@ import {
   DrawerDescription,
   DrawerClose
 } from '../../ui';
-import { renderChildren } from '../../lib/utils';
+import { renderChildren, renderNodeSlot } from '../../lib/utils';
 
 ComponentRegistry.register('drawer', 
   ({ schema, className, ...props }: { schema: DrawerSchema; className?: string; [key: string]: any }) => (
@@ -32,12 +32,20 @@ ComponentRegistry.register('drawer',
           {schema.description && <DrawerDescription>{schema.description}</DrawerDescription>}
         </DrawerHeader>
         {renderChildren(schema.content)}
-        {schema.footer && (
+{/* ⛔ No `&&` guard on a node slot (objectui#9162): `&&` evaluates to the
+            slot, so a legal authored `footer: 0` painted the character "0" —
+            and it short-circuits, so `renderChildren`'s own falsy leg never
+            ran. `renderNodeSlot` runs the wrapper only when the slot has
+            content, so the chrome disappears with it. */}
+        {renderNodeSlot(schema.footer, (footer) => (
           <DrawerFooter>
-             {renderChildren(schema.footer)}
-             {schema.showClose && <DrawerClose asChild><button type="button">Close</button></DrawerClose>} 
+             {renderChildren(footer)}
+             {/* `showClose` is a declared BOOLEAN, not a node slot — its `&&`
+                 is not the objectui#9162 construct and stays. Its coupling to
+                 `footer` is pre-existing behaviour and is unchanged here. */}
+             {schema.showClose && <DrawerClose asChild><button type="button">Close</button></DrawerClose>}
           </DrawerFooter>
-        )}
+        ))}
       </DrawerContent>
     </Drawer>
   ),

--- a/packages/components/src/renderers/overlay/sheet.tsx
+++ b/packages/components/src/renderers/overlay/sheet.tsx
@@ -17,7 +17,7 @@ import {
   SheetTitle, 
   SheetDescription
 } from '../../ui';
-import { renderChildren } from '../../lib/utils';
+import { renderChildren, renderNodeSlot } from '../../lib/utils';
 
 ComponentRegistry.register('sheet', 
   ({ schema, className, ...props }: { schema: SheetSchema; className?: string; [key: string]: any }) => (
@@ -31,11 +31,16 @@ ComponentRegistry.register('sheet',
           {schema.description && <SheetDescription>{schema.description}</SheetDescription>}
         </SheetHeader>
         {renderChildren(schema.content)}
-        {schema.footer && (
+{/* ⛔ No `&&` guard on a node slot (objectui#9162): `&&` evaluates to the
+            slot, so a legal authored `footer: 0` painted the character "0" —
+            and it short-circuits, so `renderChildren`'s own falsy leg never
+            ran. `renderNodeSlot` runs the wrapper only when the slot has
+            content, so the chrome disappears with it. */}
+        {renderNodeSlot(schema.footer, (footer) => (
           <SheetFooter>
-            {renderChildren(schema.footer)}
+            {renderChildren(footer)}
           </SheetFooter>
-        )}
+        ))}
       </SheetContent>
     </Sheet>
   ),

--- a/packages/plugin-detail/src/DetailView.tsx
+++ b/packages/plugin-detail/src/DetailView.tsx
@@ -20,6 +20,7 @@ import {
   TabsList,
   TabsTrigger,
   TabsContent,
+  renderNodeSlot,
 } from '@object-ui/components';
 import { 
   ArrowLeft, 
@@ -1437,11 +1438,19 @@ export const DetailView: React.FC<DetailViewProps> = ({
         )}
 
       {/* Custom Header */}
-      {schema.header && (
+{/* ⛔ No `&&` guard on a node slot (objectui#9162): `&&` evaluates to the
+          slot itself, so a legal authored `header: 0` — the published node union
+          carries a `z.number()` arm — painted the character "0" here. Measured
+          leaking on `origin/main` at 7d6439c4b before this change; the card's
+          census listed these two as HITS, and the probe confirmed them.
+          `renderNodeSlot` runs the wrapper only when the slot has content, so
+          the wrapping `div` disappears with it. Pinned in
+          `__tests__/DetailView.nodeSlotNumericFalsy-9162.test.tsx`. */}
+      {renderNodeSlot(schema.header, (header) => (
         <div>
-          <SchemaRenderer schema={toRenderableSchema(schema.header)} data={data} />
+          <SchemaRenderer schema={toRenderableSchema(header)} data={data} />
         </div>
-      )}
+      ))}
 
       {/* Header Highlight Area */}
       {schema.highlightFields && schema.highlightFields.length > 0 && (
@@ -1920,11 +1929,19 @@ export const DetailView: React.FC<DetailViewProps> = ({
       />
 
       {/* Custom Footer */}
-      {schema.footer && (
+{/* ⛔ No `&&` guard on a node slot (objectui#9162): `&&` evaluates to the
+          slot itself, so a legal authored `footer: 0` — the published node union
+          carries a `z.number()` arm — painted the character "0" here. Measured
+          leaking on `origin/main` at 7d6439c4b before this change; the card's
+          census listed these two as HITS, and the probe confirmed them.
+          `renderNodeSlot` runs the wrapper only when the slot has content, so
+          the wrapping `div` disappears with it. Pinned in
+          `__tests__/DetailView.nodeSlotNumericFalsy-9162.test.tsx`. */}
+      {renderNodeSlot(schema.footer, (footer) => (
         <div>
-          <SchemaRenderer schema={toRenderableSchema(schema.footer)} data={data} />
+          <SchemaRenderer schema={toRenderableSchema(footer)} data={data} />
         </div>
-      )}
+      ))}
       </div>
     </TooltipProvider>
   );

--- a/packages/plugin-detail/src/__tests__/DetailView.nodeSlotNumericFalsy-9162.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailView.nodeSlotNumericFalsy-9162.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `record:detail`'s two authored node slots — `header` and `footer` — refuse a
+ * numeric-falsy authored value instead of painting it into the DOM
+ * (objectui#9162).
+ *
+ * ## Why this file exists separately from the components one
+ *
+ * objectui#9162's own probe measured eleven leaking sites in
+ * `@object-ui/components`. These two were **census hits, not measurements** —
+ * the card's TypeScript census reported them and said so, and the triage
+ * ruling made "probe before you change it, and report the reading either way"
+ * an acceptance condition. This file is that probe, kept as the pin.
+ *
+ * **Measured on `origin/main` at `7d6439c4b`, before the repair: both LEAK.**
+ * `header: 0` and `footer: 0` each painted the character `0` into the detail
+ * surface. So they are the same defect as the eleven, not merely the same
+ * shape, and they were repaired with the same guard.
+ *
+ * ## The instrument
+ *
+ * `document.body.textContent`, compared against the baseline the same harness
+ * produces with the slot omitted. Each slot carries its own LIT CONTROL — the
+ * same slot fed `42` must reach the text — so a row cannot go green because
+ * the surface stopped rendering. A leak row whose lit control does not fire is
+ * NOT MEASURED, ⛔ not clean.
+ *
+ * ## ⛔ Not a licence to narrow the declaration
+ *
+ * objectui#7105: node slots relax the RENDERER. `anAuthoredNodeStillRenders`
+ * is the live control that the repair did not turn these into objects-only or
+ * primitives-only slots.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { DetailView } from '../DetailView';
+import type { DetailViewSchema } from '@object-ui/types';
+
+afterEach(() => cleanup());
+
+/** A sentinel distinct from every authorable value, including `undefined`. */
+const OMIT = Symbol('omit');
+
+/** Minimal record surface — enough that the view mounts its slots at all. */
+const BASE: DetailViewSchema = {
+  type: 'detail-view',
+  objectName: 'thing',
+  title: 'Fixture',
+  data: { id: 'X1', qty: 3 },
+  fields: [{ name: 'qty', label: 'Qty' }],
+};
+
+function renderSlot(slot: 'header' | 'footer', value: unknown): string {
+  const schema: Record<string, unknown> = { ...BASE };
+  if (value !== OMIT) schema[slot] = value;
+  render(<DetailView schema={schema as DetailViewSchema} />);
+  return document.body.textContent ?? '';
+}
+
+describe.each(['header', 'footer'] as const)(
+  'record:detail %s — numeric-falsy node slot (objectui#9162)',
+  (slot) => {
+    it('LIT CONTROL — the instrument sees this slot: 42 reaches the text', () => {
+      // Green in BOTH worlds by design: without it, a slot that stopped
+      // rendering entirely would make the leak rows below green while
+      // measuring nothing.
+      const baseline = renderSlot(slot, OMIT);
+      cleanup();
+      const lit = renderSlot(slot, 42);
+      expect(lit).not.toBe(baseline);
+      expect(lit).toContain('42');
+    });
+
+    it('0 does not leak', () => {
+      // RED on `origin/main` at 7d6439c4b — this slot WAS leaking, the census
+      // hit was a real defect.
+      const baseline = renderSlot(slot, OMIT);
+      cleanup();
+      expect(renderSlot(slot, 0)).toBe(baseline);
+    });
+
+    it('-0 does not leak — React prints it as the single character "0"', () => {
+      const baseline = renderSlot(slot, OMIT);
+      cleanup();
+      expect(renderSlot(slot, -0)).toBe(baseline);
+    });
+
+    it('NaN does not leak — three characters, not one', () => {
+      const baseline = renderSlot(slot, OMIT);
+      cleanup();
+      const withNaN = renderSlot(slot, NaN);
+      expect(withNaN).toBe(baseline);
+      expect(withNaN).not.toContain('NaN');
+    });
+
+    it('anAuthoredNodeStillRenders — LIVE CONTROL: still a node slot', () => {
+      expect(renderSlot(slot, { type: 'text', content: 'liveNode' })).toContain('liveNode');
+    });
+
+    it('anAuthoredStringStillRenders — LIVE CONTROL: primitives still admitted', () => {
+      expect(renderSlot(slot, 'liveText')).toContain('liveText');
+    });
+
+    describe('rowsThatCannotDiscriminate — ⛔ green before the repair too', () => {
+      it('false was ALREADY correct — React ignores `false` as a child', () => {
+        const baseline = renderSlot(slot, OMIT);
+        cleanup();
+        expect(renderSlot(slot, false)).toBe(baseline);
+      });
+
+      it("'' was ALREADY correct — an empty string contributes no characters", () => {
+        const baseline = renderSlot(slot, OMIT);
+        cleanup();
+        expect(renderSlot(slot, '')).toBe(baseline);
+      });
+    });
+  },
+);

--- a/packages/plugin-report/src/ReportViewer.tsx
+++ b/packages/plugin-report/src/ReportViewer.tsx
@@ -7,7 +7,7 @@
  */
 
 import React from 'react';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription, Button, Badge, Skeleton } from '@object-ui/components';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, Button, Badge, Skeleton, renderNodeSlot } from '@object-ui/components';
 import { SchemaRenderer, toRenderableSchema } from '@object-ui/react';
 import type { ReportViewerSchema, ReportSection, ReportExportFormat, ReportField, ReportGroupBy } from '@object-ui/types';
 import { Download, Printer, RefreshCw } from 'lucide-react';
@@ -411,14 +411,22 @@ export const ReportViewer: React.FC<ReportViewerProps> = ({ schema, onRefresh })
                     inside the renderer produced an index-keyed object and the
                     section rendered the red "Unknown component type: undefined"
                     box instead of its content. Arrays are mapped here rather
-                    than widened into the renderer's declared input. */}
+                    than widened into the renderer's declared input.
+
+                    ⛔ The single-node arm carries no `&&` guard (objectui#9162):
+                    `&&` evaluates to the slot itself, so a legal authored
+                    `content: 0` — the published node union carries a
+                    `z.number()` arm — painted the character "0".
+                    `renderNodeSlot` runs the arm only when the slot has
+                    content, and `object-ui/no-bare-node-slot-guard` keeps the
+                    `&&` spelling from coming back. */}
                 {Array.isArray(section.content)
                   ? section.content.map((node, nodeIndex) => (
                       <SchemaRenderer key={nodeIndex} schema={toRenderableSchema(node)} />
                     ))
-                  : section.content && (
-                      <SchemaRenderer schema={toRenderableSchema(section.content)} />
-                    )}
+                  : renderNodeSlot(section.content, (content) => (
+                      <SchemaRenderer schema={toRenderableSchema(content)} />
+                    ))}
               </div>
             );
           })}

--- a/packages/plugin-timeline/src/renderer.tsx
+++ b/packages/plugin-timeline/src/renderer.tsx
@@ -1298,7 +1298,11 @@ export const TimelineRenderer = ({ schema, className, ...props }: { schema: Time
                   {item.description}
                 </TimelineDescription>
               )}
-              {item.content && renderChildren(item.content)}
+              {/* ⛔ No `&&` guard on a node slot (objectui#9162): `&&`
+                  evaluates to the slot, so a legal authored `content: 0`
+                  painted the character and `renderChildren`'s own falsy leg
+                  never ran. `renderChildren` IS the guard. */}
+              {renderChildren(item.content)}
             </TimelineContent>
           </TimelineItem>
         );
@@ -1353,7 +1357,9 @@ export const TimelineRenderer = ({ schema, className, ...props }: { schema: Time
                       {item.description}
                     </TimelineDescription>
                   )}
-                  {item.content && renderChildren(item.content)}
+                  {/* ⛔ No `&&` guard on a node slot — see the vertical
+                      variant above (objectui#9162). */}
+                  {renderChildren(item.content)}
                 </div>
               </div>
               {index < items.length - 1 && (


### PR DESCRIPTION
Fixes #9162

Triage ruling (`os-musk`, 2026-09-12): **取一个守卫，⛔ 不取十一个三元。闭合这个类，不是修十一个实例。**

> ⚠️ Every JSX tag in this body is written WITHOUT angle brackets (`CardFooter`, not the
> tag spelling). GitHub's body sanitizer eats tag-shaped fragments even inside backticks
> and fenced blocks, and this body is mostly about JSX (AGENTS.md, "GitHub 会改写你写进
> issue/PR 正文的字节").

## The shape I took, and why

**One guard, no ternaries.** Both halves of the ruling's preferred direction are here:

- `renderChildren(slot)` **is** the guard for a bare slot. Its first leg already answered
  every falsy input with `null`; it was simply unreachable, because `&&` short-circuits
  ahead of it. The `&&` is deleted outright at those sites — the ruling's first choice.
- `renderNodeSlot(slot, render)` (new, exported from `@object-ui/components`) is the guard
  for a slot wrapped in chrome that must disappear with it — `CardFooter`, `DialogFooter`,
  a wrapping `div`. It runs `render` **only** when the slot has content. The ruling's
  second choice, needed because the first cannot express chrome.

Both route through **one** exported predicate, `isEmptyNodeSlot`, which `renderChildren`
now calls too. So there is one guard with two call shapes, not two guards — and ⛔ zero
hand-written ternaries were added.

⛔ **No site was left mixed.** The triage fork instruction ("if some sites cannot reach the
shared guard, list them and comment them as exceptions") did not fire: **all 19** guards
reach it. There are no exceptions to list.

`plugin-detail` came closest to being one — it renders its slots as
`SchemaRenderer schema=... data={data}`, so a pre-rendered node would not have fitted. That
is why `renderNodeSlot`'s callback receives the **slot**, not a rendered node: the one
signature covers the `renderChildren` sites and the `SchemaRenderer`-with-context sites
alike.

## ⭐ How a TWELFTH slot cannot reintroduce the construct

> A new lint rule, `object-ui/no-bare-node-slot-guard` (error, repo-wide over `**/*.tsx`),
> refuses any `&&` in JSX child position whose left operand is a node slot — and it decides
> what a node slot **is** by derivation, not by a list of names. An expression is a node
> slot in a file if **that file hands it to a node renderer**: `renderChildren(x)`,
> `renderNodeSlot(x, …)`, `toRenderableSchema(x)`, or `SchemaRenderer schema={x}`. Writing
> a twelfth slot means rendering it through one of those — that is what rendering a node
> *is* — so the rule sees the new slot in the same commit that introduces it, and the
> `&&` spelling fails CI with no list to update and nothing for anyone to remember.

That derivation is the load-bearing choice. A rule keyed on slot **names** (`children`,
`footer`, …) would have been objectui#9033's mistake one level up: right for today's names,
silent on the twelfth. The rule's spec pins exactly that — a `schema.sidePanel` guard, a
name that exists nowhere in this repo, is an `invalid` case.

Three further properties make it a closure rather than a warning:

1. **It is type-free.** The card's TypeScript census could not see sites whose `schema` is
   `any` — 53 operands it reported as *indeterminate* rather than clean. A syntactic
   derivation has no such blind spot, which is how the four extra defects below were found.
2. **The `||` chain is flattened.** `(schema.title || schema.description || schema.header) && …`
   leaks for the same reason (`undefined || 0` is `0`), so the rule looks through the chain,
   not only at the immediate left operand.
3. **The correct forms stay writable.** A declared boolean (`schema.showClose`), a declared
   string (`schema.title`), a comparison, and an `&&` in **attribute** position (handed to a
   component, not to React's child reconciler) are all `valid` cases.

## The eleven sites, each shown fixed

Every row measured through the real renderer stack, reading `document.body.textContent`
(⛔ not the RTL container — Radix portals out, which is how the card's own first probe
misread three overlay rows as clean). Every row carries its own **lit control**: the same
slot fed `42` must reach the text, or the row is NOT MEASURED rather than clean. All 14
lit controls fired in both runs.

Pin: `packages/components/src/renderers/__tests__/node-slot-numeric-falsy.test.tsx`.

| # | renderer · slot | before (`0`) | after (`0`) | lit control (`42`) |
|---|---|---|---|---|
| 1 | `container` · `children` | LEAK `'0'` | clean `''` | fired |
| 2 | `flex` · `children` | LEAK `'0'` | clean `''` | fired |
| 3 | `grid` · `children` | LEAK `'0'` | clean `''` | fired |
| 4 | `stack` · `children` | LEAK `'0'` | clean `''` | fired |
| 5 | `ui:card` · `header` | LEAK `'0'` | clean `''` | fired |
| 6 | `ui:card` · `body` | LEAK `'0'` | clean `''` | fired |
| 7 | `ui:card` · `footer` | LEAK `'0'` | clean `''` | fired |
| 8 | `dialog` · `footer` | LEAK `'0Close'` | clean `'Close'` | fired |
| 9 | `sheet` · `footer` | LEAK `'0Close'` | clean `'Close'` | fired |
| 10 | `drawer` · `footer` | LEAK `'0'` | clean `''` | fired |
| 11 | `table` · `footer` | LEAK `'H0'` | clean `'H'` | fired |

`-0` and `NaN` are asserted on every row too (`NaN` paints three characters, not one).
`false` and `''` are asserted and explicitly labelled `rowsThatCannotDiscriminate` — green
before **and** after, kept only so a later reader does not mistake them for evidence.

### `ui:card` `children` — the one row the card measured clean, and why it was not protection

Asserted here as row 12. It was clean only by the accident of operand order:
`(schema.children || schema.body)` turns `0 || undefined` into `undefined`. The proof it was
not a guard is the sibling one line up — `undefined || 0` is `0`, which is row 6. The `||`
survives as **alias resolution** (`body` is the legacy spelling of `children`, order
unchanged) and ⛔ no longer as the guard, exactly as the triage warning required.

## Four more of the same defect, from the bucket the card said was not empty

Triage acceptance #4 asked what becomes of the 53 `any`/`unknown` operands the census could
not judge. Answer: **the bucket is retired, not handed on** — the closure instrument needs
no types, so those operands are now covered like every other. Running it over the tree
surfaced four real defects inside that bucket, all repaired here:

- `page:card` · `body` and `footer` (`layout/containers.tsx`) — this renderer's `schema` is
  `any`, which is precisely why the card could not count them. Both **measured leaking**;
  both are rows 13–14 of the pin above.
- `plugin-timeline` · `item.content`, twice (vertical and horizontal variants). Same
  `renderChildren` shape as `container`.
- `plugin-report` · `section.content` (the single-node arm; the array arm was already
  correct and is untouched, objectui#4548).

## `plugin-detail`'s two sites — probed before they were touched

Triage acceptance #3: census hits, not measurements; probe first and report either way.

**Measured on `origin/main` at `7d6439c4b`: both LEAK.** `header: 0` gave
`'Fixturething0Qty3'` against a baseline of `'FixturethingQty3'`; `footer: 0` gave
`'FixturethingQty30'`. `NaN` painted three characters on both. So they are the same defect
as the eleven, not merely the same shape. Both lit controls fired.

Pin: `packages/plugin-detail/src/__tests__/DetailView.nodeSlotNumericFalsy-9162.test.tsx`.

## The control, shown unmoved

`header-bar` · `rightContent` took objectui#9033's ternary and is the negative control for
the whole census. It is unmoved in both senses:

- **Source**: the lint rule reports **zero** on `header-bar.tsx`, on `main` and on this
  branch. The ternary is an explicit `valid` case in the rule's spec — if the rule flagged
  it, the census could not tell a repaired site from an unrepaired one.
- **Runtime**: the new pin renders `header-bar` through the **same**
  `document.body.textContent` instrument, with its own lit control, and asserts `0` and
  `NaN` clean. Green before this change and green after; ⛔ this row must never move.

Its own dedicated coverage (`header-bar-right-content-numeric-falsy.test.tsx`) is untouched
and still passes.

## Proof the assertions fail on unmodified code

Both pins were written and run **before** any renderer was edited.

`packages/components/.../node-slot-numeric-falsy.test.tsx` on the unmodified tree:
`40 failed | 75 passed (115)` — 13 sites x 3 discriminating values, plus the
`cardChildrenWasCleanOnlyByAccident` row. ⭐ **Not one lit control was among the failures**,
so every red is a measurement and not a blind instrument. After the repair: `116 passed`.

`packages/plugin-detail/.../DetailView.nodeSlotNumericFalsy-9162.test.tsx` on the unmodified
`DetailView`: `6 failed | 10 passed (16)`. After: `16 passed`.

The lint rule has the same before/after, on the same tree: **19 reports across 8 files**
before, **0 across 2702 linted files** after — with `header-bar` reported by neither, which
is the control that the instrument discriminates rather than reporting nothing.

## Changeset level: `minor`

`.changeset/9162-node-slot-guard-class-closure.md`. Two reasons, and ⛔ deliberately **not**
carrying a `**BREAKING**` marker:

1. `@object-ui/components` gains public API — `renderNodeSlot` and `isEmptyNodeSlot` are new
   exports. A new export is a `minor` on its own, before any behaviour is considered.
2. Published renderers change what they emit for two authored inputs. A slot authored
   `0` / `-0` / `NaN` stops painting that character — that is the defect, and no author asked
   for it. A slot authored `[]` stops rendering **empty chrome** (an empty `CardHeader` /
   `CardContent` / `CardFooter` / the overlay footers / `TableFooter`, or `plugin-detail`'s
   wrapping `div`); chrome now appears and disappears with its content.

The second point is the one the dispatch asked me to weigh. Weighed, and measured rather
than asserted: across `examples/`, `content/` and `apps/`, **zero** authored node slots carry
a numeric value, and the single authored empty-array slot (`content/docs/utilities/vscode-extension.mdx`)
is on `div`, which never had the `&&` guard and is unaffected. No authored input stops being
accepted, no export is removed, no key stops being read, and objectui#7105 is respected — the
declarations are untouched and node slots still relax the renderer. An author who genuinely
wants the character `0` writes `"0"` or a `text` node; both are unchanged.

`major` is unavailable here by construction (one `fixed` group of 41 packages —
`check-changeset-no-major.mjs`, run by `changeset-guard.yml`).

## Acceptance notes

Out-of-scope observations, noted and ⛔ not filed:

- `drawer`'s `showClose` button only renders when `footer` is non-empty, because it lives
  inside the footer chrome. That coupling is pre-existing, unchanged here, and is a product
  question rather than a defect. Carrier: whoever next touches `overlay/drawer.tsx`.
- `renderChildren` unwraps a single-element array without routing it through
  `toRenderableSchema`, so a one-element array of a primitive takes a different path from a
  bare primitive. Not reachable from any guard changed here, and not a leak. Carrier: none.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session (as prose, because footers get rewritten): `https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ`

_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_
## Verification run (added after the local gates converged)

Gate family derived by hand from `package.json` + `.github/workflows/` (this repo has no
`scripts/pm/dispatch-gates.mjs`). Every line below is the gate's own exit code, captured
before any pipe.

| gate | result |
|---|---|
| `pnpm --filter ...^... build` (dependency closure) + full `pnpm build` | 0 |
| `type-check` — components, plugin-detail, plugin-report, plugin-timeline | 0 |
| `pnpm lint` (turbo, 47/47 packages — the new rule runs repo-wide) | 0 |
| `pnpm lint:root` | 0 errors, 32 pre-existing warnings, **none** in the new files |
| `changeset:check` (`check-changeset-fixed` + `check-changeset-no-major`) | 0 + 0 |
| `check:changeset-claims`, `check:control-bytes`, `check:test-path-roots` | 0 |
| `check:lint-rule-coverage`, `check:lint-coverage`, `check:vi-mock-override-shape` | 0 |
| `check:unreferenced-sources`, `check:side-effects-array`, `check:self-import`, `check:phantom-deps` | 0 |
| `check:doc-example-readers`, `check:new-line-citations` | 0 |
| `check:readme-exports` (after full build) | 0 — 3354 exports read from 37/40 packages |
| `check:sdui-registration-pins` (after console build) | 0 — 16/16 registrations present |
| targeted `vitest run` — the 4 changed packages + `examples/schema-catalog/` + `eslint-rules/` | 526 files / 7061 tests, all passing |
| full `pnpm test` | 3041 passed / 1 failed (3044 files); 40027 passed / 1 failed (40032 tests) |

⚠️ `check:changeset-no-major` was reachable here as an npm script and exited 0; the gate CI
actually runs is `changeset-guard.yml`, which was run in the same form.

### The one full-suite failure is objectui#9124, not this change

`scripts/__tests__/check-side-effects-array.test.ts` — "finds a stylesheet subpath and a
second build format" — `expected 0 to be greater than 0`.

Diagnosed with a two-tree control rather than asserted. The whole workspace has exactly
**one** alternate-format entry, `@object-ui/layout :: dist/index.umd.cjs`, and it only
counts as one while that file is **absent**: `classifyEntryForms` reclassifies a published
form as a real module the moment it exists on disk. So the test is green on an unbuilt tree
and red on a built one.

- BASE `7d6439c4b` in a separate worktree, unbuilt: `44 passed`, alternate-format count 1.
- This branch, after `pnpm build`: `1 failed | 43 passed`, alternate-format count 0.
- `packages/layout/dist/` is git-ignored build output; this diff touches **zero** files under
  `packages/layout` and **zero** `package.json`.
- CI's test job installs and runs `pnpm test` with no build step, so CI sees the unbuilt tree.

That is already an open card — objectui#9124, "check-side-effects-array.test.ts reds on any
tree where `packages/layout/dist/index.umd.cjs` exists". Nothing new filed.


---
_Generated by [Claude Code](https://claude.ai/code)_