### PR TITLE
docs: publish each page's own values through the scope channel on the three remaining teaching surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ npm install @object-ui/react @object-ui/components
 
 ```tsx
 import React from 'react'
-import { SchemaRenderer } from '@object-ui/react'
+import { PredicateScopeProvider, SchemaRenderer } from '@object-ui/react'
 // Importing the package registers every default renderer as a side effect —
 // there is no separate registration call.
 import '@object-ui/components'
@@ -92,15 +92,27 @@ const schema = {
 }
 
 function App() {
-  const data = {
+  // Every key of this object becomes a root the schema's expressions can read —
+  // `stats` here is what answers `${stats.users}`.
+  const scope = {
     stats: { users: 1234, revenue: "$56,789", orders: 432 }
   }
 
-  return <SchemaRenderer schema={schema} data={data} />
+  return (
+    <PredicateScopeProvider scope={scope}>
+      <SchemaRenderer schema={schema} />
+    </PredicateScopeProvider>
+  )
 }
 
 export default App
 ```
+
+Expression scope reaches the renderer through the provider, never through a prop on the
+element. `SchemaRenderer` declares exactly one prop, `schema`, and forwards every other prop
+it is handed to the component the schema names — so a value passed as `data={…}` is neither
+read nor refused, and the expression that wanted it is returned as its own source text, with
+nothing thrown and nothing logged.
 
 ### Bring your own backend
 
@@ -170,6 +182,10 @@ Vite/Next.js app. `schema-catalog` is a data package — the canonical JSON sche
 docs render, a smoke test mounts, and AI agents use as a few-shot corpus.
 
 ## Copy-Paste Schemas
+
+A `${name.…}` in any of these reads the root `name` off the scope the host published — see
+["Basic Usage"](#basic-usage) for the provider that publishes one. A head name nothing
+published is not an error: the expression is returned as its own source text.
 
 #### 📝 Contact Form
 
@@ -258,9 +274,9 @@ Object UI talks to any backend through one `DataSource` interface.
 npm install @object-ui/data-objectstack
 ```
 
-```typescript
+```tsx
 import { createObjectStackAdapter } from '@object-ui/data-objectstack';
-import { SchemaRenderer } from '@object-ui/react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
 import type { BaseSchema } from '@object-ui/types';
 
 // Your page schema — "Render a schema" above writes one out in full.
@@ -271,9 +287,17 @@ const dataSource = createObjectStackAdapter({
   token: 'your-auth-token'
 });
 
-// Use with any component
-<SchemaRenderer schema={schema} dataSource={dataSource} />
+// The adapter is injected through the provider — `SchemaRenderer` does not read
+// a `dataSource` prop, it forwards it to the component the schema names.
+<SchemaRendererProvider dataSource={dataSource}>
+  <SchemaRenderer schema={schema} />
+</SchemaRendererProvider>
 ```
+
+⛔ `dataSource` is the **adapter** — the object data renderers call `find()` on — and not an
+expression root. It is a different channel from the expression scope above: publish the values
+your `${…}` expressions read with `PredicateScopeProvider`, and inject the adapter your data
+components query with `SchemaRendererProvider`.
 
 ### Custom Data Sources
 

--- a/content/docs/guide/architecture.md
+++ b/content/docs/guide/architecture.md
@@ -52,7 +52,7 @@ ObjectUI is organized as a PNPM monorepo with clear separation of concerns:
 - **Contains**: Schema validation, expression evaluation, registries
 - **Constraint**: No UI library dependencies, logic only
 - **Features**: 
-  - Expression engine (`visible: "${data.age > 18}"`)
+  - Expression engine (`visible: "${record.age > 18}"`)
   - Schema registry and validation
   - Event system
 
@@ -132,14 +132,19 @@ A backend system sends a JSON schema:
 
 The `SchemaRenderer` component:
 
-1. Receives the schema + data context
+1. Receives the schema, and reads the expression scope off the context above it
 2. Evaluates expressions (`${user.name}`)
 3. Looks up the component type in the registry
 4. Recursively renders child schemas
 5. Handles events and state updates
 
+The scope does **not** arrive as a prop. `SchemaRenderer` declares exactly one prop, `schema`,
+and forwards everything else it is handed to the component the schema names — so a `data={…}`
+written on the element is neither read nor refused. The host publishes its values with
+`PredicateScopeProvider`, and every key it publishes becomes a root the expressions can read:
+
 ```tsx
-import { SchemaRenderer } from '@object-ui/react'
+import { PredicateScopeProvider, SchemaRenderer } from '@object-ui/react'
 import type { BaseSchema } from '@object-ui/types'
 
 // The schema from step 1, as the object the renderer receives.
@@ -153,11 +158,24 @@ const schema: BaseSchema = {
 }
 
 function App() {
-  const data = { user: { name: 'Alice' } }
+  const scope = { user: { name: 'Alice' } }
 
-  return <SchemaRenderer schema={schema} data={data} />
+  return (
+    <PredicateScopeProvider scope={scope}>
+      <SchemaRenderer schema={schema} />
+    </PredicateScopeProvider>
+  )
 }
 ```
+
+An app built on `@object-ui/app-shell` does not mount this provider itself: the shell's
+`ExpressionProvider` already feeds the same channel with the signed-in `user` (also readable as
+`current_user`) and `features`. On top of what the host published, the renderer supplies
+`record` — the row a record surface is bound to — and `page`, the page-local variables.
+
+⛔ `SchemaRendererProvider`'s `dataSource` is **not** an expression root. It carries the host's
+`DataSource` *adapter*, the object data renderers call `find()` on; the two are different
+channels on purpose.
 
 ### 3. Component Registry Lookup
 
@@ -244,10 +262,16 @@ ObjectUI includes a powerful expression engine for dynamic UIs:
 {
   "type": "button",
   "label": "Submit",
-  "visible": "${form.isValid && !form.isSubmitting}",
-  "disabled": "${form.isSubmitting}"
+  "visible": "${current_user.role === 'admin'}",
+  "disabled": "${record.status === 'locked'}"
 }
 ```
+
+`current_user` is the signed-in user the host's `ExpressionProvider` publishes; `record` is the
+row a record surface is bound to, and is the only spelling a row field has — the bare shorthand
+(`status`) and the wrong-layer `data.status` were both retired on runtime record surfaces
+(objectui#5330 phase 2). A head name outside the scope is not refused: the predicate is
+unevaluable, this surface fails soft, and the node is shown on every row.
 
 A button's text key is `label`, and `text` is not a `ButtonSchema` key at all. Nothing
 refuses the misspelling either: `BaseSchema` is `.passthrough()`, so the validator KEEPS

--- a/content/docs/guide/expressions.md
+++ b/content/docs/guide/expressions.md
@@ -570,7 +570,8 @@ All expression outputs are automatically sanitized to prevent XSS attacks.
 
 ### Expression Errors
 
-Invalid expressions show helpful error messages:
+An expression that cannot be resolved is **not** an error the reader sees, and it is not the
+same failure in both directions. Measured on the built evaluator:
 
 ```json
 {
@@ -579,7 +580,14 @@ Invalid expressions show helpful error messages:
 }
 ```
 
-Error: "Cannot read property 'invalidProperty' of undefined"
+| the scope | what the evaluator returns |
+|---|---|
+| `user` is published, `invalidProperty` is not a member of it | `undefined` — nothing is thrown |
+| no `user` root at all | the template's own **source text**, and one line on the console |
+
+So a missing member renders as nothing, and a missing root renders as the characters you
+typed. Neither raises, and neither stops the render — which is why the scope a page publishes
+has to be stated rather than assumed.
 
 ### Debug Mode
 

--- a/content/docs/guide/expressions.md
+++ b/content/docs/guide/expressions.md
@@ -15,12 +15,13 @@ Expressions are JavaScript-like code snippets embedded in schemas using the `${}
 }
 ```
 
-With data:
+With this published as the expression scope:
 ```tsx
-const data = { user: { name: "Alice" } }
+const scope = { user: { name: "Alice" } }
 ```
 
-This renders: **"Hello, Alice!"**
+This renders: **"Hello, Alice!"** — `user` is a root because the host published a key by that
+name. [Data Context](#data-context) below shows the provider that publishes one.
 
 ## Basic Syntax
 
@@ -145,25 +146,44 @@ Disable component when expression is true:
 {
   "type": "button",
   "label": "Submit",
-  "disabledOn": "${form.submitting || !form.isValid}"
+  "disabledOn": "${record.status === 'submitted'}"
 }
 ```
 
 ## Data Context
 
-### Accessing Root Data
+### Where the names come from
 
-The root data object is available directly:
+Expression scope does **not** arrive as a prop. `SchemaRenderer` declares exactly one prop,
+`schema`, and forwards every other prop it is handed straight through to the component the
+schema names — so a `data`, `dataSource` or `debug` written on the element is neither read nor
+refused. Nothing throws and nothing warns; the expression simply never resolves, and an
+unresolvable template is returned as its own source text, so the characters you typed are what
+the reader sees.
 
-<!-- doc-snippet: fragment — closes on a bare `<SchemaRenderer />` tag whose `schema` is the reader's own document, so the block is a data shape followed by a tag rather than a program -->
+The host publishes its values with `PredicateScopeProvider`, and every key it publishes becomes
+a root:
 
 ```tsx
-const data = {
-  user: { name: "Alice" },
-  settings: { theme: "dark" }
+import { PredicateScopeProvider, SchemaRenderer } from '@object-ui/react'
+import type { BaseSchema } from '@object-ui/types'
+
+// The page schema — your own document.
+declare const schema: BaseSchema
+
+// Every name here becomes a root the schema's expressions can read.
+const scope = {
+  user: { name: 'Alice' },
+  settings: { theme: 'dark' },
 }
 
-<SchemaRenderer schema={schema} data={data} />
+function App() {
+  return (
+    <PredicateScopeProvider scope={scope}>
+      <SchemaRenderer schema={schema} />
+    </PredicateScopeProvider>
+  )
+}
 ```
 
 ```json
@@ -172,6 +192,29 @@ const data = {
   "content": "Theme: ${settings.theme}"
 }
 ```
+
+The scope the evaluator builds is what you published, plus two names the renderer supplies:
+
+| name | what it holds |
+|---|---|
+| every key of `scope` | exactly what you put there — `user`, `settings`, whatever the page needs |
+| `record` | the row a record surface is bound to, when there is one |
+| `page` | page-local variables, for predicates that gate on another component's state |
+
+`current_user` is an alias of whatever you published as `user`; an app built on
+`@object-ui/app-shell` does not mount the provider itself, because the shell's
+`ExpressionProvider` already feeds the same channel with the signed-in `user` and `features`.
+
+> **`dataSource` is not an expression root.** `SchemaRendererProvider`'s `dataSource` carries
+> the host's `DataSource` *adapter* — the object renderers call `find()` on. The renderer used
+> to publish that adapter under the name `data`; an adapter answers no `data.*` path, so the
+> root was constant for every conformant host, and objectui#9308 removed it. A `${data.…}`
+> expression now reads whatever *you* published under `data`, and nothing if you published
+> none. **This changes the verdict of a gate already in the field**: `visible: "${data.x}"`
+> used to resolve to `undefined` and HIDE its node on every row; with no `data` key at all it
+> is unevaluable, this surface fails soft, and the node is SHOWN. At the runtime layer the row
+> is `record` (ADR-0089 D3) — rewrite such a gate to `record.*` rather than re-publishing a
+> `data` key.
 
 ### Scoped Data
 
@@ -420,6 +463,12 @@ or author each variant and gate it with a condition key:
 
 ## Form Expressions
 
+A form's own values are the **row under edit**, and the row is bound as `record` and nothing
+else — the bare shorthand (`country`) and the wrong-layer `data.country` were both retired on
+runtime record surfaces (objectui#5330 phase 2), and `record` is the canonical runtime-layer
+root (ADR-0089 D3). There is no `form` root: a predicate written against one is unevaluable,
+and a fail-soft surface answers it by showing the field on every row.
+
 ### Dependent Fields
 
 ```json
@@ -436,7 +485,7 @@ or author each variant and gate it with a condition key:
       "type": "select",
       "name": "state",
       "label": "State/Province",
-      "visibleOn": "${form.country === 'USA'}",
+      "visibleOn": "${record.country === 'USA'}",
       "options": ["CA", "NY", "TX"]
     }
   ]
@@ -467,7 +516,7 @@ evaluated on every component type:
 ```json
 {
   "type": "text",
-  "content": "Total: ${form.price * form.quantity}"
+  "content": "Total: ${record.price * record.quantity}"
 }
 ```
 
@@ -484,13 +533,13 @@ Expressions are re-evaluated when data changes. Avoid expensive operations:
   "content": "${users.map(u => expensiveOperation(u)).join(', ')}"
 }
 
-// ✅ Good: Pre-compute in data
+// ✅ Good: Pre-compute, and publish the result
 ```
 
 <!-- doc-snippet: fragment — the good half of a bad/good contrast: `users` and `expensiveOperation` are the reader's own rows and function, shown only to place the computation outside the expression -->
 
 ```tsx
-const data = {
+const scope = {
   processedUsers: users.map(u => expensiveOperation(u))
 }
 ```
@@ -534,19 +583,21 @@ Error: "Cannot read property 'invalidProperty' of undefined"
 
 ### Debug Mode
 
-Enable debug mode to see expression evaluation:
+`debug` is read off the same provider context as `dataSource`
+(`context?.debug || context?.debugFlags?.enabled`), never off the element — a `debug` written
+on `SchemaRenderer` is forwarded to the component the schema names, exactly like a `data` prop,
+and turns nothing on. Mount the provider instead:
 
-<!-- doc-snippet: fragment — a bare `<SchemaRenderer />` tag shown for the `debug` prop alone; `schema` and `data` are the reader's own -->
+<!-- doc-snippet: fragment — the provider pair shown for the `debug` flag alone; `schema` is the reader's own document, and `dataSource` is `null` because this mount is about the flag rather than about an adapter -->
 
 ```tsx
-<SchemaRenderer 
-  schema={schema} 
-  data={data}
-  debug={true}
-/>
+<SchemaRendererProvider dataSource={null} debug>
+  <SchemaRenderer schema={schema} />
+</SchemaRendererProvider>
 ```
 
-This logs all expression evaluations to the console.
+This logs all expression evaluations to the console. It is orthogonal to the expression scope:
+wrap this pair in a `PredicateScopeProvider` as well when you want both.
 
 ## Advanced Usage
 
@@ -567,12 +618,12 @@ const formatCurrency = (value: number) =>
 evaluateExpression('${formatCurrency(price)}', { formatCurrency, price: 1234.5 })
 ```
 
-That is the direct-evaluation path. A component expression rendered by
-`SchemaRenderer` resolves against the scope the renderer itself builds — the
-provider's data source (as `data`), the host scope (`user` / `current_user`) and
-page variables — so a function you registered elsewhere is not reachable from a
-schema expression. Compute the value before it reaches the schema, and bind the
-result.
+That is the direct-evaluation path, and `formatCurrency` is a root there because this call
+hands the evaluator its own context. A component expression rendered by `SchemaRenderer`
+resolves against a different scope — the names the host published through
+`PredicateScopeProvider`, plus `record` and `page` — so a function you registered elsewhere is
+not reachable from a schema expression. Compute the value before it reaches the schema, and
+bind the result.
 
 Hold an evaluator when you want one context reused — construct it, then call
 `evaluate`:
@@ -643,12 +694,12 @@ language's own. A membership test is written with the array method:
 
 ### 4. Use TypeScript
 
-Define your data types:
+Define the type of the scope you publish:
 
-<!-- doc-snippet: fragment — the typed data is followed by a bare `<SchemaRenderer />` tag and the literal is written as an elided `{ /* ... */ }`, so the block states a type rather than compiling -->
+<!-- doc-snippet: fragment — the typed scope is followed by a bare provider pair and the literal is written as an elided `{ /* ... */ }`, so the block states a type rather than compiling -->
 
 ```tsx
-interface UserData {
+interface AppScope {
   user: {
     name: string
     role: 'admin' | 'user'
@@ -656,8 +707,10 @@ interface UserData {
   }
 }
 
-const data: UserData = { /* ... */ }
-<SchemaRenderer schema={schema} data={data} />
+const scope: AppScope = { /* ... */ }
+<PredicateScopeProvider scope={scope}>
+  <SchemaRenderer schema={schema} />
+</PredicateScopeProvider>
 ```
 
 ## Next Steps


### PR DESCRIPTION
Part of #9297. ⚠️ Deliberately not a closing keyword: this repair covers the **three** surfaces that card's dispatch scoped, and the card's own addendum (comment `5646840050`) measured **six more sites on `content/docs/guide/schema-rendering.md`** — `status` x2, `loading`, `items`, `error` x2 — which are out of scope here. PR #9369 has since landed on `main` and moved none of them. They are cited below **by content**, never by a line address — objectui#8875's convention, and the AGENTS.md #9 class: a cross-file line number is derived once and re-derived never, and these six have already shifted under an earlier citation of them.

| section on `content/docs/guide/schema-rendering.md` | the site |
|---|---|
| `### Conditional Expressions` | the `card` node's `"title"` and its `"description"`, both opening `${status === 'active' ? …` |
| `### Loading States` | the `spinner`'s `"visibleOn": "${loading}"` |
| `### Empty States` | the `empty` node's `"visibleOn": "${items.length === 0}"` |
| `### Error States` | the `alert`'s `"visibleOn": "${error}"`, and the `"content": "${error.message}"` in its `body` |

⛔ Do not trust that table either — re-derive the set. This prints the head name of every expression on that page, multi-line templates included, and the `status`, `loading`, `items` and `error` rows are the six:

```
perl -0777 -ne 'while (/\$\{\s*([A-Za-z_\$][A-Za-z0-9_\$]*)/g) { print "$1\n" }' content/docs/guide/schema-rendering.md | sort | uniq -c | sort -rn
```

⚠️ A census anchored on the literal `${status` two-token sequence is **not** that instrument and undercounts this page: `${` sits alone at the end of its line in every multi-line template, so the head name lands on the next line and a same-line pattern cannot see it. That half stays open.

## What was wrong, and what moved

`SchemaRendererProps` declares exactly one prop, `schema`. A `data`, `dataSource` or `debug` written on the element is **forwarded** to the component the schema names — not read, not refused. Nothing throws, there is one line on the console, and the expression reaches the screen as the characters the author typed.

Per objectui#8021 leg D, moving only the wiring produces a page that reads as repaired and still prints raw source. So **both coordinates move together on every site**: the wiring becomes the provider that actually carries the value, and every head name on the page is judged against the scope the tree builds.

## Re-measured census, with the card's own lit control

Measured on this branch's base `69aa9c017` with the card's classifier — SchemaRenderer elements matched with a word boundary after the name, so `SchemaRendererProvider` is excluded by construction.

| surface | tag-shaped hits (base → head) | real JSX elements | forwarded look-alikes (base → head) |
|---|---|---|---|
| `content/docs/guide/schema-rendering.md` (out of scope) | 5 → 5 | 5 | 0 → 0 |
| `packages/react/README.md` (out of scope) | 4 → 4 | 4 | 0 → 0 |
| `content/docs/guide/expressions.md` | 6 → 3 | 3 | **3 → 0** |
| `content/docs/guide/architecture.md` | 1 → 1 | 1 | **1 → 0** |
| `README.md` (repo root) | 2 → 2 | 2 | **2 → 0** |
| **lit control** | **18 → 15** | **15** | **6 → 0** |

⭐ **The control reproduces the card's 18 exactly — and shows the 18 is not a count of elements.** Three of them are `SchemaRenderer` MENTIONS inside `doc-snippet: fragment` HTML comments on `expressions.md`, which the regex cannot tell from an element. Strip HTML comments first and the base has **15 real JSX elements**, not 18. The tag-shaped count falls to 15 here only because those three comments were rewritten; **no renderer element was added or deleted** (real elements: 15 → 15).

## Per-site judgement — 37 bare head names, individually judged

The ruling on objectui#9308 (option B) changed the question. Before it, the renderer bound a **closed** five-name root set, so "head name not in the set" was close to a verdict. After it, the root set is **open**: every key the host publishes through `PredicateScopeProvider` is a root. ⇒ the test is no longer *is this name in the set*, it is **does the page publish this name, and does it say so**.

The rule applied, stated once so each row can be checked against it: a head name **moves to `record.`** when the passage says the value is the row the surface is bound to; it **stays bare** when the passage presents it as a value the host computed and published.

### Moved — 5 sites

| site | head | why it moved |
|---|---|---|
| `expressions.md` `:148` disabledOn | `form` | `form` is not a root on any tier; nothing in ObjectUI publishes one. Rewritten to `record.status`. |
| `expressions.md` `:439` Dependent Fields | `form` | A form's own values ARE the row under edit ⇒ `record.country`. |
| `expressions.md` `:470` Computed Fields | `form` | Same row ⇒ `record.price * record.quantity`. |
| `architecture.md` `:247` Conditional Rendering | `form` | `visible` rewritten to `current_user.role` — the ambient root the host's `ExpressionProvider` really publishes. |
| `architecture.md` `:248` Conditional Rendering | `form` | `disabled` rewritten to `record.status`. |

### Judged legitimate, left bare — 32 sites

| site(s) | head | why bare is correct |
|---|---|---|
| `expressions.md` x8 | `users` | The page's running collection; a root the host publishes. The Data Context section now publishes and names it. |
| `expressions.md` `:172` | `settings` | Published in the same passage, alongside `user`, by the provider the block now mounts. |
| `expressions.md` x2 | `price` | Host-computed value in the Operators section. |
| `expressions.md` | `score`, `count`, `total`, `items` | Same class: values the host computed and published. |
| `expressions.md` x2 | `status` | Host-published status value on standalone nodes, not inside a record surface. ⛔ Not moved to `record.` — that would assert a row context the passage never establishes. |
| `expressions.md` x2 | `task` | A host-published object the card is about; same reasoning. |
| `expressions.md` `:567` | `formatCurrency` | ⭐ The card named this one: it sits in "Custom Functions", where `evaluateExpression` is handed **its own context**. Legitimate by construction. Its surrounding prose was still wrong and is repaired (see below). |
| `expressions.md` `:612` | `adultUsersScore` | "Pre-compute complex logic" — a pre-computed root the reader publishes. That IS the lesson. |
| `expressions.md` `:621`, `:626` | `x`, `isAdmin` | "Use Meaningful Variable Names" — a naming contrast. The names are root-level by construction; changing them destroys the lesson. |
| `architecture.md` x2 | `orders` | Host-published collection in Data Transformations. |
| `README.md` x7 | `stats` | The flagship example's own bag. The bare name is right; what was wrong is that it arrived as a forwarded prop. Now published through `PredicateScopeProvider`. |
| `expressions.md` | `item`, `index` | Excluded up front by the card: list renderers publish them through a different mechanism. Untouched. |
| `expressions.md` | `Math`, `new` | JS built-ins, not scope roots. My scan counts 29 heads on that page where the card counted 26; the difference is exactly these three. |

## ⭐ A site the census could not see — and it is the one the ruling breaks

`content/docs/guide/architecture.md:55` authored `visible: "${data.age > 18}"`. The census classifier held `data` in the **accepted** root set, so this site was invisible to the offender column — and `data` is precisely the root objectui#9308 retires.

Measured on the built evaluator (control and both legs in the "Verification" section): **a missing root and a present-but-undefined root are not the same.** With `{ data: undefined }` the predicate is `false`; with no `data` key at all it is unevaluable and this surface fails soft to `true`. ⇒ a `data.*` gate authored from these pages used to **hide** its node on every row and now **shows** it. The site moves to `record.age` (the runtime layer's canonical root, ADR-0089 D3) and the guide states the flip in the migration note, rather than only renaming a provider.

## The Debug Mode block — both wrong props, not one

`expressions.md`'s Debug Mode block wrote `data={…}` **and** `debug={true}` on the element. `debug` is read off the provider context (`context?.debug || context?.debugFlags?.enabled`), so both were forwarded and neither did anything. The block is now a `SchemaRendererProvider` mount (with `dataSource={null}`, since that prop is required and this mount is about the flag), and the prose names the mechanism for both props.

Adjacent to it, the Custom Functions passage still stated the old scope verbatim — *"the provider's data source (as `data`), the host scope and page variables"*. That sentence is what the ruling deletes; it is rewritten in the same commit, because leaving it would have contradicted the new Data Context table on the same page.

## Shape

Matched to PR #9369, which moved the equivalent teaching on the two surfaces this card excludes: publish host values under a real name through `PredicateScopeProvider`, read them by that name, and state that `dataSource` is the **adapter** and not a root.

## Changeset

Not owed, by measurement rather than by assumption:

```
$ node scripts/check-changeset-presence.mjs
Compared the working tree with 69aa9c017 (merge-base with origin/main): 3 file(s) changed,
0 of them published source of a package the release covers, 0 of them a manifest whose
published contract moved, 0 under a package changesets ignores, 0 changeset(s) added.
✅  No source or published contract of a released package changed in this range, so no changeset is owed.
```

## Acceptance notes

Observed while judging these pages, **noted, not filed**:

* `AGENTS.md` §3 quotes the same retired spelling this PR repairs at `architecture.md:55` — `expression eval ("visible: "${data.age > 18}"")` in the `@object-ui/core` topology row. Not touched: `AGENTS.md` is a governed surface, and one path there would move this whole PR to the human-merge route. The carrier would be whoever next edits that table.
* `content/docs/guide/expressions.md` `:226` / `:242` author `${users}` on `list.items`, a key with no carriage row — reported (report-only) by `check-doc-expression-carriage`. Pre-existing and unchanged by this PR; the gate's own header routes this class to objectui#7440 / #7444 / #7838.
* ⭐ `content/docs/guide/expressions.md` Expression Errors claimed an invalid expression yields `Cannot read property … of undefined`. The card's addendum flagged it as NOT MEASURED. It is measured below, it is wrong in both directions, and it is **repaired here** under the bounded in-place carve-out rather than filed: the first commit states two sections up that an unresolvable template is returned as its own source text, so leaving the old sentence would have made the page contradict itself in the same pull request.

## The two behaviours a reader is now told about, measured

Both legs run against the **built** evaluator (`packages/core/dist`), the same artefact `check:doc-snippets` resolves against, each with a control that fires.

**Leg 1 — the verdict flip.** At the visibility layer (`evaluateCondition`, the layer a `visible` / `visibleOn` gate uses):

```
{ data: undefined }   data.status == 'draft'             => false
no data key at all    data.status == 'draft'             => true
  CONTROL — a published root, both polarities must differ:
{ record:{status:'draft'} } record.status=='draft'       => true
{ record:{status:'open'}  } record.status=='draft'       => false
```

⇒ a `data.*` gate authored from these pages used to **hide** its node on every row and now **shows** it. One layer down, on the raw `ExpressionEvaluator`, the missing-root case returns the template's own source text — which is the interpolation half of the same fact. Both halves are in the migration note.

**Leg 2 — what an unresolvable expression really does** (the card addendum's NOT-MEASURED item):

```
{ user: { name: 'Alice' } }  ${user.invalidProperty} => undefined
{} (no user root)            ${user.invalidProperty} => "${user.invalidProperty}"
evaluateExpression, no roots ${user.invalidProperty} => "${user.invalidProperty}"
  CONTROL (a resolvable one on the same instrument):
{ user: { name: 'Alice' } }  ${user.name}            => "Alice"
```

⇒ nothing is thrown on either path. The guide said `Cannot read property 'invalidProperty' of undefined`; that is false whether or not the root exists.

**Leg 3 — a bare head name IS a root when the host publishes it**, which is what makes 32 of the 37 sites legitimate:

```
{ stats: { users: 1234 } }   ${stats.users}          => 1234
{} (nothing published)       ${stats.users}          => "${stats.users}"
```

## Verification

All runs at head `20831dc1d`, heavy ones serialised through the shared verify lock.

| run | verdict |
|---|---|
| `pnpm exec turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter) --concurrency=2` | `Tasks: 35 successful, 35 total` · `BUILD EXIT=0` |
| `pnpm check:doc-snippets` | `Semantic phase: 650 of 650 block(s) judged, 3 failed.` · `EXIT=1` — ⭐ **all three are the inherited ones**, see below |
| `pnpm check:doc-fences` | `EXIT=0` — every TypeScript block in 227 document(s) fenced ts/tsx/typescript |
| `node scripts/check-doc-component-types.mjs` | `EXIT=0` — every documented component type is registered |
| `node scripts/check-doc-example-ids.mjs` | `EXIT=0` — 414 real reference(s) resolve |
| `node scripts/check-doc-links.mjs` | `EXIT=0` — links valid across 17 scan roots |
| `node scripts/check-control-bytes.mjs` | `EXIT=0` — 7539 tracked text file(s) |
| `node scripts/check-changeset-presence.mjs` | `EXIT=0` — no changeset owed |
| `node scripts/check-changeset-claims.mjs` | `EXIT=0` (report-only) |
| `node scripts/check-doc-expression-carriage.mjs` | `EXIT=0` (report-only); its two hits on `expressions.md` (`list.items` authoring `${users}`) are pre-existing and unchanged |
| `node scripts/check-governed-queue-guard.mjs --test` (the three paths) | `✅ NOT GOVERNED — 3 path(s) checked against 5 governed surface(s); none matched` |
| named witnesses, `pnpm exec vitest run` (6 files) | `Test Files 6 passed (6)` · `Tests 112 passed (112)` · `EXIT=0` |

`check:doc-snippets`' own controls all fired in that run, so the reading is a reading and not a degraded harness: `resolution` resolved `@object-ui/types` to the built `dist/index.d.ts`, `sentinel` produced TS2305, `positive` produced 0.

**Named witnesses.** Derived by hand from `scripts/markdown-test-inputs.mjs`, not guessed: `packages/components/src/__tests__/page-body-single-node-8310.test.tsx` reads the root `README.md` (it asserts the Basic Usage schema literal still spells its child list `children`, carries `type: "grid"` and three `type: "statistic"`, and the three labels) and four tests walk `content/docs/**`. The objectui#8021 pin was run too, even though its `TEACHING_SURFACES` are the two documents this PR does not touch. All green.

**Inherited reds — named, not repaired.**

* **Doc Snippet Type Check** — the three failures above are `content/docs/guide/schema-rendering.md:99`, `:434` and `packages/react/README.md:73`, all TS2740, all on the two surfaces this PR must not touch. They are objectui#9346 verbatim, and PR #9369 is what moves them.
* **Bundle Analysis** — arrived on `main` with #9316, a maintainer decision.

Drafted by the `os-dev` seat in session `session_01UzHd6hDYatoDn17BuwKxnZ` — attribution repeated as prose here because the footer block below does not reliably survive a later edit.

---

_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_