### PR TITLE
test(app-shell): widen the declared-default ledger to every declaring field, with per-node-type spec schemas

### DIFF
--- a/.changeset/issue-9109-widen-default-ledger.md
+++ b/.changeset/issue-9109-widen-default-ledger.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: the flow-node designer's declared-default ledger now walks every declaring field against its own per-node-type spec schema instead of stopping at the approval-escalation block. No published source file moves — `@object-ui/app-shell` publishes `dist` and `src/styles.css`, and the only file touched is a `*.test.ts` under `src/views/`. Recording, not releasing (objectui#9109).

--- a/.changeset/issue-9109-widen-default-ledger.md
+++ b/.changeset/issue-9109-widen-default-ledger.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Test-only: the flow-node designer's declared-default ledger now walks every declaring field against its own per-node-type spec schema instead of stopping at the approval-escalation block. No published source file moves — `@object-ui/app-shell` publishes `dist` and `src/styles.css`, and the only file touched is a `*.test.ts` under `src/views/`. Recording, not releasing (objectui#9109).
+Test-only: the flow-node designer's declared-default ledger now walks every declaring field against its own per-node-type spec schema instead of stopping at the approval-escalation block. Two files move — the reconciliation test itself, and one doc comment in `flow-node-config.ts` that described the ledger's old narrow scope and would otherwise have been left stating something untrue. No declaration, option list, control or rendered value changes; `@object-ui/app-shell` publishes `dist` and `src/styles.css`, and none of the eight publish-contract fields moved. Recording, not releasing (objectui#9109).

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.spec-reconciliation.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.spec-reconciliation.test.ts
@@ -30,12 +30,15 @@
  * the sibling-block panels run against every spec version this repo supports.
  */
 
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import * as Automation from '@objectstack/spec/automation';
 // The Zod wrapper-key vocabulary — one list, read by the `.mjs` CI gates that
 // walk the same internals (objectui#6923, ruled 2026-08-31).
 import { ZOD_WRAPPER_KEYS } from '@object-ui/test-support';
-import { fieldsForNodeType, type FlowConfigField } from './flow-node-config';
+import { fieldsForNodeType, FLOW_NODE_TYPE_OPTIONS, type FlowConfigField } from './flow-node-config';
 
 // Feature-detected exports — absent on a spec that predates framework#4278.
 // (Truthiness alone never resolves a lazySchema proxy.)
@@ -284,7 +287,8 @@ describe('sibling-block forms ↔ FlowNodeSchema blocks (framework#4278 ratchet)
 });
 
 /**
- * **Declared defaults ↔ spec defaults — the whole escalation block** (#6794, #6620).
+ * **Declared defaults ↔ spec defaults — EVERY declaring field** (#6794, #6620,
+ * objectui#9109).
  *
  * Everything above is a KEY-set ledger: it proves the form edits exactly the
  * keys the executor reads. The default a field DECLARES is the other axis, and
@@ -292,113 +296,379 @@ describe('sibling-block forms ↔ FlowNodeSchema blocks (framework#4278 ratchet)
  * no `defaultValue` at all while the spec defaults the key to `true` (#6794),
  * then `escalation.enabled`, which declared `'false'` against a spec that had
  * flipped to `.default(true)` (#6620). Not cosmetic: `defaultValue` is what
- * `controllerAdmits` resolves an unset controller against and what a `boolean`
- * control seeds from, and it is what the ONLINE half of this form already
- * carries (a published `configSchema` sends `default: true`, which
- * `json-schema-to-fields` turns into `defaultValue: 'true'`) — so offline and
+ * `controllerAdmits` resolves an unset controller against, what a `boolean`
+ * control seeds from, and (since objectui#6830 arm A) what a `select` control
+ * states as its placeholder — and it is what the ONLINE half of this form
+ * already carries (a published `configSchema` sends `default: true`, which
+ * `json-schema-to-fields` turns into `defaultValue: 'true'`), so offline and
  * online rendered the same node from two different claims about the spec.
  *
- * ⭐ **Why this is now block-wide, and why it is the point of #6620.** The
- * previous revision scoped this to `notifySubmitter` ALONE and said so, to avoid
- * arming an on-hold card from an unrelated PR. The cost of that scoping was the
- * card's real defect: `escalation.enabled` had a "tripwire" in
- * `flow-node-config.inactiveRetained.test.ts` that reads only the TABLE, so a
- * spec bump could never redden anything — the divergence went live and stayed
- * invisible until a human happened to re-read the spec. A one-directional check
- * is not a check. This ledger walks whatever the installed spec materialises, so
- * the NEXT flip, on any key in the block, reddens here on the bump itself.
+ * ⭐ **Why this is now table-wide, and why that is objectui#9109.** The previous
+ * revision walked `field.path[1] === 'escalation'` ALONE, and said so: the
+ * scoping was deliberate while objectui#6620 was on hold. objectui#6620 closed
+ * on 2026-09-08 and the reason is spent — but the cost of that scoping had
+ * already been paid, because FOUR declarations outside the escalation block
+ * were claiming a default the installed spec applies none of, and nothing
+ * reddened. A ledger that stops one block short is the same defect as no
+ * ledger, one block later. This walks every node type in `FLOW_NODE_CONFIG`
+ * against its OWN spec schema, so a declaration cannot sit outside it.
  *
  * The expected values are READ FROM THE INSTALLED SPEC, never spelled out here:
  * objectui is the consumer, and a literal restates exactly the claim that
  * drifts — it would pass just as happily on the next upstream flip.
+ *
+ * ⛔ **What this file does NOT decide.** Both registers below record live
+ * divergences rather than asserting them away, and neither register is a
+ * waiver: every entry re-measures the spec state it claims, and the register
+ * sets must match the measured divergence sets EXACTLY, so an entry cannot
+ * outlive the divergence and a new divergence cannot hide behind one. Which END
+ * of each divergence to move — delete the declaration, or back it upstream — is
+ * a product call this repo cannot make alone (objectui#9109 triage fence 2), and
+ * a test is the wrong place to make it.
  */
-describe('approval escalation: declared defaults ↔ ApprovalEscalationSchema (#6794, #6620)', () => {
+describe('declared defaults ↔ per-node-type spec schemas (#6794, #6620, objectui#9109)', () => {
   // ⛔ The subpath is load bearing. `ApprovalEscalationSchema` is NOT on the
   // package root: `require('@objectstack/spec').ApprovalEscalationSchema` is
   // `undefined`, so a probe written that way dies with `Cannot read properties
   // of undefined` — a failure that reads as "the spec does not have it yet" and
   // sends the reader back to waiting. #6620 sat on hold behind exactly that
   // misreading. This file's own `import * as Automation` is the working spelling.
-  const EscalationSchema = spec.ApprovalEscalationSchema as
-    | { safeParse: (value: unknown) => { success: boolean; data?: Record<string, unknown> } }
-    | undefined;
-
-  /** The block's only REQUIRED key. Supplied as input, so never a default. */
-  const SUPPLIED: Record<string, unknown> = { timeoutHours: 24 };
+  const flowNodeShape = objectShape(spec.FlowNodeSchema);
 
   /**
-   * Every key the spec MATERIALISES from an omitted-key block, with its value —
-   * the runtime's own answer to "what does this node actually do", read fresh.
+   * The node-type universe, read from the TABLE'S OWN SOURCE rather than from a
+   * hand-kept list.
    *
-   * Keys we supplied are subtracted: `timeoutHours` comes back only because we
-   * sent it, and counting it would demand the form declare a default for a
-   * required key that has none.
+   * `FLOW_NODE_CONFIG` is module-private and `fieldsForNodeType` answers `[]`
+   * for a type it has never heard of, so a type added to the table but missing
+   * from a hand-kept list contributes zero fields and the ledger reports a
+   * confident nothing — which is precisely how the four declarations this card
+   * is about stayed invisible. Enumerating from the source makes the TOTAL come
+   * from the same place the readings come from (AGENTS.md: "当一次扫描的「总体」
+   * 和「逐项读取」来自不同来源时,对照必须取自总体那一侧").
+   *
+   * Rooted at `import.meta.url`, never `process.cwd()` — the cwd differs between
+   * the repo-root and package-level invocations (objectui#7791/#7799).
    */
-  function specDefaults(): Record<string, unknown> {
-    expect(
-      EscalationSchema,
-      '@objectstack/spec/automation must export ApprovalEscalationSchema',
-    ).toBeDefined();
-    const parsed = EscalationSchema!.safeParse({ ...SUPPLIED });
-    expect(parsed.success, 'a minimal escalation block must parse').toBe(true);
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(parsed.data ?? {})) if (!(k in SUPPLIED)) out[k] = v;
-    return out;
+  function nodeTypesFromSource(): string[] {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const src = fs.readFileSync(path.join(here, 'flow-node-config.ts'), 'utf8');
+    const open = src.indexOf('const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {');
+    expect(open, 'FLOW_NODE_CONFIG must still be declared with this signature').toBeGreaterThan(-1);
+    const close = src.indexOf('\n};', open);
+    expect(close, 'FLOW_NODE_CONFIG must still close at column 0').toBeGreaterThan(open);
+    return [...src.slice(open, close).matchAll(/^ {2}([A-Za-z_][A-Za-z0-9_]*):/gm)].map((m) => m[1]!);
   }
 
-  /** The approval form's escalation fields, keyed by the spec key each edits. */
-  function escalationFields(): Map<string, FlowConfigField> {
-    const out = new Map<string, FlowConfigField>();
-    for (const f of fieldsForNodeType('approval')) {
-      if (f.path[0] === 'config' && f.path[1] === 'escalation' && f.path[2]) out.set(f.path[2], f);
+  const NODE_TYPES = nodeTypesFromSource();
+
+  it('the node-type enumeration is live, not an empty regex', () => {
+    // The positive control for the scan above. A regex that stopped matching
+    // returns `[]`, and every walk below would then pass over nothing — the
+    // vacuous-green shape this whole file exists to prevent. Aliases need no
+    // sweep of their own: `fieldsForNodeType` resolves every alias to one of
+    // these canonical tables, so walking the table keys walks every field.
+    expect(NODE_TYPES.length, 'FLOW_NODE_CONFIG declares node types').toBeGreaterThan(20);
+    expect(NODE_TYPES, 'and the picker types are among them').toEqual(
+      expect.arrayContaining([...FLOW_NODE_TYPE_OPTIONS]),
+    );
+    expect(NODE_TYPES, 'including the off-picker tables a picker-only sweep would miss').toEqual(
+      expect.arrayContaining(['boundary_event', 'notify', 'legacy_action', 'join_gateway']),
+    );
+  });
+
+  /**
+   * One reconcilable region of the form: the fields under `prefix`, and the
+   * spec schema that decides what an omitted key there actually does.
+   *
+   * `supplied` names the region's REQUIRED keys. They are sent as input so the
+   * parse can succeed, then subtracted from the materialised result — counting
+   * them would demand the form declare a default for a key that has none.
+   */
+  interface DefaultScope {
+    readonly type: string;
+    readonly prefix: readonly string[];
+    readonly schema: () => unknown;
+    readonly supplied: Record<string, unknown>;
+  }
+
+  const SCOPES: readonly DefaultScope[] = [
+    {
+      type: 'approval',
+      prefix: ['config'],
+      schema: () => spec.ApprovalNodeConfigSchema,
+      supplied: { approvers: [{ type: 'user', value: 'u1' }] },
+    },
+    {
+      type: 'approval',
+      prefix: ['config', 'escalation'],
+      schema: () => spec.ApprovalEscalationSchema,
+      supplied: { timeoutHours: 24 },
+    },
+    {
+      type: 'http_request',
+      prefix: ['config'],
+      schema: () => spec.HttpConfigSchema,
+      supplied: { url: 'https://example.invalid/x' },
+    },
+    { type: 'screen', prefix: ['config'], schema: () => spec.ScreenConfigSchema, supplied: {} },
+    {
+      type: 'wait',
+      prefix: ['waitEventConfig'],
+      schema: () => unwrapped(flowNodeShape?.waitEventConfig),
+      supplied: { eventType: 'timer' },
+    },
+    {
+      type: 'boundary_event',
+      prefix: ['boundaryConfig'],
+      schema: () => unwrapped(flowNodeShape?.boundaryConfig),
+      supplied: { attachedToNodeId: 'n1', eventType: 'error' },
+    },
+  ];
+
+  const scopeId = (type: string, prefix: readonly string[]) => `${type}:${prefix.join('.')}`;
+
+  /** Every field in the table that DECLARES a default, with the scope it sits in. */
+  function declaringFields(): Array<{ scope: string; key: string; field: FlowConfigField }> {
+    const out: Array<{ scope: string; key: string; field: FlowConfigField }> = [];
+    for (const type of NODE_TYPES) {
+      for (const field of fieldsForNodeType(type)) {
+        if (field.defaultValue === undefined) continue;
+        out.push({
+          scope: scopeId(type, field.path.slice(0, -1)),
+          key: field.path[field.path.length - 1]!,
+          field,
+        });
+      }
     }
     return out;
   }
 
+  /** The form fields inside one scope, keyed by the spec key each edits. */
+  function fieldsInScope(scope: DefaultScope): Map<string, FlowConfigField> {
+    const out = new Map<string, FlowConfigField>();
+    for (const f of fieldsForNodeType(scope.type)) {
+      if (f.path.length !== scope.prefix.length + 1) continue;
+      if (!scope.prefix.every((seg, i) => f.path[i] === seg)) continue;
+      out.set(f.path[f.path.length - 1]!, f);
+    }
+    return out;
+  }
+
+  /**
+   * Every key the spec MATERIALISES from an omitted-key region, with its value —
+   * the runtime's own answer to "what does this node actually do", read fresh.
+   */
+  function specDefaults(scope: DefaultScope): Record<string, unknown> {
+    const schema = scope.schema() as
+      | { safeParse: (v: unknown) => { success: boolean; data?: Record<string, unknown> } }
+      | undefined;
+    expect(
+      schema?.safeParse,
+      `@objectstack/spec/automation must expose a parseable schema for ${scopeId(scope.type, scope.prefix)}`,
+    ).toBeTypeOf('function');
+    const parsed = schema!.safeParse({ ...scope.supplied });
+    expect(parsed.success, `a minimal ${scopeId(scope.type, scope.prefix)} region must parse`).toBe(true);
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(parsed.data ?? {})) if (!(k in scope.supplied)) out[k] = v;
+    return out;
+  }
+
+  /**
+   * ⛔ **The two registers — live divergences, recorded, not waived.**
+   *
+   * ⭐ The four unbacked declarations are NOT one class, and a register that
+   * recorded them as one would be wrong about half of them (objectui#9109
+   * measurement comment, 2026-09-11). Each entry therefore carries the spec
+   * state it claims, and `state` is RE-MEASURED below — an entry whose claim
+   * stops being true reddens as loudly as an unregistered divergence.
+   *
+   * - `required-no-default` — the spec key is REQUIRED. There is no runtime
+   *   default to state: an omitted key does not behave as the declared value,
+   *   it FAILS TO PARSE. "Unset behaves as X" is not merely unbacked here, it
+   *   is the wrong SHAPE of statement, and both of these already have on-screen
+   *   effect — each gates siblings through `controllerAdmits` on a node that
+   *   stored no value at all.
+   * - `optional-no-default` — the spec key is OPTIONAL and the installed Zod
+   *   materialises nothing for it. ⚠️ That is a statement about SCHEMA
+   *   DEFAULTING and nothing else: the flow EXECUTOR lives in `objectstack`,
+   *   `@objectstack/spec` is only the parse contract, so whether the engine
+   *   applies `GET` / create-mode when it runs the node is **NOT MEASURED**
+   *   here — ⛔ not "measured false". If it does, the fix is upstream and this
+   *   register entry is how the two ends stay connected.
+   */
+  const UNBACKED_REGISTER: ReadonlyArray<{
+    region: string;
+    key: string;
+    state: 'required-no-default' | 'optional-no-default';
+  }> = [
+    { region: 'wait:waitEventConfig', key: 'eventType', state: 'required-no-default' },
+    { region: 'boundary_event:boundaryConfig', key: 'eventType', state: 'required-no-default' },
+    { region: 'http_request:config', key: 'method', state: 'optional-no-default' },
+    { region: 'screen:config', key: 'mode', state: 'optional-no-default' },
+  ];
+
+  /**
+   * The other direction's register: the spec APPLIES a default and the form
+   * field for that key declares none — the #6794 shape exactly, found by this
+   * widening in two places the escalation-only walk could never reach.
+   * Filed separately; ⛔ not fixed here, because adding a declaration moves the
+   * ten-field acceptance pin objectui#6830 deliberately placed in
+   * `FlowNodeInspector.declaredDefault.test.tsx` and creates an on-screen claim,
+   * neither of which is this card's to decide.
+   */
+  const UNDECLARED_REGISTER: ReadonlyArray<{ region: string; key: string }> = [
+    { region: 'approval:config', key: 'lockRecord' },
+    { region: 'boundary_event:boundaryConfig', key: 'interrupting' },
+  ];
+
+  // ⚠️ `region`, not `scope`: vitest reads `$a.$b` in an `it.each` title as the
+  // PATH `a.$b`, so a dotted pair of placeholders renders `undefined` and every
+  // register row gets the same nameless title. The separator below keeps both
+  // halves addressable.
+  const rowId = (r: { region: string; key: string }) => `${r.region}.${r.key}`;
+
   it('the gate `enabled` is inside the ledger — and the ledger is not empty', () => {
-    // THE VACUITY GUARD, and the reason it names a key. Both assertions below
-    // iterate `specDefaults()`; a spec that stopped materialising anything would
-    // make each of them pass over an empty collection, which is the shape #6620's
-    // old tripwire failed in. This row fails instead — and it names `enabled`
-    // because that is the key the card was about, so the ledger's coverage of it
-    // is visible in a test name rather than only inferable from a loop.
-    const defaults = specDefaults();
+    // THE VACUITY GUARD, and the reason it names a key. Every walk below
+    // iterates materialised defaults; a spec that stopped materialising
+    // anything would make each of them pass over an empty collection, which is
+    // the shape #6620's old tripwire failed in. This row fails instead — and it
+    // names `enabled` because that is the key that card was about, so the
+    // ledger's coverage of it is visible in a test name rather than only
+    // inferable from a loop.
+    const escalation = SCOPES.find((s) => scopeId(s.type, s.prefix) === 'approval:config.escalation')!;
+    const defaults = specDefaults(escalation);
     expect(Object.keys(defaults).length, 'the spec materialises at least one default here').toBeGreaterThan(0);
     expect(typeof defaults.enabled, 'the spec materialises `enabled` from an omitted key').toBe('boolean');
+
+    const everything = SCOPES.flatMap((s) => Object.keys(specDefaults(s)));
+    expect(everything.length, 'and the table-wide walk materialises defaults in more than one scope').toBeGreaterThan(
+      Object.keys(defaults).length,
+    );
+  });
+
+  it('every declaring field in the whole table sits inside a scope', () => {
+    // ⭐ THE RATCHET, and the whole point of objectui#9109. The old walk was
+    // `field.path[1] === 'escalation'`, so four declarations sat outside it and
+    // nothing reddened. A declaration added anywhere the `SCOPES` table does not
+    // cover now fails HERE, naming itself — it can no longer go unchecked by
+    // being somewhere nobody looked.
+    const uncovered = declaringFields()
+      .filter((d) => !SCOPES.some((s) => scopeId(s.type, s.prefix) === d.scope))
+      .map((d) => `${d.scope}.${d.key} declares ${JSON.stringify(d.field.defaultValue)} with no spec scope to check it against`);
+    expect(uncovered, 'add a DefaultScope for this region, with the spec schema that governs it').toEqual([]);
+    // …and the scopes are not all empty, which is the way the line above lies.
+    expect(declaringFields().length, 'the table still declares defaults at all').toBeGreaterThan(5);
   });
 
   it('every default the spec applies is declared by the form, with the same value', () => {
-    const fields = escalationFields();
     const mismatches: string[] = [];
-    for (const [key, value] of Object.entries(specDefaults())) {
-      const field = fields.get(key);
-      if (!field) {
-        mismatches.push(`${key}: the spec defaults it, the form offers no field for it`);
-        continue;
-      }
-      // Defaults are strings in this table — booleans spelled 'true' / 'false',
-      // the spelling `controllerAdmits` compares a controller against.
-      if (field.defaultValue !== String(value)) {
-        mismatches.push(
-          `${key}: the form declares ${JSON.stringify(field.defaultValue)}, the spec applies ${JSON.stringify(String(value))}`,
-        );
+    const noField: string[] = [];
+    const undeclared: string[] = [];
+    for (const scope of SCOPES) {
+      const id = scopeId(scope.type, scope.prefix);
+      const fields = fieldsInScope(scope);
+      for (const [key, value] of Object.entries(specDefaults(scope))) {
+        const field = fields.get(key);
+        if (!field) {
+          noField.push(`${id}.${key}: the spec defaults it, the form offers no field for it`);
+        } else if (field.defaultValue === undefined) {
+          undeclared.push(`${id}.${key}`);
+        } else if (field.defaultValue !== String(value)) {
+          // Defaults are strings in this table — booleans spelled 'true' /
+          // 'false', the spelling `controllerAdmits` compares a controller
+          // against.
+          mismatches.push(
+            `${id}.${key}: the form declares ${JSON.stringify(field.defaultValue)}, the spec applies ${JSON.stringify(String(value))}`,
+          );
+        }
       }
     }
     expect(
       mismatches,
       'the hand-written table must state what an omitted key actually does at runtime',
     ).toEqual([]);
+    expect(
+      noField,
+      'a spec default with no field at all is a key-set hole, never a registerable divergence',
+    ).toEqual([]);
+    expect(
+      undeclared.sort(),
+      'the spec applies a default the form states nowhere — register it or declare it',
+    ).toEqual(UNDECLARED_REGISTER.map(rowId).sort());
   });
 
   it('and the form declares no default the spec does not apply', () => {
-    // The other direction, and not symmetric decoration: a `defaultValue` with no
-    // spec counterpart is a claim about the contract with nothing behind it, and
-    // it is ACTED ON — it resolves a `showWhen` controller and seeds a boolean
-    // control off a value the runtime never applies.
-    const defaults = specDefaults();
-    const invented = [...escalationFields()]
-      .filter(([key, f]) => f.defaultValue !== undefined && !(key in defaults))
-      .map(([key, f]) => `${key}: the form declares ${JSON.stringify(f.defaultValue)}, the spec applies none`);
-    expect(invented, 'a declared default with no spec counterpart').toEqual([]);
+    // The other direction, and not symmetric decoration: a `defaultValue` with
+    // no spec counterpart is a claim about the contract with nothing behind it,
+    // and it is ACTED ON — it resolves a `showWhen` controller, seeds a boolean
+    // control, and states itself as a select trigger's placeholder, off a value
+    // the runtime never applies.
+    const byScope = new Map(SCOPES.map((s) => [scopeId(s.type, s.prefix), specDefaults(s)]));
+    const invented = declaringFields()
+      .filter((d) => byScope.has(d.scope) && !(d.key in byScope.get(d.scope)!))
+      .map((d) => rowId({ region: d.scope, key: d.key }));
+    expect(
+      invented.sort(),
+      'a declared default with no spec counterpart — register it or remove it',
+    ).toEqual(UNBACKED_REGISTER.map(rowId).sort());
   });
+
+  it.each(UNBACKED_REGISTER)(
+    'register row $region · $key still measures as $state',
+    ({ region: id, key, state }) => {
+      // ⛔ A register entry is an ASSERTION, never a waiver: it re-measures the
+      // spec state it claims. An entry that outlives its divergence (the key
+      // gained a `.default()`, or turned optional) reddens here, which is what
+      // keeps the register shrinking rather than accumulating.
+      const scope = SCOPES.find((s) => scopeId(s.type, s.prefix) === id)!;
+      const withoutKey = Object.fromEntries(
+        Object.entries(scope.supplied).filter(([k]) => k !== key),
+      );
+      const schema = scope.schema() as {
+        safeParse: (v: unknown) => {
+          success: boolean;
+          data?: Record<string, unknown>;
+          error?: { issues: Array<{ path: PropertyKey[] }> };
+        };
+      };
+      const parsed = schema.safeParse(withoutKey);
+
+      if (state === 'required-no-default') {
+        // The sharper of the two, and it needs no executor: an omitted key does
+        // not behave as the declared value, it is REFUSED at the door.
+        expect(parsed.success, `${id}.${key}: a REQUIRED key must refuse an omitted value`).toBe(false);
+        expect(
+          parsed.error?.issues.map((i) => i.path.join('.')),
+          `${id}.${key}: and the refusal must name this key`,
+        ).toContain(key);
+      } else {
+        // Optional, and the installed Zod materialises nothing. ⚠️ Evidence
+        // about SCHEMA DEFAULTING only — the executor is in `objectstack` and
+        // is NOT MEASURED by this repo.
+        expect(parsed.success, `${id}.${key}: an OPTIONAL key must parse when omitted`).toBe(true);
+        expect(
+          parsed.data && key in parsed.data,
+          `${id}.${key}: and the spec must materialise nothing for it`,
+        ).toBe(false);
+      }
+    },
+  );
+
+  it.each(UNDECLARED_REGISTER)(
+    'register row $region · $key still measures as spec-applies-form-declares-none',
+    ({ region: id, key }) => {
+      const scope = SCOPES.find((s) => scopeId(s.type, s.prefix) === id)!;
+      expect(
+        key in specDefaults(scope),
+        `${id}.${key}: the spec must still materialise this key`,
+      ).toBe(true);
+      const field = fieldsInScope(scope).get(key);
+      expect(field, `${id}.${key}: the form must still offer a field for it`).toBeDefined();
+      expect(
+        field!.defaultValue,
+        `${id}.${key}: declare it (and drop this row) rather than leaving the register stale`,
+      ).toBeUndefined();
+    },
+  );
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
@@ -249,12 +249,20 @@ export interface FlowConfigField {
    * is cheap, a first write site is not this file's to add.
    *
    * ⚠️ A declaration here is a claim about the installed spec and is acted on
-   * as one; `flow-node-config.spec-reconciliation.test.ts` reconciles the
-   * approval-escalation block against `ApprovalEscalationSchema` so a drift
-   * there reddens on the bump. That ledger does NOT yet cover the other
-   * declaring fields (objectui#6830 measured four of them declaring a default
-   * the installed spec applies none of), so a new declaration outside that
-   * block is currently unchecked — derive it from the spec, never from taste.
+   * as one; `flow-node-config.spec-reconciliation.test.ts` reconciles EVERY
+   * declaring field against its own per-node-type spec schema, so a drift
+   * reddens on the bump. objectui#9109 widened that ledger from the
+   * approval-escalation block, which it used to walk alone — the four
+   * declarations the installed spec applies none of had been sitting outside
+   * it, unchecked, for exactly that reason. A declaration added in a region
+   * the ledger has no spec schema for now fails there by name rather than
+   * going unnoticed.
+   *
+   * What the ledger cannot decide is which END of a divergence to move: it
+   * RECORDS the unbacked declarations (and the reverse case, a spec default
+   * this table states nowhere) in registers that re-measure themselves, and
+   * leaves the choice to a human. ⇒ derive a new value from the spec, never
+   * from taste.
    */
   defaultValue?: string;
   /**


### PR DESCRIPTION
Part of #9109

The mechanical half of that card, and only that half. `flow-node-config.spec-reconciliation.test.ts`'s two default-direction assertions walked `field.path[1] === 'escalation'` alone, so the four declarations the installed spec applies none of sat outside the ledger and nothing reddened. This widens the walk to every declaring field, each against its own per-node-type spec schema.

⛔ **No `defaultValue` declaration is deleted, added or changed.** `git diff` touches zero `defaultValue` lines in `flow-node-config.ts` — verifiable with `git diff -U0 origin/main..HEAD -- packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts | grep -c defaultValue` (measured: `0`). Which END of each divergence to move is the product call triage fenced off, and a seat may not make it.

## What the ledger does now

- **The node-type universe is read from the table's own source**, not a hand-kept list. `FLOW_NODE_CONFIG` is module-private and `fieldsForNodeType` answers `[]` for a type it has never heard of, so a type added to the table but missing from a hand-kept list contributes zero fields and the ledger reports a confident nothing — which is how these four stayed invisible. Rooted at `import.meta.url`, never `process.cwd()` (#7791 / #7799); `check:test-path-roots` is green on it.
- **A scope per reconcilable region**, each a `(node type, path prefix, spec schema, required keys supplied)` tuple — `approval` config and `approval` escalation, `http_request` config, `screen` config, `wait`'s `waitEventConfig` block, `boundary_event`'s `boundaryConfig` block, and `end` config. The table that decides the set is `SCOPES` in the test, and the per-region cases the run prints are the list; ⛔ no count is restated here, because a count here would be re-derived by nothing.
- **A completeness ratchet**: every declaring field in the whole table must fall inside a scope. A declaration added where no spec schema governs it now fails by name.
- **Both directions walk**, not just the one the card named.

## ⛔ The four are NOT one class — re-derived on the tip

Measured on `origin/main` `7d6439c4b` against installed `@objectstack/spec` **17.4.0** (⚠️ re-derived, not inherited from the card's `9f5c017` reading — which reproduced exactly), counting `showWhen` controllers naming each key, with `escalation.enabled` as the lit control:

| declaration | controllers | spec state, measured |
|:--|:--:|:--|
| `wait.waitEventConfig.eventType` (`'timer'`) | **2** | **REQUIRED** enum — an omitted key is refused at `waitEventConfig.eventType` |
| `boundary_event.boundaryConfig.eventType` (`'error'`) | **3** | **REQUIRED** enum — an omitted key is refused at `boundaryConfig.eventType` |
| `http_request.config.method` (`'GET'`) | **0** | optional; the installed Zod materialises nothing |
| `screen.config.mode` (`'create'`) | **0** | optional; the installed Zod materialises nothing |
| *control* — `approval.config.escalation.enabled` | **4** | `.default(true)` — the probe finds gates when they exist |

So the register carries the state per row and re-measures it: `required-no-default` asserts the region **refuses** an omitted key and that the refusal names that key; `optional-no-default` asserts it **parses** and materialises nothing. Those are two different sentences, which is what triage asked for.

⭐ **The distinction that keeps this honest.** "The installed spec's Zod applies no default" is NOT "the runtime applies no default." The flow executor lives in `objectstack`; `@objectstack/spec` is only the parse contract. ⇒ for `http_request.method` and `screen.mode` the executor state is **NOT MEASURED** here, ⛔ not "measured false". Nothing in this PR widens into `objectstack`.

## ⚠️ Escalation trigger: it did NOT fire, with one qualification worth reading

Triage graded p2 because an omitted required key fails to parse — loud, at the door. Measured on the tip, that holds **when the block exists**:

```
wait, empty waitEventConfig                 => REJECTED at waitEventConfig.eventType
boundary, block without eventType           => REJECTED at boundaryConfig.eventType
```

⚠️ But the block being **absent entirely** is accepted:

```
wait, NO waitEventConfig block at all       => ACCEPTED
boundary, NO boundaryConfig block           => ACCEPTED
```

⇒ the author who takes the revealed `Duration` field and fills it in hits the loud refusal (`waitEventConfig` then exists without `eventType`). The author who reads the revealed fields as "this is already a timer wait" and saves without touching them produces a node that **parses clean** and carries no `eventType` anywhere — and what the engine does with it is in `objectstack`, so it is **NOT MEASURED**. That is a narrower opening than "accepted anywhere in the chain", so this PR does not treat the trigger as fired; it is recorded for the grading seat rather than acted on. ⛔ No labels changed here.

## Two findings this widening turned up, filed not fixed

The other direction of the same ledger — the spec applies a default the form states nowhere, which is #6794's shape:

- **#9277** — `approval.config.lockRecord` and `boundary_event.boundaryConfig.interrupting`. Both `boolean`, both defaulted `true` by the spec, and both declared nothing, so both boxes drew unchecked while the runtime applied `true`. ✅ **Repaired upstream by objectui#9339**, which declared both from the installed spec and moved the acceptance pin in `FlowNodeInspector.declaredDefault.test.tsx` with them. The register rows that stood in for them are retired accordingly — what the register holds is whatever its declaration lists, re-derived by the per-region walk, never a count restated here.
- **#9278** — the `end` node's Outcome field was free text whose placeholder advertised `success · failure`; `EndConfigSchema` accepts only `completed` and `refused`, and `FlowNodeSchema` enforces it. An author who typed what the box suggested wrote metadata their own loader refuses. ✅ **Repaired upstream by objectui#9337**, which made the control a spec-derived select declaring `'completed'` — and that declaration is what brought the region inside this card's fence: `end:config` is now a scope this ledger walks, reconciled against `EndConfigSchema`. It was fenced out only while it declared nothing.

✅ `approval.maxRevisions`'s duplicated `'3'` is correctly **not** filed — triage settled that.

## Tests

Measured against the tree at `b9781732a` — this dates the **act**, ⛔ it is not a claim about which commit is head (`git log b9781732a..HEAD` enumerates what landed after it). ⚠️ A later tree on this branch, `7f3b4e73e5`, took `Test (shard 1/4)` to **failure** on this very file: the completeness ratchet firing by name — `end:config.outcome declares "completed" with no spec scope to check it against` — which `3e363c672a` then fixed by bringing `end:config` into `SCOPES`. ⇒ read the table below as a record of that run, ⛔ never as the head's status; the head's own `check-runs` is the authority for that.

**Green, measured:**

| run | result |
|:--|:--|
| `vitest run …/flow-node-config.spec-reconciliation.test.ts` | 21 passed, 1 skipped (the pre-existing `SCRIPT_BUILTIN_ACTION_TYPES` feature-detect) |
| `vitest run packages/app-shell/src/views/metadata-admin/inspectors/` | **71 files, 849 passed**, 1 skipped |
| `vitest run scripts/__tests__/check-test-path-roots.test.ts …/check-changeset-presence.test.ts` | 76 passed |
| `pnpm --filter @object-ui/app-shell type-check` | exit 0 — and `tsc -p tsconfig.test.json --listFiles` confirms the changed test file is IN the checked set (1 hit), so this is coverage, not a vacuous pass |
| `changeset:check`, `check:control-bytes`, `check:spec-symbols`, `check:designer-field-key-parity`, `check:i18n-designer-parity`, `check:new-line-citations`, `check:comment-mask-corpus`, `check:changeset-claims`, `check:unreferenced-sources`, `check:shell-escape-residue` | all exit 0, each read from the gate's own printed verdict line |
| `node scripts/check-changeset-presence.mjs` | exit 0 — "declared as releasing nothing, which is the explicit exemption" |

⚠️ `check:changeset-no-major` is **not** an npm script in this repo; the real gate is `changeset:check`, run above.

**Lint — a proven narrowing, not an unmeasured skip.** Three pieces of evidence, and they must be read together:

1. **Population from eslint's own configuration.** The repo has exactly one flat config (`git ls-tree -r origin/main | grep 'eslint.config'` returns one path: `eslint.config.js`), so no package-level config governs anything separately.
2. **Count from `--format json`.** Linting `@object-ui/app-shell` — the only package this diff touches — covered **1149 files, 0 errors, 2997 warnings** (pre-existing; `lint.yml` deliberately sets no `--max-warnings`, and its own header says so). The two changed files are in that run, each with 0 errors and 0 warnings. Within the touched package the run is **complete**; there is no narrowing at all.
3. **Invariance for untouched files.** `parserOptions.project` / `projectService` appear nowhere in that config, so **type-aware linting is not enabled** — every file's verdict comes from its own bytes plus the shared config, and this diff changes neither the config nor any other package's bytes. ⇒ packages other than `app-shell` cannot change verdict.

**NOT MEASURED, declared to CI:**

- `pnpm exec vitest run packages/app-shell/` (the whole package). Two attempts under the shared verify lock: the first returned **exit 99 / queue-timeout** after waiting 540s behind another agent's 650s hold; the second **acquired the lock immediately** and was then killed by the ~10-minute foreground cap (exit 124). Reported as NOT MEASURED, ⛔ not as green. The narrowing actually run is the 71-file inspector sweep above, which contains every consumer of `flow-node-config.ts`; nothing imports the changed test file (`git grep spec-reconciliation` outside itself returns only prose mentions in comments and docs).
- `pnpm lint` repo-wide (`turbo run lint`, all packages) — killed at 560s under the lock. Superseded by the proven narrowing above.

**Blast radius (#9273).** A package-scoped run is not the blast radius *when something rendered or declared moves*. Nothing does here: the declaration table's only change is one doc comment, `git diff` touches zero `defaultValue` lines, and no option list, control kind, label or placeholder moves. ⇒ `examples/schema-catalog/` and count-shaped prose figures are not implicated. The count-shaped pin that *would* have moved — #6830's `exactly N fields declare a defaultValue` case in `FlowNodeInspector.declaredDefault.test.tsx` — is untouched by this diff and green in the inspector sweep. ⛔ Its N is deliberately not restated here: that figure moved twice while this branch was open (objectui#9337, then objectui#9339), and an earlier revision of this body quoted a value the tree had already stopped having. The case title the run prints is the only live reading of it.

## Reverse verification

Three mutations, each proved to have landed on disk before the run (an editor's exit code is not evidence: a zero-hit `perl -pi` exits 0 — the first attempt here did exactly that and the on-disk check caught it rather than yielding a fake green). Predicted directions were fixed before running; all three came out as predicted.

| mutation | predicted | measured |
|:--|:--|:--|
| add a declaring field to `loop`, a node type with **no scope** | the completeness ratchet reddens | 1 failed — *"add a DefaultScope for this region, with the spec schema that governs it"* |
| flip `http_request.method`'s register row to `required-no-default` | the register re-measurement reddens | 1 failed — *"a REQUIRED key must refuse an omitted value: expected true to be false"* |
| break the source-enumeration regex so the walk sees **zero** node types | the vacuity control reddens | **3 failed** — the live-enumeration control, the ratchet's non-empty floor, AND the unbacked-register comparison, which can no longer match an empty measured set |

The third is the load-bearing one: it proves the widened walk cannot go vacuously green, which is the failure mode #6620's old tripwire actually shipped.

**Restore leg.** Every leg restored with `git checkout HEAD -- PATH` (never bare `git checkout --`, which takes the mutation back out of the polluted index), under a `trap … EXIT INT TERM` using absolute paths from `git rev-parse --show-toplevel`. Restoration is proved by blob hash, not by exit code: `git hash-object` on each restored file is compared against that file's own `HEAD` blob, as `git rev-parse HEAD:PATH` reports it during the run; an empty hash is treated as FAILURE, and `git diff HEAD --name-only` is empty after each leg. ⛔ The hashes themselves are not quoted here — a blob hash written into prose pins one tree and goes stale at the next commit that touches the file, which is exactly what happened to the pair this paragraph used to carry: it was the `flow-node-config.ts` blob from **before** the doc-comment commit this section dates itself to, quoted as if it were that commit's. The restored tree re-runs green (21 passed, 1 skipped).

## Changeset

`.changeset/issue-9109-widen-default-ledger.md`, **empty frontmatter** — the explicit "releases nothing" declaration, which `check-changeset-presence.mjs` names as a first-class pass rather than a workaround. It is required, not optional: the gate guards `PKG/src/**` for every package in the `fixed` group with no test-file carve-out (`check-changeset-presence.mjs` line 752: `if (relative.startsWith('src/')) return true;`), and both changed files are under `packages/app-shell/src/`. It is declared as releasing nothing because **no API moves**: none of the eight publish-contract fields changed, and with comments stripped the emitted declarations are byte-identical between the two arms.

⚠️ ⛔ Not because nothing published changes — an earlier revision of this paragraph said that, and it was false. Neither changed file *path* ships (`files` is `["dist","src/styles.css","README.md","CHANGELOG.md","LICENSE"]`, and tsconfig `exclude` keeps `**/*.test.ts` out of `dist`), but this package builds with `tsc` (`"build": "tsc && node ../../scripts/check-dist-completeness.mjs"`) with `declaration: true` and `removeComments` unset, so the edited doc comment lands verbatim in the published `dist/views/metadata-admin/inspectors/flow-node-config.d.ts`. Built both arms with this package's own toolchain, at merge-base `6be9733449` and at head: that file goes **20136 → 20568 bytes**, every differing line inside the `defaultValue` doc block. A documentation-only move inside a shipped artifact is exactly what an empty frontmatter is for — so the declaration stands, and the reason it used to give did not.

## 维护者速读(草稿)

**改了什么** — 流程节点设计器里「表单声明的默认值 ↔ spec 实际默认值」这本账,以前只核对审批节点的 escalation 一块,现在核对**每一个**声明了默认值的字段,各自对自己节点类型的 spec schema。节点类型清单从表格源码本身读出,不再靠手写列表 —— 手写列表漏掉一个类型时,账本会安静地报「没问题」,这四个声明当初就是这么藏住的。

**为什么改** — 四个字段在界面上告诉作者「不填这个键就等于 X」,而装着的 spec 根本不给 X。其中两个更糟:那两个键是**必填**的,不填不是「等于 timer」,是**加载直接报错**。旧账本看不见它们,不是因为它们不重要,是因为没人往那儿看。

**风险与代价(含回滚)** — 本轮**只动测试与一条注释**,不改任何声明、选项、控件或渲染值(`git diff` 里 `defaultValue` 行改动数 = 0),changeset 空 frontmatter 声明不发版。回滚成本 = revert 这个 PR,没有数据迁移。代价在别处:账本现在把两类实际存在的分歧**记录**在两个自我复测的登记表里,登记表不是豁免 —— 分歧消失了而登记项没删,测试照样红。

**席位意见** — (待席位填写)

**你要做的** — 一个产品判断,本席位不得代答:这四个声明该**删掉**(`wait` 节点会失去「没填事件类型时也显示 Duration」这个便利),还是该**在上游补上**(`method` 要改框架;两个必填枚举则是真问题:wait 节点到底该不该有默认事件类型)?另外两张新卡 #9277 / #9278 是同一本账另一个方向翻出来的,等你分诊。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_

---
_Generated by [Claude Code](https://claude.ai/code)_