### PR TITLE
ci(workflows): state the type-check / e2e markdown reading as a measurement (objectui#9241)

### DIFF
--- a/.changeset/ci-decide-markdown-trace-9241.md
+++ b/.changeset/ci-decide-markdown-trace-9241.md
@@ -1,0 +1,13 @@
+---
+---
+
+ci(workflows): replace the `type-check` / `e2e` markdown claim in `ci.yml` with a traced reading (objectui#9241)
+
+`ci.yml`'s `test` job carried the reason for being the only job with a markdown
+second stage as an assertion — "measured: `type-check` reads no document, and no
+e2e spec does" — which nothing had measured. Both populations were run under the
+`fs` trace objectui#9096 built. The `e2e` suite opens no markdown document; the
+`type-check` job's `check:spec-symbols` gate opens every page under
+`content/docs/**`, which the decide step's pathspec excludes. Comment only — no
+job, step, exclusion list or trigger changes, and the `type-check` finding is
+returned for re-grading rather than acted on here.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,16 @@ jobs:
       # objectui#3723. `scripts/__tests__/merge-queue-reporting.test.ts` holds
       # every `CHANGED=$(git diff …)` in this file and in `lint.yml` to the
       # fail-open form, so a new gate cannot be added in the closed spelling.
+      #
+      # ⛔ This job has NO markdown second stage, and objectui#9241 measured
+      # what that costs rather than asserting it away: traced under the `fs`
+      # harness objectui#9096 built, this job's population DOES open markdown --
+      # `pnpm check:spec-symbols` reads every page under `content/docs/**`,
+      # which the pathspec below excludes. ⇒ a documentation-only pull request
+      # skips the gate that reads that documentation. The reading, and the fence
+      # around acting on it, are on the `test` job's decide step below; the
+      # widening is objectui#9241's to grade, ⛔ not a thing to add here on
+      # sight.
       - name: Decide whether this change needs a full run
         id: relevant
         run: |
@@ -801,8 +811,44 @@ jobs:
           # above dropped: does a test READ it? `markdown-test-inputs.mjs` holds
           # the derived class -- which documents, and which test reads each --
           # and audits itself against the tree. Only THIS job carries the extra
-          # stage, because only this job runs the tests that read markdown
-          # (measured: `type-check` reads no document, and no e2e spec does).
+          # stage.
+          #
+          # ⚠️ objectui#9241: the reason that used to stand here was an
+          # ASSERTION -- "only this job runs the tests that read markdown
+          # (measured: `type-check` reads no document, and no e2e spec does)".
+          # Nothing had measured it. Both populations have now been run under
+          # the same `fs` trace objectui#9096 used -- every `readFileSync` /
+          # `openSync` / `promises.readFile` door recorded, the opened markdown
+          # written out -- and the two answers differ:
+          #
+          #   e2e         ZERO. That job's Playwright suite opens no markdown
+          #               document at all. Stable across two runs, and in a run
+          #               of the same suite the same harness -- extension filter
+          #               moved off `.md` -- recorded reads from inside the
+          #               Playwright worker process, so the zero is a reading
+          #               and not a harness that never fired. ⚠️ The bound on
+          #               it: 23 of that job's 46 tests skip for want of a docs
+          #               site and a backend, in CI exactly as when this was
+          #               taken (`DOCS_BASE_URL` is set nowhere in this file and
+          #               that job starts no backend), so their bodies are
+          #               outside the reading. Static complement: no spec under
+          #               `e2e/` outside `record-header-title-width.spec.ts`
+          #               names `node:fs` at all, and that one ran.
+          #   type-check  ⛔ NOT zero. Its `check:spec-symbols` gate reads EVERY
+          #               page under `content/docs/**` -- objectui#7995 widened
+          #               that gate onto published prose deliberately, after a
+          #               wrong spec claim shipped in
+          #               `content/docs/fields/lookup.mdx` (objectui#7537).
+          #               Those pages are excluded by the very pathspec above,
+          #               so a documentation-only pull request skips the gate
+          #               whose input it just edited -- the objectui#8857 shape,
+          #               one job over.
+          #
+          # ⛔ The second reading is a FINDING, not a licence to widen anything
+          # here: objectui#9241 returns it for re-grading before a markdown
+          # stage is wired into `type-check`, and this job's stage is unchanged
+          # by it. Both readings are a SNAPSHOT -- re-take them with the trace,
+          # do not trust this block.
           #
           # ⚠️ objectui#9096: that class is now TOTAL over markdown, and this
           # comment used to claim the opposite ("the widening is deliberately
@@ -1326,6 +1372,13 @@ jobs:
       # `type-check` job above (objectui#3523). The exclusion list must stay
       # identical across the gated jobs of this workflow;
       # `scripts/__tests__/merge-queue-reporting.test.ts` fails if it drifts.
+      #
+      # This job has no markdown second stage and, unlike `type-check`, that is
+      # now a MEASUREMENT: objectui#9241 ran this job's suite under the `fs`
+      # trace objectui#9096 built and it opened no markdown document, twice, in
+      # a run where the same harness recorded non-markdown reads from inside the
+      # Playwright worker. The bound on that zero, and the `type-check` reading
+      # that did NOT come back zero, are on the `test` job's decide step above.
       - name: Decide whether this change needs a full run
         id: relevant
         run: |


### PR DESCRIPTION
Part of objectui#9241. Refs: objectui#9096 · objectui#9141 · objectui#8861 · objectui#7995 · objectui#7537 · objectui#8857

## What was wrong

`.github/workflows/ci.yml` carries three copies of the decide step's exclusion list, and only the `test` job has the markdown second stage. The reason recorded for that, inside the `test` job's decide step, was:

> (measured: `type-check` reads no document, and no e2e spec does)

That is an **assertion**. objectui#9096's whole argument was that objectui#8861's exclusion rested on a sentence that sounded right; it was settled by **tracing**, not by re-reading the sentence. The same standard had not been applied to the two sibling jobs.

## What was measured

Both populations were run under the same kind of `fs` trace harness objectui#9096 used — `readFileSync` / `openSync` / `readFile` / `promises.readFile` / `createReadStream` patched before the main module, every opened `.md` / `.mdx` path recorded with the process that opened it. Base for every number below: `852437297b` (the merge parent this branch was cut from).

| population | markdown documents opened |
|:--|:--|
| `e2e` — `playwright test --project=chromium` | **0**, twice |
| `type-check` — every `run:` step of the job | **184**, all of them `content/docs/**`, all via the `check:spec-symbols` gate |

⚠️ **The `type-check` answer is NOT zero, and that is a finding, not something this PR acts on.** objectui#7995 widened `check-spec-symbol-derivation.mjs` onto published prose deliberately, after a wrong spec claim shipped in `content/docs/fields/lookup.mdx` (objectui#7537). Those pages are excluded by the decide step's own pathspec, so a documentation-only pull request skips the gate whose input it just edited — the objectui#8857 shape, one job over. Per the card's fence, the reading is returned for re-grading **before** any trigger is widened.

## What this PR changes

Comments only, in three places in `ci.yml`:

1. the `test` job's decide step — the asserted parenthetical is replaced by the two readings, the bound on the `e2e` zero, and an explicit fence against widening on sight;
2. the `type-check` job's decide-step note — records that this job's population DOES open markdown and points at the reading;
3. the `e2e` job's decide-step note — records that its zero is now a measurement.

⛔ No job, step, `run:` body, exclusion list or trigger changes. The `type-check` and `e2e` decide-step bodies are **byte-identical to the base**; only the `test` job's body changed, and only inside shell comments.

## Probes a reviewer can re-run

All of these run from a checkout of the merge parent (`852437297b`) unless noted.

Decide-step bodies, before and after. The extractor takes the step from its `- name:` line to the next one, inside the named job:

```
awk -v job=JOBKEY '
  /^  [A-Za-z0-9_-]+:$/ { injob = ($0 == "  " job ":") }
  injob && /^      - name: Decide whether this change needs a full run$/ { instep = 1; print; next }
  instep && /^      - name: / { instep = 0 }
  instep { print }
' .github/workflows/ci.yml | sha256sum | cut -c1-16
```

| job | `852437297b` | this branch (`ae50375580`) |
|:--|:--|:--|
| `type-check` | `7664350268713855` | `7664350268713855` (unchanged) |
| `e2e` | `7664350268713855` | `7664350268713855` (unchanged) |
| `test` | `2fed82fe860762bc` | `90a2fcd81f2948f0` (comment-only) |

⚠️ The card recorded `37c2d95659c9fffa` for the first two. That value predates PR objectui#9141 and does not reproduce on this base; it was re-taken rather than inherited.

The retired assertion. ⚠️ This leg reads comments **on purpose** — the deliverable IS a comment, so a comment-blind reader would miss the change entirely:

```
grep -cF 'does).'  .github/workflows/ci.yml   # standing form:  1 on base, 0 here
grep -cF 'does)".' .github/workflows/ci.yml   # quoted as retired: 0 on base, 1 here
```

Harness fires — control with a known direction, on the `test` population objectui#9096 already measured as reading markdown:

```
pnpm exec vitest run scripts/__tests__/check-doc-links.test.ts
```

one file of that population, traced: **471** distinct markdown documents opened. The instrument is alive.

Harness fires **inside the e2e population itself** — same harness, same run, extension filter moved off `.md` onto `.tsx|.css|.yaml`: **65 records across 10 files**, 7 of them from `playwright/lib/worker/workerProcessEntry.js` — i.e. from inside the Playwright worker process, which is where a spec read would have to appear. So the `.md` zero is a reading, not a dead patch.

Determinism, direction zero: the `e2e` trace was run twice, each time `23 passed / 23 skipped`, exit 0, **0** markdown records both times.

Determinism, direction non-zero: the `type-check` trace was run twice; both runs produced **184** records and the *identical set* of 184 paths.

The excluded-input pair, counted on the base:

```
git ls-files -- 'content/docs/fields/lookup.mdx' | wc -l
# 1 — the page is tracked, and check:spec-symbols opens it

git ls-files -- . ':(exclude,glob)**/*.md' ':(exclude,glob)content/**' \
  ':(exclude,glob)docs/**' ':(exclude,glob)apps/site/**' ':(exclude,glob).changeset/**' \
  | grep -c 'content/docs/fields/lookup.mdx'
# 0 — and the decide step's pathspec drops it
```

## Checks run locally

- `pnpm exec vitest run scripts/` — 152 passed, 2 skipped (154 files), 4505 tests, exit 0. Includes all 25 test files that read `.github/workflows/ci.yml`.
- `pnpm check:control-bytes` — OK, 7541 tracked text files scanned.
- `pnpm check:new-line-citations` — 0 new citations, exit 0.
- `node scripts/check-changeset-presence.mjs` — exit 0; no changeset is owed for a workflow-comment change, and the one added declares that explicitly with empty frontmatter.
- `node scripts/check-governed-queue-guard.mjs --test .github/workflows/ci.yml` — NOT GOVERNED.

⚠️ Two environment accommodations, declared rather than hidden: the local Playwright browser bundle is revision 1194 while `@playwright/test@1.62.1` asks for 1234, so the trace runs used a symlink shim in a scratch `PLAYWRIGHT_BROWSERS_PATH` rather than `playwright install`; and `pnpm type-check` needed an 8 GiB heap locally for `@object-ui/app-shell`. Neither touches the tree.

⚠️ Bound on the `e2e` zero, stated rather than narrowed: 23 of that job's 46 tests skip for want of a docs site and a backend — in CI exactly as here, since `DOCS_BASE_URL` appears nowhere in `ci.yml` and the job starts no backend — so those bodies are outside the trace. Static complement: no spec under `e2e/` outside `record-header-title-width.spec.ts` names `node:fs` at all, and that one ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_