### PR TITLE
fix(plugin-kanban): run an authored `onCardClick` ONCE per card click (objectui#9341)

### DIFF
--- a/.changeset/9341-kanban-card-click-fires-once.md
+++ b/.changeset/9341-kanban-card-click-fires-once.md
@@ -1,0 +1,56 @@
+---
+'@object-ui/types': minor
+'@object-ui/plugin-kanban': minor
+---
+
+An `onCardClick` supplied to an `object-kanban` board runs **once** per card
+click instead of twice, and the published declaration of the key grows the
+second parameter the surviving call actually delivers (objectui#9341, maintainer
+ruling on the card, 2026-09-13).
+
+**This carries a breaking behaviour change** — the `ObjectView` case below. It
+ships `minor` because the repo has a single `fixed` group of 40 packages, so a
+`major` on either package majors all forty; the scope is stated here rather than
+encoded in the bump.
+
+## `@object-ui/plugin-kanban` — one click, one call
+
+`ObjectKanban` handed the host's function to `useNavigationOverlay` as its
+`onRowClick` **and** called it again itself on the next line. `handleClick`
+gives `onRowClick` full priority — it calls it and returns — so for a host that
+supplied `onCardClick` and no `onRowClick`, one card click ran that one function
+twice: a duplicate navigation, a duplicate analytics event or a double-open,
+depending on what the handler did. The wrapper's second call is gone.
+
+Of the two calls the deleted one was the poorer. `handleClick` forwards
+`onRowClick(record, event)`, so a host can implement Cmd/Ctrl/middle-click; the
+wrapper's call passed the record only. `onRowClick ?? onCardClick` is untouched,
+so which handler wins is exactly what it was.
+
+⚠️ **The breaking case, to check before upgrading.** A board embedded in an
+`ObjectView` gets `onRowClick` from that parent, so the parent's handler already
+won. What also happened was that the document's own `onCardClick` ran anyway —
+once, through the wrapper. It now runs **zero** times there: the winner of
+`onRowClick ?? onCardClick` answers the click outright. A host that relied on an
+authored `onCardClick` firing alongside a parent `onRowClick` must move that
+work into the parent's handler. Pinned as a reading, not left to be discovered,
+in `packages/plugin-kanban/src/__tests__/cardClickFiresOnce-9341.test.tsx`.
+
+## `@object-ui/types` — `ObjectKanbanSchema.onCardClick` declares two parameters
+
+```ts
+onCardClick?: (card: any, event?: any) => void;   // was: (card: any) => void
+```
+
+The surviving channel delivers `(record, event)`, so the one-parameter
+declaration described only the call that was deleted. Growing an optional second
+parameter is source-compatible in both directions — an existing one-argument
+handler still type-checks, and code that stores the member in a one-argument
+slot still compiles — and that claim is handed to `tsc` rather than asserted, in
+the same pin file.
+
+`event` is `any`, not `HandleClickModifiers`: that interface lives in
+`@object-ui/react`, which depends on `@object-ui/types` and is named in no
+dependency field of it. `BaseSchema`'s own `onClick` / `onChange` / `onSubmit`
+already spell this exact situation the same way. What arrives at runtime is the
+DOM click event `KanbanImpl` forwards, typed `React.MouseEvent` there.

--- a/packages/plugin-kanban/src/ObjectKanban.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.tsx
@@ -252,7 +252,18 @@ export interface ObjectKanbanComponentProps {
   /** Loading state propagated from a parent. Respected only when `data` is also provided. */
   loading?: boolean;
   onRowClick?: (record: any) => void;
-  onCardClick?: (record: any) => void;
+  /**
+   * ⚠️ TWO parameters, and the second one is not decoration: this prop is the
+   * `onCardClick` arm of `externalClick` below, which is handed to
+   * `useNavigationOverlay` as its `onRowClick` and invoked as
+   * `onRowClick(record, event)` — the modifier payload a host needs for
+   * Cmd/Ctrl/middle-click. Spelled `any` because `packages/types` declares the
+   * published twin of this key and may not name `HandleClickModifiers` (it lives
+   * in `@object-ui/react`, which depends on `@object-ui/types`), and the two
+   * faces must not disagree. `KanbanImpl` types the same channel as
+   * `React.MouseEvent`, which is what actually arrives.
+   */
+  onCardClick?: (record: any, event?: any) => void;
 }
 
 export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
@@ -1329,9 +1340,24 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
           // objectui#8307 — the lane headers count rows that came back, so when
           // the fetch saturated its window they must say `77+`, not `77`.
           countsAreWindowed,
+          // ⛔ Calls `handleClick` and NOTHING ELSE. An authored `onCardClick`
+          // already travels this one line: it is the `onCardClick` arm of
+          // `externalClick` above, which is `handleClick`'s `onRowClick`, and
+          // that arm has FULL PRIORITY inside the hook — it is called and the
+          // hook returns. A second `onCardClick?.(card)` here therefore ran the
+          // SAME function again, twice per card click (objectui#9341, measured
+          // 2 by objectui#9338's pin before it was relaxed).
+          //
+          // Of the two calls the DELETED one was the poorer: `handleClick`
+          // forwards `onRowClick(record, event)`, so the host can implement
+          // Cmd/Ctrl/middle-click, while the second call passed the record
+          // only. Dropping it also leaves `onRowClick ?? onCardClick` untouched
+          // — a board inside an `ObjectView` still gives the parent's handler
+          // priority, and now gives it OUTRIGHT rather than also running the
+          // authored one. `ObjectGallery` has written exactly this shape, with
+          // no second call, all along.
           onCardClick: (card: any, event?: any) => {
             navigation.handleClick(card, event);
-            onCardClick?.(card);
           },
           onCardMove: handleCardMove,
         }}

--- a/packages/plugin-kanban/src/__tests__/cardClickFiresOnce-9341.test.tsx
+++ b/packages/plugin-kanban/src/__tests__/cardClickFiresOnce-9341.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * One card click runs an authored `onCardClick` EXACTLY ONCE, and the call it
+ * survives as carries the modifier event (objectui#9341, maintainer ruling on
+ * the card, 2026-09-13).
+ *
+ * ## The defect
+ *
+ * `ObjectKanban` handed the same function to `useNavigationOverlay` as its
+ * `onRowClick` and then called it again itself:
+ *
+ *     const externalClick = onRowClick ?? onCardClick;
+ *     const navigation = useNavigationOverlay({ …, onRowClick: externalClick });
+ *     …
+ *     onCardClick: (card, event) => {
+ *       navigation.handleClick(card, event);
+ *       onCardClick?.(card);            // ⛔ the second call
+ *     }
+ *
+ * `handleClick` gives `onRowClick` FULL PRIORITY — it calls it and RETURNS — so
+ * for a host that supplies `onCardClick` and no `onRowClick`, that one function
+ * is both the value of `externalClick` and the one the next line calls. One
+ * click, two calls. Measured 2 by objectui#9338's pin, which relaxed its own
+ * control to "it RAN" so that this repair would not redden a file that is not
+ * about it; that control is tightened back to the exact count in the same diff
+ * as this file.
+ *
+ * ## The ruling, and why the two calls are NOT interchangeable
+ *
+ * RULING: drop the wrapper's second call. `externalClick` keeps its
+ * `onCardClick` arm.
+ *
+ * `handleClick` forwards `onRowClick(record, event)`, so a host can implement
+ * Cmd/Ctrl/middle-click; the wrapper's second call passed the record ONLY. The
+ * surviving channel is therefore the RICHER one, which is leg 2's subject — and
+ * the reason the published `ObjectKanbanSchema.onCardClick` declaration grows a
+ * second optional parameter in this same change.
+ *
+ * The same shape one surface over is already the ruling's spelling:
+ * `ObjectGallery` (`packages/plugin-list/src/ObjectGallery.tsx`) writes
+ * `onRowClick: props.onRowClick ?? props.onCardClick` into the identical hook
+ * and has NO second call.
+ *
+ * ## ⚠️ The consequence the card's text did not state — measured in leg 3
+ *
+ * The ruling's rationale says precedence is left alone, so a board inside an
+ * `ObjectView` "behaves exactly as today". That is true of the PRECEDENCE
+ * EXPRESSION and FALSE of the authored handler's call count: when a parent
+ * supplies `onRowClick` AND the document carries `onCardClick`, the authored
+ * one ran ONCE before this change (the wrapper called it) and runs ZERO times
+ * after it — the parent's handler wins OUTRIGHT, which is what
+ * `onRowClick ?? onCardClick` has always said and what nothing enforced. Leg 3
+ * pins that reading rather than leaving it to be discovered.
+ *
+ * ## Every control here can fire
+ *
+ * A count of 1 is only a reading if the instrument can report something else.
+ * Leg 1 carries the sibling `onCardMove` spy at 0 on the SAME render, so the 1
+ * is about this key and not a recorder that counts every key once; leg 4 drives
+ * the same handler TWICE and reads 2, so the counter demonstrably moves.
+ *
+ * ⚠️ No leg here depends on a throw. React 19 REPORTS a handler error out of
+ * the dispatch rather than rethrowing it, so an `expect(...).toThrow()` leg on
+ * this path could never fire.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+import type { ObjectKanbanSchema } from '@object-ui/types';
+import '../index';
+
+/** Every props object the board implementation was rendered with, in order. */
+const recorded = vi.hoisted(() => ({ impl: [] as Array<Record<string, unknown>> }));
+
+// The lazy board chunk is a prop recorder: the question is how many times the
+// handler the board was HANDED runs the authored one, not what the board draws.
+vi.mock('../KanbanImpl', () => ({
+  default: (props: Record<string, unknown>) => {
+    recorded.impl.push(props);
+    return null;
+  },
+}));
+
+const STATIC_COLUMNS = [{ id: 'todo', title: 'To Do', cards: [{ id: '1', title: 'One' }] }];
+
+/**
+ * Author a document on the PRODUCTION path — `SchemaRenderer` resolves the
+ * registry key and spreads every non-metadata schema key as a React prop — and
+ * return the props the board implementation was handed last.
+ */
+async function boardPropsFor(schemaKeys: Record<string, unknown>) {
+  const before = recorded.impl.length;
+  const { unmount } = render(
+    <SchemaRendererProvider dataSource={undefined}>
+      <SchemaRenderer
+        schema={
+          {
+            type: 'object-kanban',
+            columns: STATIC_COLUMNS,
+            ...schemaKeys,
+          } as never
+        }
+      />
+    </SchemaRendererProvider>,
+  );
+  await waitFor(() => expect(recorded.impl.length).toBeGreaterThan(before));
+  const received = recorded.impl[recorded.impl.length - 1];
+  unmount();
+  return received;
+}
+
+/** The handler the board implementation was handed, driven as a card click. */
+type BoardClick = (card: unknown, event?: unknown) => void;
+
+describe('objectui#9341 — an authored `onCardClick` runs ONCE per card click', () => {
+  it('⭐ ONE click, ONE call — with the sibling `onCardMove` spy at 0 on the same render', async () => {
+    const onCardClick = vi.fn();
+    const onCardMove = vi.fn();
+    const card = { id: '1', title: 'One' };
+
+    // ONE document, ONE render. The sibling key is the firing control: a
+    // recorder that counted every authored handler once would show 1 here too,
+    // and `onCardMove` reaches nothing on this arm (objectui#7804), so a 0
+    // beside the 1 is what makes the 1 a reading about THIS key.
+    const props = await boardPropsFor({ onCardClick, onCardMove });
+    (props.onCardClick as BoardClick)(card);
+
+    expect(
+      { cardClick: onCardClick.mock.calls.length, cardMove: onCardMove.mock.calls.length },
+      'the authored `onCardClick` must run exactly once per card click',
+    ).toEqual({ cardClick: 1, cardMove: 0 });
+  });
+
+  it('⭐ the surviving call carries the MODIFIER EVENT — the whole reason it is the one kept', async () => {
+    const onCardClick = vi.fn();
+    const card = { id: '1', title: 'One' };
+    // What `KanbanImpl` forwards is the DOM click event
+    // (`onClick={(e) => onCardClick?.(card, e)}`); only the three modifier
+    // fields are ever read, so a structural stand-in measures the channel.
+    const event = { metaKey: true, ctrlKey: false, button: 0 };
+
+    const props = await boardPropsFor({ onCardClick });
+    (props.onCardClick as BoardClick)(card, event);
+
+    expect(
+      onCardClick.mock.calls.map((args) => ({ arity: args.length, record: args[0], event: args[1] })),
+      'the kept channel is `handleClick`’s `onRowClick(record, event)` — the dropped one passed the record only',
+    ).toEqual([{ arity: 2, record: card, event }]);
+  });
+
+  it('⚠️ a parent `onRowClick` wins OUTRIGHT — the authored `onCardClick` no longer also runs', async () => {
+    const onRowClick = vi.fn();
+    const onCardClick = vi.fn();
+    const card = { id: '1', title: 'One' };
+
+    // Both reach `ObjectKanban` as React props on this path — `SchemaRenderer`
+    // spreads every non-metadata key and `ObjectKanbanRenderer` forwards its
+    // rest — which is the shape an `ObjectView`-embedded board has, with the
+    // parent supplying `onRowClick`.
+    const props = await boardPropsFor({ onRowClick, onCardClick });
+    (props.onCardClick as BoardClick)(card);
+
+    // ⛔ NOT a regression smuggled in: `externalClick = onRowClick ?? onCardClick`
+    // is untouched by this card and has always said the parent's handler wins.
+    // What changed is that the loser no longer ALSO fires.
+    expect(
+      { rowClick: onRowClick.mock.calls.length, cardClick: onCardClick.mock.calls.length },
+      'precedence is `onRowClick ?? onCardClick`; exactly one handler answers one click',
+    ).toEqual({ rowClick: 1, cardClick: 0 });
+  });
+
+  it('CONTROL — the counter moves: two clicks read 2', async () => {
+    const onCardClick = vi.fn();
+    const card = { id: '1', title: 'One' };
+
+    const props = await boardPropsFor({ onCardClick });
+    (props.onCardClick as BoardClick)(card);
+    (props.onCardClick as BoardClick)(card);
+
+    expect(onCardClick.mock.calls.length, 'a count leg whose count cannot move measures nothing').toBe(2);
+  });
+});
+
+/* ── The published face, judged by `tsc -p tsconfig.test.json` ───────────── */
+
+/**
+ * ⭐ The published-surface half of this card, MEASURED rather than asserted in
+ * prose. `ObjectKanbanSchema.onCardClick` grew a second optional parameter
+ * because the surviving channel delivers `(record, event)`; the prediction
+ * offered with the ruling was that such a widening is source-compatible. These
+ * four lines are that prediction handed to `tsc`, and the last one is the
+ * control that keeps the other three from being vacuously true.
+ *
+ * ⛔ `event` is `any`, not `HandleClickModifiers`: that interface lives in
+ * `@object-ui/react`, which depends on `@object-ui/types` and is named in no
+ * dependency field of it — `check:phantom-deps` rejects the import and it would
+ * close a cycle. `BaseSchema`'s own `onClick` / `onChange` / `onSubmit`
+ * already spell this exact situation the same way.
+ */
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+type Assignable<From, To> = [From] extends [To] ? true : false;
+type CardClick = NonNullable<ObjectKanbanSchema['onCardClick']>;
+
+export type assertion9341PublishedSignatureIsSourceCompatible = [
+  /** WIDENING direction: a host's existing one-argument handler still fits. */
+  Expect<Assignable<(card: any) => void, CardClick>>,
+  /** The reverse: code that stores the member in a one-argument slot still compiles. */
+  Expect<Assignable<CardClick, (card: any) => void>>,
+  /** The arity the channel actually delivers is now declared. */
+  Expect<Assignable<CardClick, (card: any, event?: any) => void>>,
+  /** CONTROL — `Assignable` can answer `false`: a REQUIRED second parameter does not fit. */
+  Expect<Equal<Assignable<(card: any, event: any) => void, (card: any) => void>, false>>,
+];

--- a/packages/plugin-kanban/src/__tests__/handlerKeyDispositionsMeasured-7804.test.tsx
+++ b/packages/plugin-kanban/src/__tests__/handlerKeyDispositionsMeasured-7804.test.tsx
@@ -34,8 +34,11 @@
  *     untouched and arrives at the board implementation BY IDENTITY.
  *   - `onCardClick` — RUNTIME SLOT. `ObjectKanban` replaces the schema key with
  *     its own wrapper, but `SchemaRenderer` also spreads the authored key as a
- *     React PROP, `ObjectKanbanComponentProps` declares that prop, and the
- *     wrapper CALLS it. The authored function runs.
+ *     React PROP, `ObjectKanbanComponentProps` declares that prop, and
+ *     `ObjectKanban` forwards it into `useNavigationOverlay` as `onRowClick`,
+ *     where `handleClick` gives it full priority and calls it. The authored
+ *     function runs. (Until objectui#9341 the wrapper ALSO called it directly,
+ *     which is why it ran twice — see the correction at the end of this block.)
  *   - `onCardMove` — the reading is `'retired'` and it does NOT land here.
  *     `ObjectKanban` replaces the schema key with `handleCardMove` and declares
  *     NO `onCardMove` prop (its rest parameter is discarded), so neither
@@ -101,9 +104,20 @@
  * output), but the dead-read leg of suite 2 also failed — on its lit CONTROL,
  * not on its subject. `onCardMove` was already measured dead; `onCardClick` ran
  * TWICE rather than once. That count is a defect in `ObjectKanban`'s click
- * wiring, not in this card's subject, so the control now asserts that the
- * authored handler RAN and the count is reported on its own card instead of
- * being pinned here.
+ * wiring, not in this card's subject, so the control asserted that the authored
+ * handler RAN and the count was reported on its own card instead of being
+ * pinned here.
+ *
+ * ⭐ THAT CARD LANDED (objectui#9341, maintainer ruling 2026-09-13): the
+ * wrapper's second, one-argument call is gone, the authored handler runs ONCE
+ * through `handleClick`, and the relaxed control here is TIGHTENED BACK to the
+ * exact count in that same diff — the handoff this relaxation was written for.
+ * Two readings in suite 2 and suite 3 moved with it, each for the same reason
+ * and each noted at the assertion: the surviving call carries the modifier
+ * event, so it is `(record, event)` rather than `(record)`, and the TypeScript
+ * face declares the second parameter. The exact-count reading and the modifier
+ * channel have their own file, `cardClickFiresOnce-9341.test.tsx`; what is
+ * here stays the LIT CONTROL for the dead-read leg beside it.
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -255,7 +269,14 @@ describe('suite 2 — the channels, per key, on the one surviving registration (
     // spy can only have arrived through it.
     expect(props.onCardClick).not.toBe(onCardClick);
     (props.onCardClick as (c: unknown, e?: unknown) => void)(card);
-    expect(onCardClick).toHaveBeenCalledWith(card);
+    // ⭐ Reads the WHOLE call list, not one matching call (objectui#9341). The
+    // old spelling was `toHaveBeenCalledWith(card)`, which passed on the base
+    // tree because the SECOND, one-argument call matched it — the very call
+    // that card deleted. What survives is `handleClick`'s
+    // `onRowClick(record, event)`, so the authored handler is reached once and
+    // with the event slot present. This is the channel, still measured, now
+    // measured as it actually is.
+    expect(onCardClick.mock.calls).toEqual([[card, undefined]]);
   });
 
   it('⭐ `onCardMove` reaches NOTHING — driven, not inferred, with `onCardClick` as the lit control', async () => {
@@ -280,17 +301,20 @@ describe('suite 2 — the channels, per key, on the one surviving registration (
     );
     (props.onCardClick as (c: unknown, e?: unknown) => void)(card);
 
-    // ⚠️ The control asserts that `onCardClick` RAN, deliberately not how many
-    // times. Measured on the base tree it runs TWICE per click on this path:
-    // `ObjectKanban` passes the same function to `useNavigationOverlay` as
-    // `onRowClick` — whose `handleClick` forwards to it and returns — and then
-    // calls it again itself. That is a separate defect on a separate card; a
-    // count pinned here would make fixing it red on a file that is not about
-    // it, and the control needs only to be able to fire.
+    // ⭐ TIGHTENED BACK TO THE EXACT COUNT (objectui#9341, the card this control
+    // was relaxed FOR). It read `cardClickRan: … > 0` while the base tree ran
+    // the authored handler TWICE per click — `ObjectKanban` passed the same
+    // function to `useNavigationOverlay` as `onRowClick`, whose `handleClick`
+    // forwards to it and returns, and then called it again itself. That defect
+    // is fixed in the same diff that restores this count, so the relaxation has
+    // no subject any more; leaving it would let the double fire return in
+    // silence. The exact count owns its own file
+    // (`cardClickFiresOnce-9341.test.tsx`) — here it is still just the LIT
+    // CONTROL for the dead-read reading beside it.
     expect(
-      { cardMove: onCardMove.mock.calls.length, cardClickRan: onCardClick.mock.calls.length > 0 },
+      { cardMove: onCardMove.mock.calls.length, cardClick: onCardClick.mock.calls.length },
       'the lit control `onCardClick` must run — a run where NEITHER fires measures nothing',
-    ).toEqual({ cardMove: 0, cardClickRan: true });
+    ).toEqual({ cardMove: 0, cardClick: 1 });
   });
 
   it("the prop channel is the difference: `ObjectKanbanComponentProps` declares `onCardClick` and no `onCardMove`", () => {
@@ -367,7 +391,12 @@ describe('suite 3 — the disposition is legible on BOTH faces, and they agree (
       onCardMove: member('onCardMove'),
       onQuickAdd: member('onQuickAdd'),
     }).toEqual({
-      onCardClick: '(card: any) => void',
+      // ⚠️ Two parameters since objectui#9341: the call that survives the
+      // double-fire repair is `handleClick`'s `onRowClick(record, event)`, and
+      // the one-argument spelling this pin used to read described only the
+      // deleted call. A signature pin read off disk, so it moves WITH the
+      // declaration and cannot drift from it.
+      onCardClick: '(card: any, event?: any) => void',
       // ⚠️ `undefined` is the reading, not a gap in the regex — the firing
       // control below reads a member this interface has always had. A
       // `?: never` tombstone here is what the measurement asks for and what

--- a/packages/plugin-kanban/src/__tests__/kanban-handler-slots-7664.test.tsx
+++ b/packages/plugin-kanban/src/__tests__/kanban-handler-slots-7664.test.tsx
@@ -85,9 +85,17 @@
  * `createElement` call), and `ObjectKanbanComponentProps` DECLARES
  * `onCardClick` — there is no `onCardMove` prop. So on the `'object-kanban'` key an
  * authored `onCardClick` is not merely overridden: `ObjectKanban`'s own
- * wrapper CALLS it. Suite 2 invokes the function the board was handed and
+ * wrapper RUNS it. Suite 2 invokes the function the board was handed and
  * measures that the authored one runs, with the identity check from suite 1 as
  * the control that the wrapper is genuinely interposed.
+ *
+ * ⚠️ Since objectui#9341 the wrapper reaches it INDIRECTLY — it calls
+ * `useNavigationOverlay`'s `handleClick`, which gives the same function full
+ * priority as its `onRowClick` and calls it with `(record, event)`. The wrapper
+ * used to ALSO call it directly with the record alone, which ran one authored
+ * handler twice per click; that second call is gone. Nothing about the CHANNEL
+ * this file measures changed: the prop still reaches, and the authored function
+ * still runs.
  *
  * ⇒ On every channel measured, `onCardClick` is at least as live as
  * `onCardMove`. Its #6124 disposition is RUNTIME SLOT, not `?: never`.
@@ -274,7 +282,14 @@ describe("ObjectKanban's own onCardClick wrapper CALLS the authored handler (obj
     // have arrived through it.
     expect(props.onCardClick).not.toBe(onCardClick);
     (props.onCardClick as (c: unknown, e?: unknown) => void)(card);
-    expect(onCardClick).toHaveBeenCalledWith(card);
+    // ⭐ objectui#9341 — this leg's SUBJECT is unchanged (the wrapper still
+    // runs the authored handler), but the call it runs it through moved. Two
+    // calls used to reach the spy; `toHaveBeenCalledWith(card)` matched the
+    // one-argument one, which is the call that card deleted as the poorer of
+    // the pair. The survivor is `useNavigationOverlay`'s
+    // `onRowClick(record, event)`, which carries the modifier payload. Read as
+    // the whole call list so the count is part of the reading.
+    expect(onCardClick.mock.calls).toEqual([[card, undefined]]);
   });
 });
 

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -3291,7 +3291,16 @@ export interface ObjectKanbanSchema extends BaseSchema {
    * spelling. Kept callable here because the function REACHES the board and
    * RUNS: `SchemaRenderer` spreads every non-metadata schema key as a React
    * prop, `ObjectKanbanComponentProps` declares an `onCardClick` prop, and
-   * `ObjectKanban`'s own click wrapper calls it.
+   * `ObjectKanban` forwards that prop into `useNavigationOverlay` as its
+   * `onRowClick` — where `handleClick` gives it FULL PRIORITY and calls it.
+   *
+   * ⭐ CORRECTED, NOT QUIETLY EDITED (objectui#9341). This paragraph used to
+   * end "and `ObjectKanban`'s own click wrapper calls it", which was true and
+   * was ALSO the defect: the wrapper called the authored function a SECOND
+   * time, on top of the `handleClick` call above, so one card click ran it
+   * twice. The wrapper's call is gone; the CHANNEL and every word of the
+   * argument below survive, because the prop still reaches the hook and the
+   * hook still runs it. Only the identity of the call SITE moved.
    *
    * ⚠️ It is NOT the function the board implementation receives — `ObjectKanban`
    * substitutes its own wrapper on the schema it hands down, because that
@@ -3303,8 +3312,24 @@ export interface ObjectKanbanSchema extends BaseSchema {
    * parameter — so an authored one reaches nothing, which is a `'retired'`
    * reading that `check:handler-key-reads` refuses while `KanbanRenderer` still
    * reads the key. It keeps its `KNOWN_UNDECLARED_READS` row on objectui#7804.
+   *
+   * ⚠️ TWO PARAMETERS since objectui#9341, and the second is what the surviving
+   * channel actually delivers: `handleClick` forwards `onRowClick(record,
+   * event)` so a host can implement Cmd/Ctrl/middle-click. The call this
+   * declaration used to describe — one argument — is the one that was deleted;
+   * declaring one here would have described only the dropped call.
+   *
+   * ⛔ `event` is `any` rather than `HandleClickModifiers`, and that is a
+   * MEASURED constraint, not a shortcut: that interface lives in
+   * `@object-ui/react`, which depends on THIS package and which this package's
+   * manifest does not name in any dependency field — so naming it here is a
+   * phantom dependency (`check:phantom-deps`) and closes a cycle. Re-declaring its three fields inline would
+   * put a second copy of one contract on a published face. `event?: any` is the
+   * spelling `BaseSchema`'s own `onClick` / `onChange` / `onSubmit` already use
+   * for exactly this situation, one file over. What actually arrives is the DOM
+   * click event `KanbanImpl` forwards, typed `React.MouseEvent` there.
    */
-  onCardClick?: (card: any) => void;
+  onCardClick?: (card: any, event?: any) => void;
 
   /**
    * Quick Add handler.


### PR DESCRIPTION
Fixes #9341

`ObjectKanban` handed the host's function to `useNavigationOverlay` as its `onRowClick` **and** called it again itself on the next line. `handleClick` gives `onRowClick` full priority — it calls it and returns — so for a host supplying `onCardClick` and no `onRowClick`, one card click ran that one function twice.

Per the ruling on the card: the wrapper's second call (`onCardClick?.(card)`) is dropped; `externalClick` keeps its `onCardClick` arm.

## Red-first — the pin was written and run BEFORE the code

Run on the unmodified tree (`origin/main` @ `5a41ce733`), verbatim:

```
AssertionError: the authored `onCardClick` must run exactly once per card click:
  expected { cardClick: 2, cardMove: +0 } to deeply equal { cardClick: 1, cardMove: +0 }
-   "cardClick": 1,
+   "cardClick": 2,
    "cardMove": 0,
```

It reads **2**, not 1 — with the sibling `onCardMove` spy at **0** on the same document and the same render, so the 2 is a reading about this key and not a recorder that counts everything twice.

The same run also produced the direct evidence for *which* call to drop. The two calls, in order:

```
[ { arity: 2, record: {id:'1',…}, event: {metaKey:true,…} },
  { arity: 1, record: {id:'1',…}, event: undefined } ]
```

The survivor is `handleClick`'s `onRowClick(record, event)`; the deleted one passed the record alone.

## ⚠️ One sentence of the ruling's rationale is falsified — please read this one

The rationale says precedence is left alone, so a board inside an `ObjectView` "behaves exactly as today". That is true of the **precedence expression** and **false of the authored handler's call count**. Measured, both handlers supplied:

| | before | after |
|---|---|---|
| parent `onRowClick` | 1 | 1 |
| authored `onCardClick` | **1** | **0** |

The parent's handler now wins *outright*, which is what `onRowClick ?? onCardClick` has always said and what nothing enforced. I judge this coherent with the ruling rather than contrary to it — exactly one handler answers one click in both configurations — and I implemented the ruling as written. But it **is** a breaking behaviour change for a host that relied on an authored `onCardClick` firing alongside a parent `onRowClick`, it is not stated on the card, and it is pinned as leg 3 of the new file rather than left to be discovered. The changeset calls it out.

## The published signature — the PM's prediction, measured

`ObjectKanbanSchema.onCardClick` grows the parameter the surviving channel delivers:

```ts
onCardClick?: (card: any, event?: any) => void;   // was: (card: any) => void
```

**The prediction (source-compatible in the widening direction) is NOT falsified — it is confirmed, and it is stronger than predicted: compatible in *both* directions.** Handed to `tsc` rather than asserted, with a control that proves the helper can answer `false`. `@object-ui/types type-check` and `@object-ui/plugin-kanban type-check` both exit 0.

**Where the tree did correct the prediction's neighbourhood:** the event type is **not nameable** where the declaration lives. `HandleClickModifiers` lives in `@object-ui/react`, which depends on `@object-ui/types` and is named in **no** dependency field of it — a phantom dependency and a cycle. Re-declaring its three fields inline would put a second copy of one contract on a published face. So `event` is `any`, which is the spelling `BaseSchema`'s own `onClick` / `onChange` / `onSubmit` already use for exactly this situation, one file over (`packages/types/src/base.ts`). What arrives at runtime is the DOM click event `KanbanImpl` forwards, typed `React.MouseEvent` there.

## objectui#9338's docblock — corrected in the open, not quietly

That docblock argues the PROP channel is the whole difference between this key and the sibling `onCardMove`, and that "the wrapper overrides it" separates neither. **The repair does not invalidate that reasoning.** The prop still reaches, and the authored function still runs — only the identity of the call *site* moved (the hook, not the wrapper). What *was* falsified is one clause of the sentence describing that site: "and `ObjectKanban`'s own click wrapper calls it" was true, and was also the defect. It is rewritten, with the correction labelled as a correction in the docblock itself rather than smoothed over. `onCardMove` still has no prop channel, so the distinction stands unchanged.

## objectui#9338's relaxed control

Tightened back to the exact count in this same diff, as designed:

```diff
-      { cardMove: …, cardClickRan: onCardClick.mock.calls.length > 0 },
-    ).toEqual({ cardMove: 0, cardClickRan: true });
+      { cardMove: …, cardClick: onCardClick.mock.calls.length },
+    ).toEqual({ cardMove: 0, cardClick: 1 });
```

Two further readings in that file, and one in objectui#7664's, moved *with the fix* and are updated at the assertion with the reason. ⛔ None is a loosening: each got strictly stronger.

- suite 2 call shape — `toHaveBeenCalledWith(card)` passed on the base tree *because the second, one-argument call matched it* — the very call this PR deletes. Now reads the whole call list: `expect(onCardClick.mock.calls).toEqual([[card, undefined]])`, so the count is part of the reading.
- suite 3 signature pin — reads the declaration off disk; moves with it, so the two cannot drift.
- `kanban-handler-slots-7664.test.tsx` — same call-shape reading, same repair. Its header now records that the wrapper reaches the handler *indirectly*.

## Ablation — two legs, on-disk proof before any result was read

Both under `trap … EXIT INT TERM`, restored by blob-hash equality against the HEAD blob **and** an empty `git diff HEAD`, never by an exit code.

**Leg A — the deleted call is load-bearing.** Re-inserted `onCardClick?.(card);`. On-disk proof: injected-text count `0 → 1`, `git diff HEAD --name-only` → `packages/plugin-kanban/src/ObjectKanban.tsx`. Result: `cardClickFiresOnce-9341.test.tsx` → **4 tests, 4 failed** (all four legs, including the count control reading 4 instead of 2). Restore: `head=575cdbe0… disk=575cdbe0…`, `git diff HEAD` → `''`.

**Leg B — the widened declaration is load-bearing.** Narrowed back to `(card: any) => void`. On-disk proof: narrowed count `0 → 1`, widened count `→ 0`, `git diff` names `packages/types/src/objectql.ts`. Results:

- the suite 3 signature pin goes **RED**, reading `(card: any) => void` — so the declaration change is genuinely pinned;
- ⚠️ `type-check` stays **exit 0**. Reported as measured, not hidden: that is the honest null result, because the assignability block asserts compatibility in both directions and both hold for *both* spellings. That is precisely what "source-compatible" means — no assignability assertion can distinguish them. The block measures the prediction; the signature pin is what holds the bytes.

Restore: both files hash-equal to HEAD, `git diff HEAD` → `''`.

⚠️ Note on resolution path: root `tsconfig.json` `paths` and `vitest.config.mts` `resolve.alias` both map `@object-ui/types` to `packages/types/**src**`, not `dist`. So these mutations take effect with no rebuild, and there is no stale-`.d.ts` hazard in this loop.

## Dependent-set membership read — done here, not inherited

Scanned all 47 workspace manifests. **38** name `@object-ui/types` and/or `@object-ui/plugin-kanban`; **all 38 declare `type-check`**.

⭐ The two exclusions that share a word are disjoint, measured: `.changeset/config.json`'s `ignore` list (`@object-ui/example-*`, `@object-ui/site`, `@object-ui/test-support`) excludes from **version bumping**. Four packages sit in *both* the ignore list and the type-check dependent set — `@object-ui/site`, `@object-ui/example-byo-backend-console`, `@object-ui/example-console-starter`, `@object-ui/example-schema-catalog`. `@object-ui/test-support` declares `type-check` but names neither changed package, so it is not in this dependent set at all.

## Verification

Gate family derived by hand from `package.json` + `.github/workflows/` (no `dispatch-gates.mjs` in this repo).

| run | result |
|---|---|
| `@object-ui/types type-check` | exit 0 |
| `@object-ui/plugin-kanban type-check` | exit 0 |
| `pnpm exec vitest run packages/plugin-kanban/ packages/types/` | **237 files, 4549 tests passed** |
| `check:handler-key-reads` (gate of record) | `OK  105 arm(s), 212 registration(s) (119 with an arm), 59 reachable handler read(s), 59 judged, 0 left unjudged…, 37 exempted by ledger` — unchanged |
| `check:control-bytes` | `OK (scanned 7530 tracked text file(s); skipped 85 binary)` |
| `check:changeset-presence` / `-claims` / `-fixed` / `-no-major` / `-overwrite` | all exit 0 |
| `check-governed-queue-guard --test` | `NOT GOVERNED — 6 path(s) checked against 5 governed surface(s); none matched` |

All heavy runs through `os-verify-lock.sh -- …` on slot `issue-9341-kanban`. `VERDICT` lines, in order: `command-exit 1 · held 11s · waited 278s` (red-first), `command-exit 0 · held 72s · waited 310s` (build closure), `command-exit 0 · held 133s · waited 1s`, `command-exit 0 · held 103s · waited 169s`, `queue-timeout (exit 99) · never acquired · waited 540s` (ablation, first attempt — NOT MEASURED, slot kept), `command-exit 0 · held 31s · waited 163s` (ablation, retried on the same slot), `command-exit 0 · held 127s · waited 0s` (final, at `d4f54256f`).

The report-only `check:changeset-claims` named 16 pending changesets touching my files; I read each. None claims anything about this key's *arity* or the wrapper's second call — they are all about whether the key is *declared*/refused. Nothing falsified.

In-flight disjointness confirmed by reading each PR's file list: #9343 edits `packages/types/src/crud.ts` + the ledger, not `objectql.ts`; #9310 edits `packages/plugin-kanban/src/index.tsx`, not `ObjectKanban.tsx`; #9144 / #9138 / #9339 / #9351 / #9352 fully disjoint. (#9302 is an issue, not a PR.)

## Acceptance notes

⭐ **Root of the family, filed separately — `UseNavigationOverlayOptions.onRowClick` understates its own contract.** `packages/react/src/hooks/useNavigationOverlay.ts` declares `onRowClick?: (record: Record<string, unknown>) => void` — one parameter — and then *casts it away* to call it with two:

```ts
(onRowClick as (r: Record<string, unknown>, e?: HandleClickModifiers) => void)(record, event);
```

Every consumer copies that one-argument spelling into its own pass-through prop (`ObjectKanbanComponentProps.onRowClick`, `ObjectGallery`'s pair, `KanbanRendererProps.schema.onCardClick`). This PR fixes exactly one leaf of that tree — the one the ruling named — and deliberately does not widen the others: that would be a second, unrequested move on published surfaces, enlarging what the `needs:contract-review` limb asks a reviewer to judge. Filed rather than fixed here.

⭐ **`ObjectGallery` already had the ruling's shape.** `packages/plugin-list/src/ObjectGallery.tsx:308` writes `onRowClick: props.onRowClick ?? props.onCardClick` into the identical hook and has **no** second call. The repair brings the board into line with a sibling surface rather than inventing a pattern. (noted, not filed — it is the correct state.)

`needs:contract-review` is hung on this PR for the published-signature move, matching the card's limb. ⛔ Neither limb cleared by this seat.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_