### PR TITLE
fix(prompts): renumber the category inventory and pin the letter runs

### DIFF
--- a/.changeset/9145-prompt-category-inventory.md
+++ b/.changeset/9145-prompt-category-inventory.md
@@ -1,0 +1,36 @@
+---
+---
+
+Repair the category inventory in `.github/prompts/component.prompt.md`, and pin the letter
+runs so the same gap cannot reopen (objectui#9145). Tooling and instruction files only; no
+package is released by this change.
+
+§1 Component Categories described itself twice and was wrong both times: it opened with a
+hand-written "these **3** standard slots" over **seven** sections, and those seven ran
+`A B D E F G H` — no `### C.`. To an AI author that reads this file as authoritative, a
+missing letter says *a section was dropped*, and nothing in the file said whether that was
+true.
+
+**It was not dropped.** Both halves were wrong in the file's own first commit,
+`4e7737788` ("refactor: remove outdated prompts and add new component development
+context"), and in each of the four commits that touched the file since: the letters have
+read `A B D E F G H` and the sentence has read "3" for the file's entire history, over
+seven sections throughout. So neither half drifted from a state that was once true — the
+inventory was never measured against the list it describes, and there is no `C` category
+to restore. The letters are renumbered `A`–`G`; no section is added.
+
+The count is **deleted rather than corrected**: the sentence now reads "in the standard
+slots below" and states no number at all, so the inventory is written down in exactly one
+place and there is no second copy for it to disagree with.
+
+The lettering cannot be deleted the same way — it *is* the inventory — so it is pinned
+instead. `check:prompt-keys` now also reads every `### X.` heading in `.github/prompts/**`
+and requires each `## N.` section's run to be contiguous from `A`. The run is scoped to its
+`## N.` section because the surface carries eight independent runs that each restart at `A`
+(`component.prompt.md` has a second one under §2, `engine.prompt.md` has five), so a
+file-wide sequence check would red on every correct file. A section with no letter headings
+contributes no run, and the `## N.` numbers themselves are a different claim and are not
+judged. Run on this tree: 29 headings across 8 runs, all contiguous.
+
+`engine.prompt.md`'s cross-reference to the Primitive Atoms section moved with it, `§F` to
+`§E`, in the same commit.

--- a/.github/prompts/component.prompt.md
+++ b/.github/prompts/component.prompt.md
@@ -31,7 +31,7 @@
 
 ## 1. Component Categories
 
-You will be asked to build components in these 3 standard slots. Refer to `packages/spec` for the complete Zod definitions.
+You will be asked to build components in the standard slots below. Refer to `packages/spec` for the complete Zod definitions.
 
 > ⚠️ **Read the LABEL before you copy a token out of this file — the labels below are three different
 > vocabularies, and only two of them are things you may write as a `type`.** objectui#9098 landed the
@@ -123,7 +123,7 @@ Responsible for rendering records. The specific `type` determines the Props cont
     ```
 *   **Required Types (Ref: `src/ui/view.zod.ts`):** `simple`, `tabbed`, `wizard`, `split`, `drawer`, `modal`.
 
-### D. Page Components (`page:*`)
+### C. Page Components (`page:*`)
 Reusable UI blocks for the Drag-and-Drop Page Builder.
 *   **Contract:** Must implement `PageComponentProps`.
     ```typescript
@@ -158,7 +158,7 @@ Reusable UI blocks for the Drag-and-Drop Page Builder.
 > It is no longer a page block any author can legitimately write, under any reading of this file.
 > The shell's own profile affordance is a React slot, not a page block type.
 
-### E. Dashboard Widgets (`widget:*`)
+### D. Dashboard Widgets (`widget:*`)
 Standalone cards placed on a dashboard grid.
 *   **Contract:** Must implement `DashboardWidgetProps` (Ref: `src/ui/dashboard.zod.ts`).
     ```typescript
@@ -176,7 +176,7 @@ Standalone cards placed on a dashboard grid.
     *   **Analysis:** `pivot` (Cross-Tab Table).
     *   **Content:** `table` (List), `text` (Note), `image`, `frame` (Embed).
 
-### F. Primitive Atoms — IMPORTED, never authored
+### E. Primitive Atoms — IMPORTED, never authored
 The fundamental building blocks used by all other widgets.
 *   **Contract:** Pure UI components (No metadata dependencies).
 
@@ -196,7 +196,7 @@ The fundamental building blocks used by all other widgets.
     *   Error state (Error Boundary/Message).
     *   Badge (Status Indicators).
 
-### G. Smart Actions (`action:*`)
+### F. Smart Actions (`action:*`)
 Executable elements bound to the Action Protocol. They handle permissions, loading states, and confirmation dialogs automatically.
 *   **Contract:** Must implement `ActionComponentProps` (Ref: `src/ui/action.zod.ts`).
     ```typescript
@@ -214,7 +214,7 @@ Executable elements bound to the Action Protocol. They handle permissions, loadi
     *   `action:menu`: Dropdown menu for overflow actions.
     *   `action:icon`: Icon-only trigger (for dense lists).
 
-### H. AI Interface (`ai:*`)
+### G. AI Interface (`ai:*`)
 Conversational and Generative UI components. ⚠️ This section is PROTOCOL PLACEHOLDER surface, ⛔ not
 an available component library — read the label before you write any of it.
 *   **Protocol Placeholders:** — registered, but ONLY by the opt-in placeholder module, so each one

--- a/.github/prompts/engine.prompt.md
+++ b/.github/prompts/engine.prompt.md
@@ -145,7 +145,7 @@ Scenario: User sees the record but lacks permission to view 'Salary' field.
 ### E. Theme Injection
 Scenario: App branding (`branding.primaryColor`) must apply to all Buttons.
 *   **Solution:** Convert `App.branding` values into CSS Variables (`--os-primary: #ff0000`) injected at the root `<LayoutProvider>`. All atom-level primitives (the `Button` component imported from `@object-ui/components`) consume these variables.
-    *   ⛔ `atom:` is a grouping label, NOT a registry namespace: nothing registers an `atom:` key, so it is never a `type` an author writes. See §F of `component.prompt.md` (objectui#9098).
+    *   ⛔ `atom:` is a grouping label, NOT a registry namespace: nothing registers an `atom:` key, so it is never a `type` an author writes. See §E of `component.prompt.md` (objectui#9098).
 
 ---
 

--- a/scripts/__tests__/check-prompt-component-keys.test.ts
+++ b/scripts/__tests__/check-prompt-component-keys.test.ts
@@ -34,10 +34,13 @@ import {
   PLACEHOLDER_NAMESPACE,
   PROMPT_DIR,
   analyze,
+  lettered,
+  letterRunFindings,
   partitionRegistry,
   placeholderSites,
   promptFiles,
   scanPromptKeys,
+  scanPromptSections,
 } from '../check-prompt-component-keys.mjs';
 import { INDIRECT_REGISTRATIONS, deriveRegistryKeys } from '../check-doc-component-types.mjs';
 
@@ -593,5 +596,139 @@ describe('the prompt surface this gate now reads', () => {
     for (const tombstone of ['user:profile', 'ai:chat_window', 'view:kanban']) {
       expect(prompt, `${tombstone} tombstone must still be written down`).toContain(`\`${tombstone}\``);
     }
+  });
+});
+
+// ── 8. the letter run, scoped to its section (objectui#9145) ─────────────────
+
+describe('a `## N.` section\'s `### X.` headings must run A, B, C, … without a gap', () => {
+  /** The minimum surface the earlier guards need, plus the headings under test. */
+  const runLetters = (prompt: string[]) =>
+    withTree((write) => {
+      write(PLACEHOLDER_SITE, placeholderModule(['view:kanban']));
+      write('packages/plugin-grid/src/index.tsx', "ComponentRegistry.register('grid', G, { namespace: 'view' });");
+      write(`${PROMPT_DIR}/component.prompt.md`, ['*   **Keys:** `view:grid`, etc.', '', ...prompt].join('\n'));
+    }, analyzeFixture);
+
+  it('reports the gap — the defect this card was filed for, reproduced', () => {
+    // `A B D` is the shape `component.prompt.md` §1 carried from its first
+    // commit: seven sections lettered A B D E F G H, no `### C.`.
+    const { findings } = runLetters(['## 1. Component Categories', '', '### A. One', '', '### B. Two', '', '### D. Four']);
+
+    expect(findings.map((f) => [f.key, f.reason])).toEqual([['### D.', 'letter-run-gap']]);
+    expect(findings[0].text).toContain('expected `### C.`');
+    expect(findings[0].text).toContain('heading 3 of 3');
+  });
+
+  it('reports only the FIRST mismatch in a run, not every heading after the gap', () => {
+    // A gap at C makes D, E and F wrong too. Listing all of them buries the one
+    // heading an author actually has to decide about.
+    const { findings } = runLetters([
+      '## 1. Component Categories',
+      '',
+      '### A. One',
+      '',
+      '### B. Two',
+      '',
+      '### D. Four',
+      '',
+      '### E. Five',
+      '',
+      '### F. Six',
+    ]);
+
+    expect(findings.map((f) => f.key)).toEqual(['### D.']);
+  });
+
+  it('scopes the run to its section, so a second run restarting at A is not a gap', () => {
+    // The reason this is not a file-wide sequence check: `component.prompt.md`
+    // carries a second run under §2 and `engine.prompt.md` carries five, and a
+    // file-wide check would red on every correct file on this surface.
+    const { findings, counters } = runLetters([
+      '## 1. Component Categories',
+      '',
+      '### A. One',
+      '',
+      '### B. Two',
+      '',
+      '## 2. API Reference',
+      '',
+      '### A. Field Widget Implementation',
+      '',
+      '### B. Dashboard Widget Implementation',
+    ]);
+
+    expect(findings).toEqual([]);
+    expect(counters.letterRuns).toBe(2);
+    expect(counters.letterHeadings).toBe(4);
+  });
+
+  it('does not read a heading inside a fenced code block', () => {
+    const { findings, counters } = runLetters([
+      '## 1. Component Categories',
+      '',
+      '### A. One',
+      '',
+      '```md',
+      '### D. An EXAMPLE of a heading, not a heading',
+      '```',
+      '',
+      '### B. Two',
+    ]);
+
+    expect(findings).toEqual([]);
+    expect(counters.letterHeadings).toBe(2);
+  });
+
+  it('refuses to pass when every section has lost its letter headings', () => {
+    // The collapse this guard exists for: the inventories are reformatted away
+    // and a run that reads nothing reports a pass it did not earn.
+    expect(() => runLetters(['## 1. Component Categories', '', 'Prose, and no headings at all.'])).toThrow(
+      /carry no `### X\.` heading/,
+    );
+  });
+
+  it('says nothing about a surface that has no `## N.` sections at all', () => {
+    // A run only exists inside a section, so "no sections" is not a collapsed
+    // inventory — it is a document this pin makes no claim about. Every fixture
+    // in the sections above is that shape, which is why they must stay green.
+    const { findings, counters } = runLetters(['Just a Keys bullet and nothing else.']);
+
+    expect(findings).toEqual([]);
+    expect(counters.letterRuns).toBe(0);
+  });
+});
+
+// ── 9. the live tree, under the letter-run pin ───────────────────────────────
+
+describe('the letter runs on the live prompt surface', () => {
+  const sections = () => scanPromptSections(repoRoot) as {
+    file: string;
+    section: string;
+    entries: { letter: string; line: number; text: string }[];
+  }[];
+
+  it('every run in every prompt file is contiguous from A', () => {
+    expect(letterRunFindings(lettered(sections()))).toEqual([]);
+  });
+
+  it('pins §1 of `component.prompt.md` to the seven categories, lettered A–G', () => {
+    // The corrected state. objectui#9145: this run read `A B D E F G H` — the
+    // gap was in the file's first commit, not a category that was dropped, so
+    // it is renumbered rather than filled.
+    const one = sections().find(
+      (s) => s.file === `${PROMPT_DIR}/component.prompt.md` && /^1\./.test(s.section),
+    );
+    expect(one, '§1 Component Categories must still be a `## 1.` section').toBeDefined();
+    expect(one!.entries.map((e) => e.letter)).toEqual(['A', 'B', 'C', 'D', 'E', 'F', 'G']);
+  });
+
+  it('floors the surface, so a reformat cannot quietly empty it', () => {
+    const runs = lettered(sections()) as { entries: unknown[] }[];
+    expect(runs.length, 'letter runs on the live prompt surface').toBeGreaterThanOrEqual(8);
+    expect(
+      runs.reduce((n: number, run) => n + run.entries.length, 0),
+      'lettered headings on the live prompt surface',
+    ).toBeGreaterThanOrEqual(29);
   });
 });

--- a/scripts/check-prompt-component-keys.mjs
+++ b/scripts/check-prompt-component-keys.mjs
@@ -176,6 +176,17 @@ const LIST_ITEM = /^\s*(?:[*+-]|\d+\.)\s+/;
 const FENCE = /^\s*(?:```|~~~)/;
 
 /**
+ * A `## N. Title` heading. It opens a SECTION, which is the scope a letter run
+ * is numbered within — the prompt surface carries several independent runs per
+ * file and they each restart at `A`.
+ */
+const SECTION_HEADING = /^##\s+(.*\S)\s*$/;
+
+/** A `### X. Title` heading — one entry in its section's letter run. */
+const LETTER_HEADING = /^###\s+([A-Z])\.\s/;
+
+
+/**
  * Bullet labels whose sub-bullet BLOCK teaches keys an author may write, and
  * whose every key must therefore be authorable.
  *
@@ -348,6 +359,98 @@ export function scanPromptKeys(root) {
 }
 
 /**
+ * Every `### X.` letter run in the prompt surface, grouped by the `## N.`
+ * section that scopes it (objectui#9145).
+ *
+ * ## What this reads, and why it is a SEQUENCE check rather than a count
+ *
+ * `.github/prompts/component.prompt.md` opened §1 with a hand-written "these 3
+ * standard slots" over seven sections, and those seven ran `A B D E F G H` — no
+ * `C`. Both halves were wrong in the file's FIRST commit (`4e7737788`), so
+ * neither is a drift from a state that was once true: the inventory was never
+ * measured against the list it describes.
+ *
+ * The two halves are repaired differently, and only one of them needs a gate:
+ *
+ *   THE COUNT      deleted, not pinned. The sentence no longer states a number,
+ *                  so there is no second place for the inventory to be written
+ *                  down and no way for the two to disagree. A gate comparing a
+ *                  stated count to a heading count would exist only to keep a
+ *                  construct alive that has no reason to be there.
+ *   THE LETTERING  pinned here. A letter run is not a duplicate of anything —
+ *                  it IS the inventory — so it cannot be deleted, and a gap in
+ *                  it is exactly the reading that cost this card: a missing
+ *                  letter says "a section was dropped" to an AI author that
+ *                  reads these files as authoritative, and the file itself does
+ *                  not say whether that is true.
+ *
+ * ## Why a run is scoped to its `## N.` section
+ *
+ * `component.prompt.md` carries a SECOND, independent letter run further down
+ * (`### A. Field Widget Implementation`, `### B. Dashboard Widget
+ * Implementation`) under `## 2. API Reference & Contracts`, and
+ * `engine.prompt.md` carries five. Each restarts at `A`, so a file-wide
+ * sequence check would red on every correct file here. The section heading is
+ * the boundary the author already writes.
+ *
+ * Sections with no letter headings (`## 2. Standard Contexts` in
+ * `engine.prompt.md`, whose sub-headings are backticked type names) simply
+ * contribute no run. ⛔ This does NOT judge the `## N.` numbers themselves —
+ * that is a different vocabulary and a different claim.
+ */
+export function scanLetterRuns(root) {
+  const runs = [];
+  for (const abs of promptFiles(root)) {
+    const rel = relative(root, abs).split(sep).join('/');
+    const lines = readFileSync(abs, 'utf8').split('\n');
+    const fenced = fenceMask(lines);
+    let current = null;
+
+    for (let i = 0; i < lines.length; i++) {
+      if (fenced[i]) continue;
+      const section = SECTION_HEADING.exec(lines[i]);
+      if (section) {
+        current = { file: rel, section: section[1], entries: [] };
+        runs.push(current);
+        continue;
+      }
+      const letter = LETTER_HEADING.exec(lines[i]);
+      if (!letter || !current) continue;
+      current.entries.push({ letter: letter[1], line: i + 1, text: lines[i].trim() });
+    }
+  }
+  return runs.filter((run) => run.entries.length > 0);
+}
+
+/**
+ * The first heading in each run whose letter is not the one its position calls
+ * for. Only the FIRST is reported per run: a gap at `C` makes every heading
+ * after it wrong too, and listing all of them buries the one an author has to
+ * decide about.
+ */
+export function letterRunFindings(runs) {
+  const findings = [];
+  for (const run of runs) {
+    for (let i = 0; i < run.entries.length; i++) {
+      const expected = String.fromCharCode(65 + i);
+      const entry = run.entries[i];
+      if (entry.letter === expected) continue;
+      findings.push({
+        file: `${run.file}:${entry.line}`,
+        key: `### ${entry.letter}.`,
+        text: `${entry.text}  —  expected \`### ${expected}.\`, heading ${i + 1} of ${run.entries.length} under \`## ${run.section}\``,
+        label: run.section,
+        expect: 'contiguous-letters',
+        scope: 'letter-run',
+        reason: 'letter-run-gap',
+      });
+      break;
+    }
+  }
+  return findings;
+}
+
+/**
  * Judge the prompt surface. Throws when an input is missing, because a gate
  * that cannot see its inputs must not report a pass.
  */
@@ -398,7 +501,16 @@ export function analyze(root, options = {}) {
     );
   }
 
-  const findings = [];
+  const runs = scanLetterRuns(root);
+  if (runs.length === 0) {
+    throw new Error(
+      `no \`### X.\` letter run was found under ${PROMPT_DIR}. The category inventories this gate ` +
+        'pins are gone or have been reformatted, and a run that reads nothing passes while asserting ' +
+        'nothing.',
+    );
+  }
+
+  const findings = letterRunFindings(runs);
   for (const site of taught) {
     const isAuthorable = authorable.has(site.key);
     const isPlaceholder = placeholderOnly.has(site.key);
@@ -423,6 +535,8 @@ export function analyze(root, options = {}) {
       registryKeys: registry.keys.size,
       authorable: authorable.size,
       placeholderOnly: placeholderOnly.size,
+      letterRuns: runs.length,
+      letterHeadings: runs.reduce((n, run) => n + run.entries.length, 0),
     },
   };
 }
@@ -437,6 +551,12 @@ const HINTS = {
   'unregistered-key':
     'Nothing in this repository registers this key, so it resolves to the OBJUI-001 "Unknown ' +
     'component type" panel everywhere. Teach a registered key.',
+  'letter-run-gap':
+    'The `### X.` headings under this `## N.` section do not run A, B, C, … without a gap. To an AI ' +
+    'author reading these files as authoritative, a missing letter says a section was DROPPED — and ' +
+    'nothing in the file says whether that is true (objectui#9145: the gap was a generation artifact ' +
+    'present in the file\'s first commit, not a dropped category). Renumber the run so the letters ' +
+    'are contiguous, or add the section the gap claims is missing.',
   'not-a-placeholder-key':
     'This key is taught under a `Protocol Placeholders:` label, but a REAL renderer answers it — so ' +
     'the section understates what the platform ships and steers an author away from a component that ' +
@@ -473,11 +593,15 @@ if (isEntrypoint(import.meta.url)) {
       `${counters.authorable} authorable key(s) — the ${counters.registryKeys} registered key(s) less ` +
       `the ${counters.placeholderOnly} answered only by the ${PLACEHOLDER_NAMESPACE} registration.`,
   );
+  console.log(
+    `Checked ${counters.letterHeadings} \`### X.\` heading(s) across ${counters.letterRuns} letter ` +
+      'run(s) for a contiguous A, B, C, … sequence within each `## N.` section.',
+  );
 
   if (findings.length === 0) {
     console.log(
-      'OK  Every key taught as available is answered by a real renderer, and every key taught as a ' +
-        'protocol placeholder is answered only by the placeholder.',
+      'OK  Every key taught as available is answered by a real renderer, every key taught as a ' +
+        'protocol placeholder is answered only by the placeholder, and every letter run is contiguous.',
     );
     process.exit(0);
   }

--- a/scripts/check-prompt-component-keys.mjs
+++ b/scripts/check-prompt-component-keys.mjs
@@ -394,12 +394,16 @@ export function scanPromptKeys(root) {
  * the boundary the author already writes.
  *
  * Sections with no letter headings (`## 2. Standard Contexts` in
- * `engine.prompt.md`, whose sub-headings are backticked type names) simply
- * contribute no run. ⛔ This does NOT judge the `## N.` numbers themselves —
- * that is a different vocabulary and a different claim.
+ * `engine.prompt.md`, whose sub-headings are backticked type names) are
+ * returned too, carrying an empty `entries`. They contribute no run, and the
+ * caller needs them to tell "this surface has no letter runs because it has no
+ * sections" (a fixture tree exercising the key vocabulary) apart from "this
+ * surface has sections and every run in them has vanished" (the collapse).
+ * ⛔ This does NOT judge the `## N.` numbers themselves — that is a different
+ * vocabulary and a different claim.
  */
-export function scanLetterRuns(root) {
-  const runs = [];
+export function scanPromptSections(root) {
+  const sections = [];
   for (const abs of promptFiles(root)) {
     const rel = relative(root, abs).split(sep).join('/');
     const lines = readFileSync(abs, 'utf8').split('\n');
@@ -411,7 +415,7 @@ export function scanLetterRuns(root) {
       const section = SECTION_HEADING.exec(lines[i]);
       if (section) {
         current = { file: rel, section: section[1], entries: [] };
-        runs.push(current);
+        sections.push(current);
         continue;
       }
       const letter = LETTER_HEADING.exec(lines[i]);
@@ -419,8 +423,11 @@ export function scanLetterRuns(root) {
       current.entries.push({ letter: letter[1], line: i + 1, text: lines[i].trim() });
     }
   }
-  return runs.filter((run) => run.entries.length > 0);
+  return sections;
 }
+
+/** The sections that actually carry a letter run. */
+export const lettered = (sections) => sections.filter((s) => s.entries.length > 0);
 
 /**
  * The first heading in each run whose letter is not the one its position calls
@@ -501,12 +508,13 @@ export function analyze(root, options = {}) {
     );
   }
 
-  const runs = scanLetterRuns(root);
-  if (runs.length === 0) {
+  const sections = scanPromptSections(root);
+  const runs = lettered(sections);
+  if (sections.length > 0 && runs.length === 0) {
     throw new Error(
-      `no \`### X.\` letter run was found under ${PROMPT_DIR}. The category inventories this gate ` +
-        'pins are gone or have been reformatted, and a run that reads nothing passes while asserting ' +
-        'nothing.',
+      `${sections.length} \`## N.\` section(s) under ${PROMPT_DIR} carry no \`### X.\` heading at all. ` +
+        'The category inventories this pin reads are gone or have been reformatted, and a run that ' +
+        'reads nothing passes while asserting nothing.',
     );
   }
 


### PR DESCRIPTION
Fixes #9145

`.github/prompts/component.prompt.md` described its own §1 twice and was wrong both times: it opened with a hand-written "these **3** standard slots" over **seven** sections, and those seven ran `A B D E F G H` — no `### C.`. This file is read by an AI that then writes metadata, and a missing letter says *a section was dropped* while nothing in the file says whether that is true.

## The decisive measurement: the gap is stale lettering, not a dropped category

The card left this as its one real open question, and triage reported its own probe **inconclusive** and refused to conclude from it. Two independent readings were taken, and they agree.

### 1. The file's own history — decisive, and the one that actually answers the question

The question is "was a section dropped from **this file**", so the file's history answers it directly. It has five commits, all of them enumerated:

```
$ curl -s '.../commits?path=.github/prompts/component.prompt.md&per_page=100'
44a9b4bd2  2026-09-11  fix(prompts): rule each key-teaching section … (#9143)
d2f0c108c  2026-09-11  fix(prompts): teach only view keys a real renderer answers … (#9099)
56409c28c  2026-08-03  fix(fields,components): deliver the validation slot …
5511968e9  2026-01-27  feat: add layout package with PageHeader component …
4e7737788  2026-01-26  refactor: remove outdated prompts and add new component development context
```

Read at each of them (`raw.githubusercontent.com`, no local history needed — this checkout is shallow):

| commit | §1 letters | stated count | sections |
|:--|:--|:--|:--|
| `4e7737788` (file created) | `A B D E F G H` | 3 | 7 |
| `5511968e9` | `A B D E F G H` | 3 | 7 |
| `56409c28c` | `A B D E F G H` | 3 | 7 |
| `d7f0601ee7` (base) | `A B D E F G H` | 3 | 7 |

**No `### C.` has ever existed in this file, and "3" was never true of any version of it.** Both halves were wrong in the file's first commit. So there is no `C` category to restore ⇒ renumber `A`–`G`, add no section.

⚠️ This also falsifies the card's own parenthetical: *"The count was presumably true of an earlier version of the file"*. It was not. It was a generation artifact, never a drift.

### 2. The registry prefix difference triage prescribed — run, and it falsifies the branch rule it was attached to

Triage's rule was: enumerate the prefixes the real `ComponentRegistry` registration surface registers, difference against the seven the sections cover, and *"difference non-empty ⇒ add the section; empty ⇒ renumber"*.

**Enumeration method.** `deriveRegistryKeys` from `scripts/check-doc-component-types.mjs` — the shared derivation that already feeds `check:prompt-keys`, `check:doc-types` and the CLI's known-type list. It walks `packages/`, `apps/` and `examples/` for every `.register()` / `.registerLazy()` call site on a registry receiver, resolves the key argument, follows the declared `namespace:` option, and adds the indirect registration tables. ⛔ Not a barrel file's literals. Counters for the run: `{"sourceFiles":146,"callSites":238,"resolved":233,"open":2,"indirect":132}`, 644 keys.

**Positive controls, hit in the same command** (so a zero would be a measurement, not a broken query):

```
HIT  action:button   <- packages/components/src/renderers/action/action-button.tsx:323
HIT  field:text      <- packages/components/src/renderers/placeholders.tsx
HIT  view:grid       <- packages/plugin-grid/src/index.tsx:263
HIT  page:header     <- packages/components/src/renderers/layout/containers.tsx:2143
```

**The difference set is NOT empty — 32 registered prefixes are not among the seven:**

```
app-shell: app: chart: cloud-connection: cloud: element: global: layout: marketplace: mcp:
nav: plugin-calendar: plugin-charts: plugin-chatbot: plugin-dashboard: plugin-designer:
plugin-detail: plugin-editor: plugin-form: plugin-gantt: plugin-grid: plugin-kanban:
plugin-list: plugin-map: plugin-markdown: plugin-report: plugin-timeline: plugin-tree:
plugin-view: protocol-placeholder: record: ui:
```

and the reverse leg reads **`atom:` registers 0 keys** — one of the seven "covered" prefixes is not in the registered set at all (which §E already says in prose).

**⛔ So triage's branch rule does not apply, and following it literally would have been wrong.** Three reasons, stated plainly rather than worked around:

1. **The rule assumed a 0-or-1 outcome.** Nine of those are distinct authorable prefixes (`ui:` alone carries 127 keys, `element:` 10, `record:` 14, `layout:` 5). Nine uncovered prefixes cannot be one missing letter `C`, and nothing marks which of them would sit between `view:` (B) and `page:` (D).
2. **Most of the difference is registration scope, not a type vocabulary.** `deriveRegistryKeys` adds `namespace:name` *and* the bare `name`, so `plugin-*:`, `app-shell:` and `protocol-placeholder:` are the same keys re-published under a module namespace — `protocol-placeholder:field:text` is `field:text`.
3. **A non-empty difference was never evidence of anything**, because this file does not claim to enumerate the registry. `check-prompt-component-keys.mjs` states it in its own header: *"The bullets end in `etc.` — they are examples … The other direction (a new renderer lands, the prompt does not mention it) leaves the prompt incomplete, never WRONG."* The probe could not have returned empty, so the rule hanging off it could never have fired either way.

The direction taken is the one reading 1 supports, which is stronger evidence than the proxy: it answers the actual question instead of a stand-in for it.

## What changed

**The count is deleted, not corrected.** The sentence now reads "in the standard slots below" and states no number at all, so the inventory is written down in exactly one place and there is no second copy to disagree with it. This is the repair order triage made binding — delete the construct that permits the error first — and it is why no stated-count check is added: there is no longer a count for one to read.

**The lettering is renumbered `A`–`G`.** ⛔ The second, independent letter run further down (`### A. Field Widget Implementation`, `### B. Dashboard Widget Implementation`, under `## 2. API Reference & Contracts`) is untouched. `engine.prompt.md`'s cross-reference to the Primitive Atoms section moved with the renumber, `§F` to `§E`; the three `§B` references inside `component.prompt.md` still point at View Layouts, which did not move.

**The lettering is then pinned** — second step, on the corrected state, never before it. The lettering IS the inventory, so unlike the count it cannot be deleted; `check:prompt-keys` now also requires each `## N.` section's `### X.` run to be contiguous from `A`. Scoping the run to its section is the whole design: this surface carries **eight** independent runs that each restart at `A` (a second one here, five in `engine.prompt.md`), so a file-wide sequence check would red on every correct file. ⛔ The `## N.` numbers themselves are a different vocabulary and are deliberately not judged — see the out-of-scope finding below.

## Verification

Every command below was run in a dedicated worktree at final head `9894fbf`.

**`pnpm check:prompt-keys`** — exit 0:

```
Scanned 3 prompt file(s) under .github/prompts, 2 `Keys:` bullet(s) and 4 gated label block(s),
32 taught key(s) … against 530 authorable key(s) — the 644 registered key(s) less the 114
answered only by the protocol-placeholder registration.
Checked 29 `### X.` heading(s) across 8 letter run(s) for a contiguous A, B, C, … sequence
within each `## N.` section.
OK  Every key taught as available is answered by a real renderer, every key taught as a
protocol placeholder is answered only by the placeholder, and every letter run is contiguous.
```

**Reverse verification of the pin** — the fix was committed first, then ablated, then restored, both legs proven on disk rather than by an exit code:

```
HEAD blob     : 946054c7e5eb4c8a4e59fc860cdda1f1c452800b
mutated blob  : df059b7fb177b8b01ba6c3d24b12dd059d2215a9      (### C. -> ### D., the pre-fix state)
  grep -c '^### C. Page Components' = 0   (expected 0)
  grep -c '^### D. Page Components' = 1   (expected 1)

VERDICT mutated-leg-exit=1
  .github/prompts/component.prompt.md:126  [letter-run-gap]  `### D.`
      ### D. Page Components (`page:*`)  —  expected `### C.`, heading 3 of 7 under `## 1. Component Categories`
  X  1 problem(s)          <- one, not five: only the first mismatch per run is reported,
                              and §2's run stayed green, which is the section scoping working

restore: git checkout HEAD -- (absolute path), via an EXIT/INT/TERM trap
  git diff HEAD  -> exit 0 (tree identical to HEAD)
  blob after restore = 946054c7e5eb4c8a4e59fc860cdda1f1c452800b = HEAD blob
VERDICT restored-leg-exit=0
```

**Other gates and tests**, all exit 0:

| command | reading |
|:--|:--|
| `scripts/__tests__/check-prompt-component-keys.test.ts` | 43 passed (34 pre-existing + 9 new) |
| the four other script tests that read this surface | 5 files, 211 passed — `markdown-test-inputs`, `ci-cd-pipeline-doc`, `check-installed-spec-pin-claims`, `dollar-dialect-alias-census` |
| `pnpm type-check:scripts` | exit 0 |
| `pnpm lint:root` | exit 0, `32 problems (0 errors, 32 warnings)` — every warning pre-existing, none in a file this PR touches. Whole-project run, 16.5s; ⛔ no narrowing to declare |
| `pnpm check:control-bytes` | `OK (scanned 7511 tracked text file(s); skipped 85 binary)` |
| `pnpm check:changeset-claims` | `No pending changeset names a file this change touches` (3 files changed outside `.changeset/`) |
| `pnpm check:new-line-citations` | 0 citations added |
| `node scripts/check-governed-queue-guard.mjs --test` | all three touched code paths **NOT GOVERNED**; `AGENTS.md` ⇒ **GOVERNED** as the lit control ⇒ ordinary PR route |

New tests: the `A B D` gap reproduced with the expected letter named, first-mismatch-only reporting, per-section scoping, fenced headings skipped, the collapse guard firing, the no-sections surface staying silent, and two live-tree pins (every run contiguous; §1 held to exactly `A`–`G` over seven headings).

One design change came out of the tests: the collapse guard as first written threw whenever the surface carried no `### X.` heading at all, which is every fixture tree in this gate's suite. A run only exists inside a `## N.` section, so "no sections" is not a collapsed inventory — the guard now fires on sections-present-and-no-headings, and `scanPromptSections` returns the empty sections so the two can be told apart.

## Out of scope, filed not fixed

**objectui#9319** — `.github/prompts/ui-library.prompt.md` numbers its sections `1, 3, 4, 5`, with no `## 2.`. Same hazard class, same root commit `4e7737788`, and that file has never been touched since. Left alone here: the `## N.` numbers are a different vocabulary from the `### X.` letters this PR's pin reads, and widening the pin to cover them would go past this card's ruling. Deduplicated by semantic search, which returned #9145 itself as a known hit in the same call.

## Route

Draft, as dispatched. ⛔ Not flipped ready, ⛔ no auto-merge, ⛔ not merged — the PM seat reviews and drives the merge queue.

`Fixes` rather than `Refs`: both defects the card names are closed and no part of its scope is deferred. The finding above is a different file and is carried by its own card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_