### PR TITLE
fix(ci): give the repository root a tree spelling in the markdown input ledger

### DIFF
--- a/.changeset/9142-root-markdown-shard-trigger.md
+++ b/.changeset/9142-root-markdown-shard-trigger.md
@@ -1,0 +1,11 @@
+---
+---
+
+Give the repository root a tree spelling in the markdown test-input ledger, so a root-level
+markdown document a pull request ADDS is on the `Test (shard N/4)` trigger (objectui#9142).
+A document inside a declared `…/**` tree inherits that declaration the moment it lands; the
+root had no tree spelling, so each root document was declared per file and the next one was
+on no entry at all. `check-doc-links.test.ts`, whose stated job is to fail on a root document
+with no `SCAN_ROOTS` row, was therefore the test that did not run at the one moment it was
+written to speak. `./*` is the root's spelling: depth 1, markdown only — ⛔ not a widening to
+"every markdown file". Tooling and tests only; no package is released by this change.

--- a/scripts/__tests__/markdown-test-inputs.test.ts
+++ b/scripts/__tests__/markdown-test-inputs.test.ts
@@ -55,6 +55,7 @@ import {
   declaredEntries,
   deriveCandidates,
   markdownTestInputsAmong,
+  matchesEntry,
   missingDocuments,
 } from '../markdown-test-inputs.mjs';
 
@@ -360,5 +361,126 @@ describe('objectui#9096 — `scripts` is a scan root, and the class is now total
       uncovered,
       'the class is declared TOTAL over markdown; a document outside it means the ledger lost a tree',
     ).toEqual([]);
+  });
+});
+
+/* ── objectui#9142: the repository root is a tree too ─────────────────────── */
+
+describe('objectui#9142 — a root-level markdown file a pull request ADDS', () => {
+  /**
+   * The document this card is about: a root-level markdown file that exists in
+   * no ledger entry, because nobody has written it down yet. `SECURITY.md` is
+   * the card's own example and is deliberately NOT in this tree — a planted
+   * document that already existed would prove nothing about the next one.
+   */
+  const PLANTED_ROOT_DOCUMENT = 'SECURITY.md';
+
+  it('is not in the tree — the planted document has to be absent to be a control', () => {
+    // If someone adds `SECURITY.md` for real, this fails and the next reader
+    // picks a different name rather than silently testing a declared document.
+    const tracked = execFileSync('git', ['ls-files', '--', '*.md'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    })
+      .split('\n')
+      .filter((line) => line.trim() !== '');
+    expect(tracked).not.toContain(PLANTED_ROOT_DOCUMENT);
+  });
+
+  it('FIRES: the planted root document runs the shards, and the step says so', () => {
+    // The lit control, through the REAL step out of `ci.yml` — not through the
+    // class derivation, which cannot tell a correct class from a step that
+    // never asks it. Before the `./*` spelling this read `should_run=false`
+    // with no matched line at all, which is the whole defect: the pull request
+    // page went green having run nothing, and `check-doc-links.test.ts` — the
+    // test whose stated job is to fail on a root document with no `SCAN_ROOTS`
+    // row — is the one that did not run.
+    const files = { [PLANTED_ROOT_DOCUMENT]: '# Security\n\nA root document nobody declared.\n' };
+    const outcome = runStep(TEST_STEP, files);
+    expect(outcome.shouldRun).toBe('true');
+    expect(outcome.log).toContain(PLANTED_ROOT_DOCUMENT);
+    // …and the unwidened copy of the same step, untouched by this change, is
+    // the "before" reading taken from the file rather than from history.
+    expect(runStep(TYPE_CHECK_STEP, files).shouldRun).toBe('false');
+  });
+
+  it('names the reader that is waiting on it — the invariant that replaces the list', () => {
+    const hits = markdownTestInputsAmong([PLANTED_ROOT_DOCUMENT]);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].entries).toContain('./*');
+    expect(hits[0].readers).toContain('scripts/__tests__/check-doc-links.test.ts');
+  });
+
+  it('the per-file spelling CANNOT express it — which is why a new spelling exists', () => {
+    // The pre-fix vocabulary, asserted directly: an exact entry matches one
+    // path and a `…/**` entry needs a directory above the document. A root
+    // document has neither, so no combination of the two covers the NEXT one.
+    for (const rootDocument of ['AGENTS.md', 'README.md', 'ROADMAP.md']) {
+      expect(matchesEntry(PLANTED_ROOT_DOCUMENT, rootDocument)).toBe(false);
+    }
+    expect(matchesEntry(PLANTED_ROOT_DOCUMENT, './*')).toBe(true);
+  });
+
+  it('⛔ does NOT widen to every markdown file — `./*` is depth 1, markdown only', () => {
+    // The fence objectui#9096 set and objectui#9142's triage carried: the
+    // deliverable is the documents these tests actually read, ⛔ not a glob.
+    // `./*` reaches the root and stops there.
+    for (const deeper of ['docs/NOTES.md', 'packages/plugin-grid/NOTES.md', 'a/b/SECURITY.md']) {
+      expect(matchesEntry(deeper, './*')).toBe(false);
+    }
+    for (const notMarkdown of ['SECURITY.txt', 'pnpm-lock.yaml', 'turbo.json']) {
+      expect(matchesEntry(notMarkdown, './*')).toBe(false);
+    }
+    // And through the real step: a root file that is not markdown never reaches
+    // the markdown stage at all — it is not on the exclusion list, so the first
+    // diff already runs everything. Both copies agree, which is what makes this
+    // a statement about the exclusions rather than about the markdown class.
+    const notMarkdown = { 'SECURITY.txt': 'not markdown\n' };
+    expect(runStep(TEST_STEP, notMarkdown).shouldRun).toBe('true');
+    expect(runStep(TYPE_CHECK_STEP, notMarkdown).shouldRun).toBe('true');
+  });
+
+  it('the declared population is unchanged — every tracked root document is still an input', () => {
+    const rootDocuments = execFileSync('git', ['ls-files', '--', '*.md', '*.mdx'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    })
+      .split('\n')
+      .filter((line) => line.trim() !== '' && !line.includes('/'))
+      .sort();
+
+    // Floor under the floor: an empty enumeration would satisfy the next
+    // assertion while proving nothing (objectui#8468).
+    expect(rootDocuments.length).toBeGreaterThanOrEqual(8);
+    expect(rootDocuments.filter((file) => markdownTestInputsAmong([file]).length === 0)).toEqual([]);
+  });
+
+  it('`missingDocuments()` does not red on a class entry — the trap triage named', () => {
+    // The ledger reds on a declared path that is not in the tree. `./*` names a
+    // rule, not a path, so it must be skipped the way `…/**` already is —
+    // otherwise every run of the audit reports a missing document that cannot
+    // exist.
+    expect(declaredEntries()).toContain('./*');
+    expect(missingDocuments()).toEqual([]);
+    expect(missingDocuments()).not.toContain('./*');
+  });
+
+  it('reports EVERY entry that covers a document, so the class costs no reader', () => {
+    // Entries overlap, and the root class makes that structural: `AGENTS.md` is
+    // covered by `./*` and by its own exact entry. Reporting the first match
+    // only would attribute it to whichever sorted first and drop the rest —
+    // `should_run` would be unaffected, the readers named in the log would not.
+    const hits = markdownTestInputsAmong(['AGENTS.md']);
+    expect(hits).toHaveLength(1);
+    expect(hits[0].entries).toEqual(expect.arrayContaining(['./*', 'AGENTS.md']));
+    expect(hits[0].readers.length).toBeGreaterThanOrEqual(4);
+    // The same overlap outside the root, which predates this card: a package
+    // README declared exactly AND inside `packages/**`.
+    const nested = markdownTestInputsAmong(['packages/app-shell/README.md']);
+    expect(nested[0].entries).toEqual(expect.arrayContaining(['packages/**', 'packages/app-shell/README.md']));
+    expect(nested[0].readers).toContain(
+      'packages/app-shell/src/views/metadata-admin/previews/readme-flow-canvas-draft.test.ts',
+    );
   });
 });

--- a/scripts/markdown-test-inputs.mjs
+++ b/scripts/markdown-test-inputs.mjs
@@ -129,6 +129,18 @@
  * declared document nothing reads is one extra run, and the cost of a missed
  * one is the defect this file exists to close.
  *
+ * ### The repository root is a tree too -- `./*` (objectui#9142)
+ *
+ * The entries above buy their whole value from INHERITANCE: a page added under
+ * `content/docs/` is on the trigger the moment it lands, because the tree was
+ * declared rather than its members. The repository root had no tree spelling,
+ * so its documents were declared one by one -- and a root document nobody had
+ * declared yet was not on the trigger at all. Adding `SECURITY.md` skipped
+ * `Test (shard N/4)`, and `check-doc-links.test.ts`, whose stated job is to
+ * fail on a root document with no `SCAN_ROOTS` row, was the test that did not
+ * run. `./*` is the root's tree spelling: depth 1, markdown only. See
+ * `matchesEntry()` for why depth 1 and not `**`.
+ *
  * ## ⛔ What this does NOT answer -- read this before citing it as coverage
  *
  *   1. **Test surfaces outside `SCAN_ROOTS`.** ⭐ RULED, objectui#9096 -- this
@@ -560,10 +572,18 @@ export const ADJUDICATED = new Map([
       walker: 'markdown-tree',
     },
   ],
+  // `./*` rather than the eight root documents it used to list, and the
+  // distinction is the whole of objectui#9142. This test does not read a list
+  // of root documents -- it runs `git ls-files -- '*.md'`, keeps the paths with
+  // no separator in them, and fails when one of them has no `SCAN_ROOTS` row.
+  // Its own words: "scans EVERY tracked root-level markdown file -- the
+  // invariant that replaces the list". Its input is therefore the root CLASS,
+  // and a list of the eight members was a declaration that went stale on the
+  // ninth -- at precisely the moment the test was written to speak.
   [
     'scripts/__tests__/check-doc-links.test.ts',
     {
-      reads: ['AGENTS.md', 'CHANGELOG.md', 'CLAUDE.md', 'CONTRIBUTING.md', 'LICENSE-THIRD-PARTY.md', 'QUICK_REFERENCE.md', 'README.md', 'ROADMAP.md', 'apps/**', 'content/docs/**', 'docs/ARCHITECTURE.md', 'docs/CONSOLE-STREAMLINING-SUMMARY.md', 'docs/adr/**', 'docs/audits/**', 'examples/**', 'packages/**'],
+      reads: ['./*', 'apps/**', 'content/docs/**', 'docs/ARCHITECTURE.md', 'docs/CONSOLE-STREAMLINING-SUMMARY.md', 'docs/adr/**', 'docs/audits/**', 'examples/**', 'packages/**'],
     },
   ],
   [
@@ -737,10 +757,14 @@ export const ADJUDICATED = new Map([
       walker: 'not-markdown: workspace `package.json` manifests and turbo input globs',
     },
   ],
+  // `./*` for the same reason as `check-doc-links.test.ts` above, reached by a
+  // different route: this one takes its population from `trackedFiles()` in
+  // `dollar-dialect-alias-census.mjs`, which is `git ls-files -z` -- EVERY
+  // tracked path, root documents included, with no list anywhere to update.
   [
     'scripts/__tests__/dollar-dialect-alias-census.test.ts',
     {
-      reads: ['.changeset/**', '.claude/skills/**', '.github/prompts/component.prompt.md', '.github/prompts/engine.prompt.md', '.github/prompts/ui-library.prompt.md', 'AGENTS.md', 'CHANGELOG.md', 'CLAUDE.md', 'CONTRIBUTING.md', 'LICENSE-THIRD-PARTY.md', 'QUICK_REFERENCE.md', 'README.md', 'ROADMAP.md', 'apps/**', 'content/docs/**', 'docs/ARCHITECTURE.md', 'docs/CONSOLE-STREAMLINING-SUMMARY.md', 'docs/adr/**', 'docs/audits/**', 'examples/**', 'packages/**', 'patches/README.md', 'skills/objectui/**'],
+      reads: ['./*', '.changeset/**', '.claude/skills/**', '.github/prompts/component.prompt.md', '.github/prompts/engine.prompt.md', '.github/prompts/ui-library.prompt.md', 'apps/**', 'content/docs/**', 'docs/ARCHITECTURE.md', 'docs/CONSOLE-STREAMLINING-SUMMARY.md', 'docs/adr/**', 'docs/audits/**', 'examples/**', 'packages/**', 'patches/README.md', 'skills/objectui/**'],
     },
   ],
   [
@@ -781,7 +805,7 @@ export const ADJUDICATED = new Map([
     'scripts/__tests__/markdown-test-inputs.test.ts',
     {
       reads: [],
-      notRead: ['AGENTS.md', 'README.md', 'ROADMAP.md', 'packages/plugin-dashboard/README.md'],
+      notRead: ['AGENTS.md', 'README.md', 'ROADMAP.md', 'packages/app-shell/README.md', 'packages/plugin-dashboard/README.md'],
     },
   ],
   [
@@ -823,16 +847,67 @@ export const ADJUDICATED = new Map([
 export const isMarkdown = (rel) => /\.mdx?$/.test(rel);
 
 /**
+ * Is this entry a CLASS of documents rather than one document?
+ *
+ * Two spellings, and what separates them is DEPTH:
+ *
+ *   `dir/**`   every markdown document under `dir`, at any depth.
+ *   `dir/*`    every markdown document directly IN `dir`, and none deeper.
+ *
+ * Neither names a file, so neither is something `missingDocuments()` can look
+ * for on disk -- that is the one thing this predicate is for.
+ */
+export const isClassEntry = (entry) => entry.endsWith('/**') || entry.endsWith('/*');
+
+/**
  * Does one repo-relative path match one ledger entry?
  *
  * A `…/**` entry matches every markdown document under that directory, at any
- * depth. Anything else is one exact path -- deliberately not a glob, so a new
- * document beside a declared one does not inherit its declaration by accident.
+ * depth. A `…/*` entry matches only the documents directly in it. Anything else
+ * is one exact path -- deliberately not a glob, so a new document beside a
+ * declared one does not inherit its declaration by accident.
+ *
+ * ## The repository root is spelled `./*` (objectui#9142)
+ *
+ * A document inside a declared tree inherits that tree's declaration the moment
+ * it lands -- that is what a `…/**` entry buys, and it is why a new page under
+ * `content/docs/` is on the trigger before anyone has thought about it. The
+ * repository ROOT had no tree spelling at all, so every root document was
+ * declared per file, and a root document nobody had declared yet was not on the
+ * trigger: a pull request whose only change was "add `SECURITY.md`" skipped
+ * `Test (shard N/4)`.
+ *
+ * ⇒ the test that does not run is exactly the one written to notice. Measured
+ * on `f080538813`, before this spelling existed:
+ *
+ *     LIT CONTROL  planted undeclared root doc  SECURITY.md
+ *        Test (shard N/4) step : should_run=false   matched: (none)
+ *
+ * and `scripts/__tests__/check-doc-links.test.ts` describes itself as scanning
+ * "EVERY tracked root-level markdown file -- the invariant that replaces the
+ * list", failing when a root document has no `SCAN_ROOTS` row. An invariant
+ * that replaces a list is silent at the one moment the list would have been
+ * updated. The merge queue catches it and dequeues the pull request, which is
+ * the objectui#8857 shape and the objectui#8857 cost.
+ *
+ * ⛔ `./*` is NOT a step toward "every markdown file". The depth-1 spelling is
+ * the narrowest thing that gives the root what every declared tree already has;
+ * it matches `SECURITY.md` and it does not match `docs/NOTES.md`. The resolved
+ * input list is still a resolved input list -- the fence objectui#9096 carried
+ * ("a resolved input list, ⛔ not a glob") governs this file and is intact.
  */
 export function matchesEntry(rel, entry) {
   if (entry.endsWith('/**')) {
     const prefix = `${entry.slice(0, -3)}/`;
     return rel.startsWith(prefix) && isMarkdown(rel);
+  }
+  if (entry.endsWith('/*')) {
+    // `./*` is the repository root, whose prefix is the empty string; every
+    // other `dir/*` carries its own trailing separator.
+    const dir = entry.slice(0, -2);
+    const prefix = dir === '.' ? '' : `${dir}/`;
+    if (!isMarkdown(rel) || !rel.startsWith(prefix)) return false;
+    return !rel.slice(prefix.length).includes('/');
   }
   return rel === entry;
 }
@@ -860,9 +935,24 @@ export function readersByEntry() {
  * The subset of `paths` that this repository has recorded as a test's input.
  *
  * Paths are taken as repo-relative, which is what `git diff --name-only` emits.
+ *
+ * ## Every matching entry, not the first one (objectui#9142)
+ *
+ * Entries OVERLAP, and they always have: `packages/app-shell/README.md` is one
+ * test's declared read and is also inside `packages/**`, which is another's.
+ * Reporting only the first match made the readers list an artefact of sort
+ * order -- that README reported eight readers and lost the ninth, the one whose
+ * entry names the file exactly. The root class makes the same overlap
+ * structural rather than incidental, so the union is taken here: `entries` is
+ * every rule that covers the document and `readers` is every test behind them.
+ *
+ * `should_run` does not depend on this -- one match is enough to run everything
+ * and the caller in `ci.yml` reads only the path. The readers do: they are what
+ * the log line names when it says which test is waiting on this document.
  */
 export function markdownTestInputsAmong(paths) {
   const entries = declaredEntries();
+  const readers = readersByEntry();
   const out = [];
   for (const raw of paths) {
     // `git diff --name-only` wraps a path in double quotes when it holds a byte
@@ -871,8 +961,11 @@ export function markdownTestInputsAmong(paths) {
     const unquoted = raw.trim().replace(/^"(.*)"$/, '$1');
     const rel = unquoted.replace(/^\.\//, '');
     if (!rel || !isMarkdown(rel)) continue;
-    const hit = entries.find((entry) => matchesEntry(rel, entry));
-    if (hit) out.push({ path: rel, entry: hit, readers: readersByEntry().get(hit) ?? [] });
+    const hits = entries.filter((entry) => matchesEntry(rel, entry));
+    if (!hits.length) continue;
+    const tests = new Set();
+    for (const entry of hits) for (const test of readers.get(entry) ?? []) tests.add(test);
+    out.push({ path: rel, entries: hits, readers: [...tests].sort() });
   }
   return out;
 }
@@ -1036,10 +1129,17 @@ export function auditTree(candidates) {
   return findings;
 }
 
-/** Ledger entries naming one document that is not in the tree. */
+/**
+ * Ledger entries naming one document that is not in the tree.
+ *
+ * A class entry (`…/**`, `…/*`) is skipped: it names a rule, not a file, so
+ * there is nothing to look for. objectui#9142's triage named the trap this
+ * avoids -- `missingDocuments()` reds on a declared path that is not in the
+ * tree, so a root class spelled as if it were a path would red every run.
+ */
 export function missingDocuments({ root = REPO_ROOT } = {}) {
   return declaredEntries().filter(
-    (entry) => !entry.endsWith('/**') && !existsSync(path.join(root, entry)),
+    (entry) => !isClassEntry(entry) && !existsSync(path.join(root, entry)),
   );
 }
 


### PR DESCRIPTION
Fixes #9142

A document inside a declared `…/**` tree inherits that tree's declaration the moment it lands — that is what the tree entries buy. The repository root had no tree spelling, so every root document was declared per file, and a root document nobody had declared yet was on no entry at all.

That is not cosmetic because of **where** it lands. `scripts/__tests__/check-doc-links.test.ts` describes itself as scanning *"EVERY tracked root-level markdown file — the invariant that replaces the list"*, and fails when a root document has no `SCAN_ROOTS` row. The one test written to notice a new root document is exactly the test that does not run when one is added. The merge queue catches it and dequeues the pull request — the objectui#8857 shape, and the objectui#8857 cost.

## Re-derived on today's tip, not the card's branch

Every figure in objectui#9142 was measured on `claude/issue-9096-scripts-tests-markdown-inputs` at `b41bea392`. Re-derived by content on `f080538813`:

| | card | today |
|:--|:--|:--|
| tracked root-level markdown documents | 8 | **8** (unchanged: `AGENTS.md` `CHANGELOG.md` `CLAUDE.md` `CONTRIBUTING.md` `LICENSE-THIRD-PARTY.md` `QUICK_REFERENCE.md` `README.md` `ROADMAP.md`) |
| tracked markdown documents, all declared | 1734 of 1734 | **1814 of 1814** |
| declared ledger entries | — | 70 |
| adjudicated test files | — | 94 |

objectui#9141 landed as `4c0dc090a1`, so `SCAN_ROOTS` already carries `scripts` and the card's opening sentence is a true description of `main`. Neither 1734 nor the round's later 1805 is carried forward.

## The gap, reproduced before the fix

The probe drives the **real** `Decide whether this change needs a full run` step, extracted from `ci.yml` and executed by `bash -e` against a real git repository — the same harness `scripts/__tests__/markdown-test-inputs.test.ts` already uses. On `f080538813`, before any edit:

```
LIT CONTROL  planted undeclared root doc     SECURITY.md
   Test (shard N/4) step : should_run=false   matched: (none)
   type-check step (unwidened control): should_run=false
LIT CONTROL  planted undeclared root doc     NOTES.md
   Test (shard N/4) step : should_run=false   matched: (none)
```

## The change

`matchesEntry()` gains a **depth-1** class spelling, `dir/*`, and the repository root is spelled `./*`:

- `dir/**` — every markdown document under `dir`, at any depth. (unchanged)
- `dir/*` — every markdown document **directly in** `dir`, and none deeper. (new)

`./*` matches `SECURITY.md`; it does not match `docs/NOTES.md`, `packages/plugin-grid/NOTES.md`, `SECURITY.txt` or `turbo.json`. The fence objectui#9096 set and this card's triage carried — *"a resolved input list, not a glob"* — is intact: the workflow still consults a derived, adjudicated, self-auditing list.

The two tests that take their population from `git ls-files` rather than from a list now declare `./*` in place of the eight root documents they used to enumerate: `check-doc-links.test.ts` (`git ls-files -- '*.md'`, filtered to the root) and `dollar-dialect-alias-census.test.ts` (`trackedFiles()`, i.e. `git ls-files -z`). `check-installed-spec-pin-claims.test.ts` is deliberately left alone — it carries `CHANGELOG.md` in `notRead`, so the root class is not an accurate declaration for it.

Two consequences handled:

- **`missingDocuments()` skips class entries.** Triage named this trap: it reds on a declared path that is not in the tree, and `./*` names a rule, not a path.
- **`markdownTestInputsAmong()` reports every entry that covers a document**, not the first one sorted. Entries have always overlapped — `packages/app-shell/README.md` is one test's exact declared read *and* is inside `packages/**` — and first-match-wins attributed it to whichever rule sorted first and dropped the rest. `should_run` is unaffected (one match is enough); the readers named in the step's log are not.

## Acceptance

**1 — the lit control, both sides, same probe.** Nine cases, run before and after. The complete diff of the two runs:

```diff
 LIT CONTROL  planted undeclared root doc     SECURITY.md
-   Test (shard N/4) step : should_run=false   matched: (none)
+   Test (shard N/4) step : should_run=true   matched: SECURITY.md
    type-check step (unwidened control): should_run=false
 LIT CONTROL  planted undeclared root doc     NOTES.md
-   Test (shard N/4) step : should_run=false   matched: (none)
+   Test (shard N/4) step : should_run=true   matched: NOTES.md
    type-check step (unwidened control): should_run=false
```

The other seven cases are byte-identical. `SECURITY.md` is asserted absent from the tree by a pin of its own, so the control cannot degrade into a planted document that was already declared.

**2 — the declared population does not change verdict.** Both module versions loaded side by side over all 1814 tracked markdown documents:

```
entries before: 70  after: 70
removed: [ 'CHANGELOG.md' ]      (now covered by ./*)
added:   [ './*' ]
declared before: 1814  after: 1814
lost verdict:   []
gained verdict: []
any document that LOST a reader: false
```

130 documents *gained* readers — the union recovering attributions first-match-wins had dropped, none lost. The one entry-list delta is `CHANGELOG.md`, whose only two declarants were the two tests that now spell the class; the other seven root documents keep their exact entries through `check-installed-spec-pin-claims.test.ts` and others.

The ledger's own audit is byte-identical before and after:

```
markdown-test-inputs: 94 candidate test files, all adjudicated; 70 declared entries, all present.
```

**3 — real gate output, no bare counts.** Every reading above is the step's own stdout or the gate's own verdict line. The CLI `ci.yml` calls, exercised directly:

```
$ printf 'SECURITY.md\nSECURITY.txt\ndocs/NOTES.md\nREADME.md\n' | node scripts/markdown-test-inputs.mjs --changed -
SECURITY.md
docs/NOTES.md
README.md
```

**4 — ablation.** From the committed state, the depth-1 branch guard in `matchesEntry()` was replaced by one that can never fire — the pre-fix vocabulary exactly. Mutation proven on disk in both directions:

```
HEAD blob of target     : 978c1587546a1f5ac5d5fc2bce03c5b2a3d8c7fd
on-disk blob AFTER mutation : e29549c0b46540e65300baff280df80c21adad1a
occurrences of the depth-1 guard  BEFORE: 2   AFTER: 1
occurrences of the dead guard     AFTER : 1

vitest exit=1
Tests  8 failed | 16 passed (24)
  × FIRES: the planted root document runs the shards, and the step says so
  × names the reader that is waiting on it — the invariant that replaces the list
  × the per-file spelling CANNOT express it — which is why a new spelling exists
  × the declared population is unchanged — every tracked root document is still an input
  × reports EVERY entry that covers a document, so the class costs no reader

--- the real step, ablated ---
LIT CONTROL  SECURITY.md   Test (shard N/4) step : should_run=false   matched: (none)
```

Restore proven by **state**, not by an exit code:

```
on-disk blob AFTER restore : 978c1587546a1f5ac5d5fc2bce03c5b2a3d8c7fd
HEAD blob                  : 978c1587546a1f5ac5d5fc2bce03c5b2a3d8c7fd
blob match                 : YES
git diff HEAD byte count   : 0
occurrences of the depth-1 guard restored: 2   dead guard: 0
```

## Gates run locally, exit codes captured before any pipe

| gate | exit | verdict line |
|:--|:--|:--|
| `vitest run scripts/__tests__/markdown-test-inputs.test.ts` | 0 | `Test Files 1 passed (1) / Tests 24 passed (24)` |
| `vitest run` on `check-doc-links`, `dollar-dialect-alias-census`, `check-installed-spec-pin-claims`, `merge-queue-reporting` | 0 | `Test Files 4 passed (4) / Tests 203 passed (203)` |
| `node scripts/markdown-test-inputs.mjs --audit` | 0 | `94 candidate test files, all adjudicated; 70 declared entries, all present.` |
| `node scripts/check-control-bytes.mjs` | 0 | `OK (scanned 7510 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-changeset-presence.mjs` | 0 | `1 changeset(s) added` |
| `node scripts/check-changeset-no-major.mjs` | 0 | `No changeset declares a major bump.` |
| `node scripts/check-installed-spec-pin-claims.mjs` | 0 | `OK` |
| `node scripts/check-new-cross-file-line-citations.mjs` | 0 | `0 new citation(s)` |
| `node scripts/check-governed-queue-guard.mjs --test …` | 0 | `NOT GOVERNED — 3 path(s) checked against 5 governed surface(s); none matched.` |

Lint is a **measured narrowing**, not a skip: `eslint . --no-inline-config --format json` reports a population of **4907** files, of which 79 carry errors on `origin/main` already; the two files this diff touches are in that population and report `errors 0, warnings 0`. `eslint.config.js` configures no `projectService` / `project` parser option, so type-aware linting is off and this diff cannot move the verdict on any file it does not touch. All figures come from the final commit, `88fabfe26b`.

This pull request touches `scripts/**` and `.changeset/**`, so the shards are **not** skipped on it — the repo-wide doc pins run on the pull request itself rather than first in the merge group.

## Changeset

`.changeset/9142-root-markdown-shard-trigger.md`, **empty frontmatter** (`---` then `---`) — tooling and tests only, no package is released. Added as a new file, clobbering nothing.

---

Draft on purpose: not flipped to ready, not enqueued, no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_