### PR TITLE
fix(react): UseNavigationOverlayOptions.onRowClick declares the modifier payload it is called with

### DIFF
--- a/.changeset/9357-navigation-overlay-onrowclick-arity.md
+++ b/.changeset/9357-navigation-overlay-onrowclick-arity.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/react': minor
+---
+
+`UseNavigationOverlayOptions.onRowClick` now declares the modifier payload it
+has always been called with (objectui#9357).
+
+`useNavigationOverlay`'s `handleClick` invokes the caller-supplied `onRowClick`
+with two arguments — the record, and the optional `HandleClickModifiers`
+payload (`metaKey` / `ctrlKey` / `button`) a host needs to implement
+Cmd/Ctrl/middle-click. The option declared only the record, and `handleClick`
+carried a type assertion that widened the value at the call site so the code
+would compile. The second argument was therefore invisible on the one line a
+host reads, and a host that wanted it had to discover it from the
+implementation and then spell its own second parameter optional to stay
+assignable.
+
+The declaration now names both parameters and the assertion is gone.
+
+**Not breaking, in either direction.** A one-parameter handler stays assignable
+to the widened signature (its extra parameter is optional), and a handler
+written against the widened signature was already assignable to the old one —
+measured on this change, both directions. No caller has to change; what changes
+is that a caller who wants the modifier payload can now see, from the published
+type, that it is there.
+
+Scope note: this repairs the hook's own option. The pass-through props on the
+view components that feed it — `ObjectKanban`, `ObjectGallery`, the
+`plugin-kanban` renderer's `onCardClick`, and the `onRowClick` prop on the other
+view plugins — each still declare one parameter on their own published face;
+which spelling that family converges on is objectui#9357's open question and is
+not decided here.

--- a/packages/react/src/hooks/__tests__/useNavigationOverlay.onRowClickArity-9357.test.tsx
+++ b/packages/react/src/hooks/__tests__/useNavigationOverlay.onRowClickArity-9357.test.tsx
@@ -1,0 +1,342 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#9357 — `UseNavigationOverlayOptions.onRowClick` declares the
+ * modifier payload it is actually invoked with, and `handleClick` calls it
+ * without a type assertion.
+ *
+ * ## The defect
+ *
+ * The option declared ONE parameter:
+ *
+ *     onRowClick?: (record: Record<string, unknown>) => void;
+ *
+ * and `handleClick`, 126 lines below in the same file, asserted that
+ * declaration away in order to call it with TWO — the record and the modifier
+ * payload a host needs for Cmd/Ctrl/middle-click. The assertion was the only
+ * thing holding the two apart: a declaration that had lost an argument, not a
+ * hook that needed one.
+ *
+ * ## Why the instrument here is not an assignability assertion
+ *
+ * ⭐ Widening this option is source-compatible in BOTH directions — a
+ * one-parameter handler stays assignable to a two-parameter optional
+ * signature, and a two-parameter optional handler stays assignable to the
+ * one-parameter spelling (its minimum argument count is still 1). That is the
+ * measurement `SOURCE COMPATIBILITY` below makes, and it is good news for
+ * consumers: nothing breaks either way.
+ *
+ * It is also exactly why an `extends` / assignability pin would assert
+ * NOTHING here. Both spellings satisfy each other, so such a pin is green on
+ * the broken tree and green on the repaired one — a dead instrument on a
+ * type-only card. The two instruments that CAN separate them are used
+ * instead, and both are proven able to fire:
+ *
+ *  - the COMPILE-TIME half reads the parameter LIST (`Parameters<…>` and its
+ *    `length`) through an exact-identity `Equal`, which distinguishes the two
+ *    spellings where `extends` cannot. It runs only under
+ *    `packages/react`'s `tsconfig.test.json`; vitest erases every line of it.
+ *  - the BYTES half reads the declaration and the call site off disk, so the
+ *    assertion cannot creep back in under a green type-check.
+ *
+ * The third block is a RUNTIME control: the implementation really does hand
+ * the second argument through. It was true before this card too — it is what
+ * made the assertion look harmless — so it is labelled a control rather than
+ * a pin, and it reds if a later change makes the widened declaration a
+ * promise the implementation stops keeping.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { useNavigationOverlay } from '../useNavigationOverlay';
+import type {
+  HandleClickModifiers,
+  NavigationOverlayState,
+  UseNavigationOverlayOptions,
+} from '../useNavigationOverlay';
+
+/* ------------------------------------------------------------------ *
+ * COMPILE-TIME half — erased at runtime. `tsc -p tsconfig.test.json`
+ * (chained from this package's `type-check` script) is the only thing
+ * that executes it.
+ * ------------------------------------------------------------------ */
+
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type OnRowClick = NonNullable<UseNavigationOverlayOptions['onRowClick']>;
+type OnRowClickParams = Parameters<OnRowClick>;
+
+/** The declaration as it stood before this card — the measurement subject. */
+type NarrowOnRowClick = (record: Record<string, unknown>) => void;
+
+/**
+ * THE PIN. The option takes the record AND the optional modifier payload, so
+ * its parameter list spans one-or-two rather than exactly one.
+ */
+type _AritySpansBoth = Expect<Equal<OnRowClickParams['length'], 1 | 2>>;
+type _FirstParamIsTheRecord = Expect<Equal<OnRowClickParams[0], Record<string, unknown>>>;
+type _SecondParamIsTheModifiers = Expect<
+  Equal<OnRowClickParams[1], HandleClickModifiers | undefined>
+>;
+
+/**
+ * The option and the handler that invokes it are now the SAME function type.
+ * `handleClick` always declared both parameters; this is the half that had
+ * drifted.
+ */
+type _OptionAgreesWithHandleClick = Expect<
+  Equal<OnRowClick, NavigationOverlayState['handleClick']>
+>;
+
+/**
+ * SOURCE COMPATIBILITY — the measurement, reported as a result rather than
+ * assumed. Both directions hold, so no consumer is broken by the widening in
+ * either direction of assignment...
+ */
+type _NarrowIsAssignableToWide = Expect<NarrowOnRowClick extends OnRowClick ? true : false>;
+type _WideIsAssignableToNarrow = Expect<OnRowClick extends NarrowOnRowClick ? true : false>;
+
+/**
+ * ...and THIS is the consequence that decides the instrument: because both
+ * directions hold, assignability cannot tell the repaired declaration from
+ * the broken one. Exact identity can, and does.
+ */
+type _IdentityStillSeparatesThem = Expect<Equal<Equal<OnRowClick, NarrowOnRowClick>, false>>;
+
+/**
+ * Control: the checker is live in this file and the parameter list really
+ * stops at two. If the declaration ever grew a third parameter this directive
+ * would become UNUSED and `tsc` would fail with TS2578 — which is why the
+ * control is written as an expected error rather than as another assertion.
+ */
+// @ts-expect-error the option declares no third parameter
+type _NoThirdParameter = OnRowClickParams[2];
+
+/* ------------------------------------------------------------------ *
+ * BYTES half — the declaration and the call site, read off disk.
+ * ------------------------------------------------------------------ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+// packages/react/src/hooks/__tests__  ->  repo root
+const repoRoot = path.resolve(here, '../../../../..');
+const HOOK_REL = 'packages/react/src/hooks/useNavigationOverlay.ts';
+const HOOK_ABS = path.join(repoRoot, HOOK_REL);
+
+/**
+ * Mask `//` and block comments with spaces, leaving every other byte — string
+ * contents included — in place. Quoted spans are walked rather than blanked,
+ * purely so a `//` inside a URL literal is not read as a comment start.
+ */
+function maskComments(src: string): string {
+  const out = src.split('');
+  let i = 0;
+  const n = src.length;
+  while (i < n) {
+    const c = src[i];
+    const d = src[i + 1];
+    if (c === '/' && d === '/') {
+      while (i < n && src[i] !== '\n') out[i++] = ' ';
+      continue;
+    }
+    if (c === '/' && d === '*') {
+      out[i++] = ' ';
+      out[i++] = ' ';
+      while (i < n && !(src[i] === '*' && src[i + 1] === '/')) {
+        if (src[i] !== '\n') out[i] = ' ';
+        i++;
+      }
+      if (i < n) {
+        out[i++] = ' ';
+        out[i++] = ' ';
+      }
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      const quote = c;
+      i++;
+      while (i < n) {
+        if (src[i] === '\\') {
+          i += 2;
+          continue;
+        }
+        if (src[i] === quote) {
+          i++;
+          break;
+        }
+        i++;
+      }
+      continue;
+    }
+    i++;
+  }
+  return out.join('');
+}
+
+/** The body of a `{ … }` block opened at `openIndex`, brace-balanced. */
+function blockAt(masked: string, openIndex: number): string {
+  let depth = 0;
+  for (let i = openIndex; i < masked.length; i++) {
+    if (masked[i] === '{') depth++;
+    else if (masked[i] === '}') {
+      depth--;
+      if (depth === 0) return masked.slice(openIndex + 1, i);
+    }
+  }
+  throw new Error('unbalanced block');
+}
+
+const HOOK_SOURCE = readFileSync(HOOK_ABS, 'utf8');
+const HOOK_MASKED = maskComments(HOOK_SOURCE);
+
+const OPTIONS_DECL = 'export interface UseNavigationOverlayOptions';
+const optionsOpen = HOOK_MASKED.indexOf('{', HOOK_MASKED.indexOf(OPTIONS_DECL));
+const OPTIONS_BODY = blockAt(HOOK_MASKED, optionsOpen);
+
+const HANDLE_CLICK_DECL = 'const handleClick = useCallback(';
+const handleClickOpen = HOOK_MASKED.indexOf('{', HOOK_MASKED.indexOf(HANDLE_CLICK_DECL));
+const HANDLE_CLICK_BODY = blockAt(HOOK_MASKED, handleClickOpen);
+
+/** `onRowClick` declared with a second, optional, named parameter. */
+const TWO_PARAMETER_MEMBER =
+  /onRowClick\?:\s*\(\s*record:\s*Record<string,\s*unknown>\s*,\s*event\?:\s*HandleClickModifiers\s*\)\s*=>\s*void\s*;/;
+/** `onRowClick` declared with exactly one parameter — the defect's spelling. */
+const ONE_PARAMETER_MEMBER =
+  /onRowClick\?:\s*\(\s*record:\s*Record<string,\s*unknown>\s*\)\s*=>\s*void\s*;/;
+/** Any type assertion applied to the `onRowClick` value. */
+const ONROWCLICK_ASSERTION = /\bonRowClick\s+as\b/;
+/** The call, made on the declared value with both arguments. */
+const DIRECT_TWO_ARGUMENT_CALL = /\bonRowClick\(\s*record\s*,\s*event\s*\)/;
+
+describe('the instrument can fire (controls)', () => {
+  it('anchors on this file, not on the cwd', () => {
+    expect(existsSync(path.join(repoRoot, 'pnpm-workspace.yaml'))).toBe(true);
+    expect(existsSync(HOOK_ABS)).toBe(true);
+  });
+
+  it('found both spans it reads, and they are not empty', () => {
+    expect(HOOK_MASKED).toContain(OPTIONS_DECL);
+    expect(HOOK_MASKED).toContain(HANDLE_CLICK_DECL);
+    expect(OPTIONS_BODY).toContain('onRowClick');
+    expect(HANDLE_CLICK_BODY).toContain('onRowClick');
+  });
+
+  it('flags an assertion applied to the value', () => {
+    // Assembled from fragments so this control is not itself a hit if a
+    // source-scanning gate ever walks this file.
+    const asserted = '(onRowClick' + ' as ' + '(r: R, e?: E) => void)(record, event);';
+    expect(ONROWCLICK_ASSERTION.test(maskComments(asserted))).toBe(true);
+  });
+
+  it('masks comments, so prose about the defect is not the defect', () => {
+    const commented = '// (onRowClick' + ' as ' + '(r: R) => void)(record, event);\nconst x = 1;';
+    expect(ONROWCLICK_ASSERTION.test(maskComments(commented))).toBe(false);
+    const block = '/* onRowClick' + ' as ' + 'X */\nconst x = 1;';
+    expect(ONROWCLICK_ASSERTION.test(maskComments(block))).toBe(false);
+  });
+
+  it('separates the one-parameter spelling from the two-parameter one', () => {
+    const narrow = 'onRowClick?: (record: Record<string, unknown>) => void;';
+    const wide =
+      'onRowClick?: (record: Record<string, unknown>, event?: HandleClickModifiers) => void;';
+    expect(TWO_PARAMETER_MEMBER.test(narrow)).toBe(false);
+    expect(TWO_PARAMETER_MEMBER.test(wide)).toBe(true);
+    // Both matchers are needed and neither subsumes the other: one asserts the
+    // repaired spelling is PRESENT, the other that the defect's spelling is
+    // ABSENT, and a third spelling would have to satisfy both.
+    expect(ONE_PARAMETER_MEMBER.test(narrow)).toBe(true);
+    expect(ONE_PARAMETER_MEMBER.test(wide)).toBe(false);
+  });
+});
+
+describe('UseNavigationOverlayOptions.onRowClick declares its modifier payload (objectui#9357)', () => {
+  it('declares the record and the optional modifier payload', () => {
+    expect(
+      TWO_PARAMETER_MEMBER.test(OPTIONS_BODY),
+      [
+        `${HOOK_REL}: \`UseNavigationOverlayOptions.onRowClick\` does not declare the`,
+        'modifier payload `handleClick` hands it. Every consumer reads this',
+        'declaration to learn what its own pass-through receives, so an',
+        'understated arity here is copied outward (objectui#9357).',
+      ].join('\n'),
+    ).toBe(true);
+  });
+
+  it('no longer carries the one-parameter spelling', () => {
+    const offender = OPTIONS_BODY.match(ONE_PARAMETER_MEMBER)?.[0]?.replace(/\s+/g, ' ');
+    expect(
+      offender ?? null,
+      'the option is declared with one parameter again — the objectui#9357 defect',
+    ).toBeNull();
+  });
+});
+
+describe('handleClick calls the option through its declaration (objectui#9357)', () => {
+  it('applies no type assertion to onRowClick', () => {
+    expect(
+      ONROWCLICK_ASSERTION.test(HOOK_MASKED),
+      [
+        `${HOOK_REL}: \`onRowClick\` is invoked through a type assertion.`,
+        'An assertion here is the producer paying for its own understated',
+        'declaration — AGENTS.md #0.1 sends that back to the producer, and the',
+        'producer is this file. Declare the parameter instead (objectui#9357).',
+      ].join('\n'),
+    ).toBe(false);
+  });
+
+  it('calls it with both arguments, directly', () => {
+    expect(DIRECT_TWO_ARGUMENT_CALL.test(HANDLE_CLICK_BODY)).toBe(true);
+  });
+});
+
+/* ------------------------------------------------------------------ *
+ * RUNTIME control — the implementation keeps the widened promise.
+ * ------------------------------------------------------------------ */
+
+describe('the implementation delivers what the declaration now promises', () => {
+  it('forwards the record and the modifier payload to onRowClick', () => {
+    const onRowClick = vi.fn<(record: Record<string, unknown>, event?: HandleClickModifiers) => void>();
+    const { result } = renderHook(() =>
+      useNavigationOverlay({ navigation: { mode: 'drawer' }, objectName: 'account', onRowClick }),
+    );
+
+    const record = { id: 'a1', name: 'Acme' };
+    const event: HandleClickModifiers = { metaKey: true, ctrlKey: false, button: 0 };
+    act(() => {
+      result.current.handleClick(record, event);
+    });
+
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick).toHaveBeenCalledWith(record, event);
+    // The external handler takes full priority: no overlay is opened behind it.
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('still calls a one-parameter handler, which the widening keeps legal', () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const oneArg: (record: Record<string, unknown>) => void = (record) => {
+      calls.push(record);
+    };
+    const { result } = renderHook(() =>
+      useNavigationOverlay({ navigation: { mode: 'page' }, objectName: 'account', onRowClick: oneArg }),
+    );
+
+    const record = { id: 'b2' };
+    act(() => {
+      result.current.handleClick(record);
+    });
+
+    expect(calls).toEqual([record]);
+  });
+});

--- a/packages/react/src/hooks/useNavigationOverlay.ts
+++ b/packages/react/src/hooks/useNavigationOverlay.ts
@@ -139,8 +139,23 @@ export interface UseNavigationOverlayOptions {
   objectName?: string;
   /** External onNavigate callback (e.g., from ActionProvider or parent) */
   onNavigate?: (recordId: string | number, action?: string) => void;
-  /** External onRowClick callback — if set, takes full priority */
-  onRowClick?: (record: Record<string, unknown>) => void;
+  /**
+   * External onRowClick callback — if set, takes full priority.
+   *
+   * Declares BOTH arguments `handleClick` hands it: the record, and the
+   * optional modifier payload (`HandleClickModifiers`, declared just below)
+   * that lets a host implement Cmd/Ctrl/middle-click for itself. The second
+   * argument was always delivered; until objectui#9357 this line declared only
+   * the first and `handleClick` asserted the declaration away in order to make
+   * the call — so the payload was invisible on the one line a host reads, and
+   * every consumer that passes its own handler through copied the understated
+   * spelling outward.
+   *
+   * A one-parameter handler stays assignable here, so nothing a caller already
+   * wrote has to change; what changes is that a caller who WANTS the payload
+   * can now see that it exists.
+   */
+  onRowClick?: (record: Record<string, unknown>, event?: HandleClickModifiers) => void;
 }
 
 /**
@@ -265,8 +280,14 @@ export function useNavigationOverlay(
       // External onRowClick takes full priority. Forward the modifier event
       // so parent handlers (e.g. ObjectView) can still implement Cmd/Ctrl/
       // middle-click → open in new tab.
+      //
+      // Called straight through the declaration (objectui#9357). This used to
+      // carry a type assertion widening the option to two parameters at the
+      // call — the producer paying for its own understated declaration, which
+      // AGENTS.md #0.1 sends back to the producer. The producer is this file,
+      // and the option above now declares what this line passes.
       if (onRowClick) {
-        (onRowClick as (r: Record<string, unknown>, e?: HandleClickModifiers) => void)(record, event);
+        onRowClick(record, event);
         return;
       }
 


### PR DESCRIPTION
Part of objectui#9357

> Spelling note: generic parameter lists are written as capitalised WORDS below
> (`RECORD` for the record parameter type, `OPT` for an optional arm). GitHub's
> body sanitiser deletes angle-bracket-shaped spans, code fences included, and a
> before/after table whose two rows collapse into the same string is worse than
> no table.

## The defect, re-verified against `origin/main` before any edit

`packages/react/src/hooks/useNavigationOverlay.ts`, both halves byte-for-byte, at
`2e471dc0aa23ff807aa9960618c419ecccdfdcef`:

```
:142    /** External onRowClick callback — if set, takes full priority */
:143    onRowClick?: (record: RECORD) => void;

:265    // External onRowClick takes full priority. Forward the modifier event
:268    if (onRowClick) {
:269      (onRowClick as (r: RECORD, e?: HandleClickModifiers) => void)(record, event);
```

`premise_still_valid: true` — all four lines are exactly where the card says,
126 lines apart in one file. The declaration promises one parameter; the call
site asserts the declaration away to pass two. The assertion is the only thing
holding the two apart.

One correction to the dispatch note: `HandleClickModifiers` is not *imported*
into this file — it is **declared and exported from this very file**, fourteen
lines below the option. Naming it in the option therefore costs no import at
all, which is a stronger version of the same point.

## The repair

- `UseNavigationOverlayOptions.onRowClick` now declares both parameters:
  the record, and `event?: HandleClickModifiers`.
- The assertion at the call site is **deleted**; `handleClick` now calls
  `onRowClick(record, event)` straight through the declaration.
- No consumer is edited, and no runtime code moves. Two commits follow the
  repair and neither touches an executable line — see the next section.

## What the follow-up commits changed

`02b60d8ec` is the repair above. Both commits after it are prose and pin only:

- **`d8325fa79`** — after the first contract review, the changeset stopped
  generalising. It now names the one refused class, quotes the `TS2322` that
  class raises, gives the one-line remedy, and the pin grew a
  `@ts-expect-error` row that goes red (as `TS2578`-unused) if that boundary
  ever moves. The class: a handler whose second parameter is annotated
  **narrower** than `HandleClickModifiers` — React's `MouseEvent` in practice.
- **`0d983a987`** — the second contract review found the same refuted
  generalisation still standing in the hook's JSDoc, which is the carrier that
  actually ships. Comments are not stripped for this package, so that block
  lands verbatim in `dist/hooks/useNavigationOverlay.d.ts` — the hover text
  every consumer of `@object-ui/react` reads. The sentence "a one-parameter
  handler stays assignable here, so nothing a caller already wrote has to
  change" is replaced by the qualified form the changeset already uses, so the
  CHANGELOG and the declaration now agree about the same line. Two residual
  restatements of the same claim in the pin's own prose ("nothing breaks either
  way", "no consumer is broken by the widening") are corrected the same way —
  both sit in a file this branch adds, and both were already contradicted 80
  lines below by that file's own ACCEPT-SET BOUNDARY block. Comment text only.

## Consumers, enumerated — and which ones the repair reaches

Thirteen sites call `useNavigationOverlay`; nine of them feed the repaired
option. **The repair reaches the option itself, so every one of these nine may
now pass a two-parameter handler without an assertion of its own:**

| consumer | what it feeds the option |
|---|---|
| `packages/plugin-grid/src/ObjectGrid.tsx` | `onRowClick` |
| `packages/plugin-list/src/ListView.tsx` | `onRowClick` |
| `packages/plugin-list/src/ObjectGallery.tsx` | `props.onRowClick` else `props.onCardClick` |
| `packages/plugin-kanban/src/ObjectKanban.tsx` | `externalClick` |
| `packages/plugin-calendar/src/ObjectCalendar.tsx` | `onRowClick` when not an overlay |
| `packages/plugin-gantt/src/ObjectGantt.tsx` | `onRowClick` when not an overlay |
| `packages/plugin-map/src/ObjectMap.tsx` | `onRowClick` |
| `packages/plugin-timeline/src/ObjectTimeline.tsx` | `onRowClick` else `onItemClick` |
| `packages/plugin-tree/src/ObjectTree.tsx` | `onRowClick` |

Four call the hook without the option and are untouched either way:
`app-shell`'s `InterfaceListPage.tsx`, `ObjectDataPage.tsx` and
`ObjectView.tsx`, plus the doc example in
`packages/components/src/custom/navigation-overlay.tsx`.

**What the repair does NOT reach — each is a published face of its own, and
naming the payload on it is the ruling objectui#9357 leaves open:**

- `ObjectKanbanComponentProps.onRowClick` and `.onCardClick` (`plugin-kanban`)
- `KanbanRendererProps.schema.onCardClick` (`plugin-kanban/src/index.tsx`)
- `ObjectGallery`'s `onCardClick` / `onRowClick` pair (`plugin-list`)
- the `onRowClick` prop on `ObjectGrid`, `ListView`, `ObjectCalendar`,
  `ObjectGantt`, `ObjectMap`, `ObjectTimeline`, `ObjectTree`
- `ObjectGridSchema.onRowClick` and `ObjectKanbanSchema.onCardClick` in
  `@object-ui/types`, where the card records that `HandleClickModifiers` is
  unreachable (phantom dependency plus a cycle) and `event?: any` is the
  established spelling

The three workaround call sites the card names — `app-shell`'s `ObjectView.tsx`
at lines 2734, 3120 and 3163, each spelling `(record: any, event?: OPT any)` —
are consumers of those **component props**, not of the hook option, so they
still need the workaround and are deliberately left alone.

## Source compatibility — one class DOES break, measured here rather than inherited

Two assignability directions hold between the old spelling and the new one, and
both are asserted in the pin so they cannot silently stop holding:

- a one-parameter handler is assignable to the widened option
  (`_NarrowIsAssignableToWide`);
- a handler written against the widened option is assignable to the old
  one-parameter spelling (`_WideIsAssignableToNarrow`) — its minimum argument
  count is still one.

**That is a statement about those two spellings and nothing wider.** An earlier
revision of this section read "No consumer breaks in either direction". That is
false, and the probe below refutes it.

**The one class that has to change.** A handler passed *directly* to
`useNavigationOverlay` whose second parameter is annotated **narrower** than
`HandleClickModifiers` compiled before this branch and is refused now with
`TS2322`. React's `MouseEvent` is the shape this hits in practice, because the
payload used to be discoverable only from the implementation, so a host that
wanted it wrote the annotation it saw arrive. The parameter is checked
contravariantly, so the annotation now has to *admit* `HandleClickModifiers`.
**The remedy is one line at that call site:** annotate the parameter
`HandleClickModifiers` (exported from `@object-ui/react`), or drop the
annotation and let it be inferred. Either way the handler keeps receiving
exactly what it received before — a type-level change with no runtime behaviour
attached. The changeset publishes this class and this remedy, and as of
`0d983a987` so does the shipped declaration.

**The probe, re-run at `0d983a987`.** One temporary file per case under
`packages/react/src/hooks/__tests__/`, checked with
`tsc -p packages/react/tsconfig.test.json` in two worktrees: this branch, and
the fork point taken from `git merge-base` (`b67b53bc0`) — never from
`base.sha`, which is the base BRANCH TIP and not the fork point. Each probe was
hash-proved onto disk before its run and removed under `trap ... EXIT INT TERM`,
with absence re-checked afterwards.

| probe | at `b67b53bc0` | at `0d983a987` |
|---|---|---|
| baseline, no probe file | exit 0 | exit 0 |
| POISON control, a deliberate `TS2322` | exit 2 — 1 error, on the probe line | exit 2 — 1 error, on the probe line |
| SUBJECT — second parameter annotated `React.MouseEvent` | **exit 0 — accepted** | **exit 2 — one `TS2322`, on the subject line only** |
| control A — one-parameter handler | exit 0 | exit 0 |
| control B — unannotated handler | exit 0 | exit 0 |

The POISON row is what makes the zeros readable: without it, a probe the
compiler accepted and a probe the compiler never opened render identically.

⇒ the widening **relaxes** the option for anyone who wants the payload and
**narrows** it for exactly that one annotated class. No consumer *inside this
repository* is in that class, and the repository's own type-check re-derives
that on every run rather than this sentence asserting it.

## Why the pin is not an assignability assertion — with the null result to prove it

Because both directions hold, `extends` cannot tell the repaired declaration
from the broken one. Two instruments that can are used instead, each with
controls proving it can fire:

- **compile-time** — an exact-identity read of the parameter list
  (`Parameters` and its `length`), run only by `packages/react`'s
  `tsconfig.test.json`;
- **bytes** — the declaration and the call site read off disk, root-anchored on
  the test file rather than the cwd.

### Red-first, on the unmodified tree, verbatim

`pnpm --filter @object-ui/react type-check` — exit 2:

```
src/hooks/__tests__/useNavigationOverlay.onRowClickArity-9357.test.tsx(88,31): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/hooks/__tests__/useNavigationOverlay.onRowClickArity-9357.test.tsx(91,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/hooks/__tests__/useNavigationOverlay.onRowClickArity-9357.test.tsx(91,26): error TS2493: Tuple type '[record: Record of string to unknown]' of length '1' has no element at index '1'.
src/hooks/__tests__/useNavigationOverlay.onRowClickArity-9357.test.tsx(100,3): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/hooks/__tests__/useNavigationOverlay.onRowClickArity-9357.test.tsx(116,43): error TS2344: Type 'false' does not satisfy the constraint 'true'.
```

(the TS2493 message's own generic is respelled in words for the reason at the
top; everything else is verbatim.)

`pnpm exec vitest run` on the pin — exit 1, the four assertions red and the
seven controls green:

```
 ❯ packages/react/src/hooks/__tests__/useNavigationOverlay.onRowClickArity-9357.test.tsx (11 tests | 4 failed)
     × declares the record and the optional modifier payload
     × no longer carries the one-parameter spelling
     × applies no type assertion to onRowClick
     × calls it with both arguments, directly
      Tests  4 failed | 7 passed (11)
```

### Ablation — two legs, on-disk proof before any result was read

Mechanism: mutate, `grep -c` the injected text **and** the deleted text before
reading anything, restore with `git checkout HEAD -- PATH` under
`trap ... EXIT INT TERM`, and verify the restore by blob-hash equality against
the HEAD blob **plus** an empty `git diff HEAD` — never by an exit code. Both
restores verified: `18ddadad7fecd2e38341060c0bf1e0251e4ca1d5`, diff empty.

**Leg 1 — the full pre-fix defect put back (narrow declaration + assertion).**

- `tsc --noEmit` over `src`: **exit 0**. ⭐ The defect compiled cleanly. That is
  the disease in one number: the assertion made the disagreement legal, so no
  type instrument in the tree ever objected.
- `tsc -p tsconfig.test.json`: exit 2 — the five errors above.
- vitest: exit 1 — `4 failed | 7 passed`.

**Leg 2 — the NULL RESULT the dispatch predicted, and it is a null result.**
In Leg 1's error list the two assignability assertions, at lines 108 and 109,
are **absent in both directions**: they stayed green while the declaration was
narrowed back. So did `_FirstParamIsTheRecord` at line 89, correctly — the first
parameter is identical in both spellings. Reported, not deleted: it is the
measurement that justifies the instrument choice.

**Leg 3 — widened declaration kept, the assertion alone put back.**

- `tsc --noEmit`: exit 0. `tsc -p tsconfig.test.json`: **exit 0**.
- vitest: exit 1 — `2 failed | 9 passed`, only `applies no type assertion to
  onRowClick` and `calls it with both arguments, directly`.

⇒ the type system is **completely blind** to a returning assertion once the
declaration is honest. The bytes half is the only thing in this repository that
reds on it, which is why it is in the pin.

**Runtime behaviour is unchanged, observed rather than argued.** The two runtime
control tests — the hook forwards `(record, event)` to the supplied handler, and
a one-parameter handler is still called — are green on the broken tree (they are
among the seven that passed in the red-first run and in Leg 1) and green on the
repaired one. A `tsc` type assertion is erased at emit, so the call site's
semantics could not move; this is the measurement that says so.

## Dependent-set membership read

Read from the workspace graph, not inferred:

- **type-check dependent set of `@object-ui/react`** — 32 workspace packages
  transitively depend on it (28 directly). 31 declare a `type-check` script;
  `@object-ui/example-hello-world` declares none.
- **`.changeset/config.json` `ignore`** — `@object-ui/example-*`,
  `@object-ui/site`, `@object-ui/test-support`. This excludes packages from
  **version bumping** and is a different set from the one above. Five members
  sit in both (`@object-ui/site` and the four `example-*` packages) and
  `@object-ui/test-support` sits only in `ignore` — so the overlap is partial
  and neither list may be read off the other.
- **`fixed` group** — one group of **40** packages, `@object-ui/react` among
  them. `major` is unavailable by repo rule; the changeset declares `minor`.

## Verification

Every heavy run went through `../objectstack/scripts/pm/os-verify-lock.sh --`
on a stable slot, `os-dev-9357`. VERDICT lines, quoted, never a bare exit code:

```
VERDICT command-exit 0 · held the lock 288s (4m48s) · waited 0s
    → full `pnpm build` on the UNMODIFIED tree. Tasks: 43 successful, 43 total.

VERDICT queue-timeout (exit 99) · never acquired · waited 540s (9m00s)
    → post-fix heavy batch, attempt 1. NOT MEASURED.

VERDICT queue-timeout (exit 99) · never acquired · waited 540s (9m00s) ·
    holder pid 11423, held 827s — scratchpad/issue-9318/heavy.sh
    → same batch, attempt 2, slot resumed rather than re-queued. NOT MEASURED.
```

⚠️ Eighteen minutes of queue with no turn, behind one long holder. Rather than
idle a third time, the remaining work was **narrowed, and the narrowing is
declared and measured** — not assumed:

**The narrowing, and the proof it excludes nothing.** The published `.d.ts`
surface of `@object-ui/react` was hashed file-by-file before and after the
rebuild: of **65 emitted declaration files, exactly one moved**, and inside it
exactly one declaration line changed (the rest of that hunk is doc comment). So
the only packages whose type-check can move are the ones that read
`UseNavigationOverlayOptions`. The population was measured, not guessed: twelve
packages outside `packages/react` name `useNavigationOverlay`,
`UseNavigationOverlayOptions` or `HandleClickModifiers` anywhere in their
sources. All twelve plus `@object-ui/react` were type-checked.

Unlocked runs — exit codes captured after redirecting to a file, never through a
pipe:

| run | result |
|---|---|
| `pnpm --filter @object-ui/react build` | exit 0 — `dist completeness: 1 package(s) complete (130 emitted files verified)` |
| published declaration diff, 65 files | exactly 1 file moved, 1 declaration line |
| `type-check` over the 13 affected packages, `--workspace-concurrency=2` | exit 0 — all Done, `app-shell` included |
| `vitest run packages/react/` | exit 0 — `Test Files 83 passed (83)`, `Tests 985 passed (985)` |
| `vitest run packages/plugin-kanban/ packages/plugin-list/` | exit 0 — `Test Files 130 passed (130)`, `Tests 1263 passed (1263)` |
| `pnpm --filter @object-ui/react lint` | exit 0 — 0 errors, 353 pre-existing warnings, none naming either touched file |

Gates derived by hand from the root `package.json` and `.github/workflows/`
(there is no dispatch-gates script in this repository) — all exit 0:
`check:control-bytes`, `check:test-path-roots`, `check:new-line-citations`,
`check:doc-example-readers`, `check:handler-key-reads`,
`check:changeset-claims`, `check:phantom-deps`,
`check:published-tsconfig-exclude`, `check:comment-mask-corpus`,
`check:doc-examples`, `check:unreferenced-sources`, `changeset:check`. A direct
control-byte scan over the three touched files found none.

**NOT MEASURED locally, and left to CI rather than claimed:** a full `pnpm build`
on the post-repair tree (the one that ran green was on the unmodified tree), the
four-shard `pnpm test`, the nineteen packages of the dependent set that the
declaration diff proves cannot be affected, `@object-ui/site`'s type-check
(it needs `next typegen`), and the repo-wide `pnpm lint`.

### Re-verified at `0d983a987` — the comment-only repair

Heavy runs through `../objectstack/scripts/pm/os-verify-lock.sh -c`, stable slot
`issue-9357-repair`; exit codes captured by redirect **before** any pipe, and
the wrapper's own `VERDICT command-exit` line read rather than a bare exit
variable.

| run | result |
|---|---|
| `pnpm --filter @object-ui/react build` | exit 0 — `dist completeness: 1 package(s) complete (130 emitted files verified)` |
| `pnpm --filter @object-ui/react type-check` | exit 0 — this script is `tsc --noEmit` **and** `tsc -p tsconfig.test.json`, so both `@ts-expect-error` rows are live: neither `TS2578`-unused nor masking a second error |
| `pnpm --filter @object-ui/react test` | exit 0 — `Test Files 84 passed (84)`, `Tests 995 passed (995)` |

**The carrier, before and after, read on the EMITTED declaration rather than on
the source.** Census over `packages/react/dist/hooks/useNavigationOverlay.d.ts`
after a real rebuild, newline- and JSDoc-continuation-tolerant (`perl -0777`,
continuations flattened so a `*` between two words cannot hide a match):

| term | before | after |
|---|---|---|
| "nothing a caller already wrote has to change" | 1 | **0** |
| "The exception, and the one class that has to change" | 0 | **1** |
| `TS2322` | 0 | 1 |
| `MouseEvent` | 0 | 1 |
| control `HandleClickModifiers` | 4 | 7 |
| control `objectui#9357` | 1 | 1 |
| control `Cmd/Ctrl` | 1 | 1 |
| control `UseNavigationOverlayOptions` | 2 | 2 |

The lit controls are what make that `0` a reading rather than a broken grep.

**Nothing else in the published surface moved.** Both trees hashed file by file
from the same build: **65** emitted `.d.ts` before and after, exactly **one**
hash moved (`hooks/useNavigationOverlay.d.ts`); the exported-declaration census
is **295 = 295** with an **empty** symmetric difference — and the comparison can
see a difference, because the same set poisoned with one sentinel name does
compare unequal; and `dist/index.d.ts` is **byte-identical**,
`5a1f5d143c595f68427d4a9eceb5bd87680ac069` both times. A control-byte scan over
both touched files found none, paired with a lit control on a deliberately
poisoned file.

## Inherited reds — NOT from this change, and re-derived rather than recalled

An earlier revision of this section named **Doc Snippet Type Check** and **Skill
Example Check**. Both names were wrong: at `e0c5c14b6` both read `success`.

The instrument, so this paragraph can be re-derived instead of believed:
`GET /repos/objectstack-ai/objectui/commits/REF/check-runs?per_page=100`,
paginated up to `total_count`, bucketed by `conclusion` — and by `status` for
the entries still running, which a `conclusion`-only bucket silently drops.
Readings, each carrying the ref it was taken at, 2026-09-13:

| ref | reading |
|---|---|
| `e0c5c14b6` — the reviewed head | 36 checks: 32 success, 3 skipped, **1 failure — `Bundle Analysis`**, 0 cancelled |
| `b67b53bc0` — this branch's fork point | `Bundle Analysis` `failure` |
| `e2feb13e1` — the `main` tip the review read | `Bundle Analysis` `failure` |
| `efc1c9c400` — the `main` tip at the time of writing | `Bundle Analysis` **`success`** |

⚠️ The inherited red is inherited **and moving**: red at this branch's fork
point and red on `main` when the review ran, but `main` has since gone green on
it. This branch is not synced to that tip, so re-run the instrument above at
whatever head you are looking at rather than trusting this table.
`Bundle Analysis`'s own bot comment on this PR (comment `5653469550`) calls its
verdict a broken-gauge reading on a ceiling and says explicitly that it is "not
a budget violation". This branch touches no bundle input, no chunk ceiling and
no baseline.

The three skipped entries at `e0c5c14b6` are `dependabot`, `Test (coverage)` and
the coverage shard matrix.

## Acceptance notes

- Noted, not filed: `app-shell/src/views/ObjectView.tsx` around line 2191
  declares an inline structural duplicate of `HandleClickModifiers`
  (`OPT metaKey`, `OPT ctrlKey`, `OPT button`) rather than importing the
  exported interface. Cosmetic, one file, and it belongs to whichever PR takes
  the component-prop half of objectui#9357 — successor: that PR.
- Noted, not filed: the consumer declarations listed above understate their
  arity in exactly the way this card describes. They are not a separate finding
  — objectui#9357's own "What is not decided here" section already carries them,
  and picking their spelling is a ruling.
- Noted, not filed: the stated MECHANISM for "the JSDoc ships" has been wrong in
  both review comments and in the earlier body — they credit
  `tsconfig.base.json`'s `removeComments: false`. `packages/react/tsconfig.json`
  extends the ROOT `tsconfig.json`, which does not extend `tsconfig.base.json`
  and sets no `removeComments` at all; only `tsconfig.node.json`,
  `tsconfig.scripts.json`, `tsconfig.react.json` and one example package extend
  the base. The comments ship because TypeScript's DEFAULT for `removeComments`
  is off, not because this repo turned it off. The conclusion is unchanged and
  is measured on the built artefact above; only the cited cause was wrong.
  Successor: whichever PR next edits that base config, or none.

## Disjointness against the in-flight PRs

File lists read for objectui#9356, #9343, #9144, #9339, #9351 and #9352: no
path overlap with this branch's three files. Beyond the file faces, the nearest
PR (#9356) asserts on `plugin-kanban` and `@object-ui/types` symbols; this
branch removes only one span of text, the assertion inside
`useNavigationOverlay.ts`, and a repo-wide search finds no test outside this
branch that names `UseNavigationOverlayOptions` or reads that span. The
`plugin-kanban` and `plugin-list` suites were run on this branch and are green.

## Status

⛔ Draft on purpose. The seat does not flip ready, arm auto-merge or enqueue —
the PM's — and no label is added or removed from here.

`needs:contract-review` was hung on this PR because the change moves a published
type in `@object-ui/react`. It is no longer on the PR: the clause-② review
returned **FAIL** at `e0c5c14b6` (comment `5656788876`) and the gate label was
stripped from both this PR and the card as part of that FAIL, with the handover
recorded on the card as comment `5656802868`. `0d983a987` is the one repair that
FAIL owed, plus the two body corrections and the pin-prose corrections it
flagged below the bar.

Sessions for this work, as prose so an edit cannot strip them — the
implementation session `https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ`,
and the repair session `https://claude.ai/code/session_01L5xpA5q533BgTTNADibEFt`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_

---
_Generated by [Claude Code](https://claude.ai/code)_