### PR TITLE
docs(guide): teach the provider wiring and the data. prefix the evaluator actually reads

### DIFF
--- a/.changeset/8021-schema-rendering-data-context.md
+++ b/.changeset/8021-schema-rendering-data-context.md
@@ -1,0 +1,15 @@
+---
+---
+
+Documentation and test only; nothing published moves.
+
+`content/docs/guide/schema-rendering.md` and `packages/react/README.md` taught a `data` prop
+on the `SchemaRenderer` element. `SchemaRendererProps` declares exactly one prop, `schema`,
+and forwards everything else to the component the schema names, so that prop reached the
+expression evaluator through nothing and failed silently. Both pages now teach
+`SchemaRendererProvider` with `dataSource`, and the `data.` prefix the evaluator's scope
+actually holds.
+
+`packages/components` gains `guide-schema-rendering-data-context-8021.test.tsx`, which reads
+the guide and renders it — a test file, not published source. `SchemaRendererProps` itself is
+untouched, so no consumer of any tarball sees a difference.

--- a/content/docs/guide/schema-rendering.md
+++ b/content/docs/guide/schema-rendering.md
@@ -68,33 +68,63 @@ interface BaseSchema {
   "visibleOn": "${user.role === 'admin'}",
   "body": {
     "type": "text",
-    "content": "Total Users: ${stats.totalUsers}"
+    "content": "Total Users: ${data.stats.totalUsers}"
   }
 }
 ```
 
 ## Data Context
 
-The `SchemaRenderer` accepts a `data` prop that provides context for expressions:
+Expression context does not arrive as a prop. `SchemaRenderer` declares exactly one prop,
+`schema`, and every other prop it is handed is forwarded to the component the schema names —
+so a `data` prop written on the element reaches the evaluator through nothing. Because it is
+forwarded rather than refused, nothing throws and nothing warns; the expression simply never
+resolves. The scope comes from `SchemaRendererProvider`, which publishes its `dataSource`
+under the name `data`:
 
-<!-- doc-snippet: fragment — continues the block above — SchemaRenderer and schema are already in scope there; the closing JSX line is the call shown in place, not a statement that parses on its own -->
 ```tsx
-const data = {
-  user: { name: "John", role: "admin" },
-  stats: { totalUsers: 1234 }
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react'
+import type { BaseSchema } from '@object-ui/types'
+
+// The page schema from the first example on this page.
+declare const schema: BaseSchema
+
+const dataSource = {
+  user: { name: 'John', role: 'admin' },
+  stats: { totalUsers: 1234 },
 }
 
-<SchemaRenderer schema={schema} data={data} />
+function App() {
+  return (
+    <SchemaRendererProvider dataSource={dataSource}>
+      <SchemaRenderer schema={schema} />
+    </SchemaRendererProvider>
+  )
+}
 ```
+
+The scope the evaluator builds holds four names, and nothing else:
+
+| name | what it holds |
+|---|---|
+| `data` | the `dataSource` the provider above published — everything you passed in |
+| `page` | page-local variables, for predicates that gate on another component's state |
+| `record` | the row a record surface is bound to, when there is one |
+| `current_user` (aliased to `user`) | the signed-in user, published by the host's `ExpressionProvider` — not by anything on this page |
+
+A name outside that set resolves to nothing, and an unresolvable template is not an error:
+the evaluator hands back its own source text, so the characters you typed are what the reader
+sees.
 
 ### Accessing Data in Schemas
 
-Use expression syntax `${}` to reference data:
+Use expression syntax `${}` to reference the scope, and reach your own values through the
+`data.` prefix:
 
 ```json
 {
   "type": "text",
-  "content": "Welcome, ${user.name}!"
+  "content": "Welcome, ${data.user.name}!"
 }
 ```
 
@@ -379,18 +409,33 @@ const pageSchema = {
 
 ### 2. Use Data Context Effectively
 
-Pass all necessary data upfront:
+Put everything the schema's expressions need on one `dataSource`, mounted above the tree —
+not on the renderer, which does not read it:
 
-<!-- doc-snippet: fragment — best-practice excerpt: userData, userSettings and dashboardStats are the reader's own values, and the closing JSX line is shown in place rather than as a parseable statement -->
 ```tsx
-// ✅ Good
-const data = {
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react'
+import type { BaseSchema } from '@object-ui/types'
+
+// The reader's own values.
+declare const schema: BaseSchema
+declare const userData: { name: string }
+declare const userSettings: { theme: string }
+declare const dashboardStats: { totalUsers: number }
+
+// ✅ Good — one provider, and every expression reaches it through `data.`
+const dataSource = {
   user: userData,
   settings: userSettings,
-  stats: dashboardStats
+  stats: dashboardStats,
 }
 
-<SchemaRenderer schema={schema} data={data} />
+function Dashboard() {
+  return (
+    <SchemaRendererProvider dataSource={dataSource}>
+      <SchemaRenderer schema={schema} />
+    </SchemaRendererProvider>
+  )
+}
 ```
 
 ### 3. Leverage Expressions

--- a/packages/components/src/__tests__/guide-schema-rendering-data-context-8021.test.tsx
+++ b/packages/components/src/__tests__/guide-schema-rendering-data-context-8021.test.tsx
@@ -154,17 +154,24 @@ function schemaRendererElements(src: string): string[] {
 const FORWARDED_LOOKALIKES = /\b(data|dataSource|debug)=\{/;
 
 /**
- * The teaching surfaces this repair covers. Not a glob: each document was read
- * and repaired by hand, and a new page inheriting the pin by accident is the
- * failure mode a glob would create.
+ * The teaching surfaces this repair covers IN FULL. Not a glob: each document
+ * was read and repaired by hand, and a new page inheriting the pin by accident
+ * is the failure mode a glob would create.
+ *
+ * ⚠️ Three more documents carry the same element and are deliberately NOT here.
+ * The sweep this card's triage asked for was run BEFORE any writing, and it
+ * measured 18 `<SchemaRenderer …/>` elements across five surfaces, nine of them
+ * carrying a forwarded look-alike. On `content/docs/guide/expressions.md`,
+ * `content/docs/guide/architecture.md` and the root `README.md` the element is
+ * only half the defect: their expression spellings are bare across the whole
+ * page (about fifty sites on `expressions.md` alone), and several of those are
+ * legitimate AMBIENT `user` references rather than data-scope ones. Moving only
+ * the wiring there would produce exactly leg D — a page that reads as repaired
+ * and still prints raw source — so that population is filed as its own card
+ * with the census rather than half-moved here. The two documents below are the
+ * ones where every site in the passage moves together.
  */
-const TEACHING_SURFACES = [
-  GUIDE,
-  'content/docs/guide/expressions.md',
-  'content/docs/guide/architecture.md',
-  'README.md',
-  'packages/react/README.md',
-];
+const TEACHING_SURFACES = [GUIDE, 'packages/react/README.md'];
 
 afterEach(cleanup);
 
@@ -210,18 +217,12 @@ describe('objectui#8021 legs B–D — the controls that keep the two errors apa
   });
 });
 
-describe('objectui#8021 sweep — no teaching surface hands SchemaRenderer wiring props', () => {
-  it('the scan sees the elements at all (lit control)', () => {
-    const seen = TEACHING_SURFACES.flatMap((doc) => schemaRendererElements(readDoc(doc)));
-    // Measured on the repaired tree; a scanner that stops matching would
-    // otherwise report every document below as clean.
-    expect(seen.length).toBeGreaterThanOrEqual(9);
-  });
-
+describe('objectui#8021 sweep — no repaired surface hands SchemaRenderer wiring props', () => {
   it.each(TEACHING_SURFACES)('%s', (doc) => {
-    const offenders = schemaRendererElements(readDoc(doc)).filter((el) =>
-      FORWARDED_LOOKALIKES.test(el),
-    );
-    expect(offenders).toEqual([]);
+    const elements = schemaRendererElements(readDoc(doc));
+    // Lit control, per document: a scanner that stopped matching would report
+    // an empty offender list, which is indistinguishable from a clean page.
+    expect(elements.length, `no <SchemaRenderer …/> element found in ${doc}`).toBeGreaterThan(0);
+    expect(elements.filter((el) => FORWARDED_LOOKALIKES.test(el))).toEqual([]);
   });
 });

--- a/packages/components/src/__tests__/guide-schema-rendering-data-context-8021.test.tsx
+++ b/packages/components/src/__tests__/guide-schema-rendering-data-context-8021.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The guide's Data Context passages teach a wiring that RESOLVES (objectui#8021).
+ *
+ * ## The two independent errors this file holds apart
+ *
+ * `SchemaRendererProps` declares exactly ONE prop, `schema`
+ * (`packages/react/src/SchemaRenderer.tsx`). The docblock beside it names the
+ * mechanism: the renderer "passes every prop it does not itself read straight
+ * through to the component the schema names". So a `data={…}` written on a
+ * `SchemaRenderer` element is not ignored and does not warn — it is FORWARDED,
+ * and the evaluator never sees it.
+ *
+ * The evaluator's scope is built from `usePredicateScope()` plus
+ * `current_user`, an optional `record`, `data: dataSource` and
+ * `page: pageVariables`, where `dataSource` comes from
+ * `SchemaRendererProvider`. So a host's own values are reachable only under the
+ * `data.` prefix, and a bare `${user.…}` addresses the AMBIENT signed-in user
+ * an `ExpressionProvider` publishes — never the object the page handed over.
+ *
+ * Two coordinates, and the page had both wrong. A repair that moves only one
+ * leaves it broken, which is why legs B and D below are LIT CONTROLS rather
+ * than commentary:
+ *
+ *   | leg | wiring                | expression            | rendered                |
+ *   |-----|-----------------------|-----------------------|-------------------------|
+ *   | A   | what the page teaches | what the page teaches | must be `Welcome, John!`|
+ *   | B   | `data` prop           | `data.` prefix        | `Welcome, !`            |
+ *   | C   | provider `dataSource` | `data.` prefix        | `Welcome, John!`        |
+ *   | D   | provider `dataSource` | bare `user.`          | the raw source text     |
+ *
+ * B proves the prop supplies nothing even when the expression is right; D
+ * proves the prefix is needed even when the wiring is right. Leg A is not
+ * transcribed from the page — it is READ OFF the page on every run, so it can
+ * only go green when both coordinates have moved.
+ *
+ * ## Why leg A is derived rather than listed
+ *
+ * A transcription of the fence is a second copy that drifts, and the anchors on
+ * this card already drifted twice before it was dispatched. The wiring half is
+ * read from the `## Data Context` fence and the expression half from the
+ * `### Accessing Data in Schemas` fence, then RENDERED. Edit either passage
+ * back and this file reddens.
+ *
+ * ⚠️ `content/docs/**` is EXCLUDED from `ci.yml`'s full-run decision on
+ * `pull_request`, so a green PR page is not evidence that this file ran on a
+ * docs-only edit. It lives in `packages/components` for the same reason
+ * `guide-layout-page-buttons-7926.test.tsx` does, and the document is declared
+ * in `scripts/markdown-test-inputs.mjs`.
+ *
+ * Module-scope import of the renderers, not `beforeAll` (AGENTS.md 测试纪律):
+ * registering them is an unbounded module load and must not be billed to a
+ * bounded hook timeout.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import '../renderers';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+
+/**
+ * Anchored on this file's own naked `import.meta.url`, never on
+ * `process.cwd()`: the cwd differs between a repo-root vitest invocation and a
+ * package-level one, and an assertion that reads the filesystem would otherwise
+ * grade a different tree depending on how it was started (AGENTS.md).
+ */
+function repoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 12; i += 1) {
+    if (existsSync(join(dir, 'pnpm-workspace.yaml'))) return dir;
+    dir = resolve(dir, '..');
+  }
+  throw new Error('repo root (pnpm-workspace.yaml) not found from this test file');
+}
+
+const ROOT = repoRoot();
+const GUIDE = 'content/docs/guide/schema-rendering.md';
+const readDoc = (rel: string): string => readFileSync(join(ROOT, rel), 'utf8');
+
+/** The host scope every leg is given: as a `dataSource`, or as the `data` prop. */
+const SCOPE = { user: { name: 'John', role: 'admin' }, stats: { totalUsers: 1234 } };
+
+const textNode = (content: string) => ({ type: 'text', content });
+
+/** Leg A/B wiring: the prop the page used to teach, with no provider above it. */
+function renderWithDataProp(content: string): string {
+  // `data` is deliberately not a declared prop — that IS the measurement.
+  const props = { schema: textNode(content), data: SCOPE } as never;
+  return render(<SchemaRenderer {...props} />).container.textContent ?? '';
+}
+
+/** Leg C/D wiring: the provider that actually seeds the evaluator. */
+function renderWithProvider(content: string): string {
+  return (
+    render(
+      <SchemaRendererProvider dataSource={SCOPE}>
+        <SchemaRenderer schema={textNode(content)} />
+      </SchemaRendererProvider>,
+    ).container.textContent ?? ''
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Reading the page
+// ---------------------------------------------------------------------------
+
+/** The slice of `src` from `heading` to the next heading at the same level. */
+function sectionOf(src: string, heading: string): string {
+  const level = /^#+/.exec(heading)?.[0].length ?? 2;
+  const start = src.indexOf(`\n${heading}\n`);
+  if (start < 0) throw new Error(`heading not found: ${heading}`);
+  const rest = src.slice(start + 1 + heading.length);
+  const next = new RegExp(`\\n#{1,${level}} `).exec(rest);
+  return rest.slice(0, next ? next.index : undefined);
+}
+
+/** The body of the first fenced block in `src` opened with `lang`. */
+function firstFence(src: string, lang: string): string {
+  const re = new RegExp('```' + lang + '\\s*\\n([\\s\\S]*?)\\n```');
+  const m = re.exec(src);
+  if (!m) throw new Error(`no \`\`\`${lang} fence in the section`);
+  return m[1];
+}
+
+/**
+ * Every `<SchemaRenderer …/>` element in a document.
+ *
+ * `\b` after the name is what keeps `SchemaRendererProvider` out of the set:
+ * the character after `SchemaRenderer` there is `P`, a word character, so the
+ * boundary does not match. The provider is the CORRECT carrier for these props
+ * and must not be counted as an offender.
+ */
+function schemaRendererElements(src: string): string[] {
+  return src.match(/<SchemaRenderer\b[\s\S]*?\/>/g) ?? [];
+}
+
+/**
+ * The three props that LOOK like evaluator wiring and are not: `SchemaRenderer`
+ * reads none of them. `data` and `dataSource` reach the evaluator only through
+ * `SchemaRendererProvider`; `debug` is read off the same context
+ * (`SchemaRenderer.tsx`: `context?.debug || context?.debugFlags?.enabled`).
+ * Written on the element they are forwarded to whatever component the schema
+ * names — silently.
+ */
+const FORWARDED_LOOKALIKES = /\b(data|dataSource|debug)=\{/;
+
+/**
+ * The teaching surfaces this repair covers. Not a glob: each document was read
+ * and repaired by hand, and a new page inheriting the pin by accident is the
+ * failure mode a glob would create.
+ */
+const TEACHING_SURFACES = [
+  GUIDE,
+  'content/docs/guide/expressions.md',
+  'content/docs/guide/architecture.md',
+  'README.md',
+  'packages/react/README.md',
+];
+
+afterEach(cleanup);
+
+describe('objectui#8021 leg A — the guide’s own pair, read off the page', () => {
+  it('renders the resolved value, not the characters the author typed', () => {
+    const src = readDoc(GUIDE);
+    const dataContext = sectionOf(src, '## Data Context');
+    const wiringFence = firstFence(dataContext, 'tsx');
+    const accessing = sectionOf(dataContext, '### Accessing Data in Schemas');
+    const node = JSON.parse(firstFence(accessing, 'json')) as { content?: string };
+
+    // Lit control on the READER: a silent parse failure would otherwise make
+    // this leg pass by measuring nothing.
+    expect(node.content, 'the Accessing Data fence must carry a `content` string').toEqual(
+      expect.stringContaining('${'),
+    );
+    expect(wiringFence, 'the Data Context fence must show a SchemaRenderer').toContain(
+      'SchemaRenderer',
+    );
+
+    const teachesProvider = /<SchemaRendererProvider[\s\S]*?\bdataSource=\{/.test(wiringFence);
+    const rendered = teachesProvider
+      ? renderWithProvider(node.content as string)
+      : renderWithDataProp(node.content as string);
+
+    expect(rendered).toBe('Welcome, John!');
+  });
+});
+
+describe('objectui#8021 legs B–D — the controls that keep the two errors apart', () => {
+  it('leg B: the `data` prop supplies nothing even with the `data.` prefix', () => {
+    expect(renderWithDataProp('Welcome, ${data.user.name}!')).toBe('Welcome, !');
+  });
+
+  it('leg C: provider `dataSource` plus the `data.` prefix is the green wiring', () => {
+    expect(renderWithProvider('Welcome, ${data.user.name}!')).toBe('Welcome, John!');
+  });
+
+  it('leg D: the right wiring still prints raw source for a bare `${user.…}`', () => {
+    // Nothing published `user` here, so the template is unresolvable and the
+    // evaluator hands back its own SOURCE TEXT — the failure the reader sees.
+    expect(renderWithProvider('Welcome, ${user.name}!')).toBe('Welcome, ${user.name}!');
+  });
+});
+
+describe('objectui#8021 sweep — no teaching surface hands SchemaRenderer wiring props', () => {
+  it('the scan sees the elements at all (lit control)', () => {
+    const seen = TEACHING_SURFACES.flatMap((doc) => schemaRendererElements(readDoc(doc)));
+    // Measured on the repaired tree; a scanner that stops matching would
+    // otherwise report every document below as clean.
+    expect(seen.length).toBeGreaterThanOrEqual(9);
+  });
+
+  it.each(TEACHING_SURFACES)('%s', (doc) => {
+    const offenders = schemaRendererElements(readDoc(doc)).filter((el) =>
+      FORWARDED_LOOKALIKES.test(el),
+    );
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/components/src/__tests__/guide-schema-rendering-data-context-8021.test.tsx
+++ b/packages/components/src/__tests__/guide-schema-rendering-data-context-8021.test.tsx
@@ -91,11 +91,17 @@ const SCOPE = { user: { name: 'John', role: 'admin' }, stats: { totalUsers: 1234
 
 const textNode = (content: string) => ({ type: 'text', content });
 
-/** Leg A/B wiring: the prop the page used to teach, with no provider above it. */
+/**
+ * Leg A/B wiring: the prop the page used to teach, with no provider above it.
+ *
+ * ⭐ No cast is needed, and that is itself the measurement: `SchemaRenderer`'s
+ * declared type is `SchemaRendererProps & Record<string, any>`, the open
+ * forwarding surface. TypeScript therefore ACCEPTS `data` here — the prop is
+ * not rejected anywhere, at compile time or at runtime. It is simply handed to
+ * whatever component the schema names.
+ */
 function renderWithDataProp(content: string): string {
-  // `data` is deliberately not a declared prop — that IS the measurement.
-  const props = { schema: textNode(content), data: SCOPE } as never;
-  return render(<SchemaRenderer {...props} />).container.textContent ?? '';
+  return render(<SchemaRenderer schema={textNode(content)} data={SCOPE} />).container.textContent ?? '';
 }
 
 /** Leg C/D wiring: the provider that actually seeds the evaluator. */

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -38,8 +38,13 @@ function App() {
 
 ### With Data
 
+Expression scope reaches the renderer through `SchemaRendererProvider`, never through a prop
+on the element: `SchemaRenderer` declares only `schema`, so anything else is forwarded to the
+component the schema names (see the open forwarding surface below). The provider's
+`dataSource` is what the evaluator sees under the name `data`.
+
 ```tsx
-import { SchemaRenderer } from '@object-ui/react'
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react'
 
 const schema = {
   type: 'form',
@@ -49,7 +54,7 @@ const schema = {
       // the spec's expression carriage map, so a `${…}` in ITS `value` would be
       // rendered as those characters rather than resolved.
       type: 'text',
-      content: 'Editing ${user.name}'
+      content: 'Editing ${data.user.name}'
     },
     {
       type: 'input',
@@ -59,12 +64,16 @@ const schema = {
   ]
 }
 
-const data = {
+const dataSource = {
   user: { name: 'John Doe' }
 }
 
 function App() {
-  return <SchemaRenderer schema={schema} data={data} />
+  return (
+    <SchemaRendererProvider dataSource={dataSource}>
+      <SchemaRenderer schema={schema} />
+    </SchemaRendererProvider>
+  )
 }
 ```
 

--- a/scripts/markdown-test-inputs.mjs
+++ b/scripts/markdown-test-inputs.mjs
@@ -157,25 +157,13 @@ export const ADJUDICATED = new Map([
     { reads: ['content/docs/guide/layout.md'] },
   ],
   // The four-leg render pin for objectui#8021. Leg A is READ OFF
-  // `content/docs/guide/schema-rendering.md` rather than transcribed, and the
-  // sweep arm reads the other four teaching surfaces that carried the same
-  // forwarded-prop element. The two rejected candidates are the scanner's
-  // ancestor resolutions of the bare `'README.md'` literal, which names the
-  // ROOT readme here.
+  // `content/docs/guide/schema-rendering.md` rather than transcribed -- both the
+  // wiring and the expression spelling -- and the sweep arm reads the second
+  // surface the same repair covered.
   [
     'packages/components/src/__tests__/guide-schema-rendering-data-context-8021.test.tsx',
     {
-      reads: [
-        'README.md',
-        'content/docs/guide/architecture.md',
-        'content/docs/guide/expressions.md',
-        'content/docs/guide/schema-rendering.md',
-        'packages/react/README.md',
-      ],
-      notRead: [
-        'packages/components/README.md',
-        'packages/components/src/__tests__/README.md',
-      ],
+      reads: ['content/docs/guide/schema-rendering.md', 'packages/react/README.md'],
     },
   ],
   [

--- a/scripts/markdown-test-inputs.mjs
+++ b/scripts/markdown-test-inputs.mjs
@@ -156,6 +156,28 @@ export const ADJUDICATED = new Map([
     'packages/components/src/__tests__/guide-layout-page-buttons-7926.test.tsx',
     { reads: ['content/docs/guide/layout.md'] },
   ],
+  // The four-leg render pin for objectui#8021. Leg A is READ OFF
+  // `content/docs/guide/schema-rendering.md` rather than transcribed, and the
+  // sweep arm reads the other four teaching surfaces that carried the same
+  // forwarded-prop element. The two rejected candidates are the scanner's
+  // ancestor resolutions of the bare `'README.md'` literal, which names the
+  // ROOT readme here.
+  [
+    'packages/components/src/__tests__/guide-schema-rendering-data-context-8021.test.tsx',
+    {
+      reads: [
+        'README.md',
+        'content/docs/guide/architecture.md',
+        'content/docs/guide/expressions.md',
+        'content/docs/guide/schema-rendering.md',
+        'packages/react/README.md',
+      ],
+      notRead: [
+        'packages/components/README.md',
+        'packages/components/src/__tests__/README.md',
+      ],
+    },
+  ],
   [
     'packages/components/src/__tests__/page-body-single-node-8310.test.tsx',
     {


### PR DESCRIPTION
Fixes #8021

Branch 1 of the two the triage comment named: teach the real wiring. No renderer contract
moves — `SchemaRendererProps` still declares exactly one prop.

⚠️ JSX tag shapes are spelled out in words throughout: a tag-shaped fragment does not
survive a GitHub body, and the passages this change is about are exactly JSX elements.

## The two errors, and why both had to move

`SchemaRendererProps` declares one prop, `schema`. The docblock beside it names the
consequence: the renderer "passes every prop it does not itself read straight through to the
component the schema names". So the `data={data}` the guide taught was never ignored and
never refused — it was **forwarded**, which is why nothing threw and nothing warned.

The evaluator's scope is built from `usePredicateScope()` plus `current_user`, an optional
`record`, `data: dataSource` and `page: pageVariables`, and `dataSource` comes from
`SchemaRendererProvider`. Four names. A host's own values are reachable under `data.` only;
`user` / `current_user` is the ambient signed-in user an `ExpressionProvider` publishes — a
real name, but never the object the page handed over.

## Anchors, re-derived on this branch's base (`ee5ef7748`)

The card cited `4922b83`; triage re-measured on `83d4fda16`. Both were re-derived here rather
than trusted, by reading the file:

| what | card (`4922b83`) | triage (`83d4fda16`) | **this base (`ee5ef7748`)** |
|---|---|---|---|
| `Total Users: ...stats.totalUsers` | `:70` | `:71` | **`:71`** |
| Data Context prose | `:75` | — | **`:78`** |
| first SchemaRenderer element carrying the prop | — | `:87` | **`:87`** |
| `Welcome, ...user.name!` | `:89` | `:97` | **`:97`** |
| second SchemaRenderer element carrying the prop | `:365` | `:393` | **`:393`** |

Four of the five agree with triage; the prose line had drifted again, from `:75` to `:78`.

## The required pre-step: the sibling sweep, run BEFORE writing — and it came back positive

Scan: every SchemaRenderer element in the tracked tree, matched with a word boundary after
the name so `SchemaRendererProvider` — the correct carrier — is excluded by construction.
**Lit control:** the scan found **18** elements across five teaching surfaces, so an empty
offender list would have been a reading and not a silent zero.

| surface | SchemaRenderer elements | carrying a forwarded look-alike | head names no scope holds |
|---|---|---|---|
| `content/docs/guide/schema-rendering.md` | 5 | **2** → 0 | repaired here |
| `packages/react/README.md` | 4 | **1** → 0 | repaired here |
| `content/docs/guide/expressions.md` | 6 | **3** | 26 |
| `content/docs/guide/architecture.md` | 1 | **1** | 4 |
| `README.md` (repo root) | 2 | **2** | 7 |
| **total** | **18** | **9** | — |

"Forwarded look-alike" is one of three props the renderer reads none of: `data`,
`dataSource`, and `debug` — the last comes off the same provider context
(`context?.debug || context?.debugFlags?.enabled`), so the expressions guide's Debug Mode
block is wrong on two props at once.

**So it did stop being a three-passage fix — and the sweep is split, deliberately.** This
pull request repairs, in full, the two surfaces where every site in the passage moves
together. The other three are filed as objectui#9297 with the census above, because on them
the element is only half the defect: their expression prefixes are bare page-wide (26 sites
on the expressions guide alone), several of those are legitimately about the ambient scope
or a custom evaluation context, and moving only the wiring there would produce exactly
**leg D at scale** — three pages that read as repaired and still print the characters the
author typed. Moving both halves is a rewrite of a whole guide several times over, on a
judgement this card does not settle and its dispatch refused to let a claimant invent.

## The pin: four legs, written BEFORE the repair

`packages/components/src/__tests__/guide-schema-rendering-data-context-8021.test.tsx`,
committed first (`a5e9821ae`) so the "unmodified" arm is the real base tree. Legs A–D were
reproduced rather than taken from the card's table, one `text` node each, real
`SchemaRenderer`, reading `container.textContent`:

| leg | wiring | expression | measured on the BASE tree | after |
|---|---|---|---|---|
| A | what the page teaches | what the page teaches | `Welcome, ...user.name!` (raw source) | `Welcome, John!` |
| B | `data` prop, no provider | `data.` prefix | `Welcome, !` | unchanged |
| C | provider `dataSource` | `data.` prefix | `Welcome, John!` | unchanged |
| D | provider `dataSource` | bare `user.` | `Welcome, ...user.name!` (raw source) | unchanged |

The card's table reproduced exactly. **B and D are lit controls and both fired on the base
tree** — B shows the prop supplies nothing even when the expression is right, D shows the
prefix is needed even when the wiring is right.

Base arm: `Tests 6 failed | 4 passed (10)` — leg A plus the five sweep documents red, legs
B/C/D and the scan control green. After arm: `Tests 6 passed (6)`.

**Leg A is READ OFF the page on every run** — wiring from the Data Context fence, expression
from the Accessing Data fence — rather than transcribed, because the anchors here have
already drifted twice.

## Reverse verification: one mutation per coordinate

Committed first, then mutated, then restored with `git checkout HEAD -- path` and the
restore proven by blob hash (`e9d036aab14b0ba63633baea1c42c214b7a2c0e2`) plus an empty
`git diff HEAD`, under a `trap ... EXIT INT TERM`. Each mutation was proven on disk by a
before/after `grep -c` on the text it targeted, not by the editor's exit code.

```
MUTATION 1 — wiring only (provider mount back to the forwarded prop)
  on-disk proof: provider mounts 2 -> 1; prop elements -> 1
  pin exit 1 — AssertionError: expected 'Welcome, !' to be 'Welcome, John!'
              (leg A collapses onto leg B's reading)
  restored, blob matches HEAD

MUTATION 2 — prefix only (data-prefixed spelling back to bare)
  on-disk proof: data-prefixed 1 -> 0; bare -> 1
  pin exit 1 — AssertionError: expected 'Welcome, ...user.name!' to be 'Welcome, John!'
              (leg A collapses onto leg D's reading)
  restored, blob matches HEAD
```

Direction as predicted: red both times, and each time for its own coordinate. Neither
coordinate alone keeps the pin green.

## What changed

`content/docs/guide/schema-rendering.md`

- **Data Context** — the prop example becomes a `SchemaRendererProvider` mount, and the
  section now states the four names the scope holds, including that `user` is the host's
  signed-in user rather than anything passed here.
- **Accessing Data in Schemas** — the bare spelling takes the `data.` prefix.
- **Example Schema** — `...stats.totalUsers` likewise; `stats` is in no scope at all.
- **Best Practice 2** — same element, same repair.

`packages/react/README.md` — the "With Data" block becomes a provider mount, its expression
takes the `data.` prefix, and a sentence points at the open forwarding surface this file
already documents further down.

⭐ Both rewritten guide fences now **compile** instead of carrying a `doc-snippet: fragment`
marker, so `check:doc-snippets` holds the wiring from here on: 648 blocks compiled where the
base tree compiled 646.

`scripts/markdown-test-inputs.mjs` gains the ledger entry for the new pin — without it a
docs-only pull request mutates the test's input while skipping the shard that reads it.

**Changeset:** empty frontmatter. Nothing published moves; the only file under a released
package's `src/` is the test.

## Gates

Derived by hand from `package.json` and `.github/workflows/` — this repository has no
`scripts/pm/dispatch-gates.mjs`.

| gate | result |
|---|---|
| `check:doc-snippets` (Doc Snippet Type Check) | ✅ 648/648 blocks judged, 0 failed; harness controls all passed |
| `site:build` (Build Docs) | ✅ 30 tasks |
| `check:doc-fences` (Doc Fence Language Check) | ✅ |
| `check:doc-example-ids` (Doc Example Id Check) | ✅ |
| `check:doc-types` (Doc Component Type Check) | ✅ |
| `docs:check-links` (Internal Docs Link Check) | ✅ |
| `check:doc-example-readers` | ✅ |
| `markdown-test-inputs.mjs --audit` | ✅ 48 candidates, all adjudicated; 43 entries, all present |
| `check-changeset-presence.mjs` | ✅ |
| `changeset:check` | ✅ (the `no-major` script runs inside this; no other spelling exists) |
| `check:changeset-claims` | ✅ |
| `check:readme-exports` | ✅ on the BUILT tree |
| `check:control-bytes` | ✅ (plus a direct control-byte scan over the changed files) |
| `check:new-line-citations` | ✅ |
| `check:test-path-roots` | ✅ |
| `check:unreferenced-sources` | ✅ |
| `check:docs-route-closure` | ✅ |
| `check-governed-queue-guard.mjs --test` | ✅ NOT GOVERNED — 5 paths, none matched |
| `pnpm --filter @object-ui/components type-check` | ✅ |
| `pnpm --filter @object-ui/components lint` | ✅ 0 errors (956 pre-existing warnings) |

⚠️ `check:readme-exports` was red on the **unbuilt** tree with "the population COLLAPSED —
this run proves nothing" (`typesResolved: found 0, floor is 2`). That is **NOT MEASURED**,
not a red gate; it is green after `turbo run build`.

**Tests — the blast radius, not a package scope.** The documents this change touches are
test inputs, so the run is the set of tests that read them plus the suite of the tool script
edited:

```
pnpm exec vitest run \
  scripts/__tests__/markdown-test-inputs.test.ts \
  packages/types/src/__tests__/action-callback-retired-7068.test.ts \
  packages/types/src/__tests__/component-docs-retired-handler-keys-7340.test.ts \
  packages/components/src/__tests__/guide-schema-rendering-data-context-8021.test.tsx
→ Test Files 4 passed (4) · Tests 71 passed (71)
```

The two `packages/types` files are the tests that walk `content/docs/**` as a tree; the
`scripts/__tests__` file is the suite of the ledger script this change edits. Everything
heavy ran through `/home/user/objectstack/scripts/pm/os-verify-lock.sh`, and every verdict
above is the gate's own printed line, never a bare exit status read across a pipe.

**Narrowing declared:** the repository-wide `pnpm lint` over every package was not run here;
`@object-ui/components` — the only package whose sources this change touches — was linted in
full, and the two edited non-package files were linted directly against the root flat
config. Full-farm convergence is CI's.

## Not done here, on purpose

⛔ Branch 2 — giving `SchemaRenderer` a real `data` prop — is a renderer contract change to a
published interface whose one-prop shape is deliberate and documented. Not taken inside a
docs repair. If anyone wants it, it is a separate card carrying `needs:contract-review`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_