### PR TITLE
fix(plugin-detail,plugin-form): let the declaration type the two surviving useRecordContext bindings

### DIFF
--- a/.changeset/record-context-binding-casts.md
+++ b/.changeset/record-context-binding-casts.md
@@ -1,0 +1,18 @@
+---
+---
+
+No release. Removes the two whole-context type assertions on
+`useRecordContext()` — in the `record:activity` renderer and in the line-items
+panel — so `RecordContextValue` types those bindings, and adds a census that
+keys on the BINDING rather than on an identifier name so the shape cannot come
+back (objectui#9304).
+
+Declared as no release because the level follows a measurement rather than a
+judgement. A TypeScript type assertion erases, and both renderers export an
+explicitly annotated `React.FC`, so nothing inferred reaches the emitted
+declarations. Building `@object-ui/plugin-detail` and `@object-ui/plugin-form`
+from the base tree and from this one produces 172 dist files of which 171 are
+byte-identical by sha256; every emitted `.js`, `.css` and `.d.ts` is among
+them. The single difference is one declaration sourcemap, whose `mappings`
+shift because an explanatory comment was added above an unchanged statement.
+Nothing a consumer of these packages can resolve, import or execute changes.

--- a/packages/plugin-detail/src/renderers/record-activity.tsx
+++ b/packages/plugin-detail/src/renderers/record-activity.tsx
@@ -96,7 +96,7 @@ export const RecordActivityRenderer: React.FC<RecordActivityRendererProps> = ({
   ...props
 }) => {
   const { designer } = splitDesigner(props);
-  const ctx = useRecordContext() as any;
+  const ctx = useRecordContext();
   const discussion = useDiscussionContext();
   const tt = useSafeTranslate();
 

--- a/packages/plugin-form/src/LineItemsPanel.tsx
+++ b/packages/plugin-form/src/LineItemsPanel.tsx
@@ -91,7 +91,7 @@ export const LineItemsPanel: React.FC<{ schema: LineItemsPanelSchema }> = ({ sch
   // Studio designer/palette), so it never throws — call it unconditionally to
   // keep hook order stable across renders. A null record just means "no parent
   // record bound", which the optional chaining below already handles.
-  const record = useRecordContext() as any;
+  const record = useRecordContext();
 
   const parentObject = schema.parentObject || record?.objectName;
   const parentId =

--- a/packages/plugin-form/src/LineItemsPanel.tsx
+++ b/packages/plugin-form/src/LineItemsPanel.tsx
@@ -94,6 +94,19 @@ export const LineItemsPanel: React.FC<{ schema: LineItemsPanelSchema }> = ({ sch
   const record = useRecordContext();
 
   const parentObject = schema.parentObject || record?.objectName;
+  // The assertion below is LOAD-BEARING, and only became so when the
+  // whole-context assertion on `record` was removed (objectui#9304). While the
+  // binding was `any` it did nothing at all; now `RecordContextValue.recordId`
+  // is declared `string | number | null | undefined` and
+  // `buildMasterDetailEditBatch` takes a `string` parent id, so dropping it is
+  // a real error rather than a tidy-up — measured: TS2345, `string | number`
+  // is not assignable to `string`.
+  //
+  // Kept rather than repaired here because both repairs move bytes on the wire
+  // for a numeric primary key (coercing with `String()` changes the id this
+  // panel sends; widening `masterDetailTx`'s parameter is that module's
+  // contract, not this one's), and this change is type-side with no runtime
+  // effect. The residue is tracked separately.
   const parentId =
     schema.parentId || schema.recordId || (record?.recordId as string | undefined);
 

--- a/packages/react/src/context/__tests__/useRecordContext.bindingCast.pin.test.ts
+++ b/packages/react/src/context/__tests__/useRecordContext.bindingCast.pin.test.ts
@@ -67,13 +67,18 @@ type Equal<X, Y> =
   (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2) ? true : false;
 type Expect<T extends true> = T;
 
+type HookReturn = ReturnType<typeof useRecordContext>;
+
 /**
  * The hook's answer is the declaration, not `any`. `Equal` is the form that
  * can tell those apart — a plain `extends` check passes for `any` in both
- * directions and would pin nothing.
+ * directions and would pin nothing, which is why the "not any" clause is
+ * written first and separately.
  */
-type _HookReturnsTheDeclaration = Expect<
-  Equal<ReturnType<typeof useRecordContext>, RecordContextValue | null>
+type _HookReturnIsNotAny = Expect<Equal<Equal<HookReturn, any>, false>>;
+type _HookReturnAdmitsNull = Expect<Equal<Extract<HookReturn, null>, null>>;
+type _HookReturnIsTheContextValue = Expect<
+  NonNullable<HookReturn> extends RecordContextValue<any, any> ? true : false
 >;
 
 /**
@@ -198,14 +203,17 @@ function matchSites(file: string, masked: string, re: RegExp): Site[] {
 
 function collectSourceFiles(): string[] {
   const files: string[] = [];
-  const walk = (dir: string) => {
-    let entries: ReturnType<typeof readdirSync>;
+  // Not annotated, deliberately: `ReturnType<typeof readdirSync>` picks the
+  // LAST overload of an overloaded declaration, which is the Buffer one.
+  const readDir = (dir: string) => {
     try {
-      entries = readdirSync(dir, { withFileTypes: true });
+      return readdirSync(dir, { withFileTypes: true });
     } catch {
-      return;
+      return [];
     }
-    for (const e of entries) {
+  };
+  const walk = (dir: string) => {
+    for (const e of readDir(dir)) {
       if (e.isDirectory()) {
         if (SKIP_DIRS.has(e.name)) continue;
         walk(path.join(dir, e.name));

--- a/packages/react/src/context/__tests__/useRecordContext.bindingCast.pin.test.ts
+++ b/packages/react/src/context/__tests__/useRecordContext.bindingCast.pin.test.ts
@@ -1,0 +1,322 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9304 — no consumer may bind `useRecordContext()` through a
+ * whole-context type assertion.
+ *
+ * ## What this pins, and why the read sites were not enough
+ *
+ * objectui#9197 retyped `RecordContextValue.dataSource` from an id to the
+ * `DataSource` adapter and removed the assertion at every site that READS the
+ * member. That claim is true and it landed. But in `record-activity.tsx` the
+ * `const ctx` binding itself was already asserted to `any` one scope above, so
+ * removing the narrower assertion on the read changed nothing the compiler
+ * answers: `ctx.dataSource` was `any` before and `any` after. A file can be
+ * cast-free at every read site and still be untyped.
+ *
+ * ⇒ the discriminant is the BINDING, not the identifier and not the read.
+ * The card carries the measurement that forces this: a cast list keyed on the
+ * NAME `ctx` produced a count that matched the real one by coincidence while
+ * overlapping on only six of eleven entries. An equal total is not an equal
+ * set, so this pin never counts — it enumerates call sites and classifies each
+ * one.
+ *
+ * ## Why a text scan, and what carries the type half
+ *
+ * A cast removal leaves no runtime trace: the value was always complete at
+ * runtime, which is objectui#9197's own argument. Nothing observable through
+ * rendering distinguishes the repaired tree from the broken one, so a
+ * behavioural test here would be green either way — the disease this card
+ * describes. The two halves below are therefore split on purpose:
+ *
+ *  - the RUNTIME half classifies every `useRecordContext(...)` call site in the
+ *    monorepo and reds on any that is immediately asserted. It is the half that
+ *    reddens when an assertion comes back.
+ *  - the COMPILE-TIME half proves the declaration really resolves here rather
+ *    than degrading to `any` — the characteristic dead instrument on a
+ *    type-only card. `Equal` distinguishes `any` from every other type, and the
+ *    `@ts-expect-error` control fails as an UNUSED directive (TS2578) if the
+ *    checker stops refusing a misspelled member. Both run under
+ *    `packages/react`'s `tsconfig.test.json`, never at runtime.
+ *
+ * Every control below can fire: the matcher is proven on a synthetic asserted
+ * binding, the comment mask is proven on a commented one, and the population is
+ * proven non-empty and to contain the known consumers before any absence is
+ * believed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { DataSource } from '@object-ui/types';
+import type { useRecordContext, RecordContextValue } from '../RecordContext';
+
+/* ------------------------------------------------------------------ *
+ * Compile-time half — erased at runtime; `tsc -p tsconfig.test.json`
+ * is the only thing that executes it.
+ * ------------------------------------------------------------------ */
+
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+/**
+ * The hook's answer is the declaration, not `any`. `Equal` is the form that
+ * can tell those apart — a plain `extends` check passes for `any` in both
+ * directions and would pin nothing.
+ */
+type _HookReturnsTheDeclaration = Expect<
+  Equal<ReturnType<typeof useRecordContext>, RecordContextValue | null>
+>;
+
+/**
+ * The member the removed assertions used to hide. `DataSource | undefined`,
+ * not `string` and not `any` — objectui#9197's retype, read through the
+ * declaration a consumer now gets for free.
+ */
+type _DataSourceIsTheAdapter = Expect<
+  Equal<RecordContextValue['dataSource'], DataSource | undefined>
+>;
+
+/**
+ * Control: the checker is live in this file. If module resolution ever handed
+ * `RecordContextValue` back as `any`, this directive would become UNUSED and
+ * `tsc` would fail with TS2578 — which is the point of writing the control as
+ * an expected error rather than as another assertion.
+ */
+// @ts-expect-error `objectNam` is not a declared member of RecordContextValue
+type _MisspelledMemberIsRefused = RecordContextValue['objectNam'];
+
+/* ------------------------------------------------------------------ *
+ * Runtime half — the binding-keyed census.
+ * ------------------------------------------------------------------ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+// packages/react/src/context/__tests__  ->  repo root
+const repoRoot = path.resolve(here, '../../../../..');
+
+/** Top-level directories that can hold a TypeScript consumer of the hook. */
+const SCAN_ROOTS = ['packages', 'apps', 'examples', 'e2e', 'scripts'];
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  'coverage',
+  '.next',
+  '.turbo',
+  '.vite',
+  '.git',
+]);
+
+/**
+ * Mask `//` and block comments with spaces, leaving every other byte — string
+ * contents included — in place. Quoted spans are walked rather than blanked,
+ * purely so a `//` inside a URL literal is not read as a comment start.
+ */
+function maskComments(src: string): string {
+  const out = src.split('');
+  let i = 0;
+  const n = src.length;
+  while (i < n) {
+    const c = src[i];
+    const d = src[i + 1];
+    if (c === '/' && d === '/') {
+      while (i < n && src[i] !== '\n') out[i++] = ' ';
+      continue;
+    }
+    if (c === '/' && d === '*') {
+      out[i++] = ' ';
+      out[i++] = ' ';
+      while (i < n && !(src[i] === '*' && src[i + 1] === '/')) {
+        if (src[i] !== '\n') out[i] = ' ';
+        i++;
+      }
+      if (i < n) {
+        out[i++] = ' ';
+        out[i++] = ' ';
+      }
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      const quote = c;
+      i++;
+      while (i < n) {
+        if (src[i] === '\\') {
+          i += 2;
+          continue;
+        }
+        if (src[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    i++;
+  }
+  return out.join('');
+}
+
+/** Every `useRecordContext(...)` call, asserted or not. */
+const CALL = /useRecordContext\s*(?:<[^<>()]*>)?\s*\([^()]*\)/g;
+/** The same call, immediately followed by a type assertion. */
+const CALL_THEN_AS = /useRecordContext\s*(?:<[^<>()]*>)?\s*\([^()]*\)\s*as\b/g;
+
+interface Site {
+  /** Repo-relative path of the citing file. */
+  file: string;
+  /** 1-based line of the call inside that file. */
+  line: number;
+  /** The matched text, trimmed. */
+  text: string;
+}
+
+function lineOf(src: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index; i++) if (src[i] === '\n') line++;
+  return line;
+}
+
+function matchSites(file: string, masked: string, re: RegExp): Site[] {
+  const found: Site[] = [];
+  re.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(masked)) !== null) {
+    found.push({ file, line: lineOf(masked, m.index), text: m[0].replace(/\s+/g, ' ') });
+  }
+  return found;
+}
+
+function collectSourceFiles(): string[] {
+  const files: string[] = [];
+  const walk = (dir: string) => {
+    let entries: ReturnType<typeof readdirSync>;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.isDirectory()) {
+        if (SKIP_DIRS.has(e.name)) continue;
+        walk(path.join(dir, e.name));
+      } else if (e.isFile() && /\.tsx?$/.test(e.name)) {
+        files.push(path.join(dir, e.name));
+      }
+    }
+  };
+  for (const root of SCAN_ROOTS) walk(path.join(repoRoot, root));
+  return files;
+}
+
+/** Files, call sites and asserted call sites — computed once. */
+const SOURCE_FILES = collectSourceFiles();
+
+const ALL_SITES: Site[] = [];
+const ASSERTED_SITES: Site[] = [];
+for (const abs of SOURCE_FILES) {
+  const raw = readFileSync(abs, 'utf8');
+  if (!raw.includes('useRecordContext')) continue;
+  const rel = path.relative(repoRoot, abs).split(path.sep).join('/');
+  const masked = maskComments(raw);
+  ALL_SITES.push(...matchSites(rel, masked, CALL));
+  ASSERTED_SITES.push(...matchSites(rel, masked, CALL_THEN_AS));
+}
+
+/**
+ * Consumers that must be inside the population for any absence below to be a
+ * reading rather than a collapsed scan. All four bind the hook today; the two
+ * this card repaired are named first.
+ */
+const KNOWN_CONSUMERS = [
+  'packages/plugin-detail/src/renderers/record-activity.tsx',
+  'packages/plugin-form/src/LineItemsPanel.tsx',
+  'packages/plugin-detail/src/renderers/record-history.tsx',
+  'packages/components/src/renderers/layout/containers.tsx',
+];
+
+describe('the instrument can fire (controls)', () => {
+  it('anchors on this file, not on the cwd', () => {
+    expect(existsSync(path.join(repoRoot, 'pnpm-workspace.yaml'))).toBe(true);
+    expect(existsSync(path.join(repoRoot, 'packages/react/src/context/RecordContext.tsx'))).toBe(
+      true,
+    );
+  });
+
+  it('flags an asserted binding', () => {
+    // Assembled from fragments so this control is not itself a hit when the
+    // census below walks this file — which it does, like any other source.
+    const asserted = 'const ctx = useRecordContext()' + ' as ' + 'any;';
+    expect(matchSites('synthetic.ts', maskComments(asserted), CALL_THEN_AS)).toHaveLength(1);
+  });
+
+  it('flags an asserted binding written with explicit type arguments', () => {
+    const asserted =
+      'const ctx = useRecordContext<Row, Schema>()' + ' as ' + 'Record<string, unknown>;';
+    expect(matchSites('synthetic.ts', maskComments(asserted), CALL_THEN_AS)).toHaveLength(1);
+  });
+
+  it('does not flag a plain binding', () => {
+    const plain = 'const ctx = useRecordContext();';
+    expect(matchSites('synthetic.ts', maskComments(plain), CALL)).toHaveLength(1);
+    expect(matchSites('synthetic.ts', maskComments(plain), CALL_THEN_AS)).toHaveLength(0);
+  });
+
+  it('masks comments, so prose about the defect is not a defect', () => {
+    const commented = '// const ctx = useRecordContext()' + ' as ' + 'any;\nconst x = 1;';
+    expect(matchSites('synthetic.ts', maskComments(commented), CALL_THEN_AS)).toHaveLength(0);
+    const blockCommented = '/* useRecordContext()' + ' as ' + 'any */\nconst x = 1;';
+    expect(matchSites('synthetic.ts', maskComments(blockCommented), CALL_THEN_AS)).toHaveLength(0);
+  });
+
+  it('does not mistake a URL inside a string for a comment', () => {
+    const withUrl =
+      "const url = 'https://example.test/x';\nconst ctx = useRecordContext()" + ' as ' + 'any;';
+    expect(matchSites('synthetic.ts', maskComments(withUrl), CALL_THEN_AS)).toHaveLength(1);
+  });
+
+  it('walked a real population, not an empty one', () => {
+    expect(SOURCE_FILES.length).toBeGreaterThan(500);
+    // A floor, never an exact count: an equal total is not an equal set, so the
+    // assertion that matters is the membership read below.
+    expect(ALL_SITES.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('reached every known consumer of the hook', () => {
+    const filesWithSites = new Set(ALL_SITES.map((s) => s.file));
+    for (const consumer of KNOWN_CONSUMERS) {
+      expect(
+        existsSync(path.join(repoRoot, consumer)),
+        `${consumer} is gone — update KNOWN_CONSUMERS rather than deleting the control`,
+      ).toBe(true);
+      expect(filesWithSites.has(consumer), `${consumer} carries no scanned call site`).toBe(true);
+    }
+  });
+});
+
+describe('useRecordContext bindings are typed by the declaration (objectui#9304)', () => {
+  it('no call site is bound through a type assertion', () => {
+    const offenders = ASSERTED_SITES.map((s) => `${s.file}  line ${s.line}  ${s.text}`);
+    expect(
+      offenders,
+      [
+        'A `useRecordContext()` call is bound through a type assertion.',
+        'The declaration (`RecordContextValue | null`) already types every member a',
+        'record renderer reads, so an assertion here only hides what the compiler',
+        'would have answered — and it keeps hiding it at every read below,',
+        'whether or not those reads carry casts of their own (objectui#9304).',
+        'Read the members off the binding instead; if one is genuinely missing,',
+        'declare it on `RecordContextValue`.',
+      ].join('\n'),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #9304

Two whole-context assertions on `useRecordContext()` survived objectui#9197, and on the `record:activity` renderer they made that PR's own cast removal cosmetic: the `const ctx` binding one scope above was already `any`, so `ctx?.dataSource` was `any` whether or not the read carried an assertion of its own. Both bindings now take their type from `RecordContextValue`.

## The change

| file | before | after |
|---|---|---|
| `packages/plugin-detail/src/renderers/record-activity.tsx` | the `const ctx` binding carried a whole-context assertion to ANY | bound plainly; the declaration types it |
| `packages/plugin-form/src/LineItemsPanel.tsx` | the `const record` binding carried the same | bound plainly; the declaration types it |

Plus one new pin and one changeset. No other file moves.

## The audit, re-run on this branch rather than taken from the card

⭐ Keyed on the BINDING, not on an identifier name — the card's methodological rule, adopted by triage as an acceptance condition, and the reason a cast list keyed on the name `ctx` once matched the real total by coincidence while overlapping on only six of eleven entries.

Every `useRecordContext(...)` call in `packages`, `apps`, `examples`, `e2e` and `scripts` was enumerated and classified. Exactly two were asserted, and they are the two the card names. The discriminant — *is every member read off this binding declared on `RecordContextValue`?* — holds for both:

- `record-activity.tsx` reads `objectName`, `data` (`.id` / `._id`), `recordId` and `dataSource`. All declared.
- `LineItemsPanel.tsx` reads `objectName` and `recordId`. Both declared.

⛔ The five `packages/fields` sites were not touched: they read `SchemaRendererContext`, a different declaration, and they are objectui#7912's face.

## ⭐ What the inner `LineItemsPanel` assertion turned out to be — a REAL type mismatch, not redundancy

The site the card did not name is the parent-id arm, `record?.recordId` asserted to `string | undefined`. While the binding above it was `any` the assertion did nothing at all. Measured on this branch with the outer assertion gone and this one deleted:

```
src/LineItemsPanel.tsx(262,64): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'string'.
  Type 'number' is not assignable to type 'string'.
```

⇒ it is now load-bearing: `RecordContextValue.recordId` is declared `string | number | null | undefined`, `buildMasterDetailEditBatch` takes a `string` parent id, and this assertion is the only thing that makes them meet. ⛔ It was not silently deleted, and ⛔ the outer assertion was not put back because of it. It is kept, with a comment at the site saying what it now carries and what it hides, because both repairs move runtime bytes for a numeric primary key — coercing with `String()` changes the id this panel sends, and widening the helper's parameter is `masterDetailTx`'s contract rather than this one's. Filed separately as objectui#9333.

## Instruments

**Written before the code**, so the "unmodified" arm is the real base tree. `packages/react/src/context/__tests__/useRecordContext.bindingCast.pin.test.ts`, two halves:

- a **runtime census** that enumerates and classifies every call site — the half that reddens when an assertion returns;
- a **compile-time half** that proves the declaration really resolves here instead of degrading to ANY, which is the characteristic dead instrument on a type-only card.

| run | result |
|---|---|
| pin on the base tree, before any source edit | **RED** — named exactly the two sites, all eight controls green |
| pin after the change | 9 passed |
| **ablation** — one `as any` restored in `record-activity.tsx`, nothing else | **RED**, naming that one file; controls stayed green; restore verified by blob hash and a clean `git diff HEAD` |
| **control** — a misspelled member injected on the repaired binding | `tsc` **RED**: `error TS2551: Property 'objectNam' does not exist on type 'RecordContextValue'. Did you mean 'objectName'?` |
| **control** — the pin's own expected-error directive, misspelling corrected | `tsc` **RED**: `error TS2578: Unused '@ts-expect-error' directive.` |

⚠️ Quoted compiler text above has its type arguments dropped: `RecordContextValue` is named by the checker with its two parameters, and a tag-shaped fragment does not survive this platform's body sanitiser even inside backticks.

The last row is the answer to "could this harness pass while measuring nothing": it cannot, because the directive fails as *unused* the moment the checker stops refusing a member that is not there. Two of the compile-time clauses fired on their own author during authoring — `ReturnType` of an overloaded `readdirSync` picks the Buffer overload, and `ReturnType` of a generic hook does not instantiate like a bare call site — and were repaired rather than weakened.

## ⭐ The release level, measured rather than judged

The changeset declares **no release** (empty frontmatter, the explicit exemption `check-changeset-presence.mjs` names). A type assertion erases, and both renderers export an explicitly annotated component, so nothing inferred reaches the emitted declarations. Building `@object-ui/plugin-detail` and `@object-ui/plugin-form` from the base tree and from this one:

```
172 dist files hashed on each side
171 byte-identical by sha256
  1 differing: packages/plugin-form/dist/LineItemsPanel.d.ts.map
88 non-sourcemap files (every .js, .css and .d.ts): IDENTICAL
```

The single difference is a declaration sourcemap whose mappings shift because a comment was added above an unchanged statement. ⇒ nothing a consumer can resolve, import or execute changes.

## Verification union, and why it is what it is

⚠️ A package-scoped run is not automatically the blast radius, so the exclusion is a measurement rather than an assumption. Membership read over 46 workspace packages: `@object-ui/react` has 28 direct dependents, `plugin-detail` 6, `plugin-form` 8 — `apps/site` and `apps/console` among them, and `apps/site` does declare `type-check`. The root `tsconfig.json` `paths` block aliases only `types`, `core`, `react-runtime`, `sdui-parser`, `protocol` and `console` to source trees; **none of the three changed packages is aliased**, so every dependent compiles them through their published declarations — which the table above shows are byte-identical. `packages/react`'s own `dist` is untouched: the only file added there lives under `__tests__`, which its build project excludes.

Run green on this branch:

- `pnpm --filter @object-ui/plugin-detail --filter @object-ui/plugin-form --filter @object-ui/react run type-check`
- `... run lint` (0 errors; the warning stream is pre-existing)
- `pnpm exec vitest run` on the pin file, from the repo root
- gates: `check:control-bytes` · `check:test-path-roots` · `check:published-tsconfig-exclude` · `type-check:coverage` · `check:unreferenced-sources` · `check:phantom-deps` · `check:vi-mock-specifiers` · `check:lint-rule-coverage` · `check-changeset-fixed` · `check-changeset-no-major` · `check-changeset-presence` · `check-new-cross-file-line-citations` (0 new) · `check:changeset-claims` · `check-governed-queue-guard --test` (NOT GOVERNED)

The three affected packages' full suites, from the repo root through the shared verify lock:

```
pnpm exec vitest run packages/plugin-detail/ packages/plugin-form/ packages/react/
Test Files  346 passed (346)
     Tests  3472 passed | 1 skipped (3473)
VERDICT command-exit 0
```

⚠️ The first attempt at that run returned `queue-timeout (exit 99)` after nine minutes behind another lane's `app-shell` suite. That is a not-measured reading rather than a red one; the numbers above come from the re-acquisition, which ran to completion.

## Sequencing

objectui#7912 / PR objectui#9310 is in flight on `SchemaRendererContextType`. The boundary was confirmed rather than assumed: that PR's 53-file face was read and is **disjoint** from this one's four. Its nearest approach is a sibling file in the same directory — a different pin test next to this one — not a shared file. ⇒ no blocking relation.

## Acceptance notes

- **objectui#9333** — filed. The parent-id assertion described above still narrows a declared `string | number | null | undefined` to `string`; a numeric primary key is permitted by `RecordContextValue` and by `DataSource.update`, and it would reach the batch helper typed as something it is not. Needs a decision between coercing and widening, both of which move runtime bytes.
- *noted, not filed*: the pin forbids a type assertion on the binding, but a non-null assertion on it would not be caught. That is a narrower escape — it removes only the `| null`, not the typing — and nothing in the tree uses it today. The successor that would touch this is the next card in this family, which reads the same pin.
- *noted, not filed*: `check:test-path-roots` reports 384 unclassified roots tree-wide. Pre-existing, unrelated to this diff, and the gate says so itself.

## Dedup boundary

MCP `search_issues` answered with a rate-limit error for this session's identity. The duplicate check for objectui#9333 therefore ran over the repo-scoped REST **open** issues list, fully paginated (449 issues, five pages, page six empty), with objectui#9304 carried as a known-hit control that came back lit. ⛔ No text query over CLOSED cards was possible, so a closed duplicate would not have been seen.

---

Drafted by an `os-dev` seat with Claude Code; session `https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_


---
_Generated by [Claude Code](https://claude.ai/code)_