### PR TITLE
fix(react)!: `RecordContextValue.dataSource` is the adapter it holds, not an id

### DIFF
--- a/.changeset/9197-record-context-datasource-adapter.md
+++ b/.changeset/9197-record-context-datasource-adapter.md
@@ -1,0 +1,58 @@
+---
+'@object-ui/react': minor
+'@object-ui/plugin-detail': minor
+'@object-ui/app-shell': minor
+'@object-ui/components': minor
+'@object-ui/console': minor
+---
+
+**BREAKING** — `RecordContextValue.dataSource` is the DataSource **adapter** it
+has always held, not a datasource id string.
+
+**FROM** `dataSource: 'ds_primary'` **TO** `dataSource: myAdapter` (any
+`DataSource` from `@object-ui/types`).
+
+```ts
+// before — compiled, but no producer ever did this and no reader could use it
+const ctx: RecordContextValue = { objectName: 'account', recordId: 'r1', dataSource: 'ds_primary' };
+// after
+const ctx: RecordContextValue = { objectName: 'account', recordId: 'r1', dataSource: myAdapter };
+```
+
+The member was declared `dataSource?: string` — "an optional datasource id;
+mirrors the page-level datasource override" — while the one production host
+that writes it (`@object-ui/app-shell`'s `RecordDetailView`) forwards an adapter
+OBJECT and every reader calls adapter methods on it. Measured on the base tree:
+of the provider sites in this repository that write the member, exactly one is
+non-test and it passes the adapter; the only in-repo writer of a string was a
+test fixture, which existed because the declaration invited it. So the id was
+never a contract anyone kept — it was a statement the code contradicted at every
+site, and the override it described has zero producers. Contract-first
+(Commandment #0.1): the declaration moves to what the code holds, and no second
+`dataSourceId` member is minted for a requirement nobody implements.
+
+What it bought: each reader paid for the wrong declaration with a cast at the
+point of use, and a cast deletes the compiler's answer to "does this adapter
+have the method I am about to call". All 11 record-context read sites are now
+cast-free, across `@object-ui/app-shell`, `@object-ui/components` and
+`@object-ui/plugin-detail`. The worked instance is objectui#8883's reference
+rail: it reaches `dataSource.getObjectSchema` — a REQUIRED member of
+`DataSource` — and now gets that guarantee from the compiler instead of from
+`(ctx as any)`.
+
+⚠️ Nothing to migrate at runtime and no data change: every producer already
+passed the adapter, so no value moving through this member changes. A
+TypeScript consumer outside this repo that read the member as `string` is not
+observable from here and gets a compile error (TS2322) naming the key — which
+is why the FROM/TO is spelled out above. Re-widening to `string | DataSource`
+would not be a kindness: a union member without `getObjectSchema` cannot be read
+without narrowing, so it re-breaks every reader this change repaired. Both
+directions are pinned against the real compiler in
+`RecordContext.dataSourceType.pin.test.ts`.
+
+⚠️ `SchemaRendererContextValue.dataSource` one context over is a **different**
+declaration (`any`) and is **not** touched here. Five `as any` reads in
+`@object-ui/fields` key off that context, not this one; they are unaffected by
+this change and are reported separately.
+
+objectui#9197.

--- a/apps/console/src/__tests__/record-block-record-reach.test.tsx
+++ b/apps/console/src/__tests__/record-block-record-reach.test.tsx
@@ -397,11 +397,12 @@ async function mountWithRecord(cfg: any, record: Record<string, unknown>): Promi
     <MetadataCtx.Provider value={METADATA}>
       <SchemaRendererProvider dataSource={dataSource}>
         {/*
-          `dataSource` is typed `string` on RecordContextValue (a datasource id)
-          while `record:history`, `record:reference_rail` and
-          `record:line_items` all call `.find` on it — the host passes the
-          object and the renderers cast. Passing the object is what matches the
-          runtime (app-shell RecordDetailView), not the declaration.
+          `dataSource` carries the ADAPTER, which is what `record:history`,
+          `record:reference_rail` and `record:line_items` call `.find` on. The
+          declaration says so since objectui#9197 — before that it said
+          `string` and every one of those renderers cast around it, so this
+          probe passed the object to match the runtime (app-shell
+          RecordDetailView) rather than the declaration. Both agree now.
         */}
         <RecordContextProvider
           objectName={PROBE_OBJECT}

--- a/packages/app-shell/src/views/record-attachments-renderer.tsx
+++ b/packages/app-shell/src/views/record-attachments-renderer.tsx
@@ -59,7 +59,7 @@ export const RecordAttachmentsRenderer: React.FC<RecordAttachmentsRendererProps>
       <RecordAttachmentsPanel
         objectName={objectName}
         recordId={recordId}
-        dataSource={ctx?.dataSource as any}
+        dataSource={ctx?.dataSource}
         currentUserId={user?.id}
       />
     </div>

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -508,7 +508,7 @@ const PageTabsRenderer: React.FC<any> = ({ schema, className, ...props }) => {
   //     subscriber updates with no parent re-render.
   const ctx = useRecordContext();
   const parentId = ctx?.data?.id;
-  const ds: any = ctx?.dataSource;
+  const ds = ctx?.dataSource;
 
   // Conditional tabs (framework#2606): an item-level `visibleWhen` CEL
   // predicate removes the ENTIRE tab (header + panel) when FALSE — unlike a

--- a/packages/plugin-detail/src/renderers/record-activity.tsx
+++ b/packages/plugin-detail/src/renderers/record-activity.tsx
@@ -135,10 +135,7 @@ export const RecordActivityRenderer: React.FC<RecordActivityRendererProps> = ({
 
   const objectName: string | undefined = ctx?.objectName;
   const recordId = ctx?.data?.id ?? ctx?.data?._id ?? ctx?.recordId;
-  // `RecordContextValue.dataSource` is typed `string` (a datasource id) while
-  // every host passes the object; `record:history` / `record:reference_rail`
-  // cast the same way. Matching the runtime beats matching the declaration.
-  const dataSource = ctx?.dataSource as any;
+  const dataSource = ctx?.dataSource;
 
   // Self-fetch only when nobody else owns the feed. A mounted DiscussionContext
   // has already merged `sys_comment` + `sys_activity` for this record; fetching

--- a/packages/plugin-detail/src/renderers/record-details.tsx
+++ b/packages/plugin-detail/src/renderers/record-details.tsx
@@ -603,7 +603,7 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
     <div className={className} {...designer}>
       <DetailView
         schema={synthesized}
-        dataSource={ctx.dataSource as any}
+        dataSource={ctx.dataSource}
         inlineEdit={inlineEditDefault}
       />
     </div>

--- a/packages/plugin-detail/src/renderers/record-highlights.tsx
+++ b/packages/plugin-detail/src/renderers/record-highlights.tsx
@@ -118,7 +118,7 @@ export const RecordHighlightsRenderer: React.FC<RecordHighlightsRendererProps> =
         data={ctx?.data}
         objectName={ctx?.objectName}
         objectSchema={ctx?.objectSchema as any}
-        dataSource={ctx?.dataSource as any}
+        dataSource={ctx?.dataSource}
       />
     </div>
   );

--- a/packages/plugin-detail/src/renderers/record-history.tsx
+++ b/packages/plugin-detail/src/renderers/record-history.tsx
@@ -51,7 +51,7 @@ export const RecordHistoryRenderer: React.FC<RecordHistoryRendererProps> = ({
   ...props
 }) => {
   const { designer } = splitDesigner(props);
-  const ctx = useRecordContext() as any;
+  const ctx = useRecordContext();
 
   // Spec bridge inlines `properties.*` onto the node but also preserves the raw
   // bag. Read from either location for compatibility.

--- a/packages/plugin-detail/src/renderers/record-reference-rail.tsx
+++ b/packages/plugin-detail/src/renderers/record-reference-rail.tsx
@@ -160,7 +160,7 @@ export const RecordReferenceRailRenderer: React.FC<RecordReferenceRailRendererPr
       ? ((schema as any).properties.entries as ReferenceRailEntry[])
       : [];
   const parentId = ctx?.recordId;
-  const dataSource: any = (ctx as any)?.dataSource;
+  const dataSource = ctx?.dataSource;
 
   const [states, setStates] = React.useState<Record<string, EntryState>>({});
 

--- a/packages/plugin-detail/src/renderers/record-related-list.tsx
+++ b/packages/plugin-detail/src/renderers/record-related-list.tsx
@@ -245,7 +245,7 @@ const RecordRelatedListBody: React.FC<RecordRelatedListRendererProps> = ({
         // `ElementDataSourceGate` wrote it here, which is only legitimate now
         // that the value is read.
         filter={schema.filter}
-        dataSource={ctx?.dataSource as any}
+        dataSource={ctx?.dataSource}
         add={
           (schema as any).add
             ? {
@@ -299,7 +299,7 @@ const RecordRelatedListBody: React.FC<RecordRelatedListRendererProps> = ({
             : (schema as any).add && ctx?.dataSource
               ? async (row: any) => {
                   const id = row?.id ?? row?._id;
-                  if (id != null) await (ctx!.dataSource as any).delete?.(objectName, String(id));
+                  if (id != null) await ctx?.dataSource?.delete?.(objectName, String(id));
                 }
               : undefined
         }

--- a/packages/react/src/context/RecordContext.tsx
+++ b/packages/react/src/context/RecordContext.tsx
@@ -14,6 +14,7 @@
  */
 
 import React from 'react';
+import type { DataSource } from '@object-ui/types';
 
 /**
  * Shared registry of field names currently surfaced by `record:highlights`
@@ -114,8 +115,22 @@ export interface RecordContextValue<TData = any, TObjectSchema = any> {
   objectName: string;
   /** Primary key value of the record being displayed. */
   recordId: string | number | null | undefined;
-  /** Optional datasource id; mirrors the page-level datasource override. */
-  dataSource?: string;
+  /**
+   * The data adapter the page is bound to, as the host resolved it — the same
+   * object the host hands `SchemaRendererProvider`, forwarded so that
+   * `record:*` renderers can self-fetch (related lists, activity, the
+   * reference rail) without re-plumbing it through the schema tree.
+   *
+   * Typed `DataSource`, not an id: every producer has always passed the
+   * adapter, and every reader has always called adapter methods on it
+   * (objectui#9197). `getObjectSchema` is a REQUIRED member of `DataSource`,
+   * so a reader gets the compiler's answer about it instead of a cast.
+   *
+   * Optional: hosts that render a record with no adapter bound (the Studio
+   * designer and palette previews) leave it undefined, and renderers treat
+   * that as "cannot self-fetch" rather than throwing.
+   */
+  dataSource?: DataSource;
   /** Loaded record data (flat record map). Undefined while loading. */
   data?: TData;
   /** Resolved object metadata schema (fields, label, etc.). */

--- a/packages/react/src/context/__tests__/RecordContext.dataSourceType.pin.test.ts
+++ b/packages/react/src/context/__tests__/RecordContext.dataSourceType.pin.test.ts
@@ -1,0 +1,231 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `RecordContextValue.dataSource` holds a DataSource ADAPTER, and the compiler
+ * knows it (objectui#9197).
+ *
+ * ## What went wrong, and why only the compiler can see it
+ *
+ * The member was declared `dataSource?: string` — "an optional datasource id;
+ * mirrors the page-level datasource override" — while the one production host
+ * that writes it (`app-shell/views/RecordDetailView`) forwards an adapter
+ * OBJECT, and every reader calls adapter methods on it. Zero producers ever
+ * assigned an id string. So the declaration was not a contract anyone kept: it
+ * was a statement the code contradicted at every site, and each reader paid for
+ * it with an `as any` at the point of use.
+ *
+ * The cost is exactly what a cast costs: it deletes the compiler's answer to
+ * "does this adapter have the method I am about to call". objectui#8883's
+ * reference rail is the worked instance — it reaches for
+ * `dataSource.getObjectSchema` through a cast, so nothing checks that the
+ * member is guaranteed to exist. `getObjectSchema` is a REQUIRED member of
+ * `DataSource`; the honest type was imported by these packages all along.
+ *
+ * A runtime test cannot observe any of this. Which assignments the compiler
+ * refuses is erased before an assertion could run, and `as any` makes every
+ * wrong call succeed at runtime anyway. So the gauge has to be `tsc`, driven
+ * here — the same harness as
+ * `packages/app-shell/src/__tests__/consoleActionDispatch.pin.test.ts`, for the
+ * same reason.
+ *
+ * ## Pinned in BOTH directions
+ *
+ * - The adapter direction (`ACCEPTED`): a producer may hand over a `DataSource`
+ *   and a reader may reach `getObjectSchema` off it with no cast. These rows
+ *   are the acceptance of objectui#9197; they are REFUSED by the old `string`
+ *   declaration, so reverting it turns them red.
+ * - The id-string direction (`REFUSED`): writing a bare id string into the
+ *   member is now a type error. That is the BREAKING half of this change and
+ *   the reason it ships with a FROM/TO changeset — it is pinned so nobody
+ *   quietly restores the `string` alternative as a union member "to be kind"
+ *   to an out-of-repo caller. Re-widening it to `string | DataSource` would
+ *   also re-break the acceptance rows, because a union member without
+ *   `getObjectSchema` cannot be read without narrowing.
+ *
+ * ## Resolution guard (why these controls exist)
+ *
+ * The harness resolves `@object-ui/react` and `@object-ui/types` through the
+ * repo's SOURCE `paths`, not `dist`. With default resolution an unbuilt `dist`
+ * degrades both types to `any`, every REFUSED row flips to accepted, and the
+ * pin inverts for a reason that has nothing to do with this card. The CONTROL
+ * rows are what make that visible: they are refusals that have nothing to do
+ * with `dataSource` (a misspelled key, a missing required member), so if the
+ * program ever stops resolving the real types they flip — a control that can
+ * fire. Any diagnostic landing in the virtual module's IMPORT HEADER throws
+ * loudly instead of being read as a verdict.
+ *
+ * Cost note (AGENTS.md 测试纪律): the program is built at MODULE SCOPE, so the
+ * compiler work lands in the import phase, which no test or hook timeout
+ * bounds. A `beforeAll` would put it under the narrower 10s `hookTimeout`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import ts from 'typescript';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// __tests__ → context → src → react → packages → repo root
+const REPO_ROOT = resolve(HERE, '..', '..', '..', '..', '..');
+/** The context under test, by SOURCE path — no `dist`, no barrel. */
+const CONTEXT_IMPORT = join(HERE, '..', 'RecordContext').replace(/\\/g, '/');
+
+/**
+ * One assignment or read, and whether `tsc` must refuse it.
+ * `code` emits EXACTLY one line — the line index is how a diagnostic is
+ * attributed back to a case.
+ */
+interface Case {
+  readonly what: string;
+  readonly code: string;
+  readonly refused: boolean;
+}
+
+const CTX = `(undefined as unknown as RecordContextValue)`;
+
+const CASES: readonly Case[] = [
+  // ── The acceptance of objectui#9197. These rows ARE the card. ─────────────
+  {
+    what: 'a producer may hand the member a DataSource adapter with no cast',
+    code: `const c: RecordContextValue = { objectName: 'account', recordId: 'r1', dataSource: (undefined as unknown as DataSource) };`,
+    refused: false,
+  },
+  {
+    what: "objectui#8883's rail reaches `getObjectSchema` with no cast",
+    code: `const c: (o: string) => Promise<any> = ${CTX}.dataSource!.getObjectSchema;`,
+    refused: false,
+  },
+  {
+    what: 'the member is assignable to `DataSource` once narrowed',
+    code: `const c: DataSource | undefined = ${CTX}.dataSource;`,
+    refused: false,
+  },
+  {
+    what: 'the member stays OPTIONAL — a host with no adapter still builds a value',
+    code: `const c: RecordContextValue = { objectName: 'account', recordId: 'r1' };`,
+    refused: false,
+  },
+
+  // ── The breaking half, pinned so it cannot be quietly re-widened. ─────────
+  {
+    what: 'BREAKING a datasource id string is no longer assignable to the member',
+    code: `const c: RecordContextValue = { objectName: 'account', recordId: 'r1', dataSource: 'ds_primary' };`,
+    refused: true,
+  },
+  {
+    what: 'BREAKING the member no longer reads as a string',
+    code: `const c: string | undefined = ${CTX}.dataSource;`,
+    refused: true,
+  },
+
+  // ── Controls. Nothing to do with `dataSource`; they prove the program is
+  //    resolving the real types rather than degrading everything to `any`. ──
+  {
+    what: 'CONTROL a misspelled context key is refused',
+    code: `const c: RecordContextValue = { objectName: 'account', recordId: 'r1', dataSorce: 'x' };`,
+    refused: true,
+  },
+  {
+    what: 'CONTROL a value missing the required `objectName` is refused',
+    code: `const c: RecordContextValue = { recordId: 'r1' };`,
+    refused: true,
+  },
+  {
+    what: 'CONTROL `DataSource` really declares `getObjectSchema` as REQUIRED',
+    code: `const c: DataSource = { find: (undefined as any), findOne: (undefined as any), create: (undefined as any), update: (undefined as any), delete: (undefined as any) };`,
+    refused: true,
+  },
+];
+
+const IMPORTS = [
+  `import type { DataSource } from '@object-ui/types';`,
+  `import type { RecordContextValue } from '${CONTEXT_IMPORT}';`,
+  // Keeps both imports "used", so a reader of the virtual file can see why
+  // they are here even when a case stops mentioning one of them.
+  `type _Used = [DataSource, RecordContextValue];`,
+].join('\n');
+
+/**
+ * Compile every case and return the set of case indices that produced a
+ * diagnostic.
+ *
+ * `paths` mirrors the repo root `tsconfig.json`, so the workspace specifiers
+ * resolve to source exactly as the workspace itself resolves them. See the file
+ * header for why default (`dist`-backed) resolution is not acceptable here.
+ */
+function erroringCases(): Set<number> {
+  const header = `${IMPORTS}\n`;
+  // Each case is wrapped in its own BLOCK so the `const c` declarations do not
+  // collide — a duplicate-identifier diagnostic would land on every line and
+  // read as "the compiler refuses everything", which is the one wrong answer
+  // this file must never produce. Still exactly one line per case.
+  const body = CASES.map((c) => `{ ${c.code} }`).join('\n');
+  const source = `${header}${body}\n`;
+  const headerLines = header.split('\n').length - 1;
+
+  const VIRTUAL = join(HERE, '__recordContextDataSourcePins.virtual.ts').replace(/\\/g, '/');
+  const options: ts.CompilerOptions = {
+    strict: true,
+    skipLibCheck: true,
+    noEmit: true,
+    jsx: ts.JsxEmit.ReactJSX,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ESNext,
+    baseUrl: REPO_ROOT,
+    paths: {
+      '@object-ui/types': ['packages/types/src'],
+      '@object-ui/types/*': ['packages/types/src/*'],
+      '@object-ui/core': ['packages/core/src'],
+      '@object-ui/core/*': ['packages/core/src/*'],
+    },
+  };
+  const host = ts.createCompilerHost(options);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (fileName, languageVersion, ...rest) =>
+    fileName === VIRTUAL
+      ? ts.createSourceFile(fileName, source, languageVersion, true)
+      : getSourceFile(fileName, languageVersion, ...rest);
+  const fileExists = host.fileExists.bind(host);
+  host.fileExists = (fileName) => (fileName === VIRTUAL ? true : fileExists(fileName));
+  const readFile = host.readFile.bind(host);
+  host.readFile = (fileName) => (fileName === VIRTUAL ? source : readFile(fileName));
+
+  const program = ts.createProgram([VIRTUAL], options, host);
+  const sf = program.getSourceFile(VIRTUAL);
+  if (!sf) throw new Error('virtual source file was not added to the program');
+
+  const cases = new Set<number>();
+  for (const d of [...program.getSemanticDiagnostics(sf), ...program.getSyntacticDiagnostics(sf)]) {
+    if (d.start == null) continue;
+    const index = sf.getLineAndCharacterOfPosition(d.start).line - headerLines;
+    // A diagnostic ABOVE the first case line is a broken import, not a verdict.
+    // Fail loudly rather than let it read as "the compiler accepted everything".
+    if (index < 0) {
+      throw new Error(
+        'the pin harness failed to resolve its own imports — this is a setup failure, not a ' +
+          `verdict about \`dataSource\`: ${ts.flattenDiagnosticMessageText(d.messageText, ' ')}`,
+      );
+    }
+    cases.add(index);
+  }
+  return cases;
+}
+
+// Module scope on purpose — see the file header.
+const refusedByCompiler = erroringCases();
+
+describe('`RecordContextValue.dataSource` is a DataSource adapter (objectui#9197)', () => {
+  for (const [i, c] of CASES.entries()) {
+    it(c.what, () => {
+      expect({ case: c.what, refused: refusedByCompiler.has(i) })
+        .toEqual({ case: c.what, refused: c.refused });
+    });
+  }
+});

--- a/packages/react/src/context/__tests__/RecordContext.valueShape.pin.test.tsx
+++ b/packages/react/src/context/__tests__/RecordContext.valueShape.pin.test.tsx
@@ -32,11 +32,32 @@
 import * as React from 'react';
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
+import type { DataSource } from '@object-ui/types';
 import {
   RecordContextProvider,
   useRecordContext,
   type RecordContextValue,
 } from '../RecordContext';
+
+/**
+ * A distinct `DataSource` adapter per call. `dataSource` holds the ADAPTER the
+ * host resolved, not an id (objectui#9197) — so the "before" and "after" of the
+ * `dataSource` mutation below have to be two different adapter objects, and the
+ * re-memoization they prove is by reference, which is how the real producer
+ * (`app-shell/views/RecordDetailView`) hands it down.
+ */
+let adapterSeq = 0;
+const makeDataSource = (): DataSource => {
+  const tag = `adapter_${++adapterSeq}`;
+  return {
+    find: async () => ({ data: [], total: 0 }),
+    findOne: async () => null,
+    create: async (_r, d) => d as any,
+    update: async (_r, _id, d) => d as any,
+    delete: async () => true,
+    getObjectSchema: async () => ({ name: tag }),
+  };
+};
 
 /** The keys `RecordContextProvider`'s `useMemo` dep list names, in its order. */
 const MEMO_DEP_KEYS = [
@@ -69,7 +90,7 @@ type _EveryContextKeyIsDepListed = Expect<
 const BASE: RecordContextValue = {
   objectName: 'account',
   recordId: 'rec_1',
-  dataSource: 'ds_primary',
+  dataSource: makeDataSource(),
   data: { id: 'rec_1', name: 'Acme' },
   objectSchema: { name: 'account' },
   refresh: () => {},
@@ -83,7 +104,7 @@ const BASE: RecordContextValue = {
 const CHANGED: RecordContextValue = {
   objectName: 'contact',
   recordId: 'rec_2',
-  dataSource: 'ds_secondary',
+  dataSource: makeDataSource(),
   data: { id: 'rec_2', name: 'Globex' },
   objectSchema: { name: 'contact' },
   refresh: () => {},

--- a/packages/react/src/context/__tests__/RecordContext.valueShape.pin.test.tsx
+++ b/packages/react/src/context/__tests__/RecordContext.valueShape.pin.test.tsx
@@ -52,8 +52,8 @@ const makeDataSource = (): DataSource => {
   return {
     find: async () => ({ data: [], total: 0 }),
     findOne: async () => null,
-    create: async (_r, d) => d as any,
-    update: async (_r, _id, d) => d as any,
+    create: async (_r, d) => d,
+    update: async (_r, _id, d) => d,
     delete: async () => true,
     getObjectSchema: async () => ({ name: tag }),
   };


### PR DESCRIPTION
Fixes #9197

## What was wrong

`RecordContextValue.dataSource` was declared `dataSource?: string`, documented as
"an optional datasource id; mirrors the page-level datasource override", on a
**published** type exported from `@object-ui/react`.

Nobody ever wrote an id there. The one production host that writes the member —
`app-shell`'s `RecordDetailView` — forwards an adapter OBJECT, and every reader
calls adapter methods on it. So the declaration was not a contract anyone kept;
it was a statement the code contradicted at every site, and each reader paid for
it with a cast at the point of use.

A cast there is not free: it deletes the compiler's answer to *"does this adapter
have the method I am about to call"*.

## The hard fork, re-tested here

Triage's producer scan was keyed on `RecordContextProvider` + `dataSource=` and
by its own note could not see a **directly-constructed context value object**.
The discriminant is *who writes this member*, so this branch re-ran it on that
basis (script kept out of the diff; all three legs quoted here):

| leg | method | result |
|:--|:--|:--|
| provider tags | brace-balanced scan of **every** `RecordContextProvider` open tag in the repo (88 tags), so a prop after an arrow-function value cannot hide | 23 write the member; **exactly one is non-test** |
| direct construction | every `RecordContext.Provider value=` site | **one** — inside `RecordContext.tsx` itself, fed by the provider's own props |
| annotated literals | every value annotated `RecordContextValue` | none outside the memo pin's fixtures |

The single non-test producer is `app-shell/src/views/RecordDetailView.tsx:2375`,
passing its adapter. ⇒ **No real producer writes an id string**, so candidate ①
stands and no `dataSourceId` member is minted for a requirement with zero
producers.

⚠️ One in-repo writer of a *string* did exist: the memo pin's fixtures
(`RecordContext.valueShape.pin.test.tsx`), `dataSource: 'ds_primary'`. That is a
fixture written because the declaration invited it, not a producer — nothing
reads it as an id. It is corrected in this change.

## What changed

`dataSource?: DataSource` (`@object-ui/types`), and the doc comment now
describes what the member holds instead of an override that does not exist.

## The cast family — and a correction to its count

Triage measured **11** casts with a grep keyed on the variable name `ctx`. Re-run
here, that grep still returns 11 — but **5 of those 11 read a different context**:

- `packages/fields/src/index.tsx:133`, `widgets/ObjectRefField.tsx:40`,
  `widgets/FilterConditionField.tsx:432`, `widgets/RecipientPickerField.tsx:62`,
  `widgets/CapabilityMultiSelectField.tsx:156` all name their binding `ctx` but
  assign it from **`SchemaRendererContext`**, whose `dataSource` is declared
  `any` — a different, already-filed defect (objectui#7912, cast family
  objectui#7209). Their casts are redundant against `any` **today**, before and
  after this change, so this card's type repair does not make them so and they
  are **not** touched here.

So `@object-ui/fields` is **not** in this card's blast radius. Keying on the
binding instead of the name gives the real face — and it is also 11, which is
why the coincidence is worth spelling out:

| # | site | before | after |
|:--|:--|:--|:--|
| 1 | `app-shell/views/record-attachments-renderer.tsx:62` | `ctx?.dataSource as any` | cast removed |
| 2 | `components/renderers/layout/containers.tsx:511` | `const ds: any =` | annotation removed |
| 3 | `plugin-detail/renderers/record-activity.tsx:141` | `ctx?.dataSource as any` | cast + stale comment removed |
| 4 | `plugin-detail/renderers/record-details.tsx:606` | `ctx.dataSource as any` | cast removed |
| 5 | `plugin-detail/renderers/record-highlights.tsx:121` | `ctx?.dataSource as any` | cast removed |
| 6 | `plugin-detail/renderers/record-history.tsx:54` | `useRecordContext() as any` | cast removed |
| 7 | `plugin-detail/renderers/record-reference-rail.tsx:163` | `(ctx as any)?.dataSource` | cast removed |
| 8 | `plugin-detail/renderers/record-related-list.tsx:248` | `ctx?.dataSource as any` | cast removed |
| 9 | `plugin-detail/renderers/record-related-list.tsx:299` | already cast-free | unchanged |
| 10 | `plugin-detail/renderers/record-related-list.tsx:302` | `(ctx!.dataSource as any).delete?.()` | cast removed |
| 11 | `plugin-detail/renderers/record-related-list.tsx:359` | already cast-free | unchanged |

**Remaining `as any` on this family after the change: 0**, with a lit control —
the same instrument still reports 5 hits on the `SchemaRendererContext` family it
was never measuring, so a zero here is a reading and not a broken scanner.

Sites 6 and 10 are worth a word, because neither was a pure deletion:

- **6** cast the WHOLE context, not just the member. Audited first: that file
  reads only `objectName` / `data` / `recordId` / `dataSource`, all declared, so
  the cast existed solely to escape this declaration.
- **10** became `ctx?.dataSource?.delete?.(…)`. The optional CALL is kept on
  purpose and is **not** a cast: `delete` is a required member of `DataSource`,
  but adapters that omit it at runtime currently no-op rather than throw, and
  this card does not change runtime behaviour. The rail at
  `record-reference-rail.tsx:296` guards `getObjectSchema` the same way, with a
  comment saying why.

**No cast on this family was still necessary after the repair**, so none is
listed as retained.

## The acceptance, demonstrated

objectui#8883's reference rail reaches `getObjectSchema` with no cast. It is
pinned as an executable case, not asserted in prose — see below.

## Instrument

The pin was written **BEFORE** the code changed, so the "unmodified" arm is the
real base tree (`96919a459`) — no ablation, no mutation to prove on disk, no
restore leg to get wrong.

`packages/react/src/context/__tests__/RecordContext.dataSourceType.pin.test.ts`
drives `tsc` over a virtual module resolved through the repo's SOURCE paths
(same harness as `consoleActionDispatch.pin.test.ts`), because which assignments
the compiler refuses is erased before any runtime assertion could see it.

| run | tree | result |
|:--|:--|:--|
| before | base tree `96919a459`, pin file only | `Tests 5 failed`, `4 passed (9)` |
| after | this branch | `Tests 9 passed (9)` |

The 5 that flipped are the 3 acceptance rows (adapter assignable; rail reaches
`getObjectSchema` with no cast; member assignable to `DataSource`) and the 2
BREAKING rows (id string refused; member no longer reads as a string).

**Controls: lit, and lit on BOTH arms.** The three resolution controls (a
misspelled key refused; a value missing `objectName` refused; `DataSource` really
declaring `getObjectSchema` as required) passed on the base tree and still pass —
that is what proves the harness is resolving the real types rather than
degrading them to `any`, which is the failure mode that would silently invert
every row. They are controls that CAN fire: if resolution broke, they flip.

## Verification

- `turbo run type-check` over `react`, `plugin-detail`, `app-shell`, `components`,
  `fields` and their dependency closures — **34 successful, 34 total**.
- `changeset:check` (this is the spelling that runs `check-changeset-no-major.mjs`;
  there is no `no-major` npm script) — green, `No changeset declares a major bump`.
- `check-changeset-presence.mjs`, `check:control-bytes`, `check:phantom-deps`,
  `check:self-import` — green.
- Test union over the four named packages plus `components`, `fields`,
  `examples/schema-catalog/` and `apps/console` — see the comment below for the
  result; the shared verify lock returned `queue-timeout (exit 99)` on the first
  attempt, which is NOT MEASURED rather than a red.

## Changeset

FROM/TO, shaped after objectui#8604 / objectui#9187. `minor` with a `**BREAKING**`
carrier: all 41 packages sit in one `fixed` group, so `major` is unavailable.
Breaking only for out-of-repo consumers that read the member as `string`; nothing
migrates at runtime, because every producer already passed the adapter.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_