### PR TITLE
fix(plugin-designer): the Object Manager withholds Delete on a system object

### DIFF
--- a/.changeset/9219-objectmanager-system-object-delete.md
+++ b/.changeset/9219-objectmanager-system-object-delete.md
@@ -1,0 +1,37 @@
+---
+'@object-ui/plugin-designer': patch
+---
+
+The Object Manager stops drawing a delete action it refuses to run
+(objectui#9219) — objectui#8674's defect, one component over.
+
+**The defect.** `ObjectManager`'s `handleDelete` returned early on
+`obj.isSystem`, before the confirm dialog, while the affordance was wired at the
+GRID level (`onDelete={readOnly ? undefined : handleDelete}`) — one callback,
+drawn identically for every row. So a system-object row carried a delete entry
+whose click produced no dialog, no toast and no console message. That row is on
+screen by DEFAULT: `showSystemObjects` defaults to true and the component
+filters system objects out only when it is false. `readOnly` was honest in the
+same component (the callback is withheld, so nothing is drawn); `isSystem` drew
+the entry and swallowed the click. The two states differed in the code and did
+not differ on screen.
+
+**The fix.** `ObjectManager` now passes `rowOperations`, the per-row narrowing
+objectui#8674 added to `ObjectGrid`, answering `{ delete: !!obj &&
+!obj.isSystem }` for each row — the same three lines the Field Designer got.
+A system object's row no longer offers Delete at all; an unresolvable row is
+withheld too, because `handleDelete` returns early on a missed lookup and
+offering delete there would reproduce this very defect.
+
+Edit is untouched. `isSystem` disables the `name` input inside the edit form and
+has never meant "this row is untouchable", so the modal still opens for a system
+object exactly as before. The guard inside `handleDelete` also stays, as a
+second line for anyone invoking that published prop value directly — it is just
+no longer the only refusal.
+
+**Why `patch`.** No API surface moves: no prop, type, export or signature is
+added, changed or removed, and `rowOperations` is a prop `ObjectGrid` already
+published. The only user-visible change is that an entry which never did
+anything — the click was dropped before the dialog — is no longer drawn, so
+nothing a caller could have depended on stops working. This is the level the
+merged sibling repair declared for the same defect in the same package.

--- a/packages/plugin-designer/src/ObjectManager.tsx
+++ b/packages/plugin-designer/src/ObjectManager.tsx
@@ -135,8 +135,39 @@ export function ObjectManager({
     }
   }, [objects]);
 
+  /**
+   * [objectui#9219] What THIS row may be asked to do — the per-row narrowing
+   * objectui#8674 added to `ObjectGrid`, applied to the sibling component the
+   * same defect lived in.
+   *
+   * `operations` and the `onDelete` wiring below are grid-level and identical
+   * for every row, so the refusal for a system object used to live in
+   * `handleDelete` and fire AFTER the entry had been drawn and clicked: no
+   * dialog, no toast, no console message. `readOnly` was honest in the same
+   * component (the callback is withheld, so nothing is drawn); `isSystem` drew
+   * the entry and swallowed the click, and system objects are on screen by
+   * DEFAULT (`showSystemObjects` defaults to true), so that row is reachable
+   * without the caller doing anything unusual.
+   *
+   * `delete` only. `isSystem` disables `name` in the edit form; it has never
+   * meant "this row is untouchable", and withholding Edit here would be a
+   * capability regression wearing a bug fix's clothes.
+   *
+   * An unresolvable row is withheld for the same reason and not as a
+   * defensive flourish: `handleDelete` returns early when the lookup misses,
+   * so offering delete for such a row would reproduce this very defect.
+   */
+  const rowOperations = useCallback((record: Record<string, unknown>) => {
+    const obj = objects.find((o) => o.name === record.name);
+    return { delete: !!obj && !obj.isSystem };
+  }, [objects]);
+
   const handleDelete = useCallback(async (record: Record<string, unknown>) => {
     const obj = objects.find((o) => o.name === record.name);
+    // Unreachable through the grid now that `rowOperations` withholds the
+    // action for exactly these two cases — kept because this callback is a
+    // published prop value and nothing stops a future caller invoking it
+    // directly. It must never become the ONLY refusal again.
     if (!obj || obj.isSystem) return;
     const confirmed = await confirmDialog.confirm(
       t('appDesigner.objectManager.deleteConfirmTitle'),
@@ -255,6 +286,7 @@ export function ObjectManager({
         onRowClick={handleRowClick}
         onEdit={readOnly ? undefined : handleEdit}
         onDelete={readOnly ? undefined : handleDelete}
+        rowOperations={rowOperations}
         onAddRecord={readOnly ? undefined : handleAddObject}
       />
 

--- a/packages/plugin-designer/src/__tests__/ObjectManager.systemObjectDelete-9219.test.tsx
+++ b/packages/plugin-designer/src/__tests__/ObjectManager.systemObjectDelete-9219.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9219 — the Object Manager offers no delete action on a system
+ * object. objectui#8674's defect, one component over.
+ *
+ * ## The card
+ *
+ * `handleDelete` returned early on `obj.isSystem`, before the confirm dialog,
+ * while the affordance was wired at the GRID level
+ * (`onDelete={readOnly ? undefined : handleDelete}`) — one callback, drawn for
+ * every row. So a system-object row carried a delete entry whose click
+ * produced no dialog, no toast and no console message. `readOnly` was honest
+ * in the same component (the callback is withheld, so nothing is drawn);
+ * `isSystem` drew the entry and swallowed the click. Two states that differ in
+ * the code and do not differ on screen.
+ *
+ * The row is reachable by DEFAULT: `showSystemObjects` defaults to true and
+ * `displayObjects` filters system objects out only when it is false — pinned
+ * next door by `ObjectManager.test.tsx`'s *should show system objects by
+ * default*. The first assertion below re-reads that default from this file, so
+ * the two arms that follow are known to be about a row that is actually on
+ * screen.
+ *
+ * ## ⚠️ Why this file renders the REAL `ObjectGrid`
+ *
+ * `ObjectManager.test.tsx` mounts `__mocks__/plugin-grid`, and that double
+ * draws a delete button for every row whenever `onDelete` is wired while
+ * knowing nothing about `rowOperations`. It therefore reproduces this defect by
+ * construction and is structurally blind to the repair: a pin written against
+ * it is green whether or not the fix lands. The claim under test is about what
+ * the GRID draws for a row, so the grid under test has to be the real one.
+ *
+ * Teaching the double the prop was the other admissible route. It was not
+ * taken: the semantics being asserted are the grid's intersection rules — only
+ * an explicit `false` removes, `null` / `undefined` / `{}` mean "no opinion" —
+ * and a hand-written second copy of those rules in a stub is free to drift away
+ * from the one `packages/plugin-grid` actually ships. `plugin-grid`'s own
+ * `rowOperationsPerRow-8674.test.tsx` pins the rules; this file pins that
+ * `ObjectManager` speaks them, through the same component a user sees. The
+ * sibling repair set the same precedent in
+ * `FieldDesigner.systemFieldDelete-8674.test.tsx`, whose shape this file
+ * follows deliberately.
+ *
+ * ## Every absence is paired with a presence
+ *
+ * The system row's missing Delete is read next to its surviving Edit, and next
+ * to the custom row that keeps both — in the SAME render. A lone
+ * `queryBy… === null` would be equally green if the grid never rendered, the
+ * row were addressed wrongly, or the menu never opened.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import type { ObjectDefinition } from '@object-ui/types';
+import { ActionProvider } from '@object-ui/react';
+
+import { ObjectManager } from '../ObjectManager';
+// The REAL record-level explain double and cache reset the grid suites use —
+// imported rather than restated, so this file answers that probe the same way
+// `plugin-grid`'s own suites do instead of hitting the network under happy-dom.
+import { installExplainDouble } from '../../../plugin-grid/src/__tests__/explainDouble';
+import { __clearRecordCrudVerdictCache } from '../../../plugin-grid/src/hooks/useRecordCrudVerdicts';
+
+// No `registerAllFields()`: `@object-ui/fields` is not a dependency of this
+// package, and nothing here needs a field WIDGET — the assertions read row text
+// and the row kebab's entries, both of which the grid renders on its own.
+
+/** An ordinary, author-created object — the presence half of every pair. */
+const CUSTOM: ObjectDefinition = {
+  id: 'obj_custom',
+  name: 'accounts',
+  label: 'Accounts',
+  group: 'Custom Objects',
+  isSystem: false,
+  fieldCount: 12,
+};
+
+/** A system object: the designer may not drop it, and now does not offer to. */
+const SYSTEM: ObjectDefinition = {
+  id: 'obj_system',
+  name: 'users',
+  label: 'Users',
+  group: 'System Objects',
+  isSystem: true,
+  fieldCount: 5,
+};
+
+const OBJECTS = [CUSTOM, SYSTEM];
+
+function renderManager(props: Partial<React.ComponentProps<typeof ObjectManager>> = {}) {
+  return render(
+    <ActionProvider>
+      <ObjectManager objects={OBJECTS} onObjectsChange={vi.fn()} {...props} />
+    </ActionProvider>,
+  );
+}
+
+/**
+ * What the kebab of the row displaying `name` surfaces.
+ *
+ * Located by ROW rather than by index: a row whose entries are all hidden grows
+ * no "⋮" trigger at all (#3562), so indexing into `queryAllByTestId` would
+ * silently address a different row as soon as the gating works.
+ */
+async function rowKebab(name: string): Promise<{ edit: boolean; delete: boolean; trigger: boolean }> {
+  const row = screen.getByText(name).closest('tr');
+  const trigger = row?.querySelector('[data-testid="row-action-trigger"]');
+  if (!trigger) return { edit: false, delete: false, trigger: false };
+  await userEvent.click(trigger);
+  const answer = {
+    edit: screen.queryAllByTestId('row-action-builtin-edit').length > 0,
+    delete: screen.queryAllByTestId('row-action-builtin-delete').length > 0,
+    trigger: true,
+  };
+  // Close the (portalled) menu so the next row's read sees only its own items.
+  await userEvent.keyboard('{Escape}');
+  return answer;
+}
+
+async function settle() {
+  await waitFor(() => expect(screen.getByText(SYSTEM.name)).toBeInTheDocument());
+}
+
+beforeEach(() => {
+  __clearRecordCrudVerdictCache();
+  installExplainDouble();
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('objectui#9219 · the system object draws no delete action', () => {
+  it('withholds Delete on the system row and keeps it on the custom row, at the default visibility', async () => {
+    // BOTH ARMS in one render, and no `showSystemObjects` prop — the state the
+    // card is about is the DEFAULT one. Pre-fix this read `delete: true` on
+    // both rows and the system row's click did nothing at all.
+    renderManager();
+    await settle();
+
+    // The premise, read here rather than borrowed: the system row IS on screen
+    // without anyone asking for it.
+    expect(screen.getByText(SYSTEM.name)).toBeInTheDocument();
+    expect(screen.getByText(CUSTOM.name)).toBeInTheDocument();
+
+    expect(await rowKebab(SYSTEM.name)).toEqual({ edit: true, delete: false, trigger: true });
+    expect(await rowKebab(CUSTOM.name)).toEqual({ edit: true, delete: true, trigger: true });
+  });
+
+  it('keeps the system row editable — the modal still opens, it is only delete that is refused', async () => {
+    // The narrowing is `delete` only. `isSystem` disables the `name` input
+    // inside the form; it has never meant "this row is untouchable", and a fix
+    // that withheld Edit too would be a capability regression wearing a bug
+    // fix's clothes.
+    renderManager();
+    await settle();
+
+    const row = screen.getByText(SYSTEM.name).closest('tr');
+    await userEvent.click(row!.querySelector('[data-testid="row-action-trigger"]')!);
+    await userEvent.click(screen.getAllByTestId('row-action-builtin-edit')[0]);
+
+    await waitFor(() => expect(screen.getByDisplayValue(SYSTEM.label)).toBeInTheDocument());
+  });
+
+  it('readOnly stays honest: no row actions at all, for either kind of object', async () => {
+    // The state the card called the honest one, unchanged by this fix.
+    renderManager({ readOnly: true });
+    await settle();
+
+    expect(await rowKebab(SYSTEM.name)).toEqual({ edit: false, delete: false, trigger: false });
+    expect(await rowKebab(CUSTOM.name)).toEqual({ edit: false, delete: false, trigger: false });
+  });
+});


### PR DESCRIPTION
Fixes #9219

## The defect

`packages/plugin-designer/src/ObjectManager.tsx` — `handleDelete` returned early on `obj.isSystem`, **before the confirm dialog**, while the affordance was wired at the GRID level (`onDelete={readOnly ? undefined : handleDelete}`): one callback, drawn identically for every row. So a system-object row carried a delete entry whose click produced **no dialog, no toast, no console message**.

That row is on screen **by default** — `showSystemObjects` defaults to `true`, and `displayObjects` filters system objects out only when it is `false` (pinned next door by *should show system objects by default*).

`readOnly` was honest in the same component (the callback is withheld, so nothing is drawn); `isSystem` drew the entry and swallowed the click. Two states that differ in the code and do not differ on screen. This is objectui#8674's defect, one component over.

## The change

`ObjectManager` now supplies `rowOperations`, the per-row narrowing landed by PR objectui#9224, answering `{ delete: !!obj && !obj.isSystem }` per row — the same three lines the Field Designer got.

- **`update` is untouched.** `isSystem` disables the `name` input inside the edit form; it has never meant "this row is untouchable", and withholding Edit here would be a capability regression wearing a bug repair's clothes. Pinned: the modal still opens for a system object.
- **An unresolvable row is withheld too**, not as a defensive flourish: `handleDelete` returns early on a missed lookup, so offering delete there would reproduce this very defect.
- **`handleDelete`'s `isSystem` early return stays** as the second line of defence. The guard statement is **byte-identical** — it appears as an unchanged context line in the diff; only an explanatory comment was added above it, exactly as the merged sibling repair did.
- **`ObjectGrid` itself is untouched.** The diff is two files under `packages/plugin-designer/` plus one changeset.

## The pin, and the mock trap

`ObjectManager.test.tsx` mounts `src/__tests__/__mocks__/plugin-grid.tsx`, which draws a delete button for every row whenever `onDelete` is wired and contains **zero** occurrences of `rowOperations`. It reproduces this defect by construction and is structurally blind to the repair — **a pin written against it is green either way**.

Route taken: **render the real `ObjectGrid`**, in a new file `src/__tests__/ObjectManager.systemObjectDelete-9219.test.tsx`. `vi.mock` is file-scoped, so this file sees the genuine grid while its siblings keep their double. Teaching the mock the prop was the other admissible route and was **not** taken: the semantics under assertion are the grid's intersection rules (only an explicit `false` removes; `null` / `undefined` / `{}` mean "no opinion"), and a hand-written second copy of those rules inside a stub is free to drift from the one `packages/plugin-grid` ships. `plugin-grid`'s own `rowOperationsPerRow-8674.test.tsx` pins the rules; this file pins that `ObjectManager` speaks them, through the component a user actually sees. Same precedent as `FieldDesigner.systemFieldDelete-8674.test.tsx`, whose shape this file follows deliberately.

Three cases, each absence paired with a presence **in the same render**:

1. At the default visibility, both rows present: system row `{ edit: true, delete: false }`, custom row `{ edit: true, delete: true }`.
2. The system row is still editable — the modal opens.
3. `readOnly` stays honest: no row actions at all, for either kind of object.

## Verification — all at `2ac8fc9e2`, working tree clean

Repo-root invocations throughout (`RUN v4.1.10 /home/user/objectui-issue-9219`), per AGENTS.md.

| Run | Result |
|---|---|
| `pnpm exec vitest run packages/plugin-designer/src/__tests__/ObjectManager.systemObjectDelete-9219.test.tsx` | `EXIT=0` · Test Files 1 passed · Tests 3 passed |
| `pnpm exec vitest run packages/plugin-designer/` (blast radius, see below) | `EXIT=0` · Test Files 21 passed · Tests 159 passed |
| `pnpm run type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | `EXIT=0` |
| `pnpm run lint` (package `eslint .`) | `EXIT=0` · 0 errors, 65 pre-existing warnings, **none** on either changed file |

Twelve gate scripts, each `EXIT=0` at `2ac8fc9e2`: `check-changeset-presence`, `check-changeset-fixed`, `check-changeset-no-major`, `check-changeset-claims`, `check-control-bytes`, `check-new-cross-file-line-citations`, `check-vi-mock-specifiers`, `check-vi-mock-inherit`, `check-vi-mock-override-shape`, `check-test-path-roots`, `check-shell-escape-residue`, `check-unreferenced-sources`. Their own verdict lines, not a bare `$?`:

```
✅  2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s).
✅  No changeset declares a `major` bump.
✅  No pending changeset names a file this change touches.
```

`changeset:check` is the script pair above (`check-changeset-fixed` + `check-changeset-no-major`), run individually.

**The typecheck really covers the new pin — measured, not assumed.** `tsc -p tsconfig.test.json --listFiles | grep -c ObjectManager.systemObjectDelete-9219` is `1`; the base `tsc --noEmit` program is `0`, which is why `type-check` runs both.

**Blast radius.** A package-scoped run is not automatically the blast radius (objectui#9273), so it was measured: every cross-package occurrence of `ObjectManager` outside this package is **prose in a comment**, not an import. The only importers of the component are `plugin-designer`'s own `index.tsx` and `MetadataObjectsPage.tsx`, both covered by the 21-file run. No prop, type, export or signature changed, so no consumer's surface moved.

One pre-existing cross-file line citation points into this file — `plugin-grid/src/__tests__/addRowCreatePermissionGate.test.tsx:217` cites `ObjectManager (:119)`. Line 119 is **byte-identical** before and after (the first insertion is below it); verified against `origin/main`.

## Ablation leg

Remove the `rowOperations` wiring; the pin must go red. Mutation proved on disk before the run was believed, restore under a `trap … EXIT INT TERM` with absolute paths, restore proved **by state** and never by an exit code.

```
HEAD_BLOB      = 7d642976689c203e673dcaeec44dca12d4c41612
PRE  hash      = 7d642976689c203e673dcaeec44dca12d4c41612   (matches HEAD: yes)
PRE  marker    = 1  x 'rowOperations={rowOperations}'
POST hash      = e719d142e2720e96a7e9b8cbd7e44598f5727fa7
POST marker    = 0 x 'rowOperations={rowOperations}'
MUTATION LANDED ON DISK: marker 1 -> 0, hash 7d64297… -> e719d14…
ABLATED_EXIT   = 1  (expected NON-ZERO)
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
BACK hash      = 7d642976689c203e673dcaeec44dca12d4c41612   (matches HEAD blob: yes)
BACK marker    = 1 x 'rowOperations={rowOperations}'
git diff HEAD  = 0 bytes (0 == clean)
RESTORE PROVED BY STATE.
```

The failing assertion is the card itself, not an incidental break:

```
× withholds Delete on the system row and keeps it on the custom row, at the default visibility
AssertionError: expected { edit: true, delete: true, …(1) }
                to deeply equal { edit: true, delete: false, …(1) }
```

The ablated tree draws Delete on the system row — the defect, reproduced. The script guards every failure mode loudly: an empty `git hash-object` result exits non-zero rather than reading as "nothing to compare", a marker count that does not move exits non-zero rather than letting a no-op mutation pass as a measurement, and the restore is checked three ways (hash back to the HEAD blob, marker back to 1, `git diff HEAD` zero bytes).

The fix was committed **before** the ablation, so the restore leg targets `git checkout HEAD -- …` against a real commit rather than a bare checkout that would take the mutation back out of the index.

## Changeset

`.changeset/9219-objectmanager-system-object-delete.md` — `@object-ui/plugin-designer: patch`.

Justification: no API surface moves (no prop, type, export or signature added, changed or removed; `rowOperations` is a prop `ObjectGrid` already publishes), and the only user-visible change is that an entry which **never did anything** — the click was dropped before the dialog — is no longer drawn, so nothing a caller could have depended on stops working. `minor` was considered, since a delete affordance disappearing from a published designer surface is visible; it was rejected because the surface's contract is unchanged and the behaviour is a bug repair, and because the merged sibling repair declared exactly `patch` for the same defect in the same package. `major` is unavailable by policy (one `fixed` group of 41 packages).

## Acceptance notes

- **Noted, not filed:** `src/__tests__/__mocks__/plugin-grid.tsx` still contains zero occurrences of `rowOperations`. This PR routes around it rather than through it, so nothing here depends on the double — but it remains blind to per-row gating for whoever comes next. Successor who will meet it: the next author adding a *rendered-affordance* assertion to any `plugin-designer` suite that mounts that double (today, `ObjectManager.test.tsx`). Not filed: a test double that cannot see a prop is not a product defect, not a declared-contract violation, and not a metadata trap, and the card's acceptance explicitly sanctioned leaving it untaught by taking the real-grid route.
- **Same-class sweep, zero further hits.** Every other real `ObjectGrid` call site in the repo was checked for the draw-then-swallow shape. `plugin-view`'s `ObjectView` wires `onDelete={operations.delete !== false ? handleDelete : undefined}` and its handler only bumps a refresh key — no record-level refusal hidden behind a drawn button. The remaining call sites wire no per-record refusal at all.
- No docs change is owed: `ObjectManager` is documented in neither `packages/plugin-designer/README.md` nor `content/docs/`, and this PR adds no API, so no documented statement becomes false. The `rowOperations` prop's own docs landed with objectui#9224.

Session: `https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ`


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_