### PR TITLE
test(plugin-gantt,plugin-kanban,plugin-calendar,plugin-tree): measure the overlay `navigation.mode` collapse at the shell boundary

### DIFF
--- a/.changeset/overlay-shell-mode-measurement-9113.md
+++ b/.changeset/overlay-shell-mode-measurement-9113.md
@@ -1,0 +1,9 @@
+---
+---
+
+objectui#9113 — measurement round only. Four new test files pin how each view
+renderer treats the four overlay `navigation.mode` values at the shell
+boundary, and probe whether the record-detail payload can render outside the
+Sheet. No published source changed and no published behaviour moved, so this
+declares no release deliberately rather than claiming a patch on a package
+that did not move.

--- a/packages/plugin-calendar/src/ObjectCalendar.overlayShellCollapse-9113.test.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.overlayShellCollapse-9113.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9113 — the THIRD of the three collapsing renderers, measured.
+ *
+ * The instrument, the reasoning behind it and the question-1 portability
+ * probe live in
+ * `plugin-gantt/src/ObjectGantt.overlayShellCollapse-9113.test.tsx`; the LIVE
+ * CONTROL is `plugin-tree/src/ObjectTree.overlayShellControl-9113.test.tsx`,
+ * which reads FOUR distinct boundary pairs off the identical technique.
+ *
+ * ⛔ MEASUREMENT, NOT REPAIR. Nothing here votes for a remedy.
+ *
+ * ⚠️ One difference from its two siblings is worth recording rather than
+ * smoothing over: `ObjectCalendar` reads the key off `(schema as any)`, so —
+ * unlike gantt and kanban — the authored `navigation` is not even declared on
+ * this renderer's schema type. The collapse measured below is downstream of
+ * that and independent of it.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const hookLog = vi.hoisted(() => ({
+  calls: [] as Array<{ mode: string; isOverlay: boolean }>,
+}));
+
+const shellLog = vi.hoisted(() => ({
+  entries: [] as Array<{ shell: string; mode: unknown; carriesMode: boolean; propValues: unknown[] }>,
+}));
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/react')>();
+  return {
+    ...actual,
+    useNavigationOverlay: (options: any) => {
+      const state = actual.useNavigationOverlay(options);
+      hookLog.calls.push({ mode: state.mode, isOverlay: state.isOverlay });
+      return state;
+    },
+  };
+});
+
+vi.mock('@object-ui/plugin-detail', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/plugin-detail')>();
+  return {
+    ...actual,
+    RecordDetailDrawer: (props: any) => {
+      shellLog.entries.push({
+        shell: 'RecordDetailDrawer',
+        mode: props?.mode,
+        carriesMode: props != null && 'mode' in props,
+        propValues: props ? Object.values(props) : [],
+      });
+      return null;
+    },
+    deriveRecordPageHref: () => null,
+  };
+});
+
+vi.mock('@object-ui/components', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/components')>();
+  const Real = actual.NavigationOverlay;
+  return {
+    ...actual,
+    NavigationOverlay: (props: any) => {
+      shellLog.entries.push({
+        shell: 'NavigationOverlay',
+        mode: props?.mode,
+        carriesMode: props != null && 'mode' in props,
+        propValues: props ? Object.values(props) : [],
+      });
+      return <Real {...props} />;
+    },
+  };
+});
+
+/** Clickable stand-in for the grid — the click is what opens the overlay. */
+vi.mock('./CalendarView', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return {
+    ...actual,
+    CalendarView: ({ events, onEventClick }: any) => (
+      <div data-testid="calendar-view" data-event-count={String(events.length)}>
+        {events.map((e: any) => (
+          <button
+            key={String(e.id)}
+            type="button"
+            data-testid={`cv-event-${e.id}`}
+            onClick={() => onEventClick?.(e)}
+          >
+            {e.title}
+          </button>
+        ))}
+      </div>
+    ),
+  };
+});
+
+import { ObjectCalendar } from './ObjectCalendar';
+
+const OVERLAY_MODES = ['drawer', 'modal', 'split', 'popover'] as const;
+
+/** Inside the month the calendar opens on, so the event is drawable at all. */
+const NOW = new Date();
+const ROWS = (() => {
+  const d = new Date(NOW.getFullYear(), NOW.getMonth(), 1);
+  const iso = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+    d.getDate(),
+  ).padStart(2, '0')}`;
+  return [{ id: '1', subject: 'Ada review', start_at: iso, end_at: iso }];
+})();
+
+const makeDataSource = () =>
+  ({
+    find: vi.fn(async () => ({ data: ROWS, total: ROWS.length })),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async () => ({
+      name: 'duly_event',
+      fields: {
+        id: { name: 'id', type: 'text' },
+        subject: { name: 'subject', type: 'text' },
+        start_at: { name: 'start_at', type: 'datetime' },
+        end_at: { name: 'end_at', type: 'datetime' },
+      },
+    })),
+  }) as any;
+
+async function readingsFor(mode: string) {
+  cleanup();
+  hookLog.calls = [];
+  shellLog.entries = [];
+  render(
+    <ObjectCalendar
+      schema={
+        {
+          type: 'calendar',
+          objectName: 'duly_event',
+          calendar: { titleField: 'subject', startDateField: 'start_at', endDateField: 'end_at' },
+          data: { provider: 'object', object: 'duly_event' },
+          navigation: { mode },
+        } as never
+      }
+      dataSource={makeDataSource()}
+    />,
+  );
+  const event = await screen.findByTestId('cv-event-1');
+  fireEvent.click(event);
+  await waitFor(() => expect(shellLog.entries.length).toBeGreaterThan(0));
+  return {
+    resolved: hookLog.calls[hookLog.calls.length - 1],
+    boundary: shellLog.entries[shellLog.entries.length - 1],
+  };
+}
+
+beforeEach(() => {
+  hookLog.calls = [];
+  shellLog.entries = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('MEASURED — ObjectCalendar drops the resolved mode at the shell boundary (objectui#9113)', () => {
+  it('LIT CONTROL: both instruments fire on a single mount', async () => {
+    const r = await readingsFor('drawer');
+    expect(hookLog.calls.length).toBeGreaterThan(0);
+    expect(shellLog.entries.length).toBeGreaterThan(0);
+    expect(r.resolved.isOverlay).toBe(true);
+    expect(r.boundary.shell).toBe('RecordDetailDrawer');
+  });
+
+  it.each(OVERLAY_MODES)(
+    'authored `%s`: the hook RESOLVES `%s`, and the shell receives no mode at all',
+    async (mode) => {
+      const r = await readingsFor(mode);
+      expect(r.resolved.mode).toBe(mode);
+      expect(r.resolved.isOverlay).toBe(true);
+      expect(r.boundary.shell).toBe('RecordDetailDrawer');
+      expect(r.boundary.carriesMode).toBe(false);
+      expect(r.boundary.mode).toBeUndefined();
+      expect(r.boundary.propValues).not.toContain(mode);
+    },
+  );
+
+  it('⭐ THE MEASURED READING: four authored modes produce ONE boundary pair, not four', async () => {
+    const pairs: string[] = [];
+    const resolvedModes: string[] = [];
+    for (const mode of OVERLAY_MODES) {
+      const r = await readingsFor(mode);
+      pairs.push(`${r.boundary.shell}:${String(r.boundary.mode)}`);
+      resolvedModes.push(r.resolved.mode);
+    }
+    expect(new Set(resolvedModes).size).toBe(4);
+    expect(new Set(pairs).size).toBe(1);
+    expect(pairs[0]).toBe('RecordDetailDrawer:undefined');
+  });
+});

--- a/packages/plugin-gantt/src/ObjectGantt.overlayShellCollapse-9113.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.overlayShellCollapse-9113.test.tsx
@@ -1,0 +1,399 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9113 — THE MEASURED HALF: where the resolved overlay mode is lost.
+ *
+ * The card measures that `ObjectGantt`, `ObjectKanban` and `ObjectCalendar`
+ * render the one `RecordDetailDrawer` for all four overlay `navigation.mode`
+ * values, while `ObjectGrid` and `ObjectTree` honour them through the shared
+ * `NavigationOverlay`. The LIVE CONTROL for the instrument used here is
+ * `plugin-tree/src/ObjectTree.overlayShellControl-9113.test.tsx`, which reads
+ * FOUR distinct boundary pairs off the identical technique; this file reads
+ * ONE. Neither number means anything without the other.
+ *
+ * ⛔ THIS ROUND IS A MEASUREMENT, NOT A REPAIR. Nothing here asserts what the
+ * remedy should be, and nothing here is a vote for one. The file pins what is
+ * true on the base tree so the design question is decidable from a number
+ * rather than from a reading.
+ *
+ * ## Why the assertion is on a mode VALUE and not on a rendered drawer
+ *
+ * Measured, not assumed: `packages/components/src/ui/sheet.tsx` and
+ * `.../ui/dialog.tsx` BOTH import `@radix-ui/react-dialog`, and neither
+ * stamps a `data-slot`. `drawer` and `modal` therefore reach the DOM as the
+ * same Radix role, separated only by Tailwind class strings. A DOM assertion
+ * cannot tell them apart even on the renderer that gets this right, so
+ * `expect(drawer).toBeVisible()` is blind to this defect BY CONSTRUCTION — it
+ * reads the same before and after any repair.
+ *
+ * ## ⭐ The sharpest reading in this file: the value is correct, then dropped
+ *
+ * Two instruments run against the same mount:
+ *
+ *   1. a pass-through spy on `useNavigationOverlay`, which reports what the
+ *      component RESOLVED (this is the objectui#7334 instrument, reused);
+ *   2. a pass-through recorder on both overlay components, which reports what
+ *      crossed the handoff into the shell.
+ *
+ * They disagree, and the disagreement IS the defect: the hook resolves
+ * `modal` correctly, and then the component hands the record to a component
+ * that has no mode parameter to receive it. The loss is at the handoff, not
+ * upstream of it — so this is not a re-measurement of objectui#7334, which
+ * fixed the half where the value never arrived at all.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/** What the component RESOLVED, read off the real hook on its way through. */
+const hookLog = vi.hoisted(() => ({
+  calls: [] as Array<{ mode: string; isOverlay: boolean }>,
+}));
+
+/** What crossed the handoff into an overlay shell. */
+const shellLog = vi.hoisted(() => ({
+  entries: [] as Array<{ shell: string; mode: unknown; carriesMode: boolean; propKeys: string[]; propValues: unknown[] }>,
+}));
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/react')>();
+  return {
+    ...actual,
+    useNavigationOverlay: (options: any) => {
+      const state = actual.useNavigationOverlay(options);
+      hookLog.calls.push({ mode: state.mode, isOverlay: state.isOverlay });
+      return state;
+    },
+  };
+});
+
+/**
+ * Both shells are recorded, not just the one this renderer uses. Recording
+ * only `RecordDetailDrawer` would leave "and `NavigationOverlay` was never
+ * reached" as an assumption; recorded, it is a reading.
+ */
+vi.mock('@object-ui/plugin-detail', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/plugin-detail')>();
+  return {
+    ...actual,
+    // Returns null: this file measures the HANDOFF, so the drawer's own body
+    // is not rendered here. What the body can and cannot be re-hosted in is
+    // measured separately, below, against the real components.
+    RecordDetailDrawer: (props: any) => {
+      shellLog.entries.push({
+        shell: 'RecordDetailDrawer',
+        mode: props?.mode,
+        carriesMode: props != null && 'mode' in props,
+        propKeys: props ? Object.keys(props) : [],
+        propValues: props ? Object.values(props) : [],
+      });
+      return null;
+    },
+    deriveRecordPageHref: () => null,
+  };
+});
+
+vi.mock('@object-ui/components', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/components')>();
+  const Real = actual.NavigationOverlay;
+  return {
+    ...actual,
+    NavigationOverlay: (props: any) => {
+      shellLog.entries.push({
+        shell: 'NavigationOverlay',
+        mode: props?.mode,
+        carriesMode: props != null && 'mode' in props,
+        propKeys: props ? Object.keys(props) : [],
+        propValues: props ? Object.values(props) : [],
+      });
+      return <Real {...props} />;
+    },
+  };
+});
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }));
+
+/** Clickable stand-in for the chart — the click is what opens the overlay. */
+vi.mock('./GanttView', () => ({
+  GanttView: ({ tasks, onTaskClick }: any) => (
+    <div data-testid="gantt-view">
+      {tasks.map((t: any) => (
+        <button
+          key={t.id}
+          type="button"
+          data-testid={`gv-task-${t.id}`}
+          onClick={() => onTaskClick?.(t)}
+        >
+          {t.title}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+import { SchemaRendererProvider, SchemaRenderer } from '@object-ui/react';
+import './index';
+
+/**
+ * ONE fetch double, installed at module scope and never torn down
+ * (objectui#6640 / objectui#7439). `DetailView` issues a fire-and-forget
+ * `/api/v1/security/explain` read that no barrier in these tests awaits, so a
+ * per-test teardown would restore the real `fetch` while the tree is still
+ * mounted and let the read escape to a live socket. happy-dom's document URL
+ * is `http://localhost:3000`, which is what makes a relative fetch a real TCP
+ * connection in the first place.
+ */
+vi.stubGlobal(
+  'fetch',
+  vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    headers: { get: () => 'application/json' },
+    json: async () => ({}),
+    text: async () => '{}',
+  })),
+);
+
+/** The four overlay modes the spec publishes and `NavigationOverlay` branches on. */
+const OVERLAY_MODES = ['drawer', 'modal', 'split', 'popover'] as const;
+
+const ROWS = [
+  { id: '1', subject: 'Ada onboarding', visible_from: '2099-09-01', due_date: '2099-09-03' },
+];
+
+const makeDataSource = () =>
+  ({
+    find: vi.fn(async () => ({ data: ROWS, total: ROWS.length })),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async () => ({
+      name: 'duly_task',
+      fields: {
+        id: { name: 'id', type: 'text' },
+        subject: { name: 'subject', type: 'text' },
+        visible_from: { name: 'visible_from', type: 'date' },
+        due_date: { name: 'due_date', type: 'date' },
+      },
+    })),
+  }) as any;
+
+const BASE: Record<string, any> = {
+  type: 'object-gantt',
+  objectName: 'duly_task',
+  gantt: {
+    titleField: 'subject',
+    startDateField: 'visible_from',
+    endDateField: 'due_date',
+  },
+};
+
+/**
+ * Mount the real `ObjectGantt` with one authored mode, click the task so a
+ * record is really selected, and hand back both readings for that mount.
+ */
+async function readingsFor(mode: string) {
+  cleanup();
+  hookLog.calls = [];
+  shellLog.entries = [];
+  render(
+    <SchemaRendererProvider dataSource={makeDataSource()}>
+      <SchemaRenderer schema={{ ...BASE, navigation: { mode } } as never} />
+    </SchemaRendererProvider>,
+  );
+  const task = await screen.findByTestId('gv-task-1');
+  fireEvent.click(task);
+  await waitFor(() => expect(shellLog.entries.length).toBeGreaterThan(0));
+  return {
+    resolved: hookLog.calls[hookLog.calls.length - 1],
+    boundary: shellLog.entries[shellLog.entries.length - 1],
+  };
+}
+
+beforeEach(() => {
+  hookLog.calls = [];
+  shellLog.entries = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('MEASURED — ObjectGantt drops the resolved mode at the shell boundary (objectui#9113)', () => {
+  it('LIT CONTROL: both instruments fire on a single mount', async () => {
+    // First, because every assertion below reads a captured value. A shell
+    // recorder that never fired would make "no mode crossed the boundary"
+    // vacuously true — the exact failure the card's dispatch warned about.
+    const r = await readingsFor('drawer');
+    expect(hookLog.calls.length).toBeGreaterThan(0);
+    expect(shellLog.entries.length).toBeGreaterThan(0);
+    expect(r.resolved.isOverlay).toBe(true);
+    expect(r.boundary.shell).toBe('RecordDetailDrawer');
+  });
+
+  it.each(OVERLAY_MODES)(
+    'authored `%s`: the hook RESOLVES `%s`, and the shell receives no mode at all',
+    async (mode) => {
+      const r = await readingsFor(mode);
+      // Upstream of the handoff the value is present and correct.
+      expect(r.resolved.mode).toBe(mode);
+      expect(r.resolved.isOverlay).toBe(true);
+      // At the handoff it is gone. `RecordDetailDrawer` declares no `mode`
+      // prop (see `RecordDetailDrawerProps`), and none is passed.
+      expect(r.boundary.shell).toBe('RecordDetailDrawer');
+      expect(r.boundary.carriesMode).toBe(false);
+      expect(r.boundary.mode).toBeUndefined();
+      // Nor does the value survive under some other prop name.
+      expect(r.boundary.propValues).not.toContain(mode);
+    },
+  );
+
+  it('`NavigationOverlay` is never reached from this renderer, under any overlay mode', async () => {
+    for (const mode of OVERLAY_MODES) {
+      await readingsFor(mode);
+      expect(shellLog.entries.map((e) => e.shell)).not.toContain('NavigationOverlay');
+    }
+  });
+
+  it('⭐ THE MEASURED READING: four authored modes produce ONE boundary pair, not four', async () => {
+    // Compare against the control file's FOUR. The two numbers together are
+    // the measurement this card exists to produce.
+    const pairs: string[] = [];
+    const resolvedModes: string[] = [];
+    for (const mode of OVERLAY_MODES) {
+      const r = await readingsFor(mode);
+      pairs.push(`${r.boundary.shell}:${String(r.boundary.mode)}`);
+      resolvedModes.push(r.resolved.mode);
+    }
+    // Four distinct values were resolved …
+    expect(new Set(resolvedModes).size).toBe(4);
+    // … and collapsed into one handoff.
+    expect(new Set(pairs).size).toBe(1);
+    expect(pairs).toEqual([
+      'RecordDetailDrawer:undefined',
+      'RecordDetailDrawer:undefined',
+      'RecordDetailDrawer:undefined',
+      'RecordDetailDrawer:undefined',
+    ]);
+  });
+
+  it('no diagnostic accompanies the narrowing', async () => {
+    // The card calls the failure SILENT; that is measured here rather than
+    // asserted. `sonner`'s toast is already mocked above; console is spied
+    // for the duration of one unhonourable mode.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await readingsFor('split');
+    const said = [...warn.mock.calls, ...error.mock.calls]
+      .flat()
+      .map((a) => String(a))
+      .join(' ');
+    expect(said).not.toMatch(/split/i);
+    expect(said).not.toMatch(/navigation\.mode|unsupported|not supported/i);
+    warn.mockRestore();
+    error.mockRestore();
+  });
+});
+
+/**
+ * ⭐ QUESTION 1 of the card's dispatch, answered by EXECUTION rather than by
+ * reading: "is the `Sheet` the CONTAINER or the COMPONENT?"
+ *
+ * `RecordDetailDrawer` is `<Sheet><SheetContent>` wrapping exactly one
+ * payload — `<InlineEditProvider><DetailView/><InlineEditSaveBar/></...>` —
+ * plus chrome (`SheetHeader`/`SheetTitle`, sr-only) and a drag handle. This
+ * block composes that payload from the SAME exported parts and renders it
+ * through `NavigationOverlay`'s `children` render prop in the three NON-Sheet
+ * shells. If it mounts and shows record content there, the `Sheet` is a
+ * container the payload does not depend on.
+ *
+ * ⛔ This is a PROBE, not a repair: no source file is touched, nothing is
+ * extracted, and no renderer is rewired. It measures portability only.
+ *
+ * It lives in this package because `plugin-gantt` already depends on BOTH
+ * `@object-ui/plugin-detail` and `@object-ui/components`, and because
+ * `plugin-detail` is under concurrent work this round (objectui#9197).
+ */
+describe('QUESTION 1 — the drawer payload renders in the non-Sheet shells (objectui#9113)', () => {
+  const RECORD = { id: '1', subject: 'Ada onboarding', owner: 'Grace' };
+
+  /** Compose the payload exactly as `RecordDetailDrawer` does, in one shell. */
+  async function renderPayloadInShell(mode: string) {
+    cleanup();
+    const { InlineEditProvider } = await import('@object-ui/react');
+    const { DetailView, InlineEditSaveBar } = await import('@object-ui/plugin-detail');
+    const { NavigationOverlay } = await import('@object-ui/components');
+    render(
+      <NavigationOverlay
+        isOpen
+        isOverlay
+        selectedRecord={RECORD}
+        mode={mode as any}
+        close={() => {}}
+        setIsOpen={() => {}}
+        title="Record Detail"
+        // `split` renders nothing without it — the overlay hosts the page's
+        // own main content in the left panel. That requirement is itself a
+        // finding for question 2 and is reported, not worked around.
+        mainContent={<div data-testid="main-content" />}
+      >
+        {(record) => (
+          <InlineEditProvider canEdit>
+            <DetailView
+              inlineEdit
+              schema={{
+                type: 'detail-view',
+                objectName: 'duly_task',
+                resourceId: String((record as any).id),
+                data: record,
+                columns: 2,
+                fields: [
+                  { name: 'subject', label: 'Subject', type: 'text' },
+                  { name: 'owner', label: 'Owner', type: 'text' },
+                ],
+              } as any}
+            />
+            <InlineEditSaveBar onFieldSave={async () => {}} />
+          </InlineEditProvider>
+        )}
+      </NavigationOverlay>,
+    );
+  }
+
+  /**
+   * Both field VALUES, not just the record title: the title alone also
+   * appears in `DetailView`'s header, so a payload that rendered its header
+   * and nothing else would satisfy a title-only assertion. `findAllBy` rather
+   * than `findBy` because the title legitimately appears twice — once in the
+   * header highlight, once as the `subject` field's value.
+   */
+  async function expectPayloadContent() {
+    expect((await screen.findAllByText('Ada onboarding')).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText('Grace')).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText('Owner')).length).toBeGreaterThan(0);
+  }
+
+  it('LIT CONTROL: the payload renders in the shell it ships in today (`drawer`)', async () => {
+    // Without this the three cases below could all be passing because the
+    // payload renders nothing anywhere. If THIS case fails, the three below
+    // are NOT MEASURED — they are not a negative answer.
+    await renderPayloadInShell('drawer');
+    await expectPayloadContent();
+  });
+
+  it.each(['modal', 'split', 'popover'])(
+    'the same payload renders inside the `%s` shell',
+    async (mode) => {
+      await renderPayloadInShell(mode);
+      await expectPayloadContent();
+    },
+  );
+});

--- a/packages/plugin-kanban/src/ObjectKanban.overlayShellCollapse-9113.test.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.overlayShellCollapse-9113.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9113 — the SECOND of the three collapsing renderers, measured.
+ *
+ * The instrument, the reasoning behind it and the question-1 portability
+ * probe all live in
+ * `plugin-gantt/src/ObjectGantt.overlayShellCollapse-9113.test.tsx`; its LIVE
+ * CONTROL is `plugin-tree/src/ObjectTree.overlayShellControl-9113.test.tsx`,
+ * which reads FOUR distinct boundary pairs off the identical technique. This
+ * file exists because the card names three renderers and a card that names
+ * three should measure three — the three call sites are textually alike, and
+ * "alike" is exactly the kind of claim this round is supposed to check rather
+ * than assume.
+ *
+ * ⛔ MEASUREMENT, NOT REPAIR. Nothing here votes for a remedy.
+ *
+ * ⚠️ The mode is NOT separable from the DOM here: `ui/sheet.tsx` and
+ * `ui/dialog.tsx` both import `@radix-ui/react-dialog` and neither stamps a
+ * `data-slot`, so `drawer` and `modal` would render as the same role. The
+ * reading below is the resolved mode VALUE at the shell boundary.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const hookLog = vi.hoisted(() => ({
+  calls: [] as Array<{ mode: string; isOverlay: boolean }>,
+}));
+
+const shellLog = vi.hoisted(() => ({
+  entries: [] as Array<{ shell: string; mode: unknown; carriesMode: boolean; propValues: unknown[] }>,
+}));
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/react')>();
+  return {
+    ...actual,
+    useNavigationOverlay: (options: any) => {
+      const state = actual.useNavigationOverlay(options);
+      hookLog.calls.push({ mode: state.mode, isOverlay: state.isOverlay });
+      return state;
+    },
+  };
+});
+
+vi.mock('@object-ui/plugin-detail', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/plugin-detail')>();
+  return {
+    ...actual,
+    RecordDetailDrawer: (props: any) => {
+      shellLog.entries.push({
+        shell: 'RecordDetailDrawer',
+        mode: props?.mode,
+        carriesMode: props != null && 'mode' in props,
+        propValues: props ? Object.values(props) : [],
+      });
+      return null;
+    },
+    deriveRecordPageHref: () => null,
+  };
+});
+
+vi.mock('@object-ui/components', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/components')>();
+  const Real = actual.NavigationOverlay;
+  return {
+    ...actual,
+    NavigationOverlay: (props: any) => {
+      shellLog.entries.push({
+        shell: 'NavigationOverlay',
+        mode: props?.mode,
+        carriesMode: props != null && 'mode' in props,
+        propValues: props ? Object.values(props) : [],
+      });
+      return <Real {...props} />;
+    },
+  };
+});
+
+import { I18nProvider } from '@object-ui/i18n';
+import { registerAllFields } from '@object-ui/fields';
+import { ObjectKanban } from './ObjectKanban';
+
+// Pay the board's lazy chunk at import time, not inside a `findBy` budget
+// (AGENTS.md §测试纪律) — the specifier must stay byte-identical to `./index`'s.
+import './KanbanImpl';
+
+registerAllFields();
+
+const OVERLAY_MODES = ['drawer', 'modal', 'split', 'popover'] as const;
+
+const CARDS = [{ id: '1', title: 'On the board', status: 'todo' }];
+
+async function readingsFor(mode: string) {
+  cleanup();
+  hookLog.calls = [];
+  shellLog.entries = [];
+  render(
+    <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false }}>
+      <ObjectKanban
+        schema={
+          {
+            type: 'object-kanban',
+            objectName: 'duly_card',
+            groupBy: 'status',
+            columns: [{ id: 'todo', title: 'To Do' }],
+            data: CARDS,
+            navigation: { mode },
+          } as never
+        }
+      />
+    </I18nProvider>,
+  );
+  const card = await screen.findByText('On the board');
+  fireEvent.click(card);
+  await waitFor(() => expect(shellLog.entries.length).toBeGreaterThan(0));
+  return {
+    resolved: hookLog.calls[hookLog.calls.length - 1],
+    boundary: shellLog.entries[shellLog.entries.length - 1],
+  };
+}
+
+beforeEach(() => {
+  hookLog.calls = [];
+  shellLog.entries = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('MEASURED — ObjectKanban drops the resolved mode at the shell boundary (objectui#9113)', () => {
+  it('LIT CONTROL: both instruments fire on a single mount', async () => {
+    const r = await readingsFor('drawer');
+    expect(hookLog.calls.length).toBeGreaterThan(0);
+    expect(shellLog.entries.length).toBeGreaterThan(0);
+    expect(r.resolved.isOverlay).toBe(true);
+    expect(r.boundary.shell).toBe('RecordDetailDrawer');
+  });
+
+  it.each(OVERLAY_MODES)(
+    'authored `%s`: the hook RESOLVES `%s`, and the shell receives no mode at all',
+    async (mode) => {
+      const r = await readingsFor(mode);
+      expect(r.resolved.mode).toBe(mode);
+      expect(r.resolved.isOverlay).toBe(true);
+      expect(r.boundary.shell).toBe('RecordDetailDrawer');
+      expect(r.boundary.carriesMode).toBe(false);
+      expect(r.boundary.mode).toBeUndefined();
+      expect(r.boundary.propValues).not.toContain(mode);
+    },
+  );
+
+  it('⭐ THE MEASURED READING: four authored modes produce ONE boundary pair, not four', async () => {
+    const pairs: string[] = [];
+    const resolvedModes: string[] = [];
+    for (const mode of OVERLAY_MODES) {
+      const r = await readingsFor(mode);
+      pairs.push(`${r.boundary.shell}:${String(r.boundary.mode)}`);
+      resolvedModes.push(r.resolved.mode);
+    }
+    expect(new Set(resolvedModes).size).toBe(4);
+    expect(new Set(pairs).size).toBe(1);
+    expect(pairs[0]).toBe('RecordDetailDrawer:undefined');
+  });
+});

--- a/packages/plugin-tree/src/ObjectTree.overlayShellControl-9113.test.tsx
+++ b/packages/plugin-tree/src/ObjectTree.overlayShellControl-9113.test.tsx
@@ -146,6 +146,39 @@ describe('CONTROL — ObjectTree carries the resolved mode across the shell boun
     expect(pair.mode).toBe(mode);
   });
 
+  it('⭐ SECOND READING: carrying the mode is not the same as HONOURING it', async () => {
+    // Found while establishing this control, and recorded because it prices
+    // the card's route (a) — "honour the modes in all five renderers" — quite
+    // differently from how it reads.
+    //
+    // `NavigationOverlay`'s split branch opens `if (!isOpen || !mainContent)
+    // return null`. `ObjectGrid` passes `mainContent` (it has a dedicated
+    // early-return that wraps the whole grid in the panel group);
+    // `ObjectTree` passes only `{...navigation}` + `title` + children. So the
+    // mode arrives intact — the reading above proves that — and then renders
+    // NOTHING AT ALL.
+    //
+    // The probe is the overlay's own chrome heading, which no other element
+    // on this page renders. It is a legitimate DOM read here BECAUSE the
+    // question is "did anything render", which the DOM can answer; it is
+    // still no help telling `modal` from `drawer`, which is why the readings
+    // above are on the mode value.
+    const rendered: Record<string, number> = {};
+    for (const mode of OVERLAY_MODES) {
+      await boundaryPairFor(mode);
+      rendered[mode] = screen.queryAllByText('Record Detail').length;
+    }
+    // Three of the four put an overlay on screen …
+    expect(rendered.drawer).toBeGreaterThan(0);
+    expect(rendered.modal).toBeGreaterThan(0);
+    expect(rendered.popover).toBeGreaterThan(0);
+    // … and `split` renders nothing, on a renderer this card treats as one of
+    // the two that get overlay modes RIGHT. ⛔ Not repaired here: this round
+    // is a measurement, and the fence puts `ObjectTree` out of bounds for
+    // changes. Reported so the remedy is priced against it.
+    expect(rendered.split).toBe(0);
+  });
+
   it('⭐ THE CONTROL READING: four authored modes produce FOUR distinct boundary pairs', async () => {
     // This is the number the measured half is compared against. `ObjectTree`
     // hands the shell a different mode for each authored value, so the

--- a/packages/plugin-tree/src/ObjectTree.overlayShellControl-9113.test.tsx
+++ b/packages/plugin-tree/src/ObjectTree.overlayShellControl-9113.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9113 — THE LIVE CONTROL for the overlay-shell measurement.
+ *
+ * This card measures a narrowing: `ObjectGantt`, `ObjectKanban` and
+ * `ObjectCalendar` collapse the four overlay `navigation.mode` values into one
+ * shell. A measurement of an absence is worthless unless the same instrument
+ * is shown to register a PRESENCE somewhere, so this file runs the identical
+ * instrument against `ObjectTree`, which honours the modes through the shared
+ * `NavigationOverlay`. The measured half lives in
+ * `plugin-gantt/src/ObjectGantt.overlayShellCollapse-9113.test.tsx`.
+ *
+ * ⭐ WHY THE INSTRUMENT IS NOT A DOM ASSERTION, measured rather than assumed.
+ * `packages/components/src/ui/sheet.tsx` and `.../ui/dialog.tsx` BOTH import
+ * `@radix-ui/react-dialog` — `Sheet` is `SheetPrimitive.Root` where
+ * `SheetPrimitive` *is* `@radix-ui/react-dialog`. Neither primitive stamps a
+ * `data-slot` (zero hits across both files). So `drawer` and `modal` reach the
+ * DOM as the same Radix role, separated only by Tailwind class strings, which
+ * are not a contract. A DOM-level assertion cannot tell `modal` from `drawer`
+ * EVEN HERE, on the renderer that gets it right — which is exactly why the
+ * card's dispatch forbade one. The instrument below reads the resolved MODE
+ * VALUE at the shell boundary instead.
+ *
+ * ## What "the shell boundary" means, and why the measurement is a PAIR
+ *
+ * Every one of the five view renderers resolves a mode through
+ * `useNavigationOverlay` and then hands the record to some overlay component.
+ * The observable this card needs is what crosses THAT handoff:
+ *
+ *     (shell component that receives the record, mode value it receives)
+ *
+ * On this renderer the pair's second element tracks the authored mode, so four
+ * authored modes produce FOUR distinct pairs. On the three collapsing
+ * renderers the receiving component is `RecordDetailDrawer`, which declares no
+ * mode prop at all, so four authored modes produce ONE pair. That cardinality
+ * — 4 here, 1 there — is the measurement.
+ *
+ * ⛔ This file asserts nothing about which shell is CORRECT for a tree, and
+ * nothing about the remedy. It establishes only that the instrument has the
+ * resolution the card needs.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/**
+ * The shell-boundary log. Recorded from inside a pass-through wrapper around
+ * the REAL `NavigationOverlay` — the real component still renders, so nothing
+ * about the tree's behaviour is faked away; the wrapper only reads the props
+ * on their way in.
+ */
+const shellLog = vi.hoisted(() => ({
+  entries: [] as Array<{ shell: string; mode: unknown; carriesMode: boolean }>,
+}));
+
+vi.mock('@object-ui/components', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/components')>();
+  const Real = actual.NavigationOverlay;
+  return {
+    ...actual,
+    NavigationOverlay: (props: any) => {
+      shellLog.entries.push({
+        shell: 'NavigationOverlay',
+        mode: props?.mode,
+        carriesMode: props != null && 'mode' in props,
+      });
+      return <Real {...props} />;
+    },
+  };
+});
+
+import { ObjectTree } from './ObjectTree';
+
+/** The four overlay modes the spec publishes and `NavigationOverlay` branches on. */
+const OVERLAY_MODES = ['drawer', 'modal', 'split', 'popover'] as const;
+
+const ROWS = [
+  { id: '1', name: 'Acme', parent_id: null },
+  { id: '2', name: 'Engineering', parent_id: '1' },
+];
+
+/**
+ * Mount `ObjectTree` with one authored mode, click a row so a record is really
+ * selected, and hand back the last pair that crossed the shell boundary.
+ *
+ * Rows arrive through the `data` PROP, so no `dataSource` is needed and the
+ * only variable across cases is the authored mode.
+ */
+async function boundaryPairFor(mode: string) {
+  cleanup();
+  shellLog.entries = [];
+  render(
+    <ObjectTree
+      schema={
+        {
+          type: 'object-tree',
+          objectName: 'org_chart_node',
+          parentField: 'parent_id',
+          labelField: 'name',
+          fields: ['name'],
+          navigation: { mode },
+        } as never
+      }
+      data={ROWS}
+    />,
+  );
+  const cell = await screen.findByText('Acme');
+  fireEvent.click(cell);
+  await waitFor(() => expect(shellLog.entries.length).toBeGreaterThan(0));
+  return shellLog.entries[shellLog.entries.length - 1];
+}
+
+beforeEach(() => {
+  shellLog.entries = [];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('CONTROL — ObjectTree carries the resolved mode across the shell boundary (objectui#9113)', () => {
+  it('LIT CONTROL: the shell-boundary instrument fires at all', async () => {
+    // First, for the reason the sibling files in this package put theirs
+    // first: every assertion below reads a captured pair, so an instrument
+    // that never fired would make all of them vacuous rather than red. If
+    // this case goes silent the whole measurement — here and in the gantt
+    // file, which uses the same technique — is a dark instrument.
+    const pair = await boundaryPairFor('drawer');
+    expect(shellLog.entries.length).toBeGreaterThan(0);
+    expect(pair.shell).toBe('NavigationOverlay');
+    expect(pair.carriesMode).toBe(true);
+  });
+
+  it.each(OVERLAY_MODES)('authored `%s` reaches the shell AS `%s`', async (mode) => {
+    const pair = await boundaryPairFor(mode);
+    expect(pair.shell).toBe('NavigationOverlay');
+    expect(pair.mode).toBe(mode);
+  });
+
+  it('⭐ THE CONTROL READING: four authored modes produce FOUR distinct boundary pairs', async () => {
+    // This is the number the measured half is compared against. `ObjectTree`
+    // hands the shell a different mode for each authored value, so the
+    // renderer preserves the full overlay vocabulary across the handoff.
+    const pairs: string[] = [];
+    for (const mode of OVERLAY_MODES) {
+      const pair = await boundaryPairFor(mode);
+      pairs.push(`${pair.shell}:${String(pair.mode)}`);
+    }
+    expect(new Set(pairs).size).toBe(4);
+    expect(pairs).toEqual([
+      'NavigationOverlay:drawer',
+      'NavigationOverlay:modal',
+      'NavigationOverlay:split',
+      'NavigationOverlay:popover',
+    ]);
+  });
+});


### PR DESCRIPTION
Part of #9113

## This is a measurement, not a repair

objectui#9113 is fenced: triage held it to the measuring seat's own words — a
straight swap of `RecordDetailDrawer` for `NavigationOverlay` "is not obviously
available" and the right shape "is a design question, not a mechanical one". So
no product source is touched here and no remedy is implied. What lands is the
instrument and the reading, so the question becomes decidable from numbers.

**No published behaviour moved**, so the changeset has empty frontmatter — an
explicit "releases nothing" rather than a `patch` claimed on packages that did
not move. `check-changeset-presence` confirms that is a complete answer.

## The instrument, and why it is not a DOM assertion

Measured, not assumed: `packages/components/src/ui/sheet.tsx` and
`packages/components/src/ui/dialog.tsx` **both import `@radix-ui/react-dialog`**
(`Sheet` is `SheetPrimitive.Root`, where `SheetPrimitive` is that package), and
**neither stamps a `data-slot`** — zero hits across both files. So `drawer` and
`modal` reach the DOM as the same Radix role, separated only by Tailwind class
strings, which are not a contract. A rendered assertion cannot tell them apart
even on the renderers that get this right. `expect(drawer).toBeVisible()` is
blind to this defect by construction.

The instrument is therefore the **resolved mode value at the shell boundary** —
the pair `(shell component that receives the record, mode value it receives)`.

## The readings

| Renderer | Boundary pairs for the four overlay modes | Shell reached |
|---|---|---|
| `ObjectTree` (**control**) | **4 distinct** | `NavigationOverlay`, mode carried |
| `ObjectGantt` | **1** | `RecordDetailDrawer`, no mode prop |
| `ObjectKanban` | **1** | `RecordDetailDrawer`, no mode prop |
| `ObjectCalendar` | **1** | `RecordDetailDrawer`, no mode prop |

The control reads 4, so the 1s are a measurement and not a dark instrument.

**The sharpest reading: the value is correct, then discarded.** A pass-through
spy on `useNavigationOverlay` runs against the same mount and shows the hook
resolving each of the four modes correctly. The loss is **at the handoff**, not
upstream of it — so this is not a re-measurement of objectui#7334, whose
subject was the other half: the value never arriving at all.

## Question 1, answered by execution: the Sheet is the CONTAINER

`RecordDetailDrawer` is `Sheet` wrapping exactly one payload —
`InlineEditProvider` around `DetailView` plus `InlineEditSaveBar` — plus chrome
and a drag handle. Composed from the same exported parts and rendered through
`NavigationOverlay`'s `children` render prop, that payload **mounts and shows
record content in the `modal`, `split` and `popover` shells**. A lit control
renders it in `drawer` first, so a payload that rendered nowhere could not read
as a pass.

Note also that `RecordDetailDrawer` **does not fetch the record** — it receives
`record` and `objectSchema` as props. Of the four capabilities the fence named,
record fetching is the caller's, and the other three live inside the payload.

## Two further narrowings found while establishing the control

1. **No renderer anywhere passes `popoverTrigger`.** `NavigationOverlay`'s
   popover branch falls back to a compact Dialog without it, and
   `plugin-view/src/ObjectView.tsx` documents the fallback in its own comment.
   So `popover` is a second, independent narrowing that reaches the control
   renderers too.
2. **`ObjectTree` never passes `mainContent`, which the split branch requires**
   (`if (!isOpen || !mainContent) return null`). `ObjectGrid` passes it through
   a dedicated early return; the tree does not. So on a tree an authored `split`
   arrives at the shell intact and then renders **nothing at all**. Measured in
   the control file. Not repaired — out of this card's bounds.

Together these mean "honour the modes in all five renderers" is a larger job
than the card's two-halves framing suggests.

## Files

- `packages/plugin-tree/src/ObjectTree.overlayShellControl-9113.test.tsx` — the live control.
- `packages/plugin-gantt/src/ObjectGantt.overlayShellCollapse-9113.test.tsx` — measured surface plus the question-1 portability probe.
- `packages/plugin-kanban/src/ObjectKanban.overlayShellCollapse-9113.test.tsx`
- `packages/plugin-calendar/src/ObjectCalendar.overlayShellCollapse-9113.test.tsx`

## Verification

Every verdict below is the line the tool printed, captured before any pipe.

- `vitest run` over all four files — **4 files / 30 tests passed**, under the
  shared verify lock (`VERDICT command-exit 0`).
- `type-check` for the four packages — **exit 0**. Coverage proven rather than
  assumed: `tsc -p tsconfig.test.json --listFiles` names the new gantt test file.
- `lint` for the four packages — **exit 0, 0 errors**. A whole-repo
  `eslint . --no-inline-config` run linted **4900 files**; the four new files
  carry **0 errors** (only the repo's ubiquitous `no-explicit-any` warnings).
- Gates re-run **after** committing, so the new files were inside the tracked
  population (the counts move 4898 to 4902): `check:vi-mock-specifiers`,
  `check:vi-mock-inherit`, `check:vi-mock-override-shape`, `check:control-bytes`,
  `check:changeset-claims`, `check:test-path-roots`, `changeset:check`,
  `check-changeset-presence` — all exit 0.

## Acceptance notes

- The escalation rule applies: deciding what the spec's enum should mean for
  these view types is a contract change and belongs in the decision box. This PR
  takes no such decision and recommends none.
- The dedup sweep behind the two findings above covered **open** issues only
  (450 read, with objectui#9113 itself as the known-hit control). No text query
  over closed cards was possible in this session.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_