### PR TITLE
docs(changeset): identify the release PR by its head branch, not by a title

### DIFF
--- a/.changeset/9134-release-pr-head-branch-not-title.md
+++ b/.changeset/9134-release-pr-head-branch-not-title.md
@@ -1,0 +1,9 @@
+---
+---
+
+Correct `.changeset/README.md` and `CONTRIBUTING.md` to identify the Changesets
+release PR by its head branch, `changeset-release/main`, instead of by a
+`"Version Packages"` title this repository's bot has never produced
+(objectui#9134). The head branch is the action's own convention; the title is the
+`title:` input passed in `.github/workflows/changeset-release.yml` and is
+repository-local. Documentation only; no package is released by this change.

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -86,8 +86,23 @@ Renaming the file before you commit is what actually prevents it.
 ## Automated Release Process
 
 1. **Merge PR with changeset** → Triggers automation
-2. **Bot creates "Version Packages" PR** → Updates versions and changelogs
-3. **Merge Version PR** → Automatically publishes to npm
+2. **Bot opens or refreshes the release PR** → Updates versions and changelogs
+3. **Merge the release PR** → Automatically publishes to npm
+
+**Find that release PR by its head branch, never by its title.** The
+[Changesets action](https://github.com/changesets/action) derives the head branch
+from the base branch — `changeset-release/main` here — so it is a convention that
+holds in every repository running the action:
+
+```text
+is:pr is:open head:changeset-release
+```
+
+The title is not a convention. It is the `title:` input this repository passes to
+the action in
+[`.github/workflows/changeset-release.yml`](../.github/workflows/changeset-release.yml),
+so it is repository-local configuration and differs between repositories. Read
+that input when you need the current title instead of memorising one.
 
 ## Learn More
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -596,8 +596,22 @@ Write clear, user-facing descriptions:
 The release process is automated:
 
 1. **Create PR with changes** → Include a changeset file
-2. **PR is merged** → Changeset bot creates/updates a "Version Packages" PR
-3. **Version PR is merged** → Packages are automatically published to npm
+2. **PR is merged** → The Changesets bot opens or refreshes the **release PR**
+3. **The release PR is merged** → Packages are automatically published to npm
+
+**The release PR is identified by its head branch, `changeset-release/main`, never
+by its title.** The [Changesets action](https://github.com/changesets/action)
+derives that branch from the base branch, so it is a stable convention that holds
+across repositories. The title is not: it is the `title:` input this repository
+passes to the action in
+[`.github/workflows/changeset-release.yml`](.github/workflows/changeset-release.yml),
+it is repository-local configuration, and it differs from repository to
+repository. To locate the current release PR — its number and its title included
+— search the head branch:
+
+```text
+is:pr is:open head:changeset-release
+```
 
 You don't need to manually:
 - Update version numbers


### PR DESCRIPTION
Fixes #9134

## The narrowing: the script was never wrong, the docs were

The card says the bad query 「guards every changeset-window card」. Re-verified independently on today's tip (`f080538813`) — **false**. `scripts/pm/check-half-states.mjs` already uses the identifier the card recommends:

```
:1916   if ((pr.head?.ref ?? '').startsWith('changeset-release/')) return null;
:6202   return !String(pr.head?.ref ?? '').startsWith('changeset-release/');
```

`Version Packages` occurs there 5 times: four are comment prose (`:1908`, `:2420`, `:6160`, `:11039`) and one is a **test-case name** (`:11043`) whose own fixture is `head: { ref: 'changeset-release/main' }`. No committed artefact queries that title. ⛔ This PR does not touch that script.

## What was actually wrong: the supply side

This repository's own documentation taught the phantom string — very likely where the hand-typed search came from:

| file | line | text |
|---|--:|---|
| `.changeset/README.md` | 89 | `2. **Bot creates "Version Packages" PR** → Updates versions and changelogs` |
| `CONTRIBUTING.md` | 599 | `2. **PR is merged** → Changeset bot creates/updates a "Version Packages" PR` |

This repository's bot has never produced that title.

## The identifier this PR teaches instead, and why it is checkable

The head branch `changeset-release/main` is the [Changesets action](https://github.com/changesets/action)'s own convention, derived from the base branch. The **title is not a convention** — it is an action input, set right here in the repository:

```
.github/workflows/changeset-release.yml:1254          title: 'chore: release packages'
.github/workflows/changeset-release.yml:1255          commit: 'chore: release packages'
```

So rather than restating today's title or PR number in prose — which nothing would keep true — both passages now name the head branch as the identifier and **point at that workflow input as the thing that re-derives the title**. The search query given in both docs re-derives the current release PR, number and title included.

## Lit control, measured at commit time

`is:pr is:open head:changeset-release` in this repository returns **exactly 1**: PR #5400, open since 2026-08-20, head `changeset-release/main`, base `main`, opened by `github-actions[bot]`, actual title `chore: release packages`. The query the docs used to imply returns 0, in every state, forever.

## Before/after reading, with its lit control in the same run

Same instrument, same run, both files — so "0 hits" is a reading rather than a broken grep.

| pattern | `.changeset/README.md` before → after | `CONTRIBUTING.md` before → after |
|---|--:|--:|
| `Version Packages` (removed) | 1 → **0** | 1 → **0** |
| `## Automated Release Process` / `### Release Process` (**lit control**, not removed) | 1 → **1** | 1 → **1** |
| `changeset-release` (the new identifier) | 0 → **3** | 0 → **3** |

The control is lit in the *after* column, so the zero above it is a measurement.

### Where `Version Packages` legitimately remains, and why it is left alone

Stated explicitly rather than silently left: the string survives in `scripts/pm/check-half-states.mjs` — four comment-prose mentions plus the test-case name at `:11043`. Those are correct as they stand (the predicate beneath them reads the head branch), that file is out of this card's scope, and its single writer seat is on the `objectstack` side. ⛔ Not chased out of files this card did not ask for.

The sibling half — the dispatch charter having no criterion at all for 「is a release staged?」 — was filed separately as `objectstack-ai/objectstack#17830` and is already closed by its own merged PR. Nothing owed here.

## Gates run locally, exit codes captured before any pipe

A docs-touching PR's shards are skipped by design, so these repo-wide doc pins would otherwise first execute in the merge-group build.

| gate | exit |
|---|--:|
| `node scripts/check-doc-links.mjs` — *Links are valid across 17 scan roots.* | **0** |
| `node scripts/check-doc-fence-languages.mjs` — 227 documents, no unknown fence spelling | **0** |
| `node scripts/check-changeset-presence.mjs` — 3 files changed, 0 published source, 1 changeset added | **0** |
| `node scripts/check-changeset-fixed.mjs` | **0** |
| `node scripts/check-changeset-no-major.mjs` | **0** |
| `node scripts/check-changeset-claims.mjs` — no pending changeset names a touched file | **0** |
| `node scripts/check-control-bytes.mjs` — 7510 tracked text files | **0** |
| `node scripts/check-governed-queue-guard.mjs --test` (3 paths) — *NOT GOVERNED* | **0** |

Plus a control-byte self-scan over the three edited paths: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` exits 1 (no match).

No package source is touched, so no build or package test is owed; the repo-wide suite is declared to CI.

## Scope

Exactly three paths: `CONTRIBUTING.md`, `.changeset/README.md`, and one changeset with **empty frontmatter** (the first-class "no release" declaration — `git status` showed `A`, not `M`). ⛔ No accepted set widened or narrowed, ⛔ no gate added, ⛔ no change to how releases run, ⛔ no release PR touched. Documentation recovery onto an already-declared contract.

⛔ Staying **draft** — not flipped ready, not enqueued, no auto-merge armed.

Session reference, as a code span so it survives a body edit: `https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_