### PR TITLE
fix(types): record:highlights `layout` is the contract's two values, not three

### DIFF
--- a/.changeset/9187-record-highlights-layout-two-values.md
+++ b/.changeset/9187-record-highlights-layout-two-values.md
@@ -1,0 +1,51 @@
+---
+'@object-ui/types': minor
+---
+
+**BREAKING** — `RecordHighlightsComponentProps.layout` no longer offers `grid`.
+
+**FROM** `layout: 'grid'` **TO** `layout: 'horizontal'` (the schema default) or
+`layout: 'vertical'`.
+
+```ts
+// before — compiled here, refused at publish
+const props: RecordHighlightsComponentProps = { fields: ['name'], layout: 'grid' };
+// after
+const props: RecordHighlightsComponentProps = { fields: ['name'], layout: 'horizontal' };
+```
+
+`@objectstack/spec` declares this key as
+`z.enum(['horizontal','vertical']).default('horizontal')` — a closed set of
+**two**. This type declared three, so `{ layout: 'grid' }` type-checked locally
+and the contract refused the document at publish with `invalid_value` at
+`layout`. Re-measured on the installed pin, `@objectstack/spec` 17.4.0, against
+two controls that fire on the same instrument: an arbitrary value is refused
+with the same code (so `grid` was never special-cased), and omitting the key
+parses green and takes the default (so the schema is not refusing everything).
+Contract-first (Commandment #0.1): the declaration moves to the contract, and
+the spec is not widened.
+
+Nothing to migrate at runtime, and no data change: `RecordHighlightsRenderer`
+reads no `layout` at all, and `@object-ui/plugin-detail`'s registry manifest
+already published this input as `type: 'enum', enum: ['horizontal', 'vertical']`
+— the published TypeScript face was the only layer that offered the third
+value, and it only ever reached an author who wrote `grid` exactly.
+
+⚠️ The census behind this narrowing covers this repository only, and **it found
+no in-repo authoring to migrate**: every in-tree `layout: 'grid'` belongs to a
+different component (`detail-view` in `content/docs/api/schema-reference.md` and
+`phase2-schemas.test.ts`, `ai-recommendations` in `packages/plugin-ai/README.md`),
+and the one in-repo consumer of this interface that writes a `layout`
+(`p1-spec-alignment.test.ts`) writes `'horizontal'`. So no document in this
+repository stops type-checking. A TypeScript consumer outside this repo that
+wrote `grid` is not observable from here and gets a compile error (TS2322)
+naming the key — which is why the FROM/TO is spelled out above.
+
+⚠️ The `layout` one interface up, on `RecordDetailsComponentProps`, is a
+**different** divergence and is **not** touched here: the contract refuses that
+key by name, and its removal is objectui#9040's, still open. Copying either
+declaration onto the other is refused at publish. The union landed here is
+pinned against the installed spec — in both directions, and with the sibling as
+a firing control — in `record-highlights-layout-9187.test.ts`.
+
+objectui#9187.

--- a/packages/types/src/__tests__/record-highlights-layout-9187.test.ts
+++ b/packages/types/src/__tests__/record-highlights-layout-9187.test.ts
@@ -1,0 +1,201 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9187 — `RecordHighlightsComponentProps.layout` offered THREE values
+ * where the contract declares two.
+ *
+ * The defect: this package declared `'horizontal' | 'vertical' | 'grid'` while
+ * `@objectstack/spec` declares `z.enum(['horizontal','vertical'])` behind a
+ * `.default('horizontal')`. So `{ layout: 'grid' }` type-checked here and was
+ * refused at publish with `invalid_value` — a green local build and a
+ * rejection at the only layer that matters. Direction is contract-first
+ * (Commandment #0.1, and triage's ruling on the card): the declaration moves
+ * to the contract, the contract is not widened.
+ *
+ * ── Three instruments, and they do NOT see the same thing ──────────────────
+ *
+ *   - `tsc` sees the `@ts-expect-error` leg and the `Equal` assertions. That
+ *     is the half that reaches a TypeScript author, and it means nothing
+ *     unless `type-check` runs — vitest strips types.
+ *   - vitest runs the `safeParse` legs against the INSTALLED published spec
+ *     artifact, each with a control that would have fired. ⚠️ Those legs read
+ *     the SPEC ONLY: they were green before this change and are green after,
+ *     so they are the PREMISE, never the evidence. They are labelled PREMISE
+ *     below so nobody counts them as the fix.
+ *   - vitest ALSO reads this package's own declaration as TEXT, so the
+ *     reintroduction of a third value is caught even by a run that never
+ *     type-checks. Its control is the sibling interface one screen up, whose
+ *     `layout` is still a three-value union (objectui#9040, open by ruling):
+ *     the same matcher finds THAT one, so an empty result on the highlights
+ *     key is a reading rather than a regex that cannot match anything.
+ *
+ * ⛔ The sibling is not this card's to fix, and this file must not grow into
+ * a pin that demands it: `RecordDetailsComponentProps.layout` is a tombstone
+ * the contract refuses BY NAME, with an in-repo consumer triage ruled out of
+ * scope. It appears here only as a firing control.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import type { z } from 'zod';
+import { RecordHighlightsProps } from '@objectstack/spec/ui';
+import type { RecordHighlightsComponentProps } from '../record-components';
+
+/** Rooted at THIS file, never at `process.cwd()` — the two differ per invocation. */
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DECLARATION_PATH = join(HERE, '..', 'record-components.ts');
+
+/** What an author writes for the spec's `record:highlights` props bag. */
+type SpecProps = z.input<typeof RecordHighlightsProps>;
+
+/** Invariant type equality. `A extends B` is NOT this: `never` and `any` pass that. */
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+/** The only assertion form used here — its constraint is what refuses `false`. */
+type Expect<T extends true> = T;
+
+/* ── Direction proofs: a broken instrument makes THIS file red ─────────────── */
+
+// @ts-expect-error objectui#9187 — `Expect` must refuse `false`. Widen its constraint and this directive goes unused (TS2578).
+type _ExpectRefusesFalse = Expect<false>;
+
+// @ts-expect-error objectui#9187 — `never` must NOT read as equal to `true`. An `extends`-shaped comparison would let it through.
+type _EqualRefusesNever = Expect<Equal<never, true>>;
+
+// @ts-expect-error objectui#9187 — `any` must NOT read as equal to `true`, for the same reason.
+type _EqualRefusesAny = Expect<Equal<any, true>>;
+
+/* ── The fix: the declared union IS the contract's, member for member ─────── */
+
+/**
+ * RED before objectui#9187 (three values against the contract's two), green
+ * after. This is the pin that fails if a third value is reintroduced — in
+ * either direction, because `Equal` is invariant: adding `grid` back here
+ * fails, and so would dropping `vertical`.
+ */
+type _LayoutMatchesContract = Expect<
+  Equal<RecordHighlightsComponentProps['layout'], SpecProps['layout']>
+>;
+
+/** The neighbouring keys were already right, and the narrowing must not move them. */
+type _FieldsUntouched = Expect<
+  Equal<RecordHighlightsComponentProps['fields'] extends unknown[] ? true : false, true>
+>;
+
+/* ── Literals: what a TypeScript author can and cannot write ───────────────── */
+
+/**
+ * ⭐ THE LIT CONTROL for the `tsc` instrument: a value the spec DOES accept,
+ * on the same interface, in the same position. It compiles. Without it, the
+ * refusal below is indistinguishable from a declaration that refuses
+ * everything (or from a `layout` key that stopped existing).
+ */
+const horizontalAccepted: RecordHighlightsComponentProps = {
+  fields: ['name'],
+  layout: 'horizontal',
+};
+
+/** The other accepted member, so "closed set of two" is not read as "one". */
+const verticalAccepted: RecordHighlightsComponentProps = {
+  fields: ['name'],
+  layout: 'vertical',
+};
+
+/**
+ * The card's repro. `grid` compiled before objectui#9187 and was refused at
+ * publish; now `tsc` refuses it here, which is the whole point of the change.
+ * Reintroduce the third value and this directive goes unused (TS2578).
+ */
+const gridRefused: RecordHighlightsComponentProps = {
+  fields: ['name'],
+  // @ts-expect-error objectui#9187 — the contract's set is `'horizontal' | 'vertical'`; `grid` is refused at publish with `invalid_value`.
+  layout: 'grid',
+};
+
+/** Any other value outside the closed set is refused the same way. */
+const nonsenseRefused: RecordHighlightsComponentProps = {
+  fields: ['name'],
+  // @ts-expect-error objectui#9187 — outside the contract's closed set.
+  layout: 'zzzNonsense',
+};
+
+describe('objectui#9187 — record:highlights `layout` against the installed spec', () => {
+  it('PREMISE: the contract declares exactly two members, read off the live schema', () => {
+    // Read off the schema object rather than transcribed, so a spec that adds
+    // or drops a member fails HERE first — before the pins above start
+    // asserting a shape the contract no longer has.
+    const layout = RecordHighlightsProps.def.shape.layout;
+    const entries = Object.keys(layout.def.innerType.def.entries).sort();
+    expect(entries).toEqual(['horizontal', 'vertical']);
+    expect(Object.keys(RecordHighlightsProps.def.shape).sort()).toEqual([
+      'aria',
+      'fields',
+      'layout',
+    ]);
+  });
+
+  it("PREMISE: `grid` is refused with `invalid_value` at `layout` — the card's repro", () => {
+    const refused = RecordHighlightsProps.safeParse({ fields: ['name'], layout: 'grid' });
+    expect(refused.success).toBe(false);
+    const issue = refused.error?.issues.find((i) => i.path.join('.') === 'layout');
+    expect(issue?.code).toBe('invalid_value');
+
+    // CONTROL A — an arbitrary value is refused with the SAME code, so `grid`
+    // is not special-cased by some bespoke branch.
+    const arbitrary = RecordHighlightsProps.safeParse({ fields: ['name'], layout: 'zzzNonsense' });
+    expect(arbitrary.success).toBe(false);
+    expect(arbitrary.error?.issues.find((i) => i.path.join('.') === 'layout')?.code).toBe(
+      'invalid_value',
+    );
+
+    // CONTROL B — the values the contract accepts parse green and survive, and
+    // an omitted key takes the schema default. A refusal with no control that
+    // would have fired is not a measurement; it is also what a schema that
+    // refused everything would produce.
+    const accepted = RecordHighlightsProps.safeParse({ fields: ['name'], layout: 'vertical' });
+    expect(accepted.success).toBe(true);
+    expect(accepted.data?.layout).toBe('vertical');
+    const omitted = RecordHighlightsProps.safeParse({ fields: ['name'] });
+    expect(omitted.success).toBe(true);
+    expect(omitted.data?.layout).toBe('horizontal');
+  });
+
+  it('the DECLARATION carries the contract’s two members and no third', () => {
+    const source = readFileSync(DECLARATION_PATH, 'utf8');
+
+    // Anchor on the interface so the match cannot drift onto another `layout`.
+    const block = source.slice(source.indexOf('interface RecordHighlightsComponentProps'));
+    expect(block).not.toBe('');
+    const declared = /^\s*layout\?: (.+);$/m.exec(block)?.[1];
+    expect(declared).toBe("'horizontal' | 'vertical'");
+
+    // ⭐ THE LIT CONTROL for this instrument: the SAME matcher, run against the
+    // sibling interface one screen up, finds a three-value union there
+    // (objectui#9040, open by ruling — ⛔ not this card's to fix). So the
+    // assertion above is a reading, not a matcher that can never see a third
+    // member. If #9040 ever lands, this control moves to another three-value
+    // union or becomes a literal fixture — it must never be deleted outright.
+    const siblingBlock = source.slice(source.indexOf('interface RecordDetailsComponentProps'));
+    const siblingDeclared = /^\s*layout\?: (.+);$/m.exec(siblingBlock)?.[1];
+    expect(siblingDeclared?.split('|')).toHaveLength(3);
+  });
+
+  it('the literals above are real values, not type-only decoration', () => {
+    // vitest strips types, so these expectations are NOT the assertion — the
+    // annotations are. They exist so the file also fails visibly if the
+    // literals are ever silently emptied out.
+    expect(horizontalAccepted.layout).toBe('horizontal');
+    expect(verticalAccepted.layout).toBe('vertical');
+    expect(gridRefused.layout as unknown).toBe('grid');
+    expect(nonsenseRefused.layout as unknown).toBe('zzzNonsense');
+  });
+});

--- a/packages/types/src/record-components.ts
+++ b/packages/types/src/record-components.ts
@@ -252,8 +252,34 @@ export interface RecordHighlightsComponentProps {
   fields: Array<
     string | { name: string; label?: string; icon?: string; type?: string; readonly?: boolean }
   >;
-  /** Layout mode for highlights display */
-  layout?: 'horizontal' | 'vertical' | 'grid';
+  /**
+   * Layout mode for the highlights strip, as the CLOSED SET the contract
+   * declares (`@objectstack/spec` `RecordHighlightsProps.layout` is
+   * `z.enum(['horizontal','vertical'])` behind a `.default('horizontal')`).
+   *
+   * It offered a third value, `grid`, until objectui#9187, and the contract
+   * never accepted it: measured on the installed pin, 17.4.0,
+   * `RecordHighlightsProps.safeParse({ fields: ['name'], layout: 'grid' })` is
+   * RED with `invalid_value` at `layout`. So `{ layout: 'grid' }` type-checked
+   * here and was refused at the door — a green local build and a rejection at
+   * the only layer that matters. Two controls on the same instrument fired as
+   * they should: an arbitrary value is refused with the SAME code, so `grid`
+   * was not special-cased, and omitting the key parses green, so the schema is
+   * not refusing everything. Contract-first (Commandment #0.1): the
+   * declaration moves to the contract, the contract is not widened.
+   *
+   * Every other layer already agreed with the contract — `@object-ui/plugin-detail`
+   * publishes `enum: ['horizontal', 'vertical']` for this input in its registry
+   * manifest, and `RecordHighlightsRenderer` reads no `layout` at all. This
+   * declaration was the last live holdout of the spelling.
+   *
+   * ⚠️ Do NOT copy this set onto the `layout` one interface up. That one is a
+   * tombstone the contract refuses BY NAME (objectui#9040, still open) — the
+   * same word, a different divergence, a different repair.
+   * `__tests__/record-highlights-layout-9187.test.ts` pins this union against
+   * the installed spec in both directions.
+   */
+  layout?: 'horizontal' | 'vertical';
   /** ARIA accessibility attributes */
   aria?: RecordComponentAriaProps;
 }


### PR DESCRIPTION
Fixes #9187

`RecordHighlightsComponentProps.layout` declared three values where
`@objectstack/spec` declares two, so `{ layout: 'grid' }` type-checked here and
the contract refused the document at publish. Contract-first (Commandment
#0.1): the declaration moves to the contract, the spec is not widened.

## Re-measured on the installed pin, not transcribed

The card's transcription was NOT taken as input. `RecordHighlightsProps`'s own
shape, read off the installed `@objectstack/spec` 17.4.0 artifact
(`node_modules/.pnpm/@objectstack+spec@17.4.0_.../dist/ui/index.js`):

```
shape keys        : ["fields","layout","aria"]
layout member     : default -> enum ["horizontal","vertical"]
layout default    : "horizontal"
```

Parse probes — one instrument, one loop, every row carrying `fields: ['name']`
so the document is otherwise valid:

```
{ layout: 'horizontal' }    GREEN
{ layout: 'vertical' }      GREEN
{ layout: 'grid' }          RED   invalid_value at `layout`
{ layout: 'zzzNonsense' }   RED   invalid_value at `layout`     <- CONTROL
{ }  (key omitted)          GREEN, layout defaults 'horizontal' <- CONTROL
```

Both controls fired: an arbitrary value is refused with the SAME code as
`grid`, so `grid` was never special-cased, and omitting the key parses green,
so the schema is not refusing everything. This reproduces the card's reading
independently, on the tip.

## The pin, its lit control, and what makes each fail

`packages/types/src/__tests__/record-highlights-layout-9187.test.ts`, three
instruments — and they do not see the same thing:

| instrument | what it pins | what makes it fail |
| --- | --- | --- |
| `tsc` (`tsconfig.test.json`) | `Equal[Declared['layout'], SpecInput['layout']]`, invariant | a third value added back, or an accepted one dropped |
| `tsc` | a `ts-expect-error` leg on `layout: 'grid'` | reintroducing `grid` makes the directive unused, TS2578 |
| vitest | `safeParse` legs vs the installed spec artifact | the CONTRACT changing — labelled PREMISE, never the evidence |
| vitest | the declaration read as TEXT, rooted at the test file | a third value added back, even in a run that never type-checks |

⭐ The **lit controls**, so the pin can be told apart from a pin that is not
looking: `layout: 'horizontal'` and `layout: 'vertical'` are authored as real
annotated values and compile; on the vitest side a spec-accepted value parses
green and its value survives, and the omitted key takes the schema default. The
text instrument's control is the sibling interface one screen up, whose
`layout` is still a three-value union — the SAME matcher finds THAT one, so the
two-member reading is a reading rather than a matcher that can never see a
third member.

### Reverse verification — both legs, from the committed state

Mutation and restore both proved on disk (`git hash-object` against the `HEAD`
blob), each leg under a `trap ... EXIT INT TERM` restoring with
`git checkout HEAD --`:

```
HEAD blob hash     : ae8b6c57869ee06c4bb7178138b8b2dd9926cb61
[before] fixed line 1 / mutant line 0
[after ] fixed line 0 / mutant line 1
mutated blob hash  : d5ca842dc78e77d2c509ad183a39f8a7a22f4508   (differs => it landed)

MUTANT  leg 1 vitest : exit=1  1 failed | 3 passed
        AssertionError: expected "'horizontal' | 'vertical' | 'gri…" to be "'horizontal' | 'vertical'"
MUTANT  leg 2 tsc    : exit=2
        ...9187.test.ts(86,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
        ...9187.test.ts(120,3): error TS2578: Unused 'ts-expect-error' directive.

restored blob hash : ae8b6c57869ee06c4bb7178138b8b2dd9926cb61   (== HEAD)
git diff HEAD      : empty
RESTORED leg 1 vitest : exit=0  4 passed
RESTORED leg 2 tsc    : exit=0
```

Second direction, proving the **accepted-value control is load-bearing** rather
than decoration — drop `vertical` from the union:

```
...9187.test.ts(86,3):  error TS2344: Type 'false' does not satisfy the constraint 'true'.
...9187.test.ts(110,3): error TS2322: Type '"vertical"' is not assignable to type '"horizontal"'.
restored hash == HEAD, git diff HEAD empty
```

⚠️ The `tsc` legs only mean something because `packages/types`'s `type-check`
actually compiles this file: `tsc -p tsconfig.test.json --listFiles` puts it in
the program (649 inputs; the `8604` precedent test is in the same program as a
control).

## Enumeration: does anything in-tree author `layout: 'grid'` here? Measured — no

Tree-wide, excluding the lockfile, every `layout` set to `grid`:

| hit | component it is on |
| --- | --- |
| `content/docs/api/schema-reference.md` | `detail-view` |
| `packages/types/src/__tests__/phase2-schemas.test.ts` | `detail-view` |
| `packages/plugin-ai/README.md` | `ai-recommendations` |
| `packages/app-shell/src/views/metadata-admin/SchemaForm.gridCellNaming.test.tsx` | a local test helper's own parameter type |

⇒ **zero** on `record:highlights`. The only in-repo consumer of this interface
that writes a `layout` is `packages/types/src/__tests__/p1-spec-alignment.test.ts`,
and it writes `'horizontal'` — so **no in-repo document stops type-checking**,
and that is what carries the changeset level below.

⭐ Known-hit CONTROL for that enumeration, because an empty result is otherwise
indistinguishable from a grep that cannot match: the same matcher run for the
values the spec DOES accept returns 17 hits across docs, READMEs, app code and
tests. The matcher reaches authored documents; the zero is a reading.

## Changeset level

`minor` + a `**BREAKING**` carrier
(`.changeset/9187-record-highlights-layout-two-values.md`), the shape this repo
ships for removing an accepted value from a published union — `major` is
unavailable (one `fixed` group of 41 packages). Justified by the enumeration
above: nothing in this repository authors the removed value, the renderer reads
no `layout` at all, and the registry manifest already published two values, so
the published TypeScript face was the only layer that offered it. The FROM/TO
is spelled out for the consumer outside this repo who is not observable from
here.

## Gates

Green locally, each read off the gate's own verdict line rather than a bare
exit code: `changeset:check`, `check:changeset-claims`, `check:control-bytes`,
`check:new-line-citations`, `check:test-path-roots` (this file's read is
classified `self+append`, rooted at `import.meta.url`), `check:installed-pin-claims`,
`check:spec-symbols`, plus `node scripts/check-changeset-presence.mjs`.
`packages/types` unit run: 4 passed. Governed-surface guard: NOT GOVERNED (3
paths, no match).

The downstream `type-check` closure of `@object-ui/types`
(`turbo run type-check --filter '...@object-ui/types'`, 42 packages, under the
shared verify lock) was still running when this draft opened — its verdict is
folded into a comment below, and the count-shaped-prose sweep it pairs with
found no key-count figure for this key outside CHANGELOGs, which are historical
and untouched.

## Out of scope — noted, and one filed

- ⛔ `RecordDetailsComponentProps.layout`, one interface up, is **untouched**:
  a tombstone the contract refuses by name, ledgered OPEN by objectui#9040.
  This branch only borrows it as a firing control.
- 📌 A **separate** divergence on the SAME interface, one member down, is filed
  as objectui#9280: the `fields[]` object arm declares `icon`, which the spec's
  `$strict` arm refuses (measured, with three controls). Not repaired here on
  purpose — `icon` is live on three layers and dead only on the contract, so
  the direction is a spec question, not a narrowing.

Session reference, in prose so it survives a body edit:
`https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ`

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_