### PR TITLE
fix(filter-builder): fold the operator trigger's identity comparison through the spec

### DIFF
--- a/.changeset/7561-filter-builder-operator-trigger-label.md
+++ b/.changeset/7561-filter-builder-operator-trigger-label.md
@@ -1,0 +1,49 @@
+---
+'@object-ui/components': minor
+---
+
+fix(filter-builder): the operator trigger names the operator the row holds, in any spelling of it
+
+The operator `Select` compared its value LITERALLY against the mounted
+`SelectItem`s, whose ids are this builder's own camelCase vocabulary
+(`greaterThan`, `notIn`). A condition row can legitimately carry the same
+operator under another spelling — `@objectstack/spec`'s canonical
+`greater_than`, which is what `FilterOperatorSchema` accepts and what
+`foldFilterGroupToSpecRules` persists, or the spec's alias table `gt` / `lt` /
+`eq`, which three schema-catalog entries author today. Neither matched, so
+Radix drew a **blank** operator cell over a row that went on filtering
+correctly: the user's own operator, invisible and unreachable.
+
+Everywhere the operator's *meaning* matters this component already folded
+through the spec's `normalizeFilterOperator` (`filterValueArity`,
+`reconcileOperatorForField`). The one site that did not was this identity
+comparison, and that omission — not the two vocabularies diverging — is what
+produced the blank. It now folds too, and hands the trigger the *mounted*
+spelling.
+
+**Rendered output moves** — that is the point of the fix, and it is the only
+thing consumers can observe. A previously empty operator cell now carries its
+label; measured through the real `SchemaRenderer` on the affected catalog
+entries, `text` and the SHA-256 of it change while the element count and tag
+census do not:
+
+```
+before  … Clear all Category Remove condition Price Remove condition …
+after   … Clear all Category Equals Remove condition Price Less than …
+```
+
+A consumer holding a DOM or text snapshot of a filter row whose operator was
+stored in the canonical or alias dialect will see that snapshot move. Nothing
+else does — which is why this is `minor` and carries **no** `**BREAKING**`
+marker:
+
+- no schema accepts or refuses anything it did not before;
+- no id any stored filter carries is rewritten, on render or otherwise;
+- the vocabulary the dropdown EMITS is byte-identical — no second spelling is
+  mounted, so `onChange` still hands back `lessThan` and never `lt`;
+- an operator no offered id folds onto still draws blank, because inventing a
+  label for a word this vocabulary does not contain would be a claim rather
+  than a repair.
+
+Which of the two vocabularies should win remains open and is deliberately not
+answered here (objectui#7561).

--- a/examples/schema-catalog/test/filter-builder-mirror-6939.test.tsx
+++ b/examples/schema-catalog/test/filter-builder-mirror-6939.test.tsx
@@ -71,12 +71,27 @@ type Reading = {
  * validated, while the `filter-builder` it wraps did not — and every one of the
  * five drew exactly this.
  *
- * ⚠️ The empty operator triggers in the `…Category` / `…Price` runs below are
- * NOT damage from this change and are not repaired by it: those entries author
- * `eq` / `gt` / `lt`, which no `SelectItem` in the operator dropdown carries, so
- * the trigger renders blank. It is the fourth divergence the validator half
- * reports and the ruling does not cover, and it is captured here so a later fix
- * to it has a "before" to move away from.
+ * ⚠️ ⭐ The empty operator triggers this table used to record are GONE, and
+ * that is the later fix this note was written for: objectui#7561 routed the
+ * operator `Select`'s identity comparison through `normalizeFilterOperator`,
+ * so `eq` / `gt` / `lt` — the spec's alias table, which these entries author —
+ * now resolve to the mounted `SelectItem` and the trigger names the operator.
+ * Three of the five readings moved with it, in `text` and `sha256` only:
+ *
+ *   `…Clear allCategoryRemove condition…` → `…Clear allCategoryEqualsRemove condition…`
+ *
+ * `elements` and the tag census did NOT move for any entry — the label lands
+ * in a span the trigger already mounted — which is why those two columns are
+ * untouched below and are the reading that says this was a text change, not a
+ * structural one.
+ *
+ * ⛔ The values below are therefore no longer all `3e01cb55f`: the three
+ * entries with condition rows are re-measured post-#7561 through this same
+ * `measure()`, and the two empty ones are unchanged from the original run.
+ * objectui#6939's claim is unaffected — ITS repair still moved the validator
+ * and not the renderer; what moved the renderer was a different card, and
+ * keeping a stale "before" here would only make the next reader hunt a
+ * regression that is a deliberate, ruled repair.
  */
 const PRE_REPAIR: Record<(typeof IDS)[number], Reading> = {
   'components-complex-filter-builder/empty-filter-builder': {
@@ -88,14 +103,14 @@ const PRE_REPAIR: Record<(typeof IDS)[number], Reading> = {
   'components-complex-filter-builder/product-search': {
     elements: 76,
     tags: { DIV: 20, LABEL: 1, SPAN: 10, BUTTON: 12, svg: 11, path: 19, INPUT: 3 },
-    text: 'Product Search FiltersWhereANDClear allCategoryRemove conditionPriceRemove conditionStock QuantityRemove conditionAdd filter',
-    sha256: '708dab4e6b4d8bd35777d4115ae86af02d44c5f1ed5ff7be8a4c50a40b4a6b7f',
+    text: 'Product Search FiltersWhereANDClear allCategoryEqualsRemove conditionPriceLess thanRemove conditionStock QuantityGreater thanRemove conditionAdd filter',
+    sha256: 'aa398c23811cc40717d632ff5feac486796e01bce738df72e3ea53e83e628d10',
   },
   'components-complex-filter-builder/search-interface': {
     elements: 65,
     tags: { DIV: 17, SPAN: 10, BUTTON: 12, svg: 9, path: 16, INPUT: 1 },
-    text: 'Advanced SearchBuild complex queries with multiple conditionsWhereANDClear allPublishedTrueRemove conditionViewsRemove conditionAdd filterApply FiltersClear',
-    sha256: '31b9cb48754fb0de14f23e7eb1b5804fa8862767cf509baed36927dd446c0062',
+    text: 'Advanced SearchBuild complex queries with multiple conditionsWhereANDClear allPublishedEqualsTrueRemove conditionViewsGreater thanRemove conditionAdd filterApply FiltersClear',
+    sha256: '17c0b9f574fe89cc80d8be92c53917be73c8a561461dbe7db5a3e0899d4c86ab',
   },
   'components-complex-filter-builder/user-filters': {
     elements: 11,
@@ -106,13 +121,17 @@ const PRE_REPAIR: Record<(typeof IDS)[number], Reading> = {
   'components-complex-filter-builder/with-conditions': {
     elements: 57,
     tags: { DIV: 15, LABEL: 1, SPAN: 7, BUTTON: 9, svg: 8, path: 15, INPUT: 2 },
-    text: 'User FiltersWhereANDClear allAgeRemove conditionDepartmentRemove conditionAdd filter',
-    sha256: '23cdc02620baca3e7f7e3b18615d0d02910e3cdc095e323e6f8a00acc835d24a',
+    text: 'User FiltersWhereANDClear allAgeGreater thanRemove conditionDepartmentEqualsRemove conditionAdd filter',
+    sha256: '685ae845f1ebc57c5054ec80da37582a3d387091f203b2c4166c4800cc110853',
   },
 };
 
 /** Render one entry the way the docs gallery does and measure what it drew. */
-function measure(schema: unknown): Reading & { inputs: (string | null)[]; triggers: (string | null)[] } {
+function measure(schema: unknown): Reading & {
+  inputs: (string | null)[];
+  triggers: (string | null)[];
+  fieldTriggers: (string | null)[];
+} {
   const { container, unmount } = render(
     <SchemaRenderer schema={toRenderableSchema(schema as never) as never} />,
   );
@@ -125,6 +144,15 @@ function measure(schema: unknown): Reading & { inputs: (string | null)[]; trigge
     sha256: createHash('sha256').update(text).digest('hex'),
     inputs: Array.from(container.querySelectorAll('input')).map((i) => i.getAttribute('type')),
     triggers: Array.from(container.querySelectorAll('[role="combobox"]')).map((e) => e.textContent),
+    // The FIELD trigger of each condition row, separately from the operator
+    // and value ones. A row's three cells are `div.col-span-4` inside the
+    // row grid, field first, so `:first-child` selects exactly the field cell.
+    // Needed since objectui#7561: the operator trigger now names the operator
+    // even on a row whose field def was lost, so "all triggers blank" no
+    // longer distinguishes "the field lookup failed" from "nothing rendered".
+    fieldTriggers: Array.from(
+      container.querySelectorAll('div.col-span-4:first-child [role="combobox"]'),
+    ).map((e) => e.textContent),
   };
   unmount();
   return out;
@@ -232,12 +260,24 @@ describe('objectui#6939 — the fixtures were the side that was right', () => {
     const corrected = measure(fieldsSpelledName(id));
     expect(corrected.text).not.toBe(authored.text);
     expect(corrected.sha256).not.toBe(authored.sha256);
-    // Every field trigger goes blank — the lookup `fields.find(f => f.value === …)`
+    // Every FIELD trigger goes blank — the lookup `fields.find(f => f.value === …)`
     // finds nothing — while the rows themselves survive, so the loss is the
     // field cell and not the whole tile (that is the NEXT probe's failure mode,
     // and the two must stay distinguishable).
-    expect(authored.triggers.some((t) => t !== '')).toBe(true);
-    expect(corrected.triggers.every((t) => t === '')).toBe(true);
+    //
+    // ⚠️ Read on `fieldTriggers`, not on every combobox on the tile. Until
+    // objectui#7561 the two were interchangeable here ONLY because the operator
+    // trigger was blank as well — and it was blank for an unrelated defect,
+    // these entries authoring `eq` / `lt` / `gt`. Now that the operator cell
+    // renders its label, an all-triggers reading would be answering about the
+    // operator repair rather than about the lost field, which is the one thing
+    // this probe exists to discriminate.
+    expect(authored.fieldTriggers.some((t) => t !== '')).toBe(true);
+    expect(corrected.fieldTriggers.every((t) => t === '')).toBe(true);
+    // Anti-vacuity for the line above: `every` over an EMPTY list is true, so
+    // a selector that matched nothing would pass it silently.
+    expect(corrected.fieldTriggers.length).toBe(authored.fieldTriggers.length);
+    expect(corrected.fieldTriggers.length).toBeGreaterThan(0);
     const rows = (r: { text: string }) => r.text.split('Remove condition').length - 1;
     expect(rows(corrected)).toBe(rows(authored));
     expect(rows(authored)).toBeGreaterThan(0);

--- a/examples/schema-catalog/test/filter-builder-operator-alias-trigger-7561.test.tsx
+++ b/examples/schema-catalog/test/filter-builder-operator-alias-trigger-7561.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#7561's acceptance criterion, mechanised: **same tree, swap only the
+ * operator spelling, the label must appear.**
+ *
+ * The card measured it through the real `SchemaRenderer` and reported the two
+ * columns this file re-measures rather than quotes:
+ *
+ *   as authored          `… Category Remove condition Price Remove condition …`
+ *   operators corrected  `… Category Equals Remove condition Price Less than …`
+ *
+ * Three catalog entries author the spec's alias table (`eq` / `lt` / `gt`) —
+ * `product-search`, `with-conditions`, and the `filter-builder` nested inside
+ * `search-interface`. No `SelectItem` in the operator dropdown carries those
+ * ids, and the trigger used to match its value LITERALLY against the mounted
+ * items, so all three drew a blank operator cell over rows that filtered
+ * correctly.
+ *
+ * ## Why the swap is the control and not a repair
+ *
+ * ⛔ No catalog data is changed to make this pass. The swap happens in memory,
+ * as a CONTROL: after the repair the two columns must be the SAME text, because
+ * `normalizeFilterOperator` folds `eq` and `equals` onto one operator and the
+ * trigger now resolves through it. Before the repair they differ — which is
+ * what makes this measurement able to fail.
+ *
+ * ⭐ The corrected column deliberately uses the dropdown's OWN camelCase ids
+ * (`lessThan`), not the spec's canonical `less_than`: those ids are the ones
+ * mounted, so the corrected column is the "what it would have looked like if
+ * authored in the renderer's dialect" arm the card described. Both arms
+ * rendering the same text is the claim; neither arm is a recommendation about
+ * which vocabulary an author SHOULD use — that is objectui#7561's separate
+ * ruling and is not decided here.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@object-ui/components';
+import { SchemaRenderer, toRenderableSchema } from '@object-ui/react';
+import { getExample } from '../src/index.js';
+
+/** The three entries whose rows carry an alias-table operator. */
+const AFFECTED = [
+  'components-complex-filter-builder/product-search',
+  'components-complex-filter-builder/search-interface',
+  'components-complex-filter-builder/with-conditions',
+] as const;
+
+/**
+ * The operator label each row of each entry owes, in row order. Derived by
+ * hand from the entry's own `operator` plus the field's type bucket, so a
+ * fixture edit that changed an operator would redden here rather than silently
+ * re-baseline.
+ */
+const EXPECTED: Record<(typeof AFFECTED)[number], string[]> = {
+  'components-complex-filter-builder/product-search': ['Equals', 'Less than', 'Greater than'],
+  'components-complex-filter-builder/search-interface': ['Equals', 'Greater than'],
+  'components-complex-filter-builder/with-conditions': ['Greater than', 'Equals'],
+};
+
+/** The alias spellings these entries author → the dropdown id each folds onto. */
+const CORRECTION: Record<string, string> = {
+  eq: 'equals',
+  ne: 'notEquals',
+  lt: 'lessThan',
+  lte: 'lessOrEqual',
+  gt: 'greaterThan',
+  gte: 'greaterOrEqual',
+  nin: 'notIn',
+};
+
+function asAuthored(id: (typeof AFFECTED)[number]): Record<string, unknown> {
+  return getExample(id).schema as Record<string, unknown>;
+}
+
+function builderNode(doc: Record<string, unknown>): Record<string, unknown> {
+  if (doc.type === 'filter-builder') return doc;
+  const child = (doc.children as Record<string, unknown>[]).find(
+    (c) => c.type === 'filter-builder',
+  );
+  if (!child) throw new Error('entry no longer carries a filter-builder');
+  return child;
+}
+
+/** The same entry with ONLY the operator spellings swapped — nothing else. */
+function operatorsCorrected(id: (typeof AFFECTED)[number]): Record<string, unknown> {
+  const doc = asAuthored(id);
+  const swap = (b: Record<string, unknown>) => {
+    const group = b.value as { conditions: Record<string, unknown>[] };
+    return {
+      ...b,
+      value: {
+        ...group,
+        conditions: group.conditions.map((c) => ({
+          ...c,
+          operator: CORRECTION[c.operator as string] ?? c.operator,
+        })),
+      },
+    };
+  };
+  if (doc.type === 'filter-builder') return swap(doc);
+  return {
+    ...doc,
+    children: (doc.children as Record<string, unknown>[]).map((c) =>
+      c.type === 'filter-builder' ? swap(c) : c,
+    ),
+  };
+}
+
+function measure(schema: unknown) {
+  const { container, unmount } = render(
+    <SchemaRenderer schema={toRenderableSchema(schema as never) as never} />,
+  );
+  const out = {
+    text: container.textContent ?? '',
+    // The row's cells are `div.col-span-4`, field / operator / value in order,
+    // so `nth-child(2)` is the operator cell.
+    operatorTriggers: Array.from(
+      container.querySelectorAll('div.col-span-4:nth-child(2) [role="combobox"]'),
+    ).map((e) => e.textContent),
+  };
+  unmount();
+  return out;
+}
+
+describe('objectui#7561 — the alias spellings the catalog authors render a label', () => {
+  it.each(AFFECTED)('%s: every operator cell names its operator', (id) => {
+    const m = measure(asAuthored(id));
+    // Anti-vacuity first: a selector that matched nothing would make every
+    // claim below trivially true.
+    expect(m.operatorTriggers.length).toBe(EXPECTED[id].length);
+    expect(m.operatorTriggers.length).toBeGreaterThan(0);
+    expect(m.operatorTriggers).toEqual(EXPECTED[id]);
+    // The symptom, stated as the user saw it: not one blank operator cell.
+    expect(m.operatorTriggers.filter((t) => t === '')).toEqual([]);
+  });
+
+  it.each(AFFECTED)('%s: as authored === operators corrected (the card\'s control)', (id) => {
+    const authored = measure(asAuthored(id));
+    const corrected = measure(operatorsCorrected(id));
+    expect(authored.text).toBe(corrected.text);
+    expect(authored.operatorTriggers).toEqual(corrected.operatorTriggers);
+  });
+
+  it('the control is a real swap — it changes the tree it is given', () => {
+    // Without this, a broken `operatorsCorrected` would compare each entry to
+    // ITSELF and the equality above would hold for any component at all.
+    for (const id of AFFECTED) {
+      const before = builderNode(asAuthored(id)).value as {
+        conditions: { operator: string }[];
+      };
+      const after = builderNode(operatorsCorrected(id)).value as {
+        conditions: { operator: string }[];
+      };
+      const beforeOps = before.conditions.map((c) => c.operator);
+      const afterOps = after.conditions.map((c) => c.operator);
+      expect(afterOps).not.toEqual(beforeOps);
+      // Every authored operator really is an alias-table spelling…
+      expect(beforeOps.every((o) => o in CORRECTION)).toBe(true);
+      // …and none of the swapped-in ids is, so the arms are genuinely two
+      // different dialects of the same operators.
+      expect(afterOps.some((o) => o in CORRECTION)).toBe(false);
+    }
+  });
+
+  it('⛔ the catalog files themselves still author the alias table', () => {
+    // The fix must NOT be achieved by editing catalog data (objectui#7561's
+    // fence). If someone ever "repairs" the fixtures instead, this reddens.
+    for (const id of AFFECTED) {
+      const group = builderNode(asAuthored(id)).value as {
+        conditions: { operator: string }[];
+      };
+      for (const c of group.conditions) expect(c.operator in CORRECTION).toBe(true);
+    }
+  });
+});

--- a/packages/components/src/__tests__/filter-builder-operator-alias-trigger-7561.test.tsx
+++ b/packages/components/src/__tests__/filter-builder-operator-alias-trigger-7561.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The operator trigger shows a label for every spelling of the operator the
+ * row actually holds (objectui#7561).
+ *
+ * ## The one site
+ *
+ * This component already resolves BOTH dialects everywhere the operator's
+ * MEANING matters — `filterValueArity` folds through the spec's
+ * `normalizeFilterOperator`, and so does `reconcileOperatorForField`. The one
+ * place it did not was the operator `Select`'s IDENTITY comparison:
+ * `value={condition.operator}` was matched LITERALLY against the mounted
+ * `SelectItem`s, whose ids are the dropdown's camelCase vocabulary. A row
+ * holding `greater_than` (the spec's canonical spelling) or `gt` (the spec's
+ * alias table, which three catalog entries author) matched no mounted item,
+ * and Radix drew a BLANK trigger over a row that went on filtering correctly.
+ *
+ * ⇒ The blank is NOT the vocabulary divergence. It is one site not using this
+ * component's own existing normalisation. The repair routes that one
+ * comparison through the same fold, and nothing else:
+ *
+ *   - ⛔ the mirror's accepted set is untouched;
+ *   - ⛔ no id a stored filter carries is rewritten;
+ *   - ⛔ no second spelling is admitted to the dropdown — the emitted
+ *     vocabulary is byte-identical.
+ *
+ * Which vocabulary should WIN is a separate ruling and is not decided here
+ * (objectui#7561's body; note direction 3 there collides with the
+ * `contains` / `icontains` ruling cited on objectui#7379 — `AST_OPERATOR_MAP`
+ * holds that one operator "must never be folded onto" its sibling).
+ *
+ * ## DIRECTION, predicted before running
+ *
+ * Every case in `the trigger names the operator the row holds` is RED on the
+ * base tree and green after — EXCEPT the three rows marked `overlap`.
+ * `equals` / `contains` / `in` are the three-member intersection of the two
+ * vocabularies, so they render a label TODAY; they are carried here as the
+ * OVER-REACH guard (a repair that rewrote or re-spelled the row would move
+ * them) and are explicitly NOT controls — a pin built only on them could not
+ * fail. The sharpest controls are `eq` / `lt` / `gt`, a THIRD spelling that
+ * neither vocabulary contains.
+ *
+ * The four `describe`s below the table are green in BOTH directions by
+ * construction: they are the boundaries the repair must not cross, so they
+ * fail only for a repair that over-reaches.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { normalizeFilterOperator } from '@objectstack/spec/ui';
+import { FilterBuilder, operatorsForFieldType } from '../custom/filter-builder';
+
+const FIELDS = [
+  { value: 'title', label: 'Title', type: 'text' },
+  { value: 'amount', label: 'Amount', type: 'number' },
+  { value: 'stage', label: 'Stage', type: 'select', options: [{ value: 'won', label: 'Won' }] },
+];
+
+function renderRow(condition: Record<string, unknown>) {
+  const onChange = vi.fn();
+  // Hoisted out of the JSX for the reason PR #4762's suite states: the
+  // builder re-seeds its internal state when the `value` prop's IDENTITY
+  // changes, so an inline literal would undo the interaction under test.
+  const value = { id: 'root', logic: 'and', conditions: [{ id: 'c1', ...condition }] };
+  const utils = render(
+    <FilterBuilder fields={FIELDS as never} value={value as never} onChange={onChange} />,
+  );
+  return { ...utils, onChange };
+}
+
+/** What the operator trigger DISPLAYS. Blank is the symptom this card is about. */
+function operatorTriggerText() {
+  return screen.getAllByRole('combobox')[1].textContent;
+}
+
+/**
+ * One row per spelling a stored filter can reach this builder carrying.
+ *
+ * `dialect` is load-bearing for reading a failure, not decoration:
+ *   - `canonical` — `@objectstack/spec`'s snake_case set, what the mirror
+ *     (`FilterOperatorSchema`) accepts and what `foldFilterGroupToSpecRules`
+ *     persists;
+ *   - `alias` — the spec's alias table (`eq` / `lt` / `gt` / `ne` / `nin`),
+ *     the THIRD spelling, authored today by `product-search.json`,
+ *     `with-conditions.json` and the builder nested in `search-interface.json`;
+ *   - `overlap` — the three ids both vocabularies share. NOT controls.
+ */
+const SPELLINGS: ReadonlyArray<{
+  operator: string;
+  field: string;
+  label: string;
+  dialect: 'canonical' | 'alias' | 'overlap';
+}> = [
+  // The three-member overlap — green before AND after. Over-reach guard only.
+  { operator: 'equals', field: 'title', label: 'Equals', dialect: 'overlap' },
+  { operator: 'contains', field: 'title', label: 'Contains', dialect: 'overlap' },
+  { operator: 'in', field: 'stage', label: 'In', dialect: 'overlap' },
+
+  // The spec's canonical snake_case set — the mirror accepts these and the
+  // trigger drew nothing for them.
+  { operator: 'not_equals', field: 'title', label: 'Does not equal', dialect: 'canonical' },
+  { operator: 'not_contains', field: 'title', label: 'Does not contain', dialect: 'canonical' },
+  { operator: 'starts_with', field: 'title', label: 'Starts with', dialect: 'canonical' },
+  { operator: 'ends_with', field: 'title', label: 'Ends with', dialect: 'canonical' },
+  { operator: 'is_empty', field: 'title', label: 'Is empty', dialect: 'canonical' },
+  { operator: 'is_not_empty', field: 'title', label: 'Is not empty', dialect: 'canonical' },
+  { operator: 'is_null', field: 'title', label: 'Is null', dialect: 'canonical' },
+  { operator: 'is_not_null', field: 'title', label: 'Is not null', dialect: 'canonical' },
+  { operator: 'greater_than', field: 'amount', label: 'Greater than', dialect: 'canonical' },
+  { operator: 'less_than', field: 'amount', label: 'Less than', dialect: 'canonical' },
+  {
+    operator: 'greater_than_or_equal',
+    field: 'amount',
+    label: 'Greater than or equal',
+    dialect: 'canonical',
+  },
+  {
+    operator: 'less_than_or_equal',
+    field: 'amount',
+    label: 'Less than or equal',
+    dialect: 'canonical',
+  },
+  { operator: 'not_in', field: 'stage', label: 'Not in', dialect: 'canonical' },
+
+  // The alias table — the sharpest controls, because neither vocabulary
+  // contains them and no fix that merely swapped one set for the other could
+  // make them render.
+  { operator: 'eq', field: 'title', label: 'Equals', dialect: 'alias' },
+  { operator: 'ne', field: 'title', label: 'Does not equal', dialect: 'alias' },
+  { operator: 'lt', field: 'amount', label: 'Less than', dialect: 'alias' },
+  { operator: 'gt', field: 'amount', label: 'Greater than', dialect: 'alias' },
+  { operator: 'lte', field: 'amount', label: 'Less than or equal', dialect: 'alias' },
+  { operator: 'gte', field: 'amount', label: 'Greater than or equal', dialect: 'alias' },
+  { operator: 'nin', field: 'stage', label: 'Not in', dialect: 'alias' },
+];
+
+describe('objectui#7561 — the trigger names the operator the row holds', () => {
+  it.each(SPELLINGS)(
+    '$dialect `$operator` on `$field` draws "$label"',
+    ({ operator, field, label }) => {
+      renderRow({ field, operator, value: '' });
+      expect(operatorTriggerText()).toBe(label);
+    },
+  );
+
+  it('the controls can actually fire — the table is not all overlap', () => {
+    // The instrument standard this suite is held to: a pin built only on the
+    // three-member overlap renders a label before ANY fix and therefore
+    // measures nothing. Both non-overlap dialects must be represented, and
+    // the alias family must be present in its own right.
+    const dialects = SPELLINGS.map((s) => s.dialect);
+    expect(dialects.filter((d) => d === 'canonical').length).toBeGreaterThanOrEqual(10);
+    expect(dialects.filter((d) => d === 'alias').length).toBeGreaterThanOrEqual(5);
+    // …and every non-overlap spelling really is outside the dropdown's own
+    // vocabulary, so none of them could have matched a mounted item literally.
+    const dropdownIds = new Set(operatorsForFieldType('text').concat(
+      operatorsForFieldType('number'), operatorsForFieldType('select'),
+    ).map((op) => op.value));
+    for (const s of SPELLINGS) {
+      if (s.dialect === 'overlap') expect(dropdownIds.has(s.operator)).toBe(true);
+      else expect(dropdownIds.has(s.operator)).toBe(false);
+    }
+  });
+});
+
+describe('objectui#7561 — ⛔ the repair does not rewrite what the row carries', () => {
+  it.each(['gt', 'greater_than'])('a row spelled `%s` is not migrated on render', (operator) => {
+    // The boundary the triage seat drew: fixing the BLANK must not rewrite the
+    // id any stored filter carries. Rendering is not an edit, so the component
+    // must not call back at all.
+    const { onChange } = renderRow({ field: 'amount', operator, value: '5' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('an operator NO spelling of the vocabulary folds onto still draws blank', async () => {
+    // The over-reach control, and it can fire: a repair that mounted the raw
+    // id as its own option (the shape objectui#4874 uses for the VALUE select)
+    // would print `totally_unknown` here instead of nothing.
+    expect(normalizeFilterOperator('totally_unknown')).toBe('totally_unknown');
+    renderRow({ field: 'title', operator: 'totally_unknown', value: '' });
+    expect(operatorTriggerText()).toBe('');
+    // …and the dropdown did not grow an entry for it.
+    fireEvent.keyDown(screen.getAllByRole('combobox')[1], { key: 'ArrowDown' });
+    const options = await waitFor(() => screen.getAllByRole('option'));
+    expect(options.map((o) => o.textContent)).not.toContain('totally_unknown');
+  });
+});
+
+describe('objectui#7561 — ⛔ the dropdown still emits its own vocabulary', () => {
+  it('the mounted options are exactly the bucket ids, in order', () => {
+    // ⛔ "Do not change the spellings the dropdown emits." The mounted set is
+    // the emitted set, so pinning the labels pins the emission.
+    //
+    // The order is `defaultOperators`' declaration order filtered by the
+    // bucket — NOT the bucket array's own order (`operatorsForFieldType`
+    // filters the declaration list). Recorded from the base tree.
+    renderRow({ field: 'amount', operator: 'gt', value: '5' });
+    fireEvent.keyDown(screen.getAllByRole('combobox')[1], { key: 'ArrowDown' });
+    return waitFor(() => {
+      const shown = screen.getAllByRole('option').map((o) => o.textContent);
+      expect(shown).toEqual([
+        'Equals',
+        'Does not equal',
+        'Is empty',
+        'Is not empty',
+        'Greater than',
+        'Less than',
+        'Greater than or equal',
+        'Less than or equal',
+        'Is null',
+        'Is not null',
+      ]);
+    });
+  });
+
+  it('picking an operator writes the DROPDOWN id, never the row\'s old dialect', async () => {
+    const { onChange } = renderRow({ field: 'amount', operator: 'gt', value: '5' });
+    fireEvent.keyDown(screen.getAllByRole('combobox')[1], { key: 'ArrowDown' });
+    const option = await waitFor(() => {
+      const found = screen.getAllByRole('option').find((o) => o.textContent === 'Less than');
+      expect(found, 'no "Less than" option in the dropdown').toBeTruthy();
+      return found!;
+    });
+    fireEvent.click(option);
+    const calls = onChange.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    // `lessThan`, the builder's camelCase id — NOT `lt`, and NOT `less_than`.
+    expect(calls[calls.length - 1][0].conditions[0].operator).toBe('lessThan');
+  });
+});

--- a/packages/components/src/custom/filter-builder.tsx
+++ b/packages/components/src/custom/filter-builder.tsx
@@ -393,6 +393,64 @@ export function reconcileOperatorForField(
 }
 
 /**
+ * The offered id the operator trigger COMPARES against — the last site in this
+ * component that read the operator literally instead of through the spec's
+ * fold (objectui#7561).
+ *
+ * Radix matches `SelectValue` against the `SelectItem`s actually MOUNTED, and
+ * the mounted ids are this builder's own camelCase vocabulary. A row can hold
+ * the operator under another spelling of the SAME operator and still be
+ * perfectly valid:
+ *
+ *   - the spec's canonical `greater_than`, which is what `FilterOperatorSchema`
+ *     accepts and what `foldFilterGroupToSpecRules` persists;
+ *   - the spec's alias table `gt` / `lt` / `eq`, which three schema-catalog
+ *     entries author today.
+ *
+ * Neither matched `greaterThan` literally, so the trigger drew BLANK over a row
+ * that filtered correctly — the user's own operator, invisible and unreachable.
+ * Everywhere the operator's MEANING matters this component already folds first
+ * ({@link filterValueArity}, {@link reconcileOperatorForField}); this was the
+ * one place it did not, and that omission — not the vocabulary divergence — is
+ * what produced the blank.
+ *
+ * So the comparison is made canonically and the MOUNTED spelling is handed to
+ * the trigger. Three things this deliberately does NOT do, each of them a
+ * separate ruling (objectui#7561):
+ *
+ *   1. it does not rewrite `condition.operator` — the row keeps the spelling it
+ *      arrived with, exactly as {@link reconcileOperatorForField} keeps it, and
+ *      nothing is written back on render;
+ *   2. it does not mount a new `SelectItem`, so the vocabulary the dropdown
+ *      EMITS is byte-identical — contrast the value select above, where
+ *      objectui#4874 ruling C mounts the outside-options value as its own
+ *      option. That answer is right there and wrong here: the value's domain is
+ *      the author's data, while the operator's domain is a declared vocabulary,
+ *      and mounting a foreign spelling would admit a second one;
+ *   3. it does not widen what any schema ACCEPTS.
+ *
+ * Safe to compare through because the fold is INJECTIVE over this builder's
+ * vocabulary — all 22 ids in `defaultOperators` normalize to 22 distinct
+ * canonical operators, pinned in `filter-builder-field-switch-operator.test.tsx`
+ * — so no two OFFERED operators can collapse onto one another and the match is
+ * unambiguous. An operator no offered id folds onto falls through to the row's
+ * own spelling and still draws blank: inventing a label for a word this
+ * vocabulary does not contain would be a claim, not a repair.
+ *
+ * @internal exported for tests
+ */
+export function mountedOperatorValue(
+  operator: string,
+  offeredOperators: ReadonlyArray<{ value: string }>,
+): string {
+  const canonical = normalizeFilterOperator(operator)
+  const mounted = offeredOperators.find(
+    (op) => normalizeFilterOperator(op.value) === canonical,
+  )
+  return mounted?.value ?? operator
+}
+
+/**
  * The value FAMILY a field type edits in — the same six branches
  * {@link getInputType} draws its `<input type>` from, named once so the type a
  * value is CONVERTED to and the input it is EDITED in cannot disagree
@@ -1591,7 +1649,13 @@ function FilterBuilder({
 
               <div className="col-span-4">
                 <Select
-                  value={condition.operator}
+                  // The row's operator, resolved to the id actually MOUNTED
+                  // below — see {@link mountedOperatorValue}. The row itself
+                  // keeps its own spelling; only this comparison is folded.
+                  value={mountedOperatorValue(
+                    condition.operator,
+                    getOperatorsForField(condition.field),
+                  )}
                   onValueChange={(value) => changeOperator(condition.id, value)}
                 >
                   <SelectTrigger className="h-9 text-sm">


### PR DESCRIPTION
Fixes #7561

Scope is the narrowing at objectui#7561 comment `5573457002`, not the card body: **make the operator Select's identity comparison go through `normalizeFilterOperator`** — the normalisation this component already imports and already uses elsewhere. The card body's three candidate directions are the *vocabulary* question, a separate ruling, and nothing here touches it.

## The defect, and why it is one site rather than a vocabulary fork

The operator `Select` matched its value LITERALLY against the mounted `SelectItem`s, whose ids are this builder's own camelCase vocabulary. A row can carry the same operator under another spelling of it and still be entirely valid:

- the spec's canonical `greater_than` — what `FilterOperatorSchema` accepts and what `foldFilterGroupToSpecRules` persists;
- the spec's alias table `gt` / `lt` / `eq` — which three schema-catalog entries author today.

Neither matched `greaterThan`, so Radix drew a **blank** operator cell over a row that went on filtering correctly: the user's own operator, invisible and unreachable.

Everywhere the operator's MEANING matters this component already folds first (`filterValueArity`, `reconcileOperatorForField`). This identity comparison was the one place that did not — and that omission, not the two vocabularies diverging, is what produced the blank. New `mountedOperatorValue` makes the comparison canonically and hands the trigger the MOUNTED spelling.

### The three boundaries, each a ruling — all held, and each one pinned

| boundary | how it is held | pin |
|---|---|---|
| ⛔ do not change the mirror | no file under `packages/types` is touched | the card's own reproduce command still green |
| ⛔ do not change the spellings the dropdown emits | no `SelectItem` added; `onChange` still hands back `lessThan`, never `lt` | `the mounted options are exactly the bucket ids, in order` + `picking an operator writes the DROPDOWN id` |
| ⛔ do not make the mirror accept both dialects | nothing about any schema's accept set changes | — |
| ⛔ do not rewrite a stored id | rendering is not an edit; the component does not call back | `a row spelled gt is not migrated on render` |
| ⛔ do not change catalog data | zero `examples/schema-catalog/src/**` edits | `⛔ the catalog files themselves still author the alias table` |

An operator that **no** offered id folds onto still draws blank, deliberately: inventing a label for a word this vocabulary does not contain would be a claim rather than a repair. That is the over-reach control, and it can fire — a repair that mounted the raw id as its own option (the shape objectui#4874 ruling C uses for the VALUE select) would print the raw id instead of nothing.

## The acceptance is the card's own measurement, re-measured not quoted

Same tree, swap only the operator spelling — through the real `SchemaRenderer`:

```
as authored           … Clear all Category Remove condition Price Remove condition Stock Quantity Remove condition …
operators corrected   … Clear all Category Equals Remove condition Price Less than Remove condition Stock Quantity Greater than …
```

All three affected entries (`product-search`, `with-conditions`, and the `filter-builder` nested in `search-interface`) now render the label as authored, and `as authored` is byte-identical to `operators corrected` — which is the claim, since the fold makes the two arms one operator.

### Reverse verification — the repair removed, both pins measured, then restored

Ablated on disk from the committed state (`git checkout BASE -- path`; mutation proved by blob hash `d272295…` vs HEAD `6ec603f…` and by marker counts inverting 3 → 0), then restored with `git checkout HEAD -- path` and the restore proved by an **empty** `git diff HEAD` plus a blob-hash match, not by an exit code:

| file | red under ablation | total |
|---|---|---|
| `filter-builder-operator-alias-trigger-7561.test.tsx` (components) | **20** | 29 |
| `filter-builder-operator-alias-trigger-7561.test.tsx` (catalog) | **6** | 8 |
| `filter-builder-mirror-6939.test.tsx` (catalog) | **3** | 24 |

⭐ No rebuild was needed and there is no stale-`dist` false-green risk: the root `vitest.config.mts` aliases `@object-ui/components` to `./packages/components/src`, so both pins resolve to source.

⭐ **Every control can fire.** `equals` / `contains` / `in` are the three-member overlap between the two vocabularies — they render a label *today*, before any repair — so they are carried as the OVER-REACH guard and are explicitly NOT controls. The 20 rows that move are everything else, and `eq` / `lt` / `gt` are the sharpest because they are a THIRD spelling neither vocabulary contains. The 9 both-direction guards stayed green under ablation, which is what says the 20 reds are the defect and not collateral.

## Blast radius — a rendered string moves (objectui#9273)

Not a package-scoped run. `examples/schema-catalog/` in full: **31 files / 2153 tests** green. The recorded baseline in `filter-builder-mirror-6939.test.tsx` moved for the three entries with condition rows, in `text` and `sha256` **only** — `elements` and the tag census did not move for any entry, which is the reading that says this was a text change and not a structural one. That file's own header anticipated exactly this move ("captured here so a later fix to it has a *before* to move away from"); the note now records what moved and why objectui#6939's own claim is unaffected.

One assertion in that file needed narrowing rather than re-baselining: `"correcting" the field key to name LOSES the field` asserted that **every** combobox goes blank, while what it claims is that every **field** trigger does. Until now the two were interchangeable there only because the operator trigger was blank as well — for this unrelated defect. It now reads a new `fieldTriggers` measurement, with an anti-vacuity length check so a selector that matched nothing cannot pass it silently.

Grepped repo-wide for count-shaped and prose figures: the three recorded SHA-256 values and the three rendered strings appear in that one file and nowhere else.

Cross-package sweep by grep for every test that renders a `FilterBuilder` (app-shell view-filter-fold family, `FilterModeWidget`, fields' `FilterConditionField`, plugin-list's operator parity trio, plugin-view's builder parity, data-objectstack's pin) plus the whole of `packages/components`: **282 files / 2905 tests** green. That run includes the card's own mechanical reproduction, `packages/types/src/__tests__/filter-builder-mirror-6939.test.ts` — both `the residual refusal is the operator alias and NOTHING else` assertions still pass, which is the positive evidence that the mirror is untouched.

`type-check` green for `@object-ui/components` and `@object-ui/example-schema-catalog`. ⚠️ Both reported `TS2307 Cannot find module` on first run, in files this branch never touched — the unbuilt-`dist` signature, instrumented rather than reported as a verdict; green after building each package's dependency closure.

## Changeset

`@object-ui/components: minor`. `major` is unavailable by convention — all workspace packages sit in one `fixed` group, so any `major` would drag the whole group off objectstack's cadence — and `changeset:check` (which is where `check-changeset-no-major.mjs` actually runs) is green, as is `check-changeset-presence.mjs`.

⚠️ **This changes rendered output**: a previously blank operator cell now carries its label, and that is the only thing a consumer can observe. A consumer holding a DOM or text snapshot of a filter row whose operator was stored in the canonical or alias dialect will see that snapshot move. It carries **no** `**BREAKING**` marker because nothing that validated stops validating, no stored id is rewritten, and the emitted vocabulary is byte-identical — the changeset states each of those explicitly.

`check:changeset-claims` is report-only and named two pending changesets that mention the file I edited; both re-read and both still true — `8415`'s count of sixteen `condition.id` read sites is unchanged (16 before, 16 after) and `6939`'s claims are about `f.value` lookups and `isValidGroup`, none of whose lines this diff touches.

## MUST-CHECK answered: objectstack #15442 / #15449 do NOT cover this surface

Triage flagged this as unverified and asked for a check rather than a conclusion. Both cards are **closed** (2026-09-10, delivered by objectstack PR #17257) and both are about the **container orthography** of a `filter` DOOR — the MongoDB-style `FilterConditionSchema` and four `z.unknown()` doors converging on `z.array(ViewFilterRuleSchema)` under maintainer ruling objectui#6206-B, "one filter orthography platform-wide."

Mechanical reading over both full threads (body plus all 20 comments): `filter-builder` 0 hits, `normalizeFilterOperator` 0, `FILTER_BUILDER_OPERATORS` 0, `VIEW_FILTER_OPERATORS` 0, `greaterThan` 0, `notEquals` 0, `camelCase` 0, "operator vocabulary" 0, "dropdown" 0, objectui#7561 0. The single `6939` substring is inside a hex object-id list, not a card reference.

⇒ They rule the SHAPE of the predicate container, never the SPELLING of the operator token inside it. One nuance worth recording for whoever rules the vocabulary: the orthography they converge on, `ViewFilterRuleSchema`, carries an `operator` whose vocabulary is the spec's canonical snake_case set — so that work *increases* the number of surfaces handing this builder canonical spellings, which makes this card's blank more reachable, not less. It still does not answer which spelling the dropdown should carry.

## Acceptance notes

- **Filed as objectui#9302** — a genuine sibling site, measured, out of this card's narrowed scope and not mechanical enough for the in-place exemption: `needsValueInput` reads the operator RAW against the exported `VALUELESS_FILTER_BUILDER_OPERATORS` set, so a row carrying canonical `is_null` draws a stray value input that its dropdown twin `isNull` does not (measured: 1 input vs 0, same label). Pre-existing — this repair does not cause it, but it makes the contradiction legible, since the row now reads `Is null` beside a box to type a value into. Left alone on purpose: that set is *exported* and `app-shell` already compensates one layer up, so deciding which layer owns the fold is not an execution-seat call.
- noted, not filed: objectui#7993 records that the spec treats the camelCase spellings as the **deprecated alias** form and `less_than` as canonical. That is a live input to the vocabulary ruling this card does not make; successor is whoever takes that ruling.
- ⛔ Untouched on purpose: the mirror, the dropdown's emitted ids, every catalog fixture, and `content/docs/components/complex/filter-builder.mdx` — the published doc describes operators in prose English ("greater than") and declares no spelling, so this repair falsifies nothing in it.
- The vocabulary divergence itself, and the hard constraint recorded for it — direction 3 collides with the ruling cited on objectui#7379, where `AST_OPERATOR_MAP` holds that one operator "must never be folded onto" its sibling, "That is a semantic boundary, not two spellings of one thing" — remain open and are **not** decided here. ⚠️ Triage declared that question out of this card's scope but no card yet carries it; flagged for the PM in the seat report.
- Not governed: `check-governed-queue-guard.mjs --test` reports NOT GOVERNED for all five changed paths, so the ordinary route applies. Ready/queue flip and CI convergence left to the PM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_