### PR TITLE
fix(app-shell): stop writeFields deleting a stored field named __proto__ from the object-metadata PUT body

### DIFF
--- a/.changeset/writefields-proto-key-9237.md
+++ b/.changeset/writefields-proto-key-9237.md
@@ -1,0 +1,21 @@
+---
+'@object-ui/app-shell': patch
+---
+
+fix(app-shell): stop `writeFields` deleting a stored field named `__proto__` from the object-metadata PUT body
+
+The object designer's draft serializer built its `fields` map by assigning into
+an object literal. For the one field name `__proto__` that assignment invokes
+`Object.prototype`'s accessor instead of creating an own property, so the entry
+`readFields` had just read back was dropped before `JSON.stringify` saw it.
+
+`__proto__` is a spec-legal stored field key, so the mutilated document was
+ACCEPTED: the PUT succeeded, the server stored the object without the field,
+the designer kept showing its in-memory copy, and nothing reported anything.
+Unlike every other defect in this family it is not a recoverable 422 — a reload
+does not bring the field back, because it is gone from the store. Any save or
+field reorder triggered it, including edits that never touched that field.
+
+`Object.fromEntries` defines an own property, which is why
+`MetadataService.toFieldsMap` already used it. All 14 `writeFields` call sites
+across the designer are covered by the single change.

--- a/packages/app-shell/src/views/metadata-admin/previews/object-fields-io.prototypeKey-9237.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/object-fields-io.prototypeKey-9237.test.ts
@@ -1,0 +1,177 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, expect, it } from 'vitest';
+import { ObjectSchema } from '@objectstack/spec/data';
+import { readFields, writeFields } from './object-fields-io.js';
+
+/**
+ * objectui#9237 — `writeFields` silently DELETED a stored field named
+ * `__proto__` from the PUT body, and the spec ACCEPTED the result.
+ *
+ * ## Why this class is worse than the 422s the sibling suites pin
+ *
+ * `object-fields-io.spec-keys.test.ts` and
+ * `object-fields-io.referenceCarryover-8896.test.ts` both guard REFUSAL
+ * shapes: a key the server rejects, loudly, leaving the stored document
+ * untouched and a reload as the escape. This one had no refusal anywhere in
+ * it. The old `writeFields` body was
+ *
+ *   const out: Record OF string TO unknown = {};
+ *   for (const e of view.entries) out[e.name] = e.def;
+ *
+ * and `out['__proto__'] = def` does not create a key — it invokes
+ * `Object.prototype`'s setter — so the entry `readFields` had just read back
+ * was gone before `JSON.stringify` ever saw it. The resulting document is
+ * perfectly spec-legal, the PUT succeeds, the server stores the object WITHOUT
+ * the field, and nothing anywhere reports a thing. There is no reload that
+ * recovers it, because the field is gone from the store.
+ *
+ * The trigger is an edit that never touched the field: all 14 `writeFields`
+ * call sites across the object designer re-serialize the whole map on every
+ * save and reorder.
+ *
+ * ## ⭐ Why this pin must say `__proto__` and nothing else
+ *
+ * `__proto__` is the ONLY name that reproduces. It is the single accessor on
+ * `Object.prototype`; every other member (`constructor`, `toString`,
+ * `valueOf`, `hasOwnProperty`, `prototype`) is a data property, and assignment
+ * shadows a data property with a normal own property. A pin written with one
+ * of those names is green under the repair AND green under the defect — it
+ * asserts nothing. `the name table` below makes that failure mode an
+ * executable assertion rather than a comment, so a later edit that "generalises"
+ * this pin to a prototype-reachable name turns the suite red instead of
+ * hollowing it out.
+ *
+ * ## ⭐ Why every fixture here is built by `JSON.parse`
+ *
+ * Writing the fixture as an object literal would silently void this file.
+ * `{ __proto__: def }` in source is the prototype-setter form: it sets the
+ * literal's prototype and creates NO own property, so `readFields` would emit
+ * no entry and there would be nothing for `writeFields` to lose. Stored
+ * metadata arrives over the wire as JSON, and `JSON.parse` creates a real own
+ * property — that is both the faithful construction and the only one that
+ * carries the defect. `the instrument` below asserts it rather than trusting
+ * it.
+ *
+ * ⛔ Do not assert on `ObjectSchema.safeParse(...).data`. Measured on zod
+ * 4.4.3: `z.record()` reports success and hands back an output object with the
+ * `__proto__` entry MISSING — the same construction defect, one layer up, in a
+ * dependency. Asserting on the validator's output instead of on the document
+ * we built would make this file permanently red for a reason that has nothing
+ * to do with `writeFields`.
+ */
+
+/** The round trip every draft read/write in the object designer goes through. */
+const roundTrip = (fieldsInput: unknown) => writeFields(readFields(fieldsInput));
+
+/**
+ * A stored `fields` map exactly as it arrives from
+ * `GET /api/v1/meta/object/:name` — JSON text, parsed. The prototype-reachable
+ * name sits BETWEEN two ordinary ones so the control travels in the same case,
+ * through the same call, in the same order.
+ */
+/*
+ * ⛔ Written as JSON TEXT, never as `JSON.stringify({ __proto__: … })`. That
+ * argument would be the prototype-setter literal, `stringify` would emit no
+ * such key, and this file would pass while measuring nothing.
+ */
+const STORED_JSON =
+  '{"title":{"type":"text","label":"Title"},'
+  + '"__proto__":{"type":"number","label":"Proto"},'
+  + '"owner_ref":{"type":"text","label":"Owner"}}';
+
+const storedFields = () => JSON.parse(STORED_JSON) as Record<string, unknown>;
+
+/** `writeFields`' record-shape output as the wire sees it. */
+const emittedBody = (fields: unknown) => ({
+  name: 'account',
+  label: 'Account',
+  fields: roundTrip(fields),
+});
+
+describe('the instrument', () => {
+  it('the stored fixture really carries `__proto__` as an OWN enumerable property', () => {
+    // Without this, a fixture rewritten into the object-literal form would
+    // make every assertion below vacuously green.
+    const stored = storedFields();
+    expect(Object.keys(stored)).toEqual(['title', '__proto__', 'owner_ref']);
+    expect(Object.prototype.hasOwnProperty.call(stored, '__proto__')).toBe(true);
+    expect(Object.getPrototypeOf(stored)).toBe(Object.prototype);
+  });
+
+  it('`readFields` surfaces it as an entry — the read half was never the defect', () => {
+    // objectui#9237 measured `readFields` correct and the card's acceptance
+    // forbids touching it. This is the assertion that keeps that true: if the
+    // read door ever starts losing the key, the write-side pin below would go
+    // green for the wrong reason.
+    expect(readFields(storedFields()).entries.map((e) => e.name)).toEqual(['title', '__proto__', 'owner_ref']);
+  });
+
+  it('the name table: only `__proto__` survives blind assignment, so only it can pin this', () => {
+    // Reproduces the defect locally, against plain assignment, independent of
+    // `writeFields`. Every row but the first is green BY CONSTRUCTION — that
+    // is the whole reason the acceptance on objectui#9237 names `__proto__`
+    // verbatim and refuses `constructor` and friends as substitutes.
+    const survivesBlindAssignment = (name: string): boolean => {
+      const out: Record<string, unknown> = {};
+      out[name] = { marker: true };
+      return Object.prototype.hasOwnProperty.call(out, name);
+    };
+    expect(survivesBlindAssignment('__proto__')).toBe(false);
+    for (const name of ['constructor', 'prototype', 'toString', 'hasOwnProperty', 'valueOf', 'title']) {
+      expect([name, survivesBlindAssignment(name)]).toEqual([name, true]);
+    }
+  });
+});
+
+describe('the full round trip — `readFields` then `writeFields`', () => {
+  it('⭐ keeps a stored field named `__proto__`, alongside its ordinary-name controls', () => {
+    const body = roundTrip(storedFields()) as Record<string, unknown>;
+    // Own keys, not `in` — the point is that the entry is an own property of
+    // the emitted map and not a prototype reached through it.
+    expect(Object.keys(body)).toEqual(['title', '__proto__', 'owner_ref']);
+    expect(Object.prototype.hasOwnProperty.call(body, '__proto__')).toBe(true);
+    // Read through the descriptor: plain `.` / `[]` access on this one name is
+    // ambiguous between the own property and `Object.prototype`'s accessor.
+    expect(Object.getOwnPropertyDescriptor(body, '__proto__')?.value).toEqual({ type: 'number', label: 'Proto' });
+  });
+
+  it('⭐ the wire bytes carry it — `JSON.stringify` is what the PUT actually sends', () => {
+    // The own-key assertion above and this one are not the same statement: a
+    // non-enumerable own property would satisfy that one and vanish here, and
+    // the body is serialized before it is sent.
+    const sent = JSON.parse(JSON.stringify(roundTrip(storedFields()))) as Record<string, unknown>;
+    expect(Object.keys(sent)).toEqual(['title', '__proto__', 'owner_ref']);
+  });
+
+  it('the emitted document is spec-legal — which is exactly why the loss was silent', () => {
+    // This half is the severity, not the repair. `ObjectSchema` ACCEPTS the
+    // body with the field and ACCEPTS it without: the validator can never be
+    // the thing that notices, so the pin above is the only instrument there
+    // is. `fields`' key grammar is /^[a-z_][a-z0-9_]*$/, which admits
+    // `__proto__`.
+    expect(ObjectSchema.safeParse(emittedBody(storedFields())).success).toBe(true);
+    const mutilated = { name: 'account', label: 'Account', fields: { title: { type: 'text', label: 'Title' } } };
+    expect(ObjectSchema.safeParse(mutilated).success).toBe(true);
+  });
+
+  it('control: nothing about ordinary names changed', () => {
+    const body = roundTrip(
+      JSON.parse('{"title":{"type":"text","label":"Title"},"owner_ref":{"type":"text","label":"Owner"}}'),
+    ) as Record<string, unknown>;
+    expect(Object.keys(body)).toEqual(['title', 'owner_ref']);
+    expect(ObjectSchema.safeParse(emittedBody(storedFields())).success).toBe(true);
+  });
+
+  it('control: the array shape carries the name as a VALUE and was never affected', () => {
+    // `writeFields`' array branch emits `{ name, ...def }`, so the field name
+    // is never used as a key there. Pinning it keeps the repair honest about
+    // which branch it changed.
+    const view = readFields(JSON.parse('[{"name":"__proto__","type":"number"},{"name":"title","type":"text"}]'));
+    expect(view.shape).toBe('array');
+    expect(writeFields(view)).toEqual([
+      { name: '__proto__', type: 'number' },
+      { name: 'title', type: 'text' },
+    ]);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/object-fields-io.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/object-fields-io.ts
@@ -209,9 +209,18 @@ export function writeFields(view: FieldsView): Record<string, unknown> | Array<R
   if (view.shape === 'array') {
     return view.entries.map((e) => ({ name: e.name, ...e.def }));
   }
-  const out: Record<string, unknown> = {};
-  for (const e of view.entries) out[e.name] = e.def;
-  return out;
+  // ⛔ NEVER assign into a literal here (objectui#9237). `out[e.name] = e.def`
+  // with `e.name === '__proto__'` invokes `Object.prototype`'s ONE accessor
+  // instead of creating an own property, so the entry `readFields` just read
+  // back vanishes before `JSON.stringify` sees it. `__proto__` is a spec-legal
+  // stored field key (`ObjectSchema.fields`' grammar is `/^[a-z_][a-z0-9_]*$/`),
+  // so the PUT body that results is ACCEPTED and the server stores the object
+  // WITHOUT the field — silent destruction of stored metadata by an edit that
+  // never touched it, not a recoverable 422. `Object.fromEntries` defines an
+  // own property, which is the same reason `MetadataService.toFieldsMap` uses
+  // it. `__proto__` is the only name that reproduces: every other
+  // `Object.prototype` member is a data property that assignment shadows.
+  return Object.fromEntries(view.entries.map((e) => [e.name, e.def]));
 }
 
 /** Find the index of a field by name. Returns -1 if not found. */


### PR DESCRIPTION
Fixes #9237

## What was wrong

`packages/app-shell/src/views/metadata-admin/previews/object-fields-io.ts:213` built the
object designer's `fields` map by assigning into an object literal:

```ts
const out: Record OF string TO unknown = {};   // generic spelled in WORDS on purpose:
for (const e of view.entries) out[e.name] = e.def;   // GitHub eats literal angle brackets
```

For the single field name `__proto__`, that assignment invokes `Object.prototype`'s accessor
instead of creating an own property. The entry `readFields` had just read back was therefore
gone before `JSON.stringify` ever saw it.

`__proto__` satisfies `ObjectSchema.fields`' key grammar (`/^[a-z_][a-z0-9_]*$/`), so the
mutilated document was **ACCEPTED**: the PUT succeeded, the server stored the object without
the field, the designer kept showing its in-memory copy, and nothing reported anything.

That is what separates this from every other defect in this family. The others are 422s —
loud, harmless to what is stored, and undone by a reload. This one has no refusal in it and
no reload that recovers the field, because the field is gone from the store. Any save or
field reorder triggered it, including edits that never touched the field.

## The repair

One line, at the one place that had not followed the discipline this repo already wrote down:

```ts
return Object.fromEntries(view.entries.map((e) => [e.name, e.def]));
```

`Object.fromEntries` defines an own property. `MetadataService.toFieldsMap` already used it
for exactly this reason and carries a docblock naming this hazard verbatim.

Deliberately NOT changed, per the triage ruling on the card:

- `readFields` — measured correct, and the new suite pins that it stays correct.
- All 14 `writeFields` call sites across 4 components — the repair is single-point and
  covers every one of them.
- No judgment added at the PUT door. A door guard reads the body it is handed, and a field
  that has already been dropped is not in the body; a door cannot see an absence.

## The pin

`object-fields-io.prototypeKey-9237.test.ts`, 8 assertions over the **full round trip**
(`readFields` then `writeFields`), not over `writeFields`' return value alone.

**It carries `__proto__` verbatim, with ordinary-name controls in the same case**, same call,
same order: the stored fixture is `title`, `__proto__`, `owner_ref`.

Two construction traps the suite defends against rather than merely commenting on:

1. **The pin cannot be written with any other prototype-reachable name.** `__proto__` is the
   only accessor on `Object.prototype`; `constructor`, `prototype`, `toString`,
   `hasOwnProperty` and `valueOf` are data properties that assignment shadows, so a pin using
   one of those is green under the defect too. An executable name table asserts this, so a
   later edit that "generalises" the pin turns the suite red instead of hollowing it out.
2. **Every fixture is built from JSON text.** Writing the fixture as an object literal would
   silently void the file: the `__proto__:` literal form is the prototype setter and creates
   no own property, so there would be nothing to lose. An instrument assertion checks the
   fixture really carries the name as an own enumerable property before anything else runs.
   (I hit this trap while writing the file and the instrument caught it.)

## Ablation leg — the pin was proved able to fail

Swapped `Object.fromEntries` back to blind assignment, with the mutation proved on disk and
the restore proved by state.

```
HEAD blob for target        : ff988eb7c453c00b9305e2fcad4601e41da1b014
BEFORE  fromEntries marker  : 1      assignment-STATEMENT marker : 0
        disk hash           : ff988eb7c453c00b9305e2fcad4601e41da1b014
MUTATED fromEntries marker  : 0      assignment-STATEMENT marker : 1
        disk hash           : 785b9e6ab2610a2fa97da9a19dee75e2b38ecaa4   (differs: yes)
ABLATION vitest exit        : 1
  Test Files  1 failed (1) | Tests  2 failed | 6 passed (8)
  AssertionError: expected [ 'title', 'owner_ref' ]
                to deeply equal [ 'title', '__proto__', 'owner_ref' ]
RESTORED fromEntries marker : 1      assignment-STATEMENT marker : 0
        disk hash           : ff988eb7c453c00b9305e2fcad4601e41da1b014   (== HEAD blob)
        git diff HEAD       : empty
```

The failure text is the whole card in one line: the two ordinary names survived the identical
round trip, the prototype-reachable one did not. Exactly the 2 starred assertions went red and
the 6 instrument/control assertions stayed green — the controls must not depend on the repair,
and they do not.

Notes on the method, since an ablation that silently does nothing is the failure mode here:
the first attempt was **rejected by its own on-disk check** because my marker string
`out[e.name] = e.def` also occurs in the new explanatory comment, making it a false anchor
(before-count 1, not 0). Re-anchored on the whole statement line, which exists only in mutated
code. The restore runs from a `trap ... EXIT INT TERM` using absolute paths and
`git checkout HEAD -- PATH` — never a bare `git checkout --`, which would restore from the
index the mutation had already polluted — and is proved by marker counts, blob hash and an
empty `git diff HEAD`, never by an exit code.

## Verification

| Gate | Result |
|---|---|
| new pin, repo-root vitest | `Test Files 1 passed (1)`, `Tests 8 passed (8)` |
| `vitest run packages/app-shell/src/views/metadata-admin/` | `Test Files 253 passed (253)`, `Tests 2662 passed, 1 skipped` |
| `turbo run type-check --filter=@object-ui/app-shell` | `Tasks: 30 successful, 30 total`, lock `VERDICT command-exit 0` |
| `turbo run lint --filter=@object-ui/app-shell` | exit 0, `0 errors, 2997 warnings` (all pre-existing) |
| `pnpm changeset:check` | exit 0 — no `major` declared, fixed group intact |
| `node scripts/check-changeset-presence.mjs` | exit 0 — 1 released-package source file, 1 changeset |
| `pnpm check:metadata-write-doors` | `OK 17 metadata write door(s) derived ... no writer list anywhere` |
| `pnpm check:designer-field-key-parity` | `designer-field-key-parity: OK` |
| `pnpm check:control-bytes` | `OK (scanned 7472 tracked text file(s))` |
| `pnpm check:test-path-roots` | `OK (1900 filesystem call(s) in 394 of 3078 test file(s))` |
| `pnpm check:new-line-citations` | exit 0 |
| `pnpm check:changeset-claims` | exit 0 (report-only) |
| `node scripts/check-governed-queue-guard.mjs --test` | `NOT GOVERNED — 3 path(s) checked against 5 governed surface(s)` |

Every exit code was captured before any pipe. Gate rows quote each gate's own printed verdict
line, not a bare `$?`.

**Blast radius.** objectui#9273's warning does not bite here, and that is measured rather than
assumed: the production diff is 3 lines removed and 1 added, entirely inside one function
body. No exported signature, call site, rendered node or declaration key moved, and
`object-fields-io` has no importer outside `packages/app-shell` (the only out-of-package hits
are prose references in docblocks and one gate script, all path-only, no line citations into
the edited region). So `examples/schema-catalog/` and the count-shaped and README prose
figures are not implicated.

## Changeset level

`patch`, on `@object-ui/app-shell`.

All 41 packages sit in one `fixed` group, so `major` is unavailable and a break would have to
ship as `minor` with a `**BREAKING**` carrier. **This is not a break in either direction.**
Before the change a stored `__proto__` field was destroyed on every save; after it, it
survives. No caller's input changes, no output shape changes, and nothing that worked before
stops working — the only behaviour difference is that a document which used to lose a field
now keeps it. A consumer would have to be depending on stored metadata being silently deleted
for this to break it. `patch` is the honest level.

## Scope note

`needs:contract-review` is hung on both this PR and the card, per the PM's `Clause-②: yes` —
the repair changes what a published app-shell writer emits in a PUT body. Raising a gate
cannot fail open; clearing either limb is the PM's, not mine.

## Acceptance notes

Findings made while measuring this card, reported rather than fixed here.

- ⭐ **The fork is NOT falsified — no first-party producer of the name was found**, so the card
  stays p2 on triage's reachability reading. Details and the honest limits of that search are
  in the seat's JSON report on the card. One measured correction to the card and triage text:
  the sanitiser turns `__proto__` into **`proto`** (strict `toFieldName`) or **`proto_`**
  (`toFieldNameLoose`), not `_proto_` as both state. The conclusion is unchanged and slightly
  strengthened.
- ⭐ **A second instance of this exact construction defect, one layer up, in the validator.**
  Measured on zod 4.4.3, which is what `ObjectSchema.fields` is built from: `z.record()`
  reports `success: true` and hands back an output object with the `__proto__` entry
  **missing** (input own keys `[x, __proto__]`, output own keys `[x]`). Filed separately
  against `@objectstack/spec`'s repo; see the JSON report for the issue reference. It is
  latent rather than live at the two objectstack call sites checked, because both discard the
  parsed value and use it only for refusal — but any code that stores or re-emits
  `ObjectSchema.parse(doc)` output destroys the field exactly as this PR's defect did. This is
  also why the new suite asserts on the document it built and never on
  `safeParse(...).data`; doing the latter would make it permanently red for a reason that has
  nothing to do with `writeFields`.
- noted, not filed: `check:test-path-roots` reports `381 root(s) NOT CLASSIFIED` on every run,
  i.e. the gate is blind to roughly a fifth of what it scans and says so. Pre-existing,
  untouched by this PR, and the gate already prints its own blind spot with a `--blind` flag
  to enumerate it. Successor: the next seat to work that gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_