### PR TITLE
fix(plugin-grid): the column-summary percent arm takes both halves from the declared source

### DIFF
--- a/.changeset/9269-grid-summary-percent-converged.md
+++ b/.changeset/9269-grid-summary-percent-converged.md
@@ -1,0 +1,62 @@
+---
+'@object-ui/plugin-grid': minor
+---
+
+Converge the grid column-summary footer's percent arm onto the repo's single
+percent display rule (objectui#9269).
+
+`formatSummaryLabel` in `useColumnSummary.ts` held a **hand-inlined copy of
+`percentDisplayValue`'s body** and then appended a **literal ASCII percent
+sign**:
+
+```ts
+const decimals = column?.precision ?? 0;
+const pct = (value > -1 && value < 1) ? value * 100 : value;
+formatted = `${pct.toFixed(decimals)}%`;
+```
+
+Line 2 is the expression `percentDisplayValue` in `@object-ui/core` **is**,
+character for character, so the SCALING agreed — by duplication rather than by
+reference. The CONVENTION was not taken at all. That helper's own doc comment
+makes this the judgement rather than a style preference: *"If a third surface
+ever needs percent display, it takes BOTH halves from here — the scaling AND the
+convention — or this promise breaks again in the same place."* A grid footer
+showing a percent aggregate directly beneath the percent cells it aggregates is
+such a surface, and it took neither half by reference.
+
+The arm now hands the raw stored value to `formatPercent` — the same call the
+list-view percent cell makes — with the tag from `useDisplayLocale()`, so the
+footer takes the SCALING and the locale's percent CONVENTION from one home.
+`decimals` still reads `column.precision`, unchanged.
+
+**BREAKING — a percent column summary renders differently in every non-`en`
+session, and for four-digit values in `en` too.** Nothing about the stored value
+moves; what moves is how the footer prints it, and the move is the repair: the
+footer now reads the same as the cells above it. Measured against the declared
+source in the same run:
+
+| locale | stored | before | after |
+|---|---|---|---|
+| `en` | `0.25` | `25%` | `25%` (unchanged) |
+| `en` | `1` | `1%` | `1%` (unchanged) |
+| `en` | `-5` | `-5%` | `-5%` (unchanged) |
+| `en` | `12.3` | `12%` | `12%` (unchanged) |
+| `en` | `1234.5` | `1235%` | `1,235%` — grouping |
+| `de-DE` | `0.25` | `25%` | `25 %` — no-break space before the sign |
+| `de-DE` | `1234.5` | `1235%` | `1.235 %` — grouping and affix |
+| `tr-TR` | `0.25` | `25%` | `%25` — **the sign moves to the FRONT** |
+| `tr-TR` | `1234.5` | `1235%` | `%1.235` — same |
+
+Every `en` row below four digits is byte-identical, which is exactly why a spot
+check in the default locale read clean. `tr-TR` is the row that cannot pass by
+accident: the percent sign is on the other side of the number, which a reader
+does not parse as a spacing difference. This is the harm objectui#4576 already
+measured and paid for once — the same number under two conventions, one line
+above the other.
+
+`minor` rather than `major` because all published packages here share one
+`fixed` group and a `major` would drag the group off `@objectstack`'s major
+(AGENTS.md, version alignment); the breaking semantics are stated above rather
+than carried by the level. No exported signature changes: `useColumnSummary`'s
+parameters and return shape are untouched, and `formatSummaryLabel` is private
+to the module.

--- a/packages/plugin-grid/README.md
+++ b/packages/plugin-grid/README.md
@@ -282,6 +282,15 @@ A `currency` or `percent` column formats its `sum`/`avg`/`min`/`max` in that
 unit. Counts stay plain cardinalities and percentages carry their own `%`, so
 `count_unique` on a currency column reads `Unique: 3`, not `$3.00`.
 
+A `percent` column's aggregate takes both halves of the percent rule from the
+same place the list cell above it does — `percentDisplayValue` in
+`@object-ui/core` for the fraction-vs-points scaling, and the session locale's
+own percent convention for the sign — so the footer and the cells never read
+under two conventions. A stored `1234.5` renders `Sum: 1,235%` in `en`,
+`Sum: 1.235 %` in `de-DE` (no-break space before the sign) and `Sum: %1.235` in
+`tr-TR`, where the sign goes in front of the number (objectui#9269). The width
+still comes from the column's `precision`.
+
 The footer row renders only when at least one column resolves to a summary — a
 view whose columns are all `none` (or carry no `summary`) has no footer.
 

--- a/packages/plugin-grid/src/__tests__/useColumnSummary.percentConvergence-9269.test.tsx
+++ b/packages/plugin-grid/src/__tests__/useColumnSummary.percentConvergence-9269.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9269 — the grid column-summary footer's percent branch stops
+ * re-spelling `percentDisplayValue` and stops appending a literal '%'.
+ *
+ * `formatSummaryLabel`'s `colType === 'percent'` arm held a hand-inlined copy
+ * of the declared source's body plus an ASCII percent sign:
+ *
+ *   const decimals = column?.precision ?? 0;
+ *   const pct = (value > -1 && value < 1) ? value * 100 : value;
+ *   formatted = `${pct.toFixed(decimals)}%`;
+ *
+ * Line 2 is `percentDisplayValue` in `@object-ui/core` character for
+ * character, so the SCALING agreed — by duplication, not by reference. The
+ * CONVENTION was not taken at all. `percentDisplayValue`'s own doc comment
+ * makes that the judgement rather than a style preference: "If a third surface
+ * ever needs percent display, it takes BOTH halves from here — the scaling AND
+ * the convention — or this promise breaks again in the same place."
+ *
+ * ── What this file measures ─────────────────────────────────────────────
+ * The claim is AGREEMENT BETWEEN TWO SURFACES — the footer and the list cell
+ * directly above it — so every moving row compares the hook's own label
+ * against the declared source computed in the same run (`formatPercent`, which
+ * applies `percentDisplayValue` and renders through the locale's percent
+ * affix). A hand-written expected string would restate one side and could not
+ * fail for the reason the card names.
+ *
+ * ⭐ A two-surface comparison is blind to a JOINT move: a repair that dragged
+ * both sides would keep the equality true. That is what the absolute-byte
+ * controls are for, and it is the one place a literal is the right instrument.
+ *
+ * ── Which rows can actually fire ────────────────────────────────────────
+ * ⛔ The `en` rows below four digits are NOT controls for this card: a bare
+ * '%' and the locale affix coincide there, so they read the same either way.
+ * They are overshoot detectors, pinned to exact bytes. The rows that MOVE —
+ * and therefore the ones that measure the repair — are `de-DE` (no-break space
+ * before the sign), `tr-TR` (the sign moves to the FRONT of the number) and
+ * four-digit `en` (grouping).
+ *
+ * ── Directions, predicted in writing BEFORE the first run ───────────────
+ *   en 0.25 / 1 / -5 / 12.3     GREEN on the base tree — sanity, not controls
+ *   en 1234.5                   RED on the base tree  (1235%  -> 1,235%)
+ *   de-DE 0.25 / 1234.5         RED on the base tree  (25%    -> 25 %,
+ *                                                      1235%  -> 1.235 %)
+ *   tr-TR 0.25 / 1234.5         RED on the base tree  (25%    -> %25,
+ *                                                      1235%  -> %1.235)
+ *   the prefix guard            GREEN on the base tree
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as React from 'react';
+import { renderHook } from '@testing-library/react';
+import { I18nProvider, LocalizationProvider } from '@object-ui/i18n';
+import { formatPercent } from '@object-ui/fields';
+import { percentDisplayValue } from '@object-ui/core';
+import { useColumnSummary } from '../useColumnSummary';
+
+/**
+ * The UI language is held at `en` while the TENANT locale moves. That is the
+ * real precedence `useDisplayLocale` implements (tenant locale outranks UI
+ * language), and holding the language still keeps the footer's PREFIX in
+ * English so the assertions below can name the whole label rather than
+ * fishing a substring out of it.
+ */
+function wrapper(locale: string) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false }}>
+      <LocalizationProvider value={{ locale }}>{children}</LocalizationProvider>
+    </I18nProvider>
+  );
+}
+
+/** The footer label the hook itself produces for a one-row percent column. */
+function summaryLabel(stored: number, locale: string, column: Record<string, unknown> = {}): string {
+  const cols: any[] = [{ field: 'rate', summary: 'sum', type: 'percent', ...column }];
+  const { result } = renderHook(() => useColumnSummary(cols, [{ rate: stored }]), {
+    wrapper: wrapper(locale),
+  });
+  return result.current.summaries.get('rate')?.label ?? '';
+}
+
+/**
+ * The prefix is MEASURED, not assumed.
+ *
+ * Every expectation below is spelled `PREFIX + <the declared source's bytes>`,
+ * so a bundle change to `grid.summary.sum` / `grid.summary.pattern` would
+ * otherwise reach this file as a percent failure. Reading it off a column with
+ * no percent type at all keeps the two concerns separable: if this case is the
+ * red one, the prefix moved and the percent arm is not implicated.
+ */
+const PREFIX = 'Sum: ';
+
+describe('the grid summary percent arm takes BOTH halves from the declared source (objectui#9269)', () => {
+  it('the label prefix this file builds on is the one the bundle produces', () => {
+    const cols: any[] = [{ field: 'rate', summary: 'sum' }];
+    const { result } = renderHook(() => useColumnSummary(cols, [{ rate: 25 }]), {
+      wrapper: wrapper('en'),
+    });
+    expect(result.current.summaries.get('rate')?.label).toBe(`${PREFIX}25`);
+  });
+
+  /**
+   * The card's nine-row table, asserted as an agreement table. The right-hand
+   * side is COMPUTED from the declared source in the same run, so each row
+   * measures the footer against the list-cell path rather than against a
+   * literal this file chose.
+   */
+  it.each([
+    ['en', 0.25],
+    ['en', 1],
+    ['en', -5],
+    ['en', 12.3],
+    ['en', 1234.5],
+    ['de-DE', 0.25],
+    ['de-DE', 1234.5],
+    ['tr-TR', 0.25],
+    ['tr-TR', 1234.5],
+  ])('%s / stored %p reads the same in the footer as at the declared source', (locale, stored) => {
+    expect(summaryLabel(stored, locale)).toBe(`${PREFIX}${formatPercent(stored, 0, locale)}`);
+  });
+
+  /**
+   * ⭐ THE ROWS THAT MOVE, each with the negative that names what was retired.
+   *
+   * The retired spelling is reconstructed here from `percentDisplayValue` plus
+   * a literal '%' — exactly the two halves the deleted expression held — so
+   * these lines fail if the arm ever grows a second local affix rule again,
+   * and they are the only lines in this file that can distinguish "took the
+   * convention" from "kept the scaling".
+   *
+   * ⛔ Deliberately no `en` row below four digits here: `25%` is BOTH the
+   * retired spelling and the declared one, so such a row could not fail.
+   */
+  it.each([
+    ['en', 1234.5],
+    ['de-DE', 0.25],
+    ['de-DE', 1234.5],
+    ['tr-TR', 0.25],
+    ['tr-TR', 1234.5],
+  ])('%s / stored %p no longer reads as the inlined expression plus a literal sign', (locale, stored) => {
+    const retired = `${PREFIX}${percentDisplayValue(stored).toFixed(0)}%`;
+    expect(summaryLabel(stored, locale)).not.toBe(retired);
+  });
+
+  /**
+   * `tr-TR` on its own, as bytes.
+   *
+   * It is the row that cannot pass by accident: the percent sign is on the
+   * OTHER SIDE of the number, so no spacing or separator coincidence can make
+   * the old output equal the new one. Spelled as an absolute as well as an
+   * agreement, because an agreement alone would survive a joint move.
+   */
+  it('tr-TR puts the percent sign in FRONT, as the declared source does', () => {
+    expect(summaryLabel(0.25, 'tr-TR')).toBe(`${PREFIX}%25`);
+    expect(summaryLabel(1234.5, 'tr-TR')).toBe(`${PREFIX}%1.235`);
+  });
+
+  /**
+   * The overshoot detectors. These agree today and must still agree at the
+   * SAME bytes afterwards — the `it.each` agreement table above cannot see a
+   * move that drags both sides together.
+   */
+  it.each([
+    [0.25, '25%'],
+    [1, '1%'],
+    [-5, '-5%'],
+    [12.3, '12%'],
+  ])('leaves the already-agreeing en row %p at exactly %p', (stored, unmoved) => {
+    expect(summaryLabel(stored, 'en')).toBe(`${PREFIX}${unmoved}`);
+    expect(summaryLabel(stored, 'en')).toBe(`${PREFIX}${formatPercent(stored, 0, 'en')}`);
+  });
+
+  /**
+   * The SCALING half asserted against its owning function directly, so the
+   * fraction/points boundary has a pin that does not route through the percent
+   * renderer's own behaviour.
+   *
+   * `en` only, deliberately: pulling the numerals back out of a `de-DE` or
+   * `tr-TR` string would need this file to re-implement the separators it is
+   * testing.
+   */
+  it.each([[0.25], [1], [-1], [-5], [12.3], [1234.5]])(
+    'takes its magnitude for %p from percentDisplayValue, not from a local predicate',
+    (stored) => {
+      const numerals = summaryLabel(stored, 'en').slice(PREFIX.length).replace(/[^\d.-]/g, '');
+      expect(Number(numerals)).toBe(Number(percentDisplayValue(stored).toFixed(0)));
+    },
+  );
+
+  /**
+   * `decimals` still comes from `column.precision`, unchanged by this card.
+   *
+   * ⚠️ Whether `precision` is the RIGHT member to read here is a separate,
+   * explicitly NOT MEASURED question (the neighbouring currency arm reads
+   * `scale`, with an in-code note from objectui#2131). This case pins only
+   * that the repair did not move it.
+   */
+  it('still honours the width declared by the column precision', () => {
+    expect(summaryLabel(0.12345, 'en', { precision: 2 })).toBe(
+      `${PREFIX}${formatPercent(0.12345, 2, 'en')}`,
+    );
+    expect(summaryLabel(0.12345, 'de-DE', { precision: 2 })).toBe(
+      `${PREFIX}${formatPercent(0.12345, 2, 'de-DE')}`,
+    );
+  });
+});

--- a/packages/plugin-grid/src/useColumnSummary.ts
+++ b/packages/plugin-grid/src/useColumnSummary.ts
@@ -9,7 +9,8 @@
 import { useMemo } from 'react';
 import type { ListColumn } from '@object-ui/types';
 import type { ColumnSummary } from '@objectstack/spec/ui';
-import { useLocalization, resolveFieldCurrency, createSafeTranslation } from '@object-ui/i18n';
+import { useLocalization, useDisplayLocale, resolveFieldCurrency, createSafeTranslation } from '@object-ui/i18n';
+import { formatPercent } from '@object-ui/fields';
 
 /**
  * Aggregation functions for the column footer — the spec's `ColumnSummary`
@@ -288,6 +289,15 @@ function formatSummaryLabel(
   t: SummaryTranslate,
   column?: { type?: string; currency?: string; defaultCurrency?: string; currencyConfig?: { defaultCurrency?: string }; precision?: number | null; scale?: number | null },
   tenantDefault?: string,
+  // The BCP-47 tag from `useDisplayLocale()`, threaded for the percent arm
+  // (objectui#9269). ⚠️ Scope note, so the asymmetry below reads as a bounded
+  // repair rather than an oversight: the other arms still hand `Intl` an
+  // `undefined` locale, i.e. the MACHINE's, which is the thing
+  // `useDisplayLocale`'s own doc comment tells callers not to do. That is a
+  // different defect from this one (it is about which locale, not about which
+  // source owns the percent rule) and is filed separately rather than folded
+  // in here.
+  displayLocale?: string,
 ): string {
   if (value === null) return '';
   const labelKey = TYPE_LABEL_KEYS[type as ColumnSummaryType];
@@ -328,9 +338,37 @@ function formatSummaryLabel(
       formatted = value.toLocaleString();
     }
   } else if (colType === 'percent') {
+    // objectui#9269 — the percent decision is NOT made here any more.
+    //
+    // This arm held a hand-inlined copy of `percentDisplayValue`'s body plus a
+    // literal ASCII sign:
+    //
+    //   const pct = (value > -1 && value < 1) ? value * 100 : value;
+    //   formatted = `${pct.toFixed(decimals)}%`;
+    //
+    // Line 1 is `percentDisplayValue` in `@object-ui/core` character for
+    // character, so the SCALING agreed by DUPLICATION rather than by
+    // reference. The CONVENTION was not taken at all, and that is the half a
+    // reader saw: measured against the list cell in the same run, a stored
+    // `0.25` read `25%` in this footer and `25 %` in the cell directly above
+    // it in a German session, and `%25` in a Turkish one — where the sign sits
+    // on the OTHER SIDE of the number. A four-digit value read `1235%` against
+    // `1,235%` even in `en`.
+    //
+    // `formatPercent` is the list-cell path (`PercentCellRenderer`), and it
+    // carries BOTH halves `percentDisplayValue`'s doc comment demands of a
+    // third surface: the SCALING, so the fraction/points boundary has one
+    // home, and the CONVENTION, via `style: 'percentPoints'`, so the affix is
+    // the LOCALE's rather than a literal. Taking only the first is precisely
+    // the drift objectui#4576 already paid for once.
+    //
+    // ⚠️ `decimals` still reads `precision`, NOT `scale`. Whether that is the
+    // right member here is a separate and deliberately unmeasured question —
+    // the currency arm above reads `scale` for the reason #2131 records — and
+    // this card's own table had precision agreeing on both sides (`12.3` reads
+    // `12%` either way), so it is left exactly where it was.
     const decimals = column?.precision ?? 0;
-    const pct = (value > -1 && value < 1) ? value * 100 : value;
-    formatted = `${pct.toFixed(decimals)}%`;
+    formatted = formatPercent(value, decimals, displayLocale);
   } else if (type === 'avg') {
     formatted = value.toLocaleString(undefined, { maximumFractionDigits: 2 });
   } else {
@@ -357,6 +395,11 @@ export function useColumnSummary(
   // Tenant default currency (ADR-0053) backstops a currency column that
   // declares no explicit code, so the footer agrees with the cells above it.
   const { currency: tenantCurrency } = useLocalization();
+  // The tag every field / cell / metric renderer formats `Intl` values with
+  // (tenant locale, then UI language, then `'en'`) — never `undefined`, which
+  // would be the MACHINE's locale. The percent footer goes through the same
+  // path the list cell above it does (objectui#9269).
+  const displayLocale = useDisplayLocale();
   // Aggregate-prefix bundle lookups (objectui#4024). Provider-safe: with no
   // I18nProvider this resolves the English defaults table, never a raw key.
   const { t } = useSummaryTranslation();
@@ -396,10 +439,10 @@ export function useColumnSummary(
       summaries.set(col.field, {
         field: col.field,
         value: result,
-        label: formatSummaryLabel(config.type, result, t, columnHints, tenantCurrency),
+        label: formatSummaryLabel(config.type, result, t, columnHints, tenantCurrency, displayLocale),
       });
     }
 
     return { summaries, hasSummary: summaries.size > 0 };
-  }, [columns, data, fieldMetadata, tenantCurrency, t]);
+  }, [columns, data, fieldMetadata, tenantCurrency, displayLocale, t]);
 }


### PR DESCRIPTION
Fixes #9269

`formatSummaryLabel` in `packages/plugin-grid/src/useColumnSummary.ts` (the `colType === 'percent'` arm) held a hand-inlined copy of `percentDisplayValue`'s body and then appended a literal ASCII percent sign:

```ts
const decimals = column?.precision ?? 0;
const pct = (value > -1 && value < 1) ? value * 100 : value;
formatted = `${pct.toFixed(decimals)}%`;
```

Line 2 is the expression `percentDisplayValue` in `@object-ui/core` **is**, character for character, so the SCALING agreed — by duplication rather than by reference. The CONVENTION was not taken at all. The declared source's own doc comment is what makes this a contract violation and not a style nit:

> If a third surface ever needs percent display, it takes BOTH halves from here — the scaling AND the convention — or this promise breaks again in the same place.

A grid footer showing a percent aggregate **directly beneath** the percent cells it aggregates is such a surface, and it took neither half by reference.

## The change

The arm hands the raw stored value to `formatPercent` — the same call the list-view percent cell (`PercentCellRenderer`) makes — with the tag from `useDisplayLocale()`. Both halves now come from one home: the scaling via `percentDisplayValue`, the affix via `style: 'percentPoints'`. No second local rounding or affix rule was introduced. `decimals` still reads `column.precision`, untouched.

## Measured, in one run, against the declared source

| locale | stored | before | after | what moved |
|---|---|---|---|---|
| `en` | `0.25` | `25%` | `25%` | — |
| `en` | `1` | `1%` | `1%` | — |
| `en` | `-5` | `-5%` | `-5%` | — |
| `en` | `12.3` | `12%` | `12%` | — |
| `en` | `1234.5` | `1235%` | `1,235%` | grouping |
| `de-DE` | `0.25` | `25%` | `25 %` | no-break space before the sign |
| `de-DE` | `1234.5` | `1235%` | `1.235 %` | grouping and affix |
| `tr-TR` | `0.25` | `25%` | `%25` | **the sign moves to the FRONT** |
| `tr-TR` | `1234.5` | `1235%` | `%1.235` | same |

Nine rows, independently reproduced in this container's runtime before the pin was written; they match the card's table and the triage seat's re-run row for row.

## The instrument

⭐ **The pin was written and run BEFORE the source was touched**, so the "unmodified" arm is the real base tree — no mutation to inject and no restore leg to get wrong. New file: `packages/plugin-grid/src/__tests__/useColumnSummary.percentConvergence-9269.test.tsx`.

```
base tree  (ee5ef7748, source unmodified)   Tests  12 failed | 15 passed (27)
after the change                             Tests  27 passed (27)
```

Every predicted direction landed, and every control that was supposed to fire did:

- RED on the base tree — `en 1234.5`, `de-DE 0.25`, `de-DE 1234.5`, `tr-TR 0.25`, `tr-TR 1234.5` in the agreement table; the five matching "no longer reads as the inlined expression plus a literal sign" rows; the `tr-TR` absolute-bytes case; and the `de-DE` precision case. Sample assertion text from that run: `expected 'Sum: 25%' to be 'Sum: %25'`.
- GREEN on the base tree — the prefix guard, the four `en` sub-four-digit rows, the four overshoot detectors, the six scaling-by-reference rows, and the `en` precision assertion.

⚠️ The `en` rows below four digits are **not controls** for this card and the file says so in writing: a bare `%` and the locale affix coincide there, so they read the same on both sides. They are pinned to absolute bytes as **overshoot detectors** — the two-surface agreement table alone cannot see a repair that drags both sides together. The rows that can fail for this card's reason are `de-DE`, `tr-TR` and four-digit `en`.

`tr-TR` is kept as its own case with absolute bytes because it is the one row that cannot pass by accident: the sign is on the other side of the number, so no separator or spacing coincidence can make the retired output equal the new one.

## Scope — three things deliberately left alone

1. **⛔ The scaling half was not landed on its own.** The card floated that option (zero rendered change, since the expression is already byte-identical); triage overruled it on this family's own record — objectui#9071 converged only the chip's scaling half and the residue is still open as objectui#9167. Both halves land here together, which is what the contract sentence asks for.
2. **⛔ The `PERCENT_TYPES` arm is untouched** (`percent_empty` / `percent_filled`, which also append a literal `%`). Those are computed fill ratios, not stored percent **fields**, and the declared source's contract sentence is about percent fields. Not folded in as obviously-the-same; if it is wanted it should be argued on its own.
3. **⛔ Whether `decimals` should read `scale` rather than `precision` is NOT MEASURED and stays that way.** The neighbouring currency arm reads `scale` with an in-code note (objectui#2131) that `precision` is the total digit count of a `decimal(p, s)` column. The card's own table shows precision agreeing on both sides (`12.3` reads `12%` either way), so it does not affect this verdict. Recorded below rather than repaired here.

Not blocked on objectui#9167: that card's disputed item is **precision** (the chip does not round at all), which already agrees here. What diverged here was only grouping and affix — the part objectui#9167's own body calls "almost certainly wanted on its own". No `Blocked-by:` line, and objectui#9167 is **not** addressed by this PR and stays open.

## Changeset

`.changeset/9269-grid-summary-percent-converged.md` — `@object-ui/plugin-grid: minor`, carrying a `**BREAKING**` paragraph.

Justified by measurement, not intuition: nine rows were rendered on both sides and **five of them move**, so rendered output changes in every non-`en` session and for four-digit `en` values. That is the repair, but it is a user-visible change and the changeset says so in the same table. `major` is unavailable — all packages sit in one `fixed` group and a `major` would drag the group off `@objectstack`'s major (AGENTS.md, version alignment), which `scripts/check-changeset-no-major.mjs` enforces — so breaking ships as `minor` with the semantics written out. No exported signature changes: `useColumnSummary`'s parameters and return shape are untouched and `formatSummaryLabel` is private to the module.

## Gates run locally

Derived by hand from `package.json` plus `.github/workflows/` (this repo has no dispatch-gate deriver):

| gate | verdict line |
|---|---|
| `node scripts/check-changeset-presence.mjs` | `✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `pnpm changeset:check` | `✅ All workspace packages are in the changeset fixed group.` + `✅ No changeset declares a major bump.` |
| `pnpm check:control-bytes` | `✅ check-control-bytes: OK (scanned 7489 tracked text file(s))` |
| `pnpm check:test-path-roots` | `✅ check-test-path-roots: OK` |
| `pnpm check:phantom-deps` | `✅ Every in-scope import is declared by the package that publishes it.` |
| `pnpm check:unused-deps` | `✅ Every gated declaration has a consumer in the package that declares it.` |
| `pnpm check:new-line-citations` | `VERDICT new-cross-file-line-citations: 0 new citation(s)` |

The `@object-ui/fields` import is not a new dependency edge: `plugin-grid` already declares it and `ObjectGrid.tsx` already imports `formatPercent` from it for the mobile card.

## Acceptance notes

- `scripts/check-changeset-no-major.mjs` has no npm script of its own; it runs inside `changeset:check`, which is the spelling used above.
- The blast radius was taken wider than the changed package, since a rendered string moved: a repo-wide grep for the count-shaped figures this arm produces (`1235%`, `1,235%`, `%1.235`, `1.235 %`) finds only `plugin-gantt`, `plugin-dashboard` and `app-shell` prose about **their** surfaces and their own already-landed moves — nothing describing the grid footer's percent output, in code, README or docs. Beyond the changed package: `packages/plugin-grid/` (127 files, 1133 tests) and `examples/schema-catalog/` (31 files, 2153 tests) both pass, and the full workspace build is green (43 tasks).
- `packages/plugin-grid/README.md` gains a paragraph naming the convention and the three figures that move, per Commandment #2. No existing rendered figure in that file moved; it is an addition.

### Two out-of-scope findings, both filed rather than repaired here

Each got its own dedup sweep: the open-issue set was enumerated by page number to a short page (467 rows = 451 issues + 16 pull requests) and cross-checked against this repository's `open_issues_count` of 467, with controls lit both ways in the same scan (`percentDisplayValue` returned 3 known-readable cards, an impossible token returned 0). Boundary stated: open issues only — no text query over closed cards was possible in this session.

- **objectui#9294** — the footer formats four of its five arms with **no locale argument**, i.e. the machine's locale, which `useDisplayLocale`'s own doc comment names as the one thing a caller must not do. Render-measured through the hook across three tenant locales: the currency, plain-sum, avg and percent-of-rows arms do not move at all when the tenant locale moves, while the arm this PR repaired does — that moving column is also the control proving the harness really changes the locale. Not folded in: a different mechanism (which locale, not which source owns the percent rule), reaching four arms this card has no mandate over, and every repair there moves rendered output again — including currency, where a moved separator is read as a moved decimal point in exactly the locales that swap them. ⚠️ This PR knowingly leaves that asymmetry in place for one round, and says so in a scope comment beside the new parameter.
- **objectui#9295** — `precision` vs `scale`, filed on triage's explicit instruction. Sharpened while checking it: this is **not** a footer-vs-cell disagreement. `PercentCellRenderer` reads `precision` too, so the two percent surfaces agree with each other; what they disagree with is the currency arm's stated premise, declared seventy lines away in the same `@object-ui/fields` file ("`precision` is the TOTAL digit count (`p`) … reading it here padded every value out to that width"). Exactly one of those readings can be right. Left NOT MEASURED here exactly as the triage comment fenced it.

Durable attribution, written as prose because a footer block does not reliably survive an edit: produced by an agent seat in session `session_01UzHd6hDYatoDn17BuwKxnZ`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_


---
_Generated by [Claude Code](https://claude.ai/code)_