### PR TITLE
fix(app-shell): make the flow `end` node's Outcome a spec-derived select over `completed | refused`

### DIFF
--- a/.changeset/9278-end-outcome-select.md
+++ b/.changeset/9278-end-outcome-select.md
@@ -1,0 +1,50 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The flow `end` node's Outcome control becomes a select over the two outcomes the spec
+accepts, and stops advertising two it refuses (objectui#9278).
+
+`packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts` declared the
+`end` group's `outcome` key as a free-text box with `placeholder: 'success · failure'`.
+`EndConfigSchema.outcome` is a closed enum of `completed | refused` defaulting to
+`completed`, and `FlowNodeSchema` discriminates an `end` node's config through it — so
+both printed words are refused at parse, not ignored at run time. Measured against the
+installed `@objectstack/spec` (17.4.0), with the accepted row in the same output so the
+refusals are a reading rather than a dead probe:
+
+```
+FlowNodeSchema config.outcome = "success"   => REJECTED: Invalid option: expected one of "completed"|"refused"
+FlowNodeSchema config.outcome = "failure"   => REJECTED: Invalid option: expected one of "completed"|"refused"
+FlowNodeSchema config.outcome = "completed" => ACCEPTED
+EndConfigSchema.safeParse({})               => {"outcome":"completed"}
+```
+
+The placeholder was not a neutral hint. On a key with no dropdown it was the only
+vocabulary the form offered, so the author's most likely action was to type one of the two
+words printed in the box — and the flow then failed to load. This is Commandment #0 one
+level down: the **values** are part of the contract too.
+
+The control is now a `select` whose options are exactly the spec's enum, declaring
+`defaultValue: 'completed'` so an unset key states on the trigger what the runtime applies
+to it, and the invented placeholder is gone. Both are derived from the installed spec, as
+`FlowConfigField.defaultValue`'s doc comment requires of a declaration outside the
+escalation ledger, and both are reconciled against `EndConfigSchema` in
+`FlowNodeInspector.declaredDefault.test.tsx` — through zod's public `toJSONSchema` rather
+than a respelled literal, so the claim cannot quietly rot at the next spec bump. The zh-CN
+overlay gains the two option labels and the help line.
+
+`refused` carries a cross-field rule the same parse publishes and this form has no typed
+control for: it requires a `message` saying why, as a `{token}` template, and `completed`
+refuses one. That is named in the field's help rather than left for the author to discover
+by a failed load; the key itself stays authorable through the Advanced block, which is
+reachable even when a node carries no extra keys. Filed separately rather than fixed here.
+
+`patch`, not `minor`, and not breaking — measured on three axes. The published type
+surface is unchanged: `flow-node-config` is not exported from `packages/app-shell`'s entry,
+so the emitted `dist/index.d.ts` is untouched. No authored document changes meaning: no
+metadata key is added or removed, and a stored value outside the new options still renders,
+flagged deprecated, by the branch `FlowNodeConfigField` already had. The one capability
+removed is typing an arbitrary string into this field — and every string that removes was
+already refused by the loader, so nothing that worked stops working. The same reasoning
+scored objectui#6830's select half on this file a `patch`.

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -4103,7 +4103,11 @@ const FLOW_FIELD_ZH: Record<string, Record<string, FlowFieldZh>> = {
     criteria: { label: '进入条件(旧)', help: '旧字段 —— 建议使用“进入条件”(condition)。' },
   },
   end: {
-    outcome: { label: '结果' },
+    outcome: {
+      label: '结果',
+      help: '运行在此处如何结束。“已完成”是普通终态,也是省略该键时的取值。“已拒绝”把拒绝记为一等结果 —— 它是一次成功的评估,只是结论为否 —— 并要求给出拒绝理由 message({token} 模板),在“高级”中填写。',
+      opts: { completed: '已完成', refused: '已拒绝' },
+    },
     outputVariable: { label: '输出变量' },
   },
   decision: {

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.declaredDefault.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.declaredDefault.test.tsx
@@ -63,6 +63,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
+import { z } from 'zod';
 
 // Mutable so a case can publish a server `configSchema` for one node type and
 // exercise the ONLINE field derivation, which is the other writer of
@@ -85,7 +86,7 @@ import type { MetadataSelection } from '../preview-registry';
 // instead of against a literal this file would then own a second copy of.
 // ⛔ The subpath is load bearing: `ApprovalEscalationSchema` is NOT on the
 // package root, where it reads `undefined` and any `.parse` on it throws.
-import { ApprovalEscalationSchema } from '@objectstack/spec/automation';
+import { ApprovalEscalationSchema, EndConfigSchema, FlowNodeSchema } from '@objectstack/spec/automation';
 
 /* ── The `meta/*` double (objectui#7307) ───────────────────────────────
  * `FlowNodeInspector` renders `FlowReferenceField` for every reference-kind key
@@ -588,9 +589,15 @@ describe('non-regression — a change that deletes the control must not pass thi
 
 describe('the declaration surface this card names', () => {
   /**
-   * The ten declaring fields, as `<node type>.<field id>`. Triage named this
-   * list the acceptance surface, so it is pinned: a PR that retires the
-   * property, or that adds an eleventh declaration, moves this line.
+   * The eleven declaring fields, as `<node type>.<field id>`. Triage named
+   * this list the acceptance surface, so it is pinned: a PR that retires the
+   * property, or that adds a twelfth declaration, moves this line.
+   *
+   * ⚠️ The number is NOT a constant to copy. objectui#9278 and objectui#9277
+   * both move this line from the same base, so each computed it as the value
+   * standing here when it landed PLUS its own additions, and said in its PR
+   * body where it read the base from. Do the same rather than trusting either
+   * card's arithmetic — both were done assuming the other does not exist.
    *
    * Swept over the picker's node types plus the four that carry config but are
    * not offered in the picker (ADR-0031 import/export-only, and the legacy
@@ -599,7 +606,7 @@ describe('the declaration surface this card names', () => {
    */
   const OFF_PICKER_TYPES = ['boundary_event', 'parallel_gateway', 'join_gateway', 'legacy_action', 'notify'];
 
-  it('exactly ten fields declare a defaultValue, and these are they', () => {
+  it('exactly eleven fields declare a defaultValue, and these are they', () => {
     const swept = [...FLOW_NODE_TYPE_OPTIONS, ...OFF_PICKER_TYPES];
     expect(
       FLOW_NODE_TYPE_OPTIONS.every((t) => swept.includes(t)),
@@ -620,6 +627,7 @@ describe('the declaration surface this card names', () => {
       'approval.maxRevisions',
       'approval.onEmptyApprovers',
       'boundary_event.boundaryConfig.eventType',
+      'end.outcome',
       'http_request.method',
       'screen.mode',
       'wait.waitEventConfig.eventType',
@@ -660,12 +668,13 @@ describe('the declaration surface this card names', () => {
 
     expect(
       cases.map((c) => c.id).sort(),
-      'the select-kind half of the declaration surface — seven of the ten',
+      'the select-kind half of the declaration surface — eight of the eleven',
     ).toEqual([
       'approval.behavior',
       'approval.escalation.action',
       'approval.onEmptyApprovers',
       'boundary_event.boundaryConfig.eventType',
+      'end.outcome',
       'http_request.method',
       'screen.mode',
       'wait.waitEventConfig.eventType',
@@ -683,5 +692,108 @@ describe('the declaration surface this card names', () => {
       ).toBe(true);
       cleanup();
     }
+  });
+});
+
+/* ── objectui#9278: the `end` node's Outcome vocabulary ───────────────────────
+ * `end.config.outcome` was a free-text box whose placeholder printed
+ * `success · failure`. `FlowNodeSchema` discriminates an `end` node's config
+ * through `EndConfigSchema`, whose `outcome` is a CLOSED enum of
+ * `completed | refused` — so BOTH printed words are refused at the door. On a
+ * key with no dropdown that placeholder was the only vocabulary the form
+ * offered, so the author's most likely action was to type one of the two words
+ * in the box, and the flow then failed to load. Commandment #0 one level down:
+ * the VALUES are part of the contract too.
+ *
+ * Every expectation below is DERIVED from the installed spec, through zod's
+ * public `toJSONSchema` rather than any wrapper internals — the `defaultValue`
+ * doc comment requires a declaration outside the escalation ledger to be
+ * derived from the spec rather than from taste, and a row that respelled the
+ * two words here would agree with itself while the form drifted.
+ *
+ * The parse rows are what make that derivation a READING rather than a dead
+ * probe, and they carry both signs in one output: every derived option is
+ * accepted at the door, and the two words the deleted placeholder printed are
+ * refused there. An accept-only loop would pass just as well against a schema
+ * that accepts everything.
+ * ─────────────────────────────────────────────────────────────────────────── */
+describe('the end node offers the outcomes the spec accepts (objectui#9278)', () => {
+  /** `{ enum, default }` for `EndConfigSchema.outcome`, read off the installed spec. */
+  const outcomeSchema = (
+    z.toJSONSchema(EndConfigSchema) as {
+      properties?: Record<string, { enum?: unknown[]; default?: unknown }>;
+    }
+  ).properties?.outcome;
+  const specOutcomes = (outcomeSchema?.enum ?? []) as string[];
+  const specDefault = outcomeSchema?.default as string | undefined;
+
+  /**
+   * The sibling an option requires, so an option's own row measures the OPTION.
+   * `refused` carries a cross-field rule — it requires a `message` — and a row
+   * that sent the bare key would read that refusal as "the enum rejects
+   * `refused`" and delete a value the contract declares.
+   */
+  const siblingFor = (outcome: string) =>
+    outcome === 'refused' ? { message: 'Refused: {record.name} is a confirmed duplicate' } : {};
+
+  const outcomeField = () => fieldsForNodeType('end').find((f) => f.id === 'outcome');
+
+  it('the spec still publishes the closed enum and the default this field derives from', () => {
+    // THE VACUITY GUARD. Every row below iterates `specOutcomes`; a spec that
+    // stopped publishing the enum — or a `toJSONSchema` shape this reader stops
+    // understanding — would make each of them pass over an EMPTY list, which is
+    // exactly the shape a derived expectation fails silently in.
+    expect(specOutcomes.length, 'EndConfigSchema.outcome publishes a closed enum').toBeGreaterThan(1);
+    expect(specOutcomes, 'and the default it applies to an omitted key is one of them').toContain(specDefault);
+  });
+
+  it('and FlowNodeSchema judges an end node through it — both signs, one reading', () => {
+    const verdict = (outcome: string) =>
+      FlowNodeSchema.safeParse({
+        id: 'e',
+        type: 'end',
+        label: 'E',
+        config: { outcome, ...siblingFor(outcome) },
+      }).success;
+
+    for (const outcome of specOutcomes) {
+      expect(verdict(outcome), `${outcome}: a derived option is accepted at the door`).toBe(true);
+    }
+    // The negative half, in the same reading — the two words the deleted
+    // placeholder printed, which is the whole defect this card is about.
+    expect(verdict('success'), '`success` — the old placeholder’s first word — is refused').toBe(false);
+    expect(verdict('failure'), '`failure` — its second — is refused').toBe(false);
+  });
+
+  it('the Outcome control is a select over exactly those outcomes, stating the spec default', () => {
+    const field = outcomeField();
+    expect(field, 'the end node still has an Outcome field').toBeDefined();
+    expect(field!.kind, 'an enum key is not authored as a free-text box').toBe('select');
+    expect(
+      field!.options?.map((o) => o.value),
+      'the offered vocabulary IS the spec enum, in the spec’s own order',
+    ).toEqual([...specOutcomes]);
+    expect(field!.defaultValue, 'and the form states the default the spec applies').toBe(specDefault);
+    // The invented vocabulary is gone rather than merely outvoted. A select
+    // needs no placeholder — the declared default draws in that slot — so any
+    // surviving string here would be a second, unchecked vocabulary.
+    expect(field!.placeholder, 'no invented placeholder survives on this field').toBeUndefined();
+  });
+
+  it('and it RENDERS as a combobox on an end node, stating that default on the trigger', () => {
+    // The non-regression half this file keeps beside every table claim: the
+    // three rows above are all satisfied by an inspector that renders nothing.
+    renderInspector(draftWith('end', { config: {} }));
+    expect(
+      screen.queryByRole('combobox', { name: 'Outcome' }),
+      'the Outcome control is rendered at all',
+    ).not.toBeNull();
+    const declared = outcomeField()!.options?.find((o) => o.value === specDefault);
+    expect(declared, 'the declared default must be one of the offered options').toBeDefined();
+    expect(triggerText('Outcome'), 'an unset key states the declared default').toBe(declared!.label);
+    expect(
+      triggerIsPlaceholder('Outcome'),
+      'and states it as a placeholder, never as a selection the author made',
+    ).toBe(true);
   });
 });

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
@@ -470,7 +470,29 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
     }),
   ],
   end: [
-    cfg('outcome', 'Outcome', 'text', { placeholder: 'success · failure' }),
+    // objectui#9278 — `outcome` is a CLOSED enum, and `FlowNodeSchema`
+    // discriminates an `end` node's config through `EndConfigSchema`, so a
+    // value outside it is refused at the door rather than ignored at run time.
+    // It was a free-text box whose placeholder printed `success · failure`:
+    // two words the parse contract refuses, and on a key with no dropdown that
+    // placeholder was the only vocabulary the form offered — so the author's
+    // most likely action was to type one of them, and the flow then failed to
+    // load. The options and the declared default are derived from the installed
+    // spec, as the `defaultValue` doc comment above requires of a declaration
+    // outside the escalation ledger, and reconciled against `EndConfigSchema`
+    // in `FlowNodeInspector.declaredDefault.test.tsx` so the claim cannot rot.
+    cfg('outcome', 'Outcome', 'select', {
+      options: [
+        { value: 'completed', label: 'Completed' },
+        { value: 'refused', label: 'Refused' },
+      ],
+      defaultValue: 'completed',
+      // `refused` carries a cross-field rule the spec states and this form has
+      // no typed control for yet: it REQUIRES a `message` saying why, as a
+      // {token} template. Named here so picking it is not a one-click route to
+      // a flow that will not load; the key itself stays authorable in Advanced.
+      help: 'How the run ends here. "Completed" is the ordinary terminal and is what an omitted key applies. "Refused" records a first-class refusal — a successful evaluation that says no — and requires a message saying why (a {token} template), which is set in Advanced.',
+    }),
     cfg('outputVariable', 'Output variable', 'text', { placeholder: 'result' }),
   ],
   decision: [


### PR DESCRIPTION
Fixes #9278

`end.config.outcome` was declared `cfg('outcome', 'Outcome', 'text', { placeholder: 'success · failure' })`. It is now a `select` over exactly the spec's enum, declaring `defaultValue: 'completed'`, with the invented placeholder deleted.

## The spec probe — the half triage marked NOT MEASURED, run here

Triage could not measure the spec side (`@objectstack/spec` was not installed in that container) and said so. Run at this seat against the installed **17.4.0**, with the accepted row in the same output so the refusals are a reading and not a dead probe:

```
FlowNodeSchema config.outcome = "success"   REJECTED: Invalid option: expected one of "completed"|"refused"
FlowNodeSchema config.outcome = "failure"   REJECTED: Invalid option: expected one of "completed"|"refused"
FlowNodeSchema config.outcome = "completed" ACCEPTED
EndConfigSchema.safeParse({})               {"outcome":"completed"}
```

⇒ **the card's reading holds verbatim.** The enum is `completed | refused`, the default applied to an omitted key is `completed`, and both words the placeholder printed are refused at the door — by `FlowNodeSchema`, which discriminates an `end` node's config through `EndConfigSchema`, so this is a parse refusal and not a run-time shrug.

⚠️ **The same probe surfaced a rule neither the card nor triage had seen,** because both stopped at `completed`. `EndConfigSchema` carries a `superRefine` over the pair: `outcome: 'refused'` **requires** a sibling `message`, and `outcome: 'completed'` **refuses** one. That is recorded in #9336 rather than built here — see Acceptance notes.

## The shared pin: where the base was read from

Triage ruled that neither this card nor #9277 may write a target number as a constant, because both move the same exact-count assertion from the same base. Read on `origin/main` at `0f3d15314` — which is this branch's base **and** still the tip of `origin/main` at the moment of this push, re-fetched and re-read just before opening this PR:

| assertion | base on `origin/main` `0f3d15314` | this card adds | written here |
|:--|--:|--:|--:|
| `exactly N fields declare a defaultValue` | **10** (counted off the list entries, not off the test name) | 1 (`end.outcome`) | **11** |
| `the select-kind half of the declaration surface` | **7** | 1 (`end.outcome` is select-kind) | **8** |

#9277 has **not** landed — `lockRecord` / `interrupting` still declare no `defaultValue` on `origin/main` (0 hits). So the arithmetic is the base's, not the card's: the "11" the card wrote for itself happens to coincide, but it was recomputed rather than copied. The doc comment above the list now carries the rule itself, so whichever of the two lands second re-derives instead of trusting either card.

## Derived from the spec, not respelled

The option values and the declared default are read off `EndConfigSchema` through zod's **public** `toJSONSchema` (`properties.outcome.enum` / `.default`) in `FlowNodeInspector.declaredDefault.test.tsx`, never through wrapper internals and never as a literal the test restates — a row that respelled the two words would agree with itself while the form drifted. Three controls keep that derivation honest:

- a **vacuity guard**: every derived row iterates the enum, so a spec that stopped publishing it — or a `toJSONSchema` shape this reader stops understanding — would make them all pass over an empty list. That row fails instead.
- **both signs in one reading**: every derived option is accepted by `FlowNodeSchema`, and `success` / `failure` are refused by it, in the same test. An accept-only loop would pass against a schema that accepts everything.
- a **render** row, because the three table rows above are all satisfied by an inspector that renders nothing — this file's standing discipline.

## Ablation

Both legs run on the **committed** tree, each with its mutation proven on disk (anchor counts before/after plus a live blob hash that differs from the `HEAD` blob), each restored with `git checkout HEAD -- <path>` under an `EXIT`/`INT`/`TERM` trap, and each restoration proven by `live hash == HEAD blob` **and** an empty `git diff HEAD` rather than by an exit code. Predicted direction, declared before running: **redden**.

| leg | mutation | result |
|:--|:--|:--|
| A | `'select'` back to `'text'` | **3 failed** / 23 passed — the kind row, the select-kind list, the render row |
| B | drop `defaultValue: 'completed',` | **4 failed** / 22 passed — the above plus the declaration-count list |

Both restored clean. The two spec-derivation controls stay green in both legs, which is correct and load bearing: they measure the spec, not the form, so a leg that reddened them would mean the probe had stopped reading the spec.

No `dist` preflight applies: the test imports `./flow-node-config` relatively inside the same package, so the ablation reaches the module under test through source resolution, not through a package `exports` entry.

## Verification

All commands from the repo root on `46f4e0e9`; build / type-check routed through `../objectstack/scripts/pm/os-verify-lock.sh`, verdicts read from its `VERDICT command-exit` line.

| what | result |
|:--|:--|
| `vitest run packages/app-shell/src/views/metadata-admin/` | **253 files, 2666 passed**, 1 skipped |
| `pnpm --filter "@object-ui/app-shell^..." build` | VERDICT command-exit **0** |
| `pnpm --filter @object-ui/app-shell type-check` | VERDICT command-exit **0** (it is `tsc --noEmit && tsc -p tsconfig.test.json`, so the test files are inside the reading, not excluded from it) |
| `pnpm --filter @object-ui/console --filter @object-ui/example-byo-backend-console --filter @object-ui/example-console-starter type-check` | VERDICT command-exit **0** |
| 13 `check:*` gates | all exit **0** — `i18n-designer-parity`, `i18n-keys`, `i18n-drift`, `designer-field-key-parity`, `spec-symbols`, `control-bytes`, `new-line-citations`, `installed-pin-claims`, `comment-mask-corpus`, `test-path-roots`, `vi-mock-specifiers`, `vi-mock-inherit`, `vi-mock-override-shape` |
| changeset gates | `check-changeset-presence` **0**, `check-changeset-fixed` **0**, `check-changeset-no-major` **0**, `check-changeset-claims` **0** |
| lint | `eslint .` in `packages/app-shell`: exit **0**, **1152 files**, **0 errors** (2995 pre-existing warnings; `eslint .` does not fail on warnings here) |

⚠️ The first run of the dependents' `type-check` returned `TS2307 Cannot find module '@object-ui/plugin-*'` for seven plugin packages. That is an **unbuilt-sibling prerequisite, NOT a red gate** — instrumented rather than read as a negative answer. Re-run after `pnpm --filter "@object-ui/console^..." build`: exit 0, as tabled above.

**The lint narrowing, stated as a measurement rather than asserted.** Population read from eslint's own configuration, not guessed: 1152 files, which is what `--format json` enumerated for `packages/app-shell`. Count read from that same JSON. Invariance for everything outside it: `eslint.config.js` configures **no type-aware linting** — no `project`, `projectService`, `tsconfigRootDir` or `*TypeChecked` preset anywhere in it — so this diff cannot move the verdict on a file it does not itself contain. CI still runs the whole farm.

**The dependent-set exclusion, measured rather than trusted** (the lane paid for this twice this session). Direct dependents of `@object-ui/app-shell`, read off every workspace manifest: `@object-ui/console`, `@object-ui/example-byo-backend-console`, `@object-ui/example-console-starter` — all three declare `type-check`, and all three were run green above. `@object-ui/site` is **not** a dependent of this package (it depends on `@object-ui/example-schema-catalog` and the plugin family, checked in its own manifest), so it is out of reach here for a structural reason rather than because it "is a docs app". Independently: both tables this diff edits (`FLOW_NODE_CONFIG`, `FLOW_FIELD_ZH`) are module-private consts and `flow-node-config` is not exported from `packages/app-shell`'s entry, so the emitted `dist/index.d.ts` cannot move.

## Blast radius per #9273 — something rendered moves

- `examples/schema-catalog/` — **zero** references to `outcome`, `flow-node-config` or `fieldsForNodeType`. Out of reach, measured rather than assumed.
- Count-shaped prose figures, swept repo-wide: three live figures, all in the pin file, all moved (`The ten declaring fields` in the doc comment, the test name, and `seven of the ten` in the assertion message). Two more hits are deliberately left alone and named here so review can see the decision: the file header's `The card's claim ("ten fields declare a default…")` is a **quotation** of #6830's claim at the time, and `.changeset/6830-flownode-select-declared-default.md` is another card's released note. Rewriting either would be falsifying a historical record.
- The zh-CN overlay gains the two option labels and the help line, so the localized form does not half-translate a control the English table just changed. `check:i18n-designer-parity` green.

## #9109 is NOT synced, deliberately

`UNDECLARED_REGISTER` is **0 hits** across `packages/` on `origin/main` at this push — #9109's widening has not landed, so per dispatch it is **not** built here. Nothing in this diff anticipates it.

## Changeset

`patch`, on three measured axes rather than by feel. The published type surface does not move (nothing exported changed). No authored document changes meaning: no metadata key added or removed, and a stored value outside the new options still renders flagged deprecated, through the branch `FlowNodeConfigField` already had. The one capability removed is typing an arbitrary string into this field — and every string that removes was already refused by the loader, so nothing that worked stops working. Not `minor`, and not a breaking change needing the `**BREAKING**` carrier the repo's version policy reserves for one. The same reasoning scored #6830's select half on this very file a `patch`.

## In-flight overlap

Checked rather than assumed: #9274 is in `app-shell` inspectors too but in `ReportDefaultInspector.tsx` — no file overlap with this diff. #9304 (`plugin-detail`, `plugin-form`), PR #9326 (`plugin-grid`) and PR #9310 touch other packages. #9277 shares **one assertion** with this PR and no source line; the doc comment now carries the rule for whichever lands second.

## Acceptance notes

Findings from this fence, recorded rather than ridden in. Deduped first against the full open-issue population (454 issues, reconciled against `open_issues_count` 473 minus 19 open PRs) and a bounded recent-created window including closed cards (143 issues, #9035–#9333, 50 closed), both with a known-hit control that fired. `/search/issues` is proxy-refused for this session, so closed cards older than #9035 are not text-searchable from here — naming the gap rather than implying coverage.

- **Filed as #9335** — the same two-line group's *other* field. `cfg('outputVariable', 'Output variable', 'text', …)` writes `config.outputVariable`, which `EndConfigSchema` refuses **by name** (`Unrecognized key(s) on this end node config`), measured with a positive control. It is a real key on `map` / `script` / `get_record`, just not on `end`. Left out because its repair is a genuine choice (drop the field, or a spec gap) and the acceptance here is a closed list about the line above it.
- **Filed as #9336** — `outcome: 'refused'` requires a sibling `message` that this form offers no typed control for. This PR's own change makes `refused` reachable in one click, so the cost is named in the field's `help` here rather than left silent, and the typed control is left to a seat that can rule its shape. Adding a `showWhen`-gated field would also move three further exact-count census assertions in `flow-node-config.inactiveRetained.test.ts`, which is a second verification surface rather than the same one — recorded in that card with the base figures.
- **Noted, not filed** — the pin file's header quotes #6830's "ten fields" claim, and #6830's own changeset repeats it. Both are historical records of what a card claimed, not live figures, so neither was edited. Carrier for that reading: this PR's reviewer, who is looking at the file.

Session: `session_01UzHd6hDYatoDn17BuwKxnZ`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_