### PR TITLE
test(scripts): one SPAWNERS definition for both spawn-env gates, with the fork fixture that measures it

### DIFF
--- a/.changeset/9211-spawners-single-source.md
+++ b/.changeset/9211-spawners-single-source.md
@@ -1,0 +1,27 @@
+---
+---
+
+Give the two spawned-child-environment gates ONE definition of what counts as a
+child-process spawner (objectui#9211). Test tooling only; no package is released
+by this change.
+
+`spawned-build-vitest-env-8598.test.ts` and `spawned-vitest-child-env-8616.test.ts`
+each carried a hand-maintained copy of the same `SPAWNERS` set, and the copies had
+diverged: objectui#8616's listed `fork`, objectui#8598's did not, and neither
+file's prose gave a reason. Dropping a member from a POPULATION set is a false
+GREEN — a build started as `fork('…', ['build'], { env })` never entered
+objectui#8598's census, so the gate that exists to stop `VITEST` reaching a
+spawned build would have reported clean about a call site it never looked at.
+
+The repair is the construction, not the instance: both gates now import
+`scripts/__tests__/helpers/spawners.ts`, so there is no second literal to keep
+honest. Converged upward, onto the set that includes `fork` — the other
+direction narrows a live gate's census, which is not a repair.
+
+`fork` is latent rather than live: the test tree holds zero `fork(` call sites,
+so a green suite would carry no information about whether the new member works.
+A fixture pair under `scripts/__tests__/fixtures/spawned-build-vitest-env-8598/`
+supplies the population the tree does not have — the same `fork()` build spawn
+twice, differing only in whether the child's `env:` still carries `VITEST` — and
+the gate is driven over both, asserting the population count as well as the
+verdict so an empty census fails loudly instead of clearing everything.

--- a/scripts/__tests__/fixtures/spawned-build-vitest-env-8598/fork-build-inherits.fixture.ts
+++ b/scripts/__tests__/fixtures/spawned-build-vitest-env-8598/fork-build-inherits.fixture.ts
@@ -1,0 +1,22 @@
+/**
+ * A build started with `child_process.fork`, handed the worker's environment
+ * unchanged — the LEAK objectui#8598's gate exists to refuse, spelled with the
+ * spawner that gate could not see before objectui#9211.
+ *
+ * ⚠️ Not a test and never executed: read only as TEXT by
+ * `spawned-build-vitest-env-8598.test.ts`, which parses this file and asks its
+ * own `buildSpawns()` what it finds. The `.fixture.ts` extension keeps it out
+ * of that gate's LIVE census (`/\.(test|spec)\.tsx?$/`), so the deliberate leak
+ * below cannot turn the real gate red. `tsconfig.scripts.json` compiles every
+ * `.ts` under `scripts/`, so it does have to type-check.
+ *
+ * Its pair, `fork-build-scrubbed.fixture.ts`, differs ONLY in what the `env:`
+ * does to `VITEST`. Everything else — the spawner, the arguments, the shape of
+ * the call — is byte-identical, so the verdict the gate returns is attributable
+ * to that one difference and to nothing else.
+ */
+import { fork } from 'node:child_process';
+
+export function spawnTheBuild(): void {
+  fork('scripts/run-package-build.js', ['build'], { env: { ...process.env } });
+}

--- a/scripts/__tests__/fixtures/spawned-build-vitest-env-8598/fork-build-scrubbed.fixture.ts
+++ b/scripts/__tests__/fixtures/spawned-build-vitest-env-8598/fork-build-scrubbed.fixture.ts
@@ -1,0 +1,19 @@
+/**
+ * The repaired half of the objectui#9211 pair: the same `child_process.fork`
+ * build spawn as `fork-build-inherits.fixture.ts`, with `VITEST` removed from
+ * the child's environment by the rest-pattern spelling the gate accepts.
+ *
+ * ⚠️ Not a test and never executed — see the header of its pair for why the
+ * `.fixture.ts` extension matters and what the two files are read by.
+ *
+ * The two fixtures differ only in the `env:`. This one must be judged
+ * `scrubbed`; if both came back the same, the gate would be reporting the
+ * spawner rather than the environment.
+ */
+import { fork } from 'node:child_process';
+
+const { VITEST: _vitest, ...BUILD_ENV } = process.env;
+
+export function spawnTheBuild(): void {
+  fork('scripts/run-package-build.js', ['build'], { env: BUILD_ENV });
+}

--- a/scripts/__tests__/helpers/spawners.ts
+++ b/scripts/__tests__/helpers/spawners.ts
@@ -1,0 +1,44 @@
+/**
+ * The Node child-process entry points that start a program — ONE definition
+ * (objectui#9211).
+ *
+ * ## The defect this closes
+ *
+ * Two gates derive a population of child-process call sites by AST and then
+ * judge each one's `env:` — `spawned-build-vitest-env-8598.test.ts` (does the
+ * child of a spawned BUILD still carry `VITEST`?) and
+ * `spawned-vitest-child-env-8616.test.ts` (does a spawned VITEST still carry
+ * this container's agent markers?). Each one carried its own hand-maintained
+ * copy of this set, and the copies had already diverged: objectui#8616's
+ * listed `fork`, objectui#8598's did not, and NEITHER file's prose gave a
+ * reason. Measured on `1f4e02995a` and re-measured on `b775500`, `fork` occurs
+ * in neither file outside the set literal itself — so it was drift, not an
+ * unrecorded decision.
+ *
+ * ⚠️ The direction of that drift is what makes it worth a module rather than a
+ * one-line edit. Dropping a member from a POPULATION set is a false GREEN, not
+ * a false red: a build started as `fork('…', ['build'], { env })` simply never
+ * entered objectui#8598's population, so the gate that exists to stop `VITEST`
+ * reaching a spawned build reported clean about a call site it never looked at.
+ * A gate cannot notice that it is judging fewer things than it should.
+ *
+ * ## Why the module, and not just adding `fork` back
+ *
+ * The failure is not that the two sets disagreed on a Tuesday — it is the
+ * construction that let them: one set, maintained in two places, with nothing
+ * comparing them. Repairing only the instance leaves the construction, and the
+ * next divergence is written by the same mechanism and noticed by nobody. So
+ * the correct shape is made the only spelling available: one exported constant,
+ * both gates importing it, no second literal to keep honest.
+ *
+ * ⭐ Converged UPWARD, to the set that includes `fork`. The other direction —
+ * dropping `fork` from objectui#8616's set — narrows a live gate's census, and
+ * weakening a gate is not a repair.
+ *
+ * ⚠️ `fork` is LATENT here, not live: the test tree holds zero `fork(` call
+ * sites today, so nothing is leaking through the hole this closes. That is also
+ * why `spawned-build-vitest-env-8598.test.ts` carries a fixture-driven case —
+ * against a live population of 0, adding `fork` to this set changes no observed
+ * result, and a green suite would carry no information about whether it works.
+ */
+export const SPAWNERS: ReadonlySet<string> = new Set(['spawnSync', 'spawn', 'execFileSync', 'execFile', 'execSync', 'exec', 'fork']);

--- a/scripts/__tests__/spawned-build-vitest-env-8598.test.ts
+++ b/scripts/__tests__/spawned-build-vitest-env-8598.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
+import { SPAWNERS } from './helpers/spawners';
 
 const ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
 
@@ -61,9 +62,6 @@ const ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
  *     call sites. Presence of the token was the wrong question in both
  *     directions at once. Removal is the property, so removal is what is read.
  */
-
-/** Node child-process entry points that start a program. */
-const SPAWNERS = new Set(['spawnSync', 'spawn', 'execFileSync', 'execFile', 'execSync', 'exec']);
 
 /** Test files anywhere in the workspace — the only files this gate judges. */
 function testFiles(): string[] {
@@ -284,6 +282,23 @@ function buildSpawns(file: string): BuildSpawn[] {
 const SPAWNS = testFiles().flatMap(buildSpawns);
 
 /**
+ * The gate's verdict on a set of spawns, rendered — one line per spawn that
+ * does NOT remove `VITEST`. This is the list the assertion below requires to be
+ * empty, so the fixture case at the bottom of this file can drive the REAL
+ * judgement rather than a paraphrase of it.
+ */
+function leakingIn(spawns: readonly BuildSpawn[]): string[] {
+  return spawns
+    .filter((s) => s.verdict !== 'scrubbed')
+    .map(
+      (s) =>
+        `${s.file}:${s.line} — this environment ${
+          s.verdict === 'sets' ? 'SETS `VITEST`' : 'hands the child `VITEST` unchanged'
+        }`,
+    );
+}
+
+/**
  * The floor, plus a named member.
  *
  * Two build spawns exist today, both in `cli-bin.test.ts`. The floor is set at
@@ -301,12 +316,7 @@ describe(`objectui#8598 — ${SPAWNS.length} build spawn(s) in the test tree`, (
   });
 
   it('every one of them scrubs VITEST from the child environment', () => {
-    const leaking = SPAWNS.filter((s) => s.verdict !== 'scrubbed').map(
-      (s) =>
-        `${s.file}:${s.line} — this environment ${
-          s.verdict === 'sets' ? 'SETS `VITEST`' : 'hands the child `VITEST` unchanged'
-        }`,
-    );
+    const leaking = leakingIn(SPAWNS);
 
     expect(
       leaking,
@@ -318,5 +328,69 @@ describe(`objectui#8598 — ${SPAWNS.length} build spawn(s) in the test tree`, (
         '`{ VITEST: _v, ...env }` rest pattern; both are accepted. See `BUILD_ENV` in ' +
         `${NAMED_MEMBER}:\n  ` + leaking.join('\n  '),
     ).toEqual([]);
+  });
+});
+
+/**
+ * ⭐ That this gate can see a `fork()` build at all (objectui#9211).
+ *
+ * `fork` was missing from this gate's spawner set while its objectui#8616
+ * sibling had it, and both sets were hand-maintained copies. objectui#9211
+ * replaced the two copies with one — `helpers/spawners.ts` — converging UPWARD,
+ * onto the set that includes `fork`.
+ *
+ * ⚠️ This case is not decoration, it is the only thing that measures the
+ * change. The LIVE population of `fork(` call sites across `packages`, `apps`,
+ * `scripts` and `examples` is ZERO — re-measured on this branch's base, with
+ * `spawnSync(` at 35 in the same run as the control that proves the zero is a
+ * reading and not a broken command. So against the real tree, a run with `fork`
+ * in the set and a run without it produce byte-identical results, and the whole
+ * suite going green says nothing whatsoever about whether `fork` is covered.
+ * The fixtures below supply the population the tree does not have.
+ *
+ * They are a PAIR differing only in the `env:`, so what is demonstrated is the
+ * gate judging the environment of a `fork` — not merely noticing the call:
+ *
+ *   - `fork-build-inherits.fixture.ts` hands the child `{ ...process.env }`.
+ *     The gate must report it — RED.
+ *   - `fork-build-scrubbed.fixture.ts` binds `VITEST` away with a rest pattern.
+ *     The gate must clear it — GREEN.
+ *
+ * Both legs read the population count as well as the verdict: drop `fork` from
+ * `SPAWNERS` and neither file resolves to a spawn at all, so the leaking list
+ * for the first fixture goes EMPTY and this case fails on a count of 0 rather
+ * than passing vacuously. ⛔ That is the failure mode a verdict-only assertion
+ * would have: "nothing leaks" and "nothing was looked at" are the same string.
+ *
+ * ⚠️ The fixtures carry `.fixture.ts`, which `testFiles()` does not match, so
+ * the deliberate leak in the first one is invisible to the live census above
+ * and cannot turn the real gate red.
+ */
+const FIXTURES = 'scripts/__tests__/fixtures/spawned-build-vitest-env-8598';
+
+describe('objectui#9211 — the population includes fork()', () => {
+  it('a fork() build handed the environment unchanged is SEEN, and is reported', () => {
+    const spawns = buildSpawns(`${FIXTURES}/fork-build-inherits.fixture.ts`);
+
+    expect(
+      spawns.length,
+      'The fixture holds exactly one `fork(…, [\'build\'], { env })`. A count of 0 means this ' +
+        'gate no longer treats `fork` as a spawner — check `SPAWNERS` in `helpers/spawners.ts` ' +
+        '(objectui#9211). Every assertion below would pass vacuously on an empty population.',
+    ).toBe(1);
+    expect(spawns.map((s) => s.verdict)).toEqual(['inherits']);
+    expect(leakingIn(spawns)).toEqual([
+      `${FIXTURES}/fork-build-inherits.fixture.ts:${spawns[0].line} — this environment hands the child \`VITEST\` unchanged`,
+    ]);
+  });
+
+  it('control — the same fork() with VITEST scrubbed is SEEN, and is cleared', () => {
+    const spawns = buildSpawns(`${FIXTURES}/fork-build-scrubbed.fixture.ts`);
+
+    // Same count assertion, same reason: an empty population would clear this
+    // fixture too, and for the wrong reason.
+    expect(spawns.length, 'see the sibling case — a count of 0 measures nothing').toBe(1);
+    expect(spawns.map((s) => s.verdict)).toEqual(['scrubbed']);
+    expect(leakingIn(spawns)).toEqual([]);
   });
 });

--- a/scripts/__tests__/spawned-vitest-child-env-8616.test.ts
+++ b/scripts/__tests__/spawned-vitest-child-env-8616.test.ts
@@ -6,6 +6,7 @@ import { createRequire } from 'node:module';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import ts from 'typescript';
 import { childVitestEnv } from './helpers/child-vitest-env';
+import { SPAWNERS } from './helpers/spawners';
 
 /**
  * A vitest a TEST spawns must not inherit this container's AGENT markers
@@ -74,9 +75,6 @@ import { childVitestEnv } from './helpers/child-vitest-env';
  */
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
-
-/** Node child-process entry points that start a program. */
-const SPAWNERS = new Set(['spawnSync', 'spawn', 'execFileSync', 'execFile', 'execSync', 'exec', 'fork']);
 
 /** Test files anywhere in the workspace — the only files this gate judges. */
 function testFiles(): string[] {


### PR DESCRIPTION
Fixes #9211

One `SPAWNERS` definition, imported by both spawn-env gates, including `fork` — plus the fixture pair that makes the change measurable at all.

## What was wrong

`scripts/__tests__/spawned-build-vitest-env-8598.test.ts` and `scripts/__tests__/spawned-vitest-child-env-8616.test.ts` are the same construction: derive a population of child-process call sites by AST, then judge each one's `env:`. Each carried its **own hand-maintained copy** of the spawner set, and the copies had drifted — 8616's listed `fork`, 8598's did not, and neither file's prose gave a reason.

Dropping a member from a *population* set is a **false GREEN**, not a false red. A build started as `fork('…', ['build'], { env })` never entered objectui#8598's census, so the gate that exists to stop `VITEST` reaching a spawned build would have reported clean about a call site it never looked at. A gate cannot notice that it is judging fewer things than it should.

Per the triage ruling (`#9211` comment `5645061510`), the defect is not "the two sets disagree today" — it is the construction that lets them: 先删容许出错的构造 → 让正确形态成唯一拼写 → 最后才加检查. Repairing only the instance leaves the mechanism, and the next divergence is written the same way and noticed by nobody.

## What this does

- **New**: `scripts/__tests__/helpers/spawners.ts` — one exported `SPAWNERS`, converged **upward** onto the set that includes `fork`. (The other direction, dropping `fork` from 8616, narrows a live gate's census; that is a weakening and sits on the maintainer's floor, not this seat's.)
- Both gates import it. The 8616 diff is the import swap and nothing else — its membership is unchanged and its `env:` judgement is untouched.
- The 8598 gate's leaking-list renderer is lifted into `leakingIn()` so the new case drives the **real** assertion rather than a paraphrase of it. Neither gate's `env:` judgement logic was changed.
- **New fixture pair** under `scripts/__tests__/fixtures/spawned-build-vitest-env-8598/`.

## Why the fixture is load-bearing, not decoration

Triage, in force verbatim:

> 没有这一条，这个改动**按构造就是未被测试的**：活普查面是 0，加不加 `fork` 跑出来的结果一模一样，绿色不携带任何信息。

Re-measured on this branch's base `852437297b` (⚠️ not copied from the card — the primary checkout is hundreds of commits behind):

```
target  — /(^|[^.\w])fork\(/      across packages, apps, scripts, examples
          (*.test.ts, *.spec.ts, *.tsx), comment lines excluded:   0 matches
control — the same command, same run, /(^|[^.\w])spawnSync\(/:    35 matches
          e.g. packages/cli/src/__tests__/cli-bin.test.ts:77
```

The control hits, so the zero is a reading and not a broken command. The two fixtures supply the population the tree does not have — the same `fork()` build spawn twice, differing **only** in what the `env:` does to `VITEST`:

| fixture | `env:` | gate verdict |
|:--|:--|:--|
| `fork-build-inherits.fixture.ts` | `{ ...process.env }` | `inherits` → **reported (RED)** |
| `fork-build-scrubbed.fixture.ts` | rest pattern binding `VITEST` away | `scrubbed` → **cleared (GREEN)** |

Each leg asserts the population **count** as well as the verdict, because "nothing leaks" and "nothing was looked at" render as the same empty list. The fixtures carry `.fixture.ts`, which `testFiles()` does not match, so the deliberate leak in the first one is invisible to the live census and cannot turn the real gate red.

## Ablation — that the new case measures `fork` and not something else

Committed first, then mutated on disk, with the mutation proved to have landed before anything was read, and the restore proved by state rather than by an exit code.

```
HEAD blob        = a353d34f1679d95db8b4a707df42610c150ebeda
mutation         = drop 'fork' from the single shared set
on-disk proof    "'fork']);" count 1 -> 0 ; blob 0f6b1ad6bd… != HEAD blob
mutated run      EXIT=1 — Tests  2 failed | 2 passed (4)
                 FAIL objectui#9211 … a fork() build handed the environment
                      unchanged is SEEN, and is reported — expected +0 to be 1
                 FAIL objectui#9211 … control — the same fork() with VITEST
                      scrubbed is SEEN, and is cleared — expected +0 to be 1
restore          git checkout HEAD -- THAT_FILE ; `git diff HEAD` empty ;
                 blob back to a353d34f16…
restored run     EXIT=0 — Test Files 2 passed (2) | Tests 9 passed (9)
```

⭐ The two **pre-existing** 8598 cases stayed green through the mutation. That is the triage point made mechanically: against a live `fork(` population of 0, the old suite is blind to this member in both directions.

## Acceptance, re-counted on both refs (code-only reader, comment lines excluded)

| leg | pre @ `852437297b` | post @ `dd4a6d24fa` |
|:--|--:|--:|
| `new Set(['spawnSync'` literals in `scripts/__tests__/` | 2 | **1** |
| `^const SPAWNERS = new Set(` in the two gate files | 2 | **0** |
| `^import { SPAWNERS } from './helpers/spawners';` | 0 | **2** |
| the one definition contains `'fork'` | — | **1** |

## Checks run locally

| command | result |
|:--|:--|
| `vitest run` on both gate files | `Test Files 2 passed (2)` · `Tests 9 passed (9)` (7 before) |
| `pnpm type-check:scripts` | exit 0 |
| `pnpm lint:root` | exit 0 — 0 errors, 32 pre-existing warnings, none in touched files |
| `eslint` on the six touched paths | exit 0, no output |
| `pnpm check:control-bytes` | OK |
| `pnpm check:test-path-roots` | OK |
| `pnpm check:new-line-citations` | 0 new citations, exit 0 |
| `check-changeset-presence` / `-no-major` / `-claims` | exit 0 each |
| `check-governed-queue-guard --test` on all six paths | NOT GOVERNED — ordinary PR route |
| `vitest run scripts/__tests__/scripts-type-check.test.ts` | 15 passed |

Changeset: `.changeset/9211-spawners-single-source.md`, **empty frontmatter** — test tooling only, nothing published moves. That is the declaration AGENTS.md names for this case, not an omission.

## Fences honoured

- objectui#8616's gate is not relaxed: its set membership is identical, only its source moved.
- Neither gate's `env:` judgement logic was changed.
- `content/docs/releases/` untouched.
- Cut in a dedicated worktree off `origin/main` at `852437297b`; the shared primary checkout was not edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_