### PR TITLE
fix(app-shell): a merged tool result must not rewrite an approval state

### DIFF
--- a/.changeset/9233-approval-state-survives-merge.md
+++ b/.changeset/9233-approval-state-survives-merge.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/app-shell': patch
+---
+
+A rehydrated pending approval now reaches the chat as `approval-requested`
+(objectui#9233).
+
+`toUIMessages`' `mergeToolResultsInto` step rewrote the tool part's `state` on
+every merge — `isError ? 'output-error' : 'output-available'`, unconditionally.
+The server persists conversations in ModelMessage format (a tool CALL on the
+assistant row, its RESULT on a separate `tool` row), so this merge runs on the
+main rehydration path. A pending approval was therefore terminalized before the
+mapper saw it, the `approval-requested` gate in `ChatbotEnhanced` never opened,
+and the operator got no Approve / Reject card after a reload — even though the
+id had been indexed and `decide()` was already wired (objectui#8442).
+
+**Level, by measurement, not intuition.** `patch`: no exported signature, type
+or declaration key moved (`packages/app-shell` type-checks unchanged, including
+`tsconfig.test.json`), nothing an author authored today stops rendering, and
+`approval-requested` was already a declared member of the tool-state union that
+the live floating-chat mapper has always produced. What changes is one value on
+one hydration path, in the direction of an affordance appearing where it was
+supposed to. Consumers reading `state` off `toUIMessages` output may now observe
+`approval-requested` / `approval-responded` where they previously only ever saw
+`output-available`; that is the fix, and the union did not grow.
+
+The rewrite itself is load-bearing and is kept: collapsing a dangling
+`input-streaming` / `input-available` into a terminal state is why it exists, an
+error result still wins, and both halves are pinned.

--- a/packages/app-shell/src/console/ai/__tests__/AiChatPage.approvalRehydration.test.tsx
+++ b/packages/app-shell/src/console/ai/__tests__/AiChatPage.approvalRehydration.test.tsx
@@ -1,0 +1,125 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#9233 — a rehydrated approval has to arrive with BOTH halves.
+ *
+ * The server persists conversations in ModelMessage format: a tool CALL on the
+ * assistant row, its RESULT on a separate `tool` row. Everything an operator
+ * needs to act on a pending approval travels that split:
+ *
+ *   * the `pendingActionId` — `useHitlInChat` keys its index on it, and without
+ *     an entry `decide()` short-circuits with "No pending-action id found";
+ *   * the `state` — `ChatbotEnhanced`'s `isAwaitingApproval` renders the
+ *     Approve / Reject card only on `approval-requested`.
+ *
+ * objectui#8442 landed the first half. The second was still being erased by
+ * `mergeToolResultsInto`, which rewrote the state to `output-available` on
+ * every merge — so the card never rendered and there was no button to press
+ * even though the wiring behind it was live. This file pins the whole path end
+ * to end: server rows in, a decidable approval out.
+ *
+ * It lives in a `.tsx` file on purpose. "Indexable by `useHitlInChat`" is
+ * measured by RUNNING the hook and watching the id reach the request, not by
+ * restating the hook's predicate as an assertion here — a restated predicate
+ * passes even when the hook has changed underneath it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useHitlInChat } from '@object-ui/plugin-chatbot';
+import { hydratedMessagesToChatMessages } from '../AiChatPage';
+import {
+  aiMessageRowsToServerMessages,
+  toUIMessages,
+} from '../../../hooks/useChatConversation';
+
+/** The authenticated `/conversations/:id` shape, reconstructed from flat rows. */
+function hydrateServerRows() {
+  return hydratedMessagesToChatMessages(
+    toUIMessages(
+      aiMessageRowsToServerMessages([
+        { id: 'u1', role: 'user', content: 'delete the task' },
+        {
+          id: 'a1',
+          role: 'assistant',
+          content: 'This needs your approval.',
+          tool_calls: JSON.stringify([
+            {
+              type: 'tool-call',
+              toolCallId: 'c1',
+              toolName: 'action_delete_task',
+              input: { id: 't1' },
+            },
+          ]),
+        },
+        {
+          id: 't1',
+          role: 'tool',
+          tool_call_id: 'c1',
+          content: JSON.stringify([
+            {
+              type: 'tool-result',
+              toolCallId: 'c1',
+              toolName: 'action_delete_task',
+              output: {
+                type: 'text',
+                value: JSON.stringify({
+                  status: 'pending_approval',
+                  pendingActionId: 'pa_44',
+                  toolName: 'action_delete_task',
+                }),
+              },
+            },
+          ]),
+        },
+      ]),
+    ),
+  );
+}
+
+describe('a rehydrated ModelMessage approval is decidable end to end (objectui#9233)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('hydrates to approval-requested AND reaches the server with the pending id', async () => {
+    const messages = hydrateServerRows();
+    const tool = messages[1]?.toolInvocations?.[0];
+
+    // HALF ONE — the render gate. `ChatbotEnhanced` shows the Approve / Reject
+    // card only while `state === 'approval-requested'`; any terminal state and
+    // the operator sees a finished tool call with no affordance at all.
+    expect(tool?.state).toBe('approval-requested');
+
+    // HALF TWO — the decision. Drive the REAL hook over the REAL hydrated
+    // messages: the id is never persisted as a part key, so the only way it can
+    // be here is the shared `detectPendingApproval` parse.
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      text: async () => JSON.stringify({ status: 'executed', result: { deleted: 1 } }),
+    } as Response);
+
+    const { result } = renderHook(() =>
+      useHitlInChat({ messages, apiBase: 'http://localhost:3004/api/v1/ai' }),
+    );
+    await act(async () => {
+      await result.current.decide('c1', true);
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('http://localhost:3004/api/v1/ai/pending-actions/pa_44/approve');
+    expect((init as RequestInit).method).toBe('POST');
+    // Not merely "no crash": an unindexed invocation never calls fetch at all —
+    // it sets this exact message and returns. Pinned so a regression that
+    // un-indexes the id cannot read as a pass.
+    expect(result.current.decisions['c1']?.message).not.toContain(
+      'No pending-action id found',
+    );
+    expect(result.current.decisions['c1']?.state).toBe('success');
+  });
+});

--- a/packages/app-shell/src/console/ai/__tests__/AiChatPage.hydration.test.ts
+++ b/packages/app-shell/src/console/ai/__tests__/AiChatPage.hydration.test.ts
@@ -330,15 +330,19 @@ describe('AiChatPage hydration — the approval envelope and the pending-action 
     );
     const tool = chat[1]?.toolInvocations?.[0];
     expect(tool?.pendingActionId).toBe('pa_44');
-    // ⚠️ MEASURED, and recorded here rather than asserted as desirable: on THIS
-    // sub-path the merge step rewrites the part's state to `output-available`
-    // whenever a result is merged, so the state never reaches this mapper as
-    // `approval-requested`. The id is what `useHitlInChat` indexes on, so the
-    // hook now sees this invocation either way — but the awaiting-approval CARD
-    // is gated on the state, so it does not render from this sub-path. That
-    // state rewrite is out of this card's scope (it lives in the hydration
-    // pipeline, not in this mapper); a card that fixes it turns this line red,
-    // which is the point of pinning the reading instead of describing it.
-    expect(tool?.state).toBe('output-available');
+    // TURNED OVER by objectui#9233, in place and deliberately: this line used
+    // to assert `output-available` — not because that was right, but because it
+    // was what the pipeline DID. objectui#8442 pinned the defective reading
+    // rather than describing it, precisely so the card that fixed it would meet
+    // a red line here instead of a stale sentence. This is that red line, paid.
+    //
+    // What changed: `mergeToolResultsInto` (useChatConversation.ts) no longer
+    // overwrites the state when the merged result carries the HITL pending
+    // envelope — it promotes to `approval-requested`, exactly as the live mapper
+    // (`mapMessages.extractToolInvocations`) already did. So both halves of an
+    // actionable approval now survive the ModelMessage sub-path: the id the hook
+    // indexes on, and the state `ChatbotEnhanced`'s `isAwaitingApproval` gate
+    // reads. The operator gets a real Approve / Reject card after a reload.
+    expect(tool?.state).toBe('approval-requested');
   });
 });

--- a/packages/app-shell/src/hooks/useChatConversation.test.ts
+++ b/packages/app-shell/src/hooks/useChatConversation.test.ts
@@ -86,6 +86,159 @@ describe('toUIMessages — merging tool-results onto the call (refresh survival)
   });
 });
 
+/**
+ * objectui#9233 — `mergeToolResultsInto` used to overwrite the part's `state`
+ * unconditionally on every merge, so a rehydrated pending approval reached the
+ * chat as Completed and the awaiting-approval card (gated on
+ * `state === 'approval-requested'` in `ChatbotEnhanced`) never rendered on this
+ * sub-path. The rewrite itself is load-bearing and stays — the tests at the end
+ * of this block pin that half. What must not happen is an APPROVAL state being
+ * rewritten by it.
+ */
+describe('toUIMessages — a merged result must not rewrite an approval state (objectui#9233)', () => {
+  const pendingValue = JSON.stringify({
+    status: 'pending_approval',
+    pendingActionId: 'pa_44',
+    toolName: 'action_delete_task',
+  });
+  /** The shape the server really persists for a tool result on this path. */
+  const pendingEnvelope = { type: 'text', value: pendingValue };
+
+  function rowsFor(
+    callPart: Record<string, unknown>,
+    resultPart: Record<string, unknown>,
+  ) {
+    return [
+      {
+        id: 'a1',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'This needs your approval.' }, callPart],
+      },
+      { id: 't1', role: 'tool', content: [resultPart] },
+    ];
+  }
+
+  function mergedCallPart(
+    callPart: Record<string, unknown>,
+    resultPart: Record<string, unknown>,
+  ) {
+    const out = toUIMessages(rowsFor(callPart, resultPart) as never);
+    return out[0].parts.find((p) => p.toolCallId === 'c1') as
+      | { state?: string; output?: unknown; errorText?: string }
+      | undefined;
+  }
+
+  it('promotes a merged pending-approval result to approval-requested', () => {
+    // The ModelMessage sub-path in full: the assistant row persists a bare
+    // `tool-call` with NO state, the RESULT arrives on a separate `tool` row.
+    // Merging used to write `output-available` here, which is terminal — and a
+    // terminal state is exactly what `partToolState` passes through, so the
+    // approval was unrecoverable by the time the mapper ran.
+    const part = mergedCallPart(
+      { type: 'tool-call', toolCallId: 'c1', toolName: 'action_delete_task', input: {} },
+      {
+        type: 'tool-result',
+        toolCallId: 'c1',
+        toolName: 'action_delete_task',
+        output: pendingEnvelope,
+      },
+    );
+    expect(part?.state).toBe('approval-requested');
+    // The output is still merged — the fix narrows the STATE rewrite only.
+    expect(part?.output).toEqual(pendingEnvelope);
+  });
+
+  it('promotes an unwrapped pending envelope too', () => {
+    const part = mergedCallPart(
+      { type: 'tool-call', toolCallId: 'c1', toolName: 'action_delete_task', input: {} },
+      {
+        type: 'tool-result',
+        toolCallId: 'c1',
+        toolName: 'action_delete_task',
+        output: { status: 'pending_approval', pendingActionId: 'pa_45' },
+      },
+    );
+    expect(part?.state).toBe('approval-requested');
+  });
+
+  it('leaves a part that ALREADY declares an approval state alone', () => {
+    // Assistant rows are not always ModelMessage `tool-call` entries:
+    // `contentToParts` passes a persisted UIMessage part through verbatim, so a
+    // part can arrive already carrying the approval state the server snapshotted.
+    // A later `tool` row must not overwrite it either.
+    const responded = mergedCallPart(
+      {
+        type: 'tool-action_delete_task',
+        toolCallId: 'c1',
+        toolName: 'action_delete_task',
+        state: 'approval-responded',
+      },
+      {
+        type: 'tool-result',
+        toolCallId: 'c1',
+        toolName: 'action_delete_task',
+        output: { ok: true },
+      },
+    );
+    expect(responded?.state).toBe('approval-responded');
+
+    const requested = mergedCallPart(
+      {
+        type: 'tool-action_delete_task',
+        toolCallId: 'c1',
+        toolName: 'action_delete_task',
+        state: 'approval-requested',
+      },
+      {
+        type: 'tool-result',
+        toolCallId: 'c1',
+        toolName: 'action_delete_task',
+        output: { ok: true },
+      },
+    );
+    expect(requested?.state).toBe('approval-requested');
+  });
+
+  it('still lets an ERROR result win over a pending envelope', () => {
+    // Mirrors the live mapper's `baseState !== 'output-error'` guard: a failed
+    // call is not awaiting anybody, and rendering Approve / Reject over it would
+    // offer a decision that cannot be carried out.
+    const part = mergedCallPart(
+      { type: 'tool-call', toolCallId: 'c1', toolName: 'action_delete_task', input: {} },
+      {
+        type: 'tool-result',
+        toolCallId: 'c1',
+        toolName: 'action_delete_task',
+        output: pendingEnvelope,
+        errorText: 'boom',
+      },
+    );
+    expect(part?.state).toBe('output-error');
+    expect(part?.errorText).toBe('boom');
+  });
+
+  it('STILL collapses a dangling input state when the result is ordinary', () => {
+    // The load-bearing half, pinned so the narrowing above cannot widen into
+    // "stop rewriting the state": without this collapse a reloaded conversation
+    // shows every tool "Running" forever.
+    const part = mergedCallPart(
+      {
+        type: 'tool-add_field',
+        toolCallId: 'c1',
+        toolName: 'add_field',
+        state: 'input-streaming',
+      },
+      {
+        type: 'tool-result',
+        toolCallId: 'c1',
+        toolName: 'add_field',
+        output: { status: 'drafted', drafted: [] },
+      },
+    );
+    expect(part?.state).toBe('output-available');
+  });
+});
+
 describe('aiMessageRowsToServerMessages — flat share rows → ModelMessage shape', () => {
   // The public share endpoint (`/s/:token/messages`) returns the raw, FLAT
   // `ai_messages` columns: an assistant turn's tool CALLS sit in a separate

--- a/packages/app-shell/src/hooks/useChatConversation.ts
+++ b/packages/app-shell/src/hooks/useChatConversation.ts
@@ -10,6 +10,13 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+// One parse for one contract. `detectPendingApproval` is the live mapper's own
+// reader of the framework HITL envelope, exported (objectui#8442) so this
+// hydration path cannot grow a second dialect of it (Commandment #0.1).
+// `@object-ui/plugin-chatbot` is already a static member of this package's
+// barrel closure (`index.ts` re-exports `AiChatPage`, which imports it), so
+// this adds no package edge and no eager bundle weight.
+import { detectPendingApproval } from '@object-ui/plugin-chatbot';
 
 /** Minimal UIMessage shape compatible with `@ai-sdk/react`'s `useChat`. */
 export interface HydratedUIMessagePart {
@@ -446,6 +453,9 @@ function contentToParts(content: unknown): HydratedUIMessagePart[] {
   return [];
 }
 
+/** Tool-part states that mean "a human still owes this call a decision". */
+const APPROVAL_STATES = new Set(['approval-requested', 'approval-responded']);
+
 /**
  * Merge a `tool`-role message's tool-result outputs back onto the assistant
  * tool-call parts that requested them. The server persists conversations in
@@ -455,6 +465,19 @@ function contentToParts(content: unknown): HydratedUIMessagePart[] {
  * affordances after a reload — otherwise the result, and the whole `tool` row
  * (which the UI never renders directly), is dropped and the build card + publish
  * button vanish on refresh.
+ *
+ * ⚠️ The state rewrite below is deliberately NARROW (objectui#9233). Collapsing
+ * a dangling `input-streaming` / `input-available` into a terminal state is why
+ * the rewrite exists and it stays: a snapshot that never recorded the terminal
+ * state otherwise shows every tool "Running" forever after a reload. But an
+ * APPROVAL state is not a dangling one — it is the state the awaiting-approval
+ * card renders on (`isAwaitingApproval` in `ChatbotEnhanced`). Rewriting it here
+ * meant a rehydrated pending approval reached the chat as Completed, so the
+ * operator got no Approve / Reject card at all even though `useHitlInChat` had
+ * the id and `decide()` was live. The arms below are the live mapper's
+ * (`mapMessages.extractToolInvocations`), not a second predicate: a pending
+ * envelope promotes, an error still wins over it, everything else terminalizes
+ * exactly as before.
  */
 function mergeToolResultsInto(
   content: unknown,
@@ -471,7 +494,13 @@ function mergeToolResultsInto(
     target.output = output;
     const errorText = (part as { errorText?: unknown }).errorText;
     const isError = Boolean((part as { isError?: unknown }).isError) || typeof errorText === 'string';
-    target.state = isError ? 'output-error' : 'output-available';
+    const baseState = isError ? 'output-error' : 'output-available';
+    const heldApproval =
+      typeof target.state === 'string' && APPROVAL_STATES.has(target.state)
+        ? target.state
+        : undefined;
+    const approval = detectPendingApproval(output) ? 'approval-requested' : heldApproval;
+    target.state = approval && baseState !== 'output-error' ? approval : baseState;
     if (typeof errorText === 'string') target.errorText = errorText;
   }
 }


### PR DESCRIPTION
Fixes #9233

## What was wrong

`toUIMessages`' `mergeToolResultsInto` (`packages/app-shell/src/hooks/useChatConversation.ts`) overwrote the tool part's `state` on **every** merge:

```ts
target.state = isError ? 'output-error' : 'output-available';
```

The server persists conversations in ModelMessage format — a tool CALL on the assistant row, its RESULT on a separate `tool` row — so this merge is the main rehydration path, and it ran unconditionally. A pending approval was terminalized before `hydratedMessagesToChatMessages` ever saw it, `ChatbotEnhanced`'s `isAwaitingApproval` gate (which reads `state === 'approval-requested'`) never opened, and the operator got **no Approve / Reject card at all** after a reload — even though objectui#8442 had already made the id indexable and `decide()` was live.

## The fix, and what it deliberately does NOT do

⛔ Not "stop rewriting the state". The rewrite is load-bearing: collapsing a dangling `input-streaming` / `input-available` into a terminal state is why it exists, and without it a reloaded conversation shows every tool "Running" forever. The change is the one narrow statement — **a merged result must not rewrite an APPROVAL state**:

* a merged result carrying the HITL pending envelope promotes to `approval-requested`;
* a part that already declares `approval-requested` / `approval-responded` keeps it;
* an error result still wins over both;
* everything else terminalizes exactly as before.

Those arms are the **live mapper's own** (`mapMessages.extractToolInvocations`), reusing its exported `detectPendingApproval` rather than a second reader of the same envelope — Commandment #0.1, and the reason that detector was exported in the first place. `@object-ui/plugin-chatbot` is already a static member of this package's barrel closure (`index.ts` re-exports `AiChatPage`, which imports it), so this adds no package edge and no eager bundle weight.

Two faces were left alone on purpose: `useChatConversation.ts:381` belongs to objectui#9232, and the two gate expressions in `ChatbotEnhanced` are correct — the defect was in the `state` fed to them.

## The pin that was supposed to turn over, turned over

`AiChatPage.hydration.test.ts` asserted `expect(tool?.state).toBe('output-available')` — the **defective** reading, pinned on purpose by objectui#8442 so that a card correcting it would meet a red line instead of a stale sentence. It is flipped **in place**, with the reason stated at the site. It was not deleted and not routed around.

## Instrument: the pins were written BEFORE the code

So the "defect present" arm is the **real base tree**, not an injected mutation — no marker count to prove, no restore leg to get wrong. Two commits, one command, one variable:

| commit | arm | result |
|---|---|---|
| `291a116b0` (pins only) | fix ABSENT | `Test Files 3 failed (3)` · `Tests 5 failed \| 21 passed (26)` |
| `d3c184f07` (fix added) | fix PRESENT | `Test Files 3 passed (3)` · `Tests 26 passed (26)` |

All five failures on the first arm were assertion failures on the state value (`expected 'output-available' to be 'approval-requested'`), never a module or import failure — so the control **lit**, and it lit for the reason under test.

The three assertions that read the **same** on both arms are named as such rather than offered as controls: the error-wins arm, the dangling-`input-streaming`-still-collapses arm, and the `useHitlInChat` indexing half. The first two are guards against the narrowing widening into "stop rewriting the state"; the third already worked before this PR (objectui#8442) and is pinned beside the state so the two halves of an actionable approval can never drift apart again.

The new end-to-end pin drives the **real** `useHitlInChat` over the **real** hydrated messages and asserts the id reaches the request URL — "indexable" measured, not restated as a copy of the hook's predicate.

## Verification

Measured on the final commit `8d4d06a29`.

| run | verdict |
|---|---|
| `pnpm exec vitest run packages/app-shell/ packages/plugin-chatbot/` | `Test Files 733 passed (733)` · `Tests 7188 passed \| 1 skipped (7189)` · wrapper `VERDICT command-exit 0` |
| `pnpm --filter @object-ui/app-shell type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | `VERDICT command-exit 0` — the second half covers the test files, so the new pins are type-checked, not merely run |
| `pnpm --filter @object-ui/app-shell lint` | exit 0 — 0 errors (2997 warnings, the package's standing baseline) |
| `node scripts/check-changeset-presence.mjs` | exit 0 — 4 published source files, 1 changeset |
| `pnpm changeset:check` | exit 0 — no `major`, fixed group intact |
| `check:control-bytes` · `check:new-line-citations` · `check:vi-mock-specifiers` · `check:vi-mock-inherit` · `check:vi-mock-override-shape` · `check:test-path-roots` · `check:phantom-deps` · `check:unused-deps` · `check:esm-specifiers` · `check:self-import` · `check:unreferenced-sources` · `check:changeset-claims` · `check:pre-install-import-graph` | all exit 0 |

Prerequisite first: `pnpm turbo run build --filter='@object-ui/app-shell^...'` (28 tasks, exit 0). Before it, `type-check` failed only with `TS2307: Cannot find module '@object-ui/*'` — unbuilt workspace `dist`, read as NOT MEASURED, not as a red gate.

**Lint narrowing, declared with its three pieces of evidence.** The package-scoped `eslint` run above is a narrowing of the repo-wide lint, and the narrowing is itself measured: ① the population comes from eslint's own config, not a guess — a repo-wide `eslint .` enumerated **4892** files; ② that count is read from `--format json`, not from prose; ③ this repo's eslint config declares no `parserOptions.project` / `projectService`, so linting is **not** type-aware and a change inside `packages/app-shell` cannot move the verdict on any file outside it. Repo-wide `pnpm lint` (`turbo run lint`) remains CI's run.

**Declared NOT MEASURED locally, left to CI:** `Bundle Analysis` (`check:eager-closure` + `check:eager-locale-catalogues` + `check:sdui-registration-pins`) needs a full console build; the argument that it should not move is the barrel-closure one above, and it is an argument, not a measurement. `check:readme-exports`, `check:published-dist` and `check:node-esm-load` all reported the unbuilt-`dist` prerequisite and are likewise CI's.

**Blast radius beyond the package.** No call site, rendered node or declaration key moved — one value on one internal code path — so no census or prose figure is implicated. Verified by grep: `mergeToolResultsInto` appears nowhere outside this package's own sources and the files in this diff, and no doc, example or app carries prose about the rehydrated approval state.

## Acceptance notes

* No out-of-scope changes were made and nothing filed. `useChatConversation.ts:381` (the cache-write direction) is objectui#9232's, not touched; objectui#8426 is not a blocker.
* `needs:contract-review` is hung on both this PR and the card — raising a gate cannot fail open. Clearing either limb is the PM's.
* The ready / queue flip and CI convergence are left to the PM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_