### PR TITLE
fix(plugin-grid): format every column-summary arm in the tenant locale

### DIFF
--- a/.changeset/grid-summary-footer-tenant-locale-9294.md
+++ b/.changeset/grid-summary-footer-tenant-locale-9294.md
@@ -1,0 +1,47 @@
+---
+'@object-ui/plugin-grid': minor
+---
+
+The grid column-summary footer formats in the TENANT's locale, not the machine's (objectui#9294).
+
+`formatSummaryLabel` in `packages/plugin-grid/src/useColumnSummary.ts` handed `Intl` no locale
+argument at seven call sites — the currency arm (both branches plus its constructor-threw
+fallback), the average arm, the plain numeric default, the percent-of-rows arm and the
+count/non-numeric arm. An omitted or `undefined` locale is not "no opinion": it is **the
+machine's** locale, which is neither of this renderer's two channels, and it is the one thing
+`useDisplayLocale`'s own doc comment tells callers not to do. All seven now take the concrete
+BCP-47 tag that hook already resolves (tenant locale, then UI language, then `'en'`) — the same
+tag the cells directly above the footer are formatted with, and the same one the percent column
+took in objectui#9269.
+
+**BREAKING** — rendered output moves. Not only for the sessions that were wrong: it moves in
+**every session whose browser locale differs from the tenant's**, which is the normal case for a
+German tenant staffed on English systems or the reverse. Where the two happened to agree, output
+is unchanged. Measured on one row of `1234.5` in a `EUR` column of scale 2, on a machine whose
+locale is `en-US`:
+
+| tenant locale | before (all sessions) | after |
+|---|---|---|
+| `en` | `Sum: €1,234.50` | `Sum: €1,234.50` (unchanged) |
+| `de-DE` | `Sum: €1,234.50` | `Sum: 1.234,50 €` (symbol trails, after a no-break space) |
+| `tr-TR` | `Sum: €1,234.50` | `Sum: €1.234,50` |
+
+The size of what this repairs is why it ships as a declared break rather than quietly: a `de-DE`
+tenant read `1,234.50` and parsed it by German convention as `1.2345` — three orders of magnitude
+out, on a **currency total**. It is a sharper failure than the percent-sign move its parent card
+repaired, because a sign changing sides is visible and a decimal separator changing is not:
+`1,234.5` is a perfectly ordinary German number for a completely different value.
+
+`minor` rather than `major` because this package ships in the fixed group whose major tracks
+`@objectstack`'s (see AGENTS.md, "版本号策略"), so a breaking change is carried in the body.
+
+**Not changed.** Only the locale tag moves. Every arm keeps the formatter and the fraction-digit
+widths it already had — the currency arm still reads the column's declared `scale` (objectui#2131)
+and the percent-of-rows arm still carries its own literal sign, both of which belong to
+objectui#4589's number-display policy rather than to this card. Routing these arms through
+`@object-ui/fields`' `formatCurrency` / `formatNumber` was measured and rejected for exactly that
+reason: it discards the column's declared `scale`, fires a wholeness switch that drops a whole
+amount's fraction digits, and pins the plain/average arms to a fixed decimal width — output moves
+in `en` too, which no locale repair should do. The `colType === 'percent'` arm is untouched;
+objectui#9269 landed it and it serves here as the control that proves the test fixture really
+moves the tenant locale.

--- a/packages/plugin-grid/src/__tests__/useColumnSummary.tenantLocale-9294.test.tsx
+++ b/packages/plugin-grid/src/__tests__/useColumnSummary.tenantLocale-9294.test.tsx
@@ -1,0 +1,300 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9294 — every arm of the grid column-summary footer formats in the
+ * TENANT's locale, not the MACHINE's.
+ *
+ * `formatSummaryLabel` handed `Intl` an `undefined` locale at seven call
+ * sites. `undefined` does not mean "no opinion" — it means the locale of the
+ * machine the code happens to be running on, which is neither of this
+ * renderer's two locale channels. `useDisplayLocale`'s own doc comment names
+ * this as the one thing a caller must not do, and every date, number and
+ * currency renderer goes through that hook for exactly that reason.
+ *
+ * The harm is sharper than the percent-sign move its parent card repaired.
+ * A sign changing sides is visible; a decimal separator changing is not:
+ *
+ *                     currency      plain
+ *   de-DE (correct)   1.235 EUR     1.234,5
+ *   machine(en-US)    EUR1,235      1,234.5
+ *
+ * A `de-DE` tenant reads `1,234.5` and parses it by German convention as
+ * 1.2345 — three orders of magnitude out, on a CURRENCY TOTAL, and legible as
+ * a perfectly ordinary German number the whole way.
+ *
+ * ── What this file measures: READ THE ROWS, NOT THE CELLS ────────────────
+ * The defect is not "this cell renders the wrong bytes" — it is "this cell
+ * does not move at all when the tenant locale moves". So the headline table
+ * below asserts MOVEMENT: for every arm, the `de-DE` and `tr-TR` readings must
+ * differ from the `en` one. Under the defect all three are the machine's
+ * `en-US` and the row is flat; a per-cell snapshot suite would pass happily
+ * while measuring nothing at all about the locale channel.
+ *
+ * ⭐ Movement alone is blind to a repair that threaded SOME varying locale
+ * rather than the tenant's. That is what the agreement table is for: its
+ * right-hand side is computed from the tenant tag under test in the same run,
+ * so it can only pass while the tenant channel is the live one. The two tables
+ * are a pair — neither is sufficient alone.
+ *
+ * ── The lit control ─────────────────────────────────────────────────────
+ * ⭐ The `colType === 'percent'` arm is ALREADY fixed (objectui#9269, landed
+ * as PR objectui#9293) and is deliberately untouched by this card. It is
+ * therefore the control that proves the fixture really moves the locale: it
+ * moves on the unmodified base tree. **If the control row is flat, the wrapper
+ * is inert and every other row in this file is NOT MEASURED — not a negative
+ * answer.** Its case runs first and says so in its own name.
+ *
+ * ── Which rows can actually fire ────────────────────────────────────────
+ * ⛔ The `en` rows are NOT controls. This measuring container's machine locale
+ * is `en-US`, and `en` and `en-US` were measured to render every fixture in
+ * this file identically, so an `en` row reads the same whether the tenant tag
+ * arrived or not. They are overshoot detectors. The rows that MOVE — and
+ * therefore the ones that measure the repair — are `de-DE` and `tr-TR`, which
+ * both swap the grouping and decimal marks against `en`, and which disagree
+ * with each other on where a currency symbol sits.
+ *
+ * ── Directions, predicted in writing BEFORE the first run ───────────────
+ *   the lit control (percent column)   GREEN on the base tree — it is already fixed
+ *   movement, all seven other sites    RED   on the base tree — flat rows
+ *   agreement @ en, every site         GREEN on the base tree — machine is en-US
+ *   agreement @ de-DE / tr-TR          RED   on the base tree
+ *   tr-TR currency, absolute bytes     RED   on the base tree
+ *   the prefix probes                  GREEN on the base tree
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as React from 'react';
+import { renderHook } from '@testing-library/react';
+import { I18nProvider, LocalizationProvider } from '@object-ui/i18n';
+import { formatPercent } from '@object-ui/fields';
+import { useColumnSummary } from '../useColumnSummary';
+
+/**
+ * The UI language is held at `en` while the TENANT locale moves — the real
+ * precedence `useDisplayLocale` implements (tenant locale outranks UI
+ * language). Holding the language still keeps the footer's PREFIX in English,
+ * so a failure in the number cannot be confused with a bundle move.
+ *
+ * ⚠️ No `currency` is supplied to `LocalizationProvider`, deliberately: the
+ * no-currency currency branch below needs `resolveFieldCurrency` to come back
+ * empty, and a tenant default would backstop it.
+ */
+function wrapper(locale: string) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false }}>
+      <LocalizationProvider value={{ locale }}>{children}</LocalizationProvider>
+    </I18nProvider>
+  );
+}
+
+/** The footer label the hook itself produces, for one column of one fixture. */
+function summaryLabel(locale: string, column: Record<string, unknown>, rows: unknown[]): string {
+  const cols: any[] = [column];
+  const { result } = renderHook(() => useColumnSummary(cols, rows as any[]), {
+    wrapper: wrapper(locale),
+  });
+  return result.current.summaries.get(column.field as string)?.label ?? '';
+}
+
+/** Amount chosen so that BOTH the grouping mark and the decimal mark are exercised. */
+const AMOUNT = 1234.5;
+
+/**
+ * A cardinality has to cross the thousands boundary before any locale can
+ * disagree about it, so the count arm needs four digits of rows. Built once.
+ */
+const MANY_ROWS = Array.from({ length: 1234 }, () => ({ v: 'x' }));
+
+/** Three rows, two filled — `percent_filled` lands on a repeating fraction. */
+const TWO_OF_THREE = [{ v: 'x' }, { v: 'y' }, { v: null }];
+const PERCENT_OF_ROWS = (2 / 3) * 100;
+
+/**
+ * The arms, one entry per locale-less call site the card names.
+ *
+ * `declared` is the right-hand side of the agreement table: the rendering the
+ * tenant tag itself produces, computed in the same run. It restates the
+ * formatting OPTIONS each site passes (which stay exactly where they were —
+ * this card is about which locale, not about which widths or which formatter),
+ * and nothing else.
+ */
+interface Arm {
+  site: string;
+  prefix: string;
+  column: Record<string, unknown>;
+  rows: unknown[];
+  declared: (locale: string) => string;
+}
+
+const ARMS: Arm[] = [
+  {
+    site: 'currency, explicit code',
+    prefix: 'Sum: ',
+    column: { field: 'amount', summary: 'sum', type: 'currency', currency: 'EUR', scale: 2 },
+    rows: [{ amount: AMOUNT }],
+    declared: (locale) =>
+      new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }).format(AMOUNT),
+  },
+  {
+    site: 'currency, no code resolved',
+    prefix: 'Sum: ',
+    column: { field: 'amount', summary: 'sum', type: 'currency', scale: 2 },
+    rows: [{ amount: AMOUNT }],
+    declared: (locale) =>
+      new Intl.NumberFormat(locale, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }).format(AMOUNT),
+  },
+  {
+    // `EU` is not a well-formed ISO 4217 code, so the `Intl.NumberFormat`
+    // constructor throws and the arm falls through to its own catch.
+    site: 'currency, constructor threw',
+    prefix: 'Sum: ',
+    column: { field: 'amount', summary: 'sum', type: 'currency', currency: 'EU', scale: 2 },
+    rows: [{ amount: AMOUNT }],
+    declared: (locale) => AMOUNT.toLocaleString(locale),
+  },
+  {
+    site: 'avg',
+    prefix: 'Avg: ',
+    column: { field: 'n', summary: 'avg' },
+    rows: [{ n: 1234 }, { n: 1235 }],
+    declared: (locale) => AMOUNT.toLocaleString(locale, { maximumFractionDigits: 2 }),
+  },
+  {
+    site: 'numeric default',
+    prefix: 'Sum: ',
+    column: { field: 'n', summary: 'sum' },
+    rows: [{ n: AMOUNT }],
+    declared: (locale) => AMOUNT.toLocaleString(locale),
+  },
+  {
+    site: 'percent of rows',
+    prefix: 'Filled: ',
+    column: { field: 'v', summary: 'percent_filled' },
+    rows: TWO_OF_THREE,
+    // The literal sign is #4589's surface, not this card's — only the NUMBER
+    // in front of it is claimed here.
+    declared: (locale) =>
+      `${PERCENT_OF_ROWS.toLocaleString(locale, { maximumFractionDigits: 1 })}%`,
+  },
+  {
+    site: 'non-numeric cardinality',
+    prefix: 'Count: ',
+    column: { field: 'v', summary: 'count' },
+    rows: MANY_ROWS,
+    declared: (locale) => MANY_ROWS.length.toLocaleString(locale),
+  },
+];
+
+/**
+ * ⭐ The lit control — the one arm this card must NOT touch.
+ *
+ * It moves on the base tree because objectui#9269 already repaired it, which
+ * is precisely what qualifies it: a control that cannot fire proves nothing.
+ */
+const CONTROL: Arm = {
+  site: 'percent COLUMN (objectui#9269, the lit control)',
+  prefix: 'Sum: ',
+  column: { field: 'rate', summary: 'sum', type: 'percent' },
+  rows: [{ rate: 0.25 }],
+  declared: (locale) => formatPercent(0.25, 0, locale),
+};
+
+describe('the grid summary footer formats in the tenant locale, not the machine (objectui#9294)', () => {
+  describe('the control, which has to fire before anything else here is a reading', () => {
+    it.each(['de-DE', 'tr-TR'])(
+      'the already-repaired percent column moves under %s — if it does not, the fixture is inert and every other case in this file is NOT MEASURED',
+      (locale) => {
+        expect(summaryLabel(locale, CONTROL.column, CONTROL.rows)).not.toBe(
+          summaryLabel('en', CONTROL.column, CONTROL.rows),
+        );
+      },
+    );
+
+    it.each(['en', 'de-DE', 'tr-TR'])(
+      'and it agrees with the declared percent source at %s',
+      (locale) => {
+        expect(summaryLabel(locale, CONTROL.column, CONTROL.rows)).toBe(
+          `${CONTROL.prefix}${CONTROL.declared(locale)}`,
+        );
+      },
+    );
+  });
+
+  /**
+   * ⭐⭐ The headline instrument: rows, not cells.
+   *
+   * Nothing here names a byte. Each case asks only whether the footer output
+   * CHANGED when the tenant locale changed — which is the defect stated as a
+   * measurement, and the one property a snapshot cannot accidentally satisfy.
+   */
+  describe('every arm tracks the tenant locale', () => {
+    const moves = ARMS.flatMap((arm) =>
+      (['de-DE', 'tr-TR'] as const).map((locale) => [arm.site, locale, arm] as const),
+    );
+
+    it.each(moves)('the %s arm moves when the tenant locale moves to %s', (_site, locale, arm) => {
+      const baseline = summaryLabel('en', arm.column, arm.rows);
+      expect(baseline).not.toBe('');
+      expect(summaryLabel(locale, arm.column, arm.rows)).not.toBe(baseline);
+    });
+  });
+
+  /**
+   * Which locale it moved TO. The right-hand side is computed from the tag
+   * under test, so a repair that threaded some other varying locale — the one
+   * thing the movement table above cannot see — fails here.
+   */
+  describe('and it is the TENANT locale it moved to', () => {
+    const pairs = ARMS.flatMap((arm) =>
+      (['en', 'de-DE', 'tr-TR'] as const).map((locale) => [arm.site, locale, arm] as const),
+    );
+
+    it.each(pairs)('the %s arm reads as %s renders it', (_site, locale, arm) => {
+      expect(summaryLabel(locale, arm.column, arm.rows)).toBe(
+        `${arm.prefix}${arm.declared(locale)}`,
+      );
+    });
+  });
+
+  /**
+   * `tr-TR` on the currency arm, as absolute bytes.
+   *
+   * The one place a literal is the right instrument: the agreement table would
+   * survive a joint move of both sides, and this row cannot pass by accident —
+   * `tr-TR` keeps the symbol in FRONT while writing German-shaped separators,
+   * a combination neither `en` nor the machine locale produces.
+   *
+   * ⛔ Deliberately not the `de-DE` row: its rendering carries a no-break space
+   * before the symbol, and a literal holding an invisible byte is a worse pin
+   * than no literal at all.
+   */
+  it('tr-TR renders the currency total with the symbol in front and swapped marks', () => {
+    expect(summaryLabel('tr-TR', ARMS[0].column, ARMS[0].rows)).toBe('Sum: €1.234,50');
+  });
+
+  /**
+   * The prefixes this file builds its agreement table on are MEASURED, not
+   * assumed — a bundle change to `grid.summary.*` would otherwise arrive here
+   * disguised as a locale failure.
+   */
+  it.each([...ARMS, CONTROL].map((arm) => [arm.site, arm] as const))(
+    'the %s arm carries the label prefix the bundle produces',
+    (_site, arm) => {
+      expect(summaryLabel('en', arm.column, arm.rows).startsWith(arm.prefix)).toBe(true);
+    },
+  );
+});

--- a/packages/plugin-grid/src/useColumnSummary.ts
+++ b/packages/plugin-grid/src/useColumnSummary.ts
@@ -279,25 +279,44 @@ function computeAggregation(type: string, rows: SummaryRow[], field: string): nu
  * in the packs — "separator included, so a translator owns the whole phrase
  * rather than inheriting an English-shaped glue".
  *
- * The NUMBER is untouched: every `toLocaleString` / `Intl.NumberFormat` call
- * below is exactly as it was, and stays #4589's surface rather than this
- * card's.
+ * ## Which LOCALE the number is formatted in (objectui#9294)
+ *
+ * Separate from the join above and separate from #4589's surface below: every
+ * `Intl` call here takes `displayLocale`. The WIDTHS and the choice of
+ * formatter are untouched and stay #4589's — the only thing this file claims
+ * is the tag.
+ *
+ * These calls used to pass no locale at all, which is not "no opinion" — an
+ * omitted or `undefined` locale is the MACHINE's, which is neither of this
+ * renderer's two channels, and is named by `useDisplayLocale`'s own doc
+ * comment as the one thing a caller must not do. It is also worse here than at
+ * the percent arm its parent card repaired: a percent sign changing sides is
+ * visible, a decimal separator changing is not. `1,234.5` is a perfectly
+ * ordinary German number — for a value three orders of magnitude away — and
+ * the arms below include a currency total.
  */
 function formatSummaryLabel(
   type: string,
   value: number | null,
   t: SummaryTranslate,
-  column?: { type?: string; currency?: string; defaultCurrency?: string; currencyConfig?: { defaultCurrency?: string }; precision?: number | null; scale?: number | null },
-  tenantDefault?: string,
-  // The BCP-47 tag from `useDisplayLocale()`, threaded for the percent arm
-  // (objectui#9269). ⚠️ Scope note, so the asymmetry below reads as a bounded
-  // repair rather than an oversight: the other arms still hand `Intl` an
-  // `undefined` locale, i.e. the MACHINE's, which is the thing
-  // `useDisplayLocale`'s own doc comment tells callers not to do. That is a
-  // different defect from this one (it is about which locale, not about which
-  // source owns the percent rule) and is filed separately rather than folded
-  // in here.
-  displayLocale?: string,
+  column: { type?: string; currency?: string; defaultCurrency?: string; currencyConfig?: { defaultCurrency?: string }; precision?: number | null; scale?: number | null } | undefined,
+  tenantDefault: string | undefined,
+  // The BCP-47 tag from `useDisplayLocale()` — tenant locale, then UI
+  // language, then a concrete `'en'`, never `undefined`.
+  //
+  // ⭐ Required and non-optional `string` on purpose (objectui#9294). The two
+  // parameters in front of it are spelled `T | undefined` rather than `T?`
+  // only so this one is allowed to be mandatory. Under the `displayLocale?:`
+  // it replaces, dropping the argument type-checks and the result renders as a
+  // plausible number rather than as an error — the same failure shape as the
+  // omitted locale this card repaired, one layer up, and the reason that
+  // defect was invisible in review for as long as it was. The function is
+  // module-private with a single call site, so nothing outside pays for this.
+  //
+  // ⛔ And no `?? 'en'` backstop here: that would be a renderer-side default
+  // papering over an absent channel (Commandment #0.1). The concrete fallback
+  // belongs to `useDisplayLocale`, which already owns it.
+  displayLocale: string,
 ): string {
   if (value === null) return '';
   const labelKey = TYPE_LABEL_KEYS[type as ColumnSummaryType];
@@ -308,10 +327,10 @@ function formatSummaryLabel(
     t('grid.summary.pattern', { label, value: formatted });
 
   if (PERCENT_TYPES.has(type)) {
-    return join(`${value.toLocaleString(undefined, { maximumFractionDigits: 1 })}%`);
+    return join(`${value.toLocaleString(displayLocale, { maximumFractionDigits: 1 })}%`);
   }
   if (NON_NUMERIC_TYPES.has(type)) {
-    return join(value.toLocaleString());
+    return join(value.toLocaleString(displayLocale));
   }
 
   const colType = column?.type;
@@ -324,18 +343,22 @@ function formatSummaryLabel(
     const decimals = column?.scale ?? 0;
     try {
       formatted = currency
-        ? new Intl.NumberFormat(undefined, {
+        ? new Intl.NumberFormat(displayLocale, {
             style: 'currency',
             currency,
             minimumFractionDigits: decimals,
             maximumFractionDigits: decimals,
           }).format(value)
-        : new Intl.NumberFormat(undefined, {
+        : new Intl.NumberFormat(displayLocale, {
             minimumFractionDigits: decimals,
             maximumFractionDigits: decimals,
           }).format(value);
     } catch {
-      formatted = value.toLocaleString();
+      // The throw this catches is a bad `currency` code, not a bad locale, so
+      // the fallback keeps the tag: degrading to the machine's locale here
+      // would reintroduce the defect on precisely the rows that already went
+      // wrong once.
+      formatted = value.toLocaleString(displayLocale);
     }
   } else if (colType === 'percent') {
     // objectui#9269 — the percent decision is NOT made here any more.
@@ -370,9 +393,9 @@ function formatSummaryLabel(
     const decimals = column?.precision ?? 0;
     formatted = formatPercent(value, decimals, displayLocale);
   } else if (type === 'avg') {
-    formatted = value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+    formatted = value.toLocaleString(displayLocale, { maximumFractionDigits: 2 });
   } else {
-    formatted = value.toLocaleString();
+    formatted = value.toLocaleString(displayLocale);
   }
   return join(formatted);
 }
@@ -397,8 +420,9 @@ export function useColumnSummary(
   const { currency: tenantCurrency } = useLocalization();
   // The tag every field / cell / metric renderer formats `Intl` values with
   // (tenant locale, then UI language, then `'en'`) — never `undefined`, which
-  // would be the MACHINE's locale. The percent footer goes through the same
-  // path the list cell above it does (objectui#9269).
+  // would be the MACHINE's locale. The percent footer took this path first
+  // (objectui#9269); every other arm joined it at objectui#9294, so the whole
+  // footer and the cells above it now read under one convention.
   const displayLocale = useDisplayLocale();
   // Aggregate-prefix bundle lookups (objectui#4024). Provider-safe: with no
   // I18nProvider this resolves the English defaults table, never a raw key.


### PR DESCRIPTION
Fixes #9294

`formatSummaryLabel` in `packages/plugin-grid/src/useColumnSummary.ts` handed `Intl` no locale argument at **seven** call sites. An omitted or `undefined` locale is not "no opinion" — it is the MACHINE's locale, which is neither of this renderer's two channels, and `useDisplayLocale`'s own doc comment names it as the one thing a caller must not do. All seven now take the concrete BCP-47 tag that hook resolves.

Triage counted **seven call sites** where the card says "four arms" — one arm has several branches. Both counts are right about different things; this covers seven.

## The seven, re-derived on this branch's own base (`c64975e9f`)

| # | site | before | after |
|---|---|---|---|
| 1 | percent-of-rows | `toLocaleString(undefined, {maximumFractionDigits: 1})` | `toLocaleString(displayLocale, …)` |
| 2 | count / non-numeric | `toLocaleString()` | `toLocaleString(displayLocale)` |
| 3 | currency, explicit code | `new Intl.NumberFormat(undefined, …)` | `new Intl.NumberFormat(displayLocale, …)` |
| 4 | currency, no code resolved | `new Intl.NumberFormat(undefined, …)` | `new Intl.NumberFormat(displayLocale, …)` |
| 5 | currency, constructor threw | `toLocaleString()` | `toLocaleString(displayLocale)` |
| 6 | avg | `toLocaleString(undefined, {maximumFractionDigits: 2})` | `toLocaleString(displayLocale, …)` |
| 7 | numeric default | `toLocaleString()` | `toLocaleString(displayLocale)` |

The `colType === 'percent'` arm is **untouched** — objectui#9269 landed it via PR objectui#9293, and it is this PR's control.

`displayLocale` also becomes a required, non-optional `string` (the two parameters ahead of it are respelled `T | undefined` so it can be mandatory). Under the optional spelling it replaces, dropping the argument type-checks and renders a plausible number rather than an error — the same failure shape as the omitted locale itself, one layer up. The function is module-private with a single call site, so nothing outside pays for it. Deliberately **no** `??` backstop: the concrete fallback belongs to `useDisplayLocale`, and a renderer-side default papering over an absent channel is what Commandment #0.1 forbids.

## Route taken: thread the tag — and the other route was measured, not assumed

Triage left the route open and required the shared-formatter route be **measured first**. It was measured, and rejected. Rendering `1234.5` in a `EUR` column through `@object-ui/fields`' `formatCurrency` / `formatNumber` against the options each arm passes today:

| case | today (options preserved) | via the shared formatter |
|---|---|---|
| currency, column `scale: 2` | `€1,234.50` | `€1,234.50` — agrees |
| currency, column `scale: 0` | `€1,235` | `€1,234.50` — **declared `scale` discarded** |
| currency, whole amount, `scale: 2` | `€1,235.00` | `€1,235` — **wholeness switch drops the fraction** |
| plain / avg | `1,234.5` | `1,234.50` at width 2, `1,235` at width 0 — **no width reproduces today's** |

`formatNumber` sets both fraction bounds from one `decimals` argument, so there is no value that reproduces the avg arm's `maximumFractionDigits: 2` with no minimum. Every one of those moves also fires in `en`, which a locale repair must not do — and all of them land on objectui#4589's number-display policy, which this card is fenced away from. That route would also edit `packages/fields`, which PR objectui#9310 currently holds open.

⇒ Route A: only the locale tag moves. Every arm keeps its formatter and its fraction-digit widths.

## The pin reads ROWS, not cells

`packages/plugin-grid/src/__tests__/useColumnSummary.tenantLocale-9294.test.tsx`, written **before** the code so the "unmodified" arm was the real base tree.

The defect is not "this cell renders the wrong bytes" — it is "this cell does not move at all when the tenant locale moves". So the headline table names no bytes: for every arm it asserts only that the `de-DE` and `tr-TR` readings **differ** from the `en` one. A second table then computes its right-hand side from the tag under test, so a repair that threaded *some* varying locale — the one thing a movement assertion cannot see — still fails. Neither table is sufficient alone.

**The lit control.** The already-repaired percent column moves on the unmodified base tree, which is what qualifies it: a control that cannot fire proves nothing. Its cases run first and say in their own names that if the control is flat, the fixture is inert and every other row is NOT MEASURED rather than a negative answer.

`en` rows are **not** controls: this container's machine locale is `en-US`, measured to render every fixture in the file identically to `en`. They are overshoot detectors. `de-DE` and `tr-TR` are the rows that move.

### Directions, predicted in writing before the first run — and what ran

| | predicted | observed on the base tree |
|---|---|---|
| lit control (percent column) | GREEN | GREEN (2 passed under a name-filtered run) |
| movement, the seven sites | RED | RED (14) |
| agreement at `en` | GREEN | GREEN (7) |
| agreement at `de-DE` / `tr-TR` | RED | RED (14) |
| tr-TR currency, absolute bytes | RED | RED (1) |
| prefix probes | GREEN | GREEN (8) |

Base tree: `Tests 29 failed | 20 passed (49)` — exactly the predicted partition.
After the fix, the whole package: `Test Files 128 passed (128) · Tests 1182 passed (1182)`.

### Ablation leg

One call site (the currency explicit-code branch) put back to `undefined`, from the committed tree, with the mutation proved on disk before the run (injected token +1, removed token -1, blob hash moved off the `HEAD` blob) and restored under a trap.

`Tests 5 failed | 44 passed (49)` — and the five are exactly:

- currency-explicit-code movement @ `de-DE`, @ `tr-TR`
- currency-explicit-code agreement @ `de-DE`, @ `tr-TR`
- the tr-TR absolute-byte row

Every other arm and the lit control stayed green, so the pin is site-specific rather than a blanket assertion. Restore verified **by state, not by exit code**: `git diff HEAD` empty, `git status --porcelain` empty, and the restored blob hash byte-identical to `HEAD`'s.

## Blast radius

A package-scoped run is not the blast radius, so rendered strings were swept repo-wide:

- Footer-shaped literals (`Sum:`/`Avg:`/`Count:`/`Filled:` followed by a digit or currency sign) appear outside `packages/plugin-grid` only in `CHANGELOG.md` files — historical release notes, not assertions.
- No test outside `packages/plugin-grid` asserts on a summary label. The two hits for `grid.summary.` / `useColumnSummary` elsewhere (`packages/i18n/src/__tests__/untranslated-identity-4376.test.ts`, `packages/types/src/zod/objectql.zod.ts`) are a bundle-key description and a prose comment.
- `e2e/` has no match for the summary footer at all.
- `examples/schema-catalog` carries summary schemas but pins no rendered figure.

Type-check was run over the **dependent closure, not the package**: a membership read found 7 direct dependents, 8 transitively, and every one of them declares a `type-check` script — including `@object-ui/site`, which is a direct dependent and is exactly the exclusion that went red in this lane recently. It is in the run, not out of it.

## Changeset

`@object-ui/plugin-grid: minor` with a `**BREAKING**` carrier. `major` is unavailable: this package sits in the fixed group whose major tracks `@objectstack`'s. Rendered output moves in **every session whose browser locale differs from the tenant's** — the normal case for a German tenant staffed on English systems, or the reverse — not only in the sessions that were wrong; the changeset says so with the measured table.

## Acceptance notes

Boundaries held: the `colType === 'percent'` arm is untouched, and objectui#4589's number-display policy ownership is untouched (widths, formatter choice and the percent-of-rows literal sign all stay where they are).

One out-of-scope observation, filed separately rather than folded in: `formatImportJobTime` in `packages/plugin-grid/src/ImportWizard.tsx` renders an import-job timestamp through a bare `toLocaleString()`, i.e. the same machine-locale channel, on a date rather than a number. Deduped against the fully enumerated open set (464 rows reconciled against the repository's own `open_issues_count` of 464, controls lit both ways) — objectui#7174, objectui#8209 and objectui#8507 all miss it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_