### PR TITLE
docs(skills): move the three published guides off the retired `dataSource` expression root

### DIFF
--- a/skills/objectui/guides/data-integration.md
+++ b/skills/objectui/guides/data-integration.md
@@ -9,7 +9,7 @@ Connecting schema-driven rendering to a real or mock data backend. The DataSourc
 │  Schema-Driven UI Layer     │
 │  (SchemaRenderer, Plugins)  │
 ├─────────────────────────────┤
-│  SchemaRendererProvider     │  ← dataSource prop
+│  SchemaRendererProvider     │  ← dataSource prop (the ADAPTER)
 ├─────────────────────────────┤
 │  DataSource Interface       │  ← universal API contract
 ├─────────────────────────────┤
@@ -18,7 +18,15 @@ Connecting schema-driven rendering to a real or mock data backend. The DataSourc
 └─────────────────────────────┘
 ```
 
-Components never import fetch libraries directly. They access data through `useDataScope(path)` or the DataSource methods from context.
+⚠️ That column is the FETCH channel and nothing else. The **values a page's
+`${…}` expressions and `bind` paths read** arrive on a second, independent
+channel — the ambient scope a host publishes with `PredicateScopeProvider`
+(objectui#9308). `dataSource` publishes no expression root and answers no `bind`
+path; keep the two apart when you wire a page.
+
+Components never import fetch libraries directly. They call the DataSource
+methods from context for CRUD, and read the ambient scope through
+`useDataScope(path)`.
 
 ## DataSource interface
 
@@ -151,9 +159,16 @@ const dataSource = new ObjectStackAdapter({
 
 ### Static data (no backend)
 
-For prototypes or static pages, pass a plain object as dataSource:
+For prototypes or static pages there is no adapter to inject. Publish the values
+as an ambient **scope** instead — that is the channel `bind` and `${…}` read:
 
-```typescript
+<!-- os:check -->
+```tsx
+import { PredicateScopeProvider, SchemaRenderer } from '@object-ui/react'
+import type { BaseSchema } from '@object-ui/types'
+
+declare const schema: BaseSchema
+
 const staticData = {
   customers: [
     { id: 1, name: 'Alice', email: 'alice@example.com' },
@@ -161,15 +176,25 @@ const staticData = {
   ],
   metrics: { total: 2, active: 1 },
   userRole: 'admin',
-};
+}
 
-<SchemaRendererProvider dataSource={staticData}>
-  <SchemaRenderer schema={schema} />
-</SchemaRendererProvider>
+function Prototype() {
+  return (
+    <PredicateScopeProvider scope={staticData}>
+      <SchemaRenderer schema={schema} />
+    </PredicateScopeProvider>
+  )
+}
 ```
 
 Components that read `bind` (see "Via `bind` + `useDataScope`" below) will then
 access `staticData.customers` when given `bind: "customers"`.
+
+⛔ Passing that same object as `SchemaRendererProvider`'s `dataSource` does
+**not** work and never warns: `dataSource` declares the `DataSource` adapter
+contract, it publishes no expression root, and `useDataScope` stopped walking it
+in objectui#9308. Every `bind` resolves `undefined` and every `${…}` on the
+page renders as its own source characters.
 
 ## ObjectStackAdapter
 
@@ -217,8 +242,10 @@ A component reads the `bind` field only if it calls `useDataScope`:
 }
 ```
 
-Inside the component: `const data = useDataScope("customerNames")` resolves to
-the `customerNames` array from the dataSource.
+Inside the component: `const data = useDataScope("customerNames")` resolves the
+`customerNames` array **from the ambient scope** a host published with
+`PredicateScopeProvider` — not from `SchemaRendererProvider`'s `dataSource`
+(objectui#9308).
 
 `useDataScope` is called by `list` and `tree-view` in `@object-ui/components`,
 and by the `object-*` widgets the plugin packages register (`object-grid`,
@@ -254,8 +281,9 @@ through is measured, with its open-question caveat, in
 ### Via expressions on the node
 
 Computed values go through the expression system. `content` is the text key that
-is both expression-evaluated and read back by the renderer, and the provider's
-`dataSource` is reachable under the `data` root:
+is both expression-evaluated and read back by the renderer. The roots it reads
+are the ones the host published on `PredicateScopeProvider`, so the example below
+assumes a scope carrying `data: { metrics: { total: … } }`:
 
 <!-- os:check -->
 ```json

--- a/skills/objectui/guides/schema-expressions.md
+++ b/skills/objectui/guides/schema-expressions.md
@@ -153,23 +153,29 @@ template iteration" below.
 > conformant host, and objectui#9308 removed it (maintainer ruling 2026-09-13).
 >
 > **Re-check every gate you authored from an older copy of this page: the
-> verdict moved.** Measured on the built evaluator, a root that is MISSING and a
-> root that is PRESENT-but-empty are not the same thing:
+> verdict moved.** A root that is MISSING and a root that is PRESENT-but-empty
+> are not the same thing, and the two layers that read `${…}` answer a missing
+> root differently. Measured on the built evaluator with `data.status == 'draft'`:
 >
-> | what the scope holds | `${data.status == 'draft'}` |
-> |---|---|
-> | `data` bound to the adapter, which has no `status` member | `false` |
-> | `data` present and `undefined` | `false` |
-> | no `data` root at all — what you get now unless you publish one | the condition path fail-softs to `true`; a text key renders the raw `${…}` characters, and objectui#5454's reporter warns |
+> | what the scope holds | as a predicate (`visible` / `hidden`) | interpolated into a text key (`content`) |
+> |---|---|---|
+> | `data` bound to the adapter, which has no `status` member | `false` | `false` |
+> | `data` present and `undefined` | `false` | `false` |
+> | no `data` root at all — what you get now unless you publish one | **fails soft to `true`** | **the template's own source characters are printed on screen** |
 >
-> So `"visible": "${data.status == 'draft'}"` written against the old wiring was
-> **hidden on every row**, and is now **shown on every row**. The same gate
-> spelled `"hidden"` flips the other way. Re-publishing `data` through
-> `PredicateScopeProvider` restores the old, always-`false` verdict — it does
-> not make the gate work. Give the gate a root that actually holds the row: at
-> the runtime layer that root is **`record`** (ADR-0089 D3, whose
-> `CANONICAL_ROOT_BY_LAYER` puts `record` at the runtime layer and `data` at the
-> metadata layer).
+> Read both columns. The predicate layer fails soft, so
+> `"visible": "${data.status == 'draft'}"` written against the old wiring was
+> **hidden on every row** and is now **shown on every row**; spelled `"hidden"`
+> it flips the other way. The interpolation layer does not fail soft to
+> anything — it hands back the characters you typed, so a `content` built from
+> a missing root renders the literal text `${data.status == 'draft'}` to the
+> user. objectui#5454's reporter warns about the predicate case.
+>
+> ⛔ Re-publishing `data` through `PredicateScopeProvider` restores the old,
+> always-`false` verdict — it does not make the gate work. Give the gate a root
+> that actually holds the row: at the runtime layer that root is **`record`**
+> (ADR-0089 D3, whose `CANONICAL_ROOT_BY_LAYER` puts `record` at the runtime
+> layer and `data` at the metadata layer).
 
 ### Safe globals (always available)
 - `Math` — `${Math.round(price)}`, `${Math.max(a, b)}`

--- a/skills/objectui/guides/schema-expressions.md
+++ b/skills/objectui/guides/schema-expressions.md
@@ -105,18 +105,71 @@ When the entire string is a single `${expression}`, the result preserves its typ
 
 ## Available scope variables
 
-When expressions are evaluated, these variables are in scope:
+Expression scope is published by the **host**, through `PredicateScopeProvider`.
+Every key of the `scope` you hand it becomes a root the evaluator can read:
+
+<!-- os:check -->
+```tsx
+import { PredicateScopeProvider, SchemaRenderer } from '@object-ui/react'
+import type { BaseSchema } from '@object-ui/types'
+
+declare const schema: BaseSchema
+
+// Every name here becomes a root this page's expressions can read — `data`
+// included, which is now a name YOU publish rather than one the renderer binds.
+const scope = {
+  users: [{ id: 1, name: 'Ada Lovelace' }],
+  metrics: { total: 42 },
+  data: { fieldName: 'Ada Lovelace' },
+}
+
+function Page() {
+  return (
+    <PredicateScopeProvider scope={scope}>
+      <SchemaRenderer schema={schema} />
+    </PredicateScopeProvider>
+  )
+}
+```
 
 | Variable | Source | Example |
 |----------|--------|---------|
-| Top-level data fields | `SchemaRendererProvider dataSource` | `${users}`, `${metrics.total}` |
-| `data` | Alias for dataSource root | `${data.fieldName}` |
-| `current_user` / `user` | Host predicate scope | `${current_user.email}` |
+| every key of `scope` | the host's `PredicateScopeProvider` | `${users}`, `${metrics.total}` |
+| `data` | a key of `scope` like any other — every `${data.*}` example on this page assumes a host that published one, as above | `${data.fieldName}` |
+| `current_user` / `user` | the same channel; an app-shell host's `ExpressionProvider` already feeds it | `${current_user.email}` |
+| `record` | the row a record surface is bound to, when there is one | `${record.status}` |
 | `page` | Page-local state (`PageSchema.variables`) | `${page.selectedId}` |
 
 That is the whole scope. There is **no `item` and no `index`** — the evaluator
 context is built once per node, not once per array element. See "No per-item
 template iteration" below.
+
+> ### ⛔ `dataSource` is not an expression root, and this is not a renaming
+>
+> `SchemaRendererProvider`'s `dataSource` carries the host's `DataSource`
+> **adapter** — the object a renderer calls `find()` on. The renderer used to
+> publish that adapter under the name `data`. An adapter answers no `data.*`
+> path an author would write, so that root was silently constant for every
+> conformant host, and objectui#9308 removed it (maintainer ruling 2026-09-13).
+>
+> **Re-check every gate you authored from an older copy of this page: the
+> verdict moved.** Measured on the built evaluator, a root that is MISSING and a
+> root that is PRESENT-but-empty are not the same thing:
+>
+> | what the scope holds | `${data.status == 'draft'}` |
+> |---|---|
+> | `data` bound to the adapter, which has no `status` member | `false` |
+> | `data` present and `undefined` | `false` |
+> | no `data` root at all — what you get now unless you publish one | the condition path fail-softs to `true`; a text key renders the raw `${…}` characters, and objectui#5454's reporter warns |
+>
+> So `"visible": "${data.status == 'draft'}"` written against the old wiring was
+> **hidden on every row**, and is now **shown on every row**. The same gate
+> spelled `"hidden"` flips the other way. Re-publishing `data` through
+> `PredicateScopeProvider` restores the old, always-`false` verdict — it does
+> not make the gate work. Give the gate a root that actually holds the row: at
+> the runtime layer that root is **`record`** (ADR-0089 D3, whose
+> `CANONICAL_ROOT_BY_LAYER` puts `record` at the runtime layer and `data` at the
+> metadata layer).
 
 ### Safe globals (always available)
 - `Math` — `${Math.round(price)}`, `${Math.max(a, b)}`
@@ -298,11 +351,18 @@ The `bind` field is NOT expression-evaluated. It's a path string resolved by
 }
 ```
 
-When `SchemaRendererProvider` receives
-`dataSource = { customerNames: ["Ada Lovelace", "Grace Hopper"] }`, `list` calls
-`useDataScope("customerNames")` and renders one entry per array element.
+When the host publishes
+`scope = { customerNames: ["Ada Lovelace", "Grace Hopper"] }` through
+`PredicateScopeProvider`, `list` calls `useDataScope("customerNames")` and
+renders one entry per array element.
 
-**Nested paths work:** `"bind": "app.settings.users"` resolves `dataSource.app.settings.users`.
+⛔ `bind` resolves against that same ambient scope — **not** against
+`SchemaRendererProvider`'s `dataSource`. That prop is the `DataSource` adapter,
+it has no member a `bind` path names, and objectui#9308 retired the walk over
+it. A `bind` on a page with no scope published above it resolves `undefined`,
+and each reader falls back to its own empty state.
+
+**Nested paths work:** `"bind": "app.settings.users"` resolves `scope.app.settings.users`.
 
 ### Which components read `bind`
 
@@ -390,7 +450,7 @@ section exists to close: binding `list` to ordinary records produces one empty
 
 <!-- os:check -->
 ```jsonc
-// ✅ Bound data, already node-shaped: dataSource = { rows: [{ "content": "Ada" }, { "content": "Linus" }] }
+// ✅ Bound data, already node-shaped: scope = { rows: [{ "content": "Ada" }, { "content": "Linus" }] }
 { "type": "list", "bind": "rows" }
 ```
 
@@ -563,7 +623,7 @@ When an expression isn't working:
 
 1. **Which key is it on, and does that type declare the key?** `content` and the predicate keys are evaluated and read on every type. `title` / `label` / `value` / `description` are evaluated **only on the types that declare them** — `statistic` (`label` / `value` / `description`), `card` (`title` / `description`), `button` (`label`) — and read raw everywhere else, including on a namespaced spelling such as `ui:statistic`. A `${...}` inside a `props` envelope is evaluated and then discarded. (A `properties` envelope is the one that is evaluated *and* hoisted onto the node — see [`rules/protocol.md`](../rules/protocol.md) for why that is recorded, not recommended.)
 2. Is the `${}` syntax correct? Check for unmatched braces.
-3. Is the data actually available in scope? Check `SchemaRendererProvider dataSource`.
+3. Is the data actually available in scope? Check what the host published on `PredicateScopeProvider` — ⛔ not `SchemaRendererProvider`'s `dataSource`, which publishes no expression root.
 4. For conditions: are you using `On` suffix correctly? (`hiddenOn` takes raw expression, `hidden` needs `${}` if it's a string).
 5. Does the expression use a blocked pattern? Check for constructors, `eval`, `window`, etc.
 6. Is type coercion causing issues? `${0 && "yes"}` returns `0`, not `false`.

--- a/skills/objectui/rules/protocol.md
+++ b/skills/objectui/rules/protocol.md
@@ -134,7 +134,10 @@ dropped.** The rule above is about `props`. `properties` is the spec spelling of
 the same bag, and `SchemaRenderer` evaluates it and then **hoists every key onto
 the node** (`type` / `id` excepted) before the renderer runs — so it is read by
 every namespace, not just `element:*`. Measured on `origin/main` `f1c27f037`
-with `dataSource = { label: "Evaluated Title" }`:
+with a host scope carrying `data = { label: "Evaluated Title" }` (published
+through `PredicateScopeProvider`). objectui#9308 retired the `dataSource`
+wiring this was first measured through; the envelope readings below are
+unchanged by that:
 
 | node | rendered card header |
 |---|---|
@@ -208,17 +211,27 @@ The `bind` field is NOT expression-evaluated. It's a path string resolved by `us
 ```jsonc
 {
   "type": "list",
-  "bind": "customerNames"  // Resolved as dataSource.customerNames
+  "bind": "customerNames"  // Resolved against the ambient scope
 }
 ```
 
-**Nested paths work:** `"bind": "app.settings.users"` resolves `dataSource.app.settings.users`.
+**Nested paths work:** `"bind": "app.settings.users"` resolves `scope.app.settings.users`.
+
+⛔ **The scope `bind` resolves against is the one a host publishes with
+`PredicateScopeProvider`, not `SchemaRendererProvider`'s `dataSource`.** That
+prop carries the `DataSource` **adapter** — it answers no `bind` path — and
+objectui#9308 retired the walk over it. The same ruling stopped the renderer
+publishing that adapter as the expression root `data`, so a `${data.*}` gate
+authored before it now reads whatever the HOST published under `data`, and
+nothing at all if the host published none. See "Available scope variables" in
+[`../guides/schema-expressions.md`](../guides/schema-expressions.md) for the
+verdict that move flips.
 
 **Readers only.** `list` and `tree-view` (`@object-ui/components`) and the `object-*` plugin widgets call `useDataScope`. `data-table` does NOT: it reads its rows from an inline `data` array on the node, so a `bind` on it is ignored and the table renders its header over an empty body — no error, no warning.
 
 **Provider rows into a `data-table`.** Measured on `origin/main` `f1c27f037`,
-real `SchemaRenderer` inside a `SchemaRendererProvider` holding
-`{ customers: [ 2 records ] }`, identical `columns` in every leg, reading
+real `SchemaRenderer` under a host scope publishing
+`data = { customers: [ 2 records ] }`, identical `columns` in every leg, reading
 `tbody td`:
 
 | node | rendered body cells |


### PR DESCRIPTION
Fixes #9370

⛔ **GOVERNED SURFACE** (`skills/**`, `GOVERNED_SURFACES` `skills-catalog`). This PR parks as a **draft by design** and needs an APPROVED review from an authorized approver (`os-zhuang`, `hotlong`). ⛔ Not flipped ready, not enqueued, no auto-merge. The precedent on this exact surface is #9352 / card #9311, merged as `28be0786d`.

⚠️ **Merge after #9369, and this PR states which world it measured in.** Re-derived from my own tree at base `69aa9c017`, not assumed: `SchemaRenderer.tsx` still carries the `data: dataSource` binding, and `SchemaRendererContext.tsx` still reads `const dataSource = context?.dataSource` inside `useDataScope`. **Both halves are still LIVE on this base** — #9369 is open, not merged. So these pages become true the moment #9369 lands and are ahead of the code until then. Every evaluator measurement below is from that same pre-#9369 tree, which is the right place to take it: the evaluator itself is what #9369 stops feeding, and the evaluator's own behaviour does not move. Sequencing is a maintainer decision, not something this PR can enforce.

## What moved

The maintainer ruled objectui#9308 option B on 2026-09-13: `SchemaRenderer` stops publishing the injected `DataSource` adapter as the expression root `data` (b1), and `useDataScope` — what a node's `bind` resolves through — reads the ambient scope a host publishes via `PredicateScopeProvider` instead of walking that adapter (b2). The published skill package still taught both halves.

Three files, matching the shape #9369 used for `content/docs/guide/schema-rendering.md` and `packages/react/README.md`: publish the host values under real names through `PredicateScopeProvider`, read them by those names, and state that `dataSource` is the **adapter** and not a root.

| file | what changed |
|---|---|
| `guides/schema-expressions.md` | the scope table, a new COMPILED wiring example, the migration callout, the `bind` resolution prose, the bound-list comment, debugging-checklist item 3 |
| `guides/data-integration.md` | the architecture diagram's channel split, "Static data" rewritten onto the scope channel as a COMPILED example, the `useDataScope` resolution sentence, the `data` root claim |
| `rules/protocol.md` | both measured tables' WIRING restated, the `bind` comment and nested-path sentence, plus a callout carrying the retirement and pointing at the verdict flip |

⛔ Untouched, as the card requires: the `object-*` reader-list paragraph and the `data-table` `bind` pothole (objectui#6575 still rules `data-table` does not read `bind`).

## ⭐ The part that is not a renaming

A migration note that only swaps provider names is wrong here, because the **verdict moved**. Measured by me on the built evaluator (`packages/core/dist`), with firing controls — ⛔ and the `true` on a missing root belongs to the **predicate layer**, not to the evaluator:

| scope, expression | `evaluateExpression` | `evaluateCondition` |
|---|---|---|
| CONTROL `{ data: { status: 'draft' } }`, `${data.status}` | `"draft"` | `true` |
| CONTROL same scope, `Status: ${data.status}` | `"Status: draft"` | `true` |
| CONTROL same scope, `${data.nope}` — present root, absent member | `undefined` | `false` |
| `{ data: {} }` — adapter-shaped, `${data.status == 'draft'}` | `false` | `false` |
| `{ data: undefined }`, same predicate | `false` | `false` |
| `{}` — no `data` root, `${data.status}` | `"${data.status}"` | `true` |
| `{}` — no `data` root, `Status: ${data.status}` | `"Status: ${data.status}"` | `true` |
| `{}` — no `data` root, `${data.status == 'draft'}` | `"${data.status == 'draft'}"` | `true` |

The third control is the discriminating one: a root that is PRESENT with an absent member yields `undefined`, while a root that is MISSING yields the template's own source characters. So the two layers answer a missing root differently, and each has its own reader-visible symptom:

- **predicate layer** — fails soft to `true`. A `"visible": "${data.status == 'draft'}"` authored from these pages was **hidden on every row** and is now **shown on every row**; spelled `"hidden"` it flips the other way.
- **interpolation layer** — does not fail soft at all. A `content` built from a missing root paints the literal characters `${data.status}` on screen.

The callout carries one column per layer and tells the reader to read both. It also states that re-publishing `data` restores the OLD always-`false` verdict rather than fixing the gate, and points row gates at `record` — the runtime-layer root under ADR-0089 D3.

## What I decided about the ~two dozen `${data.…}` examples

Measured, not estimated: `schema-expressions.md` carries **21** lines spelling `${data.` (one of them is the census's own scope-table row). Repo-wide under `skills/`: 21 here, 14 in `rules/protocol.md`, 5 in `page-builder.md`, 4 in `testing.md`, 2 each in `data-integration.md` and `auth-permissions.md`, 1 in `architecture.md`, plus 4 in `evals/*.json`.

**Decision: keep every one of them verbatim and make them reachable, rather than rewrite them to bare roots.** The page's new wiring example publishes a root literally named `data`, and the scope table says in a row that every `${data.*}` example on the page assumes exactly that. Three reasons this is the right divergence from #9369's `content/docs` shape:

1. **A pin renders those exact spellings.** `skill-guide-provider-envelope.test.tsx`, as re-derived in #9369, publishes `scope = { data: PROVIDER }` and renders `${data.customers}` / `${data.label}`. Rewriting the guide spellings would move that pin's subject from inside a second pull request — the "green alone, red together" shape.
2. **ADR-0089 D3 does not forbid the name.** `CANONICAL_ROOT_BY_LAYER` puts `data` at the metadata layer. What was retired is the renderer AUTO-publishing the adapter there, not the name.
3. **Most of those examples are about something else** — which text keys carry expressions, type preservation, the troubleshooting section. The root name is scaffolding, and churning 20 lines of scaffolding on a governed surface buys the reader nothing.

⛔ Nothing was silently rewritten: the only expression text this PR changes is the two `dataSource = {…}` comments that named the retired wiring.

## Re-measurement of the card's per-line census

The card measured on the objectui#9308 branch. Re-measured against `origin/main` `69aa9c017` — **every cited line still lands on the cited text**:

| cited | on `origin/main` `69aa9c017` | verdict |
|---|---|---|
| 112 | `| Top-level data fields | \`SchemaRendererProvider dataSource\` | …` | exact |
| 113 | `| \`data\` | Alias for dataSource root | …` | exact |
| 302-303 | `dataSource = { customerNames: … }`, `useDataScope("customerNames")` | exact |
| 305 | `**Nested paths work:** … resolves \`dataSource.app.settings.users\`` | exact |
| 393 | `// ✅ Bound data, already node-shaped: dataSource = { rows: … }` | exact |

`premise_still_valid: true`.

## Enumeration beyond the census (⛔ out of scope for this PR)

`--measure` judges every candidate fence, marked or not, so a page can be wrong where no gate looks. Reading the prose as well turned up two more:

- **`guides/auth-permissions.md`** carries the same retired claim in its own words — a scope table row `| \`data\` | the \`dataSource\` passed to \`SchemaRendererProvider\` |`, the sentence "Keys of the `dataSource` object are reachable only under the `data.` root", and "With no host scope mounted, `data` and `page` are all you get". ⛔ Out of scope here: **PR #9374 holds that file**, so an in-place edit would collide. Filed as #9379.
- **`guides/testing.md` Pattern 5** asserts `getByText('Secret')` for a node gated on `${userRole !== "admin"}` — a BARE root that no channel publishes, before or after the ruling. Copy the example and the assertion fails. Different defect class from this card, and independent of the ruling — it is wrong on `main` today. Filed as #9380.

Noted, not filed: the `${data.*}` examples in `page-builder.md`, `architecture.md`, `i18n.md`, `project-setup.md` and `evals/*.json` are in the same reachable-only-if-the-host-publishes class; they are not falsifiably wrong and the skills lane that takes the auth-permissions card is their natural carrier.

## Verification

Reproduce-first, as required — the harness is trustworthy before any red or green from it is read:

```text
$ node scripts/check-skill-examples.mjs --self-test     # BEFORE the build
EXIT=2 — PRECONDITION NOT MET: the self-test's type-check leg needs the workspace built

$ ...os-verify-lock.sh -c 'turbo run build $(--build-filter) --concurrency=2'
VERDICT command-exit 0 · held the lock 44s · waited 0s

$ node scripts/check-skill-examples.mjs --self-test     # AFTER the build
EXIT=0 — ✓ 59 cases pass
```

Gate, verbatim, before and after this diff:

```text
BEFORE (exit 0)
Scanned 20 guide(s) under skills, .claude/skills: 121 ts/tsx/typescript fence(s), 70 json/jsonc fence(s).
Marked: 14 ts fence(s) (floor 13), 70 json fence(s) (floor 70)
Semantic phase: 14 of 14 ts fence(s) judged, 0 failed.
JSON phase:     70 fence(s) parsed, 0 failed.
Every marked skill example holds up against the built types.

AFTER (exit 0)
Scanned 20 guide(s) under skills, .claude/skills: 122 ts/tsx/typescript fence(s), 70 json/jsonc fence(s).
Marked: 16 ts fence(s) (floor 13), 70 json fence(s) (floor 70)
Semantic phase: 16 of 16 ts fence(s) judged, 0 failed.
JSON phase:     70 fence(s) parsed, 0 failed.
Every marked skill example holds up against the built types.
```

⭐ The marked ts population moves **14 to 16** and the json population is unmoved at 70 — both floors are SHRINK-ONLY and neither is breached. The two new marked fences are the wiring examples, so the thing this card is about is now COMPILED against the built `dist/*.d.ts` rather than only read.

Derived by hand from `package.json` plus `.github/workflows/` (this repo has no `dispatch-gates.mjs`); every one run on this tree:

| gate | exit |
|---|---|
| `check-skill-examples.mjs --self-test` | 0 |
| `check-skill-examples.mjs` | 0 |
| `check-skills-paths.mjs` | 0 — 88/89 stated paths resolve, 1 pre-existing baselined |
| `check-skill-eval-tokens.mjs --self-test` / `check-skill-eval-tokens.mjs` | 0 / 0 |
| `check-control-bytes.mjs` | 0 — 7539 tracked text files |
| `check-shell-escape-residue.mjs` | 0 — 16/16 skills documents under a declared root |
| `check-new-cross-file-line-citations.mjs` | 0 — 0 new citations |
| `check-changeset-presence.mjs` | 0 |
| `check-doc-links.mjs` | 0 |
| `check-governed-queue-guard.mjs --self-test` | 0 — 185 cases |

Package tests that READ these three documents (`markdown-test-inputs.mjs --changed` names all three as test inputs, so CI runs the full shards): reported below the fold once the shared verify lock grants a turn.

Line readings for the governed surface, as the contract requires:

| reading | before | after | delta |
|---|---|---|---|
| `guides/schema-expressions.md` | 569 | 635 | +66 |
| `guides/data-integration.md` | 485 | 513 | +28 |
| `rules/protocol.md` | 341 | 354 | +13 |
| whole published package `skills/**` | 5201 | 5308 | +107 (+2.1%) |

The added lines are the correction itself: one migration callout, two now-compiled wiring examples, and the sentences that replace the retired claims. No re-wrap was used to buy lines.

## Changeset

**None owed**, by measurement rather than by inheritance:

1. `node scripts/check-changeset-presence.mjs` — "Compared the working tree with `69aa9c017` (merge-base with origin/main): 3 file(s) changed, 0 of them published source of a package the release covers, 0 of them a manifest whose published contract moved … No source or published contract of a released package changed in this range, so no changeset is owed." (exit 0)
2. Independently: **0 of 43** workspace manifests mention `skills` in `files` / `exports` / `main` / `module` / `types` / `bin`. Positive control on the same scan: 38 manifests list `dist` in `files[]`. Nothing under `skills/` is shipped by any npm package.
3. The merged precedent on this surface, `28be0786d` (#9352), changed one `skills/` file and carried no changeset.

⚠️ One inconsistency worth a maintainer's eye rather than my guess: open PR #9374, also a single `skills/` guide, DOES carry an empty-frontmatter changeset declaring "no package is released by this change". Both forms pass the gate. If the empty-frontmatter declaration is the house style for this surface, say so and I will add one.

## Governed-queue-guard verdict on this diff (verbatim)

```text
$ node scripts/check-governed-queue-guard.mjs --test skills/objectui/guides/schema-expressions.md skills/objectui/guides/data-integration.md skills/objectui/rules/protocol.md
⛔ GOVERNED — 3 of 3 path(s) are on a governed surface:
   skills/** x3 — the published skills catalog
     - skills/objectui/guides/schema-expressions.md
     - skills/objectui/guides/data-integration.md
     - skills/objectui/rules/protocol.md

   One governed path governs the WHOLE pull request — proportion is not a question.
   ⛔ Do not flip it ready, enqueue it, or arm auto-merge. Park it as a DRAFT and leave the merge
      to the maintainer; a human merge IS the review record for a governed surface.
   The merge-queue run of "Governed Surface Queue Guard" refuses this diff unless an APPROVED review by an
   authorized approver (GOVERNED_APPROVERS: os-zhuang, hotlong) is on the pull request — on
   whichever commit it was left (maintainer ruling 2026-09-04).
exit 3
```

## Clause-② — contract review

`needs:contract-review` is hung on this PR in the same stroke as opening it, mirroring the card. Published `skills/**` making falsifiable contract-semantics claims about which roots a tier binds. ⛔ The governed-surface human merge does **not** substitute for it; the two stack, and neither limb is mine to clear.

## Inherited reds — ⛔ not from this PR

- `Bundle Analysis` is red on `main` (arrived with #9316; a maintainer decision).
- `Doc Snippet Type Check` is red on `main` until #9369 lands. This diff touches no document that gate scans (`content/docs` + package READMEs + root `README.md`, explicitly not `skills/**`).

## Acceptance notes

- ⛔ No test was skipped, quarantined or weakened. No assertion was loosened. The marked-fence floors both hold and the ts population grew.
- The card's "the pins are green while the prose beside them is wrong" warning was taken literally: the six `packages/components` pins #9369 re-derived were read for what they assert about these files before a byte was changed, and every string they pin is intact — `Rule: Keys Live on the Node`, the `hoists every key onto\s+the node` regex, the absence of the two retired sentences, the `no md matches "instead of \`props.\`"` class guard, and the `"bind": "customerNames"` list example in each of the three guides.
- Noted, not filed: `rules/protocol.md`'s two measured tables still cite `origin/main` `f1c27f037` as the commit they were measured on. This PR restates their WIRING, not their outcomes, and says so inline; a re-measurement on a current commit is a separate piece of work, and the `skill-guide-provider-envelope` pin is what actually holds those outcomes today. Carrier: whoever next re-derives that pin.

## 维护者速读(草稿)

### 改了什么
把发布中的 `skills/objectui` 三份指南从「`dataSource` 就是表达式根 `data`、`bind` 走 `dataSource`」改成 ruling 之后的真实通道:宿主用 `PredicateScopeProvider` 发布作用域,`dataSource` 只是取数适配器。另外给两个接线示例加上 `os:check` 标记,让它们第一次真的被编译校验。

### 为什么改
2026-09-13 的裁决(objectui#9308 option B)已经把这两件事退役,但发布给 AI 读的技能包还在教它们。更要紧的是:这不是改名。同一条 `data.*` 门,旧接线下恒判 `false`、新接线下因为根缺失走 fail-soft 恒判 `true` —— 一个 `visible` 门从「每行都藏」变成「每行都显」。只换 provider 名字的迁移说明会让读者踩正这一脚。

### 风险与代价(含回滚)
- **排序风险(主要):** #9369 还没合。在它合进去之前,这三页描述的是尚未落地的行为。⚠️ 建议排在 #9369 之后合。
- 保留了全部 `${data.*}` 示例原文,只让接线示例发布一个叫 `data` 的根 —— 因为 `skill-guide-provider-envelope` 这个 pin 正在渲染这些拼写,改写它们会在另一个 PR 的盲区里挪动 pin 的被测主体。
- 回滚代价:纯文档,`git revert` 一笔即可,不影响任何已发布包(本仓 43 个 manifest 无一发布 `skills/`)。

### 席位意见
(留空,待 `os-zhuang` / `hotlong` 定稿)

### 你要做的
1. 确认合并顺序:先 #9369,再本 PR。
2. 作为受管面的人工合并方给出 APPROVED review(这一道是 `check-governed-queue-guard` 机械要求的)。
3. clause-② 的 `needs:contract-review` 需要一份书面复核记录后才清 —— ⛔ 两道保障叠加,人工合并不替代它。
4. 顺带定一句话:本仓单文件 `skills/` 改动到底要不要写空 frontmatter changeset(#9352 没写、#9374 写了,门禁两边都放行)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzHd6hDYatoDn17BuwKxnZ)_


---
_Generated by [Claude Code](https://claude.ai/code)_