### PR TITLE
fix(app-shell): bridge `Is null` to the spec's `$null` instead of erasing the dataset filter

### DIFF
--- a/.changeset/9363-dataset-filter-isnull-erases.md
+++ b/.changeset/9363-dataset-filter-isnull-erases.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Stop the Studio dataset-filter bridge from ERASING a stored filter when the author
+picks `Is null` (objectui#9363).
+
+`groupToCondition` had no mapping for `isNull` / `isNotNull`, so those rows fell
+through to the unmapped-operator drop. A dropped last row makes the function return
+`undefined`, and the dataset inspector commits on every change — so an author with a
+working `dataset.filter` (or a `measure.filter`) who opened the filter popover and
+switched the single condition's operator to **Is null** committed `undefined`, and the
+persisted filter was destroyed. Nothing errored and the panel still showed the
+condition. `Is null` is an ordinary entry in that menu, not an opt-in one.
+
+Both directions now bridge the spec's `$null` predicate: `isNull` serializes to
+`{ field: { $null: true } }` and `isNotNull` to `{ $null: false }`, and a stored
+`$null` reads back as the operator the author picked instead of degrading the whole
+filter to "edit it in the Source tab".
+
+`$null` stays distinct from `$exists`: `isEmpty` / `isNotEmpty` are unchanged, because
+the dropdown offers both pairs as their own rows and the spec's filter vocabulary
+carries both predicates.
+
+Operators this bridge still does not map are still dropped rather than emitted in a
+spelling that means something else — that behaviour is deliberate and is now pinned
+alongside the fix, together with the list of operators the menu offers and this bridge
+cannot store (`notContains`, `between`, `startsWith`, `endsWith`), so the next unmapped
+addition fails a test instead of erasing a filter.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/datasetFilterCondition.nullOperators-9363.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/datasetFilterCondition.nullOperators-9363.test.ts
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `Is null` must not ERASE the stored dataset filter (objectui#9363).
+ *
+ * ## The mechanism, and why it is data loss rather than a wrong result set
+ *
+ * `groupToCondition` returns `undefined` when no row survives serialization,
+ * and the Studio dataset inspector commits on EVERY change — the filter popover
+ * mounts the shared `FilterBuilder` and hands each emitted group straight to
+ * `onCommit(groupToCondition(g))`, which lands as `onPatch({ filter })` and is
+ * spread over the draft. So an author with a working `dataset.filter` who opens
+ * the inspector and switches the single condition's operator to **Is null**
+ * commits `undefined`: the persisted key is destroyed, nothing errors, and the
+ * panel still shows the condition.
+ *
+ * The inspector passes no `extraOperators`, so `isNull` / `isNotNull` are
+ * ordinary entries in the default menu — not opt-in ones. The parity block at
+ * the bottom of this file reads that offering from the builder's own exported
+ * bucket function rather than restating it.
+ *
+ * ## The distinction this file exists to keep
+ *
+ * The `continue` these two operators fell into is a DELIBERATE decision for
+ * operators the bridge does not map: dropping beats emitting a filter that
+ * means something else. That behaviour is kept, and pinned below, because a
+ * repair that made the fallback stop dropping everything it cannot map would
+ * emit wrong filters — a worse defect than this one.
+ *
+ * `isNull` / `isNotNull` are a different case and that is the whole repair: the
+ * dialect CAN express them (the spec's own `$null`, asserted below against
+ * `FILTER_OPERATORS` rather than assumed), the builder draws them as COMPLETE
+ * rows with no value input, and this inspector offers them. The drop was an
+ * unhandled operator falling into the fallback's path, not the fallback doing
+ * its job. Both readings are pinned so they stay distinguishable.
+ *
+ * ## Red-first
+ *
+ * Before the repair, the two `$null` expectations fail with `undefined` while
+ * the `equals` control in the same run passes — a table of all-`undefined`
+ * answers and a dead function are otherwise indistinguishable.
+ */
+import { describe, it, expect } from 'vitest';
+import { FILTER_OPERATORS, FieldOperatorsSchema } from '@objectstack/spec/data';
+import {
+  FILTER_BUILDER_OPERATORS,
+  VALUELESS_FILTER_BUILDER_OPERATORS,
+  operatorsForFieldType,
+} from '@object-ui/components';
+import { groupToCondition, conditionToGroup } from './datasetFilterCondition';
+import type { BuilderGroup } from './datasetFilterCondition';
+
+/** One condition row, as the builder emits it. */
+const row = (operator: string, value: unknown = ''): BuilderGroup => ({
+  id: 'g',
+  logic: 'and',
+  conditions: [{ id: 'c1', field: 'closed_at', operator, value }],
+});
+
+describe('groupToCondition — the null predicates this inspector offers (objectui#9363)', () => {
+  it('CONTROL: a mapped operator still serializes, so an empty answer below is about that operator', () => {
+    expect(groupToCondition(row('equals', 'acme'))).toEqual({ closed_at: { $eq: 'acme' } });
+  });
+
+  it('isNull serializes to the dialect\'s null predicate instead of vanishing', () => {
+    expect(
+      groupToCondition(row('isNull')),
+      'an `Is null` row serialized to nothing; committing that ERASES dataset.filter',
+    ).toEqual({ closed_at: { $null: true } });
+  });
+
+  it('isNotNull serializes to the same predicate negated', () => {
+    expect(groupToCondition(row('isNotNull'))).toEqual({ closed_at: { $null: false } });
+  });
+
+  it('keeps a null row alongside a complete one instead of dropping either', () => {
+    expect(groupToCondition({
+      id: 'g',
+      logic: 'and',
+      conditions: [
+        { id: 'c1', field: 'stage', operator: 'equals', value: 'won' },
+        { id: 'c2', field: 'closed_at', operator: 'isNull', value: '' },
+      ],
+    })).toEqual({ $and: [{ stage: { $eq: 'won' } }, { closed_at: { $null: true } }] });
+  });
+
+  it('THE DEFECT: switching the only row of a stored filter to Is null no longer commits `undefined`', () => {
+    // The exact author gesture: a dataset that already has a filter, opened in
+    // the inspector, one operator change. `undefined` here is not "unchanged" —
+    // it is what the host spreads over the draft as `{ filter: undefined }`,
+    // the same patch shape `objectChangePatch` uses to CLEAR the filter.
+    const stored = { stage: { $eq: 'won' } };
+    const { group, representable } = conditionToGroup(stored);
+    expect(representable).toBe(true);
+    const edited: BuilderGroup = {
+      ...group,
+      conditions: [{ ...group.conditions[0], operator: 'isNull', value: '' }],
+    };
+    expect(
+      groupToCondition(edited),
+      'the commit for this gesture was `undefined`, which erases the stored filter',
+    ).toEqual({ stage: { $null: true } });
+  });
+
+  it('leaves the $exists pair exactly as it was', () => {
+    expect(groupToCondition(row('isEmpty'))).toEqual({ closed_at: { $exists: false } });
+    expect(groupToCondition(row('isNotEmpty'))).toEqual({ closed_at: { $exists: true } });
+  });
+
+  it('still drops an operator it does not map, rather than emitting a wrong filter', () => {
+    // Deliberate, and kept: see this file's header. These four are OFFERED by
+    // the menu and dropped, which erases the same way — tracked as its own
+    // finding, not widened here on the way past.
+    expect(groupToCondition(row('notContains', 'a'))).toBeUndefined();
+    expect(groupToCondition(row('between', [1, 5]))).toBeUndefined();
+    expect(groupToCondition(row('startsWith', 'a'))).toBeUndefined();
+    expect(groupToCondition(row('endsWith', 'a'))).toBeUndefined();
+  });
+
+  it('an empty group is still `undefined` — that is the author CLEARING the filter', () => {
+    expect(groupToCondition({ id: 'g', logic: 'and', conditions: [] })).toBeUndefined();
+  });
+});
+
+describe('the emitted token is the spec\'s, not a local invention (objectui#9363)', () => {
+  it('`$null` is a member of the spec\'s filter operator vocabulary', () => {
+    expect(FILTER_OPERATORS).toContain('$null');
+    // Negative control: membership is a real reading, not a list that contains
+    // everything. A plausible-looking spelling this bridge could have invented
+    // is NOT in it.
+    expect(FILTER_OPERATORS).not.toContain('$isNull');
+  });
+
+  it('the spec\'s field-operator door accepts the boolean comparand and refuses a wrong one', () => {
+    expect(FieldOperatorsSchema.safeParse({ $null: true }).success).toBe(true);
+    expect(FieldOperatorsSchema.safeParse({ $null: false }).success).toBe(true);
+    // Negative control: this door judges the VALUE, so a string comparand is
+    // refused — without this leg the assertion above would pass for a schema
+    // that accepts anything.
+    expect(FieldOperatorsSchema.safeParse({ $null: 'yes' }).success).toBe(false);
+  });
+});
+
+describe('conditionToGroup — the read half round-trips the new shape (objectui#9363)', () => {
+  it('reads a stored $null back as the operator the author picked', () => {
+    expect(conditionToGroup({ closed_at: { $null: true } })).toEqual({
+      group: { id: 'g', logic: 'and', conditions: [{ id: 'c0', field: 'closed_at', operator: 'isNull', value: '' }] },
+      representable: true,
+    });
+    expect(conditionToGroup({ closed_at: { $null: false } }).group.conditions[0].operator)
+      .toBe('isNotNull');
+  });
+
+  it('round-trips condition → group → condition', () => {
+    for (const c of [{ closed_at: { $null: true } }, { closed_at: { $null: false } }]) {
+      const { group, representable } = conditionToGroup(c);
+      expect(representable, `${JSON.stringify(c)} fell back to the source editor`).toBe(true);
+      expect(groupToCondition(group)).toEqual(c);
+    }
+  });
+});
+
+/**
+ * Offered ⇄ expressible parity for THIS inspector.
+ *
+ * The direction that broke: every guard in the repo sweeps spec → objectui,
+ * asking whether an operator an author may DECLARE can be rendered. None asks
+ * whether an operator this dropdown OFFERS can be stored by the consumer that
+ * mounted it — and that is the direction where an unmapped operator becomes
+ * silent data loss rather than a rendering gap.
+ *
+ * The offering is read from the builder's own bucket function with NO
+ * `extraOperators`, which is exactly what `DatasetFilterField` passes, so a
+ * future opt-in granted at that call site has to come through here.
+ */
+const PROBE_FIELD_TYPES: ReadonlyArray<string | undefined> = [
+  undefined, 'text', 'a_type_this_builder_has_never_heard_of', 'number', 'currency',
+  'percent', 'rating', 'boolean', 'date', 'datetime', 'time', 'select', 'status',
+  'lookup', 'master_detail', 'user',
+];
+
+function offeredAcrossBuckets(extra: readonly string[]): string[] {
+  const ids = new Set<string>();
+  for (const type of PROBE_FIELD_TYPES) for (const op of operatorsForFieldType(type, extra)) ids.add(op.value);
+  return [...ids].sort();
+}
+
+/** What the dataset inspector's filter popover offers. */
+const OFFERED = offeredAcrossBuckets([]);
+
+/**
+ * Offered, and deliberately NOT expressible by this bridge today.
+ *
+ * Each one drops on commit, and a drop of the last surviving row erases the
+ * stored filter — the same mechanism objectui#9363 fixed for the null pair.
+ * They are listed rather than fixed here because mapping them is a separate
+ * decision per operator (`between` needs a both-bounds-present rule before it
+ * can be emitted at all), and a blanket "stop dropping" would emit filters that
+ * mean something else. Mapping one is what makes this list shrink — and this
+ * assertion go red until it is updated.
+ */
+const DECLARED_UNEXPRESSIBLE = ['between', 'endsWith', 'notContains', 'startsWith'];
+
+/** A value that keeps a row from being dropped as INCOMPLETE, per operator. */
+function probeValue(operator: string): unknown {
+  if (VALUELESS_FILTER_BUILDER_OPERATORS.has(operator)) return '';
+  if (operator === 'in' || operator === 'notIn') return ['a', 'b'];
+  if (operator === 'between') return [1, 5];
+  return 'x';
+}
+
+describe('every operator this inspector OFFERS is either expressible or declared (objectui#9363)', () => {
+  it('the probe types cover every bucket, so the offering below is the whole dropdown', () => {
+    // Granting every id as an opt-in yields the full drawable vocabulary only
+    // if the probe list reaches every bucket. Without this, a bucket added
+    // later would silently shrink what the partition below is asserted over.
+    expect(offeredAcrossBuckets(FILTER_BUILDER_OPERATORS)).toEqual([...FILTER_BUILDER_OPERATORS].sort());
+  });
+
+  it('partitions the offering exactly — no operator is silently unhandled', () => {
+    const expressible: string[] = [];
+    const dropped: string[] = [];
+    for (const operator of OFFERED) {
+      (groupToCondition(row(operator, probeValue(operator))) === undefined ? dropped : expressible)
+        .push(operator);
+    }
+    expect(dropped.sort()).toEqual(DECLARED_UNEXPRESSIBLE);
+    // The other half of the equality: every remaining offered id serializes.
+    expect(expressible.sort()).toEqual(OFFERED.filter((o) => !DECLARED_UNEXPRESSIBLE.includes(o)));
+    // And the null pair is on the expressible side — the card's defect, stated
+    // as a fact about the offering rather than about two literals.
+    expect(expressible).toContain('isNull');
+    expect(expressible).toContain('isNotNull');
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/datasetFilterCondition.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/datasetFilterCondition.ts
@@ -11,6 +11,11 @@
  * (nested groups, `$or`, multi-operator objects, unmapped operators) is reported
  * as NOT representable so the caller can fall back to the source editor instead
  * of silently corrupting the author's filter.
+ *
+ * The value-less operators are the exception to "field op value": the builder
+ * draws no input for them, so the row is complete without one. Both pairs the
+ * spec's vocabulary carries — `$exists` (is empty) and `$null` (is null) — are
+ * bridged here, in {@link VALUELESS_TO_MONGO}.
  */
 
 /** FilterBuilder camelCase operator → FilterCondition Mongo operator. */
@@ -24,6 +29,32 @@ const MONGO_TO_OP: Record<string, string> = {
   $eq: 'equals', $ne: 'notEquals',
   $gt: 'greaterThan', $gte: 'greaterOrEqual', $lt: 'lessThan', $lte: 'lessOrEqual',
   $contains: 'contains', $in: 'in', $nin: 'notIn',
+};
+
+/**
+ * Value-less builder operators, and the predicate each one lowers to.
+ *
+ * A row carrying one of these is COMPLETE without a value — the builder draws
+ * no input for it — so they are matched ahead of the value-completeness check
+ * in {@link groupToCondition}, not after it.
+ *
+ * `isNull` / `isNotNull` are not a spelling of `isEmpty` / `isNotEmpty`. The
+ * dropdown offers both pairs as their own rows and the spec's filter vocabulary
+ * carries both `$null` and `$exists`, so they stay distinct in both directions;
+ * collapsing them would draw two labels for one wire predicate and rewrite the
+ * author's choice when the filter is read back.
+ *
+ * objectui#9363: the null pair was missing here, so an `Is null` row — an
+ * ordinary entry in this inspector's menu, drawn as a finished row — fell
+ * through to the unmapped-operator `continue` below and was dropped. Dropping
+ * the last surviving row makes this function return `undefined`, and the
+ * inspector commits that as `{ filter: undefined }`, the same patch shape used
+ * to CLEAR the filter. So picking the entry erased the author's stored filter,
+ * with no error and the condition still on screen.
+ */
+const VALUELESS_TO_MONGO: Record<string, Record<string, boolean>> = {
+  isEmpty: { $exists: false }, isNotEmpty: { $exists: true },
+  isNull: { $null: true }, isNotNull: { $null: false },
 };
 
 export interface BuilderCondition { id?: string; field: string; operator: string; value?: unknown }
@@ -53,10 +84,17 @@ export function groupToCondition(group: BuilderGroup | undefined): FilterConditi
   const conds = (group?.conditions ?? []).filter((c) => c && c.field);
   const parts: FilterCondition[] = [];
   for (const c of conds) {
-    if (c.operator === 'isEmpty') { parts.push({ [c.field]: { $exists: false } }); continue; }
-    if (c.operator === 'isNotEmpty') { parts.push({ [c.field]: { $exists: true } }); continue; }
+    const valueless = VALUELESS_TO_MONGO[c.operator];
+    if (valueless) { parts.push({ [c.field]: { ...valueless } }); continue; }
     const mop = OP_TO_MONGO[c.operator];
-    if (!mop) continue; // unmapped (e.g. notContains/between) — drop rather than emit a bad filter
+    // Still dropped rather than emitted in a spelling that means something
+    // else. ⚠️ The drop is not free: it is what erases the stored filter when
+    // no other row survives (see VALUELESS_TO_MONGO), and this menu offers
+    // `notContains` / `between` / `startsWith` / `endsWith`, none of which this
+    // table maps. Mapping one is a per-operator decision — `between` needs a
+    // both-bounds-present rule before it can be emitted at all — so they are
+    // declared, and pinned, in `datasetFilterCondition.nullOperators-9363`.
+    if (!mop) continue;
     // Skip incomplete rows (no value typed yet) — emitting `{field:{$op:''}}` would
     // be a silently-wrong filter (matches only empty), not "no filter".
     const v = c.value;
@@ -96,6 +134,13 @@ export function conditionToGroup(cond: FilterCondition | undefined | null): { gr
       const mop = opKeys[0];
       if (mop === '$exists') {
         conditions.push({ id: `c${i}`, field, operator: v.$exists ? 'isNotEmpty' : 'isEmpty', value: '' });
+      } else if (mop === '$null') {
+        // The inverse of the write half: `$null: false` is "is not null", so
+        // the boolean picks the operator rather than becoming the row's value.
+        // Without this arm a filter this bridge now WRITES would read back as
+        // non-representable, sending the author to the Source tab for a row the
+        // builder can draw.
+        conditions.push({ id: `c${i}`, field, operator: v.$null ? 'isNull' : 'isNotNull', value: '' });
       } else {
         const op = MONGO_TO_OP[mop];
         if (!op) return { group: empty, representable: false };


### PR DESCRIPTION
Fixes #9363

`groupToCondition` had no row for `isNull` / `isNotNull`, so an `Is null` row fell through to the
unmapped-operator `continue`. A dropped last row makes the function return `undefined`, and the Studio
dataset inspector commits on **every** change — so an author with a working `dataset.filter` who opened
the filter popover and switched the single condition's operator to **Is null** committed `undefined`,
and the persisted filter was destroyed. Nothing errored; the panel still showed the condition.

## What changed

- `groupToCondition`: `isNull` serializes to `{ field: { $null: true } }`, `isNotNull` to `{ $null: false }`.
  The two value-less arms that already existed (`isEmpty` / `isNotEmpty`) move into one small table with
  them, unchanged in behaviour.
- `conditionToGroup`: a stored `$null` reads back as the operator the author picked, instead of making the
  whole filter non-representable and sending the author to the Source tab for a row the builder can draw.
  Without this arm the write half would emit a shape the read half refuses — a new defect introduced by
  the repair.
- A new pin, `datasetFilterCondition.nullOperators-9363.test.ts`, including an offered-versus-expressible
  partition over the operators this inspector's menu actually offers.

`$null` stays distinct from `$exists`. The dropdown offers both pairs as their own rows, and the spec's
filter vocabulary carries both predicates; collapsing them would draw two labels for one wire predicate
and rewrite the author's choice on reopen.

## Premise re-verified against `origin/main` — with one correction

Verified true at `69aa9c017`: the four cited lines are verbatim; `OP_TO_MONGO` has **0** rows matching
`/null/i`; `DatasetDefaultInspector` mounts the builder with no `extraOperators`, so `isNull` / `isNotNull`
are ordinary default-menu entries (only `containsCaseInsensitive` / `exists` / `notExists` are opt-in).

**Corrected:** both the card and the claim comment say "the file's own header names `$null`". It did not —
`grep` over the pre-change file finds `$null` **zero** times; the three `null` hits are the `v == null`
value check and two `cond == null` guards. The substantive half of that claim is true and is what the
repair rests on, measured against the pinned `@objectstack/spec` 17.4.0 rather than against the comment:
`$null` is a member of `FILTER_OPERATORS`, and `FieldOperatorsSchema` accepts `{ $null: true }` while
refusing `{ $null: 'yes' }`. Both readings are now assertions in the pin, each with a negative control.
(After this change the header does name `$null`.)

## Red-first, control in the same run

On the unmodified tree the new file reported `Tests 7 failed | 7 passed (14)`. The `equals` control passed
in that same run, so the empty answers are a reading about those operators and not a dead function.

```
AssertionError: the commit for this gesture was `undefined`, which erases the stored filter:
  expected undefined to deeply equal { stage: { '$null': true } }
- Expected:  { "stage": { "$null": true } }
+ Received:  undefined
```

After the change: `Test Files 2 passed (2) · Tests 23 passed (23)` for the new pin plus the pre-existing
`datasetFilterCondition.test.ts`, so the existing pins are untouched.

## The distinction is kept, and pinned

`notContains` / `between` / `startsWith` / `endsWith` still drop rather than emit a spelling that means
something else. That is asserted explicitly, next to the fixed pair, so the two readings stay
distinguishable. The repair adds table rows; it does not make the fallback stop dropping.

## Measured: does `onCommit(undefined)` really clear the stored key

The card measured only at the function boundary. Traced the rest of the path in the tree:

1. `DatasetFilterField` commits `onPatch({ filter: fc })` (and `patchMeasure(i, { filter: fc })` for a
   measure filter).
2. The host applies patches as `{ ...draft, ...patch }`, so the key is set to `undefined` — it is not
   dropped from the patch.
3. `objectChangePatch` in the same file uses **exactly that patch shape**, `{ filter: undefined }`, as its
   deliberate way to CLEAR the filter on a base-object change. Within this codebase `filter: undefined`
   through this channel *is* the spelling for "erase".
4. Save sends the whole document (`client.save(type, name, itemToSave)`), and `JSON.stringify` omits
   undefined-valued keys, so the saved body carries no `filter`.

Steps 1 to 3 are read from this repo and are decisive for the draft. Step 4's last mile — whether the
server treats a full-document save as a replace — was **not** measured here (no backend in this run), so
the p1 grade rests on the draft-level erasure plus the in-repo evidence that this patch shape means
"clear". It was not weakened by anything measured.

## Enumerated: every operator `OP_TO_MONGO` lacks

Not inferred from the two the card names. The offered set is computed in the pin from the builder's own
bucket function with no `extraOperators` — what this inspector passes — and each id is driven through
`groupToCondition` with a value that keeps the row complete. Before the change the dropped set was exactly:

`between`, `endsWith`, `isNotNull`, `isNull`, `notContains`, `startsWith`

After the change: `between`, `endsWith`, `notContains`, `startsWith` — all four **offered by this menu**
and all four erasing the stored filter the same way when they are the last surviving row.

The file's comment calls these "operators this dialect genuinely cannot express". Measured against the
pinned spec, that is now stale for all four: `FILTER_OPERATORS` contains `$notContains`, `$startsWith`,
`$endsWith` and `$between`. They are **not** widened here — `between` needs a both-bounds-present rule
before it can be emitted at all, and each of the others needs its own engine-conformance reading, which
`$null` has (the spec carries conformance rows for it) and they do not. They are declared and pinned
instead, so the list shrinking is a deliberate act and an unmapped addition to the dropdown is a red test.

## Decision: no write-direction signal in this card

The card raises the asymmetry — the read half reports `representable: false`, the write half drops
silently — and asks whether the write half should gain an equivalent. Measured before deciding:

- `groupToCondition` has exactly **one** production caller, the inspector's popover `onChange`.
- What that caller could do with a signal is bounded by the builder's state model: `FilterBuilder` keeps
  its own `filterGroup` and re-seeds it from the `value` prop whenever the two differ. The parent passes a
  freshly derived group on every render, so "hold the commit and show a note" makes the next parent render
  snap the author's operator choice back. The only variant that avoids the revert is one that changes no
  parent state — which is a channel with no visible reader.
- A signal on the return type also moves the published surface, for a channel whose one reader cannot act
  on it.

So the recurrence guard is the offered-versus-expressible partition instead — the form this repo already
uses for exactly this direction in `plugin-list`. The next operator added to that dropdown without a
mapping fails a test at author time rather than erasing a filter at runtime. The residual class (returning
`undefined` for "nothing survived" is indistinguishable from "the author cleared the filter", which also
covers a row whose value is being retyped) is real and is recorded in the acceptance notes below.

## Ablation, both legs, restored by hash

Each leg mutates on disk under `trap ... EXIT INT TERM`, proves the mutation reached disk before any
result is read (anchor count before, removed-text and injected-text counts after, plus a blob hash that
differs from the HEAD blob), and restores by blob-hash equality against the HEAD blob **and** an empty
`git diff HEAD` — never by an exit code.

| leg | mutation | predicted | observed |
|---|---|---|---|
| write | delete the two new table rows | the 6 write-side assertions red, control green | `Tests 6 failed / 8 passed (14)` — exactly those 6 |
| read | make the `$null` arm unreachable | the 2 read-side assertions red | `Tests 2 failed / 12 passed (14)` — exactly those 2 |

Both restores reported `RESTORED: blob 1cd8052cd43d3390d53ae5ed9ed197d7fca7c120 == HEAD blob ..., git diff HEAD empty`.
No null result to report on these legs: every leg could fail and did.

## Clause-② verified mechanically, not by inspection

Built `@object-ui/app-shell` through the turbo task graph, fingerprinted every emitted `.d.ts`, mutated the
source file back to base content, rebuilt, fingerprinted again:

- 461 `.d.ts` files, **byte-identical** between the two trees.
- The rebuild was a genuine cache miss (`8d0aaef40e518886` against the fixed tree's `a822ec5a72258fd3`), so
  the identity is a measurement and not a replayed cache.

No published surface moved. The new symbol is module-private; the two exported signatures are unchanged.

## Membership read

- `.changeset/config.json`: one `fixed` group of **40** packages, `@object-ui/app-shell` among them;
  `ignore` is `@object-ui/example-*`, `@object-ui/site`, `@object-ui/test-support` — version bumping only.
- Type-check set: `@object-ui/site` **has** a `type-check` script, so it is not excluded there.
- Root `build` is `turbo run build --filter=!@object-ui/site`.
- `@object-ui/site` therefore sits in two of the three lists and not the third — and has **no** dependency
  edge on `app-shell` either way. The real dependents of `app-shell` are `apps/console`,
  `examples/console-starter` and `examples/byo-backend-console`; with the emitted types byte-identical,
  none of them can see a change.

## Verification run here

- `pnpm exec vitest run packages/app-shell/` — **693 files passed, 6757 passed / 1 skipped, 0 failed**.
- `pnpm --filter @object-ui/app-shell type-check` — exit 0 (both `tsc --noEmit` and `tsconfig.test.json`;
  `--listFiles` confirms the new test file is in that program, 4522 files).
- `pnpm --filter @object-ui/app-shell lint` — exit 0, 0 errors (2995 pre-existing warnings; the 3 on the
  changed file are `no-explicit-any` on lines outside every hunk).
- `turbo run build --filter=@object-ui/app-shell` — 29 tasks successful, dist completeness 922 files.
- Gate scripts derived by hand from `package.json` + `.github/workflows/` and run here: `check:control-bytes`,
  `check:new-line-citations`, `check:action-ref-convention`, `check:shell-escape-residue`,
  `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:vi-mock-override-shape`, `check:test-path-roots`,
  `check-changeset-presence.mjs`, `check-changeset-no-major.mjs` — all exit 0.
- **NOT MEASURED:** `check:readme-exports`. It exits 1 here with 72 entries all reading
  `its type entry ./dist/index.d.ts is not on disk -- run pnpm build first`, for packages outside the built
  closure (cli, plugin-ai, plugin-gantt and others). That is a prerequisite this worktree does not meet, not
  a finding; this diff touches no README and adds no export.

## Inherited reds — not from this diff

`Doc Snippet Type Check` and `Bundle Analysis` are red on `main`. This diff touches no `content/docs/**` and
no bundle. `Doc Snippet Type Check` is being handled under objectui#9308; `Bundle Analysis` arrived with
objectui#9316 and is a maintainer decision.

## In flight

No open PR touches either file in this diff (file lists read from the PR head refs, not from titles).
The nearest by directory is #9366 (`metadata-admin/celAuthoring.ts`, `CelPredicateField.tsx`,
`clientValidation.ts`, `inspectors/ObjectFieldInspector.tsx`) — different files. #9358 edits
`components/src/custom/filter-builder.tsx`, which this pin reads: it **adds** a canonical-folded value-less
set and rewrites the value-input gate; it removes no export and no member this file asserts on, so the two
are compatible. #9362 is the sibling card and stays in `plugin-list`.

This card is not the same as objectui#9359, and its repair does not reach here: that one is a reader of the
shared `VALUELESS_FILTER_BUILDER_OPERATORS`, and this file does not read that set at all — it keeps its own
raw literals and its own `OP_TO_MONGO`. Widening the shared set would not have reached this file either.
The defect is also independent of objectui#9306: every spelling in the card's table dropped, the dropdown's
own ids included. Neither of those two cards is addressed by this pull request.

## Acceptance notes

Out of scope here, noted rather than filed by this seat — the issue API was rate-limited
(`API rate limit already exceeded`) at filing time, so these are handed back for the PM to archive:

- **`undefined` means two different things on the write half.** "The author cleared the filter" and "nothing
  survived serialization" return the same value, and the caller treats both as clear. Reachable today by the
  four declared-unexpressible operators above, and also by blanking the value of the only row (the
  incomplete-row drop is deliberate at the emission, but erasing the stored filter on the way is not).
  Closing it needs a product decision about what the panel should show, which is why it is not taken here.
- **`isEmpty` / `isNotEmpty` lower onto `$exists`, not onto an emptiness predicate.** Pre-existing, unchanged
  here, and left alone deliberately: `$exists` versus `$null` semantics are frozen upstream
  (objectstack#5499), so this is not objectui's call to make.
- Dedup for both was done on the 12 open issues carrying `package: app-shell`, read through the zero-quota
  page payload with objectui#9363 itself as a known-hit control (present, so the empty result is a reading).
  A same-class card filed without that label would not have been seen.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_