### PR TITLE
docs(ci): cite the `Bundle Analysis` classification instead of asserting it

### DIFF
--- a/.changeset/9155-bundle-analysis-classification-prose.md
+++ b/.changeset/9155-bundle-analysis-classification-prose.md
@@ -1,0 +1,14 @@
+---
+---
+
+Stop this repo's eager-closure gate prose from classifying the `Bundle Analysis`
+check against the branch-protection set (objectui#9155). Eight sentences across
+`scripts/check-eager-closure-budget.mjs`, its test and
+`.github/workflows/performance-budget.yml` asserted a fact no reader can
+re-derive from inside a checkout, and the workflow's own job-ceiling comment
+already contradicted the sentence four lines above it. They now cite the two
+readings the tree does answer — the `OPTIONAL_CONTEXTS` entry in
+`scripts/dependabot-merge-gate.mjs` with its stated path-filter reason, and the
+absence of a `merge_group` leg in the workflow's `on:` block — and a new pin
+keeps the claim out in either direction. Comments and one test only; no
+classification changed and no package is released by this change.

--- a/.github/workflows/performance-budget.yml
+++ b/.github/workflows/performance-budget.yml
@@ -10,9 +10,13 @@ on:
       # This file itself (objectui#6245). Without it a change to this gate ships
       # to `main` having never run once: the PR that edits it touches no
       # `packages/**` path, so `Bundle Analysis` never appears on it, and a
-      # wiring bug surfaces on the NEXT `packages/**` PR — a required context
-      # turning red on someone else's diff, reading to them as a bundle problem
-      # of their own. Self-inclusion is this repo's convention for a
+      # wiring bug surfaces on the NEXT `packages/**` PR — a red check on
+      # someone else's diff, reading to them as a bundle problem of their own.
+      # ⚠️ This argument does not turn on how the check is CLASSIFIED. It said
+      # otherwise until objectui#9155, and the conclusion survives losing that
+      # premise untouched: a gate that never runs on its own pull request ships
+      # its wiring bugs to the next person either way.
+      # Self-inclusion is this repo's convention for a
       # path-filtered gate: measured on `origin/main`, 5 of the 7 workflows
       # carrying a `paths:` filter list their own file, and this was one of the
       # two that did not. The cost is honest and accepted — every edit of this
@@ -62,9 +66,13 @@ on:
       # This file itself (objectui#6245). Without it a change to this gate ships
       # to `main` having never run once: the PR that edits it touches no
       # `packages/**` path, so `Bundle Analysis` never appears on it, and a
-      # wiring bug surfaces on the NEXT `packages/**` PR — a required context
-      # turning red on someone else's diff, reading to them as a bundle problem
-      # of their own. Self-inclusion is this repo's convention for a
+      # wiring bug surfaces on the NEXT `packages/**` PR — a red check on
+      # someone else's diff, reading to them as a bundle problem of their own.
+      # ⚠️ This argument does not turn on how the check is CLASSIFIED. It said
+      # otherwise until objectui#9155, and the conclusion survives losing that
+      # premise untouched: a gate that never runs on its own pull request ships
+      # its wiring bugs to the next person either way.
+      # Self-inclusion is this repo's convention for a
       # path-filtered gate: measured on `origin/main`, 5 of the 7 workflows
       # carrying a `paths:` filter list their own file, and this was one of the
       # two that did not. The cost is honest and accepted — every edit of this
@@ -121,7 +129,12 @@ jobs:
 
     # ── The job ceiling, DERIVED FOR THIS JOB (objectui#7270) ────────────
     # Before this line the only backstop was GitHub's 360-minute default, on a
-    # job this repository treats as a required context (objectui#6245). Two
+    # job that BLOCKS WHENEVER IT RUNS: `scripts/dependabot-merge-gate.mjs`
+    # lists `Bundle Analysis` under `OPTIONAL_CONTEXTS`, whose rule is present
+    # => must be `success`, absent => ignored. The word "optional" there is
+    # about this workflow's trigger-level path filter, NOT about the check being
+    # advisory, and that gate's own docblock says so (objectui#6245,
+    # objectui#9155). Two
     # incidents put a number on that exposure: objectui#5304 (`apt-get` hang)
     # and objectui#6577 (cache-save stall), both of which turned a transient
     # fault into a `cancelled` check — a gate that reports nothing.
@@ -202,8 +215,10 @@ jobs:
       # ⚠️ This job's ceiling is `timeout-minutes: 25`, DERIVED at the job
       # header above from this job's own run distribution (objectui#7270).
       # Until that line existed the ceiling was GitHub's 360-minute default on
-      # a required context (objectui#6245), so a stalled save would have held
-      # that check open for up to six hours before reporting `cancelled`. The
+      # a check that blocks whenever it runs (objectui#6245; the classification
+      # is cited once, at the job header above — objectui#9155), so a stalled
+      # save would have held that check open for up to six hours before
+      # reporting `cancelled`. The
       # bound below is still on the bookkeeping step alone, and both numbers
       # are needed: 25 minutes is the backstop, 5 minutes is what a healthy
       # save is allowed.
@@ -230,10 +245,13 @@ jobs:
       - name: Build Console
         run: pnpm --filter @object-ui/console build
 
-      # objectui#6245: `Bundle Analysis` is a required context, and GitHub does
-      # not re-run a PR's checks when the base branch moves — so a green verdict
-      # can be computed against ceiling constants `main` has since replaced, and
-      # the merge is then gated on a ceiling that no longer exists. Observed
+      # objectui#6245: GitHub does not re-run a PR's checks when the base branch
+      # moves — so a green verdict can be computed against ceiling constants
+      # `main` has since replaced, and what this job publishes is a verdict about
+      # a ceiling that no longer exists. ⛔ Nothing is claimed here about the
+      # branch-protection set (objectui#9155); `evaluateCeilingFreshness`'s
+      # docblock in `scripts/check-eager-closure-budget.mjs` carries the two
+      # readings the tree can re-derive. Observed
       # live: run 32804357171 started at 03:13:27Z, 6m50s after `0409b766d`
       # lowered MAX_EAGER_CLOSURE_GZIP_BYTES from 4,086,000 to 3,345,000, and
       # published `BUDGET_CLOSURE_BUDGET_KB: 3990.2` — the retired ceiling — as a

--- a/scripts/__tests__/check-eager-closure-budget.test.ts
+++ b/scripts/__tests__/check-eager-closure-budget.test.ts
@@ -37,6 +37,11 @@ import {
   validateReport,
 } from '../check-eager-closure-budget.mjs';
 
+// The classifier this gate's prose now CITES instead of paraphrasing
+// (objectui#9155). Imported so the must-stay leg of that pin reads the real
+// tables rather than a copy of them. Same `allowJs` inference as above.
+import { OPTIONAL_CONTEXTS, REQUIRED_CONTEXTS } from '../dependabot-merge-gate.mjs';
+
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const workflowPath = path.join(repoRoot, '.github/workflows/performance-budget.yml');
 const viteConfigPath = path.join(repoRoot, 'apps/console/vite.config.ts');
@@ -1423,9 +1428,16 @@ describe('main', () => {
 });
 
 /**
- * objectui#6245 — the fourth half. `Bundle Analysis` is a required context, and
- * GitHub does not re-run a PR's checks when the base branch moves, so a green
- * verdict can be computed against ceilings `main` has since replaced.
+ * objectui#6245 — the fourth half. GitHub does not re-run a PR's checks when the
+ * base branch moves, so a green verdict can be computed against ceilings `main`
+ * has since replaced.
+ *
+ * ⛔ This docblock classified `Bundle Analysis` against the branch-protection
+ * set until objectui#9155 and no longer does, in either direction — that set is
+ * not readable from inside a checkout. `evaluateCeilingFreshness`'s own docblock
+ * carries what the tree can re-derive instead, cited to
+ * `scripts/dependabot-merge-gate.mjs` and to the workflow's `on:` block; the pin
+ * at the bottom of this file keeps all three files off the claim.
  *
  * Not hypothetical: run 32804357171 started 6m50s after `0409b766d` lowered the
  * aggregate ceiling from 4,086,000 to 3,345,000 and published
@@ -2346,5 +2358,134 @@ describe('the ceiling note states no rendered size (objectui#8964)', () => {
         'explain, for four days, why two retired numbers were consistent with each other. Name the ' +
         'constant and let the gate print the reading (objectui#8964).',
     ).toEqual([]);
+  });
+});
+
+// ── no prose here classifies this check against branch protection ───────────
+
+/**
+ * objectui#9155 — eight sentences across this gate's three prose files stated,
+ * as a fact, that `Bundle Analysis` belongs to the branch-protection set.
+ *
+ * The repo's own machine-readable classifier answered the neighbouring question
+ * differently: `scripts/dependabot-merge-gate.mjs` lists that check under
+ * `OPTIONAL_CONTEXTS`, because this workflow filters at the trigger. And the
+ * workflow contradicted ITSELF four lines apart — its job-ceiling comment had
+ * measured that the `on:` block subscribes `push` and `pull_request` and no
+ * `merge_group`, directly under a sentence that read the other way.
+ *
+ * ⛔ The fix was NOT to flip the prose to the opposite classification. The
+ * branch-protection set is not readable from inside a checkout (AGENTS.md says
+ * so), so BOTH readings are claims no reader can re-derive, and swapping one
+ * for the other buys one round before the same drift returns. The prose now
+ * cites the two things the tree does answer, and this pin is the instrument
+ * AGENTS.md #9 asks for in exchange: the claim cannot come back in either
+ * direction without going red.
+ *
+ * ⚠️ The population is COMMENT PROSE and this pin reads it deliberately, with
+ * no code/comment split at all. A code-only reader would score the whole of
+ * objectui#9155 as a no-op, because every one of the eight sites was a comment.
+ *
+ * ⚠️ The refused phrase is ASSEMBLED below rather than written out: this file
+ * is itself in the population, and a pin that spells its own trigger fails on
+ * its own source. The must-hit control is what keeps that assembly honest.
+ *
+ * ⛔ No count of either classifier table is asserted or written here. That list
+ * grows — two correct readings taken a day apart during this card's own triage
+ * disagreed — and a size baked into a test is the same defect one level up.
+ */
+describe('no prose here classifies `Bundle Analysis` against branch protection (objectui#9155)', () => {
+  /** Assembled, never spelled: this file is inside the population it scans. */
+  const REQ = `requi${'red'}`;
+
+  /**
+   * Two forms of one claim. The first catches it asserted — and, since the
+   * negation contains the positive verbatim, asserted in reverse as well; the
+   * second catches the looser denial that drops the noun.
+   */
+  const CLASSIFIES = new RegExp(String.raw`\b${REQ}\s+contexts?\b|\bis\s+not\s+${REQ}\b`, 'gi');
+
+  /** The three files objectui#9155 is about, by the name a failure prints. */
+  const POPULATION: Record<string, string> = {
+    'check-eager-closure-budget.mjs': checkerPath,
+    'check-eager-closure-budget.test.ts': fileURLToPath(import.meta.url),
+    'performance-budget.yml': workflowPath,
+  };
+
+  /**
+   * The must-HIT control, with a known direction. Without it the three zeroes
+   * below are equally consistent with a matcher that stopped matching anything
+   * — which is how a pin on absence goes quietly green forever.
+   */
+  it('sees the retired sentence when one is put in front of it', () => {
+    expect(`\`Bundle Analysis\` is a ${REQ} context, and GitHub`.match(CLASSIFIES)).toEqual([
+      `${REQ} context`,
+    ]);
+    expect(`      # a ${REQ} context turning red on someone else's diff`.match(CLASSIFIES)).toEqual([
+      `${REQ} context`,
+    ]);
+    expect(`Bundle Analysis is not ${REQ}.`.match(CLASSIFIES)).toEqual([`is not ${REQ}`]);
+    // ...and stays quiet on the citations the prose is now allowed to carry.
+    expect(
+      'lists it under `OPTIONAL_CONTEXTS`; no `merge_group` leg in the `on:` block'.match(CLASSIFIES),
+    ).toBeNull();
+  });
+
+  it('reads three files that are really there, not three empty strings', () => {
+    for (const [name, file] of Object.entries(POPULATION)) {
+      const source = fs.readFileSync(file, 'utf8');
+      expect(source.length, `${name} read as empty`).toBeGreaterThan(1000);
+      expect(source, `${name} is no longer about this gate`).toContain('Bundle Analysis');
+    }
+  });
+
+  it.each(Object.entries(POPULATION))('%s asserts no such classification', (name, file) => {
+    const hits = [...fs.readFileSync(file, 'utf8').matchAll(CLASSIFIES)].map((m) => m[0]);
+    expect(
+      hits,
+      `${name} classifies a check against the branch-protection set (${hits.join(', ')}). That set ` +
+        'is not readable from inside a checkout, so the sentence is a standing claim no reader can ' +
+        'check and nothing goes red when it drifts — which is the whole of objectui#9155. Cite what ' +
+        'the tree answers instead: the `OPTIONAL_CONTEXTS` entry in `scripts/dependabot-merge-gate.mjs` ' +
+        "with its own stated reason, and the absence of a `merge_group` leg in the workflow's `on:` block.",
+    ).toEqual([]);
+  });
+
+  /**
+   * The must-STAY half, and the reason this block is two-sided. On its own,
+   * "the eight sentences are gone" is equally consistent with someone having
+   * converged the CLASSIFIER onto the prose — moving `Bundle Analysis` into
+   * `REQUIRED_CONTEXTS` — which is a maintainer decision this card explicitly
+   * did not make, and which `dependabot-merge-gate.mjs` reserves twice in its
+   * own comments. This leg is what tells the two apart.
+   */
+  it('leaves the classifier saying what it said: `Bundle Analysis` is still OPTIONAL', () => {
+    expect(Object.hasOwn(OPTIONAL_CONTEXTS, 'Bundle Analysis')).toBe(true);
+    expect(REQUIRED_CONTEXTS).not.toContain('Bundle Analysis');
+    // Non-empty guards: both memberships are read off tables that exist, so a
+    // pair of emptied constants cannot read as agreement.
+    expect(REQUIRED_CONTEXTS.length).toBeGreaterThan(0);
+    expect(Object.keys(OPTIONAL_CONTEXTS).length).toBeGreaterThan(0);
+    // The reason travels with the entry — the prose cites it, so it has to stay.
+    expect(OPTIONAL_CONTEXTS['Bundle Analysis']).toContain('performance-budget.yml filters on paths');
+  });
+
+  /**
+   * The other cited source, re-derived rather than restated: the prose may say
+   * this job has no `merge_group` leg only for as long as that is true of the
+   * `on:` block. Guarded by locating a block that is found and substantial
+   * first, so a renamed section cannot pass by scanning nothing.
+   */
+  it('leaves the workflow without the `merge_group` leg the prose cites the absence of', () => {
+    const source = fs.readFileSync(workflowPath, 'utf8');
+    const start = source.indexOf('\non:\n');
+    const end = source.indexOf('\npermissions:\n');
+    expect(start, 'the `on:` block is not where this pin looks for it').toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    const onBlock = source.slice(start, end);
+    expect(onBlock.length).toBeGreaterThan(200);
+    expect(onBlock).toContain('  push:');
+    expect(onBlock).toContain('  pull_request:');
+    expect(onBlock).not.toMatch(/^\s{2}merge_group:/m);
   });
 });

--- a/scripts/check-eager-closure-budget.mjs
+++ b/scripts/check-eager-closure-budget.mjs
@@ -246,10 +246,14 @@
  * The three halves above all read this file's constants and take them as given.
  * None of them can ask whether the constants THEMSELVES are current, and on a
  * `pull_request` run that question has a wrong answer that is invisible from
- * inside the checkout: `Bundle Analysis` is a required context, GitHub does not
- * re-run a PR's checks when the base branch moves, so a green verdict can be
- * computed against ceilings `main` has since replaced — and the merge is gated
- * on it. Measured, not inferred: run 32804357171 started 6m50s AFTER
+ * inside the checkout: GitHub does not re-run a PR's checks when the base
+ * branch moves, so a green verdict can be computed against ceilings `main` has
+ * since replaced, and nothing downstream can tell that green from a fresh one.
+ * ⛔ How far that green GATES is deliberately not stated here. See
+ * {@link evaluateCeilingFreshness}, which carries the two readings this tree
+ * can re-derive about this check's blocking power — and the reason the sentence
+ * that used to stand in this spot could not be re-derived by anyone
+ * (objectui#9155). Measured, not inferred: run 32804357171 started 6m50s AFTER
  * `0409b766d` lowered the aggregate ceiling to 3,345,000 and published
  * `BUDGET_CLOSURE_BUDGET_KB: 3990.2` — the retired 4,086,000 — as a success.
  *
@@ -2134,12 +2138,47 @@ export function extractCeilingDeclarations(source, names = VERDICT_CEILING_CONST
  *
  * ## The race
  *
- * `Bundle Analysis` is a required context, and a `pull_request` run checks out
- * the MERGE REF — a merge of the PR head with the base branch as GitHub last
- * computed it. GitHub does not re-run a PR's checks when the base branch moves,
- * so a green verdict can be computed against ceiling constants that `main` has
- * since replaced, and the merge is then gated on a verdict about a ceiling that
- * no longer exists.
+ * A `pull_request` run checks out the MERGE REF — a merge of the PR head with
+ * the base branch as GitHub last computed it. GitHub does not re-run a PR's
+ * checks when the base branch moves, so a green verdict can be computed against
+ * ceiling constants that `main` has since replaced, and what this job then
+ * publishes is a verdict about a ceiling that no longer exists.
+ *
+ * ## This check's blocking power — and ⛔ what is NOT claimed about it
+ *
+ * This paragraph, and seven more across this file, its test and
+ * `.github/workflows/performance-budget.yml`, used to open by classifying
+ * `Bundle Analysis` against the branch-protection set (objectui#9155). ⛔ No
+ * sentence here does that any more, in either direction. That set is not
+ * readable from inside a checkout — AGENTS.md says so — so neither the claim
+ * nor its negation can be re-derived by a reader, and a classification nobody
+ * can re-derive drifts silently while nothing goes red: the same shape as the
+ * stale figures objectui#7528 and objectui#8964 each caught one column over.
+ * ⛔ The retired sentence is not quoted back here either, for the reason the
+ * objectui#8964 note gives — a reader cannot tell a quotation from a claim. It
+ * lives in the card.
+ *
+ * Two readings the tree DOES answer, cited rather than restated:
+ *
+ *   - `scripts/dependabot-merge-gate.mjs` lists `Bundle Analysis` under
+ *     `OPTIONAL_CONTEXTS`, and spells its own reason there: this workflow
+ *     filters at the TRIGGER, so the check is simply absent on a pull request
+ *     touching none of those paths. Read that constant's docblock for what the
+ *     classification governs and what it does not — it is that gate's own
+ *     admission rule for Dependabot merges, ⛔ not a mirror of branch
+ *     protection, and its header says which in as many words.
+ *   - `.github/workflows/performance-budget.yml` subscribes `push` and
+ *     `pull_request` and nothing else: there is no `merge_group` leg in its
+ *     `on:` block, so this job cannot hold the merge queue the way `Lint` can.
+ *     Re-derive it by reading that block; that workflow's job-ceiling comment
+ *     already did, and disagreed with the sentence four lines above itself.
+ *
+ * ⚠️ Neither reading weakens the race above, which is why they are stated here
+ * rather than the sentence simply deleted: `OPTIONAL_CONTEXTS` membership means
+ * present ⇒ must be `success`, absent ⇒ ignored, so this check is blocking
+ * WHENEVER IT RUNS on either reading — and a stale green is exactly a run that
+ * happened. The freshness half below is owed on the measurement, ⛔ never on the
+ * classification.
  *
  * Observed live rather than reasoned about: run 32804357171 started at
  * 03:13:27Z, six minutes and fifty seconds after `0409b766d` lowered


### PR DESCRIPTION
Fixes #9155

## The population — re-measured, ⛔ not copied

The card says "six prose sites"; triage measured 8. Re-derived on **my own base `ffc4c4434b`** (`git show <ref>:<path>`, never the primary checkout, which is hundreds of commits behind and holds different blobs):

| file | `grep -c 'required context'` @ `ffc4c4434b` |
|:--|--:|
| `scripts/check-eager-closure-budget.mjs` | 2 |
| `scripts/__tests__/check-eager-closure-budget.test.ts` | 1 |
| `.github/workflows/performance-budget.yml` | 5 |
| **total** | **8** |

⇒ **8 sites / 3 files.** The card's six was a lower bound. All eight are changed; the one the card did not count is the self-contained rationale under `paths:` (present twice, once per trigger), where the same false premise was propping up a *different* design decision.

## The shape of the fix — ⛔ not "required" → "optional"

Triage ruled this, and it is the whole point: the branch-protection required set **is not readable from inside a checkout** (AGENTS.md says so), so *both* readings are claims no reader can re-derive. Flipping the prose to the opposite classification buys one round before the identical drift returns.

So each site now **cites** a source the tree answers, instead of restating a classification:

1. `scripts/dependabot-merge-gate.mjs` lists `Bundle Analysis` under `OPTIONAL_CONTEXTS`, carrying its own stated reason (this workflow filters at the **trigger**). That constant's docblock also says what the classification governs — that gate's own admission rule for Dependabot merges, ⛔ **not** a mirror of branch protection.
2. `.github/workflows/performance-budget.yml` subscribes `push` and `pull_request` and nothing else; there is no `merge_group` leg in its `on:` block, so this job cannot hold the merge queue the way `Lint` can.

`evaluateCeilingFreshness`'s docblock is the single place that carries both readings in full; the other seven sites point at it or at the classifier directly. ⛔ The retired sentence is **not quoted back** anywhere in the tree — the objectui#8964 note's reason applies verbatim: a reader cannot tell a quotation from a claim.

⛔ **No bare count of `REQUIRED_CONTEXTS` is written into any prose or test.** That table moves: this branch's base reads a different size than triage read a day earlier, and both readings were correct at their ref. Naming a population has no clock to restart; copying a size does.

### Triage acceptance item 5 — the `paths:` rationale survives losing its premise

Its conclusion was "this workflow must be able to run on a PR that edits it". The argument is: a gate edit touches no `packages/**` path ⇒ the gate never runs on its own PR ⇒ a wiring bug lands on the next person's diff. **That does not turn on how the check is classified at all.** Only the premise was dropped; the conclusion, the self-inclusion entries and the measured 5-of-7 convention are untouched, and the comment now says so explicitly so the next reader does not re-derive the dropped clause.

## ⛔ Fences held

- ⛔ No context enrolled or removed — `scripts/dependabot-merge-gate.mjs` is **byte-identical** (proof below).
- ⛔ No `merge_group` leg added to `performance-budget.yml`.
- ⛔ No ceiling, baseline, threshold or `timeout-minutes` moved.
- ⛔ `content/docs/releases/` untouched; the release-notes input is the changeset.

## Probes — every leg counted on a named ref, with a control that HITS

⭐ **This deliverable is almost entirely comments**, so leg 1 reads comment prose **deliberately** and leg 2 exists to show why.

**Leg 1 — comment-aware (the delivery leg).** Pre counted on `ffc4c4434b` via `git show`, post on the worktree at `05517e4d2e`:

```
for f in scripts/check-eager-closure-budget.mjs \
         scripts/__tests__/check-eager-closure-budget.test.ts \
         .github/workflows/performance-budget.yml; do
  echo "$(git show ffc4c4434b:$f | grep -c 'required context') -> $(grep -c 'required context' $f)"
done
2 -> 0      # check-eager-closure-budget.mjs
1 -> 0      # check-eager-closure-budget.test.ts
5 -> 0      # performance-budget.yml
```

**Control (known direction, must HIT, same run, same matcher):**

```
grep -c 'required context' scripts/dependabot-merge-gate.mjs      # 8   (untouched, must stay non-zero)
printf 'X is a required context, and\n' | grep -c 'required context'   # 1
```

**Leg 2 — code-only reader, stated so it is not mistaken for the delivery leg.** `grep -vE '^\s*(\*|//|/\*)'` for the scripts, `^\s*#` for the YAML:

```
check-eager-closure-budget.mjs        pre=0 post=0
check-eager-closure-budget.test.ts    pre=0 post=0
performance-budget.yml                pre=0 post=0
```

⇒ a comment-blind reader scores this entire card **0 → 0**, i.e. a no-op. That is the reading to refuse, not to trust.

**Leg 3 — the two-sided MUST-STAY leg.** Without this, "the strings changed" cannot be told from "someone converged the classifier onto the prose". Verbatim tables extracted and hashed, **with a non-empty guard** (the first version of this extractor matched nothing and produced `e3b0c44298fc1c14` — the sha256 of the empty string — on both sides, which is exactly the failure the guard exists to catch):

| table | sha256 (first 16) @ `ffc4c4434b` | @ `05517e4d2e` | bytes | entries |
|:--|:--|:--|--:|--:|
| `REQUIRED_CONTEXTS` | `af2048c135f2aaa1` | `af2048c135f2aaa1` | 1078 | 26 |
| `OPTIONAL_CONTEXTS` | `5dc36bc675a1ab04` | `5dc36bc675a1ab04` | 723 | 3 |

`sha256("") = e3b0c44298fc1c14` — matches **neither** row, so both sides read real bytes. `git diff --stat -- scripts/dependabot-merge-gate.mjs` is empty.

Read through the module rather than the text, with a control:

```
OPTIONAL has Bundle Analysis  = true    (must STAY true)
REQUIRED has Bundle Analysis  = false   (must STAY false)
REQUIRED includes 'Lint'      = true    (control, known direction, HITS)
```

**Leg 4 — negative control: no NEW branch-protection assertion.** Triage's supplement asked for this specifically, because "replace one unverifiable claim with another" is how this card gets fixed wrong:

```
grep -cEi 'required context|is not required|treats as required|not a required' <each of the 3 files>   # 0, 0, 0
same matcher on scripts/dependabot-merge-gate.mjs                                                       # 8  (control, HITS)
```

**Leg 5 — the workflow's `on:` block, re-derived rather than restated** (this is what the prose now cites):

```
name = Bundle Analysis | on keys = [ 'push', 'pull_request' ] | timeout-minutes = 25
```

**Leg 6 — the diff is comment-only in both non-test files:**

```
git diff ffc4c4434b..05517e4d2e -- scripts/check-eager-closure-budget.mjs .github/workflows/performance-budget.yml \
  | grep -E '^[-+]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[-+]\s*(\*|//|/\*|#)' | grep -vE '^[-+]\s*$'
(empty)
```

The test file *does* gain real code — the new pin — and that is the only executable change in this PR.

## The instrument, since the claim was prose (AGENTS.md #9)

A new two-sided `describe` in `scripts/__tests__/check-eager-closure-budget.test.ts` makes the claim re-derivable in exchange for removing it:

- refuses the classification phrase in **all three files**, in **either direction**, reading comment prose deliberately;
- the refused phrase is **assembled** (`` `requi${'red'}` ``) rather than spelled, because this file is inside its own population;
- a **must-hit control** proves the matcher still matches the real retired sentence, so the three zeroes cannot be green-because-empty;
- a **non-empty guard** on each file read (length + `Bundle Analysis` present);
- the **must-STAY** assertions on `OPTIONAL_CONTEXTS` / `REQUIRED_CONTEXTS`, plus the `on:`-block check.

### Ablation — both legs, rebuilt state proven on disk, restore proven by state

*Mutation A — put the retired sentence back in the workflow:*

```
injected 'PR — a required context' : 1     (⚠️ honest reading: my s/// lacked /g, so 1 of the 2
deleted  'a red check on'          : 1        identical sites mutated — one is enough to fail)
blob 9474c67ade... -> 074a807994...          (mutation proven on disk, NOT by the editor's exit code)
VERDICT mutation-exit = 1  (non-zero, as required)
  × performance-budget.yml asserts no such classification
    AssertionError: ... (required context): expected [ 'required context' ] to deeply equal []
```

*Mutation B — converge the CLASSIFIER onto the prose (the exact wrong fix this card refuses):*

```
blob a2f5ec0e23... -> e95f9f1310...          (mutation proven on disk)
VERDICT mutation-exit = 1  (non-zero)
  × leaves the classifier saying what it said: `Bundle Analysis` is still OPTIONAL
    AssertionError: expected [ 'Bundle Analysis', …(26) ] to not include 'Bundle Analysis'
```

*Restore legs (both `git checkout HEAD -- <path>`, never a bare `git checkout --`), proven by state:*

```
blob now == HEAD blob  (9474c67ade... / a2f5ec0e23...)
git diff HEAD --stat : empty
git status --porcelain: empty
re-run on restored tree: Test Files 1 passed (1) | Tests 145 passed (145)
```

## Checks run locally (verdict lines, exit codes captured before any pipe)

| command | verdict |
|:--|:--|
| `pnpm exec vitest run scripts/__tests__/check-eager-closure-budget.test.ts` | exit 0 — `Tests 145 passed (145)` (7 of them new) |
| `pnpm exec vitest run scripts/` | exit 0 — `Test Files 152 passed \| 2 skipped (154)`, `Tests 4512 passed` |
| `pnpm type-check:scripts` | exit 0 |
| `pnpm check:control-bytes` | exit 0 — `OK (scanned 7543 tracked text file(s))` |
| `node scripts/check-changeset-presence.mjs` | exit 0 — `no changeset is owed` |
| `pnpm changeset:check` | exit 0 — fixed group ✅, no `major` ✅ |
| `pnpm exec eslint --no-inline-config` on both edited JS/TS files | exit 0 — `files linted = 2, errors = 0, warnings = 0` |

Counts above were taken at final commit `05517e4d2e` (`git rev-parse --short HEAD`).

⚠️ The eslint leg is a **declared narrowing**, not the repo-wide scan: 2 files of the population eslint's own config would select. Type-aware linting is not enabled for these files, so this diff cannot move the verdict on any file it did not touch — but the repo-wide run is CI's, and that is where it stays.

⚠️ `node scripts/check-changeset-claims.mjs` (report-only, exit 0) flags `.changeset/7173-ai-pending-actions-inbox-i18n.md` because its body names `scripts/check-eager-closure-budget.mjs`. **Re-read as asked: no correction owed.** That paragraph is entirely about a per-chunk ceiling and a baseline re-pin; this PR moves no ceiling, baseline or threshold, so nothing in it went false.

A changeset is added with **empty frontmatter** — the repo's first-class "declared, not released" form — since this is comments plus one test.

## ⚠️ Reported, ⛔ not acted on

The card's own body sentence "objectui#9006 **and its triage**" is inaccurate; os-musk already measured that the false statement lived in the executing PM seat's `Claim:` comment (which self-corrected publicly), not in the triage comment. ⛔ No hunt was made for a triage misstatement that does not exist.

Whether this repo's CI topology *should* give this gate a `merge_group` leg is a maintainer decision and explicitly out of scope. ⛔ Not acted on, ⛔ not filed as a defect — `dependabot-merge-gate.mjs` already reserves that decision twice in its own comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_