### PR TITLE
fix(plugin-detail): honour showBorder on DetailSection's collapsible branch

### DIFF
--- a/.changeset/9218-detailsection-collapsible-showborder.md
+++ b/.changeset/9218-detailsection-collapsible-showborder.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+Honour `showBorder` on `DetailSection`'s collapsible branch (objectui#9218).
+
+A section authored with both `collapsible: true` and `showBorder: false` kept its
+border and shadow. `DetailSection` ends in three returns and the key was read on
+exactly two of them: the flat branch and the non-collapsible `Card` branch. The
+collapsible branch wrapped a **bare** `<Card>` and never mentioned `showBorder`, so
+the declaration was structurally unreachable there. The collapsible `<Card>` now
+carries the same decision branch 2 already made — `border-none shadow-none` when
+`showBorder === false`.
+
+**Patch, and the level is measured rather than intuited.**
+
+- *Nothing stops rendering.* No node, prop, export or registration moved. The diff
+  is one `className` on one existing `<Card>`.
+- *Nothing stops type-checking.* `showBorder` was already declared on all three of
+  its surfaces — `DetailViewSection` in `@object-ui/types`, its Zod mirror, and the
+  `detail-section` registration's `inputs` — and none of them is touched. This change
+  makes the implementation catch up with a declaration that already shipped.
+- *What an author authored today changes visually, and only in the direction they
+  asked for.* A node carrying `collapsible: true` + `showBorder: false` already
+  passed `sdui-parser`'s `validateTree` clean and then drew a border anyway; it now
+  draws none. The only behaviour that regresses is a border that was present because
+  the key was being dropped, which is the defect itself — so this is not a breaking
+  change and does not need a `**BREAKING**` carrier. A census of this repository
+  found zero authored `detail-section` nodes under `examples/`, `apps/` or `content/`,
+  so no in-repo page changes appearance.
+
+`className` deliberately stays on the outer `Collapsible` where it already was;
+relocating it is a different behaviour that objectui#9218 did not measure, and a
+drift guard now reds if a later change moves it.

--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -675,7 +675,12 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
       onOpenChange={(open) => setIsCollapsed(!open)}
       className={className}
     >
-      <Card>
+      {/*
+        objectui#9218 — the SAME decision branch 2 above makes, and only that
+        one. `className` stays on the outer `Collapsible`: relocating it is a
+        different behaviour, unmeasured by that card.
+      */}
+      <Card className={cn(section.showBorder === false ? 'border-none shadow-none' : '')}>
         <CollapsibleTrigger asChild>
           <CardHeader className={cn(
             "py-3 px-4 sm:py-4 sm:px-6 cursor-pointer hover:bg-muted/50 transition-colors",

--- a/packages/plugin-detail/src/__tests__/DetailSection.collapsibleShowBorder-9218.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailSection.collapsibleShowBorder-9218.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9218 — `DetailSection`'s COLLAPSIBLE branch honours
+ * `section.showBorder`.
+ *
+ * ## What was broken, measured rather than read
+ *
+ * `DetailSection` ends in three returns and `showBorder` appeared in exactly
+ * two of them on `a9d97be63`:
+ *
+ *  1. the flat branch — `!section.title && !section.collapsible &&
+ *     section.showBorder === false` — reads it;
+ *  2. the non-collapsible `Card` branch — `section.showBorder === false ?
+ *     'border-none shadow-none' : ''` — reads it;
+ *  3. the collapsible branch — a `Collapsible` wrapping a BARE `Card` — never
+ *     mentioned it, so the key was structurally unreachable there.
+ *
+ * `showBorder` is declared on three surfaces at once (`DetailViewSection` in
+ * `@object-ui/types`, its Zod mirror, and the `detail-section` registration's
+ * `inputs`), so `sdui-parser`'s `validateTree` told an author the node was
+ * correct and complete — and then the border stayed. Declared clean,
+ * published clean, rendered wrong: ADR-0049 enforce-or-remove shape.
+ *
+ * ## Why every row here is a RENDERING verdict
+ *
+ * Each row reads the class list of the real `Card` element, and each carries
+ * its own negative (`showBorder: true` on the same branch, same shape). A row
+ * asserting only "the prop arrived" would pass on the broken tree, which is
+ * precisely the defect.
+ *
+ * ## The control, and why it can fire
+ *
+ * The `collapsible: false` rows are the same authored node with ONE key
+ * flipped, and they were GREEN on the unmodified tree — branch 2 already read
+ * the key. They are what makes the collapsible rows a statement about the
+ * branch rather than about `showBorder` in general. Each side additionally
+ * asserts WHICH branch it landed on (`[aria-expanded]` present / absent), so
+ * a future change that quietly routes the collapsible node through branch 2
+ * reds here instead of passing silently.
+ *
+ * ## Measured legs
+ *
+ * - PIN-FIRST. This file was written before `DetailSection.tsx` was touched
+ *   and run against the unmodified base tree `a9d97be63`: `2 failed | 4
+ *   passed`. The two rows that failed are the collapsible `showBorder: false`
+ *   verdicts; both `collapsible: false` control rows, the collapsible
+ *   `showBorder: true` negative and the drift guard passed.
+ * - ABLATION. With the fix committed, deleting the new decision from the
+ *   collapsible branch's `<Card>` reddens exactly those same two rows and
+ *   nothing else. Both legs are recorded in the pull request.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { SchemaRenderer } from '@object-ui/react';
+import type { DetailViewSection } from '@object-ui/types';
+
+import { DetailSection } from '../DetailSection';
+
+// Module scope, not a hook (AGENTS.md test discipline): importing the package
+// index executes its registration side-effects, so the `detail-section` entry
+// resolved below is the very one production resolves.
+import '../index';
+
+const RECORD = { street: '1 Market St', city: 'San Francisco' };
+
+/**
+ * The node an author writes. A `title` is present on purpose: without one, a
+ * `collapsible: false` + `showBorder: false` node takes the FLAT branch and
+ * renders no `Card` at all, and the control would then be measuring a third
+ * branch instead of branch 2.
+ */
+const authoredNode = (overrides: Record<string, unknown>) =>
+  ({
+    type: 'detail-section',
+    title: 'Billing Address',
+    fields: [
+      { name: 'street', label: 'Street' },
+      { name: 'city', label: 'City' },
+    ],
+    ...overrides,
+  }) as never;
+
+/** The same section, reached the way `DetailView` / `SectionGroup` reach it. */
+const directSection = (overrides: Record<string, unknown>) =>
+  ({
+    title: 'Billing Address',
+    fields: [
+      { name: 'street', label: 'Street' },
+      { name: 'city', label: 'City' },
+    ],
+    ...overrides,
+  }) as unknown as DetailViewSection;
+
+/**
+ * The `Card` element itself, not "somewhere in the subtree". `Card`'s own base
+ * classes are `rounded-lg border bg-card text-card-foreground shadow-sm`, so
+ * `.bg-card` identifies it and survives any `className` the branch adds.
+ * Asserted unique, so the reading cannot silently become about a second card.
+ */
+const cardOf = (container: HTMLElement): HTMLElement => {
+  const cards = container.querySelectorAll<HTMLElement>('.bg-card');
+  expect(cards).toHaveLength(1);
+  return cards[0];
+};
+
+/** The disclosure affordance `CollapsibleTrigger` puts on the card header. */
+const isCollapsibleBranch = (container: HTMLElement) =>
+  container.querySelector('[aria-expanded]') !== null;
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('objectui#9218 — the collapsible branch honours showBorder', () => {
+  it('drops border and shadow on an authored collapsible node with `showBorder: false`', () => {
+    const { container } = render(
+      <SchemaRenderer
+        schema={authoredNode({ collapsible: true, showBorder: false })}
+        data={RECORD}
+      />,
+    );
+
+    // The block rendered at all — not `SchemaErrorBoundary`'s banner.
+    expect(screen.queryByText(/failed to render/i)).toBeNull();
+    // This really is branch 3, so the row below is about the collapsible card.
+    expect(isCollapsibleBranch(container)).toBe(true);
+
+    const card = cardOf(container);
+    expect(card.classList.contains('border-none')).toBe(true);
+    expect(card.classList.contains('shadow-none')).toBe(true);
+    // `cn()` is tailwind-merge: the base `shadow-sm` is displaced, not stacked.
+    expect(card.classList.contains('shadow-sm')).toBe(false);
+  });
+
+  it('keeps border and shadow on the same collapsible node with `showBorder: true`', () => {
+    const { container } = render(
+      <SchemaRenderer
+        schema={authoredNode({ collapsible: true, showBorder: true })}
+        data={RECORD}
+      />,
+    );
+
+    expect(isCollapsibleBranch(container)).toBe(true);
+
+    const card = cardOf(container);
+    expect(card.classList.contains('border-none')).toBe(false);
+    expect(card.classList.contains('shadow-none')).toBe(false);
+    expect(card.classList.contains('shadow-sm')).toBe(true);
+  });
+
+  it('reaches the same verdict through the direct `section` prop `DetailView` uses', () => {
+    const { container } = render(
+      <DetailSection
+        section={directSection({ collapsible: true, showBorder: false })}
+        data={RECORD}
+      />,
+    );
+
+    expect(isCollapsibleBranch(container)).toBe(true);
+    expect(cardOf(container).classList.contains('border-none')).toBe(true);
+  });
+
+  /**
+   * THE CONTROL — the same authored node with `collapsible` flipped, i.e.
+   * branch 2. Green on the unmodified tree, which is what makes the rows above
+   * a reading about the collapsible branch and not about `showBorder` at all.
+   */
+  it('control: the non-collapsible branch already dropped the border, and is a different branch', () => {
+    const { container } = render(
+      <SchemaRenderer
+        schema={authoredNode({ collapsible: false, showBorder: false })}
+        data={RECORD}
+      />,
+    );
+
+    // The control must be able to tell the two branches apart; if this ever
+    // reads `true` the control has stopped being a control.
+    expect(isCollapsibleBranch(container)).toBe(false);
+
+    const card = cardOf(container);
+    expect(card.classList.contains('border-none')).toBe(true);
+    expect(card.classList.contains('shadow-none')).toBe(true);
+  });
+
+  it('control negative: the non-collapsible branch keeps its border with `showBorder: true`', () => {
+    const { container } = render(
+      <SchemaRenderer
+        schema={authoredNode({ collapsible: false, showBorder: true })}
+        data={RECORD}
+      />,
+    );
+
+    expect(isCollapsibleBranch(container)).toBe(false);
+    expect(cardOf(container).classList.contains('border-none')).toBe(false);
+  });
+
+  /**
+   * DRIFT GUARD, not the pin. objectui#9218 adds two classes to the
+   * collapsible branch's `<Card>` and deliberately leaves the author's
+   * `className` on the OUTER `Collapsible` — moving it is a different
+   * behaviour that this card did not measure. This row reds if a later change
+   * relocates it.
+   */
+  it('leaves the authored className on the outer Collapsible wrapper', () => {
+    const { container } = render(
+      <DetailSection
+        section={directSection({ collapsible: true, showBorder: false })}
+        data={RECORD}
+        className="os-9218-probe"
+      />,
+    );
+
+    const marked = container.querySelector('.os-9218-probe');
+    expect(marked).not.toBeNull();
+    // The wrapper, not the card: the card is a descendant of it.
+    expect(marked!.classList.contains('bg-card')).toBe(false);
+    expect(marked!.querySelector('.bg-card')).not.toBeNull();
+  });
+});

--- a/packages/plugin-detail/src/__tests__/detailSectionAuthoredNode-8626.test.tsx
+++ b/packages/plugin-detail/src/__tests__/detailSectionAuthoredNode-8626.test.tsx
@@ -144,14 +144,17 @@ describe('objectui#8626 — an authored detail-section node renders its declared
   });
 
   /**
-   * ⚠️ Authored `collapsible: false` ON PURPOSE, and the reason is a defect
-   * this card did NOT fix: `DetailSection`'s collapsible branch renders a bare
-   * `<Card>` and never reads `section.showBorder`, so the key is honoured only
-   * on the non-collapsible branch. That is a separate, pre-existing bug inside
-   * `DetailSection` — the component this card deliberately leaves
-   * byte-identical — filed rather than repaired here. Pinning `showBorder`
-   * against the branch that DOES read it keeps this row a reading about the
-   * fold, not about that bug.
+   * Authored `collapsible: false` ON PURPOSE, so this row stays a reading
+   * about the FOLD — that `showBorder` reaches `DetailSection` at all — and
+   * not about which branch consumes it.
+   *
+   * It originally carried a second reason: `DetailSection`'s collapsible
+   * branch rendered a bare `<Card>` and never read `section.showBorder`, so
+   * only the non-collapsible branch honoured the key. That was a separate,
+   * pre-existing bug in the component this card deliberately leaves
+   * byte-identical; it was filed rather than repaired here, and objectui#9218
+   * has since closed it. The branch axis now lives where it belongs, in
+   * `DetailSection.collapsibleShowBorder-9218.test.tsx`.
    */
   it('honours `showBorder: false` by dropping the card border', () => {
     const bordered = renderAuthored({ collapsible: false, showBorder: true }).container;


### PR DESCRIPTION
Fixes #9218

## What was broken

`DetailSection` ends in three returns and `section.showBorder` was read on exactly two of them. Measured on the base tree `a9d97be63`:

1. the flat branch — `!section.title && !section.collapsible && section.showBorder === false` — reads it;
2. the non-collapsible Card branch — `section.showBorder === false ? 'border-none shadow-none' : ''` — reads it;
3. the collapsible branch — a `Collapsible` wrapping a BARE Card with no `className` at all — never mentioned it, so the key was structurally unreachable there.

`showBorder` is declared on three surfaces at once (`DetailViewSection` in `@object-ui/types`, its Zod mirror, and the `detail-section` registration's `inputs`), so `sdui-parser`'s `validateTree` told an author the node was correct and complete — and then the border stayed. Declared clean, published clean, rendered wrong: ADR-0049 enforce-or-remove shape.

## The change

One `className` on the collapsible branch's Card, carrying the same decision branch 2 already makes. Following the triage ruling, the author's own `className` deliberately stays on the outer `Collapsible` — relocating it is a different behaviour this card did not measure, and a drift-guard row reds if a later change moves it.

Branch 1 (`isFlat`, line 644) and branch 2 (line 651) are byte-identical. `@object-ui/types` and the Zod mirror are untouched — this change makes the implementation catch up with a declaration that already shipped.

## Measured legs

### 1. PIN-FIRST — the unmodified arm is the real base tree

The pin was written before the source was touched, and run against `a9d97be63` proven unmodified by state (`git diff HEAD` empty; `DetailSection.tsx` blob `ef5b78590` equal to `HEAD:packages/plugin-detail/src/DetailSection.tsx`; `showBorder` occurring exactly twice in the file):

```
Test Files  1 failed (1)
     Tests  2 failed | 4 passed (6)
  x drops border and shadow on an authored collapsible node with `showBorder: false`
  x reaches the same verdict through the direct `section` prop `DetailView` uses
```

The two reds are the collapsible `showBorder: false` verdicts. The four greens are the collapsible `showBorder: true` negative, **both `collapsible: false` control rows**, and the drift guard.

### 2. The control, and that it can fire

The control is the same authored node with one key flipped — `collapsible: false`, i.e. branch 2 — and it was already green on the unmodified tree. That is what makes the collapsible rows a statement about the branch rather than about `showBorder` in general. It is not a row that reads the same whatever happens: its paired negative (`collapsible: false` + `showBorder: true`) asserts the opposite class verdict on that same branch, so the control moves along the `showBorder` axis and only stands still along the `collapsible` axis. Each side additionally asserts WHICH branch it landed on (`aria-expanded` present / absent), so a later change that quietly routes a collapsible node through branch 2 reds here instead of passing silently.

### 3. ABLATION — with the mutation proven on disk and the restore proven by state

Run from the committed fix, under a trap with absolute paths, anchored on the exact inserted text so a zero-hit edit cannot masquerade as a mutation.

```
== PRE-MUTATION ==
HEAD blob            : 499f9078fa0355424bb982135d9c29884472b520
on-disk blob         : 499f9078fa0355424bb982135d9c29884472b520
'border-none shadow-none' count: 2   (expect 2)
== POST-MUTATION (on-disk proof, not an exit code) ==
'border-none shadow-none' count: 1   (expect 1 - branch 2 only)
bare Card count                : 1   (expect 1)
on-disk blob         : 359aa65883424ed070234b45bfc4abdbe516f101
== ABLATED RUN ==
Test Files  1 failed (1)
     Tests  2 failed | 4 passed (6)
  x drops border and shadow on an authored collapsible node with `showBorder: false`
  x reaches the same verdict through the direct `section` prop `DetailView` uses
== RESTORE (by state, not by exit code) ==
on-disk blob         : 499f9078fa0355424bb982135d9c29884472b520
HEAD blob            : 499f9078fa0355424bb982135d9c29884472b520
'border-none shadow-none' count: 2   (expect 2)
git diff HEAD (must print nothing):
RESTORE PROVEN BY STATE: blob == HEAD blob and diff is empty
```

Deleting the new decision reddens exactly the two rows the pin exists for, and nothing else — the controls stay green, so the reds are about the branch, not about the file being broken.

No `dist` preflight applies to this ablation: the root `vitest.config.mts` alias table redirects every `@object-ui/*` package specifier to its `src`, and the mutated module is reached by a relative import from the test, so the run reads the mutated source directly. The marker count and blob hash above are therefore the complete on-disk proof.

## Verification, at `fb9a47e98`

| Run | Result |
|---|---|
| `pnpm exec vitest run packages/plugin-detail/ examples/schema-catalog/` (shared verify lock, VERDICT command-exit 0) | **206 files / 3777 tests passed** |
| `pnpm --filter @object-ui/plugin-detail type-check` (after `pnpm --filter '@object-ui/plugin-detail^...' build`) | exit 0; the new pin is IN the program — `tsc -p tsconfig.test.json --listFiles` names it once, and the emitting program names it zero times, which is what `check:published-tsconfig-exclude` wants |
| `node scripts/check-changeset-presence.mjs` | exit 0 — "2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)" |
| `pnpm changeset:check` | exit 0 — "No changeset declares a `major` bump" (this is the real spelling; there is no `no-major` npm script) |
| `pnpm check:control-bytes` | exit 0 (7475 tracked text files) |
| `pnpm check:new-line-citations` | exit 0, 0 new citations |
| `pnpm check:test-path-roots` | exit 0 |
| `pnpm check:vi-mock-override-shape` | exit 0 |
| `pnpm check:changeset-claims` | exit 0 (report-only) |
| `pnpm check:sdui-registration-pins` (after building the console closure) | exit 0 — all 16 registrations present, 3 ruled controls in the derived set |

### Lint, narrowed and declared

`pnpm lint` is `turbo run lint`, i.e. `eslint .` once per package. Only the changed package's unit was run here; the other 46 belong to CI. Three readings make that a measurement rather than a skip:

1. **Population from eslint's own config, not from a guess** — `eslint .` inside `packages/plugin-detail` resolves upward to the repo's single flat `eslint.config.js` and walks the package with that config's own ignore set.
2. **Count from `--format json`** — 231 files linted, **0 errors**, 1012 warnings (all pre-existing; `--max-warnings` is deliberately unset in `lint.yml`, so warnings are not a gate). `DetailSection.tsx` reports 12 warnings, the highest at line 567 — none in the 675-688 region this change touches, and both test files report 0/0.
3. **Invariance for untouched files** — there is no type-aware linting configured anywhere in this repo (no `parserOptions.project`, no `projectService` in `eslint.config.js`, and no package-level eslint config exists), so no edit in this diff can move the verdict on a file it does not contain.

### NOT MEASURED

- `pnpm check` (the CLI self-check that `lint.yml` runs) — **NOT MEASURED, not a red gate**. It needs `packages/cli/dist/cli.js`, which is absent here; without it the command dies with a raw `MODULE_NOT_FOUND`. The build that would supply it did not get the shared verify lock: `VERDICT queue-timeout (exit 99) - never acquired - waited 540s, holder pid 20530 running `packages/app-shell/ examples/schema-catalog/` for the objectui#9196 seat. This diff contains no metadata or schema JSON, which is what that command reads; CI owns the reading.
- Repo-wide `pnpm lint` and the full `pnpm test` shard set — CI owns them, per the narrowing declared above.

### Blast radius beyond the package (objectui#9273)

No rendered node moved: this adds a `className` to an existing Card, so the DOM shape, node counts and every prose figure about them are unchanged. `examples/schema-catalog/` was run anyway and is inside the 206/3777 above. A census of `collapsible: true` across the repo finds exactly one non-test author — `RecordDetailView`'s "More details" section — and it carries `showBorder: true`, so no in-repo page changes appearance.

## Coordination with objectui#8626

**It has landed**, via `cc00c5943` / PR #9221. The coordination clause therefore applies, and this branch carries the cleanup: the `showBorder` row in `detailSectionAuthoredNode-8626.test.tsx` keeps its `collapsible: false` spelling — it is a reading about the FOLD, and that reason stands on its own — but the second reason recorded beside it, "the collapsible branch never reads the key", is retired from that comment and the branch axis is pointed at the new file. The assertions in that pin are unchanged; the edit is comment-only, and the pin still passes (7 tests).

## Changeset level: `patch`, measured

`.changeset/9218-detailsection-collapsible-showborder.md`.

- *Nothing stops rendering.* No node, prop, export or registration moved.
- *Nothing stops type-checking.* `showBorder` was already declared on all three of its surfaces and none is touched.
- *What an author authored today changes visually, only in the direction they asked for.* A node carrying `collapsible: true` + `showBorder: false` already passed `validateTree` clean and then drew a border anyway; it now draws none. The only behaviour that regresses is a border present because the key was being dropped — the defect itself — so this is not breaking and needs no `**BREAKING**` carrier. All 41 packages are one `fixed` group, so `major` is unavailable regardless; `patch` is the honest level here rather than a ceiling artefact.

## Acceptance notes

Out-of-scope observations, none filed:

- `FormSection` (`packages/plugin-form`) reads the same declared key with a different default rule — `showBorder ?? Boolean(label)` — while the detail side derives its default in `renderers/record-details.tsx` as `s.showBorder ?? (translatedTitle ? true : false)`. Two defaults for one declared key is a consistency observation, not a contract breach: the spec declares the key, not the default. Noted, not filed; the party who would touch it is whoever next unifies section chrome across form and detail.
- `pnpm check` throws a raw Node `MODULE_NOT_FOUND` when `packages/cli/dist` is absent, where its sibling `check:sdui-registration-pins` refuses loudly with the exact build command to run first. The failure mode is an unmeasured run that reads like a red gate. This is agent DX, not an author-facing contract, and CI never hits it because `lint.yml` builds the CLI first. Noted, not filed; carrier: none today.

Nothing was filed, so no dedup search was owed on this run.

Session: `https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ`

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_