### PR TITLE
fix(app-shell,i18n): stop the report inspector flattening localized titles and labels

### DIFF
--- a/.changeset/olive-falcons-invent.md
+++ b/.changeset/olive-falcons-invent.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/app-shell': minor
+'@object-ui/i18n': minor
+---
+
+fix(app-shell): the report inspector no longer destroys a localized title or label
+
+`ReportChartSchema.title` and `ReportSchema.label` are `I18nLabel` — a plain
+string **or** an inline per-locale map. The report inspector narrowed both to
+the string arm when reading and wrote the typed string back over the whole
+value, so against a stored map the two halves failed in opposite directions:
+Studio painted an empty box over a report that has a title, and the retype that
+empty box invited replaced the map with a bare string, losing every other
+locale. Committing the empty box untouched deleted the stored map outright.
+
+Reads now go through `pickLocalized` and writes through `setLocalized`, so an
+edit lands in the active locale's entry and every other locale survives. An
+author shown a display fallback from another locale can neither overwrite nor
+delete the locale it was borrowed from.
+
+**Clearing is ruled, not inherited.** Clearing the box removes only the active
+locale's entry; when that was the last entry the key is dropped entirely, which
+is byte-for-byte what clearing a plain-string value already did.
+
+**What an author who does nothing differently now gets:** a report whose title
+or label is a plain string behaves exactly as before — same box, same committed
+value, including on clear. A report whose title or label is a locale map now
+shows their own locale's string instead of a blank box, and editing it keeps
+every other language instead of deleting it.
+
+`@object-ui/i18n` gains `clearLocalized`, the clear arm of the same
+single-locale editor `setLocalized` serves. Additive: no existing export
+changed shape.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.i18nTitle.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.i18nTitle.test.tsx
@@ -1,0 +1,385 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#9274 — the report inspector's localizable text boxes must not
+ * narrow an `I18nLabel` to a plain string on the way in, nor flatten the
+ * stored locale map on the way out.
+ *
+ * `@objectstack/spec` (measured at 17.4.0, see the PR body) types
+ * `ReportChartSchema.title` — and `ReportSchema.label` — as a union of a plain
+ * string and an inline per-locale map. Against a stored map the two halves of
+ * this inspector used to fail in OPPOSITE directions and amplify each other:
+ *
+ *   READ   `typeof chart.title === 'string' ? … : ''` fails the map arm, so
+ *          Studio painted an EMPTY box over a report that has a title.
+ *   WRITE  `{ ...chart, ...patch }` put the typed string in place of the WHOLE
+ *          map, so every locale the author was not looking at was gone.
+ *
+ * ⭐ Every assertion about the write half reads the COMMITTED PATCH, never the
+ * input box. The box looking right is the defect's own symptom — a pin that
+ * only reads the input passes against the bug.
+ *
+ * ⭐ The plain-string arm is the LIT CONTROL: it must read identically before
+ * and after the repair, which is what makes the rest of this file able to fail.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ReportDefaultInspector } from './ReportDefaultInspector';
+import type { DatasetCatalogEntry } from '../previews/useDatasetCatalog';
+
+afterEach(cleanup);
+
+// Same module-scope fetch double as ReportDefaultInspector.test.tsx
+// (objectui#7439 / #6640): `useDatasetSemantics` fires a relative-URL read that
+// no test body awaits, so a per-test teardown would restore the real fetch
+// while the tree is still mounted.
+vi.stubGlobal(
+  'fetch',
+  vi.fn(async () => new Response('null', { status: 404, headers: { 'content-type': 'application/json' } })),
+);
+
+const catalog: DatasetCatalogEntry[] = [
+  {
+    name: 'sales_metrics',
+    label: 'Sales metrics',
+    dimensions: [{ name: 'stage', type: 'text' }],
+    measures: [{ name: 'total_amount', aggregate: 'sum' }],
+  },
+];
+
+const baseProps = {
+  type: 'report',
+  name: 'pipeline',
+  onSelectionChange: vi.fn(),
+  datasetCatalogOverride: catalog,
+};
+
+function labelledInput(label: string): HTMLInputElement {
+  const lab = screen.getByText(label);
+  return lab.parentElement!.querySelector('input, textarea') as HTMLInputElement;
+}
+
+/** A report with a chart, so the curated Chart panel renders its Title box. */
+function chartDraft(title: unknown) {
+  return {
+    name: 'pipeline',
+    label: 'Pipeline',
+    type: 'summary',
+    dataset: 'sales_metrics',
+    rows: ['stage'],
+    values: ['total_amount'],
+    chart: { type: 'bar', xAxis: 'stage', yAxis: 'total_amount', ...(title === undefined ? {} : { title }) },
+  };
+}
+
+/** The `chart` object of the single patch this inspector committed. */
+function committedChart(onPatch: ReturnType<typeof vi.fn>): Record<string, unknown> | undefined {
+  expect(onPatch).toHaveBeenCalledTimes(1);
+  const patch = onPatch.mock.calls[0][0] as { chart?: Record<string, unknown> };
+  return patch.chart;
+}
+
+describe('objectui#9274 — chart Title: the READ half', () => {
+  it('shows the ACTIVE locale entry of a map-valued title, not an empty box', () => {
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale="en-US"
+        draft={chartDraft({ en: 'Pricing', 'zh-CN': '定价' })}
+        onPatch={vi.fn()}
+        readOnly={false}
+      />,
+    );
+    // On the base tree this is `''` — Studio paints the absence of what the
+    // author stored. That empty box is what invites the destroying retype.
+    expect(labelledInput('Chart title').value).toBe('Pricing');
+  });
+
+  it('follows the active locale — the same map under zh-CN reads the zh-CN entry', () => {
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale="zh-CN"
+        draft={chartDraft({ en: 'Pricing', 'zh-CN': '定价' })}
+        onPatch={vi.fn()}
+        readOnly={false}
+      />,
+    );
+    expect(labelledInput('图表标题').value).toBe('定价');
+  });
+
+  it('LIT CONTROL — a plain-string title still reads verbatim', () => {
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale="en-US"
+        draft={chartDraft('Pricing')}
+        onPatch={vi.fn()}
+        readOnly={false}
+      />,
+    );
+    expect(labelledInput('Chart title').value).toBe('Pricing');
+  });
+});
+
+describe('objectui#9274 — chart Title: the WRITE half (asserted on the committed patch)', () => {
+  it('an edit lands in the active locale entry and every other locale survives verbatim', () => {
+    const onPatch = vi.fn();
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale="en-US"
+        draft={chartDraft({ en: 'Pricing', 'zh-CN': '定价', ja: '価格' })}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    fireEvent.change(labelledInput('Chart title'), { target: { value: 'Plans' } });
+
+    // On the base tree the committed `title` is the bare string 'Plans' and
+    // zh-CN / ja are gone. This is the unrecoverable half.
+    expect(committedChart(onPatch)?.title).toEqual({ en: 'Plans', 'zh-CN': '定价', ja: '価格' });
+  });
+
+  it('an edit made under zh-CN cannot touch the English entry', () => {
+    const onPatch = vi.fn();
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale="zh-CN"
+        draft={chartDraft({ en: 'Pricing', 'zh-CN': '定价' })}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    fireEvent.change(labelledInput('图表标题'), { target: { value: '套餐' } });
+    expect(committedChart(onPatch)?.title).toEqual({ en: 'Pricing', 'zh-CN': '套餐' });
+  });
+
+  it('an author shown a DISPLAY FALLBACK cannot overwrite the locale it fell back to', () => {
+    // `ja` has no entry, so the box shows the `en` string. Saving must ADD a
+    // `ja` entry, never replace the English one it was only borrowing.
+    const onPatch = vi.fn();
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale={'ja' as unknown as 'en-US'}
+        draft={chartDraft({ en: 'Pricing' })}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    const box = labelledInput('Chart title');
+    expect(box.value).toBe('Pricing');
+    fireEvent.change(box, { target: { value: '価格' } });
+    expect(committedChart(onPatch)?.title).toEqual({ en: 'Pricing', ja: '価格' });
+  });
+
+  it('LIT CONTROL — editing a plain-string title still commits the bare string', () => {
+    const onPatch = vi.fn();
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale="en-US"
+        draft={chartDraft('Pricing')}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    fireEvent.change(labelledInput('Chart title'), { target: { value: 'Plans' } });
+    expect(committedChart(onPatch)?.title).toBe('Plans');
+  });
+
+  it('LIT CONTROL — a title-bearing chart keeps its other chart keys', () => {
+    const onPatch = vi.fn();
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale="en-US"
+        draft={chartDraft('Pricing')}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    fireEvent.change(labelledInput('Chart title'), { target: { value: 'Plans' } });
+    expect(committedChart(onPatch)).toMatchObject({ type: 'bar', xAxis: 'stage', yAxis: 'total_amount' });
+  });
+});
+
+/**
+ * ⭐ THE CLEARING RULING (objectui#9274, ruled in this PR — triage deliberately
+ * did not rule it and forbade inheriting today's behaviour as the default).
+ *
+ * Clearing the box removes ONLY the active locale's entry. Sibling locales
+ * survive. When that entry was the last one, the key is dropped entirely,
+ * which is exactly what clearing a plain-string title does today.
+ *
+ * Rationale, pinned here so the next reader gets the reasoning with the
+ * assertion: "clear" is the inverse of "type", and typing can only ever reach
+ * the active locale's entry (`setLocalized` adds one rather than overwriting a
+ * display fallback). Letting CLEAR delete the whole map would reopen, through
+ * the clearing door, the exact hole this card closes on the typing door — a
+ * single-locale author destroying locales they cannot even see.
+ */
+describe('objectui#9274 — chart Title: the CLEARING ruling', () => {
+  it('clearing removes only the active locale entry; siblings survive', () => {
+    const onPatch = vi.fn();
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale="en-US"
+        draft={chartDraft({ en: 'Pricing', 'zh-CN': '定价' })}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    fireEvent.change(labelledInput('Chart title'), { target: { value: '' } });
+    expect(committedChart(onPatch)?.title).toEqual({ 'zh-CN': '定价' });
+  });
+
+  it('clearing the LAST entry drops the key entirely (chart itself survives)', () => {
+    const onPatch = vi.fn();
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale="en-US"
+        draft={chartDraft({ en: 'Pricing' })}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    fireEvent.change(labelledInput('Chart title'), { target: { value: '' } });
+    const chart = committedChart(onPatch)!;
+    expect(chart.title).toBeUndefined();
+    expect(chart).toMatchObject({ type: 'bar' });
+  });
+
+  it('clearing a DISPLAY FALLBACK is a refusal, not a deletion', () => {
+    // Shown the `en` string under `ja`, clearing must not delete English.
+    const onPatch = vi.fn();
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale={'ja' as unknown as 'en-US'}
+        draft={chartDraft({ en: 'Pricing' })}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    fireEvent.change(labelledInput('Chart title'), { target: { value: '' } });
+    expect(committedChart(onPatch)?.title).toEqual({ en: 'Pricing' });
+  });
+
+  it('LIT CONTROL — clearing a plain-string title still drops the key', () => {
+    const onPatch = vi.fn();
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale="en-US"
+        draft={chartDraft('Pricing')}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    fireEvent.change(labelledInput('Chart title'), { target: { value: '' } });
+    expect(committedChart(onPatch)?.title).toBeUndefined();
+  });
+});
+
+/**
+ * The SIBLING measured on this surface (objectui#9274's must-check).
+ *
+ * The card named `chart.subtitle` / `chart.description`. Both are real in the
+ * spec union but this inspector renders NO input for either (the curated Chart
+ * panel offers type / title / X / Y, and `chart` is in SchemaForm's
+ * `hiddenFields`), so neither has a write path to defend — see the PR body.
+ *
+ * The live sibling is the report's own top-level `label`: same union, same
+ * inspector, same narrow-then-flatten shape, and REQUIRED on every report, so
+ * strictly more reachable than `chart.title`.
+ */
+describe('objectui#9274 — the report `label` sibling: same union, same defect', () => {
+  const mapLabelDraft = {
+    name: 'pipeline',
+    label: { en: 'Pipeline', 'zh-CN': '销售漏斗' },
+    type: 'summary',
+    dataset: 'sales_metrics',
+    rows: ['stage'],
+    values: ['total_amount'],
+  };
+
+  it('reads the active locale entry instead of an empty box', () => {
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale="en-US"
+        draft={mapLabelDraft}
+        onPatch={vi.fn()}
+        readOnly={false}
+      />,
+    );
+    expect(labelledInput('Label').value).toBe('Pipeline');
+  });
+
+  it('an edit preserves every other locale (asserted on the committed patch)', () => {
+    const onPatch = vi.fn();
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale="en-US"
+        draft={mapLabelDraft}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    fireEvent.change(labelledInput('Label'), { target: { value: 'Pipeline 2' } });
+    expect(onPatch).toHaveBeenCalledWith({ label: { en: 'Pipeline 2', 'zh-CN': '销售漏斗' } });
+  });
+
+  it('clearing removes only the active locale entry', () => {
+    const onPatch = vi.fn();
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale="en-US"
+        draft={mapLabelDraft}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    fireEvent.change(labelledInput('Label'), { target: { value: '' } });
+    expect(onPatch).toHaveBeenCalledWith({ label: { 'zh-CN': '销售漏斗' } });
+  });
+
+  it('LIT CONTROL — a plain-string label still reads and commits verbatim', () => {
+    const onPatch = vi.fn();
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale="en-US"
+        draft={{ ...mapLabelDraft, label: 'Pipeline' }}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    expect(labelledInput('Label').value).toBe('Pipeline');
+    fireEvent.change(labelledInput('Label'), { target: { value: 'Pipeline 2' } });
+    expect(onPatch).toHaveBeenCalledWith({ label: 'Pipeline 2' });
+  });
+
+  it('LIT CONTROL — clearing a plain-string label still commits the empty string', () => {
+    const onPatch = vi.fn();
+    render(
+      <ReportDefaultInspector
+        {...baseProps}
+        locale="en-US"
+        draft={{ ...mapLabelDraft, label: 'Pipeline' }}
+        onPatch={onPatch}
+        readOnly={false}
+      />,
+    );
+    fireEvent.change(labelledInput('Label'), { target: { value: '' } });
+    expect(onPatch).toHaveBeenCalledWith({ label: '' });
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ReportDefaultInspector.tsx
@@ -51,6 +51,7 @@ import {
 import { getReportForm, getReportSchema } from '../report-schema.js';
 import { mergeServerFields } from '../mergeServerFields.js';
 import { t } from '../i18n.js';
+import { pickLocalized, setLocalized, clearLocalized } from '@object-ui/i18n';
 
 /**
  * Top-level report fields this inspector renders with its own dedicated
@@ -238,7 +239,12 @@ export function ReportDefaultInspector({
     typeof draft.type === 'string' ? (draft.type as string) : 'tabular';
   const typeOptions = useTypeOptions(locale);
 
-  const labelValue = typeof draft.label === 'string' ? (draft.label as string) : '';
+  // `ReportSchema.label` is an `I18nLabel` — a plain string OR an inline
+  // per-locale map (measured on @objectstack/spec 17.4.0). Narrowing it to the
+  // string arm painted an EMPTY Label box over a report that has a label, and
+  // the empty box is what invites the retype that flattens the map
+  // (objectui#9274). READ through the repo's one resolver for the union.
+  const labelValue = pickLocalized(draft.label, locale);
   const datasetName =
     typeof draft.dataset === 'string' ? (draft.dataset as string) : '';
   const values = React.useMemo(() => readNames(draft.values), [draft.values]);
@@ -299,7 +305,7 @@ export function ReportDefaultInspector({
   const chartType = typeof chart.type === 'string' ? (chart.type as string) : '';
   const chartX = typeof chart.xAxis === 'string' ? (chart.xAxis as string) : '';
   const chartY = typeof chart.yAxis === 'string' ? (chart.yAxis as string) : '';
-  const chartTitle = typeof chart.title === 'string' ? (chart.title as string) : '';
+  const chartTitle = pickLocalized(chart.title, locale);
   const commitChart = (patch: Record<string, unknown>) => {
     const next = { ...chart, ...patch };
     onPatch({ chart: next.type ? next : undefined });
@@ -360,9 +366,17 @@ export function ReportDefaultInspector({
         label={tr('engine.inspector.report.label')}
         value={labelValue}
         onCommit={(v) => {
+          // Same `I18nLabel` union, same inspector, same destructive shape as
+          // the chart title (objectui#9274) — and `label` is REQUIRED on every
+          // report, so it is the more reachable of the two. A required key
+          // spells "empty" as `''`, not as an absent key, so the clear arm's
+          // `undefined` (nothing localized left) is mapped back onto it.
+          const patch: Record<string, unknown> = {
+            label: v ? setLocalized(draft.label, locale, v) : (clearLocalized(draft.label, locale) ?? ''),
+          };
           // Live-derive the snake_case name from the label until the author
-          // edits the Name field directly (create mode only).
-          const patch: Record<string, unknown> = { label: v };
+          // edits the Name field directly (create mode only). `v` is the plain
+          // string the author just typed, which is what the slug must read.
           if (createMode && !nameTouched.current) patch.name = toFieldName(v);
           onPatch(patch);
         }}
@@ -452,7 +466,18 @@ export function ReportDefaultInspector({
                 <InspectorTextField
                   label={tr('engine.inspector.report.chartTitle')}
                   value={chartTitle}
-                  onCommit={(v) => commitChart({ title: v || undefined })}
+                  onCommit={(v) =>
+                    // ⛔ Never `{ title: v }` — with a stored locale map that is
+                    // the flattening write objectui#9274 exists to remove. The
+                    // clear arm removes ONLY this locale's entry (and drops the
+                    // key once nothing localized is left, which is exactly what
+                    // clearing a plain-string title has always done).
+                    commitChart({
+                      title: v
+                        ? setLocalized(chart.title, locale, v)
+                        : clearLocalized(chart.title, locale),
+                    })
+                  }
                   disabled={readOnly}
                 />
                 <InspectorSelectField

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -228,6 +228,32 @@ isRTL('ar'); // true
 isRTL('en'); // false
 ```
 
+### Localized value helpers — reading and editing an `I18nLabel`
+
+Server-driven metadata types a label as a plain string **or** an inline
+per-locale map (`{ en: 'Pricing', 'zh-CN': '定价' }`). An authoring surface that
+shows one locale in one text input has to answer three separate questions, so
+there are three functions and each answers exactly one:
+
+```tsx
+import { pickLocalized, setLocalized, clearLocalized } from '@object-ui/i18n';
+
+const stored = { en: 'Pricing', 'zh-CN': '定价' };
+
+pickLocalized(stored, 'en-US');          // 'Pricing'   — which entry to DISPLAY
+setLocalized(stored, 'en-US', 'Plans');  // { en: 'Plans', 'zh-CN': '定价' }
+clearLocalized(stored, 'en-US');         // { 'zh-CN': '定价' }
+```
+
+⛔ Never write the input's string back as the whole value — that replaces the
+map and every locale the author was not looking at is gone, silently, on the
+first keystroke. `setLocalized` replaces **one** entry (adding it when the
+active locale has none) and `clearLocalized` removes **one** entry (returning
+`undefined` once nothing localized is left). Both choose that entry with the
+same limbs, and deliberately stop short of `pickLocalized`'s display-only
+fallbacks, so an author editing in `fr` while shown the `en` string can neither
+overwrite nor delete English.
+
 ## Scope — the `engine.*` carve-out (metadata-admin / Studio)
 
 Not every user-facing string in this repository resolves through these packs.

--- a/packages/i18n/src/__tests__/clearLocalized.test.ts
+++ b/packages/i18n/src/__tests__/clearLocalized.test.ts
@@ -1,0 +1,117 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `clearLocalized` — the CLEAR arm of the single-locale editor (objectui#9274).
+ *
+ * `setLocalized` answers "type" and "retype". It cannot answer "clear": passing
+ * it `''` stores an entry that claims the active locale HAS a title and it is
+ * blank, which then shadows every display fallback `pickLocalized` would have
+ * offered. The alternative an authoring surface reaches for by reflex —
+ * dropping the whole value — is the objectui#9274 data loss arriving through
+ * the clearing door instead of the typing door.
+ *
+ * Three properties carry the contract:
+ *
+ *  1. **Exactly one entry leaves.** Every other locale survives byte-identical.
+ *  2. **The entry removed is the entry displayed** — it is chosen by the same
+ *     `localeWriteKey` limbs `setLocalized` writes through, so an author can
+ *     only ever clear the string they were actually looking at.
+ *  3. **A borrowed string cannot be cleared.** When the map has no entry for the
+ *     active locale the box was showing another locale's string as a display
+ *     fallback; clearing it is a refusal, not a deletion.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { clearLocalized, setLocalized, pickLocalized } from '../pickLocalized.js';
+
+describe('clearLocalized — non-map inputs have nothing localized to keep', () => {
+  it.each([
+    ['plain string', 'Revenue'],
+    ['empty string', ''],
+    ['null', null],
+    ['undefined', undefined],
+    ['array', ['Revenue']],
+  ])('%s clears to undefined', (_label, value) => {
+    expect(clearLocalized(value, 'en')).toBeUndefined();
+  });
+});
+
+describe('clearLocalized — a map loses exactly the active locale entry', () => {
+  it('removes the exact-tag entry and carries every other locale across', () => {
+    const stored = { en: 'Revenue', 'zh-CN': '收入', ja: '収益' };
+    const cleared = clearLocalized(stored, 'zh-CN') as Record<string, unknown>;
+    expect(cleared).toEqual({ en: 'Revenue', ja: '収益' });
+    expect(cleared.en).toBe(stored.en);
+    expect(cleared.ja).toBe(stored.ja);
+  });
+
+  it('follows the base-language limb — `en-US` clears the stored `en` entry', () => {
+    expect(clearLocalized({ en: 'Revenue', 'zh-CN': '收入' }, 'en-US')).toEqual({ 'zh-CN': '收入' });
+  });
+
+  it('follows the region-qualified limb — `zh` clears the stored `zh-CN` entry', () => {
+    expect(clearLocalized({ en: 'Revenue', 'zh-CN': '收入' }, 'zh')).toEqual({ en: 'Revenue' });
+  });
+
+  it('does not mutate the stored map', () => {
+    const stored = { en: 'Revenue', 'zh-CN': '收入' };
+    clearLocalized(stored, 'en');
+    expect(stored).toEqual({ en: 'Revenue', 'zh-CN': '收入' });
+  });
+
+  it('clearing the LAST entry yields undefined, never an empty map', () => {
+    expect(clearLocalized({ en: 'Revenue' }, 'en')).toBeUndefined();
+    expect(clearLocalized({ 'zh-CN': '收入' }, 'zh-CN')).toBeUndefined();
+  });
+});
+
+describe('clearLocalized — a borrowed display fallback is refused, not deleted', () => {
+  it('clearing under a locale with no entry returns the map unchanged', () => {
+    // `pickLocalized` shows the `en` string under `fr`; clearing must not be
+    // able to delete English on the strength of that loan.
+    const stored = { en: 'Revenue', 'zh-CN': '收入' };
+    expect(pickLocalized(stored, 'fr')).toBe('Revenue');
+    expect(clearLocalized(stored, 'fr')).toEqual(stored);
+  });
+
+  it('the `default` and first-value limbs are not clear targets either', () => {
+    const stored = { default: 'Revenue', 'zh-CN': '收入' };
+    expect(pickLocalized(stored, 'fr')).toBe('Revenue');
+    expect(clearLocalized(stored, 'fr')).toEqual(stored);
+  });
+
+  it('own properties only — a prototype member names no entry to clear', () => {
+    const stored = { en: 'Revenue' };
+    expect(clearLocalized(stored, 'constructor')).toEqual(stored);
+  });
+});
+
+describe('clearLocalized — paired with setLocalized', () => {
+  it('clear undoes the write it mirrors: set then clear restores the original map', () => {
+    const stored = { en: 'Revenue', 'zh-CN': '收入' };
+    for (const lang of ['en', 'en-US', 'zh-CN', 'zh'] as const) {
+      const written = setLocalized(stored, lang, 'EDITED');
+      expect(clearLocalized(written, lang)).toEqual(
+        Object.fromEntries(Object.entries(stored).filter(([, v]) => v !== pickLocalized(stored, lang))),
+      );
+    }
+  });
+
+  it('a locale ADDED by setLocalized can be cleared away again', () => {
+    const stored = { en: 'Revenue' };
+    const written = setLocalized(stored, 'ja', '売上');
+    expect(written).toEqual({ en: 'Revenue', ja: '売上' });
+    expect(clearLocalized(written, 'ja')).toEqual({ en: 'Revenue' });
+  });
+
+  it('non-string entries are carried across untouched, exactly as setLocalized does', () => {
+    const stored = { en: 'Revenue', 'zh-CN': '收入', bogus: 42 } as Record<string, unknown>;
+    expect(clearLocalized(stored, 'en')).toEqual({ 'zh-CN': '收入', bogus: 42 });
+  });
+});

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -147,7 +147,7 @@ export {
   type SpecTranslationData,
 } from './utils/index.js';
 
-export { pickLocalized, setLocalized } from './pickLocalized.js';
+export { pickLocalized, setLocalized, clearLocalized } from './pickLocalized.js';
 export { LocalizationProvider, useLocalization, type LocalizationValue } from './LocalizationContext.js';
 export { resolveFieldCurrency } from './currency.js';
 

--- a/packages/i18n/src/pickLocalized.ts
+++ b/packages/i18n/src/pickLocalized.ts
@@ -148,3 +148,44 @@ export function setLocalized(
   const o = value as Record<string, unknown>;
   return { ...o, [localeWriteKey(o, language)]: next };
 }
+
+/**
+ * Remove the `language` entry from a possibly-localized value — the CLEAR arm
+ * of the same editor {@link setLocalized} serves, and the reason it cannot be
+ * spelled as `setLocalized(value, language, '')`.
+ *
+ * A single-line authoring input has three actions, not two: type, retype, and
+ * clear. `setLocalized` answers the first two. Answering the third with "write
+ * the empty string" stores `{ en: '' }` — an entry that claims "English has a
+ * title and it is blank", which then SHADOWS every display fallback: a viewer
+ * in `en` sees nothing where the map's other locales would have been offered.
+ * Answering it with "drop the whole value" is the objectui#9274 data loss
+ * itself, arriving through the clearing door instead of the typing door.
+ *
+ * So clearing removes exactly one entry — the same entry {@link setLocalized}
+ * would have written, chosen by the same {@link localeWriteKey} limbs, which is
+ * what keeps the cleared entry the one the author was actually looking at.
+ *
+ * - Plain string / `null` / `undefined` / array: there is no map, so there is
+ *   nothing localized left — `undefined`. The caller decides how its own field
+ *   spells empty (`undefined` for an optional key, `''` for a required one).
+ * - Map with the active entry present: that entry is removed and every other
+ *   locale is carried across untouched. When it was the LAST entry the result
+ *   is `undefined` rather than `{}`, because an empty map is not a title.
+ * - Map WITHOUT an entry for the active locale: returned unchanged. The box was
+ *   showing a display fallback borrowed from another locale, and clearing a
+ *   borrowed string must not delete the locale it was borrowed from — the same
+ *   refusal {@link localeWriteKey} enforces on the write side, which is why
+ *   both read the same limbs from the same file.
+ */
+export function clearLocalized(
+  value: unknown,
+  language: string | undefined | null,
+): Record<string, unknown> | undefined {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const o = value as Record<string, unknown>;
+  const key = localeWriteKey(o, language);
+  if (!Object.prototype.hasOwnProperty.call(o, key)) return o;
+  const rest = Object.fromEntries(Object.entries(o).filter(([k]) => k !== key));
+  return Object.keys(rest).length > 0 ? rest : undefined;
+}


### PR DESCRIPTION
Fixes #9274 — the report inspector's Title box narrowed `chart.title` to a plain string and flattened the stored locale map on write.

## What was wrong

`@objectstack/spec` types `ReportChartSchema.title` as `I18nLabel` — a plain string **or** an inline per-locale map. Against a stored map the inspector's two halves failed in **opposite directions and amplified each other**:

| half | on the base tree | effect |
|:--|:--|:--|
| READ | `typeof chart.title === 'string' ? … : ''` | an **EMPTY** Title box over a report that has a title |
| WRITE | `{ ...chart, ...patch }` with `title: v` | the typed string lands **in place of the whole map** |

The damage does not need a mistake: the empty box *invites* the author to retype a title it told them was missing, and that retype is what drops every language they were not looking at. Committing the empty box untouched sent `v || undefined`, deleting the stored map outright. Ordinary trigger, silent, unrecoverable.

## The repair

The pair already existed in this repo and `@object-ui/i18n` was already a dependency; what was missing was the call.

- READ `pickLocalized(value, locale)`
- WRITE `setLocalized(value, locale, v)`

⚠️ **Note on the argument order.** The card and the dispatch both spell the write as `setLocalized(chart.title, v, activeLanguage)`. The shipped signature is `setLocalized(value, language, next)` — language second. Measured, not assumed; the code uses the real order.

No merge logic is hand-rolled. `setLocalized` deliberately stops short of `pickLocalized`'s display-only fallback limbs, so an author editing in `ja` while shown the `en` string **adds** a `ja` entry rather than overwriting English — that property is pinned here rather than merely cited.

## ⭐ The clearing ruling (this PR rules it; triage deliberately did not)

Today's behaviour — clearing deletes the whole map — is the card's own data loss, and the dispatch forbids inheriting it as the default. The ruling:

> **Clearing the box removes ONLY the active locale's entry. Sibling locales survive. When that entry was the last one the key is dropped entirely — which is byte-for-byte what clearing a plain-string title already did.**

Why this and not the two alternatives:

- **vs. "delete the whole map"** — clear is the inverse of type, and typing can only ever reach the active locale's entry. Letting clear delete the whole map reopens, through the clearing door, exactly the hole this card closes on the typing door: a single-locale author destroying locales they cannot see.
- **vs. "write the empty string"** (what `setLocalized(value, locale, '')` would do) — that stores `{ en: '' }`, an entry claiming English *has* a title and it is blank. It then **shadows** every display fallback, so an `en` viewer sees nothing where the map's other locales would have been offered. Invisible to the author, and a silent regression for readers.

A corollary falls out and is pinned: clearing a box that is showing a **borrowed** display fallback is a **refusal, not a deletion** — an author in `ja` shown the English string cannot delete English by clearing, the mirror of the guarantee `setLocalized` already gives on write.

This needed a third function, because the existing pair cannot express it: `setLocalized(v, lang, '')` is the shadowing write above, and picking the entry to remove by hand would duplicate `localeWriteKey`'s limbs — the drift hazard that doc comment exists to prevent. `clearLocalized` is added **beside** `setLocalized`, sharing the same write-key limbs, so the entry removed is always the entry displayed.

## ⭐ The siblings — measured, then answered

The card's must-check named `chart.subtitle` / `chart.description`.

- **`chart.subtitle` / `chart.description`** — both real in the spec union (verified in `ReportChartSchema`), but **this inspector renders no input for either**. The curated Chart panel offers type / title / X / Y only, and `chart` is listed in `SchemaForm`'s `hiddenFields`, so the spec-form graft does not reach them either. **No write path exists, so there is nothing to defend.** Fenced with that reason, not repaired.
- **`label` — the live sibling, and it is repaired here.** `ReportSchema.label` is the *same* union, on the *same* inspector, with the *same* narrow-then-flatten shape (`typeof draft.label === 'string' ? … : ''`, then `onPatch({ label: v })`). It is **required on every report**, so it is strictly more reachable than `chart.title`. Repairing only `title` would have left the worse of the two instances in place. Its empty spelling differs — a required key clears to `''`, not to an absent key — and that difference is preserved exactly.

## ⚠️ The spec union — triage's declared NOT MEASURED, now measured

Triage could not read it (`@objectstack/spec` was not installed in that container). **Measured here on `@objectstack/spec@17.4.0`**, from `dist/page.zod-*.d.ts`:

- `ReportChartSchema.title` — `ZodOptional` of a union of `ZodString` and an inline `Record` of string to string. **Confirmed: the union is real.**
- `ReportChartSchema.subtitle`, `ReportChartSchema.description` — the identical union.
- `ReportSchema.label` — the same union, and **not** optional.

The card's reading was correct in every limb.

## ⚠️ The falsifiable premise — NOT falsified, and still uncensused

The card's premise is that inline locale-map titles are actually used in real reports. My reading **does not falsify it**, but it does not confirm it either, and I am reporting the numbers rather than downgrading anything:

- **Zero** authored reports in this repo carry a map-valued `chart.title` or `label` (this repo ships the authoring surface, not the reports — the customer corpus is not visible from here).
- The spelling **is** live in this repo's own corpus for sibling metadata: `apps/console/src/pages/system/__tests__/AppManagementPage.search.test.tsx` stores a map-valued `label`, and `registry-inputs-spec-parity` / `component-input-union-specimens` deliberately pin that the map arm is **accepted** for a title.
- `DashboardWidgetInspector` already shipped this exact repair for the dashboard widget title on the same reasoning.

⇒ the p1 grading's premise stands as triage left it: plausible and unmeasured on real customer data. The defect is intact either way.

## Verification

Pin written **before** the code, so the "unmodified" arm is the real base tree.

**Base tree (before the fix), `ReportDefaultInspector.i18nTitle.test.tsx`:** `11 failed | 6 passed (17)` — and all **6 passing are the lit controls**, which is what proves the pin can distinguish. The two symptoms, verbatim:

```
AssertionError: expected '' to be 'Pricing'                                  ← the EMPTY box
AssertionError: expected 'Plans' to deeply equal { Object (en, zh-CN, ...) } ← the DESTROYED map
```

**After the fix:** `Test Files 2 passed (2) · Tests 29 passed (29)` (the new pin plus the pre-existing `ReportDefaultInspector.test.tsx`, unchanged).

**Contract-level pin:** `packages/i18n/src/__tests__/clearLocalized.test.ts` — `Test Files 3 passed (3) · Tests 97 passed (97)` across `clearLocalized` / `setLocalized` / `pickLocalized`.

**Ablation leg.** Restoring only the `chart.title` narrowing and the `v || undefined` write, on the committed tree:

```
BEFORE mutation:  pickLocalized(chart.title  = 1   typeof chart.title === 'string' = 0
AFTER  mutation:  pickLocalized(chart.title  = 0   typeof chart.title === 'string' = 1
  → Tests  8 failed | 9 passed (17)
```

The mutation is proven on disk by the marker counts flipping in both directions, not by an editor's exit code. Exactly the 8 chart-title map assertions go red; the 6 lit controls and the 3 `label` assertions stay green, which shows the pin is bound to the code it names rather than to the file as a whole. Restore proven by blob hash, not by an exit code:

```
HEAD_BLOB     = 8556c74318eef9c0a2d74169708ac4f6a52948f5
MUTATED_BLOB  = a9dfe4654ed3cbcf9fcfa4797b97b6b0b8401603
RESTORED_BLOB = 8556c74318eef9c0a2d74169708ac4f6a52948f5   (git diff HEAD empty)
```

**Gates** (verdict lines read from each gate's own output, never a bare exit status): `changeset:check`, `check:changeset-claims`, `check:control-bytes` (7515 files scanned), `check:new-line-citations`, `check:test-path-roots`, `check-changeset-presence` — all exit 0.

⚠️ `check:readme-exports` self-reported **population COLLAPSED** (`packagesRead 1, floor 25` — the tree was unbuilt). That is **NOT MEASURED, not a red gate**, and is recorded as such rather than as a pass.

### ⚠️ On narrowing the verification union

The dispatch's warning applies directly here, so I did the membership read before trusting anything. The transitive dependent set of the two changed packages is **33 packages**, and it **includes `@object-ui/site` (`apps/site`)**, which declares `type-check` — the exact package a previous seat excluded as "a docs app" and went red on. It is **not** excluded here.

What bounds the risk is a measurement rather than a judgement: the published surface of `@object-ui/i18n` moves **additively only** — one new export, `clearLocalized`; no existing export changed shape, arity or type. `@object-ui/app-shell`'s change is internal to one component and moves no exported type. The type-check result over that closure is recorded in the report accompanying this PR.

## Changeset

`minor` for both packages. The fixed group is **40 packages** (measured from `.changeset/config.json`), so `major` is unavailable by repo policy; nothing here needs it — this is a bug fix plus one additive export, with no `**BREAKING**` carrier warranted.

**What an author who does nothing differently now gets:** a plain-string title or label behaves exactly as before — same box, same committed value, including on clear. A *map-valued* title or label now shows their own locale's string instead of a blank box, and editing it keeps every other language instead of deleting it.

## Boundaries honoured

- ⛔ `@object-ui/plugin-report` (the renderer, objectui#9150) is **not touched** — different package, read-only site, different failure.
- ⛔ `packages/components/src/ui/**` not touched.
- ⛔ No test skipped, disabled or quarantined.
- ⛔ No in-flight overlap: objectui#9310 (`packages/react`, `packages/fields`, `apps/site`), objectui#9294 (`plugin-grid`), objectui#9304 (`plugin-detail`, `plugin-form`) — none touch `app-shell` or `i18n`.

## Acceptance notes

Observed while measuring, **not filed and not fixed here**:

- `SchemaForm` (`packages/app-shell/.../SchemaForm.tsx`) has no `I18nLabel` awareness at all. Every localizable string field routed through the spec-form graft — the report's own top-level `description`, among others — is read and written as a plain value, i.e. the same narrow-then-flatten shape as this card, but **generically, across every metadata type the graft serves**. That is a much larger surface than this card and deserves its own measurement rather than a drive-by repair here. Reported to the PM for filing.
- `pickLocalized` / `setLocalized` were undocumented public exports of `@object-ui/i18n`; the README section added here covers all three rather than only the new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_