### PR TITLE
fix(devx): pin tsBuildInfoFile outside the published dist in every composite package

### DIFF
--- a/.changeset/tsbuildinfo-outside-published-dist.md
+++ b/.changeset/tsbuildinfo-outside-published-dist.md
@@ -1,0 +1,10 @@
+---
+---
+
+Internal only — no package release.
+
+Every composite project now pins `tsBuildInfoFile` to its own package root, so the
+incremental build record is never derived into `dist`. Nothing under any package's
+`files` list changes, and no published source or publish-contract field moves:
+the diff is 30 `tsconfig.json` files, two `clean` scripts and one pin test
+(objectui#9189).

--- a/packages/app-shell/tsconfig.json
+++ b/packages/app-shell/tsconfig.json
@@ -8,6 +8,13 @@
     "types": ["node", "vite/client"],
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
 
     // See `packages/react/tsconfig.json` for the full argument: under

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -29,6 +29,13 @@
     "moduleResolution": "nodenext",
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/collaboration/tsconfig.json
+++ b/packages/collaboration/tsconfig.json
@@ -29,6 +29,13 @@
     "moduleResolution": "nodenext",
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -10,6 +10,13 @@
     // Removed rootDir to prevent file not under rootDir errors when importing from ..
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "skipLibCheck": true
   },

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,6 +5,13 @@
     "rootDir": "src",
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true
   },
   "include": ["src"],

--- a/packages/data-objectstack/package.json
+++ b/packages/data-objectstack/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "type-check": "tsc --noEmit",
     "test": "vitest run --root ../.. packages/data-objectstack/",
     "lint": "eslint ."

--- a/packages/data-objectstack/tsconfig.json
+++ b/packages/data-objectstack/tsconfig.json
@@ -2,6 +2,13 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declaration": true,
     "noEmit": false,

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -5,6 +5,13 @@
     "rootDir": "src",
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "jsx": "react-jsx",
     "lib": ["ES2020", "DOM"]

--- a/packages/mobile/tsconfig.json
+++ b/packages/mobile/tsconfig.json
@@ -29,6 +29,13 @@
     "moduleResolution": "nodenext",
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/permissions/tsconfig.json
+++ b/packages/permissions/tsconfig.json
@@ -29,6 +29,13 @@
     "moduleResolution": "nodenext",
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/plugin-calendar/tsconfig.json
+++ b/packages/plugin-calendar/tsconfig.json
@@ -9,6 +9,13 @@
     },
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/plugin-charts/tsconfig.json
+++ b/packages/plugin-charts/tsconfig.json
@@ -10,6 +10,13 @@
     "noImplicitAny": true,
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "skipLibCheck": true
   },

--- a/packages/plugin-chatbot/tsconfig.json
+++ b/packages/plugin-chatbot/tsconfig.json
@@ -9,6 +9,13 @@
     },
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/plugin-dashboard/tsconfig.json
+++ b/packages/plugin-dashboard/tsconfig.json
@@ -10,6 +10,13 @@
     // Removed explicit rootDir to prevent file not under rootDir errors when importing from workspace dependencies
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/plugin-designer/package.json
+++ b/packages/plugin-designer/package.json
@@ -22,7 +22,7 @@
   ],
   "scripts": {
     "build": "vite build",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "test": "vitest run --root ../.. packages/plugin-designer/",
     "type-check": "tsc --noEmit && tsc -p tsconfig.test.json",
     "lint": "eslint ."

--- a/packages/plugin-designer/tsconfig.json
+++ b/packages/plugin-designer/tsconfig.json
@@ -9,6 +9,13 @@
     },
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/plugin-detail/tsconfig.json
+++ b/packages/plugin-detail/tsconfig.json
@@ -9,6 +9,13 @@
     },
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/plugin-editor/tsconfig.json
+++ b/packages/plugin-editor/tsconfig.json
@@ -10,6 +10,13 @@
     "noImplicitAny": true,
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "skipLibCheck": true
   },

--- a/packages/plugin-form/tsconfig.json
+++ b/packages/plugin-form/tsconfig.json
@@ -9,6 +9,13 @@
     },
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/plugin-gantt/tsconfig.json
+++ b/packages/plugin-gantt/tsconfig.json
@@ -9,6 +9,13 @@
     },
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/plugin-grid/tsconfig.json
+++ b/packages/plugin-grid/tsconfig.json
@@ -9,6 +9,13 @@
     },
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/plugin-kanban/tsconfig.json
+++ b/packages/plugin-kanban/tsconfig.json
@@ -10,6 +10,13 @@
     // Removed rootDir to prevent file not under rootDir errors when importing from workspace dependencies
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/plugin-list/tsconfig.json
+++ b/packages/plugin-list/tsconfig.json
@@ -9,6 +9,13 @@
     },
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/plugin-map/tsconfig.json
+++ b/packages/plugin-map/tsconfig.json
@@ -9,6 +9,13 @@
     },
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/plugin-markdown/tsconfig.json
+++ b/packages/plugin-markdown/tsconfig.json
@@ -10,6 +10,13 @@
     // Removed rootDir to prevent file not under rootDir errors when importing from workspace dependencies
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/plugin-timeline/tsconfig.json
+++ b/packages/plugin-timeline/tsconfig.json
@@ -9,6 +9,13 @@
     },
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/plugin-tree/tsconfig.json
+++ b/packages/plugin-tree/tsconfig.json
@@ -9,6 +9,13 @@
     },
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "declarationMap": true,
     "skipLibCheck": true

--- a/packages/providers/tsconfig.json
+++ b/packages/providers/tsconfig.json
@@ -26,6 +26,13 @@
     "moduleResolution": "nodenext",
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true
   },
   "include": ["src"],

--- a/packages/react-runtime/tsconfig.json
+++ b/packages/react-runtime/tsconfig.json
@@ -1,6 +1,18 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": { "outDir": "dist", "rootDir": "src", "noEmit": false, "declaration": true, "composite": true, "jsx": "react-jsx", "lib": ["ES2020", "DOM"] },
+  // `tsBuildInfoFile` pins the incremental build RECORD outside the published
+  // build output in every composite package here; see the longer note in
+  // packages/components/tsconfig.json for what happens without it (objectui#9189).
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "declaration": true,
+    "composite": true,
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
+    "jsx": "react-jsx",
+    "lib": ["ES2020", "DOM"]
+  },
   "include": ["src"],
   // Tooling is excluded by DIRECTORY, not just by file NAME. A helper under
   // `__tests__/` that is not itself called `*.test.ts` is otherwise a program

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -6,6 +6,13 @@
     "jsx": "react-jsx",
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
 
     // Node's ESM resolver does NOT extension-search relative specifiers, so an

--- a/packages/sdui-parser/tsconfig.json
+++ b/packages/sdui-parser/tsconfig.json
@@ -5,6 +5,13 @@
     "rootDir": "src",
     "noEmit": false,
     "declaration": true,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "lib": ["ES2020"]
   },

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -5,6 +5,13 @@
     "rootDir": "./src",
     "declaration": true,
     "declarationMap": false,
+    // The incremental build RECORD, pinned OUTSIDE the published build output.
+    // Left unpinned, TypeScript derives it from `outDir`/`rootDir`: a package with
+    // no `rootDir` gets `dist/tsconfig.tsbuildinfo` -- inside what `files: ["dist",
+    // ...]` publishes -- and `pnpm check:published-dist` then reds on a byte-identical
+    // tree as soon as anything runs `tsc` (objectui#9189). Pinned in every composite
+    // package so the location is a decision, not a side effect of an unrelated option.
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "composite": true,
     "noEmit": false,
     "lib": ["ES2020", "DOM"],

--- a/scripts/__tests__/tsbuildinfo-outside-published-dist-9189.test.ts
+++ b/scripts/__tests__/tsbuildinfo-outside-published-dist-9189.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+import { BUILD_OUTPUT_DIRS } from '../check-published-dist-tooling.mjs';
+
+/**
+ * objectui#9189 — no incremental build RECORD may be derived into a published
+ * build output directory.
+ *
+ * ## The defect this pins shut
+ *
+ * `composite` implies `incremental`, so every composite project writes a
+ * `*.tsbuildinfo`. Where it writes it is DERIVED, not declared: with an
+ * `outDir` and no `rootDir`, TypeScript puts the record at
+ * `outDir/<configname>.tsbuildinfo` — i.e. inside `dist`, which
+ * `files: ["dist", …]` publishes whole. `pnpm check:published-dist` refuses a
+ * record there (objectui#7003), so the gate's verdict came to depend on WHEN it
+ * ran: green before anything invoked `tsc`, red after, on a byte-identical
+ * tree. A reader whose diff touched no tsconfig then reads "I broke the
+ * published surface" and goes looking in the diff for something that is not
+ * there. Measured on c64975e9f: 18 of the repository's 32 incremental projects
+ * derived their record into `dist`.
+ *
+ * ## Why the assertion is DERIVED and not a grep for the option
+ *
+ * The hazard is not a missing line; it is a location that nobody chose. Before
+ * this card 12 projects were already correct — but only as a side effect of
+ * carrying `rootDir: "src"`, which rebases the derived path back out of
+ * `outDir`. `packages/components/tsconfig.json` says in its own comment that
+ * `rootDir` was REMOVED there for an unrelated reason, and that removal is what
+ * moved its record into the published directory. So a test that checked for the
+ * presence of `tsBuildInfoFile` would pass on a project whose value still
+ * pointed into `dist`, and would red on a correct project that got there
+ * another way. Asking TypeScript where the record goes is the only question
+ * whose answer cannot drift from the compiler's.
+ *
+ * `BUILD_OUTPUT_DIRS` is imported from the gate rather than re-spelled, so a
+ * fourth output directory added over there is covered here in the same commit.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+/**
+ * Below this many incremental projects the enumeration is broken, not empty.
+ *
+ * The repository has 32 today. A collapse to a handful means `git ls-files` or
+ * the config parse stopped answering, and an empty comparison would pass while
+ * reading nothing — the vacuous shape `check-published-dist-tooling.mjs` calls
+ * out in its own header.
+ */
+const MIN_INCREMENTAL_PROJECTS = 25;
+
+/** Every tracked tsconfig, enumerated from git rather than from a hand-written list. */
+function trackedConfigs(): string[] {
+  return execFileSync('git', ['ls-files', '*tsconfig*.json'], { cwd: repoRoot, encoding: 'utf8' })
+    .split('\n')
+    .filter(Boolean);
+}
+
+/** The record path TypeScript itself would write for `configFile`, or null if it writes none. */
+function derivedRecordPath(configFile: string): string | null {
+  const absolute = path.join(repoRoot, configFile);
+  const read = ts.readConfigFile(absolute, ts.sys.readFile);
+  if (read.error) throw new Error(`cannot read ${configFile}`);
+  const parsed = ts.parseJsonConfigFileContent(
+    read.config,
+    ts.sys,
+    path.dirname(absolute),
+    undefined,
+    absolute,
+  );
+  const derived = ts.getTsBuildInfoEmitOutputFilePath?.(parsed.options);
+  return derived ? path.relative(repoRoot, derived) : null;
+}
+
+/** Whether a repo-relative path sits inside one of the gate's build output directories. */
+function insideBuildOutput(relativePath: string): boolean {
+  return relativePath.split('/').some((segment) => BUILD_OUTPUT_DIRS.includes(segment));
+}
+
+describe('incremental build records stay outside published build output (objectui#9189)', () => {
+  const projects = trackedConfigs()
+    .map((file) => ({ file, record: derivedRecordPath(file) }))
+    .filter((entry): entry is { file: string; record: string } => entry.record !== null);
+
+  it('enumerates the incremental projects it claims to judge', () => {
+    expect(projects.length).toBeGreaterThanOrEqual(MIN_INCREMENTAL_PROJECTS);
+  });
+
+  it('derives no record into a build output directory', () => {
+    const offenders = projects
+      .filter((entry) => insideBuildOutput(entry.record))
+      .map((entry) => `${entry.file} -> ${entry.record}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it('can fail: dropping the pin from a real project puts its record back in dist', () => {
+    // The control. Without it this suite would also pass on a tree where the
+    // derivation silently stopped answering — the same "confident absence" the
+    // enumeration assertion above guards from the other side.
+    const absolute = path.join(repoRoot, 'packages/components/tsconfig.json');
+    const read = ts.readConfigFile(absolute, ts.sys.readFile);
+    const parsed = ts.parseJsonConfigFileContent(
+      read.config,
+      ts.sys,
+      path.dirname(absolute),
+      undefined,
+      absolute,
+    );
+    const withoutPin = { ...parsed.options, tsBuildInfoFile: undefined };
+    const derived = ts.getTsBuildInfoEmitOutputFilePath?.(withoutPin);
+    expect(derived).toBeTruthy();
+    expect(insideBuildOutput(path.relative(repoRoot, derived as string))).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #9189

## The defect

`composite` implies `incremental`, so every composite project writes a `*.tsbuildinfo`. Where it lands is **derived, not declared**: with an `outDir` and no `rootDir`, TypeScript puts the record at `outDir/CONFIGNAME.tsbuildinfo` — inside `dist`, which `files: ["dist", ...]` publishes whole. `pnpm check:published-dist` refuses a record there (objectui#7003), so the gate's verdict came to depend on **when** it ran: green before anything invoked `tsc`, red after, on a byte-identical tree.

That is the card's sharpest sentence and triage promoted it to the basis of the ruling: *ordering decides the verdict, and nothing announces it.*

## Two premises measured FALSE — please read this before judging the diff size

Both rulings are implemented as written. But the *reasons* given for them did not survive measurement, and one of them changes what the fix has to be.

**1. The population is 18, not 2 — and the discriminator is `rootDir`, not the build tool.**

The card and triage both explain the two visible packages as "the two whose `build` is `vite build` rather than `tsc`, leaving `dist` otherwise free of tsc output", with the others hidden by "coincidental masking". Measured with TypeScript's own `getTsBuildInfoEmitOutputFilePath` at `c64975e9f`: **18 of this repository's 32 incremental projects derived their record into `dist`.** The 12 correct ones are correct because they carry `rootDir: "src"`, which rebases the derived path back out of `outDir`. Nothing is masking anything — the other 16 simply had not been type-checked in that tree.

Reproduced directly: running `tsc --noEmit` in `@object-ui/plugin-charts`, a package the card never mentions, reds the same gate.

```
@object-ui/components     [tooling-in-published-output]  packages/components/dist/tsconfig.tsbuildinfo
@object-ui/plugin-charts  [tooling-in-published-output]  packages/plugin-charts/dist/tsconfig.tsbuildinfo
```

This strengthens the scope ruling rather than weakening it. `packages/components/tsconfig.json` states in its own comment that `rootDir` was **removed** there for an unrelated reason — and that removal is exactly what moved its record into the published directory. So the 12 "already correct" packages are one unrelated edit away from joining the 18. Pinning all 30 is what makes the location a decision instead of a side effect.

**2. The shared base tsconfig cannot carry this setting.**

The ruling preferred a shared base if one exists. Package tsconfigs extend the root `tsconfig.json`, so I measured it: TypeScript resolves a relative `tsBuildInfoFile` against the config that **declares** it, not the one that inherits it. One line in the root config collapses all 30 packages onto a single repo-root `tsconfig.tsbuildinfo` — every package overwriting every other package's incremental record.

```
packages/app-shell/tsconfig.json   -> tsconfig.tsbuildinfo
packages/auth/tsconfig.json        -> tsconfig.tsbuildinfo
packages/components/tsconfig.json  -> tsconfig.tsbuildinfo     (all 30 identical)
```

So the ruling's stated fallback — "one line per package is an acceptable landing" — is not a shortcut here; it is the only spelling that gives each package its own record. (`tsconfig.base.json` exists but no package tsconfig extends it, which is worth knowing separately.)

## What changed

- **30 `packages/*/tsconfig.json`** — `"tsBuildInfoFile": "./tsconfig.tsbuildinfo"`, one line plus the shared note. For the 12 that already landed there via `rootDir`, this is a no-op in effect and pure explicitness; their derived paths are byte-identical before and after.
- **2 `clean` scripts** (`data-objectstack`, `plugin-designer`) — now `rm -rf dist tsconfig.tsbuildinfo`, matching the five packages that already spell it that way. Without this, moving the record out of `dist` would leave `rm -rf dist` deleting the outputs while keeping the record that says they exist — the objectui#6703 desync, re-opened by this very change.
- **1 pin test** — `scripts/__tests__/tsbuildinfo-outside-published-dist-9189.test.ts`. It asks *TypeScript* where each record goes rather than grepping for the option, because a presence-grep would pass on a value still pointing into `dist` and red on a project that is correct via `rootDir`. `BUILD_OUTPUT_DIRS` is imported from the gate rather than re-spelled.
- **1 changeset**, empty frontmatter — nothing published moves. `tsconfig.json` is not in any package's `files` list, and `check-changeset-presence.mjs` independently reports `0 of them published source`.

Not a tsconfig refactor: no other option moved, no config was restructured. This belongs to objectui#7212's population and does not attempt to solve it.

## The card's probe, run in order, exit codes captured before any pipe

```
# BEFORE the fix
rm -f packages/components/dist/tsconfig.tsbuildinfo
pnpm run check:published-dist                        EXIT=0   green
pnpm --filter @object-ui/components exec tsc --noEmit -p tsconfig.json
pnpm run check:published-dist                        EXIT=1   RED  <- reproduced

# AFTER the fix
rm -f packages/components/dist/tsconfig.tsbuildinfo
pnpm run check:published-dist                        EXIT=0   green
pnpm exec turbo run type-check                       EXIT=0   all 81 tasks, all 30 packages
pnpm run check:published-dist                        EXIT=0   STILL GREEN
```

The post-fix run is deliberately stronger than the card's: instead of type-checking one package, it type-checks **every** package, then asks the gate. Records inside any `dist` afterwards: **0**.

The tarball is unchanged. `6013 tarball file(s), 5857 of them build output, 0 tooling artifact(s)` on the pre-fix green run and identically on the post-fix green run; the red run in between differed by exactly the two records (`6015 / 5859 / 2`).

## Control — preserved

`@object-ui/core`, `@object-ui/react` and `@object-ui/fields` carry no record in `dist` today and sprout nothing new:

| package | before | after a full repo type-check |
|---|---|---|
| `@object-ui/core` | `packages/core/tsconfig.tsbuildinfo` | `packages/core/tsconfig.tsbuildinfo` (unchanged) |
| `@object-ui/react` | `packages/react/tsconfig.tsbuildinfo` | `packages/react/tsconfig.tsbuildinfo` (unchanged) |
| `@object-ui/fields` | none | none — its `tsconfig.json` is not composite at all |

## New location, confirmed by re-running the gate

Every record now lands at `packages/PKG/tsconfig.tsbuildinfo`. The proof is the gate, not the path: the post-fix run above was made with all 31 records present on disk and reported `0 tooling artifact(s) in build output` and no `src-tier` line — that second channel is how this gate reports a build record shipping from *outside* a build output directory, so its silence is the positive statement that the new home ships nowhere.

## Not committable at its new home

`git check-ignore --verbose` on all 31 records on disk: **31 of 31 ignored**, by `.gitignore:36:*.tsbuildinfo`. Positive control: `git check-ignore packages/components/tsconfig.json` exits 1, so the check can distinguish. `git status --porcelain` shows 0 records.

A pre-existing tree carries a stale record at the old path; measured, the next `vite build` empties `dist` and takes it, so there is no migration step.

## Ablation — the pin test can fail

Removing the pin from `packages/plugin-detail/tsconfig.json` on disk (mutation proved landed: occurrences 1 to 0, blob `7bfdd4e2` to `4c56da45`) turns it red naming the right file, and restoring via `git checkout HEAD -- ...` returns the blob to `7bfdd4e2` with `git diff HEAD` empty:

```
AssertionError: expected [ Array(1) ] to deeply equal []
+ [ "packages/plugin-detail/tsconfig.json -> packages/plugin-detail/dist/tsconfig.tsbuildinfo" ]
```

## Gates run, with exit codes

| command | exit | note |
|---|---|---|
| `pnpm exec turbo run build` | 0 | 43/43 tasks |
| `pnpm exec turbo run type-check` | 0 | 81/81 tasks — every package whose tsconfig moved |
| `pnpm run type-check:scripts` | 0 | the separate `scripts/` project; `--listFiles` confirms the new test is in its program |
| `pnpm run check:published-dist` | 0 | the card's gate, after a full type-check |
| `pnpm run check:published-tsconfig-exclude` | 0 | |
| `pnpm run check:dist-completeness` | 0 | 12 complete, 2 type-check-only |
| `pnpm run check:control-bytes` | 0 | |
| `pnpm run check:test-path-roots` | 0 | |
| `pnpm run check:new-line-citations` | 0 | |
| `pnpm run check:self-import` | 0 | |
| `pnpm run check:phantom-deps` | 0 | |
| `check-changeset-presence` / `-no-major` / `check:changeset-claims` | 0 | |
| `check-governed-queue-guard --test` | — | NOT GOVERNED, 34 paths checked |
| `pnpm exec vitest run scripts/` | 0 | 151 files, 4489 tests |
| `pnpm exec vitest run` (5 affected packages) | 0 | 714 files, 9463 tests |
| `pnpm exec eslint --no-inline-config` (34 changed files) | 0 | eslint's own verdict: 1 file linted, 33 it ignores; no type-aware linting is configured, so the diff cannot move any untouched file's result |

Repo-wide `pnpm test` and `pnpm lint` are declared to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_