### PR TITLE
fix(app-shell): the field-rule wrong-layer verdict comes from @objectstack/lint, not a second copy of it

### DIFF
--- a/.changeset/9318-field-rule-verdict-from-lint.md
+++ b/.changeset/9318-field-rule-verdict-from-lint.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/app-shell': minor
+---
+
+The wrong-layer root advisory asks the platform for its verdict instead of keeping
+a second copy of it (objectui#9318).
+
+`rowCanonAdvisory` answered "is this root bound on this surface?" from objectui's
+own knowledge — `@object-ui/core`'s detector hard-codes the single root `data`, and
+the docblock justified that from `ROW_PREDICATE_ROOTS` / `FIELD_RULE_ROOTS` /
+`FORMULA_ROOTS`. `@objectstack/lint` publishes the same judgement as
+`fieldRuleRootIssue` / `FIELD_RULE_BOUND_ROOTS`, pinned upstream. Two hand-maintained
+copies of one judgement, agreeing today, with nothing keeping them agreeing: the next
+root the platform binds or unbinds moves one and not the other, silently.
+
+A `CelSchemaHint.slot` (and the matching `CelPredicateField` prop) names the authored
+key, and on the slots the published vocabulary covers — `visibleWhen`, `readonlyWhen`,
+`requiredWhen` — the verdict and the message now come from the helper. Both are
+internal to `@object-ui/app-shell`; no package export moves.
+
+**Behaviour change, deliberate and warning-only.** Those three editors now advise on
+every root the field level leaves unbound, not only `data`: a field rule reading
+`current_user` or `app` gets the engine's own diagnostic, which refuses the
+`record.<root>` rewrite by name instead of merely omitting it. Severity stays
+objectui's own `warning` — every save gate on this tier counts `severity === 'error'`,
+so no accept set moves and no predicate already stored in customer metadata is refused.
+
+**Coverage is not shrunk to fit the helper.** Two guarded surfaces bind a different
+set, in opposite directions — a `formula` field's `expression` binds `FORMULA_ROOTS`
+(`record`, narrower) and a conditional-formatting `condition` binds
+`ROW_PREDICATE_ROOTS` (`record`, `current_user`, `user`, `features`, `os`, `ctx`,
+wider). Those keep the local instrument unchanged, and both are pinned as live
+controls against a later tidy-up that routes them through the helper anyway.

--- a/packages/app-shell/src/views/metadata-admin/CelPredicateField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/CelPredicateField.tsx
@@ -88,6 +88,14 @@ export interface CelPredicateFieldProps {
   /** Override the scope roots offered by autocomplete (see CelSchemaHint.roots). */
   roots?: string[];
   /**
+   * The authored key this editor writes (`visibleWhen`, `readonlyWhen`,
+   * `requiredWhen`) — see `CelSchemaHint.slot`. Naming it lets the wrong-layer
+   * advisory take the platform's published per-slot verdict (objectui#9318);
+   * leaving it unset keeps the local one, which is the right answer for the
+   * surfaces whose bound roots are not the field-rule set.
+   */
+  slot?: string;
+  /**
    * Engine field role (see CelSchemaHint.role). `'predicate'` (default) for
    * boolean conditions; `'value'` for formula expressions — which also turns
    * on the inferred-result-type affordance.
@@ -118,6 +126,7 @@ export function CelPredicateField({
   clause,
   scope,
   roots,
+  slot,
   role,
   onLintChange,
   onInferredTypeChange,
@@ -168,7 +177,7 @@ export function CelPredicateField({
   React.useEffect(() => {
     let cancelled = false;
     const handle = setTimeout(() => {
-      const hint = { objectName, fields: fieldNames, clause, scope, role };
+      const hint = { objectName, fields: fieldNames, clause, scope, slot, role };
       lintCelPredicate(value, hint).then((res) => {
         if (cancelled) return;
         setIssues(res);
@@ -188,7 +197,7 @@ export function CelPredicateField({
       clearTimeout(handle);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value, objectName, fieldsKey, clause, scope, role]);
+  }, [value, objectName, fieldsKey, clause, scope, slot, role]);
 
   /* Report "clean" upward when the field empties (no debounce needed). */
   React.useEffect(() => {

--- a/packages/app-shell/src/views/metadata-admin/celAuthoring.fieldRuleVerdict-9318.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/celAuthoring.fieldRuleVerdict-9318.test.ts
@@ -1,0 +1,142 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#9318 — the wrong-layer verdict comes from `@objectstack/lint`, not
+ * from a second hand-maintained copy of it.
+ *
+ * ## What moved
+ *
+ * `rowCanonAdvisory` used to answer "is this root bound on this surface?" from
+ * objectui's own knowledge: `@object-ui/core`'s `detectNonCanonicalRowSpelling`
+ * hard-codes ONE root (`data`) and objectui's docblock justified that from
+ * `ROW_PREDICATE_ROOTS` / `FIELD_RULE_ROOTS` / `FORMULA_ROOTS`. The platform
+ * publishes the same judgement as `fieldRuleRootIssue` / `FIELD_RULE_BOUND_ROOTS`.
+ * Two copies of one judgement agree today and nothing keeps them agreeing.
+ *
+ * ## What did NOT move, and is pinned here as such
+ *
+ * The helper's vocabulary is the FIELD-RULE tier: it judges against
+ * `FIELD_RULE_BOUND_ROOTS` = `record` / `previous` / `parent`. Two of the
+ * surfaces `rowCanonAdvisory` guards bind a DIFFERENT set, measured:
+ *
+ *  - the conditional-formatting `condition` binds `ROW_PREDICATE_ROOTS`
+ *    (`record`, `current_user`, `user`, `features`, `os`, `ctx`) — WIDER;
+ *  - a `formula` field's `expression` binds `FORMULA_ROOTS` (`record`) — NARROWER.
+ *
+ * So the helper's verdict is adopted exactly on the three slots whose bound set
+ * IS the field-rule set, and the local fallback is KEPT for the rest. The two
+ * "uncovered surface" pins below are live controls for the failure this card
+ * exists to stop, in miniature: routing every surface through the helper to
+ * make the code tidier would redden them.
+ *
+ * Severity stays objectui's own mapping (`warning`, never `error`) on both
+ * paths — every save gate on this tier counts `severity === 'error'`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { fieldRuleRootIssue, FIELD_RULE_BOUND_ROOTS } from '@objectstack/lint';
+import { lintCelPredicate } from './celAuthoring';
+
+const HINT = { objectName: 'account', fields: ['organization_id', 'owner_id', 'status', 'amount'] };
+/** A field conditional rule — a slot the published helper's vocabulary covers. */
+const RULE_SLOT_HINT = { ...HINT, scope: 'record' as const, slot: 'visibleWhen' as const };
+/** The same tier with no slot named — the local fallback, unchanged. */
+const UNSLOTTED_HINT = { ...HINT, scope: 'record' as const };
+
+/** objectui's own advisory sentence; the engine's never contains it. */
+const OBJECTUI_MESSAGE_MARKER = /Re-root/;
+
+describe('celAuthoring · the field-rule verdict is the published one (objectui#9318)', () => {
+  it('TRUE POSITIVE — a covered slot takes BOTH the verdict and the message from `fieldRuleRootIssue`', async () => {
+    const source = "data.status == 'x'";
+    const issues = await lintCelPredicate(source, RULE_SLOT_HINT);
+    const engine = fieldRuleRootIssue('visibleWhen', source);
+    // The helper has something to say about this source — if it ever stops,
+    // this pin is measuring nothing and must be re-derived, not relaxed.
+    expect(engine).not.toBeNull();
+    const advisory = issues.filter((i) => i.severity === 'warning' && i.message === engine!.message);
+    // Verbatim equality against the helper's OWN output, evaluated here rather
+    // than transcribed: this asserts "objectui ships the engine's message" and
+    // can never drift with upstream wording the way a quoted string would.
+    expect(advisory).toHaveLength(1);
+  });
+
+  it('ships ONE message, never both — objectui\'s sentence is gone from the covered path', async () => {
+    const issues = await lintCelPredicate("data.status == 'x'", RULE_SLOT_HINT);
+    expect(issues.filter((i) => OBJECTUI_MESSAGE_MARKER.test(i.message))).toEqual([]);
+    expect(issues.filter((i) => i.severity === 'warning')).toHaveLength(1);
+  });
+
+  it('LIVE CONTROL — the ACCEPT SET is not narrowed: the covered path raises no error', async () => {
+    // Every save gate on this tier counts `severity === 'error'` and nothing
+    // else, so "zero errors" IS "still accepted". Reddens on exactly one
+    // change — promoting the advisory to `error`.
+    const issues = await lintCelPredicate("data.status == 'x'", RULE_SLOT_HINT);
+    expect(issues.filter((i) => i.severity === 'error')).toEqual([]);
+  });
+
+  it('a root the platform DOES bind comes back clean THROUGH the new path', async () => {
+    // The ablation target: `previous` and `parent` are clean here because
+    // `FIELD_RULE_BOUND_ROOTS` says the field level binds them, not because
+    // objectui's detector only ever looked at `data`.
+    expect(await lintCelPredicate("previous.status == 'x'", RULE_SLOT_HINT)).toEqual([]);
+    expect(await lintCelPredicate('parent.status == "paid"', RULE_SLOT_HINT)).toEqual([]);
+    expect(await lintCelPredicate("record.status == 'x'", RULE_SLOT_HINT)).toEqual([]);
+  });
+
+  it('takes the WIDER verdict on a covered slot: a root no field rule binds is advised too', async () => {
+    // A declared behaviour change, and the substance of adopting the published
+    // verdict: `current_user` is in the engine's baseline `SCOPE_ROOTS`, so
+    // `validateExpression` says nothing about it, while the FIELD level does
+    // not bind it. objectui's one-root detector could never reach this.
+    const issues = await lintCelPredicate('current_user.isAdmin', RULE_SLOT_HINT);
+    const advisory = issues.filter((i) => i.severity === 'warning' && /current_user/.test(i.message));
+    expect(advisory).toHaveLength(1);
+    expect(issues.filter((i) => i.severity === 'error')).toEqual([]);
+  });
+
+  it('stands down on a parse error and on a non-CEL dialect, like the path it replaces', async () => {
+    const broken = await lintCelPredicate('data.status ==', RULE_SLOT_HINT);
+    expect(broken.some((i) => i.severity === 'error')).toBe(true);
+    expect(broken.filter((i) => i.severity === 'warning' && /\bdata\b/.test(i.message))).toEqual([]);
+    const legacy = await lintCelPredicate('${data.status}', RULE_SLOT_HINT);
+    expect(legacy.filter((i) => i.severity === 'warning' && /\bdata\b/.test(i.message))).toEqual([]);
+  });
+});
+
+describe('celAuthoring · the UNCOVERED surfaces keep the local fallback (objectui#9318 part 3)', () => {
+  it('LIVE CONTROL — a formula `expression` still gets objectui\'s message, not the engine\'s', async () => {
+    // `FORMULA_ROOTS` is `['record']` — NARROWER than `FIELD_RULE_BOUND_ROOTS`.
+    // Routing this through the helper would silently stop advising `previous.*`
+    // / `parent.*` on a surface that binds neither.
+    const issues = await lintCelPredicate('data.amount * 0.2', { ...UNSLOTTED_HINT, role: 'value' as const });
+    const advisory = issues.filter((i) => i.severity === 'warning' && OBJECTUI_MESSAGE_MARKER.test(i.message));
+    expect(advisory).toHaveLength(1);
+    expect(issues.filter((i) => i.severity === 'error')).toEqual([]);
+  });
+
+  it('LIVE CONTROL — a conditional-formatting condition is NOT advised for the roots it binds', async () => {
+    // `ROW_PREDICATE_ROOTS` carries `current_user`, `user`, `features`, `os`,
+    // `ctx` — WIDER than `FIELD_RULE_BOUND_ROOTS`. This is the pin that reddens
+    // if someone routes every `scope: 'record'` surface through the helper:
+    // the author would be told to rewrite a predicate that works.
+    expect(await lintCelPredicate('current_user.isAdmin', UNSLOTTED_HINT)).toEqual([]);
+    expect(await lintCelPredicate("os.name == 'x'", UNSLOTTED_HINT)).toEqual([]);
+  });
+
+  it('an unknown slot name falls back rather than guessing', async () => {
+    const issues = await lintCelPredicate('current_user.isAdmin', { ...UNSLOTTED_HINT, slot: 'someFutureWhen' });
+    expect(issues).toEqual([]);
+  });
+});
+
+describe('celAuthoring · platform drift tripwire (objectui#9318)', () => {
+  it('the published bound set is still the one objectui measured its coverage answer against', async () => {
+    // NOT a second copy of the verdict — the verdict is read from the helper at
+    // runtime and this assertion is never consulted by product code. It exists
+    // so that the next root the platform binds or unbinds arrives as a RED test
+    // in objectui, with the instruction to re-derive which of this repo's
+    // surfaces the helper's vocabulary still covers (PR objectui#9318 part 3).
+    expect([...FIELD_RULE_BOUND_ROOTS]).toEqual(['record', 'previous', 'parent']);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/celAuthoring.ts
+++ b/packages/app-shell/src/views/metadata-admin/celAuthoring.ts
@@ -69,6 +69,19 @@ export interface CelSchemaHint {
    */
   roots?: string[];
   /**
+   * The authored KEY this source is the value of — `visibleWhen`,
+   * `readonlyWhen`, `requiredWhen` (objectui#9318). Naming it lets the
+   * wrong-layer advisory take its verdict from `@objectstack/lint`'s published
+   * `fieldRuleRootIssue`, which judges per SLOT, instead of from a second copy
+   * of that judgement maintained here.
+   *
+   * Optional, and an unrecognised value is not an error: a surface that does
+   * not name a slot — or names one the published helper's vocabulary does not
+   * cover — keeps the local fallback. See {@link FIELD_RULE_VERDICT_SLOTS} for
+   * why that is a real set and not a formality.
+   */
+  slot?: string;
+  /**
    * The engine field role of the authoring site (mirrors `FieldRole` minus
    * `template`, which no CEL editor hosts):
    *  - `'predicate'` (default) — bare CEL expected to return bool (RLS
@@ -194,6 +207,65 @@ interface RowCanonModule {
 
 let rowCanonCached: Promise<RowCanonModule | null> | null = null;
 
+/** `@objectstack/lint`'s published per-slot verdict (objectui#9318). */
+type FieldRuleRootIssue = (slot: string, source: string) => { root: string; message: string } | null;
+
+let fieldRuleVerdictCached: Promise<FieldRuleRootIssue | null> | null = null;
+
+/**
+ * Feature-detect `fieldRuleRootIssue` on the installed `@objectstack/lint`.
+ *
+ * The `import()` must stay DYNAMIC for the same reason `securityPostureLint.ts`
+ * keeps its own dynamic — `@objectstack/lint` is the one `@objectstack/*`
+ * package the console's `vendor-objectstack` chunk group does not claim
+ * (objectui#5266), so a static import would pull the whole lint bundle onto the
+ * eager graph. Progressive enhancement, like every other entry point in this
+ * module: a lint package without the export degrades to the local fallback,
+ * never to an exception and never to silence.
+ */
+function loadFieldRuleVerdict(): Promise<FieldRuleRootIssue | null> {
+  if (!fieldRuleVerdictCached) {
+    fieldRuleVerdictCached = import('@objectstack/lint')
+      .then((m) => {
+        const fn = (m as unknown as Record<string, unknown>)?.fieldRuleRootIssue;
+        return typeof fn === 'function' ? (fn as FieldRuleRootIssue) : null;
+      })
+      .catch(() => null);
+  }
+  return fieldRuleVerdictCached;
+}
+
+/**
+ * The authored slots whose bound-root set IS the platform's field-rule set, so
+ * `fieldRuleRootIssue`'s verdict answers THIS surface's question (objectui#9318).
+ *
+ * ⚠️ This is a list of objectui's own surfaces, not a copy of the platform's
+ * judgement — the judgement itself is read from `@objectstack/lint` at call
+ * time. Membership is measured, not assumed: `ObjectFieldInspector` offers
+ * exactly `FIELD_RULE_ROOTS` (`record` / `previous` / `parent`) on these three
+ * editors, which is `FIELD_RULE_BOUND_ROOTS` verbatim.
+ *
+ * ## What is deliberately NOT here, and why the local fallback stays
+ *
+ * The helper's vocabulary does not cover every surface this advisory guards,
+ * and the two it misses differ from the field-rule set in OPPOSITE directions:
+ *
+ *  - a `formula` field's `expression` binds `FORMULA_ROOTS` — `['record']`,
+ *    strictly NARROWER. Taking the field-rule verdict there would stop advising
+ *    `previous.*` / `parent.*` on a surface that binds neither;
+ *  - a conditional-formatting `condition` binds `ROW_PREDICATE_ROOTS` —
+ *    `record`, `current_user`, `user`, `features`, `os`, `ctx`, strictly WIDER.
+ *    Taking the field-rule verdict there would tell an author to rewrite a
+ *    predicate that works.
+ *
+ * So those keep the local instrument. ⛔ Do not extend this list to "tidy up"
+ * the branch below without re-measuring the surface's bound roots first —
+ * narrowing a consumer to fit the API it adopted is the drift objectui#9318
+ * exists to stop, and `celAuthoring.fieldRuleVerdict-9318.test.ts` pins both
+ * uncovered surfaces as live controls against exactly that edit.
+ */
+const FIELD_RULE_VERDICT_SLOTS: readonly string[] = ['visibleWhen', 'readonlyWhen', 'requiredWhen'];
+
 /**
  * Load `@object-ui/core`'s row-spelling detector the same way the engine is
  * loaded: lazily, feature-detected, swallowing every failure. The detector
@@ -267,13 +339,52 @@ function loadRowCanon(): Promise<RowCanonModule | null> {
  * (ADR-0089 D3) is `views/metadata-admin/SchemaForm.tsx`, which evaluates through
  * `views/metadata-admin/predicate.ts` and never reaches this function — which is
  * why the gate below is `scope === 'record'` and not a source pattern.
+ *
+ * ## Where the VERDICT comes from since objectui#9318
+ *
+ * "Is this root bound on this surface?" is a judgement the platform publishes:
+ * `@objectstack/lint` exports `fieldRuleRootIssue` / `FIELD_RULE_BOUND_ROOTS`,
+ * pinned upstream by a test named for rejecting `data` — the LEGAL root of the
+ * same key one layer over. objectui derived the same answer independently, from
+ * `ROW_PREDICATE_ROOTS` / `FIELD_RULE_ROOTS` / `FORMULA_ROOTS` plus the single
+ * root `@object-ui/core`'s detector hard-codes. Two hand-maintained copies of
+ * one judgement: they agree today, and the next root the platform binds or
+ * unbinds moves one and not the other, silently, in the direction objectui#8166
+ * already paid for once.
+ *
+ * So on the slots the published vocabulary covers ({@link FIELD_RULE_VERDICT_SLOTS})
+ * the verdict is ASKED, not re-derived — and the engine's own message ships with
+ * it, because that message is per-root correct where objectui's single sentence
+ * is not: "Re-root the reference on `record`" is right for `data` and actively
+ * wrong for `current_user` or `app`, which are not fields of the record at all.
+ * ⛔ Exactly one message ships per finding; the two are never concatenated.
+ *
+ * Two consequences, both deliberate and both pinned:
+ *
+ *  - the covered slots now advise on EVERY root the field level leaves unbound,
+ *    not only `data` — a widening, and the substance of adopting the published
+ *    verdict. Still `warning`, so no save gate's accept set moves;
+ *  - the surfaces the vocabulary does NOT cover keep this function's own
+ *    reading, unchanged. ⛔ Their coverage is not shrunk to match the helper.
+ *
+ * Severity is the one thing that stays objectui's: `warning`, never `error`.
  */
-function rowCanonAdvisory(finding: {
-  kind: string;
-  identifier: string;
-  canonical: string;
-}): CelLintIssue | null {
-  if (finding.kind !== 'metadata-layer-root') return null;
+async function rowCanonAdvisory(source: string, slot: string | undefined): Promise<CelLintIssue | null> {
+  if (slot !== undefined && FIELD_RULE_VERDICT_SLOTS.includes(slot)) {
+    const fieldRuleRootIssue = await loadFieldRuleVerdict();
+    if (fieldRuleRootIssue) {
+      const issue = fieldRuleRootIssue(slot, source);
+      // `null` = the source does not parse, or every root it reads is bound
+      // here. Both are "nothing to report" upstream and here.
+      return issue ? { severity: 'warning', message: issue.message } : null;
+    }
+    // An older/absent `@objectstack/lint` has no verdict to give. Fall through
+    // to the local instrument rather than going quiet — progressive
+    // enhancement never costs an author a diagnostic they had yesterday.
+  }
+  const canon = await loadRowCanon();
+  const finding = canon?.detectNonCanonicalRowSpelling?.(source, null, true);
+  if (!finding || finding.kind !== 'metadata-layer-root') return null;
   return {
     severity: 'warning',
     message:
@@ -302,8 +413,10 @@ function rowCanonAdvisory(finding: {
  * expression (usually paired with `scope: 'record'`, where a bare field ref IS
  * a hard error — it silently evaluates to null at runtime).
  *
- * At `scope: 'record'` one finding comes from outside the engine: the
- * wrong-layer `data.*` advisory described on {@link rowCanonAdvisory}. It is
+ * At `scope: 'record'` one finding comes from outside `validateExpression`: the
+ * wrong-layer root advisory described on {@link rowCanonAdvisory}, whose verdict
+ * comes from `@objectstack/lint` when {@link CelSchemaHint.slot} names a slot
+ * that helper's vocabulary covers and from the local instrument otherwise. It is
  * always a `warning`, so it never narrows what this surface accepts.
  *
  * Empty input is always clean.
@@ -352,13 +465,12 @@ export async function lintCelPredicate(
         /* advisory only — never let it break the lint */
       }
     }
-    // Wrong-layer `data.*` advisory (objectui#8972) — see `rowCanonAdvisory`.
-    // Only in `record` scope, only once the predicate parses, only a WARNING.
+    // Wrong-layer root advisory (objectui#8972, verdict re-homed by objectui#9318)
+    // — see `rowCanonAdvisory`. Only in `record` scope, only once the predicate
+    // parses, only a WARNING.
     if (issues.every((i) => i.severity !== 'error') && hint.scope === 'record') {
       try {
-        const canon = await loadRowCanon();
-        const finding = canon?.detectNonCanonicalRowSpelling?.(source, null, true);
-        const advisory = finding ? rowCanonAdvisory(finding) : null;
+        const advisory = await rowCanonAdvisory(source, hint.slot);
         if (advisory) issues.push(advisory);
       } catch {
         /* advisory only — never let it break the lint */

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.ts
@@ -810,6 +810,12 @@ async function validateObjectFieldRules(draft: unknown): Promise<SchemaFormIssue
         objectName,
         fields: fieldNames,
         scope: 'record',
+        // Names the authored key so the wrong-layer advisory takes the
+        // platform's published verdict (objectui#9318). Only ERRORS are kept
+        // below, and that advisory is a `warning`, so this changes nothing
+        // this gate reports today — it keeps the two `scope: 'record'` callers
+        // asking the same question of the same authority.
+        slot: key,
       });
       for (const f of findings) {
         if (f.severity !== 'error') continue;

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
@@ -996,6 +996,12 @@ export function ObjectFieldInspector({
             fieldNames={view.entries.map((e) => e.name)}
             scope="record"
             roots={FIELD_RULE_ROOTS}
+            // The authored key, so the wrong-layer advisory reads the
+            // platform's published per-slot verdict (objectui#9318). Sound
+            // here because `FIELD_RULE_ROOTS` above IS that helper's
+            // `FIELD_RULE_BOUND_ROOTS`; the formula editor above deliberately
+            // names no slot, because `FORMULA_ROOTS` is not.
+            slot="visibleWhen"
             t={tr}
           />
           <CelPredicateField
@@ -1010,6 +1016,12 @@ export function ObjectFieldInspector({
             fieldNames={view.entries.map((e) => e.name)}
             scope="record"
             roots={FIELD_RULE_ROOTS}
+            // The authored key, so the wrong-layer advisory reads the
+            // platform's published per-slot verdict (objectui#9318). Sound
+            // here because `FIELD_RULE_ROOTS` above IS that helper's
+            // `FIELD_RULE_BOUND_ROOTS`; the formula editor above deliberately
+            // names no slot, because `FORMULA_ROOTS` is not.
+            slot="readonlyWhen"
             t={tr}
           />
           <CelPredicateField
@@ -1024,6 +1036,12 @@ export function ObjectFieldInspector({
             fieldNames={view.entries.map((e) => e.name)}
             scope="record"
             roots={FIELD_RULE_ROOTS}
+            // The authored key, so the wrong-layer advisory reads the
+            // platform's published per-slot verdict (objectui#9318). Sound
+            // here because `FIELD_RULE_ROOTS` above IS that helper's
+            // `FIELD_RULE_BOUND_ROOTS`; the formula editor above deliberately
+            // names no slot, because `FORMULA_ROOTS` is not.
+            slot="requiredWhen"
             t={tr}
           />
           <p className="text-[11px] text-muted-foreground/80 px-0.5 leading-snug">


### PR DESCRIPTION
Fixes #9440

`rowCanonAdvisory` answered *"is this root bound on this surface?"* from objectui's own
knowledge. `@objectstack/lint` publishes the same judgement. Two hand-maintained copies of
one verdict, agreeing today, with nothing keeping them agreeing.

## Second prose repair — contract review returned `FAIL` again

Contract review [`5659211993`](https://github.com/objectstack-ai/objectui/pull/9366#issuecomment-5659211993)
found **12 of the 16 discharged** and four not: the first repair replaced a false universal with a
**closed six-root enumeration**, which was false by a wider margin than the sentence it replaced.
⛔ The fix is not a better list. It is the original universal **plus the one documented exception**,
with nothing enumerated, so nothing goes stale when the root set moves.

**Re-derived here, through the BUILT dist, over the whole candidate population.**
`FIELD_RULE_JUDGED_ROOTS` and `FIELD_RULE_AMBIENT_ROOTS` are module-private at 17.4.0 (neither is
in `@objectstack/lint`'s export list), so the judged set is reconstructed as
`SCOPE_ROOTS` + the ambient root, read from `@objectstack/formula` — a **declared** dependency of
this package, not a phantom one. `SCOPE_ROOTS` has 27 members; `FIELD_RULE_BOUND_ROOTS` is
`record` / `previous` / `parent`, all three of them in `SCOPE_ROOTS`; so the candidate set
`JUDGED \ BOUND` is **25**. Sweeping all 25 through `lintCelPredicate` at `scope: 'record'` with
`slot: 'visibleWhen'`, classifying each by verbatim equality with `fieldRuleRootIssue`'s own
message: **24 advised · 1 blocked · 0 silent**, and the blocked set is exactly `["app"]`.
Controls on the same instrument: `data.status == 1` ⇒ one `warning` (lit);
`record.status == 1` / `previous.status == 1` / `parent.status == 1` ⇒ `[]` (dark, and the
helper judges none of them); `app.status == 1` ⇒ one **error**, no warning; `zzz.x == 1` ⇒ one
error and `fieldRuleRootIssue` returns `null`, so an unjudged name was never a candidate.

⭐ **The universal is now defended by an instrument rather than by prose.** A new sweep in
`celAuthoring.fieldRuleVerdict-9318.test.ts` re-derives the candidate population on every run and
asserts `silent = []`, `blocked = ['app']`, `advised = candidates − app`; a second test pins
*why* `app` is the exception (`SCOPE_ROOTS` does not contain it, the helper judges it anyway).
⚠️ The reconstruction is a declared limit, written into the test: a NEW ambient root added
upstream would be invisible to the sweep until that literal moves, and nothing in this repo can
see it. **Ablation** — removing the error gate
(`if (issues.every((i) => i.severity !== 'error') && hint.scope === 'record')` ⇒
`if (hint.scope === 'record')`, proved on disk: anchor 1→0, mutant 0→1, blob
`0120d42aba`→`91c736bc96`) reddens **exactly those two tests**
(`Tests 2 failed | 10 passed (12)`) with `expected [] to deeply equal [ 'app' ]` — the exception
itself disappearing, which is the predicted direction. Restored by hash equality to the `HEAD`
blob `0120d42aba` with `git diff HEAD` empty, under `trap … EXIT INT TERM`.

**Carriers, before → after, censused on the STORED artifacts** (the built
`dist/views/metadata-admin/celAuthoring.js`, not the source; `perl -0777` occurrence counts):
the six-root list **1→0**, `For the five further` **1→0**, `five by hand` **1→0**,
`` `current_user` text ends `` **1→0**; the replacements **0→1** each. In the changeset body:
the six-root list **1→0** and `the slots the published vocabulary covers` **1→0**, replacements
**0→1**. Lit controls unmoved — `ROW_PREDICATE_ROOTS` **3→3** in the dist and **2→2** in the
changeset, `METADATA_LAYER_ROOT` **1→1** in the dist; dark controls `strictly BROADER` and
`zzzNotPresentZZZ` **0→0** in both. ⚠️ Escaping was checked rather than assumed before those
counts were trusted: the emitted comments carry `` `record` `` **unescaped** (10 occurrences,
backslash-escaped form 0), so an unescaped needle is the right instrument for this artifact.

⛔ Three statements the review confirmed TRUE are deliberately untouched: `ROW_PREDICATE_ROOTS`
is a six-entry local constant and "five roots the field tier does not bind" is correct for it —
that is a different claim from the advised set, and it is not repaired into a universal.

## Prose repair — contract review returned `FAIL` (first round)

Contract review [`5658789972`](https://github.com/objectstack-ai/objectui/pull/9366#issuecomment-5658789972)
swept 60 claims across this PR's shipped comments, its changeset body and this description, and
found **16 false**. ⭐ The bounding is load-bearing: `@object-ui/app-shell` builds with `tsc`
(`"build": "tsc && node ../../scripts/check-dist-completeness.mjs"`), and **nothing in its config
chain sets `removeComments`** — `packages/app-shell/tsconfig.json` extends `../../tsconfig.json`,
which has no `extends` key and no `removeComments` — so tsc's own default (`false`) stands and
comments reach the emit. ⚠️ An earlier draft of this line cited `tsconfig.base.json:22` for that.
Measured: `tsconfig.base.json` is extended only by `tsconfig.node.json`, `tsconfig.scripts.json`,
`tsconfig.react.json` and `examples/byo-backend-console/tsconfig.json` — **never by app-shell**.
Right conclusion, wrong instrument; the instrument is corrected here and the conclusion is
additionally confirmed by reading the emitted bytes. `files` ships `dist/**` and `CHANGELOG.md`,
so the comments under repair are **published artifacts**, not notes.

⛔ **The mechanism is unchanged.** The repair commit moves comments, the changeset body and the
test narration only; the red-first block below still reproduces and the pins still pass. Three
of the sixteen were load-bearing rather than decorative:

- **the stated reason for taking the engine's message** (see *What changed*) was false on both
  roots it named. Because it was the justification for a behavioural choice, the question
  underneath it was re-asked rather than the sentence reworded — the swap stands, for measured
  reasons, and the old one is withdrawn in place;
- **the two arguments for keeping the local fallback on uncovered surfaces** (see *Part 3*) —
  the answer survives, both arguments were false, and the real asymmetry is written in their
  place;
- **the CI section** named two green checks and missed the one real red.

Re-read after writing, from the **built** `dist` (⛔ not the source):
`packages/app-shell/dist/views/metadata-admin/celAuthoring.js`, `perl -0777` occurrence census,
before → after — `strictly WIDER` 1→0, `strictly NARROWER` 1→0, `stop advising` 1→0,
`EVERY root the field level leaves unbound` 1→0; the four replacement anchors 0→1 each. Lit
control `ROW_PREDICATE_ROOTS` **3 before and 3 after** (same file, same census, varying only
the claim); dark control `strictly BROADER` **0 both**, so the zeros are absence and not a
broken read.

## Re-measurement — both sides, at implementation time

The card instructs that the re-measurement wins over the card. Both sets of line numbers
moved; **the exported shape did not**, so the substance survives intact.

| reading | card (`9c44eed4` / `d7f0601`) | measured now |
|---|---|---|
| objectui refs to `fieldRuleRootIssue` / `FIELD_RULE_BOUND_ROOTS` under `packages/` | 0 | **0 at `2e471dc0a`** (`git grep` exit 1; control `rowCanonAdvisory` exit 0, 4 hits) — ⚠️ no longer 0 at this PR's head, see the note under this table |
| `rowCanonAdvisory` | `celAuthoring.ts:184-283` | `celAuthoring.ts:271` on objectui `origin/main` `2e471dc0a` |
| `FIELD_RULE_BOUND_ROOTS` export | `validate-expressions.ts:688` | **`:688`** on objectstack `origin/main` `2b6a207` |
| `fieldRuleRootIssue` export | `validate-expressions.ts:790` | **`:790`** on objectstack `origin/main` `2b6a207` |
| what objectui actually consumes | — | `@objectstack/lint@17.4.0`, installed; both symbols on the package root entry |

⚠️ **That zero is scoped to `2e471dc0a`, and is false if read as a statement about this
PR's head.** Re-measured on the head tree, `git grep -c FIELD_RULE_BOUND_ROOTS -- packages/`
exits **0** and prints four files. Three are this PR's own. The fourth is **not** —
`packages/react/src/SchemaRenderer.tsx:844`, a comment that was already on `main` at this
PR's merge-base (`dfb585059`, where that grep exits 0 with exactly that one file) and that
arrived here through this PR's merge of `main`. Drift in the reading, not a fabrication, and
nothing about the seam it was measuring has moved: the four files hold no *call* of either
symbol outside `celAuthoring.ts`.

One correction to the dispatch note, offered as a reading and not a complaint: the `:680` /
`:782` figures are the sibling checkout's local `HEAD` (`86c5052`, an ancestor of
`origin/main`), not `origin/main` itself. Against `origin/main` the card's own `:688` /
`:790` still hold. Either way the line numbers are informational — what this PR consumes is
the published `dist` of `@objectstack/lint@17.4.0`, where the declared shape reads
`FIELD_RULE_BOUND_ROOTS: readonly ["record", "previous", "parent"]` and
`fieldRuleRootIssue(slot: string, source: string)`.

## Part 3 — the helper has NO slot vocabulary, so coverage is objectui's call, and the fallback stays

This is the part the card most wants answered, so it is answered first and explicitly.

`fieldRuleRootIssue` judges against `FIELD_RULE_BOUND_ROOTS` — the FIELD-RULE tier,
`record` / `previous` / `parent`. The surfaces `rowCanonAdvisory` guards are everything that
reaches `lintCelPredicate` at `scope: 'record'`. Measured, they do not share one bound set:

| surface | slot | roots objectui binds | helper's verdict applies? |
|---|---|---|---|
| field inspector `visibleWhen` / `readonlyWhen` / `requiredWhen` | the three `*When` keys | `FIELD_RULE_ROOTS` = `record`, `previous`, `parent` | **yes** — identical set |
| draft gate `validateObjectFieldRules` | the same three keys | same | **yes** |
| field inspector `formula` expression | `expression`, role `value` | `FORMULA_ROOTS` = `record` | **no** — strictly NARROWER |
| conditional-formatting `condition` | `condition` | `ROW_PREDICATE_ROOTS` = `record`, `current_user`, `user`, `features`, `os`, `ctx` | **no** — five roots the field tier does not bind, but **not a superset**: no `previous`, no `parent` |

⚠️ Neither set is *comparable* to the field-rule set — `FORMULA_ROOTS` is a proper subset of
it, and `ROW_PREDICATE_ROOTS` is not a superset, since it lacks `previous` and `parent`. The
two overlap on `record` alone. And `fieldRuleRootIssue` has **no slot vocabulary of its own**:
hand it any string and it judges against `FIELD_RULE_BOUND_ROOTS` and interpolates the name
into its message (measured on 17.4.0 — `('expression', 'current_user.x')` and
`('condition', 'current_user.x')` each return a finding, not `null`). The helper never
declines a surface, so `FIELD_RULE_VERDICT_SLOTS` is objectui's own load-bearing answer, not a
formality.

What routing the two uncovered surfaces through it would actually cost — measured, and wrong
in **opposite** directions:

- a **conditional-formatting condition** would be advised on `current_user`, `user`,
  `features`, `os` and `ctx` — five roots it binds. A false **red**: the author is told to
  rewrite a predicate that works there;
- a **formula** `expression` would get `previous.*` / `parent.*` back **clean**, because the
  helper reports them bound at the field tier, where a formula binds only `record`. A false
  **green** — and the message it does print for other roots names `previous` and `parent` as
  available here, which on this surface is wrong prose as well as a wrong verdict.

⛔ **Neither is a coverage shrink**, and the earlier draft of this section said it was.
Measured on the head tree, both surfaces report nothing at all for `previous.*` / `parent.*`
today (`lintCelPredicate("previous.status == 'x'", { scope: 'record', role: 'value' })` ⇒ `[]`,
`parent` likewise), and `@object-ui/core`'s `METADATA_LAYER_ROOT` is `'data'` — the only root
objectui has ever advised on any surface. So nothing that is advised now would stop being
advised. The hazard is the wrong-direction verdict above, not a lost one.

So those two keep the local instrument, byte-for-byte as it behaves today, and each is pinned
as a live control that reddens if a later tidy-up routes them through the helper anyway.
Ablation leg B1 below performs that exact tidy-up and shows both controls going red.

`PermissionAdvancedFacets` (RLS `USING` / `CHECK`) and `ConditionBuilder` default to
`scope: 'flattened'` and were never guarded by this advisory at all.

## What changed

`CelSchemaHint.slot` (and the matching `CelPredicateField` prop) names the authored key. On a
covered slot the verdict **and** the message are the helper's; everywhere else the local path
runs unchanged. Exactly one message ships per finding — never both.

**Why the engine's message and not objectui's.** ⚠️ An earlier draft of this section said
*"the engine's message refuses that rewrite by name"*, of `current_user` **and** `app`. That
is false on both, and it was this PR's stated reason for a behavioural choice, so it is
withdrawn rather than reworded. Measured against the installed `@objectstack/lint@17.4.0`:

- for `current_user` the engine's message **prescribes** the rewrite it was said to refuse —
  it **contains** *"To gate on record state, rewrite the predicate against `record`."*, one of
  three remedies it offers (the others being an option-level `visibleWhen` and field-level
  security). ⚠️ It does **not end** there, as an earlier draft of this line claimed: measured
  against 17.4.0, `includes(…)` is **true** and `endsWith(…)` is **false** — every covered
  slot's text closes on *"it is not a fourth answer."*;
- for `app` the engine's message **does** refuse by name (*"⛔ Do NOT write `record.app`"*) —
  and it is **unreachable from this diff**. `lintCelPredicate('app.theme == "dark"',
  { slot: 'visibleWhen', scope: 'record' })` returns exactly one issue, a pre-existing
  **error** (*"bare reference `app` … Write `record.app`."*), and the advisory is gated behind
  `issues.every((i) => i.severity !== 'error')`, so the helper is never called.

**The swap still stands, on reasons that survive measurement.** The verdict widens, and
objectui has no message for most of what it now judges. Its local instrument produces a
sentence for exactly **one** root — `@object-ui/core`'s `METADATA_LAYER_ROOT`, `data`. For
every **other** root a covered slot now reports there is no objectui sentence to keep; keeping
"objectui's message" there would mean hand-writing one per root, which is precisely the second
hand-maintained copy this card exists to delete — and they would have to be per-root, since the
engine's texts for `data`, the user-root family, the platform-wide family and the ambient family
are four different remedies, not one sentence with the root substituted. ⛔ That population is
deliberately **not** written down here — an earlier draft of this paragraph said "five further
roots", which was false — because it moves whenever the platform moves `FIELD_RULE_JUDGED_ROOTS`
or `FIELD_RULE_BOUND_ROOTS`. The sweep named above re-derives it on every run instead.

The one message genuinely **swapped** is `data`'s, and objectui's tail there
— *"Re-root the reference on `record`"* — is the half that does not generalise: right for
`data`, wrong for `current_user`, which is not a field of the record. Reading a verdict from
one authority and explaining it from another drifts the same way two verdicts do.

⛔ This changes nothing the diff **does**; it replaces the reason given for what it already
did.

**Declared behaviour change.** Those three editors now advise on **every root the field level
leaves unbound — except `app`**. ⛔ No enumeration, and that is the point: any list goes stale
the next time the platform moves a root, and two earlier drafts of this line were false in turn —
first "every unbound root" with no exception at all, then a closed six-root list that named a
fraction of the population and omitted the rest. The exception is a **mechanism**, not a special
case: the advisory runs only once the predicate is error-free
(`issues.every((i) => i.severity !== 'error')`), and `app` is the single judged root the platform
does not **declare** (`FIELD_RULE_JUDGED_ROOTS` is `SCOPE_ROOTS` plus the ambient `app`), so for
`app` alone the pre-existing bare-reference error fires first and the advisory never runs — even
though the helper judges it and carries a bespoke message for it. A name the helper does not judge
at all is stopped by that same error and was never a candidate. Severity
stays objectui's own `warning`: every save gate on this tier counts `severity === 'error'`, so
no accept set moves and nothing already stored in customer metadata is refused. The
`data.status == 'x'` case still reports at `warning`, never `error`.

Progressive enhancement is preserved throughout — the `import()` stays dynamic (a static one
would pull the lint bundle onto the eager console graph, objectui#5266), the export is
feature-detected, and a lint package without it falls through to the local instrument rather
than going quiet.

## Not reopened

The three fences the card sets are untouched: objectui already warns on wrong-layer `data.*`
and still does; the advisory stays `warning` and is never promoted; the bare-shorthand arm
stays disabled (`row = null`) on the fallback path, and the helper path has no such arm at all.

## Red-first, verbatim

The pin was written and run on the unmodified tree first:

```
 ❯ |unit| packages/app-shell/src/views/metadata-admin/celAuthoring.fieldRuleVerdict-9318.test.ts (10 tests | 3 failed)
     × TRUE POSITIVE — a covered slot takes BOTH the verdict and the message from `fieldRuleRootIssue`
     × ships ONE message, never both — objectui's sentence is gone from the covered path
     × takes the WIDER verdict on a covered slot: a root no field rule binds is advised too

AssertionError: expected [] to have a length of 1 but got +0
AssertionError: expected [ { severity: 'warning', …(1) } ] to deeply equal []
AssertionError: expected [] to have a length of 1 but got +0

 Test Files  1 failed (1)
      Tests  3 failed | 7 passed (10)
```

## Ablation — three legs, all falsifiable, no null results

Every leg mutates on disk, proves the mutation reached disk **before** any result is read, and
restores by hash equality, never by an exit code. All ran under `trap ... EXIT INT TERM`.

**Leg A — does the verdict really come from the published constant?** Mutated the installed
`@objectstack/lint@17.4.0` `dist/index.js` to drop `parent` from `FIELD_RULE_BOUND_ROOTS`.

```
PRISTINE_SHA=fef9fda4382de0c9e60582fca1b5b594eeebea16e27eee622ebdcc7f71d7c069
BEFORE orig_count=1 mut_count=0
AFTER  orig_count=0 mut_count=1
MUT_SHA=c488ed51ac8957cccf926137b892947326015059bb83647629322541acda91f7
MUTATED_VITEST_EXIT=1
RESTORED_SHA=fef9fda4382de0c9e60582fca1b5b594eeebea16e27eee622ebdcc7f71d7c069
RESTORE_PROVEN orig_count=1 mut_count=0
RESTORED_VITEST_EXIT=0
```

The reading: `parent.status == "paid"` at `visibleWhen` is immediately advised, carrying the
engine's own message (*"`visibleWhen` reads `parent`, but a field-level conditional rule binds
only `record` …"*). That is the card's required demonstration — a root the platform DOES bind
comes back clean **through the new path**, and stops being clean the moment the platform stops
binding it. The file is not git-tracked, so the restore proof is sha256 equality against the
pristine snapshot plus the anchor counts, and `git status` on the worktree is empty.

**Leg B1 — can the part-3 live controls fail?** Replaced the slot condition with an
unconditional one, i.e. performed the exact tidy-up the card warns against.

```
HEAD_BLOB=220980448c9ab1f63598067d7d1c70e1db3b87d1
B1 BEFORE anchor=1 mutant=0
B1 AFTER  anchor=0 mutant=1 blob=e95e8a8882e749743f697cc915198fbacd5ffc49
B1 MUTATED_VITEST_EXIT=1
     × LIVE CONTROL — a formula `expression` still gets objectui's message, not the engine's
     × LIVE CONTROL — a conditional-formatting condition is NOT advised for the roots it binds
     × an unknown slot name falls back rather than guessing
B1 RESTORED_BLOB=220980448c9ab1f63598067d7d1c70e1db3b87d1
B1 RESTORE_PROVEN: git diff HEAD empty
```

**Leg B2 — is the helper path actually reached?** Emptied the covered-slot list.

```
B2 BEFORE anchor=1 mutant=0
B2 AFTER  anchor=0 mutant=1 blob=59fc8a89995ec849e65a81a2849195495b2e0afd
B2 MUTATED_VITEST_EXIT=1
     × TRUE POSITIVE — a covered slot takes BOTH the verdict and the message
     × ships ONE message, never both
     × takes the WIDER verdict on a covered slot
B2 RESTORED_BLOB=220980448c9ab1f63598067d7d1c70e1db3b87d1
B2 RESTORE_PROVEN: git diff HEAD empty
```

No leg was a null result. All three could fail and all three did.

## Verification

Acceptance grep: `git grep -c fieldRuleRootIssue packages/app-shell/src` exits 0 with **two**
lines — `…/celAuthoring.fieldRuleVerdict-9318.test.ts:4` and `…/celAuthoring.ts:9`. Both are
non-zero; an earlier draft transcribed only the second, and read `:8` — correct then, stale now,
because this repair added one more mention of the symbol to that file's docblock.

objectui#8972's five pins are green **and byte-unchanged**: the pin file's blob hash equals its
`origin/main` blob (`dbfc2108221cf22955927ac565804abdc3b4a1ed` both sides), and
`celAuthoring.test.ts` reports `Tests 39 passed (39)`.

Heavy runs went through the shared verify lock on slot `os-dev-objectui-9318`:

```
os-verify-lock: VERDICT batch-last-exit 0 · held 247s        # pnpm build (BUILD_EXIT=0)
                Tasks: 43 successful, 43 total
os-verify-lock: VERDICT command-exit 0 · held 1134s · waited 345s
                type-check=0        Tasks: 81 successful, 81 total
                app-shell-vitest=0  Test Files 693 passed (693) · Tests 6753 passed | 1 skipped
```

The one skip is pre-existing; no test was skipped, quarantined or loosened by this change.

⚠️ **Those heavy figures are the implementation run, at the tree before the prose repair** —
they are not re-derived at the current head and should be read as such. Re-run after the
repair commit, through the same shared lock (slot `os-dev-objectui-9440`), all with the lock's
own `VERDICT` line as the verdict rather than a bare `$?`:

```
turbo run build --filter=@object-ui/app-shell --concurrency=2
    VERDICT command-exit 0    Tasks: 29 successful, 29 total
pnpm --filter @object-ui/app-shell run type-check      # tsc --noEmit && tsc -p tsconfig.test.json
    VERDICT command-exit 0
pnpm exec vitest run …/celAuthoring.fieldRuleVerdict-9318.test.ts …/celAuthoring.test.ts --reporter=verbose
    VERDICT command-exit 0    Test Files 2 passed (2) · Tests 49 passed (49)
    `apps/console` occurs 0 times in the verbose log, which names both files itself
```

Gates re-run on the repaired tree, each exit code captured before any pipe:
`check:control-bytes` 0, `check:changeset-claims` 0, `check:new-line-citations` 0,
`check:test-path-roots` 0, `check:shell-escape-residue` 0, `check:comment-mask-corpus` 0,
`check-changeset-presence.mjs` 0 (*"5 source file(s) of 1 released package(s) changed, and this
change declares 1 changeset(s)"*), `check-changeset-no-major.mjs` 0.

**Red-first still reproduces on the repaired tree.** The four product files reverted to the
merge-base, the mutation proved on disk first (`FIELD_RULE_VERDICT_SLOTS` occurrences 5 → 0 in
`celAuthoring.ts`) and restored under `trap … EXIT INT TERM` by blob-hash equality against
`HEAD`, never by an exit code:

```
MUTATION_ON_DISK anchor 5 -> 0
    × TRUE POSITIVE — a covered slot takes BOTH the verdict and the message from `fieldRuleRootIssue`
    × ships ONE message, never both — objectui's sentence is gone from the covered path
    × takes the WIDER verdict on a covered slot: a root no field rule binds is advised too
 Test Files  1 failed (1)
      Tests  3 failed | 7 passed (10)
RESTORE  86a5199ad7… celAuthoring.ts · 0e6247b57f… CelPredicateField.tsx
         39e9975e70… clientValidation.ts · 448e1e8711… ObjectFieldInspector.tsx   (all OK)
         git diff HEAD: EMPTY
```

Gate family, derived by hand from `package.json` plus `.github/workflows/` (this repo has no
dispatch-gates deriver), all exit 0: `check:control-bytes`, `check:designer-field-key-parity`,
`check:i18n-keys`, `check:phantom-deps`, `check:unreferenced-sources`, `check:test-path-roots`,
`check:new-line-citations`, `check:changeset-claims`, `check:eager-closure`,
`check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:vi-mock-override-shape`,
`check:self-import`, `check-changeset-presence.mjs`, `check-governed-queue-guard.mjs --test`
(NOT GOVERNED, 6 paths against 5 surfaces).

Lint was run over the whole tree rather than narrowed: `pnpm exec eslint . --format json` over
the population eslint's own config selects — **4920 files, 0 errors**, 12879 pre-existing
warnings. The five touched files carry 0 errors; their 12 warnings are pre-existing
`no-explicit-any` and `set-state-in-effect` sites this change neither adds to nor moves.

**Dependent-set membership read, done here rather than inherited.** Three different lists in
this repo share the word "exclude" and are NOT the same set:

- `.changeset/config.json` `ignore` = `@object-ui/example-*`, `@object-ui/site`,
  `@object-ui/test-support` — excluded from **version bumping** only;
- the **type-check dependent set** of `@object-ui/app-shell` = `@object-ui/console`,
  `@object-ui/example-byo-backend-console`, `@object-ui/example-console-starter` — measured by
  reading every workspace manifest for a dependency edge on `@object-ui/app-shell`;
- the root build's `--filter=!@object-ui/site`.

`@object-ui/site` sits in the first and the third and has **no** dependency edge on
`app-shell`, so it is not in the second at all; the genuine overlap between the first two is
`@object-ui/example-*`. `pnpm type-check` was run in full, so all three dependents are covered
regardless. `@object-ui/app-shell` is in the single `fixed` group of 40, so a changeset is
required and one is included (`minor`). ⚠️ `major` is not withheld "by group size", as an
earlier draft said: `scripts/check-changeset-no-major.mjs` refuses `major` for **every**
package in this repo irrespective of group, because objectui's major is pinned to
`@objectstack`'s — and it **is** available, under `OBJECTUI_ALLOW_MAJOR=1`, for the one
synchronized release that follows objectstack across ITS major.

## Clause-② — still `no`, verified rather than assumed

No exported signature of `@object-ui/app-shell` moves. `CelSchemaHint`, `CelPredicateField`,
`celAuthoring`, `rowCanonAdvisory` and `FIELD_RULE_VERDICT_SLOTS` each appear **0** times in
the built `packages/app-shell/dist/index.d.ts`, against a lit control (`MetadataResourceRouter`,
1 hit) proving the grep and the file, plus a dark control (`MetadataResourceRouterZZZ`, 0)
proving the same grep can return zero honestly. The package's `exports` map has **two**
entries — `"."` and `"./styles.css"` — not one, as an earlier draft said; the substance is
unchanged, since neither admits an importable subpath for these symbols. Nothing for me to
hang, and I have hung nothing.

## CI — named instrument, not a frozen tally

⛔ An earlier draft of this section said `main` carried two red checks, **Doc Snippet Type
Check** and **Skill Example Check**, inherited by every PR. Both halves are false. Re-derived
from `GET /repos/objectstack-ai/objectui/commits/{sha}/check-runs` (⛔ not
`actions/runs?head_sha=`):

| sha | what it is | runs | non-success |
|---|---|---|---|
| `90b0bf7162` | the head that draft described | 36 | **1** — `Bundle Analysis` |
| `dfb585059` | this PR's merge-base (from `git merge-base`, not `base.sha`) | 51 | none |
| `7ca6ddd4b5` | `main` tip, read 2026-09-14T03:40Z | 59 | none completed |

`Doc Snippet Type Check` and `Skill Example Check` read `success` at **all three**. They were
never red here, and the paragraph naming them is deleted rather than corrected.

**The one real red is `Bundle Analysis`** — job `103733469427` at `90b0bf7162`, the
`ui-components` per-chunk headroom: `387.8 KB measured / 389.6 KB ceiling (headroom 1.9 KB =
0.02x the 89.0 KB regression, under the 0.10x floor …)`. The gate states its own reading:

> This row's headroom is a standing debt that predates this change, and it moves under traffic
> that has nothing to do with the chunk … So this verdict is NOT an accusation that your diff
> spent the bytes … ⛔ There is therefore nothing here for this pull request to "fix", and the
> two edits that would turn this green are both forbidden: ⛔ never raise the ceiling, and ⛔
> never raise the allowance. Paying the row down is the open decision on the chunk … take it
> there, and **say on this pull request that you did**.

**Saying it here, as the gate asks:** the `ui-components` row is being paid down on
objectui#9251 / PR objectui#9399 (both reachable). It is not this PR's to fix, this diff does
not touch that chunk, and ⛔ neither the ceiling nor the allowance is touched here. In the same
run the entry chunk (`144.3 KB / 350 KB`), the aggregate closure (`3106.2 / 3134.8 KB`) and
ceiling freshness all pass.

⛔ The table above is a reading **at named shas**, not a live tally — this PR has been pushed
to since. Re-derive at the current head rather than trusting these counts.

## Acceptance notes

Noted while reading, deliberately **not** filed and **not** repaired here:

- `clientValidation.validateObjectFieldRules` keeps only `severity === 'error'`, so the
  advisory it now asks for is discarded the moment it is produced. That is correct for a draft
  gate and is stated in its own docblock; the slot is wired there anyway so the two
  `scope: 'record'` callers ask the same authority the same question. An observation, not a
  defect — nothing is wrong today and no reader is misled.
- ⭐ **Upstream, surfaced by this repair and deliberately not acted on here.** For `app` at a
  covered slot the author is told *"bare reference `app` … **Write `record.app`**"* by
  `@objectstack/formula`'s bare-reference check, while `@objectstack/lint`'s own message for
  the same root says *"⛔ **Do NOT write `record.app`**: `app` is not a field on this object, so
  that spelling only trades this diagnostic for an `unknown field` error on `app`."* The two
  published diagnostics contradict each other, and the error wins because it fires first. That
  is upstream of this repo and pre-existing — this diff neither creates nor worsens it, and
  ⛔ widening objectui's local path to paper over it is exactly the consumer-side workaround
  this card exists to stop. Recorded here for the seat; no card filed from this repair order.
- `FIELD_RULE_SLOT_CONSEQUENCE`'s slot vocabulary is module-private upstream, so a consumer
  cannot ask `@objectstack/lint` which slots it covers and must state its own answer, as this
  PR does in `FIELD_RULE_VERDICT_SLOTS`. A drift tripwire pins the bound set so the next
  platform move arrives as a red test here rather than as silence. Worth an upstream export
  one day; nothing is broken, so no card. Carrier for that observation: none — no queued PR or
  seat is touching that file.

Session: `https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ`

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_

---
_Generated by [Claude Code](https://claude.ai/code)_