### PR TITLE
fix(plugin-view): a stray `groupBy` no longer overrides the kanban lane on the second route

### DIFF
--- a/.changeset/9242-stray-kanban-groupby-lane-second-route.md
+++ b/.changeset/9242-stray-kanban-groupby-lane-second-route.md
@@ -1,0 +1,64 @@
+---
+"@object-ui/plugin-view": minor
+---
+
+**A stray `groupBy` in `viewOptions.kanban` no longer overrides the lane `generateViewSchema` resolved — the second route.**
+
+`plugin-view`'s `generateViewSchema` kanban branch destructured
+`columns`/`groupByField`/`groupField`/`titleField`/`conditionalFormatting` out of
+`viewOptions.kanban` and spread the **rest** *after* its own `groupBy`. A
+`groupBy` surviving in that bag therefore **overrode the lane the branch had just
+resolved** from the canonical `groupByField`, and nothing said so — the board
+simply grouped by the wrong field.
+
+This is the **second route**, not a repeat of objectui#8365. `generateViewSchema`
+runs precisely when no host supplied `renderListView` — the authored
+`object-view` element — so it never passes through `ListView`, and PR
+objectui#9236's destructure fix does not reach it. The same distinction the
+`calendar` branch records for objectui#7029.
+
+**BREAKING** (shipped as `minor`: all 41 packages sit in one `fixed` group, so
+`major` is unavailable and would drag the group off `@objectstack`'s major —
+AGENTS.md "版本号策略"). A **stored view that carries `kanban.groupBy` will now
+render a different lane than it did before**: the canonical `groupByField` wins,
+or — with no declared key at all — this branch's floor. That re-pointing is the
+ruled intent, not a side effect, but it is a real change to what an existing
+board displays and is stated here for that reason.
+
+The affected population is narrow and was measured rather than assumed: the
+contract half landed with PR objectui#9236 and already covers **both** routes —
+the view-level `KanbanConfig` mirror declares `groupBy` as a named alias refusal
+pointing at `groupByField`, so a view carrying the key is refused at every
+validating door (`os check` / `os validate`, the VS Code extension) and `tsc`
+refuses it at the authoring site. What remains, and what this change repairs, is
+a pure **behaviour** gap: a document already in storage that never passed through
+a validator.
+
+Maintainer ruling of 2026-09-12 (decision batch #117 item 5, verbatim
+「8365 同意」) — option B. Option A (strip the key and silently re-group) was not
+taken. This card applies that ruling to the second route; it re-opens nothing.
+
+**One measured difference from the `ListView` twin, and it is not cosmetic.**
+This branch floors the lane at the **literal** `'status'`
+(`groupByField || groupField || 'status'`), where `ListView` floors at
+`detectStatusField(objectDef)`. So with the stray key alone, this route answers
+`'status'` — measured on this tree, including against an object that declares no
+`status` field — where the twin would answer `undefined`. The twin's assertion
+for that arm was therefore **measured here rather than copied**, and both rows
+are pinned so that "aligning" the two routes by swapping in the detector reddens
+instead of passing quietly.
+
+Level justified by measurement, not intuition:
+
+- **Nothing stops rendering** — no crash, no new refusal at runtime; the board
+  keeps rendering, with a different (correct) lane.
+- **Nothing stops type-checking** — the type face (`groupBy?: never` on the
+  inferred authoring surface) already landed with PR objectui#9236.
+- **What an author can author today is unchanged** — the key is already refused
+  at every validating door, so no newly-authored document can legally carry it.
+
+Untouched, deliberately: the contract half (already covers both routes), the
+**live** legacy alias `kanban.groupField`, `groupBy` on the generated
+`object-kanban` node (the canonical lane key `ObjectKanban` reads), and
+`ListView` itself. The `restKanban` passthrough is kept — an undeclared sibling
+key still rides through onto the node, pinned as a control.

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -1361,7 +1361,38 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
           (Array.isArray(kanbanCfg.columns) && kanbanCfg.columns.length > 0
             ? kanbanCfg.columns
             : baseProps.fields) || [];
-        const { columns: _kanbanColumns, groupByField: _gbf, groupField: _gf, titleField: _tf, conditionalFormatting: _kanbanCf, ...restKanban } = kanbanCfg;
+        // ⭐ `groupBy` IS STRIPPED HERE (objectui#9242, maintainer ruling of
+        // 2026-09-12 — decision batch #117 item 5, option B). It is a THIRD
+        // spelling of the lane, and because it was NOT in this destructure it
+        // survived into `restKanban`, which the return below spreads AFTER the
+        // branch's own `groupBy` — so an authored `kanban.groupBy` OVERRODE the
+        // lane this branch had just resolved from `groupByField`.
+        //
+        // THE SECOND ROUTE. objectui#8365 / PR objectui#9236 closed the same
+        // shape in `ListView`, but `generateViewSchema` runs precisely when no
+        // host supplied `renderListView` — the authored `object-view` element —
+        // so that fix does not reach here. Same distinction the `calendar`
+        // branch below records for objectui#7029.
+        //
+        // ⚠️ ONE MEASURED DIFFERENCE FROM THE TWIN, and it is not cosmetic: the
+        // lane above floors at the LITERAL `'status'`, where `ListView` floors
+        // at `detectStatusField(objectDef)`. So with the stray key ALONE this
+        // route answers `'status'` — measured, including against an object that
+        // declares no `status` field — and the twin would answer `undefined`.
+        // ⛔ Do not "align" the two by swapping in the detector: that is a
+        // behaviour change on stored views and belongs on its own card.
+        //
+        // The contract half is NOT here and must not be duplicated here: the
+        // view-level `KanbanConfig` mirror (`@object-ui/types`,
+        // `zod/objectql.zod.ts`) already declares `groupBy` as a named alias
+        // refusal pointing at `groupByField`, and it covers BOTH routes. What
+        // this line closes is the residual BEHAVIOUR gap — a stored document
+        // that never passed through a validator.
+        // ⚠️ NODE-LOCAL vs VIEW-LEVEL, as everywhere in this branch: the
+        // `kanbanCfg.groupField` alias read above is LIVE and untouched, and
+        // `groupBy` on the RETURNED node is the canonical lane key
+        // `ObjectKanban` reads. Only the stray VIEW-CONFIG spelling is stripped.
+        const { columns: _kanbanColumns, groupByField: _gbf, groupField: _gf, titleField: _tf, conditionalFormatting: _kanbanCf, groupBy: _strayGroupBy, ...restKanban } = kanbanCfg;
         // Forward conditional formatting to kanban (issue #1584): nested
         // `options.kanban.conditionalFormatting` wins, then the view-level rule.
         // Those are the two places the key is DECLARED — `ObjectKanbanSchema`

--- a/packages/plugin-view/src/__tests__/ObjectView.strayGroupByLane-9242.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.strayGroupByLane-9242.test.tsx
@@ -1,0 +1,265 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9242 — a stray `groupBy` in `viewOptions.kanban` OVERRODE the lane
+ * `generateViewSchema` had just resolved. THE SECOND ROUTE.
+ *
+ * `generateViewSchema`'s kanban branch destructured
+ * `columns`/`groupByField`/`groupField`/`titleField`/`conditionalFormatting`
+ * out of `viewOptions.kanban` and spread the REST *after* its own `groupBy`. So
+ * an authored `kanban.groupBy` survived into `restKanban` and won over the
+ * canonical `groupByField` the branch had already resolved — the board grouped
+ * by the stray key, and nothing said so.
+ *
+ * ## WHY THIS IS A SECOND ROUTE, NOT A DUPLICATE OF objectui#8365
+ *
+ * `generateViewSchema` runs precisely when no host supplied `renderListView` —
+ * the authored `object-view` element — so it never passes through `ListView`,
+ * and PR objectui#9236's destructure fix does not reach it. This is the same
+ * distinction the `calendar` branch a few lines below records for objectui#7029.
+ *
+ * ## THE RULING — already made; this card only applies it to the second route
+ *
+ * Maintainer ruling of 2026-09-12 (decision batch #117 item 5, verbatim
+ * 「8365 同意」) — option B: the CANONICAL spelling wins and the stray key is
+ * refused BY NAME. Option A (strip the key and re-group in silence) was NOT
+ * taken. ⛔ This is not an open question; see objectui#8365 / PR objectui#9236.
+ *
+ * ## THE DISTINGUISHING FIXTURE, and why one lane name would not do
+ *
+ * The two spellings carry two DIFFERENT lane names. With a single name the
+ * override arm cannot fail BY CONSTRUCTION — which is exactly how the twin
+ * defect stayed invisible for so long on the first route: the one producer that
+ * fed it wrote both spellings with the same value.
+ *
+ *     kanban = { groupBy: 'LANE_FROM_STRAY_GROUPBY',
+ *                groupByField: 'LANE_FROM_CANONICAL' }
+ *
+ * ## ⭐ THE ARM THAT IS **MEASURED HERE**, NOT COPIED FROM THE TWIN
+ *
+ * `ListView` floors its lane on `detectStatusField(objectDef)`. THIS branch
+ * floors it on the LITERAL `'status'` (`groupByField || groupField || 'status'`),
+ * so the "stray key alone" control answers differently on the two routes and
+ * copying the twin's assertion would have pinned the wrong thing.
+ *
+ * Measured on this tree before this file was written (base `96919a459`, every
+ * lit control firing), `node.groupBy` per fixture:
+ *
+ *   | kanban config                          | BEFORE fix | AFTER fix  |
+ *   | -------------------------------------- | ---------- | ---------- |
+ *   | `{ groupBy: S, groupByField: C }`      | **S** ⛔   | C          |
+ *   | `{ groupBy: S }`                       | **S** ⛔   | `'status'` |
+ *   | `{ groupBy: S }`, object has NO status | **S** ⛔   | `'status'` |
+ *   | `{}`                                   | `'status'` | `'status'` |
+ *   | `{ groupByField: C }`                  | C          | C          |
+ *   | `{ groupField: C }`                    | C          | C          |
+ *
+ * The third row is the one that tells a LITERAL floor apart from a detector: an
+ * object declaring no `status` field still floors at `'status'` here, where the
+ * twin would have produced `undefined`. Pinned below for exactly that reason.
+ *
+ * ## WHAT THIS CARD DELIBERATELY DOES NOT TOUCH — four faces
+ *
+ *  1. THE CONTRACT HALF. `KanbanConfig`'s `aliasKeyRefusal` for `groupBy`
+ *     (`@object-ui/types`, `zod/objectql.zod.ts`) landed with PR objectui#9236
+ *     and already covers BOTH routes — a view carrying the key is refused at
+ *     every validating door. It is pinned in
+ *     `packages/plugin-list/src/__tests__/ListView.strayGroupByRefused-8365.test.tsx`
+ *     and `packages/types/src/__tests__/kanban-stray-group-by-refusal-8365.test.ts`;
+ *     ⛔ not re-pinned here, because what remains on this route is a BEHAVIOUR
+ *     gap — a document that never went through a validator.
+ *  2. THE LIVE LEGACY ALIAS `kanban.groupField`, a legacy spelling of the spec's
+ *     `groupByField`. Still read, still resolves the lane — CONTROL below.
+ *  3. `groupBy` ON THE GENERATED NODE. That is the canonical lane key
+ *     `ObjectKanban` actually reads (thirteen `schema.groupBy` reads in
+ *     `ObjectKanban.tsx`); the stray key is a VIEW-CONFIG spelling. Do not
+ *     confuse the two — the whole fix is to stop the second from reaching the
+ *     first.
+ *  4. `ListView` — objectui#8365's face, closed.
+ *
+ * ## REVERSE VERIFICATION (the ablation leg), direction predicted before running
+ *
+ * Run in its STRONGEST form: this file was written and run BEFORE
+ * `ObjectView.tsx` was touched, so the "unmodified" arm is the REAL BASE TREE
+ * rather than an injected mutation — no on-disk mutation to prove, no restore
+ * leg to get wrong. Predicted and then observed on `96919a459`: the three
+ * override arms go RED naming `LANE_FROM_STRAY_GROUPBY`, while every CONTROL
+ * arm (canonical, legacy alias, floor, passthrough, sibling keys) stays GREEN.
+ * The asymmetry is what shows the controls are not carrying the override arms.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import { ObjectView } from '../ObjectView';
+import type { ObjectViewSchema } from '@object-ui/types';
+
+/** The two lane names the fixture holds apart. */
+const STRAY = 'LANE_FROM_STRAY_GROUPBY';
+const CANONICAL = 'LANE_FROM_CANONICAL';
+/** The literal this branch floors the lane at — NOT a detector. */
+const FLOOR = 'status';
+
+/** Every schema the view hands to SchemaRenderer, in order. */
+const rendered: any[] = [];
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const ReactMod = await import('react');
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    SchemaRenderer: ({ schema }: any) => {
+      rendered.push(schema);
+      return <div data-testid="schema-renderer">{schema?.type}</div>;
+    },
+    SchemaRendererContext: ReactMod.createContext(null),
+    subscribeDataChanges: () => () => {},
+    notifyDataChanged: () => {},
+  };
+});
+vi.mock('@object-ui/plugin-grid', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ObjectGrid: () => <div data-testid="object-grid" />,
+}));
+vi.mock('@object-ui/plugin-form', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ObjectForm: () => <div data-testid="object-form" />,
+}));
+
+/** An object that DOES declare a `status` field. */
+const WITH_STATUS = { status: { name: 'status', type: 'text', label: 'Status' } };
+/** An object that declares NO `status` field — tells a literal floor from a detector. */
+const WITHOUT_STATUS = { name: { name: 'name', type: 'text', label: 'Name' } };
+
+const dataSource = (fields: Record<string, unknown> = WITH_STATUS): any => ({
+  find: vi.fn().mockResolvedValue({ data: [], total: 0 }),
+  findOne: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  getObjectSchema: vi.fn().mockResolvedValue({ name: 'task', fields }),
+});
+
+/**
+ * Renders a kanban view through the REGISTERED renderer's path — i.e. with no
+ * `renderListView` — and returns the `object-kanban` node the branch emits.
+ *
+ * ⚠️ `cleanup()` is load-bearing, not hygiene. Without it the previously
+ * mounted `ObjectView`s stay mounted and keep pushing into `rendered`, so
+ * `rendered[rendered.length - 1]` returns a STALE node and every reading comes
+ * back shifted by one fixture. That failure was hit while measuring this card:
+ * it renders as a plausible table in which the lit controls quietly answer the
+ * previous row's question. ⛔ Do not drop it.
+ */
+async function generatedKanbanNode(
+  kanban: Record<string, unknown>,
+  fields?: Record<string, unknown>,
+): Promise<any> {
+  cleanup();
+  rendered.length = 0;
+  render(
+    <ObjectView
+      schema={{ type: 'object-view', objectName: 'task' } as unknown as ObjectViewSchema}
+      views={[{ id: 'k', label: 'Board', type: 'kanban' as any, kanban }] as any}
+      dataSource={dataSource(fields)}
+    />,
+  );
+  await waitFor(() => expect(rendered.length).toBeGreaterThan(0));
+  const node = rendered[rendered.length - 1];
+  expect(node.type).toBe('object-kanban');
+  return node;
+}
+
+beforeEach(() => {
+  rendered.length = 0;
+});
+
+describe('objectui#9242 — the CANONICAL lane wins on the node `generateViewSchema` emits', () => {
+  it('the distinguishing fixture resolves the lane from `groupByField`, not the stray `groupBy`', async () => {
+    const node = await generatedKanbanNode({ groupBy: STRAY, groupByField: CANONICAL });
+    // Before the fix this read `LANE_FROM_STRAY_GROUPBY`: the `...restKanban`
+    // spread landed after the branch's own `groupBy`.
+    expect(node.groupBy).toBe(CANONICAL);
+    expect(node.groupBy).not.toBe(STRAY);
+  });
+
+  it('the stray VALUE does not reach the generated node under any key at all', async () => {
+    const node = await generatedKanbanNode({ groupBy: STRAY, groupByField: CANONICAL });
+    // The assertion above is about the lane key's VALUE. This one is about the
+    // stray value: it must appear nowhere on the node, including under some
+    // other key the spread might have carried it through.
+    expect(Object.values(node)).not.toContain(STRAY);
+    expect(Object.prototype.hasOwnProperty.call(node, 'groupByField')).toBe(false);
+  });
+
+  it('LANE CONTROL (measured here, ⛔ not copied from `ListView`): `groupBy` alone floors at the literal', async () => {
+    // ⭐ THE ARM THE CARD SINGLED OUT. `ListView` answers this with
+    // `detectStatusField(objectDef)`; this branch answers with the LITERAL
+    // `'status'`. Option B, not a silent re-grouping: the stray key stops
+    // steering the board, and what replaces it is this branch's own floor.
+    const node = await generatedKanbanNode({ groupBy: STRAY });
+    expect(node.groupBy).toBe(FLOOR);
+    expect(node.groupBy).not.toBe(STRAY);
+  });
+
+  it('LANE CONTROL: the floor is a LITERAL — it holds when the object declares no `status` field', async () => {
+    // This is the row that tells a literal floor apart from a detector, and so
+    // the row that would redden first if anyone ever "aligned" this branch with
+    // the twin by swapping in `detectStatusField`. That would be a behaviour
+    // change on stored views and belongs on its own card, not in a tidy-up.
+    const node = await generatedKanbanNode({ groupBy: STRAY }, WITHOUT_STATUS);
+    expect(node.groupBy).toBe(FLOOR);
+    expect(node.groupBy).not.toBe(STRAY);
+    expect(node.groupBy).toBeDefined();
+  });
+});
+
+describe('objectui#9242 — the controls, each able to fire on its own', () => {
+  it('CONTROL: the declared `kanban.groupByField` still resolves the lane by itself', async () => {
+    const node = await generatedKanbanNode({ groupByField: CANONICAL });
+    expect(node.groupBy).toBe(CANONICAL);
+  });
+
+  it('CONTROL: the LIVE legacy alias `kanban.groupField` still resolves the lane', async () => {
+    // ⚠️ The VIEW-LEVEL legacy alias is live and untouched by this card — only
+    // the third spelling is stripped. Without this arm the fix could have
+    // narrowed the alias read too and nothing here would have noticed.
+    const node = await generatedKanbanNode({ groupField: CANONICAL });
+    expect(node.groupBy).toBe(CANONICAL);
+  });
+
+  it('CONTROL: with neither declared key the lane is the floor, exactly as before this card', async () => {
+    const node = await generatedKanbanNode({});
+    expect(node.groupBy).toBe(FLOOR);
+  });
+
+  it('PASSTHROUGH CONTROL: an undeclared sibling key still rides through onto the node', async () => {
+    // The destructure strips exactly ONE more key. It does not close the bag:
+    // `restKanban` is still how renderer-ahead knobs reach the kanban node.
+    // Without this arm, someone could satisfy every assertion above by dropping
+    // the passthrough altogether.
+    const node = await generatedKanbanNode({ groupByField: CANONICAL, zzzBogusKey: 'rides-through' });
+    expect(node.zzzBogusKey).toBe('rides-through');
+    expect(node.groupBy).toBe(CANONICAL);
+  });
+
+  it('CONTROL: the rest of the kanban branch still resolves — titleField and cardFields', async () => {
+    // Without this arm every assertion above would pass just as happily against
+    // a kanban branch that had stopped emitting anything at all.
+    const node = await generatedKanbanNode({
+      groupByField: CANONICAL,
+      columns: ['name', 'amount'],
+      titleField: 'name',
+    });
+    expect(node.titleField).toBe('name');
+    expect(node.cardFields).toEqual(['name', 'amount']);
+    // `columns` on the node would be read as LANES by `object-kanban`, so the
+    // branch maps it to `cardFields` and strips it. Unchanged by this card.
+    expect(node.columns).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #9242

`generateViewSchema`'s kanban branch destructured
`columns`/`groupByField`/`groupField`/`titleField`/`conditionalFormatting` out of
`viewOptions.kanban` and spread the **rest** *after* its own `groupBy`, so a
`groupBy` surviving in the bag **overrode the lane the branch had just resolved**
from the canonical `groupByField`. The board grouped by the stray key, and
nothing said so.

**The second route, not a repeat.** `generateViewSchema` runs precisely when no
host supplied `renderListView` — the authored `object-view` element — so it never
passes through `ListView`, and objectui#9236's destructure fix does not reach it.
The same distinction the `calendar` branch a few lines below records for
objectui#7029.

## The change

One key added to the destructure at `packages/plugin-view/src/ObjectView.tsx`,
same shape as objectui#9236 used for `ListView`, plus the comment block that says
why it is there and what must not be "tidied" later.

## Verification

Measured on the distinguishing fixture, not reasoned — two **different** lane
names, because with one name the arm cannot fail by construction:

```
viewOptions.kanban = { groupBy: 'LANE_FROM_STRAY_GROUPBY',
                       groupByField: 'LANE_FROM_CANONICAL' }
```

**Reverse verification, in its strongest form.** The pin was written and run
**before** the source was touched, so the "unmodified" arm is the **real base
tree** (`96919a459`) rather than an injected mutation — nothing to prove on disk,
no restore leg to get wrong. Direction predicted, then observed:

| leg | tree | result |
|---|---|---|
| pin on untouched base | `96919a459` | **4 override arms RED**, all **5 controls GREEN** |
| pin after the one-key repair | `41d1ebc5d` | **9 / 9 GREEN** |

The RED leg failed by name in every arm, e.g.
`AssertionError: expected 'LANE_FROM_STRAY_GROUPBY' to be 'LANE_FROM_CANONICAL'`.
The asymmetry — controls green in **both** worlds — is what shows the controls
are not carrying the override arms.

### The arm that was measured here rather than copied

This branch floors the lane at the **literal** `'status'`
(`groupByField || groupField || 'status'`), where `ListView` floors at
`detectStatusField(objectDef)`. So the "stray key alone" control answers
**differently on the two routes**, and copying the twin's assertion would have
pinned the wrong thing. Measured on this tree, every lit control firing:

| `viewOptions.kanban` | before | after |
|---|---|---|
| `{ groupBy: S, groupByField: C }` | **S** | C |
| `{ groupBy: S }` | **S** | `'status'` |
| `{ groupBy: S }`, object declares **no** `status` field | **S** | `'status'` |
| `{}` | `'status'` | `'status'` |
| `{ groupByField: C }` | C | C |
| `{ groupField: C }` (live legacy alias) | C | C |

Row 3 is the one that tells a **literal** floor from a **detector**: the twin
would answer `undefined` there. It is pinned so that "aligning" the two routes by
swapping in the detector reddens instead of passing quietly.

### An instrument failure, caught and named

The first measurement run came back **shifted by one fixture** — the lit control
`{ groupByField: C }` answered `'status'`. Cause: no `cleanup()` between renders,
so previously mounted views kept pushing into the spy and the harness read a
stale node. That is an **instrument failure, not a negative answer**; the harness
was fixed and every reading above was re-taken. `cleanup()` is now load-bearing
in the pin, with a comment saying so.

### Runs

- `pnpm exec vitest run packages/plugin-view/ examples/schema-catalog/` —
  **69 files / 2478 tests passed**. `schema-catalog` is in scope deliberately: a
  rendered node moved, and a package-scoped run is not the blast radius
  (objectui#9273). Its two kanban fixtures carry `groupBy` on the **node**, which
  is the canonical lane key and untouched by this change.
- Gates, hand-derived from `package.json` + `.github/workflows/` (this repo has
  no `dispatch-gates.mjs`): `check:vi-mock-specifiers`, `check:vi-mock-inherit`,
  `check:vi-mock-override-shape`, `check:test-path-roots`, `check:control-bytes`,
  `check:new-line-citations`, `changeset:check`, `check:changeset-claims`,
  `check-changeset-presence.mjs` — **all exit 0**, read from each gate's own
  verdict line.
- `eslint` on both changed files — **0 errors** (warnings are the file's
  pre-existing house style).
- Heavy runs went through the shared verify lock; verdicts read from the
  wrapper's `VERDICT` line.

## Scope — four faces deliberately untouched

1. **The contract half.** `KanbanConfig`'s `aliasKeyRefusal` for `groupBy` landed
   with objectui#9236 and already covers **both** routes, so a view carrying the
   key is refused at every validating door. What remained here was a pure
   **behaviour** gap: a stored document that never passed a validator.
2. **The live legacy alias** `kanban.groupField` — still read, pinned as a control.
3. **`groupBy` on the generated node** — the canonical lane key `ObjectKanban`
   reads. The whole fix is to stop the stray view-config spelling reaching it.
4. **`ListView`** — objectui#8365's face, already closed.

I checked the three prose sites that could have been falsified by this change
(`packages/types/src/zod/objectql.zod.ts`, `packages/app-shell/src/views/ObjectView.tsx`,
`ObjectView.kanbanGroupByRetired-8213.test.tsx`). All three are scoped to
`ListView` and remain accurate — no prose repair was needed.

## Changeset

`minor` with a **BREAKING** carrier: all 41 packages sit in one `fixed` group, so
`major` is unavailable and would drag the group off `@objectstack`'s major. The
changeset states plainly that this **re-points the lane of already-stored views**
that never passed a validator — the ruled intent, but a real change to what an
existing board displays. Level justified by measurement: nothing stops rendering,
nothing stops type-checking (the type face landed with objectui#9236), and what
an author can author today is unchanged.

## Ruling

Maintainer ruling of 2026-09-12 (decision batch #117 item 5, verbatim
「8365 同意」) — option B. Option A (strip the key and re-group in silence) was
not taken. This card applies a **ruled** direction to the second route; nothing
here re-opens it.

## Not done here, left to the PM

CI convergence and the ready/queue flip. `needs:contract-review` is hung on both
this PR and the card.

Session: `https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ`


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_