### PR TITLE
fix(skills): guard the DataSource read in the marked data-integration example

### DIFF
--- a/skills/objectui/guides/data-integration.md
+++ b/skills/objectui/guides/data-integration.md
@@ -291,7 +291,15 @@ different envelope and behaves differently; see
 
 ### Via DataSource methods (in plugin code)
 
-Plugin components that need CRUD operations access the DataSource from context:
+Plugin components that need CRUD operations access the DataSource from context
+— and must guard it before calling. `useSchemaContext()` throws only when there
+is **no provider** above the component; a provider with **no adapter bound** is
+an ordinary, supported state (a Studio preview, a page that renders before the
+host connects its adapter, a widget test that drives `apiFetch` alone). The
+renderer itself already reads the member that way — `useDataScope` returns
+`undefined` when nothing is bound — so an unguarded call throws on its first use
+in exactly those places. Decide what the component shows while the adapter is
+absent (objectui#7912):
 
 <!-- os:check -->
 ```typescript
@@ -301,6 +309,9 @@ function MyPlugin() {
   const { dataSource } = useSchemaContext();
 
   const loadData = async () => {
+    // No adapter bound is a real state, not an error — see above.
+    if (!dataSource) return [];
+
     const result = await dataSource.find('contacts', {
       $filter: { active: true },
       $orderby: [{ field: 'name', order: 'asc' }],


### PR DESCRIPTION
Fixes #9311

One line inside one marked fence in `skills/objectui/guides/data-integration.md`, plus the prose that makes it read as teaching rather than as gate appeasement. One file, +12 / -1.

## ⚠️ This PR parks as a DRAFT by design — please do not route around it

`skills/**` is a governed surface. Measured with the repo's own tool, on this PR's own diff (`node scripts/check-governed-queue-guard.mjs --test skills/objectui/guides/data-integration.md`, exit 3), quoted verbatim:

```
⛔ GOVERNED — 1 of 1 path(s) are on a governed surface:
   skills/** x1 — the published skills catalog
     - skills/objectui/guides/data-integration.md

   One governed path governs the WHOLE pull request — proportion is not a question.
   ⛔ Do not flip it ready, enqueue it, or arm auto-merge. Park it as a DRAFT and leave the merge
      to the maintainer; a human merge IS the review record for a governed surface.
   The merge-queue run of "Governed Surface Queue Guard" refuses this diff unless an APPROVED review by an
   authorized approver (GOVERNED_APPROVERS: os-zhuang, hotlong) is on the pull request — on
   whichever commit it was left (maintainer ruling 2026-09-04).
```

That is the designed end state, not a failure. `needs:contract-review` is hung here as well: teaching that the adapter may legitimately be absent is a falsifiable contract-semantics claim about objectui#7912's ruling, and the governed-surface human merge and the clause-two review **stack** — neither substitutes for the other.

## The defect

The marked fence under "Via DataSource methods (in plugin code)" destructured `dataSource` from `useSchemaContext()` and called `.find()` on it with no guard. `useSchemaContext()` throws only when there is **no provider**; a provider with **no adapter bound** is an ordinary, supported state — a Studio preview, a page that renders before the host connects its adapter, a widget test that drives `apiFetch` alone. Published guidance copied into a plugin on such a surface therefore throws at its first call.

The `os:check` marker stays. Dropping it was the gate's other option and it is the wrong one: it retires the coverage instead of repairing the guidance, and leaves the same unguarded pattern published for readers to copy.

## ⭐ Premise correction: the red does NOT reproduce on `origin/main`

Worth stating, because anyone re-running the gate on `main` will read green and conclude the card was wrong. On `origin/main` (`a5921a0f8`) the gate IS green — `Semantic phase: 14 of 14 ts fence(s) judged, 0 failed` — because `SchemaRendererContextType.dataSource` is still declared `any` there (`packages/react/src/context/SchemaRendererContext.tsx`). The TS18049 the card quotes is produced by PR objectui#9310's narrowing, which has not landed. The card's substance is intact — the hazard is real and the narrowing only made it visible — but the reading needs its base stated.

So the repair was verified as a two-leg proof, both legs with PR objectui#9310's own copy of that one narrowing file applied on top of this branch and `@object-ui/react` rebuilt, so the change reaches the `dist/*.d.ts` the gate compiles against.

**RED leg** — narrowing applied, guide at `a5921a0f8` (unrepaired). Gate exit 1:

```
  [semantic]  skills/objectui/guides/data-integration.md:304:26  TS18049: 'dataSource' is possibly 'null' or 'undefined'.
Semantic phase: 14 of 14 ts fence(s) judged, 1 failed.
JSON phase:     70 fence(s) parsed, 0 failed.

A marked example in skills, .claude/skills no longer holds up. Fix the example, or — if it was never meant to compile on its own — remove its marker rather than weakening this gate.
```

**GREEN leg** — same narrowing, guide repaired. Gate exit 0:

```
Marked: 14 ts fence(s) (floor 13), 70 json fence(s) (floor 70) — the floor is ⛔ SHRINK-ONLY. Unmarked fences are ignored by design (opt-in).
Semantic phase: 14 of 14 ts fence(s) judged, 0 failed.
JSON phase:     70 fence(s) parsed, 0 failed.

Every marked skill example holds up against the built types.
```

**Harness soundness**, read beside both legs — a permanently green (or permanently red) harness is not a reading. `node scripts/check-skill-examples.mjs --self-test`, exit 0:

```
✓ check-skill-examples self-test: 59 cases pass (marker adjacency both directions, orphans, nested illustration, json/jsonc, the bare-`any` guard in both directions with its shrink-only baseline, the ROOT BOUND in both directions with its own shrink-only baseline and control, the PUBLISHED-TYPE inventory with its positive and negative controls plus the shadowing ledger in both directions, and the compiler legs through the real harness).
```

**Ablation hygiene.** The narrowing was applied by writing PR objectui#9310's copy of that file, proven to reach disk (marker count 0 then 2) and to reach `dist` (0 then 2) before either reading was taken; restored under a shell trap with `git checkout HEAD -- packages/react/src/context/SchemaRendererContext.tsx`, proven by blob-hash equality against the HEAD blob (`55efccde746c2f269bdc635ac71c5dd62d7d0ecb`), an empty `git diff HEAD`, and a rebuild that returned the `dist` marker count to 0.

⚠️ One honest caveat about that leg: its `turbo run build` exits 2, because PR objectui#9310 narrows 52 files and this reproduction applies one. The two residual errors are `src/hooks/useClientNotifications.ts(84,39)` and `(85,23)`, `TS2339: Property 'getClient' does not exist on type 'DataSource'` — in a file that same PR also updates. The declaration file the gate reads was still emitted and carries the narrowing, and the diagnostic reproduced is character-for-character the one PR objectui#9310's own CI reports.

## Enumeration of sibling fences — measured, not inferred from the single red

A fence without the `os:check` marker is not judged at all, so "only one red" proves nothing by itself. `--measure` judges EVERY candidate fence, marked or not; it was run twice.

**Reading 1 — the narrowing's whole footprint.** With this repair in place, the corpus census is **byte-identical** with and without PR objectui#9310's narrowing (`cmp` reports identical; 270 `[semantic]` lines in each; `Semantic phase: 97 of 121 ts fence(s) judged, 79 failed` in both). Across 121 candidate ts fences in `skills/` and `.claude/skills/`, the narrowing's entire diagnostic footprint was the one fence this PR repairs. The 79 pre-existing failures are unmarked fragments, which is why this gate is opt-in.

**Reading 2 — the same class elsewhere.** Corpus-wide there is exactly one other possibly-absent-member diagnostic, and it is present on `origin/main` today, in an UNMARKED and therefore unjudged fence:

```
  [semantic]  skills/objectui/guides/auth-permissions.md:49:20  TS18047: 'user' is possibly 'null'.
```

Filed separately as objectui#9350: `AuthContextValue` declares `user: AuthUser | null`, and `AuthProvider` hardcodes `isAuthenticated = true` in guest mode and preview mode, so that example's `isAuthenticated` guard does not imply a user — while the repo's own `UserMenu.tsx` guards both. ⛔ Not touched here: different guide, different member, and this diff is deliberately one file on a governed surface.

**grep corroboration**: `useSchemaContext` appears exactly once across both skills trees (line 298 of this guide), and no other fence reads a `dataSource` member. There was no second site of this pattern to miss.

## What this does and does NOT unblock

⛔ This does **not** turn PR objectui#9310 green. That PR carries two non-required reds: `Skill Example Check` (this card) and `Doc Snippet Type Check` (three fences teaching the second meaning of `dataSource`, tracked as objectui#9346 and held on objectui#9308, which is `needs-user-decision` — the maintainer's ruling, not a seat's). This PR removes one of those two reported reds, on its own merits.

Re-measured independently this round at `GET /repos/objectstack-ai/objectui/rules/branches/main`: rule types `deletion · non_fast_forward · merge_queue · pull_request · required_status_checks`, and the nine required contexts are `Lint`, `Type Check`, `Build & E2E`, `Test (shard 1/4)` through `(4/4)`, `Build Docs`, `Changeset Declaration`. `Skill Example Check` is not among them.

## Changeset decision: none owed, none added — measured, not assumed

- **Is `skills/` shipped by any package?** No. Scanning every workspace manifest's `files`, `exports`, `main`, `module` and `types`: **0** mention `skills`. The published skills tree is not carried by any released package.
- **The repo's own answer**, `node scripts/check-changeset-presence.mjs`, exit 0: "Compared the working tree with a5921a0f8 (merge-base with origin/main): 1 file(s) changed, 0 of them published source of a package the release covers, 0 of them a manifest whose published contract moved, 0 under a package changesets ignores, 0 changeset(s) added." then "✅ No source or published contract of a released package changed in this range, so no changeset is owed."

`Changeset Declaration` is one of the nine required contexts, so that is the gate's verdict rather than an assumption.

## Gates run locally

Derived by hand from `package.json` plus `.github/workflows/` — this repo has no dispatch-gates script. Exit codes were captured before any pipe; heavy runs went through the shared verify lock and each reported `VERDICT command-exit 0`.

| gate | command | result |
| --- | --- | --- |
| Skill Example Check | `node scripts/check-skill-examples.mjs` | exit 0 — 14/14 ts, 70/70 json |
| its harness | `node scripts/check-skill-examples.mjs --self-test` | exit 0 — 59 cases |
| Skill Guide Path Check | `node scripts/check-skills-paths.mjs` | exit 0 — 88/89 resolve, 1 baselined |
| skill eval tokens | `node scripts/check-skill-eval-tokens.mjs` | exit 0 — 0 red |
| control bytes | `node scripts/check-control-bytes.mjs` | exit 0 — 7528 text files |
| new line citations | `node scripts/check-new-cross-file-line-citations.mjs` | exit 0 — 0 new |
| changeset presence | `node scripts/check-changeset-presence.mjs` | exit 0 |
| changeset claims | `node scripts/check-changeset-claims.mjs` | exit 0 |
| governed queue guard | `node scripts/check-governed-queue-guard.mjs --test` | exit 3 — GOVERNED, quoted above |

A targeted control-byte sweep over the changed file found none.

## Published-skills size readings

- `skills/objectui/guides/data-integration.md`: **474 to 485** lines.
- whole published `skills/` tree: **5190 to 5201** lines (this is the only file changed).
- `skills/objectui/SKILL.md`: unchanged, 137 lines.

Eight of the eleven added lines are the prose AGENTS.md requires to move with a changed example; three are the guard, its blank line and its one-line comment. No net-increase ceiling was named for this card — this is the reading to price it against if one applies.

## 维护者速读(草稿)

**改了什么** —— 已发布技能指南 `skills/objectui/guides/data-integration.md` 里一个带 `os:check` 标记的示例:插件从 context 拿到 `dataSource` 之后直接调 `.find()`,现在先判空再调,并在示例上方补了一段「适配器为什么可能不在」的说明。只动这一个文件。

**为什么改** —— `useSchemaContext()` 只在**没有 Provider** 时抛错;「有 Provider、但没绑适配器」是产品里真实存在的状态(Studio 预览、宿主适配器连上之前的页面、只驱动 `apiFetch` 的组件测试)。照抄这段示例的插件,在这些界面上第一次调用就抛。这是给人和 AI 抄的示例,错的教法比一处代码缺陷传得更远。

**风险与代价(含回滚)** —— 风险低:纯文档,不动任何发布包的源码,仓库自己的 changeset 门禁判定「不欠 changeset」。回滚即 revert 这一个 commit,无数据迁移、无 API 变化。代价是本 PR 落在受管面,必须由人来合并,并且要一条授权的 APPROVED review。

**席位意见** —— (留空,待人工填写。)

**你要做的** —— 读一遍示例上方新增的那段话,是否符合你对这条契约的判断(这正是 `needs:contract-review` 要问的),然后由你来合并。⛔ 席位不翻 ready、不入队、不开 auto-merge,也不会自己留下批准记录。

## Acceptance notes

Out-of-scope findings from this card. None of them is touched by this PR.

- **Filed as objectui#9350** — `skills/objectui/guides/auth-permissions.md` teaches `user.name` behind an `isAuthenticated` guard that guest mode and preview mode hardcode true. Same class as this card, different guide and different member; the fence carries no marker, so the gate never judges it.
- **Noted, not filed** — this same guide also teaches the SECOND meaning of `dataSource`: the "Static data (no backend)" section passes a plain object as the adapter, and `rules/protocol.md` plus `guides/schema-expressions.md` document `bind` resolving `dataSource.customerNames`. Under objectui#7912's narrowing those fences would be type errors if they were marked. That is objectui#9308's open `needs-user-decision` ruling, tracked on the docs surface as objectui#9346 — the successor that will touch these files. Not re-filed here.
- **Noted, not filed** — `--measure` reports `97 of 121 ts fence(s) judged, 79 failed`. Every one is an unmarked fragment (identifiers it never declares, dev-only imports no consumer can resolve). That is the opt-in design this gate's own header argues for, not debt.
- **Noted, not filed** — MCP `search_issues` returned `total_count: 0` for three separate queries in this session, including a control whose target card title literally contains the query token. Duplicate-checking was therefore done on the repo-scoped REST list endpoint (`labels=domain:skills`, with objectui#9311 present as a passing control). Successor: the PM seat, which runs duplicate checks every round.

Session, as a code span so it survives a later edit of this body: `session_01UzHd6hDYatoDn17BuwKxnZ`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_

---
_Generated by [Claude Code](https://claude.ai/code)_