### PR TITLE
fix(app-shell): drop the `filter[...]` operator suffix instead of swallowing it into the field name

### DIFF
--- a/.changeset/9196-objectview-url-filter-operator-suffix.md
+++ b/.changeset/9196-objectview-url-filter-operator-suffix.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Stop the plain object route swallowing a `filter[...]` operator suffix into the
+FIELD NAME (objectui#9196). `ObjectView` was a THIRD reader of this URL family,
+with its own greedy field capture, so `?filter[amount][gte]=100` on
+`/apps/:app/:object` did not fail to match — it matched with the suffix inside
+the field, emitting a condition against a field literally named `amount][gte`
+that no object declares. The user got a silently WRONG query, not an ignored
+parameter and not a refusal.
+
+The route now reads through `drillUrlFilters`, the one module that owns this
+family, via a new equality-only arm (`parseUrlEqualityFilterTriples`). Both arms
+share ONE key grammar whose field slot excludes brackets, so the swallowing is
+structurally impossible rather than fixed at one call site. An operator suffix
+this route cannot execute is DROPPED — the posture the `/data` surface already
+declares in as many words ("an unknown operator suffix is ignored, never
+silently downgraded to equality"). Ignored and downgraded are two different
+outcomes and only one is correct: answering `amount = 100` when the URL asked
+for `amount >= 100` would be a wrong answer wearing a right answer's shape.
+
+⚠️ Range operators are deliberately NOT added to this route. That would widen
+the accepted set of an addressable public surface — a behaviour addition, not a
+repair — and it stays with the maintainer. The operator arm remains on the
+ADR-0055 `/data` surface only, which this change's tests pin on the same inputs
+in the same run.
+
+`patch`, justified by measurement rather than by intuition:
+
+- Nothing an author authored changes — no spec key, no metadata key, no schema
+  property is touched.
+- Nothing stops type-checking for a consumer: `drillUrlFilters` is an internal
+  module, not re-exported from `@object-ui/app-shell`'s only entry (`.` →
+  `dist/index.js`), so the new export adds no public signature.
+- The `/data` reader was differenced against its previous implementation over a
+  254-case key corpus: 244 readings identical, 10 changed, and all 10 are keys
+  whose FIELD NAME contains a `[` (`filter[a[b][gte]`), which previously emitted
+  a condition against a field named `a[b`. Every delta is a narrowing that
+  removes a wrong answer; none widens what the surface accepts.

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -15,6 +15,7 @@ import { resolveFilterPlaceholders, DENSITY_MODE_TO_ROW_HEIGHT, normalizeListVie
 import { parseUserFilterParams, applyUserFilterParams } from './userFilterUrlState.js';
 import { buildListFilterKey, readListFilterState, writeListFilterState } from './listFilterStorage.js';
 import { VALUELESS_FILTER_OPERATORS } from './viewFilterFold.js';
+import { parseUrlEqualityFilterTriples } from './drillUrlFilters.js';
 import { narrowPersonalizationOverlay, isViewConfigPermissionDeniedError } from '@object-ui/data-objectstack';
 const ObjectChart = lazy(() =>
   import('@object-ui/plugin-charts').then((m) => ({ default: m.ObjectChart })),
@@ -2086,6 +2087,17 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
      * to a single parent record. Emitted as ObjectQL triples (`[field, '=', value]`)
      * which matches the shape consumed by the list view's data fetcher when
      * merging base filters.
+     *
+     * Read through `drillUrlFilters` — the ONE module that owns this URL family
+     * — rather than a private regex here (objectui#9196). This route implements
+     * the EQUALITY arm only: an operator suffix it cannot execute
+     * (`?filter[amount][gte]=100`) is DROPPED, never downgraded to equality and
+     * never swallowed into the field name. The greedy capture this replaced did
+     * the last of those, emitting a condition against a field literally named
+     * `amount][gte` that no object declares — a silently wrong query, not an
+     * ignored parameter. Range operators live on the ADR-0055 `/data` surface
+     * (`parseUrlFilterTriples`); giving them to this route would widen an
+     * addressable public surface and is deliberately not done here.
      */
     // Dep on the serialized `filter[...]` entries only — `uf_*` user-filter
     // params also live in the URL and must not invalidate this memo (a new
@@ -2094,16 +2106,10 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
         .filter(([k]) => k.startsWith('filter['))
         .map(([k, v]) => `${k}=${v}`)
         .join('&');
-    const urlFilters = useMemo(() => {
-        const out: Array<[string, string, any]> = [];
-        new URLSearchParams(filterParamsKey).forEach((value, key) => {
-            const m = /^filter\[(.+)\]$/.exec(key);
-            if (m && m[1] && value !== '') {
-                out.push([m[1], '=', value]);
-            }
-        });
-        return out;
-    }, [filterParamsKey]);
+    const urlFilters = useMemo(
+        () => parseUrlEqualityFilterTriples(new URLSearchParams(filterParamsKey)),
+        [filterParamsKey],
+    );
 
     /**
      * End-user filter selections restored from `uf_*` URL params (ADR-0047

--- a/packages/app-shell/src/views/ObjectView.urlFilterSuffix-9196.test.ts
+++ b/packages/app-shell/src/views/ObjectView.urlFilterSuffix-9196.test.ts
@@ -1,0 +1,212 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9196 — `ObjectView` was a THIRD, drifted reader of the `filter[...]`
+ * URL family, and its drift was NOT "the operator was ignored".
+ *
+ * The reader it carried had a GREEDY field capture, so an operator-suffixed key
+ * did not fail to match — it matched with the suffix swallowed INTO THE FIELD
+ * NAME. On `/apps/:app/:object`, `?filter[amount][gte]=100` emitted a condition
+ * against a field literally named `amount][gte`, which no object declares: a
+ * silently WRONG query, not an ignored parameter and not a refusal.
+ *
+ * ## What this file pins, and what it deliberately does not
+ *
+ * The ruling on the card takes ONE of the two candidate repairs:
+ *
+ *   NOT taken — teaching this route the operator arm. That would ADD range
+ *      operators to a route that has never had them, widening the accepted set
+ *      of an addressable public surface. It is a behaviour addition, and it
+ *      belongs to the maintainer.
+ *   Taken — the route drops the operator suffix it cannot execute, which is the
+ *      posture the `/data` surface already DECLARES in as many words: "An
+ *      unknown operator suffix is ignored (never silently downgraded to
+ *      equality)."
+ *
+ * The route now reads through `drillUrlFilters`, the one module that owns this
+ * family, so there is no longer a private reader here to drift. Both arms share
+ * ONE key grammar, which is what makes the swallowing structurally impossible
+ * rather than merely fixed at one call site.
+ *
+ * ## SUITE DIRECTION — stated before running
+ *
+ *   RED on the unmodified base tree: every assertion in "the card's three rows"
+ *   that reads the object route, both assertions in "IGNORED is not DOWNGRADED",
+ *   the whole bracket battery, and both source-scan pins. On the base tree the
+ *   object-route reader does not exist as an importable function at all, so the
+ *   red arrives as a resolution failure; the behavioural before/after on the
+ *   real base-tree bytes is recorded in the PR body, measured by lifting the
+ *   live regex literal out of `ObjectView.tsx` rather than copying it.
+ *
+ *   GREEN on the base tree, by design: nothing here. The `/data` column rows are
+ *   green on both sides EXCEPT the bracketed-field row, and they are labelled
+ *   below as non-discriminating for that reason — they are recorded because they
+ *   are the evidence that the operator arm did not move, not because they pin
+ *   this change.
+ *
+ * ## Every control here can fire
+ *
+ * - The LIT CONTROL is the plain, unsuffixed `filter[field]=value` row. It must
+ *   read the same on BOTH readers and must be UNCHANGED by this repair — it is
+ *   the only evidence that ordinary equality was not broken while the suffix was
+ *   being dropped. It fires if the repair over-reaches.
+ * - The `/data` column is pinned on the SAME inputs in the SAME run. Its `gte`
+ *   row staying `['amount', '>=', '100']` is what proves the operator arm was
+ *   not moved onto the object route: it still executes there and ONLY there.
+ * - The source scan carries a positive control (`ANCHOR`), so a read of the
+ *   wrong or an empty file fails loudly instead of reporting a clean sweep.
+ * - The bracket battery carries a non-vacuity control, so a battery that
+ *   silently stopped emitting anything cannot pass by inspecting nothing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseUrlFilterTriples, parseUrlEqualityFilterTriples } from './drillUrlFilters';
+
+/** The ADR-0055 `/data` surface reader (`ObjectDataPage`). */
+const dataSurface = (qs: string) => parseUrlFilterTriples(new URLSearchParams(qs));
+/** The plain object route reader (`ObjectView`), after objectui#9196. */
+const objectRoute = (qs: string) => parseUrlEqualityFilterTriples(new URLSearchParams(qs));
+
+describe("objectui#9196 — the card's three rows, both readers, one run", () => {
+  it('row 1 — an unknown operator suffix is dropped by BOTH readers', () => {
+    expect(dataSurface('filter[owners][contains]=u1')).toEqual([]);
+    expect(objectRoute('filter[owners][contains]=u1')).toEqual([]);
+  });
+
+  it('row 2 — LIT CONTROL: plain equality is unchanged, and identical on both', () => {
+    expect(dataSurface('filter[owners]=u1')).toEqual([['owners', '=', 'u1']]);
+    expect(objectRoute('filter[owners]=u1')).toEqual([['owners', '=', 'u1']]);
+  });
+
+  it('row 3 — a range suffix executes on /data ONLY, and is dropped on the object route', () => {
+    // The `/data` half is the proof that the operator arm was NOT added here:
+    // it is exactly where it already was, and nowhere new.
+    expect(dataSurface('filter[amount][gte]=100')).toEqual([['amount', '>=', '100']]);
+    expect(objectRoute('filter[amount][gte]=100')).toEqual([]);
+  });
+
+  it('row 3, the defect itself — no condition is emitted against `amount][gte`', () => {
+    const fields = objectRoute('filter[amount][gte]=100').map(([field]) => field);
+    expect(fields).not.toContain('amount][gte');
+  });
+});
+
+describe('objectui#9196 — IGNORED is not DOWNGRADED TO EQUALITY', () => {
+  it('drops the whole key rather than filtering `amount = 100`', () => {
+    const triples = objectRoute('filter[amount][gte]=100');
+    expect(triples).toEqual([]);
+    // Stated the other way round too, because "ignored" and "downgraded" are
+    // two different outcomes and only one of them is correct: a route that
+    // cannot execute `>= 100` must not quietly answer the narrower `= 100`
+    // question. `toEqual([])` alone would also pass for a reader that refused
+    // the whole URL, so the field-level assertion names which one we mean.
+    expect(triples).not.toContainEqual(['amount', '=', '100']);
+    expect(triples.map(([field]) => field)).not.toContain('amount');
+  });
+
+  it('drops each bound of a two-bound range, not just one of them', () => {
+    expect(
+      objectRoute('filter[close_date][gte]=2026-04-01&filter[close_date][lt]=2026-07-01'),
+    ).toEqual([]);
+  });
+
+  it('keeps the OTHER conditions in the same URL — only the suffixed key is dropped', () => {
+    expect(objectRoute('filter[amount][gte]=100&filter[status]=open')).toEqual([
+      ['status', '=', 'open'],
+    ]);
+  });
+});
+
+describe('objectui#9196 — no emitted field name ever carries a bracket', () => {
+  // The simplest success criterion on the card: a condition on a field name
+  // containing a bracket is a condition no object can answer.
+  const inputs = [
+    'filter[amount][gte]=100',
+    'filter[owners][contains]=u1',
+    'filter[a][b][c]=1',
+    'filter[x][GTE]=1',
+    'filter[weird[x]=1',
+    'filter[owners]=u1',
+    'filter[account.region]=NA',
+  ];
+
+  it.each(inputs)('object route, %s', (qs) => {
+    for (const [field] of objectRoute(qs)) {
+      expect(field).not.toMatch(/[[\]]/);
+    }
+  });
+
+  it.each(inputs)('/data surface, %s', (qs) => {
+    for (const [field] of dataSurface(qs)) {
+      expect(field).not.toMatch(/[[\]]/);
+    }
+  });
+
+  it('the battery is not vacuous — it does emit conditions for the plain rows', () => {
+    // Instrument check: if every input above produced nothing, the loops would
+    // pass without ever inspecting a field name.
+    expect(inputs.flatMap((qs) => objectRoute(qs))).toEqual([
+      ['owners', '=', 'u1'],
+      ['account.region', '=', 'NA'],
+    ]);
+    expect(inputs.flatMap((qs) => dataSurface(qs))).toEqual([
+      ['amount', '>=', '100'],
+      ['owners', '=', 'u1'],
+      ['account.region', '=', 'NA'],
+    ]);
+  });
+});
+
+describe('objectui#9196 — the equality arm this route DOES implement', () => {
+  it('keeps a relationship path intact', () => {
+    expect(objectRoute('filter[account.region]=NA')).toEqual([['account.region', '=', 'NA']]);
+  });
+
+  it('skips an empty value', () => {
+    expect(objectRoute('filter[status]=')).toEqual([]);
+  });
+
+  it('ignores params outside the family', () => {
+    expect(objectRoute('recordId=abc&uf_status=open')).toEqual([]);
+  });
+
+  it('reads every plain key in a multi-condition URL', () => {
+    expect(objectRoute('filter[stage]=won&filter[region]=emea')).toEqual([
+      ['stage', '=', 'won'],
+      ['region', '=', 'emea'],
+    ]);
+  });
+});
+
+describe('objectui#9196 — `ObjectView` no longer keeps a private reader of this family', () => {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const SOURCE = readFileSync(path.join(here, 'ObjectView.tsx'), 'utf8');
+  /** Positive control: a wrong or empty read fails here, not silently below. */
+  const ANCHOR = 'const urlFilters';
+
+  it('read the file it means to scan (control)', () => {
+    expect(SOURCE).toContain(ANCHOR);
+  });
+
+  it('parses the family through the shared module instead of its own regex', () => {
+    expect(SOURCE).toContain('parseUrlEqualityFilterTriples');
+    expect(SOURCE).toContain("from './drillUrlFilters.js'");
+  });
+
+  it('declares no `filter[` regex literal of its own', () => {
+    // A regex literal is the only place the escaped bracket occurs after
+    // `filter`. The surviving plain-string use (`key.startsWith('filter[')`,
+    // which builds the memo key) has no backslash, so it is not matched here —
+    // the scan is about a fourth PARSER appearing, not about the substring.
+    expect(SOURCE).not.toMatch(/filter\\\[/);
+  });
+});

--- a/packages/app-shell/src/views/drillUrlFilters.ts
+++ b/packages/app-shell/src/views/drillUrlFilters.ts
@@ -30,6 +30,16 @@ export const URL_FILTER_OPS: Record<string, string> = { gte: '>=', lte: '<=', gt
 export const RANGE_OP_PARAM: Record<string, string> = { $gte: 'gte', $lte: 'lte', $gt: 'gt', $lt: 'lt' };
 
 /**
+ * The ONE grammar for a key in this family, so the two arms below cannot drift
+ * apart on what a field name is: `filter[<field>]`, with an OPTIONAL
+ * `[<suffix>]`. The field slot excludes both brackets, so a suffix can never be
+ * swallowed into the field name — the drift objectui#9196 measured, where a
+ * greedy field capture turned `filter[amount][gte]` into a condition against a
+ * field literally named `amount][gte` that no object declares.
+ */
+const FILTER_KEY = /^filter\[([^[\]]+)\](?:\[([^[\]]+)\])?$/;
+
+/**
  * Parse `filter[<field>]=<value>` (equality) and `filter[<field>][<op>]=<value>`
  * (range/comparison) search params into ObjectQL triples. An unknown operator
  * suffix is ignored (never silently downgraded to equality).
@@ -38,15 +48,46 @@ export function parseUrlFilterTriples(searchParams: URLSearchParams): FilterTrip
   const out: FilterTriple[] = [];
   searchParams.forEach((value, key) => {
     if (value === '') return;
-    // Operator form FIRST — the field capture must not swallow the `[op]` suffix.
-    const mOp = /^filter\[([^\]]+)\]\[([a-z]+)\]$/.exec(key);
-    if (mOp) {
-      const op = URL_FILTER_OPS[mOp[2]];
-      if (op) out.push([mOp[1], op, value]);
+    const m = FILTER_KEY.exec(key);
+    if (!m) return;
+    const [, field, suffix] = m;
+    if (suffix === undefined) {
+      out.push([field, '=', value]);
       return;
     }
-    const m = /^filter\[([^\]]+)\]$/.exec(key);
-    if (m && m[1]) out.push([m[1], '=', value]);
+    const op = URL_FILTER_OPS[suffix];
+    if (op) out.push([field, op, value]);
+  });
+  return out;
+}
+
+/**
+ * The EQUALITY-ONLY arm of the same grammar, for a surface that implements
+ * `filter[<field>]=<value>` and nothing else — today the plain object route
+ * (`/apps/:app/:object`, `ObjectView`), whose related-list "View All" buttons
+ * scope a destination list to one parent record.
+ *
+ * An operator suffix is DROPPED, exactly as `parseUrlFilterTriples` drops an
+ * operator it does not know: ignored, and in particular never silently
+ * downgraded to equality. Those are two different outcomes and only one is
+ * correct — answering the narrower `amount = 100` when the URL asked for
+ * `amount >= 100` is a wrong answer wearing a right answer's shape.
+ *
+ * ⚠️ This arm deliberately does NOT execute the operator suffix (objectui#9196).
+ * Teaching this route range operators would widen the accepted set of an
+ * addressable public surface — a behaviour addition, not a repair, and one that
+ * belongs to the maintainer rather than to a bug fix. The operator arm stays
+ * where it already is: `parseUrlFilterTriples`, on the ADR-0055 `/data` surface.
+ */
+export function parseUrlEqualityFilterTriples(searchParams: URLSearchParams): FilterTriple[] {
+  const out: FilterTriple[] = [];
+  searchParams.forEach((value, key) => {
+    if (value === '') return;
+    const m = FILTER_KEY.exec(key);
+    // `m[2] !== undefined` is the suffixed form — not executable here, so the
+    // whole condition is dropped rather than answered at the wrong operator.
+    if (!m || m[2] !== undefined) return;
+    out.push([m[1], '=', value]);
   });
   return out;
 }


### PR DESCRIPTION
Fixes #9196

## The defect, stated sharply

`ObjectView` was a THIRD reader of the `filter[...]` URL family, carrying its own
field capture. The capture was GREEDY, so an operator-suffixed key did not fail to
match — it matched with the suffix swallowed INTO THE FIELD NAME. On
`/apps/:app/:object`, `?filter[amount][gte]=100` emitted a condition against a field
literally named `amount][gte`, which no object declares.

The user therefore got a **silently wrong query** — not an ignored parameter, and not
a refusal.

## The ruling this PR implements, and the one it does not

The triage comment on the card split the two candidate repairs across the human floor.

| candidate | this PR |
|---|---|
| make this route call the operator-aware reader | **NOT implemented.** It would add range operators to a route that never had them = widening the accepted set of an addressable public surface. A behaviour addition, not a repair. It stays with the maintainer. |
| refuse / drop the operator suffix the route cannot execute | **implemented.** Pulling back to a posture the `/data` surface already declares in as many words: an unknown operator suffix is ignored, never silently downgraded to equality. |

**Explicit confirmation: candidate one was not implemented.** The evidence is in the
pin, not in this sentence — the `/data` column is asserted on the same inputs in the
same run, and `filter[amount][gte]` still reads `['amount', '>=', '100']` there and
ONLY there. If this change had taught the object route the operator arm, that row
would be indistinguishable from the object-route row; it is not.

## What changed

The route now reads through `drillUrlFilters`, the one module that owns this family,
via a new equality-only arm. Both arms share ONE key grammar whose field slot excludes
brackets, so the swallowing is structurally impossible rather than patched at one call
site. Inventing a fourth posture here is what the card identified as recurrence in
place, so the posture is copied from `/data` rather than designed anew.

## Measurements

### Before and after, on the REAL bytes

Neither column is a hand copy of the shipped function: the probe lifts the regex
literal out of `ObjectView.tsx` on disk and runs the card's three inputs through it.

| input | base tree (`a9d97be63`) | this branch |
|---|---|---|
| `filter[owners][contains]=u1` | `[["owners][contains","=","u1"]]` | `[]` |
| LIT CONTROL `filter[owners]=u1` | `[["owners","=","u1"]]` | `[["owners","=","u1"]]` |
| `filter[amount][gte]=100` | `[["amount][gte","=","100"]]` | `[]` |

After the change the probe reports `no filter[ regex literal in ObjectView.tsx` — the
private reader is gone, which is why the third column is read from the shared module.

**The lit control fires.** Plain equality is byte-identical on both sides and on both
readers; it is the only evidence that ordinary equality was not broken while the suffix
was being dropped, and it would have gone red had the repair over-reached.

### IGNORED is pinned as DISTINCT from DOWNGRADED TO EQUALITY

Two different outcomes, only one correct. `toEqual([])` alone would also pass for a
reader that refused the whole URL, so the pin names which one is meant:

- `expect(triples).toEqual([])` — the suffixed key contributes nothing;
- `expect(triples).not.toContainEqual(['amount', '=', '100'])` — and in particular it
  did not quietly answer the narrower question;
- `expect(fields).not.toContain('amount')` — no condition on that field survives at all;
- `expect(objectRoute('filter[amount][gte]=100&filter[status]=open'))` keeps only
  `['status', '=', 'open']` — the drop is scoped to the key it cannot execute.

### A bounded in-place fix on the sibling arm, declared

Sharing one grammar also tightens the field slot of the `/data` reader. That arm was
differenced against its previous implementation over a 254-case key corpus, both sides
lifted from real file bytes:

```
/data surface: 244 identical readings, 10 changed, over 254 key/value pairs
  CHANGED filter[a[b]        before ["a[b","=","100"]   after null
  CHANGED filter[a[b][gte]   before ["a[b",">=","100"]  after null
  ... 8 more, every one a key whose FIELD NAME contains an opening bracket
DIFFER CONTROL (two deliberately unequal readings compare equal?): false -> expect false
```

All ten deltas are the same defect class as this card — a bracket swallowed into the
field name — and every one is a **narrowing that removes a wrong answer**. Nothing the
surface accepts was widened. The bracket battery in the pin asserts this on both
readers.

### The pin can fire — two ablation legs, prediction stated first

Predicted before either leg ran, then observed:

| leg | predicted red | observed |
|---|---|---|
| A: greedy field capture back in the shared grammar | the three-rows suffixed rows, all three ignored-vs-downgraded cases, the bracket battery and its non-vacuity control | `17 failed / 12 passed` — exactly that set |
| B: `ObjectView.tsx` reverted to the base commit | the two source-scan pins only | `2 failed / 27 passed` — exactly those two |

Each leg's GREEN half is the other's control: leg A leaves the source scan green
(it does not touch `ObjectView.tsx`), leg B leaves every behavioural case green. The
lit control and the `ANCHOR` positive control stayed green in both.

Mutations were proven ON DISK before the runs were believed (marker counts flipped
`1 -> 0` / `0 -> 1`, blob hash `4810e6e0 -> ef88069b`; leg B marker `2 -> 0`, hash
`9fe318c0 -> 6e5d06f3`). Both restores were proven BY STATE, never by an exit code:
blob hash back to the HEAD blob and `git diff HEAD` empty, under a trap using absolute
paths. Final tree: `git diff HEAD` empty, `git status --short` empty.

## Verification

All readings below are from `c9e370c4d`, the final commit on this branch; the working
tree was byte-identical to it for every run (`git diff HEAD` empty).

| run | result |
|---|---|
| `pnpm exec vitest run packages/app-shell/ examples/schema-catalog/` | `Test Files 720 passed (720)`, `Tests 8861 passed / 1 skipped`, lock `VERDICT command-exit 0` |
| `pnpm --filter @object-ui/app-shell run type-check` | exit 0 — both `tsc --noEmit` and `tsc -p tsconfig.test.json`, so the new pin is type-checked too |
| the pin alone | `Test Files 1 passed`, `Tests 29 passed` |
| `pnpm changeset:check` | exit 0 (this is the real script name; other spellings' `254` is NOT MEASURED) |
| `node scripts/check-changeset-presence.mjs` | exit 0 — 2 published source files, 1 changeset |
| `check:control-bytes`, `check:test-path-roots`, `check:new-line-citations`, `check:unreferenced-sources`, `check:self-import`, `check:phantom-deps`, `check:shell-escape-residue` | exit 0 each |
| `eslint --no-inline-config` on the three changed files | 0 errors; `ObjectView.tsx` warnings `170 -> 169` (the change removes one `no-explicit-any` and adds none, measured against the base file through `--stdin`) |
| `node scripts/check-governed-queue-guard.mjs --test` | NOT GOVERNED — 4 paths, none matched |

`examples/schema-catalog/` was run because a package-scoped run is not the blast radius
(objectui#9273). Grep for count-shaped and README prose pins naming either reader found
none, and `drillUrlFilters` is not re-exported from this package's only entry, so the
new export adds no public signature.

**NOT MEASURED:** `check:readme-exports` exits 1 in this container with
`type entry ./dist/index.d.ts is not on disk -- run pnpm build first` for 8 unbuilt
packages. Only this package's dependency closure was built, so that is a prerequisite
miss, not a red gate; it is unrelated to this diff, which touches no README and no
`exports` field.

## Changeset

`patch` on `@object-ui/app-shell`, justified by measurement rather than intuition: no
authored key changes; no public signature is added or removed (internal module, not
re-exported); and the only behaviour deltas are the ten narrowings above plus the object
route dropping a key that previously produced a condition against a field no object
declares. Nothing that worked stops working.

## Acceptance notes

Out-of-scope observations found while measuring this reader. Neither is fixed here.

1. **Filed separately** — the memo key in the same block re-serializes params by hand
   (`map(([k, v]) => k + '=' + v).join('&')`) and re-parses the result, so a value
   containing an ampersand or a plus is mangled before it ever reaches the reader.
   Measured with a lit control: `Acme` survives, `Smith & Sons` becomes `Smith `, `A+B`
   becomes `A B`. A different mechanism from this card's, and fixing it would move the
   plain-equality control this PR depends on, so it is a separate card.
2. **Noted, not filed** — `packages/layout/src/NavigationRenderer.tsx` carries a FOURTH
   copy of the same greedy capture, for nav-item highlight matching. Measured, it fails
   safe: the authored side of the comparison never contains a suffix, the size-and-exact
   -key guard admits only false negatives, and "no highlight" is the semantically right
   answer for a URL asking a different question. Successor named: whoever takes the
   maintainer's candidate-one card lands in this file, because a route that really
   executes range operators would need the nav side to agree on operator spelling. It
   also sits in another package, so joining it to the shared module is a dependency
   -direction question, not a mechanical edit.

Neither of these is addressed here; objectui#9159 remains open and is a different gap
on the same family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_