### PR TITLE
fix(types): retire `icon` from the record:highlights `fields[]` entry arm

### DIFF
--- a/.changeset/9280-record-highlights-entry-icon-retired.md
+++ b/.changeset/9280-record-highlights-entry-icon-retired.md
@@ -1,0 +1,70 @@
+---
+'@object-ui/types': minor
+'@object-ui/plugin-detail': minor
+---
+
+Retire `icon` from the `record:highlights` `fields[]` entry, across all three layers that
+carried it (objectui#9280).
+
+**Breaking, deliberately.** `{ name: 'amount', icon: 'dollar-sign' }` on a
+`record:highlights` entry no longer type-checks. Nothing that worked stops working: the key
+was never authorable in the first place, and this change is what makes `tsc` say so.
+
+`@objectstack/spec` `RecordHighlightsProps.fields[]`'s object arm declares exactly
+`name`/`label`/`type`/`readonly` behind a `never` catchall — it is `$strict`, so an unlisted
+key is REFUSED, not stripped, and the refusal takes the WHOLE document with it. Re-measured
+on this branch against the installed pin (17.4.0) rather than inherited from the card, with
+three controls in the same pass so the instrument is not blind:
+
+```
+fields[] object-arm keys : ["label","name","readonly","type"]   catchall: never ($strict)
+{ fields: [{ name:'x', label:'L' }] }      GREEN                          <- CONTROL
+{ fields: [{ name:'x', icon:'star' }] }    RED  invalid_union at fields.0
+{ fields: [{ name:'x', zzzNonsense:1 }] }  RED  invalid_union at fields.0  <- CONTROL
+{ fields: ['x'] }                          GREEN                          <- CONTROL
+```
+
+A declared key parses green, so the arm is not refusing everything; an arbitrary key is
+refused with the SAME code as `icon`, so `icon` was not special-cased; the bare-string arm is
+untouched, so only the object arm moved.
+
+FROM → TO, per layer:
+
+- `packages/types/src/record-components.ts` — `RecordHighlightsComponentProps.fields[]`'s
+  object arm: `{ name; label?; icon?; type?; readonly? }` → **`{ name; label?; type?; readonly? }`**.
+  The key is **removed, not tombstoned**: the contract's arm is `$strict`, so the refusal an
+  author needs already exists upstream and arrives named (`invalid_union` at the entry). A
+  `?: never` tombstone buys nothing here — it is the remedy for a non-strict mirror that
+  would otherwise strip in silence, which is not this arm.
+- `packages/plugin-detail/src/renderers/record-highlights.tsx` — the entry normalizer stops
+  copying `icon: f?.icon` into the normalized entry. That read was **unreachable**, not
+  merely unused: no author could feed it past the `$strict` arm, and `HeaderHighlight`
+  renders no `.icon` on the far side either, so the copy had no consumer in either
+  direction.
+- `packages/plugin-detail/src/index.tsx` — the registry manifest's `fields` input description
+  sketched the entry as `{name,label?,icon?,type?,readonly?}` → **`{name,label?,type?,readonly?}`**.
+  The `inputs` ARE the published contract (`gen-manifest.ts` serializes them into
+  `sdui.manifest.json` and `sdui-intrinsics.d.ts`), so leaving the sketch standing would have
+  gone on teaching AI and human authors a key that gets the whole document refused at publish.
+
+**Migration.** Nothing in this repository has to change. An in-repo census over every
+`record:highlights` region (109 regions, all tracked files) scores an entry-level `icon`
+**0**, against `readonly` **23** in the same pass over the same regions — the instrument was
+not blind. If you author `icon` on a highlight entry in your own metadata, delete it: it was
+already causing the publish to refuse the document whole. Whether a highlight chip *should*
+be able to carry an icon is a separate question this change does not answer — the route for
+that is an upstream `@objectstack/spec` widening, on its own card, ⛔ never a redeclaration
+here.
+
+⚠️ `sections[].icon` on `RecordDetailsComponentProps` is a **different key on a different
+face** and is **unaffected**: the contract declares it and `DetailSection` genuinely draws
+it. Two keys sharing a word in one file are not the same key.
+
+Pinned in `packages/types/src/__tests__/record-highlights-fields-icon-9280.test.ts` across
+three instruments that do not see the same thing — a `tsc` `@ts-expect-error` leg with a
+`{name,label}` control that stays green, `safeParse` legs against the installed spec
+artifact, and a source-text read whose lit control is that very `sections[].icon` member, so
+an empty result on the highlights arm is a reading rather than a matcher that cannot match.
+`packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts` gains the
+REVERSE direction it was missing: it already failed when a spec entry key went undocumented,
+and now also fails when the description advertises an entry key the spec refuses.

--- a/packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts
+++ b/packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts
@@ -147,6 +147,34 @@ describe('record:highlights — registry inputs vs @objectstack/spec', () => {
     expect(description).toContain('readonly');
   });
 
+  it('the `fields` entry-shape sketch advertises no key the spec refuses', () => {
+    // The REVERSE direction of the check above, and the one objectui#9280 was
+    // filed for: the description sketched the entry as
+    // `{name,label?,icon?,type?,readonly?}` while the spec's object arm is
+    // `$strict` over four keys, so the manifest was teaching authors a key that
+    // gets the WHOLE document refused at publish. Under-documenting a key is a
+    // discoverability bug; over-advertising one is an impossible promise.
+    const description = fieldsInput()?.description ?? '';
+    const sketch = /\{([a-zA-Z?,\s]+)\}/.exec(description)?.[1];
+    expect(sketch, 'the description must keep an entry-shape sketch to check').toBeDefined();
+
+    const advertised = (sketch ?? '')
+      .split(',')
+      .map((k) => k.trim().replace(/\?$/, ''))
+      .filter(Boolean)
+      .sort();
+
+    // Derived from the spec at runtime, so a spec that WIDENS the arm fails
+    // here instead of leaving the sketch quietly short.
+    expect(advertised).toEqual(specEntryKeys().sort());
+
+    // ⭐ LIT CONTROL for this matcher: it really does read keys out of the
+    // sketch rather than returning an empty list that trivially compares
+    // equal. `name` is the one key the arm cannot lose.
+    expect(advertised).toContain('name');
+    expect(advertised).not.toContain('icon');
+  });
+
   it('declares no top-level input the spec does not accept', () => {
     const allowed = new Set(specTopLevelKeys());
     const offSpec = inputs().map((i) => i.name).filter((name) => !allowed.has(name));

--- a/packages/plugin-detail/src/index.tsx
+++ b/packages/plugin-detail/src/index.tsx
@@ -637,7 +637,7 @@ ComponentRegistry.register('highlights', RecordHighlightsRenderer, {
   // un-gated (pinned as `MULTI_KIND_MEMBER_CONTRACTS` in the repo-wide parity
   // gate). objectui#3407 / objectstack#5176.
   inputs: [
-    { name: 'fields', type: 'array', required: true, description: 'Key fields to highlight (1-7), bare names or {name,label?,icon?,type?,readonly?}. Set readonly: true on an entry to render that chip read-only — it suppresses the inline-edit affordance and the HeaderHighlight editability gate enforces it. Use it for hook/automation-maintained columns that must not be hand-edited from the record header; marking the OBJECT field readonly instead would also strip the hook\'s own write-back.' },
+    { name: 'fields', type: 'array', required: true, description: 'Key fields to highlight (1-7), bare names or {name,label?,type?,readonly?}. Set readonly: true on an entry to render that chip read-only — it suppresses the inline-edit affordance and the HeaderHighlight editability gate enforces it. Use it for hook/automation-maintained columns that must not be hand-edited from the record header; marking the OBJECT field readonly instead would also strip the hook\'s own write-back.' },
     { name: 'layout', type: 'enum', enum: ['horizontal', 'vertical'], description: 'Layout orientation for highlight fields' },
   ],
 });

--- a/packages/plugin-detail/src/renderers/record-highlights.tsx
+++ b/packages/plugin-detail/src/renderers/record-highlights.tsx
@@ -50,7 +50,8 @@ export const RecordHighlightsRenderer: React.FC<RecordHighlightsRendererProps> =
     required.every((p) => perms.can(objectName, p as any));
 
   const rawFields: any[] = Array.isArray(schema.fields) ? schema.fields : [];
-  // Normalize: accepts either bare strings or { name, label?, icon?, type?, readonly? }.
+  // Normalize: accepts either bare strings or { name, label?, type?, readonly? }
+  // — the four keys the contract's object arm declares, and no fifth.
   //
   // `readonly` is copied through deliberately: HeaderHighlight's editability
   // gate has always consulted `field.readonly`, but this map used to rebuild
@@ -59,13 +60,21 @@ export const RecordHighlightsRenderer: React.FC<RecordHighlightsRendererProps> =
   // never fire from authored metadata (objectstack#5077). Rebuilding key-by-key
   // rather than spreading keeps the entry shape closed — an undeclared key is
   // still not silently forwarded to the strip.
+  //
+  // `icon` was copied through here until objectui#9280 and that read was
+  // UNREACHABLE, not merely unused: `@objectstack/spec`
+  // `RecordHighlightsProps.fields[]`'s object arm is `$strict` (a `never`
+  // catchall over `name`/`label`/`type`/`readonly`), so a document carrying
+  // `icon` is refused WHOLE at publish and no author could ever feed this
+  // branch. `HeaderHighlight` renders no `.icon` either, so the copy also had
+  // no consumer on the far side. Retired in both directions rather than left
+  // standing as a read for a key nothing can author.
   const normalized = rawFields.map((f) =>
     typeof f === 'string'
       ? { name: f }
       : {
           name: f?.name,
           label: f?.label,
-          icon: f?.icon,
           type: f?.type,
           readonly: f?.readonly === true,
         },

--- a/packages/types/src/__tests__/record-highlights-fields-icon-9280.test.ts
+++ b/packages/types/src/__tests__/record-highlights-fields-icon-9280.test.ts
@@ -1,0 +1,267 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9280 — `RecordHighlightsComponentProps.fields[]`'s object arm
+ * declared a FIFTH key, `icon`, where the contract's arm is `$strict` over
+ * four.
+ *
+ * The defect: this package declared
+ * `{ name; label?; icon?; type?; readonly? }` while `@objectstack/spec`
+ * `RecordHighlightsProps.fields[]`'s object arm declares
+ * `name`/`label`/`type`/`readonly` behind a `never` catchall. `$strict` is the
+ * load-bearing half: an unlisted key is REFUSED, not stripped, and the refusal
+ * takes the whole document with it. So `{ name: 'amount', icon: 'dollar-sign' }`
+ * type-checked here and was refused at publish with `invalid_union` — a green
+ * local build and a rejection at the only layer that matters. Direction is
+ * contract-first (Commandment #0.1, and triage's ruling on the card): the
+ * declaration moves to the contract, the contract is not widened.
+ *
+ * ── Three instruments, and they do NOT see the same thing ──────────────────
+ *
+ *   - `tsc` sees the `@ts-expect-error` leg and the `Equal` assertions. That
+ *     is the half that reaches a TypeScript author, and it means nothing
+ *     unless `type-check` runs — vitest strips types.
+ *   - vitest runs the `safeParse` legs against the INSTALLED published spec
+ *     artifact, each with a control that would have fired. ⚠️ Those legs read
+ *     the SPEC ONLY: they were green before this change and are green after,
+ *     so they are the PREMISE, never the evidence. They are labelled PREMISE
+ *     below so nobody counts them as the fix.
+ *   - vitest ALSO reads this package's own declaration as TEXT, so the
+ *     reintroduction of the key is caught even by a run that never
+ *     type-checks. Its control is `sections[].icon` on the sibling interface
+ *     one screen up: the same matcher finds THAT `icon` member, so an empty
+ *     result on the highlights arm is a reading rather than a regex that
+ *     cannot match anything.
+ *
+ * ⛔ `sections[].icon` (`RecordDetailsComponentProps`) is NOT this card's to
+ * retire and this file must not grow into a pin that demands it: the contract
+ * declares it, `DetailSection` genuinely draws it, and it is a different
+ * member on a different face that merely shares the word. It appears here
+ * only as a firing control.
+ *
+ * ⚠️ This file does not decide whether a highlight chip SHOULD carry an icon.
+ * That route is an upstream `@objectstack/spec` widening on its own card.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { RecordHighlightsProps } from '@objectstack/spec/ui';
+import type { RecordHighlightsComponentProps } from '../record-components';
+
+/** Rooted at THIS file, never at `process.cwd()` — the two differ per invocation. */
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DECLARATION_PATH = join(HERE, '..', 'record-components.ts');
+
+/** Invariant type equality. `A extends B` is NOT this: `never` and `any` pass that. */
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+/** The only assertion form used here — its constraint is what refuses `false`. */
+type Expect<T extends true> = T;
+
+/* ── Direction proofs: a broken instrument makes THIS file red ─────────────── */
+
+// @ts-expect-error objectui#9280 — `Expect` must refuse `false`. Widen its constraint and this directive goes unused (TS2578).
+type _ExpectRefusesFalse = Expect<false>;
+
+// @ts-expect-error objectui#9280 — `never` must NOT read as equal to `true`. An `extends`-shaped comparison would let it through.
+type _EqualRefusesNever = Expect<Equal<never, true>>;
+
+// @ts-expect-error objectui#9280 — `any` must NOT read as equal to `true`, for the same reason.
+type _EqualRefusesAny = Expect<Equal<any, true>>;
+
+/* ── The object arm, member for member against the contract ───────────────── */
+
+/** The object arm of the declared `fields[]` element union. */
+type DeclaredEntry = Exclude<RecordHighlightsComponentProps['fields'][number], string>;
+
+/**
+ * RED before objectui#9280 (five keys against the contract's four), green
+ * after. `Equal` is invariant, so this fails in EITHER direction: adding
+ * `icon` back fails, and so would dropping `readonly`.
+ */
+type _EntryKeysMatchContract = Expect<
+  Equal<keyof DeclaredEntry, 'name' | 'label' | 'type' | 'readonly'>
+>;
+
+/** The bare-string arm is untouched by the narrowing — only the object arm moved. */
+type _StringArmSurvives = Expect<
+  Equal<Extract<RecordHighlightsComponentProps['fields'][number], string>, string>
+>;
+
+/* ── Literals: what a TypeScript author can and cannot write ───────────────── */
+
+/**
+ * ⭐ THE LIT CONTROL for the `tsc` instrument: an entry the spec DOES accept,
+ * on the same interface, in the same position. It compiles. Without it, the
+ * refusal below is indistinguishable from an arm that refuses everything (or
+ * from a `fields` key that stopped taking objects at all).
+ */
+const nameLabelAccepted: RecordHighlightsComponentProps = {
+  fields: [{ name: 'amount', label: 'Amount' }],
+};
+
+/** The other two declared keys, so "closed set of four" is not read as "two". */
+const typeReadonlyAccepted: RecordHighlightsComponentProps = {
+  fields: [{ name: 'supply_share', type: 'number', readonly: true }],
+};
+
+/** The bare-string arm, the other half of the union, still compiles. */
+const bareStringAccepted: RecordHighlightsComponentProps = {
+  fields: ['amount'],
+};
+
+/**
+ * The card's repro. `icon` compiled before objectui#9280 and was refused at
+ * publish, taking the whole document with it; now `tsc` refuses it here, which
+ * is the whole point of the change. Reintroduce the key on the arm and this
+ * directive goes unused (TS2578) — that is the ablation leg.
+ */
+const iconRefused: RecordHighlightsComponentProps = {
+  // @ts-expect-error objectui#9280 — the contract's arm is `$strict` over `name`/`label`/`type`/`readonly`; `icon` is refused at publish with `invalid_union`, whole-document.
+  fields: [{ name: 'amount', icon: 'dollar-sign' }],
+};
+
+/** Any other undeclared key is refused the same way, by the same mechanism. */
+const arbitraryKeyRefused: RecordHighlightsComponentProps = {
+  // @ts-expect-error objectui#9280 — outside the contract's closed arm, exactly as `icon` now is.
+  fields: [{ name: 'amount', zzzNonsense: 1 }],
+};
+
+/**
+ * Read the object arm off the live schema rather than transcribing it.
+ *
+ * Reached through `RecordHighlightsProps.fields` — the path that actually
+ * governs an authored entry — rather than through the exported
+ * `RecordHighlightsField` alias, so the arm measured here is the arm a
+ * document is parsed against. Walks both the zod v4 (`def`) and v3 (`_def`)
+ * internal spellings, which is why the hops are typed structurally.
+ */
+type ZodInternals = {
+  def?: Record<string, unknown>;
+  _def?: Record<string, unknown>;
+};
+const internals = (node: unknown): Record<string, unknown> => {
+  const n = (node ?? {}) as ZodInternals;
+  return { ...(n._def ?? {}), ...(n.def ?? {}) };
+};
+
+function specEntryArm(): { keys: string[]; strict: boolean } {
+  const shapeOfProps = internals(RecordHighlightsProps).shape as
+    | Record<string, unknown>
+    | undefined;
+  const fields = shapeOfProps?.fields;
+  const fieldsDef = internals(fields);
+  const element = fieldsDef.element ?? fieldsDef.type;
+  const arms = (internals(element).options ?? []) as unknown[];
+
+  for (const arm of arms) {
+    const armDef = internals(arm);
+    const rawShape = armDef.shape;
+    const resolved = (
+      typeof rawShape === 'function' ? (rawShape as () => unknown)() : rawShape
+    ) as Record<string, unknown> | undefined;
+    if (resolved && typeof resolved === 'object') {
+      const catchall = internals(armDef.catchall);
+      return {
+        keys: Object.keys(resolved).sort(),
+        strict: (catchall.type ?? catchall.typeName) === 'never',
+      };
+    }
+  }
+  return { keys: [], strict: false };
+}
+
+describe('objectui#9280 — record:highlights `fields[]` entry against the installed spec', () => {
+  it('PREMISE: the contract declares exactly four entry keys and refuses a fifth', () => {
+    // Read off the schema object rather than transcribed, so a spec that adds
+    // or drops a key fails HERE first — before the pins above start asserting
+    // a shape the contract no longer has. ⭐ If this ever reports `icon` among
+    // the keys, the contract WIDENED and this whole retirement is reversed by
+    // a new card, not by loosening the assertions below.
+    const arm = specEntryArm();
+    expect(arm.keys).toEqual(['label', 'name', 'readonly', 'type']);
+
+    // The load-bearing half. A non-strict arm would STRIP `icon` silently
+    // instead of refusing, which is a different defect with a different repair.
+    expect(arm.strict).toBe(true);
+  });
+
+  it("PREMISE: an entry carrying `icon` is refused with `invalid_union` at `fields.0` — the card's repro", () => {
+    const refused = RecordHighlightsProps.safeParse({ fields: [{ name: 'x', icon: 'star' }] });
+    expect(refused.success).toBe(false);
+    const issue = refused.error?.issues.find((i) => i.path.join('.') === 'fields.0');
+    expect(issue?.code).toBe('invalid_union');
+
+    // CONTROL A — an arbitrary key is refused with the SAME code, so `icon`
+    // is not special-cased by some bespoke branch.
+    const arbitrary = RecordHighlightsProps.safeParse({
+      fields: [{ name: 'x', zzzNonsense: 1 }],
+    });
+    expect(arbitrary.success).toBe(false);
+    expect(arbitrary.error?.issues.find((i) => i.path.join('.') === 'fields.0')?.code).toBe(
+      'invalid_union',
+    );
+
+    // CONTROL B — a declared key parses green and survives, so the arm is not
+    // refusing everything. A refusal with no control that would have fired is
+    // not a measurement.
+    const accepted = RecordHighlightsProps.safeParse({ fields: [{ name: 'x', label: 'L' }] });
+    expect(accepted.success).toBe(true);
+    expect(accepted.data?.fields[0]).toMatchObject({ name: 'x', label: 'L' });
+
+    // CONTROL C — the bare-string arm is unaffected, so the refusal above is
+    // scoped to the object arm rather than to `fields` as a whole.
+    const bare = RecordHighlightsProps.safeParse({ fields: ['x'] });
+    expect(bare.success).toBe(true);
+  });
+
+  it('the DECLARATION carries the contract’s four keys and no fifth', () => {
+    const source = readFileSync(DECLARATION_PATH, 'utf8');
+
+    // Anchor on the interface so the match cannot drift onto another `icon`.
+    const block = source.slice(source.indexOf('interface RecordHighlightsComponentProps'));
+    expect(block).not.toBe('');
+    const arm = /fields: Array<([\s\S]*?)>;/.exec(block)?.[1] ?? '';
+    expect(arm).not.toBe('');
+    expect(arm).not.toContain('icon');
+
+    // Derived, not transcribed: the arm's members ARE the contract's members.
+    const declaredKeys = Array.from(arm.matchAll(/(\w+)\??:/g))
+      .map((m) => m[1])
+      .sort();
+    expect(declaredKeys).toEqual(specEntryArm().keys);
+
+    // ⭐ THE LIT CONTROL for this instrument: the SAME `icon` matcher, run
+    // against the sibling interface one screen up, FINDS the `sections[].icon`
+    // member there (a different key on a different face — the contract
+    // declares it and `DetailSection` draws it, ⛔ not this card's to retire).
+    // So `not.toContain('icon')` above is a reading, not a matcher that can
+    // never see the word. If that member ever moves, this control moves with
+    // it — it must never be deleted outright.
+    const siblingBlock = source.slice(
+      source.indexOf('interface RecordDetailsComponentProps'),
+      source.indexOf('interface RecordHighlightsComponentProps'),
+    );
+    expect(siblingBlock).toContain('icon?: string;');
+  });
+
+  it('the literals above are real values, not type-only decoration', () => {
+    // vitest strips types, so these expectations are NOT the assertion — the
+    // annotations are. They exist so the file also fails visibly if the
+    // literals are ever silently emptied out.
+    expect(nameLabelAccepted.fields[0]).toMatchObject({ name: 'amount', label: 'Amount' });
+    expect(typeReadonlyAccepted.fields[0]).toMatchObject({ readonly: true });
+    expect(bareStringAccepted.fields[0]).toBe('amount');
+    expect(iconRefused.fields[0] as unknown).toMatchObject({ icon: 'dollar-sign' });
+    expect(arbitraryKeyRefused.fields[0] as unknown).toMatchObject({ zzzNonsense: 1 });
+  });
+});

--- a/packages/types/src/record-components.ts
+++ b/packages/types/src/record-components.ts
@@ -242,15 +242,44 @@ export interface RecordDetailsComponentProps {
 export interface RecordHighlightsComponentProps {
   /**
    * Fields to display as highlights — bare names or
-   * `{name,label?,icon?,type?,readonly?}` for inline overrides.
+   * `{name,label?,type?,readonly?}` for inline overrides, as the CLOSED SET
+   * the contract declares.
    *
    * `readonly: true` suppresses the chip's inline-edit affordance
    * (objectstack#5077) without touching the object field, which is what
    * hook-maintained columns need: marking the object field `readonly` would
    * also strip the hook's own write-back.
+   *
+   * The object arm offered a fifth key, `icon`, until objectui#9280, and the
+   * contract never accepted it. `@objectstack/spec`
+   * `RecordHighlightsProps.fields[]`'s object arm declares exactly
+   * `name`/`label`/`type`/`readonly` and carries a `never` catchall, i.e. it is
+   * `$strict`: an unlisted key is REFUSED, not stripped, and the refusal takes
+   * the WHOLE document with it. Measured on the installed pin, 17.4.0,
+   * `RecordHighlightsProps.safeParse({ fields: [{ name: 'x', icon: 'star' }] })`
+   * is RED with `invalid_union` at `fields.0`. So `{ name: 'amount', icon:
+   * 'dollar-sign' }` type-checked here and was refused at the door — a green
+   * local build and a rejection at the only layer that matters. Three controls
+   * on the same instrument fired as they should: a declared key
+   * (`{ name, label }`) parses green, so the arm is not refusing everything; an
+   * arbitrary key (`zzzNonsense`) is refused with the SAME `invalid_union`
+   * code, so `icon` was not special-cased; and the bare-string arm parses
+   * green, so only the object arm moved. Contract-first (Commandment #0.1):
+   * the declaration moves to the contract, the contract is not widened.
+   *
+   * ⚠️ Whether a highlight chip SHOULD be able to carry an icon is a separate
+   * question this narrowing does not answer. The route for it is an upstream
+   * spec widening (an `@objectstack/spec` decision, on its own card), ⛔ never
+   * a redeclaration here.
+   *
+   * ⚠️ Do NOT copy this retirement onto `sections[].icon` one screen up. That
+   * is a DIFFERENT key on a different face — `DetailSection` genuinely draws
+   * it and the contract declares it — the same word, not the same member.
+   * `__tests__/record-highlights-fields-icon-9280.test.ts` pins this arm
+   * against the installed spec in both directions.
    */
   fields: Array<
-    string | { name: string; label?: string; icon?: string; type?: string; readonly?: boolean }
+    string | { name: string; label?: string; type?: string; readonly?: boolean }
   >;
   /**
    * Layout mode for the highlights strip, as the CLOSED SET the contract


### PR DESCRIPTION
Fixes #9280

Retires `icon` from the `record:highlights` `fields[]` entry across **all three layers**
that carried it. Direction is triage's ruling on the card (retire, ⛔ not widen): widening
`@objectstack/spec` to declare `icon` would widen a published accept set — a manual-floor
decision and an objectstack matter, ⛔ not this repo's call.

⚠️ Generics below are written with SQUARE brackets: GitHub's body sanitizer eats
tag-shaped fragments, fences included.

## The two things the dispatch could not establish, established here

**1. The spec-side reading — RE-MEASURED, and it holds.** `@objectstack/spec` was not
installed in the triage or PM container, so the claim was unverified. Measured here from the
installed artifact (pin **17.4.0**), reading the arm's own shape rather than transcribing
anything:

```
fields[] object-arm keys : ["label","name","readonly","type"]
arm catchall             : never   =>  $strict (an unlisted key is REFUSED, not stripped)

{ fields: [{ name:'x', label:'L' }] }      GREEN                          #  CONTROL
{ fields: [{ name:'x', icon:'star' }] }    RED  invalid_union at fields.0
{ fields: [{ name:'x', zzzNonsense:1 }] }  RED  invalid_union at fields.0  #  CONTROL
{ fields: ['x'] }                          GREEN                          #  CONTROL
```

All three controls fired: a declared key parses green, so the arm is not refusing
everything; an arbitrary key is refused with the **same** `invalid_union` code as `icon`, so
`icon` was not special-cased; the bare-string arm is unaffected, so only the object arm
moved. ⇒ the direction stands, and the `Clause-②: no` citation is now a measurement rather
than a claim.

**2. Layer ② — LOCATED.** Triage had read only a test comment *describing* the normalizer,
never the read site. The actual read site is
`packages/plugin-detail/src/renderers/record-highlights.tsx`, in the `rawFields.map` entry
normalizer: the line was literally `icon: f?.icon,`, forwarded into `HeaderHighlight`.
⭐ Re-derived by symbol, not by the ~1-day-old line numbers.

## FROM to TO, per layer

| layer | file | FROM | TO |
| --- | --- | --- | --- |
| ① type | `packages/types/src/record-components.ts` | `{ name; label?; icon?; type?; readonly? }` | `{ name; label?; type?; readonly? }` |
| ② normalizer | `packages/plugin-detail/src/renderers/record-highlights.tsx` | copies `icon: f?.icon` into the entry | key dropped |
| ③ manifest | `packages/plugin-detail/src/index.tsx` | `fields` description sketches `{name,label?,icon?,type?,readonly?}` | `{name,label?,type?,readonly?}` |

The key is **removed, not tombstoned**. A `?: never` tombstone is the remedy for a
*non-strict* mirror that would otherwise strip in silence; this arm is `$strict`, so the
named refusal an author needs already exists upstream and arrives as `invalid_union` at the
entry.

⭐ **Nothing that worked stops working.** All three layers were already broken, not
functional: no author could get `icon` past the `$strict` arm, so the normalizer's read was
**unreachable code** and the manifest's promise was an **impossible advertisement**.
Measured here and worth recording: `HeaderHighlight` renders no `.icon` **at all**, so the
normalizer's copy had no consumer on the far side either.

## In-repo consumer census

109 `record:highlights` regions across all tracked files score an entry-level `icon` of
**0**. Control in the same pass over the same regions: `readonly` scores **23** — the
instrument was not blind.

## Verification

| leg | command | result |
| --- | --- | --- |
| build (dep closure) | `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-detail^...' build` | exit **0** |
| type-check | `pnpm --filter @object-ui/types type-check` | exit **0** |
| type-check | `pnpm --filter @object-ui/plugin-detail type-check` | exit **0** |
| tests | `pnpm --filter @object-ui/types test` | **183 files / 4197 tests passed** |
| tests | `pnpm --filter @object-ui/plugin-detail test` | **175 files / 1625 tests passed** |
| lint (the real gate) | `pnpm --filter @object-ui/types --filter @object-ui/plugin-detail lint` | exit **0** (0 errors) |

⭐ The pin file was proven to be **inside** the type-check program before any claim was made
about it: `tsc -p tsconfig.test.json --listFiles` lists
`record-highlights-fields-icon-9280.test.ts` (control: the sibling `...-layout-9187.test.ts`
is listed too). Without that, a green `type-check` would say nothing about the
`@ts-expect-error` legs.

Gates, derived from **`.github/workflows/lint.yml`'s step list** (⛔ not `package.json`),
exit codes captured by redirect before any pipe:

| gate | exit | its own verdict line |
| --- | --- | --- |
| `check-lint-coverage.mjs` | 0 | `lint coverage: 46/46 packages linted, 0 with outstanding errors` |
| `check-entry-guard.mjs` | 0 | — |
| `check-test-path-roots.mjs` | 0 | `OK (1917 filesystem call(s) in 399 of 3103 test file(s))` |
| `check-vi-mock-override-shape.mjs` | 0 | — |
| `check-changeset-presence.mjs` | 0 | `4 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major.mjs` | 0 | `No changeset declares a major bump` |
| `check-governed-queue-guard.mjs --test` | 0 | `NOT GOVERNED — 6 path(s) checked ... none matched` |

`pnpm lint` is `turbo run lint` (per-package), and both affected packages ran it green
above. `check-upstream-port-parity.mjs` and `check-bash32-floor.mjs` are **not implicated**
— this diff touches no `scripts/` file and no shell script — and are left to CI.

## Ablation — the pin can actually fail

Run from the committed state. Mutation proven **on disk before any result was read**;
restore proven **byte-identical**, not by an exit code.

```
HEAD blob            : c3c500d8fbcdce89a5a2e45469325b746eca1ebd
PRE  'label?: string; icon?'  : 0        POST (injected) : 1
PRE  'label?: string; type?'  : 1        POST (removed)  : 0
mutated blob         : b43b88e88fe8c2a42ceaeff8c1eaaa09d4c6d119   (differs from HEAD => it landed)

ABLATION_VITEST_EXIT = 1    (non-zero, required)
ABLATION_TSC_EXIT    = 2    (non-zero, required)

restored blob        : c3c500d8fbcdce89a5a2e45469325b746eca1ebd   (== HEAD blob)
git diff HEAD is empty : yes
```

The failures are the **right** ones, not merely non-zero:

```
record-highlights-fields-icon-9280.test.ts(129,3): error TS2578: Unused '@ts-expect-error' directive.
record-highlights-fields-icon-9280.test.ts(92,3):  error TS2344: Type 'false' does not satisfy the constraint 'true'.
AssertionError: expected '...string | { name: string; label?...' not to contain 'icon'
```

TS2578 **is** the acceptance criterion: with `icon` back on the arm, the entry compiles
again, so the directive goes unused. TS2344 is the invariant `Equal[...]` key-set assertion
flipping to `false`. ⭐ The `PREMISE` legs stayed **green** through the ablation — they read
the spec only, so they are the premise and never the evidence, exactly as the file labels
them. No dist hop was involved: the pin imports `'../record-components'` relatively and
re-reads the same file from disk.

## Pins added

- `packages/types/src/__tests__/record-highlights-fields-icon-9280.test.ts` — three
  instruments that do **not** see the same thing: a `tsc` `@ts-expect-error` leg with a
  `{name,label}` control that stays green; `safeParse` legs against the installed spec with
  three controls; and a source-text read whose **lit control is `sections[].icon`** one
  interface up, so an empty result on the highlights arm is a reading rather than a matcher
  that can never match.
- `packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts` gains the
  **reverse direction it was missing**. It already failed when a spec entry key went
  undocumented; it now also fails when the description advertises an entry key the spec
  refuses — the exact drift this card was filed for.

## Scope notes

- ⛔ **`sections[].icon` is untouched**, deliberately. It is a **different member on a
  different face**: the contract declares it and `DetailSection` genuinely draws it. Two keys
  sharing a word in one file are not the same key. It appears in this PR only as the lit
  control for the source-text instrument.
- ⚠️ This PR does **not** decide whether a highlight chip *should* carry an icon. If there is
  real product pull, the route is an upstream `@objectstack/spec` widening on its own card.
  ⛔ Not pre-judged here.
- `RecordHighlightsRenderer.readonly.test.tsx`'s header comment still contains the word
  `icon`. Left as-is on purpose: it is **past-tense history** describing the pre-objectstack#5077
  normalizer, and it stays true.

## Acceptance notes

- `HighlightField.icon` (`packages/types/src/views.ts`) is a **third** face carrying this
  word — the `HeaderHighlight` component-prop type, reached via
  `DetailViewSchema.highlightFields`. Measured: `HeaderHighlight` renders no `.icon`, so
  after this change the key has no producer and no consumer in-repo. **Noted, not filed**:
  `DetailViewSchema` carries function props (`onTabChange`), so it is a React props face, not
  authored metadata that someone else stores and re-authors — it is not the metadata-trap
  class, and nothing here is a reproducible defect or a declared-contract breach. Its natural
  successor is the upstream spec-widening card above, if that is ever opened; **there is no
  queued PR that would otherwise touch it.**

## Delivery posture

Draft, per the dispatch order. `needs:contract-review` hung on this PR: it is a **breaking
narrowing of a published type**. ⛔ Not flipped ready, ⛔ not enqueued, ⛔ no auto-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5xpA5q533BgTTNADibEFt)_