### PR TITLE
fix(components): fold the operator at FilterBuilder value-input gate (objectui#9302)

### DIFF
--- a/.changeset/9302-filter-builder-valueless-canonical-fold.md
+++ b/.changeset/9302-filter-builder-valueless-canonical-fold.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/components': patch
+---
+
+fix(components): `FilterBuilder`'s value-input gate folds the operator, so one operator draws one row whichever spelling it arrives in (objectui#9302)
+
+`needsValueInput` did a raw `has()` against `VALUELESS_FILTER_BUILDER_OPERATORS`,
+whose members are this builder's six camelCase dropdown ids. A row carrying the
+spec's CANONICAL spelling — `is_null`, `is_empty`, `is_not_null`,
+`is_not_empty`, which is what `foldFilterGroupToSpecRules` persists and what any
+spec-side producer emits — missed the set and was treated as value-taking. The
+row drew a box to type a value into, directly beside a trigger reading
+`Is null`. Measured through the real builder on one `text` column: the canonical
+spelling drew **1** value input where its camelCase twin drew **0**, with
+`equals` drawing 1 in both (it really does take a value).
+
+Both sides of the lookup now fold through the spec's `normalizeFilterOperator`.
+That is the same fold `filterValueArity` and `reconcileOperatorForField` in this
+component already perform, so this is one more site joining a fold the file does
+rather than a new dialect, and the canonical set is DERIVED from the exported one
+rather than restated beside it.
+
+Pre-existing, and objectui#7561 did not cause it: before that repair the same
+stray input was drawn under a **blank** trigger. What changed is that the
+contradiction became legible.
+
+**The exported set is unchanged, deliberately.** Its stated job is *which rows
+this builder leaves value-less* — a fact about the dropdown's own ids — and two
+other layers read it: `plugin-list`'s `convertFilterGroupToAST` (what the live
+grid queries) and `app-shell`'s `foldFilterGroupToSpecRules` (what a saved view
+persists, already documented as this set plus the canonical spellings only that
+layer sees). Widening it here would have made that layer's deliberate
+compensation redundant by side effect, in a file nobody is editing. The defect
+was never a set missing members; it was a reader that forgot to normalize its
+input, so the reader is what was repaired. No published type or export changes,
+and no row's stored `operator` is rewritten — rendering is not an edit.
+
+Which operator vocabulary should WIN is a separate, still-open question and is
+not decided here. The `contains` / `icontains` boundary is untouched and pinned:
+the fold this gate routes through maps neither onto the other.

--- a/packages/components/src/__tests__/filter-builder-valueless-canonical-spelling-9302.test.tsx
+++ b/packages/components/src/__tests__/filter-builder-valueless-canonical-spelling-9302.test.tsx
@@ -1,0 +1,265 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The value-input gate reads the operator through the same fold the rest of
+ * this component already uses, so BOTH spellings of one value-less operator
+ * draw the SAME row (objectui#9302).
+ *
+ * ## The one site
+ *
+ * `needsValueInput` did a raw `has()` against
+ * `VALUELESS_FILTER_BUILDER_OPERATORS`, whose members are this builder's six
+ * camelCase dropdown ids. A row carrying the spec's canonical spelling
+ * (`is_null`) missed the set and was treated as value-taking, so it drew a
+ * value box next to a trigger that reads `Is null` — two spellings of ONE
+ * operator drawing two different rows.
+ *
+ * This is the same CLASS as objectui#7561 and not the same site: that card
+ * repaired the operator trigger's identity comparison, this is the value-input
+ * gate. The component already imports `normalizeFilterOperator` and already
+ * folds through it in `filterValueArity` and `reconcileOperatorForField`, so
+ * the repair is one more site joining a fold this file already performs.
+ *
+ * ## What the repair deliberately does NOT do (the PM ruling on this card)
+ *
+ *   - ⛔ the EXPORTED set is not widened. Its stated job is *which rows this
+ *     builder leaves value-less* — a fact about the dropdown's own six ids —
+ *     and two other layers read it: `plugin-list`'s `convertFilterGroupToAST`
+ *     (what the live grid QUERIES) and `app-shell`'s
+ *     `foldFilterGroupToSpecRules` (what a saved view PERSISTS, documented as
+ *     this set PLUS the canonical spellings only that layer sees). Widening
+ *     here would make another layer's deliberate compensation redundant by
+ *     side effect, in a file nobody is editing.
+ *   - ⛔ no row's stored `operator` is rewritten; rendering is not an edit.
+ *   - ⛔ no second spelling joins the dropdown; the emitted vocabulary is
+ *     unchanged.
+ *
+ * ⛔ Out of scope, and untouched here: WHICH operator vocabulary wins
+ * (objectui#7561's open question, filed as decision card objectui#9306). It
+ * carries a hard constraint recorded on objectui#7379 — `AST_OPERATOR_MAP`
+ * holds that `contains` / `icontains` "must never be folded onto" each other,
+ * "That is a semantic boundary, not two spellings of one thing." The boundary
+ * guard below pins that the fold this repair routes through does not cross it.
+ *
+ * ## DIRECTION, predicted before running
+ *
+ * On the unmodified tree the four CANONICAL rows (`is_empty`, `is_not_empty`,
+ * `is_null`, `is_not_null`) are RED — each draws 1 value input where 0 is
+ * required. Everything else is GREEN in both directions and is carried for a
+ * named reason, not for coverage:
+ *
+ *   - the six DROPDOWN ids draw 0 today and must keep drawing 0 — the
+ *     over-reach guard. A repair that folded only one direction, or that
+ *     replaced the set's members with canonical spellings, moves these;
+ *   - `equals` is the FIRING CONTROL. It really does take a value and must
+ *     draw exactly 1 both before and after. Without it "0 inputs everywhere"
+ *     and a broken renderer are the same reading;
+ *   - `exists` / `notExists` are builder-only ids with no canonical twin in
+ *     the spec's vocabulary, so the fold returns them verbatim. They pin that
+ *     routing the lookup through the fold did not drop the two members that
+ *     have nothing to fold to.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { normalizeFilterOperator } from '@objectstack/spec/ui';
+import {
+  FilterBuilder,
+  VALUELESS_FILTER_BUILDER_OPERATORS,
+} from '../custom/filter-builder';
+
+/** One `text` column — the card's reproduction shape. */
+const FIELDS = [{ value: 'title', label: 'Title', type: 'text' }];
+
+/**
+ * One condition row. `value: ''` is the seed `addCondition` writes and what a
+ * row still carries after the operator dropdown is changed, i.e. the exact
+ * state the panel holds while the user edits.
+ *
+ * The `value` prop is hoisted out of the JSX because the builder re-seeds its
+ * internal state when that prop's IDENTITY changes.
+ */
+function renderRow(operator: string, extraOperators: readonly string[] = []) {
+  const onChange = vi.fn();
+  const value = {
+    id: 'root',
+    logic: 'and',
+    conditions: [{ id: 'c1', field: 'title', operator, value: '' }],
+  };
+  const utils = render(
+    <FilterBuilder
+      fields={FIELDS as never}
+      value={value as never}
+      onChange={onChange}
+      extraOperators={extraOperators}
+    />,
+  );
+  return { ...utils, onChange };
+}
+
+/**
+ * The value input is the only `<input>` the row draws — the field and operator
+ * pickers are Radix selects, i.e. buttons. Counting elements rather than
+ * matching a placeholder keeps this independent of the active locale.
+ */
+const valueInputCount = (container: HTMLElement) => container.querySelectorAll('input').length;
+
+/** What the operator trigger DISPLAYS — the label the stray box contradicts. */
+const operatorTriggerText = () => screen.getAllByRole('combobox')[1].textContent;
+
+/**
+ * The card's acceptance table, measured through the real `FilterBuilder`.
+ *
+ * `dialect` is load-bearing for reading a failure, not decoration:
+ *   - `dropdown` — one of this builder's own camelCase ids, i.e. a member of
+ *     the exported set. 0 inputs today and after: the over-reach guard;
+ *   - `canonical` — `@objectstack/spec`'s snake_case spelling of the SAME
+ *     operator, which a stored view carries. 1 input today (the defect), 0
+ *     after: the firing cases;
+ *   - `control` — really does take a value. 1 input in both directions.
+ */
+const ROWS: ReadonlyArray<{
+  operator: string;
+  label: string;
+  inputs: number;
+  dialect: 'dropdown' | 'canonical' | 'control';
+  /** `OPT_IN_OPERATORS` ids the consumer must grant before they are mounted. */
+  extraOperators?: readonly string[];
+}> = [
+  { operator: 'isNull', label: 'Is null', inputs: 0, dialect: 'dropdown' },
+  { operator: 'is_null', label: 'Is null', inputs: 0, dialect: 'canonical' },
+  { operator: 'isNotNull', label: 'Is not null', inputs: 0, dialect: 'dropdown' },
+  { operator: 'is_not_null', label: 'Is not null', inputs: 0, dialect: 'canonical' },
+  { operator: 'isEmpty', label: 'Is empty', inputs: 0, dialect: 'dropdown' },
+  { operator: 'is_empty', label: 'Is empty', inputs: 0, dialect: 'canonical' },
+  { operator: 'isNotEmpty', label: 'Is not empty', inputs: 0, dialect: 'dropdown' },
+  { operator: 'is_not_empty', label: 'Is not empty', inputs: 0, dialect: 'canonical' },
+  // No canonical twin exists for these two — the spec's vocabulary has no
+  // `exists` member and its alias table deliberately has no row for one.
+  //
+  // They are `OPT_IN_OPERATORS` (objectui#4736), so a consumer that does not
+  // grant them never mounts their `SelectItem` and the trigger reads blank.
+  // Granting them here is what makes this a reading about the value gate
+  // rather than about the opt-in gate — measured: without the grant the
+  // trigger is `''`, which is the documented opt-in behaviour and not a defect.
+  {
+    operator: 'exists',
+    label: 'Is set',
+    inputs: 0,
+    dialect: 'dropdown',
+    extraOperators: ['exists', 'notExists'],
+  },
+  {
+    operator: 'notExists',
+    label: 'Is not set',
+    inputs: 0,
+    dialect: 'dropdown',
+    extraOperators: ['exists', 'notExists'],
+  },
+  // THE FIRING CONTROL, in the same render as the rest.
+  { operator: 'equals', label: 'Equals', inputs: 1, dialect: 'control' },
+];
+
+describe('objectui#9302 — one operator, one row, whichever spelling it arrives in', () => {
+  it.each(ROWS)(
+    '$dialect `$operator` draws "$label" and $inputs value input(s)',
+    ({ operator, label, inputs, extraOperators }) => {
+      const { container } = renderRow(operator, extraOperators);
+      // Read the trigger in the same render: a row that draws no value input
+      // under a BLANK trigger is a different (and worse) outcome than the one
+      // this card asks for, and only reading both can tell them apart.
+      expect(operatorTriggerText()).toBe(label);
+      expect(
+        valueInputCount(container),
+        `the builder drew ${valueInputCount(container)} value input(s) for "${operator}" `
+          + `but the row reads "${label}". Two spellings of one operator must draw one row`,
+      ).toBe(inputs);
+    },
+  );
+
+  it('the firing cases really can fire — they are outside the exported set', () => {
+    // The instrument standard: a table built only on spellings the raw `has()`
+    // already matched would be green before ANY fix and would measure nothing.
+    const canonical = ROWS.filter((r) => r.dialect === 'canonical');
+    expect(canonical.length).toBeGreaterThanOrEqual(4);
+    for (const row of canonical) {
+      // Not a member — so the raw lookup could not have matched it literally…
+      expect(VALUELESS_FILTER_BUILDER_OPERATORS.has(row.operator)).toBe(false);
+      // …and it folds ONTO a member, which is what makes the repair reach it.
+      const foldedMembers = new Set(
+        [...VALUELESS_FILTER_BUILDER_OPERATORS].map(normalizeFilterOperator),
+      );
+      expect(foldedMembers.has(normalizeFilterOperator(row.operator))).toBe(true);
+    }
+    // …and the control is in neither, which is why it keeps its input.
+    expect(VALUELESS_FILTER_BUILDER_OPERATORS.has('equals')).toBe(false);
+    expect(normalizeFilterOperator('equals')).toBe('equals');
+  });
+});
+
+describe('objectui#9302 — ⛔ the repair moves nothing but the gate', () => {
+  it('the EXPORTED set keeps its dropdown-only membership', () => {
+    // Acceptance criterion 3, and the ruling's whole point: two other layers
+    // read this set, and one of them already compensates for the canonical
+    // spellings. Widening it would make that layer's deliberate half redundant
+    // by side effect. Green in both directions by construction — it fails only
+    // for a repair that widened the export instead of folding at the gate.
+    expect([...VALUELESS_FILTER_BUILDER_OPERATORS].sort()).toEqual([
+      'exists',
+      'isEmpty',
+      'isNotEmpty',
+      'isNotNull',
+      'isNull',
+      'notExists',
+    ]);
+  });
+
+  it.each(['is_null', 'isNull'])('a row spelled `%s` is not migrated on render', (operator) => {
+    // Rendering is not an edit. A "repair" that rewrote the stored id to the
+    // dropdown's spelling would also make the table above green, and would be
+    // the wrong fix — it changes what a saved view carries.
+    const { onChange } = renderRow(operator);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('an unknown operator still draws a value input', () => {
+    // The gate's default must stay "takes a value". A fold that swallowed
+    // unknown spellings into the value-less set would hide the input on a row
+    // nobody can then fill in — the objectui#4744 failure, inverted.
+    expect(normalizeFilterOperator('totally_unknown')).toBe('totally_unknown');
+    const { container } = renderRow('totally_unknown');
+    expect(valueInputCount(container)).toBe(1);
+  });
+});
+
+describe('objectui#9302 — ⛔ the fold does not cross the `contains` boundary', () => {
+  it('`contains` and `icontains` are not folded onto each other', () => {
+    // objectui#7379 / objectstack#7536: `AST_OPERATOR_MAP` holds that these
+    // "must never be folded onto" each other — "That is a semantic boundary,
+    // not two spellings of one thing." The gate now routes through
+    // `normalizeFilterOperator`, so pin that this fold leaves the boundary
+    // standing. A seat that folds those two has broken a ruling, not fixed a
+    // bug. Green in both directions by construction — a boundary guard, not a
+    // control.
+    expect(normalizeFilterOperator('contains')).toBe('contains');
+    expect(normalizeFilterOperator('icontains')).toBe('icontains');
+    expect(normalizeFilterOperator('contains')).not.toBe(normalizeFilterOperator('icontains'));
+    // …and neither is value-less under either spelling, so the gate this card
+    // repairs never had an opinion about them.
+    for (const op of ['contains', 'icontains', 'containsCaseInsensitive']) {
+      expect(VALUELESS_FILTER_BUILDER_OPERATORS.has(op)).toBe(false);
+      expect(
+        new Set([...VALUELESS_FILTER_BUILDER_OPERATORS].map(normalizeFilterOperator)).has(
+          normalizeFilterOperator(op),
+        ),
+      ).toBe(false);
+    }
+  });
+});

--- a/packages/components/src/custom/filter-builder.tsx
+++ b/packages/components/src/custom/filter-builder.tsx
@@ -267,6 +267,34 @@ export const VALUELESS_FILTER_BUILDER_OPERATORS: ReadonlySet<string> = new Set([
 ])
 
 /**
+ * The same six operators, keyed by the spelling `normalizeFilterOperator`
+ * folds each of them to — the lookup table the value-input gate below reads
+ * (objectui#9302).
+ *
+ * DERIVED, never a second literal: a hand-kept canonical copy beside the
+ * exported set is exactly how the two could come to disagree, and the
+ * disagreement would be invisible — a row that draws an input the label says
+ * it does not take.
+ *
+ * Why it exists separately instead of widening the export: the exported set
+ * states a fact about what THIS DROPDOWN draws, and its members are this
+ * builder's own camelCase ids. Two other layers read it — `plugin-list`'s
+ * `convertFilterGroupToAST` and `app-shell`'s `foldFilterGroupToSpecRules`,
+ * the latter already documented as this set PLUS the canonical spellings only
+ * that layer sees. Folding the canonical spellings INTO the export would make
+ * that layer's deliberate compensation redundant by side effect, in a file
+ * nobody is editing. The defect was never a set missing members; it was a
+ * reader that forgot to normalize its input.
+ *
+ * `exists` / `notExists` fold to themselves — the spec's vocabulary has no
+ * member for either and its alias table deliberately has no row for them — so
+ * this set is the same size as the one it derives from.
+ */
+const VALUELESS_FILTER_BUILDER_OPERATORS_CANONICAL: ReadonlySet<string> = new Set(
+  [...VALUELESS_FILTER_BUILDER_OPERATORS].map(normalizeFilterOperator),
+)
+
+/**
  * The SHAPE an operator's `value` must have — the question
  * `ViewFilterRuleSchema` asks, asked here in the one place that decides what
  * input the user is given (objectui#3958).
@@ -1279,8 +1307,19 @@ function FilterBuilder({
   // The complement of the exported set, never a second literal beside it:
   // that set's whole job is to let other layers know which rows this builder
   // leaves value-less, and a hand-kept copy here is how they drifted apart.
+  //
+  // BOTH sides are folded through the spec's `normalizeFilterOperator` — the
+  // same fold `filterValueArity` and `reconcileOperatorForField` already
+  // perform, so this is one more site joining a fold this file does rather
+  // than a new dialect. The gate used to do a raw `has()` on whatever spelling
+  // the row carried, and the set's members are the dropdown's camelCase ids:
+  // a stored rule spelled `is_null` — the spec's CANONICAL form, which is what
+  // `foldFilterGroupToSpecRules` persists and what any spec-side producer
+  // emits — missed the set and was treated as value-taking. The row then drew
+  // a box to type a value into, directly beside a trigger reading `Is null`
+  // (objectui#9302). One operator, two spellings, two different rows.
   const needsValueInput = (operator: string) => {
-    return !VALUELESS_FILTER_BUILDER_OPERATORS.has(operator)
+    return !VALUELESS_FILTER_BUILDER_OPERATORS_CANONICAL.has(normalizeFilterOperator(operator))
   }
 
   // Derived from the value FAMILY rather than from a second branch ladder over


### PR DESCRIPTION
Fixes #9302

`FilterBuilder`'s value-input gate now reads the operator through the same fold
the rest of the component already performs, so one operator draws one row
whichever spelling it arrives in.

## The one site

`needsValueInput` did a raw `has()` against `VALUELESS_FILTER_BUILDER_OPERATORS`,
whose members are this builder's six camelCase dropdown ids. Every OTHER spelling
the spec publishes for those same operators missed the set and was treated as
value-taking: the canonical members of `VIEW_FILTER_OPERATORS` those ids fold
onto — what `foldFilterGroupToSpecRules` persists and what any spec-side producer
emits — and every row of `VIEW_FILTER_OPERATOR_ALIASES` pointing at one of them.
The row drew a box to type a value into, directly beside a trigger reading
`Is null`.

⛔ Which spellings those are is not written down in this PR, in the changeset, or
in the pin's prose. The pin walks those two published tables and
`--reporter=verbose` names every row it measured, so the population is
re-derived on each run instead of restated in text that cannot move with it
(AGENTS.md #9). The first pass of this PR named four spellings where the
behaviour covers twice that, which is exactly the failure that rule describes —
repaired on objectui#9358.

Both sides of the lookup are now folded through the spec's
`normalizeFilterOperator`. That is the same fold `filterValueArity` and
`reconcileOperatorForField` in this file already use, so this is one more site
joining a fold the component performs rather than a new dialect, and the
canonical lookup set is DERIVED from the exported one rather than restated
beside it.

## Premise re-measured on this branch's base

The card's table was measured on objectui#7561's branch. Re-measured on
`origin/main` at `5a41ce733` — with that card's trigger repair landed — **the
base is unchanged and the table reproduces exactly**. The trigger column reads
`Is null` / `Is empty`, not blank.

⚠️ That citation is stale. This branch has since merged `main`, so the real fork
point — from `git merge-base`, not `base.sha` — is `dfb5850594`. The table still
reproduces there: the contract review re-derived it at that base and found the
four canonical rows red in its base-content arm.

Measured through the real builder on one `text` column, with the rows keyed by
what DERIVES them rather than by a list of spellings:

| row dialect | what enumerates it | value inputs, base | value inputs, after |
|---|---|---|---|
| dropdown id | a member of `VALUELESS_FILTER_BUILDER_OPERATORS` | 0 | 0 |
| canonical | `VIEW_FILTER_OPERATORS` ∩ that set folded through `normalizeFilterOperator` | **1** | **0** |
| alias | a row of `VIEW_FILTER_OPERATOR_ALIASES` pointing at one of those canonicals and not itself a dropdown id | **1** | **0** |
| firing control | `equals` — in neither, and it really does take a value | 1 | 1 |

The control is what makes the "after" column a reading: without a row that keeps
its input in both arms, a uniform zero and a broken renderer look the same. The
dropdown-id row is the over-reach guard in the other direction.

## What this deliberately does NOT do

- ⛔ **The exported set is not widened.** Its stated job is *which rows this
  builder leaves value-less* — a fact about the dropdown's own ids — and two
  layers read it: `plugin-list`'s `convertFilterGroupToAST` (what the live grid
  queries) and `app-shell`'s `foldFilterGroupToSpecRules` (what a saved view
  persists, already documented as this set plus the canonical spellings only
  that layer sees). Widening here would have made that layer's deliberate
  compensation redundant by side effect, in a file nobody is editing. The defect
  was never a set missing members; it was a reader that forgot to normalize its
  input, so the reader is what was repaired.
- ⛔ No row's stored `operator` is rewritten — rendering is not an edit, pinned.
- ⛔ No second spelling joins the dropdown; the emitted vocabulary is unchanged.
- ⛔ Which operator vocabulary should WIN is not decided here. The
  `contains` / `icontains` boundary recorded on objectui#7379 is untouched and
  pinned: the fold this gate routes through maps neither onto the other.
- ⛔ `packages/components/src/ui/` is not touched. The edit is in `custom/`,
  which is where wrapping belongs.

## Evidence

**Red-first**, pin written before the code and run on the unmodified tree
(`git diff HEAD` empty for every tracked file, HEAD = `5a41ce733`):

```
× 'canonical' `'is_null'` draws "'Is null'" and +0 value input(s)
× 'canonical' `'is_not_null'` draws "'Is not null'" and +0 value input(s)
× 'canonical' `'is_empty'` draws "'Is empty'" and +0 value input(s)
× 'canonical' `'is_not_empty'` draws "'Is not empty'" and +0 value input(s)
AssertionError: the builder drew 1 value input(s) for "is_null" but the row
reads "Is null". Two spellings of one operator must draw one row:
expected 1 to be +0
Tests  4 failed | 13 passed (17)
```

**Ablation**, two legs. Each mutates on disk, proves the mutation reached disk
before any result is read, and restores by blob-hash equality against the HEAD
blob plus an empty `git diff HEAD`, under a trap with absolute paths. The pin
imports the component by a relative SOURCE specifier inside its own package, so
no build step gates whether a mutation reaches the subject.

| leg | mutation | predicted | measured |
|---|---|---|---|
| 1 | gate reverted to the raw `has()`, derived set kept | the red-first set | red, same rows |
| 2 | derivation's `.map(normalizeFilterOperator)` dropped, gate fold kept | canonical + camelCase red; `exists` / `notExists` / `equals` green | red, exactly those |
| 3 (objectui#9358) | whole file put back to its base blob `6ec603fca6`, extended pin kept | every canonical and every non-dropdown alias red; dropdown ids and `equals` green | exactly that — every alias row the first pin never named is among the failures |

Both halves are load-bearing. Restore verified both times:
`RESTORED-OK blob=4c0b108908d3e8f6c1413f8aaaf3d14c55436311 git-diff-HEAD=empty`.

**Clause-② verified mechanically, not by inspection.** Built the package, put the
file back to its base content, rebuilt, and fingerprinted every emitted type
declaration: **208 files, rollup sha256 `92f47f826185fb70e804b1c74e57f107b9b311be5505ce5882aec84634115b84`
in BOTH arms — byte-identical.**

⛔ **RETRACTED as a claim about this PR, and kept only as the dated run record
it is.** That reading was taken at `30e320ab7`, before this branch published any
doc-comment repair. Two heads have moved the emitted bytes of
`dist/custom/filter-builder.d.ts` on purpose since, so the rollup is NOT
byte-identical at the current head and "no published surface moved" is false as
written. The narrower claim clause-② actually asks — no exported symbol and no
declared type added, removed or changed — is re-measured per head in the two
review sections below, and holds there rather than being inherited from here.

**Gates and suites** (targeted per this repo's own scripts and workflows; the
full farm is CI's):

| run | result |
|---|---|
| `@object-ui/components` `test` | 271 files, 2620 tests passed |
| `@object-ui/components` `type-check` | exit 0 |
| build of the package and its dependency closure | exit 0 |
| `check:control-bytes` | exit 0, 7530 files scanned |
| `check:spec-symbols` | exit 0 |
| `check:doc-example-readers`, `check:test-path-roots`, `check:vi-mock-override-shape`, `check:vi-mock-specifiers`, `check:new-line-citations`, `check:unreferenced-sources` | exit 0 |
| `check:changeset-claims` | exit 0, report-only — handled below |
| `check:readme-exports` | NOT MEASURED — "the population COLLAPSED", 28 packages unbuilt because only this closure was built. CI builds all. |

`check:changeset-claims` named two pending changesets that mention this file.
Both re-read and both still true: neither
`.changeset/6939-filter-builder-mirror.md`'s read-site list nor
`.changeset/8415-filter-builder-condition-id.md`'s cardinal is in this diff (0
hits), and the `id` read-site count is 16 on the base and 16 on this branch —
the number that changeset asserts. No correction needed.

## objectui#9358 — the coverage hole the contract review found

The review (`5654646181`, PASS) found the pin protected only half of what the
repair moves: the literal table named the canonical spellings, and the
all-lowercase alias rows moved the same way with **nothing pinning them**, so a
hand-rolled snake_case-only map would have kept the suite green while those
regressed.

Verified first, not taken on faith. Through the real builder, at the pre-repair
head `a835ae4cd1` and at this head, with `equals` and `contains` as firing
controls in the same run: every spelling the two published tables yield for a
value-less operator moves 1 → 0, the dropdown ids sit at 0 in both arms, and the
controls sit at 1 in both. The controls fired, so the zeros are a reading.

The pin's row set is now **re-derived on every run** from
`VIEW_FILTER_OPERATORS` and `VIEW_FILTER_OPERATOR_ALIASES` rather than listed.
Each derived case reads its row against the dropdown TWIN that folds onto the
same canonical spelling and asserts the two draw the same row with zero value
inputs — so no label literal is restated, and a spelling the spec adds tomorrow
is measured without an edit here.

An `it.each` over an empty or mis-derived array runs zero cases and passes, so
the derivation is guarded rather than trusted. The guard asserts FLOORS, not a
census: the table is non-empty; every canonical row has a twin and at least one
alias; the twin's trigger is neither blank nor an echo of its raw id; and the
derived table both reaches past the literal one and never drifts behind it.

Case count, from vitest's own summary rather than a line count: **17 → 30** on
this file. Leg 3 of the ablation above is this pin's own ablation — the new rows
fail when the repair is removed, so they pin something.

⛔ No production file moved for this: `needsValueInput`, the exported set and
every other export are byte-identical to `a835ae4cd1`. The diff is the pin and
the changeset.

This section and the commit above it were written by a second Claude Code seat,
session `https://claude.ai/code/session_01L5xpA5q533BgTTNADibEFt` — recorded here
as prose because the footer block below belongs to the seat that opened the PR
and a `PATCH` rewrites footers.

## Contract review FAIL — the published doc-comment repaired

The clause-② review at `7daa352f98` returned FAIL on one item, and it is not the
repair itself: the repair falsified the doc-comment of the exported set it
deliberately left alone, and that comment SHIPS. Amended in `dfbee6340a`, comment
text only — no membership change, no runtime line, the ruling untouched.

- **What was false.** "`needsValueInput` below is defined as the complement of
  this set, so the two cannot say different things", under a headline reading as
  the set of spellings the builder leaves value-less. At the merge-base the first
  was literally true; after this branch's fold the gate is the complement of that
  set's FOLD-CLOSURE under `normalizeFilterOperator`.
- **It ships — measured on the built artefact, not on the source.** Before this
  commit both sentences were emitted verbatim into
  `dist/custom/filter-builder.d.ts` (lines 151 and 157; declaration at 183).
  After it, both read **0 occurrences** in the rebuilt file, paired with two lit
  controls from that SAME emitted file: the `export declare const` line (1 hit,
  now line 195) and the objectui#4744 citation (1 hit, now line 153). The three
  corrected statements read 1 occurrence each, at lines 151, 157 and 162. All
  counts are newline-tolerant occurrence counts, not line counts.
- **The asymmetry the review named, re-measured.** The module-private canonical
  set's symbol and its docblock have **0 hits across all 208** emitted
  declaration files, while the exported symbol lights **twice** in the same file.
  The zero is therefore negative rather than void. The mechanism shows up again
  in the line accounting below: the one added in-function comment line does not
  reach the declarations at all.
- **No count is written into the published text** (AGENTS.md #9 — the rule this
  PR already invokes elsewhere). The amended comment names the instrument, the
  pin that walks the two published tables, and states no number.
- **Nothing else moved.** Every changed line in the diff is a comment line. The
  emitted declaration file grows by exactly the 12 added doc-comment lines and
  the declaration shifts by exactly 12. The pin runs **30/30** at `dfbee6340a`,
  and the set of spellings whose verdict this branch changes is byte-identical
  before and after the commit — re-derived over the whole published universe
  (`VIEW_FILTER_OPERATORS`, `VIEW_FILTER_OPERATOR_ALIASES` and the dropdown ids)
  from the installed `@objectstack/spec` 17.4.0 and from the BUILT export, with
  value-taking operators carried as unmoved controls so the divergence is a
  reading. `type-check` exit 0; `check:control-bytes`,
  `check:new-line-citations`, `check:comment-mask-corpus`,
  `check:changeset-claims` and `check-changeset-presence` all exit 0.
- ⚠️ **One consequence, stated rather than buried.** This commit DOES move bytes
  in the emitted `.d.ts`, by construction: the repair IS a change to published
  text. No declared type moves and the `export declare const` line is unchanged,
  but the review's identical-rollup reading was taken at the previous head and
  does not carry to this one.
- **Changeset.** Its `objectui#9358` citation — a PR, where its other citations
  are cards — now cites the card. The declared level `patch` is untouched, and
  the review graded it correct.

## Second contract review FAIL — the prescription repaired

The clause-② review at `dfbee6340a` returned FAIL on the same item one level in:
the first repair discharged two false published sentences and replaced them with
a third. Amended at this head, comment text only — no membership change, no
runtime line, the ruling untouched.

- **What was false, and it was false by execution rather than by reading.** The
  amended block shipped at emitted lines 162-164 of
  `dist/custom/filter-builder.d.ts`, directly above the declaration, telling a
  consumer holding a foreign spelling to fold it through `normalizeFilterOperator`
  and then ask this set — the exported set, **unfolded** — "exactly as that gate
  does". Run literally over the whole published universe (`VIEW_FILTER_OPERATORS`,
  the keys of `VIEW_FILTER_OPERATOR_ALIASES` and the dropdown ids, from the
  installed `@objectstack/spec` 17.4.0, with the set read from the BUILT bundle),
  that procedure is value-less for `exists` and `notExists` and for nothing else,
  where the gate is value-less for the whole fold-closure. It answers "takes a
  value" for every canonical and every all-lowercase-alias spelling of the
  null/empty operators — the exact population the sentence exists to serve — and
  for this dropdown's four camelCase ids as well, so a consumer following it
  landed **strictly further from the gate** than one still doing the pre-branch
  raw `has()`. The three-column table is on objectui#9302.
- **Two further ways it was false, both checked against the gate body rather
  than against the prose.** "exactly as that gate does" — the gate folds **BOTH**
  sides, and the set it consults is module-private and unreachable from the
  published declarations by this PR's own clause-② measurement, so no consumer
  reading the `.d.ts` could do "exactly" that. And the block contradicted itself
  two sentences apart: it says the gate is the complement of this set's
  FOLD-CLOSURE "not of this set itself", then instructs the consumer to ask this
  set.
- **The repair, executed rather than reasoned.** The block now prescribes the
  procedure a consumer can actually run from the PUBLISHED surface: fold this
  set's own members through `normalizeFilterOperator` **as well as** the
  spelling, and ask the result. Executed over that same universe it agrees with
  the gate on every spelling in it — with the two wrong procedures run through
  the same harness as the controls, disagreeing on 12 and 8 rows respectively,
  so the agreement is a reading and not a uniform answer. ⭐ The lesson this
  round paid for, stated once: **if the comment tells a consumer to DO
  something, execute that thing before writing it down.**
- **It ships — measured on the built artefact, not on the source.** The removed
  sentence reads **0 occurrences** in the rebuilt `dist/custom/filter-builder.d.ts`,
  paired with lit controls from that SAME emitted file: the `export declare const`
  line, the objectui#4744 citation and the objectui#9302 citation, 1 hit each.
  The replacement reads 1 hit, shipping at emitted lines 162-165. All are
  newline-tolerant occurrence counts, not line counts.
- **No behaviour moved, proved without a build.** With block and line comments
  stripped symmetrically, the code-only sha256 of
  `packages/components/src/custom/filter-builder.tsx` is **unchanged** across this
  commit while the raw blob moves — and the merge-base's code-only digest
  differs, the control that the instrument can see a real edit at all. Every
  changed line in the diff is a comment line. The pin runs **30/30** at this
  head; `type-check` exit 0.
- **No count is written into the published text** (AGENTS.md #9). The block names
  the pin that walks the two published tables and states no number.
- **Changeset.** The prose that restated a live population count in the same file
  that declares the population deliberately unlisted now names the instrument
  instead. The declared level `patch` is untouched, and the review graded it
  correct.
- **Reported, then fixed on the seat's call — `095830673a`.** The pin this PR
  adds cited `objectui#9358`, a PR, in five prose spots, the same class as the
  changeset citation already corrected, and it is **inside this diff**. The seat
  took that one rather than leaving it: four of the five sites did not mean a
  card at all — they mean "the first pass of this pin got this wrong", a fact
  about this branch — and now say so in words; the fifth is the derived suite's
  title, where the subject really is the pinned defect, so it cites the card.
  `objectui#9358` now reads **0** occurrences in that file with `objectui#9302`
  lit at **5** as the control. Prose only, mechanically: filtering the diff to
  lines that are neither a comment gutter nor a line comment leaves **exactly
  one**, the suite title. Pin still **30/30**.
- **Reported, left alone — the seat's call.** The pre-existing
  `filter-builder-valueless-operators.test.tsx:11` docblock still describes the
  export as "the operator ids for which it renders no value input", which now
  undercounts. It is **not** in this diff and it does not ship; it is carried on
  objectui#9302 with a file and a line rather than widening a fourth-round PR.

## Acceptance notes

Out of scope, noted, not filed here — carried so the reviewing seat sees it:

- ⛔ **RETRACTED, re-measured.** This bullet used to say
  `packages/plugin-list/src/ListView.tsx`'s `convertFilterGroupToAST` performs
  the SAME raw `has()` on the same exported set and, unlike `app-shell`, does
  not compensate — the objectui#4744 failure mode one layer up, for the
  canonical spelling. True when it was written; **false now.** objectui#9362 has
  merged, and re-measured on `origin/main` at `efc1c9c400`, `ListView.tsx:330-331`
  derives its canonical set from this export with `.map(normalizeFilterOperator)`
  and `:357` asks it with the folded spelling. That is the same both-sides fold
  this PR puts in the builder, and it is verbatim the procedure this head's
  doc-comment now prescribes — which is also why that prescription is not
  hypothetical. No successor is owed here, and the ruling on objectui#9302 still
  refuses to reach that layer from this file by widening the export.

## Not addressed here

Named as bare references on purpose, with no keyword in front of any of them, so
merging this PR leaves every one of them open:
objectui#7561, objectui#9306, objectui#7379, objectui#6939.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_

---
_Generated by [Claude Code](https://claude.ai/code)_