### PR TITLE
fix(charts): retire the Tremor dialect at ChartRenderer, keep the declared `categories`

### DIFF
--- a/.changeset/8650-chart-foreign-dialect-retired.md
+++ b/.changeset/8650-chart-foreign-dialect-retired.md
@@ -35,9 +35,13 @@ share one verdict:
 **Migration.** Write the canonical spellings, which every producer in the
 measured corpora already writes: `xAxisKey` (or the spec's `xAxis: { field }`)
 for the category axis, and `series` (or `categories`) for the plotted columns.
-A chart that still writes `index` / `category` binds no category axis and hits
-`AdvancedChartImpl`'s existing on-screen refusal rather than drawing a wrong
-picture; one that still writes `value` plots nothing.
+A chart that still writes `index` / `category` binds no category axis, so
+`AdvancedChartImpl` falls back to its default category key, `name`. What that
+degrades to depends on the rows, and only one half of it is a refusal: rows
+carrying no `name` column hit its existing on-screen `missing-category-key`
+refusal, while rows that DO carry one plot silently against `name` instead of
+the column the author named — a wrong picture rather than a refusal. One that
+still writes `value` plots nothing.
 
 Also deletes six `(schema as any)` casts that the published declarations had
 already made unnecessary — `colors`, `categoryColors` and `categoryOrder` on

--- a/.changeset/8650-chart-foreign-dialect-retired.md
+++ b/.changeset/8650-chart-foreign-dialect-retired.md
@@ -1,0 +1,47 @@
+---
+'@object-ui/plugin-charts': minor
+---
+
+Retire the "Tremor/simple format" adapter in `ChartRenderer` — the `index`,
+`category` and `value` reads (objectui#8650, triage ruling `5619609278` on
+AGENTS.md #0.1: route to the producer, ⛔ not a declaration).
+
+**Breaking, deliberately, for three keys — and NOT for the fourth.** The card
+filed four undeclared reads as one group. A cast-aware read census plus a
+TypeScript-checker declaredness reading measured them apart, and they do not
+share one verdict:
+
+- `index` / `category` (they aliased the category axis) and `value` (it became
+  a single series) are **retired**. They are declared on no published face —
+  not `ChartSchema`, not its zod mirror, not `ChartRendererProps.schema` — are
+  advertised by no registry `inputs`, and are taught by no doc, guide or skill.
+  A structural producer census over `packages/`, `apps/`, `examples/`,
+  `content/docs/` and the skills corpus (5695 files, 74 chart nodes) found
+  **zero** nodes writing `category` or `value` and **one** writing `index` —
+  this repo's own test for the adapter. The zero is read against controls that
+  fire in the same population (`xAxisKey` 41 nodes, `series` 44, `chartType`
+  40, `data` 52) and a nonsense key that returns 0.
+- `categories` is **not retired and is unaffected**. It is a declared member of
+  the published `ChartSchema` and of its zod mirror, is documented in the
+  schema reference as an alternative series list, and was ruled live by
+  objectui#6896. `normalizeChartSchema` — the single translation point
+  (objectui#2880 S1) — already consumed it, so `ChartRenderer`'s own branch was
+  a second, un-normalized read that no well-formed chart could reach. Removing
+  it changes nothing for a well-formed chart and removes two wrong answers for
+  a malformed one: `categories: 'revenue'` reached `.map` on a string and threw
+  during render, and a `categories` whose entries the normalizer rejects
+  produced a `[{ dataKey: '' }]` series.
+
+**Migration.** Write the canonical spellings, which every producer in the
+measured corpora already writes: `xAxisKey` (or the spec's `xAxis: { field }`)
+for the category axis, and `series` (or `categories`) for the plotted columns.
+A chart that still writes `index` / `category` binds no category axis and hits
+`AdvancedChartImpl`'s existing on-screen refusal rather than drawing a wrong
+picture; one that still writes `value` plots nothing.
+
+Also deletes six `(schema as any)` casts that the published declarations had
+already made unnecessary — `colors`, `categoryColors` and `categoryOrder` on
+`ChartRenderer`, and `colors`, `compareTo` and `series` on `ObjectChart` (the
+objectui#8327 bucket-(b) class: declared, then read through a needless cast).
+No behaviour changes with them; `ObjectChart.tsx` now has no `(schema as any)`
+read left at all.

--- a/packages/plugin-charts/src/ChartRenderer.foreignDialectRetired-8650.test.tsx
+++ b/packages/plugin-charts/src/ChartRenderer.foreignDialectRetired-8650.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#8650 — the "Tremor/simple format" adapter inside `ChartRenderer` is
+ * retired, and the four keys it read do NOT share one verdict.
+ *
+ * ## What was measured, and why the four split
+ *
+ * The card filed this as one group of four undeclared reads. A cast-aware read
+ * census (`schemaReads`, objectui#6576) plus a TypeScript-checker declaredness
+ * reading (`getPropertyOfType`, never a grep — objectui#8410) measured them
+ * apart:
+ *
+ *   - `categories` is a DECLARED member of the published `ChartSchema` and of
+ *     its zod mirror, is documented in the schema reference as an alternative
+ *     series list, and was ruled LIVE by objectui#6896. It was never a foreign
+ *     spelling. `normalizeChartSchema` — the ONE translation point
+ *     (objectui#2880 S1) — already consumed it, so `ChartRenderer`'s own branch
+ *     was a SECOND, un-normalized read of a key the normalizer owns and could
+ *     not be reached by any well-formed chart. ⇒ the branch goes, the
+ *     capability stays. The cases below pin that it still plots.
+ *   - `index`, `category` and `value` are declared on NO published face, are
+ *     advertised by no registry `inputs`, are taught by no doc or skill, and a
+ *     structural producer census over this repo found ZERO nodes writing them.
+ *     ⇒ retired, per AGENTS.md #0.1 (the remedy belongs at the producer, and
+ *     there is no producer).
+ *
+ * ## The failure mode the retirement degrades to — measured, not assumed
+ *
+ * Dropping the axis aliases does not produce a silently wrong picture:
+ * `AdvancedChartImpl` REFUSES a chart whose category axis binds to no column
+ * and says so on screen (objectui#8168's family). The refusal is what these
+ * cases observe structurally — no plot surface — rather than by its wording,
+ * which no consumer parses.
+ *
+ * ⭐ Every refusal below is read against the CANONICAL control in the same
+ * file: the same data and the same chart, written with `xAxisKey` / `series`,
+ * must plot. Without it a renderer that had stopped drawing anything at all
+ * would satisfy every negative case here.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+
+// Recharts' ResponsiveContainer measures via ResizeObserver, which reports 0×0
+// under the headless DOM, so nothing paints. Fix its size.
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: 480, height: 320 }),
+  };
+});
+
+import { ChartRenderer } from './ChartRenderer';
+// `ChartRenderer` lazy-loads its implementation; import it eagerly with the
+// SAME specifier so the dynamic import's cost lands in the import phase rather
+// than inside `waitFor`'s budget (the reasoning is spelled out in
+// `ChartRenderer.specSeries.test.tsx`).
+import './AdvancedChartImpl';
+
+afterEach(cleanup);
+
+const DATA = [
+  { month: 'Jan', revenue: 120, margin: 40 },
+  { month: 'Feb', revenue: 80, margin: 90 },
+];
+
+const marks = (c: HTMLElement) => ({
+  bars: c.querySelectorAll('.recharts-bar').length,
+  lines: c.querySelectorAll('.recharts-line').length,
+});
+
+/** Waits for the real plot past the lazy boundary, then counts the marks. */
+const plotted = async (c: HTMLElement) => {
+  await waitFor(() => expect(c.querySelector('.recharts-surface')).toBeTruthy());
+  return marks(c);
+};
+
+/** The negative reading: give the lazy chunk the same chance, then assert it never plotted. */
+const neverPlots = async (c: HTMLElement) => {
+  await new Promise((r) => setTimeout(r, 150));
+  return c.querySelector('.recharts-surface') === null;
+};
+
+const renderChart = (schema: Record<string, unknown>) =>
+  render(<ChartRenderer schema={schema as any} />).container;
+
+describe('objectui#8650 — the canonical spellings still plot (the control)', () => {
+  it('plots `xAxisKey` + `series` — every refusal below is read against this', async () => {
+    const container = renderChart({
+      type: 'chart',
+      chartType: 'bar',
+      data: DATA,
+      xAxisKey: 'month',
+      series: [{ dataKey: 'revenue' }, { dataKey: 'margin' }],
+      isAnimationActive: false,
+    });
+    expect(await plotted(container)).toEqual({ bars: 2, lines: 0 });
+  });
+});
+
+describe('objectui#8650 — `categories` is NOT retired: the declared key still plots', () => {
+  it('plots a `categories` series list through `normalizeChartSchema`', async () => {
+    // The read that used to serve this case lived in `ChartRenderer`; it is
+    // gone, and the chart still draws both columns because the ONE translation
+    // point has always consumed this key. If this case ever reds, the
+    // objectui#6896 capability was removed by accident.
+    const container = renderChart({
+      type: 'chart',
+      chartType: 'bar',
+      data: DATA,
+      xAxisKey: 'month',
+      categories: ['revenue', 'margin'],
+      isAnimationActive: false,
+    });
+    expect(await plotted(container)).toEqual({ bars: 2, lines: 0 });
+  });
+
+  it('still ignores `categories` when `series` is present — the documented precedence', async () => {
+    const container = renderChart({
+      type: 'chart',
+      chartType: 'bar',
+      data: DATA,
+      xAxisKey: 'month',
+      series: [{ dataKey: 'revenue' }],
+      categories: ['revenue', 'margin'],
+      isAnimationActive: false,
+    });
+    expect(await plotted(container)).toEqual({ bars: 1, lines: 0 });
+  });
+
+  it('no longer throws on a malformed `categories` — the retired branch called `.map` on it', async () => {
+    // `categories: 'revenue'` (a string, not a list) reached `.map` on a string
+    // in the retired branch and threw during render. The normalizer answers
+    // "no series" instead, which is the honest reading of an off-contract
+    // value: the chart mounts, and plots nothing.
+    const container = renderChart({
+      type: 'chart',
+      chartType: 'bar',
+      data: DATA,
+      xAxisKey: 'month',
+      categories: 'revenue',
+      isAnimationActive: false,
+    });
+    await waitFor(() => expect(container.querySelector('.recharts-surface')).toBeTruthy());
+    expect(marks(container)).toEqual({ bars: 0, lines: 0 });
+  });
+});
+
+describe('objectui#8650 — the foreign dialect is retired', () => {
+  it('`index` no longer binds the category axis', async () => {
+    const container = renderChart({
+      type: 'chart',
+      chartType: 'bar',
+      data: DATA,
+      index: 'month',
+      series: [{ dataKey: 'revenue' }, { dataKey: 'margin' }],
+      isAnimationActive: false,
+    });
+    expect(await neverPlots(container)).toBe(true);
+  });
+
+  it('`category` no longer binds the category axis', async () => {
+    const container = renderChart({
+      type: 'chart',
+      chartType: 'bar',
+      data: DATA,
+      category: 'month',
+      series: [{ dataKey: 'revenue' }, { dataKey: 'margin' }],
+      isAnimationActive: false,
+    });
+    expect(await neverPlots(container)).toBe(true);
+  });
+
+  it('`value` no longer becomes a single series', async () => {
+    const container = renderChart({
+      type: 'chart',
+      chartType: 'bar',
+      data: DATA,
+      xAxisKey: 'month',
+      value: 'revenue',
+      isAnimationActive: false,
+    });
+    // The axis IS bound here, so this case isolates the series half: the chart
+    // may still reach the plot surface, but nothing is plotted from `value`.
+    const surface = await new Promise<HTMLElement | null>((r) =>
+      setTimeout(() => r(container.querySelector('.recharts-surface')), 150),
+    );
+    expect(surface ? marks(container) : { bars: 0, lines: 0 }).toEqual({ bars: 0, lines: 0 });
+  });
+});

--- a/packages/plugin-charts/src/ChartRenderer.foreignDialectRetired-8650.test.tsx
+++ b/packages/plugin-charts/src/ChartRenderer.foreignDialectRetired-8650.test.tsx
@@ -33,11 +33,22 @@
  *
  * ## The failure mode the retirement degrades to — measured, not assumed
  *
- * Dropping the axis aliases does not produce a silently wrong picture:
- * `AdvancedChartImpl` REFUSES a chart whose category axis binds to no column
- * and says so on screen (objectui#8168's family). The refusal is what these
- * cases observe structurally — no plot surface — rather than by its wording,
+ * ⚠️ It is CONDITIONAL on the rows, and an earlier reading of it here was too
+ * strong. With no `xAxisKey` bound, `AdvancedChartImpl` falls back to its
+ * default category key `name`: rows carrying no `name` column — `DATA` below
+ * — hit its on-screen `missing-category-key` refusal (objectui#8168's family),
+ * but rows that DO carry one plot SILENTLY against `name`. The cases below pin
+ * the refusing half, and read the refusal by its `data-chart-error` CODE — the
+ * machine-readable half that sibling suites already pin — never by its wording,
  * which no consumer parses.
+ *
+ * ⛔ The negative form these cases used to take — sleep a fixed window, then
+ * assert no plot surface YET — is gone and must not come back. It was a race in
+ * the FALSE-GREEN direction: warm time-to-surface for the canonical control was
+ * measured at 97–168 ms (cold 578 ms) against a 150 ms window, so on a loaded
+ * runner a re-added alias that plotted LATE would satisfy it — a pin that
+ * cannot fail. A `waitFor` on the POSITIVE signal fails the other way: a slow
+ * runner makes it slower, never green.
  *
  * ⭐ Every refusal below is read against the CANONICAL control in the same
  * file: the same data and the same chart, written with `xAxisKey` / `series`,
@@ -85,10 +96,18 @@ const plotted = async (c: HTMLElement) => {
   return marks(c);
 };
 
-/** The negative reading: give the lazy chunk the same chance, then assert it never plotted. */
-const neverPlots = async (c: HTMLElement) => {
-  await new Promise((r) => setTimeout(r, 150));
-  return c.querySelector('.recharts-surface') === null;
+/**
+ * The positive reading for a retired AXIS alias: wait for the refusal
+ * `AdvancedChartImpl` renders when nothing binds the category axis. Re-add the
+ * alias and the chart plots instead, no refusal ever arrives, and this
+ * `waitFor` reddens on timeout.
+ */
+const expectCategoryAxisRefusal = async (c: HTMLElement) => {
+  await waitFor(() =>
+    expect(c.querySelector('[data-chart-error="missing-category-key"]')).not.toBeNull(),
+  );
+  // The refusal REPLACES the chart, so no plot surface may coexist with it.
+  expect(c.querySelector('.recharts-surface')).toBeNull();
 };
 
 const renderChart = (schema: Record<string, unknown>) =>
@@ -166,7 +185,7 @@ describe('objectui#8650 — the foreign dialect is retired', () => {
       series: [{ dataKey: 'revenue' }, { dataKey: 'margin' }],
       isAnimationActive: false,
     });
-    expect(await neverPlots(container)).toBe(true);
+    await expectCategoryAxisRefusal(container);
   });
 
   it('`category` no longer binds the category axis', async () => {
@@ -178,7 +197,7 @@ describe('objectui#8650 — the foreign dialect is retired', () => {
       series: [{ dataKey: 'revenue' }, { dataKey: 'margin' }],
       isAnimationActive: false,
     });
-    expect(await neverPlots(container)).toBe(true);
+    await expectCategoryAxisRefusal(container);
   });
 
   it('`value` no longer becomes a single series', async () => {
@@ -190,11 +209,11 @@ describe('objectui#8650 — the foreign dialect is retired', () => {
       value: 'revenue',
       isAnimationActive: false,
     });
-    // The axis IS bound here, so this case isolates the series half: the chart
-    // may still reach the plot surface, but nothing is plotted from `value`.
-    const surface = await new Promise<HTMLElement | null>((r) =>
-      setTimeout(() => r(container.querySelector('.recharts-surface')), 150),
-    );
-    expect(surface ? marks(container) : { bars: 0, lines: 0 }).toEqual({ bars: 0, lines: 0 });
+    // The axis IS bound here, so this case isolates the series half — and the
+    // reading is positive: a bar with an empty series list reaches the plot
+    // surface with no refusal, so `plotted` waits for that surface to ARRIVE
+    // rather than for a fixed window to elapse, and then counts. Re-add the
+    // `value` read and a bar appears on it.
+    expect(await plotted(container)).toEqual({ bars: 0, lines: 0 });
   });
 });

--- a/packages/plugin-charts/src/ChartRenderer.specSeries.test.tsx
+++ b/packages/plugin-charts/src/ChartRenderer.specSeries.test.tsx
@@ -152,14 +152,22 @@ describe('ChartRenderer — the spec `series` shape', () => {
     expect(await plotted(container)).toEqual({ bars: 2, lines: 0 });
   });
 
-  it('still adapts the Tremor-ish `categories` form', async () => {
+  it('still plots the `categories` series list', async () => {
+    // `categories` is a declared member of the published `ChartSchema` and its
+    // zod mirror, ruled LIVE by objectui#6896 — not a foreign spelling. This
+    // case used to prove `ChartRenderer`'s OWN `(schema as any).categories`
+    // branch; objectui#8650 removed that second read and the key still plots,
+    // because `normalizeChartSchema` — the one translation point — has always
+    // consumed it. The axis is written in the canonical `xAxisKey`: the
+    // Tremor-ish `index` alias that stood here is retired, and its pin lives in
+    // `ChartRenderer.foreignDialectRetired-8650.test.tsx`.
     const { container } = render(
       <ChartRenderer
         schema={{
           type: 'chart',
           chartType: 'bar',
           data: DATA,
-          index: 'month',
+          xAxisKey: 'month',
           categories: ['revenue', 'margin'],
           isAnimationActive: false,
         } as any}

--- a/packages/plugin-charts/src/ChartRenderer.tsx
+++ b/packages/plugin-charts/src/ChartRenderer.tsx
@@ -163,29 +163,49 @@ export const ChartRenderer: React.FC<ChartRendererProps> = ({ schema, onChartCli
     // `normalizeSeries` could not translate at all (no `dataKey` and no `name`
     // on any entry).
     const authored = Array.isArray(schema.series) ? schema.series : undefined;
-    let series: any[] | undefined = spec.series ?? authored;
-    let xAxisKey = schema.xAxisKey ?? spec.xAxisKey;
+    const series: any[] | undefined = spec.series ?? authored;
+    const xAxisKey = schema.xAxisKey ?? spec.xAxisKey;
     let config = schema.config;
 
-    // Adapt the Tremor/simple format (categories -> series, index -> xAxisKey)
-    if (!xAxisKey) {
-       if ((schema as any).index) xAxisKey = (schema as any).index;
-       else if ((schema as any).category) xAxisKey = (schema as any).category; // Support Pie/Donut category
-    }
-
-    if (!series) {
-       if ((schema as any).categories) {
-          series = (schema as any).categories.map((cat: string) => ({ dataKey: cat }));
-       } else if ((schema as any).value) {
-          // Single value adapter (for Pie/Simple charts)
-          series = [{ dataKey: (schema as any).value }];
-       }
-    }
+    // ⛔ The "Tremor/simple format" adapter that used to sit here is RETIRED
+    // (objectui#8650). It read four keys off `schema` behind `as any` casts --
+    // `index` / `category` (-> `xAxisKey`) and `categories` / `value`
+    // (-> `series`) -- and the census that ruled on it found the four do NOT
+    // share one verdict:
+    //
+    //   - `categories` was never a foreign spelling at all. It is a declared
+    //     member of the published `ChartSchema` and of its zod mirror,
+    //     documented in the schema reference as an ALTERNATIVE SERIES LIST, and
+    //     ruled LIVE by objectui#6896 (maintainer ruling 2026-08-31, prose
+    //     follows machine). `normalizeChartSchema` -- the ONE translation point
+    //     (objectui#2880 S1) -- already consumes it, so `spec.series` above is
+    //     populated before the old branch could be reached. That branch was a
+    //     SECOND, un-normalized read of a key the normalizer owns: the shape
+    //     objectui#7681 removed for `series`. It was unreachable for every
+    //     well-formed chart, and on malformed input it was WORSE than nothing
+    //     (`categories: 'revenue'` reached `.map` on a string and threw; a
+    //     `categories` whose entries the normalizer rejects produced
+    //     `[{ dataKey: '' }]`). The capability is untouched and stays pinned in
+    //     `normalizeChartSchema.test.ts`.
+    //   - `index`, `category` and `value` WERE a second authoring vocabulary:
+    //     declared on no published face (not `ChartSchema`, not its zod mirror,
+    //     not `ChartRendererProps.schema` above), advertised by no registry
+    //     `inputs`, taught by no doc, guide or skill, and written by ZERO
+    //     producers anywhere in this repo. AGENTS.md #0.1 puts the remedy at
+    //     the producer; with no producer to route, the read was tolerance for a
+    //     dialect nobody speaks. The canonical spellings are `xAxisKey` /
+    //     `xAxis` for the category axis and `series` / `categories` for the
+    //     plotted columns.
+    //
+    // ⛔ Do not re-add a key-aliasing branch here. A new inbound spelling is
+    // translated in `normalizeChartSchema`, which is where every other dialect
+    // this renderer accepts already resolves -- a second site here is how this
+    // one became invisible to the normalizer's own tests.
 
     // Auto-generate config/colors if missing. A spec `series[].color` is an
     // explicit author choice, so it wins over the positional palette.
     if (!config && series) {
-       const colors = (schema as any).colors || ['hsl(var(--chart-1))', 'hsl(var(--chart-2))', 'hsl(var(--chart-3))'];
+       const colors = schema.colors || ['hsl(var(--chart-1))', 'hsl(var(--chart-2))', 'hsl(var(--chart-3))'];
        const newConfig: ChartContainerConfig = {};
        series.forEach((s: any, idx: number) => {
          newConfig[s.dataKey] = { label: s.label || s.dataKey, color: s.color || colors[idx % colors.length] };
@@ -213,9 +233,9 @@ export const ChartRenderer: React.FC<ChartRendererProps> = ({ schema, onChartCli
         xAxisKey={props.xAxisKey}
         series={props.series}
         className={props.className}
-        colors={Array.isArray((schema as any).colors) ? (schema as any).colors : undefined}
-        categoryColors={(schema as any).categoryColors}
-        categoryOrder={(schema as any).categoryOrder}
+        colors={Array.isArray(schema.colors) ? schema.colors : undefined}
+        categoryColors={schema.categoryColors}
+        categoryOrder={schema.categoryOrder}
         isAnimationActive={schema.isAnimationActive}
         onChartClick={onChartClick}
         xAxis={props.spec.xAxis}

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -559,8 +559,8 @@ export const ObjectChart = (props: ObjectChartProps) => {
     [schema.filter],
   );
   const compareToKey = useMemo(
-    () => ((schema as any).compareTo ? JSON.stringify((schema as any).compareTo) : ''),
-    [(schema as any).compareTo],
+    () => (schema.compareTo ? JSON.stringify(schema.compareTo) : ''),
+    [schema.compareTo],
   );
   // ADR-0021 (#1890): a chart can bind to a semantic-layer `dataset` instead of
   // the legacy inline `objectName` + `aggregate` query. Stable key over the
@@ -811,7 +811,7 @@ export const ObjectChart = (props: ObjectChartProps) => {
           // value apart from its presence: the ONE discriminator (`.kind`) is
           // read where the shift is computed — `shiftFilterByCompareTo` — so
           // this file has no second copy of the branch table to drift from it.
-          const compareTo: CompareToConfig | undefined = (schema as any).compareTo;
+          const compareTo: CompareToConfig | undefined = schema.compareTo;
           const wantsComparison = !!compareTo && supportsCompareTo(schema.chartType);
           // shiftFilterByCompareTo expects the raw filter (with date macros)
           // so it can substitute `{current_*}` tokens or re-resolve macros
@@ -1102,7 +1102,7 @@ export const ObjectChart = (props: ObjectChartProps) => {
   // Merge data if not provided in schema. When `compareTo` is configured
   // for a supported chart type, also synthesize a second series so the
   // chart implementation renders the comparison overlay (dashed / muted).
-  const compareToConfig: CompareToConfig | undefined = (schema as any).compareTo;
+  const compareToConfig: CompareToConfig | undefined = schema.compareTo;
   // The result column this aggregate projects its value under, and the column
   // the comparison overlay arrives in (framework#3701).
   const valueKey = schema.aggregate ? aggregateValueKey(schema.aggregate) : undefined;
@@ -1114,7 +1114,7 @@ export const ObjectChart = (props: ObjectChartProps) => {
     finalData.some((row: Record<string, any>) => row[comparisonKey] != null);
 
   const augmentedSeries = useMemo(() => {
-    const existing = Array.isArray((schema as any).series) ? (schema as any).series : null;
+    const existing = Array.isArray(schema.series) ? schema.series : null;
     if (!enableComparisonSeries) return existing;
     const primary = existing || [{ dataKey: valueKey }];
     const labelMap: Record<string, string> = {
@@ -1135,7 +1135,7 @@ export const ObjectChart = (props: ObjectChartProps) => {
         variant: 'comparison',
       },
     ];
-  }, [enableComparisonSeries, (schema as any).series, valueKey, comparisonKey, schema.filter, compareToConfig]);
+  }, [enableComparisonSeries, schema.series, valueKey, comparisonKey, schema.filter, compareToConfig]);
 
   // ADR-0021 (#1759): when the chart binds to a dataset, derive data/xAxisKey/
   // series from its dimensions/measures via the shared buildChartSeries helper —
@@ -1182,11 +1182,11 @@ export const ObjectChart = (props: ObjectChartProps) => {
   // over the field's option colors. We split the two and pass the palette as
   // `colors` and the merged map as `categoryColors`.
   const explicitColorMap: Record<string, string> | null =
-    (schema as any).colors && !Array.isArray((schema as any).colors) && typeof (schema as any).colors === 'object'
-      ? ((schema as any).colors as Record<string, string>)
+    schema.colors && !Array.isArray(schema.colors) && typeof schema.colors === 'object'
+      ? schema.colors
       : null;
   const paletteColors: string[] | undefined =
-    Array.isArray((schema as any).colors) ? ((schema as any).colors as string[]) : undefined;
+    Array.isArray(schema.colors) ? schema.colors : undefined;
   const mergedCategoryColors = (fieldOptionColors || explicitColorMap)
     ? { ...(fieldOptionColors || {}), ...(explicitColorMap || {}) }
     : undefined;

--- a/packages/plugin-charts/src/normalizeChartSchema.ts
+++ b/packages/plugin-charts/src/normalizeChartSchema.ts
@@ -378,8 +378,15 @@ function normalizeAxis(raw: unknown, language: string | null | undefined): Norma
  */
 function normalizeSeries(raw: unknown, language: string | null | undefined): NormalizedSeries | undefined {
   if (!isRec(raw)) {
-    // A bare string is accepted as a shorthand for `{ name }` — the Tremor-ish
-    // `categories: ['a','b']` form ChartRenderer already adapts.
+    // A bare string is accepted as a shorthand for `{ name }` — the entry form
+    // the Tremor-ish `categories: ['a','b']` series list feeds in, one entry at
+    // a time (the branch that reads `categories` is below, in this file).
+    // ⚠️ THIS FILE is the only place that adapts it: `ChartRenderer` carried a
+    // second, un-normalized read of `categories` until objectui#8650 retired
+    // that branch, which leaves `normalizeChartSchema` the one translation
+    // point it was always meant to be (objectui#2880 S1). ⛔ Do not restore a
+    // reader-side `categories` branch to "help" — that is the second de-facto
+    // contract AGENTS.md #0.1 exists to refuse.
     const bare = str(raw);
     return bare ? { dataKey: bare } : undefined;
   }


### PR DESCRIPTION
Fixes #8650

Implements the triage ruling (comment `5619609278`): **route to the producer, ⛔ not a declaration.** The direction was not re-opened; what this PR settles is the *how*, and the measurement split the card's one group of four into two different answers.

## ⚠️ Premise falsification — all four dispatch premises, measured on `origin/main` `2e471dc0`

| # | premise as dispatched | verdict | measurement |
| --- | --- | --- | --- |
| 1 | the card's «`ObjectChart` takes `props: any`» is FALSE | **CONFIRMED** (card stale, seat correct) | `ObjectChart.tsx` declares `export interface ObjectChartProps` and `export const ObjectChart = (props: ObjectChartProps)`; the checker reads `ObjectChartProps.schema` as `ObjectChartSchema` with 37 declared named members |
| 2 | expect `series` to have moved to bucket (b) | **CONFIRMED, and wider** — all THREE moved | `colors`, `compareTo` and `series` are all declared named members of `ObjectChartSchema`. the `colors` drift was settled by objectui#7946 as well |
| 3 | question 1's premise HOLDS at the Tremor comment | **CONFIRMED verbatim** | the comment and the four casts are live, unchanged, at the lines the seat quoted |
| 4 | the card UNDER-reports the file — the census gives SEVEN | **FALSIFIED** | on today's `main` the undeclared population is the card's **four**. Of the census's seven, `colors` · `categoryColors` · `categoryOrder` are now declared members of `ChartRendererProps.schema` — they are bucket (b), not undeclared |

⭐ And a **fifth**, which neither the card nor the dispatch had: **`categories` is not a foreign key at all.** It is a declared member of the published `ChartSchema` and of its zod mirror, is documented in `content/docs/api/schema-reference.md` as "an alternative series list", and was ruled LIVE by objectui#6896 (maintainer ruling 2026-08-31, *prose follows machine*). The card's headline — "four reads are an explicit FOREIGN DIALECT" — is wrong for one of its four.

## The instrument, and the index-signature control

Reads: `schemaReads` from `packages/types/src/__tests__/widget-schema-anchors-6576.test.ts`, **verbatim** — no second scanner. Declaredness: the TypeScript checker (`getPropertiesOfType` / `getPropertyOfType`), **never a grep** (objectui#8410).

The confound the dispatch named is real and the instrument survives it:

```
ObjectChartSchema:
  string index signature                : any
  getPropertyOfType('zzqx_no_such_key') : undefined   (index signature NOT mistaken for a member)
  getPropertyOfType('type')             : DEFINED     (real member seen)
ChartRendererProps.schema:
  string index signature                : NONE        (a hand-rolled inline literal, no confound available)
  getPropertyOfType('zzqx_no_such_key') : undefined
  getPropertyOfType('type')             : DEFINED
```

⇒ an index signature that types **any** key as `any` still yields `undefined` for a nonsense key, while a real member is seen. The classification below is therefore a reading, not an artefact.

Two instrument artefacts, both disambiguated with the same instrument rather than by eye:

- `color` / `dataKey` came back "undeclared" on `ChartRenderer.tsx` because `schemaReads` is FILE-scoped and the file declares **two** props types — both are declared members of `ChartBarRendererProps.schema`.
- `chart` came back as a read on `ObjectChart.tsx` from a **docblock** sentence. Re-running the same census on a comment-stripped copy of the same source drops it and keeps `chartType` (non-vacuity).

## Re-derived read set — `ChartRenderer.tsx`

| key | read | declared on `ChartRendererProps.schema` | declared on the published `ChartSchema` | bucket | disposition |
| --- | --- | --- | --- | --- | --- |
| `categories` | yes | no | **yes** (+ zod mirror, + docs, ruled live objectui#6896) | not a dialect | branch removed as a duplicate read; **capability untouched** |
| `category` | yes | no | no | (a) | **retired** |
| `index` | yes | no | no | (a) | **retired** |
| `value` | yes | no | no | (a) | **retired** |
| `colors` | yes | **yes** | no | **(b)** | cast deleted |
| `categoryColors` | yes | **yes** | no | **(b)** | cast deleted |
| `categoryOrder` | yes | **yes** | no | **(b)** | cast deleted |

## Question 2 — `ObjectChart`'s three reads, re-classified

All three are **bucket (b): declared, then read through a needless cast.** ⛔ Nothing was declared; three casts were deleted.

| key | read sites | checker verdict on `ObjectChartSchema` | bucket |
| --- | --- | --- | --- |
| `colors` | 3 | DECLARED `string[] OR Record of string to string, optional` | (b) |
| `compareTo` | 4 | DECLARED `{ kind: previousPeriod OR previousYear; dimension?: string }, optional` | (b) |
| `series` | 2 | DECLARED `Array of { dataKey: string; … }, optional` | (b) |

`ObjectChart.tsx` now has **zero** `(schema as any)` reads left (one historical mention survives inside a comment). Deleting the casts is not a cosmetic change: with the casts gone, `type-check` now actually checks these values against their declarations — it passes, which is itself the reading that the declarations and the reads agree.

⚠️ `drillDwon` was met and ⛔ not re-reported: it is the deliberate misspelling inside a string-literal fixture feeding the census's own non-vacuity control.

## Producer measurement — which arm, and why

A structural producer census over `packages/` · `apps/` · `examples/` · `content/` · `skills/` · `.claude/` · `docs/` — **5695 files**, every object literal / JSON object / fenced-block node whose `type` is one of ChartRenderer's registry keywords (`chart`, `chart:bar`, `pie-chart`, `donut-chart`, `radar-chart`, `scatter-chart`, plus `bar-chart`): **74 chart nodes**.

| key | chart nodes writing it | note |
| --- | --: | --- |
| `category` | **0** | — |
| `value` | **0** | — |
| `index` | **1** | this repo's own test for the adapter — a pin, not a producer |
| `categories` | 4 | all tests; three of them pin objectui#6896's ruling through `ChartSchema`, not through this branch |
| `xAxisKey` | 41 | ✅ positive control |
| `series` | 44 | ✅ positive control |
| `chartType` | 40 | ✅ positive control |
| `data` | 52 | ✅ positive control |
| `zzqx_no_such_key` | **0** | ✅ negative control |

Documented / taught use, same corpora: `xAxisKey` appears in 8 doc files (positive control fires); the word "Tremor" appears in **no** doc, guide or skill — only in the in-source comment this PR removes; `index` / `category` / `value` are taught **nowhere** as chart-node keys; `categories` IS documented, and it is the one this PR does **not** retire. None of the three retired keys is advertised by any registry `inputs`.

⇒ **Zero live producers, zero taught use, no published declaration, no palette advertisement** for `index` / `category` / `value`. Per the dispatch's own rule that is the "proceed" arm, and the zero is backed by four firing positive controls and a firing negative control.

⚠️ **The failure mode this degrades to was measured — and the reading above was too strong; corrected in the 欠改 round below.** Dropping the axis aliases leaves `AdvancedChartImpl` on its default category key, `name` (`AdvancedChartImpl.tsx:865`). Only one half of that is a refusal: rows carrying **no** `name` column hit the on-screen `missing-category-key` refusal (that is the half the first run surfaced, and the half this PR's rows pin), while rows that **do** carry one plot **silently** against `name` — a wrong picture, not a refusal. The classification never rested on the loudness of the degradation, but the sentence did overstate it, and it was also in the changeset, which publishes verbatim.

## Reverse verification — commit first, then ablate, with on-disk proof

The fix was committed first, so the restore leg points at a real commit. The mutation restores the pre-fix `ChartRenderer.tsx` from the **pinned base commit** `2e471dc0aa23ff807aa9960618c419ecccdfdcef`, never from a remote-tracking name.

| leg | on-disk proof | run |
| --- | --- | --- |
| mutated (fix removed) | `schema as any` count 0 → **10**; `is RETIRED` count 1 → **0**; blob `13e49a04` ≠ HEAD blob `f2531d0a` | **4 failed / 9 passed (13)** — exactly the four retirement cases: `index`, `category`, `value`, and the malformed-`categories` throw |
| restored | blob back to `f2531d0a` (byte-identical to HEAD), `git diff HEAD` empty | **13 passed (13)** |

⭐ The three "`categories` still plots" cases pass in **both** legs. That is the reading that matters: removing `ChartRenderer`'s own branch did not remove the capability, because `normalizeChartSchema` served it all along.

⭐ The malformed-`categories` case failing in the mutated leg is what turns "the retired branch called `.map` on a string and threw" from a claim into a measurement.

The ablation script carries a `trap` on EXIT / INT / TERM calling a RESTORE function (the placeholder is spelled as a word on purpose — GitHub's body sanitizer eats angle-bracket-shaped tokens, backticks included) with absolute paths, verifies the mutation reached disk by marker count **and** by blob hash before running anything, and treats an empty hash as failure. It is a one-shot proof; no test file is left behind by it.

## Gates

| gate | exit |
| --- | --: |
| `lint:coverage` | 0 |
| `check:entry-guard` | 0 |
| `check:upstream-port-parity` | 0 |
| `check:bash32-floor` | 0 |
| `turbo run lint --filter=@object-ui/plugin-charts --force` | 0 |
| `check:vi-mock-override-shape` | 0 |
| `check:test-path-roots` | 0 |
| `check:cross-repo-closer-outcome` | 0 |
| `check:control-bytes` | 0 |
| `check:new-line-citations` | 0 |
| `check:spec-symbols` | 0 |
| `check-changeset-presence` | 0 |
| `check-changeset-no-major` | 0 |
| `@object-ui/plugin-charts type-check` | 0 |
| dependency-closure build | 0 |
| `vitest packages/plugin-charts/` | 0 — **60 files / 541 tests** (was 59 / 534) |

Every exit code captured by redirect before any pipe. `Doc Snippet Type Check` and `Skill Example Check` are red on `main` itself (chain objectui#9308 → objectui#9346); they name no file this PR touches.

## 欠改 round — the three items the ceiling-tier review logged

Head `c237b09e`, one commit on top of the reviewed head `348a4bdf`. ⛔ Not a re-litigation: the contract gate PASSed and is on record. ⛔ No accept-set change, ⛔ no declaration, ⛔ no new key, ⛔ nothing under `packages/types/`. Diff of this round = 3 files, +51 / -21.

| # | item | disposition | file:line |
|---|---|---|---|
| 1 | changeset Migration sentence overstates the failure mode | qualifier added; the `value` sentence, which measured accurate, is **byte-identical** | `.changeset/8650-chart-foreign-dialect-retired.md:39-45` |
| 2 | `neverPlots` is a race in the false-green direction | replaced with positive readings; ablation re-run below | `ChartRenderer.foreignDialectRetired-8650.test.tsx:103-114, 188, 200, 217` |
| 3 | now-false comment about a branch this PR removed | rewritten to name the reader that **does** adapt `categories` — this file | `normalizeChartSchema.ts:381-389` |

**Item 2, what changed and why it now fails the other way.** The old form slept a fixed **150 ms** and asserted "no surface yet", against a measured warm time-to-surface of **97–168 ms** for the canonical control. It discriminated in both runs so far, but a re-added alias that plotted **late** on a loaded runner would have satisfied it — a pin that cannot fail. The new form waits for the **positive** signal: `waitFor` on `[data-chart-error="missing-category-key"]` for `index` / `category` (plus "no plot surface coexists with the refusal"), and for `value` the file's existing `plotted` helper — wait for the surface to **arrive**, then count marks. A slow runner now makes these slower, never green. Observable in the ablation timings: the two axis cases redden by `waitFor` **timeout at ~1087 ms**, not by beating a window.

**Item 3 premise re-checked before complying, not assumed.** `git grep -n categories packages/plugin-charts/src/ChartRenderer.tsx` returns only comment lines — the reader-side branch is gone — so the sentence was false about the very removal it sat next to. **Item 1 premise likewise**: `AdvancedChartImpl.tsx:865` is literally `xAxisKey = 'name',`. Both held; neither was taken on report.

### Ablation, re-run on the rewritten cases

Committed first (`c237b09e`), so the restore leg points at a real commit; mutation and restore are symmetric, the script carries `trap … EXIT INT TERM`, and every path in it is absolute.

| leg | on-disk proof **before** any result | run |
|---|---|---|
| **mutated** — the retired `index` / `category` / `value` reads put back in `ChartRenderer.tsx` | anchored canonical line `1 → 0`; injected marker `0 → 2` lines; on-disk blob `16d9b712` ≠ HEAD blob `f2531d0a` | **exit 1** — `Tests 3 failed / 4 passed (7)`: exactly `index` (1087 ms), `category` (1089 ms), `value` (69 ms) |
| **restored** — `git checkout HEAD -- …` (⛔ never bare `git checkout --`, which would take the mutation back out of the index) | on-disk blob `f2531d0a` **==** HEAD blob `f2531d0a`; canonical line back to `1`, marker back to `0`; `git diff HEAD` on the path **empty** | **exit 0** — `Tests 7 passed (7)` |

The 4 that pass in **both** legs are the canonical control and the three `categories` cases — the capability this PR does not retire, unaffected by the mutation in either direction. ⚠️ Counting note, so nobody re-derives it wrong: the marker figure is `grep -c`, which counts **lines**, not occurrences — 3 injected occurrences land on 2 lines.

⭐ No build / `dist` preflight is owed for this ablation: the pin imports `./ChartRenderer` and `./AdvancedChartImpl` by **relative** specifier inside the same package, so the mutated **source** is what runs. There is no `exports`-resolved hop that a stale `dist` could keep green.

### Gates — exit code captured by redirect **before** any pipe

`cmd > log 2>&1; EXIT=$?` throughout. ⛔ Not derived from `lint.yml`: this repo's doc and skill gates each own a workflow file, and the workflow set was enumerated from `origin/main` with `git ls-tree`, not from the working tree.

| gate | exit | reading |
|---|---|---|
| `check-changeset-presence` | **0** | 5 source files of 1 released package, 1 changeset |
| `check-changeset-no-major` / `-fixed` / `-overwrite` | **0** / **0** / **0** | |
| `check-changeset-claims` | **0** | report-only; its 3 findings all name `ObjectChart.tsx` and pre-date this round |
| `check-control-bytes` | **0** | 7540 tracked text files scanned |
| `check-new-cross-file-line-citations` | **0** | 0 new citations |
| `check-test-path-roots` | **0** | |
| `check-vi-mock-override-shape` / `-specifiers` / `-inherit` | **0** / **0** / **0** | the file's `recharts` mock |
| `check-spec-symbol-derivation` | **0** | |
| `check-comment-mask-corpus` | **0** | 4922 files; residue unchanged, within the ceiling objectui#7882 holds open |
| `check-entry-guard` · `check-upstream-port-parity` · `check-bash32-floor` | **0** each | |
| `check-cross-repo-closer-outcome` · `check-lint-coverage` · `check-shell-escape-residue` | **0** each | |
| `turbo type-check --filter=@object-ui/plugin-charts` | **0** | 10 tasks, dependency closure built |
| `turbo lint --filter=@object-ui/plugin-charts` | **0** | **0 errors**, 338 warnings — the same warning count measured at `348a4bdf`, so this round adds none |
| `vitest run packages/plugin-charts/` (under the shared verify lock) | **0** | **60 files / 541 tests passed** |

Test counts before → after: pin file **7 → 7** (`it(` count on both sides; assertions rewritten, no case added or removed), `plugin-charts` package 541 passed.

⛔ Consumer packages are **not** re-run this round and none is owed: the only non-test source file touched is `normalizeChartSchema.ts`, and **every changed line in it is a comment** — mechanically, changed non-comment lines = **0**. The published face did not move.

⚠️ `Doc Snippet Type Check` and `Bundle Analysis` remain red from base-side debts (objectui#9308 via objectui#9346; objectui#9204 / objectui#9316). ⛔ Neither is this PR's, and neither was re-run.

⛔ Still draft. ⛔ Not enqueued, ⛔ no auto-merge, ⛔ no label added, moved or removed by this round.

## Acceptance notes

**Out of scope, noted, not filed** — `ChartRendererProps.schema` is a hand-rolled inline object literal that does not mirror the published `ChartSchema`: `categories` is authorable and reaches `normalizeChartSchema`, yet the props type refuses it, which is why every in-repo caller writes `as any`. That is objectui#6576's class (a widget props type anchoring its `schema` to no named type), already ruled for two other widgets, and anchoring a third published prop type is a shape decision this card explicitly forbids taking. Carrier: whoever picks up the objectui#6576 anchoring family next; this PR deliberately adds **no** declaration.

**Out of scope, noted, not filed** — `BaseSchema`'s `[key: string]: any` is the reason none of this is enforceable at authoring time; the standing defect card is objectui#7927 (`pm:blocked`).

⛔ This PR does **not** put anything in `packages/types/src/__tests__/undeclared-but-consumed-keys-6150.test.ts`, does **not** fold into objectui#8347, and adds **no** declaration to any published type — the three outcomes the card exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L5xpA5q533BgTTNADibEFt

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5xpA5q533BgTTNADibEFt)_

---
_Generated by [Claude Code](https://claude.ai/code)_